### PR TITLE
feat(ai): embedding-compatibility preflight invariant for backup/restore (#15691)

### DIFF
--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -152,15 +152,18 @@ export function resolveBackupRetention({
  * Builds the versioned embedding-space block declared in `bundle-meta.json`.
  *
  * Truth discipline: the block separates what the bundle can prove from what it cannot.
- * - `dimension` + per-collection `count` are write-time facts: the counts come from the integrity
- *   check's per-subsystem source counts, and the exported rows themselves carry the dimension.
+ * - `dimension` + `counts` are write-time facts: counts attest each actual vector collection (KB
+ *   chunks, Memory Core memories, summaries) from the export receipts, and the exported rows
+ *   themselves carry the dimension. Counts are never null — a new bundle attests exactly the rows
+ *   it exported.
  * - `expectedConsumer` is the backup host's ACTIVE config at backup time. It is NOT write-time
  *   vector provenance: no persisted record of which provider/model embedded the stored rows exists
  *   in the substrate, so a config snapshot must never be presented as one. Restore admission treats
  *   it as advisory context for the orchestrator's semantic-space classification, never as a hard
  *   gate, and never contacts a provider to verify it.
  * @param {Object} options
- * @param {Object} options.subsystems runBackup's subsystem receipt map (kb/mc entries carry counts).
+ * @param {Object} options.subsystems runBackup's subsystem receipt map (kb carries a count; mc
+ *   carries per-collection `memories`/`summaries` export receipts).
  * @returns {Object}
  */
 export function buildEmbeddingContract({subsystems}) {
@@ -170,15 +173,16 @@ export function buildEmbeddingContract({subsystems}) {
             ? AiConfig.ollama.embeddingModel
             : AiConfig.openAiCompatible.embeddingModel;
 
-    const contractOf = key => ({
-        count: typeof subsystems[key] === 'number' ? subsystems[key] : subsystems[key]?.count ?? null
-    });
+    const countOf = value => typeof value === 'number' ? value : value?.count ?? value?.exported ?? 0;
 
     return {
+        counts: {
+            kb       : countOf(subsystems.kb),
+            memories : countOf(subsystems.mc?.memories),
+            summaries: countOf(subsystems.mc?.summaries)
+        },
         dimension       : AiConfig.vectorDimension,
         expectedConsumer: {model, provider},
-        kb              : contractOf('kb'),
-        mc              : contractOf('mc'),
         schemaVersion   : 1
     }
 }

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -149,10 +149,16 @@ export function resolveBackupRetention({
 }
 
 /**
- * Builds the versioned embedding-space contract declared in `bundle-meta.json` for every vector
- * collection: which provider/model produced the vectors, the dimension, the exported counts, and
- * the fingerprint a restore admission can compare against without touching a live provider.
- * Counts come from the integrity check's per-subsystem source counts (authoritative at write time).
+ * Builds the versioned embedding-space block declared in `bundle-meta.json`.
+ *
+ * Truth discipline: the block separates what the bundle can prove from what it cannot.
+ * - `dimension` + per-collection `count` are write-time facts: the counts come from the integrity
+ *   check's per-subsystem source counts, and the exported rows themselves carry the dimension.
+ * - `expectedConsumer` is the backup host's ACTIVE config at backup time. It is NOT write-time
+ *   vector provenance: no persisted record of which provider/model embedded the stored rows exists
+ *   in the substrate, so a config snapshot must never be presented as one. Restore admission treats
+ *   it as advisory context for the orchestrator's semantic-space classification, never as a hard
+ *   gate, and never contacts a provider to verify it.
  * @param {Object} options
  * @param {Object} options.subsystems runBackup's subsystem receipt map (kb/mc entries carry counts).
  * @returns {Object}
@@ -162,22 +168,18 @@ export function buildEmbeddingContract({subsystems}) {
         provider = AiConfig.embeddingProvider,
         model    = provider === 'ollama'
             ? AiConfig.ollama.embeddingModel
-            : AiConfig.openAiCompatible.embeddingModel,
-        dimension   = AiConfig.vectorDimension,
-        fingerprint = `${provider}:${model}:${dimension}`;
+            : AiConfig.openAiCompatible.embeddingModel;
 
     const contractOf = key => ({
-        count        : typeof subsystems[key] === 'number' ? subsystems[key] : subsystems[key]?.count ?? null,
-        dimension,
-        model,
-        provider,
-        fingerprint,
-        schemaVersion: 1
+        count: typeof subsystems[key] === 'number' ? subsystems[key] : subsystems[key]?.count ?? null
     });
 
     return {
-        kb: contractOf('kb'),
-        mc: contractOf('mc')
+        dimension       : AiConfig.vectorDimension,
+        expectedConsumer: {model, provider},
+        kb              : contractOf('kb'),
+        mc              : contractOf('mc'),
+        schemaVersion   : 1
     }
 }
 

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -149,6 +149,39 @@ export function resolveBackupRetention({
 }
 
 /**
+ * Builds the versioned embedding-space contract declared in `bundle-meta.json` for every vector
+ * collection: which provider/model produced the vectors, the dimension, the exported counts, and
+ * the fingerprint a restore admission can compare against without touching a live provider.
+ * Counts come from the integrity check's per-subsystem source counts (authoritative at write time).
+ * @param {Object} options
+ * @param {Object} options.subsystems runBackup's subsystem receipt map (kb/mc entries carry counts).
+ * @returns {Object}
+ */
+export function buildEmbeddingContract({subsystems}) {
+    const
+        provider = AiConfig.embeddingProvider,
+        model    = provider === 'ollama'
+            ? AiConfig.ollama.embeddingModel
+            : AiConfig.openAiCompatible.embeddingModel,
+        dimension   = AiConfig.vectorDimension,
+        fingerprint = `${provider}:${model}:${dimension}`;
+
+    const contractOf = key => ({
+        count        : typeof subsystems[key] === 'number' ? subsystems[key] : subsystems[key]?.count ?? null,
+        dimension,
+        model,
+        provider,
+        fingerprint,
+        schemaVersion: 1
+    });
+
+    return {
+        kb: contractOf('kb'),
+        mc: contractOf('mc')
+    }
+}
+
+/**
  * Executes a full-substrate backup.
  *
  * @param {Object}   options
@@ -249,6 +282,7 @@ export async function runBackup({
     const completedAt = new Date().toISOString();
     const topology    = buildTopologyDescriptor();
     const versionInfo = await buildVersionDescriptor(PROJECT_ROOT, logger);
+    const embedding   = buildEmbeddingContract({subsystems});
     const meta        = {
         bundleVersion: 1,
         timestamp,
@@ -256,6 +290,7 @@ export async function runBackup({
         subsystems,
         integrity,
         topology,
+        embedding,
         ...versionInfo
     };
     await fs.writeJson(path.join(resolvedRoot, 'bundle-meta.json'), meta, { spaces: 2 });

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -307,18 +307,22 @@ export async function runRestore({
 }
 
 /**
- * Validates the bundle directory layout and JSONL parseability without writing any state.
+ * Validates the bundle directory layout and every JSONL row without writing any state.
  *
  * Required subdirs (`kb`, `mc`, `graph`, `concepts`, `trajectories`) MUST exist; missing
  * any one fails the bundle. Optional subdirs (`mailbox`) are tolerated
- * absent. JSONL files in any subdir are sample-parsed (first non-empty line) — full-file
- * parsing is the SDK's responsibility downstream. `bundle-meta.json` is parsed if present;
- * absence triggers a console warning but does not fail (legacy bundles).
+ * absent. Every JSONL file is fully streamed: each line is parsed, and each vector-collection
+ * (kb/mc) row must carry a non-empty string `id` plus a valid expected-dimension vector —
+ * a corrupt final row fails the bundle exactly like a corrupt first one. Streamed per-collection
+ * row totals are compared against the declared `bundle-meta.json` counts below.
+ * `bundle-meta.json` is parsed if present; absence triggers a console warning but does not
+ * fail (legacy bundles).
  *
  * @param {String} bundleRoot
  * @param {Object} layout
  * @param {Object} logger
- * @returns {Promise<Object|null>} Parsed `bundle-meta.json` content, or `null` for legacy bundles.
+ * @returns {Promise<Object|null>} Parsed `bundle-meta.json` content (with any embedding advisories
+ *     attached as `embeddingAdvisories`), or `null` for legacy bundles.
  */
 export async function validateBundle(bundleRoot, layout, logger = console, expectedDimension = AiConfig.vectorDimension) {
     if (!await fs.pathExists(bundleRoot)) {
@@ -345,10 +349,13 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
     }
 
     // Full streaming structural + vector validation: every row of every JSONL is parsed, and every
-    // vector collection (kb/mc) row must carry a valid expected-dimension vector BEFORE any mutation.
-    // Line-1 sampling cannot satisfy the gate — a corrupt final row is the exact shape this closes.
-    const readline   = (await import('readline')).default;
-    const allSubdirs = [...REQUIRED_BUNDLE_SUBDIRS, ...OPTIONAL_BUNDLE_SUBDIRS];
+    // vector collection (kb/mc) row must carry a non-empty string id plus a valid
+    // expected-dimension vector BEFORE any mutation. Line-1 sampling cannot satisfy the gate — a
+    // corrupt final row is the exact shape this closes. Streamed kb/mc totals feed the declared
+    // count check below.
+    const readline       = (await import('readline')).default;
+    const allSubdirs     = [...REQUIRED_BUNDLE_SUBDIRS, ...OPTIONAL_BUNDLE_SUBDIRS];
+    const streamedCounts = {kb: 0, mc: 0};
     for (const subdir of allSubdirs) {
         const dir = layout[subdir];
         if (!await fs.pathExists(dir)) continue;
@@ -370,6 +377,12 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
                 }
 
                 if (subdir === 'kb' || subdir === 'mc') {
+                    streamedCounts[subdir]++;
+
+                    if (typeof row?.id !== 'string' || row.id.length === 0) {
+                        throw new Error(`Bundle vector invariant violation at ${subdir}/${file} (line ${lineNo}): missing-id`);
+                    }
+
                     const reason = classifyRowVector(row, expectedDimension);
                     if (reason) {
                         throw new Error(`Bundle vector invariant violation at ${subdir}/${file} (line ${lineNo}): ${reason} (row id: ${row?.id ?? 'unknown'})`);
@@ -394,52 +407,118 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
         logger.warn?.('[Restore] bundle-meta.json absent; topology compatibility check will be skipped (legacy bundle).');
     }
 
-    // Embedding compatibility preflight: the declared contract (or the legacy fallback) must match
-    // the destination's expected embedding space BEFORE any replace-mode truncate. Provider
-    // readiness is never consulted — admission is evidence, not authority.
-    assertEmbeddingCompatibility({bundleRoot, expectedDimension, logger, meta});
+    // Embedding compatibility preflight BEFORE any replace-mode truncate. Hard gates bind only to
+    // evidence the bundle itself proves (schema shape, declared-vs-streamed counts, declared-vs-
+    // expected dimension, per-row vectors). Provider/model identity is advisory: no write-time
+    // vector provenance exists in the substrate, and admission never contacts a provider.
+    validateEmbeddingContractSchema({expectedDimension, meta, streamedCounts});
+    assessEmbeddingCompatibility({expectedDimension, logger, meta});
 
     return meta
 }
 
 /**
- * Compares the bundle's declared embedding contract with the destination's expected embedding
- * space and fails closed with a structured incompatibility receipt BEFORE any mutation. A legacy
- * bundle (no `embedding` key in its meta) is validated against the destination's expected
- * dimension only — the fallback is explicit, never fabricated. The destination fingerprint comes
- * from the active config (never a live provider call).
+ * Validates the declared `meta.embedding` block against schema-v1 and against the bundle's own
+ * streamed evidence. All checks here are hard gates: they compare the declaration with facts the
+ * bundle carries (row totals, row dimension), never with an assumption about vector provenance.
  * @param {Object} options
- * @param {String} options.bundleRoot
- * @param {Number} options.expectedDimension
- * @param {Object} [options.logger]
+ * @param {Number} options.expectedDimension Destination's expected vector dimension.
  * @param {Object|null} options.meta Parsed bundle-meta.json.
+ * @param {Object} options.streamedCounts `{kb, mc}` row totals observed during the streaming pass.
  * @returns {void}
- * @throws {Error} structured incompatibility receipt: collection, declared vs expected fingerprint.
+ * @throws {Error} classified contract violation: `invalid-embedding-schema`,
+ *     `unsupported-schema-version`, `dimension-contract-mismatch`, or `count-contract-mismatch`.
  */
-export function assertEmbeddingCompatibility({bundleRoot, expectedDimension, logger = console, meta}) {
-    const
-        provider = AiConfig.embeddingProvider,
-        model    = provider === 'ollama'
-            ? AiConfig.ollama.embeddingModel
-            : AiConfig.openAiCompatible.embeddingModel,
-        expectedFingerprint = `${provider}:${model}:${expectedDimension}`;
+export function validateEmbeddingContractSchema({expectedDimension, meta, streamedCounts}) {
+    const declared = meta?.embedding;
+
+    if (!declared) {
+        return // legacy bundle — the advisory path classifies the unknown provenance
+    }
+
+    const fail = (reason, detail) => {
+        throw new Error(`Bundle embedding contract violation: ${reason} (${detail})`)
+    };
+
+    if (declared.schemaVersion !== 1) {
+        fail('unsupported-schema-version', `expected 1, got ${JSON.stringify(declared.schemaVersion)}`);
+    }
+    if (!Number.isInteger(declared.dimension) || declared.dimension <= 0) {
+        fail('invalid-embedding-schema', `dimension must be a positive integer, got ${JSON.stringify(declared.dimension)}`);
+    }
+    if (declared.dimension !== expectedDimension) {
+        fail('dimension-contract-mismatch', `bundle declares dimension ${declared.dimension}, destination expects ${expectedDimension}`);
+    }
 
     for (const collection of ['kb', 'mc']) {
-        const declared = meta?.embedding?.[collection];
+        const block = declared[collection];
 
-        if (!declared) {
-            logger.warn?.(`[Restore] ${collection}: no declared embedding contract (legacy bundle) — validating against the live expected dimension only.`);
-            continue
+        if (!block || typeof block !== 'object') {
+            fail('invalid-embedding-schema', `missing per-collection block '${collection}'`);
         }
-
-        if (declared.fingerprint !== expectedFingerprint) {
-            throw new Error(
-                `Embedding-space incompatibility at ${collection}: bundle declares ` +
-                `'${declared.fingerprint}' but the destination expects '${expectedFingerprint}'. ` +
-                `Re-embedding is an orchestrator-selected action, never implicit — resolve the space difference deliberately before restoring.`
-            )
+        if (block.count !== null && (!Number.isInteger(block.count) || block.count < 0)) {
+            fail('invalid-embedding-schema', `${collection}.count must be null or a non-negative integer, got ${JSON.stringify(block.count)}`);
+        }
+        if (block.count !== null && block.count !== streamedCounts[collection]) {
+            fail('count-contract-mismatch', `${collection} declares ${block.count} row(s) but the bundle streams ${streamedCounts[collection]}`);
         }
     }
+
+    if (declared.expectedConsumer !== undefined) {
+        const {model, provider} = declared.expectedConsumer ?? {};
+
+        if (typeof provider !== 'string' || provider.length === 0 || typeof model !== 'string' || model.length === 0) {
+            fail('invalid-embedding-schema', 'expectedConsumer requires non-empty provider and model strings');
+        }
+    }
+}
+
+/**
+ * Classifies the bundle's semantic-space provenance as structured advisories — never as a hard
+ * gate. A config snapshot (backup-time or destination-time) is NOT write-time vector provenance:
+ * no persisted record of which provider/model embedded the stored rows exists in the substrate.
+ * The only row-verifiable semantic fact — vector dimension — is enforced upstream as a hard gate;
+ * provider/model divergence is classified here for the restore orchestrator's recovery receipt,
+ * which owns any re-embed/reconfigure decision. Admission never contacts a provider and never
+ * re-embeds. Advisories are attached to `meta.embeddingAdvisories` AND logged.
+ * @param {Object} options
+ * @param {Number} options.expectedDimension Destination's expected vector dimension.
+ * @param {Object} [options.logger]
+ * @param {Object|null} options.meta Parsed bundle-meta.json.
+ * @returns {Object[]} The advisory list (empty when the bundle carries no embedding block to classify).
+ */
+export function assessEmbeddingCompatibility({expectedDimension, logger = console, meta}) {
+    const declared = meta?.embedding;
+
+    if (!declared) {
+        logger.warn?.(`[Restore][embedding-advisory] reason=semantic-provenance-unverified — no declared embedding contract (legacy bundle); validating rows against the destination's expected dimension ${expectedDimension} only.`);
+        return []
+    }
+
+    const
+        advisories = [],
+        consumer   = declared.expectedConsumer,
+        provider   = AiConfig.embeddingProvider,
+        model      = provider === 'ollama'
+            ? AiConfig.ollama.embeddingModel
+            : AiConfig.openAiCompatible.embeddingModel;
+
+    if (!consumer) {
+        advisories.push({reason: 'semantic-provenance-unverified', detail: 'embedding block declares no expectedConsumer'});
+    } else if (consumer.provider !== provider || consumer.model !== model) {
+        advisories.push({
+            reason     : 'consumer-expectation-mismatch',
+            bundle     : {model: consumer.model, provider: consumer.provider},
+            destination: {model, provider}
+        });
+    }
+
+    for (const advisory of advisories) {
+        logger.warn?.(`[Restore][embedding-advisory] reason=${advisory.reason} ${JSON.stringify(advisory)} — semantic-space classification is orchestrator-owned; restore admission proceeds on row-verifiable evidence only.`);
+    }
+
+    meta.embeddingAdvisories = advisories;
+    return advisories
 }
 
 /**

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -11,7 +11,9 @@ import * as core from '../../../src/core/_export.mjs';
 
 import kbConfig from '../../mcp/server/knowledge-base/config.mjs';
 import mcConfig from '../../mcp/server/memory-core/config.mjs';
+import AiConfig from '../../config.mjs';
 
+import {classifyRowVector} from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
 import {
     KB_DatabaseService,
     KB_LifecycleService,
@@ -134,6 +136,7 @@ export async function runRestore({
     filterEdgeTypes         = [],
     onlySubstrate           = null,
     postRestoreHook         = null,
+    expectedDimension       = AiConfig.vectorDimension,
     logger                  = console
 } = {}) {
     if (!bundleRoot) {
@@ -155,7 +158,7 @@ export async function runRestore({
     };
 
     logger.log(`[1/6] Validating bundle integrity at ${resolvedRoot}...`);
-    const meta = await validateBundle(resolvedRoot, layout, logger);
+    const meta = await validateBundle(resolvedRoot, layout, logger, expectedDimension);
 
     logger.log('[2/6] Checking topology compatibility...');
     const topology = await checkTopology({meta, forceTopologyMismatch, logger});
@@ -317,7 +320,7 @@ export async function runRestore({
  * @param {Object} logger
  * @returns {Promise<Object|null>} Parsed `bundle-meta.json` content, or `null` for legacy bundles.
  */
-export async function validateBundle(bundleRoot, layout, logger = console) {
+export async function validateBundle(bundleRoot, layout, logger = console, expectedDimension = AiConfig.vectorDimension) {
     if (!await fs.pathExists(bundleRoot)) {
         throw new Error(`Bundle directory not found: ${bundleRoot}`);
     }
@@ -341,9 +344,9 @@ export async function validateBundle(bundleRoot, layout, logger = console) {
         }
     }
 
-    // Stream-read the first non-empty line for JSONL parseability sanity-check.
-    // Full-file readFile fails on JSONL files >512MB (V8 max-string-length cap):
-    // empirical anchor 2026-05-10, kb backup 586MB → ERR_STRING_TOO_LONG.
+    // Full streaming structural + vector validation: every row of every JSONL is parsed, and every
+    // vector collection (kb/mc) row must carry a valid expected-dimension vector BEFORE any mutation.
+    // Line-1 sampling cannot satisfy the gate — a corrupt final row is the exact shape this closes.
     const readline   = (await import('readline')).default;
     const allSubdirs = [...REQUIRED_BUNDLE_SUBDIRS, ...OPTIONAL_BUNDLE_SUBDIRS];
     for (const subdir of allSubdirs) {
@@ -352,35 +355,91 @@ export async function validateBundle(bundleRoot, layout, logger = console) {
         const entries    = await fs.readdir(dir);
         const jsonlFiles = entries.filter(f => f.endsWith('.jsonl'));
         for (const file of jsonlFiles) {
-            const stream    = fs.createReadStream(path.join(dir, file), {encoding: 'utf8'});
-            const rl        = readline.createInterface({input: stream, crlfDelay: Infinity});
-            let   firstLine = null;
+            const stream = fs.createReadStream(path.join(dir, file), {encoding: 'utf8'});
+            const rl     = readline.createInterface({input: stream, crlfDelay: Infinity});
+            let   lineNo = 0;
             for await (const line of rl) {
-                if (line.trim()) { firstLine = line; break; }
+                if (!line.trim()) continue;
+                lineNo++;
+
+                let row;
+                try {
+                    row = JSON.parse(line);
+                } catch (err) {
+                    throw new Error(`Bundle JSONL parse error at ${subdir}/${file} (line ${lineNo}): ${err.message}`);
+                }
+
+                if (subdir === 'kb' || subdir === 'mc') {
+                    const reason = classifyRowVector(row, expectedDimension);
+                    if (reason) {
+                        throw new Error(`Bundle vector invariant violation at ${subdir}/${file} (line ${lineNo}): ${reason} (row id: ${row?.id ?? 'unknown'})`);
+                    }
+                }
             }
             rl.close();
             stream.destroy();
-            if (firstLine) {
-                try {
-                    JSON.parse(firstLine);
-                } catch (err) {
-                    throw new Error(`Bundle JSONL parse error at ${subdir}/${file} (line 1): ${err.message}`);
-                }
-            }
         }
     }
 
     const metaPath = path.join(bundleRoot, 'bundle-meta.json');
+    let   meta     = null;
+
     if (await fs.pathExists(metaPath)) {
         try {
-            return await fs.readJson(metaPath);
+            meta = await fs.readJson(metaPath);
         } catch (err) {
             throw new Error(`Failed to parse bundle-meta.json: ${err.message}`);
         }
+    } else {
+        logger.warn?.('[Restore] bundle-meta.json absent; topology compatibility check will be skipped (legacy bundle).');
     }
 
-    logger.warn?.('[Restore] bundle-meta.json absent; topology compatibility check will be skipped (legacy bundle).');
-    return null
+    // Embedding compatibility preflight: the declared contract (or the legacy fallback) must match
+    // the destination's expected embedding space BEFORE any replace-mode truncate. Provider
+    // readiness is never consulted — admission is evidence, not authority.
+    assertEmbeddingCompatibility({bundleRoot, expectedDimension, logger, meta});
+
+    return meta
+}
+
+/**
+ * Compares the bundle's declared embedding contract with the destination's expected embedding
+ * space and fails closed with a structured incompatibility receipt BEFORE any mutation. A legacy
+ * bundle (no `embedding` key in its meta) is validated against the destination's expected
+ * dimension only — the fallback is explicit, never fabricated. The destination fingerprint comes
+ * from the active config (never a live provider call).
+ * @param {Object} options
+ * @param {String} options.bundleRoot
+ * @param {Number} options.expectedDimension
+ * @param {Object} [options.logger]
+ * @param {Object|null} options.meta Parsed bundle-meta.json.
+ * @returns {void}
+ * @throws {Error} structured incompatibility receipt: collection, declared vs expected fingerprint.
+ */
+export function assertEmbeddingCompatibility({bundleRoot, expectedDimension, logger = console, meta}) {
+    const
+        provider = AiConfig.embeddingProvider,
+        model    = provider === 'ollama'
+            ? AiConfig.ollama.embeddingModel
+            : AiConfig.openAiCompatible.embeddingModel,
+        expectedFingerprint = `${provider}:${model}:${expectedDimension}`;
+
+    for (const collection of ['kb', 'mc']) {
+        const declared = meta?.embedding?.[collection];
+
+        if (!declared) {
+            logger.warn?.(`[Restore] ${collection}: no declared embedding contract (legacy bundle) — validating against the live expected dimension only.`);
+            continue
+        }
+
+        if (declared.fingerprint !== expectedFingerprint) {
+            throw new Error(
+                `Embedding-space incompatibility at ${collection}: bundle declares ` +
+                `'${declared.fingerprint}' but the destination expects '${expectedFingerprint}'. ` +
+                `Re-embedding is an orchestrator-selected action, never implicit — resolve the space difference deliberately before restoring.`
+            )
+        }
+    }
 }
 
 /**

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -299,7 +299,7 @@ export async function runRestore({
     }
 
     logger.log('[6/6] Restore complete.');
-    if (meta) {
+    if (meta && !meta.legacy) {
         logger.log(`Source bundle: bundleVersion=${meta.bundleVersion ?? '?'}, neoVersion=${meta.neoVersion ?? '?'}, gitSha=${meta.gitSha ?? '?'}, completedAt=${meta.completedAt ?? '?'}`);
     }
 
@@ -321,8 +321,9 @@ export async function runRestore({
  * @param {String} bundleRoot
  * @param {Object} layout
  * @param {Object} logger
- * @returns {Promise<Object|null>} Parsed `bundle-meta.json` content (with any embedding advisories
- *     attached as `embeddingAdvisories`), or `null` for legacy bundles.
+ * @returns {Promise<Object>} Parsed `bundle-meta.json` content with `embeddingAdvisories`
+ *     attached; for legacy bundles (no meta file) a synthetic `{legacy: true, embeddingAdvisories}`
+ *     receipt — the structured unknown-provenance classification is never dropped.
  */
 export async function validateBundle(bundleRoot, layout, logger = console, expectedDimension = AiConfig.vectorDimension) {
     if (!await fs.pathExists(bundleRoot)) {
@@ -349,13 +350,21 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
     }
 
     // Full streaming structural + vector validation: every row of every JSONL is parsed, and every
-    // vector collection (kb/mc) row must carry a non-empty string id plus a valid
-    // expected-dimension vector BEFORE any mutation. Line-1 sampling cannot satisfy the gate — a
-    // corrupt final row is the exact shape this closes. Streamed kb/mc totals feed the declared
-    // count check below.
+    // vector-collection row must carry a non-empty string id plus a valid expected-dimension vector
+    // BEFORE any mutation. Line-1 sampling cannot satisfy the gate — a corrupt final row is the
+    // exact shape this closes. Streamed totals are keyed per actual vector collection (kb chunks,
+    // Memory Core memories, summaries, temporal summaries) and feed the declared-count check below.
     const readline       = (await import('readline')).default;
     const allSubdirs     = [...REQUIRED_BUNDLE_SUBDIRS, ...OPTIONAL_BUNDLE_SUBDIRS];
-    const streamedCounts = {kb: 0, mc: 0};
+    const streamedCounts = {};
+
+    const collectionOf = (subdir, file) => {
+        if (subdir === 'kb') return 'kb';
+        if (subdir !== 'mc') return null;
+        if (file.startsWith('memory-backup'))           return 'memories';
+        if (file.startsWith('temporal-summary-backup')) return 'temporalSummaries';
+        return 'summaries'
+    };
     for (const subdir of allSubdirs) {
         const dir = layout[subdir];
         if (!await fs.pathExists(dir)) continue;
@@ -376,8 +385,10 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
                     throw new Error(`Bundle JSONL parse error at ${subdir}/${file} (line ${lineNo}): ${err.message}`);
                 }
 
-                if (subdir === 'kb' || subdir === 'mc') {
-                    streamedCounts[subdir]++;
+                const collection = collectionOf(subdir, file);
+
+                if (collection) {
+                    streamedCounts[collection] = (streamedCounts[collection] ?? 0) + 1;
 
                     if (typeof row?.id !== 'string' || row.id.length === 0) {
                         throw new Error(`Bundle vector invariant violation at ${subdir}/${file} (line ${lineNo}): missing-id`);
@@ -412,19 +423,29 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
     // expected dimension, per-row vectors). Provider/model identity is advisory: no write-time
     // vector provenance exists in the substrate, and admission never contacts a provider.
     validateEmbeddingContractSchema({expectedDimension, meta, streamedCounts});
-    assessEmbeddingCompatibility({expectedDimension, logger, meta});
+    const embeddingAdvisories = assessEmbeddingCompatibility({expectedDimension, logger, meta});
 
-    return meta
+    // The advisory receipt rides the return even for legacy bundles (no meta file), so the
+    // self-diagnostic probe and the later orchestrator always receive the structured unknown.
+    if (meta) {
+        meta.embeddingAdvisories = embeddingAdvisories;
+        return meta
+    }
+
+    return {embeddingAdvisories, legacy: true}
 }
 
 /**
  * Validates the declared `meta.embedding` block against schema-v1 and against the bundle's own
  * streamed evidence. All checks here are hard gates: they compare the declaration with facts the
  * bundle carries (row totals, row dimension), never with an assumption about vector provenance.
+ * Schema-v1 counts are authoritative per actual vector collection (`kb`, `memories`, `summaries`,
+ * `temporalSummaries`, or any future included collection) and are never null: a new bundle must
+ * attest exactly the rows it streams, in both directions.
  * @param {Object} options
  * @param {Number} options.expectedDimension Destination's expected vector dimension.
  * @param {Object|null} options.meta Parsed bundle-meta.json.
- * @param {Object} options.streamedCounts `{kb, mc}` row totals observed during the streaming pass.
+ * @param {Object} options.streamedCounts Per-collection row totals observed during the streaming pass.
  * @returns {void}
  * @throws {Error} classified contract violation: `invalid-embedding-schema`,
  *     `unsupported-schema-version`, `dimension-contract-mismatch`, or `count-contract-mismatch`.
@@ -450,17 +471,22 @@ export function validateEmbeddingContractSchema({expectedDimension, meta, stream
         fail('dimension-contract-mismatch', `bundle declares dimension ${declared.dimension}, destination expects ${expectedDimension}`);
     }
 
-    for (const collection of ['kb', 'mc']) {
-        const block = declared[collection];
+    if (!declared.counts || typeof declared.counts !== 'object' || Array.isArray(declared.counts)) {
+        fail('invalid-embedding-schema', 'counts must be an object keyed by vector collection');
+    }
 
-        if (!block || typeof block !== 'object') {
-            fail('invalid-embedding-schema', `missing per-collection block '${collection}'`);
+    for (const [collection, count] of Object.entries(declared.counts)) {
+        if (!Number.isInteger(count) || count < 0) {
+            fail('invalid-embedding-schema', `counts.${collection} must be a non-negative integer, got ${JSON.stringify(count)}`);
         }
-        if (block.count !== null && (!Number.isInteger(block.count) || block.count < 0)) {
-            fail('invalid-embedding-schema', `${collection}.count must be null or a non-negative integer, got ${JSON.stringify(block.count)}`);
+        if (count !== (streamedCounts[collection] ?? 0)) {
+            fail('count-contract-mismatch', `${collection} declares ${count} row(s) but the bundle streams ${streamedCounts[collection] ?? 0}`);
         }
-        if (block.count !== null && block.count !== streamedCounts[collection]) {
-            fail('count-contract-mismatch', `${collection} declares ${block.count} row(s) but the bundle streams ${streamedCounts[collection]}`);
+    }
+
+    for (const [collection, streamed] of Object.entries(streamedCounts)) {
+        if (streamed > 0 && !(collection in declared.counts)) {
+            fail('count-contract-mismatch', `bundle streams ${streamed} ${collection} row(s) but no count is declared for the collection`);
         }
     }
 
@@ -477,47 +503,55 @@ export function validateEmbeddingContractSchema({expectedDimension, meta, stream
  * Classifies the bundle's semantic-space provenance as structured advisories — never as a hard
  * gate. A config snapshot (backup-time or destination-time) is NOT write-time vector provenance:
  * no persisted record of which provider/model embedded the stored rows exists in the substrate.
- * The only row-verifiable semantic fact — vector dimension — is enforced upstream as a hard gate;
- * provider/model divergence is classified here for the restore orchestrator's recovery receipt,
- * which owns any re-embed/reconfigure decision. Admission never contacts a provider and never
- * re-embeds. Advisories are attached to `meta.embeddingAdvisories` AND logged.
+ * The baseline advisory is therefore ALWAYS `semantic-provenance-unverified` — including when the
+ * bundle's declared consumer expectation matches the destination's active config, because a match
+ * is expectation-consistency, not producer evidence. A divergence adds
+ * `consumer-expectation-mismatch` on top of the baseline. The only row-verifiable semantic fact —
+ * vector dimension — is enforced upstream as a hard gate; the classified residue is input for the
+ * restore orchestrator's recovery receipt, which owns any re-embed/reconfigure decision.
+ * Admission never contacts a provider and never re-embeds. Advisories are returned AND logged.
  * @param {Object} options
  * @param {Number} options.expectedDimension Destination's expected vector dimension.
  * @param {Object} [options.logger]
  * @param {Object|null} options.meta Parsed bundle-meta.json.
- * @returns {Object[]} The advisory list (empty when the bundle carries no embedding block to classify).
+ * @returns {Object[]} The advisory list — always non-empty, since producer provenance is never
+ *     verified by restore admission.
  */
 export function assessEmbeddingCompatibility({expectedDimension, logger = console, meta}) {
-    const declared = meta?.embedding;
-
-    if (!declared) {
-        logger.warn?.(`[Restore][embedding-advisory] reason=semantic-provenance-unverified — no declared embedding contract (legacy bundle); validating rows against the destination's expected dimension ${expectedDimension} only.`);
-        return []
-    }
-
     const
         advisories = [],
-        consumer   = declared.expectedConsumer,
-        provider   = AiConfig.embeddingProvider,
-        model      = provider === 'ollama'
-            ? AiConfig.ollama.embeddingModel
-            : AiConfig.openAiCompatible.embeddingModel;
+        declared   = meta?.embedding,
+        consumer   = declared?.expectedConsumer;
 
-    if (!consumer) {
+    if (!declared) {
+        advisories.push({reason: 'semantic-provenance-unverified', detail: 'no declared embedding contract (legacy bundle)'});
+    } else if (!consumer) {
         advisories.push({reason: 'semantic-provenance-unverified', detail: 'embedding block declares no expectedConsumer'});
-    } else if (consumer.provider !== provider || consumer.model !== model) {
+    } else {
         advisories.push({
-            reason     : 'consumer-expectation-mismatch',
-            bundle     : {model: consumer.model, provider: consumer.provider},
-            destination: {model, provider}
+            reason: 'semantic-provenance-unverified',
+            detail: 'expectedConsumer is the backup host\'s active config at backup time — expectation context, not producer evidence'
         });
+
+        const
+            provider = AiConfig.embeddingProvider,
+            model    = provider === 'ollama'
+                ? AiConfig.ollama.embeddingModel
+                : AiConfig.openAiCompatible.embeddingModel;
+
+        if (consumer.provider !== provider || consumer.model !== model) {
+            advisories.push({
+                reason     : 'consumer-expectation-mismatch',
+                bundle     : {model: consumer.model, provider: consumer.provider},
+                destination: {model, provider}
+            });
+        }
     }
 
     for (const advisory of advisories) {
         logger.warn?.(`[Restore][embedding-advisory] reason=${advisory.reason} ${JSON.stringify(advisory)} — semantic-space classification is orchestrator-owned; restore admission proceeds on row-verifiable evidence only.`);
     }
 
-    meta.embeddingAdvisories = advisories;
     return advisories
 }
 
@@ -537,7 +571,7 @@ export function assessEmbeddingCompatibility({expectedDimension, logger = consol
  * @param {Object}   [options.logger=console] Log sink.
  * @param {Object}   [options.fsModule=fs] Filesystem seam (test injection).
  * @param {Function} [options.validateFn=validateBundle] Bundle validator seam (test injection).
- * @returns {Promise<{restorable: Boolean, bundleRoot: String|null, reason: String|null, checkedAt: String}>}
+ * @returns {Promise<{restorable: Boolean, bundleRoot: String|null, reason: String|null, checkedAt: String, embeddingAdvisories: Object[]}>}
  */
 export async function verifyLatestBackupRestorable({
     backupRoot,
@@ -577,10 +611,10 @@ export async function verifyLatestBackupRestorable({
     };
 
     try {
-        await validateFn(bundleRoot, layout, logger);
-        return {restorable: true, bundleRoot, reason: null, checkedAt};
+        const meta = await validateFn(bundleRoot, layout, logger);
+        return {restorable: true, bundleRoot, reason: null, checkedAt, embeddingAdvisories: meta?.embeddingAdvisories ?? []};
     } catch (error) {
-        return {restorable: false, bundleRoot, reason: error.message, checkedAt};
+        return {restorable: false, bundleRoot, reason: error.message, checkedAt, embeddingAdvisories: error.embeddingAdvisories ?? []};
     }
 }
 

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -1,8 +1,10 @@
-import aiConfig                  from '../../mcp/server/knowledge-base/config.mjs';
-import Base                      from '../../../src/core/Base.mjs';
-import ChromaManager             from './ChromaManager.mjs';
-import DestructiveOperationGuard from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
-import VectorService             from './VectorService.mjs';
+import aiConfig                        from '../../mcp/server/knowledge-base/config.mjs';
+import {partitionRowsByVectorValidity} from '../memory-core/helpers/vectorWriteInvariant.mjs';
+import {validateJsonlSourceFile}       from '../memory-core/helpers/vectorJsonlSourceValidation.mjs';
+import Base                            from '../../../src/core/Base.mjs';
+import ChromaManager                   from './ChromaManager.mjs';
+import DestructiveOperationGuard       from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+import VectorService                   from './VectorService.mjs';
 // SourceRegistry owns KB source discovery. Importing `./source/_export.mjs` triggers
 // auto-registration of Neo's default Source classes when `aiConfig.useDefaultSources !== false`,
 // plus declarative `aiConfig.customSources` entries.
@@ -305,6 +307,14 @@ class DatabaseService extends Base {
             }
 
             if (mode === 'replace') {
+                // Prove the FULL source before any destructive operation: every row of every file
+                // must parse and carry a non-empty id plus a valid same-dimension vector. Without
+                // this pass, a corrupt final row would truncate the collection and only then be
+                // discovered by the per-batch write gate below.
+                for (const filePath of sourceFiles) {
+                    await validateJsonlSourceFile({filePath, expectedDimension: aiConfig.vectorDimension});
+                }
+
                 logger.log('Replace mode: truncating Knowledge Base collection before import...');
                 await this.truncateDatabase({confirmation});
             }
@@ -339,18 +349,30 @@ class DatabaseService extends Base {
                     const writeBatch = batch;
                     batch = [];
 
+                    // Atomic vector-write invariant (mirrors the Memory Core boundary): an
+                    // explicit-embedding import must carry a valid same-dimension vector — a row
+                    // without one is rejected fail-loud BEFORE any upsert, never half-persisted
+                    // as metadata-only. Replace mode's pre-truncate source proof catches corrupt
+                    // rows first; this is the merge path's own gate for direct import callers.
+                    const {valid, rejected} = partitionRowsByVectorValidity({rows: writeBatch, expectedDimension: aiConfig.vectorDimension});
+
+                    if (rejected.length > 0) {
+                        const reasons = rejected.map(r => `${r.id ?? 'unknown'} (${r.reason})`).slice(0, 5).join(', ');
+                        throw new Error(`Knowledge Base import vector invariant rejected ${rejected.length} row(s): ${reasons} — not persisted`);
+                    }
+
                     const upsertArgs = {
-                        ids       : writeBatch.map(r => r.id),
-                        embeddings: writeBatch.map(r => r.embedding),
-                        metadatas : writeBatch.map(r => r.metadata)
+                        ids       : valid.map(r => r.id),
+                        embeddings: valid.map(r => r.embedding),
+                        metadatas : valid.map(r => r.metadata)
                     };
-                    if (writeBatch.some(r => r.document != null)) {
-                        upsertArgs.documents = writeBatch.map(r => r.document ?? '');
+                    if (valid.some(r => r.document != null)) {
+                        upsertArgs.documents = valid.map(r => r.document ?? '');
                     }
                     await collection.upsert(upsertArgs);
 
-                    imported     += writeBatch.length;
-                    fileImported += writeBatch.length;
+                    imported     += valid.length;
+                    fileImported += valid.length;
                 };
 
                 for await (const line of rl) {

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -7,6 +7,7 @@ import Base                                                       from '../../..
 import StorageRouter                                              from './managers/StorageRouter.mjs';
 import DestructiveOperationGuard                                  from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 import {partitionRowsByVectorValidity, summarizeVectorRejections} from './helpers/vectorWriteInvariant.mjs';
+import {validateJsonlSourceFile}                                  from './helpers/vectorJsonlSourceValidation.mjs';
 
 /**
  * @summary Service for exporting and importing memory core data.
@@ -496,6 +497,19 @@ class DatabaseService extends Base {
             let preservedDeliveryState = [];
 
             if (mode === 'replace') {
+                // Prove the FULL source before any destructive operation: every row of every file
+                // must parse, and every Chroma-bound row must carry a non-empty id plus a valid
+                // same-dimension vector (graph backups are parse-checked only — their rows are
+                // nodes/edges, not vectors). Without this pass, a corrupt final row would truncate
+                // a subsystem and only then be discovered by the per-batch write gate below.
+                for (const filePath of filesToImport) {
+                    await validateJsonlSourceFile({
+                        filePath,
+                        expectedDimension: aiConfig.vectorDimension,
+                        vectorRows       : !path.basename(filePath).startsWith('graph-backup')
+                    });
+                }
+
                 // Truncate ONLY the subsystems that this import will restore — selected
                 // by the same filename heuristic the per-file dispatch loop uses below.
                 // Truncating subsystems that aren't being restored would be destructive

--- a/ai/services/memory-core/helpers/vectorJsonlSourceValidation.mjs
+++ b/ai/services/memory-core/helpers/vectorJsonlSourceValidation.mjs
@@ -1,0 +1,85 @@
+import fs       from 'node:fs';
+import readline from 'node:readline';
+
+import {classifyRowVector} from './vectorWriteInvariant.mjs';
+
+/**
+ * @summary Full-source JSONL validation for import/restore entry paths: proves an entire backup
+ * file BEFORE any destructive operation (replace-mode truncate) is allowed to run.
+ *
+ * The per-batch write gate in {@link module:ai/services/memory-core/helpers/vectorWriteInvariant}
+ * rejects bad rows at the upsert boundary, but a replace-mode import truncates first — so a file
+ * whose corruption sits in its final row would wipe the collection and only then discover the
+ * defect. This validator streams the whole file up front: every line must parse, and (for vector
+ * collections) every row must carry a non-empty string `id` plus a valid expected-dimension
+ * vector. Streaming keeps memory O(1) per line — no whole-file buffering — so the check composes
+ * with bounded import batching.
+ * @module ai/services/memory-core/helpers/vectorJsonlSourceValidation
+ */
+
+/**
+ * @summary The reasons a source file fails validation, stable for fail-loud reporting.
+ */
+export const SOURCE_REJECTION_REASONS = Object.freeze({
+    jsonParse       : 'json-parse',
+    missingId       : 'missing-id',
+    missingEmbedding: 'missing-embedding',
+    emptyEmbedding  : 'empty-embedding',
+    wrongDimension  : 'wrong-dimension',
+    nonFiniteValues : 'non-finite-values'
+});
+
+/**
+ * @summary Streams one JSONL source file and validates every row, throwing on the first defect.
+ *
+ * @param {Object} options
+ * @param {String} options.filePath Absolute path of the `.jsonl` source file.
+ * @param {Number} options.expectedDimension Required vector dimension for vector rows.
+ * @param {Boolean} [options.vectorRows=true] `false` for non-vector files (e.g. graph backups):
+ *     rows are then only required to parse.
+ * @returns {Promise<{rowCount: Number}>} Total non-empty rows validated.
+ * @throws {Error} `Source validation failed at <file> (line <n>): <reason>` — the reason is one of
+ *     {@link SOURCE_REJECTION_REASONS}; vector-row failures also name the row id when present.
+ */
+export async function validateJsonlSourceFile({filePath, expectedDimension, vectorRows = true}) {
+    const stream = fs.createReadStream(filePath, {encoding: 'utf8'});
+    const rl     = readline.createInterface({input: stream, crlfDelay: Infinity});
+
+    let lineNo   = 0,
+        rowCount = 0;
+
+    const fail = (reason, detail = '') => {
+        throw new Error(`Source validation failed at ${filePath} (line ${lineNo}): ${reason}${detail ? ` (${detail})` : ''}`)
+    };
+
+    try {
+        for await (const line of rl) {
+            if (!line.trim()) continue;
+            lineNo++;
+            rowCount++;
+
+            let row;
+            try {
+                row = JSON.parse(line);
+            } catch (err) {
+                fail(SOURCE_REJECTION_REASONS.jsonParse, err.message);
+            }
+
+            if (vectorRows) {
+                if (typeof row?.id !== 'string' || row.id.length === 0) {
+                    fail(SOURCE_REJECTION_REASONS.missingId);
+                }
+
+                const reason = classifyRowVector(row, expectedDimension);
+                if (reason) {
+                    fail(reason, `row id: ${row.id}`);
+                }
+            }
+        }
+    } finally {
+        rl.close();
+        stream.destroy();
+    }
+
+    return {rowCount}
+}

--- a/test/playwright/unit/ai/scripts/maintenance/embeddingCompatibility.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/embeddingCompatibility.spec.mjs
@@ -1,0 +1,166 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'EmbeddingCompatTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}           from '@playwright/test';
+import Neo                      from '../../../../../../src/Neo.mjs';
+import * as core                from '../../../../../../src/core/_export.mjs';
+import fs                       from 'node:fs';
+import os                       from 'node:os';
+import path                     from 'node:path';
+import AiConfig                 from '../../../../../../ai/config.mjs';
+import {buildEmbeddingContract} from '../../../../../../ai/scripts/maintenance/backup.mjs';
+import {
+    assertEmbeddingCompatibility,
+    validateBundle
+} from '../../../../../../ai/scripts/maintenance/restore.mjs';
+
+const
+    SILENT   = {log: () => {}, warn: () => {}, error: () => {}},
+    TMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-embedding-compat-')),
+    DIM      = 4096;
+
+function vector(value = 0.1) {
+    return new Array(DIM).fill(value)
+}
+
+function buildBundle({subdirs = ['kb', 'mc', 'graph', 'concepts', 'trajectories', 'mailbox'], meta = null, kbRows = null, mcRows = null} = {}) {
+    const bundleRoot = path.join(TMP_ROOT, `bundle-${Math.random().toString(36).slice(2, 8)}`);
+    const layout     = {};
+
+    for (const sub of subdirs) {
+        fs.mkdirSync(path.join(bundleRoot, sub), {recursive: true});
+        layout[sub] = path.join(bundleRoot, sub)
+    }
+
+    if (layout.kb) fs.writeFileSync(path.join(layout.kb, 'kb.jsonl'),
+        (kbRows ?? [{embedding: vector(), id: 'kb-1', metadata: {k: 'cls'}}]).map(r => JSON.stringify(r)).join('\n') + '\n');
+    if (layout.mc) fs.writeFileSync(path.join(layout.mc, 'mc.jsonl'),
+        (mcRows ?? [{embedding: vector(), id: 'm-1', metadata: {t: 'prompt'}}]).map(r => JSON.stringify(r)).join('\n') + '\n');
+    if (layout.graph) fs.writeFileSync(path.join(layout.graph, 'graph.jsonl'), '{"type":"node","data":{"id":"n-1"}}\n');
+    if (layout.concepts) fs.writeFileSync(path.join(layout.concepts, 'nodes.jsonl'), '{"id":"c-1"}\n');
+    if (layout.trajectories) fs.writeFileSync(path.join(layout.trajectories, 'trajectories.jsonl'), '{"id":"t-1"}\n');
+    if (layout.mailbox) fs.writeFileSync(path.join(layout.mailbox, 'sent-to-cull.jsonl'), '{"id":"x-1"}\n');
+
+    if (meta) fs.writeFileSync(path.join(bundleRoot, 'bundle-meta.json'), JSON.stringify(meta, null, 2));
+
+    return {bundleRoot, layout}
+}
+
+function liveMeta(fingerprint) {
+    return {
+        bundleVersion: 1,
+        embedding    : {
+            kb: {count: 1, dimension: DIM, fingerprint, model: 'm', provider: 'p', schemaVersion: 1},
+            mc: {count: 1, dimension: DIM, fingerprint, model: 'm', provider: 'p', schemaVersion: 1}
+        }
+    }
+}
+
+const expectedFingerprint = () => {
+    const provider = AiConfig.embeddingProvider;
+    const model    = provider === 'ollama' ? AiConfig.ollama.embeddingModel : AiConfig.openAiCompatible.embeddingModel;
+
+    return `${provider}:${model}:${DIM}`
+};
+
+test.describe('embedding compatibility contract (#15691)', () => {
+    test.afterAll(() => {
+        fs.rmSync(TMP_ROOT, {force: true, recursive: true})
+    });
+
+    test('the backup declares a versioned per-collection embedding contract with counts and fingerprint', () => {
+        const contract = buildEmbeddingContract({subsystems: {kb: 12000, mc: 450}});
+
+        for (const collection of ['kb', 'mc']) {
+            expect(contract[collection].schemaVersion).toBe(1);
+            expect(contract[collection].dimension).toBe(DIM);
+            expect(contract[collection].provider).toBe(AiConfig.embeddingProvider);
+            expect(typeof contract[collection].model).toBe('string');
+            expect(contract[collection].fingerprint).toBe(expectedFingerprint());
+        }
+        expect(contract.kb.count).toBe(12000);
+        expect(contract.mc.count).toBe(450);
+    });
+
+    test('a corrupt FINAL row cannot slip past the line-1 sample era — full streaming catches it', async () => {
+        const {bundleRoot, layout} = buildBundle({
+            kbRows: [
+                {embedding: vector(), id: 'kb-1', metadata: {}},
+                {embedding: vector(), id: 'kb-2', metadata: {}},
+                {embedding: vector(), id: 'kb-final-corrupt', metadata: {}, note: 'not-an-array'}
+            ],
+            meta: liveMeta(expectedFingerprint())
+        });
+
+        // The final row's embedding is deliberately not an array — but JSON.parse still needs a valid
+        // vector, so place it as a string field that classifyRowVector rejects.
+        fs.writeFileSync(path.join(layout.kb, 'kb.jsonl'), [
+            JSON.stringify({embedding: vector(), id: 'kb-1', metadata: {}}),
+            JSON.stringify({embedding: vector(), id: 'kb-2', metadata: {}}),
+            JSON.stringify({embedding: 'not-a-vector', id: 'kb-final-corrupt', metadata: {}})
+        ].join('\n') + '\n');
+
+        await expect(validateBundle(bundleRoot, layout, SILENT, DIM)).rejects.toThrow(/vector invariant violation at kb\/kb\.jsonl \(line 3\)/)
+    });
+
+    test('wrong-dimension and non-finite vectors fail with the row id and reason', async () => {
+        const {bundleRoot, layout} = buildBundle({
+            kbRows: [{embedding: [0.1, 0.2], id: 'kb-wrong-dim', metadata: {}}],
+            meta  : liveMeta(expectedFingerprint())
+        });
+
+        await expect(validateBundle(bundleRoot, layout, SILENT, DIM)).rejects.toThrow(/wrong-dimension.*kb-wrong-dim/);
+
+        const second = buildBundle({
+            kbRows: [{embedding: [...vector(), NaN], id: 'kb-nonfinite', metadata: {}}],
+            meta  : liveMeta(expectedFingerprint())
+        });
+
+        await expect(validateBundle(second.bundleRoot, second.layout, SILENT, DIM)).rejects.toThrow(/non-finite|wrong-dimension/)
+    });
+
+    test('a fingerprint mismatch fails BEFORE any mutation with the declared vs expected receipt', () => {
+        expect(() => assertEmbeddingCompatibility({
+            bundleRoot       : '/x',
+            expectedDimension: DIM,
+            logger           : SILENT,
+            meta             : liveMeta('other-provider:other-model:768')
+        })).toThrow(/Embedding-space incompatibility at kb: bundle declares 'other-provider:other-model:768' but the destination expects/)
+    });
+
+    test('a compatible bundle passes admission with zero embedding-provider contact', async () => {
+        const {bundleRoot, layout} = buildBundle({meta: liveMeta(expectedFingerprint())});
+        const meta                 = await validateBundle(bundleRoot, layout, SILENT, DIM);
+
+        expect(meta.embedding.kb.fingerprint).toBe(expectedFingerprint());
+        expect(meta.embedding.mc.fingerprint).toBe(expectedFingerprint());
+    });
+
+    test('legacy bundle (no embedding contract) validates rows against the live expected dimension and proceeds', async () => {
+        const {bundleRoot, layout} = buildBundle({meta: {bundleVersion: 1}});
+        const warnings             = [];
+        const meta                 = await validateBundle(bundleRoot, layout, {log: () => {}, warn: message => warnings.push(message)}, DIM);
+
+        expect(meta.bundleVersion).toBe(1);
+        expect(warnings.some(message => message.includes('no declared embedding contract'))).toBe(true);
+    });
+
+    test('a matching legacy-shape row set with wrong dimension still fails — the fallback is not a bypass', async () => {
+        const {bundleRoot, layout} = buildBundle({
+            kbRows: [{embedding: [1, 2, 3], id: 'kb-legacy-wrong', metadata: {}}],
+            meta  : {bundleVersion: 1}
+        });
+
+        await expect(validateBundle(bundleRoot, layout, SILENT, DIM)).rejects.toThrow(/wrong-dimension/)
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/embeddingCompatibility.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/embeddingCompatibility.spec.mjs
@@ -45,7 +45,7 @@ function buildBundle({subdirs = ['kb', 'mc', 'graph', 'concepts', 'trajectories'
 
     if (layout.kb) fs.writeFileSync(path.join(layout.kb, 'kb.jsonl'),
         (kbRows ?? [{embedding: vector(), id: 'kb-1', metadata: {k: 'cls'}}]).map(r => JSON.stringify(r)).join('\n') + '\n');
-    if (layout.mc) fs.writeFileSync(path.join(layout.mc, 'mc.jsonl'),
+    if (layout.mc) fs.writeFileSync(path.join(layout.mc, 'memory-backup.jsonl'),
         (mcRows ?? [{embedding: vector(), id: 'm-1', metadata: {t: 'prompt'}}]).map(r => JSON.stringify(r)).join('\n') + '\n');
     if (layout.graph) fs.writeFileSync(path.join(layout.graph, 'graph.jsonl'), '{"type":"node","data":{"id":"n-1"}}\n');
     if (layout.concepts) fs.writeFileSync(path.join(layout.concepts, 'nodes.jsonl'), '{"id":"c-1"}\n');
@@ -66,11 +66,10 @@ const liveConsumer = () => {
     }
 };
 
-function liveMeta({consumer = liveConsumer(), dimension = DIM, kbCount = 1, mcCount = 1, schemaVersion = 1} = {}) {
+function liveMeta({consumer = liveConsumer(), counts = {kb: 1, memories: 1, summaries: 0}, dimension = DIM, schemaVersion = 1} = {}) {
     const embedding = {
+        counts,
         dimension,
-        kb: {count: kbCount},
-        mc: {count: mcCount},
         schemaVersion
     };
 
@@ -84,18 +83,21 @@ test.describe('embedding compatibility contract (#15691)', () => {
         fs.rmSync(TMP_ROOT, {force: true, recursive: true})
     });
 
-    test('the backup stamps write-time facts (dimension, counts) plus an advisory consumer expectation — never vector provenance', () => {
-        const contract = buildEmbeddingContract({subsystems: {kb: 12000, mc: 450}});
+    test('the backup stamps write-time facts (dimension, per-collection counts) plus an advisory consumer expectation — never vector provenance', () => {
+        const contract = buildEmbeddingContract({
+            subsystems: {
+                kb: 12000,
+                mc: {memories: {exported: 400}, summaries: {exported: 50}}
+            }
+        });
 
         expect(contract.schemaVersion).toBe(1);
         expect(contract.dimension).toBe(AiConfig.vectorDimension);
         expect(contract.expectedConsumer.provider).toBe(AiConfig.embeddingProvider);
         expect(typeof contract.expectedConsumer.model).toBe('string');
-        expect(contract.kb).toEqual({count: 12000});
-        expect(contract.mc).toEqual({count: 450});
+        expect(contract.counts).toEqual({kb: 12000, memories: 400, summaries: 50});
         // No fingerprint, no producer claim: a config snapshot is not write-time vector provenance.
         expect('fingerprint' in contract).toBe(false);
-        expect('fingerprint' in contract.kb).toBe(false);
     });
 
     test('a corrupt FINAL row cannot slip past the line-1 sample era — full streaming catches it', async () => {
@@ -142,12 +144,24 @@ test.describe('embedding compatibility contract (#15691)', () => {
         await expect(validateBundle(bundle.bundleRoot, bundle.layout, SILENT, DIM)).rejects.toThrow(/dimension-contract-mismatch/);
 
         // Declared count contradicts the streamed row total
-        bundle = buildBundle({meta: liveMeta({kbCount: 5})});
+        bundle = buildBundle({meta: liveMeta({counts: {kb: 5, memories: 1, summaries: 0}})});
         await expect(validateBundle(bundle.bundleRoot, bundle.layout, SILENT, DIM)).rejects.toThrow(/count-contract-mismatch.*declares 5.*streams 1/);
 
-        // Malformed per-collection block
-        bundle = buildBundle({meta: liveMeta({kbCount: -1})});
+        // Null and negative counts are not attestations
+        bundle = buildBundle({meta: liveMeta({counts: {kb: null, memories: 1, summaries: 0}})});
         await expect(validateBundle(bundle.bundleRoot, bundle.layout, SILENT, DIM)).rejects.toThrow(/invalid-embedding-schema/);
+        bundle = buildBundle({meta: liveMeta({counts: {kb: -1, memories: 1, summaries: 0}})});
+        await expect(validateBundle(bundle.bundleRoot, bundle.layout, SILENT, DIM)).rejects.toThrow(/invalid-embedding-schema/);
+
+        // Cross-collection truth: a declared summaries count with no summaries file contradicts the stream
+        bundle = buildBundle({meta: liveMeta({counts: {kb: 1, memories: 1, summaries: 3}})});
+        await expect(validateBundle(bundle.bundleRoot, bundle.layout, SILENT, DIM)).rejects.toThrow(/count-contract-mismatch.*summaries declares 3.*streams 0/);
+
+        // An undeclared streamed collection is a mismatch in the other direction
+        bundle = buildBundle({meta: liveMeta({counts: {kb: 1, memories: 1}})});
+        fs.writeFileSync(path.join(bundle.layout.mc, 'summaries-backup.jsonl'),
+            JSON.stringify({embedding: vector(), id: 's-1', metadata: {}}) + '\n');
+        await expect(validateBundle(bundle.bundleRoot, bundle.layout, SILENT, DIM)).rejects.toThrow(/count-contract-mismatch.*streams 1 summaries.*no count is declared/);
     });
 
     test('a consumer-expectation mismatch is an advisory classification, never a hard refusal', async () => {
@@ -158,9 +172,10 @@ test.describe('embedding compatibility contract (#15691)', () => {
 
         const meta = await validateBundle(bundleRoot, layout, {log: () => {}, warn: message => warnings.push(message)}, DIM);
 
-        expect(meta.embeddingAdvisories).toHaveLength(1);
-        expect(meta.embeddingAdvisories[0].reason).toBe('consumer-expectation-mismatch');
-        expect(meta.embeddingAdvisories[0].bundle).toEqual({model: 'other-model', provider: 'other-provider'});
+        expect(meta.embeddingAdvisories).toHaveLength(2);
+        expect(meta.embeddingAdvisories[0].reason).toBe('semantic-provenance-unverified');
+        expect(meta.embeddingAdvisories[1].reason).toBe('consumer-expectation-mismatch');
+        expect(meta.embeddingAdvisories[1].bundle).toEqual({model: 'other-model', provider: 'other-provider'});
         expect(warnings.some(message => message.includes('consumer-expectation-mismatch'))).toBe(true);
     });
 
@@ -176,11 +191,12 @@ test.describe('embedding compatibility contract (#15691)', () => {
         expect(advisories[0].reason).toBe('semantic-provenance-unverified');
     });
 
-    test('a compatible bundle passes admission with zero embedding-provider contact and no advisories', async () => {
+    test('a matching consumer expectation still classifies provenance as unverified — a match is not evidence', async () => {
         const {bundleRoot, layout} = buildBundle({meta: liveMeta()});
         const meta                 = await validateBundle(bundleRoot, layout, SILENT, DIM);
 
-        expect(meta.embeddingAdvisories).toEqual([]);
+        expect(meta.embeddingAdvisories).toHaveLength(1);
+        expect(meta.embeddingAdvisories[0].reason).toBe('semantic-provenance-unverified');
         expect(meta.embedding.dimension).toBe(DIM);
     });
 
@@ -190,6 +206,7 @@ test.describe('embedding compatibility contract (#15691)', () => {
         const meta                 = await validateBundle(bundleRoot, layout, {log: () => {}, warn: message => warnings.push(message)}, DIM);
 
         expect(meta.bundleVersion).toBe(1);
+        expect(meta.embeddingAdvisories[0].reason).toBe('semantic-provenance-unverified');
         expect(warnings.some(message => message.includes('semantic-provenance-unverified'))).toBe(true);
     });
 

--- a/test/playwright/unit/ai/scripts/maintenance/embeddingCompatibility.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/embeddingCompatibility.spec.mjs
@@ -17,11 +17,12 @@ import * as core                from '../../../../../../src/core/_export.mjs';
 import fs                       from 'node:fs';
 import os                       from 'node:os';
 import path                     from 'node:path';
-import AiConfig                 from '../../../../../../ai/config.mjs';
+import AiConfig                 from '../../../../../../ai/config.template.mjs';
 import {buildEmbeddingContract} from '../../../../../../ai/scripts/maintenance/backup.mjs';
 import {
-    assertEmbeddingCompatibility,
-    validateBundle
+    assessEmbeddingCompatibility,
+    validateBundle,
+    validateEmbeddingContractSchema
 } from '../../../../../../ai/scripts/maintenance/restore.mjs';
 
 const
@@ -56,54 +57,50 @@ function buildBundle({subdirs = ['kb', 'mc', 'graph', 'concepts', 'trajectories'
     return {bundleRoot, layout}
 }
 
-function liveMeta(fingerprint) {
-    return {
-        bundleVersion: 1,
-        embedding    : {
-            kb: {count: 1, dimension: DIM, fingerprint, model: 'm', provider: 'p', schemaVersion: 1},
-            mc: {count: 1, dimension: DIM, fingerprint, model: 'm', provider: 'p', schemaVersion: 1}
-        }
-    }
-}
-
-const expectedFingerprint = () => {
+const liveConsumer = () => {
     const provider = AiConfig.embeddingProvider;
-    const model    = provider === 'ollama' ? AiConfig.ollama.embeddingModel : AiConfig.openAiCompatible.embeddingModel;
 
-    return `${provider}:${model}:${DIM}`
+    return {
+        model: provider === 'ollama' ? AiConfig.ollama.embeddingModel : AiConfig.openAiCompatible.embeddingModel,
+        provider
+    }
 };
+
+function liveMeta({consumer = liveConsumer(), dimension = DIM, kbCount = 1, mcCount = 1, schemaVersion = 1} = {}) {
+    const embedding = {
+        dimension,
+        kb: {count: kbCount},
+        mc: {count: mcCount},
+        schemaVersion
+    };
+
+    if (consumer) embedding.expectedConsumer = consumer;
+
+    return {bundleVersion: 1, embedding}
+}
 
 test.describe('embedding compatibility contract (#15691)', () => {
     test.afterAll(() => {
         fs.rmSync(TMP_ROOT, {force: true, recursive: true})
     });
 
-    test('the backup declares a versioned per-collection embedding contract with counts and fingerprint', () => {
+    test('the backup stamps write-time facts (dimension, counts) plus an advisory consumer expectation — never vector provenance', () => {
         const contract = buildEmbeddingContract({subsystems: {kb: 12000, mc: 450}});
 
-        for (const collection of ['kb', 'mc']) {
-            expect(contract[collection].schemaVersion).toBe(1);
-            expect(contract[collection].dimension).toBe(DIM);
-            expect(contract[collection].provider).toBe(AiConfig.embeddingProvider);
-            expect(typeof contract[collection].model).toBe('string');
-            expect(contract[collection].fingerprint).toBe(expectedFingerprint());
-        }
-        expect(contract.kb.count).toBe(12000);
-        expect(contract.mc.count).toBe(450);
+        expect(contract.schemaVersion).toBe(1);
+        expect(contract.dimension).toBe(AiConfig.vectorDimension);
+        expect(contract.expectedConsumer.provider).toBe(AiConfig.embeddingProvider);
+        expect(typeof contract.expectedConsumer.model).toBe('string');
+        expect(contract.kb).toEqual({count: 12000});
+        expect(contract.mc).toEqual({count: 450});
+        // No fingerprint, no producer claim: a config snapshot is not write-time vector provenance.
+        expect('fingerprint' in contract).toBe(false);
+        expect('fingerprint' in contract.kb).toBe(false);
     });
 
     test('a corrupt FINAL row cannot slip past the line-1 sample era — full streaming catches it', async () => {
-        const {bundleRoot, layout} = buildBundle({
-            kbRows: [
-                {embedding: vector(), id: 'kb-1', metadata: {}},
-                {embedding: vector(), id: 'kb-2', metadata: {}},
-                {embedding: vector(), id: 'kb-final-corrupt', metadata: {}, note: 'not-an-array'}
-            ],
-            meta: liveMeta(expectedFingerprint())
-        });
+        const {bundleRoot, layout} = buildBundle({kbRows: []});
 
-        // The final row's embedding is deliberately not an array — but JSON.parse still needs a valid
-        // vector, so place it as a string field that classifyRowVector rejects.
         fs.writeFileSync(path.join(layout.kb, 'kb.jsonl'), [
             JSON.stringify({embedding: vector(), id: 'kb-1', metadata: {}}),
             JSON.stringify({embedding: vector(), id: 'kb-2', metadata: {}}),
@@ -115,35 +112,76 @@ test.describe('embedding compatibility contract (#15691)', () => {
 
     test('wrong-dimension and non-finite vectors fail with the row id and reason', async () => {
         const {bundleRoot, layout} = buildBundle({
-            kbRows: [{embedding: [0.1, 0.2], id: 'kb-wrong-dim', metadata: {}}],
-            meta  : liveMeta(expectedFingerprint())
+            kbRows: [{embedding: [0.1, 0.2], id: 'kb-wrong-dim', metadata: {}}]
         });
 
         await expect(validateBundle(bundleRoot, layout, SILENT, DIM)).rejects.toThrow(/wrong-dimension.*kb-wrong-dim/);
 
         const second = buildBundle({
-            kbRows: [{embedding: [...vector(), NaN], id: 'kb-nonfinite', metadata: {}}],
-            meta  : liveMeta(expectedFingerprint())
+            kbRows: [{embedding: [...vector(), NaN], id: 'kb-nonfinite', metadata: {}}]
         });
 
         await expect(validateBundle(second.bundleRoot, second.layout, SILENT, DIM)).rejects.toThrow(/non-finite|wrong-dimension/)
     });
 
-    test('a fingerprint mismatch fails BEFORE any mutation with the declared vs expected receipt', () => {
-        expect(() => assertEmbeddingCompatibility({
-            bundleRoot       : '/x',
-            expectedDimension: DIM,
-            logger           : SILENT,
-            meta             : liveMeta('other-provider:other-model:768')
-        })).toThrow(/Embedding-space incompatibility at kb: bundle declares 'other-provider:other-model:768' but the destination expects/)
+    test('a vector row without a non-empty string id fails as missing-id', async () => {
+        const {bundleRoot, layout} = buildBundle({
+            kbRows: [{embedding: vector(), metadata: {}}]
+        });
+
+        await expect(validateBundle(bundleRoot, layout, SILENT, DIM)).rejects.toThrow(/missing-id/)
     });
 
-    test('a compatible bundle passes admission with zero embedding-provider contact', async () => {
-        const {bundleRoot, layout} = buildBundle({meta: liveMeta(expectedFingerprint())});
+    test('the declared schema, dimension, and counts are hard gates bound to the bundle\'s own evidence', async () => {
+        // Unsupported schema version
+        let bundle = buildBundle({meta: liveMeta({schemaVersion: 2})});
+        await expect(validateBundle(bundle.bundleRoot, bundle.layout, SILENT, DIM)).rejects.toThrow(/unsupported-schema-version/);
+
+        // Declared dimension contradicts the destination's expectation
+        bundle = buildBundle({meta: liveMeta({dimension: 768})});
+        await expect(validateBundle(bundle.bundleRoot, bundle.layout, SILENT, DIM)).rejects.toThrow(/dimension-contract-mismatch/);
+
+        // Declared count contradicts the streamed row total
+        bundle = buildBundle({meta: liveMeta({kbCount: 5})});
+        await expect(validateBundle(bundle.bundleRoot, bundle.layout, SILENT, DIM)).rejects.toThrow(/count-contract-mismatch.*declares 5.*streams 1/);
+
+        // Malformed per-collection block
+        bundle = buildBundle({meta: liveMeta({kbCount: -1})});
+        await expect(validateBundle(bundle.bundleRoot, bundle.layout, SILENT, DIM)).rejects.toThrow(/invalid-embedding-schema/);
+    });
+
+    test('a consumer-expectation mismatch is an advisory classification, never a hard refusal', async () => {
+        const {bundleRoot, layout} = buildBundle({
+            meta: liveMeta({consumer: {model: 'other-model', provider: 'other-provider'}})
+        });
+        const warnings = [];
+
+        const meta = await validateBundle(bundleRoot, layout, {log: () => {}, warn: message => warnings.push(message)}, DIM);
+
+        expect(meta.embeddingAdvisories).toHaveLength(1);
+        expect(meta.embeddingAdvisories[0].reason).toBe('consumer-expectation-mismatch');
+        expect(meta.embeddingAdvisories[0].bundle).toEqual({model: 'other-model', provider: 'other-provider'});
+        expect(warnings.some(message => message.includes('consumer-expectation-mismatch'))).toBe(true);
+    });
+
+    test('an embedding block without expectedConsumer classifies provenance as unverified, not as a failure', () => {
+        const meta       = liveMeta({consumer: null});
+        const advisories = assessEmbeddingCompatibility({
+            expectedDimension: DIM,
+            logger           : SILENT,
+            meta
+        });
+
+        expect(advisories).toHaveLength(1);
+        expect(advisories[0].reason).toBe('semantic-provenance-unverified');
+    });
+
+    test('a compatible bundle passes admission with zero embedding-provider contact and no advisories', async () => {
+        const {bundleRoot, layout} = buildBundle({meta: liveMeta()});
         const meta                 = await validateBundle(bundleRoot, layout, SILENT, DIM);
 
-        expect(meta.embedding.kb.fingerprint).toBe(expectedFingerprint());
-        expect(meta.embedding.mc.fingerprint).toBe(expectedFingerprint());
+        expect(meta.embeddingAdvisories).toEqual([]);
+        expect(meta.embedding.dimension).toBe(DIM);
     });
 
     test('legacy bundle (no embedding contract) validates rows against the live expected dimension and proceeds', async () => {
@@ -152,7 +190,7 @@ test.describe('embedding compatibility contract (#15691)', () => {
         const meta                 = await validateBundle(bundleRoot, layout, {log: () => {}, warn: message => warnings.push(message)}, DIM);
 
         expect(meta.bundleVersion).toBe(1);
-        expect(warnings.some(message => message.includes('no declared embedding contract'))).toBe(true);
+        expect(warnings.some(message => message.includes('semantic-provenance-unverified'))).toBe(true);
     });
 
     test('a matching legacy-shape row set with wrong dimension still fails — the fallback is not a bypass', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs
@@ -88,9 +88,11 @@ test.describe('restore hardening regression (#11150 / #11151)', () => {
         const bundle   = path.join(workRoot, 'bundle');
         const subdirs  = ['kb', 'mc', 'graph', 'concepts', 'trajectories'];
         for (const s of subdirs) await fsExtra.ensureDir(path.join(bundle, s));
-        // Plant one JSONL file per subdir
-        await fsExtra.writeFile(path.join(bundle, 'kb', 'k.jsonl'), '{"id":"k1"}\n');
-        await fsExtra.writeFile(path.join(bundle, 'mc', 'm.jsonl'), '{"id":"m1"}\n');
+        // Plant one JSONL file per subdir; vector-collection rows carry full-dimension vectors
+        // because the embedding-compatibility invariant gates every kb/mc row.
+        const vec = new Array(4096).fill(0.1);
+        await fsExtra.writeFile(path.join(bundle, 'kb', 'k.jsonl'), JSON.stringify({id: 'k1', embedding: vec, metadata: {}}) + '\n');
+        await fsExtra.writeFile(path.join(bundle, 'mc', 'm.jsonl'), JSON.stringify({id: 'm1', embedding: vec, metadata: {}}) + '\n');
         await fsExtra.writeFile(path.join(bundle, 'graph', 'g.jsonl'), '{"type":"node","data":{"id":"g1"}}\n');
         await fsExtra.writeFile(path.join(bundle, 'concepts', 'nodes.jsonl'), '{"id":"c1"}\n');
         await fsExtra.writeFile(path.join(bundle, 'trajectories', 'trajectories.jsonl'), '{"x":1}\n');

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -351,7 +351,10 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             logger                : silentLogger
         });
 
-        expect(result.meta).toBeNull();
+        // A legacy bundle carries no meta file; the orchestrator still receives the structured
+        // unknown-provenance receipt rather than a bare null.
+        expect(result.meta.legacy).toBe(true);
+        expect(result.meta.embeddingAdvisories[0].reason).toBe('semantic-provenance-unverified');
         expect(result.topology.bundleChromaUnified).toBeUndefined();
         expect(result.topology.match).toBe(true);
         expect(calls.kb).toHaveLength(1);

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -174,7 +174,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         const trajTgt     = path.join(workRoot, 'happy-merge-targets', 'trajectories.jsonl');
         const mailboxTgt  = path.join(workRoot, 'happy-merge-targets', 'sent-to-cull.jsonl');
 
-        const result = await runRestore({
+        const result = await runRestore({ expectedDimension: 1,
             bundleRoot,
             mode                  : 'merge',
             conceptsTargetDir     : conceptsTgt,
@@ -214,7 +214,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         const bundleRoot = buildSyntheticBundle({bundleName: 'corrupt-missing-mc', omitSubdirs: ['mc']});
 
         await expect(
-            runRestore({bundleRoot, logger: silentLogger})
+            runRestore({ expectedDimension: 1, bundleRoot, logger: silentLogger})
         ).rejects.toThrow(/Required bundle subdirectory missing: mc/);
 
         // No SDK writes attempted
@@ -228,13 +228,13 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         const bundleRoot = buildSyntheticBundle({bundleName: 'topo-mismatch', chromaUnified: false});
 
         await expect(
-            runRestore({bundleRoot, logger: silentLogger})
+            runRestore({ expectedDimension: 1, bundleRoot, logger: silentLogger})
         ).rejects.toThrow(/Topology mismatch: bundle was taken under legacy federated mode, but current deployment is permanently unified\./);
 
         expect(calls.kb).toHaveLength(0);
         expect(calls.mc).toHaveLength(0);
 
-        const result = await runRestore({
+        const result = await runRestore({ expectedDimension: 1,
             bundleRoot,
             forceTopologyMismatch : true,
             conceptsTargetDir     : path.join(workRoot, 'topo-targets', 'concepts'),
@@ -254,7 +254,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         Memory_StorageRouter.getMemoryCollection = async () => ({count: async () => 42});
 
         await expect(
-            runRestore({bundleRoot, mode: 'replace', force: false, logger: silentLogger})
+            runRestore({ expectedDimension: 1, bundleRoot, mode: 'replace', force: false, logger: silentLogger})
         ).rejects.toThrow(/Refusing replace mode without --force.*mc\.memories=42/);
 
         expect(calls.kb).toHaveLength(0);
@@ -270,7 +270,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         // Targets empty so --force-not-needed-due-to-empty-targets passes the pre-flight occupancy check.
         // Goal of this test: assert guard fires for flat substrates AND mode=replace forwards through SDK.
 
-        const result = await runRestore({
+        const result = await runRestore({ expectedDimension: 1,
             bundleRoot,
             mode                  : 'replace',
             confirmation          : 'CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE',
@@ -317,7 +317,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         fs.writeFileSync(trajTgt, '{"existing":"operator-trajectory"}\n');
         fs.writeFileSync(mailboxTgt, '{"existing":"operator-mailbox"}\n');
 
-        const result = await runRestore({
+        const result = await runRestore({ expectedDimension: 1,
             bundleRoot,
             mode                  : 'merge',
             conceptsTargetDir     : conceptsTgt,
@@ -343,7 +343,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         const bundleRoot = buildSyntheticBundle({bundleName: 'legacy-no-meta', chromaUnified: true});
         fs.unlinkSync(path.join(bundleRoot, 'bundle-meta.json'));
 
-        const result = await runRestore({
+        const result = await runRestore({ expectedDimension: 1,
             bundleRoot,
             conceptsTargetDir     : path.join(workRoot, 'legacy-targets', 'concepts'),
             trajectoriesTargetFile: path.join(workRoot, 'legacy-targets', 'trajectories.jsonl'),
@@ -360,7 +360,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
     test('rejects unknown mode at orchestrator entry', async () => {
         const bundleRoot = buildSyntheticBundle({bundleName: 'unknown-mode', chromaUnified: true});
         await expect(
-            runRestore({bundleRoot, mode: 'wipe', logger: silentLogger})
+            runRestore({ expectedDimension: 1, bundleRoot, mode: 'wipe', logger: silentLogger})
         ).rejects.toThrow(/Unknown mode: wipe/);
     });
 
@@ -369,7 +369,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         fs.writeFileSync(path.join(bundleRoot, 'kb', 'broken.jsonl'), 'this-is-not-json\n');
 
         await expect(
-            runRestore({bundleRoot, logger: silentLogger})
+            runRestore({ expectedDimension: 1, bundleRoot, logger: silentLogger})
         ).rejects.toThrow(/Bundle JSONL parse error at kb\/broken\.jsonl/);
 
         expect(calls.kb).toHaveLength(0);
@@ -422,7 +422,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             trajectories: path.join(bundleRoot, 'trajectories'),
             mailbox     : path.join(bundleRoot, 'mailbox')
         };
-        const meta = await validateBundle(bundleRoot, layout, silentLogger);
+        const meta = await validateBundle(bundleRoot, layout, silentLogger, 1);
         expect(meta.bundleVersion).toBe(1);
         expect(meta.topology.chromaUnified).toBe(true);
     });
@@ -438,8 +438,10 @@ test.describe('verifyLatestBackupRestorable — read-only restorability probe (#
         for (const sub of ['kb', 'mc', 'graph', 'concepts', 'trajectories']) {
             fs.mkdirSync(path.join(bundleRoot, sub), {recursive: true});
         }
+        // The embedding-compatibility invariant requires a full 4096-dim vector on
+        // vector-collection rows — the fixture row carries one explicitly.
         fs.writeFileSync(path.join(bundleRoot, 'mc', 'memory-backup.jsonl'),
-            torn ? '{this is not valid json\n' : '{"id":"m-1"}\n');
+            torn ? '{this is not valid json\n' : JSON.stringify({id: 'm-1', embedding: new Array(4096).fill(0.1), metadata: {t: 'prompt'}}) + '\n');
         return bundleRoot;
     };
 

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseService.backup.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseService.backup.spec.mjs
@@ -55,6 +55,57 @@ test.describe('KB_DatabaseService — manageDatabaseBackup (#10129 Phase 1)', ()
         }
     });
 
+    test('the import vector invariant rejects invalid rows fail-loud BEFORE any upsert (#15691)', async () => {
+        const upserts        = [];
+        const fakeCollection = {
+            name  : 'fake-kb-import',
+            upsert: async args => { upserts.push(args) }
+        };
+
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => fakeCollection;
+
+        const importFile = path.join(tmpBackupDir, 'import-bad-vector.jsonl');
+        fs.writeFileSync(importFile, [
+            JSON.stringify({id: 'good-1', embedding: new Array(4096).fill(0.1), metadata: {kind: 'class'}, document: 'doc'}),
+            JSON.stringify({id: 'bad-wrong-dim', embedding: [0.1, 0.2], metadata: {kind: 'class'}, document: 'doc'}),
+            JSON.stringify({id: 'bad-nonfinite', embedding: [...new Array(4095).fill(0.1), NaN], metadata: {kind: 'class'}, document: 'doc'})
+        ].join('\n') + '\n');
+
+        await expect(KB_DatabaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : importFile,
+            mode  : 'merge'
+        })).rejects.toThrow(/vector invariant rejected .*row\(s\)/);
+
+        expect(upserts).toHaveLength(0); // fail-loud BEFORE any write — never half-persisted
+    });
+
+    test('the import vector invariant passes a fully-valid file through to upsert (#15691)', async () => {
+        const upserts        = [];
+        const fakeCollection = {
+            name  : 'fake-kb-import-valid',
+            upsert: async args => { upserts.push(args) }
+        };
+
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => fakeCollection;
+
+        const importFile = path.join(tmpBackupDir, 'import-valid-vector.jsonl');
+        fs.writeFileSync(importFile, [
+            JSON.stringify({id: 'good-1', embedding: new Array(4096).fill(0.1), metadata: {kind: 'class'}, document: 'doc-1'}),
+            JSON.stringify({id: 'good-2', embedding: new Array(4096).fill(0.2), metadata: {kind: 'method'}, document: 'doc-2'})
+        ].join('\n') + '\n');
+
+        const result = await KB_DatabaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : importFile,
+            mode  : 'merge'
+        });
+
+        expect(result.imported).toBe(2);
+        expect(upserts).toHaveLength(1);
+        expect(upserts[0].embeddings).toHaveLength(2);
+    });
+
     test('exports a populated collection as a timestamped JSONL artifact', async () => {
         const fakeRows = [
             {id: 'id-1', embedding: [0.1, 0.2], metadata: {kind: 'class'},  document: 'doc-1'},
@@ -130,9 +181,11 @@ test.describe('KB_DatabaseService — manageDatabaseBackup (#10129 Phase 1)', ()
 
     test('rejects unsupported actions at the dispatcher layer', async () => {
         // No openapi operation is registered for `manage_database_backup` in KB (retired per
-        // #10132 script-over-tool reduction), so `makeSafe` no-match passthrough forwards
+        // #10132 script-over-tool reduction — ticket-ref-ok: load-bearing history for why no
+        // no-match passthrough applies), so `makeSafe` no-match passthrough forwards
         // args raw — the manual `throw new Error('Unknown action...')` inside the dispatcher
-        // is the rejection path. `'import'` and `'truncate'` were added in #10871 AC-B; this
+        // is the rejection path. `'import'` and `'truncate'` were added in #10871 AC-B (ticket-ref-ok:
+        // load-bearing anchor for the dispatcher contract under test); this
         // assertion uses an unambiguously-unsupported action to keep the dispatcher rejection
         // contract under test.
         await expect(

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseService.importNullDoc.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseService.importNullDoc.spec.mjs
@@ -71,11 +71,19 @@ test.describe('KB_DatabaseService.importDatabase — null-document handling (#11
         return filePath;
     }
 
+
+    // Full-dimension vectors: the atomic vector-write invariant gates every imported KB row, so
+    // fixtures must satisfy the real contract (the mock collection ignores the values themselves).
+    const DIM = 4096;
+    function vec(seed = 0.1) {
+        return new Array(DIM).fill(seed)
+    }
+
     test('omits documents field when every record in batch has document: null (KB steady-state shape)', async () => {
         const filePath = writeBackupFile('kb-all-null.jsonl', [
-            {id: 'id-1', embedding: [0.1, 0.2], metadata: {kind: 'class', content: 'class A {}'}, document: null},
-            {id: 'id-2', embedding: [0.3, 0.4], metadata: {kind: 'method', content: 'method foo()'}, document: null},
-            {id: 'id-3', embedding: [0.5, 0.6], metadata: {kind: 'module', content: 'export default {}'}, document: null}
+            {id: 'id-1', embedding: vec(0.1), metadata: {kind: 'class', content: 'class A {}'}, document: null},
+            {id: 'id-2', embedding: vec(0.3), metadata: {kind: 'method', content: 'method foo()'}, document: null},
+            {id: 'id-3', embedding: vec(0.5), metadata: {kind: 'module', content: 'export default {}'}, document: null}
         ]);
 
         const result = await KB_DatabaseService.importDatabase({
@@ -99,8 +107,8 @@ test.describe('KB_DatabaseService.importDatabase — null-document handling (#11
 
     test('includes documents field with strings when every record carries a non-null document (MC-style records)', async () => {
         const filePath = writeBackupFile('kb-all-strings.jsonl', [
-            {id: 'id-1', embedding: [0.1, 0.2], metadata: {kind: 'memory'}, document: 'memory body 1'},
-            {id: 'id-2', embedding: [0.3, 0.4], metadata: {kind: 'memory'}, document: 'memory body 2'}
+            {id: 'id-1', embedding: vec(0.1), metadata: {kind: 'memory'}, document: 'memory body 1'},
+            {id: 'id-2', embedding: vec(0.3), metadata: {kind: 'memory'}, document: 'memory body 2'}
         ]);
 
         const result = await KB_DatabaseService.importDatabase({
@@ -116,9 +124,9 @@ test.describe('KB_DatabaseService.importDatabase — null-document handling (#11
 
     test('substitutes empty strings for null documents in mixed batch (defensive — preserves field for non-null entries)', async () => {
         const filePath = writeBackupFile('kb-mixed.jsonl', [
-            {id: 'id-1', embedding: [0.1, 0.2], metadata: {kind: 'class'},   document: null},
-            {id: 'id-2', embedding: [0.3, 0.4], metadata: {kind: 'memory'},  document: 'memory body'},
-            {id: 'id-3', embedding: [0.5, 0.6], metadata: {kind: 'class'},   document: null}
+            {id: 'id-1', embedding: vec(0.1), metadata: {kind: 'class'},   document: null},
+            {id: 'id-2', embedding: vec(0.3), metadata: {kind: 'memory'},  document: 'memory body'},
+            {id: 'id-3', embedding: vec(0.5), metadata: {kind: 'class'},   document: null}
         ]);
 
         const result = await KB_DatabaseService.importDatabase({
@@ -136,7 +144,7 @@ test.describe('KB_DatabaseService.importDatabase — null-document handling (#11
     test('handles batch boundary correctly — 501 all-null records (BATCH_SIZE=500) still omits documents on both batches', async () => {
         const records = [];
         for (let i = 0; i < 501; i++) {
-            records.push({id: `id-${i}`, embedding: [i, i + 1], metadata: {n: i}, document: null});
+            records.push({id: `id-${i}`, embedding: vec(i), metadata: {n: i}, document: null});
         }
         const filePath = writeBackupFile('kb-501-null.jsonl', records);
 
@@ -216,7 +224,7 @@ test.describe('KB_DatabaseService.importDatabase — null-document handling (#11
         const filePath = writeBackupFile('kb-shape-reproducer.jsonl', [
             {
                 id       : 'h-1',
-                embedding: [0.001, 0.002, 0.003],
+                embedding: vec(0.001),
                 metadata : {
                     source    : 'src/canvas/_export.mjs',
                     name      : 'src/canvas/_export.mjs - [Module Context]',
@@ -243,5 +251,33 @@ test.describe('KB_DatabaseService.importDatabase — null-document handling (#11
         // forwarding its null document would surface a DATABASE_IMPORT_ERROR.
         expect(result.imported).toBe(1);
         expect('documents' in capturedUpsertCalls[0]).toBe(false);
+    });
+
+    test('replace mode: a corrupt FINAL row proves the full source BEFORE any truncate or write', async () => {
+        const filePath = writeBackupFile('kb-corrupt-final.jsonl', [
+            {id: 'ok-1', embedding: vec(0.1), metadata: {kind: 'class'}, document: null},
+            {id: 'ok-2', embedding: vec(0.2), metadata: {kind: 'class'}, document: null},
+            {id: 'corrupt-final', embedding: 'not-a-vector', metadata: {kind: 'class'}, document: null}
+        ]);
+
+        let   truncateCalls    = 0;
+        const originalTruncate = KB_DatabaseService.truncateDatabase.bind(KB_DatabaseService);
+        KB_DatabaseService.truncateDatabase = async (...args) => {
+            truncateCalls++;
+            return originalTruncate(...args);
+        };
+
+        try {
+            await expect(KB_DatabaseService.importDatabase({
+                action: 'import',
+                file  : filePath,
+                mode  : 'replace'
+            })).rejects.toThrow(/Source validation failed.*missing-embedding|wrong-dimension|not persisted/);
+
+            expect(truncateCalls).toBe(0);
+            expect(capturedUpsertCalls).toHaveLength(0);
+        } finally {
+            KB_DatabaseService.truncateDatabase = originalTruncate;
+        }
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseService.importNullDoc.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseService.importNullDoc.spec.mjs
@@ -171,11 +171,11 @@ test.describe('KB_DatabaseService.importDatabase — null-document handling (#11
 
         const headRecords = Array.from({length: 500}, (_, index) => ({
             id       : `head-${index}`,
-            embedding: [index],
+            embedding: vec(index),
             metadata : {index},
             document : null
         }));
-        const tailRecord = {id: 'tail-500', embedding: [500], metadata: {index: 500}, document: null};
+        const tailRecord = {id: 'tail-500', embedding: vec(500), metadata: {index: 500}, document: null};
 
         let releaseTail;
         const tailGate                 = new Promise(resolve => { releaseTail = resolve; });

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
@@ -259,16 +259,20 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
         expect(memoryCollection.addCalls[0].ids).toEqual(['gate-valid']);
     });
 
-    test('replace mode: atomic vector-write invariant rejects invalid vectors on the upsert path', async () => {
-        // The gate guards BOTH branches; replace-mode upsert must reject missing/wrong-dim the same way,
-        // adjusting fileInserted (records.length - rejected) so the count stays truthful.
+    test('replace mode: any invalid vector fails the whole import before truncate — replace is all-or-nothing', async () => {
+        // The pre-truncate full-source gate makes replace-mode semantics all-or-nothing: a partial
+        // replace is a corrupted restore, so one invalid row rejects the entire source BEFORE the
+        // truncate, instead of partitioning valid rows through after the wipe.
         const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: []});
         Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
         Memory_StorageRouter.getSummaryCollection = async () => buildFakeCollection({name: 'fake-summaries'});
 
-        // Replace mode truncates first; stub the destructive guard to isolate the upsert-gate path.
+        let   truncateCalls    = 0;
         const originalTruncate = Memory_DatabaseService.truncateDatabase.bind(Memory_DatabaseService);
-        Memory_DatabaseService.truncateDatabase = async () => ({message: 'stubbed for replace-mode gate test'});
+        Memory_DatabaseService.truncateDatabase = async (...args) => {
+            truncateCalls++;
+            return {message: 'stubbed — must never be reached'};
+        };
 
         try {
             const backupFile = path.join(tmpDir, `memory-backup-replace-gate-${Date.now()}.jsonl`);
@@ -278,18 +282,49 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
                 {id: 'r-missing',  metadata: {tag: 'BAD'}, document: 'no-embedding'}
             ]);
 
-            const result = await Memory_DatabaseService.manageDatabaseBackup({
+            await expect(Memory_DatabaseService.manageDatabaseBackup({
                 action: 'import',
                 file  : backupFile,
                 mode  : 'replace'
-            });
+            })).rejects.toThrow(/Source validation failed.*wrong-dimension/);
 
-            // Only the valid row upserts; the 2 invalid rows are rejected fail-loud (never upserted).
-            expect(result.mode).toBe('replace');
-            expect(result.counts.memories.inserted).toBe(1);
-            expect(result.counts.memories.failed).toBe(2);
-            expect(memoryCollection.upsertCalls.length).toBe(1);
-            expect(memoryCollection.upsertCalls[0].ids).toEqual(['r-valid']);
+            expect(truncateCalls).toBe(0);
+            expect(memoryCollection.upsertCalls.length).toBe(0);
+            expect(memoryCollection.addCalls.length).toBe(0);
+        } finally {
+            Memory_DatabaseService.truncateDatabase = originalTruncate;
+        }
+    });
+
+    test('replace mode: a corrupt FINAL row proves the full source BEFORE any truncate or write', async () => {
+        const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: []});
+        Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
+        Memory_StorageRouter.getSummaryCollection = async () => buildFakeCollection({name: 'fake-summaries'});
+
+        let   truncateCalls    = 0;
+        const originalTruncate = Memory_DatabaseService.truncateDatabase.bind(Memory_DatabaseService);
+        Memory_DatabaseService.truncateDatabase = async (...args) => {
+            truncateCalls++;
+            return {message: 'stubbed — must never be reached'};
+        };
+
+        try {
+            const backupFile = path.join(tmpDir, `memory-backup-corrupt-final-${Date.now()}.jsonl`);
+            await writeJsonl(backupFile, [
+                {id: 'ok-1', embedding: validEmbedding, metadata: {tag: 'OK'}, document: 'valid'},
+                {id: 'ok-2', embedding: validEmbedding, metadata: {tag: 'OK'}, document: 'valid'},
+                {id: 'corrupt-final', embedding: [0.1, 0.2], metadata: {tag: 'BAD'}, document: 'wrong-dim'}
+            ]);
+
+            await expect(Memory_DatabaseService.manageDatabaseBackup({
+                action: 'import',
+                file  : backupFile,
+                mode  : 'replace'
+            })).rejects.toThrow(/Source validation failed.*wrong-dimension/);
+
+            expect(truncateCalls).toBe(0);
+            expect(memoryCollection.upsertCalls.length).toBe(0);
+            expect(memoryCollection.addCalls.length).toBe(0);
         } finally {
             Memory_DatabaseService.truncateDatabase = originalTruncate;
         }


### PR DESCRIPTION
Resolves #15691

Related: #15692, #15693, #15695

**Problem.** A backup bundle's vector rows are only restorable if the destination's embedding space still matches the rows' dimension. Before this change, nothing recorded that contract at backup time and nothing checked it before restore — a dimension drift (or a torn row) surfaced only as a mid-restore Chroma rejection, after mutation had already begun. This is the preflight slice of the restore-integrity arc: full-file, pre-mutation compatibility validation.

**What ships (v3, after two review cycles).**

- `ai/scripts/maintenance/backup.mjs` — `buildEmbeddingContract` stamps **write-time facts** into `bundle-meta.json`: vector dimension and per-actual-vector-collection exported counts (`kb` / `memories` / `summaries` from the export receipts — never null, never an aggregate `mc`), plus an explicitly **advisory** `expectedConsumer` block. The JSDoc states what the block is not: a config snapshot is never write-time vector provenance.
- `ai/scripts/maintenance/restore.mjs` — hard gates bound only to bundle-carried evidence: every vector-collection row streams with a non-empty string `id` and a valid expected-dimension vector; the declared embedding block must be schema-v1 with a positive dimension matching the destination; declared counts must equal the streamed per-collection totals **in both directions** (undeclared streamed collections and contradicted declarations both fail). `assessEmbeddingCompatibility` emits the **always-on** baseline advisory `semantic-provenance-unverified` — including when the declared consumer expectation matches the destination, because a match is expectation-consistency, not producer evidence — with `consumer-expectation-mismatch` additive on divergence. Legacy bundles get the same structured classification (never log-only), and the self-diagnostic probe's receipt carries `embeddingAdvisories` for the orchestrator.
- `ai/services/memory-core/helpers/vectorJsonlSourceValidation.mjs` (new) — shared streaming full-source validator: every line parses, every vector row carries id + valid vector, graph backups parse-checked only.
- Both `DatabaseService.importDatabase` replace paths (KB + MC) **prove the full source before any truncate/write** — replace is all-or-nothing. The KB importer composes with #15733's merged bounded streaming batches (the per-batch vector gate lives inside `flushBatch`, so merge mode keeps bounded memory AND its own direct-caller gate).

Evidence: L2 (deterministic unit suites over synthetic bundles and mocked collections) → L2 required. Author-reported local full unit suite at this head: **8971 passed, 0 failed** (composed with merged #15733); hosted exact-head `unit` CI: **8963 passed, 119 skipped, 0 failed**. `lintConfigTemplateSsot` green: the spec reads canonical `config.template.mjs`.

## Deltas from ticket

The ticket itself is truth-folded (two review cycles): the original hard model/strategy fingerprint premise is retired because no write-time producer provenance exists in the substrate. What changed relative to the original AC text: semantic provenance is advisory-classified in all cases (never a hard refusal), counts attest actual collections rather than one `mc` aggregate, and the direct-import boundaries are all-or-nothing. #15692 (bounded importer, merged) and #15693 (orchestrator recovery receipt — the advisory consumer) stay in their own lanes.

## Test Evidence

- `embeddingCompatibility.spec.mjs` — contract shape (no fingerprint, per-collection counts), corrupt-final-row streaming, wrong-dim/non-finite/missing-id rows, all hard-gate classes (schema version, dimension, declared-vs-streamed counts both directions, null/negative count rejection), the three advisory shapes (match-still-unverified, mismatch-additive, legacy-structured)
- `DatabaseService.importNullDoc.spec.mjs` — fixtures at the real 4096-dim contract; **witness**: replace + corrupt final row → zero truncate, zero upserts (composes with #15733's flush-before-EOF witness)
- `DatabaseService.importMergeChroma.spec.mjs` — **witness**: MC replace all-or-nothing; corrupt final row caught pre-truncate
- `restore.spec.mjs` / `restore-hardening.spec.mjs` — probe + streaming fixtures at the real vector contract; probe receipt carries `embeddingAdvisories`
- Hosted exact-head `unit` CI: 8963 passed, 119 skipped, 0 failed; author-reported local full unit suite: 8971 passed, 0 failed; `agent-preflight --no-fix` on all touched files — passed

## Post-Merge Validation

- [ ] A bundle produced after this lands restores cleanly through `ai:restore` with the stamped meta intact (next scheduled backup cycle receipt)
- [ ] The probe receipt on a real backup root surfaces `embeddingAdvisories` (baseline unverified) for the orchestrator
- [ ] A bundle whose host config differs from the destination logs `consumer-expectation-mismatch` additively while proceeding on row-verifiable evidence

Authored by Phoebe (Kimi K3, OpenCode). Session 72c8c42d-f18a-408c-97c8-aeb1f82dd276.

