### PR TITLE
fix(harness): parse literal imports from syntax (#15723)

### DIFF
--- a/harness/pack.mjs
+++ b/harness/pack.mjs
@@ -24,6 +24,7 @@ import fs                                           from 'node:fs';
 import {builtinModules}                             from 'node:module';
 import path                                         from 'node:path';
 import {fileURLToPath}                              from 'node:url';
+import {parse}                                      from 'acorn';
 import {ALLOWED_EXACT_PATHS, ALLOWED_PATH_PREFIXES} from './contentPolicy.mjs';
 
 const
@@ -141,37 +142,56 @@ export function deriveCopySpecs() {
     return {files: [...files].sort(), trees: [...trees].sort()}
 }
 
-const
-    IMPORT_SPECIFIER_RE = /(?:from\s+|import\s+|import\s*\(\s*)['"]([^'"\n]+)['"]/g,
-    // npm package-name shape — rejects the prose/template fragments a naive scan of JSDoc
-    // examples and interpolated strings would otherwise surface as "packages".
-    PACKAGE_NAME_RE     = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+// npm package-name shape — rejects non-package specifiers before manifest projection.
+const PACKAGE_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
 
 /**
- * @summary Strips line and block comments so JSDoc example snippets ("import x from 'pkg'") never
- * reach the specifier scan. Deliberately naive (a `//` inside a string literal would truncate the
- * line) — the derivation is fail-loud downstream: an over-strip surfaces as a missing declared
- * package at install/boot, never as a silent ship.
- * @param {String} source
- * @returns {String}
- */
-function stripComments(source) {
-    return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
-}
-
-/**
- * @summary Extracts unique string-literal module specifiers from static imports, side-effect
- * imports, re-exports, and dynamic `import()` calls after removing comments. Non-literal dynamic
- * expressions remain deliberately outside this bounded packaging guard.
+ * @summary Extracts unique string-literal module specifiers from JavaScript syntax: static imports,
+ * side-effect imports, re-exports, and dynamic `import()` expressions. Ordinary strings, template
+ * text, comments, and non-literal dynamic expressions remain inert. Module syntax is attempted
+ * first; a script fallback covers staged CommonJS sources. Unparseable source fails the pack loudly.
  * @param {String} source
  * @returns {String[]}
  */
 export function extractLiteralImportSpecifiers(source) {
+    const
+        options = {allowHashBang: true, ecmaVersion: 'latest'},
+        text    = String(source);
+
+    let ast;
+
+    try {
+        ast = parse(text, {...options, sourceType: 'module'})
+    } catch (moduleError) {
+        try {
+            ast = parse(text, {...options, allowReturnOutsideFunction: true, sourceType: 'script'})
+        } catch (scriptError) {
+            throw new SyntaxError(`pack import scan could not parse source as module (${moduleError.message}) or script (${scriptError.message})`)
+        }
+    }
+
     const specifiers = new Set();
 
-    for (const match of stripComments(source).matchAll(IMPORT_SPECIFIER_RE)) {
-        specifiers.add(match[1])
-    }
+    const visit = node => {
+        if (!node || typeof node !== 'object') return;
+
+        if ((node.type === 'ImportDeclaration' || node.type === 'ExportNamedDeclaration' || node.type === 'ExportAllDeclaration') &&
+            node.source?.type === 'Literal' && typeof node.source.value === 'string') {
+            specifiers.add(node.source.value)
+        } else if (node.type === 'ImportExpression' && node.source?.type === 'Literal' && typeof node.source.value === 'string') {
+            specifiers.add(node.source.value)
+        }
+
+        for (const value of Object.values(node)) {
+            if (Array.isArray(value)) {
+                value.forEach(visit)
+            } else if (value?.type) {
+                visit(value)
+            }
+        }
+    };
+
+    visit(ast);
 
     return [...specifiers].sort()
 }
@@ -190,8 +210,8 @@ export function extractLocalMjsImports(source) {
 
 /**
  * @summary Extracts the BARE (package) import specifiers from one module source: static imports,
- * side-effect imports, re-exports, and string-literal dynamic imports. Comments are stripped
- * first; relative (`./`), absolute, subpath-alias (`#`), and node built-in specifiers are
+ * side-effect imports, re-exports, and string-literal dynamic imports. Relative (`./`), absolute,
+ * subpath-alias (`#`), and node built-in specifiers are
  * excluded; non-npm-shaped candidates are dropped; subpath imports reduce to their package name
  * (`chromadb/x` → `chromadb`, `@scope/pkg/x` → `@scope/pkg`).
  * @param {String} source

--- a/test/playwright/unit/harness/pack.spec.mjs
+++ b/test/playwright/unit/harness/pack.spec.mjs
@@ -8,13 +8,32 @@ import {
     assertNoInstanceOverlays,
     buildNodeShim,
     buildOrganismManifest,
+    collectTreeBarePackages,
     deriveCopySpecs,
     extractBarePackages,
+    extractLiteralImportSpecifiers,
     extractLocalMjsImports,
     isInstanceOverlayPath
 } from '../../../../harness/pack.mjs';
 import {buildPackagedBrainEnv, resolveBrainMode} from '../../../../harness/brain.mjs';
 import path                                      from 'node:path';
+
+/**
+ * @summary Fails when JavaScript syntax resolves to a parent-root Brain or Body import. Normalizing
+ * the literal before comparison closes equivalent spellings such as `../middle/../ai/module.mjs`.
+ * @param {String} source
+ * @returns {void}
+ */
+function assertNoParentRootImports(source) {
+    const offenders = extractLiteralImportSpecifiers(source)
+        .map(specifier => path.posix.normalize(specifier))
+        .filter(specifier => specifier === '../ai' || specifier.startsWith('../ai/') ||
+            specifier === '../src' || specifier.startsWith('../src/'));
+
+    if (offenders.length) {
+        throw new Error(`packaged harness source imports forbidden parent roots: ${offenders.join(', ')}`)
+    }
+}
 
 test.describe('harness pack stage', () => {
     test('packaged main imports are closed over app.asar and parent-root contracts are forbidden', async () => {
@@ -35,11 +54,30 @@ test.describe('harness pack stage', () => {
             expect(builderConfig).toContain(`- ${importedFile}`)
         }
 
-        for (const source of [brainSource, capabilitySource, mainSource]) {
-            expect(source).not.toMatch(/from\s+['"]\.\.\/(?:ai|src)\//)
-        }
+        [brainSource, capabilitySource, mainSource].forEach(assertNoParentRootImports);
 
         expect(mainSource).toContain('loadFleetRuntimeContracts(organismRoot)')
+    });
+
+    test('parent-root guard covers static, re-export, side-effect, and literal dynamic imports after normalization', () => {
+        for (const source of [
+            "import Brain from '../ai/Brain.mjs';",
+            "import {Neo} from '../src/Neo.mjs';",
+            "import '../src/Neo.mjs';",
+            "export {Brain} from '../ai/Brain.mjs';",
+            "export * from '../src/core/_export.mjs';",
+            "const Brain = import('../middle/../ai/Brain.mjs');"
+        ]) {
+            expect(() => assertNoParentRootImports(source)).toThrow(/forbidden parent roots/)
+        }
+
+        expect(() => assertNoParentRootImports([
+            "const prose = \"import('../ai/Brain.mjs')\";",
+            "const template = `import('../src/Neo.mjs')`;",
+            "const runtime = import(runtimeSpecifier);",
+            "// import '../ai/Brain.mjs';",
+            "/* export * from '../src/core/_export.mjs'; */"
+        ].join('\n'))).not.toThrow()
     });
 
     test('deriveCopySpecs rides the contentPolicy allowlist plus the Brain trees, skipping node_modules entries', () => {
@@ -82,6 +120,30 @@ test.describe('harness pack stage', () => {
         expect(extractBarePackages(source)).toEqual(['@scope/pkg', 'better-sqlite3', 'chromadb', 'dotenv', 'fs-extra'])
     });
 
+    test('extractLiteralImportSpecifiers follows syntax without matching strings, templates, comments, or expressions', () => {
+        const source = [
+            "import StaticDefault from './static-default.mjs';",
+            "import './side-effect.mjs';",
+            "export {named} from './re-export.mjs';",
+            "export * from './re-export-all.mjs';",
+            "const lazy = import('./dynamic.mjs');",
+            "const prose = \"import './ordinary-string.mjs'\";",
+            "const sentence = \"value from './ordinary-from.mjs'\";",
+            "const template = `export * from './template.mjs'`;",
+            "const runtime = import(runtimeSpecifier);",
+            "// import './line-comment.mjs';",
+            "/* import('./block-comment.mjs'); */"
+        ].join('\n');
+
+        expect(extractLiteralImportSpecifiers(source)).toEqual([
+            './dynamic.mjs',
+            './re-export-all.mjs',
+            './re-export.mjs',
+            './side-effect.mjs',
+            './static-default.mjs'
+        ])
+    });
+
     test('extractLocalMjsImports covers every literal local module shape without parsing comments or expressions', () => {
         const source = [
             "import StaticDefault from './static-default.mjs';",
@@ -101,6 +163,33 @@ test.describe('harness pack stage', () => {
             'side-effect.mjs',
             'static-default.mjs'
         ])
+    });
+
+    test('collectTreeBarePackages scans staged mjs, cjs, and js files through the shared syntax scanner', async () => {
+        const root = await mkdtemp(path.join(tmpdir(), 'neo-pack-import-scan-'));
+
+        try {
+            writeFileSync(path.join(root, 'module.mjs'), [
+                "import MjsPackage from 'mjs-package';",
+                "const prose = \"import 'mjs-ghost'\";"
+            ].join('\n'), 'utf8');
+            writeFileSync(path.join(root, 'common.cjs'), [
+                "void import('cjs-package/subpath');",
+                "// import('cjs-ghost');"
+            ].join('\n'), 'utf8');
+            writeFileSync(path.join(root, 'plain.js'), [
+                "export {value} from '@scope/js-package/deep/path.mjs';",
+                "const runtime = import(runtimeSpecifier);"
+            ].join('\n'), 'utf8');
+
+            expect(collectTreeBarePackages({rootDir: root})).toEqual([
+                '@scope/js-package',
+                'cjs-package',
+                'mjs-package'
+            ])
+        } finally {
+            await rm(root, {force: true, recursive: true})
+        }
     });
 
     test('buildOrganismManifest pins scanned packages to repo-declared versions and fails loud on undeclared imports', () => {


### PR DESCRIPTION
Resolves #15723

The packaged source boundary now derives literal module specifiers from JavaScript syntax through the repository's existing Acorn authority. Static imports, side-effect imports, re-exports, and string-literal dynamic imports feed the same local-closure, bare-package, and normalized parent-root consumers; import-shaped prose, templates, comments, and computed dynamic imports stay inert.

Evidence: L2 (exact baseline falsifiers, focused unit coverage, and a production-stage-tree parser scan) → L2 required (all syntax-scanner and packaging-guard ACs). Residual: none [`#15723`].

## Deltas from ticket

None substantive. The implementation uses the prescribed existing parser dependency, attempts module syntax before a CommonJS-compatible script fallback, and keeps the installed `app.asar` local-import closure on the same shared extractor.

## Test Evidence

- Red-before exact `origin/dev` expressions: the ordinary string witness yielded `['../src/string.mjs']`, while the literal dynamic parent-root witness returned `dynamicParentRootRejected: false`.
- Green-after direct probe: the ordinary string yielded no specifiers and the normalized literal dynamic parent-root witness returned `dynamicParentRootRejected: true`.
- Packaging closure surface — `npm run test-unit -- test/playwright/unit/harness/pack.spec.mjs --workers=1 --reporter=dot` — 13 passed, including the existing packaged-main / `app.asar` closure witness.
- Production stage-tree probe through `deriveCopySpecs()` + `collectTreeBarePackages()` parsed `ai`, `apps/agentos`, `dist/development/css`, and `src` successfully.
- Changed-file preflight — `npm run agent-preflight -- harness/pack.mjs test/playwright/unit/harness/pack.spec.mjs` plus the final `--no-fix` pass — passed.
- `node --check`, `git diff --check`, cached-diff validation, and commit-time whitespace, shorthand, AiConfig-test-mutation, JSDoc-type, ticket-archaeology, staged-alignment, and parse gates — passed.

## Post-Merge Validation

- [ ] Confirm the exact-head CI unit and agent-body gates pass in sterile CI.
- [ ] Build the packaged harness on a supported host and execute the installed first-paint/import witness against the resulting `app.asar`.

Authored by Euclid (GPT-5, Codex Desktop). Session bb641b19-2dcb-4fd5-bd85-97a17cf162c3.
