### PR TITLE
fix(devindex): budget GraphQL updater work (#15745)

### DIFF
--- a/apps/devindex/services/GitHub.mjs
+++ b/apps/devindex/services/GitHub.mjs
@@ -99,9 +99,17 @@ class GitHub extends Base {
          * @member {Object} rateLimit
          */
         rateLimit: {
-            core                : {remaining: 5000, reset: null, limit: 5000},
-            search              : {remaining:   30, reset: null, limit:   30},
-            graphql             : {remaining: 5000, reset: null, limit: 5000},
+            core   : {remaining: 5000, reset: null, limit: 5000},
+            search : {remaining:   30, reset: null, limit:   30},
+            graphql: {
+                cost        : 0,
+                limit       : 5000,
+                observedCost: 0,
+                remaining   : 5000,
+                reserved    : 0,
+                reset       : null,
+                used        : 0
+            },
             integration_manifest: {remaining: 5000, reset: null, limit: 5000}
         }
     }
@@ -112,6 +120,30 @@ class GitHub extends Base {
      * @private
      */
     #authToken = null;
+    /**
+     * Active in-process GraphQL capacity reservations.
+     *
+     * JavaScript executes each reservation mutation synchronously, so concurrent updater promises
+     * cannot all admit against the same pre-reservation snapshot. The Set also makes release idempotent.
+     * @member {Set<Object>} #graphqlReservations
+     * @private
+     */
+    #graphqlReservations = new Set();
+
+    /**
+     * @summary Creates a typed GraphQL error without coupling callers to message parsing.
+     * @param {String} message
+     * @param {String} code
+     * @returns {Error}
+     * @private
+     */
+    #createGraphqlError(message, code) {
+        const error = new Error(message);
+
+        error.code = code;
+
+        return error
+    }
 
     /**
      * Fetches the GitHub authentication token from the `gh` CLI.
@@ -207,6 +239,22 @@ class GitHub extends Base {
     }
 
     /**
+     * @summary Determines whether a GraphQL failure represents primary point-budget exhaustion.
+     * This is intentionally distinct from per-query resource pressure: primary exhaustion must not
+     * be retried or split into more requests.
+     * @param {Error|String} error
+     * @returns {Boolean}
+     * @private
+     */
+    #isGraphqlPrimaryRateLimitError(error) {
+        const message = String(error?.message || error).toLowerCase();
+
+        return error?.code === 'GRAPHQL_PRIMARY_RATE_LIMIT'
+            || message.includes('api rate limit already exceeded')
+            || message.includes('api rate limit exceeded')
+    }
+
+    /**
      * @summary Determines whether a REST response status is configured as transient.
      * @param {Number} status The HTTP response status.
      * @returns {Boolean}
@@ -286,10 +334,21 @@ class GitHub extends Base {
         const remaining = headers.get('x-ratelimit-remaining');
         const reset     = headers.get('x-ratelimit-reset');
         const limit     = headers.get('x-ratelimit-limit');
+        const used      = headers.get('x-ratelimit-used');
 
-        if (remaining !== null) bucket.remaining = parseInt(remaining, 10);
-        if (reset !== null)     bucket.reset     = parseInt(reset, 10);
-        if (limit !== null)     bucket.limit     = parseInt(limit, 10);
+        if (bucketName === 'graphql') {
+            this.#updateGraphqlRateLimit({
+                limit    : limit     === null ? undefined : parseInt(limit, 10),
+                remaining: remaining === null ? undefined : parseInt(remaining, 10),
+                reset    : reset     === null ? undefined : parseInt(reset, 10),
+                used     : used      === null ? undefined : parseInt(used, 10)
+            })
+        } else {
+            if (remaining !== null) bucket.remaining = parseInt(remaining, 10);
+            if (reset !== null)     bucket.reset     = parseInt(reset, 10);
+            if (limit !== null)     bucket.limit     = parseInt(limit, 10);
+            if (used !== null)      bucket.used      = parseInt(used, 10)
+        }
 
         // Debug: Warn if headers are missing but we are at default (implying no update ever happened)
         // Only warn on successful requests to avoid noise on 4xx/5xx errors (which might lack headers)
@@ -303,6 +362,54 @@ class GitHub extends Base {
     }
 
     /**
+     * @summary Applies GraphQL limit metadata without allowing out-of-order responses to increase
+     * same-window capacity or regress a newer reset-window snapshot.
+     * @param {Object}  rateLimit
+     * @param {Boolean} [authoritative=false] True for the explicit `/rate_limit` start snapshot.
+     * @private
+     */
+    #updateGraphqlRateLimit(rateLimit, authoritative=false) {
+        if (!rateLimit) return;
+
+        const
+            bucket          = this.rateLimit.graphql,
+            resetAt         = rateLimit.resetAt ? Date.parse(rateLimit.resetAt) / 1000 : rateLimit.reset,
+            reset           = Number(resetAt),
+            remaining       = Number(rateLimit.remaining),
+            limit           = Number(rateLimit.limit),
+            used            = Number(rateLimit.used),
+            cost            = Number(rateLimit.cost),
+            currentReset    = Number(bucket.reset),
+            hasReset        = Number.isFinite(reset),
+            hasCurrentReset = bucket.reset !== null && Number.isFinite(currentReset),
+            isNewWindow     = hasReset && hasCurrentReset && reset > currentReset,
+            isStaleWindow   = !authoritative && hasReset && hasCurrentReset && reset < currentReset;
+
+        if (!isStaleWindow && Number.isFinite(remaining)) {
+            bucket.remaining = authoritative || !hasCurrentReset || isNewWindow
+                ? remaining
+                : Math.min(bucket.remaining, remaining)
+        }
+
+        if (!isStaleWindow && Number.isFinite(limit)) {
+            bucket.limit = limit
+        }
+
+        if (!isStaleWindow && Number.isFinite(used)) {
+            bucket.used = used
+        }
+
+        if (Number.isFinite(cost)) {
+            bucket.cost         = cost;
+            bucket.observedCost = (bucket.observedCost || 0) + cost
+        }
+
+        if (!isStaleWindow && hasReset) {
+            bucket.reset = reset
+        }
+    }
+
+    /**
      * Updates rate limit from GraphQL body.
      * @param {Object} rateLimit
      * @private
@@ -310,16 +417,112 @@ class GitHub extends Base {
     #updateFromBody(rateLimit) {
         if (!rateLimit) return;
 
-        // GraphQL usually maps to 'graphql' resource (which shares quota with 'core')
-        const bucket = this.rateLimit.graphql;
+        this.#updateGraphqlRateLimit(rateLimit)
+    }
 
-        if (rateLimit.remaining !== undefined) bucket.remaining = rateLimit.remaining;
-        if (rateLimit.limit !== undefined)     bucket.limit     = rateLimit.limit;
+    /**
+     * @summary Returns the shared GraphQL point-budget snapshot after subtracting active
+     * reservations and a caller-declared downstream reserve.
+     * @param {Number} [reserve=0]
+     * @returns {Object}
+     */
+    getGraphqlBudget(reserve=0) {
+        const
+            bucket            = this.rateLimit.graphql,
+            normalizedReserve = Math.max(0, Number(reserve) || 0),
+            remaining         = Math.max(0, Number(bucket.remaining) || 0),
+            reserved          = Math.max(0, Number(bucket.reserved) || 0);
 
-        if (rateLimit.resetAt) {
-            // GraphQL returns ISO string, we store epoch seconds
-            bucket.reset = Math.floor(new Date(rateLimit.resetAt).getTime() / 1000);
+        return {
+            available   : Math.max(0, remaining - reserved - normalizedReserve),
+            cost        : Number(bucket.cost) || 0,
+            limit       : Number(bucket.limit) || 0,
+            observedCost: Number(bucket.observedCost) || 0,
+            remaining,
+            reserve     : normalizedReserve,
+            reserved,
+            reset       : bucket.reset
         }
+    }
+
+    /**
+     * @summary Atomically reserves GraphQL points for one bounded unit of work.
+     * Returns `null` rather than crossing the caller's downstream reserve.
+     * @param {Number} cost
+     * @param {Number} [reserve=0]
+     * @param {String} [context='']
+     * @returns {Object|null}
+     */
+    reserveGraphqlBudget(cost, reserve=0, context='') {
+        const normalizedCost = Math.ceil(Number(cost));
+
+        if (!Number.isFinite(normalizedCost) || normalizedCost <= 0) {
+            throw new TypeError('GraphQL reservation cost must be a positive finite number')
+        }
+
+        if (this.getGraphqlBudget(reserve).available < normalizedCost) {
+            return null
+        }
+
+        const reservation = {context, cost: normalizedCost};
+
+        this.rateLimit.graphql.reserved = (this.rateLimit.graphql.reserved || 0) + normalizedCost;
+        this.#graphqlReservations.add(reservation);
+
+        return reservation
+    }
+
+    /**
+     * @summary Releases one active GraphQL reservation exactly once.
+     * @param {Object|null} reservation
+     * @returns {Boolean} True when an active reservation was released.
+     */
+    releaseGraphqlBudget(reservation) {
+        if (!reservation || !this.#graphqlReservations.delete(reservation)) {
+            return false
+        }
+
+        this.rateLimit.graphql.reserved = Math.max(
+            0,
+            (this.rateLimit.graphql.reserved || 0) - reservation.cost
+        );
+
+        return true
+    }
+
+    /**
+     * @summary Refreshes the authoritative GraphQL bucket from GitHub's no-primary-cost
+     * REST rate-limit endpoint before the updater admits work.
+     * @returns {Promise<Object>} The refreshed shared budget snapshot.
+     */
+    async refreshGraphqlRateLimit() {
+        const
+            data   = await this.rest('rate_limit', 'GraphQL Budget'),
+            status = data?.resources?.graphql;
+
+        if (!status) {
+            throw new Error('GitHub rate-limit response did not include the GraphQL bucket')
+        }
+
+        this.rateLimit.graphql.cost         = 0;
+        this.rateLimit.graphql.observedCost = 0;
+        this.#updateGraphqlRateLimit(status, true);
+
+        return this.getGraphqlBudget()
+    }
+
+    /**
+     * @summary Identifies GitHub's per-query resource ceiling without conflating it with
+     * primary point exhaustion. Updater window-splitting is authorized only for this class
+     * (plus explicit gateway timeouts), never for a depleted primary budget.
+     * @param {Error|String} error
+     * @returns {Boolean}
+     */
+    isGraphqlResourceLimitError(error) {
+        const message = String(error?.message || error).toLowerCase();
+
+        return error?.code === 'GRAPHQL_RESOURCE_LIMIT'
+            || message.includes('resource limits for this query exceeded')
     }
 
     /**
@@ -351,6 +554,13 @@ class GitHub extends Base {
             this.#updateRateLimit(response);
 
             if (!response.ok) {
+                if (response.status === 403 && this.rateLimit.graphql.remaining <= 0) {
+                    throw this.#createGraphqlError(
+                        `GraphQL Primary Rate Limit: ${response.status} ${response.statusText}`,
+                        'GRAPHQL_PRIMARY_RATE_LIMIT'
+                    )
+                }
+
                 // Retry on 5xx (Server Error) or 403 (Rate Limit/Abuse). A `>= 500` leaves a MUTATION's
                 // server-side outcome AMBIGUOUS (the write may have applied before the error), so a mutation
                 // is not replayed on it — a read still is. A `403` is a pre-execution rate-limit rejection,
@@ -371,7 +581,7 @@ class GitHub extends Base {
 
                     console.log(`${prefix} Error ${response.status}. Retrying in ${delay}ms...`);
                     await new Promise(r => setTimeout(r, delay));
-                    return this.query(query, variables, retries - 1, logContext);
+                    return this.query(query, variables, retries - 1, logContext, attempt + 1);
                 }
                 throw new Error(`GraphQL Error: ${response.status} ${response.statusText}`);
             }
@@ -391,6 +601,20 @@ class GitHub extends Base {
                     throw new Error(`GraphQL Fatal Error: ${messages}`);
                 }
 
+                if (this.rateLimit.graphql.remaining <= 0 || this.#isGraphqlPrimaryRateLimitError(messages)) {
+                    throw this.#createGraphqlError(
+                        `GraphQL Primary Rate Limit: ${messages}`,
+                        'GRAPHQL_PRIMARY_RATE_LIMIT'
+                    )
+                }
+
+                if (this.isGraphqlResourceLimitError(messages)) {
+                    throw this.#createGraphqlError(
+                        `GraphQL Query Errors: ${messages}`,
+                        'GRAPHQL_RESOURCE_LIMIT'
+                    )
+                }
+
                 // Sometimes 502s come as 200 OK with errors body. Like a `>= 500`, a gateway error leaves a
                 // MUTATION's outcome ambiguous, so it is not replayed for one — a read still is.
                 const isGatewayError = json.errors.some(e => e.message?.includes('502') || e.message?.includes('504'));
@@ -399,7 +623,7 @@ class GitHub extends Base {
                     const delay = (4 - retries) * 2000;
                     console.log(`${prefix} Gateway Error in body. Retrying in ${delay}ms...`);
                     await new Promise(r => setTimeout(r, delay));
-                    return this.query(query, variables, retries - 1, logContext);
+                    return this.query(query, variables, retries - 1, logContext, attempt + 1);
                 }
 
                 // IP Allow List restriction usually returns partial data (public contributions).
@@ -436,6 +660,14 @@ class GitHub extends Base {
 
             return json.data;
         } catch (error) {
+            if (
+                error.code === 'GRAPHQL_PRIMARY_RATE_LIMIT' ||
+                error.code === 'GRAPHQL_RESOURCE_LIMIT'
+            ) {
+                console.error(`${prefix} GraphQL Query Failed:`, error.message);
+                throw error
+            }
+
             // Fatal errors (Do not retry)
             if (error.message.includes('Could not resolve to a User') || error.message.includes('NOT_FOUND') || error.message.includes('GraphQL Fatal Error')) {
                 throw error;

--- a/apps/devindex/services/Updater.mjs
+++ b/apps/devindex/services/Updater.mjs
@@ -1,9 +1,9 @@
-import Base from '../../../src/core/Base.mjs';
-import config from './config.mjs';
-import GitHub from './GitHub.mjs';
-import Heuristics from './Heuristics.mjs';
+import Base               from '../../../src/core/Base.mjs';
+import config             from './config.mjs';
+import GitHub             from './GitHub.mjs';
+import Heuristics         from './Heuristics.mjs';
 import LocationNormalizer from './LocationNormalizer.mjs';
-import Storage from './Storage.mjs';
+import Storage            from './Storage.mjs';
 
 /**
  * @summary User Enrichment & Filtering Service.
@@ -48,7 +48,8 @@ class Updater extends Base {
      *
      * **Safe Purge Protocol (Self-Healing):**
      * This method implements a defensive strategy for handling API errors:
-     * 1.  **Transient Errors (5xx, Rate Limits):** Users are moved to the "Penalty Box" (`failed.json`) to be retried later.
+     * 1.  **Transient Errors (5xx):** Users are moved to the "Penalty Box" (`failed.json`) to be retried later.
+     *     Primary GraphQL exhaustion instead stops run-level admission without mutating the interrupted user.
      * 2.  **Fatal Errors (404, Not a User):**
      *     -   **If User Has History:** If the user exists in `users.jsonl`, we assume the 404 is a glitch or temporary suspension. They are **Protected** and moved to the Penalty Box.
      *     -   **If User Is New:** If the user has *never* been successfully indexed, they are classified as a "Bad Seed" (e.g., leaked Organization, Typo). They are **Pruned** (deleted) from the tracker immediately.
@@ -72,14 +73,28 @@ class Updater extends Base {
         let successCount    = 0;
         let failCount       = 0;
         let skipCount       = 0;
-        const saveInterval  = config.updater.saveInterval;
-        const allowlist     = await Storage.getAllowlist();
-        const richUsers     = await Storage.getUsers();
-        const richUserMap   = new Map(richUsers.map(u => [u.l.toLowerCase(), u]));
-        const concurrency   = 8; // Slightly reduced from 10 to balance speed vs stability
+        let admittedCount   = 0;
+        let stopReason      = null;
+        const
+            concurrency       = config.updater.concurrency,
+            downstreamReserve = config.github.graphqlDownstreamReserve,
+            saveInterval      = config.updater.saveInterval,
+            userReservation   = config.github.graphqlUserReservation,
+            allowlist         = await Storage.getAllowlist(),
+            richUsers         = await Storage.getUsers(),
+            richUserMap       = new Map(richUsers.map(u => [u.l.toLowerCase(), u]));
 
-        const threshold     = await Storage.getLowestContributionThreshold();
-        const minTc         = Math.max(config.github.minTotalContributions, threshold);
+        await GitHub.refreshGraphqlRateLimit();
+
+        const initialBudget = GitHub.getGraphqlBudget(downstreamReserve);
+
+        console.log(
+            `[Updater] GraphQL budget: remaining=${initialBudget.remaining}/${initialBudget.limit}, ` +
+            `reserve=${initialBudget.reserve}, userReservation=${userReservation}, concurrency=${concurrency}`
+        );
+
+        const threshold = await Storage.getLowestContributionThreshold();
+        const minTc     = Math.max(config.github.minTotalContributions, threshold);
 
         // Helper to process a single user
         const processUser = async (login) => {
@@ -107,34 +122,49 @@ class Updater extends Base {
                     console.log(`[${login}] SKIPPED (No Data/Bot)`);
                 }
             } catch (error) {
+                if (error.code === 'GRAPHQL_PRIMARY_RATE_LIMIT') {
+                    stopReason ||= 'primary-rate-limit';
+                    console.warn(`[Updater] GraphQL primary budget exhausted while processing ${login}; stopping admission.`);
+                    return
+                }
+
                 const lowerLogin = login.toLowerCase();
                 const isFatal    = error.message.includes('Could not resolve to a User') || error.message.includes('NOT_FOUND') || error.message.includes('GraphQL Fatal Error');
                 const richUser   = richUserMap.get(lowerLogin);
 
                 // ID-Based Rename Handling
                 if (isFatal && richUser && richUser.i) {
-                     try {
-                         const newLogin = await GitHub.getLoginByDatabaseId(richUser.i);
-                         if (newLogin && newLogin.toLowerCase() !== lowerLogin) {
-                             console.log(`[${login}] 🔄 RENAME DETECTED -> ${newLogin}`);
+                    try {
+                        const newLogin = await GitHub.getLoginByDatabaseId(richUser.i);
+                        if (newLogin && newLogin.toLowerCase() !== lowerLogin) {
+                            console.log(`[${login}] 🔄 RENAME DETECTED -> ${newLogin}`);
 
-                             // Fetch the replacement before staging old-login deletion. If the
-                             // replacement fetch fails, the rich historical record must stay protected.
-                             const newData = await this.fetchUserData(newLogin);
-                             if (newData) {
-                                 indexUpdates.push({ login, delete: true }); // Tracker
-                                 prunedLogins.push(login); // Rich Data
-                                 results.push(newData);
-                                 indexUpdates.push({ login: newLogin, lastUpdate: newData.lu });
-                                 // Success for new user implies we handled the 'slot' for the old user effectively
-                                 successCount++;
-                                 console.log(`[${newLogin}] Rename recovery successful.`);
-                                 return; // Done
-                             }
-                         }
-                     } catch (renameErr) {
-                         console.warn(`[${login}] Rename check failed: ${renameErr.message}`);
-                     }
+                            // Fetch the replacement before staging old-login deletion. If the
+                            // replacement fetch fails, the rich historical record must stay protected.
+                            const newData = await this.fetchUserData(newLogin);
+                            if (newData) {
+                                indexUpdates.push({ login, delete: true }); // Tracker
+                                prunedLogins.push(login); // Rich Data
+                                results.push(newData);
+                                indexUpdates.push({ login: newLogin, lastUpdate: newData.lu });
+                                // Success for new user implies we handled the 'slot' for the old user effectively
+                                successCount++;
+                                console.log(`[${newLogin}] Rename recovery successful.`);
+                                return; // Done
+                            }
+                        }
+                    } catch (renameErr) {
+                        if (renameErr.code === 'GRAPHQL_PRIMARY_RATE_LIMIT') {
+                            stopReason ||= 'primary-rate-limit';
+                            console.warn(
+                                `[Updater] GraphQL primary budget exhausted while recovering ${login}; ` +
+                                'stopping admission.'
+                            );
+                            return
+                        }
+
+                        console.warn(`[${login}] Rename check failed: ${renameErr.message}`);
+                    }
                 }
 
                 if (isFatal && !richUser) {
@@ -152,30 +182,46 @@ class Updater extends Base {
                     failedLogins.push(login); // Add to Penalty Box
                     failCount++; // Count as processed even if failed
                 }
-
-                // Kill-switch: If we hit a rate limit error, force internal state to 0 to trigger graceful shutdown
-                if (error.message.includes('rate limit')) {
-                    console.warn(`[Updater] 🚨 Rate limit hit for ${login}. Forcing shutdown sequence.`);
-                    GitHub.rateLimit.core.remaining = 0;
-                }
             }
         };
 
-        // Process in chunks
-        for (let i = 0; i < logins.length; i += concurrency) {
-            // Rate Limit Check
-            if (GitHub.rateLimit.core.remaining < 50) {
-                console.warn(`\n[Updater] ⚠️ RATE LIMIT CRITICAL: ${GitHub.rateLimit.core.remaining} requests remaining.`);
-                if (GitHub.rateLimit.core.reset) {
-                    const resetDate = new Date(GitHub.rateLimit.core.reset * 1000);
-                    console.warn(`[Updater] Limit resets at: ${resetDate.toLocaleString()}`);
+        // Admit users in bounded waves. Reservations are synchronous, so every promise in a wave
+        // observes the capacity already held by its siblings instead of one shared stale snapshot.
+        let cursor = 0;
+
+        while (cursor < logins.length && stopReason === null) {
+            const wave = [];
+
+            while (wave.length < concurrency && cursor < logins.length) {
+                const
+                    login       = logins[cursor],
+                    reservation = GitHub.reserveGraphqlBudget(
+                        userReservation,
+                        downstreamReserve,
+                        login
+                    );
+
+                if (!reservation) {
+                    break
                 }
-                console.warn(`[Updater] Stopping gracefully to preserve quota.\n`);
-                break;
+
+                cursor++;
+                admittedCount++;
+                wave.push({login, reservation})
             }
 
-            const chunk = logins.slice(i, i + concurrency);
-            await Promise.all(chunk.map(login => processUser(login)));
+            if (wave.length === 0) {
+                stopReason = 'downstream-reserve';
+                break
+            }
+
+            await Promise.all(wave.map(async ({login, reservation}) => {
+                try {
+                    await processUser(login)
+                } finally {
+                    GitHub.releaseGraphqlBudget(reservation)
+                }
+            }));
 
             // Checkpoint Save
             if (results.length >= saveInterval) {
@@ -186,6 +232,14 @@ class Updater extends Base {
                 recoveredLogins = [];
                 prunedLogins    = [];
             }
+
+            const budget = GitHub.getGraphqlBudget(downstreamReserve);
+
+            console.log(
+                `[Updater] GraphQL budget: admitted=${admittedCount}/${logins.length}, ` +
+                `observedCost=${budget.observedCost}, remaining=${budget.remaining}, ` +
+                `reserved=${budget.reserved}, reserve=${budget.reserve}`
+            )
         }
 
         // Final Save for remaining items
@@ -198,6 +252,16 @@ class Updater extends Base {
         console.log(`[Updater] Successfully Updated: ${successCount}`);
         console.log(`[Updater] Skipped/Pruned: ${skipCount}`);
         console.log(`[Updater] Failed (Penalty Box): ${failCount}`);
+        console.log(`[Updater] Admitted by GraphQL budget: ${admittedCount}/${logins.length}`);
+
+        if (stopReason) {
+            const budget = GitHub.getGraphqlBudget(downstreamReserve);
+
+            console.log(
+                `[Updater] Stop reason: ${stopReason} ` +
+                `(remaining=${budget.remaining}, reserve=${budget.reserve}, reserved=${budget.reserved})`
+            )
+        }
 
         if (initialBacklog > 0) {
             const totalProcessed = successCount + skipCount + failCount;
@@ -225,7 +289,13 @@ class Updater extends Base {
         if (failedLogins.length    > 0) await Storage.updateFailed(failedLogins, true);
         if (recoveredLogins.length > 0) await Storage.updateFailed(recoveredLogins, false);
 
-        console.log(`[Updater] Checkpoint: Saved ${results.length} records, Pruned ${prunedLogins.length} old logins. (API Quota: ${GitHub.rateLimit.core.remaining}/${GitHub.rateLimit.core.limit})`);
+        const budget = GitHub.getGraphqlBudget(config.github.graphqlDownstreamReserve);
+
+        console.log(
+            `[Updater] Checkpoint: Saved ${results.length} records, Pruned ${prunedLogins.length} old logins. ` +
+            `(GraphQL: remaining=${budget.remaining}/${budget.limit}, reserve=${budget.reserve}, ` +
+            `observedCost=${budget.observedCost})`
+        )
     }
 
     /**
@@ -245,12 +315,12 @@ class Updater extends Base {
     async fetchUserData(username) {
         // 1. Fetch Basic Profile & Social Accounts (GraphQL)
         const profileQuery = `
-            query { 
-                rateLimit { remaining limit resetAt }
-                user(login: "${username}") { 
-                    createdAt 
-                    avatarUrl 
-                    name 
+            query {
+                rateLimit { cost remaining limit resetAt }
+                user(login: "${username}") {
+                    createdAt
+                    avatarUrl
+                    name
                     location
                     company
                     bio
@@ -266,7 +336,7 @@ class Updater extends Base {
                             url
                         }
                     }
-                } 
+                }
             }`;
 
         // 2. Fetch Organizations (REST API for Public Memberships)
@@ -297,9 +367,23 @@ class Updater extends Base {
 
         if (!profileRes?.user) return null;
 
-        const { createdAt, avatarUrl, name, location, company, bio, followers, socialAccounts, isHireable, hasSponsorsListing, sponsorshipsAsMaintainer, twitterUsername, websiteUrl } = profileRes.user;
-        const startYear   = new Date(createdAt).getFullYear();
+        const {
+            avatarUrl,
+            bio,
+            company,
+            createdAt,
+            followers,
+            hasSponsorsListing,
+            isHireable,
+            location,
+            name,
+            socialAccounts,
+            sponsorshipsAsMaintainer,
+            twitterUsername,
+            websiteUrl
+        } = profileRes.user;
         const currentYear = new Date().getFullYear();
+        const startYear   = new Date(createdAt).getFullYear();
 
         // Extract LinkedIn URL
         let linkedin_url = null;
@@ -326,11 +410,11 @@ class Updater extends Base {
         const contribData = {};
 
         const fetchYears = async (fromYear, toYear) => {
-            let query = `query { 
-                rateLimit { remaining limit resetAt }
+            let query = `query {
+                rateLimit { cost remaining limit resetAt }
                 user(login: "${username}") {`;
             for (let year = fromYear; year <= toYear; year++) {
-                query += ` y${year}: contributionsCollection(from: "${year}-01-01T00:00:00Z", to: "${year}-12-31T23:59:59Z") { 
+                query += ` y${year}: contributionsCollection(from: "${year}-01-01T00:00:00Z", to: "${year}-12-31T23:59:59Z") {
                     totalCommitContributions
                     totalIssueContributions
                     totalPullRequestContributions
@@ -362,10 +446,24 @@ class Updater extends Base {
                 // 1. Try Fast Path (Batch of 4)
                 await fetchYears(chunk.start, chunk.end);
             } catch (err) {
-                // 2. Detect Failure (504/502/Timeout)
-                console.warn(`[Updater] [${username}] Batch failed (${chunk.start}-${chunk.end}). Falling back to single years...`);
+                const canSplitWindow = chunk.start < chunk.end && (
+                    GitHub.isGraphqlResourceLimitError(err) ||
+                    /\b(502|504)\b|timeout|couldn't respond/i.test(err.message)
+                );
 
-                // 3. Fallback: Process year by year
+                // Primary quota exhaustion and unrelated errors must never fan out into more
+                // requests. Only a multi-year query that hit GitHub's per-query resource/timeout
+                // ceiling is authorized to use the bounded single-year fallback.
+                if (!canSplitWindow) {
+                    throw err
+                }
+
+                console.warn(
+                    `[Updater] [${username}] Multi-year window failed (${chunk.start}-${chunk.end}); ` +
+                    'falling back to bounded single-year queries...'
+                );
+
+                // 2. Fallback: Process each year exactly once.
                 for (let y = chunk.start; y <= chunk.end; y++) {
                     try {
                         await fetchYears(y, y);
@@ -382,7 +480,7 @@ class Updater extends Base {
         }
 
         // 4. Aggregate Data & Minify
-        let total        = 0;
+        let   total      = 0;
         const yearsArr   = [];
         const commitsArr = [];
         const privateArr = [];
@@ -390,10 +488,10 @@ class Updater extends Base {
 
         // Ensure years are sorted and fill the array sequentially from startYear
         for (let year = startYear; year <= currentYear; year++) {
-            const key = `y${year}`;
+            const key        = `y${year}`;
             const collection = contribData[key];
 
-            const commits = collection?.totalCommitContributions || 0;
+            const commits      = collection?.totalCommitContributions || 0;
             const privateStats = collection?.restrictedContributionsCount || 0;
 
             // Sum up the lightweight counters

--- a/apps/devindex/services/config.mjs
+++ b/apps/devindex/services/config.mjs
@@ -1,10 +1,10 @@
-import fs from 'fs/promises';
-import path from 'path';
+import fs                from 'fs/promises';
+import path              from 'path';
 import { fileURLToPath } from 'url';
-import Base from '../../../src/core/Base.mjs';
+import Base              from '../../../src/core/Base.mjs';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __filename  = fileURLToPath(import.meta.url);
+const __dirname   = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, '../../../');
 
 /**
@@ -36,6 +36,25 @@ const defaultConfig = {
          * @type {number}
          */
         perPage: 30,
+        /**
+         * GraphQL points kept untouched for the downstream label-index rebuild.
+         *
+         * GitHub Actions' repository `GITHUB_TOKEN` currently receives a 1,000-point GraphQL
+         * window, while a future GitHub App can receive a larger one. A fixed 100-point reserve
+         * protects the small downstream query in either posture without treating the limit as 5,000.
+         * @type {number}
+         */
+        graphqlDownstreamReserve: 100,
+        /**
+         * Maximum primary GraphQL points reserved while one user is in flight.
+         *
+         * The bound covers a profile request plus the oldest observed DevIndex history (2007)
+         * split into four-year windows, every window falling back once to single years, and rename
+         * recovery margin. Unused points are released after the user settles; response-reported
+         * `cost` and `remaining` still determine later admission.
+         * @type {number}
+         */
+        graphqlUserReservation: 32,
         /**
          * Request timeout in milliseconds.
          * @type {number}
@@ -82,6 +101,11 @@ const defaultConfig = {
      */
     updater: {
         /**
+         * Maximum number of users processed concurrently after GraphQL budget admission.
+         * @type {number}
+         */
+        concurrency: 8,
+        /**
          * Number of users to process before saving a checkpoint.
          * @type {number}
          */
@@ -98,7 +122,7 @@ const defaultConfig = {
          * @type {string}
          */
         users: path.resolve(projectRoot, 'apps/devindex/resources/data/users.jsonl'),
-        
+
         /**
          * The backend discovery index (formerly users.json).
          * Contains login, id, lastUpdate timestamp.

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -47,7 +47,7 @@ const
             label  : 'DevIndex Spider'
         },
         {
-            args   : ['run', 'devindex:update', '--', '--limit=800'],
+            args   : ['run', 'devindex:update', '--', '--limit=200'],
             command: 'npm',
             label  : 'DevIndex Updater'
         },

--- a/learn/guides/devindex/data-factory/DataHygiene.md
+++ b/learn/guides/devindex/data-factory/DataHygiene.md
@@ -1,6 +1,6 @@
 # Data Hygiene & Cleanup
 
-The **Cleanup Service** ([`DevIndex.services.Cleanup`](https://github.com/neomjs/neo/blob/dev/apps/devindex/services/Cleanup.mjs)) acts as the **Garbage Collector** and **State Enforcer** for the DevIndex data pipeline. 
+The **Cleanup Service** ([`DevIndex.services.Cleanup`](https://github.com/neomjs/neo/blob/dev/apps/devindex/services/Cleanup.mjs)) acts as the **Garbage Collector** and **State Enforcer** for the DevIndex data pipeline.
 
 Because the Data Factory operates autonomously—discovering thousands of users and constantly writing to JSON files—data entropy is inevitable. The Cleanup service is invoked automatically by the Orchestrator before any major operation to ensure the system starts with a clean, consistent, and optimized state.
 
@@ -29,7 +29,7 @@ Cleanup also audits rich `users.jsonl` profiles that are missing from `tracker.j
 ### 5. The 30-Day "Penalty Box" TTL
 When the Updater encounters an error analyzing a user (e.g., a GraphQL timeout or a 404), that user is placed in `failed.json`—the "Penalty Box."
 
-Users in the Penalty Box are temporarily protected from being completely pruned from the tracker, giving them a chance to be successfully processed in a future run. However, the Cleanup service enforces a strict **30-Day Time-To-Live (TTL)**. 
+Users in the Penalty Box are temporarily protected from being completely pruned from the tracker, giving them a chance to be successfully processed in a future run. However, the Cleanup service enforces a strict **30-Day Time-To-Live (TTL)**.
 
 ```javascript readonly
 // Enforce Retention Policy (Penalty Box TTL)
@@ -44,12 +44,12 @@ for (const [login, timestamp] of failed) {
     }
 }
 ```
-If a user remains in a failed state for more than 30 days, their protection is revoked, and the standard pruning logic will expunge them from the system. 
+If a user remains in a failed state for more than 30 days, their protection is revoked, and the standard pruning logic will expunge them from the system.
 
-**Rationale & The "Right to be Forgotten":** With a 50,000 user cap and an hourly update limit of 800, the pipeline completes a full cycle of the entire index approximately every 3 days. A 30-day retention period means a user has persistently failed roughly 10 consecutive update attempts (each of which internally utilizes multiple API retries). After a month of continuous failures, it is safe to assume the profile has either been permanently banned by GitHub or the user has explicitly deleted their own account. Automatically purging these records aligns with data minimization principles and proactively respects a user's right to be forgotten if they have chosen to remove their presence from the platform.
+**Rationale & The "Right to be Forgotten":** With a 50,000-user cap and the 200-candidate hourly rollout ceiling, one theoretical full pass takes about 10.4 days; GraphQL budget admission can make a real pass longer. The 30-day TTL therefore spans up to roughly three ceiling-rate passes, not a guaranteed count of update attempts. The policy is deliberately time-based: it leaves multiple revisit opportunities for transient failures while bounding how long an unreachable, deleted, or restricted profile remains protected from normal pruning. That bounded retention aligns with data-minimization principles and respects a user's right to be forgotten without pretending the scheduler admitted the user a fixed number of times.
 
 ### 6. Canonical Sorting
-The final step of the Cleanup routine is purely for Developer Experience (DX) and Git repository health. 
+The final step of the Cleanup routine is purely for Developer Experience (DX) and Git repository health.
 
 When JSON files are modified by asynchronous services, the order of keys or array elements is often unpredictable. If committed as-is, this creates massive, noisy Git diffs, making code review impossible.
 

--- a/learn/guides/devindex/data-factory/GitHubAPI.md
+++ b/learn/guides/devindex/data-factory/GitHubAPI.md
@@ -27,38 +27,45 @@ The DevIndex requires both deep, structured data and broad, shallow data. The Gi
 
 ---
 
-## 3. Advanced Rate Limit & Abuse Handling
+## 3. GraphQL Budget & Abuse Handling
 
-GitHub's API enforces strict rate limits (typically 5,000 points per hour for GraphQL) and secondary abuse detection mechanisms. The `GitHub` service is designed to be highly resilient against these constraints.
+GitHub's GraphQL allowance depends on how a request is authenticated. In particular, the repository `GITHUB_TOKEN` used by a GitHub Actions workflow receives **1,000 points per hour per repository**, rather than the 5,000-point user or baseline GitHub App allowance. The current values and exceptions are documented in GitHub's [GraphQL primary rate limits](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api#primary-rate-limit).
 
-### Header & Body Parsing
-The service tracks rate limits across multiple "buckets" (`core`, `search`, `graphql`). It updates its internal state dynamically by parsing the `x-ratelimit-*` headers attached to every response.
+The `GitHub` service therefore treats GraphQL points as their own admission currency. REST `core` capacity never stands in for GraphQL capacity.
 
-For GraphQL, it also hooks into the `rateLimit` object returned within the JSON body, which provides the most accurate reflection of the complex query costs.
+### Authoritative Snapshot & Response Cost
 
-### GraphQL Backoff
-GraphQL requests retain their existing bounded retry policy for server failures and `403` responses. A `403` with quota remaining is treated as secondary abuse detection and receives a longer cooldown; a depleted quota remains visible through the tracked `graphql` bucket.
+Before DevIndex admits updater work, `refreshGraphqlRateLimit()` reads `resources.graphql` from GitHub's REST `/rate_limit` endpoint. GitHub documents that this endpoint does not consume REST primary quota and that its response reports the independent GraphQL bucket. Every updater GraphQL operation also selects:
 
-```javascript
-if ((response.status >= 500 || response.status === 403) && retries > 0) {
-    let delay = (4 - retries) * 2000; // Default: 2s, 4s, 6s
-
-    // Secondary Rate Limit (Abuse Detection) Handling
-    if (response.status === 403) {
-        const bucket = this.rateLimit.graphql;
-        // If we have quota remaining but get a 403, it's an abuse trigger.
-        if (bucket.remaining > 0) {
-            delay = 10000; // 10s penalty box
-        }
-    }
-    // ... retry
+```graphql
+rateLimit {
+    cost
+    remaining
+    limit
+    resetAt
 }
 ```
 
-This path is GraphQL-specific. Its caller-supplied retry budget and secondary-abuse handling should not be confused with the independently configurable REST policy.
+The service updates `cost`, `remaining`, `limit`, and reset metadata after each response. Concurrent responses in the same reset window may lower the shared `remaining` value but cannot raise it when an older response arrives late. Capacity metadata from an older reset window cannot regress a newer snapshot; its already-incurred query cost still contributes to run telemetry.
+
+### Atomic Reservations
+
+`reserveGraphqlBudget(cost, reserve, context)` synchronously subtracts an in-flight reservation before a caller starts work. Sibling promises therefore cannot all admit against the same stale snapshot. `releaseGraphqlBudget()` is idempotent and returns unused capacity when that unit of work settles.
+
+The DevIndex updater reserves at most 32 points per admitted user and keeps 100 points untouched for the downstream content-index and SEO rebuild. These are conservative admission bounds, not an assertion that every user costs 32 points: response-reported `cost` and `remaining` continue to govern each later wave.
+
+### Primary Exhaustion vs. Per-Query Resource Limits
+
+Primary point exhaustion and a single query exceeding GitHub's resource ceiling are separate failure classes:
+
+- `GRAPHQL_PRIMARY_RATE_LIMIT` stops new admission immediately. It is not retried and cannot fan out into more requests.
+- `GRAPHQL_RESOURCE_LIMIT` tells the Updater that one multi-year contribution query was too large. Only that bounded window may split into single-year queries.
+- A `403` while GraphQL points remain is treated as secondary abuse detection and retains bounded backoff.
+
+GitHub explicitly advises clients not to retry primary-limit failures before the reported reset time. Its separate [resource-limit guidance](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api#other-resource-limits) recommends simplifying or splitting an oversized query.
 
 ### GraphQL Transient Retry & the Read/Mutation Boundary
-Beyond the server-failure/`403` policy above, the GraphQL path also retries **transient** failures — transport disconnects and GitHub's intermittent 200-body API errors (e.g. `Resource not accessible by integration`) — classified from the same shared `retryableTransientErrorPatterns` source of truth the REST path uses, so the two transports cannot drift into separate hand-maintained lists. Backoff uses the shared `restRetryBaseDelayMs` / `restRetryMaxDelayMs` / `restRetryJitterRatio` configs; their legacy REST-prefixed names remain stable for operator compatibility even though both transports now consume them.
+The GraphQL path retries **transient** failures — transport disconnects and GitHub's intermittent 200-body API errors (e.g. `Resource not accessible by integration`) — classified from the same shared `retryableTransientErrorPatterns` source of truth the REST path uses, so the two transports cannot drift into separate hand-maintained lists. Backoff uses the shared `restRetryBaseDelayMs` / `restRetryMaxDelayMs` / `restRetryJitterRatio` configs; their legacy REST-prefixed names remain stable for operator compatibility even though both transports now consume them.
 
 Retry **classification** (is the failure transient?) and retry **authorization** (is replay safe?) are separate decisions. A GraphQL `query` is idempotent by spec and safe to replay; a `mutation` is not. A transport disconnect leaves a mutation's server-side outcome unknowable, and a 200-body GraphQL response can carry partial `data` beside `errors` after mutation effects have applied. Mutations therefore fail loud rather than replay on either transient path; idempotent reads retain the bounded retry.
 

--- a/learn/guides/devindex/data-factory/Orchestrator.md
+++ b/learn/guides/devindex/data-factory/Orchestrator.md
@@ -57,7 +57,7 @@ This guarantees that the services always operate on valid, sorted, and pruned da
 When the `update` command is run, the Manager doesn't just blindly pass the whole queue to the Updater. It implements a smart scheduling algorithm:
 1.  It filters out any user who has already been successfully updated *today* (based on the `lastUpdate` timestamp).
 2.  It sorts the remaining backlog, prioritizing completely new users (`lastUpdate: null`) and the oldest records first.
-3.  It slices the queue to the requested batch limit to respect API quotas.
+3.  It slices the queue to the requested candidate limit. The Updater then applies GraphQL cost admission, so the limit remains a hard ceiling rather than a promise to process every candidate.
 
 ---
 
@@ -82,11 +82,13 @@ jobs:
         run: node ./buildScripts/dataSyncPipeline.mjs
 ```
 
-For each emission attempt, the publisher installs dependencies and runs `optin`, `optout`, the random Spider strategy, the Updater, and the shared content-index/SEO rebuild in that order. The current Updater ceiling remains 800; the pipeline may perform the complete sequence twice only when `dev` advances during the first attempt.
+For each emission attempt, the publisher installs dependencies and runs `optin`, `optout`, the random Spider strategy, the Updater, and the shared content-index/SEO rebuild in that order. The Updater's 200-candidate rollout ceiling is an upper bound; GraphQL budget admission may stop earlier. The pipeline may perform the complete sequence twice only when `dev` advances during the first attempt.
 
 ### Key Pipeline Concepts
 
 1.  **Privacy-First Execution:** The `optin` and `optout` services run *before* discovery or enrichment. This ensures we never accidentally index a user who requested removal in the same hour.
-2.  **Disposable Emission Attempts:** Each attempt captures its starting `dev` SHA. After the generators finish, the publisher fetches `origin/dev`. If authority moved, it discards the runner's derived output, resets to the new head, and reruns the complete emission once.
-3.  **Bounded Freshness:** Freshness is checked after emission, after staging, and immediately before publication. A second concurrent advance resets the ephemeral checkout again and fails with the attempt plus base/current SHAs instead of entering an unbounded retry loop.
-4.  **Atomic Allowlisted Commits:** Only DevIndex JSON/JSONL output, Portal data indexes, `sitemap.xml`, and `llms.txt` can enter the generated commit. The publisher never rebases, resolves derived-file conflicts, or force-pushes; the final non-force push therefore proves that its single commit is based on the verified current `dev` head.
+2.  **Cost-Bounded Enrichment:** The 200-user argument is a rollout ceiling. The Updater admits fewer users when its shared GraphQL budget cannot preserve the downstream reserve.
+3.  **Downstream Reservation:** DevIndex leaves declared GraphQL capacity for the label-index query in the following content-index and SEO rebuild.
+4.  **Disposable Emission Attempts:** Each attempt captures its starting `dev` SHA. After the generators finish, the publisher fetches `origin/dev`. If authority moved, it discards the runner's derived output, resets to the new head, and reruns the complete emission once.
+5.  **Bounded Freshness:** Freshness is checked after emission, after staging, and immediately before publication. A second concurrent advance resets the ephemeral checkout again and fails with the attempt plus base/current SHAs instead of entering an unbounded retry loop.
+6.  **Atomic Allowlisted Commits:** Only DevIndex JSON/JSONL output, Portal data indexes, `sitemap.xml`, and `llms.txt` can enter the generated commit. The publisher never rebases, resolves derived-file conflicts, or force-pushes; the final non-force push therefore proves that its single commit is based on the verified current `dev` head.

--- a/learn/guides/devindex/data-factory/Updater.md
+++ b/learn/guides/devindex/data-factory/Updater.md
@@ -54,12 +54,12 @@ The Updater begins by fetching the user's basic profile and public social accoun
 
 ```javascript readonly
 const profileQuery = `
-    query { 
-        rateLimit { remaining limit resetAt }
-        user(login: "${username}") { 
-            createdAt 
-            avatarUrl 
-            name 
+    query {
+        rateLimit { cost remaining limit resetAt }
+        user(login: "${username}") {
+            createdAt
+            avatarUrl
+            name
             location
             company
             bio
@@ -75,19 +75,19 @@ const profileQuery = `
                     url
                 }
             }
-        } 
+        }
     }`;
 ```
 
 #### The Multi-Year Contribution Matrix
-To build the historical charts on the frontend, the DevIndex requires the total contribution count for *every year* since the user created their account. 
+To build the historical charts on the frontend, the DevIndex requires the total contribution count for *every year* since the user created their account.
 
 Fetching this sequentially (one API call per year) is too slow. Fetching it all at once often results in GitHub API timeouts (`502 Bad Gateway` or `504 Gateway Timeout`) for prolific users. The Updater implements a smart **Chunking Strategy**:
 
 ```javascript readonly
 // We split the years into chunks of 4 to prevent 502/504 errors on large accounts.
 const yearChunks = [];
-const chunkSize  = 4; 
+const chunkSize  = 4;
 for (let y = startYear; y <= currentYear; y += chunkSize) {
     const end = Math.min(y + chunkSize - 1, currentYear);
     yearChunks.push({ start: y, end });
@@ -98,9 +98,18 @@ for (const chunk of yearChunks) {
     try {
         await fetchYears(chunk.start, chunk.end); // Fast Path
     } catch (err) {
-        // Fallback: If the 4-year chunk times out, try year-by-year
+        const canSplitWindow = chunk.start < chunk.end && (
+            GitHub.isGraphqlResourceLimitError(err) ||
+            /\b(502|504)\b|timeout|couldn't respond/i.test(err.message)
+        );
+
+        if (!canSplitWindow) {
+            throw err;
+        }
+
+        // Bounded fallback: try each year once for this window only.
         for (let y = chunk.start; y <= chunk.end; y++) {
-            await fetchYears(y, y); 
+            await fetchYears(y, y);
         }
     }
 }
@@ -121,22 +130,24 @@ The internet is chaotic. Users change their names, accounts get suspended, and A
 ```mermaid
 flowchart TD
     Error((API Error)) --> Type{Error Type?}
-    
+
     Type -- 5xx / Rate Limit --> Transient[Transient Error]
     Transient --> PB[Move to Penalty Box]
-    
+
     Type -- 404 / Not Found --> Fatal{Has History?}
-    
+
     Fatal -- Yes --> Rename{Check Database ID}
     Rename -- New Login Found --> Recover[Prune Old, Fetch New immediately]
     Rename -- No New Login --> Protected[Assume Suspended / Protected in Penalty Box]
-    
+
     Fatal -- No --> BadSeed[Bad Seed / Typo]
     BadSeed --> Prune[Prune from Tracker immediately]
 ```
 
 ### 1. Transient Errors (The Penalty Box)
-If a fetch fails due to a network timeout or a GitHub rate limit, the user is moved to the `failed.json` map (the "Penalty Box") and their `lastUpdate` timestamp in the tracker is refreshed. This pushes them to the back of the queue, allowing the system to retry them naturally on a subsequent pass.
+If an individual fetch fails due to a network or upstream error, the user is moved to the `failed.json` map (the "Penalty Box") and their `lastUpdate` timestamp in the tracker is refreshed. This pushes them to the back of the queue, allowing the system to retry them naturally on a subsequent pass.
+
+Primary GraphQL quota exhaustion is deliberately different: it is a run-level capacity boundary, not evidence that the user failed. The Updater stops admitting work and checkpoints completed results without adding the interrupted login to the Penalty Box or refreshing its timestamp.
 
 ### 2. The Rename Problem (Database ID Resolution)
 The most sophisticated recovery mechanism handles account renames.
@@ -153,14 +164,14 @@ if (isFatal && richUser && richUser.i) {
             console.log(`[${login}] 🔄 RENAME DETECTED -> ${newLogin}`);
 
             // 1. Mark old login for removal
-            indexUpdates.push({ login, delete: true }); 
-            prunedLogins.push(login); 
+            indexUpdates.push({ login, delete: true });
+            prunedLogins.push(login);
 
             // 2. Fetch data for new login immediately to preserve their spot
             const newData = await this.fetchUserData(newLogin);
             // ...
         }
-    } 
+    }
     // ...
 }
 ```
@@ -198,13 +209,21 @@ This guarantees that the database remains perfectly consistent, even if the Node
 
 ## Rate Limit Protection
 
-Because the Updater consumes significant GraphQL query points, it constantly monitors the quota. Before processing *every chunk*, it checks the `core` limit. If it drops below a critical threshold (e.g., 50 requests remaining), it instantly triggers a graceful shutdown. 
+The CLI `--limit` is only a candidate ceiling. At run start, the Updater obtains an authoritative GraphQL snapshot, keeps a 100-point downstream reserve, and admits candidates in waves of at most eight. Each in-flight user atomically reserves 32 points before its promise starts.
 
 ```javascript readonly
-if (GitHub.rateLimit.core.remaining < 50) {
-    console.warn(`[Updater] ⚠️ RATE LIMIT CRITICAL: Stopping gracefully.`);
-    break; 
+const reservation = GitHub.reserveGraphqlBudget(
+    config.github.graphqlUserReservation,
+    config.github.graphqlDownstreamReserve,
+    login
+);
+
+if (!reservation) {
+    stopReason = 'downstream-reserve';
+    break;
 }
 ```
 
-This prevents the Action from failing violently and ensures that all progress made up to that point is safely checkpointed to disk.
+Reservations close the stale-snapshot race between concurrent promises. After every settled wave, actual response-reported cost and remaining capacity determine whether the next wave can start. The 32-point bound covers the profile query, the oldest observed DevIndex account history split into four-year windows, one bounded single-year fallback per window, and rename-recovery margin.
+
+The scheduled workflow begins this rollout with a hard ceiling of 200 candidates. Actual admission may be lower. Compact logs report admitted candidates, observed cost, remaining points, active reservations, the protected reserve, and any stop reason. Completed work is checkpointed before a budget stop, leaving the downstream content-index and SEO rebuild its declared reserve.

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "devindex:optout"                      : "node ./apps/devindex/services/cli.mjs optout",
         "devindex:spider"                      : "node ./apps/devindex/services/cli.mjs spider",
         "cockpit"                              : "node ./buildScripts/devCockpit.mjs",
-        "devindex:update"                      : "node ./apps/devindex/services/cli.mjs update --limit 500",
+        "devindex:update"                      : "node ./apps/devindex/services/cli.mjs update --limit 200",
         "generate-docs-json"                   : "node ./buildScripts/docs/generateDocsJson.mjs",
         "prepare"                              : "if [ \"$npm_config_package_lock_only\" = \"true\" ]; then exit 0; fi; husky && node ./ai/scripts/setup/initServerConfigs.mjs",
         "server-start"                         : "webpack serve -c ./buildScripts/webpack/webpack.server.config.mjs --open",

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -114,7 +114,7 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
             ['npm', 'run', 'devindex:optin'],
             ['npm', 'run', 'devindex:optout'],
             ['npm', 'run', 'devindex:spider', '--', '--strategy', 'random'],
-            ['npm', 'run', 'devindex:update', '--', '--limit=800'],
+            ['npm', 'run', 'devindex:update', '--', '--limit=200'],
             [process.execPath, './buildScripts/docs/rebuildContentIndexesAndSeo.mjs', '--include-labels']
         ]);
         expect(calls.every(call => call.options.cwd === '/repo')).toBe(true)

--- a/test/playwright/unit/app/devindex/GitHubService.spec.mjs
+++ b/test/playwright/unit/app/devindex/GitHubService.spec.mjs
@@ -42,6 +42,7 @@ test.describe('DevIndex GitHub service', () => {
 
         process.env.GH_TOKEN                    = 'devindex-unit-test-token';
         restClient                              = new GitHub.constructor();
+        restClient.rateLimit                    = structuredClone(GitHub.rateLimit);
         restClient.restMaxRetryAttempts         = 2;
         restClient.restRetryBaseDelayMs         = 0;
         restClient.restRetryMaxDelayMs          = 0;
@@ -359,6 +360,146 @@ test.describe('DevIndex GitHub service', () => {
     // GraphQL error, transient despite its permissions wording) as fatal on attempt 1, though OptIn calls
     // query() with 3 retries. These pin the retry — and, per the AC, that it still gives up.
 
+    test('query captures response-reported GraphQL cost and reset metadata', async () => {
+        const resetAt = '2026-07-23T10:00:00Z';
+
+        globalThis.fetch = async () => jsonResponse({
+            data: {
+                rateLimit: {
+                    cost     : 7,
+                    limit    : 1000,
+                    remaining: 731,
+                    resetAt
+                },
+                viewer: {login: 'emmy'}
+            }
+        }, {
+            headers: {
+                'x-ratelimit-limit'    : '1000',
+                'x-ratelimit-remaining': '731',
+                'x-ratelimit-reset'    : String(Date.parse(resetAt) / 1000),
+                'x-ratelimit-resource' : 'graphql'
+            }
+        });
+
+        await expect(restClient.query('query { viewer { login } rateLimit { cost remaining resetAt } }'))
+            .resolves.toMatchObject({viewer: {login: 'emmy'}});
+
+        expect(restClient.rateLimit.graphql).toMatchObject({
+            cost     : 7,
+            limit    : 1000,
+            remaining: 731,
+            reset    : Date.parse(resetAt) / 1000
+        });
+    });
+
+    test('a late response from an older reset window cannot regress current GraphQL capacity', async () => {
+        const snapshots = [
+            {
+                cost     : 1,
+                limit    : 1000,
+                remaining: 900,
+                resetAt  : '2026-07-23T11:00:00Z'
+            },
+            {
+                cost     : 2,
+                limit    : 1000,
+                remaining: 9,
+                resetAt  : '2026-07-23T10:00:00Z'
+            }
+        ];
+
+        globalThis.fetch = async () => {
+            const rateLimit = snapshots.shift();
+
+            return jsonResponse({
+                data: {
+                    rateLimit,
+                    viewer: {login: 'emmy'}
+                }
+            }, {
+                headers: {
+                    'x-ratelimit-limit'    : String(rateLimit.limit),
+                    'x-ratelimit-remaining': String(rateLimit.remaining),
+                    'x-ratelimit-reset'    : String(Date.parse(rateLimit.resetAt) / 1000),
+                    'x-ratelimit-resource' : 'graphql'
+                }
+            })
+        };
+
+        await restClient.query('query { viewer { login } rateLimit { cost remaining resetAt } }');
+        await restClient.query('query { viewer { login } rateLimit { cost remaining resetAt } }');
+
+        expect(restClient.rateLimit.graphql).toMatchObject({
+            observedCost: 3,
+            remaining   : 900,
+            reset       : Date.parse('2026-07-23T11:00:00Z') / 1000
+        });
+    });
+
+    test('GraphQL reservations atomically preserve the downstream reserve', () => {
+        restClient.rateLimit.graphql = {
+            cost        : 0,
+            limit       : 1000,
+            observedCost: 0,
+            remaining   : 196,
+            reserved    : 0,
+            reset       : null
+        };
+
+        const first  = restClient.reserveGraphqlBudget(32, 100, 'first');
+        const second = restClient.reserveGraphqlBudget(32, 100, 'second');
+        const third  = restClient.reserveGraphqlBudget(32, 100, 'third');
+        const fourth = restClient.reserveGraphqlBudget(32, 100, 'fourth');
+
+        expect(first).toBeTruthy();
+        expect(second).toBeTruthy();
+        expect(third).toBeTruthy();
+        expect(fourth).toBeNull();
+        expect(restClient.getGraphqlBudget(100)).toMatchObject({
+            available: 0,
+            remaining: 196,
+            reserve  : 100,
+            reserved : 96
+        });
+
+        expect(restClient.releaseGraphqlBudget(second)).toBe(true);
+        expect(restClient.releaseGraphqlBudget(second), 'release is idempotent').toBe(false);
+        expect(restClient.reserveGraphqlBudget(32, 100, 'replacement')).toBeTruthy();
+    });
+
+    test('query classifies primary exhaustion without retrying it as a resource-limit failure', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+
+            return jsonResponse({
+                data: {
+                    rateLimit: {
+                        cost     : 1,
+                        limit    : 1000,
+                        remaining: 0,
+                        resetAt  : '2026-07-23T10:00:00Z'
+                    }
+                },
+                errors: [{message: 'API rate limit already exceeded for site ID installation.'}]
+            }, {
+                headers: {
+                    'x-ratelimit-limit'    : '1000',
+                    'x-ratelimit-remaining': '0',
+                    'x-ratelimit-resource' : 'graphql'
+                }
+            });
+        };
+
+        const error = await restClient.query('query { viewer { login } }', {}, 3).catch(value => value);
+
+        expect(error.code).toBe('GRAPHQL_PRIMARY_RATE_LIMIT');
+        expect(restClient.isGraphqlResourceLimitError(error)).toBe(false);
+        expect(callCount).toBe(1);
+    });
+
     test('query retries the transient "Resource not accessible by integration" body error, then succeeds', async () => {
         let callCount = 0;
 
@@ -510,12 +651,11 @@ test.describe('DevIndex GitHub service', () => {
         expect(readCalls, 'an idempotent read retries the same transient failure').toBe(2);
     });
 
-    test('query does NOT replay a mutation after a 5xx server error — a read retries, and a 403 rate-limit still replays either (#15454)', async () => {
+    test('query does NOT replay a mutation after a 5xx; reads retry, while primary-limit 403 fails fast (#15454, #15745)', async () => {
         // A `>= 500` leaves a MUTATION's server-side outcome ambiguous (the write may have applied before
-        // the error), so it is not replayed — an idempotent read is. A `403` is a pre-execution rate-limit
-        // rejection (the write never ran), so it is always safe to replay, mutation or not. retries=4 zeroes
-        // this path's hardcoded `(4 - retries) * 2000` first-retry backoff — unlike the transient-body path
-        // it is not wired to the configurable delay knobs (a noted follow-up).
+        // the error), so it is not replayed — an idempotent read is. A `403` with zero GraphQL points is
+        // primary exhaustion: replay may be side-effect safe but cannot succeed before reset, so the
+        // client requires a typed fail-fast result. retries=4 zeroes the 5xx first-retry backoff.
         const mutationDoc = `
             mutation($subjectId: ID!, $body: String!) {
                 addComment(input: {subjectId: $subjectId, body: $body}) { clientMutationId }
@@ -539,19 +679,24 @@ test.describe('DevIndex GitHub service', () => {
             .resolves.toEqual({viewer: {login: 'ada'}});
         expect(readCalls, 'an idempotent read retries the same 5xx').toBe(2);
 
-        // MUTATION on a 403: IS replayed — a pre-execution rate-limit reject never ran the write. A zero
-        // remaining bucket keeps it on the standard backoff (a >0 quota would trip the 10s abuse penalty).
+        // MUTATION on a primary-limit 403: NOT replayed — zero remaining cannot recover before reset.
         restClient.rateLimit.graphql.remaining = 0;
         let rateLimitedMutationCalls = 0;
         globalThis.fetch = async () => {
             rateLimitedMutationCalls++;
-            return rateLimitedMutationCalls === 1
-                ? new Response('', {status: 403, statusText: 'Forbidden'})
-                : jsonResponse({data: {addComment: {clientMutationId: 'ok'}}});
+            return new Response('', {
+                status    : 403,
+                statusText: 'Forbidden',
+                headers   : {
+                    'x-ratelimit-remaining': '0',
+                    'x-ratelimit-resource' : 'graphql'
+                }
+            });
         };
-        await expect(restClient.query(mutationDoc, {}, 4, 'OptIn Comment'))
-            .resolves.toEqual({addComment: {clientMutationId: 'ok'}});
-        expect(rateLimitedMutationCalls, 'a 403 rate-limit is pre-execution, so a mutation safely replays').toBe(2);
+        const rateLimitError = await restClient.query(mutationDoc, {}, 4, 'OptIn Comment').catch(error => error);
+
+        expect(rateLimitError.code).toBe('GRAPHQL_PRIMARY_RATE_LIMIT');
+        expect(rateLimitedMutationCalls, 'a depleted primary budget cannot recover by replaying').toBe(1);
     });
 
     test('query does NOT replay a mutation after an in-body gateway (502/504) error — a read retries (#15454)', async () => {

--- a/test/playwright/unit/app/devindex/UpdaterGraphqlBudget.spec.mjs
+++ b/test/playwright/unit/app/devindex/UpdaterGraphqlBudget.spec.mjs
@@ -1,0 +1,232 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DevIndexUpdaterGraphqlBudgetTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import config         from '../../../../../apps/devindex/services/config.mjs';
+import GitHub         from '../../../../../apps/devindex/services/GitHub.mjs';
+import Storage        from '../../../../../apps/devindex/services/Storage.mjs';
+import Updater        from '../../../../../apps/devindex/services/Updater.mjs';
+
+test.describe.serial('DevIndex Updater GraphQL budget (#15745)', () => {
+    let originalFetchUserData,
+        originalGetAllowlist,
+        originalGetLowestContributionThreshold,
+        originalGetUsers,
+        originalQuery,
+        originalRateLimit,
+        originalRefreshGraphqlRateLimit,
+        originalRest,
+        originalUpdateFailed,
+        originalUpdateTracker,
+        originalUpdateUsers,
+        originalDeleteUsers,
+        originalConcurrency,
+        originalDownstreamReserve,
+        originalUserReservation,
+        calls;
+
+    test.beforeEach(() => {
+        originalFetchUserData                   = Updater.fetchUserData;
+        originalGetAllowlist                    = Storage.getAllowlist;
+        originalGetLowestContributionThreshold = Storage.getLowestContributionThreshold;
+        originalGetUsers                        = Storage.getUsers;
+        originalQuery                           = GitHub.query;
+        originalRateLimit                       = GitHub.rateLimit;
+        originalRefreshGraphqlRateLimit         = GitHub.refreshGraphqlRateLimit;
+        originalRest                            = GitHub.rest;
+        originalUpdateFailed                    = Storage.updateFailed;
+        originalUpdateTracker                   = Storage.updateTracker;
+        originalUpdateUsers                     = Storage.updateUsers;
+        originalDeleteUsers                     = Storage.deleteUsers;
+        originalConcurrency                     = config.updater.concurrency;
+        originalDownstreamReserve               = config.github.graphqlDownstreamReserve;
+        originalUserReservation                 = config.github.graphqlUserReservation;
+
+        calls = {
+            failedUpdates: [],
+            fetched      : [],
+            tracker      : [],
+            users        : []
+        };
+
+        config.updater.concurrency              = 8;
+        config.github.graphqlDownstreamReserve  = 100;
+        config.github.graphqlUserReservation    = 32;
+        GitHub.rateLimit                        = {
+            core: {
+                limit    : 5000,
+                remaining: 5000,
+                reset    : null
+            },
+            graphql: {
+                cost        : 0,
+                limit       : 1000,
+                observedCost: 0,
+                remaining   : 1000,
+                reserved    : 0,
+                reset       : null
+            }
+        };
+        GitHub.refreshGraphqlRateLimit           = async () => GitHub.rateLimit.graphql;
+        Storage.getAllowlist                    = async () => new Set();
+        Storage.getLowestContributionThreshold = async () => 0;
+        Storage.getUsers                        = async () => [];
+        Storage.updateFailed                    = async (logins, add) => calls.failedUpdates.push({logins, add});
+        Storage.updateTracker                   = async updates => calls.tracker.push(...updates);
+        Storage.updateUsers                     = async records => calls.users.push(...records);
+        Storage.deleteUsers                     = async () => {};
+    });
+
+    test.afterEach(() => {
+        Updater.fetchUserData                   = originalFetchUserData;
+        GitHub.query                            = originalQuery;
+        GitHub.rateLimit                        = originalRateLimit;
+        GitHub.refreshGraphqlRateLimit          = originalRefreshGraphqlRateLimit;
+        GitHub.rest                             = originalRest;
+        Storage.getAllowlist                    = originalGetAllowlist;
+        Storage.getLowestContributionThreshold = originalGetLowestContributionThreshold;
+        Storage.getUsers                        = originalGetUsers;
+        Storage.updateFailed                    = originalUpdateFailed;
+        Storage.updateTracker                   = originalUpdateTracker;
+        Storage.updateUsers                     = originalUpdateUsers;
+        Storage.deleteUsers                     = originalDeleteUsers;
+        config.updater.concurrency              = originalConcurrency;
+
+        if (originalDownstreamReserve === undefined) {
+            delete config.github.graphqlDownstreamReserve
+        } else {
+            config.github.graphqlDownstreamReserve = originalDownstreamReserve
+        }
+
+        if (originalUserReservation === undefined) {
+            delete config.github.graphqlUserReservation
+        } else {
+            config.github.graphqlUserReservation = originalUserReservation
+        }
+    });
+
+    test('high REST capacity cannot admit work when GraphQL capacity is below reserve', async () => {
+        GitHub.rateLimit.graphql.remaining = 120;
+        Updater.fetchUserData = async login => {
+            calls.fetched.push(login);
+            return {l: login, lu: '2026-07-23T09:00:00.000Z', tc: 2000}
+        };
+
+        await Updater.processBatch(['alpha', 'beta']);
+
+        expect(GitHub.rateLimit.core.remaining).toBe(5000);
+        expect(calls.fetched).toEqual([]);
+        expect(calls.users).toEqual([]);
+        expect(calls.tracker).toEqual([]);
+    });
+
+    test('capacity-derived admission stays below the CLI candidate ceiling and checkpoints admitted users', async () => {
+        GitHub.rateLimit.graphql.remaining = 164;
+        Updater.fetchUserData = async login => {
+            calls.fetched.push(login);
+            GitHub.rateLimit.graphql.remaining -= 32;
+
+            return {
+                l : login,
+                lu: `2026-07-23T09:00:0${calls.fetched.length}.000Z`,
+                tc: 2000
+            }
+        };
+
+        await Updater.processBatch(['alpha', 'beta', 'gamma', 'delta']);
+
+        expect(calls.fetched).toEqual(['alpha', 'beta']);
+        expect(calls.users.map(user => user.l)).toEqual(['alpha', 'beta']);
+        expect(calls.tracker.map(update => update.login)).toEqual(['alpha', 'beta']);
+        expect(GitHub.rateLimit.graphql.remaining).toBe(100);
+        expect(GitHub.rateLimit.graphql.reserved).toBe(0);
+    });
+
+    test('resource-limit fallback is bounded to single years and requests response cost', async () => {
+        const contributionQueries = [];
+
+        GitHub.rest = async () => [];
+        GitHub.query = async query => {
+            expect(query).toContain('rateLimit { cost remaining limit resetAt }');
+
+            if (query.includes('socialAccounts')) {
+                return {
+                    rateLimit: {cost: 1, limit: 1000, remaining: 999, resetAt: '2026-07-23T10:00:00Z'},
+                    user     : {
+                        createdAt               : '2023-01-01T00:00:00Z',
+                        followers               : {totalCount: 0},
+                        socialAccounts          : {nodes: []},
+                        sponsorshipsAsMaintainer: {totalCount: 0}
+                    }
+                }
+            }
+
+            contributionQueries.push(query);
+
+            if (contributionQueries.length === 1) {
+                const error = new Error('GraphQL Query Errors: Resource limits for this query exceeded.');
+                error.code  = 'GRAPHQL_RESOURCE_LIMIT';
+                throw error
+            }
+
+            const year = query.match(/y(\d{4}):/)?.[1];
+
+            return {
+                rateLimit: {cost: 1, limit: 1000, remaining: 998, resetAt: '2026-07-23T10:00:00Z'},
+                user     : {
+                    [`y${year}`]: {
+                        restrictedContributionsCount       : 0,
+                        totalCommitContributions           : 1,
+                        totalIssueContributions            : 0,
+                        totalPullRequestContributions      : 0,
+                        totalPullRequestReviewContributions: 0,
+                        totalRepositoryContributions       : 0,
+                        commitContributionsByRepository    : []
+                    }
+                }
+            }
+        };
+
+        await expect(originalFetchUserData.call(Updater, 'resource-heavy')).resolves.toMatchObject({
+            l : 'resource-heavy',
+            tc: 4
+        });
+        expect(contributionQueries).toHaveLength(5);
+    });
+
+    test('primary exhaustion never fans out into single-year fallback requests', async () => {
+        const contributionQueries = [];
+
+        GitHub.rest = async () => [];
+        GitHub.query = async query => {
+            if (query.includes('socialAccounts')) {
+                return {
+                    rateLimit: {cost: 1, limit: 1000, remaining: 9, resetAt: '2026-07-23T10:00:00Z'},
+                    user     : {
+                        createdAt               : '2023-01-01T00:00:00Z',
+                        followers               : {totalCount: 0},
+                        socialAccounts          : {nodes: []},
+                        sponsorshipsAsMaintainer: {totalCount: 0}
+                    }
+                }
+            }
+
+            contributionQueries.push(query);
+
+            const error = new Error('GraphQL Query Errors: API rate limit already exceeded for site ID installation.');
+            error.code  = 'GRAPHQL_PRIMARY_RATE_LIMIT';
+            throw error
+        };
+
+        await expect(originalFetchUserData.call(Updater, 'quota-exhausted'))
+            .rejects.toMatchObject({code: 'GRAPHQL_PRIMARY_RATE_LIMIT'});
+        expect(contributionQueries).toHaveLength(1);
+    });
+});

--- a/test/playwright/unit/app/devindex/UpdaterRenameRecovery.spec.mjs
+++ b/test/playwright/unit/app/devindex/UpdaterRenameRecovery.spec.mjs
@@ -20,6 +20,7 @@ test.describe.serial('DevIndex Updater rename recovery (#11516)', () => {
         originalGetLowestContributionThreshold,
         originalGetUsers,
         originalRateLimit,
+        originalRefreshGraphqlRateLimit,
         originalUpdateFailed,
         originalUpdateTracker,
         originalUpdateUsers,
@@ -33,6 +34,7 @@ test.describe.serial('DevIndex Updater rename recovery (#11516)', () => {
         originalGetLowestContributionThreshold = Storage.getLowestContributionThreshold;
         originalGetUsers                      = Storage.getUsers;
         originalRateLimit                     = GitHub.rateLimit;
+        originalRefreshGraphqlRateLimit        = GitHub.refreshGraphqlRateLimit;
         originalUpdateFailed                  = Storage.updateFailed;
         originalUpdateTracker                 = Storage.updateTracker;
         originalUpdateUsers                   = Storage.updateUsers;
@@ -49,8 +51,17 @@ test.describe.serial('DevIndex Updater rename recovery (#11516)', () => {
             core: {
                 limit    : 5000,
                 remaining: 5000
+            },
+            graphql: {
+                cost        : 0,
+                limit       : 1000,
+                observedCost: 0,
+                remaining   : 1000,
+                reserved    : 0,
+                reset       : null
             }
         };
+        GitHub.refreshGraphqlRateLimit          = async () => GitHub.rateLimit.graphql;
 
         Storage.getAllowlist                  = async () => new Set();
         Storage.getLowestContributionThreshold = async () => 0;
@@ -70,6 +81,7 @@ test.describe.serial('DevIndex Updater rename recovery (#11516)', () => {
         Updater.fetchUserData                 = originalFetchUserData;
         GitHub.getLoginByDatabaseId          = originalGetLoginByDatabaseId;
         GitHub.rateLimit                     = originalRateLimit;
+        GitHub.refreshGraphqlRateLimit        = originalRefreshGraphqlRateLimit;
         Storage.getAllowlist                 = originalGetAllowlist;
         Storage.getLowestContributionThreshold = originalGetLowestContributionThreshold;
         Storage.getUsers                     = originalGetUsers;
@@ -124,6 +136,28 @@ test.describe.serial('DevIndex Updater rename recovery (#11516)', () => {
             {login: '0xBigBoss', delete: true},
             {login: 'alleneubank', lastUpdate: replacement.lu}
         ]);
+        expect(calls.failedUpdates).toEqual([]);
+    });
+
+    test('primary exhaustion during replacement fetch leaves the old login immediately retryable', async () => {
+        GitHub.getLoginByDatabaseId = async () => 'alleneubank';
+
+        Updater.fetchUserData = async login => {
+            if (login === '0xBigBoss') {
+                throw new Error('NOT_FOUND');
+            }
+
+            const error = new Error('API rate limit already exceeded for site ID installation.');
+
+            error.code = 'GRAPHQL_PRIMARY_RATE_LIMIT';
+            throw error
+        };
+
+        await Updater.processBatch(['0xBigBoss']);
+
+        expect(calls.deleteUsers).toEqual([]);
+        expect(calls.users).toEqual([]);
+        expect(calls.tracker).toEqual([]);
         expect(calls.failedUpdates).toEqual([]);
     });
 });


### PR DESCRIPTION
Resolves #15745

Evidence: L3 focused service/updater/publisher coverage plus a live, read-only GitHub GraphQL cost probe. The three-run post-merge operational witness is tracked separately by #15751. Residual: none for the implementation contract owned by #15745.

## Deltas from ticket

- Makes the GraphQL bucket authoritative for DevIndex admission, with atomic per-user reservations, observed query-cost reconciliation, reset-window ordering, and a protected downstream reserve.
- Refreshes the GraphQL snapshot from GitHub's `/rate_limit` endpoint before admission, while retaining per-query `rateLimit` metadata as the live accounting signal.
- Separates primary quota exhaustion from single-query resource limits: primary exhaustion stops and checkpoints without retry, year-window fan-out, Penalty Box mutation, or tracker mutation; only bounded resource-limit/502/504/timeout cases may split contribution windows.
- Restores both scheduled and package-script rollout ceilings to 200; the CLI limit remains a ceiling while actual admissions are capacity-derived.
- Reconciles the publisher substrate merged by #15750: the workflow continues to delegate to `buildScripts/dataSyncPipeline.mjs`, its actual Updater invocation now carries `--limit=200`, and the publisher contract test pins that argv.
- Re-derives the 30-day Penalty Box retention rationale from the 200-candidate ceiling: a theoretical 50,000-user pass takes about 10.4 days, while GraphQL admission can make a real pass longer. The policy is therefore time-based rather than a guaranteed attempt count.
- Adds compact budget telemetry and updates the DevIndex data-factory guides to describe the runtime contract.
- Corrects one ticket premise exposed by live source inspection: the pre-change service tracked GraphQL `remaining` and reset metadata, but did **not** yet capture response `cost`. This patch adds that missing accounting.
- Adds stale-response and rename-recovery coverage beyond the original examples because both could otherwise regress a newer budget snapshot or misclassify primary exhaustion.
- Splits the post-merge scheduled-run witness into #15751 so this implementation PR can close #15745 exactly once.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/app/devindex/GitHubService.spec.mjs test/playwright/unit/app/devindex/UpdaterRenameRecovery.spec.mjs test/playwright/unit/app/devindex/UpdaterGraphqlBudget.spec.mjs test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs` — 42 passed on the rebased source, including the merged publisher contract.
- Initial red run produced four expected failures for missing cost capture, shared reservations, primary classification, and wrong-bucket admission; the added reset-window and rename-primary edge tests also failed before their fixes.
- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs` — passed against the real documentation tree.
- `npm run test-unit` — 9,040 passed, 15 failed, 6 skipped, and 48 did not run. The late failures were sandbox denials for process inspection and `.neo-ai-data` writes plus one tree-lint timeout; the isolated residual set passed 14/14 with the required permissions.
- `npm run agent-preflight -- --no-fix <13 changed files>` — passed on current head; only unrelated non-blocking stale-overlay warnings were reported.
- The real pre-commit hook passed; `git diff --check` passed.
- A live read-only probe of the updater's four-year contribution query shape reported `cost: 1`, `limit: 5000`, `remaining: 4959`. GitHub documents the independent GraphQL primary bucket and the Actions `GITHUB_TOKEN` limit of 1,000 points/hour/repository: https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api

## Post-Merge Validation

- #15751 owns the three scheduled Data Sync receipts after this change reaches `dev`.
- Each receipt records the run URL, head SHA, admitted users, observed cost, remaining capacity, reserve, stop reason, and downstream label-index outcome.
- A failed witness creates a new defect ticket; #15745 remains closed under Neo's never-reopen contract.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session `72bb1088-8ed5-48b7-a835-c288cf30e814`.
