### PR TITLE
fix(test): make component witnesses cross-platform (#15374)

### DIFF
--- a/resources/scss/src/button/Base.scss
+++ b/resources/scss/src/button/Base.scss
@@ -351,17 +351,17 @@
     &.neo-button {
         background-color: var(--button-background-color-disabled);
         border          : var(--button-border-disabled);
+        color           : inherit;
         cursor          : default;
         opacity         : var(--button-opacity-disabled);
 
         // Projecting the native disabled attribute (src/button/Base.mjs) activates the UA
         // button:disabled cascade, dormant for as long as this class was the only disabled
-        // authority. The class stays the sole visual owner: pin the one axis this block does
-        // not declare (measured leak: Chromium paints the element color as disabled GrayText).
-        // Witnessed by the render-equivalence assertion in the button component spec.
-        &:disabled {
-            color: inherit;
-        }
+        // authority. Chromium exposed both sides of the gap: native-disabled painted GrayText,
+        // while class-only retained the platform button color. Keep every root paint axis here:
+        // background, border and opacity use disabled tokens; color inherits because the child
+        // glyph/text nodes own themed colors. The attribute therefore adds semantics, never paint.
+        // Witnessed cross-platform by the render-equivalence assertion in the component spec.
 
         .neo-button-glyph {
             color: var(--button-glyph-color-disabled);

--- a/test/playwright/component/button/Base.spec.mjs
+++ b/test/playwright/component/button/Base.spec.mjs
@@ -219,9 +219,7 @@ test.describe('Neo.button.Base', () => {
         await expect(nativeButtons.nth(1)).toBeEnabled();
     });
 
-    // Linux CI Chromium resolves UA disabled paint differently than the macOS run this witness was
-    // calibrated on — the probed property set must become author-owned per platform before this gates.
-    test.fixme('disabled paint is class-owned — the native attribute contributes no UA styling', async ({page}) => {
+    test('disabled paint is class-owned — the native attribute contributes no UA styling', async ({page}) => {
         const result = await page.evaluate((config) => {
             return Neo.worker.App.createNeoInstance(config);
         }, {
@@ -244,8 +242,10 @@ test.describe('Neo.button.Base', () => {
         await expect(button).toHaveClass(/neo-disabled/);
 
         // Projecting the native attribute activates the UA `button:disabled` cascade, which had been
-        // dormant for as long as `.neo-disabled` was the only disabled authority. Same node, attribute
-        // on vs off, class constant: any inequality is user-agent paint leaking past the class.
+        // dormant for as long as `.neo-disabled` was the only disabled authority. The class explicitly
+        // owns background, border and opacity via disabled tokens, plus the root color via inheritance
+        // (child glyph/text colors have their own tokens). Same node, attribute on vs off, class constant:
+        // any inequality across these four author-owned axes is user-agent paint leaking past the class.
         const {withAttribute, classOnly} = await button.evaluate(node => {
             const probe = () => {
                 const style = getComputedStyle(node);

--- a/test/playwright/component/form/field/ComboBox.spec.mjs
+++ b/test/playwright/component/form/field/ComboBox.spec.mjs
@@ -111,9 +111,7 @@ test.describe('Neo.form.field.ComboBox', () => {
         await expect(inputField).not.toBeFocused();
     });
 
-    // Exact-equality on font-derived width fails on Linux CI (different default font metrics than
-    // macOS) — needs a tolerance band or a font-independent layout invariant before this gates.
-    test.fixme('Input wrapper fills remaining width after a left label', async ({page}) => {
+    test('Input wrapper fills remaining width after a left label', async ({page}) => {
         componentId = await createComboBox(page, {
             labelPosition: 'left',
             labelWidth   : 100,
@@ -121,19 +119,28 @@ test.describe('Neo.form.field.ComboBox', () => {
         });
 
         const sizes = await page.locator(`#${componentId}`).evaluate(element => {
-            const label   = element.querySelector('.neo-textfield-label'),
-                  wrapper = element.querySelector('.neo-input-wrapper'),
-                  input   = element.querySelector('input.neo-textfield-input:not(.neo-typeahead-input)');
+            const fieldRect   = element.getBoundingClientRect(),
+                  label       = element.querySelector('.neo-textfield-label'),
+                  labelRect   = label.getBoundingClientRect(),
+                  wrapper     = element.querySelector('.neo-input-wrapper'),
+                  wrapperRect = wrapper.getBoundingClientRect(),
+                  input       = element.querySelector('input.neo-textfield-input:not(.neo-typeahead-input)');
 
             return {
+                fieldRight  : fieldRect.right,
                 inputWidth  : input.getBoundingClientRect().width,
-                labelWidth  : label.getBoundingClientRect().width,
-                wrapperWidth: wrapper.getBoundingClientRect().width
+                labelRight  : labelRect.right,
+                labelWidth  : labelRect.width,
+                wrapperLeft : wrapperRect.left,
+                wrapperRight: wrapperRect.right
             };
         });
 
-        expect(Math.round(sizes.labelWidth)).toBe(100);
-        expect(Math.round(sizes.wrapperWidth)).toBe(240);
+        // Font rasterization can shift fractional geometry across hosts, so assert the layout contract:
+        // the configured label consumes the left edge and the wrapper spans every remaining pixel.
+        expect(Math.abs(sizes.labelWidth - 100)).toBeLessThan(1);
+        expect(Math.abs(sizes.wrapperLeft - sizes.labelRight)).toBeLessThan(1);
+        expect(Math.abs(sizes.wrapperRight - sizes.fieldRight)).toBeLessThan(1);
         expect(sizes.inputWidth).toBeGreaterThan(200);
     });
 


### PR DESCRIPTION
Resolves #15374

The two platform-sensitive component witnesses are live again. Disabled-button paint now puts the root text color under the same class-owned styling path with or without the native `disabled` attribute, while child glyphs retain their explicit disabled tokens. The ComboBox witness now checks semantic left/right edge relationships with sub-pixel tolerance instead of exact font-derived width arithmetic.

Evidence: L2 (focused macOS Chromium run plus the exact-head Linux components shard execute both restored witnesses against generated development themes) → L2 required (macOS local plus Linux CI). Residual: none.

## Deltas from ticket

- The assertion implementation still selects the ticket's author-owned paint path and semantic-geometry option without expanding scope.
- The first Linux CI run falsified the test-oracle premise because the components runner did not materialize ignored development themes. That separate shard prerequisite was delivered by #15720 / PR #15721; this PR is rebased on it and the exact-head Linux components shard is green.

## Test Evidence

- Development themes: `npm run build-themes -- -n -e dev -t all` — passed.
- Focused component witnesses: `npm run test-components -- test/playwright/component/button/Base.spec.mjs test/playwright/component/form/field/ComboBox.spec.mjs` — 11/11 passed on macOS Chromium after the theme rebuild.
- First Linux CI attempt: [run 29927439958, job 88948169504](https://github.com/neomjs/neo/actions/runs/29927439958/job/88948169504) — 44 passed / 2 failed after the dev server warned that theme assets were missing. The failures were UA-disabled paint and intrinsic inline-label width, confirming an unstyled oracle; routed to #15720 rather than weakening these assertions.
- Exact-head Linux CI after #15721: [run 29932280589, components job 88964870152](https://github.com/neomjs/neo/actions/runs/29932280589/job/88964870152) — passed at `0dff1e5ed0cd4afc49e8b4390434e62b7e2fcf7a`.
- Repository gates: `npm run agent-preflight -- --no-fix test/playwright/component/button/Base.spec.mjs test/playwright/component/form/field/ComboBox.spec.mjs` plus `git diff --check origin/dev...HEAD` — passed; unrelated local `STALE_OVERLAY` warning only.

## Post-Merge Validation

- None. #15720 merged via PR #15721 before this rebase, and the current head retains the required Linux components receipt.

## Evolution

The original exact-equality witnesses exposed two host-owned variables: native-control color resolution and font-dependent geometry. The first Linux rerun then exposed a deeper substrate variable: the CI oracle had no authored themes. The assertion repair stays narrow while #15720 repairs the shared prerequisite, preserving both causal boundaries without hard-coding a platform branch.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session cb60301d-74a4-4024-b80d-2f7efdbf9cd1.
