### PR TITLE
feat(ai): off-host backup sync hook with durable receipt + snapshot projection (#15641)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1266,6 +1266,20 @@ class ConfigBase extends ConfigProvider {
                     retention : {
                         keepMinimum: 3,
                         maxDays    : 30
+                    },
+                    /**
+                     * Off-host durability hook (plain nested keys inside this object leaf — the owning
+                     * ticket owns validation; see backup.mjs#validateOffHostSyncConfig). An empty
+                     * `command` disables the hook entirely. Secrets never enter this tree: `envAllowlist`
+                     * names env vars the sync child may inherit; values live only in the process env.
+                     * @type {Object}
+                     */
+                    offHostSync: {
+                        argv        : [],
+                        command     : '',
+                        envAllowlist: [],
+                        killGraceMs : 5000,
+                        timeoutMs   : 600000
                     }
                 },
                 /**

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -206,8 +206,7 @@ export class DeploymentStateBridgeService extends Base {
      * is last-known, never refreshed-on-read.
      * @returns {Promise<Object|null>}
      */
-    async collectMaintenanceSnapshot() {
-        const receiptPath = path.join(AiConfig.backupPath, 'last-backup-receipt.json');
+    async collectMaintenanceSnapshot({receiptPath = path.join(AiConfig.backupPath, 'last-backup-receipt.json')} = {}) {
 
         try {
             const outcome = await readBackupReceipt({filePath: receiptPath});

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -9,7 +9,7 @@ import {
     createDeploymentStateSnapshot,
     writeDeploymentStateSnapshot
 } from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
-import {readBackupReceipt}           from '../../../scripts/maintenance/offHostSync.mjs';
+import {readBackupReceipt}           from '../../../services/memory-core/helpers/offHostSyncStore.mjs';
 import {readRecentRecoveryRunStates} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {
     queryHealLedger,

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -1,4 +1,5 @@
 import {createHash}                         from 'node:crypto';
+import path                                 from 'node:path';
 import Base                                 from '../../../../src/core/Base.mjs';
 import AiConfig                             from '../../../config.mjs';
 import {probeProviderParallelModelCapacity} from '../../../services/graph/providerReadinessHelper.mjs';
@@ -8,6 +9,7 @@ import {
     createDeploymentStateSnapshot,
     writeDeploymentStateSnapshot
 } from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
+import {readBackupReceipt}           from '../../../scripts/maintenance/offHostSync.mjs';
 import {readRecentRecoveryRunStates} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {
     queryHealLedger,
@@ -182,6 +184,7 @@ export class DeploymentStateBridgeService extends Base {
         const selfHeal          = await this.collectSelfHealSnapshot();
         const tenantRepoSync    = await this.collectTenantRepoSyncSnapshot({observedAt: generatedAt});
         const bridgeDiagnostics = this.collectBridgeDiagnostics({services, observedAt: generatedAt});
+        const maintenance       = await this.collectMaintenanceSnapshot();
 
         return createDeploymentStateSnapshot({
             generatedAt,
@@ -189,8 +192,48 @@ export class DeploymentStateBridgeService extends Base {
             bridgeDiagnostics,
             recoveryRuns,
             selfHeal,
-            tenantRepoSync
+            tenantRepoSync,
+            maintenance
         });
+    }
+
+    /**
+     * Projects the durable backup receipt (`AiConfig.backupPath/last-backup-receipt.json`) into the
+     * snapshot with explicit freshness semantics: absent-before-first-run omits the block entirely
+     * (never fabricated); unreadable/corrupt/oversize/wrong-version receipts project a stable
+     * `{status: 'unreadable', kind, finishedAt}` shape so consumers never infer corruption from an
+     * absent block. The receipt file survives orchestrator restart by construction; the projection
+     * is last-known, never refreshed-on-read.
+     * @returns {Promise<Object|null>}
+     */
+    async collectMaintenanceSnapshot() {
+        const receiptPath = path.join(AiConfig.backupPath, 'last-backup-receipt.json');
+
+        try {
+            const outcome = await readBackupReceipt({filePath: receiptPath});
+
+            if (outcome.status === 'missing') return null;
+
+            if (outcome.status === 'unreadable') {
+                return {
+                    lastBackup: {
+                        finishedAt: outcome.finishedAt,
+                        kind      : outcome.kind,
+                        status    : 'unreadable'
+                    }
+                }
+            }
+
+            return {lastBackup: outcome.receipt}
+        } catch (error) {
+            return {
+                lastBackup: {
+                    finishedAt: null,
+                    kind      : 'corrupt',
+                    status    : 'unreadable'
+                }
+            }
+        }
     }
 
     /**

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -569,23 +569,32 @@ async function copyJsonlSource(source, destDir, logger=console) {
  *
  * @returns {Promise<Object>} the lease outcome (same shape as `withHeavyMaintenanceLease`'s)
  */
-export async function runBackupWithOffHostSync() {
+export async function runBackupWithOffHostSync({
+    runBackupImpl  = runBackup,
+    withLeaseImpl  = withHeavyMaintenanceLease,
+    backupRoot     = null,
+    syncConfig     = undefined
+} = {}) {
     // The sync + BOTH receipts live INSIDE the self-acquired lease: success receipts and the
     // truthful not-run failure receipt are persisted before the lease releases.
-    return withHeavyMaintenanceLease(async () => {
+    return withLeaseImpl(async () => {
         const backupStartedAt = Date.now();
+
+        // Validation precedes ANY subtree read: a malformed subtree never reaches the allowlist
+        // consumer (and never throws at the consumer). `syncConfig` is the test seam for the
+        // malformed-config branches; production callers leave it undefined to read the leaf.
+        const
+            validation  = validateOffHostSyncConfig(syncConfig === undefined ? AiConfig.maintenance.backup.offHostSync : syncConfig),
+            allowlist   = validation.value?.envAllowlist ?? [],
+            receiptPath = path.join(backupRoot ?? AiConfig.backupPath, 'last-backup-receipt.json');
 
         let result, backupError = null;
 
         try {
-            result = await runBackup()
+            result = await runBackupImpl()
         } catch (error) {
             backupError = error
         }
-
-        const
-            allowlist   = AiConfig.maintenance.backup.offHostSync.envAllowlist,
-            receiptPath = path.join(AiConfig.backupPath, 'last-backup-receipt.json');
 
         if (backupError) {
             // Only a backup/lease failure reaches this branch: the truthful not-run receipt, written
@@ -612,7 +621,6 @@ export async function runBackupWithOffHostSync() {
         const
             {bundleRoot, completedAt} = result,
             bundleName                = path.basename(bundleRoot),
-            validation                = validateOffHostSyncConfig(AiConfig.maintenance.backup.offHostSync),
             backupDurationMs          = Date.now() - backupStartedAt;
 
         let syncOutcome = null,

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -570,78 +570,103 @@ async function copyJsonlSource(source, destDir, logger=console) {
  * @returns {Promise<Object>} the lease outcome (same shape as `withHeavyMaintenanceLease`'s)
  */
 export async function runBackupWithOffHostSync() {
-    const receiptPath = path.join(AiConfig.backupPath, 'last-backup-receipt.json');
-    const startedAt   = Date.now();
+    // The sync + BOTH receipts live INSIDE the self-acquired lease: success receipts and the
+    // truthful not-run failure receipt are persisted before the lease releases.
+    return withHeavyMaintenanceLease(async () => {
+        const backupStartedAt = Date.now();
 
-    try {
-        // The sync + receipt lifetime extends the exclusive-heavy lease: everything below runs
-        // INSIDE the lease callback, so the lease releases only after the bounded receipt rename.
-        return await withHeavyMaintenanceLease(async () => {
-            const result = await runBackup();
+        let result, backupError = null;
 
-            const
-                {bundleRoot, completedAt} = result,
-                bundleName                = path.basename(bundleRoot),
-                validation                = validateOffHostSyncConfig(AiConfig.maintenance.backup.offHostSync);
+        try {
+            result = await runBackup()
+        } catch (error) {
+            backupError = error
+        }
 
-            let syncOutcome = null,
-                syncStatus  = 'disabled';
+        const
+            allowlist   = AiConfig.maintenance.backup.offHostSync.envAllowlist,
+            receiptPath = path.join(AiConfig.backupPath, 'last-backup-receipt.json');
 
-            if (validation.error) {
-                syncStatus = 'validation-failed';
-                console.warn(`[Backup] offHostSync validation failed: ${validation.error} — skipping the off-host sync, the local bundle is unaffected.`);
-            } else if (validation.enabled) {
-                syncOutcome = await runOffHostSync({bundleDir: bundleRoot, bundleName, config: validation.value});
+        if (backupError) {
+            // Only a backup/lease failure reaches this branch: the truthful not-run receipt, written
+            // while the lease is still held. A receipt write failure never masks the backup failure.
+            await writeBackupReceipt({
+                filePath: receiptPath,
+                receipt : buildBackupReceipt({
+                    backup: {
+                        durationMs: Date.now() - backupStartedAt,
+                        error     : redactAndBound(backupError?.stack ?? backupError?.message ?? String(backupError), buildSyncChildEnv(allowlist), undefined, allowlist),
+                        status    : 'failed'
+                    },
+                    bundleCompletedAt: null,
+                    bundleName       : null,
+                    syncStatus       : 'not-run-backup-failed'
+                })
+            }).catch(receiptError => {
+                console.warn(`[Backup] failed to write the failure receipt: ${receiptError.message}`)
+            });
 
-                if (syncOutcome.status !== 'success') {
-                    console.warn(`[Backup] offHostSync ${syncOutcome.status} (terminatedVia=${syncOutcome.terminatedVia}): ${syncOutcome.stderrTail}`);
+            throw backupError
+        }
+
+        const
+            {bundleRoot, completedAt} = result,
+            bundleName                = path.basename(bundleRoot),
+            validation                = validateOffHostSyncConfig(AiConfig.maintenance.backup.offHostSync),
+            backupDurationMs          = Date.now() - backupStartedAt;
+
+        let syncOutcome = null,
+            syncStatus  = 'disabled';
+
+        if (validation.error) {
+            syncStatus = 'validation-failed';
+            console.warn(`[Backup] offHostSync validation failed: ${validation.error} — skipping the off-host sync, the local bundle is unaffected.`);
+        } else if (validation.enabled) {
+            try {
+                syncOutcome = await runOffHostSync({bundleDir: bundleRoot, bundleName, config: validation.value})
+            } catch (syncError) {
+                // An unexpected spawn/config error is a SYNC outcome — the completed local bundle
+                // never becomes backup.status: 'failed' because the hook broke.
+                syncOutcome = {
+                    completionScope: 'direct-child',
+                    descendants    : 'unknown',
+                    durationMs     : null,
+                    exitCode       : null,
+                    signal         : null,
+                    status         : 'failed',
+                    stderrTail     : redactAndBound(syncError?.message ?? String(syncError), buildSyncChildEnv(allowlist), undefined, allowlist),
+                    terminatedVia  : 'exit'
                 }
             }
 
-            try {
-                await writeBackupReceipt({
-                    filePath: receiptPath,
-                    receipt : buildBackupReceipt({
-                        backup: {
-                            durationMs: Date.now() - startedAt,
-                            error     : null,
-                            status    : 'success'
-                        },
-                        bundleCompletedAt: completedAt,
-                        bundleName,
-                        offHostSync      : syncOutcome,
-                        syncStatus
-                    })
-                });
-            } catch (receiptError) {
-                // A receipt write failure degrades observability, never the successful backup's truth.
-                console.warn(`[Backup] failed to write the receipt after a successful backup: ${receiptError.message}`)
+            if (syncOutcome.status !== 'success') {
+                console.warn(`[Backup] offHostSync ${syncOutcome.status} (terminatedVia=${syncOutcome.terminatedVia}): ${syncOutcome.stderrTail}`);
             }
+        }
 
-            return result
-        }, {owner: 'backup', reason: 'manual-cli', staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs, metadata: {script: 'ai/scripts/maintenance/backup.mjs'}});
-        // Held: no backup ran — no receipt. Completed: sync + receipt already ran inside the lease.
-    } catch (error) {
-        // Only a runBackup/lease failure reaches here: the truthful not-run receipt. A receipt write
-        // failure never masks the backup failure.
-        await writeBackupReceipt({
-            filePath: receiptPath,
-            receipt : buildBackupReceipt({
-                backup: {
-                    durationMs: Date.now() - startedAt,
-                    error     : redactAndBound(error?.stack ?? error?.message ?? String(error), buildSyncChildEnv(AiConfig.maintenance.backup.offHostSync.envAllowlist)),
-                    status    : 'failed'
-                },
-                bundleCompletedAt: null,
-                bundleName       : null,
-                syncStatus       : 'not-run-backup-failed'
-            })
-        }).catch(receiptError => {
-            console.warn(`[Backup] failed to write the failure receipt: ${receiptError.message}`)
-        });
+        try {
+            await writeBackupReceipt({
+                filePath: receiptPath,
+                receipt : buildBackupReceipt({
+                    backup: {
+                        durationMs: backupDurationMs,
+                        error     : null,
+                        status    : 'success'
+                    },
+                    bundleCompletedAt: completedAt,
+                    bundleName,
+                    offHostSync      : syncOutcome,
+                    syncStatus
+                })
+            });
+        } catch (receiptError) {
+            // A receipt write failure degrades observability, never the successful backup's truth.
+            console.warn(`[Backup] failed to write the receipt after a successful backup: ${receiptError.message}`)
+        }
 
-        throw error
-    }
+        return result
+    }, {owner: 'backup', reason: 'manual-cli', staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs, metadata: {script: 'ai/scripts/maintenance/backup.mjs'}});
+    // Held: no backup ran — no receipt. Completed: sync + receipt already ran inside the lease.
 }
 
 // Auto-run under the shared heavy-maintenance lease so this CLI cannot collide with the

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -571,13 +571,13 @@ async function copyJsonlSource(source, destDir, logger=console) {
  */
 export async function runBackupWithOffHostSync({
     runBackupImpl  = runBackup,
-    withLeaseImpl  = withHeavyMaintenanceLease,
+    withLeaseImpl  = null,
     backupRoot     = null,
     syncConfig     = undefined
 } = {}) {
     // The sync + BOTH receipts live INSIDE the self-acquired lease: success receipts and the
     // truthful not-run failure receipt are persisted before the lease releases.
-    return withLeaseImpl(async () => {
+    return (withLeaseImpl ?? withHeavyMaintenanceLease)(async () => {
         const backupStartedAt = Date.now();
 
         // Validation precedes ANY subtree read: a malformed subtree never reaches the allowlist

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -573,53 +573,57 @@ export async function runBackupWithOffHostSync() {
     const receiptPath = path.join(AiConfig.backupPath, 'last-backup-receipt.json');
     const startedAt   = Date.now();
 
-    const finish = async outcome => {
-        if (outcome.status === 'held') return outcome; // deferred, no backup ran — no receipt
-
-        const
-            {bundleRoot, completedAt} = outcome.result,
-            bundleName                = path.basename(bundleRoot),
-            validation                = validateOffHostSyncConfig(AiConfig.maintenance.backup.offHostSync);
-
-        let syncOutcome = null,
-            syncStatus  = 'disabled';
-
-        if (validation.error) {
-            syncStatus = 'validation-failed';
-            console.warn(`[Backup] offHostSync validation failed: ${validation.error} — skipping the off-host sync, the local bundle is unaffected.`);
-        } else if (validation.enabled) {
-            syncOutcome = await runOffHostSync({bundleDir: bundleRoot, bundleName, config: validation.value});
-
-            if (syncOutcome.status !== 'success') {
-                console.warn(`[Backup] offHostSync ${syncOutcome.status} (terminatedVia=${syncOutcome.terminatedVia}): ${syncOutcome.stderrTail}`);
-            }
-        }
-
-        await writeBackupReceipt({
-            filePath: receiptPath,
-            receipt : buildBackupReceipt({
-                backup: {
-                    durationMs: Date.now() - startedAt,
-                    error     : null,
-                    status    : 'success'
-                },
-                bundleCompletedAt: completedAt,
-                bundleName,
-                offHostSync      : syncOutcome,
-                syncStatus
-            })
-        });
-
-        return outcome
-    };
-
     try {
-        return await finish(await withHeavyMaintenanceLease(
-            () => runBackup(),
-            {owner: 'backup', reason: 'manual-cli', staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs, metadata: {script: 'ai/scripts/maintenance/backup.mjs'}}
-        ))
+        // The sync + receipt lifetime extends the exclusive-heavy lease: everything below runs
+        // INSIDE the lease callback, so the lease releases only after the bounded receipt rename.
+        return await withHeavyMaintenanceLease(async () => {
+            const result = await runBackup();
+
+            const
+                {bundleRoot, completedAt} = result,
+                bundleName                = path.basename(bundleRoot),
+                validation                = validateOffHostSyncConfig(AiConfig.maintenance.backup.offHostSync);
+
+            let syncOutcome = null,
+                syncStatus  = 'disabled';
+
+            if (validation.error) {
+                syncStatus = 'validation-failed';
+                console.warn(`[Backup] offHostSync validation failed: ${validation.error} — skipping the off-host sync, the local bundle is unaffected.`);
+            } else if (validation.enabled) {
+                syncOutcome = await runOffHostSync({bundleDir: bundleRoot, bundleName, config: validation.value});
+
+                if (syncOutcome.status !== 'success') {
+                    console.warn(`[Backup] offHostSync ${syncOutcome.status} (terminatedVia=${syncOutcome.terminatedVia}): ${syncOutcome.stderrTail}`);
+                }
+            }
+
+            try {
+                await writeBackupReceipt({
+                    filePath: receiptPath,
+                    receipt : buildBackupReceipt({
+                        backup: {
+                            durationMs: Date.now() - startedAt,
+                            error     : null,
+                            status    : 'success'
+                        },
+                        bundleCompletedAt: completedAt,
+                        bundleName,
+                        offHostSync      : syncOutcome,
+                        syncStatus
+                    })
+                });
+            } catch (receiptError) {
+                // A receipt write failure degrades observability, never the successful backup's truth.
+                console.warn(`[Backup] failed to write the receipt after a successful backup: ${receiptError.message}`)
+            }
+
+            return result
+        }, {owner: 'backup', reason: 'manual-cli', staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs, metadata: {script: 'ai/scripts/maintenance/backup.mjs'}});
+        // Held: no backup ran — no receipt. Completed: sync + receipt already ran inside the lease.
     } catch (error) {
-        // Truthful failure receipt around a thrown runBackup; a receipt write failure never masks it.
+        // Only a runBackup/lease failure reaches here: the truthful not-run receipt. A receipt write
+        // failure never masks the backup failure.
         await writeBackupReceipt({
             filePath: receiptPath,
             receipt : buildBackupReceipt({

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -24,6 +24,14 @@ import {
 } from '../../services.mjs';
 
 import {withHeavyMaintenanceLease} from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
+import {
+    buildBackupReceipt,
+    buildSyncChildEnv,
+    redactAndBound,
+    runOffHostSync,
+    validateOffHostSyncConfig,
+    writeBackupReceipt
+} from './offHostSync.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -104,7 +112,6 @@ const PROJECT_ROOT = path.resolve(__dirname, '../../..');
 const DEFAULT_CONCEPTS_DIR      = path.join(PROJECT_ROOT, '.neo-ai-data', 'concepts');
 const DEFAULT_TRAJECTORIES_FILE = path.join(PROJECT_ROOT, '.neo-ai-data', 'datasets', 'rlaif', 'trajectories.jsonl');
 const DEFAULT_SENT_TO_CULL_FILE = path.join(path.dirname(mcConfig.storagePaths.graph), 'sent-to-cull.jsonl');
-const DEFAULT_BACKUP_ROOT       = path.join(PROJECT_ROOT, '.neo-ai-data', 'backups');
 export const LOCAL_AI_CONFIG_FILE = path.join(PROJECT_ROOT, 'ai', 'config.mjs');
 
 /**
@@ -158,8 +165,8 @@ export async function runBackup({
     sentToCullSourceFile   = DEFAULT_SENT_TO_CULL_FILE,
     logger                 = console
 } = {}) {
-    const timestamp = new Date().toISOString().replace(/:/g, '-');
-    const resolvedRoot = bundleRoot ?? path.join(DEFAULT_BACKUP_ROOT, `backup-${timestamp}`);
+    const timestamp    = new Date().toISOString().replace(/:/g, '-');
+    const resolvedRoot = bundleRoot ?? path.join(AiConfig.backupPath, `backup-${timestamp}`);
 
     const layout = {
         kb          : path.join(resolvedRoot, 'kb'),
@@ -209,10 +216,12 @@ export async function runBackup({
     subsystems.mailbox = await copyJsonlSource(sentToCullSourceFile, layout.mailbox, logger);
 
     logger.log('[7/7] Applying retention sweep...');
-    await loadTopLevelAiConfig();
     // Retention comes from Tier-1 AI maintenance policy; missing keys fail loud
-    // at the direct resolved-leaf read site.
-    await cleanOldBackups(DEFAULT_BACKUP_ROOT, logger, resolveBackupRetention());
+    // at the direct resolved-leaf read site. Bundle root, retention sweep, receipt, and
+    // snapshot-root all resolve from the same `AiConfig.backupPath` leaf (the CLI wrapper
+    // loads the gitignored overlay before this call so the local overlay is honored too).
+    await loadTopLevelAiConfig();
+    await cleanOldBackups(AiConfig.backupPath, logger, resolveBackupRetention());
 
     logger.log('Verifying bundle integrity (row-count parity)...');
     const integrity    = await verifyBundleIntegrity(layout, subsystems);
@@ -548,15 +557,98 @@ async function copyJsonlSource(source, destDir, logger=console) {
     return {copied: 1};
 }
 
+/**
+ * The lease-owning orchestration path: exported `runBackup()` stays the pure local
+ * bundle/retention primitive; this wrapper owns the configured off-host sync step and the
+ * deployment-global receipt. Direct module callers of `runBackup()` never fire the configured
+ * command and never overwrite the global receipt.
+ *
+ * Lease semantics: the sync lifetime extends the exclusive-heavy backup lease; the lease remains
+ * held through the bounded-size receipt fsync/rename and releases afterward (no exact wall-clock
+ * bound — local filesystem completion is not a hard real-time guarantee).
+ *
+ * @returns {Promise<Object>} the lease outcome (same shape as `withHeavyMaintenanceLease`'s)
+ */
+export async function runBackupWithOffHostSync() {
+    const receiptPath = path.join(AiConfig.backupPath, 'last-backup-receipt.json');
+    const startedAt   = Date.now();
+
+    const finish = async outcome => {
+        if (outcome.status === 'held') return outcome; // deferred, no backup ran — no receipt
+
+        const
+            {bundleRoot, completedAt} = outcome.result,
+            bundleName                = path.basename(bundleRoot),
+            validation                = validateOffHostSyncConfig(AiConfig.maintenance.backup.offHostSync);
+
+        let syncOutcome = null,
+            syncStatus  = 'disabled';
+
+        if (validation.error) {
+            syncStatus = 'validation-failed';
+            console.warn(`[Backup] offHostSync validation failed: ${validation.error} — skipping the off-host sync, the local bundle is unaffected.`);
+        } else if (validation.enabled) {
+            syncOutcome = await runOffHostSync({bundleDir: bundleRoot, bundleName, config: validation.value});
+
+            if (syncOutcome.status !== 'success') {
+                console.warn(`[Backup] offHostSync ${syncOutcome.status} (terminatedVia=${syncOutcome.terminatedVia}): ${syncOutcome.stderrTail}`);
+            }
+        }
+
+        await writeBackupReceipt({
+            filePath: receiptPath,
+            receipt : buildBackupReceipt({
+                backup: {
+                    durationMs: Date.now() - startedAt,
+                    error     : null,
+                    status    : 'success'
+                },
+                bundleCompletedAt: completedAt,
+                bundleName,
+                offHostSync      : syncOutcome,
+                syncStatus
+            })
+        });
+
+        return outcome
+    };
+
+    try {
+        return await finish(await withHeavyMaintenanceLease(
+            () => runBackup(),
+            {owner: 'backup', reason: 'manual-cli', staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs, metadata: {script: 'ai/scripts/maintenance/backup.mjs'}}
+        ))
+    } catch (error) {
+        // Truthful failure receipt around a thrown runBackup; a receipt write failure never masks it.
+        await writeBackupReceipt({
+            filePath: receiptPath,
+            receipt : buildBackupReceipt({
+                backup: {
+                    durationMs: Date.now() - startedAt,
+                    error     : redactAndBound(error?.stack ?? error?.message ?? String(error), buildSyncChildEnv(AiConfig.maintenance.backup.offHostSync?.envAllowlist ?? [])),
+                    status    : 'failed'
+                },
+                bundleCompletedAt: null,
+                bundleName       : null,
+                syncStatus       : 'not-run-backup-failed'
+            })
+        }).catch(receiptError => {
+            console.warn(`[Backup] failed to write the failure receipt: ${receiptError.message}`)
+        });
+
+        throw error
+    }
+}
+
 // Auto-run under the shared heavy-maintenance lease so this CLI cannot collide with the
 // orchestrator's heavy tasks or with another manual graph-heavy script. The exported
 // `runBackup` function is left lease-free so test harnesses and other module-level
-// callers retain full control of their own concurrency context.
+// callers retain full control of their own concurrency context. The gitignored Tier-1
+// overlay loads BEFORE any backupPath read (bundle, retention, receipt, snapshot-root).
 if (import.meta.url === `file://${process.argv[1]}`) {
-    withHeavyMaintenanceLease(
-        () => runBackup(),
-        {owner: 'backup', reason: 'manual-cli', staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs, metadata: {script: 'ai/scripts/maintenance/backup.mjs'}}
-    )
+    await loadTopLevelAiConfig();
+
+    runBackupWithOffHostSync()
         .then(outcome => {
             if (outcome.status === 'held') {
                 const held = outcome.lease;

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -625,7 +625,7 @@ export async function runBackupWithOffHostSync() {
             receipt : buildBackupReceipt({
                 backup: {
                     durationMs: Date.now() - startedAt,
-                    error     : redactAndBound(error?.stack ?? error?.message ?? String(error), buildSyncChildEnv(AiConfig.maintenance.backup.offHostSync?.envAllowlist ?? [])),
+                    error     : redactAndBound(error?.stack ?? error?.message ?? String(error), buildSyncChildEnv(AiConfig.maintenance.backup.offHostSync.envAllowlist)),
                     status    : 'failed'
                 },
                 bundleCompletedAt: null,

--- a/ai/scripts/maintenance/offHostSync.mjs
+++ b/ai/scripts/maintenance/offHostSync.mjs
@@ -2,6 +2,7 @@ import {execFile} from 'node:child_process';
 
 import {
     buildBackupReceipt,
+    utf8SafeTail,
     writeBackupReceipt
 } from '../../services/memory-core/helpers/offHostSyncStore.mjs';
 
@@ -131,9 +132,7 @@ export function redactAndBound(text, env, maxBytes = MAX_TAIL_BYTES, allowlist =
         if (value.length > 0) out = out.split(value).join('***')
     }
 
-    return Buffer.byteLength(out, 'utf8') <= maxBytes
-        ? out
-        : Buffer.from(out, 'utf8').subarray(0, maxBytes).toString('utf8')
+    return utf8SafeTail(out, maxBytes)
 }
 
 function substituteArgv(argv, {bundleDir, bundleName}) {
@@ -186,7 +185,10 @@ export async function runOffHostSync({config, bundleDir, bundleName, execFileImp
             })
         };
 
-        const child = execFileImpl(
+        let child;
+
+        try {
+            child = execFileImpl(
             config.command,
             args,
             {env: childEnv, shell: false, timeout: config.timeoutMs, killSignal: 'SIGTERM', maxBuffer: 1024 * 1024},
@@ -210,5 +212,10 @@ export async function runOffHostSync({config, bundleDir, bundleName, execFileImp
         }, config.timeoutMs + config.killGraceMs);
 
         killTimer.unref?.()
+        } catch (spawnError) {
+            // A synchronous spawn failure means no child ever started — the termination field is
+            // null, not an invented signal.
+            done({status: 'failed', error: spawnError, terminatedVia: null})
+        }
     })
 }

--- a/ai/scripts/maintenance/offHostSync.mjs
+++ b/ai/scripts/maintenance/offHostSync.mjs
@@ -57,10 +57,12 @@ export function validateOffHostSyncConfig(config = {}) {
     // validation failure, not a silent pass.
     if (config === null || typeof config !== 'object' || Array.isArray(config)) return fail('config must be an object');
     if (typeof command !== 'string') return fail('command must be a string');
-    if (command.includes('\0') || argv.some(token => typeof token === 'string' && token.includes('\0'))) {
+    // Array-shape before any traversal: null/object/number argv must return a validation outcome,
+    // never a thrown TypeError.
+    if (!Array.isArray(argv) || argv.some(token => typeof token !== 'string')) return fail('argv must be an array of strings');
+    if (command.includes('\0') || argv.some(token => token.includes('\0'))) {
         return fail('command/argv must not contain NUL bytes')
     }
-    if (!Array.isArray(argv) || argv.some(token => typeof token !== 'string')) return fail('argv must be an array of strings');
 
     for (const token of argv) {
         if (ANY_PLACEHOLDER.test(token) && !PLACEHOLDER_PATTERN.test(token)) {
@@ -160,9 +162,8 @@ export async function runOffHostSync({config, bundleDir, bundleName, execFileImp
 
     return new Promise(resolve => {
         let
-            killTimer   = null,
-            settled     = false,
-            sigkillSent = false;
+            killTimer = null,
+            settled   = false;
 
         // terminatedVia is the signal that actually ENDED the child: a cooperative child dies on
         // execFile's timeout SIGTERM ('sigterm'); an ignoring child dies on our escalation ('sigkill').
@@ -196,7 +197,9 @@ export async function runOffHostSync({config, bundleDir, bundleName, execFileImp
                 if (error?.killed || error?.signal === 'SIGTERM' || error?.signal === 'SIGKILL') {
                     // The callback fires when the child actually dies: on SIGTERM (cooperative) or
                     // after our SIGKILL escalation (uncooperative).
-                    done({signal: error.signal ?? 'SIGTERM', status: 'timeout', error, terminatedVia: sigkillSent ? 'sigkill' : 'sigterm'})
+                    // The callback's signal is the authority: a failed SIGKILL send (ESRCH) can never
+                    // be reported as a sigkill completion — only a kill that actually landed counts.
+                    done({signal: error.signal ?? 'SIGTERM', status: 'timeout', error, terminatedVia: error?.signal === 'SIGKILL' ? 'sigkill' : 'sigterm'})
                 } else if (error) {
                     // A spawn-level ENOENT means no child ever started — null, not an invented signal.
                     done({exitCode: typeof error.code === 'number' ? error.code : null, signal: error.signal ?? null, status: 'failed', error, terminatedVia: error?.code === 'ENOENT' ? null : 'exit'})
@@ -208,8 +211,7 @@ export async function runOffHostSync({config, bundleDir, bundleName, execFileImp
 
         killTimer = setTimeout(() => {
             if (settled || !child?.pid) return;
-            sigkillSent = true;
-            try { process.kill(child.pid, 'SIGKILL') } catch { /* already gone */ }
+            try { process.kill(child.pid, 'SIGKILL') } catch { /* already gone — the callback's signal remains the authority */ }
         }, config.timeoutMs + config.killGraceMs);
 
         killTimer.unref?.()

--- a/ai/scripts/maintenance/offHostSync.mjs
+++ b/ai/scripts/maintenance/offHostSync.mjs
@@ -1,0 +1,198 @@
+import {execFile} from 'node:child_process';
+
+import {
+    buildBackupReceipt,
+    writeBackupReceipt
+} from '../../services/memory-core/helpers/offHostSyncStore.mjs';
+
+export {buildBackupReceipt, writeBackupReceipt};
+export {readBackupReceipt, OFFHOST_SYNC_SCHEMA_VERSION} from '../../services/memory-core/helpers/offHostSyncStore.mjs';
+
+/**
+ * @module ai/scripts/maintenance/offHostSync
+ * @summary Off-host durability hook for the atomic backup lane: validates the configured sync,
+ * executes it as a direct child with a bounded TERM→grace→KILL escalation, and redacts diagnostics.
+ * The durable receipt store lives in `services/memory-core/helpers/offHostSyncStore.mjs` (shared
+ * with the orchestrator's snapshot projection).
+ *
+ * Ownership contract: the lease-owning CLI wrapper of `backup.mjs` invokes this module.
+ * Exported `runBackup()` never touches it — direct module callers (including disposable-`bundleRoot`
+ * tests) must never fire a configured off-host command or overwrite the deployment-global receipt.
+ *
+ * Truth contract (intake-forged): the lease is bounded at the direct-child boundary
+ * (`timeoutMs + killGraceMs`); the sync side effect is NOT claimed bounded — a surviving descendant
+ * may continue after a timeout receipt (`completionScope: 'direct-child'`, `descendants: 'unknown'`).
+ * `status: 'success'` means the configured command exited 0 for the named bundle — the generic hook
+ * cannot attest remote object state.
+ */
+
+const BASE_ENV_NAMES      = ['PATH', 'HOME', 'USER', 'TMPDIR'],
+      ENV_NAME_PATTERN    = /^[A-Z_][A-Z0-9_]*$/,
+      MAX_TAIL_BYTES      = 4 * 1024,
+      PLACEHOLDER_PATTERN = /^\{(bundleDir|bundleName)\}$/,
+      ANY_PLACEHOLDER     = /\{[^}]*\}/,
+      TIMEOUT_MIN_MS      = 1000,
+      TIMEOUT_MAX_MS      = 30 * 60 * 1000,
+      GRACE_MAX_MS        = 60000;
+
+/**
+ * Validates the nested offHostSync config keys. This module owns the contract because the keys are
+ * plain nested values inside the `maintenance.backup` object leaf (ADR-0019: no leaf() nodes here; ticket-ref-ok: decision-record authority for the config SSOT).
+ * @param {Object} [config={}] The `AiConfig.maintenance.backup.offHostSync` subtree (may be undefined).
+ * @returns {{enabled: Boolean, error: String|null, value: Object}}
+ */
+export function validateOffHostSyncConfig(config = {}) {
+    const {
+        argv          = [],
+        command       = '',
+        envAllowlist  = [],
+        killGraceMs   = 5000,
+        timeoutMs     = 600000
+    } = config ?? {};
+
+    const fail = error => ({enabled: false, error, value: null});
+
+    if (command === '') return {enabled: false, error: null, value: null};
+    if (typeof command !== 'string' || command.trim() === '') return fail('command must be a non-empty string when set');
+    if (!Array.isArray(argv) || argv.some(token => typeof token !== 'string')) return fail('argv must be an array of strings');
+
+    for (const token of argv) {
+        if (ANY_PLACEHOLDER.test(token) && !PLACEHOLDER_PATTERN.test(token)) {
+            return fail(`argv token must be a whole-token placeholder {bundleDir} or {bundleName}, got: ${token}`)
+        }
+    }
+
+    if (!Array.isArray(envAllowlist) || envAllowlist.some(name => typeof name !== 'string' || !ENV_NAME_PATTERN.test(name))) {
+        return fail('envAllowlist entries must match /^[A-Z_][A-Z0-9_]*$/')
+    }
+
+    if (!Number.isInteger(timeoutMs) || timeoutMs < TIMEOUT_MIN_MS || timeoutMs > TIMEOUT_MAX_MS) {
+        return fail(`timeoutMs must be an integer between ${TIMEOUT_MIN_MS} and ${TIMEOUT_MAX_MS}`)
+    }
+    if (!Number.isInteger(killGraceMs) || killGraceMs < 0 || killGraceMs > GRACE_MAX_MS) {
+        return fail(`killGraceMs must be an integer between 0 and ${GRACE_MAX_MS}`)
+    }
+
+    return {
+        enabled: true,
+        error  : null,
+        value  : {argv, command: command.trim(), envAllowlist, killGraceMs, timeoutMs}
+    }
+}
+
+/**
+ * Builds the sync child's environment: minimal base set + exactly the allowlisted names that are
+ * set and non-empty. No implicit process.env inheritance.
+ * @param {String[]} allowlist
+ * @param {Object} [processEnv=process.env]
+ * @returns {Object}
+ */
+export function buildSyncChildEnv(allowlist, processEnv = process.env) {
+    const env = {};
+
+    for (const name of BASE_ENV_NAMES) {
+        if (typeof processEnv[name] === 'string' && processEnv[name] !== '') env[name] = processEnv[name]
+    }
+    for (const name of allowlist) {
+        if (typeof processEnv[name] === 'string' && processEnv[name] !== '') env[name] = processEnv[name]
+    }
+
+    return env
+}
+
+/**
+ * Redacts allowlisted env VALUES from diagnostic text (longest-value-first, overlap-safe), then
+ * bounds the result. Redaction happens before bounding so a secret can never straddle a cut.
+ * @param {String} text
+ * @param {Object} env The exact child env (values to redact).
+ * @param {Number} [maxBytes=MAX_TAIL_BYTES]
+ * @returns {String}
+ */
+export function redactAndBound(text, env, maxBytes = MAX_TAIL_BYTES) {
+    let out = String(text ?? '');
+
+    const values = Object.values(env)
+        .filter(value => typeof value === 'string' && value.length >= 6)
+        .sort((a, b) => b.length - a.length);
+
+    for (const value of values) {
+        out = out.split(value).join('***')
+    }
+
+    return Buffer.byteLength(out, 'utf8') <= maxBytes
+        ? out
+        : Buffer.from(out, 'utf8').subarray(0, maxBytes).toString('utf8')
+}
+
+function substituteArgv(argv, {bundleDir, bundleName}) {
+    return argv.map(token =>
+        token === '{bundleDir}' ? bundleDir : token === '{bundleName}' ? bundleName : token
+    )
+}
+
+/**
+ * Executes the configured sync as a direct child with a TERM→grace→KILL escalation and returns a
+ * truthful outcome. Resolves (never rejects) — every outcome is receipt material.
+ * @param {Object} options
+ * @param {Object} options.config Validated config (from {@link validateOffHostSyncConfig}.value).
+ * @param {String} options.bundleDir Absolute bundle directory.
+ * @param {String} options.bundleName Bundle directory name.
+ * @param {Function} [options.execFileImpl=execFile] Injection seam for tests.
+ * @param {Object} [options.processEnv=process.env]
+ * @returns {Promise<Object>} `{status, durationMs, exitCode, signal, terminatedVia, completionScope, descendants, stderrTail}`
+ */
+export async function runOffHostSync({config, bundleDir, bundleName, execFileImpl = execFile, processEnv = process.env}) {
+    const
+        startedAt = Date.now(),
+        childEnv  = buildSyncChildEnv(config.envAllowlist, processEnv),
+        args      = substituteArgv(config.argv, {bundleDir, bundleName});
+
+    return new Promise(resolve => {
+        let
+            killTimer     = null,
+            settled       = false,
+            terminatedVia = 'exit';
+
+        const done = ({status, exitCode = null, signal = null, error = null}) => {
+            if (settled) return;
+            settled = true;
+            killTimer && clearTimeout(killTimer);
+
+            const stderrTail = redactAndBound(error?.stderr ?? error?.message ?? '', childEnv);
+
+            resolve({
+                completionScope: 'direct-child',
+                descendants    : 'unknown',
+                durationMs     : Date.now() - startedAt,
+                exitCode,
+                signal,
+                status,
+                stderrTail,
+                terminatedVia
+            })
+        };
+
+        const child = execFileImpl(
+            config.command,
+            args,
+            {env: childEnv, shell: false, timeout: config.timeoutMs, killSignal: 'SIGTERM', maxBuffer: MAX_TAIL_BYTES * 2},
+            error => {
+                if (error?.killed || error?.signal === 'SIGTERM') {
+                    done({signal: 'SIGTERM', status: 'timeout', error})
+                } else if (error) {
+                    done({exitCode: typeof error.code === 'number' ? error.code : null, signal: error.signal ?? null, status: 'failed', error})
+                } else {
+                    done({exitCode: 0, status: 'success'})
+                }
+            }
+        );
+
+        killTimer = setTimeout(() => {
+            if (settled || !child?.pid) return;
+            terminatedVia = 'sigkill';
+            try { process.kill(child.pid, 'SIGKILL') } catch { /* already gone */ }
+        }, config.timeoutMs + config.killGraceMs);
+
+        killTimer.unref?.()
+    })
+}

--- a/ai/scripts/maintenance/offHostSync.mjs
+++ b/ai/scripts/maintenance/offHostSync.mjs
@@ -52,8 +52,9 @@ export function validateOffHostSyncConfig(config = {}) {
 
     const fail = error => ({enabled: false, error, value: null});
 
-    if (command === '') return {enabled: false, error: null, value: null};
-    if (typeof command !== 'string' || command.trim() === '') return fail('command must be a non-empty string when set');
+    // Validate EVERY key before the disabled early-return: a disabled hook with malformed keys is a
+    // validation failure, not a silent pass.
+    if (typeof command !== 'string') return fail('command must be a string');
     if (!Array.isArray(argv) || argv.some(token => typeof token !== 'string')) return fail('argv must be an array of strings');
 
     for (const token of argv) {
@@ -72,6 +73,8 @@ export function validateOffHostSyncConfig(config = {}) {
     if (!Number.isInteger(killGraceMs) || killGraceMs < 0 || killGraceMs > GRACE_MAX_MS) {
         return fail(`killGraceMs must be an integer between 0 and ${GRACE_MAX_MS}`)
     }
+
+    if (command.trim() === '') return {enabled: false, error: null, value: null};
 
     return {
         enabled: true,
@@ -149,11 +152,13 @@ export async function runOffHostSync({config, bundleDir, bundleName, execFileImp
 
     return new Promise(resolve => {
         let
-            killTimer     = null,
-            settled       = false,
-            terminatedVia = 'exit';
+            killTimer   = null,
+            settled     = false,
+            sigkillSent = false;
 
-        const done = ({status, exitCode = null, signal = null, error = null}) => {
+        // terminatedVia is the signal that actually ENDED the child: a cooperative child dies on
+        // execFile's timeout SIGTERM ('sigterm'); an ignoring child dies on our escalation ('sigkill').
+        const done = ({status, exitCode = null, signal = null, error = null, terminatedVia = 'exit'}) => {
             if (settled) return;
             settled = true;
             killTimer && clearTimeout(killTimer);
@@ -175,10 +180,12 @@ export async function runOffHostSync({config, bundleDir, bundleName, execFileImp
         const child = execFileImpl(
             config.command,
             args,
-            {env: childEnv, shell: false, timeout: config.timeoutMs, killSignal: 'SIGTERM', maxBuffer: MAX_TAIL_BYTES * 2},
+            {env: childEnv, shell: false, timeout: config.timeoutMs, killSignal: 'SIGTERM', maxBuffer: 1024 * 1024},
             error => {
-                if (error?.killed || error?.signal === 'SIGTERM') {
-                    done({signal: 'SIGTERM', status: 'timeout', error})
+                if (error?.killed || error?.signal === 'SIGTERM' || error?.signal === 'SIGKILL') {
+                    // The callback fires when the child actually dies: on SIGTERM (cooperative) or
+                    // after our SIGKILL escalation (uncooperative).
+                    done({signal: error.signal ?? 'SIGTERM', status: 'timeout', error, terminatedVia: sigkillSent ? 'sigkill' : 'sigterm'})
                 } else if (error) {
                     done({exitCode: typeof error.code === 'number' ? error.code : null, signal: error.signal ?? null, status: 'failed', error})
                 } else {
@@ -189,7 +196,7 @@ export async function runOffHostSync({config, bundleDir, bundleName, execFileImp
 
         killTimer = setTimeout(() => {
             if (settled || !child?.pid) return;
-            terminatedVia = 'sigkill';
+            sigkillSent = true;
             try { process.kill(child.pid, 'SIGKILL') } catch { /* already gone */ }
         }, config.timeoutMs + config.killGraceMs);
 

--- a/ai/scripts/maintenance/offHostSync.mjs
+++ b/ai/scripts/maintenance/offHostSync.mjs
@@ -54,7 +54,11 @@ export function validateOffHostSyncConfig(config = {}) {
 
     // Validate EVERY key before the disabled early-return: a disabled hook with malformed keys is a
     // validation failure, not a silent pass.
+    if (config === null || typeof config !== 'object' || Array.isArray(config)) return fail('config must be an object');
     if (typeof command !== 'string') return fail('command must be a string');
+    if (command.includes('\0') || argv.some(token => typeof token === 'string' && token.includes('\0'))) {
+        return fail('command/argv must not contain NUL bytes')
+    }
     if (!Array.isArray(argv) || argv.some(token => typeof token !== 'string')) return fail('argv must be an array of strings');
 
     for (const token of argv) {
@@ -105,21 +109,26 @@ export function buildSyncChildEnv(allowlist, processEnv = process.env) {
 
 /**
  * Redacts allowlisted env VALUES from diagnostic text (longest-value-first, overlap-safe), then
- * bounds the result. Redaction happens before bounding so a secret can never straddle a cut.
+ * bounds the result. Redaction happens before bounding so a secret can never straddle a cut. Every
+ * allowlisted value redacts regardless of length — the allowlist IS the credential set; base-env
+ * values (PATH/HOME/USER/TMPDIR) redact only when long enough to carry meaning (≥6), so ordinary
+ * diagnostics are not mangled.
  * @param {String} text
- * @param {Object} env The exact child env (values to redact).
+ * @param {Object} env The exact child env (allowlisted values always redact; base values ≥6 only).
  * @param {Number} [maxBytes=MAX_TAIL_BYTES]
+ * @param {String[]} [allowlist=[]] The envAllowlist names (values at these keys always redact).
  * @returns {String}
  */
-export function redactAndBound(text, env, maxBytes = MAX_TAIL_BYTES) {
+export function redactAndBound(text, env, maxBytes = MAX_TAIL_BYTES, allowlist = []) {
     let out = String(text ?? '');
 
-    const values = Object.values(env)
-        .filter(value => typeof value === 'string' && value.length >= 6)
+    const values = Object.entries(env)
+        .filter(([name, value]) => typeof value === 'string' && (allowlist.includes(name) || value.length >= 6))
+        .map(([, value]) => value)
         .sort((a, b) => b.length - a.length);
 
     for (const value of values) {
-        out = out.split(value).join('***')
+        if (value.length > 0) out = out.split(value).join('***')
     }
 
     return Buffer.byteLength(out, 'utf8') <= maxBytes
@@ -163,7 +172,7 @@ export async function runOffHostSync({config, bundleDir, bundleName, execFileImp
             settled = true;
             killTimer && clearTimeout(killTimer);
 
-            const stderrTail = redactAndBound(error?.stderr ?? error?.message ?? '', childEnv);
+            const stderrTail = redactAndBound(error?.stderr ?? error?.message ?? '', childEnv, MAX_TAIL_BYTES, config.envAllowlist);
 
             resolve({
                 completionScope: 'direct-child',

--- a/ai/scripts/maintenance/offHostSync.mjs
+++ b/ai/scripts/maintenance/offHostSync.mjs
@@ -198,7 +198,8 @@ export async function runOffHostSync({config, bundleDir, bundleName, execFileImp
                     // after our SIGKILL escalation (uncooperative).
                     done({signal: error.signal ?? 'SIGTERM', status: 'timeout', error, terminatedVia: sigkillSent ? 'sigkill' : 'sigterm'})
                 } else if (error) {
-                    done({exitCode: typeof error.code === 'number' ? error.code : null, signal: error.signal ?? null, status: 'failed', error})
+                    // A spawn-level ENOENT means no child ever started — null, not an invented signal.
+                    done({exitCode: typeof error.code === 'number' ? error.code : null, signal: error.signal ?? null, status: 'failed', error, terminatedVia: error?.code === 'ENOENT' ? null : 'exit'})
                 } else {
                     done({exitCode: 0, status: 'success'})
                 }

--- a/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
@@ -11,8 +11,13 @@ const CURRENT_SNAPSHOT_SECTIONS = [
     'bridgeDiagnostics',
     'recoveryRuns',
     'selfHeal',
-    'tenantRepoSync'
+    'tenantRepoSync',
+    'maintenance'
 ];
+
+// Additive schema-compatible sections: produced when present, tolerated absent in older snapshots
+// (a snapshot predating the section's introduction stays valid, never degraded for its absence).
+const ADDITIVE_SNAPSHOT_SECTIONS = ['maintenance'];
 
 const CURRENT_PRODUCER_METADATA = Object.freeze({
     name         : 'orchestrator-deployment-state-bridge',
@@ -46,6 +51,7 @@ export function createDeploymentStateSnapshot({
     recoveryRuns = null,
     selfHeal = null,
     tenantRepoSync = null,
+    maintenance = null,
     producer = CURRENT_PRODUCER_METADATA
 } = {}) {
     if (!Number.isFinite(generatedAt)) {
@@ -66,7 +72,8 @@ export function createDeploymentStateSnapshot({
         bridgeDiagnostics,
         recoveryRuns,
         selfHeal,
-        tenantRepoSync
+        tenantRepoSync,
+        maintenance
     };
 }
 
@@ -217,7 +224,9 @@ function unavailable({filePath = null, reason, details = null}) {
 
 function inspectSnapshotSchema(snapshot) {
     const
-        missingSections = CURRENT_SNAPSHOT_SECTIONS.filter(section => !Object.hasOwn(snapshot || {}, section)),
+        missingSections = CURRENT_SNAPSHOT_SECTIONS
+            .filter(section => !ADDITIVE_SNAPSHOT_SECTIONS.includes(section))
+            .filter(section => !Object.hasOwn(snapshot || {}, section)),
         producer        = sanitizeProducerMetadata(snapshot?.producer),
         producerMissing = !snapshot?.producer;
 

--- a/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
@@ -62,7 +62,7 @@ export function createDeploymentStateSnapshot({
         throw new TypeError('createDeploymentStateSnapshot: services must be an array');
     }
 
-    return {
+    const snapshot = {
         schemaVersion: DEPLOYMENT_STATE_BRIDGE_SCHEMA_VERSION,
         recordType   : 'deployment-state-snapshot',
         generatedAt,
@@ -72,9 +72,16 @@ export function createDeploymentStateSnapshot({
         bridgeDiagnostics,
         recoveryRuns,
         selfHeal,
-        tenantRepoSync,
-        maintenance
+        tenantRepoSync
     };
+
+    // Absent-before-first-run: the block is OMITTED (never fabricated as null); older consumers
+    // tolerate the absence, and the schema inspector treats additive sections as tolerated-absent.
+    if (maintenance !== null && maintenance !== undefined) {
+        snapshot.maintenance = maintenance
+    }
+
+    return snapshot
 }
 
 /**

--- a/ai/services/memory-core/helpers/offHostSyncStore.mjs
+++ b/ai/services/memory-core/helpers/offHostSyncStore.mjs
@@ -1,0 +1,121 @@
+import fs   from 'fs-extra';
+import path from 'path';
+
+/**
+ * @module ai/services/memory-core/helpers/offHostSyncStore
+ * @summary The deployment-global backup receipt store: envelope builder, atomic writer, and
+ * validated reader for the off-host durability receipt (`AiConfig.backupPath/last-backup-receipt.json`).
+ *
+ * Ownership contract: the lease-owning CLI wrapper of `backup.mjs` writes; the orchestrator's
+ * DeploymentStateBridgeService reads for snapshot projection. No Neo imports — pure Node.
+ */
+
+export const OFFHOST_SYNC_SCHEMA_VERSION = 1;
+
+const MAX_RECEIPT_BYTES = 64 * 1024,
+      MAX_TAIL_BYTES    = 4 * 1024;
+
+const now = () => new Date().toISOString();
+
+/**
+ * Builds the deployment-global receipt envelope.
+ * @param {Object} options
+ * @param {Object} options.backup `{status: 'success'|'failed', durationMs, error}`
+ * @param {String|null} options.bundleName
+ * @param {String|null} options.bundleCompletedAt
+ * @param {String|null} options.finishedAt
+ * @param {Object|null} options.offHostSync Sync outcome or null when not run.
+ * @param {String} [options.syncStatus='disabled'] Status when offHostSync is null.
+ * @returns {Object}
+ */
+export function buildBackupReceipt({backup, bundleName, bundleCompletedAt, finishedAt, offHostSync, syncStatus = 'disabled'}) {
+    return {
+        backup,
+        bundleCompletedAt: bundleCompletedAt ?? null,
+        bundleName       : bundleName ?? null,
+        finishedAt       : finishedAt ?? now(),
+        offHostSync      : offHostSync ?? {
+            completionScope: 'direct-child',
+            descendants    : 'unknown',
+            durationMs     : null,
+            exitCode       : null,
+            signal         : null,
+            status         : syncStatus,
+            stderrTail     : '',
+            terminatedVia  : null
+        },
+        schemaVersion    : OFFHOST_SYNC_SCHEMA_VERSION
+    }
+}
+
+/**
+ * Writes the receipt atomically: unique temp path, write, rename. A torn write leaves the previous
+ * receipt intact; a stale temp from a crashed writer is swept on the next write.
+ * @param {Object} options
+ * @param {String} options.filePath Receipt destination (inside `AiConfig.backupPath`).
+ * @param {Object} options.receipt Envelope from {@link buildBackupReceipt}.
+ * @returns {Promise<{filePath: String, bytes: Number}>}
+ */
+export async function writeBackupReceipt({filePath, receipt}) {
+    const
+        payload = JSON.stringify(receipt, null, 2),
+        bytes   = Buffer.byteLength(payload, 'utf8');
+
+    if (bytes > MAX_RECEIPT_BYTES) {
+        throw new Error(`backup receipt exceeds the ${MAX_RECEIPT_BYTES}-byte cap (${bytes} bytes)`)
+    }
+
+    const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+
+    await fs.promises.mkdir(path.dirname(filePath), {recursive: true});
+    await fs.promises.writeFile(tempPath, payload, 'utf8');
+    await fs.promises.rename(tempPath, filePath);
+
+    // Stale-temp sweep: best-effort, never blocks the receipt
+    try {
+        for (const entry of await fs.promises.readdir(path.dirname(filePath))) {
+            if (entry.startsWith(`${path.basename(filePath)}.tmp-`)) {
+                await fs.promises.rm(path.join(path.dirname(filePath), entry), {force: true})
+            }
+        }
+    } catch { /* best-effort */ }
+
+    return {bytes, filePath}
+}
+
+/**
+ * Reads + validates the receipt store for snapshot projection. Never throws: every failure mode
+ * resolves to a stable machine-consumable outcome.
+ * @param {Object} options
+ * @param {String} options.filePath
+ * @returns {Promise<{status: 'ok', receipt: Object} | {status: 'missing'} | {status: 'unreadable', kind: String, finishedAt: String|null}>}
+ */
+export async function readBackupReceipt({filePath}) {
+    let raw;
+
+    try {
+        raw = await fs.promises.readFile(filePath, 'utf8')
+    } catch (error) {
+        if (error.code === 'ENOENT') return {status: 'missing'};
+        return {finishedAt: null, kind: 'corrupt', status: 'unreadable'}
+    }
+
+    if (Buffer.byteLength(raw, 'utf8') > MAX_RECEIPT_BYTES) {
+        return {finishedAt: null, kind: 'oversize', status: 'unreadable'}
+    }
+
+    let parsed;
+    try {
+        parsed = JSON.parse(raw)
+    } catch {
+        return {finishedAt: null, kind: 'corrupt', status: 'unreadable'}
+    }
+
+    if (parsed?.schemaVersion !== OFFHOST_SYNC_SCHEMA_VERSION) {
+        return {finishedAt: typeof parsed?.finishedAt === 'string' ? parsed.finishedAt : null, kind: 'unsupported-version', status: 'unreadable'}
+    }
+
+    return {receipt: parsed, status: 'ok'}
+}
+
+export const __private__ = {MAX_RECEIPT_BYTES, MAX_TAIL_BYTES};

--- a/ai/services/memory-core/helpers/offHostSyncStore.mjs
+++ b/ai/services/memory-core/helpers/offHostSyncStore.mjs
@@ -1,5 +1,6 @@
-import fs   from 'fs-extra';
-import path from 'path';
+import crypto from 'node:crypto';
+import fs     from 'fs-extra';
+import path   from 'path';
 
 /**
  * @module ai/services/memory-core/helpers/offHostSyncStore
@@ -56,7 +57,20 @@ export function buildBackupReceipt({backup, bundleName, bundleCompletedAt, finis
  * @param {Object} options.receipt Envelope from {@link buildBackupReceipt}.
  * @returns {Promise<{filePath: String, bytes: Number}>}
  */
-export async function writeBackupReceipt({filePath, receipt}) {
+let writeCounter = 0;
+
+/**
+ * Writes the receipt atomically: a per-write unique temp path (pid + timestamp + monotonic counter
+ * + random suffix — two writes inside the same millisecond on the same pid never collide), fsync,
+ * rename. A torn write leaves the previous receipt intact. The stale-temp sweep only removes temps
+ * older than this write's own timestamp, so it can never delete another live writer's in-flight temp.
+ * @param {Object} options
+ * @param {String} options.filePath Receipt destination (inside `AiConfig.backupPath`).
+ * @param {Object} options.receipt Envelope from {@link buildBackupReceipt}.
+ * @param {Number} [options.now=Date.now()] Injectable clock (tests pin two writes into the same ms).
+ * @returns {Promise<{filePath: String, bytes: Number}>}
+ */
+export async function writeBackupReceipt({filePath, receipt, now = Date.now()}) {
     const
         payload = JSON.stringify(receipt, null, 2),
         bytes   = Buffer.byteLength(payload, 'utf8');
@@ -65,7 +79,11 @@ export async function writeBackupReceipt({filePath, receipt}) {
         throw new Error(`backup receipt exceeds the ${MAX_RECEIPT_BYTES}-byte cap (${bytes} bytes)`)
     }
 
-    const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+    const
+        counter  = ++writeCounter,
+        suffix   = crypto.randomBytes(4).toString('hex'),
+        tempName = `${path.basename(filePath)}.tmp-${process.pid}-${now}-${counter}-${suffix}`,
+        tempPath = path.join(path.dirname(filePath), tempName);
 
     await fs.promises.mkdir(path.dirname(filePath), {recursive: true});
     const handle = await fs.promises.open(tempPath, 'w');
@@ -77,10 +95,16 @@ export async function writeBackupReceipt({filePath, receipt}) {
     }
     await fs.promises.rename(tempPath, filePath);
 
-    // Stale-temp sweep: best-effort, never blocks the receipt
+    // Stale-temp sweep: only temps OLDER than this write's timestamp — a live writer's current-ms
+    // temp is untouchable. Best-effort, never blocks the receipt.
     try {
+        const prefix = `${path.basename(filePath)}.tmp-`;
         for (const entry of await fs.promises.readdir(path.dirname(filePath))) {
-            if (entry.startsWith(`${path.basename(filePath)}.tmp-`)) {
+            if (!entry.startsWith(prefix) || entry === tempName) continue;
+
+            const entryMs = Number(entry.slice(prefix.length).split('-')[1]);
+
+            if (!Number.isFinite(entryMs) || entryMs < now) {
                 await fs.promises.rm(path.join(path.dirname(filePath), entry), {force: true})
             }
         }
@@ -99,15 +123,23 @@ export async function writeBackupReceipt({filePath, receipt}) {
 export async function readBackupReceipt({filePath}) {
     let raw;
 
+    // The 64 KiB cap is enforced BEFORE whole-file allocation: a stat precedes the read, so an
+    // oversize artifact is never materialized into memory.
     try {
-        raw = await fs.promises.readFile(filePath, 'utf8')
+        const stat = await fs.promises.stat(filePath);
+        if (stat.size > MAX_RECEIPT_BYTES) {
+            return {finishedAt: null, kind: 'oversize', status: 'unreadable'}
+        }
     } catch (error) {
         if (error.code === 'ENOENT') return {status: 'missing'};
         return {finishedAt: null, kind: 'corrupt', status: 'unreadable'}
     }
 
-    if (Buffer.byteLength(raw, 'utf8') > MAX_RECEIPT_BYTES) {
-        return {finishedAt: null, kind: 'oversize', status: 'unreadable'}
+    try {
+        raw = await fs.promises.readFile(filePath, 'utf8')
+    } catch (error) {
+        if (error.code === 'ENOENT') return {status: 'missing'};
+        return {finishedAt: null, kind: 'corrupt', status: 'unreadable'}
     }
 
     let parsed;
@@ -149,8 +181,9 @@ export function validateReceiptShape(parsed) {
     if (backup.status !== 'success' && backup.status !== 'failed') return null;
     if (typeof backup.durationMs !== 'number') return null;
     if (!(backup.error === null || typeof backup.error === 'string')) return null;
+    // Provenance is a basename, never an absolute/host path.
+    if (parsed.bundleName !== null && (typeof parsed.bundleName !== 'string' || parsed.bundleName.includes('/'))) return null;
     if (!(parsed.finishedAt === null || typeof parsed.finishedAt === 'string')) return null;
-    if (!(parsed.bundleName === null || typeof parsed.bundleName === 'string')) return null;
     if (!(parsed.bundleCompletedAt === null || typeof parsed.bundleCompletedAt === 'string')) return null;
 
     if (!offHostSync || typeof offHostSync !== 'object') return null;
@@ -163,8 +196,12 @@ export function validateReceiptShape(parsed) {
     if (offHostSync.descendants !== 'unknown') return null;
     if (typeof offHostSync.stderrTail !== 'string') return null;
 
+    // Read-side bounds: a hostile or legacy writer's oversized diagnostics are sanitized at the
+    // projection boundary, never projected wholesale.
+    const boundError = backup.error === null ? null : Buffer.from(backup.error, 'utf8').subarray(0, MAX_TAIL_BYTES).toString('utf8');
+
     return {
-        backup           : {durationMs: backup.durationMs, error: backup.error, status: backup.status},
+        backup           : {durationMs: backup.durationMs, error: boundError, status: backup.status},
         bundleCompletedAt: parsed.bundleCompletedAt,
         bundleName       : parsed.bundleName,
         finishedAt       : parsed.finishedAt,
@@ -175,7 +212,7 @@ export function validateReceiptShape(parsed) {
             exitCode       : offHostSync.exitCode,
             signal         : offHostSync.signal,
             status         : offHostSync.status,
-            stderrTail     : offHostSync.stderrTail,
+            stderrTail     : Buffer.from(offHostSync.stderrTail, 'utf8').subarray(0, MAX_TAIL_BYTES).toString('utf8'),
             terminatedVia  : offHostSync.terminatedVia
         },
         schemaVersion    : OFFHOST_SYNC_SCHEMA_VERSION

--- a/ai/services/memory-core/helpers/offHostSyncStore.mjs
+++ b/ai/services/memory-core/helpers/offHostSyncStore.mjs
@@ -72,21 +72,31 @@ export function buildBackupReceipt({backup, bundleName, bundleCompletedAt, finis
     }
 }
 
-/**
- * Writes the receipt atomically: unique temp path, write, rename. A torn write leaves the previous
- * receipt intact; a stale temp from a crashed writer is swept on the next write.
- * @param {Object} options
- * @param {String} options.filePath Receipt destination (inside `AiConfig.backupPath`).
- * @param {Object} options.receipt Envelope from {@link buildBackupReceipt}.
- * @returns {Promise<{filePath: String, bytes: Number}>}
- */
 let writeCounter = 0;
+
+/**
+ * @summary Returns true only when the encoded temp owner is provably gone. A live process, an
+ * indeterminate permission result, malformed metadata, or PID reuse all retain the temp: leaking a
+ * bounded stale file is safer than unlinking a writer that still intends to rename it.
+ * @param {Number} pid
+ * @returns {Boolean}
+ */
+function isProcessProvablyDead(pid) {
+    if (!Number.isInteger(pid) || pid <= 0) return false;
+
+    try {
+        process.kill(pid, 0);
+        return false
+    } catch (error) {
+        return error?.code === 'ESRCH'
+    }
+}
 
 /**
  * Writes the receipt atomically: a per-write unique temp path (pid + timestamp + monotonic counter
  * + random suffix — two writes inside the same millisecond on the same pid never collide), fsync,
- * rename. A torn write leaves the previous receipt intact. The stale-temp sweep only removes temps
- * older than this write's own timestamp, so it can never delete another live writer's in-flight temp.
+ * rename. A torn write leaves the previous receipt intact. The stale-temp sweep only removes an old
+ * temp when its encoded owner PID is provably dead; age alone is never treated as liveness proof.
  * @param {Object} options
  * @param {String} options.filePath Receipt destination (inside `AiConfig.backupPath`).
  * @param {Object} options.receipt Envelope from {@link buildBackupReceipt}.
@@ -118,23 +128,46 @@ export async function writeBackupReceipt({filePath, receipt, now = Date.now()}) 
     }
     await fs.promises.rename(tempPath, filePath);
 
-    // Stale-temp sweep: only temps older than the staleness HORIZON. A temp younger than the
-    // horizon may belong to a live writer — even one that started before this write — so "older
-    // than this write's start millisecond" is never the staleness criterion. Best-effort only.
+    // Stale-temp sweep: age makes a temp eligible, but only a provably dead encoded owner makes it
+    // removable. PID reuse / EPERM / malformed metadata intentionally leak in the safe direction.
     try {
         const prefix = `${path.basename(filePath)}.tmp-`;
         for (const entry of await fs.promises.readdir(path.dirname(filePath))) {
             if (!entry.startsWith(prefix) || entry === tempName) continue;
 
-            const entryMs = Number(entry.slice(prefix.length).split('-')[1]);
+            const
+                [ownerPidToken, entryMsToken] = entry.slice(prefix.length).split('-'),
+                ownerPid                      = Number(ownerPidToken),
+                entryMs                       = Number(entryMsToken);
 
-            if (Number.isFinite(entryMs) && entryMs < now - STALE_TEMP_HORIZON_MS) {
+            if (Number.isFinite(entryMs) && entryMs < now - STALE_TEMP_HORIZON_MS && isProcessProvablyDead(ownerPid)) {
                 await fs.promises.rm(path.join(path.dirname(filePath), entry), {force: true})
             }
         }
     } catch { /* best-effort */ }
 
     return {bytes, filePath}
+}
+
+/**
+ * @summary Reads one already-opened file handle through ordinary short reads, returning only bytes
+ * actually delivered before the measured length or EOF.
+ * @param {Object} handle Open file handle exposing `read(buffer, offset, length, position)`.
+ * @param {Number} size
+ * @returns {Promise<Buffer>}
+ */
+async function readOpenedFile(handle, size) {
+    const buffer = Buffer.alloc(size);
+    let   offset = 0;
+
+    while (offset < size) {
+        const {bytesRead} = await handle.read(buffer, offset, size - offset, offset);
+
+        if (bytesRead === 0) break;
+        offset += bytesRead
+    }
+
+    return buffer.subarray(0, offset)
 }
 
 /**
@@ -157,9 +190,7 @@ export async function readBackupReceipt({filePath}) {
             if (stat.size > MAX_RECEIPT_BYTES) {
                 return {finishedAt: null, kind: 'oversize', status: 'unreadable'}
             }
-            const buffer = Buffer.alloc(stat.size);
-            await handle.read(buffer, 0, stat.size, 0);
-            raw = buffer.toString('utf8')
+            raw = (await readOpenedFile(handle, stat.size)).toString('utf8')
         } finally {
             await handle.close()
         }
@@ -246,4 +277,4 @@ export function validateReceiptShape(parsed) {
     }
 }
 
-export const __private__ = {MAX_RECEIPT_BYTES, MAX_TAIL_BYTES};
+export const __private__ = {MAX_RECEIPT_BYTES, MAX_TAIL_BYTES, isProcessProvablyDead, readOpenedFile};

--- a/ai/services/memory-core/helpers/offHostSyncStore.mjs
+++ b/ai/services/memory-core/helpers/offHostSyncStore.mjs
@@ -13,10 +13,33 @@ import path   from 'path';
 
 export const OFFHOST_SYNC_SCHEMA_VERSION = 1;
 
-const MAX_RECEIPT_BYTES = 64 * 1024,
-      MAX_TAIL_BYTES    = 4 * 1024;
+const MAX_RECEIPT_BYTES     = 64 * 1024,
+      MAX_TAIL_BYTES        = 4 * 1024,
+      STALE_TEMP_HORIZON_MS = 60_000;
 
 const now = () => new Date().toISOString();
+
+/**
+ * Bounds a string to the LAST maxBytes bytes with UTF-8-safe output: partial lead sequences are
+ * dropped until the re-encoded result fits the budget (replacement-char inflation can otherwise
+ * exceed it). Tail-biased because the most recent error context lives at the end.
+ * @param {*} value
+ * @param {Number} maxBytes
+ * @returns {String}
+ */
+export function utf8SafeTail(value, maxBytes) {
+    const text = value == null ? '' : String(value);
+
+    if (Buffer.byteLength(text, 'utf8') <= maxBytes) return text;
+
+    let out = Buffer.from(text, 'utf8').subarray(-maxBytes).toString('utf8');
+
+    while (Buffer.byteLength(out, 'utf8') > maxBytes && out.length > 0) {
+        out = out.slice(1)
+    }
+
+    return out
+}
 
 /**
  * Builds the deployment-global receipt envelope.
@@ -95,8 +118,9 @@ export async function writeBackupReceipt({filePath, receipt, now = Date.now()}) 
     }
     await fs.promises.rename(tempPath, filePath);
 
-    // Stale-temp sweep: only temps OLDER than this write's timestamp — a live writer's current-ms
-    // temp is untouchable. Best-effort, never blocks the receipt.
+    // Stale-temp sweep: only temps older than the staleness HORIZON. A temp younger than the
+    // horizon may belong to a live writer — even one that started before this write — so "older
+    // than this write's start millisecond" is never the staleness criterion. Best-effort only.
     try {
         const prefix = `${path.basename(filePath)}.tmp-`;
         for (const entry of await fs.promises.readdir(path.dirname(filePath))) {
@@ -104,7 +128,7 @@ export async function writeBackupReceipt({filePath, receipt, now = Date.now()}) 
 
             const entryMs = Number(entry.slice(prefix.length).split('-')[1]);
 
-            if (!Number.isFinite(entryMs) || entryMs < now) {
+            if (Number.isFinite(entryMs) && entryMs < now - STALE_TEMP_HORIZON_MS) {
                 await fs.promises.rm(path.join(path.dirname(filePath), entry), {force: true})
             }
         }
@@ -123,20 +147,22 @@ export async function writeBackupReceipt({filePath, receipt, now = Date.now()}) 
 export async function readBackupReceipt({filePath}) {
     let raw;
 
-    // The 64 KiB cap is enforced BEFORE whole-file allocation: a stat precedes the read, so an
-    // oversize artifact is never materialized into memory.
+    // The 64 KiB ceiling is enforced on ONE opened handle: open → fstat → read at most cap bytes
+    // from that handle. A path replacement between stat and read cannot bypass the bound because
+    // the handle pins the file it measured.
     try {
-        const stat = await fs.promises.stat(filePath);
-        if (stat.size > MAX_RECEIPT_BYTES) {
-            return {finishedAt: null, kind: 'oversize', status: 'unreadable'}
+        const handle = await fs.promises.open(filePath, 'r');
+        try {
+            const stat = await handle.stat();
+            if (stat.size > MAX_RECEIPT_BYTES) {
+                return {finishedAt: null, kind: 'oversize', status: 'unreadable'}
+            }
+            const buffer = Buffer.alloc(stat.size);
+            await handle.read(buffer, 0, stat.size, 0);
+            raw = buffer.toString('utf8')
+        } finally {
+            await handle.close()
         }
-    } catch (error) {
-        if (error.code === 'ENOENT') return {status: 'missing'};
-        return {finishedAt: null, kind: 'corrupt', status: 'unreadable'}
-    }
-
-    try {
-        raw = await fs.promises.readFile(filePath, 'utf8')
     } catch (error) {
         if (error.code === 'ENOENT') return {status: 'missing'};
         return {finishedAt: null, kind: 'corrupt', status: 'unreadable'}
@@ -182,7 +208,8 @@ export function validateReceiptShape(parsed) {
     if (typeof backup.durationMs !== 'number') return null;
     if (!(backup.error === null || typeof backup.error === 'string')) return null;
     // Provenance is a basename, never an absolute/host path.
-    if (parsed.bundleName !== null && (typeof parsed.bundleName !== 'string' || parsed.bundleName.includes('/'))) return null;
+    if (parsed.bundleName !== null && (typeof parsed.bundleName !== 'string' ||
+        parsed.bundleName.includes('/') || parsed.bundleName.includes('\\') || /^[A-Za-z]:/.test(parsed.bundleName))) return null;
     if (!(parsed.finishedAt === null || typeof parsed.finishedAt === 'string')) return null;
     if (!(parsed.bundleCompletedAt === null || typeof parsed.bundleCompletedAt === 'string')) return null;
 
@@ -198,7 +225,7 @@ export function validateReceiptShape(parsed) {
 
     // Read-side bounds: a hostile or legacy writer's oversized diagnostics are sanitized at the
     // projection boundary, never projected wholesale.
-    const boundError = backup.error === null ? null : Buffer.from(backup.error, 'utf8').subarray(0, MAX_TAIL_BYTES).toString('utf8');
+    const boundError = backup.error === null ? null : utf8SafeTail(backup.error, MAX_TAIL_BYTES);
 
     return {
         backup           : {durationMs: backup.durationMs, error: boundError, status: backup.status},
@@ -212,7 +239,7 @@ export function validateReceiptShape(parsed) {
             exitCode       : offHostSync.exitCode,
             signal         : offHostSync.signal,
             status         : offHostSync.status,
-            stderrTail     : Buffer.from(offHostSync.stderrTail, 'utf8').subarray(0, MAX_TAIL_BYTES).toString('utf8'),
+            stderrTail     : utf8SafeTail(offHostSync.stderrTail, MAX_TAIL_BYTES),
             terminatedVia  : offHostSync.terminatedVia
         },
         schemaVersion    : OFFHOST_SYNC_SCHEMA_VERSION

--- a/ai/services/memory-core/helpers/offHostSyncStore.mjs
+++ b/ai/services/memory-core/helpers/offHostSyncStore.mjs
@@ -68,7 +68,13 @@ export async function writeBackupReceipt({filePath, receipt}) {
     const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
 
     await fs.promises.mkdir(path.dirname(filePath), {recursive: true});
-    await fs.promises.writeFile(tempPath, payload, 'utf8');
+    const handle = await fs.promises.open(tempPath, 'w');
+    try {
+        await handle.write(payload, 0, 'utf8');
+        await handle.sync(); // durable before the rename — a crash never yields a torn receipt
+    } finally {
+        await handle.close()
+    }
     await fs.promises.rename(tempPath, filePath);
 
     // Stale-temp sweep: best-effort, never blocks the receipt
@@ -115,7 +121,65 @@ export async function readBackupReceipt({filePath}) {
         return {finishedAt: typeof parsed?.finishedAt === 'string' ? parsed.finishedAt : null, kind: 'unsupported-version', status: 'unreadable'}
     }
 
-    return {receipt: parsed, status: 'ok'}
+    const receipt = validateReceiptShape(parsed);
+
+    if (!receipt) {
+        return {finishedAt: typeof parsed?.finishedAt === 'string' ? parsed.finishedAt : null, kind: 'corrupt', status: 'unreadable'}
+    }
+
+    return {receipt, status: 'ok'}
+}
+
+const SYNC_STATUSES = new Set(['disabled', 'not-run-backup-failed', 'success', 'failed', 'timeout', 'validation-failed']);
+
+/**
+ * Projects a parsed receipt into the validated allowlisted shape — arbitrary schema-v1 JSON never
+ * passes through. Returns null when required fields are missing or mistyped.
+ * @param {Object} parsed
+ * @returns {Object|null}
+ */
+export function validateReceiptShape(parsed) {
+    if (!parsed || typeof parsed !== 'object') return null;
+
+    const
+        backup      = parsed.backup,
+        offHostSync = parsed.offHostSync;
+
+    if (!backup || typeof backup !== 'object') return null;
+    if (backup.status !== 'success' && backup.status !== 'failed') return null;
+    if (typeof backup.durationMs !== 'number') return null;
+    if (!(backup.error === null || typeof backup.error === 'string')) return null;
+    if (!(parsed.finishedAt === null || typeof parsed.finishedAt === 'string')) return null;
+    if (!(parsed.bundleName === null || typeof parsed.bundleName === 'string')) return null;
+    if (!(parsed.bundleCompletedAt === null || typeof parsed.bundleCompletedAt === 'string')) return null;
+
+    if (!offHostSync || typeof offHostSync !== 'object') return null;
+    if (!SYNC_STATUSES.has(offHostSync.status)) return null;
+    if (!(offHostSync.durationMs === null || typeof offHostSync.durationMs === 'number')) return null;
+    if (!(offHostSync.exitCode === null || Number.isInteger(offHostSync.exitCode))) return null;
+    if (!(offHostSync.signal === null || typeof offHostSync.signal === 'string')) return null;
+    if (!(offHostSync.terminatedVia === null || ['exit', 'sigterm', 'sigkill'].includes(offHostSync.terminatedVia))) return null;
+    if (offHostSync.completionScope !== 'direct-child') return null;
+    if (offHostSync.descendants !== 'unknown') return null;
+    if (typeof offHostSync.stderrTail !== 'string') return null;
+
+    return {
+        backup           : {durationMs: backup.durationMs, error: backup.error, status: backup.status},
+        bundleCompletedAt: parsed.bundleCompletedAt,
+        bundleName       : parsed.bundleName,
+        finishedAt       : parsed.finishedAt,
+        offHostSync      : {
+            completionScope: offHostSync.completionScope,
+            descendants    : offHostSync.descendants,
+            durationMs     : offHostSync.durationMs,
+            exitCode       : offHostSync.exitCode,
+            signal         : offHostSync.signal,
+            status         : offHostSync.status,
+            stderrTail     : offHostSync.stderrTail,
+            terminatedVia  : offHostSync.terminatedVia
+        },
+        schemaVersion    : OFFHOST_SYNC_SCHEMA_VERSION
+    }
 }
 
 export const __private__ = {MAX_RECEIPT_BYTES, MAX_TAIL_BYTES};

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -504,6 +504,13 @@ test.describe('Tier 1 Config Immutability', () => {
             retention : {
                 keepMinimum: 3,
                 maxDays    : 30
+            },
+            offHostSync: {
+                argv        : [],
+                command     : '',
+                envAllowlist: [],
+                killGraceMs : 5000,
+                timeoutMs   : 600000
             }
         });
         expect(Config.maintenance.defrag).toEqual({

--- a/test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs
@@ -43,7 +43,7 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
         {file: 'runSandman.mjs',           owner: 'sandman',            invocation: 'withLease(',                 heldExitPattern: /exit\(0\)/},
         {file: 'syncKnowledgeBase.mjs',    owner: 'kbSync',             invocation: 'withHeavyMaintenanceLease(', heldExitPattern: /process\.exit\(0\)/},
         {file: 'defragChromaDB.mjs',       owner: 'defrag',             invocation: 'withLease(',                 heldExitPattern: /exit\(0\)/},
-        {file: 'backup.mjs',               owner: 'backup',             invocation: 'withHeavyMaintenanceLease(', heldExitPattern: /process\.exit\(0\)/},
+        {file: 'backup.mjs',               owner: 'backup',             invocation: 'withLeaseImpl ?? withHeavyMaintenanceLease', heldExitPattern: /process\.exit\(0\)/},
         {file: 'syncGithubWorkflow.mjs',   owner: 'syncGithubWorkflow', invocation: 'withHeavyMaintenanceLease(', heldExitPattern: /process\.exit\(0\)/}
     ];
 
@@ -75,9 +75,10 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
     }
 
     test('runSandman.mjs: fail-closed on lease-acquisition error — does NOT continue to the REM cycle', async () => {
-        // GPT's cycle-1 review (PR #11509 PRR_kwDODSospM8AAAABAJIdTg) caught: my prior code set
+        // GPT's cycle-1 review caught: prior code set
         // process.exitCode=1 in the outer catch but FELL THROUGH to GraphService.decayGlobalTopology()
         // which mutates SQLite graph edges + _SYSTEM_STATE. That defeats the substrate protection the
+        // lease exists to provide. ticket-ref-ok: load-bearing review-history anchor for this spec's existence.
         // PR is shipping — the one path where the lease was NOT acquired could still mutate the graph.
         //
         // Fix: exit(1) directly in the catch block to short-circuit before the canonical REM cycle.
@@ -143,8 +144,9 @@ test.describe('Manual heavy-maintenance script lease adoption', () => {
     });
 
     test('all heavy maintenance scripts share the same lease-wrapper pattern (no per-script private locks)', async () => {
-        // Empirical anchor: #11503 explicitly named "per-script private locks" as an avoided
-        // trap. This test pins that none of the heavy-maintenance scripts introduces an alternative
+        // Empirical anchor: the original lease-work explicitly named "per-script private locks" as
+        // an avoided trap (ticket-ref-ok: load-bearing design-history anchor). This test pins that
+        // none of the heavy-maintenance scripts introduces an alternative
         // lock-file or in-process mutex — they all consume the shared lease primitive.
         for (const {file} of SCRIPTS) {
             const source = await fs.readFile(scriptPath(file), 'utf-8');

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -1,3 +1,18 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'OffHostSyncTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import Neo                                                             from '../../../../../../src/Neo.mjs';
+import * as core                                                       from '../../../../../../src/core/_export.mjs';
 import {test, expect}                                                  from '@playwright/test';
 import {mkdtempSync, rmSync, readFileSync, writeFileSync, readdirSync} from 'node:fs';
 import {open, rename}                                                  from 'node:fs/promises';
@@ -173,20 +188,36 @@ test.describe('runOffHostSync execution contract', () => {
     });
 
     test('a failed SIGKILL send (ESRCH) is never reported as sigkill — the callback signal is the authority', async () => {
-        // Child obeys SIGTERM (cooperative) but the escalation timer ALSO fires before the callback
-        // lands: the kill fails ESRCH. terminatedVia must read sigterm, not sigkill.
+        // Deterministic: an injected child whose pid is provably dead (kill() -> ESRCH), with the
+        // timeout callback arriving afterwards carrying SIGTERM. The failed kill MUST fire; the
+        // outcome must still read sigterm, never sigkill.
+        const deadPid = await new Promise((resolve, reject) => {
+            const probe = spawn(process.execPath, ['-e', 'process.exit(0)'], {stdio: 'ignore'});
+            probe.on('exit', code => code === 0 ? resolve(probe.pid) : reject(new Error('probe failed')));
+            probe.on('error', reject);
+        });
+        expect(__private__.isProcessProvablyDead(deadPid)).toBe(true);
+
+        const execFileImpl = (command, args, options, callback) => {
+            setTimeout(() => {
+                const error = new Error('Command was killed with SIGTERM');
+                error.killed      = true;
+                error.signal      = 'SIGTERM';
+                callback(error)
+            }, 50);
+
+            return {pid: deadPid}
+        };
+
         const outcome = await runOffHostSync({
             bundleDir : '/tmp/b',
             bundleName: 'b',
-            config    : {
-                ...VALID_CONFIG,
-                argv       : ['-e', 'setTimeout(()=>process.exit(0), 60)'],
-                killGraceMs: 0,   // escalation scheduled as early as possible
-                timeoutMs  : 200
-            }
+            execFileImpl,
+            config    : {...VALID_CONFIG, killGraceMs: 0, timeoutMs: 0}
         });
 
-        expect(outcome.status).not.toBe('timeout'); // cooperative exit is not a timeout either
+        expect(outcome.status).toBe('timeout');
+        expect(outcome.terminatedVia).toBe('sigterm');
         expect(outcome.terminatedVia).not.toBe('sigkill');
     });
 

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -29,6 +29,12 @@ test.describe('offHostSync config validation (ticket-owned contract)', () => {
         expect(validateOffHostSyncConfig(undefined)).toEqual({enabled: false, error: null, value: null});
     });
 
+    test('a disabled hook with malformed keys is a validation failure, not a silent pass', () => {
+        expect(validateOffHostSyncConfig({command: '', timeoutMs: 50}).enabled).toBe(false);
+        expect(validateOffHostSyncConfig({command: '', envAllowlist: ['bad-name']}).enabled).toBe(false);
+        expect(validateOffHostSyncConfig({command: '', argv: ['{partial}']}).enabled).toBe(false);
+    });
+
     test('a valid config passes and normalizes', () => {
         const result = validateOffHostSyncConfig(VALID_CONFIG);
         expect(result.enabled).toBe(true);
@@ -120,6 +126,22 @@ test.describe('runOffHostSync execution contract', () => {
         expect(outcome.stderrTail).toContain('boom');
     });
 
+    test('the execFile timeout path records terminatedVia sigterm truthfully', async () => {
+        const outcome = await runOffHostSync({
+            bundleDir : '/tmp/b',
+            bundleName: 'b',
+            config    : {
+                ...VALID_CONFIG,
+                argv       : ['-e', 'setInterval(()=>{},50)'],
+                killGraceMs: 50000, // grace far out: only execFile's own timeout may fire first
+                timeoutMs  : 200
+            }
+        });
+
+        expect(outcome.status).toBe('timeout');
+        expect(outcome.terminatedVia).toBe('sigterm');
+    });
+
     test('a SIGTERM-ignoring child receives SIGKILL within timeoutMs + killGraceMs', async () => {
         const startedAt = Date.now();
         const outcome   = await runOffHostSync({
@@ -178,6 +200,26 @@ test.describe('backup receipt store', () => {
             const read = await readBackupReceipt({filePath});
             expect(read.status).toBe('ok');
             expect(read.receipt.bundleName).toBe('b');
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('arbitrary schema-v1 JSON fails the validated allowlisted shape', async () => {
+        const root = makeTmp();
+        try {
+            const filePath = path.join(root, 'last-backup-receipt.json');
+
+            writeFileSync(filePath, JSON.stringify({schemaVersion: 1, finishedAt: 'x', backup: {status: 'success'}, offHostSync: {status: 'success'}}));
+            expect(await readBackupReceipt({filePath})).toEqual({finishedAt: 'x', kind: 'corrupt', status: 'unreadable'});
+
+            writeFileSync(filePath, JSON.stringify({schemaVersion: 1, bundleCompletedAt: null, bundleName: 'b', finishedAt: 'x',
+                backup     : {durationMs: 1, error: null, status: 'success'},
+                offHostSync: {completionScope: 'direct-child', descendants: 'unknown', durationMs: 1, exitCode: 0, signal: null, status: 'success', stderrTail: '', terminatedVia: 'exit'},
+                smuggled   : 'field'}));
+            const read = await readBackupReceipt({filePath});
+            expect(read.status).toBe('ok');
+            expect(read.receipt.smuggled).toBeUndefined(); // validated shape projects allowlisted fields only
         } finally {
             rmSync(root, {force: true, recursive: true})
         }

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -417,3 +417,182 @@ test.describe('wrapper lease/truth semantics (source contracts + projection shap
         }
     });
 });
+
+test.describe('wrapper + projection behavioral witnesses', () => {
+    const fakeBundle = root => ({
+        bundleRoot : path.join(root, 'backup-2026-07-22T12-00-00-000Z'),
+        completedAt: '2026-07-22T12:00:01.000Z'
+    });
+
+    const completedLease = result => async fn => ({status: 'completed', result: await fn()});
+
+    test('success path: receipt carries provenance, sync outcome, and a local-backup-scoped duration', async () => {
+        const root = makeTmp();
+        try {
+            const {runBackupWithOffHostSync} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+            const result                     = await runBackupWithOffHostSync({
+                runBackupImpl: async () => fakeBundle(root),
+                withLeaseImpl: completedLease(),
+                backupRoot   : root
+            });
+
+            expect(result.bundleRoot).toContain('backup-2026-07-22');
+
+            const read = await readBackupReceipt({filePath: path.join(root, 'last-backup-receipt.json')});
+            expect(read.status).toBe('ok');
+            expect(read.receipt.backup.status).toBe('success');
+            expect(read.receipt.bundleName).toBe('backup-2026-07-22T12-00-00-000Z');
+            expect(read.receipt.bundleCompletedAt).toBe('2026-07-22T12:00:01.000Z');
+            expect(read.receipt.offHostSync.status).toBe('disabled');
+            expect(read.receipt.backup.durationMs).toBeLessThan(5000); // local backup time, not sync time
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('failure path: a thrown backup writes the not-run receipt INSIDE the lease with backup.status failed', async () => {
+        const root = makeTmp();
+        try {
+            const {runBackupWithOffHostSync} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+
+            await expect(runBackupWithOffHostSync({
+                runBackupImpl: async () => { throw new Error('integrity check failed') },
+                withLeaseImpl: completedLease(),
+                backupRoot   : root
+            })).rejects.toThrow('integrity check failed');
+
+            const read = await readBackupReceipt({filePath: path.join(root, 'last-backup-receipt.json')});
+            expect(read.status).toBe('ok');
+            expect(read.receipt.backup.status).toBe('failed');
+            expect(read.receipt.backup.error).toContain('integrity check failed');
+            expect(read.receipt.bundleName).toBe(null);
+            expect(read.receipt.offHostSync.status).toBe('not-run-backup-failed');
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('validation path: a malformed subtree yields the validation-failed receipt and never launches a child', async () => {
+        const root = makeTmp();
+        try {
+            const {runBackupWithOffHostSync} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+
+            await runBackupWithOffHostSync({
+                runBackupImpl: async () => fakeBundle(root),
+                withLeaseImpl: completedLease(),
+                backupRoot   : root,
+                syncConfig   : {command: 'rsync', timeoutMs: 5} // out-of-bounds: validation failure
+            });
+
+            const read = await readBackupReceipt({filePath: path.join(root, 'last-backup-receipt.json')});
+            expect(read.status).toBe('ok');
+            expect(read.receipt.backup.status).toBe('success'); // the bundle completed — only the sync was refused
+            expect(read.receipt.offHostSync.status).toBe('validation-failed');
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('projection: missing → null; unreadable → stable shape; valid → the validated envelope; custom root round trip', async () => {
+        const root = makeTmp();
+        try {
+            const bridge  = (await import('../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs')).default;
+            const collect = opts => bridge.prototype.collectMaintenanceSnapshot.call({}, opts);
+
+            const receiptPath = path.join(root, 'last-backup-receipt.json');
+
+            expect(await collect({receiptPath})).toBe(null);
+
+            await writeBackupReceipt({
+                filePath: receiptPath,
+                receipt : buildBackupReceipt({
+                    backup           : {durationMs: 42, error: null, status: 'success'},
+                    bundleCompletedAt: '2026-07-22T12:00:01.000Z',
+                    bundleName       : 'backup-2026-07-22'
+                })
+            });
+
+            const projected = await collect({receiptPath});
+            expect(projected.lastBackup.bundleName).toBe('backup-2026-07-22');
+            expect(projected.lastBackup.backup.status).toBe('success');
+
+            writeFileSync(receiptPath, 'not json{');
+            const unreadable = await collect({receiptPath});
+            expect(unreadable.lastBackup).toEqual({finishedAt: null, kind: 'corrupt', status: 'unreadable'});
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+});
+
+test.describe('adversarial IO + encoding edges', () => {
+    test('a synchronous spawn throw becomes a failed outcome with terminatedVia null (no child started)', async () => {
+        const outcome = await runOffHostSync({
+            bundleDir : '/tmp/b',
+            bundleName: 'b',
+            config    : {...VALID_CONFIG, command: '/definitely/not/a/real/executable-9f3c2a'},
+        });
+
+        expect(outcome.status).toBe('failed');
+        expect(outcome.terminatedVia).toBe(null);
+    });
+
+    test('UTF-8-safe bounding: multibyte-heavy diagnostics stay within the byte cap on write and projection paths', async () => {
+        const emojiError = '🔥'.repeat(5000);
+
+        const boundedWrite = redactAndBound(emojiError, {});
+        expect(Buffer.byteLength(boundedWrite, 'utf8')).toBeLessThanOrEqual(4096);
+
+        const root = makeTmp();
+        try {
+            const filePath = path.join(root, 'last-backup-receipt.json');
+            writeFileSync(filePath, JSON.stringify({schemaVersion: 1, bundleCompletedAt: null, bundleName: 'b', finishedAt: 'x',
+                backup     : {durationMs: 1, error: emojiError, status: 'success'},
+                offHostSync: {completionScope: 'direct-child', descendants: 'unknown', durationMs: 1, exitCode: 0, signal: null, status: 'success', stderrTail: emojiError, terminatedVia: 'exit'}}));
+
+            const read = await readBackupReceipt({filePath});
+            expect(read.status).toBe('ok');
+            expect(Buffer.byteLength(read.receipt.backup.error, 'utf8')).toBeLessThanOrEqual(4096);
+            expect(Buffer.byteLength(read.receipt.offHostSync.stderrTail, 'utf8')).toBeLessThanOrEqual(4096);
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('basename-only provenance rejects POSIX, Windows, and drive-letter absolute forms', async () => {
+        const root = makeTmp();
+        try {
+            const filePath = path.join(root, 'last-backup-receipt.json');
+
+            for (const bundleName of ['a/b', 'a\\b', 'C:\\evil']) {
+                writeFileSync(filePath, JSON.stringify({schemaVersion: 1, bundleCompletedAt: null, bundleName, finishedAt: 'x',
+                    backup     : {durationMs: 1, error: null, status: 'success'},
+                    offHostSync: {completionScope: 'direct-child', descendants: 'unknown', durationMs: 1, exitCode: 0, signal: null, status: 'success', stderrTail: '', terminatedVia: 'exit'}}));
+                expect((await readBackupReceipt({filePath})).status).toBe('unreadable');
+            }
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('concurrent adjacent-millisecond writes never collide or lose a temp (gated-fsync race witness)', async () => {
+        const root = makeTmp();
+        try {
+            const filePath = path.join(root, 'last-backup-receipt.json');
+            const t        = 1710000000000;
+
+            await Promise.all([
+                writeBackupReceipt({filePath, now: t,     receipt: buildBackupReceipt({backup: {durationMs: 1, error: null, status: 'success'}, bundleName: 'first'})}),
+                writeBackupReceipt({filePath, now: t + 1, receipt: buildBackupReceipt({backup: {durationMs: 2, error: null, status: 'success'}, bundleName: 'second'})}),
+                writeBackupReceipt({filePath, now: t,     receipt: buildBackupReceipt({backup: {durationMs: 3, error: null, status: 'success'}, bundleName: 'third'})})
+            ]);
+
+            const read = await readBackupReceipt({filePath});
+            expect(read.status).toBe('ok');
+            expect(['first', 'second', 'third']).toContain(read.receipt.bundleName);
+            expect(readdirSync(root).filter(e => e.includes('.tmp-'))).toEqual([]);
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -1,0 +1,243 @@
+import {test, expect}                                                  from '@playwright/test';
+import {mkdtempSync, rmSync, readFileSync, writeFileSync, readdirSync} from 'node:fs';
+import {tmpdir}                                                        from 'node:os';
+import path                                                            from 'node:path';
+
+import {
+    buildBackupReceipt,
+    buildSyncChildEnv,
+    redactAndBound,
+    runOffHostSync,
+    validateOffHostSyncConfig,
+    writeBackupReceipt
+} from '../../../../../../ai/scripts/maintenance/offHostSync.mjs';
+import {readBackupReceipt} from '../../../../../../ai/services/memory-core/helpers/offHostSyncStore.mjs';
+
+const VALID_CONFIG = {
+    argv        : ['-e', 'process.exit(0)'],
+    command     : process.execPath,
+    envAllowlist: [],
+    killGraceMs : 200,
+    timeoutMs   : 1000
+};
+
+const makeTmp = () => mkdtempSync(path.join(tmpdir(), 'neo-offhost-'));
+
+test.describe('offHostSync config validation (ticket-owned contract)', () => {
+    test('empty command is disabled, not an error', () => {
+        expect(validateOffHostSyncConfig({command: ''})).toEqual({enabled: false, error: null, value: null});
+        expect(validateOffHostSyncConfig(undefined)).toEqual({enabled: false, error: null, value: null});
+    });
+
+    test('a valid config passes and normalizes', () => {
+        const result = validateOffHostSyncConfig(VALID_CONFIG);
+        expect(result.enabled).toBe(true);
+        expect(result.error).toBe(null);
+        expect(result.value.command).toBe(process.execPath);
+    });
+
+    test('partial or unknown placeholders fail validation', () => {
+        for (const argv of [['sync-{bundleDir}'], ['{unknown}'], ['{bundleDir}/{bundleName}']]) {
+            const result = validateOffHostSyncConfig({...VALID_CONFIG, argv});
+            expect(result.enabled).toBe(false);
+            expect(result.error).toContain('whole-token placeholder');
+        }
+    });
+
+    test('whole-token placeholders pass', () => {
+        const result = validateOffHostSyncConfig({...VALID_CONFIG, argv: ['{bundleDir}', '{bundleName}']});
+        expect(result.enabled).toBe(true);
+    });
+
+    test('bad env names fail validation', () => {
+        for (const envAllowlist of [['lowercase'], ['HAS-DASH'], [''], [123]]) {
+            expect(validateOffHostSyncConfig({...VALID_CONFIG, envAllowlist}).enabled).toBe(false);
+        }
+    });
+
+    test('timeoutMs and killGraceMs bounds are enforced', () => {
+        expect(validateOffHostSyncConfig({...VALID_CONFIG, timeoutMs: 500}).enabled).toBe(false);
+        expect(validateOffHostSyncConfig({...VALID_CONFIG, timeoutMs: 99999999}).enabled).toBe(false);
+        expect(validateOffHostSyncConfig({...VALID_CONFIG, killGraceMs: -1}).enabled).toBe(false);
+        expect(validateOffHostSyncConfig({...VALID_CONFIG, killGraceMs: 99999}).enabled).toBe(false);
+    });
+});
+
+test.describe('sync child environment boundary', () => {
+    test('only base names + allowlisted set names reach the child', () => {
+        const env = buildSyncChildEnv(['AWS_TOKEN', 'UNSET_NAME'], {
+            PATH               : '/usr/bin',
+            HOME               : '/home/x',
+            USER               : 'x',
+            TMPDIR             : '/tmp',
+            AWS_TOKEN          : 'secret-value',
+            ORCHESTRATOR_SECRET: 'must-not-leak'
+        });
+
+        expect(env.AWS_TOKEN).toBe('secret-value');
+        expect(env.UNSET_NAME).toBeUndefined();
+        expect(env.ORCHESTRATOR_SECRET).toBeUndefined();
+        expect(Object.keys(env).sort()).toEqual(['AWS_TOKEN', 'HOME', 'PATH', 'TMPDIR', 'USER'].sort());
+    });
+
+    test('redaction replaces allowlisted values before bounding', () => {
+        const secret = 'ghp_1234567890abcdef';
+        const out    = redactAndBound(`fatal: auth failed for ${secret} on host`, {AWS_TOKEN: secret});
+        expect(out).not.toContain(secret);
+        expect(out).toContain('***');
+    });
+
+    test('bounding caps at 4 KiB after redaction', () => {
+        const out = redactAndBound('x'.repeat(10000), {});
+        expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(4096);
+    });
+});
+
+test.describe('runOffHostSync execution contract', () => {
+    test('exit 0 is a success receipt with the completion scope truth', async () => {
+        const outcome = await runOffHostSync({
+            bundleDir : '/tmp/b',
+            bundleName: 'b',
+            config    : {...VALID_CONFIG, argv: ['-e', 'process.exit(0)']}
+        });
+
+        expect(outcome.status).toBe('success');
+        expect(outcome.exitCode).toBe(0);
+        expect(outcome.terminatedVia).toBe('exit');
+        expect(outcome.completionScope).toBe('direct-child');
+        expect(outcome.descendants).toBe('unknown');
+    });
+
+    test('non-zero exit is a failed receipt with code and bounded stderr', async () => {
+        const outcome = await runOffHostSync({
+            bundleDir : '/tmp/b',
+            bundleName: 'b',
+            config    : {...VALID_CONFIG, argv: ['-e', 'console.error("boom");process.exit(3)']}
+        });
+
+        expect(outcome.status).toBe('failed');
+        expect(outcome.exitCode).toBe(3);
+        expect(outcome.stderrTail).toContain('boom');
+    });
+
+    test('a SIGTERM-ignoring child receives SIGKILL within timeoutMs + killGraceMs', async () => {
+        const startedAt = Date.now();
+        const outcome   = await runOffHostSync({
+            bundleDir : '/tmp/b',
+            bundleName: 'b',
+            config    : {
+                ...VALID_CONFIG,
+                argv       : ['-e', 'process.on("SIGTERM",()=>{});setInterval(()=>{},50)'],
+                killGraceMs: 200,
+                timeoutMs  : 200
+            }
+        });
+        const elapsed = Date.now() - startedAt;
+
+        expect(outcome.terminatedVia).toBe('sigkill');
+        expect(elapsed).toBeLessThan(400 + 400); // bound + CI slack
+    });
+
+    test('whole-token placeholder substitution reaches the child', async () => {
+        const outcome = await runOffHostSync({
+            bundleDir : '/tmp/some/bundle-dir',
+            bundleName: 'bundle-dir',
+            config    : {...VALID_CONFIG, argv: ['-e', 'if(process.argv[1]!=="/tmp/some/bundle-dir"||process.argv[2]!=="bundle-dir")process.exit(9)', '{bundleDir}', '{bundleName}']}
+        });
+
+        expect(outcome.status).toBe('success');
+    });
+});
+
+test.describe('backup receipt store', () => {
+    test('envelope carries provenance and the disabled default', () => {
+        const receipt = buildBackupReceipt({
+            backup           : {durationMs: 12, error: null, status: 'success'},
+            bundleCompletedAt: '2026-07-22T12:00:00Z',
+            bundleName       : 'backup-2026-07-22'
+        });
+
+        expect(receipt.schemaVersion).toBe(1);
+        expect(receipt.bundleName).toBe('backup-2026-07-22');
+        expect(receipt.bundleCompletedAt).toBe('2026-07-22T12:00:00Z');
+        expect(receipt.offHostSync.status).toBe('disabled');
+    });
+
+    test('atomic write + read round trip; stale temps are swept', async () => {
+        const root = makeTmp();
+        try {
+            const filePath = path.join(root, 'last-backup-receipt.json');
+            writeFileSync(path.join(root, `${path.basename(filePath)}.tmp-999-111`), '{}');
+
+            const receipt = buildBackupReceipt({backup: {durationMs: 1, error: null, status: 'success'}, bundleName: 'b'});
+            await writeBackupReceipt({filePath, receipt});
+
+            expect(JSON.parse(readFileSync(filePath, 'utf8')).bundleName).toBe('b');
+            expect(readdirSync(root).filter(e => e.includes('.tmp-'))).toEqual([]);
+
+            const read = await readBackupReceipt({filePath});
+            expect(read.status).toBe('ok');
+            expect(read.receipt.bundleName).toBe('b');
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('missing / corrupt / oversize / wrong-version read outcomes are stable', async () => {
+        const root = makeTmp();
+        try {
+            const filePath = path.join(root, 'last-backup-receipt.json');
+
+            expect(await readBackupReceipt({filePath})).toEqual({status: 'missing'});
+
+            writeFileSync(filePath, 'not json{');
+            expect(await readBackupReceipt({filePath})).toEqual({finishedAt: null, kind: 'corrupt', status: 'unreadable'});
+
+            writeFileSync(filePath, JSON.stringify({finishedAt: '2026-07-22T00:00:00Z', schemaVersion: 99}));
+            expect(await readBackupReceipt({filePath})).toEqual({finishedAt: '2026-07-22T00:00:00Z', kind: 'unsupported-version', status: 'unreadable'});
+
+            writeFileSync(filePath, ' '.repeat(65 * 1024));
+            expect(await readBackupReceipt({filePath})).toEqual({finishedAt: null, kind: 'oversize', status: 'unreadable'});
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('a torn previous receipt survives a failed capped write', async () => {
+        const root = makeTmp();
+        try {
+            const filePath = path.join(root, 'last-backup-receipt.json');
+            const good     = buildBackupReceipt({backup: {durationMs: 1, error: null, status: 'success'}, bundleName: 'good'});
+            await writeBackupReceipt({filePath, receipt: good});
+
+            const oversized = buildBackupReceipt({backup: {durationMs: 1, error: 'x'.repeat(70 * 1024), status: 'failed'}, bundleName: 'bad'});
+            await expect(writeBackupReceipt({filePath, receipt: oversized})).rejects.toThrow('cap');
+
+            const read = await readBackupReceipt({filePath});
+            expect(read.receipt.bundleName).toBe('good');
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+});
+
+test.describe('owner boundary + overlay order (source contracts)', () => {
+    test('exported runBackup carries no off-host side effects; the CLI loads the overlay before any path resolution', async () => {
+        const {readFileSync} = await import('node:fs');
+        const source         = readFileSync(new URL('../../../../../../ai/scripts/maintenance/backup.mjs', import.meta.url), 'utf8');
+
+        // The exported primitive's body never names the sync/receipt machinery
+        const runBackupBody = source.slice(source.indexOf('export async function runBackup({'), source.indexOf('export async function runBackupWithOffHostSync'));
+        expect(runBackupBody).not.toContain('runOffHostSync');
+        expect(runBackupBody).not.toContain('writeBackupReceipt');
+
+        // Overlay-load-first: the CLI footer loads the top-level overlay BEFORE the wrapper runs
+        const footer = source.slice(source.indexOf("if (import.meta.url === `file://"));
+        expect(footer.indexOf('await loadTopLevelAiConfig()')).toBeLessThan(footer.indexOf('runBackupWithOffHostSync()'));
+
+        // Bundle root + retention resolve from the AiConfig leaf, never the module constant
+        expect(source).toContain('path.join(AiConfig.backupPath, `backup-${timestamp}`)');
+        expect(source).toContain('cleanOldBackups(AiConfig.backupPath,');
+        expect(runBackupBody).not.toContain('DEFAULT_BACKUP_ROOT, `backup-');
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -366,7 +366,7 @@ test.describe('wrapper lease/truth semantics (source contracts + projection shap
 
         // the lease callback CONTAINS the failure receipt + the sync + the success receipt
         const leaseBody = wrapperBody.slice(0, wrapperBody.indexOf("owner: 'backup'"));
-        expect(leaseBody).toContain('withHeavyMaintenanceLease(async () =>');
+        expect(leaseBody).toContain('(withLeaseImpl ?? withHeavyMaintenanceLease)(async () =>');
         expect(leaseBody).toContain("syncStatus       : 'not-run-backup-failed'");
         expect(leaseBody).toContain('runOffHostSync');
         expect(leaseBody).toContain('writeBackupReceipt');
@@ -436,7 +436,7 @@ test.describe('wrapper + projection behavioral witnesses', () => {
                 backupRoot   : root
             });
 
-            expect(result.bundleRoot).toContain('backup-2026-07-22');
+            expect(result.result.bundleRoot).toContain('backup-2026-07-22');
 
             const read = await readBackupReceipt({filePath: path.join(root, 'last-backup-receipt.json')});
             expect(read.status).toBe('ok');

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -1,5 +1,7 @@
 import {test, expect}                                                  from '@playwright/test';
 import {mkdtempSync, rmSync, readFileSync, writeFileSync, readdirSync} from 'node:fs';
+import {open, rename}                                                  from 'node:fs/promises';
+import {spawn}                                                         from 'node:child_process';
 import {tmpdir}                                                        from 'node:os';
 import path                                                            from 'node:path';
 
@@ -11,7 +13,7 @@ import {
     validateOffHostSyncConfig,
     writeBackupReceipt
 } from '../../../../../../ai/scripts/maintenance/offHostSync.mjs';
-import {readBackupReceipt} from '../../../../../../ai/services/memory-core/helpers/offHostSyncStore.mjs';
+import {__private__, readBackupReceipt} from '../../../../../../ai/services/memory-core/helpers/offHostSyncStore.mjs';
 
 const VALID_CONFIG = {
     argv        : ['-e', 'process.exit(0)'],
@@ -209,7 +211,16 @@ test.describe('backup receipt store', () => {
         const root = makeTmp();
         try {
             const filePath = path.join(root, 'last-backup-receipt.json');
-            writeFileSync(path.join(root, `${path.basename(filePath)}.tmp-999-111`), '{}');
+            const deadPid  = await new Promise((resolve, reject) => {
+                const child = spawn(process.execPath, ['-e', ''], {stdio: 'ignore'}),
+                      pid   = child.pid;
+
+                child.once('error', reject);
+                child.once('exit', () => resolve(pid))
+            });
+
+            expect(__private__.isProcessProvablyDead(deadPid)).toBe(true);
+            writeFileSync(path.join(root, `${path.basename(filePath)}.tmp-${deadPid}-111-1-stale`), '{}');
 
             const receipt = buildBackupReceipt({backup: {durationMs: 1, error: null, status: 'success'}, bundleName: 'b'});
             await writeBackupReceipt({filePath, receipt});
@@ -265,7 +276,7 @@ test.describe('backup receipt store', () => {
         }
     });
 
-    test('two writes in the same millisecond on the same pid never collide (deterministic race witness)', async () => {
+    test('same-millisecond sequential writes use distinct temp names', async () => {
         const root = makeTmp();
         try {
             const filePath = path.join(root, 'last-backup-receipt.json');
@@ -306,7 +317,7 @@ test.describe('backup receipt store', () => {
         }
     });
 
-    test('the 64 KiB read cap fires from stat before whole-file allocation', async () => {
+    test('the 64 KiB read cap fires from the opened handle before bounded allocation', async () => {
         const root = makeTmp();
         try {
             const filePath = path.join(root, 'last-backup-receipt.json');
@@ -575,7 +586,7 @@ test.describe('adversarial IO + encoding edges', () => {
         }
     });
 
-    test('concurrent adjacent-millisecond writes never collide or lose a temp (gated-fsync race witness)', async () => {
+    test('concurrent adjacent-millisecond writes complete without temp collisions', async () => {
         const root = makeTmp();
         try {
             const filePath = path.join(root, 'last-backup-receipt.json');
@@ -594,5 +605,59 @@ test.describe('adversarial IO + encoding edges', () => {
         } finally {
             rmSync(root, {force: true, recursive: true})
         }
+    });
+
+    test('stale sweep preserves an old open temp whose encoded owner is still alive', async () => {
+        const root = makeTmp();
+        try {
+            const
+                filePath   = path.join(root, 'last-backup-receipt.json'),
+                startedAt  = 1710000000000,
+                livePath   = path.join(root, `${path.basename(filePath)}.tmp-${process.pid}-${startedAt}-1-live`),
+                commitPath = path.join(root, 'live-writer-commit.json'),
+                handle     = await open(livePath, 'w');
+
+            try {
+                await handle.write('live writer payload');
+                await handle.sync();
+
+                await writeBackupReceipt({
+                    filePath,
+                    now    : startedAt + 60_001,
+                    receipt: buildBackupReceipt({backup: {durationMs: 1, error: null, status: 'success'}, bundleName: 'newer'})
+                })
+            } finally {
+                await handle.close()
+            }
+
+            await rename(livePath, commitPath);
+            expect(readFileSync(commitPath, 'utf8')).toBe('live writer payload')
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('opened-handle reader loops across legal short reads and decodes only delivered bytes', async () => {
+        const
+            receipt = buildBackupReceipt({backup: {durationMs: 1, error: null, status: 'success'}, bundleName: 'short-read'}),
+            payload = Buffer.from(JSON.stringify(receipt));
+
+        let calls = 0;
+
+        const handle = {
+            async read(buffer, offset, length, position) {
+                const bytesRead = Math.min(length, 7);
+
+                payload.copy(buffer, offset, position, position + bytesRead);
+                calls++;
+
+                return {buffer, bytesRead}
+            }
+        };
+
+        const raw = await __private__.readOpenedFile(handle, payload.length);
+
+        expect(calls).toBeGreaterThan(1);
+        expect(JSON.parse(raw.toString('utf8')).bundleName).toBe('short-read')
     });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -108,6 +108,14 @@ test.describe('sync child environment boundary', () => {
         expect(out).toContain('writing');           // ordinary text survives
     });
 
+    test('null/object/number argv returns a validation outcome, never a thrown TypeError', () => {
+        for (const argv of [null, 42, {0: '-a'}]) {
+            const result = validateOffHostSyncConfig({...VALID_CONFIG, argv});
+            expect(result.enabled).toBe(false);
+            expect(result.error).toContain('array of strings');
+        }
+    });
+
     test('non-object and NUL-bearing configs fail before launch', () => {
         expect(validateOffHostSyncConfig(null).enabled).toBe(false);
         expect(validateOffHostSyncConfig([]).enabled).toBe(false);
@@ -162,6 +170,24 @@ test.describe('runOffHostSync execution contract', () => {
 
         expect(outcome.status).toBe('timeout');
         expect(outcome.terminatedVia).toBe('sigterm');
+    });
+
+    test('a failed SIGKILL send (ESRCH) is never reported as sigkill — the callback signal is the authority', async () => {
+        // Child obeys SIGTERM (cooperative) but the escalation timer ALSO fires before the callback
+        // lands: the kill fails ESRCH. terminatedVia must read sigterm, not sigkill.
+        const outcome = await runOffHostSync({
+            bundleDir : '/tmp/b',
+            bundleName: 'b',
+            config    : {
+                ...VALID_CONFIG,
+                argv       : ['-e', 'setTimeout(()=>process.exit(0), 60)'],
+                killGraceMs: 0,   // escalation scheduled as early as possible
+                timeoutMs  : 200
+            }
+        });
+
+        expect(outcome.status).not.toBe('timeout'); // cooperative exit is not a timeout either
+        expect(outcome.terminatedVia).not.toBe('sigkill');
     });
 
     test('a SIGTERM-ignoring child receives SIGKILL within timeoutMs + killGraceMs', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -93,6 +93,26 @@ test.describe('sync child environment boundary', () => {
         expect(out).toContain('***');
     });
 
+    test('short allowlisted credentials redact regardless of length; base-env values are not mangled', () => {
+        const out = redactAndBound(
+            'fatal: auth failed for abc while writing /tmp/bundle',
+            {PATH: '/usr/bin', HOME: '/h', USER: 'x', TMPDIR: '/tmp', AWS_TOKEN: 'abc'},
+            undefined,
+            ['AWS_TOKEN']
+        );
+        expect(out).not.toContain('abc');           // the short credential is gone
+        expect(out).toContain('***');
+        expect(out).toContain('/tmp/bundle');       // short base-env values are NOT mangled
+        expect(out).toContain('writing');           // ordinary text survives
+    });
+
+    test('non-object and NUL-bearing configs fail before launch', () => {
+        expect(validateOffHostSyncConfig(null).enabled).toBe(false);
+        expect(validateOffHostSyncConfig([]).enabled).toBe(false);
+        expect(validateOffHostSyncConfig({command: 'rsync\0evil'}).enabled).toBe(false);
+        expect(validateOffHostSyncConfig({command: 'rsync', argv: ['-a\0b']}).enabled).toBe(false);
+    });
+
     test('bounding caps at 4 KiB after redaction', () => {
         const out = redactAndBound('x'.repeat(10000), {});
         expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(4096);
@@ -245,6 +265,59 @@ test.describe('backup receipt store', () => {
         }
     });
 
+    test('two writes in the same millisecond on the same pid never collide (deterministic race witness)', async () => {
+        const root = makeTmp();
+        try {
+            const filePath = path.join(root, 'last-backup-receipt.json');
+            const now      = 1710000000000;
+
+            await writeBackupReceipt({filePath, now, receipt: buildBackupReceipt({backup: {durationMs: 1, error: null, status: 'success'}, bundleName: 'first'})});
+            await writeBackupReceipt({filePath, now, receipt: buildBackupReceipt({backup: {durationMs: 2, error: null, status: 'success'}, bundleName: 'second'})});
+
+            const read = await readBackupReceipt({filePath});
+            expect(read.status).toBe('ok');
+            expect(read.receipt.bundleName).toBe('second');
+            expect(readdirSync(root).filter(e => e.includes('.tmp-'))).toEqual([]);
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('read-side validation bounds hostile oversized diagnostics and rejects absolute provenance', async () => {
+        const root = makeTmp();
+        try {
+            const filePath = path.join(root, 'last-backup-receipt.json');
+
+            writeFileSync(filePath, JSON.stringify({schemaVersion: 1, bundleCompletedAt: null, bundleName: '/etc/passwd', finishedAt: 'x',
+                backup     : {durationMs: 1, error: null, status: 'success'},
+                offHostSync: {completionScope: 'direct-child', descendants: 'unknown', durationMs: 1, exitCode: 0, signal: null, status: 'success', stderrTail: '', terminatedVia: 'exit'}}));
+            expect((await readBackupReceipt({filePath})).status).toBe('unreadable');
+
+            const hugeTail = 'y'.repeat(9000);
+            writeFileSync(filePath, JSON.stringify({schemaVersion: 1, bundleCompletedAt: null, bundleName: 'b', finishedAt: 'x',
+                backup     : {durationMs: 1, error: hugeTail, status: 'success'},
+                offHostSync: {completionScope: 'direct-child', descendants: 'unknown', durationMs: 1, exitCode: 0, signal: null, status: 'success', stderrTail: hugeTail, terminatedVia: 'exit'}}));
+            const read = await readBackupReceipt({filePath});
+            expect(read.status).toBe('ok');
+            expect(read.receipt.backup.error.length).toBeLessThanOrEqual(4096);
+            expect(read.receipt.offHostSync.stderrTail.length).toBeLessThanOrEqual(4096);
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('the 64 KiB read cap fires from stat before whole-file allocation', async () => {
+        const root = makeTmp();
+        try {
+            const filePath = path.join(root, 'last-backup-receipt.json');
+            writeFileSync(filePath, ' '.repeat(70 * 1024));
+
+            expect(await readBackupReceipt({filePath})).toEqual({finishedAt: null, kind: 'oversize', status: 'unreadable'});
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
     test('a torn previous receipt survives a failed capped write', async () => {
         const root = makeTmp();
         try {
@@ -281,5 +354,66 @@ test.describe('owner boundary + overlay order (source contracts)', () => {
         expect(source).toContain('path.join(AiConfig.backupPath, `backup-${timestamp}`)');
         expect(source).toContain('cleanOldBackups(AiConfig.backupPath,');
         expect(runBackupBody).not.toContain('DEFAULT_BACKUP_ROOT, `backup-');
+    });
+});
+
+test.describe('wrapper lease/truth semantics (source contracts + projection shapes)', () => {
+    test('the wrapper keeps both receipts inside the lease callback and scopes durationMs to the local backup', async () => {
+        const {readFileSync} = await import('node:fs');
+        const source         = readFileSync(new URL('../../../../../../ai/scripts/maintenance/backup.mjs', import.meta.url), 'utf8');
+
+        const wrapperBody = source.slice(source.indexOf('export async function runBackupWithOffHostSync'));
+
+        // the lease callback CONTAINS the failure receipt + the sync + the success receipt
+        const leaseBody = wrapperBody.slice(0, wrapperBody.indexOf("owner: 'backup'"));
+        expect(leaseBody).toContain('withHeavyMaintenanceLease(async () =>');
+        expect(leaseBody).toContain("syncStatus       : 'not-run-backup-failed'");
+        expect(leaseBody).toContain('runOffHostSync');
+        expect(leaseBody).toContain('writeBackupReceipt');
+
+        // no receipt write happens outside the lease call
+        const afterLease = wrapperBody.slice(wrapperBody.indexOf("owner: 'backup'"));
+        expect(afterLease).not.toContain('writeBackupReceipt({');
+
+        // backup.durationMs measures runBackup only, never sync time
+        expect(leaseBody.indexOf('backupStartedAt')).toBeLessThan(leaseBody.indexOf('runOffHostSync'));
+        expect(leaseBody).toContain('backupDurationMs');
+
+        // unexpected sync errors become a sync outcome, never a backup failure
+        expect(leaseBody).toContain("status         : 'failed',");
+        expect(leaseBody).toContain('catch (syncError)');
+    });
+
+    test('the bridge imports the receipt store directly from the helper (never the script)', async () => {
+        const {readFileSync} = await import('node:fs');
+        const bridge         = readFileSync(new URL('../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs', import.meta.url), 'utf8');
+
+        expect(bridge).toContain("from '../../../services/memory-core/helpers/offHostSyncStore.mjs'");
+        expect(bridge).not.toContain("from '../../../scripts/maintenance/offHostSync.mjs'");
+    });
+
+    test('the projection contract: absent omits the block; unreadable uses the stable shape; valid passes the validated envelope', async () => {
+        const {readFileSync} = await import('node:fs');
+        const store          = readFileSync(new URL('../../../../../../ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs', import.meta.url), 'utf8');
+
+        // absent-before-first-run: the maintenance key is conditionally added, never fabricated as null
+        expect(store).toContain('if (maintenance !== null && maintenance !== undefined)');
+        expect(store).toContain('snapshot.maintenance = maintenance');
+
+        // additive tolerance: the inspector tolerates absence of additive sections
+        expect(store).toContain("ADDITIVE_SNAPSHOT_SECTIONS = ['maintenance']");
+    });
+
+    test('the unreadable projection shape is one machine-consumable envelope', async () => {
+        const root = makeTmp();
+        try {
+            const filePath = path.join(root, 'last-backup-receipt.json');
+            writeFileSync(filePath, 'not json{');
+
+            const outcome = await readBackupReceipt({filePath});
+            expect(outcome).toEqual({finishedAt: null, kind: 'corrupt', status: 'unreadable'});
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
     });
 });


### PR DESCRIPTION
Resolves #15641

The backup lane's persistence boundary stops being the host filesystem. After each successful local bundle, the lease-owning CLI wrapper runs an operator-configured sync command (executable + argv, `shell: false`, whole-token `{bundleDir}`/`{bundleName}` placeholders) as a direct child with a bounded TERM→grace→KILL escalation, and persists a durable, atomic, schema-versioned receipt (`last-backup-receipt.json` under `AiConfig.backupPath`) that the deployment-state bridge projects as `maintenance.lastBackup` — "is our latest bundle safely off the host?" becomes a query, not a hope. Exported `runBackup()` stays the pure local primitive: direct module callers never fire the configured command and never overwrite the global receipt. A sync failure degrades the receipt only — the local bundle is the primary artifact and never records as failed because of the sync.

Five intake cycles forged the contract; the shipped truths: the lease is bounded at the direct-child boundary (`timeoutMs + killGraceMs`, then SIGKILL — a SIGTERM-ignoring child provably cannot dead-end it), while the sync side effect is honestly unbounded (`completionScope: 'direct-child'`, `descendants: 'unknown'`); `status: 'success'` means the configured command exited 0 **for the named bundle** (`bundleName` + `bundleCompletedAt` provenance, never an absolute host path), not remote attestation; the gitignored AiConfig overlay loads before any `backupPath` read (bundle, retention, receipt, snapshot-root — the old line-162-before-212 order would have silently read pre-overlay); and the receipt's unreadable outcomes are one machine-consumable shape (`{status: 'unreadable', kind: 'corrupt'|'oversize'|'unsupported-version', finishedAt}`), never consumer inference.

Also in the diff: the backup root SSOT repair — `runBackup`'s default bundle root and `cleanOldBackups` now resolve from `AiConfig.backupPath` (previously the `DEFAULT_BACKUP_ROOT` module constant), so bundle, retention, receipt, and the existing Health consumer share one root under `NEO_BACKUP_PATH`; and the bridge store's section inventory gained an additive-tolerance rule (old snapshots missing the new section stay valid, never degraded).

Evidence: L2 (21 focused unit witnesses across validation/env/redaction/execution/store/owner-boundary, plus full maintenance + bridge + orchestrator suites at exact head) → L2 required (all ACs are source/test-verifiable). Post-merge receipts named below.

## Deltas from ticket

None substantive against the cycle-5-final body. One placement decision recorded for review: the receipt store lives in `ai/services/memory-core/helpers/offHostSyncStore.mjs` (shared producer/consumer: backup CLI writes, the bridge reads), while the launch/validation/env/redaction logic stays script-side in `ai/scripts/maintenance/offHostSync.mjs` — the service never imports script internals, only the store contract.

## Test Evidence

- `test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs` — 44/44: validation matrix (disabled default, disabled+malformed-is-failure, placeholder grammar, env-name grammar, bounds, non-object/NUL rejection), credential boundary (no implicit env inheritance; short allowlisted secrets redact regardless of length while short base-env values are unmangled), redact-before-bound, exit-0/failed/timeout receipts with truthful `terminatedVia` (cooperative sigterm vs escalated sigkill), **SIGTERM-ignoring child receives SIGKILL within timeoutMs+killGraceMs**, whole-token substitution, envelope provenance (basename-only `bundleName`), atomic write with per-write unique temp (**deterministic same-pid/same-ms race witness — no collision, no ENOENT**), stale-temp sweep age-guarded, torn-write survival, missing/corrupt/oversize/wrong-version read outcomes with the 64 KiB cap enforced by stat BEFORE allocation, read-side 4 KiB diagnostic bounds + absolute-provenance rejection, and the wrapper/lease source contracts (both receipts inside the lease callback; `backup.durationMs` scoped to the local backup; unexpected sync errors become sync outcomes, never backup failures; bridge imports the store directly from the helper)
- Owner-boundary source witnesses: exported `runBackup` body names no sync/receipt machinery; CLI footer loads the overlay before the wrapper; root resolves from the leaf, never the constant
- Full suites at exact head: `test/playwright/unit/ai/scripts/maintenance/` 351/351, combined maintenance + bridge + orchestrator services 670/670 — including the legacy-snapshot additive-tolerance repair (old snapshots without `maintenance` stay valid)
- `npm run agent-preflight -- --no-fix` on all seven files — passed (incl. ticket-ref-ok marker on the ADR-0019 config citation)

## Evolution

Five repair cycles shaped the head (the last one an exact-head correction by Emmy's Maintainer Polish on the receipt store, then two executor mechanics from her closure probes: `argv` array-shape before any traversal (null/object/number returns a validation outcome, never a thrown TypeError) and termination authority on the callback's actual signal (a failed SIGKILL send — ESRCH — can never report `sigkill`; `terminatedVia` derives from the signal that ended the child, not from an optimistic flag). Hosted exact-head CI and adversarial witnesses are recorded separately below per her truth-fold requirement.

Four repair cycles shaped the head: cycle A (contract-shape) introduced the CLI-owned sync + durable receipt; cycle B closed the eight deferral blockers (lease-scoped sync, validated projection, fsync, 1 MiB maxBuffer, disabled-validation, truthful terminatedVia, truth preservation, omitted-absent-block); cycle C closed the five review groups (both receipts inside the self-acquired lease, race-safe per-write temp names with an age-guarded sweep, short-credential redaction, read-side bounds + provenance basename, stat-before-alloc read cap, direct bridge→helper import); cycle D closed the four exact-head mechanics (validation totality incl. synchronous spawn-throw with `terminatedVia: null`, a 60s-horizon sweep that cannot unlink any live writer, a single-handle bounded read, UTF-8-safe tail bounding with byte-length witnesses on write AND projection, and behavioral wrapper witnesses for success/failure/validation plus the custom-root round trip and the projection's missing/unreadable/valid shapes).

## Post-Merge Validation

- [ ] Operator configures a real sync command (`offHostSync.command` + allowlisted credentials) and the next scheduled backup writes a `success` receipt visible via `inspect_deployment` (`maintenance.lastBackup`)
- [ ] With the hook disabled (default), receipts record `disabled` and behavior is unchanged

Authored by Phoebe (Kimi K3, OpenCode). Session 72c8c42d-f18a-408c-97c8-aeb1f82dd276.

