### PR TITLE
feat(ai): add restore target-set meter (#15755)

### DIFF
--- a/ai/scripts/benchmark/helpers/targetSetMeasurementCore.mjs
+++ b/ai/scripts/benchmark/helpers/targetSetMeasurementCore.mjs
@@ -1,0 +1,555 @@
+/**
+ * @module ai/scripts/benchmark/helpers/targetSetMeasurementCore
+ * @summary Pure contract and aggregation core for the disposable
+ * `restore-empty-target` target-set meter.
+ *
+ * The privileged recovery operation is deliberately absent. Callers inject an
+ * adapter and feed its progress, batch, provider-trace, and resource receipts
+ * into `TargetSetMeasurementRecorder`. This keeps the meter in the observation
+ * world while the injected recovery action remains the sole mutation owner.
+ *
+ * The report refuses three common forms of success theatre:
+ *
+ * - a completed run must observe every canonical target-set phase in order;
+ * - a fixture receipt must name exact memories, summaries, graph, and vector
+ *   cardinalities;
+ * - synthetic controls remain non-authoritative even when every assertion is
+ *   green.
+ *
+ * @see learn/agentos/decisions/0027-autonomous-data-recovery-actuator.md
+ * @see https://github.com/neomjs/neo/issues/15695
+ * @see https://github.com/neomjs/neo/issues/15740
+ */
+
+/**
+ * The action phases whose individual cost the target-set meter measures.
+ * @type {ReadonlyArray<String>}
+ */
+export const TARGET_SET_PHASES = Object.freeze([
+    'admission',
+    'stage-memories',
+    'stage-summaries',
+    'stage-graph',
+    'validate-staged-target-set',
+    'promote-memories',
+    'promote-summaries',
+    'promote-graph',
+    'revalidate-production',
+    'terminal-settlement'
+]);
+
+/**
+ * The two authoritative scale profiles. Graph cardinality is intentionally
+ * constant across profiles: a 64-node / 63-edge deterministic chain is large
+ * enough to exercise both graph record types while keeping graph cost fixed as
+ * the vector axis moves 5k → 20k. It is an instrumentation topology, not a
+ * claim about production graph density, and avoids a fabricated one-to-one
+ * relationship between graph and vector rows.
+ * @type {Readonly<Object>}
+ */
+export const TARGET_SET_PROFILES = Object.freeze({
+    '5k-target-set': Object.freeze({
+        graphEdges: 63,
+        graphNodes: 64,
+        memories  : 5000,
+        summaries : 5000
+    }),
+    '20k-target-set': Object.freeze({
+        graphEdges: 63,
+        graphNodes: 64,
+        memories  : 20000,
+        summaries : 20000
+    })
+});
+
+/**
+ * Synthetic control shapes supported by the disposable runner.
+ * @type {ReadonlyArray<String>}
+ */
+export const TARGET_SET_CONTROL_SCENARIOS = Object.freeze([
+    'full',
+    'interrupt-pre-promotion',
+    'reconcile-after-memories'
+]);
+
+const
+    EVIDENCE_CLASSES = Object.freeze(['exact-head-candidate', 'synthetic-control']),
+    TERMINAL_PHASE   = 'terminal-settlement';
+
+/**
+ * @summary Resolves one fixed scale profile without exposing the frozen source
+ * object to mutation.
+ *
+ * @param {String} name Profile name.
+ * @returns {{graphEdges: Number, graphNodes: Number, memories: Number, name: String, summaries: Number}}
+ * @throws {Error} When the profile name is unknown.
+ */
+export function resolveTargetSetProfile(name) {
+    const profile = TARGET_SET_PROFILES[name];
+
+    if (!profile) {
+        throw new Error(`Unknown target-set profile "${name}". Expected one of: ${Object.keys(TARGET_SET_PROFILES).join(', ')}`)
+    }
+
+    return {name, ...profile}
+}
+
+/**
+ * @summary Stateful, clock-injected report recorder for one target-set
+ * measurement. It performs no I/O and owns no recovery operation.
+ */
+export class TargetSetMeasurementRecorder {
+    /**
+     * @param {Object} options
+     * @param {'exact-head-candidate'|'synthetic-control'} options.evidenceClass
+     * @param {String|null} [options.implementationHead=null] Exact implementation head for candidate evidence.
+     * @param {Function} [options.now=Date.now] Injected epoch-ms clock.
+     * @param {String} options.profileName One key from `TARGET_SET_PROFILES`.
+     * @param {String|null} [options.repositoryHead=null] Checked-out repository head.
+     * @param {String|null} [options.scenario=null] Synthetic control scenario.
+     */
+    constructor({
+        evidenceClass,
+        implementationHead = null,
+        now                = Date.now,
+        profileName,
+        repositoryHead     = null,
+        scenario           = null
+    } = {}) {
+        if (!EVIDENCE_CLASSES.includes(evidenceClass)) {
+            throw new Error(`evidenceClass must be one of: ${EVIDENCE_CLASSES.join(', ')}`)
+        }
+        if (typeof now !== 'function') {
+            throw new Error('TargetSetMeasurementRecorder requires an injected clock function')
+        }
+        if (evidenceClass === 'exact-head-candidate' && !/^[0-9a-f]{40}$/i.test(implementationHead ?? '')) {
+            throw new Error('exact-head-candidate evidence requires a 40-character implementationHead')
+        }
+        if (evidenceClass === 'synthetic-control' && !TARGET_SET_CONTROL_SCENARIOS.includes(scenario)) {
+            throw new Error(`synthetic-control requires one scenario: ${TARGET_SET_CONTROL_SCENARIOS.join(', ')}`)
+        }
+
+        this.evidenceClass     = evidenceClass;
+        this.implementationHead = implementationHead;
+        this.now               = now;
+        this.profile           = resolveTargetSetProfile(profileName);
+        this.repositoryHead    = repositoryHead;
+        this.scenario          = scenario;
+        this.startedAtMs       = this.#timestamp();
+    }
+
+    /**
+     * @member {Object|null} fixture=null
+     */
+    fixture = null
+    /**
+     * @member {Object[]} receipts=[]
+     */
+    receipts = []
+    /**
+     * @member {Object[]} checkpoints=[]
+     */
+    checkpoints = []
+    /**
+     * @member {Object} phaseTimings={}
+     */
+    phaseTimings = {}
+    /**
+     * @member {Object} batchMaxima={}
+     */
+    batchMaxima = {}
+    /**
+     * @member {Object|null} activePhase=null
+     */
+    activePhase = null
+    /**
+     * @member {Object|null} providerTrace=null
+     */
+    providerTrace = null
+    /**
+     * @member {Object[]} providerCalls=[]
+     */
+    providerCalls = []
+    /**
+     * @member {Object} resourceRoles={}
+     */
+    resourceRoles = {}
+    /**
+     * @member {Number} resourceSampleCount=0
+     */
+    resourceSampleCount = 0
+    /**
+     * @member {Object} nodeHighWater
+     */
+    nodeHighWater = {
+        heapUsedBytes: 0,
+        rssBytes     : 0
+    }
+    /**
+     * @member {Number} tempDiskHighWaterBytes=0
+     */
+    tempDiskHighWaterBytes = 0
+
+    /**
+     * @summary Records the exact generated fixture shape. Vector row counts and
+     * graph cardinalities must match the named profile; serialized graph bytes
+     * and vector dimension are measured facts rather than profile guesses.
+     *
+     * @param {Object} fixture
+     * @param {Number} fixture.graphEdges
+     * @param {Number} fixture.graphNodes
+     * @param {Number} fixture.graphSerializedBytes
+     * @param {Number} fixture.memories
+     * @param {Number} fixture.summaries
+     * @param {Number} fixture.vectorDimension
+     */
+    recordFixture(fixture = {}) {
+        const expected      = this.profile;
+        const integerFields = [
+            'graphEdges',
+            'graphNodes',
+            'graphSerializedBytes',
+            'memories',
+            'summaries',
+            'vectorDimension'
+        ];
+
+        for (const key of integerFields) {
+            if (!Number.isInteger(fixture[key]) || fixture[key] < (key === 'graphSerializedBytes' || key === 'vectorDimension' ? 1 : 0)) {
+                throw new Error(`fixture.${key} must be a ${key === 'graphSerializedBytes' || key === 'vectorDimension' ? 'positive' : 'non-negative'} integer`)
+            }
+        }
+
+        for (const key of ['graphEdges', 'graphNodes', 'memories', 'summaries']) {
+            if (fixture[key] !== expected[key]) {
+                throw new Error(`fixture.${key}=${fixture[key]} does not match ${expected.name} (${expected[key]})`)
+            }
+        }
+
+        this.fixture = {...fixture}
+    }
+
+    /**
+     * @summary Declares which provider entrypoints the adapter actually traced.
+     * A zero-call receipt without a declared trace surface is refused.
+     *
+     * @param {Object} trace
+     * @param {String} trace.coverage Human-readable trace boundary.
+     * @param {String[]} trace.entrypoints Exact wrapped/injected entrypoint names.
+     */
+    declareProviderTrace({coverage, entrypoints} = {}) {
+        if (typeof coverage !== 'string' || coverage.length === 0 || !Array.isArray(entrypoints) || entrypoints.length === 0 ||
+            entrypoints.some(item => typeof item !== 'string' || item.length === 0)) {
+            throw new Error('provider trace requires a coverage string and at least one named entrypoint')
+        }
+
+        this.providerTrace = {coverage, entrypoints: [...new Set(entrypoints)]}
+    }
+
+    /**
+     * @summary Records one observed provider or re-embedding entrypoint call.
+     *
+     * @param {Object} call
+     * @param {String} call.entrypoint
+     * @param {Number} [call.atMs] Injected timestamp override.
+     */
+    recordProviderCall({entrypoint, atMs = this.#timestamp()} = {}) {
+        if (!this.providerTrace) {
+            throw new Error('declareProviderTrace() must run before provider calls are recorded')
+        }
+        if (!this.providerTrace.entrypoints.includes(entrypoint)) {
+            throw new Error(`provider call entrypoint "${entrypoint}" is outside the declared trace surface`)
+        }
+
+        this.providerCalls.push({atMs: this.#finiteTimestamp(atMs), entrypoint})
+    }
+
+    /**
+     * @summary Records a vector store request size and retains the maximum per
+     * collection plus the global maximum.
+     *
+     * @param {Object} batch
+     * @param {'memories'|'summaries'} batch.collection
+     * @param {Number} batch.size
+     */
+    recordBatch({collection, size} = {}) {
+        if (!['memories', 'summaries'].includes(collection) || !Number.isInteger(size) || size <= 0) {
+            throw new Error('batch receipt requires collection memories|summaries and a positive integer size')
+        }
+
+        this.batchMaxima[collection] = Math.max(this.batchMaxima[collection] ?? 0, size)
+    }
+
+    /**
+     * @summary Declares one sampled process role. Non-separable roles remain in
+     * the report with their reason instead of disappearing into a Node-only sum.
+     *
+     * @param {Object} role
+     * @param {String} role.name
+     * @param {Number|null} [role.pid=null]
+     * @param {String|null} [role.reason=null]
+     * @param {Boolean} role.separable
+     */
+    declareResourceRole({name, pid = null, reason = null, separable} = {}) {
+        if (typeof name !== 'string' || name.length === 0 || typeof separable !== 'boolean') {
+            throw new Error('resource role requires a name and boolean separable flag')
+        }
+        if (separable && (!Number.isInteger(pid) || pid <= 0)) {
+            throw new Error(`separable resource role "${name}" requires a positive pid`)
+        }
+        if (!separable && (typeof reason !== 'string' || reason.length === 0)) {
+            throw new Error(`non-separable resource role "${name}" requires a reason`)
+        }
+
+        this.resourceRoles[name] = {
+            pid,
+            reason,
+            rssHighWaterBytes: 0,
+            sampleCount      : 0,
+            separable
+        }
+    }
+
+    /**
+     * @summary Records one simultaneous resource sample.
+     *
+     * @param {Object} sample
+     * @param {Object} sample.node
+     * @param {Number} sample.node.heapUsedBytes
+     * @param {Number} sample.node.rssBytes
+     * @param {Object} [sample.processes={}] Role-keyed `{rssBytes}` samples.
+     * @param {Number} sample.tempDiskBytes
+     */
+    recordResourceSample({node, processes = {}, tempDiskBytes} = {}) {
+        const values = [node?.heapUsedBytes, node?.rssBytes, tempDiskBytes];
+
+        if (!values.every(value => Number.isFinite(value) && value >= 0)) {
+            throw new Error('resource sample requires non-negative finite Node heap/RSS and temp-disk bytes')
+        }
+
+        this.resourceSampleCount++;
+        this.nodeHighWater.heapUsedBytes = Math.max(this.nodeHighWater.heapUsedBytes, node.heapUsedBytes);
+        this.nodeHighWater.rssBytes      = Math.max(this.nodeHighWater.rssBytes, node.rssBytes);
+        this.tempDiskHighWaterBytes      = Math.max(this.tempDiskHighWaterBytes, tempDiskBytes);
+
+        for (const [name, value] of Object.entries(processes)) {
+            const role = this.resourceRoles[name];
+
+            if (!role || !role.separable) {
+                throw new Error(`resource sample names undeclared or non-separable role "${name}"`)
+            }
+            if (!Number.isFinite(value?.rssBytes) || value.rssBytes < 0) {
+                throw new Error(`resource sample for "${name}" requires non-negative finite rssBytes`)
+            }
+
+            role.sampleCount++;
+            role.rssHighWaterBytes = Math.max(role.rssHighWaterBytes, value.rssBytes)
+        }
+    }
+
+    /**
+     * @summary Records a control/restart boundary without pretending it is an
+     * ADR action phase.
+     *
+     * @param {Object} checkpoint
+     * @param {String} checkpoint.kind
+     * @param {Object} [checkpoint.detail={}]
+     * @param {Number} [checkpoint.atMs]
+     */
+    recordCheckpoint({kind, detail = {}, atMs = this.#timestamp()} = {}) {
+        if (typeof kind !== 'string' || kind.length === 0 || detail === null || typeof detail !== 'object' || Array.isArray(detail)) {
+            throw new Error('checkpoint requires a kind string and object detail')
+        }
+
+        this.checkpoints.push({atMs: this.#finiteTimestamp(atMs), detail: {...detail}, kind})
+    }
+
+    /**
+     * @summary Records one phase start/completion receipt and enforces the
+     * canonical order. An interrupted/failed run may jump from a completed
+     * prefix to terminal settlement; only a `completed` run may claim all
+     * phases.
+     *
+     * @param {Object} receipt
+     * @param {Number} [receipt.atMs]
+     * @param {Object} [receipt.counts={}]
+     * @param {String} receipt.phase
+     * @param {'started'|'completed'} receipt.state
+     */
+    recordProgress({atMs = this.#timestamp(), counts = {}, phase, state} = {}) {
+        if (!TARGET_SET_PHASES.includes(phase) || !['started', 'completed'].includes(state)) {
+            throw new Error('progress receipt requires a canonical phase and state started|completed')
+        }
+        if (counts === null || typeof counts !== 'object' || Array.isArray(counts) ||
+            Object.values(counts).some(value => !Number.isInteger(value) || value < 0)) {
+            throw new Error('progress counts must be an object of non-negative integers')
+        }
+
+        atMs = this.#finiteTimestamp(atMs);
+
+        if (state === 'started') {
+            if (this.activePhase) {
+                throw new Error(`cannot start "${phase}" while "${this.activePhase.phase}" is active`)
+            }
+            if (this.phaseTimings[phase]) {
+                throw new Error(`phase "${phase}" already completed`)
+            }
+
+            const completed     = Object.keys(this.phaseTimings);
+            const expected      = TARGET_SET_PHASES[completed.length];
+            const earlyTerminal = phase === TERMINAL_PHASE && expected !== TERMINAL_PHASE;
+
+            if (phase !== expected && !earlyTerminal) {
+                throw new Error(`phase "${phase}" is out of order; expected "${expected}"`)
+            }
+
+            this.activePhase = {phase, startedAtMs: atMs}
+        } else {
+            if (this.activePhase?.phase !== phase) {
+                throw new Error(`cannot complete "${phase}" without its active start receipt`)
+            }
+
+            const durationMs = atMs - this.activePhase.startedAtMs;
+
+            if (durationMs < 0) {
+                throw new Error(`phase "${phase}" completed before it started`)
+            }
+
+            this.phaseTimings[phase] = {
+                completedAtMs: atMs,
+                counts       : {...counts},
+                durationMs,
+                startedAtMs  : this.activePhase.startedAtMs
+            };
+            this.activePhase = null
+        }
+
+        this.receipts.push({atMs, counts: {...counts}, phase, state})
+    }
+
+    /**
+     * @summary Finalizes the immutable report. `completed` requires all phases;
+     * interrupted/failed controls require truthful terminal settlement and
+     * enumerate every skipped phase.
+     *
+     * @param {Object} outcome
+     * @param {String|null} [outcome.detail=null]
+     * @param {'completed'|'failed'|'interrupted'} outcome.status
+     * @returns {Object}
+     */
+    finish({detail = null, status} = {}) {
+        if (!['completed', 'failed', 'interrupted'].includes(status)) {
+            throw new Error('measurement status must be completed, failed, or interrupted')
+        }
+        if (this.activePhase) {
+            throw new Error(`cannot finish while "${this.activePhase.phase}" is active`)
+        }
+        if (!this.fixture) {
+            throw new Error('cannot finish without an exact fixture receipt')
+        }
+        if (!this.providerTrace) {
+            throw new Error('cannot finish without a declared provider trace surface')
+        }
+        if (this.resourceSampleCount === 0) {
+            throw new Error('cannot finish without at least one resource sample')
+        }
+        if (!this.phaseTimings[TERMINAL_PHASE]) {
+            throw new Error('cannot finish without terminal-settlement timing')
+        }
+
+        const completedPhases = Object.keys(this.phaseTimings);
+        const skippedPhases   = TARGET_SET_PHASES.filter(phase => !this.phaseTimings[phase]);
+
+        if (status === 'completed' && skippedPhases.length > 0) {
+            throw new Error(`completed measurement is missing phases: ${skippedPhases.join(', ')}`)
+        }
+        if (status === 'completed' && ['memories', 'summaries'].some(collection => !this.batchMaxima[collection])) {
+            throw new Error('completed measurement requires observed vector batch sizes for memories and summaries')
+        }
+        if (status === 'completed' && ['chroma', 'sqlite'].some(role => !this.resourceRoles[role])) {
+            throw new Error('completed measurement requires declared Chroma and SQLite resource roles')
+        }
+        if (status === 'completed' && this.evidenceClass === 'exact-head-candidate' &&
+            (!this.resourceRoles.chroma.separable || this.resourceRoles.chroma.sampleCount === 0)) {
+            throw new Error('exact-head candidate evidence requires at least one separable Chroma RSS sample')
+        }
+
+        const finishedAtMs       = this.#timestamp();
+        const resources          = Object.fromEntries(Object.entries(this.resourceRoles).map(([name, role]) => [name, {...role}]));
+        const globalBatchMaximum = Math.max(0, ...Object.values(this.batchMaxima));
+        const authoritative      = false;
+        const authorityReason    = this.evidenceClass === 'synthetic-control'
+            ? 'Synthetic/seam controls cannot satisfy the #15740 exact-head merge gate.'
+            : 'Candidate evidence requires publication against the exact #15740 PR head and maintainer review.';
+
+        return {
+            authority: {
+                authoritative,
+                mergeGateSatisfied: false,
+                reason            : authorityReason
+            },
+            batches: {
+                globalMaximum: globalBatchMaximum,
+                perCollection: {...this.batchMaxima}
+            },
+            checkpoints       : this.checkpoints.map(item => ({...item, detail: {...item.detail}})),
+            completedPhases,
+            detail,
+            evidenceClass     : this.evidenceClass,
+            finishedAtMs,
+            fixture           : {...this.fixture, profileName: this.profile.name},
+            implementationHead: this.implementationHead,
+            phaseTimings      : Object.fromEntries(Object.entries(this.phaseTimings).map(([phase, timing]) => [phase, {
+                ...timing,
+                counts: {...timing.counts}
+            }])),
+            profile : {...this.profile},
+            progress: {
+                first   : this.receipts[0] ? {...this.receipts[0], counts: {...this.receipts[0].counts}} : null,
+                last    : this.receipts.at(-1) ? {...this.receipts.at(-1), counts: {...this.receipts.at(-1).counts}} : null,
+                receipts: this.receipts.map(item => ({...item, counts: {...item.counts}}))
+            },
+            providerTrace: {
+                ...this.providerTrace,
+                callCount: this.providerCalls.length,
+                calls    : this.providerCalls.map(item => ({...item}))
+            },
+            repositoryHead: this.repositoryHead,
+            resources     : {
+                node: {
+                    heapUsedHighWaterBytes: this.nodeHighWater.heapUsedBytes,
+                    rssHighWaterBytes     : this.nodeHighWater.rssBytes,
+                    sampleCount           : this.resourceSampleCount
+                },
+                processes             : resources,
+                tempDiskHighWaterBytes: this.tempDiskHighWaterBytes
+            },
+            scenario   : this.scenario,
+            skippedPhases,
+            startedAtMs: this.startedAtMs,
+            status,
+            wallTimeMs : finishedAtMs - this.startedAtMs
+        }
+    }
+
+    /**
+     * @returns {Number}
+     * @private
+     */
+    #timestamp() {
+        return this.#finiteTimestamp(this.now())
+    }
+
+    /**
+     * @param {Number} value
+     * @returns {Number}
+     * @private
+     */
+    #finiteTimestamp(value) {
+        if (!Number.isFinite(value)) {
+            throw new Error(`measurement clock must return a finite timestamp, got ${value}`)
+        }
+
+        return value
+    }
+}

--- a/ai/scripts/benchmark/restore-empty-target-meter.mjs
+++ b/ai/scripts/benchmark/restore-empty-target-meter.mjs
@@ -1,0 +1,877 @@
+import {Command}                             from 'commander';
+import {execFile}                            from 'node:child_process';
+import {once}                                from 'node:events';
+import {createReadStream, createWriteStream} from 'node:fs';
+import {
+    copyFile,
+    mkdir,
+    mkdtemp,
+    readdir,
+    rename,
+    rm,
+    stat,
+    writeFile
+} from 'node:fs/promises';
+import os              from 'node:os';
+import path            from 'node:path';
+import readline        from 'node:readline';
+import {promisify}     from 'node:util';
+import {pathToFileURL} from 'node:url';
+import {
+    TARGET_SET_CONTROL_SCENARIOS,
+    TARGET_SET_PROFILES,
+    TargetSetMeasurementRecorder,
+    resolveTargetSetProfile
+} from './helpers/targetSetMeasurementCore.mjs';
+
+const
+    execFileAsync            = promisify(execFile),
+    VECTOR_BATCH_SIZE        = 250,
+    SYNTHETIC_PROVIDER_TRACE = 'synthetic-control.provider-call';
+
+/**
+ * @module ai/scripts/benchmark/restore-empty-target-meter
+ * @summary Disposable 5k/20k restore target-set measurement runner.
+ *
+ * The runner creates a fresh bundle, staging root, and production-shaped root
+ * under one OS-temporary directory, samples Node/process RSS plus disk
+ * high-water marks, and writes a provenance-bearing JSON report. It supports:
+ *
+ * - synthetic file controls, which prove the instrument's phase/resource
+ *   accounting but are permanently non-authoritative; and
+ * - an injected adapter module, which lets the exact recovery-action
+ *   implementation drive the same recorder without moving recovery authority
+ *   into this benchmark script.
+ *
+ * No live Memory Core path is accepted. The root is created internally with
+ * `mkdtemp()` and removed after the report is written unless `--keep-root` is
+ * explicit.
+ *
+ * Synthetic control:
+ * `node ai/scripts/benchmark/restore-empty-target-meter.mjs --profile 5k-target-set --dimension 4096 --control full`
+ *
+ * Exact-head candidate (after the recovery-action adapter exists):
+ * `node ai/scripts/benchmark/restore-empty-target-meter.mjs --profile 5k-target-set --dimension 4096 --adapter ./path/to/exact-head-adapter.mjs`
+ *
+ * @see ai/scripts/benchmark/helpers/targetSetMeasurementCore.mjs
+ * @see learn/agentos/decisions/0027-autonomous-data-recovery-actuator.md
+ * @see https://github.com/neomjs/neo/issues/15695
+ */
+
+/**
+ * Adapter contract consumed by exact-head mode. The recovery-side module exports
+ * `runTargetSetMeasurementAdapter(context)` and returns
+ * `{status: 'completed'|'failed'|'interrupted', detail}`. It must drive the
+ * canonical progress phases itself; register the Chroma process and the
+ * SQLite/shared-process accounting boundary; wrap the real embedding and
+ * re-embedding entrypoints through `traceProviders` + `recordProviderCall`;
+ * and report each actual vector request through `recordBatch`.
+ *
+ * The adapter owns invocation only. The actuator remains the mutation
+ * authority, and the recorder will still label the result an
+ * `exact-head-candidate` requiring public exact-head review.
+ *
+ * @typedef {Object} TargetSetMeasurementAdapterContext
+ * @property {Object} fixture Disposable profile input and run-owned paths.
+ * @property {Function} recordBatch
+ * @property {Function} recordCheckpoint
+ * @property {Function} recordProgress
+ * @property {Function} recordProviderCall
+ * @property {Function} registerProcess
+ * @property {Function} registerSharedRole
+ * @property {Function} sampleNow
+ * @property {Function} traceProviders
+ */
+
+/**
+ * @summary Writes one deterministic explicit-vector JSONL fixture without
+ * retaining the profile's rows or vectors in memory.
+ *
+ * @param {Object} options
+ * @param {'memories'|'summaries'} options.collection
+ * @param {Number} options.dimension
+ * @param {String} options.file
+ * @param {Number} options.rows
+ * @returns {Promise<{bytes: Number, rows: Number}>}
+ */
+export async function writeVectorFixture({collection, dimension, file, rows}) {
+    if (!['memories', 'summaries'].includes(collection) || !Number.isInteger(dimension) || dimension <= 0 ||
+        !Number.isInteger(rows) || rows <= 0) {
+        throw new Error('writeVectorFixture requires memories|summaries plus positive integer rows and dimension')
+    }
+
+    await mkdir(path.dirname(file), {recursive: true});
+
+    const
+        embedding = `[${new Array(dimension).fill('0').join(',')}]`,
+        stream    = createWriteStream(file, {encoding: 'utf8'});
+
+    try {
+        for (let index = 0; index < rows; index++) {
+            const id   = `${collection}-${String(index).padStart(6, '0')}`;
+            const line = `{"id":"${id}","embedding":${embedding},"metadata":{"fixture":"#15695","collection":"${collection}"},"document":"${id}"}\n`;
+
+            if (!stream.write(line)) {
+                await once(stream, 'drain')
+            }
+        }
+    } finally {
+        stream.end()
+    }
+
+    await once(stream, 'close');
+
+    return {bytes: (await stat(file)).size, rows}
+}
+
+/**
+ * @summary Writes the deterministic graph fixture in the canonical
+ * `{type:'node'|'edge', data}` backup JSONL shape.
+ *
+ * @param {Object} options
+ * @param {Number} options.edges
+ * @param {String} options.file
+ * @param {Number} options.nodes
+ * @returns {Promise<{bytes: Number, edges: Number, nodes: Number}>}
+ */
+export async function writeGraphFixture({edges, file, nodes}) {
+    if (!Number.isInteger(nodes) || nodes <= 0 || !Number.isInteger(edges) || edges < 0 || edges >= nodes) {
+        throw new Error('writeGraphFixture requires nodes > 0 and 0 <= edges < nodes')
+    }
+
+    await mkdir(path.dirname(file), {recursive: true});
+
+    const stream = createWriteStream(file, {encoding: 'utf8'});
+
+    try {
+        for (let index = 0; index < nodes; index++) {
+            const id   = `target-set-node-${String(index).padStart(3, '0')}`;
+            const line = JSON.stringify({
+                type: 'node',
+                data: {
+                    id,
+                    properties: {fixture: '#15695', ordinal: index},
+                    type      : 'TARGET_SET_FIXTURE'
+                }
+            }) + '\n';
+
+            if (!stream.write(line)) await once(stream, 'drain')
+        }
+
+        for (let index = 0; index < edges; index++) {
+            const source = `target-set-node-${String(index).padStart(3, '0')}`;
+            const target = `target-set-node-${String(index + 1).padStart(3, '0')}`;
+            const line   = JSON.stringify({
+                type: 'edge',
+                data: {
+                    id        : `${source}->${target}:TARGET_SET_SEQUENCE`,
+                    properties: {fixture: '#15695', ordinal: index},
+                    source,
+                    target,
+                    type      : 'TARGET_SET_SEQUENCE',
+                    weight    : 1
+                }
+            }) + '\n';
+
+            if (!stream.write(line)) await once(stream, 'drain')
+        }
+    } finally {
+        stream.end()
+    }
+
+    await once(stream, 'close');
+
+    return {bytes: (await stat(file)).size, edges, nodes}
+}
+
+/**
+ * @summary Creates one self-contained fixture bundle plus empty staging and
+ * production roots. Optional non-target bundle directories exist but remain
+ * empty so the fixture cannot imply that concepts, trajectories, mailbox, or
+ * Knowledge Base belong to the accepted v1 target set.
+ *
+ * @param {Object} options
+ * @param {Number} options.dimension
+ * @param {String} options.profileName
+ * @param {String} options.root
+ * @returns {Promise<Object>}
+ */
+export async function createTargetSetFixture({dimension, profileName, root}) {
+    const profile = resolveTargetSetProfile(profileName);
+    const bundle  = path.join(root, 'bundle');
+    const paths   = {
+        bundle,
+        graphFile     : path.join(bundle, 'graph', 'graph-backup-target-set.jsonl'),
+        memoriesFile  : path.join(bundle, 'mc', 'memory-backup-target-set.jsonl'),
+        productionRoot: path.join(root, 'production'),
+        stagingRoot   : path.join(root, 'staging'),
+        summariesFile : path.join(bundle, 'mc', 'summaries-backup-target-set.jsonl')
+    };
+
+    await Promise.all([
+        'kb',
+        'mc',
+        'graph',
+        'concepts',
+        'trajectories',
+        'mailbox'
+    ].map(dir => mkdir(path.join(bundle, dir), {recursive: true})));
+    await Promise.all([
+        mkdir(paths.productionRoot, {recursive: true}),
+        mkdir(paths.stagingRoot,    {recursive: true})
+    ]);
+
+    const [memories, summaries, graph] = await Promise.all([
+        writeVectorFixture({
+            collection: 'memories',
+            dimension,
+            file      : paths.memoriesFile,
+            rows      : profile.memories
+        }),
+        writeVectorFixture({
+            collection: 'summaries',
+            dimension,
+            file      : paths.summariesFile,
+            rows      : profile.summaries
+        }),
+        writeGraphFixture({
+            edges: profile.graphEdges,
+            file : paths.graphFile,
+            nodes: profile.graphNodes
+        })
+    ]);
+
+    const meta = {
+        bundleVersion: 1,
+        embedding    : {
+            counts: {
+                memories : profile.memories,
+                summaries: profile.summaries
+            },
+            dimension,
+            schemaVersion: 1
+        },
+        fixture: {
+            fixtureClass: 'deterministic-target-set-measurement',
+            issue       : 15695,
+            profileName
+        },
+        subsystems: {
+            graph: {edges: graph.edges, nodes: graph.nodes},
+            mc   : {memories: profile.memories, summaries: profile.summaries}
+        }
+    };
+
+    await writeFile(path.join(bundle, 'bundle-meta.json'), JSON.stringify(meta, null, 2));
+
+    return {
+        dimension,
+        graph,
+        memories,
+        meta,
+        paths,
+        profile,
+        summaries
+    }
+}
+
+/**
+ * @summary Recursively measures logical regular-file bytes below one
+ * disposable root. Missing paths contribute zero so cleanup races cannot
+ * invent a failure.
+ *
+ * @param {String} root
+ * @returns {Promise<Number>}
+ */
+export async function directorySizeBytes(root) {
+    let entries;
+
+    try {
+        entries = await readdir(root, {withFileTypes: true})
+    } catch (error) {
+        if (error?.code === 'ENOENT') return 0;
+        throw error
+    }
+
+    let bytes = 0;
+
+    for (const entry of entries) {
+        const target = path.join(root, entry.name);
+
+        if (entry.isDirectory()) {
+            bytes += await directorySizeBytes(target)
+        } else if (entry.isFile()) {
+            bytes += (await stat(target)).size
+        }
+    }
+
+    return bytes
+}
+
+/**
+ * @summary Samples resident bytes for a declared external process.
+ *
+ * @param {Number} pid
+ * @returns {Promise<Number|null>}
+ */
+export async function samplePidRss(pid) {
+    try {
+        const {stdout} = await execFileAsync('ps', ['-o', 'rss=', '-p', String(pid)]);
+        const rssKb    = Number(stdout.trim());
+
+        return Number.isFinite(rssKb) ? rssKb * 1024 : null
+    } catch (error) {
+        return null
+    }
+}
+
+/**
+ * @summary Streams and validates one explicit-vector fixture.
+ *
+ * @param {Object} options
+ * @param {Number} options.dimension
+ * @param {Number} options.expectedRows
+ * @param {String} options.file
+ * @returns {Promise<Number>} Valid row count.
+ */
+export async function validateVectorFixture({dimension, expectedRows, file}) {
+    const input = createReadStream(file, {encoding: 'utf8'});
+    const lines = readline.createInterface({input, crlfDelay: Infinity});
+    let   rows  = 0;
+
+    try {
+        for await (const line of lines) {
+            if (!line.trim()) continue;
+
+            const record = JSON.parse(line);
+
+            if (typeof record.id !== 'string' || !Array.isArray(record.embedding) ||
+                record.embedding.length !== dimension || record.embedding.some(value => !Number.isFinite(value))) {
+                throw new Error(`invalid explicit-vector fixture row ${rows + 1} in ${file}`)
+            }
+
+            rows++
+        }
+    } finally {
+        lines.close();
+        input.destroy()
+    }
+
+    if (rows !== expectedRows) {
+        throw new Error(`fixture row mismatch for ${file}: expected ${expectedRows}, observed ${rows}`)
+    }
+
+    return rows
+}
+
+/**
+ * @summary Streams and validates the graph backup fixture.
+ *
+ * @param {Object} options
+ * @param {Number} options.expectedEdges
+ * @param {Number} options.expectedNodes
+ * @param {String} options.file
+ * @returns {Promise<{edges: Number, nodes: Number}>}
+ */
+export async function validateGraphFixture({expectedEdges, expectedNodes, file}) {
+    const input = createReadStream(file, {encoding: 'utf8'});
+    const lines = readline.createInterface({input, crlfDelay: Infinity});
+    let   edges = 0, nodes = 0;
+
+    try {
+        for await (const line of lines) {
+            if (!line.trim()) continue;
+
+            const record = JSON.parse(line);
+
+            if (record.type === 'node' && typeof record.data?.id === 'string') {
+                nodes++
+            } else if (record.type === 'edge' && record.data?.source && record.data?.target && record.data?.type) {
+                edges++
+            } else {
+                throw new Error(`invalid graph fixture record in ${file}`)
+            }
+        }
+    } finally {
+        lines.close();
+        input.destroy()
+    }
+
+    if (nodes !== expectedNodes || edges !== expectedEdges) {
+        throw new Error(`graph fixture mismatch: expected ${expectedNodes}/${expectedEdges} nodes/edges, observed ${nodes}/${edges}`)
+    }
+
+    return {edges, nodes}
+}
+
+/**
+ * @summary Copies a vector fixture in bounded batches and reports the observed
+ * request maximum to the recorder. The synthetic control writes files, not
+ * Chroma; its batch receipt proves meter plumbing only.
+ *
+ * @param {Object} options
+ * @param {'memories'|'summaries'} options.collection
+ * @param {String} options.source
+ * @param {String} options.target
+ * @param {TargetSetMeasurementRecorder} options.recorder
+ * @returns {Promise<Number>} Copied rows.
+ */
+export async function copyVectorFixtureInBatches({collection, recorder, source, target}) {
+    await mkdir(path.dirname(target), {recursive: true});
+
+    const
+        input  = createReadStream(source, {encoding: 'utf8'}),
+        lines  = readline.createInterface({input, crlfDelay: Infinity}),
+        output = createWriteStream(target, {encoding: 'utf8'});
+
+    let batch = [], copied = 0;
+
+    const flush = async () => {
+        if (batch.length === 0) return;
+
+        const batchSize = batch.length;
+
+        recorder.recordBatch({collection, size: batchSize});
+        const payload = batch.join('');
+        batch = [];
+        copied += batchSize;
+
+        if (!output.write(payload)) await once(output, 'drain')
+    };
+
+    try {
+        for await (const line of lines) {
+            if (!line.trim()) continue;
+
+            batch.push(line + '\n');
+            if (batch.length === VECTOR_BATCH_SIZE) await flush()
+        }
+
+        await flush()
+    } finally {
+        lines.close();
+        input.destroy();
+        output.end()
+    }
+
+    await once(output, 'close');
+
+    return copied
+}
+
+/**
+ * @summary Runs one named phase around an async operation.
+ *
+ * @param {TargetSetMeasurementRecorder} recorder
+ * @param {String} phase
+ * @param {Function} operation
+ * @returns {Promise<Object>} Phase counts.
+ * @private
+ */
+async function runPhase(recorder, phase, operation) {
+    recorder.recordProgress({phase, state: 'started'});
+
+    const counts = await operation() ?? {};
+
+    recorder.recordProgress({counts, phase, state: 'completed'});
+    return counts
+}
+
+/**
+ * @summary Validates all three files at one control root.
+ *
+ * @param {Object} options
+ * @param {Number} options.dimension
+ * @param {Object} options.files
+ * @param {Object} options.profile
+ * @returns {Promise<Object>}
+ * @private
+ */
+async function validateTargetSet({dimension, files, profile}) {
+    const [memories, summaries, graph] = await Promise.all([
+        validateVectorFixture({dimension, expectedRows: profile.memories,  file: files.memories}),
+        validateVectorFixture({dimension, expectedRows: profile.summaries, file: files.summaries}),
+        validateGraphFixture({
+            expectedEdges: profile.graphEdges,
+            expectedNodes: profile.graphNodes,
+            file         : files.graph
+        })
+    ]);
+
+    return {
+        graphEdges: graph.edges,
+        graphNodes: graph.nodes,
+        memories,
+        summaries
+    }
+}
+
+/**
+ * @summary Executes the explicitly non-authoritative file control. It mirrors
+ * the action's phase order without importing or simulating the recovery state
+ * machine.
+ *
+ * @param {Object} options
+ * @param {Object} options.fixture
+ * @param {TargetSetMeasurementRecorder} options.recorder
+ * @param {Function} options.sampleNow
+ * @param {String} options.scenario
+ * @returns {Promise<{detail: String, status: 'completed'|'interrupted'}>}
+ */
+export async function runSyntheticControl({fixture, recorder, sampleNow, scenario}) {
+    const
+        {dimension, paths, profile} = fixture,
+        staged                      = {
+            graph    : path.join(paths.stagingRoot, 'graph', 'graph-backup-target-set.jsonl'),
+            memories : path.join(paths.stagingRoot, 'mc', 'memory-backup-target-set.jsonl'),
+            summaries: path.join(paths.stagingRoot, 'mc', 'summaries-backup-target-set.jsonl')
+        },
+        production = {
+            graph    : path.join(paths.productionRoot, 'graph', 'graph-backup-target-set.jsonl'),
+            memories : path.join(paths.productionRoot, 'mc', 'memory-backup-target-set.jsonl'),
+            summaries: path.join(paths.productionRoot, 'mc', 'summaries-backup-target-set.jsonl')
+        };
+
+    await runPhase(recorder, 'admission', () => validateTargetSet({
+        dimension,
+        files: {
+            graph    : paths.graphFile,
+            memories : paths.memoriesFile,
+            summaries: paths.summariesFile
+        },
+        profile
+    }));
+
+    await runPhase(recorder, 'stage-memories', async () => ({
+        memories: await copyVectorFixtureInBatches({
+            collection: 'memories',
+            recorder,
+            source    : paths.memoriesFile,
+            target    : staged.memories
+        })
+    }));
+    await runPhase(recorder, 'stage-summaries', async () => ({
+        summaries: await copyVectorFixtureInBatches({
+            collection: 'summaries',
+            recorder,
+            source    : paths.summariesFile,
+            target    : staged.summaries
+        })
+    }));
+    await runPhase(recorder, 'stage-graph', async () => {
+        await mkdir(path.dirname(staged.graph), {recursive: true});
+        await copyFile(paths.graphFile, staged.graph);
+        return {graphEdges: profile.graphEdges, graphNodes: profile.graphNodes}
+    });
+    await runPhase(recorder, 'validate-staged-target-set', () => validateTargetSet({
+        dimension,
+        files: staged,
+        profile
+    }));
+
+    if (scenario === 'interrupt-pre-promotion') {
+        await sampleNow();
+        recorder.recordCheckpoint({
+            detail: {afterPhase: 'validate-staged-target-set', retainedBytes: await directorySizeBytes(path.dirname(paths.bundle))},
+            kind  : 'synthetic-interruption'
+        });
+        await runPhase(recorder, 'terminal-settlement', async () => ({
+            retainedBytes: await directorySizeBytes(path.dirname(paths.bundle))
+        }));
+
+        return {
+            detail: 'Synthetic interruption after staged validation; production remained untouched.',
+            status: 'interrupted'
+        }
+    }
+
+    await runPhase(recorder, 'promote-memories', async () => {
+        await mkdir(path.dirname(production.memories), {recursive: true});
+        await rename(staged.memories, production.memories);
+        return {memories: profile.memories}
+    });
+
+    if (scenario === 'reconcile-after-memories') {
+        await sampleNow();
+        recorder.recordCheckpoint({
+            detail: {afterPhase: 'promote-memories', retainedBytes: await directorySizeBytes(path.dirname(paths.bundle))},
+            kind  : 'synthetic-reconciliation-boundary'
+        })
+    }
+
+    await runPhase(recorder, 'promote-summaries', async () => {
+        await mkdir(path.dirname(production.summaries), {recursive: true});
+        await rename(staged.summaries, production.summaries);
+        return {summaries: profile.summaries}
+    });
+    await runPhase(recorder, 'promote-graph', async () => {
+        await mkdir(path.dirname(production.graph), {recursive: true});
+        await rename(staged.graph, production.graph);
+        return {graphEdges: profile.graphEdges, graphNodes: profile.graphNodes}
+    });
+    await runPhase(recorder, 'revalidate-production', () => validateTargetSet({
+        dimension,
+        files: production,
+        profile
+    }));
+    await runPhase(recorder, 'terminal-settlement', async () => ({
+        retainedBytes: await directorySizeBytes(path.dirname(paths.bundle))
+    }));
+
+    return {
+        detail: scenario === 'reconcile-after-memories'
+            ? 'Synthetic forward reconciliation resumed after memories promotion.'
+            : 'Synthetic full phase control completed.',
+        status: 'completed'
+    }
+}
+
+/**
+ * @summary Starts a non-overlapping resource sampler and exposes an immediate
+ * sample hook for crash-control boundaries.
+ *
+ * @param {Object} options
+ * @param {Number} options.intervalMs
+ * @param {TargetSetMeasurementRecorder} options.recorder
+ * @param {String} options.root
+ * @returns {{sampleNow: Function, stop: Function}}
+ * @private
+ */
+function startSampler({intervalMs, recorder, root}) {
+    let running = true;
+
+    const sampleNow = async () => {
+        const memory    = process.memoryUsage();
+        const processes = {};
+
+        for (const [name, role] of Object.entries(recorder.resourceRoles)) {
+            if (!role.separable) continue;
+
+            const rssBytes = await samplePidRss(role.pid);
+            if (rssBytes !== null) processes[name] = {rssBytes}
+        }
+
+        recorder.recordResourceSample({
+            node: {
+                heapUsedBytes: memory.heapUsed,
+                rssBytes     : memory.rss
+            },
+            processes,
+            tempDiskBytes: await directorySizeBytes(root)
+        })
+    };
+
+    const loop = (async () => {
+        while (running) {
+            await sampleNow();
+            if (running) await new Promise(resolve => setTimeout(resolve, intervalMs))
+        }
+    })();
+
+    return {
+        sampleNow,
+        async stop() {
+            running = false;
+            await loop;
+            await sampleNow()
+        }
+    }
+}
+
+/**
+ * @summary Reads the repository head and dirtiness used to bind candidate
+ * evidence. Exact-head adapter mode refuses a dirty worktree.
+ *
+ * @returns {Promise<{dirty: Boolean, head: String|null}>}
+ * @private
+ */
+async function readGitIdentity() {
+    try {
+        const [{stdout: head}, {stdout: statusOutput}] = await Promise.all([
+            execFileAsync('git', ['rev-parse', 'HEAD']),
+            execFileAsync('git', ['status', '--porcelain'])
+        ]);
+
+        return {dirty: statusOutput.trim().length > 0, head: head.trim()}
+    } catch (error) {
+        return {dirty: true, head: null}
+    }
+}
+
+/**
+ * @summary Runs the CLI.
+ *
+ * @returns {Promise<void>}
+ * @private
+ */
+async function main() {
+    const program = new Command()
+        .requiredOption('--profile <name>', `fixture profile (${Object.keys(TARGET_SET_PROFILES).join(' | ')})`)
+        .requiredOption('--dimension <number>', 'explicit vector dimension')
+        .option('--control <scenario>', `synthetic control (${TARGET_SET_CONTROL_SCENARIOS.join(' | ')})`)
+        .option('--adapter <module>', 'exact-head adapter module exporting runTargetSetMeasurementAdapter(context)')
+        .option('--sample-interval <ms>', 'resource sampling interval', '25')
+        .option('--out <file>', 'JSON report path (defaults to the OS temp directory)')
+        .option('--keep-root', 'retain the disposable bundle/staging/production root after the run', false)
+        .parse(process.argv);
+
+    const options    = program.opts();
+    const dimension  = Number(options.dimension);
+    const intervalMs = Number(options.sampleInterval);
+
+    resolveTargetSetProfile(options.profile);
+
+    if (!Number.isInteger(dimension) || dimension <= 0) {
+        throw new Error(`--dimension must be a positive integer, got "${options.dimension}"`)
+    }
+    if (!Number.isInteger(intervalMs) || intervalMs <= 0) {
+        throw new Error(`--sample-interval must be a positive integer, got "${options.sampleInterval}"`)
+    }
+    if (Boolean(options.control) === Boolean(options.adapter)) {
+        throw new Error('choose exactly one of --control or --adapter')
+    }
+    if (options.control && !TARGET_SET_CONTROL_SCENARIOS.includes(options.control)) {
+        throw new Error(`unknown control "${options.control}"`)
+    }
+
+    const
+        gitIdentity = await readGitIdentity(),
+        root        = await mkdtemp(path.join(os.tmpdir(), 'neo-target-set-meter-')),
+        reportFile  = path.resolve(options.out ?? path.join(
+            os.tmpdir(),
+            `neo-target-set-report-${options.profile}-${Date.now()}.json`
+        )),
+        evidenceClass = options.control ? 'synthetic-control' : 'exact-head-candidate';
+
+    if (evidenceClass === 'exact-head-candidate' && (gitIdentity.dirty || !gitIdentity.head)) {
+        await rm(root, {force: true, recursive: true});
+        throw new Error('exact-head adapter mode requires a clean git worktree with a resolvable HEAD')
+    }
+
+    const recorder = new TargetSetMeasurementRecorder({
+        evidenceClass,
+        implementationHead: evidenceClass === 'exact-head-candidate' ? gitIdentity.head : null,
+        profileName       : options.profile,
+        repositoryHead    : gitIdentity.head,
+        scenario          : options.control ?? null
+    });
+
+    recorder.recordCheckpoint({
+        detail: {dirty: gitIdentity.dirty, head: gitIdentity.head},
+        kind  : 'repository-identity'
+    });
+    recorder.recordCheckpoint({
+        detail: {
+            sampleIntervalMs   : intervalMs,
+            tempDiskMeasurement: 'logical regular-file bytes (sum of stat.size) below the disposable root'
+        },
+        kind: 'measurement-contract'
+    });
+
+    if (options.control) {
+        recorder.declareProviderTrace({
+            coverage   : 'synthetic adapter seam only; no production provider entrypoint is imported',
+            entrypoints: [SYNTHETIC_PROVIDER_TRACE]
+        });
+        recorder.declareResourceRole({
+            name     : 'chroma',
+            reason   : 'synthetic file control starts no Chroma process',
+            separable: false
+        });
+        recorder.declareResourceRole({
+            name     : 'sqlite',
+            reason   : 'synthetic file control starts no SQLite process',
+            separable: false
+        })
+    }
+
+    const sampler = startSampler({intervalMs, recorder, root});
+    let   report, samplerStopped = false;
+
+    try {
+        const fixture = await createTargetSetFixture({
+            dimension,
+            profileName: options.profile,
+            root
+        });
+
+        recorder.recordFixture({
+            graphEdges              : fixture.graph.edges,
+            graphNodes              : fixture.graph.nodes,
+            graphSerializedBytes    : fixture.graph.bytes,
+            memories                : fixture.memories.rows,
+            memoriesSerializedBytes : fixture.memories.bytes,
+            summaries               : fixture.summaries.rows,
+            summariesSerializedBytes: fixture.summaries.bytes,
+            vectorDimension         : dimension
+        });
+
+        let outcome;
+
+        if (options.control) {
+            outcome = await runSyntheticControl({
+                fixture,
+                recorder,
+                sampleNow: sampler.sampleNow,
+                scenario : options.control
+            })
+        } else {
+            const adapterUrl = pathToFileURL(path.resolve(options.adapter)).href;
+            const adapter    = await import(adapterUrl);
+
+            if (typeof adapter.runTargetSetMeasurementAdapter !== 'function') {
+                throw new Error(`${options.adapter} must export async runTargetSetMeasurementAdapter(context)`)
+            }
+
+            outcome = await adapter.runTargetSetMeasurementAdapter({
+                fixture,
+                recordBatch       : receipt => recorder.recordBatch(receipt),
+                recordCheckpoint  : receipt => recorder.recordCheckpoint(receipt),
+                recordProgress    : receipt => recorder.recordProgress(receipt),
+                recordProviderCall: receipt => recorder.recordProviderCall(receipt),
+                registerProcess   : receipt => recorder.declareResourceRole({...receipt, separable: true}),
+                registerSharedRole: receipt => recorder.declareResourceRole({...receipt, separable: false}),
+                sampleNow         : sampler.sampleNow,
+                traceProviders    : receipt => recorder.declareProviderTrace(receipt)
+            })
+        }
+
+        await sampler.stop();
+        samplerStopped = true;
+        report = recorder.finish(outcome)
+    } finally {
+        if (!samplerStopped) {
+            await sampler.stop();
+            samplerStopped = true
+        }
+
+        await mkdir(path.dirname(reportFile), {recursive: true});
+
+        if (report) {
+            await writeFile(reportFile, JSON.stringify(report, null, 2))
+        }
+
+        const reportInsideRoot = reportFile === root || reportFile.startsWith(root + path.sep);
+
+        if (!options.keepRoot && !reportInsideRoot) {
+            await rm(root, {force: true, recursive: true})
+        }
+    }
+
+    console.log(`[restore-empty-target-meter] report: ${reportFile}`);
+    console.log(`[restore-empty-target-meter] evidence=${report.evidenceClass} status=${report.status} authoritative=${report.authority.authoritative}`);
+    console.log(`[restore-empty-target-meter] ${report.authority.reason}`);
+
+    if (options.keepRoot) {
+        console.log(`[restore-empty-target-meter] disposable root retained by request: ${root}`)
+    }
+}
+
+const isDirectRun = import.meta.url === `file://${process.argv[1]}`;
+
+if (isDirectRun) {
+    main().catch(error => {
+        console.error(`[restore-empty-target-meter] ${error.stack ?? error.message}`);
+        process.exit(1)
+    })
+}

--- a/test/playwright/unit/ai/scripts/benchmark/TargetSetMeasurementCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/TargetSetMeasurementCore.spec.mjs
@@ -1,0 +1,378 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+import {
+    TARGET_SET_PHASES,
+    TARGET_SET_PROFILES,
+    TargetSetMeasurementRecorder,
+    resolveTargetSetProfile
+} from '../../../../../../ai/scripts/benchmark/helpers/targetSetMeasurementCore.mjs';
+import {
+    copyVectorFixtureInBatches,
+    createTargetSetFixture,
+    directorySizeBytes,
+    runSyntheticControl,
+    validateGraphFixture,
+    validateVectorFixture,
+    writeGraphFixture,
+    writeVectorFixture
+} from '../../../../../../ai/scripts/benchmark/restore-empty-target-meter.mjs';
+
+/**
+ * @summary Unit coverage for the pure target-set report contract and the small,
+ * disposable fixture primitives used by the target-set meter.
+ *
+ * The suite intentionally does not run the 5k/20k controls: those are
+ * measurement executions, not unit fixtures. It pins the fixed profile
+ * cardinalities, ADR phase order, high-water aggregation, provider trace,
+ * interruption truthfulness, non-authoritative control label, and streaming
+ * fixture format without touching Chroma, SQLite, providers, or live paths.
+ */
+test.describe('ai/scripts/benchmark target-set measurement (#15695)', () => {
+    /**
+     * Builds a fully configured recorder whose clock advances one millisecond
+     * per receipt.
+     *
+     * @param {Object} options
+     * @param {'exact-head-candidate'|'synthetic-control'} [options.evidenceClass='synthetic-control']
+     * @param {String|null} [options.implementationHead=null]
+     * @param {String|null} [options.scenario='full']
+     * @returns {TargetSetMeasurementRecorder}
+     */
+    function createRecorder({
+        evidenceClass     = 'synthetic-control',
+        implementationHead = null,
+        scenario           = 'full'
+    } = {}) {
+        let clock = 1000;
+
+        const recorder = new TargetSetMeasurementRecorder({
+            evidenceClass,
+            implementationHead,
+            now           : () => ++clock,
+            profileName   : '5k-target-set',
+            repositoryHead: 'a'.repeat(40),
+            scenario
+        });
+
+        recorder.recordFixture({
+            graphEdges          : 63,
+            graphNodes          : 64,
+            graphSerializedBytes: 8192,
+            memories            : 5000,
+            summaries           : 5000,
+            vectorDimension     : 4096
+        });
+        recorder.declareProviderTrace({
+            coverage   : 'test provider seam',
+            entrypoints: ['embedText', 'embedTexts']
+        });
+        recorder.declareResourceRole({name: 'chroma', pid: 42, separable: true});
+        recorder.declareResourceRole({
+            name     : 'sqlite',
+            reason   : 'better-sqlite3 shares the measured Node process',
+            separable: false
+        });
+        recorder.recordBatch({collection: 'memories',  size: 250});
+        recorder.recordBatch({collection: 'summaries', size: 125});
+        recorder.recordResourceSample({
+            node         : {heapUsedBytes: 100, rssBytes: 200},
+            processes    : {chroma: {rssBytes: 300}},
+            tempDiskBytes: 400
+        });
+        recorder.recordResourceSample({
+            node         : {heapUsedBytes: 150, rssBytes: 180},
+            processes    : {chroma: {rssBytes: 280}},
+            tempDiskBytes: 450
+        });
+
+        return recorder
+    }
+
+    /**
+     * Completes each supplied phase with deterministic count receipts.
+     *
+     * @param {TargetSetMeasurementRecorder} recorder
+     * @param {String[]} phases
+     */
+    function completePhases(recorder, phases) {
+        for (const phase of phases) {
+            recorder.recordProgress({phase, state: 'started'});
+            recorder.recordProgress({
+                counts: {
+                    graphEdges: 63,
+                    graphNodes: 64,
+                    memories  : 5000,
+                    summaries : 5000
+                },
+                phase,
+                state: 'completed'
+            })
+        }
+    }
+
+    test('fixes 5k/20k vector profiles while keeping graph cardinality independent', () => {
+        expect(resolveTargetSetProfile('5k-target-set')).toEqual({
+            graphEdges: 63,
+            graphNodes: 64,
+            memories  : 5000,
+            name      : '5k-target-set',
+            summaries : 5000
+        });
+        expect(resolveTargetSetProfile('20k-target-set')).toEqual({
+            graphEdges: 63,
+            graphNodes: 64,
+            memories  : 20000,
+            name      : '20k-target-set',
+            summaries : 20000
+        });
+        expect(TARGET_SET_PROFILES['5k-target-set'].graphNodes)
+            .toBe(TARGET_SET_PROFILES['20k-target-set'].graphNodes);
+        expect(() => resolveTargetSetProfile('10k-target-set')).toThrow(/Unknown target-set profile/)
+    });
+
+    test('emits a complete ordered report with phase, progress, batch, provider, and high-water receipts', () => {
+        const recorder = createRecorder();
+
+        recorder.recordProviderCall({entrypoint: 'embedText'});
+        completePhases(recorder, TARGET_SET_PHASES);
+
+        const report = recorder.finish({detail: 'control complete', status: 'completed'});
+
+        expect(report.completedPhases).toEqual(TARGET_SET_PHASES);
+        expect(report.skippedPhases).toEqual([]);
+        expect(report.progress.first).toMatchObject({phase: 'admission', state: 'started'});
+        expect(report.progress.last).toMatchObject({phase: 'terminal-settlement', state: 'completed'});
+        expect(report.phaseTimings['stage-memories'].durationMs).toBe(1);
+        expect(report.batches).toEqual({
+            globalMaximum: 250,
+            perCollection: {memories: 250, summaries: 125}
+        });
+        expect(report.providerTrace).toMatchObject({
+            callCount  : 1,
+            coverage   : 'test provider seam',
+            entrypoints: ['embedText', 'embedTexts']
+        });
+        expect(report.resources.node).toEqual({
+            heapUsedHighWaterBytes: 150,
+            rssHighWaterBytes     : 200,
+            sampleCount           : 2
+        });
+        expect(report.resources.processes.chroma.rssHighWaterBytes).toBe(300);
+        expect(report.resources.processes.sqlite).toMatchObject({
+            reason   : 'better-sqlite3 shares the measured Node process',
+            separable: false
+        });
+        expect(report.resources.tempDiskHighWaterBytes).toBe(450);
+        expect(report.authority).toEqual({
+            authoritative     : false,
+            mergeGateSatisfied: false,
+            reason            : 'Synthetic/seam controls cannot satisfy the #15740 exact-head merge gate.'
+        })
+    });
+
+    test('rejects out-of-order success and a profile-mismatched fixture', () => {
+        const recorder = createRecorder();
+
+        expect(() => recorder.recordProgress({phase: 'stage-memories', state: 'started'}))
+            .toThrow(/out of order/);
+
+        const mismatch = new TargetSetMeasurementRecorder({
+            evidenceClass: 'synthetic-control',
+            now          : () => 1,
+            profileName  : '5k-target-set',
+            scenario     : 'full'
+        });
+
+        expect(() => mismatch.recordFixture({
+            graphEdges          : 63,
+            graphNodes          : 64,
+            graphSerializedBytes: 1,
+            memories            : 20000,
+            summaries           : 5000,
+            vectorDimension     : 4096
+        })).toThrow(/fixture.memories=20000 does not match 5k-target-set/)
+    });
+
+    test('records an interrupted pre-promotion prefix without pretending skipped phases ran', () => {
+        const recorder = createRecorder({scenario: 'interrupt-pre-promotion'});
+
+        completePhases(recorder, TARGET_SET_PHASES.slice(0, 5));
+        recorder.recordCheckpoint({
+            detail: {retainedBytes: 12345},
+            kind  : 'synthetic-interruption'
+        });
+        completePhases(recorder, ['terminal-settlement']);
+
+        const report = recorder.finish({detail: 'interrupted', status: 'interrupted'});
+
+        expect(report.status).toBe('interrupted');
+        expect(report.completedPhases).toEqual([
+            ...TARGET_SET_PHASES.slice(0, 5),
+            'terminal-settlement'
+        ]);
+        expect(report.skippedPhases).toEqual([
+            'promote-memories',
+            'promote-summaries',
+            'promote-graph',
+            'revalidate-production'
+        ]);
+        expect(report.checkpoints[0]).toMatchObject({
+            detail: {retainedBytes: 12345},
+            kind  : 'synthetic-interruption'
+        });
+        expect(report.authority.authoritative).toBe(false)
+    });
+
+    test('requires an exact full SHA for candidate evidence and still leaves merge-gate authority external', () => {
+        expect(() => createRecorder({
+            evidenceClass     : 'exact-head-candidate',
+            implementationHead: 'abc',
+            scenario          : null
+        })).toThrow(/40-character implementationHead/);
+
+        const recorder = createRecorder({
+            evidenceClass     : 'exact-head-candidate',
+            implementationHead: 'b'.repeat(40),
+            scenario          : null
+        });
+
+        completePhases(recorder, TARGET_SET_PHASES);
+
+        const report = recorder.finish({status: 'completed'});
+
+        expect(report.implementationHead).toBe('b'.repeat(40));
+        expect(report.authority.mergeGateSatisfied).toBe(false);
+        expect(report.authority.reason).toContain('publication against the exact #15740 PR head')
+    });
+
+    test('writes and validates small streaming fixtures with exact graph bytes', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-target-set-core-spec-'));
+
+        try {
+            const memoriesFile  = path.join(root, 'memory.jsonl');
+            const summariesFile = path.join(root, 'summaries.jsonl');
+            const graphFile     = path.join(root, 'graph.jsonl');
+
+            const memories = await writeVectorFixture({
+                collection: 'memories',
+                dimension : 4,
+                file      : memoriesFile,
+                rows      : 251
+            });
+            const summaries = await writeVectorFixture({
+                collection: 'summaries',
+                dimension : 4,
+                file      : summariesFile,
+                rows      : 2
+            });
+            const graph = await writeGraphFixture({edges: 2, file: graphFile, nodes: 3});
+
+            expect(await validateVectorFixture({dimension: 4, expectedRows: 251, file: memoriesFile})).toBe(251);
+            expect(await validateVectorFixture({dimension: 4, expectedRows: 2, file: summariesFile})).toBe(2);
+            expect(await validateGraphFixture({expectedEdges: 2, expectedNodes: 3, file: graphFile}))
+                .toEqual({edges: 2, nodes: 3});
+            expect(memories.bytes).toBeGreaterThan(0);
+            expect(summaries.bytes).toBeGreaterThan(0);
+            expect(graph.bytes).toBe(fs.statSync(graphFile).size);
+            expect(await directorySizeBytes(root)).toBe(memories.bytes + summaries.bytes + graph.bytes)
+        } finally {
+            fs.rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('reports the actual 250-row synthetic copy maximum rather than the file cardinality', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-target-set-batch-spec-'));
+
+        try {
+            const source   = path.join(root, 'source.jsonl');
+            const target   = path.join(root, 'target.jsonl');
+            const recorder = createRecorder();
+
+            await writeVectorFixture({
+                collection: 'memories',
+                dimension : 2,
+                file      : source,
+                rows      : 251
+            });
+
+            expect(await copyVectorFixtureInBatches({
+                collection: 'memories',
+                recorder,
+                source,
+                target
+            })).toBe(251);
+            expect(recorder.batchMaxima.memories).toBe(250);
+            expect(await validateVectorFixture({dimension: 2, expectedRows: 251, file: target})).toBe(251)
+        } finally {
+            fs.rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    test('runs the fixed 5k file control through every phase while keeping authority false', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-target-set-control-spec-'));
+
+        try {
+            let clock = 5000;
+
+            const recorder = new TargetSetMeasurementRecorder({
+                evidenceClass : 'synthetic-control',
+                now           : () => ++clock,
+                profileName   : '5k-target-set',
+                repositoryHead: 'c'.repeat(40),
+                scenario      : 'full'
+            });
+            const fixture = await createTargetSetFixture({
+                dimension  : 1,
+                profileName: '5k-target-set',
+                root
+            });
+
+            recorder.recordFixture({
+                graphEdges          : fixture.graph.edges,
+                graphNodes          : fixture.graph.nodes,
+                graphSerializedBytes: fixture.graph.bytes,
+                memories            : fixture.memories.rows,
+                summaries           : fixture.summaries.rows,
+                vectorDimension     : 1
+            });
+            recorder.declareProviderTrace({
+                coverage   : 'synthetic test seam',
+                entrypoints: ['synthetic.provider']
+            });
+            recorder.declareResourceRole({
+                name     : 'chroma',
+                reason   : 'not started by the file control',
+                separable: false
+            });
+            recorder.declareResourceRole({
+                name     : 'sqlite',
+                reason   : 'not started by the file control',
+                separable: false
+            });
+
+            const sampleNow = async () => recorder.recordResourceSample({
+                node         : {heapUsedBytes: 10, rssBytes: 20},
+                tempDiskBytes: await directorySizeBytes(root)
+            });
+
+            await sampleNow();
+            const outcome = await runSyntheticControl({
+                fixture,
+                recorder,
+                sampleNow,
+                scenario: 'full'
+            });
+            const report = recorder.finish(outcome);
+
+            expect(report.status).toBe('completed');
+            expect(report.completedPhases).toEqual(TARGET_SET_PHASES);
+            expect(report.batches.globalMaximum).toBe(250);
+            expect(report.providerTrace.callCount).toBe(0);
+            expect(report.authority.mergeGateSatisfied).toBe(false)
+        } finally {
+            fs.rmSync(root, {force: true, recursive: true})
+        }
+    })
+});


### PR DESCRIPTION
Resolves #15755

Related: #15695
Related: #15740

Adds a disposable `restore-empty-target` meter with fixed 5k/20k memories + summaries profiles, a deterministic graph fixture, canonical phase/progress accounting, resource and provider receipts, synthetic interruption/reconciliation controls, and an injected exact-head adapter seam. The instrument creates only run-owned OS-temporary roots and keeps persistent recovery authority outside the benchmark.

Evidence: L3 (real disposable CLI controls plus focused contract/integration coverage) → L3 required (all #15755 harness ACs). No close-target residuals. The parent #15695 exact-#15740 production-store receipt remains `NOT_YET_MEASURED — BLOCKED_BY #15740 implementation head`.

## Deltas from ticket

None substantive. The implementation follows the ticket's matched sibling placement:

- `ai/scripts/benchmark/restore-empty-target-meter.mjs` owns CLI/I/O, fixture generation, sampling, and adapter loading.
- `ai/scripts/benchmark/helpers/targetSetMeasurementCore.mjs` owns the clock-injected pure report contract.
- `test/playwright/unit/ai/scripts/benchmark/TargetSetMeasurementCore.spec.mjs` pins profiles, phase ordering, receipts, high-water aggregation, evidence class, and disposable fixture primitives.

The graph fixture is deliberately constant at 64 nodes / 63 edges across both vector profiles. It measures a fixed graph axis and does not imply one graph record per vector row.

## Test Evidence

- `npm run agent-preflight -- --no-fix <3 changed files>` — passed; ticket archaeology and block alignment are clean. Only unrelated non-blocking stale-overlay warnings for existing `ai/config.mjs` leaves were reported.
- `node --check <3 changed files>` — passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/benchmark/TargetSetMeasurementCore.spec.mjs` — 10 passed.
- `npm run test-unit` — 9,037 passed, 6 skipped, 16 failed, and 65 did not run. None of the target-set tests failed. The failures were outside the changed tree and clustered in wake/process inspection, cross-server tool smoke, lifecycle file-lock/process cases, the real-tree timeout, two Chroma timestamp-drift cases, and one MemoryService timer case.
- Pre-commit hooks passed: whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, block alignment, and parse.

Real disposable 4,096-dimensional controls:

| Profile / scenario | Status | Wall ms | Node heap HWM bytes | Node RSS HWM bytes | Logical temp-file HWM bytes | Batch max | Provider calls |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 5k / full | completed | 902 | 51,435,560 | 173,228,032 | 166,397,154 | 250 | 0 |
| 20k / full | completed | 3,489 | 96,092,808 | 267,419,648 | 665,447,159 | 250 | 0 |
| 5k / interrupt before promotion | interrupted | 624 | 50,610,848 | 165,511,168 | 166,397,154 | 250 | 0 |
| 5k / reconcile after memories | completed | 901 | 59,330,592 | 183,369,728 | 166,397,154 | 250 | 0 |

Every fixture records 64 graph nodes, 63 graph edges, and 23,354 serialized graph bytes. The interruption checkpoint follows staged validation; the reconciliation checkpoint follows memories promotion.

Evidence boundary: these controls copy files and trace only the synthetic adapter seam. They start no Chroma or SQLite process, so Chroma RSS, SQLite/process RSS, and production embedding-entrypoint calls are `NOT_MEASURED`; zeroes are not inferred. Every report mechanically emits `authoritative=false` and `mergeGateSatisfied=false`.

## Post-Merge Validation

- On the exact clean #15740 implementation head, inject the real action adapter and execute both 5k/20k profiles.
- Append the exact-head receipts to #15695, including separable Chroma RSS, the SQLite/shared-process boundary, real provider-entrypoint coverage, phase scaling, and the cloud deployment envelope.
- Route any unsafe or unbounded phase to its owning fix before #15740 merges. Keep #15695 open until that receipt exists; it is never reopened.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session `72bb1088-8ed5-48b7-a835-c288cf30e814`.
