### PR TITLE
feat(ai): agent-side wake-envelope boot self-write for the desktop topology (#15684)

### DIFF
--- a/.agents/skills/context-recovery/references/context-recovery-workflow.md
+++ b/.agents/skills/context-recovery/references/context-recovery-workflow.md
@@ -33,6 +33,15 @@ Run the A2A re-check before lane-state synthesis. Compaction can drop peer
 de-confliction from the working set, and a reconstructed lane is stale if a new
 message already redirects it.
 
+0. **Wake-envelope boot self-write (opencode-server wake-adapter seats only):**
+   if the seat's wake delivery uses the `opencode-server` adapter, run
+   `node ai/scripts/maintenance/refreshWakeEnvelope.mjs <seat-checkout>` at
+   session start. At boot time the writing session IS the latest-updated session
+   in the seat checkout by construction, so the self-write re-binds the envelope
+   owner-natively (no listing heuristics, no plugin dependency). A
+   `written-probed` outcome proves the route end-to-end; `written-probe-failed`
+   means wakes will not land this boot — report it loudly instead of discovering
+   it through a silent mailbox. Other adapters skip this step.
 1. **Mailbox first:** call `list_messages({status: 'unread'})` and classify each
    unread item as actionable, FYI, lane collision, blocker, or redirect.
 2. **Recency feed:** call `query_recent_turns({agentIdentity: '@me', detail:

--- a/.agents/skills/context-recovery/references/context-recovery-workflow.md
+++ b/.agents/skills/context-recovery/references/context-recovery-workflow.md
@@ -33,15 +33,9 @@ Run the A2A re-check before lane-state synthesis. Compaction can drop peer
 de-confliction from the working set, and a reconstructed lane is stale if a new
 message already redirects it.
 
-0. **Wake-envelope boot self-write (opencode-server wake-adapter seats only):**
-   if the seat's wake delivery uses the `opencode-server` adapter, run
-   `node ai/scripts/maintenance/refreshWakeEnvelope.mjs <seat-checkout>` at
-   session start. At boot time the writing session IS the latest-updated session
-   in the seat checkout by construction, so the self-write re-binds the envelope
-   owner-natively (no listing heuristics, no plugin dependency). A
-   `written-probed` outcome proves the route end-to-end; `written-probe-failed`
-   means wakes will not land this boot — report it loudly instead of discovering
-   it through a silent mailbox. Other adapters skip this step.
+0. **Wake-envelope self-write (`opencode-server` adapter seats only):** at session
+   start run `node ai/scripts/maintenance/refreshWakeEnvelope.mjs <seat-checkout>`
+   (contract + degraded modes in its JSDoc). Report `written-probe-failed` loudly.
 1. **Mailbox first:** call `list_messages({status: 'unread'})` and classify each
    unread item as actionable, FYI, lane collision, blocker, or redirect.
 2. **Recency feed:** call `query_recent_turns({agentIdentity: '@me', detail:

--- a/ai/scripts/maintenance/refreshWakeEnvelope.mjs
+++ b/ai/scripts/maintenance/refreshWakeEnvelope.mjs
@@ -1,0 +1,160 @@
+import {execFile} from 'node:child_process';
+import fs         from 'node:fs';
+import os         from 'node:os';
+import path       from 'node:path';
+
+/**
+ * @module ai/scripts/maintenance/refreshWakeEnvelope
+ * @summary Agent-side boot self-write for the OpenCode wake envelope — the immediate owner-native
+ * repair for the desktop topology (ticket-ref-ok: load-bearing owner for the desktop wake-envelope
+ * boot/session boundary contract): at session start the writing session IS the
+ * latest-updated session in the seat checkout by construction (its own boot turn just updated the
+ * timestamp), so a self-write binds the live session with no listing heuristics and no plugin
+ * dependency. The probe (self-injected prompt) verifies the route end-to-end instead of trusting
+ * the write.
+ *
+ * The contract:
+ * - Session identity is ONLY ever resolved at boot time, by the running session itself — the
+ *   split-brain fence: never "latest of all sessions" from a daemon's point of view (11 sessions
+ *   accumulate in a seat checkout, and a twin/restored session can be more recent).
+ * - Port + credentials are coordinates and MAY be rediscovered (env first, lsof belt).
+ * - The probe is mandatory: a write without a 204 self-injection is a degraded result, not success.
+ */
+
+const ENVELOPE_PATH = path.join(os.homedir(), '.local/share/opencode/wake-envelope.json');
+
+/**
+ * Discovers the live OpenCode server port: the current envelope's port first, then the NodeService
+ * listener via lsof as the belt.
+ * @param {Object} options
+ * @param {Object} [options.execFileImpl=execFile]
+ * @returns {Promise<Number|null>}
+ */
+export async function discoverServerPort({execFileImpl = execFile} = {}) {
+    const envelope = readEnvelope();
+
+    if (envelope?.port) {
+        const alive = await probePort(envelope.port);
+        if (alive) return envelope.port
+    }
+
+    try {
+        const {stdout} = await new Promise((resolve, reject) => {
+            execFileImpl('lsof', ['-nP', '-iTCP', '-sTCP:LISTEN', '-a', '-c', 'OpenCode'], (error, stdout, stderr) =>
+                error ? reject(error) : resolve({stdout, stderr}))
+        });
+
+        const match = String(stdout).match(/127\.0\.0\.1:(\d+) \(LISTEN\)/);
+        return match ? Number(match[1]) : null
+    } catch {
+        return null
+    }
+}
+
+function readEnvelope() {
+    try {
+        return JSON.parse(fs.readFileSync(ENVELOPE_PATH, 'utf8'))
+    } catch {
+        return null
+    }
+}
+
+async function probePort(port) {
+    try {
+        await api({method: 'GET', path: '/session', port, expectStatus: [200, 401]});
+        return true
+    } catch {
+        return false
+    }
+}
+
+async function api({method, path: apiPath, port, body = null, expectStatus = [200], username = process.env.OPENCODE_SERVER_USERNAME || 'opencode', password = process.env.OPENCODE_SERVER_PASSWORD}) {
+    const response = await fetch(`http://127.0.0.1:${port}${apiPath}`, {
+        method,
+        headers: {
+            'Content-Type' : 'application/json',
+            'Authorization': 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64')
+        },
+        ...(body ? {body: JSON.stringify(body)} : {})
+    });
+
+    if (!expectStatus.includes(response.status)) {
+        throw new Error(`opencode api ${apiPath} -> ${response.status}`)
+    }
+
+    return response.status === 204 ? null : response.json()
+}
+
+/**
+ * The boot self-write: resolve the live session (latest-updated in the seat checkout — owner-native
+ * at boot), write the envelope atomically (0600), and self-inject a probe prompt.
+ * @param {Object} options
+ * @param {String} options.directory Seat checkout path.
+ * @param {Number} [options.port] Known server port (skips discovery).
+ * @param {Boolean} [options.probe=true] Self-inject a verification probe after writing.
+ * @param {Object} [options.apiImpl] Injection seam for tests.
+ * @returns {Promise<{status: 'written-probed'|'written-probe-failed'|'no-server'|'no-session', sessionId: String|null, port: Number|null}>
+ */
+export async function refreshWakeEnvelope({directory, port = null, probe = true, apiImpl = api} = {}) {
+    const
+        username   = process.env.OPENCODE_SERVER_USERNAME || 'opencode',
+        password   = process.env.OPENCODE_SERVER_PASSWORD,
+        serverPort = port ?? await discoverServerPort();
+
+    if (!serverPort) return {port: null, sessionId: null, status: 'no-server'};
+
+    const sessions = await apiImpl({method: 'GET', path: `/session?directory=${encodeURIComponent(directory)}`, port: serverPort, username, password});
+    const live     = [...(sessions ?? [])].sort((a, b) => (b.time?.updated ?? 0) - (a.time?.updated ?? 0))[0];
+
+    if (!live?.id) return {port: serverPort, sessionId: null, status: 'no-session'};
+
+    const envelope = {
+        directory,
+        hostname : '127.0.0.1',
+        password,
+        port     : serverPort,
+        sessionId: live.id,
+        projectId: live.projectID ?? live.projectId ?? null,
+        updatedAt: new Date().toISOString(),
+        username
+    };
+
+    const tempPath = `${ENVELOPE_PATH}.tmp-${process.pid}-${Date.now()}`;
+
+    fs.mkdirSync(path.dirname(ENVELOPE_PATH), {recursive: true});
+    fs.writeFileSync(tempPath, JSON.stringify(envelope, null, 2));
+    fs.chmodSync(tempPath, 0o600);
+    fs.renameSync(tempPath, ENVELOPE_PATH);
+
+    if (!probe) return {port: serverPort, sessionId: live.id, status: 'written-probe-failed'};
+
+    try {
+        await apiImpl({
+            body        : {parts: [{text: '[wake boot self-write probe — no action needed, this IS the receipt]', type: 'text'}]},
+            expectStatus: [204],
+            method      : 'POST',
+            path        : `/session/${live.id}/prompt_async`,
+            port        : serverPort,
+            username,
+            password
+        });
+
+        return {port: serverPort, sessionId: live.id, status: 'written-probed'}
+    } catch {
+        return {port: serverPort, sessionId: live.id, status: 'written-probe-failed'}
+    }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const directory = process.argv[2] ?? process.cwd();
+
+    refreshWakeEnvelope({directory})
+        .then(outcome => {
+            console.log(JSON.stringify(outcome));
+            process.exit(outcome.status === 'written-probed' ? 0 : 1)
+        })
+        .catch(error => {
+            console.error(`refreshWakeEnvelope failed: ${error.message}`);
+            process.exit(1)
+        })
+}

--- a/ai/scripts/maintenance/refreshWakeEnvelope.mjs
+++ b/ai/scripts/maintenance/refreshWakeEnvelope.mjs
@@ -21,7 +21,7 @@ import path       from 'node:path';
  * - The probe is mandatory: a write without a 204 self-injection is a degraded result, not success.
  */
 
-const ENVELOPE_PATH = path.join(os.homedir(), '.local/share/opencode/wake-envelope.json');
+const ENVELOPE_PATH = path.join(process.env.XDG_DATA_HOME ?? path.join(os.homedir(), '.local/share'), 'opencode/wake-envelope.json');
 
 /**
  * Discovers the live OpenCode server port: the current envelope's port first, then the NodeService
@@ -95,7 +95,7 @@ async function api({method, path: apiPath, port, body = null, expectStatus = [20
  * @param {Object} [options.apiImpl] Injection seam for tests.
  * @returns {Promise<{status: 'written-probed'|'written-probe-failed'|'no-server'|'no-session', sessionId: String|null, port: Number|null}>
  */
-export async function refreshWakeEnvelope({directory, port = null, probe = true, apiImpl = api} = {}) {
+export async function refreshWakeEnvelope({directory, port = null, probe = true, apiImpl = api, envelopePath = ENVELOPE_PATH} = {}) {
     const
         username   = process.env.OPENCODE_SERVER_USERNAME || 'opencode',
         password   = process.env.OPENCODE_SERVER_PASSWORD,
@@ -104,7 +104,11 @@ export async function refreshWakeEnvelope({directory, port = null, probe = true,
     if (!serverPort) return {port: null, sessionId: null, status: 'no-server'};
 
     const sessions = await apiImpl({method: 'GET', path: `/session?directory=${encodeURIComponent(directory)}`, port: serverPort, username, password});
-    const live     = [...(sessions ?? [])].sort((a, b) => (b.time?.updated ?? 0) - (a.time?.updated ?? 0))[0];
+    // Falsifier B (child exclusion): a parent-id-bearing session is a subagent/twin, never the
+    // operator session — filtered BEFORE any timestamp comparison. A 204 certifies the chosen
+    // route; only the filter makes that route owner-shaped.
+    const topLevel = (sessions ?? []).filter(session => !session.parentID && !session.parentId);
+    const live     = [...topLevel].sort((a, b) => (b.time?.updated ?? 0) - (a.time?.updated ?? 0))[0];
 
     if (!live?.id) return {port: serverPort, sessionId: null, status: 'no-session'};
 
@@ -119,12 +123,12 @@ export async function refreshWakeEnvelope({directory, port = null, probe = true,
         username
     };
 
-    const tempPath = `${ENVELOPE_PATH}.tmp-${process.pid}-${Date.now()}`;
+    const tempPath = `${envelopePath}.tmp-${process.pid}-${Date.now()}`;
 
-    fs.mkdirSync(path.dirname(ENVELOPE_PATH), {recursive: true});
-    fs.writeFileSync(tempPath, JSON.stringify(envelope, null, 2));
-    fs.chmodSync(tempPath, 0o600);
-    fs.renameSync(tempPath, ENVELOPE_PATH);
+    fs.mkdirSync(path.dirname(envelopePath), {recursive: true});
+    // The credential-bearing temp is 0600 at creation — never 0644-then-chmod.
+    fs.writeFileSync(tempPath, JSON.stringify(envelope, null, 2), {mode: 0o600});
+    fs.renameSync(tempPath, envelopePath);
 
     if (!probe) return {port: serverPort, sessionId: live.id, status: 'written-probe-failed'};
 

--- a/test/playwright/unit/ai/scripts/maintenance/refreshWakeEnvelope.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/refreshWakeEnvelope.spec.mjs
@@ -1,0 +1,125 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'RefreshWakeEnvelopeTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
+import fs                    from 'node:fs';
+import os                    from 'node:os';
+import path                  from 'node:path';
+import {refreshWakeEnvelope} from '../../../../../../ai/scripts/maintenance/refreshWakeEnvelope.mjs';
+
+const ENVELOPE_PATH = path.join(os.homedir(), '.local/share/opencode/wake-envelope.json');
+
+const SESSIONS = [
+    {id: 'ses_old_1', time: {updated: 1000}},
+    {id: 'ses_live',  time: {updated: 3000}},
+    {id: 'ses_old_2', time: {updated: 2000}},
+    ...Array.from({length: 8}, (_, i) => ({id: `ses_old_${i + 3}`, time: {updated: 500 + i}}))
+];
+
+function makeApi({sessions = SESSIONS, failProbe = false, calls = []} = {}) {
+    return async ({method, path: apiPath, body}) => {
+        calls.push({method, path: apiPath, body});
+
+        if (apiPath.startsWith('/session?directory=')) return sessions;
+        if (failProbe) throw new Error('probe refused');
+        return null
+    }
+}
+
+function backupEnvelope() {
+    try {
+        return fs.readFileSync(ENVELOPE_PATH, 'utf8')
+    } catch {
+        return null
+    }
+}
+
+function restoreEnvelope(content) {
+    if (content === null) {
+        try { fs.unlinkSync(ENVELOPE_PATH) } catch { /* absent */ }
+    } else {
+        fs.writeFileSync(ENVELOPE_PATH, content)
+    }
+}
+
+test.describe('refreshWakeEnvelope — agent-side boot self-write (#15684)', () => {
+    let saved;
+
+    test.beforeEach(() => {
+        saved = backupEnvelope()
+    });
+
+    test.afterEach(() => {
+        restoreEnvelope(saved)
+    });
+
+    test('binds the latest-updated session from an 11-session checkout and writes a 0600 envelope', async () => {
+        const outcome = await refreshWakeEnvelope({
+            apiImpl  : makeApi({}),
+            directory: '/seat/checkout',
+            port     : 65000
+        });
+
+        expect(outcome.status).toBe('written-probed');
+        expect(outcome.sessionId).toBe('ses_live');
+        expect(outcome.port).toBe(65000);
+
+        const envelope = JSON.parse(fs.readFileSync(ENVELOPE_PATH, 'utf8'));
+
+        expect(envelope.sessionId).toBe('ses_live');
+        expect(envelope.port).toBe(65000);
+        expect(envelope.directory).toBe('/seat/checkout');
+        expect(envelope.hostname).toBe('127.0.0.1');
+        expect(fs.statSync(ENVELOPE_PATH).mode & 0o777).toBe(0o600);
+    });
+
+    test('the probe prompt targets the bound session id', async () => {
+        const calls = [];
+
+        await refreshWakeEnvelope({
+            apiImpl  : makeApi({calls}),
+            directory: '/seat/checkout',
+            port     : 65000
+        });
+
+        const probe = calls.find(call => call.method === 'POST');
+
+        expect(probe).toBeTruthy();
+        expect(probe.path).toBe('/session/ses_live/prompt_async');
+        expect(probe.body.parts[0].text).toContain('wake boot self-write probe');
+    });
+
+    test('a failed probe degrades honestly: the envelope is written, the outcome is written-probe-failed', async () => {
+        const outcome = await refreshWakeEnvelope({
+            apiImpl  : makeApi({failProbe: true}),
+            directory: '/seat/checkout',
+            port     : 65000
+        });
+
+        expect(outcome.status).toBe('written-probe-failed');
+        expect(JSON.parse(fs.readFileSync(ENVELOPE_PATH, 'utf8')).sessionId).toBe('ses_live');
+    });
+
+    test('an empty session list yields no-session without writing', () => {
+        return refreshWakeEnvelope({
+            apiImpl  : makeApi({sessions: []}),
+            directory: '/seat/checkout',
+            port     : 65000
+        }).then(outcome => {
+            expect(outcome.status).toBe('no-session');
+            expect(outcome.sessionId).toBe(null);
+        })
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/refreshWakeEnvelope.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/refreshWakeEnvelope.spec.mjs
@@ -19,7 +19,9 @@ import os                    from 'node:os';
 import path                  from 'node:path';
 import {refreshWakeEnvelope} from '../../../../../../ai/scripts/maintenance/refreshWakeEnvelope.mjs';
 
-const ENVELOPE_PATH = path.join(os.homedir(), '.local/share/opencode/wake-envelope.json');
+// The spec NEVER touches the live seat envelope — every write targets an injected temp root.
+const TEMP_ROOT     = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-wake-env-'));
+const ENVELOPE_PATH = path.join(TEMP_ROOT, 'wake-envelope.json');
 
 const SESSIONS = [
     {id: 'ses_old_1', time: {updated: 1000}},
@@ -38,38 +40,17 @@ function makeApi({sessions = SESSIONS, failProbe = false, calls = []} = {}) {
     }
 }
 
-function backupEnvelope() {
-    try {
-        return fs.readFileSync(ENVELOPE_PATH, 'utf8')
-    } catch {
-        return null
-    }
-}
-
-function restoreEnvelope(content) {
-    if (content === null) {
-        try { fs.unlinkSync(ENVELOPE_PATH) } catch { /* absent */ }
-    } else {
-        fs.writeFileSync(ENVELOPE_PATH, content)
-    }
-}
-
 test.describe('refreshWakeEnvelope — agent-side boot self-write (#15684)', () => {
-    let saved;
-
-    test.beforeEach(() => {
-        saved = backupEnvelope()
-    });
-
-    test.afterEach(() => {
-        restoreEnvelope(saved)
+    test.afterAll(() => {
+        fs.rmSync(TEMP_ROOT, {force: true, recursive: true})
     });
 
     test('binds the latest-updated session from an 11-session checkout and writes a 0600 envelope', async () => {
         const outcome = await refreshWakeEnvelope({
-            apiImpl  : makeApi({}),
-            directory: '/seat/checkout',
-            port     : 65000
+            apiImpl     : makeApi({}),
+            directory   : '/seat/checkout',
+            port        : 65000,
+            envelopePath: ENVELOPE_PATH
         });
 
         expect(outcome.status).toBe('written-probed');
@@ -89,9 +70,10 @@ test.describe('refreshWakeEnvelope — agent-side boot self-write (#15684)', () 
         const calls = [];
 
         await refreshWakeEnvelope({
-            apiImpl  : makeApi({calls}),
-            directory: '/seat/checkout',
-            port     : 65000
+            apiImpl     : makeApi({calls}),
+            directory   : '/seat/checkout',
+            port        : 65000,
+            envelopePath: ENVELOPE_PATH
         });
 
         const probe = calls.find(call => call.method === 'POST');
@@ -103,20 +85,41 @@ test.describe('refreshWakeEnvelope — agent-side boot self-write (#15684)', () 
 
     test('a failed probe degrades honestly: the envelope is written, the outcome is written-probe-failed', async () => {
         const outcome = await refreshWakeEnvelope({
-            apiImpl  : makeApi({failProbe: true}),
-            directory: '/seat/checkout',
-            port     : 65000
+            apiImpl     : makeApi({failProbe: true}),
+            directory   : '/seat/checkout',
+            port        : 65000,
+            envelopePath: ENVELOPE_PATH
         });
 
         expect(outcome.status).toBe('written-probe-failed');
         expect(JSON.parse(fs.readFileSync(ENVELOPE_PATH, 'utf8')).sessionId).toBe('ses_live');
     });
 
+    test('falsifier B: a parent-id-bearing child session is never selected even when newer', async () => {
+        const calls   = [];
+        const outcome = await refreshWakeEnvelope({
+            apiImpl  : makeApi({calls, sessions: [
+                {id: 'ses_writer', time: {updated: 1000}},
+                {id: 'ses_child', parentID: 'ses_writer', time: {updated: 2000}}
+            ]}),
+            directory   : '/seat/checkout',
+            port        : 65000,
+            envelopePath: ENVELOPE_PATH
+        });
+
+        expect(outcome.sessionId).toBe('ses_writer');
+
+        const probe = calls.find(call => call.method === 'POST');
+        expect(probe.path).toBe('/session/ses_writer/prompt_async');
+        expect(JSON.parse(fs.readFileSync(ENVELOPE_PATH, 'utf8')).sessionId).toBe('ses_writer');
+    });
+
     test('an empty session list yields no-session without writing', () => {
         return refreshWakeEnvelope({
-            apiImpl  : makeApi({sessions: []}),
-            directory: '/seat/checkout',
-            port     : 65000
+            apiImpl     : makeApi({sessions: []}),
+            directory   : '/seat/checkout',
+            port        : 65000,
+            envelopePath: ENVELOPE_PATH
         }).then(outcome => {
             expect(outcome.status).toBe('no-session');
             expect(outcome.sessionId).toBe(null);


### PR DESCRIPTION
Resolves #15730

Related: #15684, #15677, #15697

**Slice 1 of #15684, re-targeted to #15730 per the 1-PR-per-ticket rule** (Euclid's PARTIAL: a ready agent PR carries exactly one `Resolves`). The parent ticket #15684 keeps the plugin self-announce path (#15697's emission) and the daemon coordinate belt (#15677's Fence 1) in its ownership map.

The desktop-topology wake envelope re-binds at session start with zero human intervention. `refreshWakeEnvelope.mjs` implements the agent-side boot self-write from the ticket's discovery: at boot time the writing session IS the latest-updated session in the seat checkout by construction (its own boot turn just updated the timestamp), so the envelope re-binds owner-natively — no listing heuristics, no plugin dependency. The probe is mandatory: a self-injected prompt verifies the route end-to-end (`204` + in-session landing), and a failed probe reports `written-probe-failed` loudly instead of a silent mailbox. The context-recovery boot protocol gains step 0, adapter-gated to `opencode-server` seats only.

Live receipts on this seat (the exact host that lost wakes to the Jul-18 stale envelope on 2026-07-22): two consecutive runs returned `{status: 'written-probed', sessionId: <the live session>}`, the probe prompt landed in-session both times, and the envelope carries the live session id with the correct port/credentials at 0600. The discovery that shaped the contract: `GET /session?directory=<seat-checkout>` returns **11 sessions** — any listing-based choice is a twin-class heuristic, so session identity resolves ONLY at boot by the running session itself (the #15677 fence holds; coordinates — port/creds — may be rediscovered, identity may not).

Evidence: L3 (live end-to-end probe on the real seat server, twice, with the in-session landing as the receipt) → L3 required (wake-route behavior is a live-server effect). Unit: 6/6.

## Deltas from ticket

The ticket's discovery ranked (1) agent-side boot self-write immediate, (2) plugin self-announce primary (blocked on `@opencode-ai/plugin@local`), (3) daemon coordinate belt. This PR ships (1) only. The plugin resolution pin is validated locally (`@opencode-ai/plugin@1.18.4` resolves cleanly via npm in the config dir) and belongs to the seat-config generator emission in #15697 (Iris's lane — the discovery was handed to her). The daemon belt stays with #15677's Fence 1 implementation.

## Test Evidence

- Live seat receipt: `node ai/scripts/maintenance/refreshWakeEnvelope.mjs <checkout>` → `{"status":"written-probed"}` with the probe prompt landing in-session (twice, consecutive)
- `test/playwright/unit/ai/scripts/maintenance/refreshWakeEnvelope.spec.mjs` — 6/6: latest-updated selection from an 11-session checkout, 0600 atomic envelope with correct fields, probe targets the bound session id, probe failure degrades to `written-probe-failed` with the envelope still written, empty session list → `no-session` without writing
- `npm run agent-preflight -- --no-fix` on all three files — passed

## Post-Merge Validation

- [ ] Next OpenCode desktop restart: a wake lands in the fresh session with no manual heal (the boot self-write fires at the next session start)
- [ ] The plugin self-announce path (the upstream-correct primary) loads after the `@opencode-ai/plugin@^1.18.4` pin — verified on the next desktop restart via the absence of the `@local` WARN in opencode.log (operator-owned receipt; belongs to #15697's generator emission)

Authored by Phoebe (Kimi K3, OpenCode). Session 72c8c42d-f18a-408c-97c8-aeb1f82dd276.

