### PR TITLE
fix(ai): revalidate legacy tenant repo checkpoints (#15761)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -24,6 +24,11 @@ import {
     buildTenantRepoSyncTrigger,
     isRepoDue
 } from '../scheduling/tenantRepoSync.mjs';
+import {
+    classifyTenantRepoCheckpoint,
+    normalizeTenantRepoCheckpointState,
+    TENANT_REPO_INGEST_CONTRACT_VERSION
+} from './tenantRepoCheckpointValidity.mjs';
 
 const KB_CONFIG_BOOTSTRAP_PROJECTION_BY_STATUS = Object.freeze({
     missing: {
@@ -598,9 +603,11 @@ export class DeploymentStateBridgeService extends Base {
             },
             errors         = [];
 
-        let enabled       = null,
-            taskState     = null,
-            configSummary = {
+        let enabled                    = null,
+            taskState                  = null,
+            configEnumerationAvailable = true,
+            revisionStateAvailable     = true,
+            configSummary              = {
                 status       : 'unavailable',
                 repoCount    : 0,
                 disabledCount: 0,
@@ -646,6 +653,7 @@ export class DeploymentStateBridgeService extends Base {
             repos = Array.isArray(resolvedConfig.tenantRepos) ? resolvedConfig.tenantRepos : [];
             configSummary = summarizeTenantRepoConfig(repos, resolvedConfig.configDiagnostics);
         } catch (error) {
+            configEnumerationAvailable = false;
             errors.push(summarizeDiagnosticError(error, 'tenant-repo-config-read-failed'));
             configSummary = {
                 ...configSummary,
@@ -664,6 +672,7 @@ export class DeploymentStateBridgeService extends Base {
                 strict  : true
             });
         } catch (error) {
+            revisionStateAvailable = false;
             errors.push(summarizeDiagnosticError(error, 'tenant-repo-revision-state-read-failed'));
         }
 
@@ -672,6 +681,7 @@ export class DeploymentStateBridgeService extends Base {
             observedAt,
             taskState,
             persistedRepoState: persistedRevisions[createTenantRepoLabel(repo)] || null,
+            revisionStateAvailable,
             globalCadenceMs   : scheduler.globalCadenceMs,
             jitterRatio       : scheduler.jitterRatio
         }));
@@ -691,8 +701,12 @@ export class DeploymentStateBridgeService extends Base {
             }),
             enabled,
             scheduler,
-            task  : summarizeTenantRepoTaskState(taskState),
-            config: configSummary,
+            task                  : summarizeTenantRepoTaskState(taskState),
+            config                : configSummary,
+            checkpointRevalidation: summarizeCheckpointRevalidation({
+                repoStates,
+                stateAvailable: configEnumerationAvailable && revisionStateAvailable
+            }),
             repos : repoStates,
             errors
         };
@@ -980,14 +994,15 @@ function summarizeTenantRepoTaskCompletion(completion) {
     }
 
     const summary = {
-        status        : completion.status || null,
-        reason        : completion.reason || null,
-        reasonCode    : completion.reasonCode || null,
-        repoCount     : numberOrNull(completion.repoCount),
-        completedCount: numberOrNull(completion.completedCount),
-        failedCount   : numberOrNull(completion.failedCount),
-        notDueCount   : numberOrNull(completion.notDueCount),
-        repos         : []
+        status                   : completion.status || null,
+        reason                   : completion.reason || null,
+        reasonCode               : completion.reasonCode || null,
+        repoCount                : numberOrNull(completion.repoCount),
+        completedCount           : numberOrNull(completion.completedCount),
+        failedCount              : numberOrNull(completion.failedCount),
+        notDueCount              : numberOrNull(completion.notDueCount),
+        revalidationDeferredCount: numberOrNull(completion.revalidationDeferredCount),
+        repos                    : []
     };
 
     if (Array.isArray(completion.repos)) {
@@ -1013,34 +1028,96 @@ function summarizeTenantRepoOutcome(outcome) {
     };
 }
 
-function summarizeTenantRepoState({repo, observedAt, taskState, persistedRepoState, globalCadenceMs, jitterRatio}) {
+/**
+ * @summary Builds aggregate, non-identifying checkpoint-revalidation counts for
+ * the tenant-repo deployment snapshot.
+ * @param {Object} options
+ * @param {Object[]} options.repoStates Redacted per-repo diagnostic rows.
+ * @param {Boolean} options.stateAvailable Whether repo enumeration and the persisted manifest were readable.
+ * @returns {Object}
+ */
+function summarizeCheckpointRevalidation({repoStates, stateAvailable}) {
+    const summary = {
+        status                      : stateAvailable ? 'available' : 'unavailable',
+        currentIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+        pendingCount                : stateAvailable ? 0 : null,
+        failedCount                 : stateAvailable ? 0 : null,
+        completeCount               : stateAvailable ? 0 : null,
+        uninitializedCount          : stateAvailable ? 0 : null,
+        unsupportedCount            : stateAvailable ? 0 : null
+    };
+
+    if (!stateAvailable) {
+        return summary;
+    }
+
+    for (const repoState of repoStates) {
+        const countKey = `${repoState.checkpointStatus}Count`;
+
+        if (Object.hasOwn(summary, countKey)) {
+            summary[countKey]++;
+        }
+    }
+
+    return summary;
+}
+
+/**
+ * @summary Projects one configured repository into a redacted scheduler and
+ * checkpoint-revalidation diagnostic row.
+ * @param {Object} options
+ * @param {Object} options.repo Effective tenant-repo configuration.
+ * @param {Number} options.observedAt Snapshot epoch.
+ * @param {Object|null} options.taskState Current scheduler task state.
+ * @param {Object|null} options.persistedRepoState Persisted checkpoint state.
+ * @param {Boolean} options.revisionStateAvailable Whether the manifest was readable.
+ * @param {Number} options.globalCadenceMs Global per-repo cadence.
+ * @param {Number} options.jitterRatio Deterministic jitter ratio.
+ * @returns {Object}
+ */
+function summarizeTenantRepoState({
+    repo,
+    observedAt,
+    taskState,
+    persistedRepoState,
+    revisionStateAvailable,
+    globalCadenceMs,
+    jitterRatio
+}) {
     const
-        disabled = isTenantRepoDisabled(repo),
-        dueState = disabled
-            ? {due: false, effectiveCadenceMs: null, jitterMs: null, backoffMultiplier: null, lastRunAttemptAt: persistedRepoState?.lastRunAttemptAt || 0}
-            : isRepoDue({repo, persistedRepoState, now: observedAt, globalCadenceMs, jitterRatio}),
-        nextDueAtMs  = Number.isFinite(dueState.effectiveCadenceMs)
+        normalizedCheckpoint = normalizeTenantRepoCheckpointState(persistedRepoState),
+        checkpointStatus     = revisionStateAvailable
+            ? classifyTenantRepoCheckpoint(normalizedCheckpoint)
+            : 'unavailable',
+        disabled              = isTenantRepoDisabled(repo),
+        dueState              = disabled
+            ? {due: false, effectiveCadenceMs: null, jitterMs: null, backoffMultiplier: null, lastRunAttemptAt: normalizedCheckpoint?.lastRunAttemptAt || 0}
+            : isRepoDue({repo, persistedRepoState: normalizedCheckpoint, now: observedAt, globalCadenceMs, jitterRatio}),
+        nextDueAtMs           = Number.isFinite(dueState.effectiveCadenceMs)
             ? ((dueState.lastRunAttemptAt || 0) > 0 ? dueState.lastRunAttemptAt + dueState.effectiveCadenceMs : observedAt)
             : null,
-        lastOutcome  = findTenantRepoOutcome(taskState?.lastCompletion, repo),
-        lastAttempt  = persistedRepoState?.lastRunAttemptAt || 0,
-        failures     = persistedRepoState?.consecutiveFailures ?? 0;
+        lastOutcome           = findTenantRepoOutcome(taskState?.lastCompletion, repo),
+        lastAttempt           = normalizedCheckpoint?.lastRunAttemptAt || 0,
+        failures              = normalizedCheckpoint?.consecutiveFailures ?? 0;
 
     return {
-        identityHash       : hashTenantRepoIdentity(repo),
-        tenantHash         : hashValue(repo.tenantId),
-        repoHash           : hashValue(repo.repoSlug),
-        configTier         : repo.configTier || 'unreported',
+        identityHash                      : hashTenantRepoIdentity(repo),
+        tenantHash                        : hashValue(repo.tenantId),
+        repoHash                          : hashValue(repo.repoSlug),
+        configTier                        : repo.configTier || 'unreported',
         disabled,
-        status             : classifyTenantRepoState({disabled, due: dueState.due, persistedRepoState, lastOutcome}),
-        due                : disabled ? false : dueState.due,
-        nextDueAt          : Number.isFinite(nextDueAtMs) ? new Date(nextDueAtMs).toISOString() : null,
-        lastIngestedRev    : shortRevision(persistedRepoState?.lastIngestedRev),
-        lastRunAttemptAt   : lastAttempt > 0 ? new Date(lastAttempt).toISOString() : null,
-        consecutiveFailures: failures,
-        effectiveCadenceMs : dueState.effectiveCadenceMs,
-        jitterMs           : dueState.jitterMs,
-        backoffMultiplier  : dueState.backoffMultiplier,
+        status                            : classifyTenantRepoState({disabled, due: dueState.due, persistedRepoState: normalizedCheckpoint, lastOutcome}),
+        due                               : disabled ? false : dueState.due,
+        nextDueAt                         : Number.isFinite(nextDueAtMs) ? new Date(nextDueAtMs).toISOString() : null,
+        lastIngestedRev                   : shortRevision(normalizedCheckpoint?.lastIngestedRev),
+        lastRunAttemptAt                  : lastAttempt > 0 ? new Date(lastAttempt).toISOString() : null,
+        consecutiveFailures               : failures,
+        checkpointStatus,
+        ingestContractVersion             : normalizedCheckpoint?.ingestContractVersion ?? null,
+        lastAttemptedIngestContractVersion: normalizedCheckpoint?.lastAttemptedIngestContractVersion ?? null,
+        effectiveCadenceMs                : dueState.effectiveCadenceMs,
+        jitterMs                          : dueState.jitterMs,
+        backoffMultiplier                 : dueState.backoffMultiplier,
         lastOutcome
     };
 }

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -13,6 +13,13 @@ import {
     TenantRepoSyncError,
     isTenantRepoSyncErrorCode
 } from './TenantRepoSyncErrors.mjs';
+import {
+    classifyTenantRepoCheckpoint,
+    normalizeTenantRepoCheckpointState,
+    requiresTenantRepoCheckpointRevalidation,
+    TENANT_REPO_INGEST_CONTRACT_VERSION,
+    TenantRepoCheckpointStatus
+} from './tenantRepoCheckpointValidity.mjs';
 
 const
     BOUNDED_KB_ERROR_CODE_PATTERN = /^KB_[A-Z0-9_]{1,120}$/,
@@ -389,10 +396,24 @@ class TenantRepoSyncService extends Base {
 
         const resolvedRevisionsPath = revisionsFilePath || this.defaultRevisionsFilePath();
         const ingestionService      = knowledgeBaseIngestionService || await this.resolveIngestionService();
-        const persistedRevisions    = await this.readPersistedRevisions({filePath: resolvedRevisionsPath});
-        const repoStates            = [];
-        let   completedCount        = 0;
-        let   failedCount           = 0;
+        const persistedRevisions    = await this.readPersistedRevisions({
+            filePath: resolvedRevisionsPath,
+            strict  : true
+        });
+
+        if (Object.values(persistedRevisions).some(
+            state => classifyTenantRepoCheckpoint(state) === TenantRepoCheckpointStatus.UNSUPPORTED
+        )) {
+            throw new TenantRepoSyncError(
+                KB_TENANT_REPO_SYNC_SYNC_FAILED,
+                'Tenant-repo checkpoint state was written by a newer ingestion contract.',
+                {phase: 'checkpoint-contract-validation'}
+            );
+        }
+
+        const repoStates     = [];
+        let   completedCount = 0;
+        let   failedCount    = 0;
 
         // Per-runTask concurrency gate caps simultaneous git/ingest work.
         // Fresh instance per call so live `concurrencyLimit` / `concurrencyGateTimeoutMs`
@@ -403,7 +424,8 @@ class TenantRepoSyncService extends Base {
             timeoutMs: this.concurrencyGateTimeoutMs
         });
 
-        let notDueCount = 0;
+        let notDueCount               = 0;
+        let revalidationDeferredCount = 0;
 
         // Bootstrap-spread seeding prevents all fresh repos (`lastRunAttemptAt = 0`)
         // from becoming due on the first sweep regardless of jitter; `(now - 0)`
@@ -425,9 +447,11 @@ class TenantRepoSyncService extends Base {
                         ? repo.cadenceMs
                         : globalCadenceMs;
                     persistedRevisions[repoLabel] = {
-                        lastIngestedRev    : null,
-                        lastRunAttemptAt   : sweepStartedMs - baseCadenceMs,
-                        consecutiveFailures: 0
+                        lastIngestedRev                   : null,
+                        lastRunAttemptAt                  : sweepStartedMs - baseCadenceMs,
+                        consecutiveFailures               : 0,
+                        ingestContractVersion             : null,
+                        lastAttemptedIngestContractVersion: null
                     };
                     seededAny = true;
                     writeLog?.('INFO', `[TenantRepoSync] Bootstrap-seeding ${repoLabel} (sync scheduled within jitter window).`);
@@ -438,10 +462,50 @@ class TenantRepoSyncService extends Base {
             }
         }
 
-        await Promise.all(repos.map(async (repo) => {
-            const repoLabel  = `${repo.tenantId}/${repo.repoSlug}`;
-            const priorState = persistedRevisions[repoLabel] || null;
-            const startedMs  = Date.now();
+        // Existing jitter spreads brand-new repo states, but legacy checkpoints
+        // already have persisted timestamps and can all be due on the first upgraded
+        // sweep. Admit at most one concurrency window of automatic null-base replays
+        // per sweep. Oldest attempts go first; label ordering makes ties stable across
+        // restarts. Manual selectors remain an explicit operator bypass.
+        const revalidationAdmissionLabels = new Set();
+        if (!onlyRepoSlugs) {
+            const admissionObservedAt = Date.now();
+            const dueLegacyRepos      = repos
+                .map(repo => {
+                    const
+                        repoLabel  = `${repo.tenantId}/${repo.repoSlug}`,
+                        priorState = persistedRevisions[repoLabel] || null,
+                        dueState   = isRepoDue({
+                            repo,
+                            persistedRepoState: priorState,
+                            now               : admissionObservedAt,
+                            globalCadenceMs,
+                            jitterRatio
+                        });
+
+                    return {repoLabel, priorState, dueState};
+                })
+                .filter(({priorState, dueState}) =>
+                    dueState.due && requiresTenantRepoCheckpointRevalidation(priorState)
+                )
+                .sort((a, b) =>
+                    (a.priorState?.lastRunAttemptAt ?? 0) - (b.priorState?.lastRunAttemptAt ?? 0)
+                    || a.repoLabel.localeCompare(b.repoLabel)
+                )
+                .slice(0, this.concurrencyLimit);
+
+            for (const {repoLabel} of dueLegacyRepos) {
+                revalidationAdmissionLabels.add(repoLabel);
+            }
+        }
+
+        const syncRepo = async (repo) => {
+            const
+                repoLabel            = `${repo.tenantId}/${repo.repoSlug}`,
+                priorState           = persistedRevisions[repoLabel] || null,
+                checkpointStatus     = classifyTenantRepoCheckpoint(priorState),
+                revalidationRequired = requiresTenantRepoCheckpointRevalidation(priorState),
+                startedMs            = Date.now();
 
             // Per-repo due check applies deterministic jitter + exponential backoff on
             // top of configured cadence. Manual CLI runs (onlyRepoSlugs filter)
@@ -466,12 +530,32 @@ class TenantRepoSyncService extends Base {
                         lastIngestedRev    : priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : null,
                         lastSyncAt         : priorState?.lastRunAttemptAt ? new Date(priorState.lastRunAttemptAt).toISOString() : null,
                         status             : 'not-due',
+                        checkpointStatus,
                         nextDueAt          : new Date(nextDueAtMs).toISOString(),
                         effectiveCadenceMs : dueState.effectiveCadenceMs,
                         consecutiveFailures: priorState?.consecutiveFailures ?? 0
                     });
                     return; // skip semaphore + work entirely
                 }
+            }
+
+            if (
+                revalidationRequired
+                && !onlyRepoSlugs
+                && !revalidationAdmissionLabels.has(repoLabel)
+            ) {
+                revalidationDeferredCount++;
+                writeLog?.('INFO', `[TenantRepoSync] ${repoLabel} legacy checkpoint replay deferred by the per-sweep admission cap.`);
+                repoStates.push({
+                    tenantId           : repo.tenantId,
+                    repoSlug           : repo.repoSlug,
+                    lastIngestedRev    : priorState.lastIngestedRev.slice(0, 8),
+                    lastSyncAt         : priorState.lastRunAttemptAt ? new Date(priorState.lastRunAttemptAt).toISOString() : null,
+                    status             : 'revalidation-deferred',
+                    checkpointStatus,
+                    consecutiveFailures: priorState.consecutiveFailures ?? 0
+                });
+                return;
             }
 
             let slotAcquired = false;
@@ -498,13 +582,19 @@ class TenantRepoSyncService extends Base {
                     tenantId       : repo.tenantId,
                     repoSlug       : repo.repoSlug,
                     mirrorRoot     : repo.mirrorRoot,
-                    lastIngestedRev: fullReplay ? null : (priorState?.lastIngestedRev || null),
-                    newHead        : repo.branchRef || 'HEAD',
-                    rootKind       : repo.rootKind || 'external-source',
-                    parserId       : repo.parserId,
-                    parserVersion  : repo.parserVersion,
+                    lastIngestedRev: fullReplay || revalidationRequired
+                        ? null
+                        : (priorState?.lastIngestedRev || null),
+                    newHead      : repo.branchRef || 'HEAD',
+                    rootKind     : repo.rootKind || 'external-source',
+                    parserId     : repo.parserId,
+                    parserVersion: repo.parserVersion,
                     gitMirror
                 });
+
+                if (typeof envelope?.headRevision !== 'string' || !envelope.headRevision.trim()) {
+                    throw new Error('Tenant-repo ingestion envelope did not prove a head revision.');
+                }
 
                 const ingestResult = assertErrorFreeIngestionSummary(await ingestionService.ingestSourceFiles({
                     ...envelope,
@@ -516,9 +606,11 @@ class TenantRepoSyncService extends Base {
                 // successful sync). lastRunAttemptAt advances to
                 // startedMs so subsequent due-checks measure from the actual attempt.
                 persistedRevisions[repoLabel] = {
-                    lastIngestedRev    : envelope.headRevision || priorState?.lastIngestedRev || null,
-                    lastRunAttemptAt   : startedMs,
-                    consecutiveFailures: 0
+                    lastIngestedRev                   : envelope.headRevision || priorState?.lastIngestedRev || null,
+                    lastRunAttemptAt                  : startedMs,
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
                 };
 
                 const durationMs = Date.now() - startedMs;
@@ -534,17 +626,19 @@ class TenantRepoSyncService extends Base {
                     lastIngestedRev     : shortHead,
                     lastSyncAt          : new Date().toISOString(),
                     status              : 'active',
+                    checkpointStatus    : TenantRepoCheckpointStatus.COMPLETE,
                     lastSyncDeletedCount: deleted
                 });
                 completedCount++;
                 healthService?.recordTaskOutcome?.(taskName, 'completed', {
-                    repo        : repoLabel,
-                    tenantId    : repo.tenantId,
-                    repoSlug    : repo.repoSlug,
+                    repo            : repoLabel,
+                    tenantId        : repo.tenantId,
+                    repoSlug        : repo.repoSlug,
                     ingested,
                     deleted,
-                    headRevision: shortHead,
-                    durationMs
+                    headRevision    : shortHead,
+                    durationMs,
+                    checkpointStatus: TenantRepoCheckpointStatus.COMPLETE
                 });
             } catch (e) {
                 const code            = isTenantRepoSyncErrorCode(e.code) ? e.code : KB_TENANT_REPO_SYNC_SYNC_FAILED;
@@ -558,9 +652,11 @@ class TenantRepoSyncService extends Base {
                 // start, not last-success).
                 const nextFailureCount = (priorState?.consecutiveFailures ?? 0) + 1;
                 persistedRevisions[repoLabel] = {
-                    lastIngestedRev    : priorState?.lastIngestedRev || null,
-                    lastRunAttemptAt   : startedMs,
-                    consecutiveFailures: nextFailureCount
+                    lastIngestedRev                   : priorState?.lastIngestedRev || null,
+                    lastRunAttemptAt                  : startedMs,
+                    consecutiveFailures               : nextFailureCount,
+                    ingestContractVersion             : priorState?.ingestContractVersion ?? null,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
                 };
 
                 const failedRepoState = {
@@ -569,6 +665,7 @@ class TenantRepoSyncService extends Base {
                     lastIngestedRev    : priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : null,
                     lastSyncAt         : new Date().toISOString(),
                     status             : 'degraded',
+                    checkpointStatus   : classifyTenantRepoCheckpoint(persistedRevisions[repoLabel]),
                     lastErrorCode      : code,
                     consecutiveFailures: nextFailureCount
                 };
@@ -586,14 +683,30 @@ class TenantRepoSyncService extends Base {
                     error   : e.message,
                     code,
                     ...(sourceErrorCode ? {sourceErrorCode} : {}),
-                    consecutiveFailures: nextFailureCount
+                    consecutiveFailures: nextFailureCount,
+                    checkpointStatus   : failedRepoState.checkpointStatus
                 });
                 // Continue with remaining repos — per-repo failure isolation is the
                 // tenant deployment contract.
             } finally {
                 if (slotAcquired) semaphore.release();
             }
-        }));
+        };
+
+        // Reserved migration work runs as a bounded first cohort. Normal repos
+        // are not enqueued until those admitted replays settle, so their
+        // concurrency-gate timeout clocks cannot expire behind intentionally
+        // prioritized migration work.
+        const
+            admittedRevalidationRepos = repos.filter(repo =>
+                revalidationAdmissionLabels.has(`${repo.tenantId}/${repo.repoSlug}`)
+            ),
+            remainingRepos = repos.filter(repo =>
+                !revalidationAdmissionLabels.has(`${repo.tenantId}/${repo.repoSlug}`)
+            );
+
+        await Promise.all(admittedRevalidationRepos.map(syncRepo));
+        await Promise.all(remainingRepos.map(syncRepo));
 
         await this.writePersistedRevisions({filePath: resolvedRevisionsPath, revisions: persistedRevisions});
 
@@ -606,7 +719,7 @@ class TenantRepoSyncService extends Base {
             ? 'completed' // all repos were not-due; cycle ran cleanly
             : (failedCount === 0 ? 'completed' : (completedCount > 0 ? 'completed' : 'failed'));
 
-        writeLog?.('INFO', `[TenantRepoSync] Cycle summary: ${repos.length} repos, ${completedCount} completed, ${failedCount} failed, ${notDueCount} not-due.`);
+        writeLog?.('INFO', `[TenantRepoSync] Cycle summary: ${repos.length} repos, ${completedCount} completed, ${failedCount} failed, ${notDueCount} not-due, ${revalidationDeferredCount} revalidation-deferred.`);
 
         return {
             status,
@@ -615,6 +728,7 @@ class TenantRepoSyncService extends Base {
                 completedCount,
                 failedCount,
                 notDueCount,
+                revalidationDeferredCount,
                 repos    : repoStates
             }
         };
@@ -700,22 +814,23 @@ class TenantRepoSyncService extends Base {
      * Current per-repo persisted state shape:
      * ```
      * {
-     *   lastIngestedRev    : '<sha>',
-     *   lastRunAttemptAt   : <ms-epoch>,
-     *   consecutiveFailures: <int>
+     *   lastIngestedRev                    : '<sha>',
+     *   lastRunAttemptAt                   : <ms-epoch>,
+     *   consecutiveFailures                : <int>,
+     *   ingestContractVersion              : <int|null>,
+     *   lastAttemptedIngestContractVersion : <int|null>
      * }
      * ```
      *
      * Backward-compatible read: legacy persistence stored bare SHA strings under
-     * `revisions[label]`. On read, string-shaped entries are auto-migrated to the
-     * full object shape (lastIngestedRev = old-string; lastRunAttemptAt = 0;
-     * consecutiveFailures = 0). Next write persists the new shape, completing the
-     * migration in-place.
+     * `revisions[label]`. On read, string-shaped entries are normalized to the full
+     * state shape without manufacturing an ingestion-contract proof. The scheduler
+     * therefore admits one bounded null-base replay before trusting that head.
      *
      * @param {Object} options
      * @param {String} options.filePath
      * @param {Boolean} [options.strict=false] Throw on corrupt/unreadable files instead of returning an empty map.
-     * @returns {Promise<Object<String, {lastIngestedRev: String, lastRunAttemptAt: Number, consecutiveFailures: Number}>>}
+     * @returns {Promise<Object<String, Object>>}
      */
     async readPersistedRevisions({filePath, strict = false}) {
         if (!await fs.pathExists(filePath)) {
@@ -723,23 +838,31 @@ class TenantRepoSyncService extends Base {
         }
         try {
             const data = await fs.readJson(filePath);
-            if (!data || typeof data !== 'object' || !data.revisions) return {};
+            if (
+                !data
+                || typeof data !== 'object'
+                || !data.revisions
+                || typeof data.revisions !== 'object'
+                || Array.isArray(data.revisions)
+            ) {
+                if (strict) {
+                    const error = new Error(`Tenant-repo-sync revisions at ${filePath} have an invalid shape.`);
+                    error.code  = 'KB_TENANT_REPO_SYNC_REVISIONS_INVALID';
+                    throw error;
+                }
+                return {};
+            }
 
             const normalized = {};
             for (const [label, value] of Object.entries(data.revisions)) {
-                if (typeof value === 'string') {
-                    // Legacy shape: bare SHA string. Migrate to full state shape on read.
-                    normalized[label] = {
-                        lastIngestedRev    : value,
-                        lastRunAttemptAt   : 0,
-                        consecutiveFailures: 0
-                    };
-                } else if (value && typeof value === 'object') {
-                    normalized[label] = {
-                        lastIngestedRev    : value.lastIngestedRev || null,
-                        lastRunAttemptAt   : Number.isFinite(value.lastRunAttemptAt) ? value.lastRunAttemptAt : 0,
-                        consecutiveFailures: Number.isFinite(value.consecutiveFailures) ? value.consecutiveFailures : 0
-                    };
+                const checkpointState = normalizeTenantRepoCheckpointState(value);
+
+                if (checkpointState) {
+                    normalized[label] = checkpointState;
+                } else if (strict) {
+                    const error = new Error('Tenant-repo-sync revision entry has an invalid shape.');
+                    error.code  = 'KB_TENANT_REPO_SYNC_REVISIONS_INVALID';
+                    throw error;
                 }
             }
             return normalized;

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -1,0 +1,193 @@
+/**
+ * @module ai/daemons/orchestrator/services/tenantRepoCheckpointValidity
+ * @summary Pure checkpoint-contract normalization and revalidation classification
+ * for the orchestrator-owned tenant-repo ingestion lane.
+ *
+ * A persisted repository head is trusted as an incremental base only when
+ * `ingestContractVersion` proves it was written after an error-free ingestion
+ * summary. Older records remain usable recovery evidence, but require one
+ * bounded null-base replay before they become current.
+ */
+
+/**
+ * @summary Current success contract for tenant-repo ingestion checkpoints.
+ *
+ * Version 1 means the persisted head advanced only after
+ * `assertErrorFreeIngestionSummary()` accepted the Knowledge Base result.
+ *
+ * @type {Number}
+ */
+export const TENANT_REPO_INGEST_CONTRACT_VERSION = 1;
+
+/**
+ * @summary Internal checkpoint-revalidation classifications.
+ *
+ * `INVALID` is a fail-closed reader sentinel, not a per-repo deployment
+ * diagnostic: the canonical strict reader makes the aggregate unavailable
+ * instead of projecting a partially trusted manifest.
+ *
+ * @enum {String}
+ */
+export const TenantRepoCheckpointStatus = Object.freeze({
+    COMPLETE     : 'complete',
+    FAILED       : 'failed',
+    INVALID      : 'invalid',
+    PENDING      : 'pending',
+    UNINITIALIZED: 'uninitialized',
+    UNSUPPORTED  : 'unsupported'
+});
+
+/**
+ * @summary Normalizes one persisted tenant-repo checkpoint without upgrading its
+ * success proof.
+ *
+ * Bare SHA strings and object records without version fields remain unproved.
+ * This is deliberate: shape migration must never manufacture evidence that the
+ * historical ingestion completed without errors.
+ *
+ * @param {String|Object} value Persisted revision-map entry.
+ * @returns {Object|null} Normalized checkpoint state, or `null` for an invalid entry.
+ */
+export function normalizeTenantRepoCheckpointState(value) {
+    if (typeof value === 'string') {
+        return {
+            lastIngestedRev                   : value || null,
+            lastRunAttemptAt                  : 0,
+            consecutiveFailures               : 0,
+            ingestContractVersion             : null,
+            lastAttemptedIngestContractVersion: null
+        };
+    }
+
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+
+    if (hasMalformedContractVersion(value)) {
+        return null;
+    }
+
+    return {
+        lastIngestedRev                    : typeof value.lastIngestedRev === 'string' && value.lastIngestedRev
+            ? value.lastIngestedRev
+            : null,
+        lastRunAttemptAt                  : normalizeNonNegativeNumber(value.lastRunAttemptAt),
+        consecutiveFailures               : normalizeFailureCount(value.consecutiveFailures),
+        ingestContractVersion             : normalizeContractVersion(value.ingestContractVersion),
+        lastAttemptedIngestContractVersion: normalizeContractVersion(value.lastAttemptedIngestContractVersion)
+    };
+}
+
+/**
+ * @summary Classifies whether a checkpoint is pending, failed, complete,
+ * uninitialized, invalid, or from an unsupported future contract.
+ *
+ * `lastAttemptedIngestContractVersion` distinguishes a legacy checkpoint that
+ * has never been tried by this contract (`pending`) from one whose bounded replay
+ * failed (`failed`) without relying on historical failure counters.
+ *
+ * @param {String|Object|null} state Persisted checkpoint state.
+ * @returns {String} One `TenantRepoCheckpointStatus` value.
+ */
+export function classifyTenantRepoCheckpoint(state) {
+    if (hasMalformedContractVersion(state)) {
+        return TenantRepoCheckpointStatus.INVALID;
+    }
+
+    const normalizedState = normalizeTenantRepoCheckpointState(state);
+
+    if (state !== null && state !== undefined && !normalizedState) {
+        return TenantRepoCheckpointStatus.INVALID;
+    }
+
+    const
+        ingestVersion  = normalizedState?.ingestContractVersion ?? null,
+        attemptVersion = normalizedState?.lastAttemptedIngestContractVersion ?? null;
+
+    if (
+        ingestVersion > TENANT_REPO_INGEST_CONTRACT_VERSION
+        || attemptVersion > TENANT_REPO_INGEST_CONTRACT_VERSION
+    ) {
+        return TenantRepoCheckpointStatus.UNSUPPORTED;
+    }
+
+    if (!normalizedState?.lastIngestedRev) {
+        return TenantRepoCheckpointStatus.UNINITIALIZED;
+    }
+
+    if (ingestVersion === TENANT_REPO_INGEST_CONTRACT_VERSION) {
+        return TenantRepoCheckpointStatus.COMPLETE;
+    }
+
+    if (attemptVersion === TENANT_REPO_INGEST_CONTRACT_VERSION) {
+        return TenantRepoCheckpointStatus.FAILED;
+    }
+
+    return TenantRepoCheckpointStatus.PENDING;
+}
+
+/**
+ * @summary Returns whether the stored head must be replayed from a null base
+ * before it may be trusted by the current ingestion contract.
+ *
+ * @param {Object|null} state Normalized persisted checkpoint state.
+ * @returns {Boolean}
+ */
+export function requiresTenantRepoCheckpointRevalidation(state) {
+    const status = classifyTenantRepoCheckpoint(state);
+
+    return status === TenantRepoCheckpointStatus.PENDING
+        || status === TenantRepoCheckpointStatus.FAILED;
+}
+
+/**
+ * @summary Detects present-but-invalid checkpoint contract markers.
+ *
+ * An absent field or explicit `null` means the checkpoint predates that proof
+ * field. Any other non-positive-integer representation is corrupt persisted
+ * state and must never be downgraded into the legacy replay path.
+ *
+ * @param {*} state Candidate persisted checkpoint state.
+ * @returns {Boolean}
+ */
+function hasMalformedContractVersion(state) {
+    if (!state || typeof state !== 'object' || Array.isArray(state)) {
+        return false;
+    }
+
+    return [
+        'ingestContractVersion',
+        'lastAttemptedIngestContractVersion'
+    ].some(key =>
+        Object.hasOwn(state, key)
+        && state[key] !== null
+        && normalizeContractVersion(state[key]) === null
+    );
+}
+
+/**
+ * @summary Accepts only positive integer checkpoint-contract versions.
+ * @param {*} value Candidate persisted version.
+ * @returns {Number|null}
+ */
+function normalizeContractVersion(value) {
+    return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+/**
+ * @summary Normalizes persisted failure counts to non-negative integers.
+ * @param {*} value Candidate persisted failure count.
+ * @returns {Number}
+ */
+function normalizeFailureCount(value) {
+    return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+/**
+ * @summary Normalizes persisted epoch values to non-negative finite numbers.
+ * @param {*} value Candidate persisted epoch.
+ * @returns {Number}
+ */
+function normalizeNonNegativeNumber(value) {
+    return Number.isFinite(value) && value > 0 ? value : 0;
+}

--- a/learn/agentos/cloud-deployment/MigrationPath.md
+++ b/learn/agentos/cloud-deployment/MigrationPath.md
@@ -42,6 +42,22 @@ The new config keys (`useDefaultSources`, `rawRepoSource`, `useDefaultParsers`, 
 
 How a multi-tenant deployment *stores* its per-tenant configuration — the `KnowledgeBaseTenantConfig` graph-node shape, the `kb-config.yaml` bootstrap-vs-canonical semantics, config-version metadata — is defined by #11637 and documented in **[Configuration](./Configuration.md)**. A deployment's tenant config resolves through three tiers: the `kb-config:<tenantId>` graph node → the `kb-config.yaml` bootstrap → the local `config.mjs` defaults. This tiering now also covers `tenantRepos` (the pull-mode polling config), resolved via `listConfiguredTenantRepos`.
 
+## Tenant-repo checkpoint revalidation
+
+Pull-mode deployments upgrading from a release that could persist a repository
+head after an error-bearing ingestion summary do not need to delete state or
+run an in-container recovery command. Unversioned checkpoint heads are treated
+as historically unknown and receive one automatic null-base replay.
+
+Migration is gradual: the one-minute scheduler sweep admits no more than the
+configured tenant-repo concurrency limit, while per-repo cadence, deterministic
+jitter, failure backoff, and the normal concurrency semaphore remain active.
+Failures preserve the old head and stay eligible for a later retry. Only a
+clean Knowledge Base summary writes the current success-contract marker and
+returns that repo to incremental ingestion. The deployment-state snapshot
+exposes aggregate and hashed per-repo progress; scoped CLI `--full` replay
+remains an optional acceleration override.
+
 ## Breaking-change inventory
 
 There are **no breaking changes** for an existing single-repo deployment. The substrate is additive end-to-end. The only "migration" a single-repo operator performs is `git pull` — the defaults handle the rest.

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -223,7 +223,8 @@ Toggles:
 | Env var | AiConfig path | Default | Effect |
 |---|---|---|---|
 | `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED` | `orchestrator.cloudOnly.tenantRepoSyncEnabled` | cloud profile: enabled; local: disabled | Master toggle for the periodic lane |
-| `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS` | `orchestrator.intervals.tenantRepoSyncMs` | 30 minutes | Period between sweeps |
+| `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS` | `orchestrator.intervals.tenantRepoSyncMs` | 30 minutes | Base per-repo ingestion cadence before deterministic jitter and failure backoff |
+| `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS` | `orchestrator.tenantRepoSync.sweepCadenceMs` | 1 minute | Scheduler scan cadence for admitting repos whose individual cadence is due |
 
 The `cloudOnly` collection is the inverse-polarity sibling of `localOnly`. `null` means "use the deployment-profile default" (cloud enables, local disables); explicit `true`/`false` overrides. Local Neo-maintainer deployments default-off because most operator checkouts don't have `tenantRepos[]` configured.
 
@@ -240,8 +241,9 @@ node ./ai/scripts/maintenance/syncTenantRepos.mjs --full --repo-slug a/b  # scop
 
 `--full` requires at least one explicit, repeatable `--repo-slug` selector. It builds the selected
 repo envelopes from a null revision base while retaining each stored checkpoint until the replay
-returns an error-free ingestion summary. Use it after correcting an ingestion failure when an older
-deployment may already have checkpointed the failed head; do not delete the revisions file.
+returns an error-free ingestion summary. Current releases automatically revalidate unversioned
+checkpoints through the periodic lane; use `--full` only to accelerate or explicitly repeat one
+selected repo after correcting its underlying failure. Do not delete the revisions file.
 
 Exit code: `0` on `completed`, `1` on `failed` or `skipped` (no-tenant-repos-configured), `2` on argument error, and `3` when a requested repo slug is not configured. The CLI uses an in-memory `TaskStateService` stand-in so it works without an orchestrator-daemon state-dir; it does not race against a running Orchestrator's lane.
 
@@ -257,6 +259,20 @@ The env var names the **parent** of `tenant-repos/`; `deriveTenantRepoMirrorPath
 
 The mirror directory is a deployment cache, not authoritative state. Per-repo `lastIngestedRev` is stored separately in `<orchestrator-data-dir>/tenant-repo-sync-revisions.json` (sibling to the orchestrator state file) so the next sync can compute the incremental diff.
 
+Each checkpoint also carries `ingestContractVersion`, written together with the
+head only after the Knowledge Base returns an explicit error-free summary, and
+`lastAttemptedIngestContractVersion`, which records a failed revalidation
+attempt without advancing the head. A head without the current success marker
+has unknown historical validity and is never used as an incremental base.
+
+After an upgrade, the periodic lane automatically replays such legacy
+checkpoints from a null base. It admits at most `concurrencyLimit` legacy
+replays per scheduler sweep, ordered by the oldest prior attempt, while normal
+repos retain their cadence and the semaphore still bounds simultaneous work.
+A failed replay preserves the old head and participates in the existing
+exponential backoff. A clean replay co-writes the new head and current proof
+markers in one repo record, after which normal incremental sync resumes.
+
 ### Redeploy Posture
 
 Mirrors are reproducible from upstream git. **Backup is not required** for correctness — on redeploy, `GitMirror.cloneIfMissing()` re-clones any missing mirror on the next sync. Operators who want faster cold-start recovery may include the `tenant-repo-mirrors` volume in their backup bundle, but this is an operational preference, not a Chroma/MC correctness dependency.
@@ -269,17 +285,19 @@ Per-repo freshness is surfaced through the existing Memory Core healthcheck orch
 
 ```js
 {
-    reason     : 'periodic-sweep:1800000' | 'manual' | 'no-tenant-repos-configured',
-    repoCount  : 3,
-    completedCount: 3,
-    failedCount   : 0,
+    reason                       : 'periodic-sweep:60000' | 'manual' | 'no-tenant-repos-configured',
+    repoCount                    : 3,
+    completedCount               : 3,
+    failedCount                  : 0,
+    revalidationDeferredCount     : 0,
     repos: [
         {
             tenantId             : 'neomjs',
             repoSlug             : 'neomjs/create-app',
             lastIngestedRev      : 'a1b2c3d4',    // short SHA from the most recent successful ingest
             lastSyncAt           : '2026-05-25T05:30:00.000Z',
-            status               : 'active',      // 'active' | 'degraded' | 'quarantined' | 'disabled'
+            status               : 'active',      // also degraded, revalidation-deferred, quarantined, or disabled
+            checkpointStatus     : 'complete',    // 'pending' | 'failed' | 'complete' | 'uninitialized' | 'unsupported'
             lastSyncDeletedCount : 0,
             lastErrorCode        : null,          // present only when status !== 'active'
             lastSourceErrorCode  : null           // optional bounded source code, e.g. KB_GITMIRROR_FETCH_FAILED
@@ -296,7 +314,12 @@ surface when a cloud KB is healthy but empty: it combines the orchestrator enabl
 state, config-tier counts, per-repo due/backoff state, and bounded failure codes without exposing
 clone URLs, credentials, or raw logs. If tenant-config graph discovery itself fails, the snapshot
 reports a degraded/unreadable config state rather than flattening that failure into
-`no-configured-repos`.
+`no-configured-repos`. Its `checkpointRevalidation` aggregate reports the
+current contract version plus pending, failed, complete, uninitialized, and
+unsupported counts. Present-but-malformed version fields fail closed by making
+the checkpoint aggregate unavailable; counts are likewise unavailable when repo
+enumeration or revision-state reading fails. Existing per-repo rows add only the version values and
+`checkpointStatus` beside their already-hashed identities.
 
 ### Repo Freshness Status Enum
 

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -209,15 +209,30 @@ For pull-mode deployments with configured `tenantRepos[]`, call `inspect_deploym
 Current releases accept a tenant-repo ingest as successful only when the returned summary contains
 an array-valued, empty `errors` field. A failed attempt keeps the last known-good revision. If the
 deployment was upgraded after an older release had already advanced its checkpoint on an
-error-bearing summary, a normal retry can produce an empty incremental envelope. Recover only the
-affected repo with:
+error-bearing summary, the stored head has no current success proof. The periodic lane classifies
+that repo as `checkpointStatus: pending` and performs one bounded null-base replay automatically.
+Only `concurrencyLimit` legacy checkpoints are admitted per one-minute scheduler sweep; failures
+become `checkpointStatus: failed`, preserve the old head, and retry through normal backoff.
+
+Inspect `tenantRepoSync.checkpointRevalidation` for pending, failed, complete, uninitialized, and
+unsupported counts. The aggregate is unavailable when repository enumeration, revision-state
+reading, or persisted-marker validation fails, because an all-zero projection cannot prove an empty checkpoint set.
+Per-repo rows use hashed identities and expose the same `checkpointStatus` without clone URLs,
+refs, credentials, or raw errors. A future/unsupported contract marker requires upgrading this
+runtime. A present but malformed marker is invalid persisted state. Both fail closed and are never
+silently downgraded; malformed state makes the aggregate unavailable rather than fabricating a
+per-repo classification.
+
+After correcting the underlying failure, ordinary periodic retry is sufficient. To accelerate one
+known repo rather than wait for its cadence/backoff, use the scoped operator override:
 
 ```text
 node ./ai/scripts/maintenance/syncTenantRepos.mjs --full --repo-slug <slug>
 ```
 
 `--full` is rejected without an explicit repo selector. It does not delete the stored checkpoint:
-a failed replay preserves it, while an error-free replay advances it to the current head.
+a failed replay preserves it, while an error-free replay advances it to the current head and writes
+the current success-contract marker.
 
 If the deployment snapshot is fresh but the tool returns `status: degraded` with
 `reason: snapshot-section-missing` or `snapshot-producer-metadata-missing`, fix

--- a/learn/agentos/tooling/KnowledgeBaseMcpApi.md
+++ b/learn/agentos/tooling/KnowledgeBaseMcpApi.md
@@ -48,7 +48,13 @@ cloud ingestion. Use it when a KB is healthy but empty and tenant repositories
 are expected: it reports the orchestrator enablement gate, scheduler cadence,
 task state, effective repo-config counts/tiers, redacted per-repo due state, and
 stable failure reason codes without exposing clone URLs, credentials, or raw
-logs.
+logs. Its `checkpointRevalidation` aggregate reports the current ingestion
+contract version and pending, failed, complete, uninitialized, and unsupported
+checkpoint counts. Counts are unavailable when repository enumeration,
+revision-state reading, or persisted-marker validation fails. The existing hashed per-repo rows expose the corresponding
+`checkpointStatus` and version markers. After an upgrade, pending legacy
+checkpoints replay automatically through the bounded periodic lane; these tools
+remain read-only observation surfaces rather than replay actuators.
 
 `inspect_deployment` and `get_deployment_state_snapshot` include a
 `bridgeDiagnostics` envelope when the orchestrator's deployment-state bridge

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -6,6 +6,9 @@ import Neo                            from '../../../../../../../src/Neo.mjs';
 import * as core                      from '../../../../../../../src/core/_export.mjs';
 import AiConfig                       from '../../../../../../../ai/config.template.mjs';
 import {DeploymentStateBridgeService} from '../../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs';
+import {
+    TENANT_REPO_INGEST_CONTRACT_VERSION
+} from '../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
 
 const OBSERVED_AT = 1710000000000;
 let originalDeploymentStateBridgeConfig,
@@ -573,6 +576,46 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         }
     });
 
+    test('collectTenantRepoSyncSnapshot marks checkpoint counts unavailable when repo enumeration throws (#15761)', async () => {
+        const configError = new Error('repo config unavailable');
+        configError.code  = 'KB_TENANT_REPO_CONFIG_UNAVAILABLE';
+
+        const service = createService({
+            taskStateService: {
+                getTaskState() {
+                    return null;
+                }
+            },
+            tenantRepoSyncService: {
+                async resolveTenantReposConfig() {
+                    throw configError;
+                },
+                defaultRevisionsFilePath() {
+                    return '/state/revisions.json';
+                },
+                async readPersistedRevisions() {
+                    return {};
+                }
+            },
+            tenantRepoSyncEnabledReader: () => true
+        });
+
+        const tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(tenantRepoSync.status).toBe('degraded');
+        expect(tenantRepoSync.config.status).toBe('degraded');
+        expect(tenantRepoSync.repos).toEqual([]);
+        expect(tenantRepoSync.checkpointRevalidation).toEqual({
+            status                      : 'unavailable',
+            currentIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+            pendingCount                : null,
+            failedCount                 : null,
+            completeCount               : null,
+            uninitializedCount          : null,
+            unsupportedCount            : null
+        });
+    });
+
     for (const failure of [
         {
             status      : 'read-failed',
@@ -704,9 +747,11 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                 async readPersistedRevisions() {
                     return {
                         'tenant-a/private/repo': {
-                            lastIngestedRev    : 'abcdef1234567890',
-                            lastRunAttemptAt   : OBSERVED_AT - 1_000,
-                            consecutiveFailures: 0
+                            lastIngestedRev                   : 'abcdef1234567890',
+                            lastRunAttemptAt                  : OBSERVED_AT - 1_000,
+                            consecutiveFailures               : 0,
+                            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
                         }
                     };
                 }
@@ -727,7 +772,8 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             status             : 'not-due',
             due                : false,
             lastIngestedRev    : 'abcdef123456',
-            consecutiveFailures: 0
+            consecutiveFailures: 0,
+            checkpointStatus   : 'complete'
         });
         expect(JSON.stringify(tenantRepoSync)).not.toContain('tenant-a');
         expect(JSON.stringify(tenantRepoSync)).not.toContain('private/repo');
@@ -781,9 +827,11 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                 async readPersistedRevisions() {
                     return {
                         'tenant-a/private/repo': {
-                            lastIngestedRev    : 'fedcba9876543210',
-                            lastRunAttemptAt   : OBSERVED_AT - 60_000,
-                            consecutiveFailures: 2
+                            lastIngestedRev                   : 'fedcba9876543210',
+                            lastRunAttemptAt                  : OBSERVED_AT - 60_000,
+                            consecutiveFailures               : 2,
+                            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
                         }
                     };
                 }
@@ -810,6 +858,101 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             }
         });
         expect(JSON.stringify(tenantRepoSync)).not.toContain('env:TOKEN');
+    });
+
+    test('collectTenantRepoSyncSnapshot exposes redacted mixed checkpoint-revalidation state (#15761)', async () => {
+        const repos = [
+            {tenantId: 'tenant-a', repoSlug: 'private/pending',       cloneUrl: 'https://git.example/pending.git',       credentialRef: 'env:PENDING_TOKEN'},
+            {tenantId: 'tenant-b', repoSlug: 'private/failed',        cloneUrl: 'https://git.example/failed.git',        credentialRef: 'env:FAILED_TOKEN'},
+            {tenantId: 'tenant-c', repoSlug: 'private/complete',      cloneUrl: 'https://git.example/complete.git',      credentialRef: 'env:COMPLETE_TOKEN'},
+            {tenantId: 'tenant-d', repoSlug: 'private/uninitialized', cloneUrl: 'https://git.example/uninitialized.git', credentialRef: 'env:FRESH_TOKEN'},
+            {tenantId: 'tenant-e', repoSlug: 'private/unsupported',   cloneUrl: 'https://git.example/unsupported.git',   credentialRef: 'env:FUTURE_TOKEN'}
+        ];
+        const service = createService({
+            taskStateService: {
+                getTaskState() {
+                    return null;
+                }
+            },
+            tenantRepoSyncService: {
+                async resolveTenantReposConfig() {
+                    return {tenantRepos: repos};
+                },
+                defaultRevisionsFilePath() {
+                    return '/state/revisions.json';
+                },
+                async readPersistedRevisions() {
+                    return {
+                        'tenant-a/private/pending': {
+                            lastIngestedRev                   : 'aaaaaaaaaaaaaaaa',
+                            lastRunAttemptAt                  : OBSERVED_AT - 60_000,
+                            consecutiveFailures               : 4,
+                            ingestContractVersion             : null,
+                            lastAttemptedIngestContractVersion: null
+                        },
+                        'tenant-b/private/failed': {
+                            lastIngestedRev                   : 'bbbbbbbbbbbbbbbb',
+                            lastRunAttemptAt                  : OBSERVED_AT - 30_000,
+                            consecutiveFailures               : 1,
+                            ingestContractVersion             : null,
+                            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                        },
+                        'tenant-c/private/complete': {
+                            lastIngestedRev                   : 'cccccccccccccccc',
+                            lastRunAttemptAt                  : OBSERVED_AT - 10_000,
+                            consecutiveFailures               : 0,
+                            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                        },
+                        'tenant-e/private/unsupported': {
+                            lastIngestedRev                   : 'eeeeeeeeeeeeeeee',
+                            lastRunAttemptAt                  : OBSERVED_AT - 5_000,
+                            consecutiveFailures               : 0,
+                            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION + 1,
+                            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION + 1
+                        }
+                    };
+                }
+            },
+            tenantRepoSyncEnabledReader: () => true
+        });
+
+        const tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(tenantRepoSync.checkpointRevalidation).toEqual({
+            status                      : 'available',
+            currentIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+            pendingCount                : 1,
+            failedCount                 : 1,
+            completeCount               : 1,
+            uninitializedCount          : 1,
+            unsupportedCount            : 1
+        });
+        expect(tenantRepoSync.repos.map(repo => repo.checkpointStatus)).toEqual([
+            'pending',
+            'failed',
+            'complete',
+            'uninitialized',
+            'unsupported'
+        ]);
+        expect(tenantRepoSync.repos[0]).toMatchObject({
+            ingestContractVersion             : null,
+            lastAttemptedIngestContractVersion: null
+        });
+        expect(tenantRepoSync.repos[1]).toMatchObject({
+            ingestContractVersion             : null,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        });
+
+        const serialized = JSON.stringify(tenantRepoSync);
+        for (const secret of [
+            'tenant-a', 'tenant-b', 'tenant-c', 'tenant-d', 'tenant-e',
+            'private/pending', 'private/failed', 'private/complete', 'private/uninitialized', 'private/unsupported',
+            'PENDING_TOKEN', 'FAILED_TOKEN', 'COMPLETE_TOKEN', 'FRESH_TOKEN', 'FUTURE_TOKEN',
+            'https://git.example'
+        ]) {
+            expect(serialized).not.toContain(secret);
+        }
     });
 
     test('collectTenantRepoSyncSnapshot degrades when revision state is unreadable', async () => {
@@ -859,6 +1002,15 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         expect(tenantRepoSync.errors[0]).toMatchObject({
             reason: 'tenant-repo-revision-state-read-failed',
             code  : 'KB_TENANT_REPO_SYNC_REVISIONS_READ_FAILED'
+        });
+        expect(tenantRepoSync.checkpointRevalidation).toEqual({
+            status                      : 'unavailable',
+            currentIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+            pendingCount                : null,
+            failedCount                 : null,
+            completeCount               : null,
+            uninitializedCount          : null,
+            unsupportedCount            : null
         });
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -25,6 +25,9 @@ import path            from 'path';
 import {fileURLToPath} from 'url';
 
 import TenantRepoSyncService        from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
+import {
+    TENANT_REPO_INGEST_CONTRACT_VERSION
+} from '../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
 import {deriveTenantRepoMirrorPath} from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 import {
     buildRunTaskOptions,
@@ -289,14 +292,25 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(ingestedSlugs).toEqual(['org/a', 'org/c']);
     });
 
-    test('persisted revisions are read on subsequent run and passed as lastIngestedRev', async () => {
+    test('current-contract checkpoints are read on subsequent run and passed as lastIngestedRev', async () => {
         const taskStateService = createInMemoryTaskStateService();
 
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/seeded'});
 
-        // Seed the revisions file with a prior run
+        // Seed the revisions file with a checkpoint proved by the current
+        // error-free ingestion contract.
         await fs.ensureDir(path.dirname(revisionsFile));
-        await fs.writeJson(revisionsFile, {revisions: {'t1/org/seeded': 'sha-prior-run'}});
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                't1/org/seeded': {
+                    lastIngestedRev                   : 'sha-prior-run',
+                    lastRunAttemptAt                  : 0,
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                }
+            }
+        });
 
         let   capturedLastIngestedRev   = null;
         const envelopeWatchingGitMirror = {
@@ -352,9 +366,11 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await fs.writeJson(revisionsFile, {
             revisions: {
                 [`t1/${repoSlug}`]: {
-                    lastIngestedRev    : 'sha-good',
-                    lastRunAttemptAt   : 0,
-                    consecutiveFailures: 0
+                    lastIngestedRev                   : 'sha-good',
+                    lastRunAttemptAt                  : 0,
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
                 }
             }
         });
@@ -411,6 +427,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(failed.details.failedCount).toBe(1);
         expect(failed.details.repos[0]).toMatchObject({
             status             : 'degraded',
+            checkpointStatus   : 'complete',
             lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
             lastSourceErrorCode: 'KB_VECTOR_EMBED_FAILED',
             consecutiveFailures: 1
@@ -420,8 +437,10 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         let persisted = await fs.readJson(revisionsFile);
         expect(persisted.revisions[`t1/${repoSlug}`]).toMatchObject({
-            lastIngestedRev    : 'sha-good',
-            consecutiveFailures: 1
+            lastIngestedRev                   : 'sha-good',
+            consecutiveFailures               : 1,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
         });
 
         const recovered = await TenantRepoSyncService.runTask(options);
@@ -450,9 +469,11 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             await fs.writeJson(revisionsFile, {
                 revisions: {
                     [`t1/${repoSlug}`]: {
-                        lastIngestedRev    : 'sha-known-good',
-                        lastRunAttemptAt   : 0,
-                        consecutiveFailures: 2
+                        lastIngestedRev                   : 'sha-known-good',
+                        lastRunAttemptAt                  : 0,
+                        consecutiveFailures               : 2,
+                        ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
                     }
                 }
             });
@@ -543,9 +564,11 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await fs.writeJson(revisionsFile, {
             revisions: {
                 [`t1/${repoSlug}`]: {
-                    lastIngestedRev    : 'sha-old-checkpoint',
-                    lastRunAttemptAt   : 0,
-                    consecutiveFailures: 2
+                    lastIngestedRev                   : 'sha-old-checkpoint',
+                    lastRunAttemptAt                  : 0,
+                    consecutiveFailures               : 2,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
                 }
             }
         });
@@ -599,9 +622,419 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         persisted = await fs.readJson(revisionsFile);
         expect(persisted.revisions[`t1/${repoSlug}`]).toMatchObject({
-            lastIngestedRev    : 'sha-replay-clean',
-            consecutiveFailures: 0
+            lastIngestedRev                   : 'sha-replay-clean',
+            consecutiveFailures               : 0,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
         });
+    });
+
+    test('legacy checkpoint revalidation retries returned and thrown failures from a null base before proving the new head (#15761)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/legacy-retry',
+            envelopeCalls    = [];
+        let ingestAttempt = 0;
+
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                [`t1/${repoSlug}`]: {
+                    lastIngestedRev    : 'sha-legacy-head',
+                    lastRunAttemptAt   : 0,
+                    consecutiveFailures: 0
+                }
+            }
+        });
+
+        const options = {
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/legacy-retry.git'
+            }]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder({captureCalls: envelopeCalls}),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory() {
+                    ingestAttempt++;
+
+                    if (ingestAttempt === 1) {
+                        return {ingested: 1, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_FAILED'}]}
+                    }
+
+                    if (ingestAttempt === 2) {
+                        throw new Error('bounded thrown failure')
+                    }
+
+                    return {ingested: 1, deleted: 0, errors: []}
+                }
+            }),
+            revisionsFilePath: revisionsFile,
+            globalCadenceMs  : 0,
+            jitterRatio      : 0,
+            seedBootstrap    : false
+        };
+
+        for (const expectedFailureCount of [1, 2]) {
+            const failed = await TenantRepoSyncService.runTask(options);
+
+            expect(failed.status).toBe('failed');
+            expect(failed.details.repos[0]).toMatchObject({
+                status             : 'degraded',
+                checkpointStatus   : 'failed',
+                consecutiveFailures: expectedFailureCount
+            });
+
+            const persisted = await fs.readJson(revisionsFile);
+            expect(persisted.revisions[`t1/${repoSlug}`]).toMatchObject({
+                lastIngestedRev                   : 'sha-legacy-head',
+                consecutiveFailures               : expectedFailureCount,
+                ingestContractVersion             : null,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            });
+        }
+
+        const recovered = await TenantRepoSyncService.runTask(options);
+
+        expect(recovered.status).toBe('completed');
+        expect(envelopeCalls).toHaveLength(3);
+        expect(envelopeCalls.every(call => call.args.lastIngestedRev === null)).toBe(true);
+
+        const persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions[`t1/${repoSlug}`]).toMatchObject({
+            lastIngestedRev                   : `sha-head-${repoSlug}`,
+            consecutiveFailures               : 0,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        });
+    });
+
+    test('periodic migration admits at most concurrencyLimit legacy replays per sweep while current repos stay incremental (#15761)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            legacySlugs      = ['org/legacy-a', 'org/legacy-b', 'org/legacy-c'],
+            currentSlug      = 'org/current',
+            envelopeCalls    = [];
+
+        TenantRepoSyncService.concurrencyLimit = 2;
+
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                't1/org/legacy-a': {lastIngestedRev: 'sha-a', lastRunAttemptAt: 0, consecutiveFailures: 0},
+                't1/org/legacy-b': {lastIngestedRev: 'sha-b', lastRunAttemptAt: 0, consecutiveFailures: 0},
+                't1/org/legacy-c': {lastIngestedRev: 'sha-c', lastRunAttemptAt: 0, consecutiveFailures: 0},
+                't1/org/current' : {
+                    lastIngestedRev                   : 'sha-current',
+                    lastRunAttemptAt                  : 0,
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                }
+            }
+        });
+
+        const options = {
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [...legacySlugs, currentSlug].map(repoSlug => ({
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: `https://github.com/neomjs/${repoSlug}.git`
+            }))},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder({captureCalls: envelopeCalls}),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 0,
+            jitterRatio                  : 0,
+            seedBootstrap                : false
+        };
+
+        const firstSweep = await TenantRepoSyncService.runTask(options);
+
+        expect(firstSweep.status).toBe('completed');
+        expect(firstSweep.details).toMatchObject({
+            completedCount           : 3,
+            revalidationDeferredCount: 1
+        });
+        expect(envelopeCalls.filter(call => call.args.lastIngestedRev === null)).toHaveLength(2);
+        expect(envelopeCalls.find(call => call.args.repoSlug === currentSlug).args.lastIngestedRev).toBe('sha-current');
+        const firstSweepCallCount = envelopeCalls.length;
+
+        let persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions['t1/org/legacy-a'].ingestContractVersion).toBe(TENANT_REPO_INGEST_CONTRACT_VERSION);
+        expect(persisted.revisions['t1/org/legacy-b'].ingestContractVersion).toBe(TENANT_REPO_INGEST_CONTRACT_VERSION);
+        expect(persisted.revisions['t1/org/legacy-c'].ingestContractVersion).toBeNull();
+
+        const secondSweep = await TenantRepoSyncService.runTask(options);
+
+        expect(secondSweep.status).toBe('completed');
+        expect(secondSweep.details.revalidationDeferredCount).toBe(0);
+        expect(envelopeCalls.filter(call =>
+            call.args.repoSlug === 'org/legacy-c' && call.args.lastIngestedRev === null
+        )).toHaveLength(1);
+        for (const repoSlug of ['org/legacy-a', 'org/legacy-b']) {
+            const secondSweepCall = envelopeCalls
+                .slice(firstSweepCallCount)
+                .find(call => call.args.repoSlug === repoSlug);
+
+            expect(secondSweepCall.args.lastIngestedRev).toBe(`sha-head-${repoSlug}`);
+        }
+
+        persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions['t1/org/legacy-c'].ingestContractVersion).toBe(TENANT_REPO_INGEST_CONTRACT_VERSION);
+    });
+
+    test('admitted legacy replay gets the semaphore before a slow current repo across repeated sweeps (#15761)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            currentSlug      = 'org/current-slow',
+            legacySlug       = 'org/legacy-starvation',
+            mirrorCalls      = [],
+            envelopeCalls    = [];
+
+        TenantRepoSyncService.concurrencyLimit         = 1;
+        TenantRepoSyncService.concurrencyGateTimeoutMs = 15;
+
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                [`t1/${currentSlug}`]: {
+                    lastIngestedRev                   : 'sha-current',
+                    lastRunAttemptAt                  : 0,
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                },
+                [`t1/${legacySlug}`]: {
+                    lastIngestedRev    : 'sha-legacy',
+                    lastRunAttemptAt   : 0,
+                    consecutiveFailures: 0
+                }
+            }
+        });
+
+        const slowCurrentMirror = {
+            async cloneIfMissing(args) {
+                mirrorCalls.push({op: 'cloneIfMissing', args});
+
+                if (args.repoSlug === currentSlug) {
+                    await new Promise(resolve => setTimeout(resolve, 40));
+                }
+            },
+            async fetch(args) {
+                mirrorCalls.push({op: 'fetch', args});
+            },
+            async resolveHead({ref}) {
+                return `sha-for-${ref}`;
+            },
+            async isAncestor() {
+                return true;
+            },
+            async diffRevisions() {
+                return {addedOrChanged: [], deleted: []};
+            }
+        };
+        const options = {
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: currentSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/current.git'},
+                {tenantId: 't1', repoSlug: legacySlug,  mirrorRoot, cloneUrl: 'https://github.com/neomjs/legacy.git'}
+            ]},
+            gitMirror                    : slowCurrentMirror,
+            envelopeBuilder              : makeFakeEnvelopeBuilder({captureCalls: envelopeCalls}),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 0,
+            jitterRatio                  : 0,
+            seedBootstrap                : false
+        };
+
+        for (let sweep = 0; sweep < 3; sweep++) {
+            const result = await TenantRepoSyncService.runTask(options);
+
+            expect(result.status).toBe('completed');
+        }
+
+        expect(mirrorCalls[0]).toMatchObject({
+            op  : 'cloneIfMissing',
+            args: {repoSlug: legacySlug}
+        });
+        expect(envelopeCalls.filter(call =>
+            call.args.repoSlug === legacySlug && call.args.lastIngestedRev === null
+        )).toHaveLength(1);
+
+        const persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions[`t1/${legacySlug}`]).toMatchObject({
+            lastIngestedRev                   : `sha-head-${legacySlug}`,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        });
+    });
+
+    test('slow admitted replay settles before current repo timeout accounting begins (#15761)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            currentSlug      = 'org/current-fast',
+            legacySlug       = 'org/legacy-slow',
+            envelopeCalls    = [];
+
+        TenantRepoSyncService.concurrencyLimit         = 1;
+        TenantRepoSyncService.concurrencyGateTimeoutMs = 15;
+
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                [`t1/${currentSlug}`]: {
+                    lastIngestedRev                   : 'sha-current',
+                    lastRunAttemptAt                  : 0,
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                },
+                [`t1/${legacySlug}`]: {
+                    lastIngestedRev    : 'sha-legacy',
+                    lastRunAttemptAt   : 0,
+                    consecutiveFailures: 0
+                }
+            }
+        });
+
+        const slowLegacyMirror = {
+            async cloneIfMissing({repoSlug}) {
+                if (repoSlug === legacySlug) {
+                    await new Promise(resolve => setTimeout(resolve, 40));
+                }
+            },
+            async fetch() {},
+            async resolveHead({ref}) {
+                return `sha-for-${ref}`;
+            },
+            async isAncestor() {
+                return true;
+            },
+            async diffRevisions() {
+                return {addedOrChanged: [], deleted: []};
+            }
+        };
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: currentSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/current.git'},
+                {tenantId: 't1', repoSlug: legacySlug,  mirrorRoot, cloneUrl: 'https://github.com/neomjs/legacy.git'}
+            ]},
+            gitMirror                    : slowLegacyMirror,
+            envelopeBuilder              : makeFakeEnvelopeBuilder({captureCalls: envelopeCalls}),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 0,
+            jitterRatio                  : 0,
+            seedBootstrap                : false
+        });
+
+        expect(result).toMatchObject({
+            status : 'completed',
+            details: {
+                completedCount: 2,
+                failedCount   : 0
+            }
+        });
+        expect(result.details.repos.find(repo => repo.repoSlug === currentSlug)).toMatchObject({
+            status          : 'active',
+            checkpointStatus: 'complete'
+        });
+        expect(envelopeCalls.find(call => call.args.repoSlug === currentSlug).args.lastIngestedRev).toBe('sha-current');
+        expect(envelopeCalls.find(call => call.args.repoSlug === legacySlug).args.lastIngestedRev).toBeNull();
+    });
+
+    for (const {label, marker} of [
+        {label: 'string success marker',     marker: {ingestContractVersion: '2'}},
+        {label: 'fractional success marker', marker: {ingestContractVersion: 1.5}},
+        {label: 'negative attempt marker',   marker: {lastAttemptedIngestContractVersion: -1}},
+        {label: 'zero attempt marker',       marker: {lastAttemptedIngestContractVersion: 0}}
+    ]) {
+        test(`malformed ${label} fails closed without authorizing legacy replay (#15761)`, async () => {
+            const
+                taskStateService = createInMemoryTaskStateService(),
+                mirrorCalls      = [],
+                repoSlug         = 'org/malformed-contract';
+
+            await fs.writeJson(revisionsFile, {
+                revisions: {
+                    [`t1/${repoSlug}`]: {
+                        lastIngestedRev    : 'sha-preserve',
+                        lastRunAttemptAt   : 0,
+                        consecutiveFailures: 0,
+                        ...marker
+                    }
+                }
+            });
+            const originalManifest = await fs.readFile(revisionsFile, 'utf8');
+
+            const result = await TenantRepoSyncService.runTask({
+                reason           : 'periodic-sweep:60000',
+                taskStateService,
+                tenantReposConfig: {tenantRepos: [{
+                    tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/malformed.git'
+                }]},
+                gitMirror                    : makeFakeGitMirror({captureCalls: mirrorCalls}),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService(),
+                revisionsFilePath            : revisionsFile,
+                globalCadenceMs              : 0,
+                jitterRatio                  : 0,
+                seedBootstrap                : false
+            });
+
+            expect(result.status).toBe('failed');
+            expect(result.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_SYNC_FAILED');
+            expect(mirrorCalls).toHaveLength(0);
+            expect(await fs.readFile(revisionsFile, 'utf8')).toBe(originalManifest);
+        });
+    }
+
+    test('future checkpoint-contract markers fail closed without downgrade or repo work (#15761)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            mirrorCalls      = [],
+            repoSlug         = 'org/future-contract',
+            futureVersion    = TENANT_REPO_INGEST_CONTRACT_VERSION + 1;
+
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                [`t1/${repoSlug}`]: {
+                    lastIngestedRev                   : 'sha-future',
+                    lastRunAttemptAt                  : 0,
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : futureVersion,
+                    lastAttemptedIngestContractVersion: futureVersion,
+                    futureOnlyField                   : 'preserve-me'
+                }
+            }
+        });
+        const originalManifest = await fs.readFile(revisionsFile, 'utf8');
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/future.git'
+            }]},
+            gitMirror                    : makeFakeGitMirror({captureCalls: mirrorCalls}),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 0,
+            jitterRatio                  : 0,
+            seedBootstrap                : false
+        });
+
+        expect(result.status).toBe('failed');
+        expect(result.details).toMatchObject({
+            reasonCode: 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+            meta      : {phase: 'checkpoint-contract-validation'}
+        });
+        expect(mirrorCalls).toHaveLength(0);
+        expect(await fs.readFile(revisionsFile, 'utf8')).toBe(originalManifest);
     });
 
     test('full replay without an explicit repo selector fails before repo work begins (#15748)', async () => {
@@ -807,6 +1240,29 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(warn.level).toBe('WARN');
     });
 
+    test('corrupt persisted revision state fails closed without being overwritten as bootstrap (#15761)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            malformedJson    = '{"revisions":';
+
+        await fs.writeFile(revisionsFile, malformedJson);
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug: 'org/repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/repo.git'
+            }]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile
+        });
+
+        expect(result.status).toBe('failed');
+        expect(await fs.readFile(revisionsFile, 'utf8')).toBe(malformedJson);
+    });
+
     test('writePersistedRevisions wraps fs write failure as KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED', async () => {
         const readOnlyParent = path.join(tmpDir, 'read-only-parent');
         await fs.ensureDir(readOnlyParent);
@@ -1010,7 +1466,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'neomjs/recent-repo'});
 
         const result = await TenantRepoSyncService.runTask({
-            reason           : 'periodic-sweep:1800000',
+            reason           : 'periodic-sweep:60000',
             taskStateService,
             tenantReposConfig: {tenantRepos: [
                 {tenantId: 't1', repoSlug: 'neomjs/recent-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/recent-repo.git'}
@@ -1030,6 +1486,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         const repoState = result.details.repos[0];
         expect(repoState.status).toBe('not-due');
+        expect(repoState.checkpointStatus).toBe('pending');
         expect(repoState.nextDueAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
         expect(repoState.effectiveCadenceMs).toBeGreaterThan(0);
         expect(repoState.consecutiveFailures).toBe(0);
@@ -1072,9 +1529,11 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // Persistence reflects the failure increment for next cycle's backoff calculation.
         const persisted = await fs.readJson(revisionsFile);
         expect(persisted.revisions['t1/neomjs/failing-repo']).toEqual({
-            lastIngestedRev    : null,
-            lastRunAttemptAt   : expect.any(Number),
-            consecutiveFailures: 1
+            lastIngestedRev                   : null,
+            lastRunAttemptAt                  : expect.any(Number),
+            consecutiveFailures               : 1,
+            ingestContractVersion             : null,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
         });
     });
 
@@ -1086,9 +1545,11 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await fs.writeJson(revisionsFile, {
             revisions: {
                 't1/neomjs/recovering-repo': {
-                    lastIngestedRev    : 'sha-old',
-                    lastRunAttemptAt   : 0, // very stale — backoff'd cadence is exceeded
-                    consecutiveFailures: 3
+                    lastIngestedRev                   : 'sha-old',
+                    lastRunAttemptAt                  : 0, // very stale — backoff'd cadence is exceeded
+                    consecutiveFailures               : 3,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
                 }
             }
         });
@@ -1118,6 +1579,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
     test('jitter+backoff: backward-compatible read of pre-AC1 string-shaped persistence (#11942 AC1)', async () => {
         const taskStateService = createInMemoryTaskStateService();
+        const envelopeCalls    = [];
 
         // Pre-AC1 persistence shape: bare SHA strings under revisions.
         await fs.writeJson(revisionsFile, {
@@ -1135,14 +1597,15 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 {tenantId: 't1', repoSlug: 'neomjs/legacy-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/legacy-repo.git'}
             ]},
             gitMirror                    : makeFakeGitMirror(),
-            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder({captureCalls: envelopeCalls}),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
             revisionsFilePath            : revisionsFile
         });
 
-        // Successful migration: pre-AC1 SHA was read as lastIngestedRev with zeroed state;
-        // run proceeds normally; persistence rewritten in new shape.
+        // A bare SHA has no error-free success proof. The upgrade therefore performs
+        // one harmless null-base replay before persisting the current contract marker.
         expect(result.status).toBe('completed');
+        expect(envelopeCalls[0].args.lastIngestedRev).toBeNull();
 
         const persisted = await fs.readJson(revisionsFile);
         const state     = persisted.revisions['t1/neomjs/legacy-repo'];
@@ -1150,6 +1613,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(state.lastIngestedRev).toBeTruthy();
         expect(state.consecutiveFailures).toBe(0); // success path resets
         expect(state.lastRunAttemptAt).toBeGreaterThan(0);
+        expect(state.ingestContractVersion).toBe(TENANT_REPO_INGEST_CONTRACT_VERSION);
+        expect(state.lastAttemptedIngestContractVersion).toBe(TENANT_REPO_INGEST_CONTRACT_VERSION);
     });
 
     test('jitter+backoff: onlyRepoSlugs (manual CLI path) bypasses due-check (#11942 AC1)', async () => {
@@ -1161,9 +1626,11 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await fs.writeJson(revisionsFile, {
             revisions: {
                 't1/neomjs/manual-repo': {
-                    lastIngestedRev    : 'sha-recent',
-                    lastRunAttemptAt   : recentMs,
-                    consecutiveFailures: 0
+                    lastIngestedRev                   : 'sha-recent',
+                    lastRunAttemptAt                  : recentMs,
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
                 }
             }
         });


### PR DESCRIPTION
Resolves #15761

Related: #15759

Tenant-repo polling now records which error-free ingestion contract authorized each persisted head. Unversioned legacy heads are automatically revalidated from a null base through the existing periodic lane, with at most one concurrency window admitted per sweep. A failed replay preserves the old head and records retry/backoff evidence; a clean replay atomically writes the new head and current proof marker. The deployment bridge exposes redacted pending, failed, complete, uninitialized, and unsupported counts without turning malformed or unreadable state into false all-zero health.

Decision Record impact: aligned with ADR 0014 and ADR 0019; no amendment required. The existing orchestrator lane remains the sole owner of acquisition, ingestion admission, scheduling, and checkpoint persistence. AiConfig access stays at the existing service use sites, and the deployment bridge remains the public redaction boundary.

Evidence: L2 (real filesystem persistence plus service, scheduler, diagnostics, redaction, retry, and CLI-adjacent unit coverage) → L2 required (the close-target ACs are internal state-machine and persistence contracts; container-recreation durability is separately proven by merged `#15764`). No residuals.

## Deltas from ticket

- The proof record uses both `ingestContractVersion` and `lastAttemptedIngestContractVersion`, so diagnostics distinguish never-attempted legacy state from a failed current-contract replay without trusting historical failure counters.
- Admitted migration work runs as a bounded first cohort. Normal repos are enqueued only after that cohort settles, preventing either legacy starvation behind slow current work or false current-repo timeouts behind intentionally prioritized migration.
- Valid future contract markers fail closed without rewriting the manifest. Present-but-malformed markers make the aggregate unavailable rather than being coerced into legacy state or projected as an impossible partial count.
- An unresolved repository-config universe also makes aggregate checkpoint counts unavailable; degraded bootstrap diagnostics with safely resolved fallback repos remain countable.
- The manual scoped `--full` path remains an optional acceleration mechanism, not the normal upgrade-recovery path.

## Test Evidence

- Tenant-repo state machine, filesystem persistence, bounded replay admission, starvation inversions, malformed/future markers, retry/recovery, deployment projection, redaction, and scheduler contracts: `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs` — 99 passed on rebased commit `8c188f601d`.
- Cloud deployment guides: `npm run ai:lint-guides` — 0 hard errors; 28 repository-wide warnings.
- Static gates: JSDoc types, shorthand, parse, staged block alignment, ticket archaeology, client-name scan, and `git diff --check` — passed.
- Pre-commit hook: whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, staged block alignment, and parse — passed.
- Agent gates: `npm run agent-preflight -- --no-fix --pr-body /private/tmp/neo-pr-15761-body.md <nine changed files>` — passed.

## Post-Merge Validation

- [ ] On a non-production pull-mode cloud upgrade with more legacy repos than `concurrencyLimit` plus at least one current repo, confirm one bounded legacy cohort runs per sweep, current work remains isolated, and `checkpointRevalidation` converges from pending/failed to complete.
- [ ] Recreate the orchestrator container without deleting its named volume and confirm pending or failed replay/backoff state resumes from the persisted manifest supplied by `#15764`.

## Evolution

Adversarial pre-PR probes exposed two queue/diagnostic traps that ordinary green tests missed. First, malformed version fields were initially normalized into legacy state; the canonical reader now fails closed and preserves the raw manifest. Second, prioritizing replay entries only inside one FIFO semaphore moved starvation from legacy repos to current repos; the final two-cohort shape delays normal timeout accounting until bounded migration work has settled.

Authored by Euclid (GPT-5.6, Codex Desktop). Session 6f1cb766-e35c-495f-bf54-c1a6ad43197e.
