### PR TITLE
fix(build): regenerate stale Data Sync output (#15746)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -19,69 +19,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run DevIndex Opt-In
+      - name: Run bounded Data Sync emission and publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run devindex:optin
-
-      - name: Run DevIndex Opt-Out
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run devindex:optout
-
-      - name: Run DevIndex Spider
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run devindex:spider -- --strategy random
-
-      - name: Run DevIndex Updater
-        run: npm run devindex:update -- --limit=800
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Rebuild Indexes & SEO
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node ./buildScripts/docs/rebuildContentIndexesAndSeo.mjs --include-labels
-
-      - name: Commit, Rebase and Push
-        run: |
-          # Configure Git
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # Check for changes in specific files
-          if [[ -n $(git status -s apps/devindex/resources/data/*.json* apps/portal/resources/data apps/portal/sitemap.xml apps/portal/llms.txt) ]]; then
-            echo "Changes detected in data files."
-
-            # Stage the files
-            git add apps/devindex/resources/data/*.json* apps/portal/resources/data apps/portal/sitemap.xml apps/portal/llms.txt
-
-            # Commit (neo repo). --no-verify: generated data fails whitespace hooks. NEO_SKIP_TICKET_ARCHAEOLOGY:
-            # the explicit archaeology-gate exemption for the generated-data class (declares intent + future-proofs;
-            # co-exists with --no-verify, which these commits still need for whitespace).
-            NEO_SKIP_TICKET_ARCHAEOLOGY=1 git commit --no-verify -m "chore(data): Hourly data sync pipeline update [skip ci]"
-
-            # Discard any other unstaged changes to allow rebase
-            git reset --hard
-
-            # Rebase on top of remote changes to handle concurrent pushes
-            git pull origin dev --rebase
-
-            # Push changes
-            git push origin dev
-          else
-            echo "No changes detected. Skipping commit."
-          fi
+        run: node ./buildScripts/dataSyncPipeline.mjs
 
       - name: Push Data to neomjs/pages
         env:

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -1,0 +1,462 @@
+#!/usr/bin/env node
+
+import {spawn}         from 'node:child_process';
+import path            from 'node:path';
+import process         from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+/**
+ * @module buildScripts.dataSyncPipeline
+ * @summary Runs the scheduled Data Sync emission from a verified `dev` head and
+ * publishes one allowlisted generated-data commit without rebasing.
+ *
+ * A concurrent `dev` advance invalidates the entire emission attempt. The
+ * ephemeral Actions checkout is reset to the new remote authority and the full
+ * pipeline is rerun once; a second advance fails cleanly after another reset.
+ */
+
+export const GENERATED_DATA_PATHS = [
+    ':(glob)apps/devindex/resources/data/*.json*',
+    'apps/portal/resources/data',
+    'apps/portal/sitemap.xml',
+    'apps/portal/llms.txt'
+];
+
+const
+    commitMessage    = 'chore(data): Hourly data sync pipeline update [skip ci]',
+    remoteDevRef     = 'refs/remotes/origin/dev',
+    emissionCommands = [
+        {
+            args   : ['ci'],
+            command: 'npm',
+            label  : 'install dependencies'
+        },
+        {
+            args   : ['run', 'devindex:optin'],
+            command: 'npm',
+            label  : 'DevIndex Opt-In'
+        },
+        {
+            args   : ['run', 'devindex:optout'],
+            command: 'npm',
+            label  : 'DevIndex Opt-Out'
+        },
+        {
+            args   : ['run', 'devindex:spider', '--', '--strategy', 'random'],
+            command: 'npm',
+            label  : 'DevIndex Spider'
+        },
+        {
+            args   : ['run', 'devindex:update', '--', '--limit=800'],
+            command: 'npm',
+            label  : 'DevIndex Updater'
+        },
+        {
+            args   : ['./buildScripts/docs/rebuildContentIndexesAndSeo.mjs', '--include-labels'],
+            command: process.execPath,
+            label  : 'content indexes and SEO'
+        }
+    ];
+
+/**
+ * @summary Runs one child process with argv-array isolation and optional output capture.
+ * @param {String}   command Executable name or path.
+ * @param {String[]} args Executable arguments.
+ * @param {Object}   [options]
+ * @param {Boolean}  [options.capture=false] Capture stdout/stderr instead of inheriting them.
+ * @param {String}   [options.cwd=process.cwd()] Child working directory.
+ * @param {Object}   [options.env=process.env] Child environment.
+ * @returns {Promise<{stderr: String, stdout: String}>}
+ */
+export function executeCommand(command, args, {
+    capture = false,
+    cwd     = process.cwd(),
+    env     = process.env
+} = {}) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            cwd,
+            env,
+            stdio: capture ? ['ignore', 'pipe', 'pipe'] : 'inherit'
+        });
+        let stderr = '',
+            stdout = '';
+
+        if (capture) {
+            child.stdout.on('data', chunk => {
+                stdout += chunk
+            });
+            child.stderr.on('data', chunk => {
+                stderr += chunk
+            })
+        }
+
+        child.on('error', reject);
+        child.on('close', code => {
+            if (code === 0) {
+                resolve({stderr, stdout});
+                return
+            }
+
+            const detail = stderr.trim();
+            const error  = new Error(
+                `${command} ${args.join(' ')} exited with code ${code}${detail ? `: ${detail}` : ''}`
+            );
+
+            error.code   = code;
+            error.stderr = stderr;
+            error.stdout = stdout;
+            reject(error)
+        })
+    })
+}
+
+/**
+ * @summary Identifies paths admitted to the generated Data Sync publication commit.
+ * @param {String} filePath Repository-relative path.
+ * @returns {Boolean}
+ */
+export function isGeneratedDataPath(filePath) {
+    return /^apps\/devindex\/resources\/data\/[^/]+\.json.*$/u.test(filePath)
+        || filePath === 'apps/portal/sitemap.xml'
+        || filePath === 'apps/portal/llms.txt'
+        || filePath.startsWith('apps/portal/resources/data/')
+}
+
+/**
+ * @summary Executes one git argv sequence through the injected process boundary.
+ * @param {Function} execute Child-process executor.
+ * @param {String}   cwd Repository root.
+ * @param {String[]} args Git arguments.
+ * @param {Object}   [options]
+ * @param {Boolean}  [options.capture=true] Capture command output.
+ * @param {Object}   [options.env=process.env] Command environment.
+ * @returns {Promise<{stderr: String, stdout: String}>}
+ */
+async function git(execute, cwd, args, {capture = true, env = process.env} = {}) {
+    return execute('git', args, {capture, cwd, env})
+}
+
+/**
+ * @summary Reads one git revision as a normalized SHA.
+ * @param {Function} execute Child-process executor.
+ * @param {String}   cwd Repository root.
+ * @param {String}   ref Git revision.
+ * @returns {Promise<String>}
+ */
+async function readSha(execute, cwd, ref) {
+    const {stdout} = await git(execute, cwd, ['rev-parse', ref]);
+
+    return stdout.trim()
+}
+
+/**
+ * @summary Refreshes the local `origin/dev` tracking ref and returns its SHA.
+ * @param {Function} execute Child-process executor.
+ * @param {String}   cwd Repository root.
+ * @returns {Promise<String>}
+ */
+async function fetchRemoteDev(execute, cwd) {
+    await git(execute, cwd, ['fetch', 'origin', `dev:${remoteDevRef}`]);
+
+    return readSha(execute, cwd, 'origin/dev')
+}
+
+/**
+ * @summary Restores the ephemeral runner to a clean current `origin/dev` checkout.
+ * @param {Function} execute Child-process executor.
+ * @param {String}   cwd Repository root.
+ * @returns {Promise<String>} Restored remote SHA.
+ */
+async function restoreRemoteDev(execute, cwd) {
+    const remoteSha = await fetchRemoteDev(execute, cwd);
+
+    await git(execute, cwd, ['reset', '--hard', 'origin/dev']);
+    await git(execute, cwd, ['clean', '-fd', '--', ...GENERATED_DATA_PATHS]);
+
+    return remoteSha
+}
+
+/**
+ * @summary Reads the repository-relative paths currently staged for publication.
+ * @param {Function} execute Child-process executor.
+ * @param {String}   cwd Repository root.
+ * @returns {Promise<String[]>}
+ */
+async function readStagedPaths(execute, cwd) {
+    const {stdout} = await git(execute, cwd, ['diff', '--cached', '--name-only']);
+
+    return stdout.trim().split('\n').map(file => file.trim()).filter(Boolean)
+}
+
+/**
+ * @summary Rejects any staged path outside the generated-data publication allowlist.
+ * @param {String[]} paths Repository-relative staged paths.
+ * @returns {void}
+ */
+function assertGeneratedOnly(paths) {
+    const rejected = paths.filter(filePath => !isGeneratedDataPath(filePath));
+
+    if (rejected.length > 0) {
+        throw new Error(`Data Sync staging rejected non-generated paths: ${rejected.join(', ')}`)
+    }
+}
+
+/**
+ * @summary Emits compact attempt/base/current freshness telemetry.
+ * @param {Object}   options
+ * @param {Number}   options.attempt Current attempt number.
+ * @param {String}   options.baseSha Emission base SHA.
+ * @param {String}   options.currentSha Current remote SHA.
+ * @param {Function} options.log Telemetry sink.
+ * @param {Number}   options.maxAttempts Maximum attempt count.
+ * @param {String}   options.phase Freshness checkpoint name.
+ * @returns {Promise<void>}
+ */
+async function logFreshness({attempt, baseSha, currentSha, log, maxAttempts, phase}) {
+    log(
+        `[DataSync] freshness phase=${phase} attempt=${attempt}/${maxAttempts} ` +
+        `base=${baseSha} current=${currentSha}`
+    )
+}
+
+/**
+ * @summary Discards one stale emission and either prepares the retry or fails cleanly on exhaustion.
+ * @param {Object}   options
+ * @param {Number}   options.attempt Current attempt number.
+ * @param {String}   options.baseSha Emission base SHA.
+ * @param {String}   options.currentSha Current remote SHA.
+ * @param {Function} options.execute Child-process executor.
+ * @param {String}   options.cwd Repository root.
+ * @param {Function} options.log Telemetry sink.
+ * @param {Number}   options.maxAttempts Maximum attempt count.
+ * @param {String}   options.phase Freshness checkpoint name.
+ * @returns {Promise<void>}
+ */
+async function recoverStaleAttempt({
+    attempt,
+    baseSha,
+    currentSha,
+    execute,
+    cwd,
+    log,
+    maxAttempts,
+    phase
+}) {
+    await logFreshness({attempt, baseSha, currentSha, log, maxAttempts, phase});
+    log(`[DataSync] stale-head action=discard-and-reset attempt=${attempt}/${maxAttempts}`);
+    await restoreRemoteDev(execute, cwd);
+
+    if (attempt >= maxAttempts) {
+        throw new Error(
+            `Data Sync stopped cleanly because dev advanced during all ${maxAttempts} emission attempts ` +
+            `(last phase=${phase}, base=${baseSha}, current=${currentSha})`
+        )
+    }
+}
+
+/**
+ * @summary Runs the complete generated-output emission sequence for one fresh-head attempt.
+ * @param {Object}   options
+ * @param {Number}   options.attempt Current attempt number.
+ * @param {String}   options.cwd Repository root.
+ * @param {Function} options.execute Child-process executor.
+ * @param {Function} options.log Telemetry sink.
+ * @returns {Promise<void>}
+ */
+export async function emitGeneratedData({attempt, cwd, execute = executeCommand, log = console.log}) {
+    for (const {args, command, label} of emissionCommands) {
+        log(`[DataSync] emit attempt=${attempt} stage=${label}`);
+        await execute(command, args, {cwd, env: process.env})
+    }
+}
+
+/**
+ * @summary Emits and publishes generated Data Sync output from a verified current `dev` head.
+ *
+ * Each attempt is disposable. If `origin/dev` advances after emission, after staging, or
+ * immediately before a non-force push, the runner resets to the new authority and re-emits
+ * once. Exhaustion always leaves the ephemeral checkout at the current remote head.
+ *
+ * @param {Object}   [options]
+ * @param {String}   [options.cwd=process.cwd()] Repository root.
+ * @param {Function} [options.emit=emitGeneratedData] Complete per-attempt emission callback.
+ * @param {Function} [options.execute=executeCommand] Child-process executor.
+ * @param {Function} [options.log=console.log] Compact telemetry sink.
+ * @param {Number}   [options.maxAttempts=2] Maximum fresh-head emission attempts.
+ * @returns {Promise<{attempts: Number, baseSha: String, changed: Boolean, pushed: Boolean}>}
+ */
+export async function runDataSyncPipeline({
+    cwd         = process.cwd(),
+    emit        = emitGeneratedData,
+    execute     = executeCommand,
+    log         = console.log,
+    maxAttempts = 2
+} = {}) {
+    if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+        throw new TypeError('maxAttempts must be a positive integer')
+    }
+
+    await git(execute, cwd, ['config', 'user.name', 'github-actions[bot]']);
+    await git(execute, cwd, [
+        'config',
+        'user.email',
+        '41898282+github-actions[bot]@users.noreply.github.com'
+    ]);
+    await restoreRemoteDev(execute, cwd);
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const baseSha = await readSha(execute, cwd, 'HEAD');
+
+        log(`[DataSync] attempt=${attempt}/${maxAttempts} base=${baseSha}`);
+        await emit({attempt, baseSha, cwd, execute, log});
+
+        let currentSha = await fetchRemoteDev(execute, cwd);
+
+        await logFreshness({
+            attempt,
+            baseSha,
+            currentSha,
+            log,
+            maxAttempts,
+            phase: 'post-emission'
+        });
+
+        if (currentSha !== baseSha) {
+            await recoverStaleAttempt({
+                attempt,
+                baseSha,
+                currentSha,
+                execute,
+                cwd,
+                log,
+                maxAttempts,
+                phase: 'post-emission'
+            });
+            continue
+        }
+
+        const {stdout: status} = await git(execute, cwd, [
+            'status',
+            '--porcelain',
+            '--untracked-files=all',
+            '--',
+            ...GENERATED_DATA_PATHS
+        ]);
+
+        if (!status.trim()) {
+            log(`[DataSync] publish attempt=${attempt}/${maxAttempts} result=no-generated-changes`);
+
+            return {attempts: attempt, baseSha, changed: false, pushed: false}
+        }
+
+        await git(execute, cwd, ['add', '-A', '--', ...GENERATED_DATA_PATHS]);
+
+        const stagedPaths = await readStagedPaths(execute, cwd);
+
+        assertGeneratedOnly(stagedPaths);
+        log(`[DataSync] staged attempt=${attempt}/${maxAttempts} files=${stagedPaths.length}`);
+
+        currentSha = await fetchRemoteDev(execute, cwd);
+        await logFreshness({
+            attempt,
+            baseSha,
+            currentSha,
+            log,
+            maxAttempts,
+            phase: 'post-stage'
+        });
+
+        if (currentSha !== baseSha) {
+            await recoverStaleAttempt({
+                attempt,
+                baseSha,
+                currentSha,
+                execute,
+                cwd,
+                log,
+                maxAttempts,
+                phase: 'post-stage'
+            });
+            continue
+        }
+
+        await git(execute, cwd, ['commit', '--no-verify', '-m', commitMessage], {
+            env: {...process.env, NEO_SKIP_TICKET_ARCHAEOLOGY: '1'}
+        });
+
+        currentSha = await fetchRemoteDev(execute, cwd);
+        await logFreshness({
+            attempt,
+            baseSha,
+            currentSha,
+            log,
+            maxAttempts,
+            phase: 'pre-push'
+        });
+
+        if (currentSha !== baseSha) {
+            await recoverStaleAttempt({
+                attempt,
+                baseSha,
+                currentSha,
+                execute,
+                cwd,
+                log,
+                maxAttempts,
+                phase: 'pre-push'
+            });
+            continue
+        }
+
+        try {
+            await git(execute, cwd, ['push', 'origin', 'HEAD:dev'], {capture: false})
+        } catch (error) {
+            currentSha = await fetchRemoteDev(execute, cwd);
+            await restoreRemoteDev(execute, cwd);
+
+            if (currentSha !== baseSha) {
+                await logFreshness({
+                    attempt,
+                    baseSha,
+                    currentSha,
+                    log,
+                    maxAttempts,
+                    phase: 'push-rejected'
+                });
+
+                if (attempt < maxAttempts) {
+                    log(`[DataSync] stale-head action=discard-and-reset attempt=${attempt}/${maxAttempts}`);
+                    continue
+                }
+
+                throw new Error(
+                    `Data Sync stopped cleanly because dev advanced during all ${maxAttempts} emission attempts ` +
+                    `(last phase=push-rejected, base=${baseSha}, current=${currentSha})`,
+                    {cause: error}
+                )
+            }
+
+            throw new Error(
+                `Data Sync publication failed while dev remained at ${baseSha}: ${error.message}`,
+                {cause: error}
+            )
+        }
+
+        log(`[DataSync] publish attempt=${attempt}/${maxAttempts} result=pushed base=${baseSha}`);
+
+        return {attempts: attempt, baseSha, changed: true, pushed: true}
+    }
+
+    throw new Error(`Data Sync exhausted ${maxAttempts} attempts without a terminal result`)
+}
+
+const modulePath   = fileURLToPath(import.meta.url);
+const cliEntryPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+
+if (cliEntryPath === modulePath) {
+    runDataSyncPipeline().catch(error => {
+        console.error(`[DataSync] ${error.message}`);
+        process.exitCode = 1
+    })
+}

--- a/learn/guides/devindex/data-factory/Orchestrator.md
+++ b/learn/guides/devindex/data-factory/Orchestrator.md
@@ -5,7 +5,7 @@ The DevIndex Data Factory is essentially a collection of specialized micro-servi
 This layer is comprised of three distinct parts:
 1.  **The Entry Point:** `apps/devindex/services/cli.mjs`
 2.  **The Command Router:** [`DevIndex.services.Manager`](https://github.com/neomjs/neo/blob/dev/apps/devindex/services/Manager.mjs)
-3.  **The Automated Pipeline:** `.github/workflows/devindex-pipeline.yml`
+3.  **The Automated Pipeline:** `.github/workflows/data-sync-pipeline.yml`
 
 ---
 
@@ -63,43 +63,30 @@ When the `update` command is run, the Manager doesn't just blindly pass the whol
 
 ## The Automated Pipeline (GitHub Actions)
 
-While a developer can run commands manually via the CLI, the DevIndex is designed to be fully autonomous. The ultimate orchestrator is the GitHub Actions workflow defined in `.github/workflows/devindex-pipeline.yml`.
+While a developer can run commands manually via the CLI, the DevIndex is designed to be fully autonomous. The ultimate orchestrator is the GitHub Actions workflow defined in `.github/workflows/data-sync-pipeline.yml`. The workflow delegates the mutation-sensitive part to `buildScripts/dataSyncPipeline.mjs`, keeping the bounded Git state machine executable and testable outside YAML.
 
-This workflow runs on an **hourly schedule** and strings the individual services together into a single, atomic "Data Factory" assembly line:
+This workflow runs on an **hourly schedule**, checks out the complete `dev` history, and invokes one bounded publisher:
 
 ```yaml readonly
 jobs:
   run-pipeline:
     steps:
-      # 1. Process Privacy Requests First
-      - name: Run DevIndex Opt-In
-        run: npm run devindex:optin
-        
-      - name: Run DevIndex Opt-Out
-        run: npm run devindex:optout
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
 
-      # 2. Aggressive Discovery (3x Loop)
-      - name: Run DevIndex Spider
-        run: |
-          for i in 1 2 3; do
-            npm run devindex:spider -- --strategy random
-          done
-
-      # 3. Enrichment & Processing
-      - name: Run DevIndex Updater
-        run: npm run devindex:update -- --limit=800
-
-      # 4. Atomic Persistence
-      - name: Commit, Rebase and Push
-        run: |
-          git add apps/devindex/resources/*.json*
-          git commit -m "chore(devindex): Hourly pipeline update [skip ci]"
-          git pull origin dev --rebase
-          git push origin dev
+      - name: Run bounded Data Sync emission and publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node ./buildScripts/dataSyncPipeline.mjs
 ```
 
-### Key Pipeline Concepts:
+For each emission attempt, the publisher installs dependencies and runs `optin`, `optout`, the random Spider strategy, the Updater, and the shared content-index/SEO rebuild in that order. The current Updater ceiling remains 800; the pipeline may perform the complete sequence twice only when `dev` advances during the first attempt.
 
-1.  **Privacy-First Execution:** The `optin` and `optout` services run *before* any discovery or enrichment. This ensures we never accidentally index a user who requested removal in the same hour.
-2.  **The 3x Spider Loop:** Because the Spider uses a random-walk algorithm, running it multiple times consecutively (before the Updater) significantly broadens the discovery net while utilizing very little API quota.
-3.  **Atomic Commits:** Rather than each service committing its own changes independently (which would cause massive Git conflicts), the services modify the local JSON files on the runner. Only at the very end of the hourly pipeline are all changes bundled into a single, atomic commit containing the fully processed data. The `[skip ci]` flag prevents infinite loops.
+### Key Pipeline Concepts
+
+1.  **Privacy-First Execution:** The `optin` and `optout` services run *before* discovery or enrichment. This ensures we never accidentally index a user who requested removal in the same hour.
+2.  **Disposable Emission Attempts:** Each attempt captures its starting `dev` SHA. After the generators finish, the publisher fetches `origin/dev`. If authority moved, it discards the runner's derived output, resets to the new head, and reruns the complete emission once.
+3.  **Bounded Freshness:** Freshness is checked after emission, after staging, and immediately before publication. A second concurrent advance resets the ephemeral checkout again and fails with the attempt plus base/current SHAs instead of entering an unbounded retry loop.
+4.  **Atomic Allowlisted Commits:** Only DevIndex JSON/JSONL output, Portal data indexes, `sitemap.xml`, and `llms.txt` can enter the generated commit. The publisher never rebases, resolves derived-file conflicts, or force-pushes; the final non-force push therefore proves that its single commit is based on the verified current `dev` head.

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -1,0 +1,263 @@
+import {test, expect} from '@playwright/test';
+import {execFileSync} from 'node:child_process';
+import fs             from 'node:fs/promises';
+import os             from 'node:os';
+import path           from 'node:path';
+import process        from 'node:process';
+
+import {
+    emitGeneratedData,
+    executeCommand,
+    GENERATED_DATA_PATHS,
+    isGeneratedDataPath,
+    runDataSyncPipeline
+} from '../../../../../buildScripts/dataSyncPipeline.mjs';
+
+const generatedFile = 'apps/devindex/resources/data/users.jsonl';
+
+function runGit(cwd, args) {
+    return execFileSync('git', args, {
+        cwd,
+        encoding: 'utf8',
+        stdio   : ['ignore', 'pipe', 'pipe']
+    }).trim()
+}
+
+async function write(repo, relativePath, content) {
+    const filePath = path.join(repo, relativePath);
+
+    await fs.mkdir(path.dirname(filePath), {recursive: true});
+    await fs.writeFile(filePath, content)
+}
+
+function configureAuthor(repo) {
+    runGit(repo, ['config', 'user.name', 'Data Sync Test']);
+    runGit(repo, ['config', 'user.email', 'data-sync@example.test'])
+}
+
+async function createRepositoryFixture() {
+    const
+        root   = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-data-sync-')),
+        origin = path.join(root, 'origin.git'),
+        seed   = path.join(root, 'seed'),
+        runner = path.join(root, 'runner'),
+        peer   = path.join(root, 'peer');
+
+    runGit(root, ['init', '--bare', '--initial-branch=dev', origin]);
+    runGit(root, ['clone', origin, seed]);
+    configureAuthor(seed);
+    await write(seed, generatedFile, 'generated:v1\n');
+    await write(seed, 'apps/portal/resources/data/tickets/index.json', '{"version":1}\n');
+    await write(seed, 'apps/portal/sitemap.xml', '<urlset />\n');
+    await write(seed, 'apps/portal/llms.txt', 'v1\n');
+    await write(seed, 'source.txt', 'v1\n');
+    runGit(seed, ['add', '.']);
+    runGit(seed, ['commit', '-m', 'initial']);
+    runGit(seed, ['push', '-u', 'origin', 'dev']);
+
+    runGit(root, ['clone', '--branch', 'dev', origin, runner]);
+    runGit(root, ['clone', '--branch', 'dev', origin, peer]);
+    configureAuthor(runner);
+    configureAuthor(peer);
+
+    return {origin, peer, root, runner}
+}
+
+async function advanceRemote(peer, version) {
+    runGit(peer, ['pull', '--ff-only', 'origin', 'dev']);
+    await write(peer, 'source.txt', `${version}\n`);
+    await write(peer, generatedFile, `peer:${version}\n`);
+    runGit(peer, ['add', 'source.txt', generatedFile]);
+    runGit(peer, ['commit', '-m', `advance ${version}`]);
+    runGit(peer, ['push', 'origin', 'dev'])
+}
+
+function readRemoteFile({origin, root}, relativePath) {
+    return runGit(root, ['--git-dir', origin, 'show', `dev:${relativePath}`])
+}
+
+function remoteSubjects({origin, root}) {
+    return runGit(root, ['--git-dir', origin, 'log', '--format=%s', 'dev']).split('\n')
+}
+
+test.describe('Data Sync pipeline publisher (#15746)', () => {
+    test('defines the explicit generated-data allowlist', () => {
+        expect(GENERATED_DATA_PATHS).toEqual([
+            ':(glob)apps/devindex/resources/data/*.json*',
+            'apps/portal/resources/data',
+            'apps/portal/sitemap.xml',
+            'apps/portal/llms.txt'
+        ]);
+        expect(isGeneratedDataPath('apps/devindex/resources/data/users.jsonl')).toBe(true);
+        expect(isGeneratedDataPath('apps/devindex/resources/data/nested/users.jsonl')).toBe(false);
+        expect(isGeneratedDataPath('apps/portal/resources/data/tickets/index.json')).toBe(true);
+        expect(isGeneratedDataPath('apps/portal/sitemap.xml')).toBe(true);
+        expect(isGeneratedDataPath('apps/portal/llms.txt')).toBe(true);
+        expect(isGeneratedDataPath('src/ManualEdit.mjs')).toBe(false)
+    });
+
+    test('runs the complete generated-output emission sequence in order', async () => {
+        const calls = [];
+
+        await emitGeneratedData({
+            attempt: 1,
+            cwd    : '/repo',
+            execute: async (command, args, options) => {
+                calls.push({args, command, options});
+                return {stderr: '', stdout: ''}
+            },
+            log: () => {}
+        });
+
+        expect(calls.map(({args, command}) => [command, ...args])).toEqual([
+            ['npm', 'ci'],
+            ['npm', 'run', 'devindex:optin'],
+            ['npm', 'run', 'devindex:optout'],
+            ['npm', 'run', 'devindex:spider', '--', '--strategy', 'random'],
+            ['npm', 'run', 'devindex:update', '--', '--limit=800'],
+            [process.execPath, './buildScripts/docs/rebuildContentIndexesAndSeo.mjs', '--include-labels']
+        ]);
+        expect(calls.every(call => call.options.cwd === '/repo')).toBe(true)
+    });
+
+    test('publishes one atomic generated commit when dev stays unchanged', async () => {
+        const fixture = await createRepositoryFixture();
+
+        try {
+            let emissions = 0;
+
+            const result = await runDataSyncPipeline({
+                cwd : fixture.runner,
+                emit: async ({attempt, cwd}) => {
+                    emissions++;
+                    await write(cwd, generatedFile, `generated:v1:attempt-${attempt}\n`)
+                },
+                log: () => {}
+            });
+
+            expect(result).toMatchObject({attempts: 1, changed: true, pushed: true});
+            expect(emissions).toBe(1);
+            expect(readRemoteFile(fixture, generatedFile)).toBe('generated:v1:attempt-1');
+            expect(remoteSubjects(fixture)).toEqual([
+                'chore(data): Hourly data sync pipeline update [skip ci]',
+                'initial'
+            ])
+        } finally {
+            await fs.rm(fixture.root, {recursive: true, force: true})
+        }
+    });
+
+    test('discards a stale attempt, re-emits from the new dev head, and never rebases or force-pushes', async () => {
+        const
+            fixture  = await createRepositoryFixture(),
+            commands = [];
+
+        try {
+            let emissions = 0;
+
+            const result = await runDataSyncPipeline({
+                cwd    : fixture.runner,
+                execute: async (command, args, options) => {
+                    commands.push([command, ...args]);
+                    return executeCommand(command, args, options)
+                },
+                emit: async ({attempt, cwd}) => {
+                    emissions++;
+                    const source = (await fs.readFile(path.join(cwd, 'source.txt'), 'utf8')).trim();
+
+                    await write(cwd, generatedFile, `generated:${source}:attempt-${attempt}\n`);
+
+                    if (attempt === 1) {
+                        await advanceRemote(fixture.peer, 'v2')
+                    }
+                },
+                log: () => {}
+            });
+
+            expect(result).toMatchObject({attempts: 2, changed: true, pushed: true});
+            expect(emissions).toBe(2);
+            expect(readRemoteFile(fixture, generatedFile)).toBe('generated:v2:attempt-2');
+            expect(remoteSubjects(fixture)).toEqual([
+                'chore(data): Hourly data sync pipeline update [skip ci]',
+                'advance v2',
+                'initial'
+            ]);
+            expect(commands.some(([, ...args]) => args.includes('rebase'))).toBe(false);
+            expect(commands.some(([, ...args]) => args.some(arg => arg.startsWith('--force')))).toBe(false)
+        } finally {
+            await fs.rm(fixture.root, {recursive: true, force: true})
+        }
+    });
+
+    test('cleans the runner and fails explicitly when dev advances during both attempts', async () => {
+        const
+            fixture = await createRepositoryFixture(),
+            logs    = [];
+
+        try {
+            await expect(runDataSyncPipeline({
+                cwd : fixture.runner,
+                emit: async ({attempt, cwd}) => {
+                    const source = (await fs.readFile(path.join(cwd, 'source.txt'), 'utf8')).trim();
+
+                    await write(cwd, generatedFile, `generated:${source}:attempt-${attempt}\n`);
+                    await advanceRemote(fixture.peer, `v${attempt + 1}`)
+                },
+                log: message => logs.push(message)
+            })).rejects.toThrow(/dev advanced during all 2 emission attempts/u);
+
+            expect(runGit(fixture.runner, ['rev-parse', 'HEAD'])).toBe(
+                runGit(fixture.runner, ['rev-parse', 'origin/dev'])
+            );
+            expect(runGit(fixture.runner, ['status', '--porcelain'])).toBe('');
+            expect(remoteSubjects(fixture)).toEqual(['advance v3', 'advance v2', 'initial']);
+            expect(logs.some(message => message.includes('attempt=2/2'))).toBe(true)
+        } finally {
+            await fs.rm(fixture.root, {recursive: true, force: true})
+        }
+    });
+
+    test('stages only allowlisted output even when emission touches an unrelated tracked file', async () => {
+        const fixture = await createRepositoryFixture();
+
+        try {
+            await write(fixture.runner, 'source.txt', 'manual-local-change\n');
+
+            await runDataSyncPipeline({
+                cwd : fixture.runner,
+                emit: async ({cwd}) => {
+                    await write(cwd, generatedFile, 'generated:v1:allowlisted\n');
+                    await write(cwd, 'source.txt', 'manual-emission-change\n')
+                },
+                log: () => {}
+            });
+
+            const publishedPaths = runGit(fixture.root, [
+                '--git-dir',
+                fixture.origin,
+                'show',
+                '--format=',
+                '--name-only',
+                'dev'
+            ]).split('\n').filter(Boolean);
+
+            expect(publishedPaths).toEqual([generatedFile]);
+            expect(readRemoteFile(fixture, 'source.txt')).toBe('v1')
+        } finally {
+            await fs.rm(fixture.root, {recursive: true, force: true})
+        }
+    });
+
+    test('the workflow delegates publication to the bounded publisher', async () => {
+        const workflow = await fs.readFile(
+            path.resolve(process.cwd(), '.github/workflows/data-sync-pipeline.yml'),
+            'utf8'
+        );
+
+        expect(workflow).toContain('node ./buildScripts/dataSyncPipeline.mjs');
+        expect(workflow).toContain('ref: dev');
+        expect(workflow).toContain('fetch-depth: 0');
+        expect(workflow).not.toContain('git pull origin dev --rebase');
+        expect(workflow).not.toContain('git push origin dev')
+    })
+});

--- a/test/playwright/unit/ai/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs
@@ -112,14 +112,21 @@ test.describe('rebuildContentIndexesAndSeo (#13260)', () => {
     });
 
     test('data-sync pipeline delegates to the shared helper instead of duplicating the seven derive commands', async () => {
-        const workflow = await fs.readFile(path.resolve(process.cwd(), '.github/workflows/data-sync-pipeline.yml'), 'utf8');
+        const [workflow, publisher] = await Promise.all([
+            fs.readFile(path.resolve(process.cwd(), '.github/workflows/data-sync-pipeline.yml'), 'utf8'),
+            fs.readFile(path.resolve(process.cwd(), 'buildScripts/dataSyncPipeline.mjs'), 'utf8')
+        ]);
+        const delegatedPipeline = workflow + publisher;
 
-        expect(workflow).toContain('node ./buildScripts/docs/rebuildContentIndexesAndSeo.mjs --include-labels');
-        expect(workflow).not.toContain('node ./buildScripts/docs/index/labels.mjs');
-        expect(workflow).not.toContain('node ./buildScripts/docs/index/release.mjs');
-        expect(workflow).not.toContain('node ./buildScripts/docs/index/pulls.mjs');
-        expect(workflow).not.toContain('node ./buildScripts/docs/index/discussions.mjs');
-        expect(workflow).not.toContain('node ./buildScripts/docs/index/tickets.mjs');
-        expect(workflow).toContain('GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n        run: node ./buildScripts/docs/rebuildContentIndexesAndSeo.mjs --include-labels');
+        expect(workflow).toContain('node ./buildScripts/dataSyncPipeline.mjs');
+        expect(publisher).toContain('./buildScripts/docs/rebuildContentIndexesAndSeo.mjs');
+        expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/labels.mjs');
+        expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/release.mjs');
+        expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/pulls.mjs');
+        expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/discussions.mjs');
+        expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/tickets.mjs');
+        expect(workflow).toContain(
+            'GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n        run: node ./buildScripts/dataSyncPipeline.mjs'
+        );
     });
 });


### PR DESCRIPTION
Resolves #15746

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session `72bb1088-8ed5-48b7-a835-c288cf30e814`.

Evidence: L3 deterministic temporary-repository integration coverage for the complete Git publication contract. Residual: none for the ticket acceptance criteria.

## Deltas from ticket

- Extracts the mutation-sensitive Actions path into `buildScripts/dataSyncPipeline.mjs`, so the Git state machine is executable and testable outside YAML.
- Captures the emission base SHA and checks `origin/dev` after emission, after staging, and immediately before publication.
- Treats every stale attempt as disposable: reset to the current remote authority, clean generated paths, and rerun the complete emission once. A second advance cleans the runner and fails with attempt plus base/current SHA telemetry.
- Publishes one allowlisted generated-data commit with a non-force push. The recovery path contains no rebase or derived-output conflict resolution.
- Makes the checkout authority explicit (`ref: dev`, full history), retains the shared content-index/SEO builder, and corrects the Data Factory guide's stale workflow and retry description.
- Deliberately preserves the current Updater ceiling of 800. GraphQL cost budgeting and the 200 ceiling belong to sibling #15745; whichever sibling lands second must reconcile its workflow touch against this extracted publisher.

## Test Evidence

- The first focused run failed at import because `buildScripts/dataSyncPipeline.mjs` did not exist, establishing the red baseline.
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs test/playwright/unit/ai/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs` — 13/13 passed. The harness uses real temporary bare/runner/peer repositories and deterministically covers unchanged `dev`, a same-artifact advance with complete re-emission, bounded second-advance failure with a clean runner, the staging allowlist, and the no-rebase/no-force contract.
- `npm run test-unit` — 8,992 passed, 17 failed, 6 skipped, and 92 did not run. None of the new Data Sync tests failed. An unprivileged residual rerun reduced the set to 12; the permission-aware rerun cleared 11 sandbox-dependent lifecycle/wake failures (13/14 passed). The remaining unchanged `SessionSummaryDegradedFallback` case also fails alone, and `git diff origin/dev` is empty for its source and spec.
- `npm run agent-preflight -- --no-fix <5 changed files>` — passed; only unrelated non-blocking stale-overlay warnings were reported.
- The real pre-commit hook passed after applying its block-alignment formatter. `node --check buildScripts/dataSyncPipeline.mjs` and `git diff --check` passed.

## Post-Merge Validation

- Observe the next scheduled Data Sync run. If `dev` advances during emission, retain the compact attempt/base/current log as an operational witness that the deterministic contract exercised in tests also fired in Actions.
- This observation is not a ticket-closing residual; #15746 can close with the merging PR and must not be reopened.
