### PR TITLE
fix(agentos): derive App Worker transport from href (#15706)

### DIFF
--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -19,6 +19,22 @@ export function resolveFleetWindowId({fallbackWindowId, apps = Neo.apps, windows
     return live?.id ?? (apps?.[fallbackWindowId] ? fallbackWindowId : null)
 }
 
+/**
+ * @summary Resolves the AgentOS Fleet transport from the authoritative serialized worker URL.
+ *
+ * Both initial worker creation and late `startWorker()` registration already carry the absolute
+ * main-thread `location.href`. Deriving the scheme from that value keeps one URL authority instead
+ * of adding a second `protocol` field that can drift between producer paths. A missing or malformed
+ * `href` throws before bridge installation, preserving the fail-closed transport boundary.
+ *
+ * @param {Object} urlConfig
+ * @param {String} urlConfig.href Absolute main-thread URL serialized into `Neo.config.url`.
+ * @returns {'shell'|'browser'}
+ */
+export function resolveFleetTransportMode({href}) {
+    return new URL(href).protocol === 'app:' ? 'shell' : 'browser'
+}
+
 export const onStart = () => {
     const
         fallbackWindowId = Neo.bootingWindowId,
@@ -34,7 +50,7 @@ export const onStart = () => {
     // Without the bearer the bridge installs fail-closed: every call rejects locally, named.
     const bearerToken = globalThis.AgentOS?.fleet?.bearerToken ?? null;
 
-    if (Neo.config.url.protocol === 'app:') {
+    if (resolveFleetTransportMode(Neo.config.url) === 'shell') {
         const route = () => resolveFleetWindowId({fallbackWindowId});
 
         installFleetBridge({

--- a/test/playwright/unit/apps/agentos/app.spec.mjs
+++ b/test/playwright/unit/apps/agentos/app.spec.mjs
@@ -23,4 +23,13 @@ test.describe('AgentOS packaged Fleet window routing', () => {
         expect(resolveFleetWindowId({apps: {popup: {}}, fallbackWindowId: 'popup', windows})).toBe('popup');
         expect(resolveFleetWindowId({apps: {}, fallbackWindowId: 'popup', windows})).toBeNull()
     })
+
+    test('derives shell versus browser transport from the existing worker URL envelope', async () => {
+        const {resolveFleetTransportMode} = await import('../../../../../apps/agentos/app.mjs');
+
+        expect(resolveFleetTransportMode({href: 'app://neo-agentos/index.html', search: ''})).toBe('shell');
+        expect(resolveFleetTransportMode({href: 'http://127.0.0.1:8080/apps/agentos/', search: '?fleetUrl=x'})).toBe('browser');
+        expect(resolveFleetTransportMode({href: 'https://example.test/apps/agentos/', search: ''})).toBe('browser');
+        expect(() => resolveFleetTransportMode({search: ''})).toThrow()
+    })
 });


### PR DESCRIPTION
Resolves #15706

The AgentOS App Worker now derives its Fleet transport from the authoritative absolute `Neo.config.url.href`: packaged `app:` URLs select the named shell capability, browser origins retain the authenticated HTTP path, and missing or malformed href values fail before bridge installation. The existing `{href, search}` worker envelope stays unchanged, so initial creation and late `startWorker()` cannot drift through a redundant protocol field.

Evidence: L3 (rebuilt packaged Brain-on binary proves real `fleetRoster` crossings before and after popup close, capability rejection, secret custody, teardown, and port release) → L3 required (real packaged initial/late App Worker Fleet transport). No residuals. Related populated-roster isolation remains #15680.

## Deltas from ticket

- V-B-A falsified the original producer-side `protocol` addition: both producer paths already carry absolute `href`, so the repair derives the scheme once at the consumer.
- The close-target ACs were refined after the packaged profile returned a legitimate empty registry and a current-head liveness journey stayed in `sample`; deterministic populated-roster rendering remains #15680 rather than being folded into this transport regression.

## Test Evidence

- AgentOS selector: `npm run test-unit -- test/playwright/unit/apps/agentos/app.spec.mjs` — 2/2 passed after the `origin/dev` rebase.
- Source gates: `npm run agent-preflight -- --no-fix apps/agentos/app.mjs test/playwright/unit/apps/agentos/app.spec.mjs` — passed; `node --check` on both touched files and `git diff --check` — passed.
- Packaged AgentOS: `npm --prefix harness run dist` followed by the real packaged binary with `NEO_HARNESS_SMOKE=1` — passed with `firstWorkerCrossing: true`, `workerAfterPopupClose: true`, `fleetRoster` and `fleetActivity` on both legs, exact preload keys, forged-sender rejection, no secret leaks, clean teardown, and released ports.
- Populated-roster journey: `NEO_E2E_PORT=8121 npx playwright test agentos/FleetCockpitLivenessNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — host-permitted run reached the real bridge but failed after 30 seconds with grid adapter `sample` instead of `live`; this is the open host/profile registry-isolation defect in #15680 and is not a #15706 close gate.

## Post-Merge Validation

- [ ] Re-run the packaged Brain-on smoke from the next `dev` artifact and retain both App Worker crossing flags plus the security/teardown receipt.
- [ ] Validate deterministic populated-roster rendering through #15680 after its registry-isolation repair lands.

## Evolution

The implementation started from the ticket's duplicated-field prescription, but direct inspection and URL probes showed `href` already owns the scheme. A second evidence step then separated transport success from roster population: an empty response can prove the App Worker crossed even while the UI intentionally preserves its zero-setup sample.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session cb60301d-74a4-4024-b80d-2f7efdbf9cd1.
