### PR TITLE
fix(test): isolate Boot envelope empty-env fixture (#15622)

### DIFF
--- a/test/playwright/unit/ai/mcp/server/shared/services/BootEnvelopeResolver.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/BootEnvelopeResolver.spec.mjs
@@ -52,7 +52,23 @@ test.describe('Neo.ai.mcp.server.shared.services.BootEnvelopeResolver (#12418)',
         expect(BootEnvelopeResolver.resolveOverrideMetadata({
             NEO_HARNESS_INSTANCE_ADDRESS     : '',
             NEO_HARNESS_INSTANCE_ADDRESS_TYPE: '   '
+        }, {
+            enableParentChainFallback: false
         })).toBeNull();
+    });
+
+    test('empty-string env vars still permit the Electron parent-chain fallback', () => {
+        expect(BootEnvelopeResolver.resolveOverrideMetadata({
+            NEO_HARNESS_INSTANCE_ADDRESS     : '',
+            NEO_HARNESS_INSTANCE_ADDRESS_TYPE: '   '
+        }, {
+            bootPid : 90001,
+            platform: 'darwin',
+            psOutput: PS_ELECTRON_PARENT_CHAIN
+        })).toEqual({
+            instanceAddress: NEO_DIR,
+            addressType    : 'userDataDir'
+        });
     });
 
     test('userDataDir envelope yields the generic address override the daemon reads', () => {


### PR DESCRIPTION
Resolves #15622

The Boot envelope unit fixture no longer lets the host process topology decide its empty-string default-instance assertion. That row disables the existing parent-chain fallback explicitly, while a new deterministic witness supplies an Electron helper-to-main process snapshot and proves that the same empty strings remain absent values which permit fallback discovery.

Evidence: L2 (exact-source falsifier plus deterministic injected Electron parent-chain coverage and focused unit execution) → L2 required (fixture isolation and regression witness through the existing injectable seam). No residuals.

## Deltas from ticket

The ticket described a “parent env” carrying `--user-data-dir`; the production source of authority is the injected `ps` command-line snapshot. The witness uses that actual seam. No environment scrubbing or production code change was introduced.

## Test Evidence

- Pre-change exact-source falsifier: empty strings plus the injected Electron chain resolved `{instanceAddress: NEO_DIR, addressType: 'userDataDir'}`; the same envelope with `enableParentChainFallback:false` returned `null`.
- Touched surface — `BootEnvelopeResolver`: `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/BootEnvelopeResolver.spec.mjs` — 18 passed.
- Changed-file preflight: `npm run agent-preflight -- --no-fix test/playwright/unit/ai/mcp/server/shared/services/BootEnvelopeResolver.spec.mjs` — passed.
- Full unit suite: 8,937 passed and 6 skipped; two unrelated full-order/load cases failed (`Auth.spec.mjs` and `lintTreeJson.spec.mjs`). The immediate exact two-spec rerun passed 42/42.
- `git diff --check`, cached diff validation, and commit-time whitespace, shorthand, AiConfig-test-mutation, JSDoc-type, ticket-archaeology, staged-alignment, and parse gates — passed.

## Post-Merge Validation

- [ ] Confirm the exact-head CI unit job passes in sterile CI.
- [ ] Run the focused Boot suite on an Electron-parent-chain seat as an independent host-topology receipt.

Authored by Euclid (GPT-5, Codex Desktop). Session bb641b19-2dcb-4fd5-bd85-97a17cf162c3.
