### PR TITLE
fix(ai): fail closed on tenant ingest errors (#15748)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -14,7 +14,9 @@ import {
     isTenantRepoSyncErrorCode
 } from './TenantRepoSyncErrors.mjs';
 
-const PERSISTED_REVISIONS_FILE_NAME = 'tenant-repo-sync-revisions.json';
+const
+    BOUNDED_KB_ERROR_CODE_PATTERN = /^KB_[A-Z0-9_]{1,120}$/,
+    PERSISTED_REVISIONS_FILE_NAME = 'tenant-repo-sync-revisions.json';
 
 /**
  * @summary In-memory async semaphore with optional slot-acquisition timeout.
@@ -79,13 +81,51 @@ function createConcurrencySemaphore({limit, timeoutMs = 0}) {
 }
 
 function getSourceErrorCode(error, outerCode) {
-    const sourceCode = error?.code;
+    const sourceCode = error?.sourceErrorCode || error?.code;
 
     if (typeof sourceCode !== 'string' || sourceCode === outerCode) {
         return null;
     }
 
-    return /^KB_[A-Z0-9_]{1,120}$/.test(sourceCode) ? sourceCode : null;
+    return BOUNDED_KB_ERROR_CODE_PATTERN.test(sourceCode) ? sourceCode : null;
+}
+
+/**
+ * @summary Fails closed unless the KB ingestion result explicitly proves an error-free summary.
+ *
+ * `KnowledgeBaseIngestionService.ingestSourceFiles()` is intentionally fail-soft:
+ * ingestion failures are returned inside `summary.errors` rather than necessarily
+ * rejecting the promise. The tenant-repo caller therefore accepts only an object
+ * with an array-valued, empty `errors` field before advancing revision state.
+ *
+ * Error messages and details from the summary are deliberately not copied into the
+ * thrown error. The first bounded `KB_*` code is retained separately as source
+ * provenance so the existing per-repo catch path can expose it as
+ * `lastSourceErrorCode` without replacing the stable outer sync-failure code.
+ *
+ * @param {Object} summary Returned KB ingestion summary.
+ * @returns {Object} The validated error-free summary.
+ * @throws {Error} When the summary shape is ambiguous or contains any errors.
+ */
+function assertErrorFreeIngestionSummary(summary) {
+    if (!summary || typeof summary !== 'object' || Array.isArray(summary) || !Array.isArray(summary.errors)) {
+        throw new Error('Knowledge Base ingestion returned an invalid summary.')
+    }
+
+    if (summary.errors.length > 0) {
+        const error      = new Error('Knowledge Base ingestion returned an error-bearing summary.');
+        const sourceCode = summary.errors
+            .map(item => item?.code)
+            .find(code => typeof code === 'string' && BOUNDED_KB_ERROR_CODE_PATTERN.test(code));
+
+        if (sourceCode) {
+            error.sourceErrorCode = sourceCode
+        }
+
+        throw error
+    }
+
+    return summary
 }
 
 /**
@@ -100,6 +140,7 @@ function getSourceErrorCode(error, outerCode) {
  *          -> GitMirror.cloneIfMissing + GitMirror.fetch
  *          -> buildIngestEnvelope({tenantId, repoSlug, mirrorRoot, lastIngestedRev, ...})
  *          -> KnowledgeBaseIngestionService.ingestSourceFiles(envelope) (viaMcp: false)
+ *          -> require an explicit error-free ingestion summary
  *          -> persist lastIngestedRev for next cycle
  * ```
  *
@@ -218,6 +259,7 @@ class TenantRepoSyncService extends Base {
      * @param {Object} [options.gitMirror=GitMirror] Injectable mirror primitive (test seam).
      * @param {Object} [options.knowledgeBaseIngestionService] KB ingestion service singleton (test seam). Resolved from `ai/services.mjs` if omitted.
      * @param {String[]} [options.onlyRepoSlugs] If provided, only sync repos whose `repoSlug` is in the list. Used by the manual CLI run path. Empty filter result against non-empty list surfaces `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED`.
+     * @param {Boolean} [options.fullReplay=false] Build selected-repo envelopes from a null revision base. Requires non-empty `onlyRepoSlugs`; persisted checkpoints remain unchanged until each replay completes without summary errors.
      * @param {String} [options.revisionsFilePath] Override the per-tenant-repo lastIngestedRev persistence file path (test seam). Defaults to `<orchestrator dataDir leaf>/tenant-repo-sync-revisions.json`.
      * @param {Function} [options.envelopeBuilder=buildIngestEnvelope] Injectable envelope-builder (test seam). Production callers omit; unit tests pass a fake that returns canned envelope shape.
      * @returns {Promise<Object>} `{status, details}` — status ∈ {`completed`, `failed`, `skipped`}.
@@ -232,6 +274,7 @@ class TenantRepoSyncService extends Base {
         gitMirror = GitMirror,
         knowledgeBaseIngestionService,
         onlyRepoSlugs,
+        fullReplay = false,
         revisionsFilePath,
         envelopeBuilder = buildIngestEnvelope,
         globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
@@ -252,7 +295,7 @@ class TenantRepoSyncService extends Base {
         try {
             const result = await this.syncTenantRepos({
                 writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
-                taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder,
+                fullReplay, taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder,
                 globalCadenceMs, jitterRatio, seedBootstrap
             });
             const status         = result.status;
@@ -301,11 +344,19 @@ class TenantRepoSyncService extends Base {
      */
     async syncTenantRepos({
         writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
-        taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder = buildIngestEnvelope,
+        fullReplay = false, taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder = buildIngestEnvelope,
         globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
         jitterRatio     = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
         seedBootstrap   = true
     }) {
+        if (fullReplay && (!Array.isArray(onlyRepoSlugs) || onlyRepoSlugs.length === 0)) {
+            throw new TenantRepoSyncError(
+                KB_TENANT_REPO_SYNC_SYNC_FAILED,
+                'Full replay requires at least one explicitly selected repo slug.',
+                {phase: 'full-replay-validation'}
+            )
+        }
+
         const resolvedConfig = tenantReposConfig || await this.resolveTenantReposConfig({ingestionService: knowledgeBaseIngestionService});
         const allRepos       = resolvedConfig.tenantRepos || [];
         const repos          = onlyRepoSlugs
@@ -447,7 +498,7 @@ class TenantRepoSyncService extends Base {
                     tenantId       : repo.tenantId,
                     repoSlug       : repo.repoSlug,
                     mirrorRoot     : repo.mirrorRoot,
-                    lastIngestedRev: priorState?.lastIngestedRev || null,
+                    lastIngestedRev: fullReplay ? null : (priorState?.lastIngestedRev || null),
                     newHead        : repo.branchRef || 'HEAD',
                     rootKind       : repo.rootKind || 'external-source',
                     parserId       : repo.parserId,
@@ -455,10 +506,10 @@ class TenantRepoSyncService extends Base {
                     gitMirror
                 });
 
-                const ingestResult = await ingestionService.ingestSourceFiles({
+                const ingestResult = assertErrorFreeIngestionSummary(await ingestionService.ingestSourceFiles({
                     ...envelope,
                     viaMcp: false // operator-bulk path
-                });
+                }));
 
                 // Persist full per-repo state on success. Reset consecutiveFailures
                 // to 0 (backoff is the multiplier-component of effectiveCadence; reset on

--- a/ai/scripts/maintenance/syncTenantRepos.mjs
+++ b/ai/scripts/maintenance/syncTenantRepos.mjs
@@ -11,8 +11,11 @@
  *   node ./ai/scripts/maintenance/syncTenantRepos.mjs                # all configured tenantRepos
  *   node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <slug>  # subset
  *   node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug a/b --repo-slug c/d  # multiple
+ *   node ./ai/scripts/maintenance/syncTenantRepos.mjs --full --repo-slug <slug>  # scoped full replay
  *
- * Exit code: 0 on `completed`, 1 on `failed` or `skipped` (no-tenant-repos-configured).
+ * Exit code: 0 on `completed`, 1 on `failed` or `skipped`
+ * (no-tenant-repos-configured), 2 on argument error, and 3 when a selected
+ * repo slug is not configured.
  *
  * Mirrors the operator-side pattern of `ai/scripts/maintenance/backup.mjs` and the
  * other `./maintenance/*` scripts — bootstrap Neo namespace then invoke a service.
@@ -21,13 +24,24 @@
  * @see learn/agentos/cloud-deployment/TenantIngestionModel.md
  */
 
-import Neo from '../../../src/Neo.mjs';
-import * as core from '../../../src/core/_export.mjs';
+import Neo             from '../../../src/Neo.mjs';
+import * as core       from '../../../src/core/_export.mjs';
+import {pathToFileURL} from 'url';
 
 import TenantRepoSyncService from '../../daemons/orchestrator/services/TenantRepoSyncService.mjs';
 
+/**
+ * @summary Parses manual tenant-repo-sync selectors and scoped replay intent.
+ *
+ * Full replay is intentionally unavailable without at least one explicit repo
+ * selector. This prevents an accidental deployment-wide reset of incremental
+ * envelope bases.
+ *
+ * @param {String[]} argv Node-style argv including executable and script path.
+ * @returns {Object} Parsed replay intent, optional help flag, and selected repo slugs.
+ */
 function parseArgs(argv) {
-    const args = {repoSlugs: []};
+    const args = {fullReplay: false, repoSlugs: []};
     for (let i = 2; i < argv.length; i++) {
         const v = argv[i];
         if (v === '--repo-slug' || v === '-r') {
@@ -37,20 +51,29 @@ function parseArgs(argv) {
             }
             args.repoSlugs.push(next);
             i++;
+        } else if (v === '--full') {
+            args.fullReplay = true;
         } else if (v === '--help' || v === '-h') {
             args.help = true;
         } else {
             throw new Error(`Unknown argument: ${v}`);
         }
     }
+
+    if (args.fullReplay && args.repoSlugs.length === 0) {
+        throw new Error('--full requires at least one --repo-slug selector.')
+    }
+
     return args;
 }
 
 function printHelp() {
-    console.log(`Usage: node ./ai/scripts/maintenance/syncTenantRepos.mjs [--repo-slug <slug>]...
+    console.log(`Usage: node ./ai/scripts/maintenance/syncTenantRepos.mjs [--repo-slug <slug>]... [--full]
 
 Forces a single tenant-repo-sync sweep. With no flags, processes every configured
 tenantRepo. Pass --repo-slug to scope to a specific repo (repeatable).
+Pass --full only with one or more --repo-slug selectors to rebuild those repos
+from a null revision base. Stored checkpoints advance only after an error-free replay.
 
 Exit codes:
   0  completed (or partial-completed with at least one repo successful)
@@ -85,6 +108,24 @@ function createInMemoryTaskStateService() {
     };
 }
 
+/**
+ * @summary Builds the service dispatch envelope from validated CLI arguments.
+ * @param {Object} options
+ * @param {{fullReplay: Boolean, repoSlugs: String[]}} options.parsed
+ * @param {Object} options.taskStateService
+ * @param {Function} options.writeLog
+ * @returns {Object}
+ */
+function buildRunTaskOptions({parsed, taskStateService, writeLog}) {
+    return {
+        reason       : 'manual',
+        taskStateService,
+        writeLog,
+        onlyRepoSlugs: parsed.repoSlugs.length > 0 ? parsed.repoSlugs : undefined,
+        fullReplay   : parsed.fullReplay
+    }
+}
+
 async function main() {
     let parsed;
     try {
@@ -101,14 +142,13 @@ async function main() {
     }
 
     const taskStateService = createInMemoryTaskStateService();
-    const writeLog = (level, msg) => console.log(`[${level}] ${msg}`);
+    const writeLog         = (level, msg) => console.log(`[${level}] ${msg}`);
 
-    const result = await TenantRepoSyncService.runTask({
-        reason          : 'manual',
+    const result = await TenantRepoSyncService.runTask(buildRunTaskOptions({
+        parsed,
         taskStateService,
-        writeLog,
-        onlyRepoSlugs   : parsed.repoSlugs.length > 0 ? parsed.repoSlugs : undefined
-    });
+        writeLog
+    }));
 
     console.log(JSON.stringify(result, null, 2));
 
@@ -121,8 +161,12 @@ async function main() {
     process.exit(1);
 }
 
-main().catch(err => {
-    console.error('Fatal:', err.message);
-    if (err.stack) console.error(err.stack);
-    process.exit(2);
-});
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+    main().catch(err => {
+        console.error('Fatal:', err.message);
+        if (err.stack) console.error(err.stack);
+        process.exit(2);
+    })
+}
+
+export {buildRunTaskOptions, parseArgs};

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -235,9 +235,15 @@ For bootstrap, one-off after a config change, or scoped re-sync, use the standal
 node ./ai/scripts/maintenance/syncTenantRepos.mjs                   # all configured tenantRepos
 node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug a/b   # subset
 node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug a/b --repo-slug c/d
+node ./ai/scripts/maintenance/syncTenantRepos.mjs --full --repo-slug a/b  # scoped full replay
 ```
 
-Exit code: `0` on `completed`, `1` on `failed` or `skipped` (no-tenant-repos-configured), `2` on argument error. The CLI uses an in-memory `TaskStateService` stand-in so it works without an orchestrator-daemon state-dir; it does not race against a running Orchestrator's lane.
+`--full` requires at least one explicit, repeatable `--repo-slug` selector. It builds the selected
+repo envelopes from a null revision base while retaining each stored checkpoint until the replay
+returns an error-free ingestion summary. Use it after correcting an ingestion failure when an older
+deployment may already have checkpointed the failed head; do not delete the revisions file.
+
+Exit code: `0` on `completed`, `1` on `failed` or `skipped` (no-tenant-repos-configured), `2` on argument error, and `3` when a requested repo slug is not configured. The CLI uses an in-memory `TaskStateService` stand-in so it works without an orchestrator-daemon state-dir; it does not race against a running Orchestrator's lane.
 
 ### Mirror Volume
 
@@ -329,7 +335,8 @@ When a repo enters `quarantined`, the lane stops attempting it on periodic cycle
    - `lastSourceErrorCode: KB_GITMIRROR_CLONE_FAILED` / `KB_GITMIRROR_FETCH_FAILED` → verify upstream access, token read scope, repo path, and network egress.
    - Persistent network/DNS error → the deployment can't reach the upstream remote; verify network egress.
    - Repository deleted / renamed upstream → update the `tenantRepos[]` config or remove the entry.
-4. Once the underlying issue is resolved, force a manual sync via `node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <slug>`. A successful run returns the repo to `active`.
+4. Once the underlying issue is resolved, retry via `node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <slug>`. Current releases preserve the last known-good checkpoint on any returned ingestion error.
+5. If the deployment was upgraded from a release that could checkpoint an error-bearing summary, or the ordinary retry produces no files because the stored base is already the failed head, run `node ./ai/scripts/maintenance/syncTenantRepos.mjs --full --repo-slug <slug>`. A failed replay retains the old checkpoint; only an error-free replay replaces it and returns the repo to `active`.
 
 The lane never silently abandons a `quarantined` repo — operator action is the recovery path. Webhook-driven retry on git push is deferred.
 
@@ -359,7 +366,7 @@ A single `repoSlug` can be served by both surfaces, but the operational rules ar
 - **Deployment compose / volume:** add `tenant-repo-mirrors` to the `cloud` profile and mount at `NEO_TENANT_REPO_MIRROR_ROOT`. See [`DeploymentCookbook.md`](../DeploymentCookbook.md) for the canonical compose shape.
 - **Tenant config storage:** `tenantRepos[]` is persisted via `KnowledgeBaseIngestionService.setTenantConfig({tenantId, config})` when a tenant-config operator tool is added. Cross-tenant writes remain rejected by the existing RLS gate; missing/invalid `credentialRef` or credential-bearing `cloneUrl` surfaces stable rejection errors at normalization.
 - **Parser/source-family dispatch:** pull-mode files enter the same parser/source-family model as push/bulk ingestion. No new parser contract is introduced by server-side git acquisition; the [Parser Dispatch](#parser-dispatch) and [Source-Family Inventory](#source-family-inventory) tables above apply unchanged. Unsupported source families use [`CustomSources.md`](./CustomSources.md) / [`CustomParsers.md`](./CustomParsers.md) guidance, not a pull-specific path.
-- **Deletion telemetry:** the `lastSyncDeletedCount` health field surfaces the per-cycle deletion count from the ingestion summary. Partial ingest or manifest update failure leaves `lastIngestedRev` unchanged so the next cycle re-detects and retries deletion idempotently.
+- **Deletion telemetry:** the `lastSyncDeletedCount` health field surfaces the per-cycle deletion count from the ingestion summary. The pull caller accepts only a summary with an array-valued, empty `errors` field; partial ingest, malformed summary, or manifest update failure leaves `lastIngestedRev` unchanged so the next cycle re-detects and retries deletion idempotently.
 
 ## Evidence Boundary
 

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -188,7 +188,20 @@ A freshly deployed Knowledge Base can be **healthy but empty**: `healthcheck` re
 
 For push-mode deployments, trigger the deployment's ingestion entry point once, then query again.
 
-For pull-mode deployments with configured `tenantRepos[]`, call `inspect_deployment` or `get_deployment_state_snapshot` and inspect the `tenantRepoSync` section before taking manual action. It distinguishes disabled, true no-configured-repos, not-due, running, completed, failed, and degraded/unreadable state without exposing credentials or raw logs. A degraded config-read error means the graph/YAML/default config resolver could not prove the effective `tenantRepos`; treat that differently from a real empty config. If the task is configured but has not advanced, use the stable reason code and per-repo hashed state there to decide whether to wait for the next due sweep, fix credentials/config, or run `node ./ai/scripts/maintenance/syncTenantRepos.mjs` inside the orchestrator container. When `lastErrorCode` is `KB_TENANT_REPO_SYNC_SYNC_FAILED`, check `lastSourceErrorCode`: `KB_GITMIRROR_CREDENTIAL_REF_INVALID`, `KB_GITMIRROR_CLONE_FAILED`, or `KB_GITMIRROR_FETCH_FAILED` points to the credential/ref/upstream access path before generic ingestion debugging.
+For pull-mode deployments with configured `tenantRepos[]`, call `inspect_deployment` or `get_deployment_state_snapshot` and inspect the `tenantRepoSync` section before taking manual action. It distinguishes disabled, true no-configured-repos, not-due, running, completed, failed, and degraded/unreadable state without exposing credentials or raw logs. A degraded config-read error means the graph/YAML/default config resolver could not prove the effective `tenantRepos`; treat that differently from a real empty config. If the task is configured but has not advanced, use the stable reason code and per-repo hashed state there to decide whether to wait for the next due sweep, fix credentials/config, or run `node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <slug>` inside the orchestrator container. When `lastErrorCode` is `KB_TENANT_REPO_SYNC_SYNC_FAILED`, check `lastSourceErrorCode`: `KB_GITMIRROR_CREDENTIAL_REF_INVALID`, `KB_GITMIRROR_CLONE_FAILED`, or `KB_GITMIRROR_FETCH_FAILED` points to the credential/ref/upstream access path before generic ingestion debugging. `KB_VECTOR_EMBED_FAILED` means the repository fetch and envelope reached the ingestion layer but vector writes failed; correct the embedding path before retrying.
+
+Current releases accept a tenant-repo ingest as successful only when the returned summary contains
+an array-valued, empty `errors` field. A failed attempt keeps the last known-good revision. If the
+deployment was upgraded after an older release had already advanced its checkpoint on an
+error-bearing summary, a normal retry can produce an empty incremental envelope. Recover only the
+affected repo with:
+
+```text
+node ./ai/scripts/maintenance/syncTenantRepos.mjs --full --repo-slug <slug>
+```
+
+`--full` is rejected without an explicit repo selector. It does not delete the stored checkpoint:
+a failed replay preserves it, while an error-free replay advances it to the current head.
 
 If the deployment snapshot is fresh but the tool returns `status: degraded` with
 `reason: snapshot-section-missing` or `snapshot-producer-metadata-missing`, fix

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -26,6 +26,10 @@ import {fileURLToPath} from 'url';
 
 import TenantRepoSyncService        from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
 import {deriveTenantRepoMirrorPath} from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
+import {
+    buildRunTaskOptions,
+    parseArgs
+} from '../../../../../../../ai/scripts/maintenance/syncTenantRepos.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -73,10 +77,15 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         };
     }
 
-    function makeFakeIngestionService({captureCalls = []} = {}) {
+    function makeFakeIngestionService({captureCalls = [], summaryFactory} = {}) {
         return {
             async ingestSourceFiles(payload) {
                 captureCalls.push({op: 'ingestSourceFiles', payload});
+
+                if (summaryFactory) {
+                    return summaryFactory(payload)
+                }
+
                 return {
                     ingested           : payload.files?.length || 0,
                     deleted            : payload.deleted?.length || 0,
@@ -330,6 +339,290 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         expect(result.status).toBe('completed');
         expect(capturedLastIngestedRev).toBe('sha-prior-run');
+    });
+
+    test('error-bearing ingestion summary fails closed and the next run reuses the last good revision (#15748)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/error-summary',
+            envelopeCalls    = [],
+            logs             = [];
+        let ingestCallCount = 0;
+
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                [`t1/${repoSlug}`]: {
+                    lastIngestedRev    : 'sha-good',
+                    lastRunAttemptAt   : 0,
+                    consecutiveFailures: 0
+                }
+            }
+        });
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const envelopeBuilder = async args => {
+            envelopeCalls.push(args);
+            return {
+                tenantId    : args.tenantId,
+                repoSlug    : args.repoSlug,
+                files       : [{sourcePath: 'fake.txt', repoSlug: args.repoSlug, content: 'x'}],
+                deleted     : [],
+                headRevision: envelopeCalls.length === 1 ? 'sha-failed-head' : 'sha-recovered-head',
+                ...(args.lastIngestedRev ? {baseRevision: args.lastIngestedRev} : {})
+            }
+        };
+        const ingestionService = makeFakeIngestionService({
+            summaryFactory() {
+                ingestCallCount++;
+
+                if (ingestCallCount === 1) {
+                    return {
+                        ingested           : 1,
+                        deleted            : 0,
+                        embeddingsGenerated: 0,
+                        errors             : [
+                            {code: 'unsafe-code', message: 'TOKEN=must-not-project'},
+                            {code: 'KB_VECTOR_EMBED_FAILED', message: 'credential=must-not-project', details: {sourceContent: 'private'}}
+                        ]
+                    }
+                }
+
+                return {ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: []}
+            }
+        });
+        const options = {
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/error-summary.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder,
+            knowledgeBaseIngestionService: ingestionService,
+            onlyRepoSlugs                : [repoSlug],
+            revisionsFilePath            : revisionsFile,
+            writeLog                     : (...args) => logs.push(args.join(' '))
+        };
+
+        const failed = await TenantRepoSyncService.runTask(options);
+
+        expect(failed.status).toBe('failed');
+        expect(failed.details.completedCount).toBe(0);
+        expect(failed.details.failedCount).toBe(1);
+        expect(failed.details.repos[0]).toMatchObject({
+            status             : 'degraded',
+            lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+            lastSourceErrorCode: 'KB_VECTOR_EMBED_FAILED',
+            consecutiveFailures: 1
+        });
+        expect(JSON.stringify(failed)).not.toContain('must-not-project');
+        expect(logs.join('\n')).not.toContain('must-not-project');
+
+        let persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions[`t1/${repoSlug}`]).toMatchObject({
+            lastIngestedRev    : 'sha-good',
+            consecutiveFailures: 1
+        });
+
+        const recovered = await TenantRepoSyncService.runTask(options);
+
+        expect(recovered.status).toBe('completed');
+        expect(envelopeCalls).toHaveLength(2);
+        expect(envelopeCalls[0].lastIngestedRev).toBe('sha-good');
+        expect(envelopeCalls[1].lastIngestedRev).toBe('sha-good');
+
+        persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions[`t1/${repoSlug}`]).toMatchObject({
+            lastIngestedRev    : 'sha-recovered-head',
+            consecutiveFailures: 0
+        });
+    });
+
+    for (const {label, summary} of [
+        {label: 'missing errors field', summary: {ingested: 1}},
+        {label: 'non-array errors field', summary: {ingested: 1, errors: {code: 'KB_VECTOR_EMBED_FAILED'}}}
+    ]) {
+        test(`${label} fails closed without advancing the persisted revision (#15748)`, async () => {
+            const
+                taskStateService = createInMemoryTaskStateService(),
+                repoSlug         = `org/${label.replaceAll(' ', '-')}`;
+
+            await fs.writeJson(revisionsFile, {
+                revisions: {
+                    [`t1/${repoSlug}`]: {
+                        lastIngestedRev    : 'sha-known-good',
+                        lastRunAttemptAt   : 0,
+                        consecutiveFailures: 2
+                    }
+                }
+            });
+            await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+            const result = await TenantRepoSyncService.runTask({
+                reason           : 'manual',
+                taskStateService,
+                tenantReposConfig: {tenantRepos: [
+                    {tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/summary-shape.git'}
+                ]},
+                gitMirror                    : makeFakeGitMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService({summaryFactory: () => summary}),
+                onlyRepoSlugs                : [repoSlug],
+                revisionsFilePath            : revisionsFile
+            });
+
+            expect(result.status).toBe('failed');
+            expect(result.details.repos[0]).toMatchObject({
+                status             : 'degraded',
+                lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+                consecutiveFailures: 3
+            });
+            expect(result.details.repos[0].lastSourceErrorCode).toBeUndefined();
+
+            const persisted = await fs.readJson(revisionsFile);
+            expect(persisted.revisions[`t1/${repoSlug}`]).toMatchObject({
+                lastIngestedRev    : 'sha-known-good',
+                consecutiveFailures: 3
+            });
+        })
+    }
+
+    test('mixed cycle counts an error-bearing summary as failed while preserving per-repo isolation (#15748)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            badSlug          = 'org/summary-bad',
+            goodSlug         = 'org/summary-good';
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: badSlug});
+        await provisionMirrorDir({tenantId: 't1', repoSlug: goodSlug});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: badSlug,  mirrorRoot, cloneUrl: 'https://github.com/neomjs/bad.git'},
+                {tenantId: 't1', repoSlug: goodSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/good.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory(payload) {
+                    return payload.repoSlug === badSlug
+                        ? {ingested: 1, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_FAILED'}]}
+                        : {ingested: 1, deleted: 0, errors: []}
+                }
+            }),
+            onlyRepoSlugs    : [badSlug, goodSlug],
+            revisionsFilePath: revisionsFile
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details.completedCount).toBe(1);
+        expect(result.details.failedCount).toBe(1);
+        expect(result.details.repos.find(repo => repo.repoSlug === badSlug)).toMatchObject({
+            status             : 'degraded',
+            lastSourceErrorCode: 'KB_VECTOR_EMBED_FAILED'
+        });
+        expect(result.details.repos.find(repo => repo.repoSlug === goodSlug).status).toBe('active');
+
+        const persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions[`t1/${badSlug}`]).toMatchObject({
+            lastIngestedRev    : null,
+            consecutiveFailures: 1
+        });
+        expect(persisted.revisions[`t1/${goodSlug}`].lastIngestedRev).toBe(`sha-head-${goodSlug}`);
+    });
+
+    test('scoped full replay keeps the old checkpoint on failure and replaces it only after clean completion (#15748)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/full-replay',
+            envelopeCalls    = [];
+        let ingestCallCount = 0;
+
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                [`t1/${repoSlug}`]: {
+                    lastIngestedRev    : 'sha-old-checkpoint',
+                    lastRunAttemptAt   : 0,
+                    consecutiveFailures: 2
+                }
+            }
+        });
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const options = {
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/full-replay.git'}
+            ]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => {
+                envelopeCalls.push(args);
+                return {
+                    tenantId    : args.tenantId,
+                    repoSlug    : args.repoSlug,
+                    files       : [{sourcePath: 'fake.txt', repoSlug: args.repoSlug, content: 'x'}],
+                    deleted     : [],
+                    headRevision: envelopeCalls.length === 1 ? 'sha-replay-failed' : 'sha-replay-clean'
+                }
+            },
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory() {
+                    ingestCallCount++;
+                    return ingestCallCount === 1
+                        ? {ingested: 1, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_FAILED'}]}
+                        : {ingested: 1, deleted: 0, errors: []}
+                }
+            }),
+            onlyRepoSlugs    : [repoSlug],
+            fullReplay       : true,
+            revisionsFilePath: revisionsFile
+        };
+
+        const failedReplay = await TenantRepoSyncService.runTask(options);
+
+        expect(failedReplay.status).toBe('failed');
+        expect(envelopeCalls[0].lastIngestedRev).toBeNull();
+
+        let persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions[`t1/${repoSlug}`]).toMatchObject({
+            lastIngestedRev    : 'sha-old-checkpoint',
+            consecutiveFailures: 3
+        });
+
+        const cleanReplay = await TenantRepoSyncService.runTask(options);
+
+        expect(cleanReplay.status).toBe('completed');
+        expect(envelopeCalls[1].lastIngestedRev).toBeNull();
+
+        persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions[`t1/${repoSlug}`]).toMatchObject({
+            lastIngestedRev    : 'sha-replay-clean',
+            consecutiveFailures: 0
+        });
+    });
+
+    test('full replay without an explicit repo selector fails before repo work begins (#15748)', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/unscoped', mirrorRoot, cloneUrl: 'https://github.com/neomjs/unscoped.git'}
+            ]},
+            fullReplay       : true,
+            revisionsFilePath: revisionsFile
+        });
+
+        expect(result.status).toBe('failed');
+        expect(result.details).toMatchObject({
+            reasonCode: 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+            meta      : {phase: 'full-replay-validation'}
+        });
+        expect(await fs.pathExists(revisionsFile)).toBe(false);
     });
 
     test('health payload: per-repo details.repos[] carries operator-visible freshness fields on success', async () => {
@@ -1329,5 +1622,49 @@ test.describe('TenantRepoSyncService.resolveTenantReposConfig — Tier-1 mirrorR
         });
 
         expect(result.tenantRepos[0].mirrorRoot).toBe('/app/.neo-ai-data');
+    });
+});
+
+test.describe('syncTenantRepos manual CLI (#15748)', () => {
+    test('parses repeatable repo selectors with explicit full replay', () => {
+        expect(parseArgs([
+            'node',
+            'syncTenantRepos.mjs',
+            '--repo-slug',
+            'org/a',
+            '--full',
+            '-r',
+            'org/b'
+        ])).toEqual({
+            fullReplay: true,
+            repoSlugs : ['org/a', 'org/b']
+        });
+    });
+
+    test('rejects full replay without a repo selector', () => {
+        expect(() => parseArgs(['node', 'syncTenantRepos.mjs', '--full']))
+            .toThrow('--full requires at least one --repo-slug selector.')
+    });
+
+    test('dispatches full replay and selectors to TenantRepoSyncService', () => {
+        const
+            taskStateService = {name: 'task-state'},
+            writeLog         = () => {},
+            options          = buildRunTaskOptions({
+                parsed: {
+                    fullReplay: true,
+                    repoSlugs : ['org/a', 'org/b']
+                },
+                taskStateService,
+                writeLog
+            });
+
+        expect(options).toEqual({
+            reason       : 'manual',
+            taskStateService,
+            writeLog,
+            onlyRepoSlugs: ['org/a', 'org/b'],
+            fullReplay   : true
+        });
     });
 });


### PR DESCRIPTION
Resolves #15748

Tenant repo polling now accepts an ingest as successful only when the Knowledge Base returns an object with an array-valued, empty `errors` field. Returned errors and ambiguous summary shapes enter the existing per-repo failure path, preserving the last known-good revision and backoff state while exposing only the first bounded `KB_*` source code. The manual CLI also gains selector-required `--full` replay so an already-poisoned checkpoint can be repaired without deleting global revision state.

Decision Record impact: aligned with ADR 0014 and the existing tenant-repo-sync service boundary; no amendment required.

Evidence: L2 (real service seam, filesystem persistence, CLI parser/dispatch, and error-projection unit coverage) → L2 required (all close-target ACs are internal caller and persistence contracts). No residuals.

## Deltas from ticket

None substantive.

## Test Evidence

- Tenant repo sync + manual CLI: `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — 47 passed.
- Adjacent ingestion/error/deployment-state contracts: `npm run test-unit -- IngestionService.spec.mjs TenantRepoSyncErrors.spec.mjs DeploymentStateBridgeService.spec.mjs` — 68 passed.
- Full unit suite: `npm run test-unit` — 9,068 passed, 6 skipped, 33 did not run; two load-sensitive failures (`McpServerListToolsSmoke` and `lintTreeJson`) both passed in the exact isolated rerun (59 passed).
- Cloud deployment guides: `npm run ai:lint-guides` — 0 hard errors; 28 repository-wide warnings.
- Static gates: `git diff --check`; `node --check` for both modified runtime modules; client-name scrub over all five files — clean.
- Agent gates: `npm run agent-preflight -- --no-fix --pr-body /private/tmp/neo-pr-15748-body.md <five changed files>` — passed.

## Post-Merge Validation

- [ ] On the next pull-mode cloud deployment, run one scoped replay against a non-production fixture repo and confirm `tenantRepoSync` advances only after an error-free summary.

Authored by Euclid (GPT-5.6, Codex Desktop). Session fc1a49c1-e30a-4e3a-960a-e0596367a4c1.
