### PR TITLE
fix(ai): make bootstrap diagnostics fail-honest (#15749)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -25,6 +25,38 @@ import {
     isRepoDue
 } from '../scheduling/tenantRepoSync.mjs';
 
+const KB_CONFIG_BOOTSTRAP_PROJECTION_BY_STATUS = Object.freeze({
+    missing: {
+        errorCode   : null,
+        messageClass: null
+    },
+    empty: {
+        errorCode   : null,
+        messageClass: null
+    },
+    loaded: {
+        errorCode   : null,
+        messageClass: null
+    },
+    'read-failed': {
+        errorCode   : 'KB_CONFIG_BOOTSTRAP_READ_FAILED',
+        messageClass: 'filesystem-read'
+    },
+    'parse-failed': {
+        errorCode   : 'KB_CONFIG_BOOTSTRAP_PARSE_FAILED',
+        messageClass: 'yaml-parse'
+    },
+    'invalid-shape': {
+        errorCode   : 'KB_CONFIG_BOOTSTRAP_INVALID_SHAPE',
+        messageClass: 'document-shape'
+    }
+});
+const KB_CONFIG_BOOTSTRAP_FAILURE_STATUSES = new Set([
+    'read-failed',
+    'parse-failed',
+    'invalid-shape'
+]);
+
 /**
  * @summary Writes a bounded, graph-independent deployment-state snapshot for KB/MC tools.
  *
@@ -612,7 +644,7 @@ export class DeploymentStateBridgeService extends Base {
 
             const resolvedConfig = await this.tenantRepoSyncService.resolveTenantReposConfig();
             repos = Array.isArray(resolvedConfig.tenantRepos) ? resolvedConfig.tenantRepos : [];
-            configSummary = summarizeTenantRepoConfig(repos);
+            configSummary = summarizeTenantRepoConfig(repos, resolvedConfig.configDiagnostics);
         } catch (error) {
             errors.push(summarizeDiagnosticError(error, 'tenant-repo-config-read-failed'));
             configSummary = {
@@ -649,12 +681,19 @@ export class DeploymentStateBridgeService extends Base {
             recordType   : 'tenant-repo-sync-deployment-state',
             source,
             observedAt,
-            status       : classifyTenantRepoSyncStatus({enabled, taskState, repoCount: repos.length, schedulerDue: scheduler.due, errors}),
+            status       : classifyTenantRepoSyncStatus({
+                enabled,
+                taskState,
+                repoCount   : repos.length,
+                schedulerDue: scheduler.due,
+                configStatus: configSummary.status,
+                errors
+            }),
             enabled,
             scheduler,
-            task         : summarizeTenantRepoTaskState(taskState),
-            config       : configSummary,
-            repos        : repoStates,
+            task  : summarizeTenantRepoTaskState(taskState),
+            config: configSummary,
+            repos : repoStates,
             errors
         };
     }
@@ -833,7 +872,18 @@ function summarizeDiagnosticError(error, reason) {
     };
 }
 
-function summarizeTenantRepoConfig(repos) {
+/**
+ * @summary Summarizes effective tenant-repo config and projects bounded bootstrap provenance.
+ *
+ * Bootstrap document content never crosses this public diagnostic boundary. Failure fields are
+ * derived from the allowlisted status rather than copied from the upstream payload, preventing a
+ * malformed diagnostic from carrying paths, YAML, tenant identities, credentials, or raw messages.
+ *
+ * @param {Object[]} repos Effective tenant repository entries.
+ * @param {Object} [configDiagnostics] Resolver-owned bounded config diagnostics.
+ * @returns {Object}
+ */
+function summarizeTenantRepoConfig(repos, configDiagnostics) {
     const tierCounts    = {};
     let   disabledCount = 0;
 
@@ -846,12 +896,64 @@ function summarizeTenantRepoConfig(repos) {
         }
     }
 
+    const
+        bootstrap = summarizeKbConfigBootstrapDiagnostic(
+            configDiagnostics && configDiagnostics.bootstrap
+        ),
+        errors = bootstrap && KB_CONFIG_BOOTSTRAP_FAILURE_STATUSES.has(bootstrap.status)
+            ? [{
+                reason      : `kb-config-bootstrap-${bootstrap.status}`,
+                code        : bootstrap.errorCode,
+                messageClass: bootstrap.messageClass
+            }]
+            : [];
+
     return {
-        status   : 'available',
+        status   : errors.length > 0 ? 'degraded' : 'available',
         repoCount: repos.length,
         disabledCount,
         tierCounts,
-        errors   : []
+        bootstrap,
+        errors
+    };
+}
+
+/**
+ * @summary Reduces an internal bootstrap diagnostic to the public allowlisted projection.
+ * @param {*} diagnostic Candidate resolver diagnostic.
+ * @returns {Object|null} Safe bootstrap state, or `null` for a legacy absent diagnostic.
+ */
+function summarizeKbConfigBootstrapDiagnostic(diagnostic) {
+    if (diagnostic === null || diagnostic === undefined) {
+        return null;
+    }
+
+    const
+        candidateStatus = typeof diagnostic === 'object' && diagnostic
+            ? diagnostic.status
+            : null,
+        status = Object.hasOwn(KB_CONFIG_BOOTSTRAP_PROJECTION_BY_STATUS, candidateStatus)
+            ? candidateStatus
+            : 'invalid-shape',
+        projection = KB_CONFIG_BOOTSTRAP_PROJECTION_BY_STATUS[status];
+
+    let tenantCount = null;
+
+    if (status === 'missing' || status === 'empty') {
+        tenantCount = 0;
+    } else if (
+        status === 'loaded' &&
+        Number.isInteger(diagnostic.tenantCount) &&
+        diagnostic.tenantCount >= 0
+    ) {
+        tenantCount = diagnostic.tenantCount;
+    }
+
+    return {
+        status,
+        tenantCount,
+        errorCode   : projection.errorCode,
+        messageClass: projection.messageClass
     };
 }
 
@@ -943,8 +1045,23 @@ function summarizeTenantRepoState({repo, observedAt, taskState, persistedRepoSta
     };
 }
 
-function classifyTenantRepoSyncStatus({enabled, taskState, repoCount, schedulerDue, errors}) {
+/**
+ * @summary Classifies the tenant-repo-sync deployment state, including fail-honest config diagnostics.
+ * @param {Object} options
+ * @param {Boolean|null} options.enabled Runtime enablement.
+ * @param {Object|null} options.taskState Persisted task state.
+ * @param {Number} options.repoCount Effective repository count.
+ * @param {Boolean|null} options.schedulerDue Scheduler due state.
+ * @param {String} options.configStatus Config diagnostic status.
+ * @param {Object[]} options.errors Snapshot collection failures.
+ * @returns {String}
+ */
+function classifyTenantRepoSyncStatus({enabled, taskState, repoCount, schedulerDue, configStatus, errors}) {
     if (errors.length > 0) {
+        return 'degraded';
+    }
+
+    if (configStatus === 'degraded') {
         return 'degraded';
     }
 

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -621,7 +621,7 @@ class TenantRepoSyncService extends Base {
     }
 
     /**
-     * Resolves the effective `tenantRepos` across all tenants via the tiered resolver
+     * @summary Resolves the effective `tenantRepos` across all tenants via the tiered resolver
      * `KnowledgeBaseIngestionService.listConfiguredTenantRepos` (graph node > `kb-config.yaml`
      * bootstrap > `aiConfig.tenantRepos[]` default, per-tenant single-winner, flattened). Replaces
      * the prior direct `aiConfig.tenantRepos` read so the documented bootstrap / graph tiers are
@@ -652,7 +652,8 @@ class TenantRepoSyncService extends Base {
      * @param {Object} [options.orchestratorConfig=AiConfig.orchestrator] Stub for the AiConfig.orchestrator section (test seam).
      * @param {Object} [options.env=process.env] Stub for the env-var lookup (test seam).
      * @param {Object} [options.ingestionService] Stub KB ingestion service (test seam); defaults to the live singleton.
-     * @returns {Promise<{tenantRepos: Array<Object>}>}
+     * @returns {Promise<{tenantRepos: Array<Object>, configDiagnostics: Object}>} Effective repos with
+     *     the Knowledge Base resolver's bounded config diagnostics preserved unchanged.
      */
     async resolveTenantReposConfig({tier1MirrorRoot, orchestratorConfig = AiConfig.orchestrator, env = process.env, ingestionService} = {}) {
         const tier1Default = tier1MirrorRoot

--- a/ai/services/graph/ollamaStuckRunnerLiveness.mjs
+++ b/ai/services/graph/ollamaStuckRunnerLiveness.mjs
@@ -6,7 +6,7 @@
  * prefill) at ~100%×N-cores while serving nothing else, because `OLLAMA_NUM_PARALLEL=1`
  * queues every other request behind it. Residency probes pass; the deployment burns.
  * (Empirical anchor: a `gemma4` chat runner pegged at 399.7% for 58h of CPU-time with an
- * idle orchestrator and no users — the klarso incident.)
+ * idle orchestrator and no users in a cloud deployment.)
  *
  * The only honest signal is whether a real inference **canary** completes. The hard part is
  * NOT restarting a *legitimately-long* request — that is a self-inflicted outage. So a

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -26,8 +26,22 @@ import {fileURLToPath} from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
-const LOCAL_EMBEDDING_PROVIDERS = new Set(['openAiCompatible', 'ollama']);
-const PARSED_CHUNK_SCHEMA_PATH  = path.join(__dirname, 'parser/parsed-chunk-v1.schema.json');
+const LOCAL_EMBEDDING_PROVIDERS           = new Set(['openAiCompatible', 'ollama']);
+const PARSED_CHUNK_SCHEMA_PATH            = path.join(__dirname, 'parser/parsed-chunk-v1.schema.json');
+const KB_CONFIG_BOOTSTRAP_FAILURE_DETAILS = Object.freeze({
+    'read-failed': {
+        errorCode   : 'KB_CONFIG_BOOTSTRAP_READ_FAILED',
+        messageClass: 'filesystem-read'
+    },
+    'parse-failed': {
+        errorCode   : 'KB_CONFIG_BOOTSTRAP_PARSE_FAILED',
+        messageClass: 'yaml-parse'
+    },
+    'invalid-shape': {
+        errorCode   : 'KB_CONFIG_BOOTSTRAP_INVALID_SHAPE',
+        messageClass: 'document-shape'
+    }
+});
 
 /**
  * @summary Orchestrates tenant-aware Knowledge Base ingestion pushes.
@@ -1290,27 +1304,114 @@ class IngestionService extends Base {
     }
 
     /**
-     * @summary Reads the optional `kb-config.yaml` deployment bootstrap, fail-soft.
+     * @summary Reads the optional `kb-config.yaml` bootstrap with bounded diagnostic provenance.
      *
-     * The bootstrap is a deployment-root first-deploy convenience (`{tenants: {<tenantId>: {...}}}`);
-     * the `KnowledgeBaseTenantConfig` graph node remains the canonical store. A missing or malformed
-     * file resolves to `null` so `getTenantConfig` falls through to the default registry rather than
-     * throwing.
-     * @returns {Object|null} The parsed bootstrap document, or `null` when absent / unreadable.
+     * Runtime resolution remains fail-soft: every non-loaded state carries `document:null`, allowing
+     * callers to continue to the AiConfig fallback. Diagnostics distinguish absence, an empty YAML
+     * document, filesystem failure, parse failure, and a top-level contract failure without retaining
+     * the host path, source text, raw error message, stack, tenant identities, or repository config.
+     *
+     * @param {Object} [options]
+     * @param {Object} [options.fileSystem=fs] File reader test seam.
+     * @returns {{status: ('missing'|'empty'|'loaded'|'read-failed'|'parse-failed'|'invalid-shape'), document: Object|null, tenantCount: Number|null, errorCode: String|null, messageClass: String|null}}
      * @protected
      */
-    readKbConfigBootstrap() {
+    readKbConfigBootstrapResult({fileSystem = fs} = {}) {
+        let source;
+
         try {
             const bootstrapPath = path.join(aiConfig.neoRootDir, 'kb-config.yaml');
 
-            if (!fs.existsSync(bootstrapPath)) {
-                return null;
+            source = fileSystem.readFileSync(bootstrapPath, 'utf8');
+        } catch (error) {
+            if (error && error.code === 'ENOENT') {
+                return {
+                    status      : 'missing',
+                    document    : null,
+                    tenantCount : 0,
+                    errorCode   : null,
+                    messageClass: null
+                };
             }
 
-            return yaml.load(fs.readFileSync(bootstrapPath, 'utf8')) || null;
-        } catch {
-            return null;
+            return {
+                status     : 'read-failed',
+                document   : null,
+                tenantCount: null,
+                ...KB_CONFIG_BOOTSTRAP_FAILURE_DETAILS['read-failed']
+            };
         }
+
+        if (source.split(/\r?\n/u).every(line => /^\s*(?:#.*)?$/u.test(line))) {
+            return {
+                status      : 'empty',
+                document    : null,
+                tenantCount : 0,
+                errorCode   : null,
+                messageClass: null
+            };
+        }
+
+        let document;
+
+        try {
+            document = yaml.load(source);
+        } catch {
+            return {
+                status     : 'parse-failed',
+                document   : null,
+                tenantCount: null,
+                ...KB_CONFIG_BOOTSTRAP_FAILURE_DETAILS['parse-failed']
+            };
+        }
+
+        if (document === null || document === undefined) {
+            return {
+                status      : 'empty',
+                document    : null,
+                tenantCount : 0,
+                errorCode   : null,
+                messageClass: null
+            };
+        }
+
+        if (
+            typeof document !== 'object' ||
+            Array.isArray(document) ||
+            !Object.hasOwn(document, 'tenants') ||
+            !document.tenants ||
+            typeof document.tenants !== 'object' ||
+            Array.isArray(document.tenants)
+        ) {
+            return {
+                status     : 'invalid-shape',
+                document   : null,
+                tenantCount: null,
+                ...KB_CONFIG_BOOTSTRAP_FAILURE_DETAILS['invalid-shape']
+            };
+        }
+
+        return {
+            status      : 'loaded',
+            document,
+            tenantCount : Object.keys(document.tenants).length,
+            errorCode   : null,
+            messageClass: null
+        };
+    }
+
+    /**
+     * @summary Reads the optional `kb-config.yaml` deployment bootstrap, fail-soft.
+     *
+     * This compatibility path intentionally returns only the valid parsed document. Missing, empty,
+     * unreadable, malformed, and invalid-shape inputs resolve to `null`, preserving graph → YAML →
+     * AiConfig precedence for existing tenant-config consumers.
+     *
+     * @returns {Object|null} The valid parsed bootstrap document, or `null`.
+     * @protected
+     */
+    readKbConfigBootstrap() {
+        return this.readKbConfigBootstrapResult().document;
     }
 
     /**
@@ -1330,12 +1431,13 @@ class IngestionService extends Base {
      * `tenants.*` keys, plus the distinct `tenantId`s in `aiConfig.tenantRepos[]`. Graph-tier
      * enumeration stays inside `GraphService.listNodeRecordsByType()` so the resolver does not issue
      * raw graph scans or bypass the graph service's RLS/visibility boundary.
-     * @returns {Promise<{tenantRepos: Array<Object>}>} Contract-normalized; throws on a malformed entry.
+     * @returns {Promise<{tenantRepos: Array<Object>, configDiagnostics: {bootstrap: Object}}>} Contract-normalized repos plus bounded bootstrap provenance; throws on a malformed entry.
      */
     async listConfiguredTenantRepos() {
         await this.graphService.ready();
 
-        const bootstrap       = this.readKbConfigBootstrap(),
+        const bootstrapResult = this.readKbConfigBootstrapResult(),
+              bootstrap       = bootstrapResult.document,
               yamlTenants     = (bootstrap && bootstrap.tenants) || {},
               defaultRepos    = Array.isArray(aiConfig.tenantRepos) ? aiConfig.tenantRepos : [],
               graphRecords    = this.listTenantConfigRecords(),
@@ -1389,7 +1491,17 @@ class IngestionService extends Base {
             }));
         }
 
-        return normalizeTenantRepoConfig({tenantRepos: effective});
+        return normalizeTenantRepoConfig({
+            tenantRepos      : effective,
+            configDiagnostics: {
+                bootstrap: {
+                    status      : bootstrapResult.status,
+                    tenantCount : bootstrapResult.tenantCount,
+                    errorCode   : bootstrapResult.errorCode,
+                    messageClass: bootstrapResult.messageClass
+                }
+            }
+        });
     }
 
     /**

--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -118,7 +118,13 @@ tenants:
 
 The `tenantRepos:` block is the bootstrap tier for the pull-mode polling config — `listConfiguredTenantRepos()` resolves it under the graph node → `kb-config.yaml` → `aiConfig` tiering. Graph-only tenant config nodes are included through the graph service's RLS-aware tenant-config enumeration surface; an unreadable graph tier degrades deployment diagnostics instead of silently behaving like an empty pull-mode config.
 
-The YAML is bootstrap-only — the graph node is canonical once written. A malformed or absent file is fail-soft (logged, treated as absent → tier 3).
+The YAML is bootstrap-only — the graph node is canonical once written. Runtime resolution stays
+fail-soft: a missing, empty, unreadable, malformed, or invalid-shape file cannot block a valid graph
+or AiConfig fallback. Diagnostics remain fail-honest, however. The deployment snapshot projects
+`tenantRepoSync.config.bootstrap` with one of `missing`, `empty`, `loaded`, `read-failed`,
+`parse-failed`, or `invalid-shape`, plus only a tenant count and bounded code/message class.
+Bootstrap content, host paths, raw errors, tenant/repository identities, clone URLs, and credential
+references never cross that diagnostic boundary.
 
 **Config versioning.** Every ingested chunk is stamped with the `tenantConfigVersion` active at ingest time (server-stamped chunk metadata). A tier-3 (default-registry) resolution stamps `tenantConfigVersion: 0`. The stamp lets a future config change drive retroactive invalidation of chunks ingested under a now-stale config.
 

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -188,6 +188,22 @@ A freshly deployed Knowledge Base can be **healthy but empty**: `healthcheck` re
 
 For push-mode deployments, trigger the deployment's ingestion entry point once, then query again.
 
+For a pull-mode deployment, read `tenantRepoSync.config.bootstrap` before treating an empty repo
+count as intentional:
+
+| Bootstrap status | Meaning | Operator action |
+|---|---|---|
+| `missing` | The optional `kb-config.yaml` file is not mounted. | Confirm graph/AiConfig is the intended authority, or mount the bootstrap file. This state does not degrade diagnostics. |
+| `empty` | The file was readable but contained no YAML document. | Add the intended `tenants:` mapping, or keep the file empty when another tier is authoritative. This state does not degrade diagnostics. |
+| `loaded` | The file matched the `{tenants: {...}}` contract. | Compare `tenantCount`, effective `repoCount`, and `tierCounts` to the intended deployment. A zero tenant count is valid. |
+| `read-failed` | The file exists or was addressed, but the service could not read it. | Fix mount visibility, ownership, or permissions, then refresh the deployment snapshot. |
+| `parse-failed` | The file was readable but was not valid YAML. | Validate and correct YAML syntax, redeploy the file, then refresh the snapshot. |
+| `invalid-shape` | YAML parsed, but the top level was not an object containing an object-valued `tenants` mapping. | Restore the documented `tenants:` bootstrap shape, then refresh the snapshot. |
+
+The three failure states degrade the config diagnostic without discarding safely resolved graph or
+AiConfig fallback repos. The snapshot deliberately omits paths, YAML content, tenant/repository
+identities, clone URLs, credentials, tokens, stacks, and raw filesystem/parser messages.
+
 For pull-mode deployments with configured `tenantRepos[]`, call `inspect_deployment` or `get_deployment_state_snapshot` and inspect the `tenantRepoSync` section before taking manual action. It distinguishes disabled, true no-configured-repos, not-due, running, completed, failed, and degraded/unreadable state without exposing credentials or raw logs. A degraded config-read error means the graph/YAML/default config resolver could not prove the effective `tenantRepos`; treat that differently from a real empty config. If the task is configured but has not advanced, use the stable reason code and per-repo hashed state there to decide whether to wait for the next due sweep, fix credentials/config, or run `node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <slug>` inside the orchestrator container. When `lastErrorCode` is `KB_TENANT_REPO_SYNC_SYNC_FAILED`, check `lastSourceErrorCode`: `KB_GITMIRROR_CREDENTIAL_REF_INVALID`, `KB_GITMIRROR_CLONE_FAILED`, or `KB_GITMIRROR_FETCH_FAILED` points to the credential/ref/upstream access path before generic ingestion debugging. `KB_VECTOR_EMBED_FAILED` means the repository fetch and envelope reached the ingestion layer but vector writes failed; correct the embedding path before retrying.
 
 Current releases accept a tenant-repo ingest as successful only when the returned summary contains

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -472,7 +472,17 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             },
             tenantRepoSyncService: {
                 async resolveTenantReposConfig() {
-                    return {tenantRepos: []};
+                    return {
+                        tenantRepos      : [],
+                        configDiagnostics: {
+                            bootstrap: {
+                                status      : 'missing',
+                                tenantCount : 0,
+                                errorCode   : null,
+                                messageClass: null
+                            }
+                        }
+                    };
                 },
                 defaultRevisionsFilePath() {
                     return '/state/tenant-repo-sync-revisions.json';
@@ -494,7 +504,13 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             enabled: true,
             config : {
                 status   : 'available',
-                repoCount: 0
+                repoCount: 0,
+                bootstrap: {
+                    status      : 'missing',
+                    tenantCount : 0,
+                    errorCode   : null,
+                    messageClass: null
+                }
             },
             task: {
                 lastCompletion: {
@@ -506,6 +522,152 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             errors: []
         });
     });
+
+    test('collectTenantRepoSyncSnapshot keeps empty and loaded bootstrap states non-degraded', async () => {
+        const cases = [
+            {status: 'empty', tenantCount: 0},
+            {status: 'loaded', tenantCount: 0},
+            {status: 'loaded', tenantCount: 2}
+        ];
+
+        for (const bootstrap of cases) {
+            const service = createService({
+                taskStateService: {
+                    getTaskState() {
+                        return null;
+                    }
+                },
+                tenantRepoSyncService: {
+                    async resolveTenantReposConfig() {
+                        return {
+                            tenantRepos      : [],
+                            configDiagnostics: {
+                                bootstrap: {
+                                    ...bootstrap,
+                                    errorCode   : null,
+                                    messageClass: null
+                                }
+                            }
+                        };
+                    },
+                    defaultRevisionsFilePath() {
+                        return '/state/revisions.json';
+                    },
+                    async readPersistedRevisions() {
+                        return {};
+                    }
+                },
+                tenantRepoSyncEnabledReader: () => true
+            });
+
+            const tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+            expect(tenantRepoSync.status).toBe('no-configured-repos');
+            expect(tenantRepoSync.config).toMatchObject({
+                status   : 'available',
+                repoCount: 0,
+                bootstrap
+            });
+            expect(tenantRepoSync.config.errors).toEqual([]);
+            service.destroy();
+        }
+    });
+
+    for (const failure of [
+        {
+            status      : 'read-failed',
+            errorCode   : 'KB_CONFIG_BOOTSTRAP_READ_FAILED',
+            messageClass: 'filesystem-read'
+        },
+        {
+            status      : 'parse-failed',
+            errorCode   : 'KB_CONFIG_BOOTSTRAP_PARSE_FAILED',
+            messageClass: 'yaml-parse'
+        },
+        {
+            status      : 'invalid-shape',
+            errorCode   : 'KB_CONFIG_BOOTSTRAP_INVALID_SHAPE',
+            messageClass: 'document-shape'
+        }
+    ]) {
+        test(`collectTenantRepoSyncSnapshot degrades ${failure.status} while preserving fallback repo counts`, async () => {
+            const service = createService({
+                taskStateService: {
+                    getTaskState() {
+                        return null;
+                    }
+                },
+                tenantRepoSyncService: {
+                    async resolveTenantReposConfig() {
+                        return {
+                            tenantRepos: [{
+                                tenantId     : 'private-tenant',
+                                repoSlug     : 'private/repo',
+                                cloneUrl     : 'https://git.example/private/repo.git',
+                                credentialRef: 'env:TOKEN',
+                                configTier   : 'aiConfig'
+                            }],
+                            configDiagnostics: {
+                                bootstrap: {
+                                    status      : failure.status,
+                                    tenantCount : 999,
+                                    errorCode   : 'token-secret',
+                                    messageClass: 'stack-secret',
+                                    path        : '/srv/private/kb-config.yaml',
+                                    rawYaml     : 'yaml-secret',
+                                    document    : {
+                                        tenants: {
+                                            'private-tenant': {
+                                                cloneUrl: 'https://token-secret@git.example/private/repo.git'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        };
+                    },
+                    defaultRevisionsFilePath() {
+                        return '/state/revisions.json';
+                    },
+                    async readPersistedRevisions() {
+                        return {};
+                    }
+                },
+                tenantRepoSyncEnabledReader: () => true
+            });
+
+            const tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+            expect(tenantRepoSync.status).toBe('degraded');
+            expect(tenantRepoSync.config).toMatchObject({
+                status   : 'degraded',
+                repoCount: 1,
+                bootstrap: {
+                    status      : failure.status,
+                    tenantCount : null,
+                    errorCode   : failure.errorCode,
+                    messageClass: failure.messageClass
+                },
+                errors: [{
+                    reason      : `kb-config-bootstrap-${failure.status}`,
+                    code        : failure.errorCode,
+                    messageClass: failure.messageClass
+                }]
+            });
+            expect(tenantRepoSync.repos).toHaveLength(1);
+            expect(tenantRepoSync.errors).toEqual([]);
+
+            const serialized = JSON.stringify(tenantRepoSync);
+            expect(serialized).not.toContain('private-tenant');
+            expect(serialized).not.toContain('private/repo');
+            expect(serialized).not.toContain('TOKEN');
+            expect(serialized).not.toContain('/srv/private');
+            expect(serialized).not.toContain('token-secret');
+            expect(serialized).not.toContain('stack-secret');
+            expect(serialized).not.toContain('yaml-secret');
+            service.destroy();
+        });
+    }
 
     test('collectTenantRepoSyncSnapshot reports not-due repos with hashed identities only', async () => {
         const service = createService({

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1570,6 +1570,34 @@ test.describe('TenantRepoSyncService.resolveTenantReposConfig — Tier-1 mirrorR
         expect(overrides.mirrorRoot).toBe('/custom/root');
     });
 
+    test('preserves bounded bootstrap diagnostics while materializing mirror roots', async () => {
+        const bootstrap = {
+            status      : 'parse-failed',
+            tenantCount : null,
+            errorCode   : 'KB_CONFIG_BOOTSTRAP_PARSE_FAILED',
+            messageClass: 'yaml-parse'
+        };
+        const ingestionStub = {
+            listConfiguredTenantRepos: async () => ({
+                tenantRepos: [{
+                    tenantId     : 't1',
+                    repoSlug     : 'org/repo',
+                    cloneUrl     : 'https://github.com/neomjs/a.git',
+                    credentialRef: 'env:T'
+                }],
+                configDiagnostics: {bootstrap}
+            })
+        };
+
+        const result = await TenantRepoSyncService.resolveTenantReposConfig({
+            ingestionService: ingestionStub,
+            tier1MirrorRoot : '/app/.neo-ai-data'
+        });
+
+        expect(result.tenantRepos[0].mirrorRoot).toBe('/app/.neo-ai-data');
+        expect(result.configDiagnostics).toEqual({bootstrap});
+    });
+
     test('Tier-1 default + deriveTenantRepoMirrorPath produces canonical no-double-segment path', async () => {
         const ingestionStub = {
             listConfiguredTenantRepos: async () => ({tenantRepos: [

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -735,6 +735,191 @@ test.describe('IngestionService.ingestSourceFiles', () => {
     });
 });
 
+test.describe('IngestionService.readKbConfigBootstrapResult (#15749)', () => {
+    let Service;
+
+    test.beforeAll(async () => {
+        Service = (await import('../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
+    });
+
+    test('distinguishes a missing optional bootstrap without degrading it', () => {
+        const error = new Error('/srv/private/kb-config.yaml was not found');
+        error.code = 'ENOENT';
+
+        const result = Service.readKbConfigBootstrapResult({
+            fileSystem: {
+                readFileSync() {
+                    throw error;
+                }
+            }
+        });
+
+        expect(result).toEqual({
+            status      : 'missing',
+            document    : null,
+            tenantCount : 0,
+            errorCode   : null,
+            messageClass: null
+        });
+        expect(JSON.stringify(result)).not.toContain('/srv/private');
+    });
+
+    test('returns a bounded read-failed diagnostic without the raw filesystem error', () => {
+        const error = new Error('EACCES: token-secret at /srv/private/kb-config.yaml');
+        error.code = 'EACCES';
+
+        const result = Service.readKbConfigBootstrapResult({
+            fileSystem: {
+                readFileSync() {
+                    throw error;
+                }
+            }
+        });
+
+        expect(result).toEqual({
+            status      : 'read-failed',
+            document    : null,
+            tenantCount : null,
+            errorCode   : 'KB_CONFIG_BOOTSTRAP_READ_FAILED',
+            messageClass: 'filesystem-read'
+        });
+
+        const serialized = JSON.stringify(result);
+        expect(serialized).not.toContain('token-secret');
+        expect(serialized).not.toContain('/srv/private');
+        expect(serialized).not.toContain('EACCES');
+    });
+
+    test('distinguishes malformed YAML without retaining source content or parser messages', () => {
+        const result = Service.readKbConfigBootstrapResult({
+            fileSystem: {
+                readFileSync() {
+                    return 'tenants:\n  tenant-a: [token-secret';
+                }
+            }
+        });
+
+        expect(result).toEqual({
+            status      : 'parse-failed',
+            document    : null,
+            tenantCount : null,
+            errorCode   : 'KB_CONFIG_BOOTSTRAP_PARSE_FAILED',
+            messageClass: 'yaml-parse'
+        });
+        expect(JSON.stringify(result)).not.toContain('token-secret');
+        expect(JSON.stringify(result)).not.toContain('tenant-a');
+    });
+
+    test('distinguishes an empty YAML document as a non-error state', () => {
+        const result = Service.readKbConfigBootstrapResult({
+            fileSystem: {
+                readFileSync() {
+                    return '# intentionally empty\n';
+                }
+            }
+        });
+
+        expect(result).toEqual({
+            status      : 'empty',
+            document    : null,
+            tenantCount : 0,
+            errorCode   : null,
+            messageClass: null
+        });
+    });
+
+    test('rejects invalid top-level and tenants shapes without projecting parsed content', () => {
+        for (const source of [
+            '- tenant-a',
+            '{}',
+            'tenants:\n  - tenant-a'
+        ]) {
+            const result = Service.readKbConfigBootstrapResult({
+                fileSystem: {
+                    readFileSync() {
+                        return source;
+                    }
+                }
+            });
+
+            expect(result).toEqual({
+                status      : 'invalid-shape',
+                document    : null,
+                tenantCount : null,
+                errorCode   : 'KB_CONFIG_BOOTSTRAP_INVALID_SHAPE',
+                messageClass: 'document-shape'
+            });
+            expect(JSON.stringify(result)).not.toContain('tenant-a');
+        }
+    });
+
+    test('loads a valid empty tenants map with an explicit zero count', () => {
+        const result = Service.readKbConfigBootstrapResult({
+            fileSystem: {
+                readFileSync() {
+                    return 'tenants: {}';
+                }
+            }
+        });
+
+        expect(result).toEqual({
+            status      : 'loaded',
+            document    : {tenants: {}},
+            tenantCount : 0,
+            errorCode   : null,
+            messageClass: null
+        });
+    });
+
+    test('loads valid configured tenants and reports only their count beside the document', () => {
+        const result = Service.readKbConfigBootstrapResult({
+            fileSystem: {
+                readFileSync() {
+                    return [
+                        'tenants:',
+                        '  tenant-a:',
+                        '    tenantRepos: []',
+                        '  tenant-b:',
+                        '    useDefaultSources: false'
+                    ].join('\n');
+                }
+            }
+        });
+
+        expect(result.status).toBe('loaded');
+        expect(result.tenantCount).toBe(2);
+        expect(Object.keys(result.document.tenants)).toEqual(['tenant-a', 'tenant-b']);
+        expect(result.errorCode).toBeNull();
+        expect(result.messageClass).toBeNull();
+    });
+
+    test('keeps readKbConfigBootstrap as the document-only compatibility path', () => {
+        const original = Service.readKbConfigBootstrapResult;
+
+        try {
+            Service.readKbConfigBootstrapResult = () => ({
+                status      : 'loaded',
+                document    : {tenants: {}},
+                tenantCount : 0,
+                errorCode   : null,
+                messageClass: null
+            });
+            expect(Service.readKbConfigBootstrap()).toEqual({tenants: {}});
+
+            Service.readKbConfigBootstrapResult = () => ({
+                status      : 'parse-failed',
+                document    : null,
+                tenantCount : null,
+                errorCode   : 'KB_CONFIG_BOOTSTRAP_PARSE_FAILED',
+                messageClass: 'yaml-parse'
+            });
+            expect(Service.readKbConfigBootstrap()).toBeNull();
+        } finally {
+            Service.readKbConfigBootstrapResult = original;
+        }
+    });
+});
+
 test.describe('IngestionService.tenantConfig (#11637)', () => {
     let Service;
     let originals;
@@ -949,19 +1134,39 @@ test.describe('IngestionService.listConfiguredTenantRepos (#12145)', () => {
     test.beforeEach(() => {
         graphStub = createGraphStub();
         originals = {
-            graphService         : Service.graphService,
-            readKbConfigBootstrap: Service.readKbConfigBootstrap
+            graphService               : Service.graphService,
+            readKbConfigBootstrapResult: Service.readKbConfigBootstrapResult
         };
         originalAiConfigRepos = aiConfig.tenantRepos;
 
-        Service.graphService          = graphStub;
-        Service.readKbConfigBootstrap = () => null;
+        Service.graphService = graphStub;
+        setBootstrapDiagnostic({
+            status      : 'missing',
+            document    : null,
+            tenantCount : 0,
+            errorCode   : null,
+            messageClass: null
+        });
     });
 
     test.afterEach(() => {
         Object.assign(Service, originals);
         aiConfig.tenantRepos = originalAiConfigRepos;
     });
+
+    function setBootstrapDiagnostic(diagnostic) {
+        Service.readKbConfigBootstrapResult = () => diagnostic;
+    }
+
+    function setBootstrapDocument(document) {
+        setBootstrapDiagnostic({
+            status      : 'loaded',
+            document,
+            tenantCount : Object.keys(document.tenants).length,
+            errorCode   : null,
+            messageClass: null
+        });
+    }
 
     function seedGraphConfig(tenantId, tenantRepos) {
         graphStub.store.set(`kb-config:${tenantId}`, {
@@ -972,14 +1177,14 @@ test.describe('IngestionService.listConfiguredTenantRepos (#12145)', () => {
     }
 
     test('flattens per-tenant yaml-tier tenantRepos across tenants and stamps tenantId', async () => {
-        Service.readKbConfigBootstrap = () => ({
+        setBootstrapDocument({
             tenants: {
                 'tenant-a': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/a.git', credentialRef: 'env:A'}]},
                 'tenant-b': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/b.git', credentialRef: 'env:B'}]}
             }
         });
 
-        const {tenantRepos} = await Service.listConfiguredTenantRepos();
+        const {tenantRepos, configDiagnostics} = await Service.listConfiguredTenantRepos();
 
         expect(tenantRepos).toHaveLength(2);
         expect(tenantRepos.find(r => r.tenantId === 'tenant-a')).toMatchObject({
@@ -988,11 +1193,20 @@ test.describe('IngestionService.listConfiguredTenantRepos (#12145)', () => {
         expect(tenantRepos.find(r => r.tenantId === 'tenant-b')).toMatchObject({
             cloneUrl: 'https://github.com/neomjs/b.git', credentialRef: 'env:B', configTier: 'yaml'
         });
+        expect(configDiagnostics).toEqual({
+            bootstrap: {
+                status      : 'loaded',
+                tenantCount : 2,
+                errorCode   : null,
+                messageClass: null
+            }
+        });
+        expect(configDiagnostics.bootstrap).not.toHaveProperty('document');
     });
 
     test('graph-node tier wins WHOLESALE over yaml for the same tenant (no within-tenant merge)', async () => {
         seedGraphConfig('tenant-a', [{cloneUrl: 'https://github.com/neomjs/graph.git', credentialRef: 'env:G'}]);
-        Service.readKbConfigBootstrap = () => ({
+        setBootstrapDocument({
             tenants: {'tenant-a': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/yaml.git', credentialRef: 'env:Y'}]}}
         });
 
@@ -1006,7 +1220,7 @@ test.describe('IngestionService.listConfiguredTenantRepos (#12145)', () => {
 
     test('includes graph-only tenantRepos discovered through the graph service enumeration surface', async () => {
         seedGraphConfig('graph-only-tenant', [{cloneUrl: 'https://github.com/neomjs/x.git', credentialRef: 'env:X'}]);
-        Service.readKbConfigBootstrap = () => ({
+        setBootstrapDocument({
             tenants: {'tenant-a': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/a.git', credentialRef: 'env:A'}]}}
         });
 
@@ -1026,7 +1240,7 @@ test.describe('IngestionService.listConfiguredTenantRepos (#12145)', () => {
     });
 
     test('propagates the access-contract rejection for a yaml entry missing credentialRef', async () => {
-        Service.readKbConfigBootstrap = () => ({
+        setBootstrapDocument({
             tenants: {'tenant-a': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/a.git'}]}}
         });
 
@@ -1041,13 +1255,13 @@ test.describe('IngestionService.listConfiguredTenantRepos (#12145)', () => {
 
     test('fails loud when graph-tier tenant discovery is unavailable', async () => {
         delete graphStub.listNodeRecordsByType;
-        Service.readKbConfigBootstrap = () => ({tenants: {'tenant-a': {tenantRepos: []}}});
+        setBootstrapDocument({tenants: {'tenant-a': {tenantRepos: []}}});
 
         await expect(Service.listConfiguredTenantRepos()).rejects.toThrow('GraphService.listNodeRecordsByType');
     });
 
     test('returns an empty array when no tenant declares tenantRepos', async () => {
-        Service.readKbConfigBootstrap = () => ({tenants: {'tenant-a': {useDefaultSources: false}}});
+        setBootstrapDocument({tenants: {'tenant-a': {useDefaultSources: false}}});
 
         const {tenantRepos} = await Service.listConfiguredTenantRepos();
         expect(tenantRepos).toEqual([]);
@@ -1058,7 +1272,7 @@ test.describe('IngestionService.listConfiguredTenantRepos (#12145)', () => {
         // the tenant; it must win wholesale even though the array is empty — selecting on length > 0
         // would leak the yaml/default repos back in (the cycle-1 fallback bug).
         seedGraphConfig('tenant-a', []);
-        Service.readKbConfigBootstrap = () => ({
+        setBootstrapDocument({
             tenants: {'tenant-a': {tenantRepos: [{cloneUrl: 'https://github.com/neomjs/yaml.git', credentialRef: 'env:Y'}]}}
         });
 
@@ -1068,11 +1282,46 @@ test.describe('IngestionService.listConfiguredTenantRepos (#12145)', () => {
 
     test('yaml tier with empty tenantRepos suppresses the aiConfig default tier for that tenant (presence-based winner)', async () => {
         aiConfig.tenantRepos = [{tenantId: 'tenant-a', cloneUrl: 'https://github.com/neomjs/default.git', credentialRef: 'env:D'}];
-        Service.readKbConfigBootstrap = () => ({
+        setBootstrapDocument({
             tenants: {'tenant-a': {tenantRepos: []}}
         });
 
         const {tenantRepos} = await Service.listConfiguredTenantRepos();
         expect(tenantRepos).toEqual([]);
+    });
+
+    test('preserves fallback repos while reporting a bounded bootstrap read failure', async () => {
+        aiConfig.tenantRepos = [{
+            tenantId     : 'tenant-a',
+            cloneUrl     : 'https://github.com/neomjs/default.git',
+            credentialRef: 'env:D'
+        }];
+        setBootstrapDiagnostic({
+            status      : 'read-failed',
+            document    : null,
+            tenantCount : null,
+            errorCode   : 'KB_CONFIG_BOOTSTRAP_READ_FAILED',
+            messageClass: 'filesystem-read',
+            rawMessage  : 'token-secret at /srv/private/kb-config.yaml'
+        });
+
+        const {tenantRepos, configDiagnostics} = await Service.listConfiguredTenantRepos();
+
+        expect(tenantRepos).toHaveLength(1);
+        expect(tenantRepos[0]).toMatchObject({
+            tenantId  : 'tenant-a',
+            configTier: 'aiConfig',
+            repoSlug  : 'github.com/neomjs/default'
+        });
+        expect(configDiagnostics).toEqual({
+            bootstrap: {
+                status      : 'read-failed',
+                tenantCount : null,
+                errorCode   : 'KB_CONFIG_BOOTSTRAP_READ_FAILED',
+                messageClass: 'filesystem-read'
+            }
+        });
+        expect(JSON.stringify(configDiagnostics)).not.toContain('token-secret');
+        expect(JSON.stringify(configDiagnostics)).not.toContain('/srv/private');
     });
 });


### PR DESCRIPTION
Resolves #15749

Cloud deployment snapshots now distinguish a missing, empty, loaded, unreadable, malformed, or invalid-shape `kb-config.yaml` bootstrap without changing graph → YAML → AiConfig precedence. The Knowledge Base resolver forwards only bounded bootstrap provenance beside the effective repos, and the deployment bridge independently derives an allowlisted public projection: missing/empty/loaded remain available, while read/parse/shape failures degrade config diagnostics without hiding safely resolved fallback repo counts. Cloud operator docs map each state to its corrective action, and the stuck-runner empirical anchor is now client-neutral while retaining its model, CPU, and duration evidence.

Decision Record impact: aligned with ADR 0014 and ADR 0019; no amendment required. The existing Knowledge Base resolver remains the bootstrap authority, AiConfig is read only at the existing use site, and the public deployment bridge remains the redaction boundary.

Evidence: L2 (real YAML parser plus resolver, propagation, redaction, and snapshot unit coverage) → L2 required (all close-target ACs are internal diagnostic contracts and documentation). No residuals.

## Deltas from ticket

None substantive.

## Test Evidence

- Bootstrap loader, graph/YAML/AiConfig precedence, diagnostic propagation, public snapshot projection, and redaction: `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs` — 120 passed after rebasing onto current `origin/dev`.
- Runtime syntax: `node --check` for `IngestionService.mjs`, `TenantRepoSyncService.mjs`, `DeploymentStateBridgeService.mjs`, and `ollamaStuckRunnerLiveness.mjs` — passed.
- Cloud deployment guides: `npm run ai:lint-guides` — 0 hard errors; 28 repository-wide warnings.
- Static gates: `git diff origin/dev...HEAD --check`; current-source organization-name scan of the liveness anchor — passed.
- Agent gates: `npm run agent-preflight -- --no-fix --pr-body /private/tmp/neo-pr-15749-body.md <nine changed files>` — passed.

## Post-Merge Validation

- [ ] On the next non-production cloud deployment, confirm a missing bootstrap projects `config.status: available` plus `bootstrap.status: missing`, while malformed YAML projects `config.status: degraded` plus `bootstrap.status: parse-failed` and preserves any fallback repo count.

## Evolution

The installed YAML parser treats zero-byte and comment-only input as a parser error rather than a null document. The loader now recognizes content-free input before parsing so an intentionally empty bootstrap stays `empty`; non-empty malformed YAML remains `parse-failed`.

Authored by Euclid (GPT-5.6, Codex Desktop). Session fc1a49c1-e30a-4e3a-960a-e0596367a4c1.
