### PR TITLE
fix(agentos): explicitly-wired fleet bridges render the true zero state (#15680)

### DIFF
--- a/apps/agentos/view/ViewportController.mjs
+++ b/apps/agentos/view/ViewportController.mjs
@@ -53,7 +53,10 @@ class ViewportController extends Controller {
      *     not a live handle carrying the credentialed `send`).
      */
     wireFleetBridge(config) {
-        installFleetBridge(config);
+        // The injector IS the selection act: Neural Link, tests, and dev tooling wiring a bridge
+        // here means "this source was deliberately chosen" — its empty registry renders the true
+        // zero state. The packaged/default boot installs elsewhere and keeps the sample flagship.
+        installFleetBridge({...config, selected: true});
         return true
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -2072,9 +2072,11 @@ class FleetCockpit extends Container {
             // The shipped sample is the cold-first-run authority. A reachable but fresh/empty
             // private registry has answered, but it has not supplied a working fleet and no source
             // was selected — replacing the sample here would turn successful boot into an empty
-            // flagship. Once selected or once any populated snapshot made the surface live, empty
-            // regains its ordinary authoritative meaning (the real fleet may genuinely drain).
-            if (!me.rosterWired && mapped.length === 0 && me.rosterSourceMode !== 'selected') {
+            // flagship. An explicitly wired bridge (the injector marks it `selected`) IS a source
+            // selection, so its empty registry renders the true zero state; once any populated
+            // snapshot made the surface live, empty regains its ordinary authoritative meaning
+            // (the real fleet may genuinely drain).
+            if (!me.rosterWired && mapped.length === 0 && !bridge?.selected && me.rosterSourceMode !== 'selected') {
                 return
             }
 

--- a/src/ai/fleet/installFleetBridge.mjs
+++ b/src/ai/fleet/installFleetBridge.mjs
@@ -48,6 +48,9 @@ const FORBIDDEN_URL_CREDENTIAL_PARAMS = ['bearer', 'bearerToken', 'fleetBearer',
  * @param {Function} [opts.send=null]                      Packaged-shell transport; mutually exclusive
  *     with `url` / `bearerToken`.
  * @param {'worker'|'shell'} [opts.credentialIngress='worker'] Public credential-custody fact.
+ * @param {Boolean}  [opts.selected=false]                 Whether this install is an explicit source
+ *     selection (the injector path) versus the boot default. Selected bridges render an empty
+ *     registry's true zero state; unselected defaults keep the zero-setup sample.
  * @param {Object}   [opts.target=globalThis]              Injectable global for tests.
  * @returns {Object} the installed registry bridge (also reachable at `target.AgentOS.fleet.registryBridge`).
  */
@@ -57,6 +60,7 @@ export function installFleetBridge({
     fetchImpl = globalThis.fetch,
     send = null,
     credentialIngress = 'worker',
+    selected = false,
     target = globalThis
 } = {}) {
     const endpointError = 'installFleetBridge requires an absolute loopback HTTP(S) fleet URL';
@@ -127,6 +131,14 @@ export function installFleetBridge({
     Object.defineProperty(registryBridge, 'credentialIngress', {
         configurable: true,
         value       : credentialIngress
+    });
+
+    // An explicitly wired bridge (the ViewportController injector — Neural Link, tests, dev
+    // tooling) marks `selected: true`: an empty registry from a deliberately chosen source renders
+    // its TRUE zero state, while the boot-default install keeps the zero-setup sample flagship.
+    Object.defineProperty(registryBridge, 'selected', {
+        configurable: true,
+        value       : selected
     });
 
     agentOS.fleet                = agentOS.fleet || {};

--- a/test/playwright/unit/ai/services/fleet/installFleetBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/installFleetBridge.spec.mjs
@@ -28,6 +28,17 @@ const fleetUrl   = 'http://127.0.0.1:8083/fleet',
       okFetch    = () => async () => ({json: async () => ({ok: true, result: null})});
 
 test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->fleet HTTP transport', () => {
+    test('the selected flag: default install is unselected; the injector-style install stamps selected', () => {
+        const targetDefault  = {},
+              targetSelected = {};
+
+        const bridgeDefault  = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target: targetDefault});
+        const bridgeSelected = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), selected: true, target: targetSelected});
+
+        expect(Object.getOwnPropertyDescriptor(bridgeDefault, 'selected')).toMatchObject({enumerable: false, value: false});
+        expect(Object.getOwnPropertyDescriptor(bridgeSelected, 'selected')).toMatchObject({enumerable: false, value: true});
+    });
+
     test('publishes AgentOS.fleet.registryBridge with exactly the wire operations', () => {
         const target = {};
         const bridge = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target});


### PR DESCRIPTION
Resolves #15680

Source-mode AgentOS E2E journeys boot against the host's real fleet-registry state — every swarm seat false-redded on `Fleet · 7 agents` (now 10) against journeys written for a zero state. Root cause, verified live on this host (two `devFleetServer` processes on 8083, 10-agent sample): the cockpit's `loadRoster` cold-first-run guard refuses to replace the sample flagship with an empty wired registry — even when the wiring was deliberate. The guard was right for the zero-setup default (#15564: a fresh private registry must not blank the sample first paint) and wrong for an explicitly chosen source.

The fix is a one-flag semantic: `installFleetBridge` stamps `selected: false` by default; the `ViewportController.wireFleetBridge` injector (Neural Link, tests, dev tooling — the selection act) stamps `selected: true`; the guard now reads `!bridge?.selected`, so an explicitly wired empty registry renders the TRUE zero state (bootstrap CTA → graduation → CTA retirement → Start), while the packaged/default boot (`app.mjs` onStart, which never touches the injector) keeps the zero-setup sample flagship untouched.

Evidence: L3 (the exact failing journey green on the host that reddened it, plus the unselected-path render unchanged) → L3 required (rendered-surface behavior change). Residual: the `cockpit-default-shell` visual golden is stale from the `#15621` roster-seed change (1983px / 1% content drift — pre-existing on dev, NOT this branch; the visual spec has no bridge, so the guard never fires there; refresh belongs to the FM visual lane, not this PR).

## Deltas from ticket

The ticket sketched two isolation shapes (spec-side roster seed vs profile isolation). The diagnosis found a third, better one: the isolation exists (the journey already wires an empty loopback) — the blocker was the cockpit treating a deliberately-wired empty registry as unselected. The fix is the source-selection semantic (`selected` on the bridge), not a test workaround or a second registry.

## Test Evidence

- `test/playwright/e2e/agentos/AddAgentJourneyNL.spec.mjs` (the exact July-20 failing journey): **1/1 green on this host** — with TWO live `devFleetServer` processes on 8083 and the 10-agent sample present (the exact red environment: "Fleet · 7 agents" then, "Fleet · 10 agents" now)
- `test/playwright/e2e/agentos/` full directory: green (309s benchmark, zero failures)
- `test/playwright/unit/ai/services/fleet/installFleetBridge.spec.mjs`: 13/13 (incl. the new `selected` flag witness: default unselected, injector-style selected)
- `npm run agent-preflight -- --no-fix` on all four files: passed

## Post-Merge Validation

- [ ] The visual lane refreshes the `cockpit-default-shell` golden under its refresh discipline (stale since `#15621` — pre-existing, owned there, not here)
- [ ] Any future explicit consumer of `installFleetBridge` that IS a zero-setup default keeps `selected: false` (the default) — the sample contract depends on it

Authored by Phoebe (Kimi K3, OpenCode). Session 72c8c42d-f18a-408c-97c8-aeb1f82dd276.
