### PR TITLE
feat(harness): harden first-paint receipt guards (#15714)

### DIFF
--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -438,7 +438,9 @@ function sanitizeBootReport(report) {
 }
 
 /**
- * @summary Reduces an untrusted first-paint report to bounded semantic primitives.
+ * @summary Reduces an untrusted first-paint report to bounded semantic primitives, stamping
+ * shell-launch-to-accepted-receipt `firstPaintMs` while preserving renderer-load-to-semantic-ready
+ * `rendererFirstPaintMs`.
  * @param {*} report
  * @returns {Object|null}
  */

--- a/harness/pack.mjs
+++ b/harness/pack.mjs
@@ -160,6 +160,35 @@ function stripComments(source) {
 }
 
 /**
+ * @summary Extracts unique string-literal module specifiers from static imports, side-effect
+ * imports, re-exports, and dynamic `import()` calls after removing comments. Non-literal dynamic
+ * expressions remain deliberately outside this bounded packaging guard.
+ * @param {String} source
+ * @returns {String[]}
+ */
+export function extractLiteralImportSpecifiers(source) {
+    const specifiers = new Set();
+
+    for (const match of stripComments(source).matchAll(IMPORT_SPECIFIER_RE)) {
+        specifiers.add(match[1])
+    }
+
+    return [...specifiers].sort()
+}
+
+/**
+ * @summary Extracts direct or descendant `./` `.mjs` dependencies for the harness app.asar file
+ * closure. Parent-root imports remain forbidden by the separate packaged-main contract.
+ * @param {String} source
+ * @returns {String[]}
+ */
+export function extractLocalMjsImports(source) {
+    return extractLiteralImportSpecifiers(source)
+        .filter(specifier => specifier.startsWith('./') && specifier.endsWith('.mjs'))
+        .map(specifier => specifier.slice(2))
+}
+
+/**
  * @summary Extracts the BARE (package) import specifiers from one module source: static imports,
  * side-effect imports, re-exports, and string-literal dynamic imports. Comments are stripped
  * first; relative (`./`), absolute, subpath-alias (`#`), and node built-in specifiers are
@@ -173,9 +202,7 @@ export function extractBarePackages(source) {
         builtins = new Set(builtinModules),
         packages = new Set();
 
-    for (const match of stripComments(source).matchAll(IMPORT_SPECIFIER_RE)) {
-        const specifier = match[1];
-
+    for (const specifier of extractLiteralImportSpecifiers(source)) {
         if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('#') || specifier.startsWith('node:')) {
             continue
         }

--- a/harness/preload.cjs
+++ b/harness/preload.cjs
@@ -94,7 +94,7 @@ const timer = setInterval(() => {
 
 // Separate from generic boot: the product receipt waits for the exact cold-first-paint semantics,
 // while popup/shared-heap boot reports remain fast even if a later window has already promoted live.
-const firstPaintTimer = setInterval(() => {
+const firstPaintTimer = setInterval(function reportFirstPaint() {
     const
         elapsed  = Date.now() - t0,
         snapshot = collectFirstPaintSnapshot(),

--- a/test/playwright/unit/harness/pack.spec.mjs
+++ b/test/playwright/unit/harness/pack.spec.mjs
@@ -10,6 +10,7 @@ import {
     buildOrganismManifest,
     deriveCopySpecs,
     extractBarePackages,
+    extractLocalMjsImports,
     isInstanceOverlayPath
 } from '../../../../harness/pack.mjs';
 import {buildPackagedBrainEnv, resolveBrainMode} from '../../../../harness/brain.mjs';
@@ -28,8 +29,7 @@ test.describe('harness pack stage', () => {
 
         expect(builderConfig).toContain('- fleetCapability.mjs');
 
-        const localMainImports = [...mainSource.matchAll(/from\s+['"]\.\/([^'"]+\.mjs)['"]/g)]
-            .map(match => match[1]);
+        const localMainImports = extractLocalMjsImports(mainSource);
 
         for (const importedFile of localMainImports) {
             expect(builderConfig).toContain(`- ${importedFile}`)
@@ -80,6 +80,27 @@ test.describe('harness pack stage', () => {
         ].join('\n');
 
         expect(extractBarePackages(source)).toEqual(['@scope/pkg', 'better-sqlite3', 'chromadb', 'dotenv', 'fs-extra'])
+    });
+
+    test('extractLocalMjsImports covers every literal local module shape without parsing comments or expressions', () => {
+        const source = [
+            "import StaticDefault from './static-default.mjs';",
+            "export {named} from './re-export.mjs';",
+            "import './side-effect.mjs';",
+            "const lazy = import('./dynamic.mjs');",
+            "const variable = import(runtimeSpecifier);",
+            "import '../outside-root.mjs';",
+            "// import './line-comment.mjs';",
+            "/* import './block-comment.mjs'; */",
+            "import 'bare-package';"
+        ].join('\n');
+
+        expect(extractLocalMjsImports(source)).toEqual([
+            'dynamic.mjs',
+            're-export.mjs',
+            'side-effect.mjs',
+            'static-default.mjs'
+        ])
     });
 
     test('buildOrganismManifest pins scanned packages to repo-declared versions and fails loud on undeclared imports', () => {

--- a/test/playwright/unit/harness/preload.spec.mjs
+++ b/test/playwright/unit/harness/preload.spec.mjs
@@ -9,12 +9,17 @@ const mainPath    = new URL('../../../../harness/main.mjs', import.meta.url);
  * @summary Executes the CommonJS preload against capability-shaped Electron mocks without booting
  * Electron. Timers and DOM diagnostics are retained as inert seams; the test owns only the exposed
  * bridge contract.
- * @param {Object} [options={}] Mock clock and DOM surfaces.
+ * @param {Object} [options={}] Mock clock, DOM, and timer-registration surfaces.
+ * @param {Object} [options.clock]
+ * @param {Object} [options.dom]
+ * @param {Boolean} [options.precedeWithUnrelatedTimer=false]
  * @returns {Promise<Object>}
  */
-async function loadPreload({clock={now: 0}, dom={}} = {}) {
+async function loadPreload({clock={now: 0}, dom={}, precedeWithUnrelatedTimer=false} = {}) {
     const
-        intervals     = [],
+        intervals     = precedeWithUnrelatedTimer
+            ? [{cleared: false, fn: function unrelatedTimer() {}}]
+            : [],
         invokes       = [],
         exposed       = {},
         sends         = [],
@@ -64,6 +69,20 @@ async function loadPreload({clock={now: 0}, dom={}} = {}) {
     });
 
     return {exposed, intervals, invokes, sends}
+}
+
+/**
+ * @summary Resolves the product first-paint reporter by its semantic callback name and fails loud
+ * when the production preload exposes a missing or ambiguous timer seam.
+ * @param {Object[]} intervals
+ * @returns {Object}
+ */
+function getFirstPaintReporter(intervals) {
+    const reporters = intervals.filter(({fn}) => fn.name === 'reportFirstPaint');
+
+    expect(reporters, 'exactly one named first-paint reporter').toHaveLength(1);
+
+    return reporters[0]
 }
 
 test.describe('Electron harness preload capability', () => {
@@ -119,10 +138,14 @@ test.describe('Electron harness preload capability', () => {
                         '.fm-fleet-cockpit .fm-agent-card'                                     : cards,
                         '.fm-fleet-cockpit .fm-fusion-tour, .fm-fleet-cockpit .fm-tour-caption': []
                     }
-                }
-            });
+                },
+                precedeWithUnrelatedTimer: true
+            }),
+            firstPaintReporter = getFirstPaintReporter(intervals);
 
-        intervals[1].fn();
+        expect(intervals.findIndex(interval => interval === firstPaintReporter)).toBeGreaterThan(0);
+
+        firstPaintReporter.fn();
 
         expect(sends).toContainEqual(['shell-first-paint-report', {
             activityLabel       : 'sample · live feed pending',
@@ -133,7 +156,7 @@ test.describe('Electron harness preload capability', () => {
             timedOut            : false,
             tourControlCount    : 0
         }]);
-        expect(intervals[1].cleared).toBe(true)
+        expect(firstPaintReporter.cleared).toBe(true)
     })
 
     test('times out honestly when demo controls or missing cards prevent the product receipt', async () => {
@@ -156,13 +179,14 @@ test.describe('Electron harness preload capability', () => {
                         '.fm-fleet-cockpit .fm-fusion-tour, .fm-fleet-cockpit .fm-tour-caption': [{}]
                     }
                 }
-            });
+            }),
+            firstPaintReporter = getFirstPaintReporter(intervals);
 
-        intervals[1].fn();
+        firstPaintReporter.fn();
         expect(sends.filter(([channel]) => channel === 'shell-first-paint-report')).toEqual([]);
 
         clock.now = 60001;
-        intervals[1].fn();
+        firstPaintReporter.fn();
 
         expect(sends).toContainEqual(['shell-first-paint-report', {
             activityLabel       : 'sample · live feed pending',
@@ -173,6 +197,6 @@ test.describe('Electron harness preload capability', () => {
             timedOut            : true,
             tourControlCount    : 1
         }]);
-        expect(intervals[1].cleared).toBe(true)
+        expect(firstPaintReporter.cleared).toBe(true)
     })
 });


### PR DESCRIPTION
Resolves #15714

The packaged first-paint receipt now carries mechanical decay guards at each owning seam: its dual clocks are explicit in JSDoc, preload tests select a named semantic reporter even when another timer precedes it, and the app.asar closure reuses the packer's comment-stripped import scanner for static, re-export, side-effect, and literal dynamic local `.mjs` dependencies.

Evidence: L2 (focused harness unit tests execute timer selection and literal-import extraction; source/preflight gates verify the owning files) → L2 required (all close-target ACs are static or focused-test contracts). No residuals.

## Deltas from ticket

- Reused the existing `harness/pack.mjs` literal-specifier scanner for both bare packages and local `.mjs` closure instead of introducing a second parser.
- Corrected the ticket's unrelated ADR-0036 citation during intake; the change remains aligned with accepted ADR-0034 only.

## Test Evidence

- Harness first-paint + packaging guards: `npm run test-unit -- test/playwright/unit/harness/preload.spec.mjs test/playwright/unit/harness/pack.spec.mjs` — 14/14 passed.
- Parse/static gates: `node --check` on all five touched files plus `git diff --check` — passed.
- Repository gates: `npm run agent-preflight -- --no-fix harness/main.mjs harness/preload.cjs harness/pack.mjs test/playwright/unit/harness/preload.spec.mjs test/playwright/unit/harness/pack.spec.mjs` — passed; unrelated local `STALE_OVERLAY` warning only.

## Post-Merge Validation

- [ ] Confirm the next packaged artifact build retains a closed app.asar module graph when a supported local import shape changes.

## Evolution

Source inspection showed that `harness/pack.mjs` already owns a comment-stripped scanner covering the required literal import forms for bare-package derivation. Exporting that scanner's local-module projection keeps one parsing authority and makes the builder-file assertion fail loud across the same supported syntax.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session cb60301d-74a4-4024-b80d-2f7efdbf9cd1.
