### PR TITLE
fix(ai): persist cloud orchestrator state (#15759)

### DIFF
--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -129,8 +129,18 @@ function removePidFile() {
     } catch (e) {}
 }
 
-async function enforceSingleton() {
-    const pidFile = pidFilePath();
+/**
+ * @summary Reconciles the persisted daemon PID file and claims it for this process.
+ *
+ * A cloud container recreation may preserve a PID from the prior process epoch.
+ * Dead or unrelated holders are safe to replace; only a live command belonging
+ * to this daemon receives the graceful-termination path.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.pidFile=pidFilePath()] PID-file override for isolated recovery tests.
+ * @returns {Promise<void>}
+ */
+export async function enforceSingleton({pidFile = pidFilePath()} = {}) {
 
     if (fs.existsSync(pidFile)) {
         try {

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -191,6 +191,7 @@ services:
       - NEO_ORCHESTRATOR_MLX_ENABLED=false
       - NEO_ORCHESTRATOR_LMS_ENABLED=false
       - NEO_ORCHESTRATOR_OLLAMA_ENABLED=false
+      - NEO_AI_ORCHESTRATOR_DIR=/app/.neo-ai-data/orchestrator-daemon
       - NEO_TENANT_REPO_MIRROR_ROOT=/app/.neo-ai-data
       - NEO_HANDOFF_FILE_PATH=/app/.neo-ai-data/handoff/sandman_handoff.md
       - NEO_MODEL_PROVIDER=${NEO_MODEL_PROVIDER:-}
@@ -212,6 +213,12 @@ services:
       - NEO_ORCHESTRATOR_RUNTIME_ACCESS_READ_OPERATIONS=inspect,logs,stats
       - NEO_ORCHESTRATOR_RUNTIME_ACCESS_LIFECYCLE_OPERATIONS=restart
     volumes:
+      # Scheduler cadence, tenant-repo revisions, recovery ledgers, logs, and
+      # process-epoch files share AiConfig.orchestrator.dataDir. Persist the
+      # directory as one orchestrator-owned lifecycle boundary: PID/lease files
+      # remain safely reclaimable on boot, while continuity state survives a
+      # container recreate. This named volume is durability, not off-host backup.
+      - orchestrator-state:/app/.neo-ai-data/orchestrator-daemon
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
       - tenant-repo-mirrors:/app/.neo-ai-data/tenant-repos
       # The `golden-path` scheduler lane writes the handoff and its derived
@@ -250,7 +257,7 @@ services:
     # margin) = orchestrator is alive and polling. 90s start_period covers the
     # first-poll latency on cold container boot.
     healthcheck:
-      test: ["CMD-SHELL", "node -e \"const fs=require('fs');const f=(process.env.NEO_AI_ORCHESTRATOR_DIR||'/app/.neo-ai-data/orchestrator-daemon')+'/orchestrator-state.json';try{const m=fs.statSync(f).mtimeMs;process.exit(Date.now()-m<600000?0:1)}catch(e){process.exit(1)}\""]
+      test: ["CMD-SHELL", "node -e \"const fs=require('fs');const d=process.env.NEO_AI_ORCHESTRATOR_DIR;if(!d)process.exit(1);const f=d+'/orchestrator-state.json';try{const m=fs.statSync(f).mtimeMs;process.exit(Date.now()-m<600000?0:1)}catch(e){process.exit(1)}\""]
       interval: 60s
       timeout: 5s
       retries: 3
@@ -344,6 +351,7 @@ networks:
 
 volumes:
   chroma-data:
+  orchestrator-state:
   shared-sqlite-data:
   shared-handoff-data:
   tenant-repo-mirrors:

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -89,6 +89,12 @@ Delivered by Sub C / Sub D:
 - Healthcheck/readiness semantics for KB and MC, plus cloud-orchestrator startup
   gating on healthy MCP server containers.
 
+Delivered by follow-up persistence hardening:
+
+- A dedicated `orchestrator-state` named volume, explicitly bound through
+  `NEO_AI_ORCHESTRATOR_DIR`, so scheduler, tenant-ingestion, recovery, and
+  diagnostic continuity survives orchestrator-container recreation.
+
 Still owned by follow-up deployment hardening:
 
 - Optional platform variants for Kubernetes, managed Chroma, managed SQL, and
@@ -128,9 +134,19 @@ The deployment substrates have different recovery properties:
   scales with tenant count.
 - Memory Core graph/session data is a primary store. A wipe between backups is
   data loss.
+- Orchestrator runtime continuity lives on the `orchestrator-state` named volume
+  at `/app/.neo-ai-data/orchestrator-daemon`. It survives a container recreate
+  when the Compose project name stays stable. This includes task cadence,
+  tenant-repo revision/backoff state, recovery ledgers, and logs. Persisted PID
+  and lease files are process-epoch artifacts; boot reconciliation safely
+  reclaims dead owners instead of deleting the continuity directory.
 - Backup bundles persist via a host bind-mount (`./.neo-ai-data/backups` on the
   `cloud`-profile orchestrator) that survives container rebuilds; off-site copy
   or a managed-object-storage target is the disaster-recovery layer above that.
+
+A named volume is **container-recreation durability**, not disaster recovery.
+The current backup bundle does not copy `orchestrator-state`; include that
+volume in an explicit off-host backup policy before claiming host-loss recovery.
 
 The orchestrator consumes model-provider endpoints for `summary`, `dream`, and
 similar lanes. External provider endpoints are the MVP default. A self-hosted
@@ -373,8 +389,10 @@ so the `GitMirror` primitive has a persistent clone target. The env-bound Tier-1
 the helper `deriveTenantRepoMirrorPath` appends the `tenant-repos/<tenant>/<repo>` segment. Per-repo `lastIngestedRev`
 persistence lives in the orchestrator state dir
 (`<NEO_AI_ORCHESTRATOR_DIR>/tenant-repo-sync-revisions.json`), so it survives a
-container restart alongside the rest of the orchestrator state. The mirror cache
-itself is reproducible from upstream git — backup is optional, not load-bearing.
+container restart on the dedicated `orchestrator-state` named volume. This is
+not an off-host backup claim: the mirror cache itself is reproducible from
+upstream git, while operators who require host-loss recovery for revision
+continuity must back up the orchestrator-state volume separately.
 
 The `tenant-repo-sync` lane is gated by `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED`
 (cloud profile default-on; local maintainer profile default-off) and runs on a

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -685,11 +685,15 @@ Minimum handoff checklist:
 ```text
 [ ] shared-sqlite-data volume or managed graph-store path is persistent.
 [ ] shared-handoff-data is mounted by orchestrator and mc-server at the configured handoff path.
+[ ] orchestrator-state is mounted at NEO_AI_ORCHESTRATOR_DIR; record hashes for
+    orchestrator-state.json and tenant-repo-sync-revisions.json before redeploy.
 [ ] after a successful golden-path cycle, get_sandman_handoff returns non-null content.
 [ ] backup bundles write to the redeploy-safe backup mount.
 [ ] after docker compose down && docker compose up --build, MC healthcheck is healthy.
 [ ] the memory written in Milestone 1 can still be queried.
 [ ] get_sandman_handoff still returns the pre-redeploy handoff until the next cycle replaces it.
+[ ] the orchestrator state/revision values and hashes still match after the
+    recreated orchestrator starts; stale PID/lease artifacts did not block boot.
 [ ] KB Neo-shared content is either still present or re-synced successfully.
 [ ] tenant content is either still present or re-pushed by the hook/CI job.
 [ ] endpoint URLs, token source, tenant id, repo slug, and known failure signatures are documented for the next agent.

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -46,6 +46,7 @@ The deployment's persistent state (`ai/deploy/docker-compose.yml`):
 | Memory Core graph + sessions — the **primary store** | `shared-sqlite-data` named volume → `/app/.neo-ai-data/sqlite` | `down -v`, or the Compose project name changes |
 | Chroma vectors | `chroma-data` named volume → `/chroma/unified` (set via `PERSIST_DIRECTORY`) | `down -v`, or the project name changes (recoverable by re-sync/re-push, at cost) |
 | Sandman handoff + derived route artifacts | `shared-handoff-data` named volume → `/app/.neo-ai-data/handoff` (writer and reader share `NEO_HANDOFF_FILE_PATH`) | `down -v`, or the Compose project name changes |
+| Orchestrator task, tenant-repo revision/backoff, recovery, and diagnostic state | `orchestrator-state` named volume → `/app/.neo-ai-data/orchestrator-daemon` (bound through `NEO_AI_ORCHESTRATOR_DIR`) | `down -v`, or the Compose project name changes |
 | Backup bundles | host bind-mount `./.neo-ai-data/backups` on the `cloud`-profile `orchestrator` | the compose file's host location changes between runs |
 | TLS certs / CA | `caddy-data` / `caddy-config` named volumes (`ingress` profile) | `down -v` (re-issued on next start — watch ACME rate limits) |
 | Local model store — opt-in `local-model` profile | `local-model-data` named volume → `/root/.ollama` | `down -v`, or the project name changes (recoverable — re-pull the models) |
@@ -56,9 +57,14 @@ Three rules keep a redeploy job safe:
 2. **Pin the Compose project name.** Named volumes are identified as `<project-name>_<volume>`. The project name defaults to the compose-file directory's basename (`deploy`). A redeploy run with a different `--project-name` (or after the compose file moves) gets *fresh, empty* volumes — the old data is intact but unreferenced. Pass an explicit, stable `--project-name` (the reference script pins one) so every redeploy reattaches the same volumes.
 3. **Deploy from a stable host location.** The backup-bundle bind-mount `./.neo-ai-data/backups` resolves relative to the compose file's project directory. If the deployment repo is checked out to a different host path on each run — common with ephemeral CI runners — the bind-mount points at a different host directory each time and prior bundles are orphaned. Deploy from a **persistent checkout location** on the deployment host, not an ephemeral per-run runner workspace; or retarget backups to an absolute host path / managed object storage.
 
-Off-site copy of the backup bundles is the disaster-recovery layer *above* redeploy-safety: redeploy-safety keeps state across a container *recreate*; backups plus off-site copy cover host loss.
+Off-site copy is the disaster-recovery layer *above* redeploy-safety:
+redeploy-safety keeps named-volume state across a container *recreate*, while
+host-loss recovery requires exporting every load-bearing named volume. The
+current logical backup bundle does not include `orchestrator-state`; copy or
+export that volume separately before claiming that its task/revision/recovery
+state is off-host backed up.
 
-**Verification:** the redeploy-survival check is [Day-0 Tutorial Milestone 7](./Day0Tutorial.md) — a `docker compose down && docker compose up --build` cycle, then confirm the Memory Core store, Sandman handoff, and backup bundles are intact. Run that check once when the pipeline is first wired; subsequent redeploys rely on the named-volume + project-name + bind-mount contract above.
+**Verification:** the redeploy-survival check is [Day-0 Tutorial Milestone 7](./Day0Tutorial.md) — a `docker compose down && docker compose up --build` cycle, then confirm the Memory Core store, Sandman handoff, orchestrator task/revision state, and backup bundles are intact. Run that check once when the pipeline is first wired; subsequent redeploys rely on the named-volume + project-name + bind-mount contract above.
 
 ## The health gate
 
@@ -75,6 +81,7 @@ A deploy job that does not gate on health reports success while serving a broken
 |---|---|---|
 | Healthcheck never goes healthy after redeploy | image build broken, a required env var unset, or Chroma unreachable | fail the job; surface `docker compose logs`; the prior volumes are intact for a retry |
 | Memory Core store empty after redeploy | the job ran `docker compose down -v`, or redeployed under a different `--project-name` | never `-v`; pin `--project-name` — the old volume still holds the data, reattach it |
+| Tenant-repo revisions or orchestrator task history reset after redeploy | `orchestrator-state` is absent/replaced, or `NEO_AI_ORCHESTRATOR_DIR` does not match its mount target | reattach the stable volume and keep the env, mount, and healthcheck on `/app/.neo-ai-data/orchestrator-daemon` |
 | `get_sandman_handoff` returns `handoff-not-found` after a successful cycle | writer and reader do not share `NEO_HANDOFF_FILE_PATH`, or `shared-handoff-data` was replaced | inspect both service env/mounts; reattach the stable named volume; never repair this by KB-ingesting the handoff |
 | Backup bundles missing after redeploy | redeployed from a different host checkout location (relative bind-mount) | deploy from a stable checkout path; recover bundles from the prior host directory |
 | TLS cert re-issued / ACME rate-limited each deploy | `caddy-data` removed by `down -v` | stop using `-v` so the issued certs persist |

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -261,7 +261,7 @@ The mirror directory is a deployment cache, not authoritative state. Per-repo `l
 
 Mirrors are reproducible from upstream git. **Backup is not required** for correctness — on redeploy, `GitMirror.cloneIfMissing()` re-clones any missing mirror on the next sync. Operators who want faster cold-start recovery may include the `tenant-repo-mirrors` volume in their backup bundle, but this is an operational preference, not a Chroma/MC correctness dependency.
 
-`lastIngestedRev` persistence in `tenant-repo-sync-revisions.json` IS load-bearing for incremental ingestion. Treat that file as part of the orchestrator state dir (already backed up alongside the orchestrator's other state).
+`lastIngestedRev` persistence in `tenant-repo-sync-revisions.json` IS load-bearing for incremental ingestion. The canonical cloud profile keeps that file on the dedicated `orchestrator-state` named volume, so it survives orchestrator-container recreation under a stable Compose project name. That volume is **not** an off-host backup; include it in an explicit backup/export policy before claiming host-loss recovery.
 
 ### Health and Telemetry
 

--- a/test/playwright/integration/AdoptionLadderJourney.integration.spec.mjs
+++ b/test/playwright/integration/AdoptionLadderJourney.integration.spec.mjs
@@ -1,19 +1,23 @@
-import {randomUUID}                                                       from 'node:crypto';
-import {test, expect}                                                     from '@playwright/test';
+import {spawnSync}                                                         from 'node:child_process';
+import {randomUUID}                                                        from 'node:crypto';
+import fs                                                                  from 'node:fs';
+import {fileURLToPath}                                                     from 'node:url';
+import {test, expect}                                                      from '@playwright/test';
+import * as yaml                                                           from 'js-yaml';
 import {callHealthcheck, callJsonTool, createIdentityClient, getReadiness} from './fixtures/mcpClient.mjs';
 
 /**
- * #11725 Sub D — the incremental adoption-ladder journey proof (Discussion #11718 §8).
+ * The incremental adoption-ladder journey proof.
  *
  * The per-capability integration specs (`healthcheck`, `RemoteMcpTransport`,
  * `ai/kb-ingestion/multi-tenant`, `BackupRestoreWipe`) each prove ONE rung in isolation.
  * This spec proves the operator JOURNEY: the adoption-ladder milestones run as an ordered,
  * each-independently-verifiable sequence against the same Dockerized cloud-profile stack a
- * fresh operator deploys — the central #11720 mission proof ("a fresh agent/operator
+ * fresh operator deploys — the central cloud-deployment proof ("a fresh agent/operator
  * completes the adoption ladder without tacit maintainer knowledge").
  *
- * Test-evidence lane (1) — CI-safe deterministic (per @neo-gpt's #11718 test-strategy
- * `DC_kwDODSospM4BA4Rx`): runs against `ai/deploy/docker-compose.test.yml` via the
+ * Test-evidence lane (1) — CI-safe deterministic: runs against
+ * `ai/deploy/docker-compose.test.yml` via the
  * integration `composeWebServer`; no heavyweight local-model inference. Lanes (2) the
  * heavyweight local/docker provider proof and (3) the manual real-world harness demo are
  * kept distinct and are not run here.
@@ -24,21 +28,51 @@ import {callHealthcheck, callJsonTool, createIdentityClient, getReadiness} from 
  * reconciliation) remain owned by the per-capability specs above; duplicating them here
  * would couple the journey proof to embedding-fixture internals.
  *
- * Ladder coverage (`Refs #11725`): milestones 0-5 run as LIVE rungs — the connectivity
+ * Ladder coverage: milestones 0-5 run as LIVE rungs — the connectivity
  * ladder (0-2) plus tenant ingestion (3), the `parsed-chunk-v1` client-side-parser
- * transport gate (4), and the bulk/backfill volume gate (5). Milestones 6-7 are
- * documented-DEFERRED rungs, not fabricated assertions: server-side clone (6) is post-MVP
- * (#11731 exploration; ADR 0014 D3 keeps it out of the MVP profile) and the full
- * backup → redeploy → handoff round-trip (7) is owned by the per-capability backup specs
- * plus test-evidence lane (3) — a single Playwright spec cannot redeploy the
- * `composeWebServer` stack mid-run. Each deferred rung carries a precise `test.skip`
- * citation so the ladder reaches all 8 milestones without over-claiming.
+ * transport gate (4), and the bulk/backfill volume gate (5). Milestone 6 remains
+ * a documented-DEFERRED rung, not a fabricated assertion: server-side clone is
+ * post-MVP and deliberately kept out of the MVP profile.
+ * Milestone 7's backup → redeploy → handoff round-trip is split honestly: this spec runs a
+ * Docker-backed container-recreation witness for the orchestrator's dedicated
+ * state volume, while the whole-stack backup/restore/handoff round-trip remains
+ * owned by the per-capability specs plus test-evidence lane (3). A single
+ * Playwright spec cannot redeploy the shared `composeWebServer` stack mid-run.
  *
  * @see https://github.com/neomjs/neo/issues/11725
  */
 
-const KB_URL = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
-const MC_URL = process.env.NEO_INTEGRATION_MC_URL || 'http://127.0.0.1:13001';
+const KB_URL                  = process.env.NEO_INTEGRATION_KB_URL || 'http://127.0.0.1:13000';
+const MC_URL                  = process.env.NEO_INTEGRATION_MC_URL || 'http://127.0.0.1:13001';
+const PRODUCTION_COMPOSE_PATH = fileURLToPath(
+    new URL('../../../ai/deploy/docker-compose.yml', import.meta.url)
+);
+
+/**
+ * @summary Runs a Docker CLI command and returns its trimmed stdout.
+ * @param {String[]} args Docker CLI arguments.
+ * @returns {String}
+ */
+function runDocker(args) {
+    const result = spawnSync('docker', args, {encoding: 'utf8'});
+
+    if (result.status !== 0) {
+        throw new Error(
+            `docker ${args.join(' ')} failed (${result.status}): ${result.stderr || result.stdout}`
+        );
+    }
+
+    return result.stdout.trim();
+}
+
+/**
+ * @summary Parses the final JSON line emitted by a short-lived witness container.
+ * @param {String} output Captured container stdout.
+ * @returns {Object}
+ */
+function parseLastJsonLine(output) {
+    return JSON.parse(output.split('\n').at(-1));
+}
 
 /**
  * Builds a well-formed `parsed-chunk-v1` record — the shape a fresh operator's client-side
@@ -216,7 +250,7 @@ test.describe('Adoption-ladder journey proof — #11725 Sub D (milestones 0-7)',
         }));
 
         try {
-            const result    = await client.callTool({
+            const result = await client.callTool({
                 name     : 'ingest_source_files',
                 arguments: {tenantId: 'journey-operator', repoSlug: 'journey-ladder', files: oversizedBatch}
             });
@@ -246,7 +280,93 @@ test.describe('Adoption-ladder journey proof — #11725 Sub D (milestones 0-7)',
         );
     });
 
-    test('Milestone 7 — backup → redeploy → handoff: round-trip owned by the per-capability backup specs', async () => {
+    test('Milestone 7a — orchestrator continuity state survives a fresh container on its named volume', () => {
+        const compose      = yaml.load(fs.readFileSync(PRODUCTION_COMPOSE_PATH, 'utf8'));
+        const orchestrator = compose.services.orchestrator;
+        const dataDirEntry = orchestrator.environment.find(entry =>
+            entry.startsWith('NEO_AI_ORCHESTRATOR_DIR=')
+        );
+        const dataDir    = dataDirEntry?.slice(dataDirEntry.indexOf('=') + 1);
+        const stateMount = orchestrator.volumes.find(entry =>
+            typeof entry === 'string' && entry.endsWith(`:${dataDir}`)
+        );
+        const composeVolumeName  = stateMount?.slice(0, stateMount.indexOf(':'));
+        const witnessVolumeName  = `neo-15759-orchestrator-state-${randomUUID()}`;
+        const mount              = `${witnessVolumeName}:${dataDir}`;
+        const representativeData = {
+            'orchestrator-state.json': {
+                tasks: {'tenant-repo-sync': {lastRunAt: 1784822400000, status: 'completed'}}
+            },
+            'tenant-repo-sync-revisions.json': {
+                revisions: {
+                    'fixture/repo': {
+                        lastIngestedRev    : 'fixture-revision',
+                        lastRunAttemptAt   : 1784822400000,
+                        consecutiveFailures: 0
+                    }
+                }
+            },
+            'restore-empty-target-ledger/fixture-run.json': {
+                operationId: 'fixture-run',
+                phase      : 'committed'
+            },
+            'orchestrator-daemon.pid'     : '2147483647',
+            'heavy-maintenance-lease.json': {
+                owner     : 'fixture-maintenance',
+                pid       : 2147483647,
+                acquiredAt: '2026-07-22T00:00:00.000Z',
+                token     : 'fixture-token'
+            }
+        };
+        const witnessScript = `
+            const crypto = require('node:crypto');
+            const fs = require('node:fs');
+            const os = require('node:os');
+            const path = require('node:path');
+            const dir = process.argv[1];
+            const input = process.argv[2] ? JSON.parse(process.argv[2]) : null;
+            if (input) {
+                for (const [name, value] of Object.entries(input)) {
+                    const target = path.join(dir, name);
+                    fs.mkdirSync(path.dirname(target), {recursive: true});
+                    fs.writeFileSync(target, typeof value === 'string' ? value : JSON.stringify(value));
+                }
+            }
+            const names = input ? Object.keys(input) : JSON.parse(process.argv[3]);
+            const values = Object.fromEntries(names.map(name => {
+                const raw = fs.readFileSync(path.join(dir, name));
+                return [name, {
+                    hash : crypto.createHash('sha256').update(raw).digest('hex'),
+                    value: name.endsWith('.json') ? JSON.parse(raw) : raw.toString()
+                }];
+            }));
+            process.stdout.write(JSON.stringify({containerId: os.hostname(), values}));
+        `;
+
+        expect(dataDir).toBe('/app/.neo-ai-data/orchestrator-daemon');
+        expect(compose.volumes).toHaveProperty(composeVolumeName);
+        expect(composeVolumeName).toBe('orchestrator-state');
+
+        runDocker(['volume', 'create', witnessVolumeName]);
+
+        try {
+            const written = parseLastJsonLine(runDocker([
+                'run', '--rm', '--volume', mount, 'node:24-alpine',
+                'node', '-e', witnessScript, dataDir, JSON.stringify(representativeData), '[]'
+            ]));
+            const readBack = parseLastJsonLine(runDocker([
+                'run', '--rm', '--volume', mount, 'node:24-alpine',
+                'node', '-e', witnessScript, dataDir, '', JSON.stringify(Object.keys(representativeData))
+            ]));
+
+            expect(readBack.containerId).not.toBe(written.containerId);
+            expect(readBack.values).toEqual(written.values);
+        } finally {
+            runDocker(['volume', 'rm', witnessVolumeName]);
+        }
+    });
+
+    test('Milestone 7b — full backup → redeploy → handoff remains a separate whole-stack proof', async () => {
         test.skip(true,
             'The backup → wipe → restore round-trip is owned by KBBackupRestoreWipe.integration.spec.mjs ' +
             '(#11644) and BackupRestoreWipe.integration.spec.mjs. The full redeploy → handoff demo — ' +

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -1,9 +1,12 @@
 import {test, expect} from '@playwright/test';
 import fs             from 'fs';
+import os             from 'os';
 import path           from 'path';
+import * as yaml      from 'js-yaml';
 import '../../../../../../src/Neo.mjs';
 import '../../../../../../src/core/_export.mjs';
 import {
+    enforceSingleton,
     LOCAL_AI_CONFIG_FILE,
     isOrchestratorDaemonCommand,
     loadLocalAiConfig
@@ -325,6 +328,52 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(isOrchestratorDaemonCommand('node /repo/ai/daemons/wake/daemon.mjs')).toBe(false);
         expect(isOrchestratorDaemonCommand(`node /repo/${legacyScriptsPath}`)).toBe(false);
         expect(isOrchestratorDaemonCommand('node daemon.mjs')).toBe(false);
+    });
+
+    test('#15759: cloud Compose gives the AiConfig data dir one dedicated, sole-owner volume', () => {
+        const compose        = yaml.load(fs.readFileSync(path.resolve(process.cwd(), 'ai/deploy/docker-compose.yml'), 'utf8'));
+        const dataDir        = '/app/.neo-ai-data/orchestrator-daemon';
+        const volumeName     = 'orchestrator-state';
+        const expectedMount  = `${volumeName}:${dataDir}`;
+        const orchestrator   = compose.services.orchestrator;
+        const healthcheckCmd = orchestrator.healthcheck.test.join(' ');
+
+        expect(compose.volumes).toHaveProperty(volumeName);
+        expect(orchestrator.environment).toContain(`NEO_AI_ORCHESTRATOR_DIR=${dataDir}`);
+        expect(orchestrator.volumes).toContain(expectedMount);
+        expect(healthcheckCmd).toContain('process.env.NEO_AI_ORCHESTRATOR_DIR');
+        expect(healthcheckCmd).not.toContain(`||'${dataDir}'`);
+
+        for (const [serviceName, service] of Object.entries(compose.services)) {
+            if (serviceName === 'orchestrator') continue;
+
+            expect(
+                service.volumes || [],
+                `${serviceName} must not read or write the orchestrator-owned state volume`
+            ).not.toContain(expectedMount);
+            expect(
+                (service.volumes || []).some(mount =>
+                    typeof mount === 'string' &&
+                    (mount.startsWith(`${volumeName}:`) || mount.endsWith(`:${dataDir}`))
+                ),
+                `${serviceName} must not alias the orchestrator-owned source or target`
+            ).toBe(false);
+        }
+    });
+
+    test('#15759: a dead persisted daemon PID is reclaimed on the next process epoch', async () => {
+        const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-orchestrator-stale-pid-'));
+        const pidFile = path.join(dataDir, 'orchestrator-daemon.pid');
+
+        try {
+            fs.writeFileSync(pidFile, '2147483647', 'utf8');
+
+            await enforceSingleton({pidFile});
+
+            expect(fs.readFileSync(pidFile, 'utf8')).toBe(String(process.pid));
+        } finally {
+            fs.rmSync(dataDir, {recursive: true, force: true});
+        }
     });
 
     test('loads gitignored top-level AI config only when present', async () => {


### PR DESCRIPTION
Resolves #15759

The cloud orchestrator now owns a dedicated `orchestrator-state` named volume at the existing `AiConfig.orchestrator.dataDir` path. Compose binds `NEO_AI_ORCHESTRATOR_DIR` explicitly, the healthcheck fails closed on that same env-owned path, and no sibling service can mount the source or target. Scheduler cadence, tenant-repo revision/backoff state, recovery ledgers, logs, and process-epoch artifacts therefore share one container-recreation lifecycle boundary.

Persisting process artifacts does not turn them into permanent blockers: the daemon's existing singleton reconciliation is now directly testable and proves a dead PID is replaced, while the established heavy-maintenance lease coverage proves dead owners are reclaimed. Cloud guides now distinguish named-volume durability from off-host backup and no longer claim that the revision manifest is already backed up.

Decision Record impact: aligned with ADR 0014 and ADR 0019; no amendment required. The orchestrator remains its own cloud container, persistence stays at the existing Compose boundary, and consumers continue reading `AiConfig.orchestrator.dataDir` rather than re-reading or re-deriving env state.

Evidence: L3 (real Docker named-volume container recreation in CI, plus local static/unit proof) → L3 required (the ticket requires a live or CI recreate witness). The `integration-unified` job executed Milestone 7a in 561ms and finished 49 passed / 2 skipped. The external cloud deployment remains a post-merge rollout validation, not evidence fabricated by local logic tests.

## Deltas from ticket

- No state format or scheduler redesign. The change supplies the missing deployment lifecycle boundary.
- The Compose contract test pins declaration, sole ownership, env binding, mount target, and healthcheck alignment.
- The integration journey derives the volume name and target from production Compose, writes representative task, revision/backoff, recovery-ledger, PID, and lease artifacts in one short-lived container, then verifies identical SHA-256 values from a different fresh container.
- The full shared-stack backup → redeploy → handoff round-trip remains separately owned; this PR does not stop the integration suite's shared Compose stack mid-run or call a named volume disaster recovery.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs` — 40 passed.
- `docker compose -f ai/deploy/docker-compose.yml --profile cloud config --quiet` — passed.
- Local `npm run test-integration-unified -- test/playwright/integration/AdoptionLadderJourney.integration.spec.mjs` — the spec loaded successfully; 9 tests skipped because Docker/Colima is not running locally.
- GitHub `integration-unified` — passed in 3m59s; Milestone 7a executed the real two-container named-volume hash witness in 561ms, and the job finished 49 passed / 2 skipped.
- `npm run ai:lint-config-template-ssot` — passed.
- `npm run ai:lint-guides` — 0 hard findings; 28 repository-wide warnings.
- `npm run agent-preflight` — passed; only unrelated non-blocking stale-overlay warnings for the existing local `ai/config.mjs` remained.
- Pre-commit hooks passed: whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, block alignment, and parse.

## Post-Merge Validation

- On the next cloud rollout, record `orchestrator-state.json` and `tenant-repo-sync-revisions.json` values/hashes, recreate the orchestrator container without `down -v`, and verify the values persist, the healthcheck becomes healthy, and stale PID/lease artifacts do not block boot.
- Confirm operators pin the Compose project name; changing it intentionally selects a different named volume.
- Define a separate off-host export policy for `orchestrator-state` before claiming host-loss recovery.

## Evolution

The older deployment story treated broad “redeploy-safe persistence” as if it covered every orchestrator-owned file. Current-source falsification exposed the gap: the healthcheck depended on a state file stored only on the ephemeral container layer. The new contract test makes env, mount, ownership, and healthcheck alignment one mechanically checked boundary, while the Docker witness keeps local logic correctness distinct from container-recreation evidence.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session `72bb1088-8ed5-48b7-a835-c288cf30e814`.
