### PR TITLE
fix(ai): bound malformed Docker label mismatches (#15768)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
@@ -392,6 +392,9 @@ export class DeploymentRuntimeAccessService extends Base {
     /**
      * @summary Verifies that Docker returned the exact project-and-service identity requested.
      *
+     * Missing or malformed label maps fail through the existing bounded mismatch reasons. Diagnostic
+     * details describe only the expected lookup contract and never echo label values returned by Docker.
+     *
      * @param {Object} options
      * @param {Object} options.container Docker container-list item.
      * @param {String} options.serviceKey Expected Compose service key.
@@ -400,7 +403,7 @@ export class DeploymentRuntimeAccessService extends Base {
      * @returns {void}
      */
     assertTargetIdentity({container, serviceKey, composeProject, filters}) {
-        const labels = container && typeof container.Labels === 'object'
+        const labels = container?.Labels && typeof container.Labels === 'object'
             ? container.Labels
             : {};
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
@@ -337,6 +337,47 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
         expect(calls).toHaveLength(1);
     });
 
+    test('routes null or absent Docker labels through bounded project mismatches', async () => {
+        const attempts = [
+            service => service.readObserve({serviceKey: 'mc-server', operation: 'inspect'}),
+            service => service.applyLifecycle({serviceKey: 'mc-server', operation: 'restart'})
+        ];
+
+        for (const labels of [null, undefined]) {
+            for (const attempt of attempts) {
+                const container = makeContainer();
+
+                if (labels === undefined) {
+                    delete container.Labels
+                } else {
+                    container.Labels = labels
+                }
+
+                const {service, calls} = createService({containers: [container]});
+
+                try {
+                    const error = await attempt(service).catch(e => e);
+
+                    expect(error).not.toBeInstanceOf(TypeError);
+                    expect(error).toMatchObject({
+                        reason : 'compose-project-mismatch',
+                        message: 'Docker target did not prove the configured Compose project identity',
+                        details: {
+                            composeProject: 'neo',
+                            serviceKey    : 'mc-server',
+                            matchCount    : 1
+                        }
+                    });
+                    expect(calls).toHaveLength(1);
+                    expect(calls[0].path).toContain('/containers/json?');
+                    expect(calls[0].path).not.toContain('container-abc');
+                } finally {
+                    service.destroy()
+                }
+            }
+        }
+    });
+
     test('fails closed when a service resolves ambiguously inside the configured project', async () => {
         const {service} = createService({
             containers: [


### PR DESCRIPTION
Resolves #15768

Malformed Docker container-list responses with `Labels: null` or no `Labels` map now stay inside the runtime holder's existing bounded identity-mismatch contract. Both observe and lifecycle paths return `compose-project-mismatch` before any target-specific socket access, while diagnostics retain only the expected lookup contract and never echo Docker-returned label values.

Related: #15762

Evidence: L2 (Neo-native unit coverage exercises both runtime-access paths, malformed response shapes, bounded details, and socket-call boundaries) → L2 required (all close-target ACs). No residuals.

## Deltas from ticket

None substantive. The optional configuration-summary trim cleanup remains out of scope because it is independent of the malformed-response failure.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs` — 17/17 passed, including existing adversarial identity fixtures.
- Direct isolated probe — pre-fix: raw `TypeError`; post-fix: bounded `compose-project-mismatch`.
- `node --check ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs` — passed.
- `node --check test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs` — passed.
- `node buildScripts/util/check-jsdoc-types.mjs` — 1,878 files scanned; 0 unparseable type expressions.
- `npm run agent-preflight -- ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs` — passed; only unrelated stale-overlay warnings.
- `npm run test-unit` — 9,113 passed before 14 unrelated failures interrupted the run. A one-worker `--last-failed` rerun cleared 3; the remaining 11 were restricted-sandbox process-inspection and `.neo-ai-data` write failures. Re-running that exact residual set outside the restricted sandbox passed 13/13 including setup and teardown.

## Post-Merge Validation

- [x] None required; the close-target behavior is deterministic and covered at the runtime holder boundary.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex) consuming Vega's ticket — session A 9af3c9a5-efc2-4716-bb5c-19289e22ddcc, session B 72bb1088-8ed5-48b7-a835-c288cf30e814.
