### PR TITLE
feat(ai): implement restore-empty-target action (#15740)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -14,56 +14,68 @@ import MaintenanceBackpressureService, {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
     DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
 } from './services/MaintenanceBackpressureService.mjs';
-import {buildConfiguredTaskDefinitions as buildConfiguredTaskDefinitionsImport}                     from './services/ConfiguredTaskDefinitionsService.mjs';
-import PrimaryRepoSyncService                                                                       from './services/PrimaryRepoSyncService.mjs';
-import TenantRepoSyncService                                                                        from './services/TenantRepoSyncService.mjs';
-import {getDueTask as summaryGetDueTaskImport}                                                      from './scheduling/summary.mjs';
-import {getDueTask as backupGetDueTaskImport}                                                       from './scheduling/backup.mjs';
-import {getDueTask as graphLogCompactionGetDueTaskImport}                                           from './scheduling/graphLogCompaction.mjs';
-import {getDueTask as primaryDevSyncGetDueTaskImport}                                               from './scheduling/primaryDevSync.mjs';
-import {getDueTask as goldenPathGetDueTaskImport}                                                   from './scheduling/goldenPath.mjs';
-import {getDueTask as dreamGetDueTaskImport}                                                        from './scheduling/dream.mjs';
-import {getDueTask as embedDrainLivenessWatchdogGetDueTaskImport}                                   from './scheduling/embedDrainLivenessWatchdog.mjs';
-import memoryCoreConfig                                                                             from '../../mcp/server/memory-core/config.mjs';
-import MailboxService                                                                               from '../../services/memory-core/MailboxService.mjs';
-import WakeSubscriptionService                                                                      from '../../services/memory-core/WakeSubscriptionService.mjs';
-import RequestContextService                                                                        from '../../mcp/server/shared/services/RequestContextService.mjs';
-import {normalizeAgentIdentityNodeId}                                                               from '../../graph/normalizeAgentIdentityNodeId.mjs';
-import TaskStateService                                                                             from './services/TaskStateService.mjs';
-import ProcessSupervisorService                                                                     from './services/ProcessSupervisorService.mjs';
-import DeploymentRuntimeAccessService                                                               from './services/DeploymentRuntimeAccessService.mjs';
-import DeploymentStateBridgeService                                                                 from './services/DeploymentStateBridgeService.mjs';
-import RecoveryActuatorService                                                                      from './services/RecoveryActuatorService.mjs';
-import ContainerHealthDiagnosisService                                                              from './services/ContainerHealthDiagnosisService.mjs';
-import {buildBootIdentitySource}                                                                    from './services/buildBootIdentitySource.mjs';
-import {recordBootIdentityFact}                                                                     from './services/recordBootIdentityFact.mjs';
-import DataIntegrityDiagnosisService                                                                from './services/DataIntegrityDiagnosisService.mjs';
-import DataRecoveryActuatorService                                                                  from './services/DataRecoveryActuatorService.mjs';
-import {auditChromaVectorCoverage}                                                                  from '../../scripts/maintenance/checkChromaIntegrity.mjs';
-import {createReEmbedMissingHeal, createReEmbedMissingHealOperation}                                from '../../services/memory-core/helpers/reEmbedMissingHeal.mjs';
-import {appendHealEvent, healEventsToRecentRuns, queryHealLedger, readHealLedger}                   from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
-import {validateHealLedgerRetention}                                                                from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
-import {detectChronicUnsafeInput}                                                                   from '../../services/memory-core/helpers/healActionDispatch.mjs';
-import {quarantineCollection, storeFenceTargets, unquarantineCollection}                            from '../../services/memory-core/helpers/quarantineStore.mjs';
-import {createFreezeHealOperation, createStoreFenceOperations, runFreezeReprobe}                    from '../../services/memory-core/helpers/freezeReprobeRunner.mjs';
-import {createThrottleShedHealOperation}                                                            from '../../services/memory-core/helpers/throttleShedHeal.mjs';
-import {decideSystemicCircuit, foldSystemicCircuitState}                                            from '../../services/memory-core/helpers/healSystemicCircuit.mjs';
-import {Memory_StorageRouter as StorageRouter, Memory_TextEmbeddingService as TextEmbeddingService} from '../../services.mjs';
-import {buildDataIntegrityCoverageDiagnosis}                                                        from './services/dataIntegrityCoverageDiagnosis.mjs';
-import {assembleDataIntegrityEvidence}                                                              from './services/dataIntegrityEvidenceAssembler.mjs';
-import {createLiveDimensionConsistencyGatherer}                                                     from './services/dimensionConsistencyGatherer.mjs';
-import DreamService                                                                                 from './services/DreamService.mjs';
-import SwarmHeartbeatService                                                                        from './services/SwarmHeartbeatService.mjs';
-import GoldenPathSynthesizer                                                                        from '../../services/graph/GoldenPathSynthesizer.mjs';
-import {getDueTask as tenantRepoSyncGetDueTaskImport}                                               from './scheduling/tenantRepoSync.mjs';
-import {TASK_REGISTRY}                                                                              from './scheduling/registry.mjs';
+import {buildConfiguredTaskDefinitions as buildConfiguredTaskDefinitionsImport}   from './services/ConfiguredTaskDefinitionsService.mjs';
+import PrimaryRepoSyncService                                                     from './services/PrimaryRepoSyncService.mjs';
+import TenantRepoSyncService                                                      from './services/TenantRepoSyncService.mjs';
+import {getDueTask as summaryGetDueTaskImport}                                    from './scheduling/summary.mjs';
+import {getDueTask as backupGetDueTaskImport}                                     from './scheduling/backup.mjs';
+import {getDueTask as graphLogCompactionGetDueTaskImport}                         from './scheduling/graphLogCompaction.mjs';
+import {getDueTask as primaryDevSyncGetDueTaskImport}                             from './scheduling/primaryDevSync.mjs';
+import {getDueTask as goldenPathGetDueTaskImport}                                 from './scheduling/goldenPath.mjs';
+import {getDueTask as dreamGetDueTaskImport}                                      from './scheduling/dream.mjs';
+import {getDueTask as embedDrainLivenessWatchdogGetDueTaskImport}                 from './scheduling/embedDrainLivenessWatchdog.mjs';
+import memoryCoreConfig                                                           from '../../mcp/server/memory-core/config.mjs';
+import MailboxService                                                             from '../../services/memory-core/MailboxService.mjs';
+import WakeSubscriptionService                                                    from '../../services/memory-core/WakeSubscriptionService.mjs';
+import RequestContextService                                                      from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {normalizeAgentIdentityNodeId}                                             from '../../graph/normalizeAgentIdentityNodeId.mjs';
+import TaskStateService                                                           from './services/TaskStateService.mjs';
+import ProcessSupervisorService                                                   from './services/ProcessSupervisorService.mjs';
+import DeploymentRuntimeAccessService                                             from './services/DeploymentRuntimeAccessService.mjs';
+import DeploymentStateBridgeService                                               from './services/DeploymentStateBridgeService.mjs';
+import RecoveryActuatorService                                                    from './services/RecoveryActuatorService.mjs';
+import ContainerHealthDiagnosisService                                            from './services/ContainerHealthDiagnosisService.mjs';
+import {buildBootIdentitySource}                                                  from './services/buildBootIdentitySource.mjs';
+import {recordBootIdentityFact}                                                   from './services/recordBootIdentityFact.mjs';
+import DataIntegrityDiagnosisService                                              from './services/DataIntegrityDiagnosisService.mjs';
+import DataRecoveryActuatorService                                                from './services/DataRecoveryActuatorService.mjs';
+import {auditChromaVectorCoverage}                                                from '../../scripts/maintenance/checkChromaIntegrity.mjs';
+import {createReEmbedMissingHeal, createReEmbedMissingHealOperation}              from '../../services/memory-core/helpers/reEmbedMissingHeal.mjs';
+import {appendHealEvent, healEventsToRecentRuns, queryHealLedger, readHealLedger} from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
+import {validateHealLedgerRetention}                                              from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
+import {detectChronicUnsafeInput}                                                 from '../../services/memory-core/helpers/healActionDispatch.mjs';
+import {quarantineCollection, storeFenceTargets, unquarantineCollection}          from '../../services/memory-core/helpers/quarantineStore.mjs';
+import {createFreezeHealOperation, createStoreFenceOperations, runFreezeReprobe}  from '../../services/memory-core/helpers/freezeReprobeRunner.mjs';
+import {createThrottleShedHealOperation}                                          from '../../services/memory-core/helpers/throttleShedHeal.mjs';
+import {decideSystemicCircuit, foldSystemicCircuitState}                          from '../../services/memory-core/helpers/healSystemicCircuit.mjs';
+import {
+    Memory_ChromaManager as ChromaManager,
+    Memory_GraphService as GraphService,
+    Memory_StorageRouter as StorageRouter,
+    Memory_TextEmbeddingService as TextEmbeddingService
+} from '../../services.mjs';
+import {createRestoreEmptyTargetOperation} from '../../services/memory-core/helpers/restoreEmptyTargetOperation.mjs';
+import {createRestoreTargetSetStorage}     from '../../services/memory-core/helpers/restoreTargetSetStorage.mjs';
+import {
+    appendRestoreTargetSetTransition,
+    readRestoreTargetSetTransitions
+} from '../../services/memory-core/helpers/restoreTargetSetStateStore.mjs';
+import {buildDataIntegrityCoverageDiagnosis}          from './services/dataIntegrityCoverageDiagnosis.mjs';
+import {assembleDataIntegrityEvidence}                from './services/dataIntegrityEvidenceAssembler.mjs';
+import {createLiveDimensionConsistencyGatherer}       from './services/dimensionConsistencyGatherer.mjs';
+import DreamService                                   from './services/DreamService.mjs';
+import SwarmHeartbeatService                          from './services/SwarmHeartbeatService.mjs';
+import GoldenPathSynthesizer                          from '../../services/graph/GoldenPathSynthesizer.mjs';
+import {getDueTask as tenantRepoSyncGetDueTaskImport} from './scheduling/tenantRepoSync.mjs';
+import {TASK_REGISTRY}                                from './scheduling/registry.mjs';
 import {
     buildOrchestratorSchedulingOptions,
     runSchedulingPipeline
 } from './scheduling/pipeline.mjs';
 import {DEFAULT_SCRIPT_DIR} from './taskDefinitions.mjs';
 import {
-    inspectHeavyMaintenanceLeaseSync
+    inspectHeavyMaintenanceLeaseSync,
+    withHeavyMaintenanceLease
 } from './services/heavyMaintenanceLeasePrimitives.mjs';
 
 /** @summary Opens/creates the orchestrator sqlite DB via the shared Memory Core schema bootstrap. */
@@ -469,8 +481,91 @@ export class Orchestrator extends Base {
             expectedDimension: AiConfig.vectorDimension
         });
 
-        const healLedgerDir    = path.join(this.dataDir, 'data-heal-events');
-        const freezeRecordsDir = path.join(this.dataDir, 'data-freeze-records');
+        const healLedgerDir      = path.join(this.dataDir, 'data-heal-events');
+        const freezeRecordsDir   = path.join(this.dataDir, 'data-freeze-records');
+        const restoreLedgerDir   = path.join(this.dataDir, 'restore-empty-target-ledger');
+        const restoreStagingRoot = path.join(this.dataDir, 'restore-empty-target-staging');
+
+        let restoreStoragePromise = null;
+
+        const getRestoreStorage = () => {
+            if (!restoreStoragePromise) {
+                restoreStoragePromise = (async () => {
+                    await Promise.all([
+                        StorageRouter.ready(),
+                        ChromaManager.ready(),
+                        GraphService.ready()
+                    ]);
+
+                    const graphDb = GraphService.db?.storage?.db;
+                    if (!graphDb) {
+                        throw new Error('restore-empty-target requires the live Memory Core graph database')
+                    }
+
+                    return createRestoreTargetSetStorage({
+                        chromaClient          : ChromaManager.client,
+                        dummyEmbeddingFunction: AiConfig.dummyEmbeddingFunction,
+                        graphDb,
+                        expectedDestinations  : {
+                            memories : memoryCoreConfig.collections.memory,
+                            summaries: memoryCoreConfig.collections.session,
+                            graph    : memoryCoreConfig.storagePaths.graph
+                        },
+                        stagingRoot              : restoreStagingRoot,
+                        invalidateCollectionCache: type => ChromaManager.invalidateCollectionCache(type),
+                        syncGraphCache           : () => GraphService.db?.syncCache?.()
+                    })
+                })()
+            }
+
+            return restoreStoragePromise
+        };
+
+        const restoreEmptyTarget = createRestoreEmptyTargetOperation({
+            withWriterFence: async (identity, task) => {
+                const result = await withHeavyMaintenanceLease(task, {
+                    owner       : 'restore-empty-target',
+                    reason      : 'target-set-recovery',
+                    metadata    : identity,
+                    leasePath   : this.maintenanceBackpressureService.resolveHeavyMaintenanceLeasePath(),
+                    staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs
+                });
+
+                return ['completed', 'inherited'].includes(result.status)
+                    ? result.result
+                    : {
+                        status: 'deferred',
+                        detail: {
+                            reason: 'writer-fence-not-acquired',
+                            holder: result.lease?.owner ?? null
+                        }
+                    }
+            },
+            inspectFreshTargetSet: async context =>
+                (await getRestoreStorage()).inspectFreshTargetSet(context),
+            stageTargetSet: async context =>
+                (await getRestoreStorage()).stageTargetSet(context),
+            validateStagedTargetSet: async context =>
+                (await getRestoreStorage()).validateStagedTargetSet(context),
+            promoteComponent: async context =>
+                (await getRestoreStorage()).promoteComponent(context),
+            revalidateProductionTargetSet: async context =>
+                (await getRestoreStorage()).revalidateProductionTargetSet(context),
+            reconcileAttempt: async context =>
+                (await getRestoreStorage()).reconcileAttempt(context),
+            cleanupUnpromotedStaging: async context =>
+                (await getRestoreStorage()).cleanupUnpromotedStaging(context),
+            cleanupCommittedArtifacts: async context =>
+                (await getRestoreStorage()).cleanupCommittedArtifacts(context),
+            readTransitions: ({attemptFingerprint}) => readRestoreTargetSetTransitions({
+                dir: restoreLedgerDir,
+                attemptFingerprint
+            }),
+            appendTransition: transition => appendRestoreTargetSetTransition(
+                transition,
+                {dir: restoreLedgerDir}
+            )
+        });
 
         return ClassSystemUtil.beforeSetInstance(value, DataRecoveryActuatorService, {
             healOperations: {
@@ -528,23 +623,24 @@ export class Orchestrator extends Base {
                 // so it is independent of reactive-config set ordering.
                 'throttle-shed': createThrottleShedHealOperation({
                     setShedWindow: (durationMs, now) => this.maintenanceBackpressureService.setShedWindow(durationMs, now)
-                })
+                }),
+                'restore-empty-target': restoreEmptyTarget
             },
             // The ledger is observability, never a gate: readHealLedger now THROWS on an unreadable FILE, so an
             // unreadable ledger must not block a heal — degrade the anti-thrash projection to "no recent runs".
-            recentRunsReader : async collectionName => {
+            recentRunsReader : async targetKey => {
                 let events = [];
                 try {
                     events = await readHealLedger({dir: healLedgerDir});
                 } catch (error) {
                     this.writeLog?.('WARN', `[Orchestrator] heal-ledger read failed for recentRuns; proceeding with none: ${error.message}`);
                 }
-                return healEventsToRecentRuns(queryHealLedger(events, {collections: [collectionName]}));
+                return healEventsToRecentRuns(queryHealLedger(events, {collections: [targetKey]}));
             },
             // Retention is read + VALIDATED from the AiConfig provider at the append boundary; the pure ledger helper
             // owns no production default.
-            recordRun        : async ({action, collection, at}) => appendHealEvent(
-                {type: action, collection, status: 'attempt'},
+            recordRun        : async ({action, collection, recoveryUnitKey, at}) => appendHealEvent(
+                {type: action, collection: collection ?? recoveryUnitKey, status: 'attempt'},
                 {
                     dir: healLedgerDir,
                     now: at,
@@ -554,8 +650,8 @@ export class Orchestrator extends Base {
                     )
                 }
             ),
-            recordHealOutcome: async ({action, collection, status, detail, healedAt}) => appendHealEvent(
-                {type: action, collection, status, detail},
+            recordHealOutcome: async ({action, collection, recoveryUnitKey, status, detail, healedAt}) => appendHealEvent(
+                {type: action, collection: collection ?? recoveryUnitKey, status, detail},
                 {
                     dir: healLedgerDir,
                     now: healedAt,
@@ -904,6 +1000,7 @@ export class Orchestrator extends Base {
         this.containerHealthDiagnosisService = {};
         this.deploymentStateBridgeService = {};
         this.recoveryActuatorService = {};
+        this.dataRecoveryActuatorService = {};
         this.dataIntegrityDiagnosisService = {};
         this.processSupervisorService.recoverTasks();
 

--- a/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
@@ -8,10 +8,10 @@ import {classifyDataIntegrityMode, DataIntegrityTerminal} from './dataIntegrityM
  * its AUTONOMOUS heal action via the recovery actuator's `applyHeal` sink.
  *
  * There is NO `escalate` and NO operator in the loop: in a cloud deployment there is no human to page or
- * acknowledge, so every actionable mode routes to an autonomous heal (re-embed-missing, restore-delta-merge,
- * quarantine, freeze, defrag…) — or the safe-default `quarantine` where the specific repair is not yet built.
- * The runner only routes; the actuator executes — the interim actuator defers every action (detected +
- * recorded, never a page) until the heal ops are wired, so it contains nothing yet. Safety comes from the
+ * acknowledge, so every actionable collection mode routes to an autonomous
+ * heal (re-embed-missing, quarantine, freeze, defrag…). The separate typed
+ * fresh-empty bootstrap route may select `restore-empty-target`; ordinary wipe
+ * evidence never does. The runner only routes; the actuator executes. Safety comes from the
  * actuator's bounded envelope (snapshot, reversibility, durable audit record, rate-limit), not from a human
  * gate that does not exist.
  *
@@ -51,7 +51,8 @@ export class DataIntegrityDiagnosisService extends Base {
      */
     evidenceGatherer = null
     /**
-     * The recovery actuator exposing `applyHeal({action, collection, evidence, now})`. Every actionable mode
+     * The recovery actuator exposing
+     * `applyHeal({action, collection?, targetSet?, evidence, now})`. Every actionable mode
      * routes here — there is no escalate/operator sink. Set-once injected dependency — a plain class field.
      * @member {Object|null} recoveryActuator=null
      */

--- a/ai/daemons/orchestrator/services/DataRecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/DataRecoveryActuatorService.mjs
@@ -1,23 +1,23 @@
 import Base           from '../../../../src/core/Base.mjs';
 import {dispatchHeal} from '../../../services/memory-core/helpers/healActionDispatch.mjs';
+import {
+    deriveRestoreTargetSetIdentity,
+    RESTORE_EMPTY_TARGET_ACTION
+} from '../../../services/memory-core/helpers/restoreTargetSetContract.mjs';
 
 /**
  * @module ai/daemons/orchestrator/services/DataRecoveryActuatorService
  * @summary The autonomous data-recovery actuator — the `applyHeal` terminal that replaces the DELETED
- * `escalate`/`page` path. Given a classifier's heal action + the target collection, it runs the action through
+ * `escalate`/`page` path. Given a classifier's heal action and its collection or
+ * target-set identity, it runs the action through
  * the pure dispatch core's safety gate (`dispatchHeal`: rate-limit + anti-thrash) and executes the heal via an
  * INJECTED operation. **No operator, no escalate:** a held / unwired / failed heal is RECORDED in the returned
  * outcome, never paged. In an operatorless cloud deploy a runtime page is incoherent; this is the autonomous
  * terminal the data-integrity runner routes every diagnosis to.
  *
- * ⚠️ **INTERIM (the escalate-deletion cutover — a gated-actuator bridge).** The privileged heal operations
- * (re-embed-missing / re-embed-rows / restore-delta-merge / quarantine / defrag) are NOT wired here yet — they
- * arrive via the wired-actuator follow-up (itself gated on the raw-evidence producer re-route). Until then
- * `healOperations` is empty, so every cleared action resolves to `deferred` (autonomous, recorded, never a
- * page) — already strictly better than the deleted escalate, which paged into an operatorless void. The
- * follow-up injects the real `healOperations` + the `recentRuns` reader/recorder, turning *defer* into *act*
- * without touching this seam: the runner's `applyHeal({action, collection, evidence, now})` contract is stable
- * across the interim → wired transition.
+ * Privileged operations are injected at the orchestrator boundary. Unwired
+ * actions remain autonomous `deferred` outcomes; `restore-empty-target` is
+ * wired as one target-set mutation and never receives a synthetic collection.
  *
  * Collaborators are injected (the operations, the anti-thrash store; the clock rides in `applyHeal`), so the
  * unit is pure-testable and the AiConfig SSOT leaves are read at the orchestrator use-site, never re-derived
@@ -39,18 +39,17 @@ class DataRecoveryActuatorService extends Base {
 
     /**
      * Injected privileged heal operations: `{ '<action>': async ({collection, evidence, now}) => ({status, detail}) }`.
-     * **Interim:** empty → every action defers (autonomous, never a page). The wired-actuator follow-up adds
-     * re-embed / restore / quarantine / defrag. A set-once injected dependency — a plain field, not a reactive
+     * An unwired action defers (autonomous, never a page). A set-once injected
+     * dependency — a plain field, not a reactive
      * config (assigned once at construction, never observed), so the Config-controller machinery would be pure
      * overhead.
      * @member {Object} healOperations={}
      */
     healOperations = {}
     /**
-     * Injected recent-runs reader: `async (collection) => Object[]` — the anti-thrash history the dispatch
-     * core's gate consults. **Interim:** null → the gate sees no history (always within-bounds), which is safe
-     * because no mutating op runs yet (all-defer). The wired-actuator follow-up supplies the real per-collection
-     * store. A set-once injected dependency.
+     * Injected recent-runs reader: `async (targetKey) => Object[]` — collection
+     * name for collection actions, canonical recovery-unit key for target-set
+     * recovery.
      * @member {Function|null} recentRunsReader=null
      */
     recentRunsReader = null
@@ -79,17 +78,33 @@ class DataRecoveryActuatorService extends Base {
      *
      * @param {Object} options
      * @param {String} options.action The classifier's terminal heal action (a member of `HEAL_ACTIONS`, or a nullish/unknown action which the gate resolves to a recorded no-op).
-     * @param {String} options.collection The target collection.
+     * @param {String} [options.collection] Collection-scoped target.
+     * @param {Object} [options.targetSet] `restore-empty-target` target set.
      * @param {Object} [options.evidence] The diagnosis evidence, passed through to the wired operation.
      * @param {Number} options.now Epoch milliseconds (the injected clock, supplied by the runner).
      * @returns {Promise<Object>} The dispatch outcome record `{action, collection, status, detail, healedAt}` — never a page.
      */
-    async applyHeal({action, collection, evidence, now} = {}) {
-        const recentRuns = typeof this.recentRunsReader === 'function' ? await this.recentRunsReader(collection) : [];
+    async applyHeal({action, collection, targetSet, evidence, now} = {}) {
+        let targetKey = collection;
+
+        if (action === RESTORE_EMPTY_TARGET_ACTION) {
+            try {
+                targetKey = deriveRestoreTargetSetIdentity(targetSet).recoveryUnitKey
+            } catch {
+                // `dispatchHeal` owns the fail-closed unsafe-input decision for a
+                // malformed target set. No history lookup is needed first.
+                targetKey = null
+            }
+        }
+
+        const recentRuns = typeof this.recentRunsReader === 'function' && targetKey
+            ? await this.recentRunsReader(targetKey)
+            : [];
 
         const outcome = await dispatchHeal({
             action,
             collection,
+            targetSet,
             evidence,
             recentRuns,
             now,

--- a/ai/daemons/orchestrator/services/dataIntegrityModeClassifier.mjs
+++ b/ai/daemons/orchestrator/services/dataIntegrityModeClassifier.mjs
@@ -18,6 +18,14 @@
  * @see ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.mjs
  */
 
+import {
+    normalizeRestoreTargetSetDescriptor,
+    RESTORE_EMPTY_TARGET_ACTION
+} from '../../../services/memory-core/helpers/restoreTargetSetContract.mjs';
+import {
+    normalizeRestoreTargetSetAdmission
+} from '../../../services/memory-core/helpers/restoreTargetSetAdmission.mjs';
+
 /**
  * @summary The autonomous terminal actions a corruption mode routes to. There is deliberately NO `escalate`
  * or `page` action — every terminal is autonomous and bounded. Where the specific repair action is not yet
@@ -31,8 +39,8 @@ export const DataIntegrityTerminal = Object.freeze({
     REEMBED_MISSING    : 're-embed-missing',
     /** Dimension-targeted: a few wrong-dimension vectors — re-embed exactly those rows. */
     REEMBED_ROWS       : 're-embed-rows',
-    /** Wipe: metadata-without-vector, documents also gone — restore the last-good backup and delta-merge newer rows. */
-    RESTORE_DELTA_MERGE: 'restore-delta-merge',
+    /** Typed, default-off fresh-empty bootstrap only: restore one admitted three-destination target set. */
+    RESTORE_EMPTY_TARGET: RESTORE_EMPTY_TARGET_ACTION,
     /** Safe-default terminal: when the actuator executes it, fences the collection from similarity-serving (a corrupt index is never served). Bounded, lossless, reversible. The interim actuator defers it. */
     QUARANTINE         : 'quarantine',
     /** Systemic false-storm (mass mismatch): freeze the collection — never trigger a mass auto-re-embed. */
@@ -108,8 +116,8 @@ export function classifyDataIntegrityMode({
             return decision(collection, 'wal-stall', DataIntegrityTerminal.REEMBED_MISSING,
                 'metadata-without-vector, documents intact — lossless autonomous re-embed');
         }
-        return decision(collection, 'wipe', DataIntegrityTerminal.RESTORE_DELTA_MERGE,
-            'metadata-without-vector, documents also gone — restore + delta-merge');
+        return decision(collection, 'wipe', DataIntegrityTerminal.QUARANTINE,
+            'metadata-without-vector, documents also gone — contain; count/loss evidence cannot select target-set restore');
     }
 
     if (sizeAnomaly) {
@@ -118,6 +126,63 @@ export function classifyDataIntegrityMode({
     }
 
     return decision(collection, 'clean', DataIntegrityTerminal.NONE, 'no integrity signal');
+}
+
+/**
+ * @summary Maps only the typed, default-off fresh-empty bootstrap diagnosis to
+ * `restore-empty-target`.
+ *
+ * This classifier-owned boundary admits only an explicitly typed fresh-bootstrap
+ * recovery. Ordinary wipe or count-loss evidence cannot enter this route, and a
+ * malformed target set fails closed to `none`.
+ *
+ * @param {Object} diagnosis
+ * @param {'fresh-empty-bootstrap'} diagnosis.type Typed diagnosis discriminator.
+ * @param {Boolean} diagnosis.enabled Explicit default-off opt-in.
+ * @param {Object} diagnosis.targetSet Canonical v1 target-set descriptor.
+ * @returns {Object} Classification decision with the admitted target set only
+ * when the route is accepted.
+ */
+export function classifyFreshEmptyBootstrapDiagnosis({
+    type,
+    enabled = false,
+    targetSet
+} = {}) {
+    if (type !== 'fresh-empty-bootstrap' || enabled !== true) {
+        return {
+            accepted      : false,
+            autonomous    : true,
+            mode          : 'not-fresh-empty-bootstrap',
+            terminalAction: DataIntegrityTerminal.NONE,
+            reason        : 'restore-empty-target requires an explicitly enabled typed fresh-empty bootstrap diagnosis'
+        }
+    }
+
+    try {
+        const
+            descriptor = normalizeRestoreTargetSetDescriptor(targetSet),
+            admission  = normalizeRestoreTargetSetAdmission(
+                targetSet?.admission,
+                descriptor
+            );
+
+        return {
+            accepted      : true,
+            autonomous    : true,
+            mode          : 'fresh-empty-bootstrap',
+            terminalAction: DataIntegrityTerminal.RESTORE_EMPTY_TARGET,
+            reason        : 'typed fresh-empty bootstrap diagnosis admitted for target-set recovery',
+            targetSet     : {...descriptor, admission}
+        }
+    } catch (error) {
+        return {
+            accepted      : false,
+            autonomous    : true,
+            mode          : 'invalid-fresh-empty-bootstrap',
+            terminalAction: DataIntegrityTerminal.NONE,
+            reason        : error.message
+        }
+    }
 }
 
 /**

--- a/ai/graph/bootSeedManifest.mjs
+++ b/ai/graph/bootSeedManifest.mjs
@@ -1,0 +1,246 @@
+import {createHash} from 'crypto';
+
+import {IDENTITIES} from './identityRoots.mjs';
+
+/**
+ * @module ai/graph/bootSeedManifest
+ * @summary Canonical, enumerable v1 manifest for every deterministic Native Edge
+ * Graph record created by ordinary Memory Core boot.
+ *
+ * Boot and fresh-target recovery both consume this module. Adding a boot seed
+ * anywhere else makes the recovery predicate fail closed because the persisted
+ * graph can no longer equal this complete manifest.
+ */
+
+/**
+ * @member {Number}
+ */
+export const GRAPH_BOOT_SEED_VERSION = 1;
+
+const FIXED_NODE_SPECS = Object.freeze([
+    Object.freeze({
+        id         : 'frontier',
+        type       : 'SYSTEM_ANCHOR',
+        name       : 'Active Context Frontier',
+        description: 'The shifting focal point of the active Neo OS agent session.'
+    }),
+    Object.freeze({
+        id         : 'Neo-Master-Architecture',
+        type       : 'System',
+        name       : 'Global System Primer',
+        description: 'Core framework tenets: 1. All Playwright tests must be run using "npm run test-unit -- [file]". No npx. 2. UI debugging and application state inspection must use the Neural Link MCP tools. 3. Look at .agents/skills for reusable agent workflows.'
+    })
+]);
+
+const FIXED_EDGE_SPECS = Object.freeze([
+    Object.freeze({
+        source    : 'frontier',
+        target    : 'Neo-Master-Architecture',
+        type      : 'SYSTEM_TENET',
+        weight    : 1,
+        properties: Object.freeze({userId: null})
+    })
+]);
+
+/**
+ * @summary Returns a detached manifest whose node specs are suitable for
+ * `GraphService.upsertGlobalNode()` and whose edge specs are suitable for
+ * `GraphService.linkGlobalNodes()`.
+ *
+ * @param {Object} [options]
+ * @param {Object[]} [options.identities=IDENTITIES] Canonical identity roots.
+ * @returns {{version: Number, nodes: Object[], edges: Object[], fingerprint: String}}
+ */
+export function createGraphBootSeedManifest({identities = IDENTITIES} = {}) {
+    if (!Array.isArray(identities)) {
+        throw new TypeError('createGraphBootSeedManifest: identities must be an array')
+    }
+
+    const
+        nodes       = [...FIXED_NODE_SPECS, ...identities].map(cloneJsonValue),
+        edges       = FIXED_EDGE_SPECS.map(cloneJsonValue),
+        fingerprint = fingerprintGraphBootSeedRecords({nodes, edges});
+
+    return {
+        version: GRAPH_BOOT_SEED_VERSION,
+        nodes,
+        edges,
+        fingerprint
+    }
+}
+
+/**
+ * @summary Projects one boot node input spec into its exact persisted graph
+ * record shape.
+ *
+ * `GraphService.upsertGlobalNode()` folds `name` and `description` into
+ * `properties`, maps `type` to `label`, and forces `userId: null`.
+ *
+ * @param {Object} spec Boot node spec.
+ * @returns {{id: String, label: String, properties: Object}}
+ */
+export function createGraphBootSeedNodeRecord(spec = {}) {
+    if (typeof spec.id !== 'string' || spec.id.length === 0) {
+        throw new TypeError('createGraphBootSeedNodeRecord: spec.id is required')
+    }
+
+    return pruneUndefined({
+        id        : spec.id,
+        label     : spec.type || spec.label || 'NODE',
+        properties: {
+            name            : spec.name || spec.id,
+            description     : spec.description || '',
+            semanticVectorId: spec.semanticVectorId,
+            state           : spec.state,
+            updatedAt       : spec.updatedAt,
+            ...(spec.properties || {}),
+            userId: null
+        }
+    })
+}
+
+/**
+ * @summary Projects one boot edge input spec into the canonical persisted
+ * comparison shape. The storage-minted random edge id is deliberately excluded;
+ * source, target, type, and the complete properties record are normative.
+ *
+ * @param {Object} spec Boot edge spec or persisted edge record.
+ * @returns {{source: String, target: String, type: String, properties: Object}}
+ */
+export function createGraphBootSeedEdgeRecord(spec = {}) {
+    for (const key of ['source', 'target', 'type']) {
+        if (typeof spec[key] !== 'string' || spec[key].length === 0) {
+            throw new TypeError(`createGraphBootSeedEdgeRecord: spec.${key} is required`)
+        }
+    }
+
+    return pruneUndefined({
+        source    : spec.source,
+        target    : spec.target,
+        type      : spec.type,
+        properties: {
+            weight: spec.weight ?? spec.properties?.weight ?? 1,
+            ...(spec.properties || {}),
+            userId: null
+        }
+    })
+}
+
+/**
+ * @summary Evaluates whether the complete persisted graph record set is exactly
+ * the canonical boot seed—no extra, missing, or altered node/edge.
+ *
+ * Rows may be raw parsed records, SQLite `{data}` rows, or JSON strings. Schema
+ * tables never enter this record-level API and therefore cannot affect the
+ * predicate.
+ *
+ * @param {Object} options
+ * @param {Object[]|String[]} options.nodes Persisted node records.
+ * @param {Object[]|String[]} options.edges Persisted edge records.
+ * @param {Object} [options.manifest=createGraphBootSeedManifest()] Expected manifest.
+ * @returns {{fresh: Boolean, reason: String|null, expectedFingerprint: String, observedFingerprint: String, nodeCount: Number, edgeCount: Number}}
+ */
+export function evaluateGraphBootSeedFreshness({
+    nodes,
+    edges,
+    manifest = createGraphBootSeedManifest()
+} = {}) {
+    if (!Array.isArray(nodes) || !Array.isArray(edges)) {
+        throw new TypeError('evaluateGraphBootSeedFreshness: nodes and edges arrays are required')
+    }
+
+    const
+        expectedNodes       = manifest.nodes.map(createGraphBootSeedNodeRecord),
+        expectedEdges       = manifest.edges.map(createGraphBootSeedEdgeRecord),
+        observedNodes       = nodes.map(parseGraphRecord).map(normalizePersistedNodeRecord),
+        observedEdges       = edges.map(parseGraphRecord).map(createGraphBootSeedEdgeRecord),
+        expectedFingerprint = fingerprintNormalizedGraphRecords({nodes: expectedNodes, edges: expectedEdges}),
+        observedFingerprint = fingerprintNormalizedGraphRecords({nodes: observedNodes, edges: observedEdges}),
+        fresh               = expectedFingerprint === observedFingerprint;
+
+    return {
+        fresh,
+        reason: fresh
+            ? null
+            : `persisted graph differs from boot seed v${GRAPH_BOOT_SEED_VERSION} ` +
+              `(nodes ${observedNodes.length}/${expectedNodes.length}, edges ${observedEdges.length}/${expectedEdges.length})`,
+        expectedFingerprint,
+        observedFingerprint,
+        nodeCount: observedNodes.length,
+        edgeCount: observedEdges.length
+    }
+}
+
+/**
+ * @summary Computes the canonical boot-seed fingerprint from input specs.
+ *
+ * @param {Object} options
+ * @param {Object[]} options.nodes Boot node specs.
+ * @param {Object[]} options.edges Boot edge specs.
+ * @returns {String} `sha256:<hex>`.
+ */
+export function fingerprintGraphBootSeedRecords({nodes = [], edges = []} = {}) {
+    return fingerprintNormalizedGraphRecords({
+        nodes: nodes.map(createGraphBootSeedNodeRecord),
+        edges: edges.map(createGraphBootSeedEdgeRecord)
+    })
+}
+
+function fingerprintNormalizedGraphRecords({nodes, edges}) {
+    const value = {
+        version: GRAPH_BOOT_SEED_VERSION,
+        nodes  : [...nodes].sort(compareCanonical),
+        edges  : [...edges].sort(compareCanonical)
+    };
+
+    return `sha256:${createHash('sha256').update(canonicalJson(value)).digest('hex')}`
+}
+
+function normalizePersistedNodeRecord(record) {
+    if (!record || typeof record !== 'object') {
+        throw new TypeError('normalizePersistedNodeRecord: graph node record must be an object')
+    }
+
+    const id = record.id;
+    if (typeof id !== 'string' || id.length === 0) {
+        throw new TypeError('normalizePersistedNodeRecord: record.id is required')
+    }
+
+    return pruneUndefined({
+        id,
+        label     : record.label || record.type || 'NODE',
+        properties: cloneJsonValue(record.properties || {})
+    })
+}
+
+function parseGraphRecord(value) {
+    if (typeof value === 'string') {
+        return JSON.parse(value)
+    }
+    if (value && typeof value.data === 'string') {
+        return JSON.parse(value.data)
+    }
+    return value
+}
+
+function compareCanonical(a, b) {
+    return canonicalJson(a).localeCompare(canonicalJson(b))
+}
+
+function canonicalJson(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonicalJson).join(',')}]`
+    }
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',')}}`
+    }
+    return JSON.stringify(value)
+}
+
+function pruneUndefined(value) {
+    return JSON.parse(JSON.stringify(value))
+}
+
+function cloneJsonValue(value) {
+    return JSON.parse(JSON.stringify(value))
+}

--- a/ai/scripts/benchmark/restore-empty-target-meter.mjs
+++ b/ai/scripts/benchmark/restore-empty-target-meter.mjs
@@ -281,13 +281,19 @@ export async function createTargetSetFixture({dimension, profileName, root}) {
  * invent a failure.
  *
  * @param {String} root
+ * @param {Object} [fileSystem]
+ * @param {Function} [fileSystem.readDirectory]
+ * @param {Function} [fileSystem.readStat]
  * @returns {Promise<Number>}
  */
-export async function directorySizeBytes(root) {
+export async function directorySizeBytes(root, {
+    readDirectory = readdir,
+    readStat      = stat
+} = {}) {
     let entries;
 
     try {
-        entries = await readdir(root, {withFileTypes: true})
+        entries = await readDirectory(root, {withFileTypes: true})
     } catch (error) {
         if (error?.code === 'ENOENT') return 0;
         throw error
@@ -299,9 +305,13 @@ export async function directorySizeBytes(root) {
         const target = path.join(root, entry.name);
 
         if (entry.isDirectory()) {
-            bytes += await directorySizeBytes(target)
+            bytes += await directorySizeBytes(target, {readDirectory, readStat})
         } else if (entry.isFile()) {
-            bytes += (await stat(target)).size
+            try {
+                bytes += (await readStat(target)).size
+            } catch (error) {
+                if (error?.code !== 'ENOENT') throw error
+            }
         }
     }
 

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -8,6 +8,7 @@ import StorageRouter                                              from './manage
 import DestructiveOperationGuard                                  from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 import {partitionRowsByVectorValidity, summarizeVectorRejections} from './helpers/vectorWriteInvariant.mjs';
 import {validateJsonlSourceFile}                                  from './helpers/vectorJsonlSourceValidation.mjs';
+import {importGraphJsonl}                                         from './helpers/graphJsonlImport.mjs';
 
 /**
  * @summary Service for exporting and importing memory core data.
@@ -268,98 +269,14 @@ class DatabaseService extends Base {
             });
 
             logger.log(`Replace mode: Truncating existing Graph Nodes and Edges...`);
-            db.prepare('DELETE FROM Nodes').run();
-            db.prepare('DELETE FROM Edges').run();
         }
 
-        const fs       = (await import('fs-extra')).default;
-        const readline = (await import('readline')).default;
-
-        const fileStream = fs.createReadStream(filePath);
-        const rl         = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
-
-        let imported = 0;
-
-        // Mode-dependent INSERT semantics:
-        //   - 'replace' mode: TRUNCATE-then-OR-REPLACE. Conflict impossible after truncate,
-        //     OR REPLACE retained for backward parity. Backup IS the new state.
-        //   - 'merge' mode: OR IGNORE. Preserves live rows when IDs collide; backup-only IDs
-        //     still INSERT; live-only IDs untouched. This preserves live post-wipe re-ingestion
-        //     while letting backups fill records that are genuinely missing.
-        const conflictClause = mode === 'replace' ? 'OR REPLACE' : 'OR IGNORE';
-        const insertNode     = db.prepare(`INSERT ${conflictClause} INTO Nodes (id, user_id, data) VALUES (?, ?, ?)`);
-        const insertEdge     = db.prepare(`
-            INSERT ${conflictClause} INTO Edges (id, user_id, source, target, type, data)
-            VALUES (?, ?, ?, ?, ?, ?)
-        `);
-
-        // Truthful counters distinguish inserted (`changes === 1`) from skippedExisting
-        // (`changes === 0`; OR IGNORE no-op) and failed (exception per record). better-sqlite3
-        // exposes this through `stmt.run().changes`.
-        const counts = {
-            nodes: {inserted: 0, skippedExisting: 0, failed: 0},
-            edges: {inserted: 0, skippedExisting: 0, failed: 0}
-        };
-
-        // Run within a transaction for speed
-        const insertBatch = db.transaction((records) => {
-            for (const record of records) {
-                if (record.type === 'node') {
-                    try {
-                        const result = insertNode.run(
-                            record.data.id,
-                            record.data.properties?.userId || record.data.user_id || null,
-                            JSON.stringify(record.data)
-                        );
-                        if (result.changes === 1) counts.nodes.inserted++;
-                        else                       counts.nodes.skippedExisting++;
-                    } catch (e) {
-                        counts.nodes.failed++;
-                        if (counts.nodes.failed <= 5) logger.warn(`[importGraph] node insert failed for id=${record.data?.id}: ${e.message}`);
-                    }
-                } else if (record.type === 'edge') {
-                    const edgeData = record.data;
-                    const edgeId   = edgeData.id || `${edgeData.source}->${edgeData.target}:${edgeData.type}`;
-
-                    if (!edgeData.source || !edgeData.target || !edgeData.type) {
-                        counts.edges.failed++;
-                        if (counts.edges.failed <= 5) logger.warn(`[importGraph] edge missing source/target/type: id=${edgeId}`);
-                        continue;
-                    }
-
-                    try {
-                        const result = insertEdge.run(
-                            edgeId,
-                            edgeData.properties?.userId || edgeData.user_id || null,
-                            edgeData.source,
-                            edgeData.target,
-                            edgeData.type,
-                            JSON.stringify(edgeData)
-                        );
-                        if (result.changes === 1) counts.edges.inserted++;
-                        else                       counts.edges.skippedExisting++;
-                    } catch (e) {
-                        counts.edges.failed++;
-                        if (counts.edges.failed <= 5) logger.warn(`[importGraph] edge insert failed for id=${edgeId}: ${e.message}`);
-                    }
-                }
-                imported++;
-            }
+        const {imported, counts} = await importGraphJsonl({
+            db,
+            filePath,
+            mode,
+            warn: message => logger.warn(message)
         });
-
-        const batch = [];
-        for await (const line of rl) {
-            if (line.trim()) {
-                batch.push(JSON.parse(line));
-                if (batch.length >= 2000) {
-                     insertBatch(batch);
-                     batch.length = 0;
-                }
-            }
-        }
-        if (batch.length > 0) {
-             insertBatch(batch);
-        }
 
         const summary = `nodes(inserted=${counts.nodes.inserted}, skipped=${counts.nodes.skippedExisting}, failed=${counts.nodes.failed}) ` +
                         `edges(inserted=${counts.edges.inserted}, skipped=${counts.edges.skippedExisting}, failed=${counts.edges.failed})`;

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -1,13 +1,14 @@
-import path                from 'path';
-import aiConfig            from '../../mcp/server/memory-core/config.mjs';
-import logger              from '../../mcp/server/memory-core/logger.mjs';
-import Base                from '../../../src/core/Base.mjs';
-import CoreDatabase        from '../../../ai/graph/Database.mjs';
-import SQLite              from '../../../ai/graph/storage/SQLite.mjs';
-import { IDENTITIES }      from '../../../ai/graph/identityRoots.mjs';
-import { normalizeUserId } from '../../mcp/server/shared/services/RequestContextService.mjs';
-import fsExtra             from 'fs-extra';
-import {projectNode}       from './nodeProjection.mjs';
+import path                          from 'path';
+import aiConfig                      from '../../mcp/server/memory-core/config.mjs';
+import logger                        from '../../mcp/server/memory-core/logger.mjs';
+import Base                          from '../../../src/core/Base.mjs';
+import CoreDatabase                  from '../../../ai/graph/Database.mjs';
+import SQLite                        from '../../../ai/graph/storage/SQLite.mjs';
+import { IDENTITIES }                from '../../../ai/graph/identityRoots.mjs';
+import {createGraphBootSeedManifest} from '../../../ai/graph/bootSeedManifest.mjs';
+import { normalizeUserId }           from '../../mcp/server/shared/services/RequestContextService.mjs';
+import fsExtra                       from 'fs-extra';
+import {projectNode}                 from './nodeProjection.mjs';
 
 /**
  * Row-level-security visibility predicate for an in-memory graph **node or edge**, mirroring
@@ -144,50 +145,14 @@ class GraphService extends Base {
                 await storage.load();
                 this.graphInitError = null;
 
-                // Ensure the frontier node exists to prevent context frontier errors
+                // One enumerable manifest is shared by ordinary boot and the exact
+                // restore-empty-target freshness proof. Boot remains additive-only:
+                // missing records are provisioned, existing records are never replayed
+                // from a potentially stale process-local registry.
                 try {
-                    this.db.getAdjacentNodes('frontier', 'both'); // trigger lazy load
-                    if (!this.db.nodes.has('frontier')) {
-                        this.upsertGlobalNode({
-                            id         : 'frontier',
-                            type       : 'SYSTEM_ANCHOR',
-                            name       : 'Active Context Frontier',
-                            description: 'The shifting focal point of the active Neo OS agent session.'
-                        });
-                    }
+                    this.provisionMissingBootSeeds();
                 } catch (error) {
-                    logger.warn(`[GraphService] Non-fatal DB contention during 'frontier' seed: ${error.message}`);
-                }
-
-                // --- 1. THE GLOBAL SYSTEM PRIMER ---
-                // Inject the Master Architecture Tenets directly into the Native Graph at boot.
-                // Because this is anchored to the 'frontier' with a protected SYSTEM_TENET edge,
-                // it acts as a deterministic onboarding payload for every agent session.
-                try {
-                    this.db.getAdjacentNodes('Neo-Master-Architecture', 'both');
-                    if (!this.db.nodes.has('Neo-Master-Architecture')) {
-                        this.upsertGlobalNode({
-                            id         : 'Neo-Master-Architecture',
-                            type       : 'System',
-                            name       : 'Global System Primer',
-                            description: 'Core framework tenets: 1. All Playwright tests must be run using "npm run test-unit -- [file]". No npx. 2. UI debugging and application state inspection must use the Neural Link MCP tools. 3. Look at .agents/skills for reusable agent workflows.'
-                        });
-                    }
-                    this.linkGlobalNodes('frontier', 'Neo-Master-Architecture', 'SYSTEM_TENET', 1.0);
-                } catch (error) {
-                    logger.warn(`[GraphService] Non-fatal DB contention during Master Architecture seed: ${error.message}`);
-                }
-
-                // --- 2. AGENT IDENTITY SUBSTRATE SEEDING ---
-                // Eliminates the "seed → restart-again" recovery loop for fresh local setups.
-                // Ordinary boot is additive-only: a stale process may provision a missing root, but
-                // must never replay its process-local registry over an existing graph identity.
-                // Intentional canonical updates belong to seedAgentIdentities.mjs after the owning
-                // runtime checkout has pulled the merged registry.
-                try {
-                    this.provisionMissingIdentityRoots();
-                } catch (error) {
-                    logger.warn(`[GraphService] Non-fatal DB contention during Identity Substrate seed: ${error.message}`);
+                    logger.warn(`[GraphService] Non-fatal DB contention during canonical boot-seed provisioning: ${error.message}`);
                 }
 
                 logger.log('[GraphService] SQLite database mounted securely via ai.graph.Database.');
@@ -202,6 +167,53 @@ class GraphService extends Base {
         })();
 
         await this._initPromise;
+    }
+
+    /**
+     * @summary Provisions every missing record from the canonical graph boot-seed
+     * manifest without rewriting an existing node or edge.
+     *
+     * The explicit edge-existence check is load-bearing: calling `linkNodes` on
+     * every boot increments an existing edge's weight, which would make a
+     * deterministic fresh graph cease to match its own boot fingerprint after
+     * the second process start.
+     *
+     * @param {Object} [manifest=createGraphBootSeedManifest()] Enumerable seed manifest.
+     * @returns {{nodesCreated: Number, edgesCreated: Number}}
+     */
+    provisionMissingBootSeeds(manifest = createGraphBootSeedManifest()) {
+        let nodesCreated = 0,
+            edgesCreated = 0;
+
+        for (const node of manifest.nodes) {
+            this.db.getAdjacentNodes(node.id, 'both');
+
+            if (!this.db.nodes.has(node.id)) {
+                this.upsertGlobalNode(node);
+                nodesCreated++;
+            }
+        }
+
+        const storageDb = this.db?.storage?.db;
+        if (!storageDb) {
+            throw new Error('provisionMissingBootSeeds: graph storage database is required')
+        }
+
+        const findEdge = storageDb.prepare(`
+            SELECT id
+            FROM Edges
+            WHERE source = ? AND target = ? AND type = ?
+            LIMIT 1
+        `);
+
+        for (const edge of manifest.edges) {
+            if (!findEdge.get(edge.source, edge.target, edge.type)) {
+                this.linkGlobalNodes(edge.source, edge.target, edge.type, edge.weight);
+                edgesCreated++;
+            }
+        }
+
+        return {nodesCreated, edgesCreated}
     }
 
     /**

--- a/ai/services/memory-core/helpers/graphJsonlImport.mjs
+++ b/ai/services/memory-core/helpers/graphJsonlImport.mjs
@@ -1,0 +1,163 @@
+import fs       from 'fs';
+import readline from 'readline';
+
+/**
+ * @module ai/services/memory-core/helpers/graphJsonlImport
+ * @summary Canonical bounded Native Edge Graph JSONL importer shared by
+ * operator restore and isolated target-set staging.
+ */
+
+/**
+ * @summary Imports canonical `{type:'node'|'edge', data}` JSONL records into an
+ * opened graph SQLite database.
+ *
+ * The caller owns destructive-target admission. `replace` clears graph rows
+ * before importing; staging callers use it only on a run-owned disposable DB,
+ * while `DatabaseService` applies its production guard first.
+ *
+ * @param {Object} options
+ * @param {Object} options.db Open better-sqlite3 database with Nodes/Edges.
+ * @param {String} options.filePath JSONL source.
+ * @param {'merge'|'replace'} options.mode Import mode.
+ * @param {Number} [options.batchSize=2000] Maximum transaction batch.
+ * @param {Function} [options.warn=()=>{}] Bounded warning sink.
+ * @returns {Promise<{imported: Number, counts: Object, mode: String, maxBatchSize: Number}>}
+ */
+export async function importGraphJsonl({
+    db,
+    filePath,
+    mode,
+    batchSize = 2000,
+    warn = () => {}
+} = {}) {
+    if (!db || typeof db.prepare !== 'function' || typeof db.transaction !== 'function') {
+        throw new TypeError('importGraphJsonl: opened better-sqlite3 db is required')
+    }
+    if (typeof filePath !== 'string' || filePath.length === 0) {
+        throw new TypeError('importGraphJsonl: filePath is required')
+    }
+    if (!['merge', 'replace'].includes(mode)) {
+        throw new TypeError("importGraphJsonl: mode must be 'merge' or 'replace'")
+    }
+    if (!Number.isInteger(batchSize) || batchSize <= 0) {
+        throw new TypeError('importGraphJsonl: batchSize must be a positive integer')
+    }
+
+    if (mode === 'replace') {
+        db.transaction(() => {
+            db.prepare('DELETE FROM Edges').run();
+            db.prepare('DELETE FROM Nodes').run();
+        }).immediate()
+    }
+
+    const
+        conflictClause = mode === 'replace' ? 'OR REPLACE' : 'OR IGNORE',
+        insertNode     = db.prepare(`INSERT ${conflictClause} INTO Nodes (id, user_id, data) VALUES (?, ?, ?)`),
+        insertEdge     = db.prepare(`
+            INSERT ${conflictClause} INTO Edges (id, user_id, source, target, type, data)
+            VALUES (?, ?, ?, ?, ?, ?)
+        `),
+        counts         = {
+            nodes: {inserted: 0, skippedExisting: 0, failed: 0},
+            edges: {inserted: 0, skippedExisting: 0, failed: 0}
+        };
+
+    let imported    = 0;
+    let maxObserved = 0;
+
+    const insertBatch = db.transaction(records => {
+        for (const record of records) {
+            if (record.type === 'node') {
+                try {
+                    const result = insertNode.run(
+                        record.data.id,
+                        record.data.properties?.userId || record.data.user_id || null,
+                        JSON.stringify(record.data)
+                    );
+                    if (result.changes === 1) {
+                        counts.nodes.inserted++
+                    } else {
+                        counts.nodes.skippedExisting++
+                    }
+                } catch (error) {
+                    counts.nodes.failed++;
+                    if (counts.nodes.failed <= 5) {
+                        warn(`[importGraphJsonl] node insert failed for id=${record.data?.id}: ${error.message}`)
+                    }
+                }
+            } else if (record.type === 'edge') {
+                const
+                    edgeData = record.data,
+                    edgeId   = edgeData.id || `${edgeData.source}->${edgeData.target}:${edgeData.type}`;
+
+                if (!edgeData.source || !edgeData.target || !edgeData.type) {
+                    counts.edges.failed++;
+                    if (counts.edges.failed <= 5) {
+                        warn(`[importGraphJsonl] edge missing source/target/type: id=${edgeId}`)
+                    }
+                    imported++;
+                    continue
+                }
+
+                try {
+                    const result = insertEdge.run(
+                        edgeId,
+                        edgeData.properties?.userId || edgeData.user_id || null,
+                        edgeData.source,
+                        edgeData.target,
+                        edgeData.type,
+                        JSON.stringify(edgeData)
+                    );
+                    if (result.changes === 1) {
+                        counts.edges.inserted++
+                    } else {
+                        counts.edges.skippedExisting++
+                    }
+                } catch (error) {
+                    counts.edges.failed++;
+                    if (counts.edges.failed <= 5) {
+                        warn(`[importGraphJsonl] edge insert failed for id=${edgeId}: ${error.message}`)
+                    }
+                }
+            }
+
+            imported++
+        }
+    });
+
+    const
+        input = fs.createReadStream(filePath),
+        lines = readline.createInterface({input, crlfDelay: Infinity}),
+        batch = [];
+
+    try {
+        for await (const line of lines) {
+            if (!line.trim()) {
+                continue
+            }
+
+            batch.push(JSON.parse(line));
+
+            if (batch.length === batchSize) {
+                maxObserved = Math.max(maxObserved, batch.length);
+                insertBatch(batch);
+                batch.length = 0
+            }
+        }
+
+        if (batch.length > 0) {
+            maxObserved = Math.max(maxObserved, batch.length);
+            insertBatch(batch)
+        }
+    } finally {
+        lines.close();
+        input.destroy()
+    }
+
+    return {
+        imported,
+        counts,
+        mode,
+        maxBatchSize: maxObserved
+    }
+}

--- a/ai/services/memory-core/helpers/healActionDispatch.mjs
+++ b/ai/services/memory-core/helpers/healActionDispatch.mjs
@@ -15,6 +15,11 @@
  * placement-independent decision every shape of the actuator (dedicated service or extended) consumes.
  */
 
+import {
+    deriveRestoreTargetSetIdentity,
+    RESTORE_EMPTY_TARGET_ACTION
+} from './restoreTargetSetContract.mjs';
+
 /**
  * The DISPATCHABLE heal actions (the classifier's `terminalAction` vocabulary). Non-mutating containment
  * (`freeze` / `quarantine` / `throttle-shed`) is always safe to apply; the rest are mutating (see `MUTATING_HEAL_ACTIONS`).
@@ -22,7 +27,7 @@
  * before the vocabulary check, never dispatched.
  * @type {String[]}
  */
-export const HEAL_ACTIONS = Object.freeze(['re-embed-missing', 're-embed-rows', 'restore-delta-merge', 'quarantine', 'freeze', 'throttle-shed', 'defrag']);
+export const HEAL_ACTIONS = Object.freeze(['re-embed-missing', 're-embed-rows', RESTORE_EMPTY_TARGET_ACTION, 'quarantine', 'freeze', 'throttle-shed', 'defrag']);
 
 /**
  * The non-dispatchable no-op sentinel: the classifier emits `none` for a clean collection (nothing to heal).
@@ -38,7 +43,7 @@ export const NO_HEAL_ACTION = 'none';
  * `freeze`, `quarantine` + `throttle-shed` are non-mutating containment and are exempt.
  * @type {String[]}
  */
-export const MUTATING_HEAL_ACTIONS = Object.freeze(['re-embed-missing', 're-embed-rows', 'restore-delta-merge', 'defrag']);
+export const MUTATING_HEAL_ACTIONS = Object.freeze(['re-embed-missing', 're-embed-rows', RESTORE_EMPTY_TARGET_ACTION, 'defrag']);
 
 /**
  * Default dispatch bounds: at most 3 mutating runs of the same action+collection per hour, with a 10-minute
@@ -56,19 +61,42 @@ export const DEFAULT_DISPATCH_BOUNDS = Object.freeze({maxRunsPerWindow: 3, windo
  *
  * @param {Object} options
  * @param {String} [options.action] The heal action (the classifier's `terminalAction`).
- * @param {String} [options.collection] The target collection (the anti-thrash / rate key, with `action`).
- * @param {Object[]} [options.recentRuns=[]] Recent heal runs `[{action, collection, at}]` (epoch ms) for anti-thrash + rate.
+ * @param {String} [options.collection] The target collection for collection-scoped actions.
+ * @param {Object} [options.targetSet] The canonical v1 descriptor for `restore-empty-target`.
+ * @param {Object[]} [options.recentRuns=[]] Recent heal runs. Collection actions key by
+ * `collection`; target-set recovery keys by `recoveryUnitKey`.
  * @param {{maxRunsPerWindow: Number, windowMs: Number, cooldownMs: Number}} [options.bounds=DEFAULT_DISPATCH_BOUNDS]
  * @param {Number} [options.now] Epoch milliseconds (the injected clock).
  * @returns {Object} `{execute, status, reason}`. `status ∈ {execute, no-op, unknown-action, unsafe-input, thrash-cooldown, rate-limited}`.
  */
-export function decideHealAction({action, collection, recentRuns = [], bounds = DEFAULT_DISPATCH_BOUNDS, now} = {}) {
+export function decideHealAction({action, collection, targetSet, recentRuns = [], bounds = DEFAULT_DISPATCH_BOUNDS, now} = {}) {
     if (action === NO_HEAL_ACTION || action == null) {
         return {execute: false, status: 'no-op', reason: 'no-heal-action'};
     }
 
     if (!HEAL_ACTIONS.includes(action)) {
         return {execute: false, status: 'unknown-action', reason: `unknown heal action: ${action}`};
+    }
+
+    let targetIdentity = null;
+
+    if (action === RESTORE_EMPTY_TARGET_ACTION) {
+        if (collection !== undefined && collection !== null) {
+            return {execute: false, status: 'unsafe-input', reason: `'${RESTORE_EMPTY_TARGET_ACTION}' rejects collection and requires targetSet`}
+        }
+
+        try {
+            targetIdentity = deriveRestoreTargetSetIdentity(targetSet);
+        } catch (error) {
+            return {execute: false, status: 'unsafe-input', reason: error.message}
+        }
+    } else {
+        if (targetSet !== undefined && targetSet !== null) {
+            return {execute: false, status: 'unsafe-input', reason: `collection-scoped '${action}' rejects targetSet`}
+        }
+        if (typeof collection !== 'string' || collection.length === 0) {
+            return {execute: false, status: 'unsafe-input', reason: `collection-scoped '${action}' requires a non-empty collection`}
+        }
     }
 
     // Non-mutating containment is always safe to apply — no rate/thrash bound.
@@ -78,9 +106,6 @@ export function decideHealAction({action, collection, recentRuns = [], bounds = 
 
     // A mutating heal MUST carry the full safety context or the rate + anti-thrash gate cannot bind. Fail
     // CLOSED on a missing target/clock — an under-specified mutating heal must never execute unbounded.
-    if (typeof collection !== 'string' || collection.length === 0) {
-        return {execute: false, status: 'unsafe-input', reason: `mutating '${action}' requires a non-empty collection (the anti-thrash key)`};
-    }
     if (!Number.isFinite(now)) {
         return {execute: false, status: 'unsafe-input', reason: `mutating '${action}' requires a finite 'now' (cooldown/window clock)`};
     }
@@ -93,24 +118,35 @@ export function decideHealAction({action, collection, recentRuns = [], bounds = 
         return {execute: false, status: 'unsafe-input', reason: `mutating '${action}' requires finite bounds {maxRunsPerWindow, windowMs, cooldownMs}`};
     }
 
-    const sameTarget = (Array.isArray(recentRuns) ? recentRuns : [])
-        .filter(run => run?.action === action && run?.collection === collection);
+    const
+        targetKey  = targetIdentity?.recoveryUnitKey ?? collection,
+        sameTarget = (Array.isArray(recentRuns) ? recentRuns : [])
+            .filter(run => run?.action === action && (
+                targetIdentity
+                    ? run?.recoveryUnitKey === targetKey || run?.collection === targetKey
+                    : run?.collection === targetKey
+            ));
 
     // Anti-thrash: a same-action+collection run inside the cooldown → hold.
     const lastAt = sameTarget.reduce((latest, run) => (Number.isFinite(run?.at) && run.at > latest ? run.at : latest), -Infinity);
 
     if (Number.isFinite(lastAt) && now - lastAt < cooldownMs) {
-        return {execute: false, status: 'thrash-cooldown', reason: `${action} on ${collection} ran ${now - lastAt}ms ago (< ${cooldownMs}ms cooldown)`};
+        return {execute: false, status: 'thrash-cooldown', reason: `${action} on ${targetKey} ran ${now - lastAt}ms ago (< ${cooldownMs}ms cooldown)`};
     }
 
     // Rate-limit: too many runs of this action+collection inside the window → hold.
     const inWindow = sameTarget.filter(run => Number.isFinite(run?.at) && now - run.at < windowMs).length;
 
     if (inWindow >= maxRunsPerWindow) {
-        return {execute: false, status: 'rate-limited', reason: `${action} on ${collection} hit ${inWindow}/${maxRunsPerWindow} runs in ${windowMs}ms`};
+        return {execute: false, status: 'rate-limited', reason: `${action} on ${targetKey} hit ${inWindow}/${maxRunsPerWindow} runs in ${windowMs}ms`};
     }
 
-    return {execute: true, status: 'execute', reason: 'within bounds'};
+    return {
+        execute: true,
+        status : 'execute',
+        reason : 'within bounds',
+        ...(targetIdentity || {})
+    };
 }
 
 /**
@@ -127,7 +163,8 @@ export function decideHealAction({action, collection, recentRuns = [], bounds = 
  *
  * @param {Object} options
  * @param {String} [options.action] The heal action (the classifier's `terminalAction`).
- * @param {String} [options.collection] The target collection.
+ * @param {String} [options.collection] The target collection for collection-scoped actions.
+ * @param {Object} [options.targetSet] The canonical target-set descriptor for `restore-empty-target`.
  * @param {Object} [options.evidence] The diagnosis evidence passed through to the operation.
  * @param {Object[]} [options.recentRuns=[]] Recent heal runs for the safety gate (anti-thrash + rate).
  * @param {Object} [options.bounds] The dispatch bounds (defaults to `DEFAULT_DISPATCH_BOUNDS` in `decideHealAction`).
@@ -136,11 +173,15 @@ export function decideHealAction({action, collection, recentRuns = [], bounds = 
  * @param {Function} [options.recordRun] `async ({action, collection, at}) => void` — persists a mutating ATTEMPT for future anti-thrash. **Required for mutating actions** — absent → the heal fails closed (`unsafe-input`: no recorder, no mutation). Called before execution for every mutating heal (success OR failure), so a failed heal cannot hot-loop.
  * @returns {Promise<Object>} `outcomeRecord` = `{action, collection, status, detail, healedAt}`.
  */
-export async function dispatchHeal({action, collection, evidence, recentRuns = [], bounds, now, healOperations = {}, recordRun} = {}) {
-    const decision = decideHealAction({action, collection, recentRuns, bounds, now});
+export async function dispatchHeal({action, collection, targetSet, evidence, recentRuns = [], bounds, now, healOperations = {}, recordRun} = {}) {
+    const decision       = decideHealAction({action, collection, targetSet, recentRuns, bounds, now});
+    const identityFields = decision.recoveryUnitKey ? {
+        recoveryUnitKey   : decision.recoveryUnitKey,
+        attemptFingerprint: decision.attemptFingerprint
+    } : {};
 
     if (!decision.execute) {
-        return {action, collection, status: decision.status, detail: decision.reason, healedAt: now};
+        return {action, collection, ...identityFields, status: decision.status, detail: decision.reason, healedAt: now};
     }
 
     const operation = healOperations?.[action];
@@ -149,7 +190,7 @@ export async function dispatchHeal({action, collection, evidence, recentRuns = [
     // `deferred` outcome — autonomous, never a page. (Until quarantine itself is wired it defers too — the
     // interim detects + records rather than contains; containment lands with the wired containment op.)
     if (typeof operation !== 'function') {
-        return {action, collection, status: 'deferred', detail: `no heal operation wired for '${action}'`, healedAt: now};
+        return {action, collection, ...identityFields, status: 'deferred', detail: `no heal operation wired for '${action}'`, healedAt: now};
     }
 
     const isMutating = MUTATING_HEAL_ACTIONS.includes(action);
@@ -158,7 +199,7 @@ export async function dispatchHeal({action, collection, evidence, recentRuns = [
     // recorder, no mutation. (Containment is unbounded and needs no recorder.) The invariant holds on EVERY
     // path, not only when a recordRun happens to be wired.
     if (isMutating && typeof recordRun !== 'function') {
-        return {action, collection, status: 'unsafe-input', detail: `mutating '${action}' requires a recordRun to persist the anti-thrash attempt (no recorder, no mutation)`, healedAt: now};
+        return {action, collection, ...identityFields, status: 'unsafe-input', detail: `mutating '${action}' requires a recordRun to persist the anti-thrash attempt (no recorder, no mutation)`, healedAt: now};
     }
 
     // Record the mutating ATTEMPT BEFORE execution so a throwing/failing heal still enters the anti-thrash
@@ -166,18 +207,31 @@ export async function dispatchHeal({action, collection, evidence, recentRuns = [
     // CLOSED rather than risk an unrecorded loop.
     if (isMutating) {
         try {
-            await recordRun({action, collection, at: now});
+            await recordRun({action, collection, ...identityFields, at: now});
         } catch (recordError) {
-            return {action, collection, status: 'failed', detail: `anti-thrash recordRun failed pre-execution: ${recordError?.message ?? String(recordError)}`, healedAt: now};
+            return {action, collection, ...identityFields, status: 'failed', detail: `anti-thrash recordRun failed pre-execution: ${recordError?.message ?? String(recordError)}`, healedAt: now};
         }
     }
 
     try {
-        const result = await operation({collection, evidence, now});
-        return {action, collection, status: result?.status ?? 'healed', detail: result?.detail ?? result ?? null, healedAt: now};
+        const result = await operation({
+            collection,
+            targetSet,
+            evidence,
+            now,
+            ...identityFields
+        });
+        return {
+            action,
+            collection,
+            ...identityFields,
+            status  : result?.status ?? 'healed',
+            detail  : result?.detail ?? result ?? null,
+            healedAt: now
+        };
     } catch (error) {
         // A failed heal is already recorded (above) — never escalated; autonomous self-heal degrades to a recorded fault.
-        return {action, collection, status: 'failed', detail: error?.message ?? String(error), healedAt: now};
+        return {action, collection, ...identityFields, status: 'failed', detail: error?.message ?? String(error), healedAt: now};
     }
 }
 

--- a/ai/services/memory-core/helpers/restoreEmptyTargetOperation.mjs
+++ b/ai/services/memory-core/helpers/restoreEmptyTargetOperation.mjs
@@ -1,0 +1,372 @@
+import {
+    deriveRestoreTargetSetIdentity,
+    RESTORE_EMPTY_TARGET_ACTION,
+    RESTORE_TARGET_ROLES
+} from './restoreTargetSetContract.mjs';
+import {
+    createRestoreTargetSetReceipt,
+    isRestoreTargetSetCommitted,
+    RESTORE_TARGET_SET_TERMINALS
+} from './restoreTargetSetStateStore.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/restoreEmptyTargetOperation
+ * @summary Fenced, crash-resumable controller for the exact
+ * `restore-empty-target` action.
+ *
+ * Store-specific staging and promotion mechanics are injected. This controller
+ * owns ordering, strict transitions, forward-only reconciliation, and the
+ * committed-only eligibility boundary.
+ */
+
+const PROMOTION_STATES = Object.freeze({
+    memories : 'promoted:memories',
+    summaries: 'promoted:summaries',
+    graph    : 'promoted:graph'
+});
+
+/**
+ * @summary Creates the actuator operation consumed by `dispatchHeal`.
+ *
+ * @param {Object} collaborators
+ * @param {Function} collaborators.withWriterFence `async (identity, task)`.
+ * @param {Function} collaborators.inspectFreshTargetSet Under-fence production proof.
+ * @param {Function} collaborators.stageTargetSet Creates/loads isolated staging.
+ * @param {Function} collaborators.validateStagedTargetSet Validates all staged targets.
+ * @param {Function} collaborators.promoteComponent Ordered per-role promotion.
+ * @param {Function} collaborators.revalidateProductionTargetSet Complete post-promotion validation.
+ * @param {Function} collaborators.reconcileAttempt Resume proof for an existing nonterminal ledger.
+ * @param {Function} collaborators.cleanupUnpromotedStaging Deletes only run-owned unpromoted staging.
+ * @param {Function} [collaborators.cleanupCommittedArtifacts=async()=>{}] Best-effort
+ * cleanup of run-owned parking/staging after strict commit.
+ * @param {Function} collaborators.readTransitions Strict ledger reader.
+ * @param {Function} collaborators.appendTransition Strict ledger appender.
+ * @param {Function} [collaborators.clock=Date.now] Injected live clock.
+ * @returns {Function} Heal operation.
+ */
+export function createRestoreEmptyTargetOperation({
+    withWriterFence,
+    inspectFreshTargetSet,
+    stageTargetSet,
+    validateStagedTargetSet,
+    promoteComponent,
+    revalidateProductionTargetSet,
+    reconcileAttempt,
+    cleanupUnpromotedStaging,
+    cleanupCommittedArtifacts = async () => {},
+    readTransitions,
+    appendTransition,
+    clock = Date.now
+} = {}) {
+    const required = {
+        withWriterFence,
+        inspectFreshTargetSet,
+        stageTargetSet,
+        validateStagedTargetSet,
+        promoteComponent,
+        revalidateProductionTargetSet,
+        reconcileAttempt,
+        cleanupUnpromotedStaging,
+        cleanupCommittedArtifacts,
+        readTransitions,
+        appendTransition,
+        clock
+    };
+
+    for (const [name, value] of Object.entries(required)) {
+        if (typeof value !== 'function') {
+            throw new TypeError(`createRestoreEmptyTargetOperation: ${name} must be a function`)
+        }
+    }
+
+    return async function restoreEmptyTarget({
+        targetSet,
+        recoveryUnitKey,
+        attemptFingerprint
+    } = {}) {
+        const identity = deriveRestoreTargetSetIdentity(targetSet);
+
+        if (identity.recoveryUnitKey !== recoveryUnitKey ||
+            identity.attemptFingerprint !== attemptFingerprint) {
+            throw new Error('restore-empty-target dispatch identity does not match the canonical target set')
+        }
+
+        const context = {
+            action    : RESTORE_EMPTY_TARGET_ACTION,
+            descriptor: identity.descriptor,
+            targetSet,
+            recoveryUnitKey,
+            attemptFingerprint
+        };
+
+        return withWriterFence({
+            recoveryUnitKey,
+            attemptFingerprint
+        }, async () => executeUnderFence({
+            context,
+            inspectFreshTargetSet,
+            stageTargetSet,
+            validateStagedTargetSet,
+            promoteComponent,
+            revalidateProductionTargetSet,
+            reconcileAttempt,
+            cleanupUnpromotedStaging,
+            cleanupCommittedArtifacts,
+            readTransitions,
+            appendTransition,
+            clock
+        }))
+    }
+}
+
+async function executeUnderFence({
+    context,
+    inspectFreshTargetSet,
+    stageTargetSet,
+    validateStagedTargetSet,
+    promoteComponent,
+    revalidateProductionTargetSet,
+    reconcileAttempt,
+    cleanupUnpromotedStaging,
+    cleanupCommittedArtifacts,
+    readTransitions,
+    appendTransition,
+    clock
+}) {
+    let   transitions  = await readTransitions(context);
+    let   latest       = transitions.at(-1)?.state ?? null;
+    const isNewAttempt = transitions.length === 0;
+
+    if (RESTORE_TARGET_SET_TERMINALS.includes(latest)) {
+        return outcomeFromTransitions({context, transitions})
+    }
+
+    let staging          = null;
+    let validationResult = null;
+    let promotionStarted = latest?.startsWith('promoted:') || latest === 'validated';
+
+    try {
+        if (latest === null) {
+            await append('admitted', {
+                bundleManifestFingerprint     : context.descriptor.bundleManifestFingerprint,
+                admissionDescriptorFingerprint: context.descriptor.admissionDescriptorFingerprint
+            });
+            latest = 'admitted';
+        }
+
+        if (latest === 'interrupted') {
+            await append('fenced', {resumed: true});
+            latest = 'fenced';
+        } else if (latest === 'admitted') {
+            await append('fenced', {resumed: false});
+            latest = 'fenced';
+        }
+
+        if (!isNewAttempt) {
+            const reconciliation = await reconcileAttempt({
+                ...context,
+                transitions
+            });
+
+            if (!reconciliation?.safe) {
+                await append('failed-contained', {
+                    reason       : boundedText(reconciliation?.reason || 'reconciliation could not prove the ledger/storage boundary'),
+                    observedState: reconciliation?.observedState ?? null,
+                    ledgerState  : latest
+                });
+                return outcomeFromTransitions({
+                    context,
+                    transitions,
+                    failure: new Error(reconciliation?.reason || 'restore target-set reconciliation failed')
+                })
+            }
+
+            staging = reconciliation.staging ?? null;
+        }
+
+        if (latest === 'fenced') {
+            const freshProof = await inspectFreshTargetSet(context);
+
+            if (freshProof?.destinationTopologyFingerprint !== context.descriptor.destinationTopologyFingerprint) {
+                await append('deferred-target-not-empty', {
+                    reason                     : 'destination-topology-fingerprint-mismatch',
+                    observedTopologyFingerprint: freshProof?.destinationTopologyFingerprint ?? null
+                });
+                return outcomeFromTransitions({context, transitions})
+            }
+            if (freshProof?.fresh !== true) {
+                await append('deferred-target-not-empty', {
+                    reason: boundedText(freshProof?.reason || 'target set is not seed-aware empty')
+                });
+                return outcomeFromTransitions({context, transitions})
+            }
+
+            staging = await stageTargetSet(context);
+            validationResult = await validateStagedTargetSet({
+                ...context,
+                staging
+            });
+
+            if (validationResult?.valid !== true) {
+                throw createPhaseError('staged-target-set-invalid', validationResult?.reason || 'staged target-set validation failed')
+            }
+
+            await append('staged', {
+                componentFingerprints: validationResult.componentFingerprints ?? null
+            });
+            latest = 'staged';
+        }
+
+        for (const role of RESTORE_TARGET_ROLES) {
+            const state = PROMOTION_STATES[role];
+
+            if (hasState(transitions, state)) {
+                promotionStarted = true;
+                continue
+            }
+
+            promotionStarted = true;
+            const promotion = await promoteComponent({
+                ...context,
+                staging,
+                role,
+                transitions
+            });
+
+            await append(state, {
+                fingerprint: promotion?.fingerprint ?? null,
+                count      : promotion?.count ?? null
+            });
+            latest = state;
+        }
+
+        if (latest !== 'validated') {
+            validationResult = await revalidateProductionTargetSet({
+                ...context,
+                staging,
+                transitions
+            });
+
+            if (validationResult?.valid !== true) {
+                throw createPhaseError('production-target-set-invalid', validationResult?.reason || 'production target-set validation failed')
+            }
+
+            await append('validated', {
+                componentFingerprints: validationResult.componentFingerprints ?? null
+            });
+            latest = 'validated';
+        }
+
+        await append('committed', {
+            serviceEligible: true
+        });
+
+        const outcome = outcomeFromTransitions({
+            context,
+            transitions,
+            validationResult
+        })
+
+        try {
+            await cleanupCommittedArtifacts({
+                ...context,
+                staging,
+                transitions
+            })
+        } catch {
+            // Strict `committed` is already durable. Run-owned artifact cleanup is
+            // best-effort observability debt and cannot revoke completion.
+        }
+
+        return outcome
+    } catch (error) {
+        if (isRestoreTargetSetCommitted(transitions)) {
+            return outcomeFromTransitions({context, transitions, validationResult})
+        }
+
+        try {
+            if (promotionStarted) {
+                const current = transitions.at(-1)?.state;
+                if (!RESTORE_TARGET_SET_TERMINALS.includes(current)) {
+                    await append('failed-contained', {
+                        reason: boundedText(error.message),
+                        code  : error.code ?? 'restore-target-set-failed-after-promotion'
+                    })
+                }
+            } else {
+                await cleanupUnpromotedStaging({
+                    ...context,
+                    staging,
+                    transitions
+                });
+
+                const current = transitions.at(-1)?.state;
+                if (!RESTORE_TARGET_SET_TERMINALS.includes(current)) {
+                    await append('interrupted', {
+                        reason    : boundedText(error.message),
+                        resumeFrom: current
+                    })
+                }
+            }
+        } catch (settlementError) {
+            error.settlementError = settlementError
+        }
+
+        throw error
+    }
+
+    async function append(state, details) {
+        const transition = await appendTransition({
+            ...context,
+            state,
+            at: getTimestamp(clock),
+            details
+        });
+
+        transitions = [...transitions, transition]
+        return transition
+    }
+}
+
+function outcomeFromTransitions({
+    context,
+    transitions,
+    validationResult = null,
+    failure = null
+}) {
+    const receipt = createRestoreTargetSetReceipt({
+        transitions,
+        recoveryUnitKey   : context.recoveryUnitKey,
+        attemptFingerprint: context.attemptFingerprint,
+        descriptor        : context.descriptor,
+        validationResult,
+        failure
+    });
+
+    return {
+        status: receipt.terminal ?? 'interrupted',
+        detail: receipt
+    }
+}
+
+function hasState(transitions, state) {
+    return transitions.some(transition => transition.state === state)
+}
+
+function getTimestamp(clock) {
+    const value = clock();
+    if (!Number.isFinite(value) || value < 0) {
+        throw new TypeError('restore-empty-target clock must return a non-negative finite epoch millisecond')
+    }
+    return value
+}
+
+function createPhaseError(code, message) {
+    const error = new Error(message);
+    error.code  = code;
+    return error
+}
+
+function boundedText(value) {
+    return String(value).slice(0, 500)
+}

--- a/ai/services/memory-core/helpers/restoreTargetSetAdmission.mjs
+++ b/ai/services/memory-core/helpers/restoreTargetSetAdmission.mjs
@@ -1,0 +1,318 @@
+import {createHash} from 'node:crypto';
+import fs           from 'node:fs';
+import readline     from 'node:readline';
+
+import {fingerprintCanonical}    from './restoreTargetSetContract.mjs';
+import {validateJsonlSourceFile} from './vectorJsonlSourceValidation.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/restoreTargetSetAdmission
+ * @summary Provider-free, full-source admission for one v1
+ * `restore-empty-target` bundle slice.
+ *
+ * Admission is intentionally detached from mutation. It streams every source,
+ * validates every vector row and the graph envelope, and fingerprints the exact
+ * files. The actuator re-checks these
+ * fingerprints before staging so a post-admission source swap fails closed.
+ */
+
+export const RESTORE_TARGET_SET_ADMISSION_VERSION = 1;
+
+/**
+ * @summary Fully admits the three files consumed by target-set recovery.
+ *
+ * @param {Object} options
+ * @param {String} options.bundleManifestPath Admitted bundle manifest file.
+ * @param {String} options.memoriesFile Memories JSONL.
+ * @param {String} options.summariesFile Summaries JSONL.
+ * @param {String} options.graphFile Graph JSONL.
+ * @param {Number} options.expectedDimension Configured vector dimension.
+ * @returns {Promise<Object>} Detached admission descriptor.
+ */
+export async function admitRestoreTargetSetBundle({
+    bundleManifestPath,
+    memoriesFile,
+    summariesFile,
+    graphFile,
+    expectedDimension
+} = {}) {
+    validateExpectedDimension(expectedDimension);
+    validateFilePath(bundleManifestPath, 'bundleManifestPath');
+    validateFilePath(memoriesFile, 'memoriesFile');
+    validateFilePath(summariesFile, 'summariesFile');
+    validateFilePath(graphFile, 'graphFile');
+
+    const [
+        bundleManifestFingerprint,
+        memories,
+        summaries,
+        graph
+    ] = await Promise.all([
+        fingerprintFile(bundleManifestPath),
+        inspectVectorFile({filePath: memoriesFile, expectedDimension}),
+        inspectVectorFile({filePath: summariesFile, expectedDimension}),
+        inspectGraphFile(graphFile)
+    ]);
+
+    const components = {
+        memories: {
+            fileFingerprint: memories.fileFingerprint,
+            rowCount       : memories.rowCount
+        },
+        summaries: {
+            fileFingerprint: summaries.fileFingerprint,
+            rowCount       : summaries.rowCount
+        },
+        graph: {
+            fileFingerprint  : graph.fileFingerprint,
+            rowCount         : graph.rowCount,
+            nodeCount        : graph.nodeCount,
+            edgeCount        : graph.edgeCount,
+            recordFingerprint: graph.recordFingerprint
+        }
+    };
+
+    const descriptorFingerprint = fingerprintAdmissionDescriptor({
+        expectedDimension,
+        components
+    });
+
+    return {
+        schemaVersion: RESTORE_TARGET_SET_ADMISSION_VERSION,
+        status       : 'admitted',
+        bundleManifestFingerprint,
+        descriptorFingerprint,
+        expectedDimension,
+        components   : {
+            memories : {...components.memories, filePath: memoriesFile},
+            summaries: {...components.summaries, filePath: summariesFile},
+            graph    : {...components.graph, filePath: graphFile}
+        }
+    }
+}
+
+/**
+ * @summary Validates and detaches a request-carried admission descriptor.
+ *
+ * @param {Object} admission Candidate admission.
+ * @param {Object} targetDescriptor Canonical target-set descriptor.
+ * @returns {Object} Detached normalized admission.
+ */
+export function normalizeRestoreTargetSetAdmission(admission, targetDescriptor) {
+    if (admission?.schemaVersion !== RESTORE_TARGET_SET_ADMISSION_VERSION ||
+        admission?.status !== 'admitted') {
+        throw new Error('restore target-set requires a v1 admitted source descriptor')
+    }
+
+    validateExpectedDimension(admission.expectedDimension);
+
+    const components = {};
+
+    for (const role of ['memories', 'summaries', 'graph']) {
+        const component = admission.components?.[role];
+        validateFilePath(component?.filePath, `${role}.filePath`);
+        validateFingerprint(component?.fileFingerprint, `${role}.fileFingerprint`);
+        validateCount(component?.rowCount, `${role}.rowCount`);
+
+        components[role] = {
+            filePath       : component.filePath,
+            fileFingerprint: component.fileFingerprint,
+            rowCount       : component.rowCount
+        };
+
+        if (role === 'graph') {
+            validateCount(component.nodeCount, 'graph.nodeCount');
+            validateCount(component.edgeCount, 'graph.edgeCount');
+            validateFingerprint(component.recordFingerprint, 'graph.recordFingerprint');
+            components.graph.nodeCount         = component.nodeCount;
+            components.graph.edgeCount         = component.edgeCount;
+            components.graph.recordFingerprint = component.recordFingerprint
+        }
+    }
+
+    validateFingerprint(admission.bundleManifestFingerprint, 'bundleManifestFingerprint');
+    validateFingerprint(admission.descriptorFingerprint, 'descriptorFingerprint');
+
+    const expectedDescriptorFingerprint = fingerprintAdmissionDescriptor({
+        expectedDimension: admission.expectedDimension,
+        components
+    });
+
+    if (admission.descriptorFingerprint !== expectedDescriptorFingerprint) {
+        throw new Error('restore target-set admission descriptor fingerprint mismatch')
+    }
+    if (targetDescriptor?.bundleManifestFingerprint !== admission.bundleManifestFingerprint) {
+        throw new Error('restore target-set bundle manifest fingerprint does not match admission')
+    }
+    if (targetDescriptor?.admissionDescriptorFingerprint !== admission.descriptorFingerprint) {
+        throw new Error('restore target-set descriptor fingerprint does not match admission')
+    }
+
+    return {
+        schemaVersion            : RESTORE_TARGET_SET_ADMISSION_VERSION,
+        status                   : 'admitted',
+        bundleManifestFingerprint: admission.bundleManifestFingerprint,
+        descriptorFingerprint    : admission.descriptorFingerprint,
+        expectedDimension        : admission.expectedDimension,
+        components
+    }
+}
+
+/**
+ * @summary Recomputes a file SHA-256 for action-time source immutability proof.
+ *
+ * @param {String} filePath Source file.
+ * @returns {Promise<String>} `sha256:<hex>`.
+ */
+export function fingerprintRestoreSourceFile(filePath) {
+    validateFilePath(filePath, 'filePath');
+    return fingerprintFile(filePath)
+}
+
+async function inspectVectorFile({filePath, expectedDimension}) {
+    const [{rowCount}, fileFingerprint] = await Promise.all([
+        validateJsonlSourceFile({filePath, expectedDimension, vectorRows: true}),
+        fingerprintFile(filePath)
+    ]);
+
+    return {rowCount, fileFingerprint}
+}
+
+async function inspectGraphFile(filePath) {
+    const
+        input = fs.createReadStream(filePath, {encoding: 'utf8'}),
+        lines = readline.createInterface({input, crlfDelay: Infinity}),
+        nodes = [],
+        edges = [];
+
+    let lineNumber = 0;
+
+    try {
+        for await (const line of lines) {
+            if (!line.trim()) {
+                continue
+            }
+
+            lineNumber++;
+
+            let record;
+            try {
+                record = JSON.parse(line)
+            } catch (error) {
+                throw new Error(`restore graph source line ${lineNumber} is invalid JSON: ${error.message}`)
+            }
+
+            validateGraphRecord(record, lineNumber);
+            const canonical = canonicalJson(record.data);
+
+            if (record.type === 'node') {
+                nodes.push(canonical)
+            } else {
+                edges.push(canonical)
+            }
+        }
+    } finally {
+        lines.close();
+        input.destroy()
+    }
+
+    return {
+        fileFingerprint  : await fingerprintFile(filePath),
+        rowCount         : nodes.length + edges.length,
+        nodeCount        : nodes.length,
+        edgeCount        : edges.length,
+        recordFingerprint: fingerprintCanonical({
+            nodes: nodes.sort(),
+            edges: edges.sort()
+        })
+    }
+}
+
+function validateGraphRecord(record, lineNumber) {
+    if (!record || !['node', 'edge'].includes(record.type) ||
+        !record.data || typeof record.data !== 'object') {
+        throw new Error(`restore graph source line ${lineNumber} must be a node/edge envelope`)
+    }
+    if (record.type === 'node' && (
+        typeof record.data.id !== 'string' || record.data.id.length === 0
+    )) {
+        throw new Error(`restore graph source line ${lineNumber} node requires id`)
+    }
+    if (record.type === 'edge') {
+        for (const key of ['source', 'target', 'type']) {
+            if (typeof record.data[key] !== 'string' || record.data[key].length === 0) {
+                throw new Error(`restore graph source line ${lineNumber} edge requires ${key}`)
+            }
+        }
+    }
+}
+
+function fingerprintAdmissionDescriptor({expectedDimension, components}) {
+    return fingerprintCanonical({
+        schemaVersion: RESTORE_TARGET_SET_ADMISSION_VERSION,
+        expectedDimension,
+        components   : {
+            memories: {
+                fileFingerprint: components.memories.fileFingerprint,
+                rowCount       : components.memories.rowCount
+            },
+            summaries: {
+                fileFingerprint: components.summaries.fileFingerprint,
+                rowCount       : components.summaries.rowCount
+            },
+            graph: {
+                fileFingerprint  : components.graph.fileFingerprint,
+                rowCount         : components.graph.rowCount,
+                nodeCount        : components.graph.nodeCount,
+                edgeCount        : components.graph.edgeCount,
+                recordFingerprint: components.graph.recordFingerprint
+            }
+        }
+    })
+}
+
+function fingerprintFile(filePath) {
+    return new Promise((resolve, reject) => {
+        const
+            hash  = createHash('sha256'),
+            input = fs.createReadStream(filePath);
+
+        input.on('data', chunk => hash.update(chunk));
+        input.on('error', reject);
+        input.on('end', () => resolve(`sha256:${hash.digest('hex')}`))
+    })
+}
+
+function validateExpectedDimension(value) {
+    if (!Number.isInteger(value) || value <= 0) {
+        throw new TypeError('restore target-set expectedDimension must be a positive integer')
+    }
+}
+
+function validateFilePath(value, name) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new TypeError(`restore target-set ${name} is required`)
+    }
+}
+
+function validateFingerprint(value, name) {
+    if (!/^sha256:[0-9a-f]{64}$/i.test(value ?? '')) {
+        throw new TypeError(`restore target-set ${name} must be a sha256:<64-hex> fingerprint`)
+    }
+}
+
+function validateCount(value, name) {
+    if (!Number.isInteger(value) || value < 0) {
+        throw new TypeError(`restore target-set ${name} must be a non-negative integer`)
+    }
+}
+
+function canonicalJson(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonicalJson).join(',')}]`
+    }
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',')}}`
+    }
+    return JSON.stringify(value)
+}

--- a/ai/services/memory-core/helpers/restoreTargetSetContract.mjs
+++ b/ai/services/memory-core/helpers/restoreTargetSetContract.mjs
@@ -1,0 +1,190 @@
+import {createHash} from 'crypto';
+
+/**
+ * @module ai/services/memory-core/helpers/restoreTargetSetContract
+ * @summary Canonical v1 identity contract for the `restore-empty-target`
+ * Memory Core recovery unit.
+ *
+ * A recovery-unit key deliberately excludes the admitted bundle, so swapping
+ * bundles cannot evade cooldown. The attempt fingerprint adds both admitted
+ * source fingerprints and therefore owns idempotent crash resume.
+ */
+
+export const RESTORE_EMPTY_TARGET_ACTION = 'restore-empty-target';
+export const RESTORE_TARGET_SET_VERSION  = 1;
+
+export const RESTORE_TARGET_ROLES = Object.freeze([
+    'memories',
+    'summaries',
+    'graph'
+]);
+
+const DESTINATION_KINDS = Object.freeze({
+    memories : 'chroma',
+    summaries: 'chroma',
+    graph    : 'sqlite-graph'
+});
+
+/**
+ * @summary Builds the canonical v1 descriptor and derives its topology
+ * fingerprint.
+ *
+ * @param {Object} options
+ * @param {String} options.memoriesCollection Configured memories collection.
+ * @param {String} options.summariesCollection Configured summaries collection.
+ * @param {String} options.graphDestination Configured SQLite graph identity.
+ * @param {String} options.bundleManifestFingerprint Admitted bundle manifest SHA-256.
+ * @param {String} options.admissionDescriptorFingerprint Provider-free admission descriptor SHA-256.
+ * @returns {Object} Canonical descriptor.
+ */
+export function createRestoreTargetSetDescriptor({
+    memoriesCollection,
+    summariesCollection,
+    graphDestination,
+    bundleManifestFingerprint,
+    admissionDescriptorFingerprint
+} = {}) {
+    const destinations = [
+        {role: 'memories',  kind: DESTINATION_KINDS.memories,  id: memoriesCollection},
+        {role: 'summaries', kind: DESTINATION_KINDS.summaries, id: summariesCollection},
+        {role: 'graph',     kind: DESTINATION_KINDS.graph,     id: graphDestination}
+    ];
+
+    validateDestinations(destinations);
+    validateFingerprint(bundleManifestFingerprint, 'bundleManifestFingerprint');
+    validateFingerprint(admissionDescriptorFingerprint, 'admissionDescriptorFingerprint');
+
+    return {
+        version                       : RESTORE_TARGET_SET_VERSION,
+        destinations,
+        destinationTopologyFingerprint: fingerprintCanonical({
+            version: RESTORE_TARGET_SET_VERSION,
+            destinations
+        }),
+        bundleManifestFingerprint,
+        admissionDescriptorFingerprint
+    }
+}
+
+/**
+ * @summary Validates and detaches an externally supplied target-set descriptor.
+ *
+ * The ordered roles and kinds are closed in v1. A topology fingerprint is
+ * recomputed rather than trusted, and source fingerprints must be SHA-256.
+ *
+ * @param {Object} descriptor Candidate descriptor.
+ * @returns {Object} Canonical detached descriptor.
+ */
+export function normalizeRestoreTargetSetDescriptor(descriptor = {}) {
+    if (descriptor.version !== RESTORE_TARGET_SET_VERSION) {
+        throw new Error(`restore target-set version must be ${RESTORE_TARGET_SET_VERSION}`)
+    }
+
+    const destinations = Array.isArray(descriptor.destinations)
+        ? descriptor.destinations.map(destination => ({
+            role: destination?.role,
+            kind: destination?.kind,
+            id  : destination?.id
+        }))
+        : [];
+
+    validateDestinations(destinations);
+    validateFingerprint(descriptor.bundleManifestFingerprint, 'bundleManifestFingerprint');
+    validateFingerprint(descriptor.admissionDescriptorFingerprint, 'admissionDescriptorFingerprint');
+    validateFingerprint(descriptor.destinationTopologyFingerprint, 'destinationTopologyFingerprint');
+
+    const expectedTopologyFingerprint = fingerprintCanonical({
+        version: RESTORE_TARGET_SET_VERSION,
+        destinations
+    });
+
+    if (descriptor.destinationTopologyFingerprint !== expectedTopologyFingerprint) {
+        throw new Error('restore target-set destinationTopologyFingerprint does not match its ordered destinations')
+    }
+
+    return {
+        version                       : RESTORE_TARGET_SET_VERSION,
+        destinations,
+        destinationTopologyFingerprint: expectedTopologyFingerprint,
+        bundleManifestFingerprint     : descriptor.bundleManifestFingerprint,
+        admissionDescriptorFingerprint: descriptor.admissionDescriptorFingerprint
+    }
+}
+
+/**
+ * @summary Derives the bundle-independent recovery-unit key and the
+ * bundle-specific attempt fingerprint.
+ *
+ * @param {Object} descriptor Candidate target-set descriptor.
+ * @returns {{descriptor: Object, recoveryUnitKey: String, attemptFingerprint: String}}
+ */
+export function deriveRestoreTargetSetIdentity(descriptor) {
+    const normalized = normalizeRestoreTargetSetDescriptor(descriptor);
+
+    const recoveryUnitKey = `${RESTORE_EMPTY_TARGET_ACTION}:v${RESTORE_TARGET_SET_VERSION}:${
+        fingerprintCanonical({
+            action                        : RESTORE_EMPTY_TARGET_ACTION,
+            version                       : normalized.version,
+            destinations                  : normalized.destinations,
+            destinationTopologyFingerprint: normalized.destinationTopologyFingerprint
+        }).slice('sha256:'.length)
+    }`;
+
+    const attemptFingerprint = fingerprintCanonical({
+        recoveryUnitKey,
+        bundleManifestFingerprint     : normalized.bundleManifestFingerprint,
+        admissionDescriptorFingerprint: normalized.admissionDescriptorFingerprint
+    });
+
+    return {
+        descriptor: normalized,
+        recoveryUnitKey,
+        attemptFingerprint
+    }
+}
+
+/**
+ * @summary Creates a stable SHA-256 over a recursively key-sorted JSON value.
+ *
+ * @param {*} value JSON-compatible value.
+ * @returns {String} `sha256:<hex>`.
+ */
+export function fingerprintCanonical(value) {
+    return `sha256:${createHash('sha256').update(canonicalJson(value)).digest('hex')}`
+}
+
+function validateDestinations(destinations) {
+    if (destinations.length !== RESTORE_TARGET_ROLES.length) {
+        throw new Error(`restore target-set requires exactly ${RESTORE_TARGET_ROLES.length} ordered destinations`)
+    }
+
+    destinations.forEach((destination, index) => {
+        const expectedRole = RESTORE_TARGET_ROLES[index];
+
+        if (destination.role !== expectedRole) {
+            throw new Error(`restore target-set destination ${index} must have role '${expectedRole}'`)
+        }
+        if (destination.kind !== DESTINATION_KINDS[expectedRole]) {
+            throw new Error(`restore target-set '${expectedRole}' destination must have kind '${DESTINATION_KINDS[expectedRole]}'`)
+        }
+        if (typeof destination.id !== 'string' || destination.id.length === 0) {
+            throw new Error(`restore target-set '${expectedRole}' destination requires a non-empty id`)
+        }
+    })
+}
+
+function validateFingerprint(value, name) {
+    if (!/^sha256:[0-9a-f]{64}$/i.test(value ?? '')) {
+        throw new Error(`restore target-set ${name} must be a sha256:<64-hex> fingerprint`)
+    }
+}
+
+function canonicalJson(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonicalJson).join(',')}]`
+    }
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',')}}`
+    }
+    return JSON.stringify(value)
+}

--- a/ai/services/memory-core/helpers/restoreTargetSetStateStore.mjs
+++ b/ai/services/memory-core/helpers/restoreTargetSetStateStore.mjs
@@ -1,0 +1,318 @@
+import fs   from 'fs/promises';
+import path from 'path';
+
+/**
+ * @module ai/services/memory-core/helpers/restoreTargetSetStateStore
+ * @summary Strict append-only component ledger for one
+ * `restore-empty-target` attempt.
+ *
+ * Storage observations never create transitions. The writer must append each
+ * semantic boundary explicitly, and only `committed` opens service eligibility.
+ */
+
+export const RESTORE_TARGET_SET_STATES = Object.freeze([
+    'admitted',
+    'fenced',
+    'staged',
+    'promoted:memories',
+    'promoted:summaries',
+    'promoted:graph',
+    'validated',
+    'committed',
+    'deferred-target-not-empty',
+    'interrupted',
+    'failed-contained'
+]);
+
+export const RESTORE_TARGET_SET_TERMINALS = Object.freeze([
+    'committed',
+    'deferred-target-not-empty',
+    'failed-contained'
+]);
+
+const ALLOWED_NEXT_STATES = Object.freeze({
+    '<start>'                  : Object.freeze(['admitted']),
+    admitted                   : Object.freeze(['fenced', 'interrupted', 'failed-contained']),
+    fenced                     : Object.freeze(['staged', 'deferred-target-not-empty', 'interrupted', 'failed-contained']),
+    staged                     : Object.freeze(['promoted:memories', 'interrupted', 'failed-contained']),
+    'promoted:memories'        : Object.freeze(['promoted:summaries', 'failed-contained']),
+    'promoted:summaries'       : Object.freeze(['promoted:graph', 'failed-contained']),
+    'promoted:graph'           : Object.freeze(['validated', 'failed-contained']),
+    validated                  : Object.freeze(['committed', 'failed-contained']),
+    interrupted                : Object.freeze(['fenced', 'failed-contained']),
+    committed                  : Object.freeze([]),
+    'deferred-target-not-empty': Object.freeze([]),
+    'failed-contained'         : Object.freeze([])
+});
+
+/**
+ * @summary Builds the gitignored per-attempt ledger file name.
+ *
+ * @param {String} attemptFingerprint Canonical SHA-256 attempt fingerprint.
+ * @returns {String}
+ */
+export function getRestoreTargetSetStateFileName(attemptFingerprint) {
+    validateFingerprint(attemptFingerprint, 'attemptFingerprint');
+    return `${attemptFingerprint.slice('sha256:'.length)}.jsonl`
+}
+
+/**
+ * @summary Reads and validates every transition for one attempt.
+ *
+ * A malformed line, identity drift, sequence gap, or illegal state edge fails
+ * loud. Recovery cannot silently skip a broken authority record.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Ledger directory.
+ * @param {String} options.attemptFingerprint Attempt identity.
+ * @returns {Promise<Object[]>}
+ */
+export async function readRestoreTargetSetTransitions({dir, attemptFingerprint} = {}) {
+    validateDir(dir, 'readRestoreTargetSetTransitions');
+    validateFingerprint(attemptFingerprint, 'attemptFingerprint');
+
+    const filePath = path.join(dir, getRestoreTargetSetStateFileName(attemptFingerprint));
+
+    let text;
+    try {
+        text = await fs.readFile(filePath, 'utf8');
+    } catch (error) {
+        if (error?.code === 'ENOENT') {
+            return []
+        }
+        throw error
+    }
+
+    const transitions = text
+        .split('\n')
+        .filter(Boolean)
+        .map((line, index) => {
+            try {
+                return JSON.parse(line)
+            } catch (error) {
+                throw new Error(`restore target-set ledger line ${index + 1} is invalid JSON: ${error.message}`)
+            }
+        });
+
+    validateTransitionChain(transitions, {attemptFingerprint});
+    return transitions
+}
+
+/**
+ * @summary Strict-appends one semantic transition after validating the complete
+ * existing chain.
+ *
+ * @param {Object} transition
+ * @param {String} transition.attemptFingerprint Attempt identity.
+ * @param {String} transition.recoveryUnitKey Bundle-independent recovery unit.
+ * @param {String} transition.state Next strict state.
+ * @param {Number} transition.at Epoch milliseconds.
+ * @param {Object} [transition.details={}] Bounded state detail.
+ * @param {Object} options
+ * @param {String} options.dir Ledger directory.
+ * @returns {Promise<Object>} Appended transition.
+ */
+export async function appendRestoreTargetSetTransition({
+    attemptFingerprint,
+    recoveryUnitKey,
+    state,
+    at,
+    details = {}
+} = {}, {dir} = {}) {
+    validateDir(dir, 'appendRestoreTargetSetTransition');
+    validateFingerprint(attemptFingerprint, 'attemptFingerprint');
+    validateRecoveryUnitKey(recoveryUnitKey);
+    validateState(state);
+    validateTimestamp(at);
+    validateDetails(details);
+
+    await fs.mkdir(dir, {recursive: true});
+
+    const
+        transitions = await readRestoreTargetSetTransitions({dir, attemptFingerprint}),
+        previous    = transitions.at(-1) ?? null,
+        allowed     = ALLOWED_NEXT_STATES[previous?.state ?? '<start>'];
+
+    if (!allowed.includes(state)) {
+        throw new Error(`illegal restore target-set transition ${previous?.state ?? '<start>'} -> ${state}`)
+    }
+    if (previous && previous.recoveryUnitKey !== recoveryUnitKey) {
+        throw new Error('restore target-set recoveryUnitKey drift inside one attempt ledger')
+    }
+
+    const entry = {
+        schemaVersion: 1,
+        type         : 'restore-target-set-transition',
+        attemptFingerprint,
+        recoveryUnitKey,
+        sequence     : transitions.length + 1,
+        previousState: previous?.state ?? null,
+        state,
+        at,
+        details
+    };
+
+    const filePath = path.join(dir, getRestoreTargetSetStateFileName(attemptFingerprint));
+    await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, 'utf8');
+
+    return entry
+}
+
+/**
+ * @summary Returns true only when the latest strict transition is `committed`.
+ *
+ * @param {Object[]} transitions Validated transition chain.
+ * @returns {Boolean}
+ */
+export function isRestoreTargetSetCommitted(transitions = []) {
+    return transitions.at(-1)?.state === 'committed'
+}
+
+/**
+ * @summary Builds the bounded, redacted recovery receipt projected to
+ * diagnostics and selector consumers.
+ *
+ * @param {Object} options
+ * @param {Object[]} options.transitions Strict transition chain.
+ * @param {String} options.recoveryUnitKey Recovery unit identity.
+ * @param {String} options.attemptFingerprint Attempt identity.
+ * @param {Object} options.descriptor Canonical target-set descriptor.
+ * @param {Object|null} [options.validationResult=null] Final validation summary.
+ * @param {Object|null} [options.failure=null] Redacted terminal failure.
+ * @returns {Object}
+ */
+export function createRestoreTargetSetReceipt({
+    transitions = [],
+    recoveryUnitKey,
+    attemptFingerprint,
+    descriptor,
+    validationResult = null,
+    failure = null
+} = {}) {
+    validateTransitionChain(transitions, {attemptFingerprint, recoveryUnitKey});
+
+    const
+        first           = transitions[0] ?? null,
+        last            = transitions.at(-1) ?? null,
+        serviceEligible = isRestoreTargetSetCommitted(transitions);
+
+    return {
+        schemaVersion                 : 1,
+        action                        : 'restore-empty-target',
+        recoveryUnitKey,
+        attemptFingerprint,
+        targetSetVersion              : descriptor?.version ?? null,
+        destinationTopologyFingerprint: descriptor?.destinationTopologyFingerprint ?? null,
+        destinationTransitions        : transitions.map(({sequence, state, at}) => ({sequence, state, at})),
+        validationResult,
+        terminal                      : RESTORE_TARGET_SET_TERMINALS.includes(last?.state) ? last.state : null,
+        serviceEligible,
+        startedAt                     : first?.at ?? null,
+        completedAt                   : RESTORE_TARGET_SET_TERMINALS.includes(last?.state) ? last.at : null,
+        wallClockMs                   : first && last ? Math.max(0, last.at - first.at) : null,
+        failure                       : redactFailure(failure)
+    }
+}
+
+/**
+ * @summary Validates a full transition chain without reading storage.
+ *
+ * @param {Object[]} transitions Candidate transitions.
+ * @param {Object} [expected={}]
+ * @param {String} [expected.attemptFingerprint] Expected attempt.
+ * @param {String} [expected.recoveryUnitKey] Expected recovery unit.
+ * @returns {void}
+ */
+export function validateTransitionChain(transitions, {
+    attemptFingerprint,
+    recoveryUnitKey
+} = {}) {
+    if (!Array.isArray(transitions)) {
+        throw new TypeError('restore target-set transitions must be an array')
+    }
+
+    let previous = null;
+
+    transitions.forEach((entry, index) => {
+        if (!entry || entry.schemaVersion !== 1 || entry.type !== 'restore-target-set-transition') {
+            throw new Error(`restore target-set transition ${index + 1} has an invalid envelope`)
+        }
+
+        validateFingerprint(entry.attemptFingerprint, 'attemptFingerprint');
+        validateRecoveryUnitKey(entry.recoveryUnitKey);
+        validateState(entry.state);
+        validateTimestamp(entry.at);
+        validateDetails(entry.details);
+
+        if (entry.sequence !== index + 1) {
+            throw new Error(`restore target-set transition sequence gap at ${index + 1}`)
+        }
+        if (entry.previousState !== (previous?.state ?? null)) {
+            throw new Error(`restore target-set previousState mismatch at sequence ${entry.sequence}`)
+        }
+        if (!ALLOWED_NEXT_STATES[previous?.state ?? '<start>'].includes(entry.state)) {
+            throw new Error(`illegal restore target-set transition ${previous?.state ?? '<start>'} -> ${entry.state}`)
+        }
+        if (previous && (
+            previous.attemptFingerprint !== entry.attemptFingerprint ||
+            previous.recoveryUnitKey !== entry.recoveryUnitKey
+        )) {
+            throw new Error(`restore target-set identity drift at sequence ${entry.sequence}`)
+        }
+        if (attemptFingerprint && entry.attemptFingerprint !== attemptFingerprint) {
+            throw new Error('restore target-set attemptFingerprint does not match requested ledger')
+        }
+        if (recoveryUnitKey && entry.recoveryUnitKey !== recoveryUnitKey) {
+            throw new Error('restore target-set recoveryUnitKey does not match requested receipt')
+        }
+
+        previous = entry
+    })
+}
+
+function redactFailure(failure) {
+    if (!failure) {
+        return null
+    }
+
+    return {
+        code   : typeof failure.code === 'string' ? failure.code.slice(0, 120) : 'restore-target-set-failed',
+        message: String(failure.message ?? failure).replaceAll(/(token|secret|password|key)=\S+/gi, '$1=[redacted]').slice(0, 500)
+    }
+}
+
+function validateDir(dir, caller) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError(`${caller}: dir is required`)
+    }
+}
+
+function validateFingerprint(value, name) {
+    if (!/^sha256:[0-9a-f]{64}$/i.test(value ?? '')) {
+        throw new TypeError(`${name} must be a sha256:<64-hex> fingerprint`)
+    }
+}
+
+function validateRecoveryUnitKey(value) {
+    if (typeof value !== 'string' || !value.startsWith('restore-empty-target:v1:')) {
+        throw new TypeError('recoveryUnitKey must be a canonical restore-empty-target:v1 key')
+    }
+}
+
+function validateState(value) {
+    if (!RESTORE_TARGET_SET_STATES.includes(value)) {
+        throw new TypeError(`unknown restore target-set state '${value}'`)
+    }
+}
+
+function validateTimestamp(value) {
+    if (!Number.isFinite(value) || value < 0) {
+        throw new TypeError('restore target-set transition timestamp must be a non-negative finite number')
+    }
+}
+
+function validateDetails(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new TypeError('restore target-set transition details must be an object')
+    }
+}

--- a/ai/services/memory-core/helpers/restoreTargetSetStorage.mjs
+++ b/ai/services/memory-core/helpers/restoreTargetSetStorage.mjs
@@ -78,23 +78,35 @@ export function createRestoreTargetSetStorage({
         cleanupCommittedArtifacts
     };
 
+    /**
+     * @summary Proves that both canonical vector collections exist and that the
+     * complete production target set remains seed-aware empty.
+     */
     async function inspectFreshTargetSet(context) {
         const admission = normalizeContext(context, expectedDestinations);
         onPhase({phase: 'action-time-proof', event: 'start'});
 
         const
-            memories       = await getCanonicalCollection('memories'),
-            summaries      = await getCanonicalCollection('summaries'),
-            memoryCount    = await memories.count(),
-            summaryCount   = await summaries.count(),
+            memories       = await getCollection(expectedDestinations.memories),
+            summaries      = await getCollection(expectedDestinations.summaries),
+            memoryCount    = memories ? await memories.count() : null,
+            summaryCount   = summaries ? await summaries.count() : null,
             graphFreshness = inspectGraphBootFreshness(graphDb),
             fresh          = memoryCount === 0 &&
                 summaryCount === 0 &&
                 graphFreshness.fresh;
 
         const reasons = [];
-        if (memoryCount !== 0) reasons.push(`memories count is ${memoryCount}`);
-        if (summaryCount !== 0) reasons.push(`summaries count is ${summaryCount}`);
+        if (!memories) {
+            reasons.push(`canonical memories collection '${expectedDestinations.memories}' is missing`)
+        } else if (memoryCount !== 0) {
+            reasons.push(`memories count is ${memoryCount}`)
+        }
+        if (!summaries) {
+            reasons.push(`canonical summaries collection '${expectedDestinations.summaries}' is missing`)
+        } else if (summaryCount !== 0) {
+            reasons.push(`summaries count is ${summaryCount}`)
+        }
         if (!graphFreshness.fresh) reasons.push(graphFreshness.reason);
 
         const result = {
@@ -103,8 +115,8 @@ export function createRestoreTargetSetStorage({
             destinationTopologyFingerprint: context.descriptor.destinationTopologyFingerprint,
             admissionDescriptorFingerprint: admission.descriptorFingerprint,
             components                    : {
-                memories : {count: memoryCount},
-                summaries: {count: summaryCount},
+                memories : {count: memoryCount, exists: Boolean(memories)},
+                summaries: {count: summaryCount, exists: Boolean(summaries)},
                 graph    : graphFreshness
             }
         };
@@ -250,6 +262,10 @@ export function createRestoreTargetSetStorage({
         return result
     }
 
+    /**
+     * @summary Reconciles strict-ledger state with canonical, shadow, and
+     * parking storage without inferring an unrecorded promotion transition.
+     */
     async function reconcileAttempt(context) {
         const
             admission = normalizeContext(context, expectedDestinations),
@@ -266,16 +282,26 @@ export function createRestoreTargetSetStorage({
         for (const role of VECTOR_ROLES) {
             const
                 promoted  = transitions.some(item => item.state === `promoted:${role}`),
-                canonical = await getCanonicalCollection(role),
-                liveCount = await canonical.count(),
+                canonical = await getCollection(expectedDestinations[role]),
                 shadow    = await getCollection(staging.collections[role].shadow),
-                parking   = await getCollection(staging.collections[role].parking);
+                parking   = await getCollection(staging.collections[role].parking),
+                liveCount = canonical ? await canonical.count() : null;
 
             observed[role] = {
+                canonical: Boolean(canonical),
                 liveCount,
                 shadow : Boolean(shadow),
                 parking: Boolean(parking)
             };
+
+            if (!canonical) {
+                return unsafeReconciliation(
+                    parking
+                        ? `${role} canonical storage is missing after vector promotion began`
+                        : `${role} canonical storage is missing`,
+                    observed
+                )
+            }
 
             if (promoted) {
                 if (!parking || shadow || liveCount !== admission.components[role].rowCount) {
@@ -352,6 +378,10 @@ export function createRestoreTargetSetStorage({
         }
     }
 
+    /**
+     * @summary Deletes run-owned staging only when neither the ledger nor
+     * vector-store topology indicates that production promotion may have begun.
+     */
     async function cleanupUnpromotedStaging(context) {
         const transitions = context.transitions ?? [];
 
@@ -364,6 +394,18 @@ export function createRestoreTargetSetStorage({
             expectedDestinations,
             stagingRoot
         });
+
+        for (const role of VECTOR_ROLES) {
+            const
+                canonical = await getCollection(expectedDestinations[role]),
+                parking   = await getCollection(staging.collections[role].parking);
+
+            if (!canonical || parking) {
+                throw new Error(
+                    `refusing to delete restore staging because ${role} vector promotion may have begun`
+                )
+            }
+        }
 
         for (const role of VECTOR_ROLES) {
             await deleteRunOwnedCollection(staging.collections[role].shadow)

--- a/ai/services/memory-core/helpers/restoreTargetSetStorage.mjs
+++ b/ai/services/memory-core/helpers/restoreTargetSetStorage.mjs
@@ -1,0 +1,836 @@
+import fs   from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+    evaluateGraphBootSeedFreshness
+} from '../../../graph/bootSeedManifest.mjs';
+import {importGraphJsonl} from './graphJsonlImport.mjs';
+import {
+    fingerprintRestoreSourceFile,
+    normalizeRestoreTargetSetAdmission
+} from './restoreTargetSetAdmission.mjs';
+import {
+    fingerprintCanonical,
+    RESTORE_TARGET_ROLES
+} from './restoreTargetSetContract.mjs';
+import {
+    importVectorJsonlToEmptyCollection,
+    validateVectorCollectionFromJsonl
+} from './vectorJsonlImport.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/restoreTargetSetStorage
+ * @summary Production store adapter for the fenced `restore-empty-target`
+ * controller.
+ *
+ * Chroma components use run-owned shadow and parking collections. Graph staging
+ * uses one run-owned SQLite file and promotes last in a single SQLite
+ * transaction. Reconciliation compares strict-ledger state with actual stores;
+ * it never infers a missing transition from observed live state.
+ */
+
+const VECTOR_ROLES = Object.freeze(['memories', 'summaries']);
+
+/**
+ * @summary Creates store collaborators consumed by
+ * `createRestoreEmptyTargetOperation`.
+ *
+ * @param {Object} options
+ * @param {Object} options.chromaClient Raw Chroma client.
+ * @param {Object} options.dummyEmbeddingFunction Provider-free EF.
+ * @param {Object} options.graphDb Open production better-sqlite3 graph DB.
+ * @param {Object} options.expectedDestinations `{memories,summaries,graph}`.
+ * @param {String} options.stagingRoot Gitignored run-owned staging directory.
+ * @param {Function} [options.invalidateCollectionCache=()=>{}] Cache invalidator.
+ * @param {Function} [options.syncGraphCache=()=>{}] Native graph cache sync.
+ * @param {Function} [options.onPhase=()=>{}] Measurement/diagnostic observer.
+ * @returns {Object} Controller collaborator methods.
+ */
+export function createRestoreTargetSetStorage({
+    chromaClient,
+    dummyEmbeddingFunction,
+    graphDb,
+    expectedDestinations,
+    stagingRoot,
+    invalidateCollectionCache = () => {},
+    syncGraphCache = () => {},
+    onPhase = () => {}
+} = {}) {
+    validateDependencies({
+        chromaClient,
+        dummyEmbeddingFunction,
+        graphDb,
+        expectedDestinations,
+        stagingRoot,
+        invalidateCollectionCache,
+        syncGraphCache,
+        onPhase
+    });
+
+    return {
+        inspectFreshTargetSet,
+        stageTargetSet,
+        validateStagedTargetSet,
+        promoteComponent,
+        revalidateProductionTargetSet,
+        reconcileAttempt,
+        cleanupUnpromotedStaging,
+        cleanupCommittedArtifacts
+    };
+
+    async function inspectFreshTargetSet(context) {
+        const admission = normalizeContext(context, expectedDestinations);
+        onPhase({phase: 'action-time-proof', event: 'start'});
+
+        const
+            memories       = await getCanonicalCollection('memories'),
+            summaries      = await getCanonicalCollection('summaries'),
+            memoryCount    = await memories.count(),
+            summaryCount   = await summaries.count(),
+            graphFreshness = inspectGraphBootFreshness(graphDb),
+            fresh          = memoryCount === 0 &&
+                summaryCount === 0 &&
+                graphFreshness.fresh;
+
+        const reasons = [];
+        if (memoryCount !== 0) reasons.push(`memories count is ${memoryCount}`);
+        if (summaryCount !== 0) reasons.push(`summaries count is ${summaryCount}`);
+        if (!graphFreshness.fresh) reasons.push(graphFreshness.reason);
+
+        const result = {
+            fresh,
+            reason                        : reasons.join('; ') || null,
+            destinationTopologyFingerprint: context.descriptor.destinationTopologyFingerprint,
+            admissionDescriptorFingerprint: admission.descriptorFingerprint,
+            components                    : {
+                memories : {count: memoryCount},
+                summaries: {count: summaryCount},
+                graph    : graphFreshness
+            }
+        };
+
+        onPhase({phase: 'action-time-proof', event: 'complete', result});
+        return result
+    }
+
+    async function stageTargetSet(context) {
+        const
+            admission = normalizeContext(context, expectedDestinations),
+            staging   = createStagingDescriptor({
+                attemptFingerprint: context.attemptFingerprint,
+                expectedDestinations,
+                stagingRoot
+            });
+
+        await fs.mkdir(stagingRoot, {recursive: true});
+
+        for (const role of VECTOR_ROLES) {
+            onPhase({phase: `stage-${role}`, event: 'start'});
+            await ensureVectorShadow({
+                role,
+                component        : admission.components[role],
+                expectedDimension: admission.expectedDimension,
+                shadowName       : staging.collections[role].shadow
+            });
+            onPhase({phase: `stage-${role}`, event: 'complete'})
+        }
+
+        onPhase({phase: 'stage-graph', event: 'start'});
+        await ensureGraphStaging({
+            graphPath: staging.graphPath,
+            component: admission.components.graph
+        });
+        onPhase({phase: 'stage-graph', event: 'complete'});
+
+        return staging
+    }
+
+    async function validateStagedTargetSet(context) {
+        const
+            admission = normalizeContext(context, expectedDestinations),
+            staging   = context.staging ?? createStagingDescriptor({
+                attemptFingerprint: context.attemptFingerprint,
+                expectedDestinations,
+                stagingRoot
+            });
+
+        onPhase({phase: 'validate-staged-target-set', event: 'start'});
+        const components = {};
+
+        for (const role of VECTOR_ROLES) {
+            const collection = await getCollection(staging.collections[role].shadow);
+            if (!collection) {
+                return {valid: false, reason: `missing ${role} staging collection`}
+            }
+
+            components[role] = await validateVectorCollectionFromJsonl({
+                collection,
+                filePath               : admission.components[role].filePath,
+                expectedDimension      : admission.expectedDimension,
+                expectedFileFingerprint: admission.components[role].fileFingerprint,
+                expectedRowCount       : admission.components[role].rowCount
+            })
+        }
+
+        components.graph = await validateGraphFile({
+            graphPath: staging.graphPath,
+            component: admission.components.graph
+        });
+
+        const result = {
+            valid                : true,
+            componentFingerprints: projectFingerprints(components),
+            components
+        };
+
+        onPhase({phase: 'validate-staged-target-set', event: 'complete', result});
+        return result
+    }
+
+    async function promoteComponent(context) {
+        const
+            admission = normalizeContext(context, expectedDestinations),
+            staging   = context.staging ?? createStagingDescriptor({
+                attemptFingerprint: context.attemptFingerprint,
+                expectedDestinations,
+                stagingRoot
+            }),
+            role      = context.role;
+
+        if (!RESTORE_TARGET_ROLES.includes(role)) {
+            throw new Error(`unknown restore target-set promotion role '${role}'`)
+        }
+
+        onPhase({phase: `promote-${role}`, event: 'start'});
+
+        const result = role === 'graph'
+            ? await promoteGraph({
+                graphPath: staging.graphPath,
+                component: admission.components.graph
+            })
+            : await promoteVector({
+                role,
+                component        : admission.components[role],
+                expectedDimension: admission.expectedDimension,
+                names            : staging.collections[role]
+            });
+
+        onPhase({phase: `promote-${role}`, event: 'complete', result});
+        return result
+    }
+
+    async function revalidateProductionTargetSet(context) {
+        const admission = normalizeContext(context, expectedDestinations);
+        onPhase({phase: 'revalidate-production', event: 'start'});
+
+        const components = {};
+
+        for (const role of VECTOR_ROLES) {
+            components[role] = await validateVectorCollectionFromJsonl({
+                collection             : await getCanonicalCollection(role),
+                filePath               : admission.components[role].filePath,
+                expectedDimension      : admission.expectedDimension,
+                expectedFileFingerprint: admission.components[role].fileFingerprint,
+                expectedRowCount       : admission.components[role].rowCount
+            })
+        }
+
+        components.graph = validateGraphDatabase({
+            db       : graphDb,
+            component: admission.components.graph
+        });
+
+        const result = {
+            valid                : true,
+            componentFingerprints: projectFingerprints(components),
+            components
+        };
+
+        onPhase({phase: 'revalidate-production', event: 'complete', result});
+        return result
+    }
+
+    async function reconcileAttempt(context) {
+        const
+            admission = normalizeContext(context, expectedDestinations),
+            staging   = createStagingDescriptor({
+                attemptFingerprint: context.attemptFingerprint,
+                expectedDestinations,
+                stagingRoot
+            }),
+            transitions = context.transitions ?? [],
+            latest      = transitions.at(-1)?.state ?? null,
+            staged      = transitions.some(item => item.state === 'staged'),
+            observed    = {};
+
+        for (const role of VECTOR_ROLES) {
+            const
+                promoted  = transitions.some(item => item.state === `promoted:${role}`),
+                canonical = await getCanonicalCollection(role),
+                liveCount = await canonical.count(),
+                shadow    = await getCollection(staging.collections[role].shadow),
+                parking   = await getCollection(staging.collections[role].parking);
+
+            observed[role] = {
+                liveCount,
+                shadow : Boolean(shadow),
+                parking: Boolean(parking)
+            };
+
+            if (promoted) {
+                if (!parking || shadow || liveCount !== admission.components[role].rowCount) {
+                    return unsafeReconciliation(
+                        `${role} storage does not match its promoted ledger state`,
+                        observed
+                    )
+                }
+                try {
+                    await validateVectorCollectionFromJsonl({
+                        collection             : canonical,
+                        filePath               : admission.components[role].filePath,
+                        expectedDimension      : admission.expectedDimension,
+                        expectedFileFingerprint: admission.components[role].fileFingerprint,
+                        expectedRowCount       : admission.components[role].rowCount
+                    })
+                } catch (error) {
+                    return unsafeReconciliation(`${role} promoted fingerprint mismatch: ${error.message}`, observed)
+                }
+            } else {
+                if (liveCount !== 0 || parking) {
+                    return unsafeReconciliation(
+                        `${role} live storage advanced without a promoted transition`,
+                        observed
+                    )
+                }
+                if (staged && !shadow) {
+                    return unsafeReconciliation(
+                        `${role} staging is missing for ledger state ${latest}`,
+                        observed
+                    )
+                }
+            }
+        }
+
+        const
+            graphPromoted  = transitions.some(item => item.state === 'promoted:graph'),
+            graphFreshness = inspectGraphBootFreshness(graphDb);
+
+        observed.graph = {
+            liveFingerprint: fingerprintGraphDatabase(graphDb),
+            stagingPath    : staging.graphPath
+        };
+
+        if (graphPromoted) {
+            try {
+                validateGraphDatabase({db: graphDb, component: admission.components.graph})
+            } catch (error) {
+                return unsafeReconciliation(`graph promoted fingerprint mismatch: ${error.message}`, observed)
+            }
+        } else if (!graphFreshness.fresh) {
+            return unsafeReconciliation(
+                'graph live storage advanced without a promoted transition',
+                observed
+            )
+        }
+
+        if (staged) {
+            try {
+                const result = await validateStagedTargetSet({...context, staging});
+                if (!result.valid) {
+                    return unsafeReconciliation(result.reason, observed)
+                }
+            } catch (error) {
+                return unsafeReconciliation(`staging reconciliation failed: ${error.message}`, observed)
+            }
+        }
+
+        return {
+            safe         : true,
+            staging,
+            observedState: latest,
+            observed
+        }
+    }
+
+    async function cleanupUnpromotedStaging(context) {
+        const transitions = context.transitions ?? [];
+
+        if (transitions.some(item => item.state.startsWith('promoted:'))) {
+            throw new Error('refusing to delete restore staging after production promotion began')
+        }
+
+        const staging = context.staging ?? createStagingDescriptor({
+            attemptFingerprint: context.attemptFingerprint,
+            expectedDestinations,
+            stagingRoot
+        });
+
+        for (const role of VECTOR_ROLES) {
+            await deleteRunOwnedCollection(staging.collections[role].shadow)
+        }
+
+        await removeGraphStaging(staging.graphPath)
+    }
+
+    async function cleanupCommittedArtifacts(context) {
+        const staging = createStagingDescriptor({
+            attemptFingerprint: context.attemptFingerprint,
+            expectedDestinations,
+            stagingRoot
+        });
+
+        for (const role of VECTOR_ROLES) {
+            await deleteRunOwnedCollection(staging.collections[role].parking)
+        }
+
+        await removeGraphStaging(staging.graphPath)
+    }
+
+    async function ensureVectorShadow({
+        role,
+        component,
+        expectedDimension,
+        shadowName
+    }) {
+        let shadow = await getCollection(shadowName);
+
+        if (shadow) {
+            try {
+                return await validateVectorCollectionFromJsonl({
+                    collection             : shadow,
+                    filePath               : component.filePath,
+                    expectedDimension,
+                    expectedFileFingerprint: component.fileFingerprint,
+                    expectedRowCount       : component.rowCount
+                })
+            } catch {
+                await deleteRunOwnedCollection(shadowName);
+                shadow = null
+            }
+        }
+
+        shadow = await chromaClient.createCollection({
+            name             : shadowName,
+            embeddingFunction: dummyEmbeddingFunction,
+            metadata         : {
+                'neo:owner': 'restore-empty-target',
+                'neo:role' : role
+            }
+        });
+
+        return importVectorJsonlToEmptyCollection({
+            collection             : shadow,
+            filePath               : component.filePath,
+            expectedDimension,
+            expectedFileFingerprint: component.fileFingerprint,
+            expectedRowCount       : component.rowCount,
+            recordBatch            : receipt => onPhase({
+                phase: `stage-${role}`,
+                event: 'batch',
+                receipt
+            })
+        })
+    }
+
+    async function ensureGraphStaging({graphPath, component}) {
+        try {
+            return await validateGraphFile({graphPath, component})
+        } catch {
+            await removeGraphStaging(graphPath)
+        }
+
+        const db = await openGraphStagingDatabase(graphPath);
+
+        try {
+            const fingerprint = await fingerprintRestoreSourceFile(component.filePath);
+            if (fingerprint !== component.fileFingerprint) {
+                throw new Error('restore graph source changed after admission')
+            }
+
+            const receipt = await importGraphJsonl({
+                db,
+                filePath: component.filePath,
+                mode    : 'replace'
+            });
+
+            if (receipt.counts.nodes.failed !== 0 ||
+                receipt.counts.edges.failed !== 0) {
+                throw new Error('restore graph staging importer rejected one or more records')
+            }
+        } finally {
+            db.close()
+        }
+
+        return validateGraphFile({graphPath, component})
+    }
+
+    async function validateGraphFile({graphPath, component}) {
+        const db = await openGraphStagingDatabase(graphPath, {create: false});
+        try {
+            return validateGraphDatabase({db, component})
+        } finally {
+            db.close()
+        }
+    }
+
+    async function promoteVector({
+        role,
+        component,
+        expectedDimension,
+        names
+    }) {
+        const
+            live   = await getCanonicalCollection(role),
+            shadow = await getCollection(names.shadow);
+
+        if (!shadow) {
+            throw new Error(`restore ${role} shadow collection is missing`)
+        }
+        if (await live.count() !== 0) {
+            throw new Error(`restore ${role} live collection changed before promotion`)
+        }
+        if (await getCollection(names.parking)) {
+            throw new Error(`restore ${role} parking collection already exists`)
+        }
+
+        await validateVectorCollectionFromJsonl({
+            collection             : shadow,
+            filePath               : component.filePath,
+            expectedDimension,
+            expectedFileFingerprint: component.fileFingerprint,
+            expectedRowCount       : component.rowCount
+        });
+
+        await live.modify({name: names.parking});
+        await shadow.modify({name: expectedDestinations[role]});
+        invalidateCollectionCache(role === 'memories' ? 'memory' : 'summary');
+
+        const canonical = await getCanonicalCollection(role);
+        await validateVectorCollectionFromJsonl({
+            collection             : canonical,
+            filePath               : component.filePath,
+            expectedDimension,
+            expectedFileFingerprint: component.fileFingerprint,
+            expectedRowCount       : component.rowCount
+        });
+
+        return {
+            fingerprint: component.fileFingerprint,
+            count      : component.rowCount,
+            parkingName: names.parking
+        }
+    }
+
+    async function promoteGraph({graphPath, component}) {
+        await withGraphStagingDb(
+            graphPath,
+            db => validateGraphDatabase({db, component})
+        );
+
+        const fresh = inspectGraphBootFreshness(graphDb);
+        if (!fresh.fresh) {
+            throw new Error(`restore graph live database changed before promotion: ${fresh.reason}`)
+        }
+
+        graphDb.prepare('ATTACH DATABASE ? AS restore_stage').run(graphPath);
+        try {
+            graphDb.transaction(() => {
+                graphDb.prepare('DELETE FROM restore_stage.PriorEdges').run();
+                graphDb.prepare('DELETE FROM restore_stage.PriorNodes').run();
+                graphDb.prepare(`
+                    INSERT INTO restore_stage.PriorNodes (id, user_id, data)
+                    SELECT id, user_id, data FROM main.Nodes
+                `).run();
+                graphDb.prepare(`
+                    INSERT INTO restore_stage.PriorEdges (id, user_id, source, target, type, data)
+                    SELECT id, user_id, source, target, type, data FROM main.Edges
+                `).run();
+
+                graphDb.prepare('DELETE FROM main.Edges').run();
+                graphDb.prepare('DELETE FROM main.Nodes').run();
+                graphDb.prepare(`
+                    INSERT INTO main.Nodes (id, user_id, data)
+                    SELECT id, user_id, data FROM restore_stage.Nodes
+                `).run();
+                graphDb.prepare(`
+                    INSERT INTO main.Edges (id, user_id, source, target, type, data)
+                    SELECT id, user_id, source, target, type, data FROM restore_stage.Edges
+                `).run()
+            }).immediate()
+        } finally {
+            graphDb.prepare('DETACH DATABASE restore_stage').run()
+        }
+
+        syncGraphCache();
+        const result = validateGraphDatabase({db: graphDb, component});
+
+        return {
+            fingerprint: result.fingerprint,
+            count      : result.rowCount
+        }
+    }
+
+    async function getCanonicalCollection(role) {
+        const collection = await getCollection(expectedDestinations[role]);
+        if (!collection) {
+            throw new Error(`canonical ${role} collection '${expectedDestinations[role]}' is missing`)
+        }
+        return collection
+    }
+
+    async function getCollection(name) {
+        try {
+            return await chromaClient.getCollection({
+                name,
+                embeddingFunction: dummyEmbeddingFunction
+            })
+        } catch (error) {
+            if (isCollectionMissing(error)) {
+                return null
+            }
+            throw error
+        }
+    }
+
+    async function deleteRunOwnedCollection(name) {
+        if (!isRunOwnedCollectionName(name)) {
+            throw new Error(`refusing to delete non-run-owned collection '${name}'`)
+        }
+
+        if (await getCollection(name)) {
+            await chromaClient.deleteCollection({name})
+        }
+    }
+}
+
+function normalizeContext(context, expectedDestinations) {
+    const descriptor = context?.descriptor;
+    assertDestinationIdentity(descriptor, expectedDestinations);
+    return normalizeRestoreTargetSetAdmission(context?.targetSet?.admission, descriptor)
+}
+
+function assertDestinationIdentity(descriptor, expected) {
+    const byRole = Object.fromEntries(
+        (descriptor?.destinations ?? []).map(item => [item.role, item.id])
+    );
+
+    for (const role of RESTORE_TARGET_ROLES) {
+        if (byRole[role] !== expected[role]) {
+            throw new Error(
+                `restore target-set ${role} destination '${byRole[role] ?? 'missing'}' ` +
+                `does not match configured '${expected[role]}'`
+            )
+        }
+    }
+}
+
+function createStagingDescriptor({
+    attemptFingerprint,
+    expectedDestinations,
+    stagingRoot
+}) {
+    const suffix = attemptFingerprint.replace('sha256:', '').slice(0, 20);
+
+    return {
+        owner      : 'restore-empty-target',
+        attemptFingerprint,
+        collections: {
+            memories: {
+                shadow : `${expectedDestinations.memories}-restore-shadow-${suffix}`,
+                parking: `${expectedDestinations.memories}-restore-parking-${suffix}`
+            },
+            summaries: {
+                shadow : `${expectedDestinations.summaries}-restore-shadow-${suffix}`,
+                parking: `${expectedDestinations.summaries}-restore-parking-${suffix}`
+            }
+        },
+        graphPath: path.join(stagingRoot, `${suffix}.sqlite`)
+    }
+}
+
+function inspectGraphBootFreshness(db) {
+    return evaluateGraphBootSeedFreshness({
+        nodes: db.prepare('SELECT data FROM Nodes ORDER BY id').all(),
+        edges: db.prepare('SELECT data FROM Edges ORDER BY id').all()
+    })
+}
+
+function validateGraphDatabase({db, component}) {
+    const
+        nodeRows = db.prepare('SELECT data FROM Nodes ORDER BY id').all(),
+        edgeRows = db.prepare('SELECT data FROM Edges ORDER BY id').all(),
+        result   = {
+            valid      : true,
+            rowCount   : nodeRows.length + edgeRows.length,
+            nodeCount  : nodeRows.length,
+            edgeCount  : edgeRows.length,
+            fingerprint: fingerprintGraphRecords({
+                nodes: nodeRows,
+                edges: edgeRows
+            })
+        };
+
+    if (result.rowCount !== component.rowCount ||
+        result.nodeCount !== component.nodeCount ||
+        result.edgeCount !== component.edgeCount ||
+        result.fingerprint !== component.recordFingerprint) {
+        throw new Error(
+            `restore graph validation mismatch: rows=${result.rowCount}/${component.rowCount}, ` +
+            `nodes=${result.nodeCount}/${component.nodeCount}, ` +
+            `edges=${result.edgeCount}/${component.edgeCount}, ` +
+            `fingerprint=${result.fingerprint}/${component.recordFingerprint}`
+        )
+    }
+
+    return result
+}
+
+function fingerprintGraphDatabase(db) {
+    return fingerprintGraphRecords({
+        nodes: db.prepare('SELECT data FROM Nodes ORDER BY id').all(),
+        edges: db.prepare('SELECT data FROM Edges ORDER BY id').all()
+    })
+}
+
+function fingerprintGraphRecords({nodes, edges}) {
+    return fingerprintCanonical({
+        nodes: nodes.map(parseGraphRow).map(canonicalJson).sort(),
+        edges: edges.map(parseGraphRow).map(canonicalJson).sort()
+    })
+}
+
+async function openGraphStagingDatabase(filePath, {create = true} = {}) {
+    if (!create) {
+        await fs.access(filePath)
+    } else {
+        await fs.mkdir(path.dirname(filePath), {recursive: true})
+    }
+
+    const Database = (await import('better-sqlite3')).default;
+    const db       = new Database(filePath);
+
+    db.pragma('journal_mode = WAL');
+    db.pragma('foreign_keys = ON');
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS Nodes (
+            id TEXT PRIMARY KEY,
+            user_id TEXT,
+            data TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS Edges (
+            id TEXT PRIMARY KEY,
+            user_id TEXT,
+            source TEXT NOT NULL,
+            target TEXT NOT NULL,
+            type TEXT NOT NULL,
+            data TEXT NOT NULL,
+            FOREIGN KEY (source) REFERENCES Nodes(id) ON DELETE CASCADE,
+            FOREIGN KEY (target) REFERENCES Nodes(id) ON DELETE CASCADE
+        );
+        CREATE TABLE IF NOT EXISTS PriorNodes (
+            id TEXT PRIMARY KEY,
+            user_id TEXT,
+            data TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS PriorEdges (
+            id TEXT PRIMARY KEY,
+            user_id TEXT,
+            source TEXT NOT NULL,
+            target TEXT NOT NULL,
+            type TEXT NOT NULL,
+            data TEXT NOT NULL
+        );
+    `);
+
+    return db
+}
+
+async function withGraphStagingDb(filePath, callback) {
+    const db = await openGraphStagingDatabase(filePath, {create: false});
+    try {
+        return callback(db)
+    } finally {
+        db.close()
+    }
+}
+
+async function removeGraphStaging(filePath) {
+    for (const candidate of [filePath, `${filePath}-wal`, `${filePath}-shm`]) {
+        await fs.rm(candidate, {force: true})
+    }
+}
+
+function projectFingerprints(components) {
+    return Object.fromEntries(
+        RESTORE_TARGET_ROLES.map(role => [role, components[role].fingerprint])
+    )
+}
+
+function unsafeReconciliation(reason, observedState) {
+    return {
+        safe: false,
+        reason,
+        observedState
+    }
+}
+
+function parseGraphRow(row) {
+    return typeof row === 'string'
+        ? JSON.parse(row)
+        : typeof row?.data === 'string' ? JSON.parse(row.data) : row
+}
+
+function canonicalJson(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonicalJson).join(',')}]`
+    }
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',')}}`
+    }
+    return JSON.stringify(value)
+}
+
+function isCollectionMissing(error) {
+    return /not found|does not exist|could not be found/i.test(error?.message ?? '')
+}
+
+function isRunOwnedCollectionName(name) {
+    return typeof name === 'string' &&
+        /-restore-(?:shadow|parking)-[0-9a-f]{20}$/.test(name)
+}
+
+function validateDependencies(options) {
+    for (const method of ['createCollection', 'deleteCollection', 'getCollection']) {
+        if (typeof options.chromaClient?.[method] !== 'function') {
+            throw new TypeError(`restore target-set Chroma client requires ${method}()`)
+        }
+    }
+    if (!options.dummyEmbeddingFunction ||
+        typeof options.dummyEmbeddingFunction.generate !== 'function') {
+        throw new TypeError('restore target-set dummyEmbeddingFunction is required')
+    }
+    if (!options.graphDb ||
+        typeof options.graphDb.prepare !== 'function' ||
+        typeof options.graphDb.transaction !== 'function') {
+        throw new TypeError('restore target-set production graphDb is required')
+    }
+    for (const role of RESTORE_TARGET_ROLES) {
+        if (typeof options.expectedDestinations?.[role] !== 'string' ||
+            options.expectedDestinations[role].length === 0) {
+            throw new TypeError(`restore target-set expectedDestinations.${role} is required`)
+        }
+    }
+    if (typeof options.stagingRoot !== 'string' ||
+        options.stagingRoot.length === 0) {
+        throw new TypeError('restore target-set stagingRoot is required')
+    }
+    for (const name of [
+        'invalidateCollectionCache',
+        'syncGraphCache',
+        'onPhase'
+    ]) {
+        if (typeof options[name] !== 'function') {
+            throw new TypeError(`restore target-set ${name} must be a function`)
+        }
+    }
+}

--- a/ai/services/memory-core/helpers/vectorJsonlImport.mjs
+++ b/ai/services/memory-core/helpers/vectorJsonlImport.mjs
@@ -1,0 +1,253 @@
+import fs       from 'node:fs';
+import readline from 'node:readline';
+
+import {fingerprintRestoreSourceFile} from './restoreTargetSetAdmission.mjs';
+import {validateJsonlSourceFile}      from './vectorJsonlSourceValidation.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/vectorJsonlImport
+ * @summary Provider-free bounded JSONL loader and read-back validator for
+ * run-owned Chroma staging collections.
+ */
+
+export const CHROMA_VECTOR_IMPORT_BATCH_SIZE = 250;
+
+/**
+ * @summary Imports explicit stored vectors into an empty collection in bounded
+ * batches and validates every batch by ID/read-back.
+ *
+ * @param {Object} options
+ * @param {Object} options.collection Run-owned empty Chroma collection.
+ * @param {String} options.filePath Admitted JSONL.
+ * @param {Number} options.expectedDimension Vector dimension.
+ * @param {String} options.expectedFileFingerprint Admitted source SHA-256.
+ * @param {Number} options.expectedRowCount Admitted row count.
+ * @param {Number} [options.batchSize=250] Bounded request size.
+ * @param {Function} [options.recordBatch=()=>{}] Measurement callback.
+ * @returns {Promise<Object>} Count/fingerprint/batch receipt.
+ */
+export async function importVectorJsonlToEmptyCollection({
+    collection,
+    filePath,
+    expectedDimension,
+    expectedFileFingerprint,
+    expectedRowCount,
+    batchSize = CHROMA_VECTOR_IMPORT_BATCH_SIZE,
+    recordBatch = () => {}
+} = {}) {
+    validateCollection(collection);
+    validateBatchSize(batchSize);
+
+    const initialCount = await collection.count();
+    if (initialCount !== 0) {
+        throw new Error(`restore vector staging collection must be empty, observed ${initialCount}`)
+    }
+
+    await assertAdmittedVectorSource({
+        filePath,
+        expectedDimension,
+        expectedFileFingerprint,
+        expectedRowCount
+    });
+
+    let rowCount     = 0,
+        batchCount   = 0,
+        maxBatchSize = 0;
+
+    await forEachVectorBatch(filePath, batchSize, async rows => {
+        await collection.add(toChromaPayload(rows));
+        await validateVectorRowsInCollection({collection, rows});
+
+        rowCount     += rows.length;
+        batchCount++;
+        maxBatchSize = Math.max(maxBatchSize, rows.length);
+        recordBatch({
+            batchNumber: batchCount,
+            batchSize  : rows.length,
+            rowCount
+        })
+    });
+
+    const finalCount = await collection.count();
+    if (rowCount !== expectedRowCount || finalCount !== expectedRowCount) {
+        throw new Error(
+            `restore vector staging count mismatch: source=${expectedRowCount}, streamed=${rowCount}, stored=${finalCount}`
+        )
+    }
+
+    return {
+        valid      : true,
+        rowCount,
+        fingerprint: expectedFileFingerprint,
+        batchCount,
+        maxBatchSize
+    }
+}
+
+/**
+ * @summary Validates a collection against one admitted JSONL without retaining
+ * the full source or ID set.
+ *
+ * @param {Object} options See import function, excluding recordBatch.
+ * @returns {Promise<Object>} Validation receipt.
+ */
+export async function validateVectorCollectionFromJsonl({
+    collection,
+    filePath,
+    expectedDimension,
+    expectedFileFingerprint,
+    expectedRowCount,
+    batchSize = CHROMA_VECTOR_IMPORT_BATCH_SIZE
+} = {}) {
+    validateCollection(collection);
+    validateBatchSize(batchSize);
+
+    await assertAdmittedVectorSource({
+        filePath,
+        expectedDimension,
+        expectedFileFingerprint,
+        expectedRowCount
+    });
+
+    let rowCount = 0;
+
+    await forEachVectorBatch(filePath, batchSize, async rows => {
+        await validateVectorRowsInCollection({collection, rows});
+        rowCount += rows.length
+    });
+
+    const count = await collection.count();
+    if (rowCount !== expectedRowCount || count !== expectedRowCount) {
+        throw new Error(
+            `restore vector validation count mismatch: source=${expectedRowCount}, streamed=${rowCount}, stored=${count}`
+        )
+    }
+
+    return {
+        valid      : true,
+        rowCount,
+        fingerprint: expectedFileFingerprint
+    }
+}
+
+async function assertAdmittedVectorSource({
+    filePath,
+    expectedDimension,
+    expectedFileFingerprint,
+    expectedRowCount
+}) {
+    const [{rowCount}, fingerprint] = await Promise.all([
+        validateJsonlSourceFile({filePath, expectedDimension, vectorRows: true}),
+        fingerprintRestoreSourceFile(filePath)
+    ]);
+
+    if (fingerprint !== expectedFileFingerprint) {
+        throw new Error('restore vector source changed after admission')
+    }
+    if (rowCount !== expectedRowCount) {
+        throw new Error(`restore vector admitted row count drift: expected ${expectedRowCount}, observed ${rowCount}`)
+    }
+}
+
+async function forEachVectorBatch(filePath, batchSize, callback) {
+    const
+        input = fs.createReadStream(filePath, {encoding: 'utf8'}),
+        lines = readline.createInterface({input, crlfDelay: Infinity}),
+        batch = [];
+
+    try {
+        for await (const line of lines) {
+            if (!line.trim()) {
+                continue
+            }
+
+            batch.push(JSON.parse(line));
+
+            if (batch.length === batchSize) {
+                await callback(batch.splice(0, batch.length))
+            }
+        }
+
+        if (batch.length > 0) {
+            await callback(batch.splice(0, batch.length))
+        }
+    } finally {
+        lines.close();
+        input.destroy()
+    }
+}
+
+async function validateVectorRowsInCollection({collection, rows}) {
+    const
+        ids      = rows.map(row => row.id),
+        response = await collection.get({
+            ids,
+            include: ['embeddings', 'metadatas', 'documents']
+        }),
+        observed = new Map();
+
+    for (let index = 0; index < (response?.ids?.length ?? 0); index++) {
+        observed.set(response.ids[index], {
+            id       : response.ids[index],
+            embedding: Array.from(response.embeddings?.[index] ?? []),
+            metadata : response.metadatas?.[index] ?? null,
+            document : response.documents?.[index] ?? null
+        })
+    }
+
+    if (observed.size !== rows.length) {
+        throw new Error(`restore vector read-back coverage mismatch: expected ${rows.length}, observed ${observed.size}`)
+    }
+
+    for (const row of rows) {
+        if (canonicalJson(normalizeVectorRow(observed.get(row.id))) !==
+            canonicalJson(normalizeVectorRow(row))) {
+            throw new Error(`restore vector read-back mismatch for id '${row.id}'`)
+        }
+    }
+}
+
+function toChromaPayload(rows) {
+    return {
+        ids       : rows.map(row => row.id),
+        embeddings: rows.map(row => row.embedding),
+        metadatas : rows.map(row => row.metadata ?? null),
+        documents : rows.map(row => row.document ?? null)
+    }
+}
+
+function normalizeVectorRow(row) {
+    return {
+        id       : row?.id,
+        embedding: Array.from(row?.embedding ?? []),
+        metadata : row?.metadata ?? null,
+        document : row?.document ?? null
+    }
+}
+
+function validateCollection(collection) {
+    for (const method of ['add', 'count', 'get']) {
+        if (typeof collection?.[method] !== 'function') {
+            throw new TypeError(`restore vector collection requires ${method}()`)
+        }
+    }
+}
+
+function validateBatchSize(value) {
+    if (!Number.isInteger(value) || value <= 0 ||
+        value > CHROMA_VECTOR_IMPORT_BATCH_SIZE) {
+        throw new TypeError(
+            `restore vector batchSize must be 1..${CHROMA_VECTOR_IMPORT_BATCH_SIZE}`
+        )
+    }
+}
+
+function canonicalJson(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonicalJson).join(',')}]`
+    }
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',')}}`
+    }
+    return JSON.stringify(value)
+}

--- a/test/playwright/restoreEmptyTargetMeasurementAdapter.mjs
+++ b/test/playwright/restoreEmptyTargetMeasurementAdapter.mjs
@@ -1,0 +1,490 @@
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import Database       from 'better-sqlite3';
+import {ChromaClient} from 'chromadb';
+
+import {
+    createGraphBootSeedEdgeRecord,
+    createGraphBootSeedManifest,
+    createGraphBootSeedNodeRecord
+} from '../../ai/graph/bootSeedManifest.mjs';
+import {
+    createRestoreEmptyTargetOperation
+} from '../../ai/services/memory-core/helpers/restoreEmptyTargetOperation.mjs';
+import {
+    admitRestoreTargetSetBundle
+} from '../../ai/services/memory-core/helpers/restoreTargetSetAdmission.mjs';
+import {
+    createRestoreTargetSetDescriptor,
+    deriveRestoreTargetSetIdentity
+} from '../../ai/services/memory-core/helpers/restoreTargetSetContract.mjs';
+import {
+    appendRestoreTargetSetTransition,
+    readRestoreTargetSetTransitions
+} from '../../ai/services/memory-core/helpers/restoreTargetSetStateStore.mjs';
+import {
+    createRestoreTargetSetStorage
+} from '../../ai/services/memory-core/helpers/restoreTargetSetStorage.mjs';
+import {
+    registerNeoChromaEmbeddingFunctions
+} from '../../ai/services/shared/vector/chromaClientPrimitives.mjs';
+import {startChromaProcess, stopDetachedProcess} from './chromaProcess.mjs';
+import {resolveFreePortSync}                     from './resolveFreePort.mjs';
+
+/**
+ * @module test/playwright/restoreEmptyTargetMeasurementAdapter
+ * @summary Exact-head adapter from the disposable target-set meter to the
+ * production `restore-empty-target` operation and store collaborators.
+ *
+ * The adapter starts one private Chroma process below the meter-owned temporary
+ * root, creates a real SQLite graph with the canonical boot seeds, admits the
+ * generated source bundle, and invokes the production operation. It never opens
+ * configured Memory Core paths. The meter remains the report authority and
+ * samples the registered Chroma PID while this adapter owns lifecycle cleanup.
+ */
+
+const
+    ADMISSION_PHASE = 'admission',
+    ACTION_PHASES   = Object.freeze([
+        'stage-memories',
+        'stage-summaries',
+        'stage-graph',
+        'validate-staged-target-set',
+        'promote-memories',
+        'promote-summaries',
+        'promote-graph',
+        'revalidate-production'
+    ]),
+    TERMINAL_PHASE  = 'terminal-settlement';
+
+/**
+ * @summary Converts production store phase events into the meter's canonical
+ * progress, batch, and action-time-proof receipts.
+ *
+ * @param {Object} options
+ * @param {Object} options.fixture Meter fixture.
+ * @param {Function} options.recordBatch Meter batch callback.
+ * @param {Function} options.recordCheckpoint Meter checkpoint callback.
+ * @param {Function} options.recordProgress Meter phase callback.
+ * @returns {Function} Production `onPhase` observer.
+ */
+export function createRestoreMeasurementPhaseObserver({
+    fixture,
+    recordBatch,
+    recordCheckpoint,
+    recordProgress
+} = {}) {
+    for (const [name, value] of Object.entries({
+        recordBatch,
+        recordCheckpoint,
+        recordProgress
+    })) {
+        if (typeof value !== 'function') {
+            throw new TypeError(`restore measurement observer requires ${name}()`)
+        }
+    }
+    if (!fixture?.profile) {
+        throw new TypeError('restore measurement observer requires fixture.profile')
+    }
+
+    return event => {
+        const {phase} = event ?? {};
+
+        if (phase === 'action-time-proof') {
+            if (event.event === 'complete') {
+                recordCheckpoint({
+                    kind  : 'action-time-proof',
+                    detail: {
+                        fresh : event.result?.fresh === true,
+                        reason: event.result?.reason ?? null,
+                        destinationTopologyFingerprint:
+                            event.result?.destinationTopologyFingerprint ?? null
+                    }
+                })
+            }
+            return
+        }
+
+        if (!ACTION_PHASES.includes(phase)) {
+            throw new Error(`restore measurement observed unknown production phase '${phase}'`)
+        }
+
+        if (event.event === 'batch') {
+            const collection = phase === 'stage-memories'
+                ? 'memories'
+                : phase === 'stage-summaries' ? 'summaries' : null;
+
+            if (!collection) {
+                throw new Error(`restore measurement observed a batch outside vector staging: ${phase}`)
+            }
+
+            recordBatch({
+                collection,
+                size: event.receipt?.batchSize
+            });
+            return
+        }
+
+        if (!['start', 'complete'].includes(event.event)) {
+            throw new Error(`restore measurement observed unknown event '${event.event}' for ${phase}`)
+        }
+
+        recordProgress({
+            phase,
+            state : event.event === 'start' ? 'started' : 'completed',
+            counts: event.event === 'complete'
+                ? createPhaseCounts(fixture.profile, phase)
+                : {}
+        })
+    }
+}
+
+/**
+ * @summary Runs the exact production action against disposable Chroma and
+ * SQLite targets created below the meter fixture root.
+ *
+ * @param {Object} context Meter adapter callbacks and fixture.
+ * @returns {Promise<{status: 'completed', detail: Object}>} Compact terminal
+ * measurement outcome.
+ */
+export async function runTargetSetMeasurementAdapter({
+    fixture,
+    recordBatch,
+    recordCheckpoint,
+    recordProgress,
+    recordProviderCall,
+    registerProcess,
+    registerSharedRole,
+    sampleNow,
+    traceProviders
+} = {}) {
+    validateAdapterContext({
+        fixture,
+        recordBatch,
+        recordCheckpoint,
+        recordProgress,
+        recordProviderCall,
+        registerProcess,
+        registerSharedRole,
+        sampleNow,
+        traceProviders
+    });
+
+    const
+        fixtureRoot  = path.dirname(fixture.paths.bundle),
+        repoRoot     = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..'),
+        host         = '127.0.0.1',
+        port         = resolveFreePortSync(),
+        chromaData   = path.join(fixture.paths.productionRoot, 'neo-chroma-unit-test-target-set'),
+        chromaLog    = path.join(fixture.paths.productionRoot, 'neo-chroma-unit-test-target-set.log'),
+        graphPath    = path.join(fixture.paths.productionRoot, 'target-set-graph.sqlite'),
+        ledgerDir    = path.join(fixture.paths.productionRoot, 'restore-ledger'),
+        destinations = {
+            memories : 'test-restore-target-memories',
+            summaries: 'test-restore-target-summaries',
+            graph    : graphPath
+        },
+        observer = createRestoreMeasurementPhaseObserver({
+            fixture,
+            recordBatch,
+            recordCheckpoint,
+            recordProgress
+        });
+
+    let chromaPid = null,
+        graphDb   = null,
+        stopError = null;
+
+    traceProviders({
+        coverage: 'The production restore storage accepts only explicit vectors; its sole embedding-capable ' +
+            'collaborator is the guarded Chroma dummy embedding function.',
+        entrypoints: ['dummy_embedding_function.generate']
+    });
+    registerSharedRole({
+        name  : 'sqlite',
+        reason: 'better-sqlite3 executes inside the measured Node adapter process'
+    });
+
+    const dummyEmbeddingFunction = createGuardedEmbeddingFunction(recordProviderCall);
+    registerNeoChromaEmbeddingFunctions({dummyEmbeddingFunction});
+
+    try {
+        chromaPid = await startChromaProcess({
+            repoRoot,
+            dataDir: chromaData,
+            host,
+            port,
+            logPath: chromaLog
+        });
+        registerProcess({name: 'chroma', pid: chromaPid});
+
+        const client = new ChromaClient({host, port, ssl: false});
+        await client.heartbeat();
+        await sampleNow();
+
+        await client.createCollection({
+            name             : destinations.memories,
+            embeddingFunction: dummyEmbeddingFunction
+        });
+        await client.createCollection({
+            name             : destinations.summaries,
+            embeddingFunction: dummyEmbeddingFunction
+        });
+
+        graphDb = createGraphDatabase(graphPath);
+        seedGraphBootManifest(graphDb);
+
+        recordCheckpoint({
+            kind  : 'disposable-store-ready',
+            detail: {
+                chromaPid,
+                graphDestination   : path.basename(graphPath),
+                memoriesCollection : destinations.memories,
+                summariesCollection: destinations.summaries
+            }
+        });
+
+        recordProgress({phase: ADMISSION_PHASE, state: 'started', counts: {}});
+        const admission = await admitRestoreTargetSetBundle({
+            bundleManifestPath: path.join(fixture.paths.bundle, 'bundle-meta.json'),
+            memoriesFile      : fixture.paths.memoriesFile,
+            summariesFile     : fixture.paths.summariesFile,
+            graphFile         : fixture.paths.graphFile,
+            expectedDimension : fixture.dimension
+        });
+        recordProgress({
+            phase : ADMISSION_PHASE,
+            state : 'completed',
+            counts: createPhaseCounts(fixture.profile, ADMISSION_PHASE)
+        });
+
+        const
+            targetSet = {
+                ...createRestoreTargetSetDescriptor({
+                    memoriesCollection            : destinations.memories,
+                    summariesCollection           : destinations.summaries,
+                    graphDestination              : destinations.graph,
+                    bundleManifestFingerprint     : admission.bundleManifestFingerprint,
+                    admissionDescriptorFingerprint: admission.descriptorFingerprint
+                }),
+                admission
+            },
+            identity = deriveRestoreTargetSetIdentity(targetSet),
+            storage  = createRestoreTargetSetStorage({
+                chromaClient        : client,
+                dummyEmbeddingFunction,
+                graphDb,
+                expectedDestinations: destinations,
+                stagingRoot         : fixture.paths.stagingRoot,
+                invalidateCollectionCache() {},
+                syncGraphCache() {},
+                onPhase: observer
+            }),
+            operation = createRestoreEmptyTargetOperation({
+                withWriterFence: createSingleWriterFence(recordCheckpoint),
+                ...storage,
+                readTransitions: ({attemptFingerprint}) => readRestoreTargetSetTransitions({
+                    dir: ledgerDir,
+                    attemptFingerprint
+                }),
+                appendTransition: input => appendRestoreTargetSetTransition(input, {
+                    dir: ledgerDir
+                })
+            }),
+            outcome = await operation({
+                targetSet,
+                ...identity
+            });
+
+        if (outcome.status !== 'committed' ||
+            outcome.detail?.serviceEligible !== true) {
+            throw new Error(`exact restore measurement did not commit: ${outcome.status}`)
+        }
+
+        recordProgress({phase: TERMINAL_PHASE, state: 'started', counts: {}});
+        await sampleNow();
+        recordCheckpoint({
+            kind  : 'strict-ledger-terminal',
+            detail: {
+                serviceEligible: true,
+                terminal       : outcome.detail.terminal,
+                transitionCount: outcome.detail.destinationTransitions.length
+            }
+        });
+        recordProgress({
+            phase : TERMINAL_PHASE,
+            state : 'completed',
+            counts: {
+                transitions: outcome.detail.destinationTransitions.length
+            }
+        });
+
+        return {
+            status: 'completed',
+            detail: {
+                serviceEligible: true,
+                terminal       : outcome.detail.terminal,
+                transitionCount: outcome.detail.destinationTransitions.length
+            }
+        }
+    } finally {
+        graphDb?.close();
+
+        if (chromaPid !== null) {
+            const stopped = await stopDetachedProcess(chromaPid);
+
+            recordCheckpoint({
+                kind  : 'disposable-chroma-stop',
+                detail: stopped
+            });
+
+            if (!stopped.groupEmpty) {
+                stopError = new Error(`disposable Chroma process group ${chromaPid} survived teardown`)
+            }
+        }
+
+        if (stopError) {
+            throw stopError
+        }
+    }
+}
+
+function createPhaseCounts(profile, phase) {
+    const counts = {
+        memories  : profile.memories,
+        summaries : profile.summaries,
+        graphNodes: profile.graphNodes,
+        graphEdges: profile.graphEdges
+    };
+
+    if (phase.endsWith('memories')) {
+        return {memories: counts.memories}
+    }
+    if (phase.endsWith('summaries')) {
+        return {summaries: counts.summaries}
+    }
+    if (phase.endsWith('graph')) {
+        return {
+            graphNodes: counts.graphNodes,
+            graphEdges: counts.graphEdges
+        }
+    }
+
+    return counts
+}
+
+function createGuardedEmbeddingFunction(recordProviderCall) {
+    const embeddingFunction = {
+        name: 'dummy_embedding_function',
+        getConfig() {
+            return {}
+        },
+        async generate() {
+            recordProviderCall({entrypoint: 'dummy_embedding_function.generate'});
+            throw new Error('restore measurement refused an unexpected embedding-function call')
+        }
+    };
+
+    embeddingFunction.constructor = {
+        buildFromConfig: () => embeddingFunction
+    };
+
+    return embeddingFunction
+}
+
+function createSingleWriterFence(recordCheckpoint) {
+    let active = false;
+
+    return async (identity, task) => {
+        if (active) {
+            throw new Error('restore measurement writer fence is already held')
+        }
+
+        active = true;
+        recordCheckpoint({
+            kind  : 'writer-fence-acquired',
+            detail: {
+                attemptFingerprint: identity.attemptFingerprint,
+                recoveryUnitKey   : identity.recoveryUnitKey
+            }
+        });
+
+        try {
+            return await task()
+        } finally {
+            active = false
+        }
+    }
+}
+
+function createGraphDatabase(filePath) {
+    const db = new Database(filePath);
+    db.pragma('foreign_keys = ON');
+    db.exec(`
+        CREATE TABLE Nodes (
+            id TEXT PRIMARY KEY,
+            user_id TEXT,
+            data TEXT NOT NULL
+        );
+        CREATE TABLE Edges (
+            id TEXT PRIMARY KEY,
+            user_id TEXT,
+            source TEXT NOT NULL,
+            target TEXT NOT NULL,
+            type TEXT NOT NULL,
+            data TEXT NOT NULL,
+            FOREIGN KEY (source) REFERENCES Nodes(id) ON DELETE CASCADE,
+            FOREIGN KEY (target) REFERENCES Nodes(id) ON DELETE CASCADE
+        );
+    `);
+    return db
+}
+
+function seedGraphBootManifest(db) {
+    const
+        manifest = createGraphBootSeedManifest(),
+        addNode  = db.prepare('INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)'),
+        addEdge  = db.prepare(
+            'INSERT INTO Edges (id, user_id, source, target, type, data) VALUES (?, ?, ?, ?, ?, ?)'
+        );
+
+    for (const node of manifest.nodes.map(createGraphBootSeedNodeRecord)) {
+        addNode.run(node.id, null, JSON.stringify(node))
+    }
+    for (const [index, edge] of manifest.edges.map(createGraphBootSeedEdgeRecord).entries()) {
+        const record = {id: `boot-edge-${index}`, ...edge};
+
+        addEdge.run(
+            record.id,
+            null,
+            record.source,
+            record.target,
+            record.type,
+            JSON.stringify(record)
+        )
+    }
+}
+
+function validateAdapterContext(context) {
+    if (!context.fixture?.paths ||
+        !context.fixture?.profile ||
+        !Number.isInteger(context.fixture?.dimension)) {
+        throw new TypeError('restore target-set measurement adapter requires a complete fixture')
+    }
+
+    for (const name of [
+        'recordBatch',
+        'recordCheckpoint',
+        'recordProgress',
+        'recordProviderCall',
+        'registerProcess',
+        'registerSharedRole',
+        'sampleNow',
+        'traceProviders'
+    ]) {
+        if (typeof context[name] !== 'function') {
+            throw new TypeError(`restore target-set measurement adapter requires ${name}()`)
+        }
+    }
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DataIntegrityDiagnosisService.spec.mjs
@@ -79,7 +79,7 @@ test.describe('Neo.ai.daemons.services.DataIntegrityDiagnosisService', () => {
         expect(actuator.calls.applyHeal[0].evidence).toMatchObject({missingFromVectorCount: 200, documentsPresentCount: 200});
     });
 
-    test('wipe (docs gone) → restore-delta-merge; systemic mismatch → freeze (never mass re-embed)', async () => {
+    test('wipe (docs gone) → quarantine; systemic mismatch → freeze (never mass re-embed)', async () => {
         const actuator = fakeActuator(),
               service  = createService({
                   evidenceGatherer: async () => [
@@ -93,7 +93,7 @@ test.describe('Neo.ai.daemons.services.DataIntegrityDiagnosisService', () => {
 
         expect(decision.status).toBe('healed');
         const actions = decision.heals.map(h => h.action);
-        expect(actions).toContain('restore-delta-merge');
+        expect(actions).toContain('quarantine');
         expect(actions).toContain('freeze');
         expect(actuator.calls.applyHeal).toHaveLength(2);
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DataRecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DataRecoveryActuatorService.spec.mjs
@@ -2,8 +2,19 @@ import {test, expect}              from '@playwright/test';
 import Neo                         from '../../../../../../../src/Neo.mjs';
 import * as core                   from '../../../../../../../src/core/_export.mjs';
 import DataRecoveryActuatorService from '../../../../../../../ai/daemons/orchestrator/services/DataRecoveryActuatorService.mjs';
+import {
+    createRestoreTargetSetDescriptor,
+    deriveRestoreTargetSetIdentity
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetContract.mjs';
 
-const NOW = 1_000_000_000_000;
+const NOW        = 1_000_000_000_000;
+const TARGET_SET = createRestoreTargetSetDescriptor({
+    memoriesCollection            : 'neo-agent-memory',
+    summariesCollection           : 'neo-agent-sessions',
+    graphDestination              : '/data/graph.sqlite',
+    bundleManifestFingerprint     : `sha256:${'a'.repeat(64)}`,
+    admissionDescriptorFingerprint: `sha256:${'b'.repeat(64)}`
+});
 
 /**
  * The interim autonomous data-recovery actuator: `applyHeal` is the escalate-replacement terminal.
@@ -60,6 +71,43 @@ test.describe('DataRecoveryActuatorService.applyHeal — autonomous terminal (no
         const outcome = await actuator.applyHeal({action: 're-embed-missing', collection: 'c1', now: NOW});
         expect(outcome.status).toBe('unsafe-input');
         expect(['escalate', 'escalated', 'page', 'paged']).not.toContain(outcome.status);
+    });
+
+    test('target-set recovery reads and records anti-thrash by canonical recovery-unit key', async () => {
+        const
+            seen     = [],
+            attempts = [],
+            identity = deriveRestoreTargetSetIdentity(TARGET_SET),
+            actuator = Neo.create(DataRecoveryActuatorService, {
+                recentRunsReader: async targetKey => {
+                    seen.push(targetKey);
+                    return []
+                },
+                recordRun     : async attempt => attempts.push(attempt),
+                healOperations: {
+                    'restore-empty-target': async input => ({
+                        status: 'committed',
+                        detail: input.recoveryUnitKey
+                    })
+                }
+            });
+
+        const outcome = await actuator.applyHeal({
+            action   : 'restore-empty-target',
+            targetSet: TARGET_SET,
+            now      : NOW
+        });
+
+        expect(seen).toEqual([identity.recoveryUnitKey]);
+        expect(attempts[0]).toMatchObject({
+            action            : 'restore-empty-target',
+            recoveryUnitKey   : identity.recoveryUnitKey,
+            attemptFingerprint: identity.attemptFingerprint
+        });
+        expect(outcome).toMatchObject({
+            status         : 'committed',
+            recoveryUnitKey: identity.recoveryUnitKey
+        })
     });
 });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityEvidenceAssembler.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityEvidenceAssembler.spec.mjs
@@ -68,7 +68,7 @@ test.describe('assembleDataIntegrityEvidence — producers→classifier glue', (
             collectionSizes             : {'neo-agent-memory': 1000},
             documentsPresentByCollection: {'neo-agent-memory': 0}
         });
-        expect(classifyDataIntegrityMode(wipe[0])).toMatchObject({mode: 'wipe', terminalAction: 'restore-delta-merge'});
+        expect(classifyDataIntegrityMode(wipe[0])).toMatchObject({mode: 'wipe', terminalAction: 'quarantine'});
 
         // Store-level sqlite failure → quarantine.
         const sqlite = assembleDataIntegrityEvidence({

--- a/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityModeClassifier.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/dataIntegrityModeClassifier.spec.mjs
@@ -1,5 +1,59 @@
 import {test, expect}                                                               from '@playwright/test';
-import {classifyDataIntegrityMode, DataIntegrityTerminal, DEFAULT_FALSE_STORM_RATE} from '../../../../../../../ai/daemons/orchestrator/services/dataIntegrityModeClassifier.mjs';
+import {
+    classifyDataIntegrityMode,
+    classifyFreshEmptyBootstrapDiagnosis,
+    DataIntegrityTerminal,
+    DEFAULT_FALSE_STORM_RATE
+} from '../../../../../../../ai/daemons/orchestrator/services/dataIntegrityModeClassifier.mjs';
+import {
+    createRestoreTargetSetDescriptor,
+    fingerprintCanonical
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetContract.mjs';
+
+const ADMISSION_COMPONENTS = {
+    memories: {
+        fileFingerprint: `sha256:${'c'.repeat(64)}`,
+        rowCount       : 5
+    },
+    summaries: {
+        fileFingerprint: `sha256:${'d'.repeat(64)}`,
+        rowCount       : 3
+    },
+    graph: {
+        fileFingerprint  : `sha256:${'e'.repeat(64)}`,
+        rowCount         : 3,
+        nodeCount        : 2,
+        edgeCount        : 1,
+        recordFingerprint: `sha256:${'f'.repeat(64)}`
+    }
+};
+const ADMISSION_FINGERPRINT = fingerprintCanonical({
+    schemaVersion    : 1,
+    expectedDimension: 4096,
+    components       : ADMISSION_COMPONENTS
+});
+const ADMISSION = {
+    schemaVersion            : 1,
+    status                   : 'admitted',
+    bundleManifestFingerprint: `sha256:${'a'.repeat(64)}`,
+    descriptorFingerprint    : ADMISSION_FINGERPRINT,
+    expectedDimension        : 4096,
+    components               : {
+        memories : {...ADMISSION_COMPONENTS.memories, filePath: '/bundle/memories.jsonl'},
+        summaries: {...ADMISSION_COMPONENTS.summaries, filePath: '/bundle/summaries.jsonl'},
+        graph    : {...ADMISSION_COMPONENTS.graph, filePath: '/bundle/graph.jsonl'}
+    }
+};
+const TARGET_SET = {
+    ...createRestoreTargetSetDescriptor({
+    memoriesCollection            : 'neo-agent-memory',
+    summariesCollection           : 'neo-agent-sessions',
+    graphDestination              : '/data/graph.sqlite',
+    bundleManifestFingerprint     : `sha256:${'a'.repeat(64)}`,
+    admissionDescriptorFingerprint: ADMISSION_FINGERPRINT
+    }),
+    admission: ADMISSION
+};
 
 test.describe('dataIntegrityModeClassifier', () => {
     test('clean evidence → clean / none', () => {
@@ -14,10 +68,65 @@ test.describe('dataIntegrityModeClassifier', () => {
         expect(d.autonomous).toBe(true);
     });
 
-    test('coverage gap + documents also gone → wipe / restore-delta-merge', () => {
+    test('coverage gap + documents also gone → wipe / quarantine (count evidence cannot select target-set restore)', () => {
         const d = classifyDataIntegrityMode({rowCount: 1000, missingFromVectorCount: 200, documentsPresentCount: 50});
         expect(d.mode).toBe('wipe');
-        expect(d.terminalAction).toBe(DataIntegrityTerminal.RESTORE_DELTA_MERGE);
+        expect(d.terminalAction).toBe(DataIntegrityTerminal.QUARANTINE);
+    });
+
+    test('only an explicitly enabled typed bootstrap diagnosis selects restore-empty-target', () => {
+        expect(classifyFreshEmptyBootstrapDiagnosis({
+            type     : 'fresh-empty-bootstrap',
+            enabled  : true,
+            targetSet: TARGET_SET
+        })).toMatchObject({
+            accepted      : true,
+            mode          : 'fresh-empty-bootstrap',
+            terminalAction: DataIntegrityTerminal.RESTORE_EMPTY_TARGET,
+            targetSet     : TARGET_SET
+        });
+
+        expect(classifyFreshEmptyBootstrapDiagnosis({
+            type     : 'wipe',
+            enabled  : true,
+            targetSet: TARGET_SET
+        })).toMatchObject({accepted: false, terminalAction: DataIntegrityTerminal.NONE});
+
+        expect(classifyFreshEmptyBootstrapDiagnosis({
+            type     : 'fresh-empty-bootstrap',
+            enabled  : false,
+            targetSet: TARGET_SET
+        })).toMatchObject({accepted: false, terminalAction: DataIntegrityTerminal.NONE});
+    });
+
+    test('typed bootstrap selection fails closed on a tampered topology fingerprint', () => {
+        const tampered = structuredClone(TARGET_SET);
+        tampered.destinations[0].id = 'different';
+
+        expect(classifyFreshEmptyBootstrapDiagnosis({
+            type     : 'fresh-empty-bootstrap',
+            enabled  : true,
+            targetSet: tampered
+        })).toMatchObject({
+            accepted      : false,
+            mode          : 'invalid-fresh-empty-bootstrap',
+            terminalAction: DataIntegrityTerminal.NONE
+        });
+    });
+
+    test('typed bootstrap selection fails closed without the admitted source descriptor', () => {
+        const noAdmission = structuredClone(TARGET_SET);
+        delete noAdmission.admission;
+
+        expect(classifyFreshEmptyBootstrapDiagnosis({
+            type     : 'fresh-empty-bootstrap',
+            enabled  : true,
+            targetSet: noAdmission
+        })).toMatchObject({
+            accepted      : false,
+            mode          : 'invalid-fresh-empty-bootstrap',
+            terminalAction: DataIntegrityTerminal.NONE
+        })
     });
 
     test('row-count regressed → count-loss / quarantine', () => {

--- a/test/playwright/unit/ai/graph/bootSeedManifest.spec.mjs
+++ b/test/playwright/unit/ai/graph/bootSeedManifest.spec.mjs
@@ -1,0 +1,73 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    createGraphBootSeedEdgeRecord,
+    createGraphBootSeedManifest,
+    createGraphBootSeedNodeRecord,
+    evaluateGraphBootSeedFreshness,
+    GRAPH_BOOT_SEED_VERSION
+} from '../../../../../ai/graph/bootSeedManifest.mjs';
+import {IDENTITIES} from '../../../../../ai/graph/identityRoots.mjs';
+
+test.describe('graph boot-seed manifest', () => {
+    test('enumerates the fixed roots, every identity root, and one system edge', () => {
+        const manifest = createGraphBootSeedManifest();
+
+        expect(manifest.version).toBe(GRAPH_BOOT_SEED_VERSION);
+        expect(manifest.nodes.map(node => node.id)).toEqual([
+            'frontier',
+            'Neo-Master-Architecture',
+            ...IDENTITIES.map(identity => identity.id)
+        ]);
+        expect(manifest.edges).toEqual([expect.objectContaining({
+            source: 'frontier',
+            target: 'Neo-Master-Architecture',
+            type  : 'SYSTEM_TENET',
+            weight: 1
+        })]);
+        expect(manifest.fingerprint).toMatch(/^sha256:[0-9a-f]{64}$/);
+    });
+
+    test('accepts only the complete exact persisted seed record set', () => {
+        const
+            manifest = createGraphBootSeedManifest(),
+            nodes    = manifest.nodes.map(createGraphBootSeedNodeRecord),
+            edges    = manifest.edges.map((edge, index) => ({
+                id: `storage-minted-${index}`,
+                ...createGraphBootSeedEdgeRecord(edge)
+            }));
+
+        expect(evaluateGraphBootSeedFreshness({nodes, edges, manifest})).toMatchObject({
+            fresh    : true,
+            reason   : null,
+            nodeCount: nodes.length,
+            edgeCount: 1
+        });
+    });
+
+    test('rejects extra, missing, or altered records and ignores only the random edge id', () => {
+        const
+            manifest = createGraphBootSeedManifest(),
+            nodes    = manifest.nodes.map(createGraphBootSeedNodeRecord),
+            edge     = createGraphBootSeedEdgeRecord(manifest.edges[0]);
+
+        const extraNode = [...nodes, {
+            id        : 'unexpected',
+            label     : 'NODE',
+            properties: {name: 'unexpected', description: '', userId: null}
+        }];
+        expect(evaluateGraphBootSeedFreshness({nodes: extraNode, edges: [edge], manifest}).fresh).toBe(false);
+
+        expect(evaluateGraphBootSeedFreshness({nodes: nodes.slice(1), edges: [edge], manifest}).fresh).toBe(false);
+
+        const alteredNodes = structuredClone(nodes);
+        alteredNodes[0].properties.description = 'altered';
+        expect(evaluateGraphBootSeedFreshness({nodes: alteredNodes, edges: [edge], manifest}).fresh).toBe(false);
+
+        expect(evaluateGraphBootSeedFreshness({
+            nodes,
+            edges: [{id: 'any-id', ...edge, properties: {...edge.properties, weight: 1.1}}],
+            manifest
+        }).fresh).toBe(false);
+    });
+});

--- a/test/playwright/unit/ai/scripts/benchmark/TargetSetMeasurementCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/TargetSetMeasurementCore.spec.mjs
@@ -282,6 +282,26 @@ test.describe('ai/scripts/benchmark target-set measurement (#15695)', () => {
         }
     });
 
+    test('ignores transient files removed between directory enumeration and stat', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-target-set-race-spec-'));
+
+        try {
+            fs.writeFileSync(path.join(root, 'chroma.sqlite3-journal'), 'transient');
+
+            const readStat = async () => {
+                const error = new Error('transient file disappeared');
+
+                error.code = 'ENOENT';
+
+                throw error
+            };
+
+            expect(await directorySizeBytes(root, {readStat})).toBe(0)
+        } finally {
+            fs.rmSync(root, {force: true, recursive: true})
+        }
+    });
+
     test('reports the actual 250-row synthetic copy maximum rather than the file cardinality', async () => {
         const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-target-set-batch-spec-'));
 

--- a/test/playwright/unit/ai/scripts/benchmark/restoreEmptyTargetMeasurementAdapter.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/restoreEmptyTargetMeasurementAdapter.spec.mjs
@@ -1,0 +1,122 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    createRestoreMeasurementPhaseObserver
+} from '../../../../restoreEmptyTargetMeasurementAdapter.mjs';
+
+test.describe('restore-empty-target exact-head measurement adapter', () => {
+    test('maps production store events to exact meter phases, counts, batches, and proof', () => {
+        const
+            batches     = [],
+            checkpoints = [],
+            progress    = [],
+            observer    = createRestoreMeasurementPhaseObserver({
+                fixture: {
+                    profile: {
+                        memories  : 5000,
+                        summaries : 5000,
+                        graphNodes: 64,
+                        graphEdges: 63
+                    }
+                },
+                recordBatch     : receipt => batches.push(receipt),
+                recordCheckpoint: receipt => checkpoints.push(receipt),
+                recordProgress  : receipt => progress.push(receipt)
+            });
+
+        observer({phase: 'action-time-proof', event: 'start'});
+        observer({
+            phase : 'action-time-proof',
+            event : 'complete',
+            result: {
+                fresh                         : true,
+                reason                        : null,
+                destinationTopologyFingerprint: 'sha256:topology'
+            }
+        });
+        observer({phase: 'stage-memories', event: 'start'});
+        observer({
+            phase  : 'stage-memories',
+            event  : 'batch',
+            receipt: {batchSize: 250}
+        });
+        observer({phase: 'stage-memories', event: 'complete'});
+        observer({phase: 'stage-summaries', event: 'start'});
+        observer({phase: 'stage-summaries', event: 'complete'});
+        observer({phase: 'stage-graph', event: 'start'});
+        observer({phase: 'stage-graph', event: 'complete'});
+        observer({phase: 'validate-staged-target-set', event: 'start'});
+        observer({phase: 'validate-staged-target-set', event: 'complete'});
+        observer({phase: 'promote-memories', event: 'start'});
+        observer({phase: 'promote-memories', event: 'complete'});
+        observer({phase: 'promote-summaries', event: 'start'});
+        observer({phase: 'promote-summaries', event: 'complete'});
+        observer({phase: 'promote-graph', event: 'start'});
+        observer({phase: 'promote-graph', event: 'complete'});
+        observer({phase: 'revalidate-production', event: 'start'});
+        observer({phase: 'revalidate-production', event: 'complete'});
+
+        expect(checkpoints).toEqual([{
+            kind  : 'action-time-proof',
+            detail: {
+                fresh                         : true,
+                reason                        : null,
+                destinationTopologyFingerprint: 'sha256:topology'
+            }
+        }]);
+        expect(batches).toEqual([{collection: 'memories', size: 250}]);
+        expect(progress.map(item => `${item.phase}:${item.state}`)).toEqual([
+            'stage-memories:started',
+            'stage-memories:completed',
+            'stage-summaries:started',
+            'stage-summaries:completed',
+            'stage-graph:started',
+            'stage-graph:completed',
+            'validate-staged-target-set:started',
+            'validate-staged-target-set:completed',
+            'promote-memories:started',
+            'promote-memories:completed',
+            'promote-summaries:started',
+            'promote-summaries:completed',
+            'promote-graph:started',
+            'promote-graph:completed',
+            'revalidate-production:started',
+            'revalidate-production:completed'
+        ]);
+        expect(progress.find(item => item.phase === 'promote-memories' &&
+            item.state === 'completed').counts).toEqual({memories: 5000});
+        expect(progress.find(item => item.phase === 'promote-graph' &&
+            item.state === 'completed').counts).toEqual({
+            graphNodes: 64,
+            graphEdges: 63
+        });
+        expect(progress.find(item => item.phase === 'revalidate-production' &&
+            item.state === 'completed').counts).toEqual({
+            memories  : 5000,
+            summaries : 5000,
+            graphNodes: 64,
+            graphEdges: 63
+        })
+    });
+
+    test('fails closed on unknown production events', () => {
+        const observer = createRestoreMeasurementPhaseObserver({
+            fixture: {
+                profile: {
+                    memories  : 1,
+                    summaries : 1,
+                    graphNodes: 1,
+                    graphEdges: 0
+                }
+            },
+            recordBatch() {},
+            recordCheckpoint() {},
+            recordProgress() {}
+        });
+
+        expect(() => observer({phase: 'unexpected', event: 'complete'}))
+            .toThrow(/unknown production phase/);
+        expect(() => observer({phase: 'promote-graph', event: 'batch'}))
+            .toThrow(/batch outside vector staging/)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -21,6 +21,10 @@ import fs              from 'fs-extra';
 import path            from 'path';
 import os              from 'os';
 import {getPaths}      from '../../../../../../ai/graph/queries/traversal.mjs';
+import {
+    createGraphBootSeedManifest,
+    evaluateGraphBootSeedFreshness
+} from '../../../../../../ai/graph/bootSeedManifest.mjs';
 
 test.describe('Neo.ai.services.memory-core.GraphService', () => {
     let GraphService;
@@ -1104,6 +1108,45 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
             label     : 'AgentIdentity',
             properties: {participationStatus: 'temporarily_unreachable', userId: null}
         });
+    });
+
+    test('boot and recovery share one exact idempotent seed manifest', () => {
+        const
+            manifest = createGraphBootSeedManifest(),
+            first    = GraphService.provisionMissingBootSeeds(manifest),
+            db       = GraphService.db.storage.db,
+            before   = db.prepare(`
+                SELECT data
+                FROM Edges
+                WHERE source = 'frontier'
+                  AND target = 'Neo-Master-Architecture'
+                  AND type = 'SYSTEM_TENET'
+            `).get().data,
+            second   = GraphService.provisionMissingBootSeeds(manifest),
+            after    = db.prepare(`
+                SELECT data
+                FROM Edges
+                WHERE source = 'frontier'
+                  AND target = 'Neo-Master-Architecture'
+                  AND type = 'SYSTEM_TENET'
+            `).get().data,
+            freshness = evaluateGraphBootSeedFreshness({
+                nodes: db.prepare('SELECT data FROM Nodes').all(),
+                edges: db.prepare('SELECT data FROM Edges').all(),
+                manifest
+            });
+
+        expect(first).toEqual({
+            nodesCreated: manifest.nodes.length,
+            edgesCreated: manifest.edges.length
+        });
+        expect(second).toEqual({nodesCreated: 0, edgesCreated: 0});
+        expect(after).toBe(before);
+        expect(freshness).toMatchObject({
+            fresh    : true,
+            nodeCount: manifest.nodes.length,
+            edgeCount: manifest.edges.length
+        })
     });
 
     test('cross-tenant data isolation and identity stamping', async () => {

--- a/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healActionDispatch.spec.mjs
@@ -10,8 +10,20 @@ import {
     MUTATING_HEAL_ACTIONS,
     NO_HEAL_ACTION
 } from '../../../../../../../ai/services/memory-core/helpers/healActionDispatch.mjs';
+import {
+    createRestoreTargetSetDescriptor,
+    deriveRestoreTargetSetIdentity,
+    RESTORE_EMPTY_TARGET_ACTION
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetContract.mjs';
 
-const NOW = 10_000_000;
+const NOW        = 10_000_000;
+const TARGET_SET = createRestoreTargetSetDescriptor({
+    memoriesCollection            : 'neo-agent-memory',
+    summariesCollection           : 'neo-agent-sessions',
+    graphDestination              : '/data/graph.sqlite',
+    bundleManifestFingerprint     : `sha256:${'a'.repeat(64)}`,
+    admissionDescriptorFingerprint: `sha256:${'b'.repeat(64)}`
+});
 
 test.describe('decideHealAction — autonomous bounded-dispatch safety gate', () => {
     test('action none / absent → no-op (nothing to heal)', () => {
@@ -66,6 +78,42 @@ test.describe('decideHealAction — autonomous bounded-dispatch safety gate', ()
             .toMatchObject({execute: false, status: 'unsafe-input'});
     });
 
+    test('restore-empty-target requires targetSet, rejects collection, and keys anti-thrash by recovery unit', () => {
+        const identity = deriveRestoreTargetSetIdentity(TARGET_SET);
+
+        expect(decideHealAction({action: RESTORE_EMPTY_TARGET_ACTION, now: NOW}))
+            .toMatchObject({execute: false, status: 'unsafe-input'});
+        expect(decideHealAction({
+            action    : RESTORE_EMPTY_TARGET_ACTION,
+            collection: 'synthetic-collection',
+            targetSet : TARGET_SET,
+            now       : NOW
+        })).toMatchObject({execute: false, status: 'unsafe-input'});
+
+        expect(decideHealAction({
+            action    : RESTORE_EMPTY_TARGET_ACTION,
+            targetSet : TARGET_SET,
+            recentRuns: [{
+                action         : RESTORE_EMPTY_TARGET_ACTION,
+                recoveryUnitKey: identity.recoveryUnitKey,
+                at             : NOW - 1
+            }],
+            now: NOW
+        })).toMatchObject({
+            execute: false,
+            status : 'thrash-cooldown'
+        });
+    });
+
+    test('collection-scoped actions reject targetSet even when a collection is present', () => {
+        expect(decideHealAction({
+            action    : 'quarantine',
+            collection: 'mc',
+            targetSet : TARGET_SET,
+            now       : NOW
+        })).toMatchObject({execute: false, status: 'unsafe-input'});
+    });
+
     test('fail-closed: a mutating action with a non-finite now → unsafe-input (no cooldown/window clock)', () => {
         expect(decideHealAction({action: 'defrag', collection: 'mc'}))
             .toMatchObject({execute: false, status: 'unsafe-input'});
@@ -90,6 +138,8 @@ test.describe('decideHealAction — autonomous bounded-dispatch safety gate', ()
         expect(Object.isFrozen(MUTATING_HEAL_ACTIONS)).toBe(true);
         expect(MUTATING_HEAL_ACTIONS.every(a => HEAL_ACTIONS.includes(a))).toBe(true);
         expect(HEAL_ACTIONS).toContain('quarantine'); // quarantine is a containment heal-action
+        expect(HEAL_ACTIONS).toContain(RESTORE_EMPTY_TARGET_ACTION);
+        expect(HEAL_ACTIONS).not.toContain('restore-delta-merge');
         expect(DEFAULT_DISPATCH_BOUNDS.maxRunsPerWindow).toBeGreaterThan(0);
         // the no-op sentinel is non-dispatchable: it lives OUTSIDE HEAL_ACTIONS and resolves to no-op.
         expect(NO_HEAL_ACTION).toBe('none');
@@ -131,11 +181,55 @@ test.describe('dispatchHeal — actuator core dispatch (safety gate + injected e
         expect(runs).toEqual([{action: 're-embed-missing', collection: 'mc-memory', at: NOW}]);
     });
 
-    test('an executable action with NO wired operation → deferred (the missing-logic gap, autonomous, no page)', async () => {
-        const outcome = await dispatchHeal({action: 'restore-delta-merge', collection: 'mc', now: NOW, healOperations: {}});
+    test('an executable target-set action with NO wired operation → deferred (autonomous, no page)', async () => {
+        const outcome = await dispatchHeal({
+            action        : RESTORE_EMPTY_TARGET_ACTION,
+            targetSet     : TARGET_SET,
+            now           : NOW,
+            healOperations: {}
+        });
 
-        expect(outcome).toMatchObject({status: 'deferred', healedAt: NOW});
+        expect(outcome).toMatchObject({
+            action            : RESTORE_EMPTY_TARGET_ACTION,
+            status            : 'deferred',
+            healedAt          : NOW,
+            recoveryUnitKey   : deriveRestoreTargetSetIdentity(TARGET_SET).recoveryUnitKey,
+            attemptFingerprint: deriveRestoreTargetSetIdentity(TARGET_SET).attemptFingerprint
+        });
         expect(outcome.detail).toMatch(/no heal operation wired/);
+    });
+
+    test('target-set dispatch records and invokes the operation with canonical identities', async () => {
+        const
+            calls    = [],
+            records  = [],
+            expected = deriveRestoreTargetSetIdentity(TARGET_SET),
+            outcome  = await dispatchHeal({
+                action        : RESTORE_EMPTY_TARGET_ACTION,
+                targetSet     : TARGET_SET,
+                now           : NOW,
+                healOperations: {
+                    [RESTORE_EMPTY_TARGET_ACTION]: async input => {
+                        calls.push(input);
+                        return {status: 'committed', detail: {serviceEligible: true}}
+                    }
+                },
+                recordRun: async record => records.push(record)
+            });
+
+        expect(records).toEqual([expect.objectContaining({
+            action            : RESTORE_EMPTY_TARGET_ACTION,
+            collection        : undefined,
+            recoveryUnitKey   : expected.recoveryUnitKey,
+            attemptFingerprint: expected.attemptFingerprint,
+            at                : NOW
+        })]);
+        expect(calls).toEqual([expect.objectContaining({
+            targetSet         : TARGET_SET,
+            recoveryUnitKey   : expected.recoveryUnitKey,
+            attemptFingerprint: expected.attemptFingerprint
+        })]);
+        expect(outcome).toMatchObject({status: 'committed', detail: {serviceEligible: true}});
     });
 
     test('a throwing operation → failed (recorded, never escalated)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/helpers/restoreEmptyTargetOperation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/restoreEmptyTargetOperation.spec.mjs
@@ -1,0 +1,302 @@
+import fs   from 'fs/promises';
+import os   from 'os';
+import path from 'path';
+
+import {test, expect} from '@playwright/test';
+
+import {createRestoreEmptyTargetOperation} from '../../../../../../../ai/services/memory-core/helpers/restoreEmptyTargetOperation.mjs';
+import {
+    appendRestoreTargetSetTransition,
+    readRestoreTargetSetTransitions
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetStateStore.mjs';
+import {
+    createRestoreTargetSetDescriptor,
+    deriveRestoreTargetSetIdentity
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetContract.mjs';
+
+const TARGET_SET = createRestoreTargetSetDescriptor({
+    memoriesCollection            : 'neo-agent-memory',
+    summariesCollection           : 'neo-agent-sessions',
+    graphDestination              : '/data/graph.sqlite',
+    bundleManifestFingerprint     : `sha256:${'a'.repeat(64)}`,
+    admissionDescriptorFingerprint: `sha256:${'b'.repeat(64)}`
+});
+const IDENTITY = deriveRestoreTargetSetIdentity(TARGET_SET);
+
+test.describe('restoreEmptyTargetOperation', () => {
+    let dir;
+
+    test.beforeEach(async () => {
+        dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-restore-empty-target-operation-'));
+    });
+
+    test.afterEach(async () => {
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('holds one writer fence across proof, staging, ordered promotion, validation, and commit', async () => {
+        const
+            events    = [],
+            clock     = createClock(),
+            operation = createOperation({
+                clock,
+                onFence(active) {
+                    events.push(active ? 'fence:acquired' : 'fence:released')
+                },
+                inspectFreshTargetSet: async () => {
+                    events.push('proof');
+                    return {
+                        fresh                         : true,
+                        destinationTopologyFingerprint: TARGET_SET.destinationTopologyFingerprint
+                    }
+                },
+                stageTargetSet: async () => {
+                    events.push('stage');
+                    return {id: 'staging'}
+                },
+                validateStagedTargetSet: async () => {
+                    events.push('validate-staged');
+                    return {valid: true, componentFingerprints: {memories: 'm', summaries: 's', graph: 'g'}}
+                },
+                promoteComponent: async ({role}) => {
+                    events.push(`promote:${role}`);
+                    return {fingerprint: role, count: 1}
+                },
+                revalidateProductionTargetSet: async () => {
+                    events.push('revalidate-production');
+                    return {valid: true, componentFingerprints: {memories: 'm', summaries: 's', graph: 'g'}}
+                }
+            });
+
+        const outcome = await operation({
+            targetSet: TARGET_SET,
+            ...IDENTITY
+        });
+
+        expect(events).toEqual([
+            'fence:acquired',
+            'proof',
+            'stage',
+            'validate-staged',
+            'promote:memories',
+            'promote:summaries',
+            'promote:graph',
+            'revalidate-production',
+            'fence:released'
+        ]);
+        expect(outcome).toMatchObject({
+            status: 'committed',
+            detail: {
+                terminal       : 'committed',
+                serviceEligible: true
+            }
+        });
+
+        expect((await readLedger()).map(item => item.state)).toEqual([
+            'admitted',
+            'fenced',
+            'staged',
+            'promoted:memories',
+            'promoted:summaries',
+            'promoted:graph',
+            'validated',
+            'committed'
+        ]);
+    });
+
+    test('under-fence drift settles deferred-target-not-empty with zero staging or promotion', async () => {
+        let staged   = false,
+            promoted = false;
+
+        const operation = createOperation({
+            inspectFreshTargetSet: async () => ({
+                fresh                         : false,
+                reason                        : 'memories count is 1',
+                destinationTopologyFingerprint: TARGET_SET.destinationTopologyFingerprint
+            }),
+            stageTargetSet: async () => {
+                staged = true
+            },
+            promoteComponent: async () => {
+                promoted = true
+            }
+        });
+
+        const outcome = await operation({targetSet: TARGET_SET, ...IDENTITY});
+
+        expect(outcome).toMatchObject({
+            status: 'deferred-target-not-empty',
+            detail: {serviceEligible: false}
+        });
+        expect(staged).toBe(false);
+        expect(promoted).toBe(false);
+        expect((await readLedger()).map(item => item.state)).toEqual([
+            'admitted',
+            'fenced',
+            'deferred-target-not-empty'
+        ]);
+    });
+
+    for (const resumeState of ['staged', 'promoted:memories', 'promoted:summaries', 'promoted:graph', 'validated']) {
+        test(`reconciles and resumes the same attempt from ${resumeState}`, async () => {
+            await seedLedgerThrough(resumeState);
+
+            const promoted  = [];
+            const operation = createOperation({
+                reconcileAttempt: async ({transitions}) => ({
+                    safe         : true,
+                    staging      : {id: 'recovered-staging'},
+                    observedState: transitions.at(-1).state
+                }),
+                promoteComponent: async ({role}) => {
+                    promoted.push(role);
+                    return {fingerprint: role, count: 1}
+                }
+            });
+
+            const outcome = await operation({targetSet: TARGET_SET, ...IDENTITY});
+
+            expect(outcome.status).toBe('committed');
+
+            const alreadyPromotedCount = {
+                staged              : 0,
+                'promoted:memories' : 1,
+                'promoted:summaries': 2,
+                'promoted:graph'    : 3,
+                validated           : 3
+            }[resumeState];
+            expect(promoted).toEqual(['memories', 'summaries', 'graph'].slice(alreadyPromotedCount));
+        });
+    }
+
+    test('an observed component ahead of the strict ledger settles failed-contained instead of inferring a transition', async () => {
+        await seedLedgerThrough('staged');
+
+        const operation = createOperation({
+            reconcileAttempt: async () => ({
+                safe         : false,
+                observedState: 'promoted:memories',
+                reason       : 'live memories changed but promoted:memories was never appended'
+            })
+        });
+
+        const outcome = await operation({targetSet: TARGET_SET, ...IDENTITY});
+
+        expect(outcome).toMatchObject({
+            status: 'failed-contained',
+            detail: {serviceEligible: false}
+        });
+        expect((await readLedger()).at(-1).state).toBe('failed-contained');
+    });
+
+    for (const failedState of [
+        'admitted',
+        'fenced',
+        'staged',
+        'promoted:memories',
+        'promoted:summaries',
+        'promoted:graph',
+        'validated',
+        'committed'
+    ]) {
+        test(`transition write failure at ${failedState} never opens eligibility`, async () => {
+            const operation = createOperation({
+                appendTransition: async input => {
+                    if (input.state === failedState) {
+                        throw new Error(`append failed at ${failedState}`)
+                    }
+                    return appendRestoreTargetSetTransition(input, {dir})
+                }
+            });
+
+            await expect(operation({targetSet: TARGET_SET, ...IDENTITY}))
+                .rejects.toThrow(`append failed at ${failedState}`);
+
+            const transitions = await readLedger();
+            expect(transitions.at(-1)?.state).not.toBe('committed');
+        });
+    }
+
+    async function seedLedgerThrough(lastState) {
+        const states = [
+            'admitted',
+            'fenced',
+            'staged',
+            'promoted:memories',
+            'promoted:summaries',
+            'promoted:graph',
+            'validated'
+        ];
+
+        for (const [index, state] of states.entries()) {
+            await appendRestoreTargetSetTransition({
+                ...IDENTITY,
+                state,
+                at     : 100 + index,
+                details: {}
+            }, {dir});
+
+            if (state === lastState) {
+                return
+            }
+        }
+    }
+
+    function createOperation(overrides = {}) {
+        let fenceActive = false;
+
+        const base = {
+            clock          : createClock(),
+            withWriterFence: async (identity, task) => {
+                expect(identity).toEqual({
+                    recoveryUnitKey   : IDENTITY.recoveryUnitKey,
+                    attemptFingerprint: IDENTITY.attemptFingerprint
+                });
+                expect(fenceActive).toBe(false);
+                fenceActive = true;
+                overrides.onFence?.(true);
+                try {
+                    return await task()
+                } finally {
+                    overrides.onFence?.(false);
+                    fenceActive = false
+                }
+            },
+            inspectFreshTargetSet: async () => ({
+                fresh                         : true,
+                destinationTopologyFingerprint: TARGET_SET.destinationTopologyFingerprint
+            }),
+            stageTargetSet         : async () => ({id: 'staging'}),
+            validateStagedTargetSet: async () => ({
+                valid                : true,
+                componentFingerprints: {memories: 'm', summaries: 's', graph: 'g'}
+            }),
+            promoteComponent             : async ({role}) => ({fingerprint: role, count: 1}),
+            revalidateProductionTargetSet: async () => ({
+                valid                : true,
+                componentFingerprints: {memories: 'm', summaries: 's', graph: 'g'}
+            }),
+            reconcileAttempt        : async () => ({safe: true, staging: {id: 'staging'}}),
+            cleanupUnpromotedStaging: async () => {},
+            readTransitions         : async ({attemptFingerprint}) => readRestoreTargetSetTransitions({
+                dir,
+                attemptFingerprint
+            }),
+            appendTransition: async input => appendRestoreTargetSetTransition(input, {dir})
+        };
+
+        return createRestoreEmptyTargetOperation({...base, ...overrides})
+    }
+
+    function readLedger() {
+        return readRestoreTargetSetTransitions({
+            dir,
+            attemptFingerprint: IDENTITY.attemptFingerprint
+        })
+    }
+});
+
+function createClock() {
+    let now = 1_000;
+    return () => now++
+}

--- a/test/playwright/unit/ai/services/memory-core/helpers/restoreTargetSetContract.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/restoreTargetSetContract.spec.mjs
@@ -1,0 +1,78 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    createRestoreTargetSetDescriptor,
+    deriveRestoreTargetSetIdentity,
+    normalizeRestoreTargetSetDescriptor,
+    RESTORE_EMPTY_TARGET_ACTION,
+    RESTORE_TARGET_ROLES,
+    RESTORE_TARGET_SET_VERSION
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetContract.mjs';
+
+const
+    BUNDLE_A    = `sha256:${'a'.repeat(64)}`,
+    BUNDLE_B    = `sha256:${'b'.repeat(64)}`,
+    ADMISSION_A = `sha256:${'c'.repeat(64)}`,
+    ADMISSION_B = `sha256:${'d'.repeat(64)}`;
+
+function createDescriptor({
+    bundleManifestFingerprint      = BUNDLE_A,
+    admissionDescriptorFingerprint = ADMISSION_A
+} = {}) {
+    return createRestoreTargetSetDescriptor({
+        memoriesCollection : 'neo-agent-memory',
+        summariesCollection: 'neo-agent-sessions',
+        graphDestination   : '/data/graph.sqlite',
+        bundleManifestFingerprint,
+        admissionDescriptorFingerprint
+    })
+}
+
+test.describe('restore target-set identity contract', () => {
+    test('creates the closed ordered v1 descriptor and verifies its topology fingerprint', () => {
+        const descriptor = createDescriptor();
+
+        expect(descriptor).toMatchObject({
+            version     : RESTORE_TARGET_SET_VERSION,
+            destinations: [
+                {role: 'memories',  kind: 'chroma',       id: 'neo-agent-memory'},
+                {role: 'summaries', kind: 'chroma',       id: 'neo-agent-sessions'},
+                {role: 'graph',     kind: 'sqlite-graph', id: '/data/graph.sqlite'}
+            ],
+            bundleManifestFingerprint     : BUNDLE_A,
+            admissionDescriptorFingerprint: ADMISSION_A
+        });
+        expect(descriptor.destinations.map(item => item.role)).toEqual(RESTORE_TARGET_ROLES);
+        expect(normalizeRestoreTargetSetDescriptor(descriptor)).toEqual(descriptor);
+    });
+
+    test('the recovery-unit key is bundle-independent while the attempt fingerprint is bundle-specific', () => {
+        const first  = deriveRestoreTargetSetIdentity(createDescriptor());
+        const second = deriveRestoreTargetSetIdentity(createDescriptor({
+            bundleManifestFingerprint     : BUNDLE_B,
+            admissionDescriptorFingerprint: ADMISSION_B
+        }));
+
+        expect(first.recoveryUnitKey).toBe(second.recoveryUnitKey);
+        expect(first.recoveryUnitKey).toContain(`${RESTORE_EMPTY_TARGET_ACTION}:v1:`);
+        expect(first.attemptFingerprint).not.toBe(second.attemptFingerprint);
+    });
+
+    test('fails closed on role reordering, topology drift, or non-SHA source fingerprints', () => {
+        const reordered = createDescriptor();
+        reordered.destinations.reverse();
+        expect(() => normalizeRestoreTargetSetDescriptor(reordered)).toThrow(/destination 0/);
+
+        const topologyDrift = createDescriptor();
+        topologyDrift.destinations[0].id = 'different-memory';
+        expect(() => normalizeRestoreTargetSetDescriptor(topologyDrift)).toThrow(/destinationTopologyFingerprint/);
+
+        expect(() => createRestoreTargetSetDescriptor({
+            memoriesCollection            : 'm',
+            summariesCollection           : 's',
+            graphDestination              : 'g',
+            bundleManifestFingerprint     : 'not-a-sha',
+            admissionDescriptorFingerprint: ADMISSION_A
+        })).toThrow(/bundleManifestFingerprint/);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/restoreTargetSetStateStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/restoreTargetSetStateStore.spec.mjs
@@ -1,0 +1,153 @@
+import fs   from 'fs/promises';
+import os   from 'os';
+import path from 'path';
+
+import {test, expect} from '@playwright/test';
+
+import {
+    appendRestoreTargetSetTransition,
+    createRestoreTargetSetReceipt,
+    getRestoreTargetSetStateFileName,
+    isRestoreTargetSetCommitted,
+    readRestoreTargetSetTransitions
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetStateStore.mjs';
+import {
+    createRestoreTargetSetDescriptor,
+    deriveRestoreTargetSetIdentity
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetContract.mjs';
+
+const DESCRIPTOR = createRestoreTargetSetDescriptor({
+    memoriesCollection            : 'neo-agent-memory',
+    summariesCollection           : 'neo-agent-sessions',
+    graphDestination              : '/data/graph.sqlite',
+    bundleManifestFingerprint     : `sha256:${'a'.repeat(64)}`,
+    admissionDescriptorFingerprint: `sha256:${'b'.repeat(64)}`
+});
+const IDENTITY = deriveRestoreTargetSetIdentity(DESCRIPTOR);
+
+test.describe('restoreTargetSetStateStore', () => {
+    let dir;
+
+    test.beforeEach(async () => {
+        dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-restore-target-set-state-'));
+    });
+
+    test.afterEach(async () => {
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('strict-appends the complete semantic chain and opens eligibility only at committed', async () => {
+        const states = [
+            'admitted',
+            'fenced',
+            'staged',
+            'promoted:memories',
+            'promoted:summaries',
+            'promoted:graph',
+            'validated',
+            'committed'
+        ];
+
+        for (const [index, state] of states.entries()) {
+            const before = await readRestoreTargetSetTransitions({
+                dir,
+                attemptFingerprint: IDENTITY.attemptFingerprint
+            });
+            expect(isRestoreTargetSetCommitted(before)).toBe(false);
+
+            await appendRestoreTargetSetTransition({
+                ...IDENTITY,
+                state,
+                at     : 1_000 + index,
+                details: {}
+            }, {dir});
+        }
+
+        const transitions = await readRestoreTargetSetTransitions({
+            dir,
+            attemptFingerprint: IDENTITY.attemptFingerprint
+        });
+
+        expect(transitions.map(entry => entry.state)).toEqual(states);
+        expect(transitions.map(entry => entry.sequence)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+        expect(isRestoreTargetSetCommitted(transitions)).toBe(true);
+
+        expect(createRestoreTargetSetReceipt({
+            transitions,
+            ...IDENTITY,
+            descriptor: DESCRIPTOR
+        })).toMatchObject({
+            terminal       : 'committed',
+            serviceEligible: true,
+            wallClockMs    : 7
+        });
+    });
+
+    test('rejects a skipped transition and never fabricates eligibility', async () => {
+        await appendRestoreTargetSetTransition({
+            ...IDENTITY,
+            state  : 'admitted',
+            at     : 1,
+            details: {}
+        }, {dir});
+
+        await expect(appendRestoreTargetSetTransition({
+            ...IDENTITY,
+            state  : 'staged',
+            at     : 2,
+            details: {}
+        }, {dir})).rejects.toThrow(/illegal.*admitted -> staged/);
+
+        const transitions = await readRestoreTargetSetTransitions({
+            dir,
+            attemptFingerprint: IDENTITY.attemptFingerprint
+        });
+        expect(isRestoreTargetSetCommitted(transitions)).toBe(false);
+    });
+
+    test('fails loud on corrupt JSON or identity drift', async () => {
+        await fs.mkdir(dir, {recursive: true});
+        await fs.writeFile(
+            path.join(dir, getRestoreTargetSetStateFileName(IDENTITY.attemptFingerprint)),
+            '{broken\n',
+            'utf8'
+        );
+
+        await expect(readRestoreTargetSetTransitions({
+            dir,
+            attemptFingerprint: IDENTITY.attemptFingerprint
+        })).rejects.toThrow(/invalid JSON/);
+    });
+
+    test('redacts secret-shaped failure detail in the bounded receipt', () => {
+        const transitions = [{
+            schemaVersion: 1,
+            type         : 'restore-target-set-transition',
+            ...IDENTITY,
+            sequence     : 1,
+            previousState: null,
+            state        : 'admitted',
+            at           : 1,
+            details      : {}
+        }, {
+            schemaVersion: 1,
+            type         : 'restore-target-set-transition',
+            ...IDENTITY,
+            sequence     : 2,
+            previousState: 'admitted',
+            state        : 'failed-contained',
+            at           : 2,
+            details      : {}
+        }];
+
+        const receipt = createRestoreTargetSetReceipt({
+            transitions,
+            ...IDENTITY,
+            descriptor: DESCRIPTOR,
+            failure   : new Error('provider token=super-secret')
+        });
+
+        expect(receipt.serviceEligible).toBe(false);
+        expect(receipt.failure.message).toBe('provider token=[redacted]');
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/restoreTargetSetStorage.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/restoreTargetSetStorage.spec.mjs
@@ -1,0 +1,559 @@
+import fs   from 'node:fs/promises';
+import os   from 'node:os';
+import path from 'node:path';
+
+import {setup}        from '../../../../../setup.mjs';
+import {test, expect} from '@playwright/test';
+import Database       from 'better-sqlite3';
+
+import '../../../../../../../src/Neo.mjs';
+
+import {
+    createGraphBootSeedEdgeRecord,
+    createGraphBootSeedManifest,
+    createGraphBootSeedNodeRecord
+} from '../../../../../../../ai/graph/bootSeedManifest.mjs';
+import {
+    createRestoreEmptyTargetOperation
+} from '../../../../../../../ai/services/memory-core/helpers/restoreEmptyTargetOperation.mjs';
+import {
+    admitRestoreTargetSetBundle
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetAdmission.mjs';
+import {
+    createRestoreTargetSetStorage
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetStorage.mjs';
+import {
+    appendRestoreTargetSetTransition,
+    readRestoreTargetSetTransitions
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetStateStore.mjs';
+import {
+    createRestoreTargetSetDescriptor,
+    deriveRestoreTargetSetIdentity
+} from '../../../../../../../ai/services/memory-core/helpers/restoreTargetSetContract.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'RestoreTargetSetStorageTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+test.describe('restoreTargetSetStorage — fake Chroma + disposable SQLite target set', () => {
+    let fixture;
+
+    test.beforeEach(async () => {
+        fixture = await createFixture()
+    });
+
+    test.afterEach(async () => {
+        fixture.graphDb.close();
+        await fs.rm(fixture.root, {recursive: true, force: true})
+    });
+
+    test('stages, validates, promotes memories → summaries → graph, and commits provider-free', async () => {
+        const
+            phases    = [],
+            storage   = createStorage(fixture, event => phases.push(event)),
+            operation = createRestoreEmptyTargetOperation({
+                withWriterFence: async (identity, task) => task(),
+                ...storage,
+                readTransitions: ({attemptFingerprint}) => readRestoreTargetSetTransitions({
+                    dir: fixture.ledgerDir,
+                    attemptFingerprint
+                }),
+                appendTransition: input => appendRestoreTargetSetTransition(input, {
+                    dir: fixture.ledgerDir
+                })
+            }),
+            identity = deriveRestoreTargetSetIdentity(fixture.targetSet),
+            outcome  = await operation({
+                targetSet: fixture.targetSet,
+                ...identity
+            });
+
+        expect(outcome).toMatchObject({
+            status: 'committed',
+            detail: {
+                terminal       : 'committed',
+                serviceEligible: true
+            }
+        });
+        expect(await fixture.client.getCollection({
+            name: fixture.destinations.memories
+        }).then(collection => collection.count())).toBe(3);
+        expect(await fixture.client.getCollection({
+            name: fixture.destinations.summaries
+        }).then(collection => collection.count())).toBe(2);
+        expect(fixture.graphDb.prepare('SELECT COUNT(*) AS count FROM Nodes').get().count).toBe(2);
+        expect(fixture.graphDb.prepare('SELECT COUNT(*) AS count FROM Edges').get().count).toBe(1);
+        expect(fixture.providerCalls).toBe(0);
+        expect(fixture.cacheInvalidations).toEqual(['memory', 'summary']);
+        expect(fixture.graphCacheSyncs).toBe(1);
+
+        const phaseNames = phases
+            .filter(event => event.event === 'complete')
+            .map(event => event.phase);
+
+        expect(phaseNames).toEqual([
+            'action-time-proof',
+            'stage-memories',
+            'stage-summaries',
+            'stage-graph',
+            'validate-staged-target-set',
+            'promote-memories',
+            'promote-summaries',
+            'promote-graph',
+            'revalidate-production'
+        ]);
+
+        const transitions = await readRestoreTargetSetTransitions({
+            dir               : fixture.ledgerDir,
+            attemptFingerprint: identity.attemptFingerprint
+        });
+        expect(transitions.map(item => item.state)).toEqual([
+            'admitted',
+            'fenced',
+            'staged',
+            'promoted:memories',
+            'promoted:summaries',
+            'promoted:graph',
+            'validated',
+            'committed'
+        ])
+    });
+
+    test('rejects a non-seed graph under the fence with zero staging/promotion', async () => {
+        fixture.graphDb.prepare(
+            'INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)'
+        ).run('unexpected', null, JSON.stringify({
+            id        : 'unexpected',
+            label     : 'NODE',
+            properties: {}
+        }));
+
+        const
+            storage  = createStorage(fixture),
+            identity = deriveRestoreTargetSetIdentity(fixture.targetSet),
+            proof    = await storage.inspectFreshTargetSet({
+                targetSet : fixture.targetSet,
+                descriptor: identity.descriptor,
+                ...identity
+            });
+
+        expect(proof.fresh).toBe(false);
+        expect(proof.reason).toContain('persisted graph differs from boot seed')
+    });
+
+    test('detects a live component that advanced without its strict transition', async () => {
+        const
+            storage  = createStorage(fixture),
+            identity = deriveRestoreTargetSetIdentity(fixture.targetSet),
+            context  = {
+                targetSet : fixture.targetSet,
+                descriptor: identity.descriptor,
+                ...identity
+            },
+            staging = await storage.stageTargetSet(context);
+
+        await storage.validateStagedTargetSet({...context, staging});
+        await storage.promoteComponent({...context, staging, role: 'memories'});
+
+        const reconciliation = await storage.reconcileAttempt({
+            ...context,
+            transitions: [
+                transition(identity, 1, null, 'admitted'),
+                transition(identity, 2, 'admitted', 'fenced'),
+                transition(identity, 3, 'fenced', 'staged')
+            ]
+        });
+
+        expect(reconciliation).toMatchObject({
+            safe  : false,
+            reason: 'memories live storage advanced without a promoted transition'
+        })
+    });
+});
+
+test.describe('restoreTargetSetStorage — live disposable Chroma + SQLite target set', () => {
+    let AiConfig;
+    let ChromaManager;
+    let fixture;
+
+    test.beforeAll(async () => {
+        [
+            {default: AiConfig},
+            {default: ChromaManager}
+        ] = await Promise.all([
+            import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs'),
+            import('../../../../../../../ai/services/memory-core/managers/ChromaManager.mjs')
+        ]);
+
+        await ChromaManager.ready()
+    });
+
+    test.beforeEach(async ({}, testInfo) => {
+        fixture = await createFixture({
+            client                : ChromaManager.client,
+            dummyEmbeddingFunction: AiConfig.dummyEmbeddingFunction,
+            collectionSuffix      : `${process.pid}-${testInfo.workerIndex}-${Date.now()}`
+        })
+    });
+
+    test.afterEach(async () => {
+        await deleteFixtureCollections(fixture);
+        fixture.graphDb.close();
+        await fs.rm(fixture.root, {recursive: true, force: true})
+    });
+
+    test('executes the provider-free ordered promotion against the live Chroma SDK', async () => {
+        const
+            storage   = createStorage(fixture),
+            operation = createRestoreEmptyTargetOperation({
+                withWriterFence: async (identity, task) => task(),
+                ...storage,
+                readTransitions: ({attemptFingerprint}) => readRestoreTargetSetTransitions({
+                    dir: fixture.ledgerDir,
+                    attemptFingerprint
+                }),
+                appendTransition: input => appendRestoreTargetSetTransition(input, {
+                    dir: fixture.ledgerDir
+                })
+            }),
+            identity = deriveRestoreTargetSetIdentity(fixture.targetSet),
+            outcome  = await operation({
+                targetSet: fixture.targetSet,
+                ...identity
+            });
+
+        expect(outcome).toMatchObject({
+            status: 'committed',
+            detail: {
+                terminal       : 'committed',
+                serviceEligible: true
+            }
+        });
+        expect(await fixture.client.getCollection({
+            name             : fixture.destinations.memories,
+            embeddingFunction: fixture.dummyEmbeddingFunction
+        }).then(collection => collection.count())).toBe(3);
+        expect(await fixture.client.getCollection({
+            name             : fixture.destinations.summaries,
+            embeddingFunction: fixture.dummyEmbeddingFunction
+        }).then(collection => collection.count())).toBe(2);
+        expect(fixture.graphDb.prepare('SELECT COUNT(*) AS count FROM Nodes').get().count).toBe(2);
+        expect(fixture.graphDb.prepare('SELECT COUNT(*) AS count FROM Edges').get().count).toBe(1);
+        expect(fixture.providerCalls).toBe(0)
+    });
+});
+
+async function createFixture({
+    client = createFakeChromaClient(),
+    dummyEmbeddingFunction = null,
+    collectionSuffix = process.pid
+} = {}) {
+    const
+        root               = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-restore-target-set-storage-')),
+        bundleManifestPath = path.join(root, 'bundle-meta.json'),
+        memoriesFile       = path.join(root, 'memory-backup.jsonl'),
+        summariesFile      = path.join(root, 'summaries-backup.jsonl'),
+        graphFile          = path.join(root, 'graph-backup.jsonl'),
+        graphPath          = path.join(root, 'production-graph.sqlite'),
+        ledgerDir          = path.join(root, 'ledger'),
+        stagingRoot        = path.join(root, 'staging'),
+        graphDb            = createGraphDb(graphPath),
+        destinations       = {
+            memories : `test-memories-${collectionSuffix}`,
+            summaries: `test-summaries-${collectionSuffix}`,
+            graph    : graphPath
+        };
+
+    let   providerCalls            = 0;
+    const guardedEmbeddingFunction = dummyEmbeddingFunction ? {
+        name       : dummyEmbeddingFunction.name,
+        getConfig  : () => dummyEmbeddingFunction.getConfig(),
+        constructor: dummyEmbeddingFunction.constructor,
+        async generate(...args) {
+            providerCalls++;
+            return dummyEmbeddingFunction.generate(...args)
+        }
+    } : {
+        name: 'neo-test-dummy',
+        getConfig() {
+            return {}
+        },
+        async generate() {
+            providerCalls++;
+            throw new Error('provider path must remain unused')
+        }
+    };
+
+    await fs.writeFile(bundleManifestPath, JSON.stringify({bundleVersion: 1}));
+    await writeJsonl(memoriesFile, [
+        vectorRow('memory-1', [1, 0, 0]),
+        vectorRow('memory-2', [0, 1, 0]),
+        vectorRow('memory-3', [0, 0, 1])
+    ]);
+    await writeJsonl(summariesFile, [
+        vectorRow('summary-1', [0.5, 0.5, 0]),
+        vectorRow('summary-2', [0, 0.5, 0.5])
+    ]);
+    await writeJsonl(graphFile, [
+        {
+            type: 'node',
+            data: {
+                id        : 'restored-a',
+                label     : 'MEMORY',
+                properties: {name: 'A', userId: null}
+            }
+        },
+        {
+            type: 'node',
+            data: {
+                id        : 'restored-b',
+                label     : 'SESSION',
+                properties: {name: 'B', userId: null}
+            }
+        },
+        {
+            type: 'edge',
+            data: {
+                id        : 'restored-edge',
+                source    : 'restored-a',
+                target    : 'restored-b',
+                type      : 'SUMMARIZED_IN',
+                properties: {weight: 1, userId: null}
+            }
+        }
+    ]);
+
+    seedBootGraph(graphDb);
+    await client.createCollection({
+        name             : destinations.memories,
+        embeddingFunction: guardedEmbeddingFunction
+    });
+    await client.createCollection({
+        name             : destinations.summaries,
+        embeddingFunction: guardedEmbeddingFunction
+    });
+
+    const admission = await admitRestoreTargetSetBundle({
+        bundleManifestPath,
+        memoriesFile,
+        summariesFile,
+        graphFile,
+        expectedDimension: 3
+    });
+    const targetSet = {
+        ...createRestoreTargetSetDescriptor({
+            memoriesCollection            : destinations.memories,
+            summariesCollection           : destinations.summaries,
+            graphDestination              : destinations.graph,
+            bundleManifestFingerprint     : admission.bundleManifestFingerprint,
+            admissionDescriptorFingerprint: admission.descriptorFingerprint
+        }),
+        admission
+    };
+
+    return {
+        root,
+        ledgerDir,
+        stagingRoot,
+        client,
+        graphDb,
+        destinations,
+        dummyEmbeddingFunction: guardedEmbeddingFunction,
+        targetSet,
+        cacheInvalidations    : [],
+        graphCacheSyncs       : 0,
+        get providerCalls() {
+            return providerCalls
+        }
+    }
+}
+
+async function deleteFixtureCollections(fixture) {
+    const
+        identity = deriveRestoreTargetSetIdentity(fixture.targetSet),
+        suffix   = identity.attemptFingerprint.replace('sha256:', '').slice(0, 20),
+        names    = [
+            fixture.destinations.memories,
+            `${fixture.destinations.memories}-restore-shadow-${suffix}`,
+            `${fixture.destinations.memories}-restore-parking-${suffix}`,
+            fixture.destinations.summaries,
+            `${fixture.destinations.summaries}-restore-shadow-${suffix}`,
+            `${fixture.destinations.summaries}-restore-parking-${suffix}`
+        ];
+
+    for (const name of names) {
+        try {
+            await fixture.client.deleteCollection({name})
+        } catch {}
+    }
+}
+
+function createStorage(fixture, onPhase = () => {}) {
+    return createRestoreTargetSetStorage({
+        chromaClient          : fixture.client,
+        dummyEmbeddingFunction: fixture.dummyEmbeddingFunction,
+        graphDb               : fixture.graphDb,
+        expectedDestinations  : fixture.destinations,
+        stagingRoot           : fixture.stagingRoot,
+        invalidateCollectionCache(type) {
+            fixture.cacheInvalidations.push(type)
+        },
+        syncGraphCache() {
+            fixture.graphCacheSyncs++
+        },
+        onPhase
+    })
+}
+
+function createFakeChromaClient() {
+    const collections = new Map();
+
+    const client = {
+        async createCollection({name}) {
+            if (collections.has(name)) {
+                throw new Error(`collection '${name}' already exists`)
+            }
+
+            const rows       = new Map();
+            const collection = {
+                name,
+                async add({ids, embeddings, metadatas, documents}) {
+                    ids.forEach((id, index) => {
+                        if (rows.has(id)) {
+                            throw new Error(`duplicate id '${id}'`)
+                        }
+                        rows.set(id, {
+                            id,
+                            embedding: [...embeddings[index]],
+                            metadata : structuredClone(metadatas[index]),
+                            document : documents[index]
+                        })
+                    })
+                },
+                async count() {
+                    return rows.size
+                },
+                async get({ids}) {
+                    const selected = ids
+                        .filter(id => rows.has(id))
+                        .map(id => rows.get(id));
+
+                    return {
+                        ids       : selected.map(row => row.id),
+                        embeddings: selected.map(row => [...row.embedding]),
+                        metadatas : selected.map(row => structuredClone(row.metadata)),
+                        documents : selected.map(row => row.document)
+                    }
+                },
+                async modify({name: nextName}) {
+                    if (collections.has(nextName)) {
+                        throw new Error(`collection '${nextName}' already exists`)
+                    }
+                    collections.delete(collection.name);
+                    collection.name = nextName;
+                    collections.set(nextName, collection)
+                }
+            };
+
+            collections.set(name, collection);
+            return collection
+        },
+        async deleteCollection({name}) {
+            if (!collections.delete(name)) {
+                throw new Error(`collection '${name}' not found`)
+            }
+        },
+        async getCollection({name}) {
+            const collection = collections.get(name);
+            if (!collection) {
+                throw new Error(`collection '${name}' not found`)
+            }
+            return collection
+        }
+    };
+
+    return client
+}
+
+function createGraphDb(filePath) {
+    const db = new Database(filePath);
+    db.pragma('foreign_keys = ON');
+    db.exec(`
+        CREATE TABLE Nodes (
+            id TEXT PRIMARY KEY,
+            user_id TEXT,
+            data TEXT NOT NULL
+        );
+        CREATE TABLE Edges (
+            id TEXT PRIMARY KEY,
+            user_id TEXT,
+            source TEXT NOT NULL,
+            target TEXT NOT NULL,
+            type TEXT NOT NULL,
+            data TEXT NOT NULL,
+            FOREIGN KEY (source) REFERENCES Nodes(id) ON DELETE CASCADE,
+            FOREIGN KEY (target) REFERENCES Nodes(id) ON DELETE CASCADE
+        );
+    `);
+    return db
+}
+
+function seedBootGraph(db) {
+    const
+        manifest = createGraphBootSeedManifest(),
+        addNode  = db.prepare('INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)'),
+        addEdge  = db.prepare(
+            'INSERT INTO Edges (id, user_id, source, target, type, data) VALUES (?, ?, ?, ?, ?, ?)'
+        );
+
+    for (const node of manifest.nodes.map(createGraphBootSeedNodeRecord)) {
+        addNode.run(node.id, null, JSON.stringify(node))
+    }
+    for (const [index, edge] of manifest.edges.map(createGraphBootSeedEdgeRecord).entries()) {
+        const record = {id: `boot-edge-${index}`, ...edge};
+        addEdge.run(
+            record.id,
+            null,
+            record.source,
+            record.target,
+            record.type,
+            JSON.stringify(record)
+        )
+    }
+}
+
+function vectorRow(id, embedding) {
+    return {
+        id,
+        embedding,
+        metadata: {id},
+        document: `document:${id}`
+    }
+}
+
+async function writeJsonl(filePath, rows) {
+    await fs.writeFile(
+        filePath,
+        `${rows.map(row => JSON.stringify(row)).join('\n')}\n`
+    )
+}
+
+function transition(identity, sequence, previousState, state) {
+    return {
+        schemaVersion: 1,
+        type         : 'restore-target-set-transition',
+        ...identity,
+        sequence,
+        previousState,
+        state,
+        at     : sequence,
+        details: {}
+    }
+}

--- a/test/playwright/unit/ai/services/memory-core/helpers/restoreTargetSetStorage.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/restoreTargetSetStorage.spec.mjs
@@ -176,6 +176,144 @@ test.describe('restoreTargetSetStorage — fake Chroma + disposable SQLite targe
             reason: 'memories live storage advanced without a promoted transition'
         })
     });
+
+    for (const role of ['memories', 'summaries']) {
+        test(`contains a crash between the ${role} canonical-to-parking and shadow-to-canonical renames`, async () => {
+            const
+                storage  = createStorage(fixture),
+                identity = deriveRestoreTargetSetIdentity(fixture.targetSet),
+                context  = {
+                    targetSet : fixture.targetSet,
+                    descriptor: identity.descriptor,
+                    ...identity
+                },
+                staging   = await storage.stageTargetSet(context),
+                states    = ['admitted', 'fenced', 'staged'],
+                rowCounts = {memories: 3, summaries: 2};
+
+            await storage.validateStagedTargetSet({...context, staging});
+
+            if (role === 'summaries') {
+                await storage.promoteComponent({...context, staging, role: 'memories'});
+                states.push('promoted:memories')
+            }
+
+            for (const [index, state] of states.entries()) {
+                await appendRestoreTargetSetTransition({
+                    ...identity,
+                    state,
+                    at     : index + 1,
+                    details: {}
+                }, {dir: fixture.ledgerDir})
+            }
+
+            const live = await fixture.client.getCollection({
+                name             : fixture.destinations[role],
+                embeddingFunction: fixture.dummyEmbeddingFunction
+            });
+
+            await live.modify({name: staging.collections[role].parking});
+
+            const transitions = await readRestoreTargetSetTransitions({
+                dir               : fixture.ledgerDir,
+                attemptFingerprint: identity.attemptFingerprint
+            });
+            const reconciliation = await storage.reconcileAttempt({
+                ...context,
+                transitions
+            });
+
+            expect(reconciliation).toMatchObject({
+                safe         : false,
+                reason       : `${role} canonical storage is missing after vector promotion began`,
+                observedState: {
+                    [role]: {
+                        canonical: false,
+                        liveCount: null,
+                        shadow   : true,
+                        parking  : true
+                    }
+                }
+            });
+
+            const freshProof = await storage.inspectFreshTargetSet(context);
+            expect(freshProof).toMatchObject({
+                fresh : false,
+                reason: expect.stringContaining(
+                    `canonical ${role} collection '${fixture.destinations[role]}' is missing`
+                ),
+                components: {
+                    [role]: {
+                        count : null,
+                        exists: false
+                    }
+                }
+            });
+
+            await expect(storage.cleanupUnpromotedStaging({
+                ...context,
+                staging,
+                transitions
+            })).rejects.toThrow(
+                role === 'memories'
+                    ? 'refusing to delete restore staging because memories vector promotion may have begun'
+                    : 'refusing to delete restore staging after production promotion began'
+            );
+
+            const operation = createRestoreEmptyTargetOperation({
+                withWriterFence: async (identity, task) => task(),
+                ...storage,
+                readTransitions: ({attemptFingerprint}) => readRestoreTargetSetTransitions({
+                    dir: fixture.ledgerDir,
+                    attemptFingerprint
+                }),
+                appendTransition: input => appendRestoreTargetSetTransition(input, {
+                    dir: fixture.ledgerDir
+                })
+            });
+            const firstOutcome = await operation({
+                targetSet: fixture.targetSet,
+                ...identity
+            });
+
+            expect(firstOutcome).toMatchObject({
+                status: 'failed-contained',
+                detail: {
+                    terminal       : 'failed-contained',
+                    serviceEligible: false
+                }
+            });
+
+            const terminalTransitions = await readRestoreTargetSetTransitions({
+                dir               : fixture.ledgerDir,
+                attemptFingerprint: identity.attemptFingerprint
+            });
+            const secondOutcome = await operation({
+                targetSet: fixture.targetSet,
+                ...identity
+            });
+
+            expect(secondOutcome).toMatchObject({
+                status: 'failed-contained',
+                detail: {
+                    terminal       : 'failed-contained',
+                    serviceEligible: false
+                }
+            });
+            expect(await readRestoreTargetSetTransitions({
+                dir               : fixture.ledgerDir,
+                attemptFingerprint: identity.attemptFingerprint
+            })).toEqual(terminalTransitions);
+            expect(await fixture.client.getCollection({
+                name             : staging.collections[role].shadow,
+                embeddingFunction: fixture.dummyEmbeddingFunction
+            }).then(collection => collection.count())).toBe(rowCounts[role]);
+            expect(await fixture.client.getCollection({
+                name             : staging.collections[role].parking,
+                embeddingFunction: fixture.dummyEmbeddingFunction
+            }).then(collection => collection.count())).toBe(0)
+        })
+    }
 });
 
 test.describe('restoreTargetSetStorage — live disposable Chroma + SQLite target set', () => {


### PR DESCRIPTION
Resolves #15740

Related: #15639
Related: #15691
Related: #15692
Related: #15695
Related: #15739
Related: #15743
Related: #15756

Implements the orchestrator-owned `restore-empty-target` action for one admitted Memory Core target set: memories Chroma, summaries Chroma, and the SQLite graph. The action is default-off, classifier-selected, provider-free, writer-fenced, staged into run-owned destinations, promoted in memories → summaries → graph order, reconciled after crashes, and service-eligible only after a fail-loud strict ledger reaches `committed`.

Evidence: L3 (exact-head real disposable Chroma + SQLite execution at 5k/20k, plus focused unit/integration coverage) → L3 required (the complete #15740 action boundary and #15695 scale gate). No #15740 close-target residuals. The separate #15639 selector/consumer implementation remains with #15639, as this ticket's Out of Scope section requires.

## Deltas from ticket

No action-contract widening:

- One canonical `ai/graph/bootSeedManifest.mjs` is consumed by both graph boot and recovery proof. Freshness is exact-set/fingerprint equality, not row-count or loose “system-looking” state.
- The target-set descriptor, recovery-unit key, attempt fingerprint, admission, strict transition ledger, operation controller, and storage adapter are separate helpers under the existing Memory Core helper substrate.
- The existing graph JSONL importer was extracted into a shared helper so ordinary restore and isolated staging cannot drift into two import authorities.
- `restore-delta-merge` is removed from the action vocabulary without an alias. Collection-scoped actions reject `targetSet`; `restore-empty-target` requires `targetSet` and rejects `collection`.
- The merged #15756 meter receives a test-side adapter for the production action. A transient Chroma journal-file race discovered by the first exact run is contained by treating only `ENOENT` between directory enumeration and `stat()` as zero bytes; every other sampling error still fails loud.

The #15639 consumer is intentionally not implemented here. This PR exposes and pins the typed admitted-action boundary; #15639 must later consume that boundary without adding an importer or restore child process.

## Test Evidence

- Exact head `b61528dcdf6b86fde6eaa5d569a8ba3b8a4099e1`.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/restoreTargetSetStorage.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/restoreEmptyTargetOperation.spec.mjs` — 24 passed on the exact head, including both vector half-rename crash windows, failed-contained settlement, preservation, and repeated-resume idempotence.
- `npm run test-unit` on the equivalent pre-rebase implementation head — 9,104 passed, 6 skipped, 13 failed, and 32 did not run. All 13 failures were outside the changed tree and clustered in sandbox-blocked `ps`, `.neo-ai-data` permission/lifecycle cases, one AiConfig singleton-bleed case, and the real-tree timeout.
- `npm run agent-preflight -- --no-fix <changed files>` — passed. Only unrelated non-blocking stale-overlay warnings for existing `ai/config.mjs` leaves were reported.
- Pre-commit hooks passed: whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, block alignment, and parse.

Exact-head disposable target-set receipt:

| Profile | Status / terminal | Wall ms | Node heap HWM | Node RSS HWM | Chroma RSS HWM | Temp-disk HWM | Batch max | Provider calls |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 5k per vector store | completed / committed | 24,206 | 201,342,512 B | 451,428,352 B | 343,392,256 B | 271,468,720 B | 250 | 0 |
| 20k per vector store | completed / committed | 98,226 | 199,786,320 B | 462,602,240 B | 855,539,712 B | 1,034,193,943 B | 250 | 0 |

Both runs used 4,096-dimensional explicit vectors, 64 graph nodes, 63 graph edges, and 23,354 serialized graph bytes. Every named phase emitted separate start/completion receipts; all three staging targets validated before promotion; the strict ledger emitted eight transitions and opened eligibility only at `committed`. SQLite is intentionally non-separable because `better-sqlite3` executes inside the measured Node process. Chroma is separable and supplied 357 / 1,454 RSS samples.

The 4× vector-row increase produced 4.06× wall time, effectively flat Node heap/RSS, 2.49× Chroma RSS, and 3.81× logical temporary disk. The observed 20k Node RSS is 43.1% of the deployment's declared 1 GiB orchestrator limit; Chroma RSS is 39.8% of its declared 2 GiB limit. These are isolated action high-water marks, not a claim about full steady-state container co-residency, and the separate maxima must not be summed as a simultaneous peak.

Full phase/resource receipt: [#15695 exact-head receipt refresh](https://github.com/neomjs/neo/issues/15695#issuecomment-5060420247).

Report SHA-256:

- 5k: `658bce3ff64324d18fe83cc03e50993c05b6cadaf73d68cc87b5ac161fe2eaea`
- 20k: `a32c8004c542f9aa547d333d0e10761dc82dc753d22d479a77fcfef04a863246`

## Post-Merge Validation

- When #15639 lands, verify that it submits only the admitted `restore-empty-target` request and contains no importer invocation or restore child process.
- On the first cloud execution, compare cgroup baseline + action telemetry with the declared 1 GiB orchestrator / 2 GiB Chroma limits. The exact-head receipt measures action-specific high-water marks, not unrelated daemon baseline load.

## Signal Ledger

- GPT author: [AUTHOR_SIGNAL at the exact body hash](https://github.com/neomjs/neo/discussions/14032#discussioncomment-17739925), comment `DC_kwDODSospM4BDrCV`.
- Kimi non-author: [GRADUATION_APPROVED at the exact body hash](https://github.com/neomjs/neo/discussions/14032#discussioncomment-17739901), comment `DC_kwDODSospM4BDrB9`.
- Refreshed STEP_BACK: [signal-cycle gate and measured-evidence owner](https://github.com/neomjs/neo/discussions/14032#discussioncomment-17739888), comment `DC_kwDODSospM4BDrBw`.

## Unresolved Dissent

Empty for `restore-empty-target` at the folded-body anchor. The approval explicitly excludes `restore-shadow-fill`, count-based promotion, and replay.

## Unresolved Liveness

Gemini remains operator-benched under the Discussion's reactivation rule. Re-poll on reactivation before using a Gemini signal as authority for an action-contract change.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session `72bb1088-8ed5-48b7-a835-c288cf30e814`.
