### PR TITLE
fix(ai): bound vector restore importer memory (#15692)

### DIFF
--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -155,7 +155,7 @@ class DatabaseService extends Base {
         logger.log(`Found ${count} documents in ${collection.name} to export.`);
 
         await fs.ensureDir(backupPath);
-        const timestamp = new Date().toISOString().replace(/:/g, '-');
+        const timestamp   = new Date().toISOString().replace(/:/g, '-');
         const backupFile  = path.join(backupPath, `${filePrefix}-${timestamp}.jsonl`);
         const writeStream = fs.createWriteStream(backupFile);
 
@@ -267,6 +267,9 @@ class DatabaseService extends Base {
      * @param {String}        options.file               Absolute path to a JSONL file OR a directory containing `.jsonl` files.
      * @param {String}       [options.mode='merge']      `'merge'` upserts on top of existing data; `'replace'` truncates the collection first via the destructive-operation guard.
      * @param {String|Object} [options.confirmation]     Explicit production confirmation token (forwarded to `truncateDatabase` when mode is `'replace'`).
+     * Parsing and Chroma writes share the existing 500-row bound: a source file is
+     * never materialized in full before its first write.
+     *
      * @returns {Promise<{message: String, imported: Number, mode: String}>}
      */
     async importDatabase({file, mode = 'merge', confirmation} = {}) {
@@ -314,21 +317,6 @@ class DatabaseService extends Base {
             for (const filePath of sourceFiles) {
                 logger.log(`Importing: ${filePath}`);
 
-                const fileStream = fs.createReadStream(filePath);
-                const rl         = readline.createInterface({input: fileStream, crlfDelay: Infinity});
-                const records    = [];
-
-                for await (const line of rl) {
-                    if (line.trim()) {
-                        records.push(JSON.parse(line));
-                    }
-                }
-
-                if (records.length === 0) {
-                    logger.log(`No records found in ${filePath}. Skipping.`);
-                    continue;
-                }
-
                 // KB chunks store content in `metadata.content`, not in Chroma's
                 // primary `document` slot — so 100% of KB backup records carry `document: null`.
                 // Chroma's `collection.upsert` rejects null entries in the `documents` array
@@ -336,19 +324,49 @@ class DatabaseService extends Base {
                 // `documents` field entirely when every record in the batch has a null doc;
                 // substitute empty strings for any remaining nulls in mixed batches so each
                 // array element satisfies Chroma's string-shape requirement uniformly.
-                const BATCH_SIZE = 500;
-                for (let i = 0; i < records.length; i += BATCH_SIZE) {
-                    const batch      = records.slice(i, i + BATCH_SIZE);
+                const BATCH_SIZE   = 500;
+                const fileStream   = fs.createReadStream(filePath);
+                const rl           = readline.createInterface({input: fileStream, crlfDelay: Infinity});
+                let   batch        = [];
+                let   fileImported = 0;
+
+                const flushBatch = async () => {
+                    if (batch.length === 0) return;
+
+                    // Detach the full batch before awaiting Chroma. The readline loop cannot
+                    // grow it while the write is pending, and the completed rows become
+                    // collectible as soon as this flush returns.
+                    const writeBatch = batch;
+                    batch = [];
+
                     const upsertArgs = {
-                        ids       : batch.map(r => r.id),
-                        embeddings: batch.map(r => r.embedding),
-                        metadatas : batch.map(r => r.metadata)
+                        ids       : writeBatch.map(r => r.id),
+                        embeddings: writeBatch.map(r => r.embedding),
+                        metadatas : writeBatch.map(r => r.metadata)
                     };
-                    if (batch.some(r => r.document != null)) {
-                        upsertArgs.documents = batch.map(r => r.document ?? '');
+                    if (writeBatch.some(r => r.document != null)) {
+                        upsertArgs.documents = writeBatch.map(r => r.document ?? '');
                     }
                     await collection.upsert(upsertArgs);
-                    imported += batch.length;
+
+                    imported     += writeBatch.length;
+                    fileImported += writeBatch.length;
+                };
+
+                for await (const line of rl) {
+                    if (!line.trim()) continue;
+
+                    batch.push(JSON.parse(line));
+
+                    if (batch.length === BATCH_SIZE) {
+                        await flushBatch();
+                    }
+                }
+
+                await flushBatch();
+
+                if (fileImported === 0) {
+                    logger.log(`No records found in ${filePath}. Skipping.`);
                 }
             }
 

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -435,7 +435,11 @@ class DatabaseService extends Base {
      * @param {String}        options.mode The import mode: 'merge' or 'replace'.
      * @param {Boolean}      [options.reEmbed=false] If true, regenerates embeddings for all records.
      * @param {String|Object} [options.confirmation] Explicit production confirmation token.
-     * @returns {Promise<{imported: number, total: number, mode: string}>}
+     * Chroma-backed JSONL files are parsed, validated, existence-filtered, and
+     * written inside the existing 250-row bound; neither rows nor merge IDs are
+     * retained for the full file.
+     *
+     * @returns {Promise<{message: string, imported: number, mode: string, counts: Object}>}
      */
     async importDatabase({file, mode, reEmbed=false, confirmation, preserveDeliveryReadState = false}) {
         try {
@@ -567,26 +571,6 @@ class DatabaseService extends Base {
                     ? subsystemCounts.memories
                     : isTemporalSummaryBackup ? subsystemCounts.temporalSummaries : subsystemCounts.summaries;
 
-                const fileStream = fs.createReadStream(filePath);
-                const rl         = readline.createInterface({input: fileStream, crlfDelay: Infinity});
-                const records    = [];
-
-                for await (const line of rl) {
-                    if (line.trim()) {
-                        records.push(JSON.parse(line));
-                    }
-                }
-
-                if (records.length === 0) {
-                    logger.log(`No records found in ${filePath}. Skipping.`);
-                    continue;
-                }
-
-                if (reEmbed) {
-                    logger.log(`Re-embedding enabled. Stripping ${records.length} existing embeddings...`);
-                    records.forEach(r => delete r.embedding);
-                }
-
                 // Chroma has TWO upsert/add limits: (1) record-count cap ~5461; (2) HTTP
                 // body size cap that 413-rejects large payloads. With 4096-dim qwen3
                 // embeddings (~32KB each) + document text, per-record is ~35-40KB.
@@ -596,31 +580,43 @@ class DatabaseService extends Base {
                 //   - 4000 records: "413: Payload Too Large"
                 const CHROMA_UPSERT_CHUNK_SIZE = 250;
 
-                let fileInserted        = 0;
-                let fileSkippedExisting = 0;
-                let fileFailed          = 0;
+                let fileInserted         = 0;
+                let fileSkippedExisting  = 0;
+                let fileFailed           = 0;
+                let batch                = [];
+                let batchNumber          = 0;
+                let fileRecordsProcessed = 0;
 
-                if (mode === 'merge') {
-                    // Preserve-live merge, matching graph-side INSERT OR IGNORE semantics. Chunked
-                    // existence-check via `collection.get({ids})`, then `collection.add()` for the
-                    // missing-ID subset only. Live records are NOT overwritten, so the running
-                    // daemon's authoritative state survives.
-                    const existingIds = new Set();
-                    for (let i = 0; i < records.length; i += CHROMA_UPSERT_CHUNK_SIZE) {
-                        const chunkIds  = records.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE).map(r => r.id);
-                        const existence = await collection.get({ids: chunkIds, include: []});
-                        existence.ids.forEach(id => existingIds.add(id));
+                const flushBatch = async () => {
+                    if (batch.length === 0) return;
+
+                    // Detach before awaiting the store so rows and ID state stay scoped to
+                    // this one Chroma request. The async readline loop is naturally paused
+                    // until the flush completes.
+                    let chunk = batch;
+                    batch = [];
+                    batchNumber++;
+                    fileRecordsProcessed += chunk.length;
+
+                    if (reEmbed) {
+                        chunk.forEach(record => delete record.embedding);
                     }
 
-                    const missing = records.filter(r => !existingIds.has(r.id));
-                    fileSkippedExisting = existingIds.size;
+                    if (mode === 'merge') {
+                        // Preserve-live merge, matching graph-side INSERT OR IGNORE semantics.
+                        // Existence state is deliberately batch-local: after add() settles,
+                        // both the Set and missing rows can be collected before the next read.
+                        const chunkIds    = chunk.map(record => record.id);
+                        const existence   = await collection.get({ids: chunkIds, include: []});
+                        const existingIds = new Set(existence.ids);
 
-                    if (existingIds.size > 0) {
-                        logger.log(`  merge mode: ${existingIds.size} live ID(s) preserved; ${missing.length} new record(s) to insert.`);
-                    }
+                        chunk = chunk.filter(record => !existingIds.has(record.id));
+                        fileSkippedExisting += existingIds.size;
 
-                    for (let i = 0; i < missing.length; i += CHROMA_UPSERT_CHUNK_SIZE) {
-                        let chunk = missing.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE);
+                        if (existingIds.size > 0) {
+                            logger.log(`  merge batch ${batchNumber}: ${existingIds.size} live ID(s) preserved; ${chunk.length} new record(s) to insert.`);
+                        }
+
                         // reEmbed strips vectors (Chroma re-embeds), so the invariant guards only the
                         // explicit-embedding path: reject any row lacking a valid same-dimension vector.
                         if (!reEmbed) {
@@ -633,7 +629,7 @@ class DatabaseService extends Base {
                             chunk = valid;
                         }
                         if (chunk.length === 0) {
-                            continue;
+                            return;
                         }
                         try {
                             await collection.add({
@@ -645,19 +641,12 @@ class DatabaseService extends Base {
                             fileInserted += chunk.length;
                         } catch (e) {
                             fileFailed += chunk.length;
-                            logger.error(`[importMemories] add failed for chunk ${Math.floor(i / CHROMA_UPSERT_CHUNK_SIZE) + 1}: ${e.message}`);
+                            logger.error(`[importMemories] add failed for chunk ${batchNumber}: ${e.message}`);
                         }
-                        if (missing.length > CHROMA_UPSERT_CHUNK_SIZE) {
-                            logger.log(`  added chunk ${Math.floor(i / CHROMA_UPSERT_CHUNK_SIZE) + 1}/${Math.ceil(missing.length / CHROMA_UPSERT_CHUNK_SIZE)} (${chunk.length} records)`);
-                        }
-                    }
-                } else {
-                    // Replace mode: subsystem already truncated above; upsert is safe
-                    // (no live rows to collide with). Fail-fast on chunk error matches
-                    // fail-fast behavior; the outer try/catch wraps it as DATABASE_IMPORT_ERROR.
-                    let replaceRejected = 0;
-                    for (let i = 0; i < records.length; i += CHROMA_UPSERT_CHUNK_SIZE) {
-                        let chunk = records.slice(i, i + CHROMA_UPSERT_CHUNK_SIZE);
+                    } else {
+                        // Replace mode: subsystem already truncated above; upsert is safe
+                        // (no live rows to collide with). Fail-fast on chunk error matches
+                        // fail-fast behavior; the outer try/catch wraps it as DATABASE_IMPORT_ERROR.
                         // reEmbed strips vectors (Chroma re-embeds), so the invariant guards only the
                         // explicit-embedding path: reject any row lacking a valid same-dimension vector.
                         if (!reEmbed) {
@@ -665,12 +654,12 @@ class DatabaseService extends Base {
                             if (rejected.length > 0) {
                                 const {count, byReason} = summarizeVectorRejections(rejected);
                                 logger.error(`[importMemories] vector-write invariant rejected ${count} row(s) without a valid same-dimension vector ${JSON.stringify(byReason)} — not persisted`);
-                                replaceRejected += rejected.length;
+                                fileFailed += rejected.length;
                             }
                             chunk = valid;
                         }
                         if (chunk.length === 0) {
-                            continue;
+                            return;
                         }
                         await collection.upsert({
                             ids       : chunk.map(r => r.id),
@@ -678,12 +667,28 @@ class DatabaseService extends Base {
                             metadatas : chunk.map(r => r.metadata),
                             documents : chunk.map(r => r.document)
                         });
-                        if (records.length > CHROMA_UPSERT_CHUNK_SIZE) {
-                            logger.log(`  upserted chunk ${Math.floor(i / CHROMA_UPSERT_CHUNK_SIZE) + 1}/${Math.ceil(records.length / CHROMA_UPSERT_CHUNK_SIZE)} (${chunk.length} records)`);
-                        }
+                        fileInserted += chunk.length;
                     }
-                    fileFailed   += replaceRejected;
-                    fileInserted  = records.length - replaceRejected;
+                };
+
+                const fileStream = fs.createReadStream(filePath);
+                const rl         = readline.createInterface({input: fileStream, crlfDelay: Infinity});
+
+                for await (const line of rl) {
+                    if (!line.trim()) continue;
+
+                    batch.push(JSON.parse(line));
+
+                    if (batch.length === CHROMA_UPSERT_CHUNK_SIZE) {
+                        await flushBatch();
+                    }
+                }
+
+                await flushBatch();
+
+                if (fileRecordsProcessed === 0) {
+                    logger.log(`No records found in ${filePath}. Skipping.`);
+                    continue;
                 }
 
                 chromaCounts.inserted            += fileInserted;

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseService.importNullDoc.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseService.importNullDoc.spec.mjs
@@ -20,7 +20,9 @@ import Neo             from '../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 import fs              from 'fs';
+import fsExtra         from 'fs-extra';
 import path            from 'path';
+import {Readable}      from 'stream';
 
 // Serial: this spec mutates KB_ChromaManager.getKnowledgeBaseCollection singleton via beforeAll.
 test.describe.configure({mode: 'serial'});
@@ -89,9 +91,9 @@ test.describe('KB_DatabaseService.importDatabase — null-document handling (#11
         expect(upsert.ids).toEqual(['id-1', 'id-2', 'id-3']);
         expect(upsert.embeddings).toHaveLength(3);
         expect(upsert.metadatas).toHaveLength(3);
-        // The fix: `documents` field MUST be absent from the upsert payload when every
-        // record's document is null. Pre-#11653, this field was passed as [null,null,null]
-        // which Chroma rejects with "Expected each document to be a string, but got object".
+        // The `documents` field MUST be absent from the upsert payload when every
+        // record's document is null. Passing [null,null,null] makes Chroma reject
+        // the request with "Expected each document to be a string, but got object".
         expect('documents' in upsert).toBe(false);
     });
 
@@ -155,15 +157,67 @@ test.describe('KB_DatabaseService.importDatabase — null-document handling (#11
         expect(capturedUpsertCalls[1].ids).toHaveLength(1);
     });
 
+    test('flushes the first 500 rows before the JSONL stream reaches EOF', async () => {
+        const filePath = path.join(tmpDir, 'kb-gated-stream.jsonl');
+        fs.writeFileSync(filePath, 'stream content is supplied by the gated fixture\n');
+
+        const headRecords = Array.from({length: 500}, (_, index) => ({
+            id       : `head-${index}`,
+            embedding: [index],
+            metadata : {index},
+            document : null
+        }));
+        const tailRecord = {id: 'tail-500', embedding: [500], metadata: {index: 500}, document: null};
+
+        let releaseTail;
+        const tailGate                 = new Promise(resolve => { releaseTail = resolve; });
+        const originalCreateReadStream = fsExtra.createReadStream;
+
+        fsExtra.createReadStream = () => Readable.from((async function * gatedJsonl() {
+            for (const record of headRecords) {
+                yield `${JSON.stringify(record)}\n`;
+            }
+
+            // A whole-file materializer deadlocks here because only the first store
+            // write releases EOF. A streaming importer flushes row 500, then proceeds.
+            await tailGate;
+            yield `${JSON.stringify(tailRecord)}\n`;
+        })());
+
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => ({
+            upsert: async args => {
+                capturedUpsertCalls.push(args);
+                if (capturedUpsertCalls.length === 1) releaseTail();
+            }
+        });
+
+        let timeoutId;
+        try {
+            const result = await Promise.race([
+                KB_DatabaseService.importDatabase({file: filePath, mode: 'merge'}),
+                new Promise((_, reject) => {
+                    timeoutId = setTimeout(() => reject(new Error('first KB batch was not flushed before EOF')), 5000);
+                })
+            ]);
+
+            expect(result.imported).toBe(501);
+            expect(capturedUpsertCalls.map(call => call.ids.length)).toEqual([500, 1]);
+        } finally {
+            clearTimeout(timeoutId);
+            releaseTail();
+            fsExtra.createReadStream = originalCreateReadStream;
+        }
+    });
+
     test('reproducer for the 2026-05-19 restore failure: real KB backup shape (24,418 records all-null docs) succeeds', async () => {
         // Synthetic minimal reproducer mirroring the actual `backup-2026-05-19T13-08-14.283Z`
         // shape audit: 100% of records have `document: null`; metadata carries `content`,
         // `source`, `name`, `hash`, `kind`, `className`, `type`, `id`.
         const filePath = writeBackupFile('kb-shape-reproducer.jsonl', [
             {
-                id: 'h-1',
+                id       : 'h-1',
                 embedding: [0.001, 0.002, 0.003],
-                metadata: {
+                metadata : {
                     source    : 'src/canvas/_export.mjs',
                     name      : 'src/canvas/_export.mjs - [Module Context]',
                     line_start: 1,
@@ -185,8 +239,8 @@ test.describe('KB_DatabaseService.importDatabase — null-document handling (#11
             mode  : 'merge'
         });
 
-        // Pre-#11653: this throws `DATABASE_IMPORT_ERROR: Expected each document to be a string, but got object`.
-        // Post-#11653: imports cleanly because `documents` is omitted from the upsert.
+        // The real backup shape imports cleanly because `documents` is omitted;
+        // forwarding its null document would surface a DATABASE_IMPORT_ERROR.
         expect(result.imported).toBe(1);
         expect('documents' in capturedUpsertCalls[0]).toBe(false);
     });

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
@@ -39,20 +39,24 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
     function buildFakeCollection({name, liveIds = []}) {
         const live        = new Set(liveIds);
         const addCalls    = [];
+        const calls       = [];
         const upsertCalls = [];
 
         return {
             name,
             _live: live,
             addCalls,
+            calls,
             upsertCalls,
             get  : async ({ids = [], include}) => {
+                calls.push({type: 'get', ids: [...ids]});
                 // Existence-check shape: `get({ids, include: []})` — return live overlap.
                 const overlap = ids.filter(id => live.has(id));
                 return {ids: overlap};
             },
             add: async (payload) => {
                 addCalls.push(payload);
+                calls.push({type: 'add', ids: [...payload.ids]});
                 // Merge mode contract: `add()` rejects on duplicate ID (Chroma's
                 // insert-only primitive). Assert that here so a regression in the
                 // preflight filter would surface as a test failure.
@@ -65,6 +69,7 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
             },
             upsert: async (payload) => {
                 upsertCalls.push(payload);
+                calls.push({type: 'upsert', ids: [...payload.ids]});
                 for (const id of payload.ids) {
                     live.add(id);
                 }
@@ -195,6 +200,36 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
         expect(memoryCollection.upsertCalls.length).toBe(0);
     });
 
+    test('merge mode: each 250-row existence check is followed by its write before the next batch', async () => {
+        const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: []});
+        Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
+        Memory_StorageRouter.getSummaryCollection = async () => buildFakeCollection({name: 'fake-summaries'});
+
+        const backupFile = path.join(tmpDir, `memory-backup-bounded-merge-${Date.now()}.jsonl`);
+        const records    = Array.from({length: 501}, (_, index) => ({
+            id       : `bounded-${index}`,
+            embedding: validEmbedding,
+            metadata : {index},
+            document : `document-${index}`
+        }));
+        await writeJsonl(backupFile, records);
+
+        const result = await Memory_DatabaseService.manageDatabaseBackup({
+            action: 'import',
+            file  : backupFile,
+            mode  : 'merge'
+        });
+
+        expect(result.imported).toBe(501);
+        expect(memoryCollection.calls.map(call => call.type)).toEqual([
+            'get', 'add',
+            'get', 'add',
+            'get', 'add'
+        ]);
+        expect(memoryCollection.calls.map(call => call.ids.length)).toEqual([250, 250, 250, 250, 1, 1]);
+        expect(Math.max(...memoryCollection.calls.map(call => call.ids.length))).toBe(250);
+    });
+
     test('merge mode: atomic vector-write invariant rejects rows lacking a valid same-dimension vector', async () => {
         // The gate (non-reEmbed) must reject missing / empty / wrong-dimension embeddings fail-loud, so a
         // metadata-only row is never half-persisted (the corruption shape the invariant exists to prevent).
@@ -294,6 +329,38 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
             expect(result.counts.memories.inserted).toBe(2);
             // add() is the merge-mode primitive; never called in replace mode
             expect(memoryCollection.addCalls.length).toBe(0);
+        } finally {
+            Memory_DatabaseService.truncateDatabase = originalTruncate;
+        }
+    });
+
+    test('replace mode: streams 501 records through bounded 250-row upserts', async () => {
+        const memoryCollection = buildFakeCollection({name: 'fake-memories', liveIds: []});
+        Memory_StorageRouter.getMemoryCollection  = async () => memoryCollection;
+        Memory_StorageRouter.getSummaryCollection = async () => buildFakeCollection({name: 'fake-summaries'});
+
+        const originalTruncate = Memory_DatabaseService.truncateDatabase.bind(Memory_DatabaseService);
+        Memory_DatabaseService.truncateDatabase = async () => ({message: 'stubbed for bounded replace test'});
+
+        try {
+            const backupFile = path.join(tmpDir, `memory-backup-bounded-replace-${Date.now()}.jsonl`);
+            const records    = Array.from({length: 501}, (_, index) => ({
+                id       : `replace-${index}`,
+                embedding: validEmbedding,
+                metadata : {index},
+                document : `document-${index}`
+            }));
+            await writeJsonl(backupFile, records);
+
+            const result = await Memory_DatabaseService.manageDatabaseBackup({
+                action: 'import',
+                file  : backupFile,
+                mode  : 'replace'
+            });
+
+            expect(result.imported).toBe(501);
+            expect(memoryCollection.calls.map(call => call.type)).toEqual(['upsert', 'upsert', 'upsert']);
+            expect(memoryCollection.upsertCalls.map(call => call.ids.length)).toEqual([250, 250, 1]);
         } finally {
             Memory_DatabaseService.truncateDatabase = originalTruncate;
         }


### PR DESCRIPTION
Resolves #15692

Vector restore imports now flush during async JSONL iteration instead of retaining a complete file before the first Chroma request. Knowledge Base writes remain capped at 500 rows; Memory Core merge now performs each existence check and missing-row write inside one 250-row batch, while replace mode streams the same 250-row upserts. Existing importer arguments, return envelopes, preserve-live counts, explicit-vector behavior, and destructive-operation guards remain unchanged.

Evidence: L2 (native importer/restore specs plus disposable 5k/20k child-process measurements with strict collection seams) → L2 required (bounded row/ID retention, truthful counts, and zero new provider authority). No close-target residuals.

Related: #15691
Related: #15693
Related: #15695

## Deltas from ticket

None substantive from the rewritten live ticket. Intake first removed durable checkpoint, retry, shadow/fence/promotion, and orchestrator receipt work from this leaf; those contracts now live exclusively in #15693. This PR therefore adds no cursor, callback, checkpoint store, scheduler, or re-embedding path.

## Test Evidence

- Knowledge Base importer: gated-EOF proof demonstrates that row 500 reaches `upsert()` before the final JSONL row becomes readable; 500/1 payload boundary and null-document behavior remain covered.
- Memory Core importer: 501-row merge proves `get → add → get → add → get → add` ordering with maximum 250-row ID/write payloads; 501-row replace proves `250 / 250 / 1` upserts.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/DatabaseService.importNullDoc.spec.mjs test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs` — **18 passed**.
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs test/playwright/unit/ai/scripts/maintenance/restore-hardening.spec.mjs test/playwright/unit/ai/scripts/maintenance/restore-filters.spec.mjs` — **35 passed**.
- `npm run agent-preflight` — **passed** on the staged four-file candidate; commit hooks independently passed whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, block alignment, and parse checks.
- Disposable preserved-vector controls, 4,096 dimensions:

  | Importer | Rows | Wall | Peak Node RSS | Store pattern |
  | --- | ---: | ---: | ---: | --- |
  | MC merge | 5,000 | 155.3 ms | 164.6 MiB | 20 `get` + 20 `add`, max 250 |
  | MC merge | 20,000 | 553.2 ms | 228.0 MiB | 80 `get` + 80 `add`, max 250 |
  | KB merge | 5,000 | 91.8 ms | 166.2 MiB | 10 `upsert`, max 500 |
  | KB merge | 20,000 | 298.5 ms | 226.5 MiB | 40 `upsert`, max 500 |

  The pre-change 20k mock-store controls recorded in #15695 were 921.5 MiB MC RSS and 934.2 MiB KB RSS. The new controls scale request count while holding row/ID state to the configured batch.

## Post-Merge Validation

- [ ] On the next off-host restore after merge, append operational RSS and observed batch maxima to #15695 or the consuming #15693 run. This is corroboration, not a #15692 close blocker; the leaf's deterministic L2 evidence is complete.

## Evolution

The original ticket combined a measured importer-memory problem with a not-yet-owned durable resume contract. Live intake found that ADR-0027 and #15693 already own recovery-run persistence, retry reconciliation, heavy-maintenance fencing, resumable shadows, and validation-clean promotion. Narrowing before code kept this diff data-plane-only and made the public importer contracts smaller rather than larger.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session cb60301d-74a4-4024-b80d-2f7efdbf9cd1.
