### PR TITLE
fix(deploy): persist sandman handoff across containers

### DIFF
--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -119,6 +119,10 @@ services:
       - NEO_CHROMA_PORT=8000
       - MCP_HTTP_PORT=3001
       - NEO_MEMORY_DB_PATH=/app/.neo-ai-data/sqlite/memory-core-graph.sqlite
+      # The cloud Golden Path writer and this MCP reader resolve one handoff file.
+      # Keep the path on their dedicated shared volume so container recreates do
+      # not erase the morning surface served by get_sandman_handoff.
+      - NEO_HANDOFF_FILE_PATH=/app/.neo-ai-data/handoff/sandman_handoff.md
       # Single-process container = no orchestrator-supervised embed daemon: the server hosts the
       # WAL drain loop itself (sole-drainer invariant — exactly one loop per WAL dir; never enable
       # alongside the embed daemon). Without it, the decoupled add_memory writes the WAL but nothing
@@ -142,6 +146,7 @@ services:
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
     volumes:
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
+      - shared-handoff-data:/app/.neo-ai-data/handoff:ro
     depends_on:
       chroma:
         condition: service_healthy
@@ -187,6 +192,7 @@ services:
       - NEO_ORCHESTRATOR_LMS_ENABLED=false
       - NEO_ORCHESTRATOR_OLLAMA_ENABLED=false
       - NEO_TENANT_REPO_MIRROR_ROOT=/app/.neo-ai-data
+      - NEO_HANDOFF_FILE_PATH=/app/.neo-ai-data/handoff/sandman_handoff.md
       - NEO_MODEL_PROVIDER=${NEO_MODEL_PROVIDER:-}
       - NEO_EMBEDDING_PROVIDER=${NEO_EMBEDDING_PROVIDER:-}
       - NEO_OPENAI_COMPATIBLE_HOST=${NEO_OPENAI_COMPATIBLE_HOST:-}
@@ -208,6 +214,9 @@ services:
     volumes:
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
       - tenant-repo-mirrors:/app/.neo-ai-data/tenant-repos
+      # The `golden-path` scheduler lane writes the handoff and its derived
+      # route artifacts here; mc-server mounts the same directory read-side.
+      - shared-handoff-data:/app/.neo-ai-data/handoff
       # Redeploy-safe backup persistence (Sub C #11724): the cloud-safe `backup`
       # scheduler lane writes bundles here. A host bind-mount keeps them across
       # container rebuilds and host-accessible for off-site copy / inspection.
@@ -336,6 +345,7 @@ networks:
 volumes:
   chroma-data:
   shared-sqlite-data:
+  shared-handoff-data:
   tenant-repo-mirrors:
   caddy-data:
   caddy-config:

--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -182,6 +182,23 @@ configured chat and embedding model ids, both role routes must pass, and the
 deployment must not depend on switching hosts or rebuilding model context
 between role calls.
 
+## Sandman handoff persistence
+
+The cloud `golden-path` scheduler lane writes the Dream Pipeline's morning
+surface, while Memory Core serves it to remote agents through
+`get_sandman_handoff`. Both processes must resolve the same persistent file:
+
+| Variable | Local default | Production compose value | Consumers |
+|---|---|---|---|
+| `NEO_HANDOFF_FILE_PATH` | `<repo>/resources/content/sandman_handoff.md` | `/app/.neo-ai-data/handoff/sandman_handoff.md` on the `shared-handoff-data` named volume | `orchestrator` writer + `mc-server` reader |
+
+Leave the variable unset for local repository workflows. In the cloud profile,
+the production compose sets it explicitly in both containers and mounts the same
+directory into each; `mc-server` receives a read-only mount so the orchestrator
+remains the sole writer. `kb-server` does not mount this volume: the handoff is
+short-lived operational state served by Memory Core, not Knowledge Base corpus
+content.
+
 ## Related
 
 - [Overview](./Overview.md) — the contract split + default-source inheritance.

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -684,13 +684,35 @@ Minimum handoff checklist:
 
 ```text
 [ ] shared-sqlite-data volume or managed graph-store path is persistent.
+[ ] shared-handoff-data is mounted by orchestrator and mc-server at the configured handoff path.
+[ ] after a successful golden-path cycle, get_sandman_handoff returns non-null content.
 [ ] backup bundles write to the redeploy-safe backup mount.
 [ ] after docker compose down && docker compose up --build, MC healthcheck is healthy.
 [ ] the memory written in Milestone 1 can still be queried.
+[ ] get_sandman_handoff still returns the pre-redeploy handoff until the next cycle replaces it.
 [ ] KB Neo-shared content is either still present or re-synced successfully.
 [ ] tenant content is either still present or re-pushed by the hook/CI job.
 [ ] endpoint URLs, token source, tenant id, repo slug, and known failure signatures are documented for the next agent.
 ```
+
+Use the authenticated Memory Core caller from Milestone 1 for the live handoff
+probe:
+
+```bash
+node /tmp/day0-call-tool.mjs \
+  "$NEO_MC_MCP_BASE_URL" \
+  "$NEO_OPERATOR_IDENTITY" \
+  get_sandman_handoff
+```
+
+Run it after the orchestrator reports a successful `golden-path` cycle and
+record `path`, `mtimeMs`, plus a hash of `content`. Run it again immediately
+after the recreate, before another Golden Path cycle can replace the artifact.
+`content` must remain non-null and its recorded hash and `mtimeMs` must match.
+The returned container path must be the configured
+`/app/.neo-ai-data/handoff/sandman_handoff.md`. A
+`reason: "handoff-not-found"` envelope is a failed persistence proof, not an
+acceptable empty state.
 
 Production compose persistence is documented in the
 [Deployment Cookbook](../DeploymentCookbook.md). Do not treat a demo stack that

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -45,6 +45,7 @@ The deployment's persistent state (`ai/deploy/docker-compose.yml`):
 |---|---|---|
 | Memory Core graph + sessions — the **primary store** | `shared-sqlite-data` named volume → `/app/.neo-ai-data/sqlite` | `down -v`, or the Compose project name changes |
 | Chroma vectors | `chroma-data` named volume → `/chroma/unified` (set via `PERSIST_DIRECTORY`) | `down -v`, or the project name changes (recoverable by re-sync/re-push, at cost) |
+| Sandman handoff + derived route artifacts | `shared-handoff-data` named volume → `/app/.neo-ai-data/handoff` (writer and reader share `NEO_HANDOFF_FILE_PATH`) | `down -v`, or the Compose project name changes |
 | Backup bundles | host bind-mount `./.neo-ai-data/backups` on the `cloud`-profile `orchestrator` | the compose file's host location changes between runs |
 | TLS certs / CA | `caddy-data` / `caddy-config` named volumes (`ingress` profile) | `down -v` (re-issued on next start — watch ACME rate limits) |
 | Local model store — opt-in `local-model` profile | `local-model-data` named volume → `/root/.ollama` | `down -v`, or the project name changes (recoverable — re-pull the models) |
@@ -57,7 +58,7 @@ Three rules keep a redeploy job safe:
 
 Off-site copy of the backup bundles is the disaster-recovery layer *above* redeploy-safety: redeploy-safety keeps state across a container *recreate*; backups plus off-site copy cover host loss.
 
-**Verification:** the redeploy-survival check is [Day-0 Tutorial Milestone 7](./Day0Tutorial.md) — a `docker compose down && docker compose up --build` cycle, then confirm the Memory Core store and backup bundles are intact. Run that check once when the pipeline is first wired; subsequent redeploys rely on the named-volume + project-name + bind-mount contract above.
+**Verification:** the redeploy-survival check is [Day-0 Tutorial Milestone 7](./Day0Tutorial.md) — a `docker compose down && docker compose up --build` cycle, then confirm the Memory Core store, Sandman handoff, and backup bundles are intact. Run that check once when the pipeline is first wired; subsequent redeploys rely on the named-volume + project-name + bind-mount contract above.
 
 ## The health gate
 
@@ -74,6 +75,7 @@ A deploy job that does not gate on health reports success while serving a broken
 |---|---|---|
 | Healthcheck never goes healthy after redeploy | image build broken, a required env var unset, or Chroma unreachable | fail the job; surface `docker compose logs`; the prior volumes are intact for a retry |
 | Memory Core store empty after redeploy | the job ran `docker compose down -v`, or redeployed under a different `--project-name` | never `-v`; pin `--project-name` — the old volume still holds the data, reattach it |
+| `get_sandman_handoff` returns `handoff-not-found` after a successful cycle | writer and reader do not share `NEO_HANDOFF_FILE_PATH`, or `shared-handoff-data` was replaced | inspect both service env/mounts; reattach the stable named volume; never repair this by KB-ingesting the handoff |
 | Backup bundles missing after redeploy | redeployed from a different host checkout location (relative bind-mount) | deploy from a stable checkout path; recover bundles from the prior host directory |
 | TLS cert re-issued / ACME rate-limited each deploy | `caddy-data` removed by `down -v` | stop using `-v` so the issued certs persist |
 

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -259,9 +259,9 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
     });
 
     test('production compose pins cloud-profile local wake and mailbox boundaries', () => {
-        const compose           = readProductionCompose();
-        const orchestratorEnv   = environmentMap(compose.services.orchestrator);
-        const memoryCoreEnv     = environmentMap(compose.services['mc-server']);
+        const compose         = readProductionCompose();
+        const orchestratorEnv = environmentMap(compose.services.orchestrator);
+        const memoryCoreEnv   = environmentMap(compose.services['mc-server']);
 
         expect(orchestratorEnv).toMatchObject({
             NEO_AI_DEPLOYMENT_MODE                              : 'cloud',
@@ -277,12 +277,32 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
         expect(memoryCoreEnv.NEO_MAILBOX_DEFAULT_REPLY_POLICY).toBe('blocked');
     });
 
-    test('production compose keeps local-model as an opt-in provider profile', () => {
+    test('production compose persists the sandman handoff across its writer and reader', () => {
         const compose         = readProductionCompose();
-        const localModel      = compose.services['local-model'];
+        const handoffMount    = 'shared-handoff-data:/app/.neo-ai-data/handoff';
+        const readerMount     = handoffMount + ':ro';
+        const handoffPath     = '/app/.neo-ai-data/handoff/sandman_handoff.md';
+        const knowledgeBase   = compose.services['kb-server'];
+        const memoryCore      = compose.services['mc-server'];
+        const orchestrator    = compose.services.orchestrator;
+        const memoryCoreEnv   = environmentMap(memoryCore);
+        const orchestratorEnv = environmentMap(orchestrator);
+
+        expect(orchestratorEnv.NEO_HANDOFF_FILE_PATH).toBe(handoffPath);
+        expect(memoryCoreEnv.NEO_HANDOFF_FILE_PATH).toBe(handoffPath);
+        expect(orchestrator.volumes).toContain(handoffMount);
+        expect(memoryCore.volumes).toContain(readerMount);
+        expect(knowledgeBase.volumes).not.toContain(handoffMount);
+        expect(knowledgeBase.volumes).not.toContain(readerMount);
+        expect(compose.volumes).toHaveProperty('shared-handoff-data');
+    });
+
+    test('production compose keeps local-model as an opt-in provider profile', () => {
+        const compose          = readProductionCompose();
+        const localModel       = compose.services['local-model'];
         const knowledgeBaseEnv = environmentMap(compose.services['kb-server']);
-        const memoryCoreEnv   = environmentMap(compose.services['mc-server']);
-        const orchestratorEnv = environmentMap(compose.services.orchestrator);
+        const memoryCoreEnv    = environmentMap(compose.services['mc-server']);
+        const orchestratorEnv  = environmentMap(compose.services.orchestrator);
 
         expect(localModel.profiles).toEqual(['local-model']);
         expect(localModel.image).toBe('${NEO_LOCAL_MODEL_IMAGE:-ollama/ollama:latest}');


### PR DESCRIPTION
Resolves #15604

Evidence: L1 compose-contract coverage (16/16) plus a successful real `docker compose config` parse. L3 requires a running cloud-profile container recreate and authenticated `get_sandman_handoff` probe; #15604 AC2 is explicitly annotated `[L3-deferred — operator handoff needed]`. Residual: the live recreate witness described below, not an implementation-contract gap.

## Deltas from ticket

- Wires the existing `NEO_HANDOFF_FILE_PATH` leaf to `/app/.neo-ai-data/handoff/sandman_handoff.md` in the cloud-profile `orchestrator` and `mc-server` containers.
- Adds a dedicated `shared-handoff-data` named volume: read/write for the Golden Path writer in `orchestrator`, read-only for `get_sandman_handoff` in `mc-server`, and intentionally absent from `kb-server`.
- Corrects one drifted ticket premise: current `dev` schedules Golden Path in its own `golden-path` lane rather than through DreamService. Both execute in `orchestrator`, so the deployment-owned persistence fix is unchanged.
- Extends the existing compose diagnostics contract to pin matching env paths, writer/read-only mount modes, the dedicated volume declaration, and the KB exclusion.
- Documents the deployment-owned writer/reader boundary, local fallback behavior, and the exact Day-0 live persistence probe.
- Records the graph-backed v2 / tenant-scoping design input in D#15595 without importing that high-blast design into this wiring ticket: https://github.com/neomjs/neo/discussions/15595#discussioncomment-17750584

## Test Evidence

- Initial focused red run failed on the absent `NEO_HANDOFF_FILE_PATH` wiring.
- `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs` — 16 passed on current head `b9f9d41598c517f96660f19df8b5d8c0c19c1985`.
- `docker compose -f ai/deploy/docker-compose.yml --profile cloud config --quiet` — passed against the real compose parser.
- `npm run test-unit` — 9,016 passed, 14 failed, 6 skipped, and 65 did not run. Every failure passed its exact isolated rerun; the process-inspection cases required the host permissions denied by the initial sandbox.
- `npm run agent-preflight -- <5 changed files>` — passed; only unrelated non-blocking stale-overlay warnings were reported.
- The real pre-commit hooks and `git diff --check` passed.
- L3 was not run locally: the Docker CLI is present, but `/var/run/docker.sock` and `/Applications/Docker.app` are absent. No live-container claim is inferred from the L1 evidence.

## Post-Merge Validation

- On a deployment host, wait for a successful `golden-path` cycle, then invoke authenticated `get_sandman_handoff` using the Day-0 caller documented in `learn/agentos/cloud-deployment/Day0Tutorial.md`.
- Record returned `path`, `mtimeMs`, and a hash of `content`. The path must be `/app/.neo-ai-data/handoff/sandman_handoff.md`; `content` must be non-null.
- Recreate the cloud-profile `orchestrator` and `mc-server` containers without deleting named volumes, then invoke the tool again before the next Golden Path cycle.
- The second probe must preserve the first hash and `mtimeMs`. A `handoff-not-found` envelope is a failed persistence witness and warrants a new defect ticket; #15604 is never reopened.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session `72bb1088-8ed5-48b7-a835-c288cf30e814`.
