### PR TITLE
test(ai): session summarization latency is telemetry, not a gate (#15722)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
@@ -573,8 +573,14 @@ test.describe('Memory Core Offline Summarization', () => {
 
         const durationMs = end - start;
 
+        // Elapsed latency is an OBSERVATION, not a gate: it moves with model load, host load, and
+        // cold/warm model state (a 43.6s red on a loaded live seat proved a hard number is ambient,
+        // not defect signal). The deterministic contract is that summarization completes and
+        // returns the session. A real latency regression belongs to the benchmark class, not a
+        // pass/fail unit assertion.
+        console.log(`[SessionSummarization] live summarization latency: ${durationMs}ms`);
+
         expect(result).not.toBeNull();
         expect(result.sessionId).toBe(perfSessionId);
-        expect(durationMs).toBeLessThan(40000);
     });
 });


### PR DESCRIPTION
Resolves #15722

Euclid's intake receipt (his live seat, `origin/dev`): the live model call measured **43,629 ms** against the spec's hard **40,000 ms** assertion — the only red in the file, and not a defect: elapsed latency moves with model load, host load, and cold/warm model state. A hard wall-clock threshold on a model-latency assertion is non-deterministic by construction.

**Decision (the ticket's own option b):** the deterministic contract is that summarization *completes and returns the session* — latency is telemetry, not a gate. The assertion is replaced with a logged observation (`console.log` of the measured latency), preserving the signal as a record without making ambient load a pass/fail input. A real latency regression belongs to the benchmark class, not a unit assertion.

Evidence: L2 (the spec passes with the completion contract intact; the old gate's red was ambient by construction — Euclid's 43.6s receipt) → L2 required (test-shape change only, no runtime behavior).

## Deltas from ticket

The ticket offered three options (deterministic-gate / statistical-threshold / remove-the-hard-number). Chose the third: no latency gate at all in the unit layer, with the observation preserved as a log line. The completion contract (`result` non-null, correct `sessionId`) is unchanged.

## Test Evidence

- `test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs` — 8/8 passed (the full file, incl. the live-model path that measured 29.5s on this host; the latency now logs as telemetry)
- `npm run agent-preflight -- --no-fix` — passed

## Post-Merge Validation

- [ ] A loaded live seat (Euclid's, which measured 43.6s) goes green on the file without environment changes

Authored by Phoebe (Kimi K3, OpenCode). Session 72c8c42d-f18a-408c-97c8-aeb1f82dd276.
