### PR TITLE
fix(test): materialize themes before component runs (#15720)

### DIFF
--- a/test/playwright/playwright.config.component.mjs
+++ b/test/playwright/playwright.config.component.mjs
@@ -17,6 +17,7 @@ export default defineConfig({
     outputDir    : './test-results/component',
     fullyParallel: false, // CRITICAL
     workers      : 1,     // CRITICAL
+    globalSetup  : './e2e/globalSetup.mjs',
 
     reporter: [['list']],
 
@@ -26,11 +27,11 @@ export default defineConfig({
     },
 
     webServer: {
-        // --no-open: CI runners are headless; webpack's browser-open attempt is noise there and
-        // pointless locally under a test runner. NEVER reuse: an already-listening server from a
-        // foreign clone satisfies the readiness URL and silently serves the wrong tree to every spec
-        // (false reds AND, worse, false greens) — the exact trap this suite hit repeatedly.
-        command            : `npm run server-start -- --port ${PORT} --no-open`,
+        // Playwright starts webServer before globalSetup. Run the shared idempotent theme preflight
+        // here as well, so a tracked-only checkout cannot serve UA-only layout to component witnesses.
+        // --no-open keeps headless CI quiet. NEVER reuse: a foreign server can satisfy readiness while
+        // serving the wrong tree (false reds AND, worse, false greens).
+        command            : `node ./e2e/globalSetup.mjs && npm run server-start -- --port ${PORT} --no-open`,
         url                : `http://localhost:${PORT}`,
         reuseExistingServer: false
     },


### PR DESCRIPTION
Resolves #15720

The Playwright component suite now owns the same generated-theme prerequisite as ordinary source E2E. It invokes the landed, idempotent `e2e/globalSetup.mjs` both before web-server startup and as Playwright `globalSetup`, so a tracked-only checkout cannot serve UA-only layout while reporting component-test results.

Evidence: L3 (real focused component runner started after the entire ignored `dist` tree was moved outside the checkout; the shared preflight materialized a complete 640-file theme census, started the correct server/browser, and executed the suite) → L3 required (tracked-only component launch with authored CSS). Residual at PR-open: exact-head Linux CI still needs to exercise the same clean-runner path.

## Deltas from ticket

- None. The implementation reuses the #15449 executable preflight at both ordering seams and adds no new inspector, builder, cache, generated artifact, or workflow-only path.

## Test Evidence

- Tracked-only prerequisite witness: moved the ignored `dist` tree outside the checkout, then ran `npm run test-components -- test/playwright/component/button/Base.spec.mjs test/playwright/component/form/field/ComboBox.spec.mjs` — the preflight rebuilt themes before server startup; 9 passed and the two #15374 witnesses remained intentionally skipped on `dev`.
- Post-build inspector: `ready: true`, `expectedCss: 640`, and zero missing, stale, symlinked, map-missing, or invalid-map results. The original generated tree was restored afterward.
- Source/config gates: `node --check test/playwright/playwright.config.component.mjs`, `git diff --check`, and `npm run agent-preflight -- --no-fix test/playwright/playwright.config.component.mjs` — passed; unrelated local `STALE_OVERLAY` warning only.

## Post-Merge Validation

- [ ] Rebase PR #15719 onto the landed preflight and retain its exact-head Linux `components` receipt for both restored #15374 witnesses.

## Evolution

The merged dev-server warning turned a misleading pair of cross-platform reds into a causal substrate signal: CI was rendering without the authored SCSS at all. Reusing the existing self-healing prerequisite at the component entrypoint repairs the oracle instead of weakening either witness.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session cb60301d-74a4-4024-b80d-2f7efdbf9cd1.
