### PR TITLE
fix(ai): lease persistent writer locks (#15681)

### DIFF
--- a/src/ai/LockRegistry.mjs
+++ b/src/ai/LockRegistry.mjs
@@ -129,29 +129,63 @@ class LockRegistry extends Base {
      * Re-acquiring an identical lock by the same writer is re-entrant (granted, no duplicate appended).
      * @param {Object[]} lockTable The caller-held active locks.
      * @param {Object} lock        The lock to acquire.
-     * @returns {{lockTable: Object[], granted: Boolean, conflict: Object|null, errors: String[]}}
+     * @returns {{lockTable: Object[], granted: Boolean, conflict: Object|null, errors: String[], created: Boolean, reentrant: Boolean, acquiredLock: Object|null}}
      */
     static acquire(lockTable, lock) {
         const table = Array.isArray(lockTable) ? lockTable : [],
               norm  = LockRegistry.normalizeLock(lock);
 
         if (!norm) {
-            return {lockTable: table, granted: false, conflict: null, errors: ['invalid lock descriptor']}
+            return {
+                lockTable   : table,
+                granted     : false,
+                conflict    : null,
+                errors      : ['invalid lock descriptor'],
+                created     : false,
+                reentrant   : false,
+                acquiredLock: null
+            }
         }
 
         const conflict = LockRegistry.findConflict(table, norm);
 
         if (conflict) {
-            return {lockTable: table, granted: false, conflict, errors: []}
+            return {
+                lockTable   : table,
+                granted     : false,
+                conflict,
+                errors      : [],
+                created     : false,
+                reentrant   : false,
+                acquiredLock: null
+            }
         }
 
-        const key = LockRegistry.lockKey(norm);
+        const
+            key      = LockRegistry.lockKey(norm),
+            existing = table.find(held => LockRegistry.lockKey(held) === key);
 
-        if (table.some(held => LockRegistry.lockKey(held) === key)) {
-            return {lockTable: table, granted: true, conflict: null, errors: []} // re-entrant, idempotent
+        if (existing) {
+            return {
+                lockTable   : table,
+                granted     : true,
+                conflict    : null,
+                errors      : [],
+                created     : false,
+                reentrant   : true,
+                acquiredLock: existing
+            }
         }
 
-        return {lockTable: [...table, norm], granted: true, conflict: null, errors: []}
+        return {
+            lockTable   : [...table, norm],
+            granted     : true,
+            conflict    : null,
+            errors      : [],
+            created     : true,
+            reentrant   : false,
+            acquiredLock: norm
+        }
     }
 
     /**
@@ -187,7 +221,7 @@ class LockRegistry extends Base {
      * @returns {{lockTable: Object[], released: Number}}
      */
     static releaseAll(lockTable, selector = {}) {
-        const table = Array.isArray(lockTable) ? lockTable : [],
+        const table                = Array.isArray(lockTable) ? lockTable : [],
               {agentId, sessionId} = selector;
 
         if (agentId === undefined && sessionId === undefined) {

--- a/src/ai/WriteGuard.mjs
+++ b/src/ai/WriteGuard.mjs
@@ -2,33 +2,60 @@ import Base         from '../core/Base.mjs';
 import LockRegistry from './LockRegistry.mjs';
 
 /**
- * Defensive copy of a lock descriptor — the lock object **and** its `subtreePath` array — so the in-heap
- * authority never hands a caller a reference into its live held-lock state.
- * @param {Object} lock
+ * @summary Defensively copies one held lease, including its nested subtree path.
+ * @param {Object} lease
  * @returns {Object}
  */
-const copyLock = lock => ({agentId: lock.agentId, sessionId: lock.sessionId, subtreePath: [...lock.subtreePath]});
+function copyLease(lease) {
+    const copy = {
+        agentId    : lease.agentId,
+        sessionId  : lease.sessionId,
+        subtreePath: [...lease.subtreePath]
+    };
+
+    ['token', 'acquiredAt', 'lastTouchAt', 'inFlight'].forEach(field => {
+        if (Object.hasOwn(lease, field)) {
+            copy[field] = lease[field]
+        }
+    });
+
+    return copy
+}
+
+/**
+ * @summary Defensively copies an acquisition receipt for an operation owner.
+ * @param {Object} lease
+ * @param {Boolean} created
+ * @param {Boolean} reentrant
+ * @returns {Object}
+ */
+const copyAcquisition = (lease, created, reentrant) => ({
+    ...copyLease(lease),
+    created,
+    reentrant
+});
+
+/**
+ * @summary Defensively copies an observable lease lifecycle receipt.
+ * @param {Object} receipt
+ * @returns {Object}
+ */
+const copyReceipt = receipt => ({...receipt, subtreePath: [...receipt.subtreePath]});
 
 /**
  * @summary The in-heap authoritative layer that holds the live topological-lock state for one App-Worker
  * heap and enforces it on write-class Neural Link operations.
  *
- * Where `Neo.ai.LockRegistry` is the *stateless* conflict math over a caller-held table, `WriteGuard` is the
- * *stateful authority*: it owns the live lock table for one application heap (the shared truth, per the
- * co-habitation premise) and exposes the write-lifecycle API the in-app Neural Link client calls before it
- * applies a write-class operation. A write **acquires and holds** a subtree lock; a *different* agent's
- * overlapping write is denied while that lock is held; the lock is released explicitly, or swept on
- * disconnect. Held-until-release — not per-op — is the minimum that prevents cross-writer corruption while
- * two agents share one heap.
+ * A granted write remains held until an explicit fenced release, disconnect sweep, or idle lease expiry.
+ * Every held entry carries a monotonic token, acquisition/touch timestamps, and an in-flight count. Lazy
+ * request/inspection sweeps reclaim only idle expired generations; an admitted synchronous or async
+ * operation increments `inFlight`, so it can never expire while application code is executing. Tokens fence
+ * touch/end/release calls: an old operation cannot mutate or remove a successor generation after expiry.
  *
- * It is deliberately a heap-side authority: the heap is the truth, and any Bridge-level check is advisory
- * routing, never the lock owner. `subtreePath` is supplied by the caller (the client derives the absolute
- * root→node component path from the live tree), so this class stays pure over its inputs and is unit-testable
- * via event sequences with no live-heap or socket dependency.
- *
- * Scope boundary: this is the authority + its lock-state API. The client write-path wiring (intercepting
- * write-class ops, deriving the path, surfacing a denial), Bridge advisory mirroring, and lock leases (TTL
- * expiry for silent holders) are named follow-up slices.
+ * The clock is injected through {@link nowFn}; no timer belongs to this heap authority. Lifecycle receipts
+ * are bounded and independently inspectable, while every outward lock/acquisition/receipt remains a deep
+ * defensive copy. The exact `(agentId, sessionId)` writer key and held-until-release regime remain the
+ * source-of-authority contract.
  * @class Neo.ai.WriteGuard
  * @extends Neo.core.Base
  */
@@ -42,77 +69,385 @@ class WriteGuard extends Base {
     }
 
     /**
-     * The live held-lock table — the authoritative truth for this heap. Each entry is a normalized
-     * `{agentId, sessionId, subtreePath}` lock currently held by a writer.
+     * Idle lease duration. In-flight work is never eligible regardless of elapsed time.
+     * @member {Number} leaseTtlMs=300000
+     */
+    leaseTtlMs = 300_000
+
+    /**
+     * Injected deterministic clock.
+     * @member {Function} nowFn
+     */
+    nowFn = () => Date.now()
+
+    /**
+     * Maximum independently inspectable lifecycle receipts retained in heap memory.
+     * @member {Number} receiptLimit=100
+     */
+    receiptLimit = 100
+
+    /**
+     * The live held-lease table for this heap.
      * @member {Object[]} locks=[]
      * @protected
      */
     locks = []
 
     /**
-     * @summary Acquire-and-hold a write lock for a target component subtree.
-     * Delegates the conflict decision to `Neo.ai.LockRegistry.acquire`; on a grant the lock is **retained**
-     * in the live table (held until {@link releaseWrite} or {@link releaseAgent}), so a later overlapping
-     * write by a *different* writer is denied for as long as the holder keeps it. Re-acquiring an identical
-     * lock by the same writer is re-entrant (granted, no duplicate). A malformed lock or a cross-writer
-     * conflict is denied and the table is left unchanged (fail-closed). The returned `conflict` is a
-     * defensive copy of the blocking holder, never a live reference into the held table.
+     * Bounded lifecycle receipt ledger.
+     * @member {Object[]} receiptLog=[]
+     * @protected
+     */
+    receiptLog = []
+
+    /**
+     * Monotonic fenced-token source for this heap generation.
+     * @member {Number} tokenSequence=0
+     * @protected
+     */
+    tokenSequence = 0
+
+    /**
+     * @summary Acquire-and-hold a write lease, returning creation/re-entry provenance and its fenced token.
+     *
+     * A lazy sweep runs first. Same-writer exact re-entry refreshes `lastTouchAt` and returns the existing
+     * token; a newly-created hold receives a new token. Invalid clock/TTL configuration denies without
+     * mutating existing state. `reclaimed` contains the independently inspectable expiry receipts observed
+     * by this request.
      * @param {Object} lock
-     * @param {String} lock.agentId
-     * @param {String} lock.sessionId
-     * @param {String[]} lock.subtreePath  Absolute root→node component-id path, supplied by the caller.
-     * @returns {{granted: Boolean, conflict: Object|null, errors: String[]}}
+     * @returns {{granted: Boolean, conflict: Object|null, errors: String[], created: Boolean, reentrant: Boolean, token: Number|null, acquisition: Object|null, reclaimed: Object[]}}
      */
     requestWrite(lock) {
-        const {lockTable, granted, conflict, errors} = LockRegistry.acquire(this.locks, lock);
+        const now = this.readNow();
 
-        if (granted) {
-            this.locks = lockTable
+        if (now === null || !this.hasValidTtl()) {
+            return {
+                granted    : false,
+                conflict   : null,
+                errors     : [now === null ? 'invalid-write-lease-clock' : 'invalid-write-lease-ttl'],
+                created    : false,
+                reentrant  : false,
+                token      : null,
+                acquisition: null,
+                reclaimed  : []
+            }
         }
 
-        return {granted, conflict: conflict ? copyLock(conflict) : null, errors}
+        const reclaimed = this.sweepExpired(now);
+        const {lockTable, granted, conflict, errors, created, reentrant, acquiredLock} =
+            LockRegistry.acquire(this.locks, lock);
+
+        if (!granted) {
+            return {
+                granted,
+                conflict   : conflict ? copyLease(conflict) : null,
+                errors,
+                created,
+                reentrant,
+                token      : null,
+                acquisition: null,
+                reclaimed
+            }
+        }
+
+        const lease = created
+            ? {
+                ...acquiredLock,
+                token      : ++this.tokenSequence,
+                acquiredAt : now,
+                lastTouchAt: now,
+                inFlight   : 0,
+                // Once another operation re-enters this generation, the creator no longer has exclusive
+                // authority to auto-release it on failure. TTL/disconnect remain the safe cleanup paths.
+                shared     : false
+            }
+            : {...acquiredLock, lastTouchAt: now, shared: true};
+
+        this.locks = lockTable.map(held => held === acquiredLock ? lease : held);
+
+        return {
+            granted,
+            conflict   : null,
+            errors,
+            created,
+            reentrant,
+            token      : lease.token,
+            acquisition: copyAcquisition(lease, created, reentrant),
+            reclaimed
+        }
     }
 
     /**
-     * @summary Release one held lock (same writer + same subtree), idempotently.
-     * Releasing a lock that is not held is a no-op; a *different* writer's lock on the same subtree is
-     * never released by this call.
-     * @param {Object} lock The same descriptor shape passed to {@link requestWrite}.
-     * @returns {{released: Boolean}}
+     * @summary Begin an admitted operation under its fenced acquisition and protect it from expiry.
+     * @param {Object} acquisition Receipt returned by {@link requestWrite}.
+     * @returns {{began: Boolean}}
      */
-    releaseWrite(lock) {
-        const before = this.locks.length;
+    beginWrite(acquisition) {
+        const current = this.findCurrent(acquisition),
+              now     = this.readNow();
 
-        this.locks = LockRegistry.release(this.locks, lock).lockTable;
+        if (!current || now === null) {
+            return {began: false}
+        }
 
-        return {released: this.locks.length < before}
+        this.replaceCurrent(current, {
+            ...current,
+            lastTouchAt: now,
+            inFlight   : current.inFlight + 1
+        });
+
+        return {began: true}
     }
 
     /**
-     * @summary Release every lock a writer holds — the disconnect / worker-restart sweep hook.
-     * Pass `agentId` and/or `sessionId`; a lock is swept when it matches all provided fields. A
-     * selector-less call sweeps nothing (fail-closed).
+     * @summary End an admitted operation and apply acquisition-aware failure semantics.
+     *
+     * Successful operations retain the hold. Failed operations release only a lock newly created by this
+     * acquisition when the caller proves `pre-mutation` or `rollback-complete`, no other operation remains
+     * in flight, and the generation was never shared by re-entry. Re-entrant and unknown partial-mutation
+     * failures retain the hold, emit a receipt, and become idle-TTL reclaimable. A stale token is a no-op
+     * and cannot affect a successor generation.
+     * @param {Object} acquisition Receipt returned by {@link requestWrite}.
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.failed=false]
+     * @param {'pre-mutation'|'rollback-complete'|'unknown'} [options.mutationDisposition='unknown']
+     * @param {Error|String} [options.error]
+     * @returns {{ended: Boolean, released: Boolean, retained: Boolean}}
+     */
+    endWrite(acquisition, {failed=false, mutationDisposition='unknown', error} = {}) {
+        const current = this.findCurrent(acquisition);
+
+        if (!current || current.inFlight < 1) {
+            return {ended: false, released: false, retained: false}
+        }
+
+        const
+            observedAt = this.readNow() ?? current.lastTouchAt,
+            updated    = {
+                ...current,
+                lastTouchAt: observedAt,
+                inFlight   : current.inFlight - 1
+            },
+            safeToRelease = failed && acquisition.created === true && updated.inFlight === 0 &&
+                current.shared !== true &&
+                (mutationDisposition === 'pre-mutation' || mutationDisposition === 'rollback-complete');
+
+        this.replaceCurrent(current, updated);
+
+        if (!failed) {
+            return {ended: true, released: false, retained: true}
+        }
+
+        const errorMessage = error instanceof Error ? error.message : typeof error === 'string' ? error : null;
+
+        if (safeToRelease) {
+            this.locks = this.locks.filter(held => held !== updated);
+            this.recordReceipt('error-release', updated, observedAt, {mutationDisposition, error: errorMessage});
+
+            return {ended: true, released: true, retained: false}
+        }
+
+        this.recordReceipt('error-retained', updated, observedAt, {mutationDisposition, error: errorMessage});
+
+        return {ended: true, released: false, retained: true}
+    }
+
+    /**
+     * @summary Refresh the current generation only when the fenced token still matches.
+     * @param {Object} acquisition Receipt returned by {@link requestWrite}.
+     * @returns {{touched: Boolean}}
+     */
+    touchWrite(acquisition) {
+        const current = this.findCurrent(acquisition),
+              now     = this.readNow();
+
+        if (!current || now === null) {
+            return {touched: false}
+        }
+
+        this.replaceCurrent(current, {...current, lastTouchAt: now});
+
+        return {touched: true}
+    }
+
+    /**
+     * @summary Release one idle held generation with the exact acquisition token.
+     *
+     * Descriptor-only or stale-token calls are rejected; an in-flight operation is never explicitly
+     * released through this path. Disconnect release remains separately authoritative.
+     * @param {Object} acquisition Receipt returned by {@link requestWrite}.
+     * @returns {{released: Boolean, reason: String|null}}
+     */
+    releaseWrite(acquisition) {
+        const current = this.findCurrent(acquisition);
+
+        if (!current) {
+            return {released: false, reason: 'stale-token'}
+        }
+        if (current.inFlight > 0) {
+            return {released: false, reason: 'in-flight'}
+        }
+
+        const observedAt = this.readNow() ?? current.lastTouchAt;
+
+        this.locks = this.locks.filter(held => held !== current);
+        this.recordReceipt('explicit-release', current, observedAt);
+
+        return {released: true, reason: null}
+    }
+
+    /**
+     * @summary Release every lock a writer holds — the immediate disconnect / worker-restart authority.
      * @param {Object} selector
      * @param {String} [selector.agentId]
      * @param {String} [selector.sessionId]
      * @returns {{released: Number}}
      */
     releaseAgent(selector) {
-        const {lockTable, released} = LockRegistry.releaseAll(this.locks, selector);
+        const before                = this.locks;
+        const {lockTable, released} = LockRegistry.releaseAll(before, selector);
+        const observedAt            = this.readNow();
 
         this.locks = lockTable;
+
+        if (released > 0) {
+            before.filter(held => !lockTable.includes(held)).forEach(held => {
+                this.recordReceipt('disconnect-release', held, observedAt ?? held.lastTouchAt)
+            })
+        }
 
         return {released}
     }
 
     /**
-     * @summary A deep snapshot of the currently-held locks (introspection).
-     * Every returned lock — including its `subtreePath` array — is a copy, so a caller cannot mutate the
-     * live held-lock state through the result (neither the array nor the lock objects nor their paths).
+     * @summary Deep snapshot of currently-held leases after an inspection-time lazy sweep.
      * @returns {Object[]}
      */
     heldLocks() {
-        return this.locks.map(copyLock)
+        const now = this.readNow();
+
+        if (now !== null && this.hasValidTtl()) {
+            this.sweepExpired(now)
+        }
+
+        return this.locks.map(copyLease)
+    }
+
+    /**
+     * @summary Deep snapshot of the bounded independently inspectable lifecycle receipt ledger.
+     * @returns {Object[]}
+     */
+    leaseReceipts() {
+        const now = this.readNow();
+
+        if (now !== null && this.hasValidTtl()) {
+            this.sweepExpired(now)
+        }
+
+        return this.receiptLog.map(copyReceipt)
+    }
+
+    /**
+     * @summary Read the injected clock without allowing a broken clock to mutate lease state.
+     * @returns {Number|null}
+     * @protected
+     */
+    readNow() {
+        try {
+            const now = this.nowFn();
+            return Number.isFinite(now) ? now : null
+        } catch {
+            return null
+        }
+    }
+
+    /**
+     * @summary Whether the configured idle TTL can safely drive expiry.
+     * @returns {Boolean}
+     * @protected
+     */
+    hasValidTtl() {
+        return Number.isFinite(this.leaseTtlMs) && this.leaseTtlMs > 0
+    }
+
+    /**
+     * @summary Resolve a live lease only when descriptor and fenced token both match.
+     * @param {Object} acquisition
+     * @returns {Object|null}
+     * @protected
+     */
+    findCurrent(acquisition) {
+        const norm = LockRegistry.normalizeLock(acquisition);
+
+        if (!norm || !Number.isInteger(acquisition?.token) || acquisition.token < 1) {
+            return null
+        }
+
+        const key = LockRegistry.lockKey(norm);
+
+        return this.locks.find(held => held.token === acquisition.token && LockRegistry.lockKey(held) === key) || null
+    }
+
+    /**
+     * @summary Replace one live lease by object identity.
+     * @param {Object} current
+     * @param {Object} replacement
+     * @protected
+     */
+    replaceCurrent(current, replacement) {
+        this.locks = this.locks.map(held => held === current ? replacement : held)
+    }
+
+    /**
+     * @summary Reclaim only idle expired generations and emit one receipt per reclaimed lease.
+     * @param {Number} now
+     * @returns {Object[]} Defensive expiry receipt copies.
+     * @protected
+     */
+    sweepExpired(now) {
+        const kept = [], reclaimed = [];
+
+        this.locks.forEach(held => {
+            const expired = held.inFlight === 0 && Number.isFinite(held.lastTouchAt) &&
+                now - held.lastTouchAt >= this.leaseTtlMs;
+
+            if (expired) {
+                reclaimed.push(this.recordReceipt('expired', held, now))
+            } else {
+                kept.push(held)
+            }
+        });
+
+        this.locks = kept;
+
+        return reclaimed
+    }
+
+    /**
+     * @summary Append a bounded lifecycle receipt without letting observability change a lock decision.
+     * @param {String} reason
+     * @param {Object} lease
+     * @param {Number} observedAt
+     * @param {Object} [details={}]
+     * @returns {Object} Defensive receipt copy.
+     * @protected
+     */
+    recordReceipt(reason, lease, observedAt, details = {}) {
+        const receipt = {
+            ...copyLease(lease),
+            reason,
+            observedAt,
+            ...details
+        };
+
+        try {
+            const limit = Number.isInteger(this.receiptLimit) && this.receiptLimit > 0 ? this.receiptLimit : 100;
+            this.receiptLog = [...this.receiptLog, receipt].slice(-limit)
+        } catch {
+            // Observability failure must never alter the lock decision.
+        }
+
+        return copyReceipt(receipt)
     }
 }
 

--- a/src/ai/admitWrite.mjs
+++ b/src/ai/admitWrite.mjs
@@ -6,19 +6,23 @@ import {resolveWriteLock} from './resolveWriteLock.mjs';
  * The single enforcement step a write-class service runs before it mutates. It composes the two halves of the
  * multi-writer regime: {@link Neo.ai.resolveWriteLock} decides *what lock* a request needs (or that it is legacy /
  * undecidable), and the injected `writeGuard` ({@link Neo.ai.WriteGuard}) *acquires and holds* that lock — denying a
- * cross-writer overlap. The result is a plain verdict (`admitted` / `reason` / `conflict`); acting on it — mutate vs
- * throw — stays in the caller, so this stays a pure function over its inputs and is unit-provable with a stub guard.
+ * cross-writer overlap. The result includes the guard's fenced `acquisition` receipt when enforced admission
+ * succeeds; the operation owner retains that receipt to begin/end in-flight protection and conditionally release
+ * only its own generation. Acting on the verdict — mutate vs throw — stays in the caller, so this remains a pure
+ * function over its inputs and is unit-provable with a stub guard.
  *
  * Fail-closed by construction — only a fully-valid, non-conflicting agent request (or a genuinely legacy one) admits:
- * - **decision not enforced** (`context` absent → legacy / non-agent frame): `{admitted: true}` — write unguarded.
+ * - **decision not enforced** (`context` absent → legacy / non-agent frame): `{admitted: true,
+ *   acquisition: null}` — write unguarded.
  * - **enforced, no lock** (incomplete identity / unresolvable target): `{admitted: false, reason}` — deny, no mutate;
  *   `reason` is `resolveWriteLock`'s (`'incomplete-identity'` | `'unresolvable-target'`).
  * - **enforced, lock, but no `writeGuard`**: `{admitted: false, reason: 'no-write-guard'}` — a misconfiguration where
  *   enforcement is required but no heap authority exists denies rather than silently mutating (never fail open).
- * - **enforced, lock, guard grants** (no overlap, or same-writer re-entrant): `{admitted: true}` — the lock is now
- *   **held** in the guard's table until release (disconnect sweep).
- * - **enforced, lock, guard denies** (a *different* writer holds an overlapping subtree): `{admitted: false,
- *   reason: 'conflict', conflict}` — deny, no mutate; `conflict` is the guard's defensive copy of the holder.
+ * - **enforced, lock, guard grants** (no overlap, or same-writer re-entrant): `{admitted: true, acquisition}` — the
+ *   lock is now **held** and the caller owns the scoped fenced receipt.
+ * - **enforced, lock, guard denies**: `{admitted: false, reason, conflict}` — a cross-writer overlap reports
+ *   `reason: 'conflict'` plus the guard's defensive holder copy; an unavailable lease clock/config reports the
+ *   guard's precise fail-closed error code with no false conflict.
  *
  * @param {Object}        params
  * @param {Object|null}   params.context     The Bridge-stamped `{agentId, sessionId}` writer pair, or `null` /
@@ -27,8 +31,8 @@ import {resolveWriteLock} from './resolveWriteLock.mjs';
  * @param {Function}      params.parentOf    `(id: String) => String|null|undefined` — injected parent lookup, exactly
  *                                            as {@link Neo.ai.deriveSubtreePath} consumes it (`id => Neo.getComponent(id)?.parentId`).
  * @param {Object}        params.writeGuard  The heap's {@link Neo.ai.WriteGuard} instance (`requestWrite(lock) →
- *                                            {granted, conflict}`). Required only when the decision is enforced with a lock.
- * @returns {{admitted: Boolean, reason: (String|null), conflict: (Object|null)}}
+ *                                            {granted, conflict, errors, acquisition}`). Required only when enforced.
+ * @returns {{admitted: Boolean, reason: (String|null), conflict: (Object|null), acquisition: (Object|null)}}
  *   `admitted:true` ⇒ the caller may mutate (the lock, if any, is held). `admitted:false` ⇒ the caller must NOT mutate;
  *   `reason` names why and `conflict` (when present) is the overlapping holder.
  */
@@ -37,23 +41,28 @@ export function admitWrite({context, componentId, parentOf, writeGuard}) {
 
     // Legacy / non-agent frame — the multi-writer regime does not apply; write unguarded.
     if (!decision.enforced) {
-        return {admitted: true, reason: null, conflict: null}
+        return {admitted: true, reason: null, conflict: null, acquisition: null}
     }
 
     // Enforced, but identity / target is undecidable — fail closed (deny, no mutate).
     if (!decision.lock) {
-        return {admitted: false, reason: decision.reason, conflict: null}
+        return {admitted: false, reason: decision.reason, conflict: null, acquisition: null}
     }
 
     // Enforced with a valid lock, but no heap authority to hold it — fail closed rather than mutate unguarded.
     if (!writeGuard) {
-        return {admitted: false, reason: 'no-write-guard', conflict: null}
+        return {admitted: false, reason: 'no-write-guard', conflict: null, acquisition: null}
     }
 
     // Acquire-and-hold; a cross-writer overlap is denied with a copy of the conflicting holder.
-    const {granted, conflict} = writeGuard.requestWrite(decision.lock);
+    const {granted, conflict, errors=[], acquisition} = writeGuard.requestWrite(decision.lock);
 
     return granted
-        ? {admitted: true,  reason: null,       conflict: null}
-        : {admitted: false, reason: 'conflict', conflict}
+        ? {admitted: true,  reason: null,       conflict: null, acquisition: acquisition || null}
+        : {
+            admitted   : false,
+            reason     : conflict ? 'conflict' : errors[0] || 'write-guard-denied',
+            conflict   : conflict || null,
+            acquisition: null
+        }
 }

--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -99,6 +99,11 @@ class InstanceService extends Service {
             reverseConfig = this.safeSerialize(createConfig),
             parent        = parentId ? Neo.getComponent(parentId) : null;
 
+        let acquisition = null,
+            instance,
+            mutationStarted = false,
+            rollbackComplete = false;
+
         if (parentId) {
             if (!parent) {
                 throw new Error(`Parent component not found: ${parentId}`)
@@ -108,43 +113,58 @@ class InstanceService extends Service {
                 throw new Error(`Parent is not a container: ${parentId}`)
             }
 
-            this.assertWritable(context, parentId)
+            acquisition = this.assertWritable(context, parentId)
         }
 
-        const instance = createConfig.ntype ? Neo.ntype(createConfig) : Neo.create(createConfig);
+        try {
+            // Construction can register an instance before throwing, so failures from this point are
+            // conservatively unknown unless the parent-add rollback below completes.
+            mutationStarted = true;
+            instance = createConfig.ntype ? Neo.ntype(createConfig) : Neo.create(createConfig);
 
-        if (!instance) {
-            throw new Error('create_instance: Neo.create returned no instance.')
-        }
-
-        let attachedInstance = instance;
-
-        if (parent) {
-            try {
-                attachedInstance = parent.add(instance)
-            } catch (error) {
-                instance.destroy();
-                throw error
+            if (!instance) {
+                throw new Error('create_instance: Neo.create returned no instance.')
             }
+
+            let attachedInstance = instance;
+
+            if (parent) {
+                try {
+                    attachedInstance = parent.add(instance)
+                } catch (error) {
+                    instance.destroy();
+                    rollbackComplete = true;
+                    throw error
+                }
+            }
+
+            this.recordUndo(context, this.buildCreateInstanceReverse({
+                config  : reverseConfig,
+                context,
+                instance: attachedInstance,
+                parentId
+            }));
+
+            const result = {
+                id       : attachedInstance.id,
+                className: attachedInstance.className
+            };
+
+            if (parentId) {
+                result.parentId = parentId
+            }
+
+            this.finishWritable(acquisition);
+
+            return result
+        } catch (error) {
+            this.failWritable(
+                acquisition,
+                error,
+                rollbackComplete ? 'rollback-complete' : mutationStarted ? 'unknown' : 'pre-mutation'
+            );
+            throw error
         }
-
-        this.recordUndo(context, this.buildCreateInstanceReverse({
-            config  : reverseConfig,
-            context,
-            instance: attachedInstance,
-            parentId
-        }));
-
-        const result = {
-            id       : attachedInstance.id,
-            className: attachedInstance.className
-        };
-
-        if (parentId) {
-            result.parentId = parentId
-        }
-
-        return result
     }
 
     /**
@@ -337,12 +357,12 @@ class InstanceService extends Service {
         }
 
         return {
-            sequenceId       : `${id}:${++this.undoSequence}`,
-            originWriter     : {agentId: context.agentId, sessionId: context.sessionId},
+            sequenceId  : `${id}:${++this.undoSequence}`,
+            originWriter: {agentId: context.agentId, sessionId: context.sessionId},
             targetSubtreePath,
-            forward          : {tool: 'create_instance', args: forwardArgs},
-            reverse          : {tool: 'destroy_instance', args: {id}},
-            label            : `create ${config.ntype || config.className || 'instance'}${parentId ? ` in ${parentId}` : ''}`
+            forward     : {tool: 'create_instance', args: forwardArgs},
+            reverse     : {tool: 'destroy_instance', args: {id}},
+            label       : `create ${config.ntype || config.className || 'instance'}${parentId ? ` in ${parentId}` : ''}`
         }
     }
 
@@ -369,8 +389,15 @@ class InstanceService extends Service {
         }
 
         if (Neo.getComponent(id)) {
-            this.assertWritable(context, id);
-            instance.destroy(true)
+            const acquisition = this.assertWritable(context, id);
+
+            try {
+                instance.destroy(true);
+                this.finishWritable(acquisition)
+            } catch (error) {
+                this.failWritable(acquisition, error, 'unknown');
+                throw error
+            }
         } else {
             instance.destroy()
         }
@@ -381,13 +408,15 @@ class InstanceService extends Service {
     /**
      * Enforces the multi-writer write-lock before a write-class op mutates: composes the {@link Neo.ai.admitWrite}
      * decision with this heap's {@link Neo.ai.Client#writeGuard} and **throws** a deny (no mutation) when the write is
-     * not admitted. A bare / legacy frame (no `context`) is unguarded — backward-compatible with non-agent callers.
+     * not admitted. On enforced admission it starts in-flight protection and returns the fenced acquisition receipt
+     * to the operation owner. A bare / legacy frame (no `context`) is unguarded and returns `null`.
      * @param {Object|null} context The Bridge-stamped `{agentId, sessionId}` writer pair, or null/undefined (legacy).
      * @param {String} id The target component id whose subtree the write locks.
+     * @returns {Object|null} Fenced acquisition receipt for an enforced write, otherwise `null`.
      * @protected
      */
     assertWritable(context, id) {
-        const {admitted, reason, conflict} = admitWrite({
+        const {admitted, reason, conflict, acquisition} = admitWrite({
             context,
             componentId: id,
             parentOf   : cid => Neo.getComponent(cid)?.parentId,
@@ -397,6 +426,44 @@ class InstanceService extends Service {
         if (!admitted) {
             const heldBy = conflict ? ` (held by ${conflict.agentId} / ${conflict.sessionId})` : '';
             throw new Error(`Write denied for ${id}: ${reason}${heldBy}`)
+        }
+
+        if (acquisition) {
+            const writeGuard = this.client?.writeGuard,
+                  {began}    = writeGuard?.beginWrite(acquisition) || {began: false};
+
+            if (!began) {
+                if (acquisition.created) {
+                    writeGuard?.releaseWrite(acquisition)
+                }
+                throw new Error(`Write denied for ${id}: stale-acquisition`)
+            }
+        }
+
+        return acquisition
+    }
+
+    /**
+     * @summary End a successful write operation while retaining its held lease.
+     * @param {Object|null} acquisition Fenced receipt returned by {@link assertWritable}.
+     * @protected
+     */
+    finishWritable(acquisition) {
+        if (acquisition) {
+            this.client?.writeGuard?.endWrite(acquisition)
+        }
+    }
+
+    /**
+     * @summary End a failed write with phase-aware release/retain semantics and an observable receipt.
+     * @param {Object|null} acquisition Fenced receipt returned by {@link assertWritable}.
+     * @param {Error} error The operation failure.
+     * @param {'pre-mutation'|'rollback-complete'|'unknown'} mutationDisposition Proven mutation phase.
+     * @protected
+     */
+    failWritable(acquisition, error, mutationDisposition) {
+        if (acquisition) {
+            this.client?.writeGuard?.endWrite(acquisition, {failed: true, mutationDisposition, error})
         }
     }
 
@@ -415,20 +482,29 @@ class InstanceService extends Service {
             throw new Error(`Instance not found: ${id}`)
         }
 
-        this.assertWritable(context, id);
+        const acquisition = this.assertWritable(context, id);
 
-        // Capture the reverse (the pre-set values) BEFORE mutating, so an agent can undo this write. Best-effort +
-        // fail-closed: only an enforcement-granted *agent* write (a writer identity in `context`) is captured, and a
-        // malformed / unserializable reverse is dropped, never thrown into the write path. A replay
-        // (`context.undoReplay`, set by {@link #undo} / {@link #redo}) is NOT captured — re-applying a captured op
-        // must never enqueue a new transaction.
-        const undoOp = context?.undoReplay ? null : this.buildSetReverse({context, id, instance, properties});
+        let mutationStarted = false;
 
-        instance.set(properties);
+        try {
+            // Capture the reverse (the pre-set values) BEFORE mutating, so an agent can undo this write. Best-effort +
+            // fail-closed: only an enforcement-granted *agent* write (a writer identity in `context`) is captured, and a
+            // malformed / unserializable reverse is dropped, never thrown into the write path. A replay
+            // (`context.undoReplay`, set by {@link #undo} / {@link #redo}) is NOT captured — re-applying a captured op
+            // must never enqueue a new transaction.
+            const undoOp = context?.undoReplay ? null : this.buildSetReverse({context, id, instance, properties});
 
-        this.recordUndo(context, undoOp);
+            mutationStarted = true;
+            instance.set(properties);
 
-        return {success: true}
+            this.recordUndo(context, undoOp);
+            this.finishWritable(acquisition);
+
+            return {success: true}
+        } catch (error) {
+            this.failWritable(acquisition, error, mutationStarted ? 'unknown' : 'pre-mutation');
+            throw error
+        }
     }
 
     /**
@@ -462,12 +538,12 @@ class InstanceService extends Service {
         });
 
         return {
-            sequenceId       : `${id}:${++this.undoSequence}`,
-            originWriter     : {agentId: context.agentId, sessionId: context.sessionId},
+            sequenceId  : `${id}:${++this.undoSequence}`,
+            originWriter: {agentId: context.agentId, sessionId: context.sessionId},
             targetSubtreePath,
-            forward          : {tool: 'set_instance_properties', args: {id, properties}},
-            reverse          : {tool: 'set_instance_properties', args: {id, properties: oldValues}},
-            label            : `set ${Object.keys(properties).join(', ')} on ${id}`
+            forward     : {tool: 'set_instance_properties', args: {id, properties}},
+            reverse     : {tool: 'set_instance_properties', args: {id, properties: oldValues}},
+            label       : `set ${Object.keys(properties).join(', ')} on ${id}`
         }
     }
 
@@ -515,12 +591,12 @@ class InstanceService extends Service {
         }
 
         return {
-            sequenceId       : `${newId}:${++this.undoSequence}`,
-            originWriter     : {agentId: context.agentId, sessionId: context.sessionId},
+            sequenceId  : `${newId}:${++this.undoSequence}`,
+            originWriter: {agentId: context.agentId, sessionId: context.sessionId},
             targetSubtreePath,
-            forward          : {tool: 'create_component', args: {parentId: id, config: args[0]}},
-            reverse          : {tool: 'call_method', args: {id: newId, method: 'destroy', args: [true]}},
-            label            : `create ${args[0].ntype || args[0].className || 'component'} in ${id}`
+            forward     : {tool: 'create_component', args: {parentId: id, config: args[0]}},
+            reverse     : {tool: 'call_method', args: {id: newId, method: 'destroy', args: [true]}},
+            label       : `create ${args[0].ntype || args[0].className || 'component'} in ${id}`
         }
     }
 
@@ -579,12 +655,12 @@ class InstanceService extends Service {
         }
 
         return {
-            sequenceId       : `${id}:${++this.undoSequence}`,
-            originWriter     : {agentId: context.agentId, sessionId: context.sessionId},
+            sequenceId  : `${id}:${++this.undoSequence}`,
+            originWriter: {agentId: context.agentId, sessionId: context.sessionId},
             targetSubtreePath,
-            forward          : {tool: 'remove_component', args: {componentId: id}},
-            reverse          : {tool: 'call_method', args: {id: parentId, method: 'insert', args: [index, config]}},
-            label            : `remove ${id} from ${parentId}`
+            forward     : {tool: 'remove_component', args: {componentId: id}},
+            reverse     : {tool: 'call_method', args: {id: parentId, method: 'insert', args: [index, config]}},
+            label       : `remove ${id} from ${parentId}`
         }
     }
 
@@ -1050,19 +1126,30 @@ class InstanceService extends Service {
             throw new Error(`Method not found: ${method} on instance ${id}`)
         }
 
-        this.assertWritable(context, id);
+        const acquisition = this.assertWritable(context, id);
 
-        // remove_component reverse-capture must snapshot the component's re-creatable state BEFORE destroy runs (the
-        // instance is gone afterwards); create_component's capture is post-call (the new child's id is the `add`
-        // return). A server-stamped marker + the canonical shape gate each; a generic call_method + an undo replay
-        // capture nothing. See {@link #buildRemoveReverse} / {@link #buildCreateReverse}.
-        const removeOp = this.buildRemoveReverse({context, id, method, args, undoKind, instance});
+        let mutationStarted = false;
 
-        const result = await scope[methodName].call(scope, ...args);
+        try {
+            // remove_component reverse-capture must snapshot the component's re-creatable state BEFORE destroy runs (the
+            // instance is gone afterwards); create_component's capture is post-call (the new child's id is the `add`
+            // return). A server-stamped marker + the canonical shape gate each; a generic call_method + an undo replay
+            // capture nothing. See {@link #buildRemoveReverse} / {@link #buildCreateReverse}.
+            const removeOp = this.buildRemoveReverse({context, id, method, args, undoKind, instance});
 
-        this.recordUndo(context, removeOp || this.buildCreateReverse({context, id, method, args, undoKind, result}));
+            mutationStarted = true;
+            const result = await scope[methodName].call(scope, ...args);
 
-        return {result: this.safeSerialize(result)}
+            this.recordUndo(context, removeOp || this.buildCreateReverse({context, id, method, args, undoKind, result}));
+            const serializedResult = this.safeSerialize(result);
+
+            this.finishWritable(acquisition);
+
+            return {result: serializedResult}
+        } catch (error) {
+            this.failWritable(acquisition, error, mutationStarted ? 'unknown' : 'pre-mutation');
+            throw error
+        }
     }
 }
 

--- a/test/playwright/unit/ai/ClientAgentDisconnect.spec.mjs
+++ b/test/playwright/unit/ai/ClientAgentDisconnect.spec.mjs
@@ -92,7 +92,9 @@ test.describe('Neo.ai.Client - agent disconnect lock release', () => {
         const result = client.handleAgentDisconnected({agentId: 'neo-opus-ada', sessionId: 'sess-1'});
 
         expect(result.released).toBe(1);
-        expect(client.writeGuard.heldLocks()).toEqual([lock('neo-opus-ada', 'sess-2', ['root', 'b'])])
+        expect(client.writeGuard.heldLocks()).toEqual([
+            expect.objectContaining(lock('neo-opus-ada', 'sess-2', ['root', 'b']))
+        ])
     });
 
     test('an unknown disconnected writer is a no-op', () => {
@@ -101,7 +103,9 @@ test.describe('Neo.ai.Client - agent disconnect lock release', () => {
         const result = client.handleAgentDisconnected({agentId: 'neo-opus-vega', sessionId: 'sess-2'});
 
         expect(result.released).toBe(0);
-        expect(client.writeGuard.heldLocks()).toEqual([lock('neo-opus-ada', 'sess-1', ['root', 'panel'])])
+        expect(client.writeGuard.heldLocks()).toEqual([
+            expect.objectContaining(lock('neo-opus-ada', 'sess-1', ['root', 'panel']))
+        ])
     });
 
     test('half-stamped disconnect frames fail closed and do not sweep broad selectors', () => {
@@ -121,9 +125,9 @@ test.describe('Neo.ai.Client - agent disconnect lock release', () => {
         }
 
         expect(client.writeGuard.heldLocks()).toEqual([
-            lock('neo-opus-ada',  'sess-1', ['root', 'a']),
-            lock('neo-opus-ada',  'sess-2', ['root', 'b']),
-            lock('neo-opus-vega', 'sess-1', ['root', 'c'])
+            expect.objectContaining(lock('neo-opus-ada',  'sess-1', ['root', 'a'])),
+            expect.objectContaining(lock('neo-opus-ada',  'sess-2', ['root', 'b'])),
+            expect.objectContaining(lock('neo-opus-vega', 'sess-1', ['root', 'c']))
         ])
     });
 

--- a/test/playwright/unit/ai/LockRegistry.spec.mjs
+++ b/test/playwright/unit/ai/LockRegistry.spec.mjs
@@ -145,6 +145,9 @@ test.describe('Neo.ai.LockRegistry', () => {
             const result = LockRegistry.acquire([], lock('ada', 's1', ['root']));
 
             expect(result.granted).toBe(true);
+            expect(result.created).toBe(true);
+            expect(result.reentrant).toBe(false);
+            expect(result.acquiredLock).toEqual(lock('ada', 's1', ['root']));
             expect(result.conflict).toBeNull();
             expect(result.errors).toEqual([]);
             expect(result.lockTable).toHaveLength(1);
@@ -173,6 +176,9 @@ test.describe('Neo.ai.LockRegistry', () => {
                   second = LockRegistry.acquire(first.lockTable, lock('ada', 's1', ['root', 'p']));
 
             expect(second.granted).toBe(true);
+            expect(second.created).toBe(false);
+            expect(second.reentrant).toBe(true);
+            expect(second.acquiredLock).toBe(first.lockTable[0]);
             expect(second.lockTable).toHaveLength(1);
         });
 

--- a/test/playwright/unit/ai/WriteGuard.spec.mjs
+++ b/test/playwright/unit/ai/WriteGuard.spec.mjs
@@ -49,10 +49,10 @@ test.describe('Neo.ai.WriteGuard', () => {
     });
 
     test('the held lock blocks the second writer until released, then grants', () => {
-        guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root', 'panel'])).acquisition;
         expect(guard.requestWrite(lock('vega', 's2', ['root', 'panel'])).granted).toBe(false);
 
-        guard.releaseWrite(lock('ada', 's1', ['root', 'panel']));
+        guard.releaseWrite(acquisition);
         expect(guard.requestWrite(lock('vega', 's2', ['root', 'panel'])).granted).toBe(true);
     });
 
@@ -72,18 +72,20 @@ test.describe('Neo.ai.WriteGuard', () => {
     });
 
     test('releaseWrite is a no-op for a lock that is not held', () => {
-        guard.requestWrite(lock('ada', 's1', ['root']));
-        const result = guard.releaseWrite(lock('ada', 's1', ['other']));
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition,
+              result      = guard.releaseWrite({...acquisition, subtreePath: ['other']});
 
         expect(result.released).toBe(false);
+        expect(result.reason).toBe('stale-token');
         expect(guard.heldLocks()).toHaveLength(1);
     });
 
     test('releaseWrite never releases a different writer holding the same subtree', () => {
-        guard.requestWrite(lock('ada', 's1', ['root']));
-        const result = guard.releaseWrite(lock('vega', 's2', ['root']));
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition,
+              result      = guard.releaseWrite({...acquisition, agentId: 'vega', sessionId: 's2'});
 
         expect(result.released).toBe(false);
+        expect(result.reason).toBe('stale-token');
         expect(guard.heldLocks()).toHaveLength(1);
     });
 
@@ -97,6 +99,16 @@ test.describe('Neo.ai.WriteGuard', () => {
         expect(result.released).toBe(2);
         expect(guard.heldLocks()).toHaveLength(1);
         expect(guard.heldLocks()[0].agentId).toBe('vega');
+    });
+
+    test('disconnect release is immediate even while the matching generation is in flight', () => {
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(acquisition);
+
+        expect(guard.releaseAgent({agentId: 'ada', sessionId: 's1'})).toEqual({released: 1});
+        expect(guard.heldLocks()).toHaveLength(0);
+        expect(guard.leaseReceipts().at(-1).reason).toBe('disconnect-release')
     });
 
     test('after a disconnect-sweep the freed subtree is grantable to another writer', () => {
@@ -137,5 +149,203 @@ test.describe('Neo.ai.WriteGuard', () => {
         // the live lock still blocks vega on the original subtree
         expect(guard.requestWrite(lock('vega', 's2', ['root', 'panel'])).granted).toBe(false);
         expect(guard.heldLocks()[0].subtreePath).toEqual(['root', 'panel']);
+    });
+
+    test('reports created vs re-entrant acquisition and refreshes the same fenced token', () => {
+        let now = 1_000;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const first = guard.requestWrite(lock('ada', 's1', ['root']));
+
+        expect(first.created).toBe(true);
+        expect(first.reentrant).toBe(false);
+        expect(first.acquisition).toMatchObject({created: true, reentrant: false, acquiredAt: 1_000, lastTouchAt: 1_000, inFlight: 0});
+
+        now = 1_050;
+
+        const second = guard.requestWrite(lock('ada', 's1', ['root']));
+
+        expect(second.created).toBe(false);
+        expect(second.reentrant).toBe(true);
+        expect(second.token).toBe(first.token);
+        expect(second.acquisition).toMatchObject({created: false, reentrant: true, acquiredAt: 1_000, lastTouchAt: 1_050});
+        expect(guard.heldLocks()).toHaveLength(1)
+    });
+
+    test('lazily reclaims an idle lease at the TTL boundary and returns an expiry receipt', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const first = guard.requestWrite(lock('ada', 's1', ['root']));
+
+        now = 100;
+
+        const takeover = guard.requestWrite(lock('vega', 's2', ['root']));
+
+        expect(takeover.granted).toBe(true);
+        expect(takeover.created).toBe(true);
+        expect(takeover.token).not.toBe(first.token);
+        expect(takeover.reclaimed).toHaveLength(1);
+        expect(takeover.reclaimed[0]).toMatchObject({reason: 'expired', token: first.token, observedAt: 100});
+        expect(guard.heldLocks()[0]).toMatchObject({agentId: 'vega', sessionId: 's2'});
+        expect(guard.leaseReceipts()[0].reason).toBe('expired')
+    });
+
+    test('never sweeps an in-flight async operation, then expires from its end touch', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const first = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        expect(guard.beginWrite(first).began).toBe(true);
+
+        now = 1_000;
+        expect(guard.requestWrite(lock('vega', 's2', ['root'])).granted).toBe(false);
+        expect(guard.endWrite(first)).toEqual({ended: true, released: false, retained: true});
+
+        now = 1_099;
+        expect(guard.requestWrite(lock('vega', 's2', ['root'])).granted).toBe(false);
+
+        now = 1_100;
+        expect(guard.requestWrite(lock('vega', 's2', ['root'])).granted).toBe(true)
+    });
+
+    test('a stale token cannot touch or release a successor generation', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const stale = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        now = 100;
+
+        const successor = guard.requestWrite(lock('vega', 's2', ['root'])).acquisition;
+
+        expect(guard.touchWrite(stale)).toEqual({touched: false});
+        expect(guard.releaseWrite(stale)).toEqual({released: false, reason: 'stale-token'});
+        expect(guard.heldLocks()).toHaveLength(1);
+        expect(guard.heldLocks()[0].token).toBe(successor.token)
+    });
+
+    test('fenced explicit release refuses in-flight work and succeeds after end', () => {
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(acquisition);
+        expect(guard.releaseWrite(acquisition)).toEqual({released: false, reason: 'in-flight'});
+        guard.endWrite(acquisition);
+        expect(guard.releaseWrite(acquisition)).toEqual({released: true, reason: null});
+        expect(guard.heldLocks()).toHaveLength(0)
+    });
+
+    test('a newly-created pre-mutation failure releases and emits an error-release receipt', () => {
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(acquisition);
+        const outcome = guard.endWrite(acquisition, {
+            failed             : true,
+            mutationDisposition: 'pre-mutation',
+            error              : new Error('validation failed')
+        });
+
+        expect(outcome).toEqual({ended: true, released: true, retained: false});
+        expect(guard.heldLocks()).toHaveLength(0);
+        expect(guard.leaseReceipts().at(-1)).toMatchObject({reason: 'error-release', mutationDisposition: 'pre-mutation', error: 'validation failed'})
+    });
+
+    test('a re-entrant failure never releases the pre-existing hold', () => {
+        guard.requestWrite(lock('ada', 's1', ['root']));
+        const reentrant = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(reentrant);
+        const outcome = guard.endWrite(reentrant, {failed: true, mutationDisposition: 'pre-mutation'});
+
+        expect(reentrant.created).toBe(false);
+        expect(outcome).toEqual({ended: true, released: false, retained: true});
+        expect(guard.heldLocks()).toHaveLength(1);
+        expect(guard.leaseReceipts().at(-1).reason).toBe('error-retained')
+    });
+
+    test('a creator failure cannot release a generation another re-entrant operation already shared', () => {
+        const creator = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(creator);
+
+        const reentrant = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(reentrant);
+        guard.endWrite(reentrant);
+
+        expect(guard.endWrite(creator, {failed: true, mutationDisposition: 'pre-mutation'}))
+            .toEqual({ended: true, released: false, retained: true});
+        expect(guard.heldLocks()).toHaveLength(1);
+        expect(guard.leaseReceipts().at(-1).reason).toBe('error-retained')
+    });
+
+    test('an unknown partial-mutation failure retains the hold and becomes TTL-reclaimable', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.beginWrite(acquisition);
+        now = 10;
+        expect(guard.endWrite(acquisition, {failed: true, mutationDisposition: 'unknown'}))
+            .toEqual({ended: true, released: false, retained: true});
+
+        now = 109;
+        expect(guard.requestWrite(lock('vega', 's2', ['root'])).granted).toBe(false);
+
+        now = 110;
+        const takeover = guard.requestWrite(lock('vega', 's2', ['root']));
+        expect(takeover.granted).toBe(true);
+        expect(takeover.reclaimed[0].reason).toBe('expired')
+    });
+
+    test('lease and receipt snapshots cannot mutate live metadata', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition,
+              snapshot    = guard.heldLocks();
+
+        snapshot[0].token = 999;
+        snapshot[0].subtreePath.push('tamper');
+        expect(guard.heldLocks()[0]).toMatchObject({token: acquisition.token, subtreePath: ['root']});
+
+        now = 100;
+        guard.heldLocks();
+
+        const receipts = guard.leaseReceipts();
+        receipts[0].subtreePath.push('tamper');
+        expect(guard.leaseReceipts()[0].subtreePath).toEqual(['root'])
+    });
+
+    test('invalid clock or TTL denies without mutating an existing valid hold', () => {
+        let now = 0;
+        guard = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now});
+
+        const acquisition = guard.requestWrite(lock('ada', 's1', ['root'])).acquisition;
+
+        guard.nowFn = () => NaN;
+        expect(guard.requestWrite(lock('vega', 's2', ['other'])))
+            .toMatchObject({granted: false, errors: ['invalid-write-lease-clock']});
+        expect(guard.heldLocks()[0].token).toBe(acquisition.token);
+
+        guard.nowFn = () => now;
+        guard.leaseTtlMs = 0;
+        expect(guard.requestWrite(lock('vega', 's2', ['other'])))
+            .toMatchObject({granted: false, errors: ['invalid-write-lease-ttl']});
+        expect(guard.heldLocks()[0].token).toBe(acquisition.token)
+    });
+
+    test('bounds the lifecycle receipt ledger without changing release decisions', () => {
+        guard = Neo.create(WriteGuard, {receiptLimit: 2});
+
+        ['a', 'b', 'c'].forEach(path => {
+            const acquisition = guard.requestWrite(lock('ada', 's1', [path])).acquisition;
+            expect(guard.releaseWrite(acquisition)).toEqual({released: true, reason: null})
+        });
+
+        expect(guard.leaseReceipts()).toHaveLength(2);
+        expect(guard.leaseReceipts().map(receipt => receipt.subtreePath[0])).toEqual(['b', 'c'])
     });
 });

--- a/test/playwright/unit/ai/admitWrite.spec.mjs
+++ b/test/playwright/unit/ai/admitWrite.spec.mjs
@@ -25,10 +25,11 @@ import {admitWrite}    from '../../../../src/ai/admitWrite.mjs';
 //
 // Linear component tree  root → mid → leaf  (parentOf returns the parent id; falsy at the root).
 const
-    PARENTS  = {leaf: 'mid', mid: 'root', root: null},
-    parentOf = id => PARENTS[id],
-    CTX_A    = {agentId: 'agent-a', sessionId: 'sess-a'},
-    CTX_B    = {agentId: 'agent-b', sessionId: 'sess-b'};
+    PARENTS             = {leaf: 'mid', mid: 'root', root: null},
+    parentOf            = id => PARENTS[id],
+    CTX_A               = {agentId: 'agent-a', sessionId: 'sess-a'},
+    CTX_A_OTHER_SESSION = {agentId: 'agent-a', sessionId: 'sess-b'},
+    CTX_B               = {agentId: 'agent-b', sessionId: 'sess-b'};
 
 // A guard stub that records every lock it is asked to hold and returns a scripted verdict.
 const stubGuard = verdict => {
@@ -41,7 +42,7 @@ test.describe('admitWrite (NL write-enforcement orchestration)', () => {
         const guard = stubGuard({granted: false}); // would DENY if consulted — proves the unguarded path skips it
         for (const absent of [null, undefined, 'x', 42, true]) {
             expect(admitWrite({context: absent, componentId: 'leaf', parentOf, writeGuard: guard}))
-                .toEqual({admitted: true, reason: null, conflict: null})
+                .toEqual({admitted: true, reason: null, conflict: null, acquisition: null})
         }
         expect(guard.calls).toHaveLength(0)
     });
@@ -50,7 +51,7 @@ test.describe('admitWrite (NL write-enforcement orchestration)', () => {
         const guard = stubGuard({granted: true}); // would GRANT if consulted
         for (const bad of [{agentId: '', sessionId: 'sess-a'}, {agentId: 'agent-a', sessionId: ''}, {}, {foo: 1}]) {
             expect(admitWrite({context: bad, componentId: 'leaf', parentOf, writeGuard: guard}))
-                .toEqual({admitted: false, reason: 'incomplete-identity', conflict: null})
+                .toEqual({admitted: false, reason: 'incomplete-identity', conflict: null, acquisition: null})
         }
         expect(guard.calls).toHaveLength(0)
     });
@@ -59,7 +60,7 @@ test.describe('admitWrite (NL write-enforcement orchestration)', () => {
         const guard = stubGuard({granted: true});
         for (const badId of ['', 'document.body']) {
             expect(admitWrite({context: CTX_A, componentId: badId, parentOf, writeGuard: guard}))
-                .toEqual({admitted: false, reason: 'unresolvable-target', conflict: null})
+                .toEqual({admitted: false, reason: 'unresolvable-target', conflict: null, acquisition: null})
         }
         expect(guard.calls).toHaveLength(0)
     });
@@ -67,14 +68,14 @@ test.describe('admitWrite (NL write-enforcement orchestration)', () => {
     test('enforced + valid lock but NO writeGuard → denied (no-write-guard); never fails open on a misconfig', () => {
         for (const noGuard of [undefined, null]) {
             expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: noGuard}))
-                .toEqual({admitted: false, reason: 'no-write-guard', conflict: null})
+                .toEqual({admitted: false, reason: 'no-write-guard', conflict: null, acquisition: null})
         }
     });
 
     test('enforced + guard grants → admitted; the EXACT resolved absolute lock is what gets held', () => {
         const guard = stubGuard({granted: true, conflict: null});
         expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: guard}))
-            .toEqual({admitted: true, reason: null, conflict: null});
+            .toEqual({admitted: true, reason: null, conflict: null, acquisition: null});
         // the descriptor handed to the authority is resolveWriteLock's absolute root→node lock, verbatim
         expect(guard.calls).toEqual([{agentId: 'agent-a', sessionId: 'sess-a', subtreePath: ['root', 'mid', 'leaf']}])
     });
@@ -83,7 +84,14 @@ test.describe('admitWrite (NL write-enforcement orchestration)', () => {
         const holder = {agentId: 'agent-b', sessionId: 'sess-b', subtreePath: ['root']},
               guard  = stubGuard({granted: false, conflict: holder});
         expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: guard}))
-            .toEqual({admitted: false, reason: 'conflict', conflict: holder})
+            .toEqual({admitted: false, reason: 'conflict', conflict: holder, acquisition: null})
+    });
+
+    test('enforced + unavailable lease clock → denied with the precise guard reason, not a false conflict', () => {
+        const guard = Neo.create(WriteGuard, {nowFn: () => NaN});
+
+        expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: guard}))
+            .toEqual({admitted: false, reason: 'invalid-write-lease-clock', conflict: null, acquisition: null})
     });
 
     // ── integration: the REAL WriteGuard + LockRegistry conflict math (the actual enforcement, not a mock) ──
@@ -91,7 +99,9 @@ test.describe('admitWrite (NL write-enforcement orchestration)', () => {
         const guard = Neo.create('Neo.ai.WriteGuard');
 
         // writer A acquires (and holds) the 'mid' subtree
-        expect(admitWrite({context: CTX_A, componentId: 'mid', parentOf, writeGuard: guard}).admitted).toBe(true);
+        const first = admitWrite({context: CTX_A, componentId: 'mid', parentOf, writeGuard: guard});
+        expect(first.admitted).toBe(true);
+        expect(first.acquisition).toMatchObject({created: true, reentrant: false, token: expect.any(Number)});
         expect(guard.heldLocks()).toHaveLength(1);
 
         // writer B writes 'leaf' — a descendant of A's held 'mid' → genuine overlap → denied, nothing held for B
@@ -102,7 +112,9 @@ test.describe('admitWrite (NL write-enforcement orchestration)', () => {
         expect(guard.heldLocks()).toHaveLength(1);
 
         // the SAME writer A re-acquiring an overlapping subtree is re-entrant → still admitted
-        expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: guard}).admitted).toBe(true)
+        const reentrant = admitWrite({context: CTX_A, componentId: 'mid', parentOf, writeGuard: guard});
+        expect(reentrant.admitted).toBe(true);
+        expect(reentrant.acquisition).toMatchObject({created: false, reentrant: true, token: first.acquisition.token})
     });
 
     test('REAL WriteGuard — disjoint subtrees: two writers both admitted (no false-positive conflict)', () => {
@@ -128,7 +140,7 @@ test.describe('InstanceService write enforcement (wiring)', () => {
             service = Neo.create('Neo.ai.client.InstanceService', {client: {writeGuard: guard}}),
             tree    = {leaf: {parentId: 'mid'}, mid: {parentId: 'root'}, root: {parentId: null}};
 
-        let setCalls = 0;
+        let   setCalls     = 0;
         const fakeInstance = {set() {setCalls++}};
 
         const origGet = Neo.get, origGetComponent = Neo.getComponent;
@@ -149,6 +161,106 @@ test.describe('InstanceService write enforcement (wiring)', () => {
             service.setInstanceProperties({id: 'leaf', properties: {x: 3}});
             expect(setCalls).toBe(2)
         } finally {
+            Neo.get = origGet; Neo.getComponent = origGetComponent
+        }
+    })
+
+    test('an async call stays in-flight beyond TTL and expires only after its completion touch', async () => {
+        let now = 0, resolveRun, markStarted;
+
+        const
+            started = new Promise(resolve => { markStarted = resolve }),
+            guard   = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now}),
+            service = Neo.create(InstanceService, {client: {writeGuard: guard}}),
+            fake    = {
+                run() {
+                    markStarted();
+                    return new Promise(resolve => { resolveRun = resolve })
+                }
+            },
+            origGet = Neo.get,
+            origGetComponent = Neo.getComponent;
+
+        Neo.get          = () => fake;
+        Neo.getComponent = id => id === 'leaf' ? {parentId: null} : null;
+
+        try {
+            const call = service.callMethod({id: 'leaf', method: 'run'}, CTX_A);
+            await started;
+
+            now = 1_000;
+            expect(admitWrite({context: CTX_B, componentId: 'leaf', parentOf: () => null, writeGuard: guard}).admitted).toBe(false);
+            expect(guard.heldLocks()[0].inFlight).toBe(1);
+
+            resolveRun('done');
+            await expect(call).resolves.toEqual({result: 'done'});
+            expect(guard.heldLocks()[0]).toMatchObject({inFlight: 0, lastTouchAt: 1_000});
+
+            now = 1_100;
+            expect(admitWrite({context: CTX_B, componentId: 'leaf', parentOf: () => null, writeGuard: guard}).admitted).toBe(true)
+        } finally {
+            Neo.get = origGet; Neo.getComponent = origGetComponent
+        }
+    });
+
+    test('a persistent call failure retains until TTL, then admits the same identity in a distinct session', async () => {
+        let now = 0;
+
+        const
+            guard   = Neo.create(WriteGuard, {leaseTtlMs: 100, nowFn: () => now}),
+            service = Neo.create(InstanceService, {client: {writeGuard: guard}}),
+            fake    = {
+                async fail() {
+                    now = 10;
+                    throw new Error('partial mutation unknown')
+                }
+            },
+            origGet = Neo.get,
+            origGetComponent = Neo.getComponent;
+
+        Neo.get          = () => fake;
+        Neo.getComponent = id => id === 'leaf' ? {parentId: null} : null;
+
+        try {
+            await expect(service.callMethod({id: 'leaf', method: 'fail'}, CTX_A)).rejects.toThrow('partial mutation unknown');
+            expect(guard.heldLocks()[0]).toMatchObject({agentId: 'agent-a', inFlight: 0, lastTouchAt: 10});
+            expect(guard.leaseReceipts().at(-1)).toMatchObject({reason: 'error-retained', mutationDisposition: 'unknown'});
+
+            now = 109;
+            expect(admitWrite({context: CTX_A_OTHER_SESSION, componentId: 'leaf', parentOf: () => null, writeGuard: guard}).admitted).toBe(false);
+
+            now = 110;
+            expect(admitWrite({context: CTX_A_OTHER_SESSION, componentId: 'leaf', parentOf: () => null, writeGuard: guard}).admitted).toBe(true)
+        } finally {
+            Neo.get = origGet; Neo.getComponent = origGetComponent
+        }
+    });
+
+    test('pre-mutation failure releases only a newly-created acquisition, never a re-entrant hold', async () => {
+        const
+            guard                  = Neo.create(WriteGuard),
+            service                = Neo.create(InstanceService, {client: {writeGuard: guard}}),
+            fake                   = {run() { throw new Error('method must not run') }},
+            origBuildRemoveReverse = service.buildRemoveReverse,
+            origGet                = Neo.get,
+            origGetComponent       = Neo.getComponent;
+
+        Neo.get          = () => fake;
+        Neo.getComponent = id => id === 'leaf' ? {parentId: null} : null;
+        service.buildRemoveReverse = () => { throw new Error('capture failed before mutation') };
+
+        try {
+            await expect(service.callMethod({id: 'leaf', method: 'run'}, CTX_A)).rejects.toThrow('capture failed before mutation');
+            expect(guard.heldLocks()).toHaveLength(0);
+            expect(guard.leaseReceipts().at(-1).reason).toBe('error-release');
+
+            guard.requestWrite({agentId: CTX_A.agentId, sessionId: CTX_A.sessionId, subtreePath: ['leaf']});
+
+            await expect(service.callMethod({id: 'leaf', method: 'run'}, CTX_A)).rejects.toThrow('capture failed before mutation');
+            expect(guard.heldLocks()).toHaveLength(1);
+            expect(guard.leaseReceipts().at(-1).reason).toBe('error-retained')
+        } finally {
+            service.buildRemoveReverse = origBuildRemoveReverse;
             Neo.get = origGet; Neo.getComponent = origGetComponent
         }
     })


### PR DESCRIPTION
Resolves #15681

Adds a scoped lease lifecycle to the App-Worker `WriteGuard` without changing the exact `(agentId, sessionId)` writer key or held-until-release authority. Locks now carry fenced tokens, deterministic touch/expiry metadata, and in-flight protection; `admitWrite` passes the acquisition receipt into every guarded `InstanceService` write path so async work cannot expire mid-operation and failure cleanup can distinguish new, re-entrant, rolled-back, and potentially partial mutations. Bounded lifecycle receipts make expiry, disconnect, explicit release, and error retention independently observable.

Evidence: L2 (deterministic state-transition, in-process service integration, and Bridge identity suites) → L2 required (all close-target ACs are internal App-Worker contracts). No residuals.

## Deltas from ticket

- No substantive scope change.
- Conservative concurrency refinement: a creator failure auto-releases only when its generation was never shared by re-entry and no other operation remains in flight. Shared generations retain and defer cleanup to TTL or disconnect.
- Lease clock/config denials keep their precise fail-closed reason through `admitWrite` instead of surfacing as a false writer conflict.

## Test Evidence

- Write lease authority (`LockRegistry`, `WriteGuard`, `admitWrite`): creation/re-entry provenance, TTL boundary, in-flight protection, stale-token fencing, phase-aware failure, concurrent re-entry, bounded receipts, defensive snapshots, and invalid-clock/TTL preservation all pass.
- Write-path integration (`InstanceService`): create/destroy, set-property, arbitrary async call, undo/redo, named transactions, and archive replay regressions pass.
- Writer identity and cleanup: exact-session disconnect coverage and the signed Bridge `?id=` spoof falsifier pass; the incident reproduction proves a persistent failed writer retains until expiry while the same identity in a distinct session remains a separate writer.
- Command: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/ClientAgentDisconnect.spec.mjs test/playwright/unit/ai/LockRegistry.spec.mjs test/playwright/unit/ai/WriteGuard.spec.mjs test/playwright/unit/ai/admitWrite.spec.mjs test/playwright/unit/ai/InstanceServiceUndoCapture.spec.mjs test/playwright/unit/ai/InstanceServiceCreateInstance.spec.mjs test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs test/playwright/unit/ai/InstanceServiceRemoveUndoCapture.spec.mjs test/playwright/unit/ai/InstanceServiceListTransactions.spec.mjs test/playwright/unit/ai/InstanceServiceCreateUndoCapture.spec.mjs test/playwright/unit/ai/InstanceServiceUndo.spec.mjs test/playwright/unit/ai/InstanceServiceRedo.spec.mjs test/playwright/unit/ai/client/InstanceService.spec.mjs test/playwright/unit/ai/services/neural-link/InstanceServiceCreateInstance.spec.mjs test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs` — 158 passed.
- `npm run agent-preflight -- --no-fix <8 touched files>` — all requested source, JSDoc, parse, alignment, archaeology, whitespace, and test-mutation gates passed.

## Post-Merge Validation

- [ ] Optional live smoke: induce an application-method failure from a persistent Neural Link writer, observe the retained/error receipt, and confirm a distinct session is admitted after idle expiry without reloading the App Worker.
- [ ] Optional live smoke: disconnect a writer during an in-flight operation and confirm the immediate disconnect-release receipt.

Authored by Euclid (GPT-5.6, Codex Desktop). Session bb641b19-2dcb-4fd5-bd85-97a17cf162c3.
