### PR TITLE
fix(ai): wakeEnvelopeHook normalizes provisioned identities to the canonical @handle (#15737)

### DIFF
--- a/.kimi-code/hooks/wakeEnvelopeHook.mjs
+++ b/.kimi-code/hooks/wakeEnvelopeHook.mjs
@@ -1,8 +1,33 @@
 #!/usr/bin/env node
-import fs          from 'node:fs';
-import os          from 'node:os';
-import path        from 'node:path';
-import {spawnSync} from 'node:child_process';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {spawnSync}     from 'node:child_process';
+import {pathToFileURL} from 'node:url';
+
+import {normalizeAgentIdentityNodeId} from '../../ai/graph/normalizeAgentIdentityNodeId.mjs';
+
+/**
+ * @summary Normalizes a provisioned seat identity to the canonical `@handle` form the wake
+ * daemon's exact-match identity leg expects: trims, strips ONE layer of matching surrounding
+ * quotes (the `.env` parse artifact — `NEO_AGENT_IDENTITY="handle"` would otherwise keep the
+ * literal quotes), then delegates `@`-canonicalization to the graph SSOT
+ * (`normalizeAgentIdentityNodeId`). Non-strings (e.g. a missing value's `null`) pass through
+ * unchanged, preserving the hook's fail-open posture.
+ * @param {*} raw The raw identity from `process.env.NEO_AGENT_IDENTITY` or the checkout `.env`.
+ * @returns {*} Canonical `@handle`, or the unchanged non-string input.
+ */
+export function normalizeAgentIdentity(raw) {
+    if (typeof raw !== 'string') return raw;
+
+    const trimmed = raw.trim(),
+          quoted  = trimmed.length > 1 && (
+              (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+              (trimmed.startsWith("'") && trimmed.endsWith("'"))
+          );
+
+    return normalizeAgentIdentityNodeId(quoted ? trimmed.slice(1, -1) : trimmed)
+}
 
 /**
  * @summary Kimi Code `SessionStart` hook: refreshes the seat's wake envelope with the exact
@@ -41,15 +66,18 @@ const CHECKOUT_ROOT = path.resolve(import.meta.dirname, '../..');
 
 /**
  * @summary Reads the seat's agent identity for the envelope's owner-identity leg: first from the
- * process env, then from the checkout's `.env` (the fleet seat config provisions it there).
+ * process env, then from the checkout's `.env` (the fleet seat config provisions it there). Both
+ * sources flow through `normalizeAgentIdentity` — the daemon compares the envelope value EXACTLY
+ * against the subscription's canonical `@handle`, so a quoted or `@`-less provisioned value must
+ * never reach the envelope.
  * @returns {String|null}
  */
 function readAgentIdentity() {
-    if (process.env.NEO_AGENT_IDENTITY) return process.env.NEO_AGENT_IDENTITY;
+    if (process.env.NEO_AGENT_IDENTITY) return normalizeAgentIdentity(process.env.NEO_AGENT_IDENTITY);
 
     try {
         const match = fs.readFileSync(path.join(CHECKOUT_ROOT, '.env'), 'utf8').match(/^NEO_AGENT_IDENTITY=(.+)$/m);
-        return match ? match[1].trim() : null
+        return match ? normalizeAgentIdentity(match[1]) : null
     } catch {
         return null
     }
@@ -70,32 +98,42 @@ function readProcessStartTime(pid) {
     }
 }
 
-let input = '';
+/**
+ * @summary Runs the stdin adapter while preserving Kimi Code's fail-open hook boundary.
+ * @returns {void}
+ */
+function main() {
+    let input = '';
 
-process.stdin.on('data', chunk => { input += chunk });
+    process.stdin.on('data', chunk => { input += chunk });
 
-process.stdin.on('end', () => {
-    try {
-        const payload                      = JSON.parse(input),
-              {session_id: sessionId, cwd} = payload || {};
+    process.stdin.on('end', () => {
+        try {
+            const payload                      = JSON.parse(input),
+                  {session_id: sessionId, cwd} = payload || {};
 
-        if (typeof sessionId === 'string' && sessionId.length > 0 && typeof cwd === 'string' && cwd.length > 0) {
-            fs.writeFileSync(
-                ENVELOPE_PATH,
-                JSON.stringify({
-                    sessionId,
-                    cwd,
-                    pid          : process.ppid,
-                    pidStartedAt : readProcessStartTime(process.ppid),
-                    agentIdentity: readAgentIdentity(),
-                    updatedAt    : new Date().toISOString()
-                }, null, 2),
-                {mode: 0o600}
-            );
+            if (typeof sessionId === 'string' && sessionId.length > 0 && typeof cwd === 'string' && cwd.length > 0) {
+                fs.writeFileSync(
+                    ENVELOPE_PATH,
+                    JSON.stringify({
+                        sessionId,
+                        cwd,
+                        pid          : process.ppid,
+                        pidStartedAt : readProcessStartTime(process.ppid),
+                        agentIdentity: readAgentIdentity(),
+                        updatedAt    : new Date().toISOString()
+                    }, null, 2),
+                    {mode: 0o600}
+                );
+            }
+        } catch {
+            // Fail-open: a malformed payload or write failure must never disturb the session.
         }
-    } catch {
-        // Fail-open: a malformed payload or write failure must never disturb the session.
-    }
 
-    process.exit(0);
-});
+        process.exit(0);
+    });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+}

--- a/test/playwright/unit/hooks/wakeEnvelopeHook.spec.mjs
+++ b/test/playwright/unit/hooks/wakeEnvelopeHook.spec.mjs
@@ -1,0 +1,99 @@
+import {expect, test}  from '@playwright/test';
+import {spawnSync}     from 'node:child_process';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {normalizeAgentIdentity} from '../../../../.kimi-code/hooks/wakeEnvelopeHook.mjs';
+
+const hookPath = fileURLToPath(new URL('../../../../.kimi-code/hooks/wakeEnvelopeHook.mjs', import.meta.url));
+
+// The hook is stdin-driven with the payload on stdin and the envelope written under
+// KIMI_CODE_HOME. The .env identity SOURCE is deliberately not fixture-driven: the hook reads
+// the checkout's real .env (host state, not repo fixture), so the file-source path is covered
+// by the shared normalizeAgentIdentity unit cases + the env-source spawn cases below.
+
+/**
+ * @summary Spawns the hook with a SessionStart payload and returns the written envelope.
+ * @param {Object} options
+ * @param {Object} options.env Extra env (merged over process.env).
+ * @returns {Object}
+ */
+function runHook({env}) {
+    const
+        kimiHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-envelope-hook-')),
+        result   = spawnSync(process.execPath, [hookPath], {
+            encoding: 'utf8',
+            env     : {...process.env, KIMI_CODE_HOME: kimiHome, ...env},
+            input   : JSON.stringify({hook_event_name: 'SessionStart', session_id: 'session_spec', cwd: '/seat/checkout'}),
+            timeout : 5000
+        });
+
+    expect(result.status).toBe(0);
+
+    return JSON.parse(fs.readFileSync(path.join(kimiHome, 'wake-envelope.json'), 'utf8'));
+}
+
+test.describe('wakeEnvelopeHook identity normalization (#15737)', () => {
+    test('normalizeAgentIdentity: every provisioned shape lands on the canonical @handle', () => {
+        // The four shapes a seat .env / launch env actually carries — the daemon compares the
+        // envelope EXACTLY against the subscription's canonical identity, so all must agree.
+        expect(normalizeAgentIdentity('neo-kimi-iris')).toBe('@neo-kimi-iris');       // bare
+        expect(normalizeAgentIdentity('@neo-kimi-iris')).toBe('@neo-kimi-iris');      // canonical
+        expect(normalizeAgentIdentity('"neo-kimi-iris"')).toBe('@neo-kimi-iris');     // double-quoted
+        expect(normalizeAgentIdentity("'neo-kimi-iris'")).toBe('@neo-kimi-iris');     // single-quoted
+        expect(normalizeAgentIdentity('"@neo-kimi-iris"')).toBe('@neo-kimi-iris');    // quoted canonical
+        expect(normalizeAgentIdentity('  neo-kimi-iris  ')).toBe('@neo-kimi-iris');   // padded
+
+        // Fail-open preserved: a missing/unprovisioned value stays a non-string null/undefined,
+        // never an invented identity. An empty string stays empty (the daemon refuses it loudly).
+        expect(normalizeAgentIdentity(null)).toBe(null);
+        expect(normalizeAgentIdentity(undefined)).toBe(undefined);
+        expect(normalizeAgentIdentity('')).toBe('');
+    });
+
+    test('SessionStart spawn: a quoted env identity is written to the envelope canonicalized', () => {
+        const envelope = runHook({env: {NEO_AGENT_IDENTITY: '"neo-kimi-iris"'}});
+
+        expect(envelope.agentIdentity).toBe('@neo-kimi-iris');
+        expect(envelope.sessionId).toBe('session_spec');
+        expect(Number.isInteger(envelope.pid)).toBe(true);
+    });
+
+    test('SessionStart spawn: a bare env identity is canonicalized identically', () => {
+        const envelope = runHook({env: {NEO_AGENT_IDENTITY: 'neo-kimi-iris'}});
+
+        expect(envelope.agentIdentity).toBe('@neo-kimi-iris');
+    });
+
+    test('SessionStart spawn: the envelope lands mode 0600 under KIMI_CODE_HOME', () => {
+        const
+            kimiHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-envelope-hook-')),
+            result   = spawnSync(process.execPath, [hookPath], {
+                encoding: 'utf8',
+                env     : {...process.env, KIMI_CODE_HOME: kimiHome, NEO_AGENT_IDENTITY: '@neo-kimi-iris'},
+                input   : JSON.stringify({hook_event_name: 'SessionStart', session_id: 'session_spec', cwd: '/seat/checkout'}),
+                timeout : 5000
+            });
+
+        expect(result.status).toBe(0);
+
+        const stat = fs.statSync(path.join(kimiHome, 'wake-envelope.json'));
+        expect(stat.mode & 0o777).toBe(0o600);
+    });
+
+    test('fail-open: a malformed stdin payload exits 0 and writes nothing', () => {
+        const
+            kimiHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-envelope-hook-')),
+            result   = spawnSync(process.execPath, [hookPath], {
+                encoding: 'utf8',
+                env     : {...process.env, KIMI_CODE_HOME: kimiHome},
+                input   : 'not json',
+                timeout : 5000
+            });
+
+        expect(result.status).toBe(0);
+        expect(fs.existsSync(path.join(kimiHome, 'wake-envelope.json'))).toBe(false);
+    });
+});


### PR DESCRIPTION
Resolves #15737

Fixes the wake-envelope identity parse the #15665 PMV surfaced live on the Iris seat: `.kimi-code/hooks/wakeEnvelopeHook.mjs` recorded `NEO_AGENT_IDENTITY="neo-kimi-iris"` from the seat `.env` VERBATIM — quotes kept, `@` never added — while the `kimi-pull-bridge` delivery leg compares the envelope's `agentIdentity` exactly against the subscription's canonical `@handle`. Every delivery refused with `subscription identity … does not match seat owner …`, and the next `SessionStart` fire would have overwritten the PMV's hand-written envelope with the refusing value.

- New exported `normalizeAgentIdentity(raw)`: trims, strips ONE layer of matching surrounding quotes (the `.env` parse artifact), then delegates `@`-canonicalization to the existing graph SSOT `normalizeAgentIdentityNodeId` — no second canonicalizer invented. Non-strings pass through unchanged, so a missing value still returns `null` (fail-open preserved; the daemon's refusal stays loud and actionable).
- Both identity sources (`process.env.NEO_AGENT_IDENTITY` and the checkout `.env` regex) now flow through it.
- The stdin flow moves behind the sibling-hook `main()` + `pathToFileURL` guard so the pure function is spec-importable (turnPresenceHook shape).

Evidence: L1 (pure-function spec + end-to-end spawns against a fixture `KIMI_CODE_HOME`) → L1 required; the post-fix live hook fire is covered by the #15665 PMV chain at the seat's next boot. Residual: none for this contract [#15737].

## Deltas from ticket

None — exactly the ticket's prescription (normalize at the writer; the daemon's exact match stays).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/hooks/ --reporter=dot` — **223 passed (1.1s)**: the new `wakeEnvelopeHook.spec.mjs` pins all four provisioned shapes → `@neo-kimi-iris` (bare / canonical / double-quoted / single-quoted, plus padded and quoted-canonical), `null`/`undefined`/`''` pass-through, two end-to-end `SessionStart` spawns (quoted + bare env identity both land canonical in the written envelope, integer pid), the 0600 mode contract under `KIMI_CODE_HOME`, and the malformed-stdin fail-open (exit 0, no write) — plus the full hooks directory as regression guard.
- `node --check` on the edited hook.
- The `.env` file SOURCE is deliberately not fixture-driven (the hook reads the checkout's real `.env` — host state); the file-source path shares the same `normalizeAgentIdentity` call site the spec pins, noted in the spec header.

## Post-Merge Validation

- [ ] At the Iris seat's next TUI boot, the SessionStart hook rewrites the hand-written PMV envelope; verify `agentIdentity` stays `@neo-kimi-iris` (the #15665 leg-3 true-wake chain then runs unblocked on the identity leg).

Authored by Iris (Moonshot Kimi K3, Kimi Code). Session 004ae595-0152-4994-a61e-623b3f383e78.
