### PR TITLE
feat(ai): abort embedding probes at consumer deadlines (#15694)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1097,6 +1097,9 @@ class ConfigBase extends ConfigProvider {
                     maxBackoffMs               : leaf(HOUR_MS, 'NEO_RECOVERY_ACTUATOR_MAX_BACKOFF_MS', 'number'),
                     verifyCooldownMs           : leaf(60 * 1000, 'NEO_RECOVERY_ACTUATOR_VERIFY_COOLDOWN_MS', 'number'),
                     healthyObservationThreshold: leaf(1, 'NEO_RECOVERY_ACTUATOR_HEALTHY_OBSERVATION_THRESHOLD', 'number'),
+                    // Due-only freeze re-probes own a transport deadline distinct from healthcheck cadence.
+                    // The orchestrator reads this leaf at the use site; consumers never re-derive it from env.
+                    freezeReprobeTimeoutMs     : leaf(30 * 1000, 'NEO_RECOVERY_ACTUATOR_FREEZE_REPROBE_TIMEOUT_MS', 'number'),
                     /**
                      * Heal-event ledger retention (the observability sink must not become its own disk leak). The
                      * append-time auto-prune keeps the newest `maxEvents` once the file crosses `pruneTriggerBytes`.

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -6,7 +6,9 @@ import path            from 'path';
 import Base            from '../../../src/core/Base.mjs';
 import ClassSystemUtil from '../../../src/util/ClassSystem.mjs';
 import AiConfig        from '../../config.mjs';
-import HealthService   from '../../services/memory-core/HealthService.mjs';
+import HealthService, {
+    createEmbeddingProbeTimeoutError
+}                      from '../../services/memory-core/HealthService.mjs';
 import SQLite          from '../../graph/storage/SQLite.mjs';
 import MaintenanceBackpressureService, {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
@@ -573,16 +575,44 @@ export class Orchestrator extends Base {
      * consistency. Any error → an inconclusive reading, so `decideFreezeReprobe` fails closed to stay-frozen. The
      * embedder fault is systemic, so the canary is collection-agnostic (the parameter satisfies the cycle contract).
      * @param {String} [collectionName] The frozen collection (unused — the embedder health is systemic).
+     * @param {Object} [options={}] Test-isolation seams; production callers omit this object.
+     * @param {Function} [options.embedTexts] Embedding transport seam.
+     * @param {Number} [options.timeoutMs] Deadline override for deterministic tests.
      * @returns {Promise<{embedderHealthy: Boolean, dimensionConsistent: Boolean}>}
      */
-    async probeFrozenCollectionHealth(collectionName) {
+    async probeFrozenCollectionHealth(collectionName, options = {}) {
+        const
+            embedTexts     = options.embedTexts || ((texts, provider, embedOptions) => TextEmbeddingService.embedTexts(texts, provider, embedOptions)),
+            operationLabel = 'Orchestrator freeze re-probe',
+            timeoutMs      = options.timeoutMs ?? AiConfig.orchestrator.recoveryActuator.freezeReprobeTimeoutMs;
+
+        let timeoutId;
+
         try {
-            const [vector] = await TextEmbeddingService.embedTexts(['__freeze-reprobe-health-canary__'], AiConfig.embeddingProvider),
+            const controller    = new AbortController(),
+                  timeoutError  = createEmbeddingProbeTimeoutError(operationLabel, timeoutMs),
+                  deadline      = new Promise((_, reject) => {
+                      timeoutId = setTimeout(() => {
+                          reject(timeoutError);
+                          controller.abort(timeoutError);
+                      }, timeoutMs);
+                  });
+
+            const [vector] = await Promise.race([
+                      embedTexts(
+                          ['__freeze-reprobe-health-canary__'],
+                          AiConfig.embeddingProvider,
+                          {signal: controller.signal, operationLabel}
+                      ),
+                      deadline
+                  ]),
                   ok       = Array.isArray(vector) && vector.length === AiConfig.vectorDimension;
 
             return {embedderHealthy: ok, dimensionConsistent: ok};
         } catch (error) {
             return {embedderHealthy: false, dimensionConsistent: false}; // inconclusive → stay frozen (fail closed)
+        } finally {
+            clearTimeout(timeoutId);
         }
     }
 

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -217,6 +217,7 @@
         "orchestrator.recoveryActuator.chronicUnsafeInput.threshold",
         "orchestrator.recoveryActuator.chronicUnsafeInput.windowMs",
         "orchestrator.recoveryActuator.enabled",
+        "orchestrator.recoveryActuator.freezeReprobeTimeoutMs",
         "orchestrator.recoveryActuator.healAttemptsPath",
         "orchestrator.recoveryActuator.healLedger",
         "orchestrator.recoveryActuator.healLedger.maxEvents",

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -374,16 +374,61 @@ export function getLmsLoadedModels(payload) {
  * @param {Function} [options.execFileFn=execFile] Child-process seam for tests.
  * @param {String} [options.freshness='force'] `routine` enables TTL caching; `force` bypasses completed cache.
  * @param {Number} [options.cacheTtlMs] Required for routine caching.
+ * @param {AbortSignal} [options.signal] Caller-owned cancellation signal. Signal-bearing probes are
+ *     intentionally not coalesced because one caller must not abort another caller's shared child.
  * @returns {Promise<Object[]>}
  */
 export function fetchLmsLoadedModels({
     timeoutMs,
     execFileFn = execFile,
     freshness  = PROVIDER_DISCOVERY_FORCE,
-    cacheTtlMs
+    cacheTtlMs,
+    signal
 } = {}) {
     if (typeof timeoutMs !== 'number') {
         return Promise.reject(new TypeError('fetchLmsLoadedModels: timeoutMs is required'));
+    }
+
+    const runProbe = () => new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+            const abortError = signal.reason instanceof Error ? signal.reason : Object.assign(
+                new Error('fetchLmsLoadedModels aborted'),
+                {name: 'AbortError', code: 'ABORT_ERR'}
+            );
+
+            reject(abortError);
+            return;
+        }
+
+        execFileFn('lms', ['ps', '--json'], lmsExecOptions({timeout: timeoutMs, ...(signal ? {signal} : {})}), (error, stdout = '', stderr = '') => {
+            if (error) {
+                const isCallerAbort = signal?.aborted && (
+                    error === signal.reason ||
+                    error?.cause === signal.reason ||
+                    error?.name === 'AbortError' ||
+                    error?.code === 'ABORT_ERR'
+                );
+
+                if (isCallerAbort) {
+                    reject(signal.reason instanceof Error ? signal.reason : error);
+                    return;
+                }
+
+                reject(new Error(`lms ps --json failed: ${error.message}${stderr ? `; stderr=${stderr.trim()}` : ''}`));
+                return;
+            }
+
+            try {
+                resolve(getLmsLoadedModels(JSON.parse(stdout || '[]')));
+            } catch (parseError) {
+                reject(new Error(`lms ps --json returned invalid JSON: ${parseError.message}`));
+            }
+        });
+    });
+
+    if (signal) {
+        assertProviderDiscoveryFreshness({freshness, cacheTtlMs, caller: 'fetchLmsLoadedModels'});
+        return runProbe();
     }
 
     return runProviderDiscoveryProbe({
@@ -391,22 +436,7 @@ export function fetchLmsLoadedModels({
         freshness,
         cacheTtlMs,
         caller: 'fetchLmsLoadedModels',
-        runProbe() {
-            return new Promise((resolve, reject) => {
-                execFileFn('lms', ['ps', '--json'], lmsExecOptions({timeout: timeoutMs}), (error, stdout = '', stderr = '') => {
-                    if (error) {
-                        reject(new Error(`lms ps --json failed: ${error.message}${stderr ? `; stderr=${stderr.trim()}` : ''}`));
-                        return;
-                    }
-
-                    try {
-                        resolve(getLmsLoadedModels(JSON.parse(stdout || '[]')));
-                    } catch (parseError) {
-                        reject(new Error(`lms ps --json returned invalid JSON: ${parseError.message}`));
-                    }
-                });
-            });
-        }
+        runProbe
     });
 }
 

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -163,6 +163,54 @@ export function buildEmbeddingProviderBlock(cfg) {
 }
 
 /**
+ * @summary Creates the structural caller-owned deadline error shared by embedding-probe consumers.
+ * @param {String} operationLabel Bounded diagnostic label.
+ * @param {Number} timeoutMs Consumer-owned deadline in milliseconds.
+ * @returns {Error}
+ */
+export function createEmbeddingProbeTimeoutError(operationLabel, timeoutMs) {
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        throw new TypeError(`Embedding probe timeoutMs must be a positive number, got ${timeoutMs}`);
+    }
+
+    const error = new Error(`${operationLabel} timed out after ${timeoutMs}ms`);
+    error.code           = 'EMBEDDING_PROBE_TIMEOUT';
+    error.operationLabel = operationLabel;
+    error.timeoutMs      = timeoutMs;
+
+    return error;
+}
+
+const EMBEDDING_PROBE_PUBLIC_REASON_MAX_LENGTH = 96;
+
+/**
+ * @summary Maps provider failures to a bounded public receipt without exposing provider payloads.
+ * @param {Error} error Embedding failure observed by the health consumer.
+ * @returns {{error: String, errorClassification: String, errorCode: String}}
+ */
+function describeEmbeddingProbeFailure(error) {
+    const knownCode = [
+        'ABORT_ERR',
+        'EMBEDDING_PROBE_TIMEOUT',
+        'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
+        'PROVIDER_TIMEOUT'
+    ].includes(error?.code) ? error.code : error?.name === 'AbortError' ? 'ABORT_ERR' : 'EMBEDDING_PROVIDER_ERROR';
+    const errorClassification = knownCode === 'EMBEDDING_PROBE_TIMEOUT'
+        ? 'consumer-probe-timeout'
+        : ['OPENAI_COMPATIBLE_REQUEST_TIMEOUT', 'PROVIDER_TIMEOUT'].includes(knownCode)
+            ? 'provider-timeout'
+            : knownCode === 'ABORT_ERR'
+                ? 'upstream-abort'
+                : 'provider-failure';
+
+    return {
+        error    : `${errorClassification}:${knownCode}`.substring(0, EMBEDDING_PROBE_PUBLIC_REASON_MAX_LENGTH),
+        errorClassification,
+        errorCode: knownCode
+    };
+}
+
+/**
  * @summary Probes the active embedding write path used by Memory Core writes.
  *
  * Memory writes fail before ChromaDB insertion when the active embedding provider cannot return a
@@ -177,7 +225,8 @@ export function buildEmbeddingProviderBlock(cfg) {
  * @param {Function} [options.now=Date.now] Time source for deterministic tests.
  * @param {Number} [options.timeoutMs=aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs] Max time to wait for the provider.
  * @returns {Promise<{status: String, provider: String, dimensions: Number|null,
- *     expectedDimensions: Number|null, durationMs: Number, error: String|undefined}>}
+ *     expectedDimensions: Number|null, durationMs: Number, error: String|undefined,
+ *     errorClassification: String|undefined, errorCode: String|undefined}>}
  */
 export async function buildEmbeddingWriteCanaryBlock({
     cfg       = aiConfig,
@@ -189,18 +238,31 @@ export async function buildEmbeddingWriteCanaryBlock({
     const readNow            = typeof now === 'function' ? now : () => (typeof now === 'number' ? now : now.getTime()),
           startedAt          = readNow(),
           provider           = cfg.embeddingProvider || 'openAiCompatible',
-          expectedDimensions = cfg.vectorDimension ?? null;
+          expectedDimensions = cfg.vectorDimension ?? null,
+          operationLabel     = 'Embedding write canary';
+
+    let timeoutId;
 
     try {
-        const probe = embedText || (async (text, explicitProvider) => {
+        const probe = embedText || (async (text, explicitProvider, options) => {
             const {default: TextEmbeddingService} = await import('./TextEmbeddingService.mjs');
-            return TextEmbeddingService.embedText(text, explicitProvider);
+            return TextEmbeddingService.embedText(text, explicitProvider, options);
         });
-        const embedding = await withTimeout(
-                  Promise.resolve(probe(input, provider)),
-                  timeoutMs,
-                  'Embedding write canary'
-              ),
+        const controller    = new AbortController(),
+              timeoutError  = createEmbeddingProbeTimeoutError(operationLabel, timeoutMs),
+              deadline      = new Promise((_, reject) => {
+                  timeoutId = setTimeout(() => {
+                      reject(timeoutError);
+                      controller.abort(timeoutError);
+                  }, timeoutMs);
+              }),
+              embedding    = await Promise.race([
+                  Promise.resolve(probe(input, provider, {
+                      signal: controller.signal,
+                      operationLabel
+                  })),
+                  deadline
+              ]),
               dimensions = Array.isArray(embedding) ? embedding.length : null,
               durationMs = Math.max(0, readNow() - startedAt);
 
@@ -234,14 +296,18 @@ export async function buildEmbeddingWriteCanaryBlock({
             durationMs
         };
     } catch (error) {
+        const failure = describeEmbeddingProbeFailure(error);
+
         return {
             status    : 'failed',
             provider,
             dimensions: null,
             expectedDimensions,
             durationMs: Math.max(0, readNow() - startedAt),
-            error     : error.message
+            ...failure
         };
+    } finally {
+        clearTimeout(timeoutId);
     }
 }
 

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -1,8 +1,11 @@
-import {GoogleGenerativeAI} from '@google/generative-ai';
-import aiConfig             from '../../mcp/server/memory-core/config.mjs';
-import Base                 from '../../../src/core/Base.mjs';
-import logger               from '../../mcp/server/memory-core/logger.mjs';
-import OllamaProvider       from '../../provider/Ollama.mjs';
+import {
+    GoogleGenerativeAI,
+    GoogleGenerativeAIAbortError
+}                           from '@google/generative-ai';
+import aiConfig       from '../../mcp/server/memory-core/config.mjs';
+import Base           from '../../../src/core/Base.mjs';
+import logger         from '../../mcp/server/memory-core/logger.mjs';
+import OllamaProvider from '../../provider/Ollama.mjs';
 import {
     withLmsEmbeddingInputSuffix
 }                           from '../shared/vector/lmsEmbeddingInputSuffix.mjs';
@@ -14,6 +17,159 @@ import {
 
 const DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS = 60 * 60 * 1000;
 const OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE   = /openAiCompatible embedding error HTTP (408|429|503|504):/;
+const EMBEDDING_OPERATION_LABEL_MAX_LENGTH         = 120;
+
+/**
+ * @summary Normalizes the additive embedding-call options without widening provider authority.
+ * @param {Object} options Caller options.
+ * @param {String} defaultOperationLabel Provider-scoped fallback label.
+ * @returns {{signal: AbortSignal|undefined, operationLabel: String}}
+ */
+function normalizeEmbeddingOptions(options, defaultOperationLabel) {
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+        throw new TypeError('TextEmbeddingService: options must be an object containing only signal and operationLabel');
+    }
+
+    const unknownKeys = Object.keys(options).filter(key => !['signal', 'operationLabel'].includes(key));
+
+    if (unknownKeys.length > 0) {
+        throw new TypeError(`TextEmbeddingService: unsupported embedding option(s): ${unknownKeys.join(', ')}`);
+    }
+    if (options.signal !== undefined && (
+        typeof options.signal?.aborted !== 'boolean' ||
+        typeof options.signal?.addEventListener !== 'function' ||
+        typeof options.signal?.removeEventListener !== 'function'
+    )) {
+        throw new TypeError('TextEmbeddingService: options.signal must be an AbortSignal');
+    }
+    if (options.operationLabel !== undefined && typeof options.operationLabel !== 'string') {
+        throw new TypeError('TextEmbeddingService: options.operationLabel must be a string');
+    }
+
+    const requestedLabel = options.operationLabel?.trim() || defaultOperationLabel;
+
+    return {
+        signal        : options.signal,
+        operationLabel: requestedLabel.substring(0, EMBEDDING_OPERATION_LABEL_MAX_LENGTH)
+    };
+}
+
+/**
+ * @summary Restores an Error-valued caller abort reason or creates the bounded structural fallback.
+ * @param {AbortSignal} signal Aborted upstream signal.
+ * @param {String} operationLabel Bounded operation label.
+ * @returns {Error}
+ */
+function getEmbeddingAbortError(signal, operationLabel) {
+    if (signal?.reason instanceof Error) {
+        return signal.reason;
+    }
+
+    const error = new Error(`${operationLabel} aborted`);
+    error.name           = 'AbortError';
+    error.code           = 'ABORT_ERR';
+    error.operationLabel = operationLabel;
+
+    return error;
+}
+
+/**
+ * @summary Distinguishes caller cancellation from an earlier provider failure that already won the race.
+ * @param {Error} error Observed adapter/provider error.
+ * @param {AbortSignal|undefined} signal Caller signal.
+ * @returns {Boolean}
+ */
+function isCallerAbortError(error, signal) {
+    if (!signal?.aborted) return false;
+    if (error === signal.reason) return true;
+
+    return error?.name === 'AbortError' ||
+        error instanceof GoogleGenerativeAIAbortError ||
+        error?.code === 'ABORT_ERR';
+}
+
+/**
+ * @summary Fails synchronously before an aborted embedding phase can start more local work.
+ * @param {AbortSignal|undefined} signal Upstream cancellation signal.
+ * @param {String} operationLabel Bounded operation label.
+ * @returns {void}
+ */
+function throwIfEmbeddingAborted(signal, operationLabel) {
+    if (signal?.aborted) {
+        throw getEmbeddingAbortError(signal, operationLabel);
+    }
+}
+
+/**
+ * @summary Waits on a Neo-owned timer that is cancelled and detached on upstream abort.
+ * @param {Number} delayMs Delay in milliseconds.
+ * @param {AbortSignal|undefined} signal Upstream cancellation signal.
+ * @param {String} operationLabel Bounded operation label.
+ * @returns {Promise<void>}
+ */
+function waitForAbortableDelay(delayMs, signal, operationLabel) {
+    throwIfEmbeddingAborted(signal, operationLabel);
+
+    return new Promise((resolve, reject) => {
+        let settled = false;
+        let timer;
+
+        const cleanup = () => {
+            clearTimeout(timer);
+            signal?.removeEventListener('abort', onAbort);
+        };
+        const settle = (fn, value) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            fn(value);
+        };
+        const onAbort = () => settle(reject, getEmbeddingAbortError(signal, operationLabel));
+
+        signal?.addEventListener('abort', onAbort, {once: true});
+        timer = setTimeout(() => settle(resolve), Math.max(0, delayMs || 0));
+
+        if (signal?.aborted) {
+            onAbort();
+        }
+    });
+}
+
+/**
+ * @summary Projects an abort error into a bounded structural log reason.
+ * @param {Error} error Caller or provider abort error.
+ * @returns {String}
+ */
+function describeEmbeddingAbortReason(error) {
+    if ([
+        'ABORT_ERR',
+        'EMBEDDING_PROBE_TIMEOUT',
+        'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
+        'PROVIDER_TIMEOUT'
+    ].includes(error?.code)) {
+        return error.code;
+    }
+
+    return ['AbortError', 'Error', 'GoogleGenerativeAIAbortError'].includes(error?.name)
+        ? error.name
+        : 'Error';
+}
+
+/**
+ * @summary Emits bounded, input-free observability for one caller-owned embedding abort.
+ * @param {Object} options Abort observation.
+ * @returns {void}
+ */
+function logEmbeddingAbort({provider, operation, error}) {
+    logger.warn('[TextEmbeddingService] embedding operation aborted.', {
+        provider,
+        operationLabel: operation.operationLabel,
+        phase         : operation.phase,
+        classification: error?.code === 'EMBEDDING_PROBE_TIMEOUT' ? 'consumer-probe-timeout' : 'upstream-abort',
+        durationMs    : Math.max(0, Date.now() - operation.startedAt),
+        reason        : describeEmbeddingAbortReason(error)
+    });
+}
 
 /**
  * Determines whether TextEmbeddingService needs a Gemini embedding client for the active provider.
@@ -62,10 +218,12 @@ function describeOpenAiCompatibleTimeout(requestTimeoutMs) {
  * single-embedding calls send their provider request before the next batch sub-request.
  *
  * @param {Number} delayMs Delay in milliseconds.
+ * @param {AbortSignal|undefined} signal Upstream cancellation signal.
+ * @param {String} operationLabel Bounded operation label.
  * @returns {Promise<void>}
  */
-function waitForOpenAiCompatibleBatchYield(delayMs) {
-    return new Promise(resolve => setTimeout(resolve, Math.max(0, delayMs || 0)));
+function waitForOpenAiCompatibleBatchYield(delayMs, signal, operationLabel) {
+    return waitForAbortableDelay(delayMs, signal, operationLabel);
 }
 
 /**
@@ -163,14 +321,56 @@ class TextEmbeddingService extends Base {
      * @private
      */
     #enqueueOpenAiCompatiblePost(inputData, options, priority) {
+        const {operation, operationLabel, signal} = options;
+
+        throwIfEmbeddingAborted(signal, operationLabel);
+
         return new Promise((resolve, reject) => {
-            this.#openAiCompatiblePostQueue.push({
+            const task = {
+                dispatched: false,
                 inputData,
                 options,
                 priority,
-                reject,
-                resolve
-            });
+                settled   : false
+            };
+
+            const cleanup = () => {
+                signal?.removeEventListener('abort', task.onAbort);
+            };
+            const settle = (fn, value) => {
+                if (task.settled) return;
+                task.settled = true;
+                cleanup();
+                fn(value);
+            };
+
+            task.resolve = value => settle(resolve, value);
+            task.reject  = error => settle(reject, error);
+            task.onAbort = () => {
+                if (task.dispatched || task.settled) return;
+
+                const taskIndex = this.#openAiCompatiblePostQueue.indexOf(task);
+
+                if (taskIndex !== -1) {
+                    this.#openAiCompatiblePostQueue.splice(taskIndex, 1);
+                }
+
+                task.reject(getEmbeddingAbortError(signal, operationLabel));
+            };
+            task.markDispatched = () => {
+                task.dispatched = true;
+                cleanup();
+            };
+
+            signal?.addEventListener('abort', task.onAbort, {once: true});
+
+            if (signal?.aborted) {
+                task.onAbort();
+                return;
+            }
+
+            operation.phase = 'queued';
+            this.#openAiCompatiblePostQueue.push(task);
 
             this.#drainOpenAiCompatiblePostQueue();
         });
@@ -190,6 +390,8 @@ class TextEmbeddingService extends Base {
             while (this.#openAiCompatiblePostQueue.length > 0) {
                 const taskIndex = this.#getNextOpenAiCompatiblePostQueueIndex(),
                       task      = this.#openAiCompatiblePostQueue.splice(taskIndex, 1)[0];
+
+                task.markDispatched();
 
                 try {
                     task.resolve(await this.#postOpenAiCompatible(task.inputData, task.options));
@@ -229,16 +431,19 @@ class TextEmbeddingService extends Base {
      * the LM Studio CLI from unit tests while preserving the same normalized model shape.
      *
      * @param {Number} timeoutMs LM Studio CLI timeout.
+     * @param {AbortSignal|undefined} signal Upstream cancellation signal exposed to the test seam.
+     * @param {String} operationLabel Bounded operation label.
      * @returns {Promise<Object[]>}
      * @private
      */
-    async #getOpenAiCompatibleLoadedModels(timeoutMs) {
+    async #getOpenAiCompatibleLoadedModels(timeoutMs, signal, operationLabel) {
         if (this.openAiCompatibleLoadedModelsProbe) {
-            return this.openAiCompatibleLoadedModelsProbe({timeoutMs});
+            return this.openAiCompatibleLoadedModelsProbe({timeoutMs, signal});
         }
 
         const {fetchLmsLoadedModels} = await import('../graph/providerReadinessHelper.mjs');
-        return fetchLmsLoadedModels({timeoutMs});
+        throwIfEmbeddingAborted(signal, operationLabel);
+        return fetchLmsLoadedModels({timeoutMs, signal});
     }
 
     /**
@@ -319,10 +524,16 @@ class TextEmbeddingService extends Base {
      * loaded context than Neo's `localModels.embedding.contextLimitTokens` leaf. Fetching the
      * resident row also exposes LMS model metadata used for request-boundary token handling.
      *
+     * @param {AbortSignal|undefined} signal Upstream cancellation signal.
+     * @param {String} operationLabel Bounded operation label.
+     * @param {Object} operation Mutable local-phase observability record.
      * @returns {Promise<{configuredContextLength: Number, loadedModel: Object, model: String}|null>}
      * @private
      */
-    async #getOpenAiCompatibleEmbeddingRuntime() {
+    async #getOpenAiCompatibleEmbeddingRuntime(signal, operationLabel, operation) {
+        operation.phase = 'preflight';
+        throwIfEmbeddingAborted(signal, operationLabel);
+
         if (!this.#shouldAssertOpenAiCompatibleEmbeddingContext()) {
             return null;
         }
@@ -345,10 +556,16 @@ class TextEmbeddingService extends Base {
         let loadedModels;
 
         try {
-            loadedModels = await this.#getOpenAiCompatibleLoadedModels(timeoutMs);
+            loadedModels = await this.#getOpenAiCompatibleLoadedModels(timeoutMs, signal, operationLabel);
         } catch (error) {
+            if (isCallerAbortError(error, signal)) {
+                throw getEmbeddingAbortError(signal, operationLabel);
+            }
+
             throw new Error(`TextEmbeddingService: unable to verify LM Studio embedding context for '${model}': ${error.message}`);
         }
+
+        throwIfEmbeddingAborted(signal, operationLabel);
 
         const loadedModel = loadedModels.find(item => item.id === model);
 
@@ -411,14 +628,18 @@ class TextEmbeddingService extends Base {
     /**
      * @summary Prepares OpenAI-compatible embedding input at the provider request boundary.
      * @param {String|String[]} inputData The caller's original text input.
+     * @param {AbortSignal|undefined} signal Upstream cancellation signal.
+     * @param {String} operationLabel Bounded operation label.
+     * @param {Object} operation Mutable local-phase observability record.
      * @returns {Promise<String|String[]>}
      * @private
      */
-    async #prepareOpenAiCompatibleEmbeddingInput(inputData) {
+    async #prepareOpenAiCompatibleEmbeddingInput(inputData, signal, operationLabel, operation) {
         const
-            runtime          = await this.#getOpenAiCompatibleEmbeddingRuntime(),
+            runtime          = await this.#getOpenAiCompatibleEmbeddingRuntime(signal, operationLabel, operation),
             requestInputData = runtime ? withLmsEmbeddingInputSuffix(inputData, runtime.loadedModel, {log: logger}) : inputData;
 
+        throwIfEmbeddingAborted(signal, operationLabel);
         this.#assertOpenAiCompatibleEmbeddingContext(requestInputData, runtime);
 
         return requestInputData;
@@ -438,6 +659,9 @@ class TextEmbeddingService extends Base {
      * @param {Number} options.unloadRetriesLeft Number of unload retries remaining.
      * @param {Number} [options.contentionRetriesLeft=0] Number of contention-timeout retries remaining.
      * @param {Number} [options.requestTimeoutMs=3600000] Request timeout in milliseconds.
+     * @param {AbortSignal} [options.signal] Upstream cancellation signal.
+     * @param {String} options.operationLabel Bounded operation label.
+     * @param {Object} options.operation Mutable local-phase observability record.
      * @returns {Promise<Object>}
      * @private
      */
@@ -445,7 +669,10 @@ class TextEmbeddingService extends Base {
         const {
             unloadRetriesLeft,
             contentionRetriesLeft = 0,
-            requestTimeoutMs      = DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS
+            requestTimeoutMs      = DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS,
+            signal,
+            operationLabel,
+            operation
         } = options;
         const {
             host,
@@ -456,23 +683,43 @@ class TextEmbeddingService extends Base {
         } = aiConfig.openAiCompatible;
 
         try {
-            const parsedUrl = new URL(`${host}/v1/embeddings`);
+            operation.phase = 'transport-setup';
+            throwIfEmbeddingAborted(signal, operationLabel);
+
+            const parsedUrl  = new URL(`${host}/v1/embeddings`);
             const httpModule = parsedUrl.protocol === 'https:' ? await import('https') : await import('http');
 
+            throwIfEmbeddingAborted(signal, operationLabel);
+
+            let req, abortHandler;
+            let settled = false;
             let resolveFunc, rejectFunc;
             const responsePromise = new Promise((res, rej) => {
                 resolveFunc = res;
                 rejectFunc = rej;
             });
+            const cleanup = () => {
+                signal?.removeEventListener('abort', abortHandler);
+            };
+            const settle = (fn, value) => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                fn(value);
+            };
+            const resolveOnce = value => settle(resolveFunc, value);
+            const rejectOnce  = error => settle(rejectFunc, error);
 
             const reqHeaders = { 'Content-Type': 'application/json' };
             if (apiKey) {
                 reqHeaders.Authorization = `Bearer ${apiKey}`;
             }
 
-            const req = httpModule.request(parsedUrl, {
+            operation.phase = 'in-flight';
+            req = httpModule.request(parsedUrl, {
                 method : 'POST',
                 headers: reqHeaders,
+                signal,
                 timeout: requestTimeoutMs
             }, (res) => {
                 let body = '';
@@ -483,33 +730,53 @@ class TextEmbeddingService extends Base {
                         // default vs :1234 LM Studio) or a non-resident model is diagnosable from the error
                         // alone — not a bare "resource could not be found". The `HTTP <status>:` prefix MUST
                         // stay verbatim: OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE classifies on it.
-                        rejectFunc(new Error(`openAiCompatible embedding error HTTP ${res.statusCode}: ${body} [endpoint=${parsedUrl.href}, model='${embeddingModel}']`));
+                        rejectOnce(new Error(`openAiCompatible embedding error HTTP ${res.statusCode}: ${body} [endpoint=${parsedUrl.href}, model='${embeddingModel}']`));
                     } else {
                         try {
                             const result = JSON.parse(body);
-                            resolveFunc(result);
+                            resolveOnce(result);
                         } catch (e) {
-                            rejectFunc(new Error(`Failed to parse openAiCompatible response: ${e.message}`));
+                            rejectOnce(new Error(`Failed to parse openAiCompatible response: ${e.message}`));
                         }
                     }
                 });
+                res.on('error', error => rejectOnce(isCallerAbortError(error, signal) ? getEmbeddingAbortError(signal, operationLabel) : error));
             });
 
-            req.on('error', (err) => rejectFunc(err));
+            abortHandler = () => {
+                const error = getEmbeddingAbortError(signal, operationLabel);
+
+                // Node's native `http.request({signal})` listener owns the single request destroy.
+                // This Neo-owned listener restores the caller reason without issuing a second destroy.
+                rejectOnce(error);
+            };
+            signal?.addEventListener('abort', abortHandler, {once: true});
+
+            req.on('error', err => rejectOnce(isCallerAbortError(err, signal) ? getEmbeddingAbortError(signal, operationLabel) : err));
             req.on('timeout', () => {
                 const err = new Error(`openAiCompatible request timed out after ${describeOpenAiCompatibleTimeout(requestTimeoutMs)}`);
                 err.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
-                req.destroy();
-                rejectFunc(err);
+                rejectOnce(err);
+                if (!req.destroyed) {
+                    req.destroy(err);
+                }
             });
 
-            req.write(JSON.stringify({ model: embeddingModel, input: inputData }));
-            req.end();
+            if (signal?.aborted) {
+                abortHandler();
+            } else {
+                req.write(JSON.stringify({ model: embeddingModel, input: inputData }));
+                req.end();
+            }
 
             return await responsePromise;
         } catch (err) {
+            if (isCallerAbortError(err, signal)) {
+                throw getEmbeddingAbortError(signal, operationLabel);
+            }
+
             // Shape C (HTTP 404): the model is not resident at the provider (sustained eviction / never
-            // loaded) — the live #14154 trigger. A 404 on /v1/embeddings means model-not-found, so it gets
+            // loaded). A 404 on /v1/embeddings means model-not-found, so it gets
             // the same bounded model-load-wait retry; it stays fail-loud on a permanent 404 (retries exhaust).
             const isModelLoadError = (err.message.includes('HTTP 400') && (
                 err.message.includes('Model was unloaded') ||              // Shape A — JIT-unload-then-queued-request
@@ -519,21 +786,29 @@ class TextEmbeddingService extends Base {
 
             if (unloadRetriesLeft > 0 && isModelLoadError) {
                 logger.log(`[TextEmbeddingService] embedding-provider model-load failure detected (Shape ${err.message.includes('Model was unloaded') ? 'A' : err.message.includes('HTTP 404') ? 'C' : 'B'}), retrying (remaining retries: ${unloadRetriesLeft})`);
-                await new Promise(r => setTimeout(r, unloadRetryDelayMs));
+                operation.phase = 'retry-delay';
+                await waitForAbortableDelay(unloadRetryDelayMs, signal, operationLabel);
                 return this.#postOpenAiCompatible(inputData, {
                     unloadRetriesLeft: unloadRetriesLeft - 1,
                     contentionRetriesLeft,
-                    requestTimeoutMs
+                    requestTimeoutMs,
+                    signal,
+                    operationLabel,
+                    operation
                 });
             }
 
             if (contentionRetriesLeft > 0 && isOpenAiCompatibleContentionTimeoutError(err)) {
                 logger.log(`[TextEmbeddingService] embedding-provider contention timeout detected, retrying (remaining contention retries: ${contentionRetriesLeft})`);
-                await new Promise(r => setTimeout(r, contentionRetryDelayMs));
+                operation.phase = 'retry-delay';
+                await waitForAbortableDelay(contentionRetryDelayMs, signal, operationLabel);
                 return this.#postOpenAiCompatible(inputData, {
                     unloadRetriesLeft,
                     contentionRetriesLeft: contentionRetriesLeft - 1,
-                    requestTimeoutMs
+                    requestTimeoutMs,
+                    signal,
+                    operationLabel,
+                    operation
                 });
             }
             if (isOpenAiCompatibleContentionTimeoutError(err)) {
@@ -653,22 +928,32 @@ class TextEmbeddingService extends Base {
      * @summary Runs the native Ollama embedding call with request-shape and timeout parity.
      * @param {String|String[]} inputData Text input to embed.
      * @param {String} operationLabel Safe diagnostic label for timeout errors.
+     * @param {AbortSignal|undefined} signal Upstream cancellation signal.
+     * @param {Object} operation Mutable local-phase observability record.
      * @returns {Promise<Object>}
      * @private
      */
-    async #embedOllama(inputData, operationLabel) {
+    async #embedOllama(inputData, operationLabel, signal, operation) {
         const
             provider         = this.#getOllamaProvider(),
             requestTimeoutMs = this.#getOllamaEmbeddingTimeoutMs();
 
         try {
+            operation.phase = 'in-flight';
+            throwIfEmbeddingAborted(signal, operationLabel);
+
             return await provider.embed(inputData, {
                 num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
                 operationLabel,
+                ...(signal ? {signal} : {}),
                 timeoutMs: requestTimeoutMs,
-                truncate: false
+                truncate : false
             });
         } catch (err) {
+            if (isCallerAbortError(err, signal)) {
+                throw getEmbeddingAbortError(signal, operationLabel);
+            }
+
             if (err?.code === PROVIDER_TIMEOUT_CODE) {
                 this.#emitOllamaEmbeddingTimeoutFriction(inputData, requestTimeoutMs, err);
             }
@@ -686,10 +971,12 @@ class TextEmbeddingService extends Base {
      * enter the provider queue before the next batch chunk.
      *
      * @param {String[]} texts The texts to embed.
+     * @param {Object} options Abort and observability context.
      * @returns {Promise<number[][]>}
      * @private
      */
-    async #embedOpenAiCompatibleBatch(texts) {
+    async #embedOpenAiCompatibleBatch(texts, options) {
+        const {operation, operationLabel, signal} = options;
         const {
             unloadRetryCount        = 3,
             batchEmbeddingChunkSize = 5,
@@ -701,10 +988,16 @@ class TextEmbeddingService extends Base {
               data             = [];
 
         for (let offset = 0; offset < texts.length; offset += chunkSize) {
+            operation.phase = 'batch-chunk';
+            throwIfEmbeddingAborted(signal, operationLabel);
+
             const chunk  = texts.slice(offset, offset + chunkSize),
                   result = await this.#enqueueOpenAiCompatiblePost(chunk, {
                       unloadRetriesLeft: unloadRetryCount,
-                      requestTimeoutMs
+                      requestTimeoutMs,
+                      signal,
+                      operationLabel,
+                      operation
                   }, 'batch');
 
             data.push(...(result.data || []).map(item => ({
@@ -713,7 +1006,8 @@ class TextEmbeddingService extends Base {
             })));
 
             if (offset + chunkSize < texts.length) {
-                await waitForOpenAiCompatibleBatchYield(batchEmbeddingYieldMs);
+                operation.phase = 'batch-yield';
+                await waitForOpenAiCompatibleBatchYield(batchEmbeddingYieldMs, signal, operationLabel);
             }
         }
 
@@ -729,43 +1023,70 @@ class TextEmbeddingService extends Base {
      *
      * @param {String} text The text to embed.
      * @param {String} explicitProvider The embedding provider to use.
+     * @param {Object} [options={}] Abort/diagnostic options.
+     * @param {AbortSignal} [options.signal] Caller-owned cancellation signal.
+     * @param {String} [options.operationLabel] Bounded diagnostic label.
      * @returns {Promise<number[]>}
      */
-    async embedText(text, explicitProvider) {
+    async embedText(text, explicitProvider, options = {}) {
         if (!explicitProvider) throw new Error('TextEmbeddingService.embedText requires an explicit provider argument');
 
-        if (explicitProvider === 'openAiCompatible') {
-            const {
-                unloadRetryCount          = 3,
-                contentionRetryCount      = 2,
-                contentionTimeoutMs       = 15000
-            } = aiConfig.openAiCompatible;
-            const requestText = await this.#prepareOpenAiCompatibleEmbeddingInput(text);
-            const result      = await this.#enqueueOpenAiCompatiblePost(requestText, {
-                unloadRetriesLeft    : unloadRetryCount,
-                contentionRetriesLeft: contentionRetryCount,
-                requestTimeoutMs     : contentionTimeoutMs
-            }, 'interactive');
-            return result.data?.[0]?.embedding;
-        } else if (explicitProvider === 'ollama') {
-            // Native Ollama returns `{embeddings: [[...]]}` even for single-input;
-            // project the single inner array since this method is the per-text variant.
-            const result = await this.#embedOllama(text, 'TextEmbeddingService.embedText native Ollama embedding');
-            return result.embeddings?.[0];
-        } else if (explicitProvider === 'gemini') {
-            const geminiKey = aiConfig.geminiApiKey;
-            if (!geminiKey) {
-                 throw new Error('Semantic search unavailable: GEMINI_API_KEY is missing.');
+        const defaultOperationLabel = explicitProvider === 'ollama'
+                  ? 'TextEmbeddingService.embedText native Ollama embedding'
+                  : `TextEmbeddingService.embedText ${explicitProvider} embedding`,
+              {signal, operationLabel} = normalizeEmbeddingOptions(options, defaultOperationLabel),
+              operation                = {operationLabel, phase: 'entry', startedAt: Date.now()};
+
+        try {
+            throwIfEmbeddingAborted(signal, operationLabel);
+
+            if (explicitProvider === 'openAiCompatible') {
+                const {
+                    unloadRetryCount          = 3,
+                    contentionRetryCount      = 2,
+                    contentionTimeoutMs       = 15000
+                } = aiConfig.openAiCompatible;
+                const requestText = await this.#prepareOpenAiCompatibleEmbeddingInput(text, signal, operationLabel, operation);
+                const result      = await this.#enqueueOpenAiCompatiblePost(requestText, {
+                    unloadRetriesLeft    : unloadRetryCount,
+                    contentionRetriesLeft: contentionRetryCount,
+                    requestTimeoutMs     : contentionTimeoutMs,
+                    signal,
+                    operationLabel,
+                    operation
+                }, 'interactive');
+                return result.data?.[0]?.embedding;
+            } else if (explicitProvider === 'ollama') {
+                // Native Ollama returns `{embeddings: [[...]]}` even for single-input;
+                // project the single inner array since this method is the per-text variant.
+                const result = await this.#embedOllama(text, operationLabel, signal, operation);
+                return result.embeddings?.[0];
+            } else if (explicitProvider === 'gemini') {
+                const geminiKey = aiConfig.geminiApiKey;
+                if (!geminiKey) {
+                     throw new Error('Semantic search unavailable: GEMINI_API_KEY is missing.');
+                }
+                if (!this.embeddingModel) {
+                     throw new Error('Google Generative AI Client not initialized properly.');
+                }
+
+                operation.phase = 'in-flight';
+                const result = await this.embeddingModel.embedContent(text, signal ? {signal} : undefined);
+                return result.embedding.values;
+            } else {
+                // Unknown provider names fail loudly rather than silently fall back to
+                // the Gemini path — silent fallback is speculative-support.
+                throw new Error(`TextEmbeddingService: unsupported embedding provider '${explicitProvider}'. Expected one of: 'gemini', 'openAiCompatible', 'ollama'.`);
             }
-            if (!this.embeddingModel) {
-                 throw new Error('Google Generative AI Client not initialized properly.');
+        } catch (error) {
+            if (isCallerAbortError(error, signal)) {
+                const abortError = getEmbeddingAbortError(signal, operationLabel);
+
+                logEmbeddingAbort({provider: explicitProvider, operation, error: abortError});
+                throw abortError;
             }
-            const result = await this.embeddingModel.embedContent(text);
-            return result.embedding.values;
-        } else {
-            // Unknown provider names fail loudly rather than silently fall back to
-            // the Gemini path — silent fallback is speculative-support.
-            throw new Error(`TextEmbeddingService: unsupported embedding provider '${explicitProvider}'. Expected one of: 'gemini', 'openAiCompatible', 'ollama'.`);
+
+            throw error;
         }
     }
 
@@ -777,34 +1098,57 @@ class TextEmbeddingService extends Base {
      *
      * @param {String[]} texts The texts to embed.
      * @param {String} explicitProvider The embedding provider to use.
+     * @param {Object} [options={}] Abort/diagnostic options.
+     * @param {AbortSignal} [options.signal] Caller-owned cancellation signal.
+     * @param {String} [options.operationLabel] Bounded diagnostic label.
      * @returns {Promise<number[][]>}
      */
-    async embedTexts(texts, explicitProvider) {
+    async embedTexts(texts, explicitProvider, options = {}) {
         if (!explicitProvider) throw new Error('TextEmbeddingService.embedTexts requires an explicit provider argument');
 
-        if (explicitProvider === 'openAiCompatible') {
-            const requestTexts = await this.#prepareOpenAiCompatibleEmbeddingInput(texts);
-            return this.#embedOpenAiCompatibleBatch(requestTexts);
-        } else if (explicitProvider === 'ollama') {
-            // Ollama's `/api/embed` accepts array-of-strings natively + returns
-            // a parallel embeddings array — no per-text fan-out needed.
-            const result = await this.#embedOllama(texts, 'TextEmbeddingService.embedTexts native Ollama embedding');
-            return result.embeddings || [];
-        } else if (explicitProvider === 'gemini') {
-            const geminiKey = aiConfig.geminiApiKey;
-            if (!geminiKey) {
-                 throw new Error('Semantic search unavailable: GEMINI_API_KEY is missing.');
+        const defaultOperationLabel = explicitProvider === 'ollama'
+                  ? 'TextEmbeddingService.embedTexts native Ollama embedding'
+                  : `TextEmbeddingService.embedTexts ${explicitProvider} embedding`,
+              {signal, operationLabel} = normalizeEmbeddingOptions(options, defaultOperationLabel),
+              operation                = {operationLabel, phase: 'entry', startedAt: Date.now()};
+
+        try {
+            throwIfEmbeddingAborted(signal, operationLabel);
+
+            if (explicitProvider === 'openAiCompatible') {
+                const requestTexts = await this.#prepareOpenAiCompatibleEmbeddingInput(texts, signal, operationLabel, operation);
+                return this.#embedOpenAiCompatibleBatch(requestTexts, {signal, operationLabel, operation});
+            } else if (explicitProvider === 'ollama') {
+                // Ollama's `/api/embed` accepts array-of-strings natively + returns
+                // a parallel embeddings array — no per-text fan-out needed.
+                const result = await this.#embedOllama(texts, operationLabel, signal, operation);
+                return result.embeddings || [];
+            } else if (explicitProvider === 'gemini') {
+                const geminiKey = aiConfig.geminiApiKey;
+                if (!geminiKey) {
+                     throw new Error('Semantic search unavailable: GEMINI_API_KEY is missing.');
+                }
+                if (!this.embeddingModel) {
+                     throw new Error('Google Generative AI Client not initialized properly.');
+                }
+
+                operation.phase = 'in-flight';
+                const requests = texts.map(text => ({model: aiConfig.embeddingModel, content: {parts: [{text}]}}));
+                const result   = await this.embeddingModel.batchEmbedContents({requests}, signal ? {signal} : undefined);
+                return result.embeddings.map(e => e.values);
+            } else {
+                // Unknown provider names fail loudly (matches `embedText`).
+                throw new Error(`TextEmbeddingService: unsupported embedding provider '${explicitProvider}'. Expected one of: 'gemini', 'openAiCompatible', 'ollama'.`);
             }
-            if (!this.embeddingModel) {
-                 throw new Error('Google Generative AI Client not initialized properly.');
+        } catch (error) {
+            if (isCallerAbortError(error, signal)) {
+                const abortError = getEmbeddingAbortError(signal, operationLabel);
+
+                logEmbeddingAbort({provider: explicitProvider, operation, error: abortError});
+                throw abortError;
             }
 
-            const requests = texts.map(text => ({model: aiConfig.embeddingModel, content: {parts: [{text}]}}));
-            const result   = await this.embeddingModel.batchEmbedContents({ requests });
-            return result.embeddings.map(e => e.values);
-        } else {
-            // Unknown provider names fail loudly (matches `embedText`).
-            throw new Error(`TextEmbeddingService: unsupported embedding provider '${explicitProvider}'. Expected one of: 'gemini', 'openAiCompatible', 'ollama'.`);
+            throw error;
         }
     }
 }

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -462,6 +462,12 @@ test.describe('Tier 1 Config Immutability', () => {
             });
             isolatedConfig.setEnvOverride('NEO_RECOVERY_ACTUATOR_HEAL_LEDGER_MAX_EVENTS', 1234);
             expect(isolatedConfig.orchestrator.recoveryActuator.healLedger.maxEvents).toBe(1234);
+
+            expect(isolatedConfig.orchestrator.recoveryActuator.freezeReprobeTimeoutMs).toBe(
+                Number(process.env.NEO_RECOVERY_ACTUATOR_FREEZE_REPROBE_TIMEOUT_MS) || 30000
+            );
+            isolatedConfig.setEnvOverride('NEO_RECOVERY_ACTUATOR_FREEZE_REPROBE_TIMEOUT_MS', 4321);
+            expect(isolatedConfig.orchestrator.recoveryActuator.freezeReprobeTimeoutMs).toBe(4321);
         } finally {
             isolatedConfig.destroy();
         }

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -229,6 +229,110 @@ function restoreConfigObject(target, prior) {
 }
 
 test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
+    test('freeze re-probe forwards one bounded signal and clears its deadline after success (#15694)', async () => {
+        const orchestrator = Object.create(Orchestrator.prototype);
+
+        let captured;
+        const result = await orchestrator.probeFrozenCollectionHealth('memory', {
+            timeoutMs : 10,
+            embedTexts: async (texts, provider, options) => {
+                captured = {texts, provider, options};
+                return [new Array(AiConfig.vectorDimension).fill(0.1)];
+            }
+        });
+
+        expect(result).toEqual({embedderHealthy: true, dimensionConsistent: true});
+        expect(captured).toMatchObject({
+            texts   : ['__freeze-reprobe-health-canary__'],
+            provider: AiConfig.embeddingProvider,
+            options : {operationLabel: 'Orchestrator freeze re-probe'}
+        });
+        expect(captured.options.signal).toBeInstanceOf(AbortSignal);
+
+        await new Promise(resolve => setTimeout(resolve, 20));
+        expect(captured.options.signal.aborted).toBe(false);
+    });
+
+    test('freeze re-probe aborts a hung embedding with the structured consumer deadline (#15694)', async () => {
+        const orchestrator = Object.create(Orchestrator.prototype);
+
+        let probeSignal;
+        const result = await orchestrator.probeFrozenCollectionHealth('memory', {
+            timeoutMs : 5,
+            embedTexts: async (texts, provider, options) => new Promise((resolve, reject) => {
+                probeSignal = options.signal;
+                options.signal.addEventListener('abort', () => reject(options.signal.reason), {once: true});
+            })
+        });
+
+        expect(result).toEqual({embedderHealthy: false, dimensionConsistent: false});
+        expect(probeSignal.aborted).toBe(true);
+        expect(probeSignal.reason).toMatchObject({
+            code          : 'EMBEDDING_PROBE_TIMEOUT',
+            operationLabel: 'Orchestrator freeze re-probe',
+            timeoutMs     : 5
+        });
+    });
+
+    test('freeze re-probe resolves fail-closed when an adapter ignores cancellation (#15694)', async () => {
+        test.setTimeout(1000);
+
+        const orchestrator = Object.create(Orchestrator.prototype);
+
+        let probeSignal;
+        const result = await orchestrator.probeFrozenCollectionHealth('memory', {
+            timeoutMs : 5,
+            embedTexts: async (texts, provider, options) => {
+                probeSignal = options.signal;
+                return new Promise(() => {});
+            }
+        });
+
+        expect(result).toEqual({embedderHealthy: false, dimensionConsistent: false});
+        expect(probeSignal.aborted).toBe(true);
+        expect(probeSignal.reason).toMatchObject({
+            code          : 'EMBEDDING_PROBE_TIMEOUT',
+            operationLabel: 'Orchestrator freeze re-probe',
+            timeoutMs     : 5
+        });
+    });
+
+    test('freeze re-probe stays failed when an abort listener resolves a valid vector (#15694)', async () => {
+        const orchestrator = Object.create(Orchestrator.prototype);
+
+        const result = await orchestrator.probeFrozenCollectionHealth('memory', {
+            timeoutMs : 5,
+            embedTexts: async (texts, provider, options) => new Promise(resolve => {
+                options.signal.addEventListener('abort', () => {
+                    resolve([new Array(AiConfig.vectorDimension).fill(0.1)]);
+                }, {once: true});
+            })
+        });
+
+        expect(result).toEqual({embedderHealthy: false, dimensionConsistent: false});
+    });
+
+    test('freeze re-probe keeps every provider and caller cancellation failure frozen (#15694)', async () => {
+        const failures = [
+            Object.assign(new Error('OpenAI timeout'), {code: 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT'}),
+            Object.assign(new Error('Ollama timeout'), {code: 'PROVIDER_TIMEOUT'}),
+            Object.assign(new Error('caller cancellation'), {name: 'AbortError', code: 'ABORT_ERR'}),
+            new Error('generic embedding failure')
+        ];
+
+        for (const failure of failures) {
+            const orchestrator = Object.create(Orchestrator.prototype);
+            const result       = await orchestrator.probeFrozenCollectionHealth('session', {
+                timeoutMs : 50,
+                embedTexts: async () => {
+                    throw failure;
+                }
+            });
+
+            expect(result).toEqual({embedderHealthy: false, dimensionConsistent: false});
+        }
+    });
+
     test('boot-identity caller seam: initBootIdentitySource() + poll() writes a codebook-valid advisory fact the fleet reader serves', async () => {
         const dir          = fs.mkdtempSync(path.join(os.tmpdir(), 'orch-boot-identity-')),
               orchestrator = createTestOrchestrator();

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -382,7 +382,7 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
             const provider = Neo.create(OllamaProvider, {
                 embeddingModel: 'qwen3-embedding-test',
                 host,
-                modelName: 'gemma4-test'
+                modelName     : 'gemma4-test'
             });
 
             const error = await provider.embed('hello', {
@@ -428,6 +428,46 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
             // Honored upstream signal → an AbortError, NOT a hang and NOT the provider-timeout shape.
             expect(error.code === 'ABORT_ERR' || error.name === 'AbortError').toBe(true);
             expect(error.code).not.toBe('PROVIDER_TIMEOUT');
+        } finally {
+            await new Promise(resolve => server.close(resolve));
+        }
+    });
+
+    test('Ollama.embed() honors options.signal and closes a hung native transport (#15694)', async () => {
+        let markRequestReceived;
+        let socketClosed = false;
+
+        const requestReceived = new Promise(resolve => markRequestReceived = resolve);
+        const server          = http.createServer((req, res) => {
+            res.on('close', () => socketClosed = true);
+            req.on('data', () => {});
+            req.on('end', () => markRequestReceived());
+        });
+        await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+        const host = `http://127.0.0.1:${server.address().port}`;
+
+        try {
+            const
+                provider   = Neo.create(OllamaProvider, {
+                    embeddingModel: 'qwen3-embedding-test',
+                    host,
+                    modelName     : 'gemma4-test'
+                }),
+                controller = new AbortController(),
+                promise    = provider.embed('hello', {
+                    signal        : controller.signal,
+                    timeoutMs     : 1000,
+                    operationLabel: 'native embedding cancellation probe'
+                });
+
+            await requestReceived;
+            controller.abort(new Error('cancel native embedding transport'));
+
+            const error = await promise.then(() => null, item => item);
+
+            expect(error.code === 'ABORT_ERR' || error.name === 'AbortError').toBe(true);
+            expect(error.code).not.toBe('PROVIDER_TIMEOUT');
+            await expect.poll(() => socketClosed).toBe(true);
         } finally {
             await new Promise(resolve => server.close(resolve));
         }

--- a/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
@@ -22,10 +22,13 @@ const LMS_BIN = path.join(os.homedir(), '.lmstudio', 'bin');
 const SEP     = process.platform === 'win32' ? ';' : ':';
 
 test.describe('lmsExecOptions — embedding-readiness PATH fix', () => {
-    let lmsExecOptions;
+    let fetchLmsLoadedModels, lmsExecOptions;
 
     test.beforeAll(async () => {
-        lmsExecOptions = (await import('../../../../../../ai/services/graph/providerReadinessHelper.mjs')).lmsExecOptions;
+        const mod = await import('../../../../../../ai/services/graph/providerReadinessHelper.mjs');
+
+        fetchLmsLoadedModels = mod.fetchLmsLoadedModels;
+        lmsExecOptions       = mod.lmsExecOptions;
     });
 
     test('augments PATH with the LM Studio bin dir', () => {
@@ -65,5 +68,67 @@ test.describe('lmsExecOptions — embedding-readiness PATH fix', () => {
         expect(opts.env.FOO).toBe('bar'); // caller env preserved (not clobbered)
         expect(entries).toContain('/custom/bin'); // caller PATH preserved
         expect(entries).toContain(LMS_BIN);       // lms bin dir augmented onto the caller PATH
+    });
+
+    test('pre-aborted loaded-model probes reject before spawning a child', async () => {
+        const
+            controller = new AbortController(),
+            reason     = new Error('cancel before provider preflight'),
+            calls      = [];
+
+        controller.abort(reason);
+
+        let observed;
+        try {
+            await fetchLmsLoadedModels({
+                timeoutMs : 100,
+                signal    : controller.signal,
+                execFileFn: (...args) => calls.push(args)
+            });
+        } catch (error) {
+            observed = error;
+        }
+
+        expect(observed).toBe(reason);
+        expect(calls).toEqual([]);
+    });
+
+    test('signal-owned loaded-model probes do not coalesce or poison sibling callers', async () => {
+        const
+            firstController  = new AbortController(),
+            secondController = new AbortController(),
+            callbacks        = [],
+            signals          = [],
+            execFileFn       = (file, args, options, callback) => {
+                signals.push(options.signal);
+                callbacks.push(callback);
+            },
+            firstPromise     = fetchLmsLoadedModels({
+                timeoutMs: 100,
+                signal   : firstController.signal,
+                execFileFn
+            }),
+            secondPromise    = fetchLmsLoadedModels({
+                timeoutMs: 100,
+                signal   : secondController.signal,
+                execFileFn
+            }),
+            reason           = new Error('cancel only the first preflight');
+
+        expect(signals).toEqual([firstController.signal, secondController.signal]);
+
+        firstController.abort(reason);
+        callbacks[0](Object.assign(new Error('child aborted'), {name: 'AbortError'}));
+        callbacks[1](null, JSON.stringify([{identifier: 'embedding-model'}]), '');
+
+        let observed;
+        try {
+            await firstPromise;
+        } catch (error) {
+            observed = error;
+        }
+
+        expect(observed).toBe(reason);
+        await expect(secondPromise).resolves.toEqual([{id: 'embedding-model'}]);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -586,7 +586,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         // Degradation DETECTION survives the trim via status + details; the verbose writeCanary
         // sub-object no longer ships in the payload.
         expect(refreshed.providers.embedding).not.toHaveProperty('writeCanary');
-        expect(refreshed.details).toContain('Embedding write canary failed: embedding provider busy');
+        expect(refreshed.details).toContain('Embedding write canary failed: provider-failure:EMBEDDING_PROVIDER_ERROR');
         expect(refreshed.details).not.toContain('All features are operational');
     });
 
@@ -703,7 +703,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         // The lean payload omits the writeCanary sub-object; a failed probe still degrades the
         // probe via status + a details entry naming the failure.
         expect(result.providers.embedding).not.toHaveProperty('writeCanary');
-        expect(result.details).toContain('Embedding write canary failed: embedding provider busy');
+        expect(result.details).toContain('Embedding write canary failed: provider-failure:EMBEDDING_PROVIDER_ERROR');
         expect(result.details).not.toContain('All features are operational');
     });
 
@@ -715,7 +715,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         });
 
         expect(result.status).toBe('degraded');
-        expect(result.details).toContain('Embedding write canary failed: Embedding write canary timed out after 5ms');
+        expect(result.details).toContain('Embedding write canary failed: consumer-probe-timeout:EMBEDDING_PROBE_TIMEOUT');
         expect(result.details).not.toContain('All features are operational');
     });
 
@@ -930,17 +930,22 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
 
     test('reports healthy when the active provider returns a vector', async () => {
         let   nowCalls = 0;
-        const result   = await buildEmbeddingWriteCanaryBlock({
+        let   probeSignal;
+        const result = await buildEmbeddingWriteCanaryBlock({
             cfg: {
                 embeddingProvider: 'openAiCompatible',
                 vectorDimension  : 3
             },
-            embedText: async (input, provider) => {
+            embedText: async (input, provider, options) => {
                 expect(input).toBe('neo-healthcheck-embedding-write-canary');
                 expect(provider).toBe('openAiCompatible');
+                expect(options.operationLabel).toBe('Embedding write canary');
+                expect(options.signal).toBeInstanceOf(AbortSignal);
+                probeSignal = options.signal;
                 return [0.1, 0.2, 0.3];
             },
-            now: () => nowCalls++ ? 125 : 100
+            now      : () => nowCalls++ ? 125 : 100,
+            timeoutMs: 10
         });
 
         expect(result).toEqual({
@@ -950,6 +955,9 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
             expectedDimensions: 3,
             durationMs        : 25
         });
+
+        await new Promise(resolve => setTimeout(resolve, 20));
+        expect(probeSignal.aborted).toBe(false);
     });
 
     test('reports failed when the active provider throws', async () => {
@@ -965,33 +973,97 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
         });
 
         expect(result).toMatchObject({
-            status            : 'failed',
-            provider          : 'openAiCompatible',
-            dimensions        : null,
-            expectedDimensions: 4096,
-            durationMs        : 0,
-            error             : 'embedding provider busy'
+            status             : 'failed',
+            provider           : 'openAiCompatible',
+            dimensions         : null,
+            expectedDimensions : 4096,
+            durationMs         : 0,
+            error              : 'provider-failure:EMBEDDING_PROVIDER_ERROR',
+            errorClassification: 'provider-failure',
+            errorCode          : 'EMBEDDING_PROVIDER_ERROR'
         });
     });
 
-    test('#13458: reports failed when the active provider never resolves', async () => {
+    test('redacts and bounds an untrusted provider error before it reaches the health receipt', async () => {
+        const secret = 'sk-live-secret-must-not-escape';
         const result = await buildEmbeddingWriteCanaryBlock({
             cfg: {
                 embeddingProvider: 'openAiCompatible',
                 vectorDimension  : 4096
             },
-            embedText: async () => new Promise(() => {}),
+            embedText: async () => {
+                throw Object.assign(
+                    new Error(`provider body=${secret}; endpoint=https://private.invalid; ${'x'.repeat(500)}`),
+                    {code: `UNTRUSTED_${secret}`}
+                );
+            },
+            now: () => 100
+        });
+
+        expect(result).toMatchObject({
+            status             : 'failed',
+            error              : 'provider-failure:EMBEDDING_PROVIDER_ERROR',
+            errorClassification: 'provider-failure',
+            errorCode          : 'EMBEDDING_PROVIDER_ERROR'
+        });
+        expect(result.error.length).toBeLessThanOrEqual(96);
+        expect(JSON.stringify(result)).not.toContain(secret);
+        expect(JSON.stringify(result)).not.toContain('private.invalid');
+    });
+
+    test('#13458: reports failed when the active provider never resolves', async () => {
+        let probeSignal;
+
+        const result = await buildEmbeddingWriteCanaryBlock({
+            cfg: {
+                embeddingProvider: 'openAiCompatible',
+                vectorDimension  : 4096
+            },
+            embedText: async (input, provider, options) => new Promise((resolve, reject) => {
+                probeSignal = options.signal;
+                options.signal.addEventListener('abort', () => reject(options.signal.reason), {once: true});
+            }),
             now      : () => 100,
             timeoutMs: 5
         });
 
         expect(result).toMatchObject({
-            status            : 'failed',
-            provider          : 'openAiCompatible',
-            dimensions        : null,
-            expectedDimensions: 4096,
-            durationMs        : 0,
-            error             : 'Embedding write canary timed out after 5ms'
+            status             : 'failed',
+            provider           : 'openAiCompatible',
+            dimensions         : null,
+            expectedDimensions : 4096,
+            durationMs         : 0,
+            error              : 'consumer-probe-timeout:EMBEDDING_PROBE_TIMEOUT',
+            errorClassification: 'consumer-probe-timeout',
+            errorCode          : 'EMBEDDING_PROBE_TIMEOUT'
+        });
+        expect(probeSignal.aborted).toBe(true);
+        expect(probeSignal.reason).toMatchObject({
+            code          : 'EMBEDDING_PROBE_TIMEOUT',
+            operationLabel: 'Embedding write canary',
+            timeoutMs     : 5
+        });
+    });
+
+    test('deadline stays failed when an abort listener resolves a valid vector (#15694)', async () => {
+        const result = await buildEmbeddingWriteCanaryBlock({
+            cfg: {
+                embeddingProvider: 'openAiCompatible',
+                vectorDimension  : 3
+            },
+            embedText: async (input, provider, options) => new Promise(resolve => {
+                options.signal.addEventListener('abort', () => resolve([0.1, 0.2, 0.3]), {once: true});
+            }),
+            now      : () => 100,
+            timeoutMs: 5
+        });
+
+        expect(result).toMatchObject({
+            status             : 'failed',
+            dimensions         : null,
+            error              : 'consumer-probe-timeout:EMBEDDING_PROBE_TIMEOUT',
+            errorClassification: 'consumer-probe-timeout',
+            errorCode          : 'EMBEDDING_PROBE_TIMEOUT'
         });
     });
 

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -14,6 +14,8 @@ setup({
 });
 
 import {test, expect} from '@playwright/test';
+import {execFile}     from 'child_process';
+import {promisify}    from 'util';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import {
@@ -21,6 +23,41 @@ import {
     getAggregatedFrictions
 }                     from '../../../../../../ai/services/memory-core/helpers/consumerFrictionHelper.mjs';
 import {PROVIDER_TIMEOUT_CODE} from '../../../../../../ai/provider/createTimeoutError.mjs';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * @summary Runs a config-sensitive embedding probe in a fresh process before any AiConfig singleton exists.
+ * @param {Function} probe Self-contained async child probe.
+ * @param {Object} [env={}] Environment overrides materialized by the child config provider.
+ * @returns {Promise<Object>} Last-line JSON evidence emitted by the child probe.
+ */
+async function runIsolatedEmbeddingProbe(probe, env = {}) {
+    const source = `
+        const {setup} = await import('./test/playwright/setup.mjs');
+        await import('./src/Neo.mjs');
+        await import('./src/core/_export.mjs');
+        setup({
+            neoConfig: {unitTestMode: true},
+            appConfig: {name: 'TextEmbeddingIsolatedProbe', isMounted: () => true, vnodeInitialising: false}
+        });
+        await (${probe.toString()})();
+    `;
+    const {stdout} = await execFileAsync(process.execPath, ['--input-type=module', '-e', source], {
+        cwd: process.cwd(),
+        env: {
+            ...process.env,
+            NEO_UNIT_TEST_MODE: 'true',
+            ...env
+        },
+        killSignal: 'SIGKILL',
+        maxBuffer : 1024 * 1024,
+        timeout   : 10_000
+    });
+    const lines = stdout.trim().split(/\r?\n/).filter(Boolean);
+
+    return JSON.parse(lines.at(-1));
+}
 
 /**
  * @summary Coverage for the TextEmbeddingService Gemini-init gate.
@@ -215,5 +252,520 @@ test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', ()
         await expect(TextEmbeddingService.embedTexts(['a', 'b'], 'mystery-provider')).rejects.toThrow(
             /unsupported embedding provider 'mystery-provider'.*Expected one of.*gemini.*openAiCompatible.*ollama/
         );
+    });
+});
+
+test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellation contract', () => {
+    let TextEmbeddingService;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs');
+
+        TextEmbeddingService = mod.default;
+    });
+
+    test.afterEach(() => {
+        TextEmbeddingService.ollamaProvider = null;
+    });
+
+    test('Ollama receives the identical signal and restores the exact caller Error', async () => {
+        const
+            controller = new AbortController(),
+            reason     = new Error('stop native Ollama transport');
+
+        let capturedSignal;
+        TextEmbeddingService.ollamaProvider = {
+            embed(input, options) {
+                capturedSignal = options.signal;
+
+                return new Promise((resolve, reject) => {
+                    options.signal.addEventListener('abort', () => {
+                        reject(Object.assign(new Error('provider wrapper'), {name: 'AbortError'}));
+                    }, {once: true});
+                });
+            }
+        };
+
+        const embeddingPromise = TextEmbeddingService.embedText('hello', 'ollama', {
+            signal        : controller.signal,
+            operationLabel: 'Ollama health probe'
+        });
+
+        controller.abort(reason);
+
+        let observed;
+        try {
+            await embeddingPromise;
+        } catch (error) {
+            observed = error;
+        }
+
+        expect(capturedSignal).toBe(controller.signal);
+        expect(observed).toBe(reason);
+        expect(observed.code).not.toBe(PROVIDER_TIMEOUT_CODE);
+    });
+
+    test('non-Error abort reasons become a bounded structural AbortError before provider work', async () => {
+        const
+            controller     = new AbortController(),
+            operationLabel = 'x'.repeat(160);
+
+        let providerCalls = 0;
+        TextEmbeddingService.ollamaProvider = {
+            async embed() {
+                providerCalls++;
+                return {embeddings: [[0.1]]};
+            }
+        };
+        controller.abort('opaque-reason');
+
+        let observed;
+        try {
+            await TextEmbeddingService.embedText('hello', 'ollama', {
+                signal: controller.signal,
+                operationLabel
+            });
+        } catch (error) {
+            observed = error;
+        }
+
+        expect(providerCalls).toBe(0);
+        expect(observed).toMatchObject({
+            name          : 'AbortError',
+            code          : 'ABORT_ERR',
+            operationLabel: 'x'.repeat(120)
+        });
+        expect(observed.message).toBe(`${'x'.repeat(120)} aborted`);
+    });
+
+    test('rejects unknown call options before provider dispatch', async () => {
+        let providerCalls = 0;
+        TextEmbeddingService.ollamaProvider = {
+            async embed() {
+                providerCalls++;
+                return {embeddings: [[0.1]]};
+            }
+        };
+
+        await expect(TextEmbeddingService.embedText('hello', 'ollama', {timeoutMs: 5}))
+            .rejects.toThrow(/unsupported embedding option\(s\): timeoutMs/);
+        expect(providerCalls).toBe(0);
+    });
+
+    test('Gemini forwards signals and preserves the complete SDK abort taxonomy in an isolated config process', async () => {
+        const evidence = await runIsolatedEmbeddingProbe(async () => {
+            const {GoogleGenerativeAIAbortError} = await import('@google/generative-ai');
+            const {default: Service}             = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
+
+            const forwardController = new AbortController();
+            const calls             = [];
+
+            Service.embeddingModel = {
+                async embedContent(request, requestOptions) {
+                    calls.push({kind: 'single', requestOptions});
+                    return {embedding: {values: [0.1, 0.2]}};
+                },
+                async batchEmbedContents(request, requestOptions) {
+                    calls.push({kind: 'batch', requestOptions});
+                    return {embeddings: [{values: [0.3]}, {values: [0.4]}]};
+                }
+            };
+
+            const single = await Service.embedText('one', 'gemini', {signal: forwardController.signal});
+            const batch  = await Service.embedTexts(['two', 'three'], 'gemini', {signal: forwardController.signal});
+
+            const exactController = new AbortController();
+            const exactReason     = new Error('cancel Gemini probe');
+            Service.embeddingModel = {
+                embedContent(input, requestOptions) {
+                    return new Promise((resolve, reject) => {
+                        requestOptions.signal.addEventListener('abort', () => {
+                            reject(new GoogleGenerativeAIAbortError('SDK wrapped the caller abort'));
+                        }, {once: true});
+                    });
+                }
+            };
+            const exactPromise = Service.embedText('exact', 'gemini', {signal: exactController.signal});
+            exactController.abort(exactReason);
+            let exactObserved;
+            try {
+                await exactPromise;
+            } catch (error) {
+                exactObserved = error;
+            }
+
+            const fallbackController = new AbortController();
+            Service.embeddingModel = {
+                embedContent(input, requestOptions) {
+                    return new Promise((resolve, reject) => {
+                        requestOptions.signal.addEventListener('abort', () => {
+                            reject(new GoogleGenerativeAIAbortError('SDK dropped a non-Error reason'));
+                        }, {once: true});
+                    });
+                }
+            };
+            const fallbackPromise = Service.embedText('fallback', 'gemini', {
+                signal        : fallbackController.signal,
+                operationLabel: 'g'.repeat(160)
+            });
+            fallbackController.abort('opaque-reason');
+            let fallbackObserved;
+            try {
+                await fallbackPromise;
+            } catch (error) {
+                fallbackObserved = error;
+            }
+
+            const liveController = new AbortController();
+            const liveWrapper    = new GoogleGenerativeAIAbortError('SDK aborted independently');
+            Service.embeddingModel = {
+                async embedContent() {
+                    throw liveWrapper;
+                }
+            };
+            let liveObserved;
+            try {
+                await Service.embedText('live', 'gemini', {signal: liveController.signal});
+            } catch (error) {
+                liveObserved = error;
+            }
+
+            console.log(JSON.stringify({
+                single,
+                batch,
+                singleSignalForwarded: calls[0].requestOptions.signal === forwardController.signal,
+                batchSignalForwarded : calls[1].requestOptions.signal === forwardController.signal,
+                exactReasonRestored  : exactObserved === exactReason,
+                fallback             : {
+                    name          : fallbackObserved?.name,
+                    code          : fallbackObserved?.code,
+                    operationLabel: fallbackObserved?.operationLabel,
+                    message       : fallbackObserved?.message
+                },
+                liveWrapperPreserved: liveObserved === liveWrapper,
+                liveSignalAborted   : liveController.signal.aborted
+            }));
+        }, {GEMINI_API_KEY: 'unit-test-key'});
+
+        expect(evidence).toEqual({
+            single               : [0.1, 0.2],
+            batch                : [[0.3], [0.4]],
+            singleSignalForwarded: true,
+            batchSignalForwarded : true,
+            exactReasonRestored  : true,
+            fallback             : {
+                name          : 'AbortError',
+                code          : 'ABORT_ERR',
+                operationLabel: 'g'.repeat(120),
+                message       : `${'g'.repeat(120)} aborted`
+            },
+            liveWrapperPreserved: true,
+            liveSignalAborted   : false
+        });
+    });
+
+    test('OpenAI-compatible retry and batch delays stop before later work in an isolated config process', async () => {
+        const evidence = await runIsolatedEmbeddingProbe(async () => {
+            const http                = await import('node:http');
+            const {getEventListeners} = await import('node:events');
+
+            let behavior                           = 'success';
+            let closedHungRequests                 = 0;
+            let heldResponse                       = null;
+            let nextRequestObservedAfterAbortClose = false;
+            let requestCount                       = 0;
+            let requestInputs                      = [];
+
+            const server = http.createServer((request, response) => {
+                requestCount++;
+                response.on('close', () => {
+                    if (!response.writableEnded) {
+                        closedHungRequests++;
+                    }
+                });
+
+                let body = '';
+                request.on('data', chunk => body += chunk);
+                request.on('end', () => {
+                    const payload = JSON.parse(body);
+                    requestInputs.push(payload.input);
+
+                    if (behavior === 'model-load') {
+                        response.writeHead(400, {'Content-Type': 'application/json'});
+                        response.end(JSON.stringify({error: 'Model was unloaded while the request was still in queue.'}));
+                    } else if (behavior === 'contention') {
+                        response.writeHead(408, {'Content-Type': 'application/json'});
+                        response.end(JSON.stringify({error: 'provider contention'}));
+                    } else {
+                        if (behavior === 'hold-first' && requestCount === 1) {
+                            heldResponse = response;
+                            return;
+                        }
+                        if (behavior === 'hold-first') {
+                            nextRequestObservedAfterAbortClose = closedHungRequests > 0;
+                        }
+
+                        const inputs = Array.isArray(payload.input) ? payload.input : [payload.input];
+                        response.writeHead(200, {'Content-Type': 'application/json'});
+                        response.end(JSON.stringify({
+                            data: inputs.map((input, index) => ({index, embedding: [index + 0.1]}))
+                        }));
+                    }
+                });
+            });
+            await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+            try {
+                Object.assign(process.env, {
+                NEO_OPENAI_COMPATIBLE_HOST                      : `http://127.0.0.1:${server.address().port}`,
+                NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT        : '2',
+                NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS     : '500',
+                NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT    : '2',
+                NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS : '500',
+                NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS     : '5000',
+                NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: '1',
+                NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_TIMEOUT_MS: '5000',
+                NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS  : '500'
+            });
+
+            const {default: Service} = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
+            const waitFor            = async (condition, label) => {
+                const startedAt = Date.now();
+
+                while (Date.now() - startedAt < 1000) {
+                    if (condition()) return;
+                    await new Promise(resolve => setTimeout(resolve, 1));
+                }
+
+                throw new Error(`Timed out waiting for ${label}`);
+            };
+            const capture = async promise => {
+                try {
+                    await promise;
+                } catch (error) {
+                    return error;
+                }
+
+                throw new Error('Expected isolated embedding probe to reject');
+            };
+            const resetServerState = nextBehavior => {
+                behavior                           = nextBehavior;
+                closedHungRequests                 = 0;
+                heldResponse                       = null;
+                nextRequestObservedAfterAbortClose = false;
+                requestCount                       = 0;
+                requestInputs                      = [];
+            };
+
+            resetServerState('success');
+            let preflightCalls = 0;
+            Service.openAiCompatibleLoadedModelsProbe = async () => {
+                preflightCalls++;
+                return [];
+            };
+            const preAbortedController = new AbortController();
+            const preAbortedReason     = new Error('cancel before embedding entry');
+            preAbortedController.abort(preAbortedReason);
+            const preAbortedObserved = await capture(Service.embedText('never-send', 'openAiCompatible', {
+                signal        : preAbortedController.signal,
+                operationLabel: 'pre-aborted probe'
+            }));
+            const preAborted = {
+                exactReason: preAbortedObserved === preAbortedReason,
+                listeners  : getEventListeners(preAbortedController.signal, 'abort').length,
+                preflightCalls,
+                requestCount
+            };
+
+            resetServerState('success');
+            let readinessSignal;
+            Service.openAiCompatibleLoadedModelsProbe = ({signal}) => new Promise((resolve, reject) => {
+                readinessSignal = signal;
+                signal.addEventListener('abort', () => reject(Object.assign(
+                    new Error('preflight wrapper'),
+                    {name: 'AbortError'}
+                )), {once: true});
+            });
+            const readinessController = new AbortController();
+            const readinessReason     = new Error('cancel LMS readiness child');
+            const readinessPromise    = Service.embedText('never-send', 'openAiCompatible', {
+                signal        : readinessController.signal,
+                operationLabel: 'preflight cancellation probe'
+            });
+            await waitFor(() => readinessSignal === readinessController.signal, 'preflight signal hand-off');
+            readinessController.abort(readinessReason);
+            const readinessObserved = await capture(readinessPromise);
+            const readiness         = {
+                exactReason: readinessObserved === readinessReason,
+                listeners  : getEventListeners(readinessController.signal, 'abort').length,
+                requestCount
+            };
+            Service.openAiCompatibleLoadedModelsProbe = null;
+
+            resetServerState('hold-first');
+            const blockerPromise = Service.embedTexts(['blocker'], 'openAiCompatible');
+            await waitFor(() => heldResponse !== null, 'first provider request gate');
+
+            const queuedController = new AbortController();
+            const queuedReason     = new Error('cancel queued batch');
+            const queuedPromise    = Service.embedTexts(['do-not-send'], 'openAiCompatible', {
+                signal        : queuedController.signal,
+                operationLabel: 'queued cancellation probe'
+            });
+            await waitFor(
+                () => getEventListeners(queuedController.signal, 'abort').length === 1,
+                'queued abort listener'
+            );
+            queuedController.abort(queuedReason);
+            const queuedObserved = await capture(queuedPromise);
+
+            heldResponse.writeHead(200, {'Content-Type': 'application/json'});
+            heldResponse.end(JSON.stringify({data: [{index: 0, embedding: [7.1, 7.2, 7.3]}]}));
+            heldResponse = null;
+            await blockerPromise;
+            await Service.embedText('after-abort', 'openAiCompatible');
+            const queued = {
+                exactReason: queuedObserved === queuedReason,
+                listeners  : getEventListeners(queuedController.signal, 'abort').length,
+                requestInputs
+            };
+
+            resetServerState('hold-first');
+            const inFlightController = new AbortController();
+            const inFlightReason     = new Error('cancel active socket');
+            const inFlightPromise    = Service.embedText('hung', 'openAiCompatible', {
+                signal        : inFlightController.signal,
+                operationLabel: 'in-flight cancellation probe'
+            });
+            await waitFor(() => requestCount === 1, 'hung provider request');
+            const afterInFlightPromise = Service.embedText('after-socket-abort', 'openAiCompatible');
+            inFlightController.abort(inFlightReason);
+            const inFlightObserved = await capture(inFlightPromise);
+            await afterInFlightPromise;
+            await waitFor(() => closedHungRequests === 1, 'active socket close');
+            const inFlight = {
+                closedHungRequests,
+                exactReason: inFlightObserved === inFlightReason,
+                listeners  : getEventListeners(inFlightController.signal, 'abort').length,
+                nextRequestObservedAfterAbortClose,
+                requestCount
+            };
+
+            const runDelayedAbort = async (nextBehavior, input, batch = false) => {
+                resetServerState(nextBehavior);
+
+                const controller = new AbortController();
+                const reason     = new Error(`cancel ${nextBehavior}`);
+                const promise    = batch
+                    ? Service.embedTexts(input, 'openAiCompatible', {signal: controller.signal, operationLabel: nextBehavior})
+                    : Service.embedText(input, 'openAiCompatible', {signal: controller.signal, operationLabel: nextBehavior});
+
+                await waitFor(
+                    () => requestCount === 1 && getEventListeners(controller.signal, 'abort').length === 1,
+                    `${nextBehavior} abortable delay`
+                );
+                controller.abort(reason);
+
+                const observed = await capture(promise);
+                await new Promise(resolve => setTimeout(resolve, 30));
+
+                return {
+                    exactReason: observed === reason,
+                    requestCount,
+                    listeners  : getEventListeners(controller.signal, 'abort').length
+                };
+            };
+
+            const modelLoad  = await runDelayedAbort('model-load', 'retry-once');
+            const contention = await runDelayedAbort('contention', 'retry-once');
+            const batchYield = await runDelayedAbort('success', ['first', 'second'], true);
+
+                console.log(JSON.stringify({
+                    preAborted,
+                    readiness,
+                    queued,
+                    inFlight,
+                    modelLoad,
+                    contention,
+                    batchYield
+                }));
+            } finally {
+                server.closeAllConnections?.();
+                await new Promise(resolve => server.close(resolve));
+            }
+        });
+
+        expect(evidence).toEqual({
+            preAborted: {exactReason: true, listeners: 0, preflightCalls: 0, requestCount: 0},
+            readiness : {exactReason: true, listeners: 0, requestCount: 0},
+            queued    : {
+                exactReason  : true,
+                listeners    : 0,
+                requestInputs: [['blocker'], 'after-abort']
+            },
+            inFlight: {
+                closedHungRequests                : 1,
+                exactReason                       : true,
+                listeners                         : 0,
+                nextRequestObservedAfterAbortClose: true,
+                requestCount                      : 2
+            },
+            modelLoad : {exactReason: true, requestCount: 1, listeners: 0},
+            contention: {exactReason: true, requestCount: 1, listeners: 0},
+            batchYield: {exactReason: true, requestCount: 1, listeners: 0}
+        });
+    });
+
+    test('OpenAI-compatible provider timeout wins a later caller abort in an isolated config process', async () => {
+        const evidence = await runIsolatedEmbeddingProbe(async () => {
+            const http                = await import('node:http');
+            const {getEventListeners} = await import('node:events');
+
+            let   requestCount = 0;
+            const server       = http.createServer(request => {
+                requestCount++;
+                request.resume();
+            });
+            await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+            try {
+                Object.assign(process.env, {
+                    NEO_OPENAI_COMPATIBLE_HOST                  : `http://127.0.0.1:${server.address().port}`,
+                    NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT: '0',
+                    NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS : '10'
+                });
+
+                const {default: Service} = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
+                const controller         = new AbortController();
+
+                let observed;
+                try {
+                    await Service.embedText('timeout', 'openAiCompatible', {
+                        signal        : controller.signal,
+                        operationLabel: 'provider timeout race probe'
+                    });
+                } catch (error) {
+                    observed = error;
+                }
+
+                controller.abort(new Error('late caller abort'));
+                await new Promise(resolve => setTimeout(resolve, 20));
+
+                console.log(JSON.stringify({
+                    code     : observed?.code,
+                    listeners: getEventListeners(controller.signal, 'abort').length,
+                    requestCount
+                }));
+            } finally {
+                server.closeAllConnections?.();
+                await new Promise(resolve => server.close(resolve));
+            }
+        });
+
+        expect(evidence).toEqual({
+            code        : 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
+            listeners   : 0,
+            requestCount: 1
+        });
     });
 });


### PR DESCRIPTION
Resolves #15694

Embedding probes now terminate their locally owned work at the consumer deadline instead of merely abandoning the await. The cached Memory Core write canary and the due-only Orchestrator freeze re-probe each own an `AbortController`; `TextEmbeddingService` propagates that signal through OpenAI-compatible preflight, queueing, sockets, retry delays, chunks, and batch yields, through native Ollama transport, and through Gemini's per-call request options with caller-reason restoration. Diagnostics remain evidence-only and failed freeze probes remain frozen.

Evidence: L2 (isolated unit plus local HTTP/socket witnesses for queue disposal, in-flight abort, retry/yield cutoff, error taxonomy, and fail-closed consumers) → L2 required (every close-target AC is locally observable). No residuals.

## Authority boundary

- Orchestrator ownership of embedding and eventual re-embedding decisions is unchanged.
- Preserved-vector restore remains provider-free; this PR adds no restore probe or restore-wide provider gate.
- The health canary still produces cached diagnostic evidence only. It cannot select or execute a healing action.
- The freeze re-probe still runs only after the existing due/back-off decision. Deadline, abort, provider timeout, and provider failure all map to inconclusive evidence, so the existing decider stays frozen.
- No action-admission canary, per-row probe, importer-batch probe, or provider warming policy is introduced.

## Provider contract

| Branch | Local guarantee | Admitted residual |
| --- | --- | --- |
| OpenAI-compatible | Pre-aborted and queued-aborted work opens no request; active requests are destroyed; preflight, retries, recursive attempts, chunk transitions, and batch yields observe the signal; provider-owned deadlines remain `OPENAI_COMPATIBLE_REQUEST_TIMEOUT`. | Work already accepted by a remote provider may continue after local socket destruction. |
| Ollama | The caller signal reaches the native request path and remains distinct from the existing `PROVIDER_TIMEOUT`. | Server-side completion after disconnect is not asserted. |
| Gemini | Both single and batch calls receive the signal; caller abort restores the exact Error-valued reason or a bounded `AbortError` / `ABORT_ERR`; unrelated SDK errors retain identity. | The installed SDK defines client-local cancellation only, so remote computation/billing may continue; SDK-owned listener lifetime is outside Neo's cleanup authority. |

## Deltas from ticket

None substantive. The implementation additionally pins an adversarial settlement race: each consumer rejects its authoritative deadline before broadcasting abort, so an adapter abort listener that resolves a plausible vector cannot convert timeout evidence into success. Signal-bearing LM Studio readiness probes also bypass shared coalescing so one caller's cancellation cannot poison another caller.

The new `NEO_RECOVERY_ACTUATOR_FREEZE_REPROBE_TIMEOUT_MS` binding is additive and follows the clean-slate env-var rule; there is no legacy alias or deprecation chain.

## Test Evidence

- `npm run agent-preflight -- --no-fix <12 touched files>` — passed all requested gates; only the two known non-blocking stale-overlay default warnings were reported.
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs` — 17 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` — 71 passed.
- `npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs` — 27 passed, 1 expected environment-gated skip.
- `npm run test-unit -- test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs` — 9 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` — 66 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs` — 19 passed.
- Final isolated touched-surface total: 209 passed, 1 expected skip.
- `node buildScripts/util/check-jsdoc-types.mjs` — 1,868 files scanned, 0 unparseable expressions.
- `node buildScripts/util/check-block-alignment.mjs --staged`, `git diff --cached --check`, syntax checks, config SSOT lint, and commit hooks — passed.
- Full `npm run test-unit` snapshot: 9,010 passed, 6 skipped, 14 failed, 72 not run. None of the 14 failures is on a #15694 production path: 5 wake-daemon `ps` fixture failures and 1 MCP smoke config/environment failure reproduced in isolation; 6 lifecycle cases hit local `.neo-ai-data` `EPERM`; the one `lintTreeJson` timeout reran 23/23 green; the one `MemoryService.WriteAhead` ordering failure reran 12/12 green.
- A deliberately mixed six-file invocation produced 191 passed, 1 skipped, and 8 config-sensitive failures after `config.template.spec.mjs` shared partially mutated template state with consumer suites. Every directly touched file passes in isolation as listed above; the mixed result is test-topology contamination, not counted as product evidence.

## Post-Merge Validation

- [ ] Confirm required GitHub CI checks are green on the merge candidate.
- [ ] In a confidential cloud deployment, confirm a timed-out due freeze re-probe emits a bounded failure receipt and remains frozen without starting later provider work.
- [ ] Under shared-provider load, confirm local queue latency recovers after a cancelled canary while preserving the documented remote-continuation residuals.

## Commit

- `9e97ae530d` — abort embedding probes at consumer deadlines and pin cleanup, taxonomy, and authority witnesses.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session cb60301d-74a4-4024-b80d-2f7efdbf9cd1.
