### PR TITLE
fix(ai): serialize tenant-repo sync across processes (#15763)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1168,14 +1168,18 @@ class ConfigBase extends ConfigProvider {
                  * - `leaseStaleAfterMs` bounds the cross-process tenant-repo-sync lease that
                  *   serializes the daemon's periodic sweep against the manual CLI over the
                  *   shared revisions manifest. Crashed owners are reclaimed immediately via
-                 *   pid-liveness; this TTL is the backstop for a live-but-wedged owner, so it
-                 *   must comfortably exceed one full sweep.
+                 *   pid-liveness; this TTL is only the backstop for a live-but-wedged owner
+                 *   and MUST comfortably exceed the longest legitimate sweep (clone + ingest
+                 *   across every configured repo) — the six-hour default mirrors the
+                 *   heavy-maintenance lease authority. Ownership is additionally re-verified
+                 *   at every manifest commit point, so an evicted writer aborts instead of
+                 *   overlapping the new owner.
                  *
                  * @type {Object}
                  */
                 tenantRepoSync: {
                     jitterRatio      : leaf(0.20, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO', 'number'),
-                    leaseStaleAfterMs: leaf(15 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_LEASE_STALE_AFTER_MS', 'number'),
+                    leaseStaleAfterMs: leaf(6 * 60 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_LEASE_STALE_AFTER_MS', 'number'),
                     sweepCadenceMs   : leaf(60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS', 'number')
                 },
                 /**

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1165,12 +1165,18 @@ class ConfigBase extends ConfigProvider {
                  *   the jitter window. A short sweep cadence + a long per-repo cadence means
                  *   each sweep checks all repos against their individual due-times; repos
                  *   become due at different sweeps based on their deterministic jitter offset.
+                 * - `leaseStaleAfterMs` bounds the cross-process tenant-repo-sync lease that
+                 *   serializes the daemon's periodic sweep against the manual CLI over the
+                 *   shared revisions manifest. Crashed owners are reclaimed immediately via
+                 *   pid-liveness; this TTL is the backstop for a live-but-wedged owner, so it
+                 *   must comfortably exceed one full sweep.
                  *
                  * @type {Object}
                  */
                 tenantRepoSync: {
-                    jitterRatio   : leaf(0.20, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO', 'number'),
-                    sweepCadenceMs: leaf(60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS', 'number')
+                    jitterRatio      : leaf(0.20, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO', 'number'),
+                    leaseStaleAfterMs: leaf(15 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_LEASE_STALE_AFTER_MS', 'number'),
+                    sweepCadenceMs   : leaf(60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS', 'number')
                 },
                 /**
                  * Orchestrator-owned MLX inference server config. Operators tune via gitignored

--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -21,6 +21,10 @@ export const KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT = 'KB_TENANT_REPO_SYNC
 // lease. Surfaced as a `skipped` reasonCode (never thrown) so the periodic lane and
 // the manual CLI can branch on it without treating operator ownership as an error.
 export const KB_TENANT_REPO_SYNC_LEASE_HELD = 'KB_TENANT_REPO_SYNC_LEASE_HELD';
+// Commit-point fence: lease ownership was lost (TTL eviction or takeover) between
+// acquisition and a manifest write. The sweep aborts WITHOUT writing, so an evicted
+// writer can never overlap the new owner's manifest commits.
+export const KB_TENANT_REPO_SYNC_LEASE_LOST = 'KB_TENANT_REPO_SYNC_LEASE_LOST';
 
 /**
  * @summary Frozen enumeration of all valid tenant-repo-sync error codes.
@@ -40,7 +44,8 @@ export const TENANT_REPO_SYNC_ERROR_CODES = Object.freeze([
     KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
-    KB_TENANT_REPO_SYNC_LEASE_HELD
+    KB_TENANT_REPO_SYNC_LEASE_HELD,
+    KB_TENANT_REPO_SYNC_LEASE_LOST
 ]);
 
 const TENANT_REPO_SYNC_ERROR_CODE_SET = new Set(TENANT_REPO_SYNC_ERROR_CODES);

--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -17,6 +17,10 @@ export const KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED    = 'KB_TENANT_REPO_SYNC_R
 export const KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND       = 'KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND';
 export const KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED = 'KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED';
 export const KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT = 'KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT';
+// Non-failure defer reason: another process holds the cross-process tenant-repo-sync
+// lease. Surfaced as a `skipped` reasonCode (never thrown) so the periodic lane and
+// the manual CLI can branch on it without treating operator ownership as an error.
+export const KB_TENANT_REPO_SYNC_LEASE_HELD = 'KB_TENANT_REPO_SYNC_LEASE_HELD';
 
 /**
  * @summary Frozen enumeration of all valid tenant-repo-sync error codes.
@@ -35,7 +39,8 @@ export const TENANT_REPO_SYNC_ERROR_CODES = Object.freeze([
     KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
     KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
-    KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT
+    KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
+    KB_TENANT_REPO_SYNC_LEASE_HELD
 ]);
 
 const TENANT_REPO_SYNC_ERROR_CODE_SET = new Set(TENANT_REPO_SYNC_ERROR_CODES);

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -14,12 +14,17 @@ import {
 import {isRepoDue} from '../scheduling/tenantRepoSync.mjs';
 import {
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
+    KB_TENANT_REPO_SYNC_LEASE_HELD,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
     TenantRepoSyncError,
     isTenantRepoSyncErrorCode
 } from './TenantRepoSyncErrors.mjs';
+import {
+    acquireHeavyMaintenanceLease,
+    releaseHeavyMaintenanceLease
+} from './heavyMaintenanceLeasePrimitives.mjs';
 import {
     classifyTenantRepoCheckpoint,
     normalizeTenantRepoCheckpointState,
@@ -29,10 +34,11 @@ import {
 } from './tenantRepoCheckpointValidity.mjs';
 
 const
-    ACCESS_CONFIG_FINGERPRINT_KEY = randomBytes(32),
-    ACCESS_READINESS_MIN_TTL_MS   = 15 * 60 * 1000,
-    BOUNDED_KB_ERROR_CODE_PATTERN = /^KB_[A-Z0-9_]{1,120}$/,
-    PERSISTED_REVISIONS_FILE_NAME = 'tenant-repo-sync-revisions.json';
+    ACCESS_CONFIG_FINGERPRINT_KEY    = randomBytes(32),
+    ACCESS_READINESS_MIN_TTL_MS      = 15 * 60 * 1000,
+    BOUNDED_KB_ERROR_CODE_PATTERN    = /^KB_[A-Z0-9_]{1,120}$/,
+    PERSISTED_REVISIONS_FILE_NAME    = 'tenant-repo-sync-revisions.json',
+    TENANT_REPO_SYNC_LEASE_FILE_NAME = 'tenant-repo-sync-lease.json';
 
 /**
  * @summary In-memory async semaphore with optional slot-acquisition timeout.
@@ -605,6 +611,7 @@ class TenantRepoSyncService extends Base {
      * @param {String[]} [options.onlyRepoSlugs] If provided, only sync repos whose `repoSlug` is in the list. Used by the manual CLI run path. Empty filter result against non-empty list surfaces `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED`.
      * @param {Boolean} [options.fullReplay=false] Build selected-repo envelopes from a null revision base. Requires non-empty `onlyRepoSlugs`; persisted checkpoints remain unchanged until each replay completes without summary errors.
      * @param {String} [options.revisionsFilePath] Override the per-tenant-repo lastIngestedRev persistence file path (test seam). Defaults to `<orchestrator dataDir leaf>/tenant-repo-sync-revisions.json`.
+     * @param {Number} [options.leaseStaleAfterMs] Override the cross-process lease TTL (test seam). Defaults to the `orchestrator.tenantRepoSync.leaseStaleAfterMs` leaf. Crashed owners recover immediately via pid-liveness; the TTL only bounds a live-but-wedged owner.
      * @param {Function} [options.envelopeBuilder=buildIngestEnvelope] Injectable envelope-builder (test seam). Production callers omit; unit tests pass a fake that returns canned envelope shape.
      * @returns {Promise<Object>} `{status, details}` — status ∈ {`completed`, `failed`, `skipped`}.
      */
@@ -620,10 +627,11 @@ class TenantRepoSyncService extends Base {
         onlyRepoSlugs,
         fullReplay = false,
         revisionsFilePath,
-        envelopeBuilder = buildIngestEnvelope,
-        globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
-        jitterRatio     = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
-        seedBootstrap   = true
+        envelopeBuilder   = buildIngestEnvelope,
+        globalCadenceMs   = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
+        jitterRatio       = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
+        leaseStaleAfterMs = AiConfig.data.orchestrator.tenantRepoSync.leaseStaleAfterMs,
+        seedBootstrap     = true
     } = {}) {
         const state = taskStateService.getTaskState(taskName);
 
@@ -634,12 +642,62 @@ class TenantRepoSyncService extends Base {
             return {status: 'skipped', details};
         }
 
+        // Cross-process serialization: the daemon's periodic sweep and the manual CLI are
+        // separate processes sharing one revisions manifest, and the injected task-state
+        // guard above is process-local only. One dedicated tokenized lease — a sibling
+        // file of the manifest, so lock and data share a persistence/recovery boundary —
+        // makes them mutually exclusive. Contention is a non-failure deferral that never
+        // mutates any repo's checkpoint, attempt timestamp, or backoff state. Crashed
+        // owners recover instantly via pid-liveness; the TTL bounds wedged-but-alive ones.
+        const resolvedRevisionsPath = revisionsFilePath || this.defaultRevisionsFilePath();
+        const resolvedLeasePath     = path.join(path.dirname(resolvedRevisionsPath), TENANT_REPO_SYNC_LEASE_FILE_NAME);
+
+        let acquisition;
+        try {
+            acquisition = await acquireHeavyMaintenanceLease({
+                owner       : `tenant-repo-sync:${reason === 'manual' ? 'manual' : 'scheduler'}`,
+                reason      : 'tenant-repo-sync',
+                leasePath   : resolvedLeasePath,
+                staleAfterMs: leaseStaleAfterMs
+            });
+        } catch (e) {
+            // An IO failure while creating the lease (unwritable state dir, broken volume)
+            // is a lane failure, not a crash: keep the structured-result contract.
+            const details = {
+                reason,
+                phase     : 'lease-acquire',
+                error     : e.message,
+                reasonCode: KB_TENANT_REPO_SYNC_SYNC_FAILED
+            };
+            taskStateService.markFailed(taskName, null, {status: 'failed', ...details});
+            writeLog?.('ERROR', `[TenantRepoSync] Failed: ${KB_TENANT_REPO_SYNC_SYNC_FAILED} (lease-acquire: ${e.message})`);
+            healthService?.recordTaskOutcome?.(taskName, 'failed', details);
+            return {status: 'failed', details};
+        }
+
+        if (!acquisition.acquired) {
+            const heldLease = acquisition.lease;
+            const details   = {
+                reason,
+                skippedAt      : new Date().toISOString(),
+                reasonCode     : KB_TENANT_REPO_SYNC_LEASE_HELD,
+                leaseOwner     : heldLease?.owner || 'unknown',
+                leaseAcquiredAt: heldLease?.acquiredAt || null,
+                leaseExpiresAt : heldLease?.expiresAt || null
+            };
+            writeLog?.('INFO', `[TenantRepoSync] Deferring; cross-process lease held by ${details.leaseOwner}.`);
+            taskStateService.markSkipped(taskName, {status: 'skipped', ...details});
+            healthService?.recordTaskOutcome?.(taskName, 'skipped', details);
+            return {status: 'skipped', details};
+        }
+
         taskStateService.markStarted(taskName, reason);
 
         try {
             const result = await this.syncTenantRepos({
                 writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
-                fullReplay, taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder,
+                fullReplay, taskStateService, healthService, taskName, envelopeBuilder,
+                revisionsFilePath: resolvedRevisionsPath,
                 globalCadenceMs, jitterRatio, seedBootstrap
             });
             const status         = result.status;
@@ -677,6 +735,11 @@ class TenantRepoSyncService extends Base {
             writeLog?.('ERROR', `[TenantRepoSync] Failed: ${code} (${e.message})`);
             healthService?.recordTaskOutcome?.(taskName, 'failed', details);
             return {status: 'failed', details};
+        } finally {
+            // Token-guarded release on every settled path (success, returned-error result,
+            // throw). A hard process crash skips this block by definition — the next
+            // acquirer then reclaims via the pid-liveness stale check instead.
+            await releaseHeavyMaintenanceLease({token: acquisition.lease.token, leasePath: resolvedLeasePath});
         }
     }
 
@@ -1232,9 +1295,16 @@ class TenantRepoSyncService extends Base {
      * directory on first write so a fresh deployment doesn't need explicit dir
      * provisioning.
      *
+     * Atomic whole-file replacement: the document is written to a temporary
+     * sibling, fsynced, then renamed over the target. A process crash at any
+     * point therefore leaves either the previous complete manifest or the new
+     * complete manifest on disk — never a truncated JSON document (which the
+     * strict reader would otherwise fail-close the whole lane on).
+     *
      * Throws `TenantRepoSyncError(KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED)` on
      * write failure so the next cycle re-detects the same diff and retries
-     * idempotently (per-repo failure isolation contract).
+     * idempotently (per-repo failure isolation contract). The temporary sibling
+     * is best-effort removed on failure.
      *
      * @param {Object} options
      * @param {String} options.filePath
@@ -1242,10 +1312,22 @@ class TenantRepoSyncService extends Base {
      * @returns {Promise<void>}
      */
     async writePersistedRevisions({filePath, revisions}) {
+        const tmpPath = `${filePath}.tmp-${process.pid}`;
+
         try {
             await fs.ensureDir(path.dirname(filePath));
-            await fs.writeJson(filePath, {revisions}, {spaces: 2});
+
+            const fd = await fs.open(tmpPath, 'w');
+            try {
+                await fs.write(fd, JSON.stringify({revisions}, null, 2) + '\n');
+                await fs.fsync(fd);
+            } finally {
+                await fs.close(fd);
+            }
+
+            await fs.rename(tmpPath, filePath);
         } catch (e) {
+            await fs.remove(tmpPath).catch(() => {});
             throw new TenantRepoSyncError(
                 KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
                 `Failed to persist tenant-repo-sync revisions at ${filePath}: ${e.message}`,

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -25,7 +25,8 @@ import {
 import {
     acquireHeavyMaintenanceLease,
     inspectHeavyMaintenanceLease,
-    releaseHeavyMaintenanceLease
+    releaseHeavyMaintenanceLease,
+    renewHeavyMaintenanceLease
 } from './heavyMaintenanceLeasePrimitives.mjs';
 import {
     classifyTenantRepoCheckpoint,
@@ -614,6 +615,7 @@ class TenantRepoSyncService extends Base {
      * @param {Boolean} [options.fullReplay=false] Build selected-repo envelopes from a null revision base. Requires non-empty `onlyRepoSlugs`; persisted checkpoints remain unchanged until each replay completes without summary errors.
      * @param {String} [options.revisionsFilePath] Override the per-tenant-repo lastIngestedRev persistence file path (test seam). Defaults to `<orchestrator dataDir leaf>/tenant-repo-sync-revisions.json`.
      * @param {Number} [options.leaseStaleAfterMs] Override the cross-process lease TTL (test seam). Defaults to the `orchestrator.tenantRepoSync.leaseStaleAfterMs` leaf. Crashed owners recover immediately via pid-liveness; the TTL only bounds a live-but-wedged owner.
+     * @param {Number} [options.leaseRenewalIntervalMs] Override the lease renewal cadence (test seam). Defaults to `max(5000, floor(leaseStaleAfterMs / 3))` — a live, renewing run never reaches its TTL deadline, so a replacement owner cannot start repo work while this one is still making progress.
      * @param {Function} [options.envelopeBuilder=buildIngestEnvelope] Injectable envelope-builder (test seam). Production callers omit; unit tests pass a fake that returns canned envelope shape.
      * @returns {Promise<Object>} `{status, details}` — status ∈ {`completed`, `failed`, `skipped`}.
      */
@@ -633,6 +635,7 @@ class TenantRepoSyncService extends Base {
         globalCadenceMs   = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
         jitterRatio       = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
         leaseStaleAfterMs = AiConfig.data.orchestrator.tenantRepoSync.leaseStaleAfterMs,
+        leaseRenewalIntervalMs,
         seedBootstrap     = true
     } = {}) {
         const state = taskStateService.getTaskState(taskName);
@@ -695,18 +698,70 @@ class TenantRepoSyncService extends Base {
 
         taskStateService.markStarted(taskName, reason);
 
-        // Commit-point fence: manifest writes re-verify lease ownership right before
-        // committing. A live-but-slow sweep that outlives the TTL (and is reclaimed
-        // by a new owner) therefore aborts WITHOUT writing instead of overlapping
-        // the new owner's manifest — the fencing half of the exclusivity contract;
-        // pid-liveness + the TTL backstop are the acquisition half.
+        // Work-level exclusivity is three cooperating parts:
+        //
+        // 1. RENEWAL — a live run extends its own deadline every
+        //    `renewalIntervalMs` (default TTL/3, floor 5s), so a run that is
+        //    still making progress never becomes TTL-stale and can never be
+        //    reclaimed mid-work. Losing a renewal (replaced lease, missing
+        //    file, IO failure) latches `leaseLost`.
+        // 2. WORK FENCES — `leaseGuard` runs before each repo's git phase,
+        //    before each KB ingest, and before every manifest commit. A run
+        //    whose ownership is no longer provable stops STARTING protected
+        //    work at the next fence instead of overlapping the successor;
+        //    in-flight work is bounded to at most one fenced step.
+        // 3. TTL BACKSTOP — pid-liveness + the (renewal-refreshed) deadline
+        //    still bound a crashed or fully wedged owner for successors.
+        let leaseLost      = false,
+            renewalStopped = false,
+            renewalTimer   = null;
+
+        const renewalIntervalMsResolved = leaseRenewalIntervalMs ?? Math.max(5000, Math.floor(leaseStaleAfterMs / 3));
+
+        const scheduleRenewal = () => {
+            renewalTimer = setTimeout(async () => {
+                try {
+                    const renewal = await renewHeavyMaintenanceLease({
+                        token       : acquisition.lease.token,
+                        leasePath   : resolvedLeasePath,
+                        staleAfterMs: leaseStaleAfterMs
+                    });
+
+                    if (!renewal.renewed) {
+                        leaseLost = true;
+                        writeLog?.('WARN', `[TenantRepoSync] Lease renewal lost ownership (${renewal.status}); aborting at the next fence.`);
+                        return;
+                    }
+                } catch (e) {
+                    leaseLost = true;
+                    writeLog?.('WARN', `[TenantRepoSync] Lease renewal failed (${e.message}); aborting at the next fence.`);
+                    return;
+                }
+
+                if (!renewalStopped) {
+                    scheduleRenewal();
+                }
+            }, renewalIntervalMsResolved);
+            renewalTimer.unref?.();
+        };
+        scheduleRenewal();
+
         const leaseGuard = async () => {
+            if (leaseLost) {
+                throw new TenantRepoSyncError(
+                    KB_TENANT_REPO_SYNC_LEASE_LOST,
+                    'Tenant-repo-sync lease ownership was lost (renewal failure); aborting before further protected work.',
+                    {phase: 'lease-fence'}
+                );
+            }
+
             const currentLease = await inspectHeavyMaintenanceLease({leasePath: resolvedLeasePath});
 
             if (!currentLease.active || currentLease.lease?.token !== acquisition.lease.token) {
+                leaseLost = true;
                 throw new TenantRepoSyncError(
                     KB_TENANT_REPO_SYNC_LEASE_LOST,
-                    'Tenant-repo-sync lease ownership was lost before a manifest commit; aborting without writing.',
+                    'Tenant-repo-sync lease ownership was lost; aborting before further protected work.',
                     {phase: 'lease-fence'}
                 );
             }
@@ -758,6 +813,10 @@ class TenantRepoSyncService extends Base {
             // Token-guarded release on every settled path (success, returned-error result,
             // throw). A hard process crash skips this block by definition — the next
             // acquirer then reclaims via the pid-liveness stale check instead.
+            renewalStopped = true;
+            if (renewalTimer) {
+                clearTimeout(renewalTimer);
+            }
             await releaseHeavyMaintenanceLease({token: acquisition.lease.token, leasePath: resolvedLeasePath});
         }
     }
@@ -841,6 +900,7 @@ class TenantRepoSyncService extends Base {
         const repoStates     = [];
         let   completedCount = 0;
         let   failedCount    = 0;
+        let   abortedCount   = 0;
 
         // Per-runTask concurrency gate caps simultaneous git/ingest work.
         // Fresh instance per call so live `concurrencyLimit` / `concurrencyGateTimeoutMs`
@@ -991,6 +1051,12 @@ class TenantRepoSyncService extends Base {
             try {
                 await semaphore.acquire();
                 slotAcquired = true;
+
+                // Work fence: do not START this repo's git phase without provable
+                // lease ownership. A run that lost its lease (renewal failure or
+                // reclamation) stops here instead of running git work concurrently
+                // with its successor.
+                await leaseGuard();
                 writeLog?.('INFO', `[TenantRepoSync] Refreshing ${repoLabel}.`);
 
                 await gitMirror.cloneIfMissing({
@@ -1026,6 +1092,10 @@ class TenantRepoSyncService extends Base {
                 if (typeof envelope?.headRevision !== 'string' || !envelope.headRevision.trim()) {
                     throw new Error('Tenant-repo ingestion envelope did not prove a head revision.');
                 }
+
+                // Work fence: the KB write is the second substrate mutation this
+                // lane protects (the manifest commit being the first).
+                await leaseGuard();
 
                 const ingestResult = assertErrorFreeIngestionSummary(await ingestionService.ingestSourceFiles({
                     ...envelope,
@@ -1072,6 +1142,26 @@ class TenantRepoSyncService extends Base {
                     checkpointStatus: TenantRepoCheckpointStatus.COMPLETE
                 });
             } catch (e) {
+                // Lease loss is a RUN-level abort, not a repo failure: leave the
+                // repo's checkpoint, attempt timestamp, and backoff state untouched
+                // (the successor owns forward progress now), record an 'aborted'
+                // repo state, and let the post-sweep check raise the structural
+                // LEASE_LOST for the whole run.
+                if (e.code === KB_TENANT_REPO_SYNC_LEASE_LOST) {
+                    abortedCount++;
+                    writeLog?.('WARN', `[TenantRepoSync] ${repoLabel} aborted: lease ownership lost before protected work.`);
+                    repoStates.push({
+                        tenantId           : repo.tenantId,
+                        repoSlug           : repo.repoSlug,
+                        lastIngestedRev    : priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : null,
+                        lastSyncAt         : priorState?.lastRunAttemptAt ? new Date(priorState.lastRunAttemptAt).toISOString() : null,
+                        status             : 'aborted-lease-lost',
+                        checkpointStatus,
+                        consecutiveFailures: priorState?.consecutiveFailures ?? 0
+                    });
+                    return;
+                }
+
                 const code            = isTenantRepoSyncErrorCode(e.code) ? e.code : KB_TENANT_REPO_SYNC_SYNC_FAILED;
                 const sourceErrorCode = getSourceErrorCode(e, code);
                 const sourceSuffix    = sourceErrorCode ? ` source=${sourceErrorCode}` : '';
@@ -1142,6 +1232,18 @@ class TenantRepoSyncService extends Base {
 
         await Promise.all(admittedRevalidationRepos.map(syncRepo));
         await Promise.all(remainingRepos.map(syncRepo));
+
+        // Any lease-lost abort makes the whole run structurally failed: partial
+        // per-repo results must not be committed (the successor's run is the
+        // authoritative one), and per-repo backoff state was deliberately left
+        // untouched above.
+        if (abortedCount > 0) {
+            throw new TenantRepoSyncError(
+                KB_TENANT_REPO_SYNC_LEASE_LOST,
+                `Tenant-repo-sync lease ownership was lost mid-sweep; ${abortedCount} repo(s) aborted before protected work and no manifest was committed.`,
+                {phase: 'lease-fence', abortedCount}
+            );
+        }
 
         await leaseGuard();
         await this.writePersistedRevisions({filePath: resolvedRevisionsPath, revisions: persistedRevisions});

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -15,6 +15,7 @@ import {isRepoDue} from '../scheduling/tenantRepoSync.mjs';
 import {
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
     KB_TENANT_REPO_SYNC_LEASE_HELD,
+    KB_TENANT_REPO_SYNC_LEASE_LOST,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
@@ -23,6 +24,7 @@ import {
 } from './TenantRepoSyncErrors.mjs';
 import {
     acquireHeavyMaintenanceLease,
+    inspectHeavyMaintenanceLease,
     releaseHeavyMaintenanceLease
 } from './heavyMaintenanceLeasePrimitives.mjs';
 import {
@@ -693,10 +695,27 @@ class TenantRepoSyncService extends Base {
 
         taskStateService.markStarted(taskName, reason);
 
+        // Commit-point fence: manifest writes re-verify lease ownership right before
+        // committing. A live-but-slow sweep that outlives the TTL (and is reclaimed
+        // by a new owner) therefore aborts WITHOUT writing instead of overlapping
+        // the new owner's manifest — the fencing half of the exclusivity contract;
+        // pid-liveness + the TTL backstop are the acquisition half.
+        const leaseGuard = async () => {
+            const currentLease = await inspectHeavyMaintenanceLease({leasePath: resolvedLeasePath});
+
+            if (!currentLease.active || currentLease.lease?.token !== acquisition.lease.token) {
+                throw new TenantRepoSyncError(
+                    KB_TENANT_REPO_SYNC_LEASE_LOST,
+                    'Tenant-repo-sync lease ownership was lost before a manifest commit; aborting without writing.',
+                    {phase: 'lease-fence'}
+                );
+            }
+        };
+
         try {
             const result = await this.syncTenantRepos({
                 writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
-                fullReplay, taskStateService, healthService, taskName, envelopeBuilder,
+                fullReplay, taskStateService, healthService, taskName, envelopeBuilder, leaseGuard,
                 revisionsFilePath: resolvedRevisionsPath,
                 globalCadenceMs, jitterRatio, seedBootstrap
             });
@@ -752,6 +771,7 @@ class TenantRepoSyncService extends Base {
     async syncTenantRepos({
         writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
         fullReplay = false, taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder = buildIngestEnvelope,
+        leaseGuard      = async () => {},
         globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
         jitterRatio     = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
         seedBootstrap   = true
@@ -865,6 +885,7 @@ class TenantRepoSyncService extends Base {
                 }
             }
             if (seededAny) {
+                await leaseGuard();
                 await this.writePersistedRevisions({filePath: resolvedRevisionsPath, revisions: persistedRevisions});
             }
         }
@@ -1122,6 +1143,7 @@ class TenantRepoSyncService extends Base {
         await Promise.all(admittedRevalidationRepos.map(syncRepo));
         await Promise.all(remainingRepos.map(syncRepo));
 
+        await leaseGuard();
         await this.writePersistedRevisions({filePath: resolvedRevisionsPath, revisions: persistedRevisions});
 
         // Status logic: not-due repos don't change the success/failure tally — a cycle
@@ -1309,25 +1331,31 @@ class TenantRepoSyncService extends Base {
      * @param {Object} options
      * @param {String} options.filePath
      * @param {Object<String, String>} options.revisions
+     * @param {Object} [options.fsModule=fs] File-system implementation seam (fault-injection test seam).
      * @returns {Promise<void>}
      */
-    async writePersistedRevisions({filePath, revisions}) {
+    async writePersistedRevisions({filePath, revisions, fsModule = fs}) {
         const tmpPath = `${filePath}.tmp-${process.pid}`;
 
         try {
-            await fs.ensureDir(path.dirname(filePath));
+            await fsModule.ensureDir(path.dirname(filePath));
 
-            const fd = await fs.open(tmpPath, 'w');
+            // writeFile carries Node's full-write contract (it retries partial
+            // writes internally), unlike a single unchecked fs.write() whose
+            // bytesWritten may be short. Only after the COMPLETE payload exists
+            // is it fsynced and atomically renamed over the target.
+            await fsModule.writeFile(tmpPath, JSON.stringify({revisions}, null, 2) + '\n');
+
+            const fd = await fsModule.open(tmpPath, 'r+');
             try {
-                await fs.write(fd, JSON.stringify({revisions}, null, 2) + '\n');
-                await fs.fsync(fd);
+                await fsModule.fsync(fd);
             } finally {
-                await fs.close(fd);
+                await fsModule.close(fd);
             }
 
-            await fs.rename(tmpPath, filePath);
+            await fsModule.rename(tmpPath, filePath);
         } catch (e) {
-            await fs.remove(tmpPath).catch(() => {});
+            await fsModule.remove(tmpPath).catch(() => {});
             throw new TenantRepoSyncError(
                 KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
                 `Failed to persist tenant-repo-sync revisions at ${filePath}: ${e.message}`,

--- a/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
+++ b/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
@@ -318,7 +318,59 @@ export function acquireHeavyMaintenanceLeaseSync({
         return {status: 'held', acquired: false, lease: current.lease};
     }
 
-    fsModule.removeSync(leasePath);
+    // Identity-preserving takeover — sync mirror of the async contract above:
+    // atomic rename-aside, verify the moved lease is the inspected one, restore
+    // a mistakenly-moved fresh lease via non-clobbering link().
+    const claimPath = `${leasePath}.reclaim-${crypto.randomUUID()}`;
+
+    try {
+        fsModule.renameSync(leasePath, claimPath);
+    } catch (e) {
+        if (e.code !== 'ENOENT') {
+            throw e;
+        }
+
+        try {
+            writeLeaseFileSync(leasePath, lease, fsModule);
+            return {status: 'acquired-after-stale', acquired: true, previousStatus: current.status, lease};
+        } catch (e2) {
+            if (e2.code !== 'EEXIST') {
+                throw e2;
+            }
+
+            const raced = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+            return {status: 'held', acquired: false, lease: raced.lease};
+        }
+    }
+
+    let movedToken  = null,
+        movedParsed = false;
+
+    try {
+        movedToken  = JSON.parse(fsModule.readFileSync(claimPath, 'utf8'))?.token ?? null;
+        movedParsed = true;
+    } catch (e) {}
+
+    const inspectedToken  = current.lease?.token ?? null;
+    const identityMatches = current.status === 'malformed'
+        ? !movedParsed
+        : movedParsed && movedToken === inspectedToken;
+
+    if (!identityMatches) {
+        try {
+            fsModule.linkSync(claimPath, leasePath);
+        } catch (e) {}
+        try {
+            fsModule.removeSync(claimPath);
+        } catch (e) {}
+
+        const raced = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+        return {status: 'held', acquired: false, lease: raced.lease};
+    }
+
+    try {
+        fsModule.removeSync(claimPath);
+    } catch (e) {}
 
     try {
         writeLeaseFileSync(leasePath, lease, fsModule);
@@ -421,7 +473,67 @@ export async function acquireHeavyMaintenanceLease({
         return {status: 'held', acquired: false, lease: current.lease};
     }
 
-    await fsModule.remove(leasePath);
+    // Identity-preserving takeover. An unconditional remove() here is a TOCTOU
+    // hazard: contender B could delete contender A's FRESH lease using B's older
+    // stale verdict, letting both return `acquired`. rename() is the atomic
+    // exclusivity point — exactly one contender can move the path aside — and the
+    // moved file is then verified to BE the lease that was inspected. Moving a
+    // different (fresh) lease restores it via link(), which fails on EEXIST
+    // instead of overwriting a newer claim.
+    const claimPath = `${leasePath}.reclaim-${crypto.randomUUID()}`;
+
+    try {
+        await fsModule.rename(leasePath, claimPath);
+    } catch (e) {
+        if (e.code !== 'ENOENT') {
+            throw e;
+        }
+
+        // Another reclaimer moved it first (or the owner released). A plain
+        // exclusive create decides the winner; EEXIST defers to them.
+        try {
+            await writeLeaseFile(leasePath, lease, fsModule);
+            return {status: 'acquired-after-stale', acquired: true, previousStatus: current.status, lease};
+        } catch (e2) {
+            if (e2.code !== 'EEXIST') {
+                throw e2;
+            }
+
+            const raced = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+            return {status: 'held', acquired: false, lease: raced.lease};
+        }
+    }
+
+    let movedToken  = null,
+        movedParsed = false;
+
+    try {
+        movedToken  = JSON.parse(await fsModule.readFile(claimPath, 'utf8'))?.token ?? null;
+        movedParsed = true;
+    } catch (e) {}
+
+    const inspectedToken  = current.lease?.token ?? null;
+    const identityMatches = current.status === 'malformed'
+        ? !movedParsed
+        : movedParsed && movedToken === inspectedToken;
+
+    if (!identityMatches) {
+        // We moved a lease that is NOT the one we inspected — someone acquired
+        // legitimately in between. Restore without clobbering and defer.
+        try {
+            await fsModule.link(claimPath, leasePath);
+        } catch (e) {}
+        try {
+            await fsModule.remove(claimPath);
+        } catch (e) {}
+
+        const raced = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+        return {status: 'held', acquired: false, lease: raced.lease};
+    }
+
+    try {
+        await fsModule.remove(claimPath);
+    } catch (e) {}
 
     try {
         await writeLeaseFile(leasePath, lease, fsModule);

--- a/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
+++ b/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
@@ -234,6 +234,7 @@ export const LIFECYCLE_GUARD_SUFFIX = '.lifecycle-guard';
 const
     DEFAULT_GUARD_STALE_AFTER_MS = 10000,
     GUARD_MAX_ATTEMPTS           = 100,
+    GUARD_OWNER_FILE_PREFIX      = 'owner-',
     GUARD_RETRY_DELAY_MS         = 10;
 
 function lifecycleGuardPath(leasePath) {
@@ -241,87 +242,187 @@ function lifecycleGuardPath(leasePath) {
 }
 
 /**
- * @summary Serializes every read-verify-mutate lease transition through one directory mutex.
+ * @summary Serializes every read-verify-mutate lease transition through one identity-carrying directory mutex.
  *
- * `mkdir` is the atomic entry point: exactly one participant creates the guard
- * directory; everyone else observes `EEXIST` and retries briefly. Recovery,
- * release, and renewal all mutate the canonical lease name based on a fresh
- * read taken INSIDE the guard, which removes the check-then-act windows the
- * unguarded rename-aside takeover had (a moved-aside fresh lease left the
- * canonical name claimable while its owner still believed it held it).
+ * Entry is atomic-with-identity: the entrant stages a directory containing its
+ * unique `owner-<token>` file and `rename()`s it onto the canonical guard name.
+ * POSIX rename refuses a non-empty target, so a LIVE guard can never be
+ * replaced; exactly one entrant wins a vacant name. Recovery, release, and
+ * renewal all mutate the canonical lease name based on a fresh read taken
+ * INSIDE the guard — never on a pre-guard observation.
  *
  * Plain acquisition deliberately stays OUTSIDE the guard: an exclusive `wx`
  * create is already atomic, and a guarded recoverer's unlink→create window
  * admitting an outside `wx` winner is safe — the recoverer's own exclusive
- * create then fails `EEXIST` and defers. At no point can two participants both
- * hold a success verdict for the same interval.
+ * create then fails `EEXIST` and defers.
  *
- * Crash recovery: a guard directory whose mtime is older than
- * `guardStaleAfterMs` (default 10s — several orders of magnitude above the
- * microsecond-scale hold time of the fs transitions it protects) is treated as
- * abandoned and removed. The residual double-entry window this leaves requires
- * a holder to stall longer than the threshold INSIDE a millisecond-scale
- * critical section; normal-operation transitions are fully serialized. Guard
- * aging deliberately uses the physical clock (not the injectable `now` lease
- * seam): lease TTL math is logical time for deterministic tests, guard aging
- * is crash detection — tests steer it via `fs.utimes` + the
- * `guardStaleAfterMs` option instead.
+ * Abandoned-guard recovery is identity-safe: staleness is judged on the mtime
+ * of the owner token the CURRENT guard carries, and the steal consumes exactly
+ * the OBSERVED artifacts — `unlink` of the specific observed owner filename
+ * (`ENOENT` ⇒ the observed guard is already gone or replaced ⇒ abort) followed
+ * by `rmdir`, which the filesystem itself fails with `ENOTEMPTY` when any
+ * OTHER entrant's token is present. Removing a replacement guard by pathname —
+ * the cycle-3 reviewer-reproduced double-entry — is therefore structurally
+ * impossible: no step of the steal can consume artifacts it did not observe.
+ *
+ * Residual bound (stated precisely): a holder stalled past `guardStaleAfterMs`
+ * (default 10s vs µs-scale guarded sections) can be evicted by a legitimate
+ * steal. Every lease mutation inside the critical section re-verifies live
+ * ownership via {@link verifyLifecycleGuardOwnership} immediately before
+ * acting, so a resumed evicted holder DEFERS instead of mutating — the
+ * remaining exposure is the single stat→syscall gap of that probe, reachable
+ * only by a holder that both stalled past the threshold and resumed inside
+ * that gap. Live transitions cannot be evicted or replaced.
+ *
+ * Guard aging deliberately uses the physical clock (not the injectable `now`
+ * lease seam): lease TTL math is logical time for deterministic tests, guard
+ * aging is crash detection — tests steer it via `fs.utimes` on the owner file
+ * (or the empty legacy dir) + the `guardStaleAfterMs` option instead.
  *
  * @param {Object} options
  * @param {String} options.leasePath Canonical lease file path.
  * @param {Object} options.fsModule File-system implementation seam.
- * @param {Number} [options.guardStaleAfterMs=10000] Age after which an abandoned guard is reclaimed.
- * @returns {Promise<Boolean>} `true` when entered; `false` when attempts were exhausted (contention).
+ * @param {Number} [options.guardStaleAfterMs=10000] Age after which an abandoned guard is reclaimable.
+ * @returns {Promise<Object|null>} `{ownerFilePath}` when entered; `null` when attempts were exhausted (contention).
  */
 async function enterLifecycleGuard({leasePath, fsModule, guardStaleAfterMs = DEFAULT_GUARD_STALE_AFTER_MS}) {
     const guardPath = lifecycleGuardPath(leasePath);
 
     for (let attempt = 0; attempt < GUARD_MAX_ATTEMPTS; attempt++) {
+        if (attempt > 0) {
+            await new Promise(resolve => setTimeout(resolve, GUARD_RETRY_DELAY_MS));
+        }
+
+        const token         = crypto.randomUUID(),
+              stagingPath   = `${guardPath}.enter-${token}`,
+              ownerFileName = `${GUARD_OWNER_FILE_PREFIX}${token}`;
+
         try {
-            await fsModule.mkdir(guardPath);
-            return true;
+            await fsModule.mkdir(stagingPath);
+            await fsModule.writeFile(path.join(stagingPath, ownerFileName), '', 'utf8');
+            await fsModule.rename(stagingPath, guardPath);
+            return {ownerFilePath: path.join(guardPath, ownerFileName)};
         } catch (e) {
+            await fsModule.remove(stagingPath).catch(() => {});
+
             if (e.code === 'ENOENT') {
                 await fsModule.ensureDir(path.dirname(guardPath));
                 continue;
             }
-            if (e.code !== 'EEXIST') {
+            if (e.code !== 'EEXIST' && e.code !== 'ENOTEMPTY' && e.code !== 'ENOTDIR') {
                 throw e;
             }
         }
 
-        let mtimeMs;
+        // Guard held by someone. Observe its CURRENT identity artifacts; only a
+        // fully stale observation may be consumed, and only artifact-by-artifact.
+        let observedNames;
         try {
-            mtimeMs = (await fsModule.stat(guardPath)).mtimeMs;
+            observedNames = await fsModule.readdir(guardPath);
         } catch (e) {
-            if (e.code === 'ENOENT') {
-                continue; // holder exited between our mkdir and stat — retry immediately
+            if (e.code === 'ENOENT' || e.code === 'ENOTDIR') {
+                continue; // vacated between rename-failure and observation — retry
             }
             throw e;
         }
 
-        if (Date.now() - mtimeMs >= guardStaleAfterMs) {
+        let newestMtimeMs = null,
+            unobservable  = false;
+
+        if (observedNames.length === 0) {
+            // Interrupted-entry / legacy artifact: an empty guard dir. Judge by dir mtime.
             try {
-                await fsModule.rmdir(guardPath);
+                newestMtimeMs = (await fsModule.stat(guardPath)).mtimeMs;
             } catch (e) {
-                if (e.code !== 'ENOENT') {
+                if (e.code === 'ENOENT') continue;
+                throw e;
+            }
+        } else {
+            for (const name of observedNames) {
+                try {
+                    const {mtimeMs} = await fsModule.stat(path.join(guardPath, name));
+                    newestMtimeMs   = newestMtimeMs === null ? mtimeMs : Math.max(newestMtimeMs, mtimeMs);
+                } catch (e) {
+                    if (e.code === 'ENOENT' || e.code === 'ENOTDIR') {
+                        unobservable = true; // contents changed under observation — not ours to judge
+                        break;
+                    }
                     throw e;
                 }
             }
-            continue;
         }
 
-        await new Promise(resolve => setTimeout(resolve, GUARD_RETRY_DELAY_MS));
+        if (unobservable || Date.now() - newestMtimeMs < guardStaleAfterMs) {
+            continue; // live (or unjudgeable) guard — wait
+        }
+
+        // Identity-safe steal: consume exactly what was observed. Any ENOENT means
+        // the observed guard no longer exists as observed — abort, never escalate
+        // to pathname-based removal.
+        let stealAborted = false;
+        for (const name of observedNames) {
+            try {
+                await fsModule.unlink(path.join(guardPath, name));
+            } catch (e) {
+                if (e.code === 'ENOENT' || e.code === 'ENOTDIR') {
+                    stealAborted = true;
+                    break;
+                }
+                throw e;
+            }
+        }
+        if (stealAborted) continue;
+
+        try {
+            await fsModule.rmdir(guardPath);
+        } catch (e) {
+            // ENOTEMPTY: another entrant claimed the vacancy mid-steal — theirs now.
+            if (e.code !== 'ENOENT' && e.code !== 'ENOTEMPTY') {
+                throw e;
+            }
+        }
+        // Next attempt's staged rename competes for the vacant name.
     }
 
-    return false;
+    return null;
 }
 
-async function exitLifecycleGuard({leasePath, fsModule}) {
+/**
+ * @summary Proves this entrant still owns the lifecycle guard — called immediately before every
+ * lease mutation inside the critical section, so an evicted stalled holder defers instead of
+ * mutating a successor's state.
+ *
+ * @param {Object} options
+ * @param {String} options.ownerFilePath Owner-token path returned by {@link enterLifecycleGuard}.
+ * @param {Object} options.fsModule File-system implementation seam.
+ * @returns {Promise<Boolean>}
+ */
+async function verifyLifecycleGuardOwnership({ownerFilePath, fsModule}) {
     try {
-        await fsModule.rmdir(lifecycleGuardPath(leasePath));
+        await fsModule.stat(ownerFilePath);
+        return true;
     } catch (e) {
-        if (e.code !== 'ENOENT') {
+        if (e.code === 'ENOENT' || e.code === 'ENOTDIR') {
+            return false;
+        }
+        throw e;
+    }
+}
+
+async function exitLifecycleGuard({ownerFilePath, fsModule}) {
+    try {
+        await fsModule.unlink(ownerFilePath);
+    } catch (e) {
+        if (e.code !== 'ENOENT' && e.code !== 'ENOTDIR') {
+            throw e;
+        }
+    }
+
+    try {
+        await fsModule.rmdir(path.dirname(ownerFilePath));
+    } catch (e) {
+        // ENOTEMPTY: a new entrant renamed onto the name during our µs exit window — theirs now.
+        if (e.code !== 'ENOENT' && e.code !== 'ENOTEMPTY') {
             throw e;
         }
     }
@@ -335,60 +436,138 @@ async function exitLifecycleGuard({leasePath, fsModule}) {
  * quanta; the spin budget is capped by `GUARD_MAX_ATTEMPTS`.
  *
  * @param {Object} options See {@link enterLifecycleGuard}.
- * @returns {Boolean}
+ * @returns {Object|null}
  */
 function enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs = DEFAULT_GUARD_STALE_AFTER_MS}) {
     const guardPath = lifecycleGuardPath(leasePath);
 
     for (let attempt = 0; attempt < GUARD_MAX_ATTEMPTS; attempt++) {
+        if (attempt > 0) {
+            const spinUntil = Date.now() + GUARD_RETRY_DELAY_MS;
+            while (Date.now() < spinUntil) {
+                // bounded sync spin — see @summary
+            }
+        }
+
+        const token         = crypto.randomUUID(),
+              stagingPath   = `${guardPath}.enter-${token}`,
+              ownerFileName = `${GUARD_OWNER_FILE_PREFIX}${token}`;
+
         try {
-            fsModule.mkdirSync(guardPath);
-            return true;
+            fsModule.mkdirSync(stagingPath);
+            fsModule.writeFileSync(path.join(stagingPath, ownerFileName), '', 'utf8');
+            fsModule.renameSync(stagingPath, guardPath);
+            return {ownerFilePath: path.join(guardPath, ownerFileName)};
         } catch (e) {
+            try {
+                fsModule.removeSync(stagingPath);
+            } catch (cleanupError) {}
+
             if (e.code === 'ENOENT') {
                 fsModule.ensureDirSync(path.dirname(guardPath));
                 continue;
             }
-            if (e.code !== 'EEXIST') {
+            if (e.code !== 'EEXIST' && e.code !== 'ENOTEMPTY' && e.code !== 'ENOTDIR') {
                 throw e;
             }
         }
 
-        let mtimeMs;
+        let observedNames;
         try {
-            mtimeMs = fsModule.statSync(guardPath).mtimeMs;
+            observedNames = fsModule.readdirSync(guardPath);
         } catch (e) {
-            if (e.code === 'ENOENT') {
+            if (e.code === 'ENOENT' || e.code === 'ENOTDIR') {
                 continue;
             }
             throw e;
         }
 
-        if (Date.now() - mtimeMs >= guardStaleAfterMs) {
+        let newestMtimeMs = null,
+            unobservable  = false;
+
+        if (observedNames.length === 0) {
             try {
-                fsModule.rmdirSync(guardPath);
+                newestMtimeMs = fsModule.statSync(guardPath).mtimeMs;
             } catch (e) {
-                if (e.code !== 'ENOENT') {
+                if (e.code === 'ENOENT') continue;
+                throw e;
+            }
+        } else {
+            for (const name of observedNames) {
+                try {
+                    const {mtimeMs} = fsModule.statSync(path.join(guardPath, name));
+                    newestMtimeMs   = newestMtimeMs === null ? mtimeMs : Math.max(newestMtimeMs, mtimeMs);
+                } catch (e) {
+                    if (e.code === 'ENOENT' || e.code === 'ENOTDIR') {
+                        unobservable = true;
+                        break;
+                    }
                     throw e;
                 }
             }
+        }
+
+        if (unobservable || Date.now() - newestMtimeMs < guardStaleAfterMs) {
             continue;
         }
 
-        const spinUntil = Date.now() + GUARD_RETRY_DELAY_MS;
-        while (Date.now() < spinUntil) {
-            // bounded sync spin — see @summary
+        let stealAborted = false;
+        for (const name of observedNames) {
+            try {
+                fsModule.unlinkSync(path.join(guardPath, name));
+            } catch (e) {
+                if (e.code === 'ENOENT' || e.code === 'ENOTDIR') {
+                    stealAborted = true;
+                    break;
+                }
+                throw e;
+            }
+        }
+        if (stealAborted) continue;
+
+        try {
+            fsModule.rmdirSync(guardPath);
+        } catch (e) {
+            if (e.code !== 'ENOENT' && e.code !== 'ENOTEMPTY') {
+                throw e;
+            }
         }
     }
 
-    return false;
+    return null;
 }
 
-function exitLifecycleGuardSync({leasePath, fsModule}) {
+/**
+ * @summary Synchronous mirror of {@link verifyLifecycleGuardOwnership}.
+ *
+ * @param {Object} options See {@link verifyLifecycleGuardOwnership}.
+ * @returns {Boolean}
+ */
+function verifyLifecycleGuardOwnershipSync({ownerFilePath, fsModule}) {
     try {
-        fsModule.rmdirSync(lifecycleGuardPath(leasePath));
+        fsModule.statSync(ownerFilePath);
+        return true;
     } catch (e) {
-        if (e.code !== 'ENOENT') {
+        if (e.code === 'ENOENT' || e.code === 'ENOTDIR') {
+            return false;
+        }
+        throw e;
+    }
+}
+
+function exitLifecycleGuardSync({ownerFilePath, fsModule}) {
+    try {
+        fsModule.unlinkSync(ownerFilePath);
+    } catch (e) {
+        if (e.code !== 'ENOENT' && e.code !== 'ENOTDIR') {
+            throw e;
+        }
+    }
+
+    try {
+        fsModule.rmdirSync(path.dirname(ownerFilePath));
+    } catch (e) {
+        if (e.code !== 'ENOENT' && e.code !== 'ENOTEMPTY') {
             throw e;
         }
     }
@@ -486,7 +665,9 @@ export function acquireHeavyMaintenanceLeaseSync({
 
     // Guarded recovery — sync mirror of the async contract above: mutate only on
     // a fresh re-inspection taken INSIDE the lifecycle guard.
-    if (!enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs})) {
+    const guardEntry = enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs});
+
+    if (!guardEntry) {
         const raced = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
         return {status: 'held', acquired: false, guardContended: true, lease: raced.lease};
     }
@@ -499,6 +680,11 @@ export function acquireHeavyMaintenanceLeaseSync({
         }
 
         if (reinspect.status !== 'missing') {
+            if (!verifyLifecycleGuardOwnershipSync({ownerFilePath: guardEntry.ownerFilePath, fsModule})) {
+                const raced = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+                return {status: 'held', acquired: false, guardEvicted: true, lease: raced.lease};
+            }
+
             try {
                 fsModule.unlinkSync(leasePath);
             } catch (e) {
@@ -528,7 +714,7 @@ export function acquireHeavyMaintenanceLeaseSync({
                 lease
             };
     } finally {
-        exitLifecycleGuardSync({leasePath, fsModule});
+        exitLifecycleGuardSync({ownerFilePath: guardEntry.ownerFilePath, fsModule});
     }
 }
 
@@ -550,7 +736,9 @@ export function releaseHeavyMaintenanceLeaseSync({
         throw new Error('Heavy-maintenance lease token is required for release.');
     }
 
-    if (!enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs})) {
+    const guardEntry = enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs});
+
+    if (!guardEntry) {
         throw new Error(`Heavy-maintenance lease release could not enter the lifecycle guard: ${lifecycleGuardPath(leasePath)}`);
     }
 
@@ -565,11 +753,15 @@ export function releaseHeavyMaintenanceLeaseSync({
             return {status: 'not-owner', released: false, lease: current.lease};
         }
 
+        if (!verifyLifecycleGuardOwnershipSync({ownerFilePath: guardEntry.ownerFilePath, fsModule})) {
+            return {status: 'not-owner', released: false, guardEvicted: true, lease: current.lease};
+        }
+
         fsModule.removeSync(leasePath);
 
         return {status: 'released', released: true, lease: current.lease};
     } finally {
-        exitLifecycleGuardSync({leasePath, fsModule});
+        exitLifecycleGuardSync({ownerFilePath: guardEntry.ownerFilePath, fsModule});
     }
 }
 
@@ -596,7 +788,9 @@ export function renewHeavyMaintenanceLeaseSync({
         throw new TypeError('renewHeavyMaintenanceLeaseSync: staleAfterMs (positive ms) is required — resolve it from AiConfig at the boundary; this Neo/Base-free primitive carries no TTL default by design.');
     }
 
-    if (!enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs})) {
+    const guardEntry = enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs});
+
+    if (!guardEntry) {
         throw new Error(`Heavy-maintenance lease renewal could not enter the lifecycle guard: ${lifecycleGuardPath(leasePath)}`);
     }
 
@@ -609,6 +803,10 @@ export function renewHeavyMaintenanceLeaseSync({
 
         if (!current.lease || current.lease.token !== token) {
             return {status: 'not-owner', renewed: false, lease: current.lease};
+        }
+
+        if (!verifyLifecycleGuardOwnershipSync({ownerFilePath: guardEntry.ownerFilePath, fsModule})) {
+            return {status: 'not-owner', renewed: false, guardEvicted: true, lease: current.lease};
         }
 
         const nowMs   = toTimestamp(now);
@@ -638,7 +836,7 @@ export function renewHeavyMaintenanceLeaseSync({
 
         return {status: 'renewed', renewed: true, lease: renewed};
     } finally {
-        exitLifecycleGuardSync({leasePath, fsModule});
+        exitLifecycleGuardSync({ownerFilePath: guardEntry.ownerFilePath, fsModule});
     }
 }
 
@@ -698,11 +896,13 @@ export async function acquireHeavyMaintenanceLease({
     // Guarded recovery. The pre-guard stale observation above is only an
     // admission ticket: a peer may legitimately replace, renew, or release the
     // lease at any moment after it. Every mutation therefore acts exclusively
-    // on the fresh re-inspection taken INSIDE the lifecycle guard, and the
-    // guard serializes recovery against release and renewal. An outside plain
-    // acquirer winning the unlink→create window is deferred to via EEXIST —
-    // exactly one participant ever holds a success verdict.
-    if (!await enterLifecycleGuard({leasePath, fsModule, guardStaleAfterMs})) {
+    // on the fresh re-inspection taken INSIDE the lifecycle guard, re-proves
+    // live guard ownership immediately before mutating, and the guard
+    // serializes recovery against release and renewal. An outside plain
+    // acquirer winning the unlink→create window is deferred to via EEXIST.
+    const guardEntry = await enterLifecycleGuard({leasePath, fsModule, guardStaleAfterMs});
+
+    if (!guardEntry) {
         const raced = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
         return {status: 'held', acquired: false, guardContended: true, lease: raced.lease};
     }
@@ -715,6 +915,11 @@ export async function acquireHeavyMaintenanceLease({
         }
 
         if (reinspect.status !== 'missing') {
+            if (!await verifyLifecycleGuardOwnership({ownerFilePath: guardEntry.ownerFilePath, fsModule})) {
+                const raced = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+                return {status: 'held', acquired: false, guardEvicted: true, lease: raced.lease};
+            }
+
             try {
                 await fsModule.unlink(leasePath);
             } catch (e) {
@@ -744,7 +949,7 @@ export async function acquireHeavyMaintenanceLease({
                 lease
             };
     } finally {
-        await exitLifecycleGuard({leasePath, fsModule});
+        await exitLifecycleGuard({ownerFilePath: guardEntry.ownerFilePath, fsModule});
     }
 }
 
@@ -774,7 +979,9 @@ export async function releaseHeavyMaintenanceLease({
     // Token validation and removal execute inside ONE guarded section: a
     // replacement owner appearing between an unguarded check and the unlink can
     // no longer be removed by the outgoing owner's release.
-    if (!await enterLifecycleGuard({leasePath, fsModule, guardStaleAfterMs})) {
+    const guardEntry = await enterLifecycleGuard({leasePath, fsModule, guardStaleAfterMs});
+
+    if (!guardEntry) {
         throw new Error(`Heavy-maintenance lease release could not enter the lifecycle guard: ${lifecycleGuardPath(leasePath)}`);
     }
 
@@ -789,11 +996,15 @@ export async function releaseHeavyMaintenanceLease({
             return {status: 'not-owner', released: false, lease: current.lease};
         }
 
+        if (!await verifyLifecycleGuardOwnership({ownerFilePath: guardEntry.ownerFilePath, fsModule})) {
+            return {status: 'not-owner', released: false, guardEvicted: true, lease: current.lease};
+        }
+
         await fsModule.remove(leasePath);
 
         return {status: 'released', released: true, lease: current.lease};
     } finally {
-        await exitLifecycleGuard({leasePath, fsModule});
+        await exitLifecycleGuard({ownerFilePath: guardEntry.ownerFilePath, fsModule});
     }
 }
 
@@ -840,7 +1051,9 @@ export async function renewHeavyMaintenanceLease({
         throw new TypeError('renewHeavyMaintenanceLease: staleAfterMs (positive ms) is required — resolve it from AiConfig at the boundary; this Neo/Base-free primitive carries no TTL default by design.');
     }
 
-    if (!await enterLifecycleGuard({leasePath, fsModule, guardStaleAfterMs})) {
+    const guardEntry = await enterLifecycleGuard({leasePath, fsModule, guardStaleAfterMs});
+
+    if (!guardEntry) {
         throw new Error(`Heavy-maintenance lease renewal could not enter the lifecycle guard: ${lifecycleGuardPath(leasePath)}`);
     }
 
@@ -853,6 +1066,10 @@ export async function renewHeavyMaintenanceLease({
 
         if (!current.lease || current.lease.token !== token) {
             return {status: 'not-owner', renewed: false, lease: current.lease};
+        }
+
+        if (!await verifyLifecycleGuardOwnership({ownerFilePath: guardEntry.ownerFilePath, fsModule})) {
+            return {status: 'not-owner', renewed: false, guardEvicted: true, lease: current.lease};
         }
 
         const nowMs   = toTimestamp(now);
@@ -880,7 +1097,7 @@ export async function renewHeavyMaintenanceLease({
 
         return {status: 'renewed', renewed: true, lease: renewed};
     } finally {
-        await exitLifecycleGuard({leasePath, fsModule});
+        await exitLifecycleGuard({ownerFilePath: guardEntry.ownerFilePath, fsModule});
     }
 }
 

--- a/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
+++ b/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
@@ -229,6 +229,171 @@ function writeLeaseFileSync(leasePath, lease, fsModule) {
     fsModule.writeFileSync(leasePath, JSON.stringify(lease, null, 2), {encoding: 'utf8', flag: 'wx'});
 }
 
+export const LIFECYCLE_GUARD_SUFFIX = '.lifecycle-guard';
+
+const
+    DEFAULT_GUARD_STALE_AFTER_MS = 10000,
+    GUARD_MAX_ATTEMPTS           = 100,
+    GUARD_RETRY_DELAY_MS         = 10;
+
+function lifecycleGuardPath(leasePath) {
+    return `${leasePath}${LIFECYCLE_GUARD_SUFFIX}`;
+}
+
+/**
+ * @summary Serializes every read-verify-mutate lease transition through one directory mutex.
+ *
+ * `mkdir` is the atomic entry point: exactly one participant creates the guard
+ * directory; everyone else observes `EEXIST` and retries briefly. Recovery,
+ * release, and renewal all mutate the canonical lease name based on a fresh
+ * read taken INSIDE the guard, which removes the check-then-act windows the
+ * unguarded rename-aside takeover had (a moved-aside fresh lease left the
+ * canonical name claimable while its owner still believed it held it).
+ *
+ * Plain acquisition deliberately stays OUTSIDE the guard: an exclusive `wx`
+ * create is already atomic, and a guarded recoverer's unlink→create window
+ * admitting an outside `wx` winner is safe — the recoverer's own exclusive
+ * create then fails `EEXIST` and defers. At no point can two participants both
+ * hold a success verdict for the same interval.
+ *
+ * Crash recovery: a guard directory whose mtime is older than
+ * `guardStaleAfterMs` (default 10s — several orders of magnitude above the
+ * microsecond-scale hold time of the fs transitions it protects) is treated as
+ * abandoned and removed. The residual double-entry window this leaves requires
+ * a holder to stall longer than the threshold INSIDE a millisecond-scale
+ * critical section; normal-operation transitions are fully serialized. Guard
+ * aging deliberately uses the physical clock (not the injectable `now` lease
+ * seam): lease TTL math is logical time for deterministic tests, guard aging
+ * is crash detection — tests steer it via `fs.utimes` + the
+ * `guardStaleAfterMs` option instead.
+ *
+ * @param {Object} options
+ * @param {String} options.leasePath Canonical lease file path.
+ * @param {Object} options.fsModule File-system implementation seam.
+ * @param {Number} [options.guardStaleAfterMs=10000] Age after which an abandoned guard is reclaimed.
+ * @returns {Promise<Boolean>} `true` when entered; `false` when attempts were exhausted (contention).
+ */
+async function enterLifecycleGuard({leasePath, fsModule, guardStaleAfterMs = DEFAULT_GUARD_STALE_AFTER_MS}) {
+    const guardPath = lifecycleGuardPath(leasePath);
+
+    for (let attempt = 0; attempt < GUARD_MAX_ATTEMPTS; attempt++) {
+        try {
+            await fsModule.mkdir(guardPath);
+            return true;
+        } catch (e) {
+            if (e.code === 'ENOENT') {
+                await fsModule.ensureDir(path.dirname(guardPath));
+                continue;
+            }
+            if (e.code !== 'EEXIST') {
+                throw e;
+            }
+        }
+
+        let mtimeMs;
+        try {
+            mtimeMs = (await fsModule.stat(guardPath)).mtimeMs;
+        } catch (e) {
+            if (e.code === 'ENOENT') {
+                continue; // holder exited between our mkdir and stat — retry immediately
+            }
+            throw e;
+        }
+
+        if (Date.now() - mtimeMs >= guardStaleAfterMs) {
+            try {
+                await fsModule.rmdir(guardPath);
+            } catch (e) {
+                if (e.code !== 'ENOENT') {
+                    throw e;
+                }
+            }
+            continue;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, GUARD_RETRY_DELAY_MS));
+    }
+
+    return false;
+}
+
+async function exitLifecycleGuard({leasePath, fsModule}) {
+    try {
+        await fsModule.rmdir(lifecycleGuardPath(leasePath));
+    } catch (e) {
+        if (e.code !== 'ENOENT') {
+            throw e;
+        }
+    }
+}
+
+/**
+ * @summary Synchronous mirror of {@link enterLifecycleGuard} for orchestrator-poll callers.
+ *
+ * The retry delay is a bounded synchronous spin: the guard protects
+ * microsecond-scale fs transitions, so a contended entry resolves within a few
+ * quanta; the spin budget is capped by `GUARD_MAX_ATTEMPTS`.
+ *
+ * @param {Object} options See {@link enterLifecycleGuard}.
+ * @returns {Boolean}
+ */
+function enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs = DEFAULT_GUARD_STALE_AFTER_MS}) {
+    const guardPath = lifecycleGuardPath(leasePath);
+
+    for (let attempt = 0; attempt < GUARD_MAX_ATTEMPTS; attempt++) {
+        try {
+            fsModule.mkdirSync(guardPath);
+            return true;
+        } catch (e) {
+            if (e.code === 'ENOENT') {
+                fsModule.ensureDirSync(path.dirname(guardPath));
+                continue;
+            }
+            if (e.code !== 'EEXIST') {
+                throw e;
+            }
+        }
+
+        let mtimeMs;
+        try {
+            mtimeMs = fsModule.statSync(guardPath).mtimeMs;
+        } catch (e) {
+            if (e.code === 'ENOENT') {
+                continue;
+            }
+            throw e;
+        }
+
+        if (Date.now() - mtimeMs >= guardStaleAfterMs) {
+            try {
+                fsModule.rmdirSync(guardPath);
+            } catch (e) {
+                if (e.code !== 'ENOENT') {
+                    throw e;
+                }
+            }
+            continue;
+        }
+
+        const spinUntil = Date.now() + GUARD_RETRY_DELAY_MS;
+        while (Date.now() < spinUntil) {
+            // bounded sync spin — see @summary
+        }
+    }
+
+    return false;
+}
+
+function exitLifecycleGuardSync({leasePath, fsModule}) {
+    try {
+        fsModule.rmdirSync(lifecycleGuardPath(leasePath));
+    } catch (e) {
+        if (e.code !== 'ENOENT') {
+            throw e;
+        }
+    }
+}
+
 /**
  * @summary Synchronous overload of {@link inspectHeavyMaintenanceLease}.
  *
@@ -294,6 +459,7 @@ export function acquireHeavyMaintenanceLeaseSync({
     now          = new Date(),
     pid          = process.pid,
     staleAfterMs,
+    guardStaleAfterMs,
     isPidAlive: isPidAliveFn = isPidAlive,
     token
 } = {}) {
@@ -318,75 +484,51 @@ export function acquireHeavyMaintenanceLeaseSync({
         return {status: 'held', acquired: false, lease: current.lease};
     }
 
-    // Identity-preserving takeover — sync mirror of the async contract above:
-    // atomic rename-aside, verify the moved lease is the inspected one, restore
-    // a mistakenly-moved fresh lease via non-clobbering link().
-    const claimPath = `${leasePath}.reclaim-${crypto.randomUUID()}`;
+    // Guarded recovery — sync mirror of the async contract above: mutate only on
+    // a fresh re-inspection taken INSIDE the lifecycle guard.
+    if (!enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs})) {
+        const raced = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+        return {status: 'held', acquired: false, guardContended: true, lease: raced.lease};
+    }
 
     try {
-        fsModule.renameSync(leasePath, claimPath);
-    } catch (e) {
-        if (e.code !== 'ENOENT') {
-            throw e;
+        const reinspect = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+
+        if (reinspect.active) {
+            return {status: 'held', acquired: false, lease: reinspect.lease};
+        }
+
+        if (reinspect.status !== 'missing') {
+            try {
+                fsModule.unlinkSync(leasePath);
+            } catch (e) {
+                if (e.code !== 'ENOENT') {
+                    throw e;
+                }
+            }
         }
 
         try {
             writeLeaseFileSync(leasePath, lease, fsModule);
-            return {status: 'acquired-after-stale', acquired: true, previousStatus: current.status, lease};
-        } catch (e2) {
-            if (e2.code !== 'EEXIST') {
-                throw e2;
+        } catch (e) {
+            if (e.code !== 'EEXIST') {
+                throw e;
             }
 
             const raced = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
             return {status: 'held', acquired: false, lease: raced.lease};
         }
-    }
 
-    let movedToken  = null,
-        movedParsed = false;
-
-    try {
-        movedToken  = JSON.parse(fsModule.readFileSync(claimPath, 'utf8'))?.token ?? null;
-        movedParsed = true;
-    } catch (e) {}
-
-    const inspectedToken  = current.lease?.token ?? null;
-    const identityMatches = current.status === 'malformed'
-        ? !movedParsed
-        : movedParsed && movedToken === inspectedToken;
-
-    if (!identityMatches) {
-        try {
-            fsModule.linkSync(claimPath, leasePath);
-        } catch (e) {}
-        try {
-            fsModule.removeSync(claimPath);
-        } catch (e) {}
-
-        const raced = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
-        return {status: 'held', acquired: false, lease: raced.lease};
-    }
-
-    try {
-        fsModule.removeSync(claimPath);
-    } catch (e) {}
-
-    try {
-        writeLeaseFileSync(leasePath, lease, fsModule);
-        return {
-            status        : current.status === 'malformed' ? 'acquired-after-malformed' : 'acquired-after-stale',
-            acquired      : true,
-            previousStatus: current.status,
-            lease
-        };
-    } catch (e) {
-        if (e.code !== 'EEXIST') {
-            throw e;
-        }
-
-        const raced = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
-        return {status: 'held', acquired: false, lease: raced.lease};
+        return reinspect.status === 'missing'
+            ? {status: 'acquired', acquired: true, lease}
+            : {
+                status        : reinspect.status === 'malformed' ? 'acquired-after-malformed' : 'acquired-after-stale',
+                acquired      : true,
+                previousStatus: reinspect.status,
+                lease
+            };
+    } finally {
+        exitLifecycleGuardSync({leasePath, fsModule});
     }
 }
 
@@ -401,25 +543,103 @@ export function releaseHeavyMaintenanceLeaseSync({
     leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
     fsModule  = fs,
     now       = new Date(),
+    guardStaleAfterMs,
     isPidAlive: isPidAliveFn = isPidAlive
 } = {}) {
     if (!token) {
         throw new Error('Heavy-maintenance lease token is required for release.');
     }
 
-    const current = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
-
-    if (current.status === 'missing') {
-        return {status: 'missing', released: false};
+    if (!enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs})) {
+        throw new Error(`Heavy-maintenance lease release could not enter the lifecycle guard: ${lifecycleGuardPath(leasePath)}`);
     }
 
-    if (!current.lease || current.lease.token !== token) {
-        return {status: 'not-owner', released: false, lease: current.lease};
+    try {
+        const current = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+
+        if (current.status === 'missing') {
+            return {status: 'missing', released: false};
+        }
+
+        if (!current.lease || current.lease.token !== token) {
+            return {status: 'not-owner', released: false, lease: current.lease};
+        }
+
+        fsModule.removeSync(leasePath);
+
+        return {status: 'released', released: true, lease: current.lease};
+    } finally {
+        exitLifecycleGuardSync({leasePath, fsModule});
+    }
+}
+
+/**
+ * @summary Synchronous overload of {@link renewHeavyMaintenanceLease}.
+ *
+ * @param {Object} options See {@link renewHeavyMaintenanceLease}.
+ * @returns {Object}
+ */
+export function renewHeavyMaintenanceLeaseSync({
+    token,
+    staleAfterMs,
+    leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
+    fsModule  = fs,
+    now       = new Date(),
+    guardStaleAfterMs,
+    isPidAlive: isPidAliveFn = isPidAlive
+} = {}) {
+    if (!token) {
+        throw new Error('Heavy-maintenance lease token is required for renewal.');
     }
 
-    fsModule.removeSync(leasePath);
+    if (!Number.isFinite(staleAfterMs) || staleAfterMs <= 0) {
+        throw new TypeError('renewHeavyMaintenanceLeaseSync: staleAfterMs (positive ms) is required — resolve it from AiConfig at the boundary; this Neo/Base-free primitive carries no TTL default by design.');
+    }
 
-    return {status: 'released', released: true, lease: current.lease};
+    if (!enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs})) {
+        throw new Error(`Heavy-maintenance lease renewal could not enter the lifecycle guard: ${lifecycleGuardPath(leasePath)}`);
+    }
+
+    try {
+        const current = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+
+        if (current.status === 'missing') {
+            return {status: 'missing', renewed: false};
+        }
+
+        if (!current.lease || current.lease.token !== token) {
+            return {status: 'not-owner', renewed: false, lease: current.lease};
+        }
+
+        const nowMs   = toTimestamp(now);
+        const renewed = {
+            ...current.lease,
+            staleAfterMs,
+            renewedAt: new Date(nowMs).toISOString(),
+            expiresAt: new Date(nowMs + staleAfterMs).toISOString()
+        };
+
+        const tmpPath = `${leasePath}.renew-tmp-${process.pid}`;
+        try {
+            fsModule.writeFileSync(tmpPath, JSON.stringify(renewed, null, 2), 'utf8');
+            const fd = fsModule.openSync(tmpPath, 'r+');
+            try {
+                fsModule.fsyncSync(fd);
+            } finally {
+                fsModule.closeSync(fd);
+            }
+            fsModule.renameSync(tmpPath, leasePath);
+        } catch (e) {
+            try {
+                fsModule.removeSync(tmpPath);
+            } catch (cleanupError) {}
+            throw e;
+        }
+
+        return {status: 'renewed', renewed: true, lease: renewed};
+    } finally {
+        exitLifecycleGuardSync({leasePath, fsModule});
+    }
 }
 
 /**
@@ -437,6 +657,7 @@ export function releaseHeavyMaintenanceLeaseSync({
  * @param {Date|Number|String} [options.now=new Date()] Current time.
  * @param {Number} [options.pid=process.pid] Owning process ID.
  * @param {Number} options.staleAfterMs Stale TTL in ms — REQUIRED; resolved from AiConfig at the boundary (no primitive default).
+ * @param {Number} [options.guardStaleAfterMs] Lifecycle-guard crash-recovery age override (stale/malformed recovery only).
  * @param {String} [options.token] Owner release token.
  * @returns {Promise<Object>}
  */
@@ -449,6 +670,7 @@ export async function acquireHeavyMaintenanceLease({
     now          = new Date(),
     pid          = process.pid,
     staleAfterMs,
+    guardStaleAfterMs,
     isPidAlive: isPidAliveFn = isPidAlive,
     token
 } = {}) {
@@ -473,83 +695,56 @@ export async function acquireHeavyMaintenanceLease({
         return {status: 'held', acquired: false, lease: current.lease};
     }
 
-    // Identity-preserving takeover. An unconditional remove() here is a TOCTOU
-    // hazard: contender B could delete contender A's FRESH lease using B's older
-    // stale verdict, letting both return `acquired`. rename() is the atomic
-    // exclusivity point — exactly one contender can move the path aside — and the
-    // moved file is then verified to BE the lease that was inspected. Moving a
-    // different (fresh) lease restores it via link(), which fails on EEXIST
-    // instead of overwriting a newer claim.
-    const claimPath = `${leasePath}.reclaim-${crypto.randomUUID()}`;
+    // Guarded recovery. The pre-guard stale observation above is only an
+    // admission ticket: a peer may legitimately replace, renew, or release the
+    // lease at any moment after it. Every mutation therefore acts exclusively
+    // on the fresh re-inspection taken INSIDE the lifecycle guard, and the
+    // guard serializes recovery against release and renewal. An outside plain
+    // acquirer winning the unlink→create window is deferred to via EEXIST —
+    // exactly one participant ever holds a success verdict.
+    if (!await enterLifecycleGuard({leasePath, fsModule, guardStaleAfterMs})) {
+        const raced = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+        return {status: 'held', acquired: false, guardContended: true, lease: raced.lease};
+    }
 
     try {
-        await fsModule.rename(leasePath, claimPath);
-    } catch (e) {
-        if (e.code !== 'ENOENT') {
-            throw e;
+        const reinspect = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+
+        if (reinspect.active) {
+            return {status: 'held', acquired: false, lease: reinspect.lease};
         }
 
-        // Another reclaimer moved it first (or the owner released). A plain
-        // exclusive create decides the winner; EEXIST defers to them.
+        if (reinspect.status !== 'missing') {
+            try {
+                await fsModule.unlink(leasePath);
+            } catch (e) {
+                if (e.code !== 'ENOENT') {
+                    throw e;
+                }
+            }
+        }
+
         try {
             await writeLeaseFile(leasePath, lease, fsModule);
-            return {status: 'acquired-after-stale', acquired: true, previousStatus: current.status, lease};
-        } catch (e2) {
-            if (e2.code !== 'EEXIST') {
-                throw e2;
+        } catch (e) {
+            if (e.code !== 'EEXIST') {
+                throw e;
             }
 
             const raced = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
             return {status: 'held', acquired: false, lease: raced.lease};
         }
-    }
 
-    let movedToken  = null,
-        movedParsed = false;
-
-    try {
-        movedToken  = JSON.parse(await fsModule.readFile(claimPath, 'utf8'))?.token ?? null;
-        movedParsed = true;
-    } catch (e) {}
-
-    const inspectedToken  = current.lease?.token ?? null;
-    const identityMatches = current.status === 'malformed'
-        ? !movedParsed
-        : movedParsed && movedToken === inspectedToken;
-
-    if (!identityMatches) {
-        // We moved a lease that is NOT the one we inspected — someone acquired
-        // legitimately in between. Restore without clobbering and defer.
-        try {
-            await fsModule.link(claimPath, leasePath);
-        } catch (e) {}
-        try {
-            await fsModule.remove(claimPath);
-        } catch (e) {}
-
-        const raced = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
-        return {status: 'held', acquired: false, lease: raced.lease};
-    }
-
-    try {
-        await fsModule.remove(claimPath);
-    } catch (e) {}
-
-    try {
-        await writeLeaseFile(leasePath, lease, fsModule);
-        return {
-            status        : current.status === 'malformed' ? 'acquired-after-malformed' : 'acquired-after-stale',
-            acquired      : true,
-            previousStatus: current.status,
-            lease
-        };
-    } catch (e) {
-        if (e.code !== 'EEXIST') {
-            throw e;
-        }
-
-        const raced = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
-        return {status: 'held', acquired: false, lease: raced.lease};
+        return reinspect.status === 'missing'
+            ? {status: 'acquired', acquired: true, lease}
+            : {
+                status        : reinspect.status === 'malformed' ? 'acquired-after-malformed' : 'acquired-after-stale',
+                acquired      : true,
+                previousStatus: reinspect.status,
+                lease
+            };
+    } finally {
+        await exitLifecycleGuard({leasePath, fsModule});
     }
 }
 
@@ -561,6 +756,7 @@ export async function acquireHeavyMaintenanceLease({
  * @param {String} [options.leasePath=DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH] Lease file path.
  * @param {Object} [options.fsModule=fs] File-system implementation seam.
  * @param {Date|Number|String} [options.now=new Date()] Current time.
+ * @param {Number} [options.guardStaleAfterMs] Lifecycle-guard crash-recovery age override.
  * @returns {Promise<Object>}
  */
 export async function releaseHeavyMaintenanceLease({
@@ -568,25 +764,124 @@ export async function releaseHeavyMaintenanceLease({
     leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
     fsModule  = fs,
     now       = new Date(),
+    guardStaleAfterMs,
     isPidAlive: isPidAliveFn = isPidAlive
 } = {}) {
     if (!token) {
         throw new Error('Heavy-maintenance lease token is required for release.');
     }
 
-    const current = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
-
-    if (current.status === 'missing') {
-        return {status: 'missing', released: false};
+    // Token validation and removal execute inside ONE guarded section: a
+    // replacement owner appearing between an unguarded check and the unlink can
+    // no longer be removed by the outgoing owner's release.
+    if (!await enterLifecycleGuard({leasePath, fsModule, guardStaleAfterMs})) {
+        throw new Error(`Heavy-maintenance lease release could not enter the lifecycle guard: ${lifecycleGuardPath(leasePath)}`);
     }
 
-    if (!current.lease || current.lease.token !== token) {
-        return {status: 'not-owner', released: false, lease: current.lease};
+    try {
+        const current = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+
+        if (current.status === 'missing') {
+            return {status: 'missing', released: false};
+        }
+
+        if (!current.lease || current.lease.token !== token) {
+            return {status: 'not-owner', released: false, lease: current.lease};
+        }
+
+        await fsModule.remove(leasePath);
+
+        return {status: 'released', released: true, lease: current.lease};
+    } finally {
+        await exitLifecycleGuard({leasePath, fsModule});
+    }
+}
+
+/**
+ * @summary Extends the current owner's lease deadline without changing ownership.
+ *
+ * The work-level half of the exclusivity contract: `isLeaseStale` classifies a
+ * live process as expired the moment its deadline passes, so any owner whose
+ * work can outlive `staleAfterMs` MUST renew periodically while working. A
+ * renewing live owner never reaches its deadline, which is what makes
+ * "live expiry starts overlapping work" structurally impossible instead of
+ * merely unlikely. Renewal failure (`renewed: false` or a thrown IO error)
+ * means ownership is no longer provable — the caller must stop starting new
+ * protected work and abort at its next fence.
+ *
+ * Runs inside the lifecycle guard: verification and rewrite cannot interleave
+ * with a recovery or release. The rewrite is full-write + fsync + atomic
+ * rename, so readers outside the guard never observe a partial payload and the
+ * canonical name never goes absent mid-renewal.
+ *
+ * @param {Object} options
+ * @param {String} options.token Owner token returned by acquire.
+ * @param {Number} options.staleAfterMs Renewed TTL in ms — REQUIRED; resolved from AiConfig at the boundary (no primitive default).
+ * @param {String} [options.leasePath=DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH] Lease file path.
+ * @param {Object} [options.fsModule=fs] File-system implementation seam.
+ * @param {Date|Number|String} [options.now=new Date()] Current time.
+ * @param {Number} [options.guardStaleAfterMs] Lifecycle-guard crash-recovery age override.
+ * @returns {Promise<Object>} `{status: 'renewed', renewed: true, lease}` on success; `{status: 'missing'|'not-owner', renewed: false}` when ownership is not provable.
+ */
+export async function renewHeavyMaintenanceLease({
+    token,
+    staleAfterMs,
+    leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
+    fsModule  = fs,
+    now       = new Date(),
+    guardStaleAfterMs,
+    isPidAlive: isPidAliveFn = isPidAlive
+} = {}) {
+    if (!token) {
+        throw new Error('Heavy-maintenance lease token is required for renewal.');
     }
 
-    await fsModule.remove(leasePath);
+    if (!Number.isFinite(staleAfterMs) || staleAfterMs <= 0) {
+        throw new TypeError('renewHeavyMaintenanceLease: staleAfterMs (positive ms) is required — resolve it from AiConfig at the boundary; this Neo/Base-free primitive carries no TTL default by design.');
+    }
 
-    return {status: 'released', released: true, lease: current.lease};
+    if (!await enterLifecycleGuard({leasePath, fsModule, guardStaleAfterMs})) {
+        throw new Error(`Heavy-maintenance lease renewal could not enter the lifecycle guard: ${lifecycleGuardPath(leasePath)}`);
+    }
+
+    try {
+        const current = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
+
+        if (current.status === 'missing') {
+            return {status: 'missing', renewed: false};
+        }
+
+        if (!current.lease || current.lease.token !== token) {
+            return {status: 'not-owner', renewed: false, lease: current.lease};
+        }
+
+        const nowMs   = toTimestamp(now);
+        const renewed = {
+            ...current.lease,
+            staleAfterMs,
+            renewedAt: new Date(nowMs).toISOString(),
+            expiresAt: new Date(nowMs + staleAfterMs).toISOString()
+        };
+
+        const tmpPath = `${leasePath}.renew-tmp-${process.pid}`;
+        try {
+            await fsModule.writeFile(tmpPath, JSON.stringify(renewed, null, 2), 'utf8');
+            const fd = await fsModule.open(tmpPath, 'r+');
+            try {
+                await fsModule.fsync(fd);
+            } finally {
+                await fsModule.close(fd);
+            }
+            await fsModule.rename(tmpPath, leasePath);
+        } catch (e) {
+            await fsModule.remove(tmpPath).catch(() => {});
+            throw e;
+        }
+
+        return {status: 'renewed', renewed: true, lease: renewed};
+    } finally {
+        await exitLifecycleGuard({leasePath, fsModule});
+    }
 }
 
 /**

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -242,6 +242,7 @@
         "orchestrator.tenantRepoMirrorRoot",
         "orchestrator.tenantRepoSync",
         "orchestrator.tenantRepoSync.jitterRatio",
+        "orchestrator.tenantRepoSync.leaseStaleAfterMs",
         "orchestrator.tenantRepoSync.sweepCadenceMs",
         "orchestrator.wakeDispatch",
         "orchestrator.wakeDispatch.attemptTimeoutSeconds",

--- a/ai/scripts/maintenance/syncTenantRepos.mjs
+++ b/ai/scripts/maintenance/syncTenantRepos.mjs
@@ -14,8 +14,11 @@
  *   node ./ai/scripts/maintenance/syncTenantRepos.mjs --full --repo-slug <slug>  # scoped full replay
  *
  * Exit code: 0 on `completed`, 1 on `failed` or `skipped`
- * (no-tenant-repos-configured), 2 on argument error, and 3 when a selected
- * repo slug is not configured.
+ * (no-tenant-repos-configured), 2 on argument error, 3 when a selected
+ * repo slug is not configured, and 4 when another process (the orchestrator's
+ * periodic sweep or a second CLI run) holds the cross-process tenant-repo-sync
+ * lease. The lease serializes both entry paths over the shared revisions
+ * manifest; a held lease is a bounded busy result, never a silent race.
  *
  * Mirrors the operator-side pattern of `ai/scripts/maintenance/backup.mjs` and the
  * other `./maintenance/*` scripts — bootstrap Neo namespace then invoke a service.
@@ -29,6 +32,10 @@ import * as core       from '../../../src/core/_export.mjs';
 import {pathToFileURL} from 'url';
 
 import TenantRepoSyncService from '../../daemons/orchestrator/services/TenantRepoSyncService.mjs';
+import {
+    KB_TENANT_REPO_SYNC_LEASE_HELD,
+    KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED
+} from '../../daemons/orchestrator/services/TenantRepoSyncErrors.mjs';
 
 /**
  * @summary Parses manual tenant-repo-sync selectors and scoped replay intent.
@@ -75,10 +82,16 @@ tenantRepo. Pass --repo-slug to scope to a specific repo (repeatable).
 Pass --full only with one or more --repo-slug selectors to rebuild those repos
 from a null revision base. Stored checkpoints advance only after an error-free replay.
 
+Runs are serialized against the orchestrator's periodic sweep through a
+cross-process lease next to the revisions manifest: if another sync is active,
+this CLI exits immediately with code 4 instead of racing it. Crashed lease
+owners recover automatically; simply re-run.
+
 Exit codes:
   0  completed (or partial-completed with at least one repo successful)
   1  failed (all repos failed) or skipped (no configured tenantRepos)
   3  --repo-slug requested but the named repo is not configured (KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED)
+  4  another process holds the tenant-repo-sync lease (KB_TENANT_REPO_SYNC_LEASE_HELD) — retry after it finishes
   2  argument-parse error`);
 }
 
@@ -152,13 +165,37 @@ async function main() {
 
     console.log(JSON.stringify(result, null, 2));
 
+    if (result.details?.reasonCode === KB_TENANT_REPO_SYNC_LEASE_HELD) {
+        console.error(
+            `Another tenant-repo sync holds the cross-process lease (owner: ${result.details.leaseOwner}, ` +
+            `expires: ${result.details.leaseExpiresAt}). Retry after it finishes.`
+        );
+    }
+
+    process.exit(resolveExitCode(result));
+}
+
+/**
+ * @summary Maps a `TenantRepoSyncService.runTask` result to the CLI's documented exit code.
+ *
+ * Kept pure and exported so the exit-code contract is unit-testable without
+ * spawning the CLI. The mapping is part of the operator interface: runbooks and
+ * pipelines branch on these codes, so changes here are contract changes.
+ *
+ * @param {Object} result `{status, details}` shape returned by `runTask`.
+ * @returns {Number} 0 completed · 4 cross-process lease held · 3 requested repo not configured · 1 failed/skipped otherwise.
+ */
+function resolveExitCode(result) {
     if (result.status === 'completed') {
-        process.exit(0);
+        return 0;
     }
-    if (result.status === 'failed' && result.details?.reasonCode === 'KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED') {
-        process.exit(3);
+    if (result.details?.reasonCode === KB_TENANT_REPO_SYNC_LEASE_HELD) {
+        return 4;
     }
-    process.exit(1);
+    if (result.status === 'failed' && result.details?.reasonCode === KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED) {
+        return 3;
+    }
+    return 1;
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
@@ -169,4 +206,4 @@ if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
     })
 }
 
-export {buildRunTaskOptions, parseArgs};
+export {buildRunTaskOptions, parseArgs, resolveExitCode};

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -234,7 +234,7 @@ Toggles:
 | `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED` | `orchestrator.cloudOnly.tenantRepoSyncEnabled` | cloud profile: enabled; local: disabled | Master toggle for the periodic lane |
 | `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS` | `orchestrator.intervals.tenantRepoSyncMs` | 30 minutes | Base per-repo ingestion cadence before deterministic jitter and failure backoff |
 | `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS` | `orchestrator.tenantRepoSync.sweepCadenceMs` | 1 minute | Scheduler scan cadence for admitting repos whose individual cadence is due |
-| `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_LEASE_STALE_AFTER_MS` | `orchestrator.tenantRepoSync.leaseStaleAfterMs` | 6 hours | TTL backstop on the cross-process sync lease for a live-but-wedged owner. Must comfortably exceed the longest legitimate sweep; crashed owners recover instantly via pid-liveness, and lease ownership is re-verified at every manifest commit, so an evicted writer aborts instead of overlapping |
+| `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_LEASE_STALE_AFTER_MS` | `orchestrator.tenantRepoSync.leaseStaleAfterMs` | 6 hours | TTL backstop on the cross-process sync lease for a fully wedged owner. A live sweep renews its lease every `max(5s, TTL/3)` so it never expires mid-work; crashed owners recover instantly via pid-liveness, and ownership is re-verified at work fences (per-repo git phase, KB ingest, manifest commit), so an evicted writer aborts instead of overlapping |
 
 The `cloudOnly` collection is the inverse-polarity sibling of `localOnly`. `null` means "use the deployment-profile default" (cloud enables, local disables); explicit `true`/`false` overrides. Local Neo-maintainer deployments default-off because most operator checkouts don't have `tenantRepos[]` configured.
 
@@ -276,11 +276,26 @@ one persistence boundary) before reading or writing it; exactly one writer can
 exist at a time, so a manual replay can never erase a periodic update or vice
 versa. A held lease defers the periodic sweep with the non-failure reason
 `KB_TENANT_REPO_SYNC_LEASE_HELD` and touches no repo's checkpoint, attempt
-timestamp, or backoff state; crashed lease owners recover immediately via
-pid-liveness and wedged owners via the `leaseStaleAfterMs` TTL. Second, manifest
-writes are atomic — a temporary sibling file is written, fsynced, and renamed
-over the target — so a crash mid-write leaves the previous complete document
-readable instead of a truncated JSON the strict reader would fail-close on.
+timestamp, or backoff state. Second, manifest writes are atomic — a temporary
+sibling file is written, fsynced, and renamed over the target — so a crash
+mid-write leaves the previous complete document readable instead of a truncated
+JSON the strict reader would fail-close on.
+
+The lease's exclusivity itself rests on three cooperating mechanisms. Every
+read-verify-mutate transition on an existing lease record — stale recovery,
+release, renewal — is serialized through a short-lived lifecycle guard
+(`tenant-repo-sync-lease.json.lifecycle-guard`), so a transition only ever acts
+on state it re-observed inside the guard; plain acquisition stays an atomic
+exclusive create. A running sweep renews its own lease every
+`max(5s, TTL/3)`, so a live owner never reaches its deadline and cannot be
+reclaimed mid-work; crashed owners recover immediately via pid-liveness and a
+fully wedged owner via the `leaseStaleAfterMs` TTL backstop. And ownership is
+re-verified at work fences — before each repo's git phase, before each
+Knowledge Base ingest, and before every manifest commit — so a run whose
+renewal failed (or whose lease was reclaimed) aborts with
+`KB_TENANT_REPO_SYNC_LEASE_LOST` before starting further protected work, leaves
+every repo's checkpoint and backoff state untouched, and never commits a
+partial sweep.
 
 Each checkpoint also carries `ingestContractVersion`, written together with the
 head only after the Knowledge Base returns an explicit error-free summary, and

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -254,7 +254,7 @@ returns an error-free ingestion summary. Current releases automatically revalida
 checkpoints through the periodic lane; use `--full` only to accelerate or explicitly repeat one
 selected repo after correcting its underlying failure. Do not delete the revisions file.
 
-Exit code: `0` on `completed`, `1` on `failed` or `skipped` (no-tenant-repos-configured), `2` on argument error, and `3` when a requested repo slug is not configured. The CLI uses an in-memory `TaskStateService` stand-in so it works without an orchestrator-daemon state-dir; it does not race against a running Orchestrator's lane.
+Exit code: `0` on `completed`, `1` on `failed` or `skipped` (no-tenant-repos-configured), `2` on argument error, `3` when a requested repo slug is not configured, and `4` when another process holds the cross-process tenant-repo-sync lease (`KB_TENANT_REPO_SYNC_LEASE_HELD`). The CLI uses an in-memory `TaskStateService` stand-in so it works without an orchestrator-daemon state-dir; serialization against a running Orchestrator's periodic lane comes from the shared lease, not from task state — a held lease is a bounded busy exit, never a silent race.
 
 ### Mirror Volume
 
@@ -267,6 +267,19 @@ Exit code: `0` on `completed`, `1` on `failed` or `skipped` (no-tenant-repos-con
 The env var names the **parent** of `tenant-repos/`; `deriveTenantRepoMirrorPath` appends the `tenant-repos/<tenant>/<repo>` segment so the same root can host other gitignored substrate-data subdirs. Per-repo `tenantRepos[].mirrorRoot` overrides this Tier-1 default when present.
 
 The mirror directory is a deployment cache, not authoritative state. Per-repo `lastIngestedRev` is stored separately in `<orchestrator-data-dir>/tenant-repo-sync-revisions.json` (sibling to the orchestrator state file) so the next sync can compute the incremental diff.
+
+Two invariants protect that manifest. First, every sync — the daemon's periodic
+sweep and the manual CLI alike — must acquire the dedicated cross-process lease
+(`tenant-repo-sync-lease.json`, a sibling of the manifest so lock and data share
+one persistence boundary) before reading or writing it; exactly one writer can
+exist at a time, so a manual replay can never erase a periodic update or vice
+versa. A held lease defers the periodic sweep with the non-failure reason
+`KB_TENANT_REPO_SYNC_LEASE_HELD` and touches no repo's checkpoint, attempt
+timestamp, or backoff state; crashed lease owners recover immediately via
+pid-liveness and wedged owners via the `leaseStaleAfterMs` TTL. Second, manifest
+writes are atomic — a temporary sibling file is written, fsynced, and renamed
+over the target — so a crash mid-write leaves the previous complete document
+readable instead of a truncated JSON the strict reader would fail-close on.
 
 Each checkpoint also carries `ingestContractVersion`, written together with the
 head only after the Knowledge Base returns an explicit error-free summary, and

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -234,6 +234,7 @@ Toggles:
 | `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED` | `orchestrator.cloudOnly.tenantRepoSyncEnabled` | cloud profile: enabled; local: disabled | Master toggle for the periodic lane |
 | `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS` | `orchestrator.intervals.tenantRepoSyncMs` | 30 minutes | Base per-repo ingestion cadence before deterministic jitter and failure backoff |
 | `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS` | `orchestrator.tenantRepoSync.sweepCadenceMs` | 1 minute | Scheduler scan cadence for admitting repos whose individual cadence is due |
+| `NEO_ORCHESTRATOR_TENANT_REPO_SYNC_LEASE_STALE_AFTER_MS` | `orchestrator.tenantRepoSync.leaseStaleAfterMs` | 6 hours | TTL backstop on the cross-process sync lease for a live-but-wedged owner. Must comfortably exceed the longest legitimate sweep; crashed owners recover instantly via pid-liveness, and lease ownership is re-verified at every manifest commit, so an evicted writer aborts instead of overlapping |
 
 The `cloudOnly` collection is the inverse-polarity sibling of `localOnly`. `null` means "use the deployment-profile default" (cloud enables, local disables); explicit `true`/`false` overrides. Local Neo-maintainer deployments default-off because most operator checkouts don't have `tenantRepos[]` configured.
 

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -267,7 +267,14 @@ The CLI and the daemon's periodic sweep serialize through a cross-process lease 
 revisions manifest. Exit code `4` (reason `KB_TENANT_REPO_SYNC_LEASE_HELD`) means another sync is
 active — retry after it finishes; a periodic sweep deferred the same way reports a `skipped`
 outcome with that reason and no backoff mutation. Crashed lease owners recover automatically on
-the next attempt (pid-liveness), and wedged-but-alive owners expire via `leaseStaleAfterMs`.
+the next attempt (pid-liveness). A live sweep renews its lease every `max(5s, TTL/3)`, so
+`leaseStaleAfterMs` only ever expires an owner that stopped renewing (fully wedged or gone); a run
+that loses its lease anyway fails with `KB_TENANT_REPO_SYNC_LEASE_LOST` at its next work fence —
+before further git, ingest, or manifest work — leaving checkpoints, backoff state, and the new
+owner's lease untouched, so the failure is safe to retry once the concurrent run finishes. Lease
+transitions themselves (recovery, release, renewal) serialize through a sibling
+`…lease.json.lifecycle-guard` directory; an abandoned guard from a hard crash self-heals after
+~10 seconds and needs no operator action.
 
 Manifest writes are atomic (temp sibling + fsync + rename), so upgrades from this release forward
 cannot produce a torn `tenant-repo-sync-revisions.json`. Should a manifest from an older release

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -263,6 +263,18 @@ node ./ai/scripts/maintenance/syncTenantRepos.mjs --full --repo-slug <slug>
 a failed replay preserves it, while an error-free replay advances it to the current head and writes
 the current success-contract marker.
 
+The CLI and the daemon's periodic sweep serialize through a cross-process lease next to the
+revisions manifest. Exit code `4` (reason `KB_TENANT_REPO_SYNC_LEASE_HELD`) means another sync is
+active — retry after it finishes; a periodic sweep deferred the same way reports a `skipped`
+outcome with that reason and no backoff mutation. Crashed lease owners recover automatically on
+the next attempt (pid-liveness), and wedged-but-alive owners expire via `leaseStaleAfterMs`.
+
+Manifest writes are atomic (temp sibling + fsync + rename), so upgrades from this release forward
+cannot produce a torn `tenant-repo-sync-revisions.json`. Should a manifest from an older release
+(or exotic filesystem damage) fail the strict read anyway, deleting the file is the safe last
+resort: it costs one full re-ingestion pass, because every head then classifies `uninitialized`
+and replays from a null base under the normal bounded admission — never hand-edit it instead.
+
 If the deployment snapshot is fresh but the tool returns `status: degraded` with
 `reason: snapshot-section-missing` or `snapshot-producer-metadata-missing`, fix
 the bridge producer before debugging repo credentials or embeddings. Those

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -1367,7 +1367,7 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         };
 
         const result = acquireHeavyMaintenanceLeaseSync({
-            leasePath, owner: 'S', token: 'token-s', fsModule: racingFs, guardStaleAfterMs: 1_000
+            leasePath, owner: 'S', token: 'token-s', fsModule: racingFs, guardStaleAfterMs: 60_000
         });
 
         expect(result.acquired).toBe(false);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -7,6 +7,7 @@ import {
     HeavyMaintenanceLeaseService,
     acquireHeavyMaintenanceLease as _rawAcquireHeavyMaintenanceLease,
     acquireHeavyMaintenanceLeaseSync as _rawAcquireHeavyMaintenanceLeaseSync,
+    buildLeasePayload,
     inspectHeavyMaintenanceLease,
     inspectHeavyMaintenanceLeaseSync,
     isPidAlive,
@@ -142,7 +143,7 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         expect(service.shouldYield(lease, {now: new Date('2026-05-16T20:03:00.000Z')})).toBe(false);
         // explicit per-call override wins over the reactive default
         expect(service.shouldYield(lease, {now: new Date('2026-05-16T20:06:00.000Z'), maxActiveHoldMs: 30 * 60 * 1000})).toBe(false);
-        // fail-safe: a falsy bound → never yields (byte-identical back-compat; #14186's absent/0-leaf path)
+        // fail-safe: a falsy bound → never yields (byte-identical back-compat for the absent/0-leaf path)
         expect(service.shouldYield(lease, {now: new Date('2026-05-16T23:00:00.000Z'), maxActiveHoldMs: 0})).toBe(false)
     });
 
@@ -866,5 +867,114 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
             token: 'service-token',
             now  : new Date('2026-05-16T20:00:00.000Z')
         })).resolves.toMatchObject({status: 'released'});
+    });
+
+    test('stale takeover is identity-preserving — two reclaimers cannot both acquire (#15763)', async () => {
+        const leasePath = createLeasePath('two-reclaimer-takeover');
+
+        // Seed a genuinely stale lease (dead pid).
+        await fs.writeJson(leasePath, buildLeasePayload({
+            owner       : 'crashed-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : 2147483647,
+            token       : 'stale-token'
+        }));
+
+        // Contender B blocks at its takeover point (the atomic rename), which by
+        // construction is AFTER B's stale inspection — the exact interleave where
+        // the previous unconditional remove() let both contenders acquire.
+        let bAtTakeover,
+            releaseB;
+        const bArrived = new Promise(resolve => bAtTakeover = resolve);
+        const bGate    = new Promise(resolve => releaseB = resolve);
+        const gatedFs  = {
+            ...fs,
+            async rename(...args) {
+                bAtTakeover();
+                await bGate;
+                return fs.rename(...args);
+            }
+        };
+
+        const contenderB = acquireHeavyMaintenanceLease({leasePath, owner: 'B', token: 'token-b', fsModule: gatedFs});
+
+        await bArrived;
+
+        // Contender A completes a full takeover while B is paused pre-rename.
+        const resultA = await acquireHeavyMaintenanceLease({leasePath, owner: 'A', token: 'token-a'});
+        expect(resultA).toMatchObject({acquired: true, status: 'acquired-after-stale'});
+
+        releaseB();
+        const resultB = await contenderB;
+
+        // Exactly one acquirer; the live lease belongs to that winner.
+        expect(resultB.acquired).toBe(false);
+        expect(resultB.status).toBe('held');
+        expect((await fs.readJson(leasePath)).token).toBe('token-a');
+    });
+
+    test('sync stale takeover restores a fresh lease it did not inspect (#15763)', () => {
+        const leasePath = createLeasePath('sync-takeover-restore');
+
+        fs.writeJsonSync(leasePath, buildLeasePayload({
+            owner       : 'crashed-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : 2147483647,
+            token       : 'stale-token'
+        }));
+
+        // Simulate the race at the atomic boundary: between this contender's stale
+        // inspection and its rename, another process replaces the lease with a
+        // FRESH one. The moved file then fails identity verification and must be
+        // restored intact instead of deleted.
+        let   swapped  = false;
+        const racingFs = {
+            ...fs,
+            renameSync(...args) {
+                if (!swapped) {
+                    swapped = true;
+                    fs.writeJsonSync(leasePath, buildLeasePayload({
+                        owner       : 'fresh-owner',
+                        staleAfterMs: TEST_LEASE_STALE_MS,
+                        pid         : process.pid,
+                        token       : 'fresh-token'
+                    }));
+                }
+                return fs.renameSync(...args);
+            }
+        };
+
+        const result = acquireHeavyMaintenanceLeaseSync({leasePath, owner: 'reclaimer', token: 'token-r', fsModule: racingFs});
+
+        expect(result.acquired).toBe(false);
+        expect(result.status).toBe('held');
+        expect(fs.readJsonSync(leasePath).token).toBe('fresh-token');
+    });
+
+    test('a live owner inside its TTL cannot be reclaimed; the boundary is the documented backstop (#15763)', async () => {
+        const leasePath  = createLeasePath('live-owner-ttl-boundary');
+        const acquiredAt = new Date('2026-07-23T12:00:00.000Z');
+
+        await fs.writeJson(leasePath, buildLeasePayload({
+            owner       : 'live-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : process.pid,
+            token       : 'live-token',
+            now         : acquiredAt
+        }));
+
+        const justBefore = await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner: 'contender',
+            now  : new Date(acquiredAt.getTime() + TEST_LEASE_STALE_MS - 1)
+        });
+        expect(justBefore).toMatchObject({status: 'held', acquired: false});
+
+        const atBoundary = await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner: 'contender',
+            now  : new Date(acquiredAt.getTime() + TEST_LEASE_STALE_MS)
+        });
+        expect(atBoundary).toMatchObject({acquired: true, status: 'acquired-after-stale'});
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -1119,10 +1119,13 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         }));
 
         // A holder crashed inside the critical section: the guard directory
-        // survives with an old mtime and no live owner behind it.
+        // survives carrying its owner token with an old mtime and no live
+        // owner behind it — the identity-safe steal path must consume it.
+        const crashedOwnerFile = path.join(guardPath, 'owner-crashed');
         await fs.ensureDir(guardPath);
+        await fs.writeFile(crashedOwnerFile, '', 'utf8');
         const past = new Date(Date.now() - 60_000);
-        await fs.utimes(guardPath, past, past);
+        await fs.utimes(crashedOwnerFile, past, past);
 
         const result = await acquireHeavyMaintenanceLease({
             leasePath,
@@ -1130,6 +1133,28 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
             token            : 'token-r',
             guardStaleAfterMs: 1_000
         });
+
+        expect(result).toMatchObject({acquired: true, status: 'acquired-after-stale'});
+        expect(await fs.pathExists(guardPath)).toBe(false);
+    });
+
+    test('an interrupted-entry empty guard is recovered by atomic replacement (#15763)', async () => {
+        const leasePath = createLeasePath('empty-guard');
+        const guardPath = `${leasePath}${LIFECYCLE_GUARD_SUFFIX}`;
+
+        await fs.writeJson(leasePath, buildLeasePayload({
+            owner       : 'crashed-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : 2147483647,
+            token       : 'stale-token'
+        }));
+
+        // An EMPTY guard dir is never a live entrant under the owner-token
+        // protocol (every real entry is born carrying its token via the staged
+        // rename), so the atomic rename may replace it without waiting.
+        await fs.ensureDir(guardPath);
+
+        const result = await acquireHeavyMaintenanceLease({leasePath, owner: 'recoverer', token: 'token-r'});
 
         expect(result).toMatchObject({acquired: true, status: 'acquired-after-stale'});
         expect(await fs.pathExists(guardPath)).toBe(false);
@@ -1146,17 +1171,211 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
             token       : 'stale-token'
         }));
 
-        // A FRESH guard held by a live peer for the whole retry budget: the
-        // contender must exhaust its attempts and defer — never bypass the
-        // guard to mutate the (stale) lease underneath the peer's transition.
+        // A live guard carries its holder's FRESH owner token for the whole
+        // retry budget: the contender can neither replace it (rename refuses a
+        // non-empty target) nor steal it (fresh mtime) — it must exhaust its
+        // attempts and defer, never mutating the (stale) lease underneath the
+        // peer's transition.
+        const liveOwnerFile = path.join(guardPath, 'owner-live-peer');
         await fs.ensureDir(guardPath);
+        await fs.writeFile(liveOwnerFile, '', 'utf8');
 
         const result = await acquireHeavyMaintenanceLease({leasePath, owner: 'contender', token: 'token-c'});
 
         expect(result).toMatchObject({acquired: false, status: 'held', guardContended: true});
         expect((await fs.readJson(leasePath)).token).toBe('stale-token');
+        expect(await fs.pathExists(liveOwnerFile)).toBe(true);
 
-        await fs.rmdir(guardPath);
+        await fs.remove(guardPath);
+    });
+
+    test('two contenders recovering one abandoned guard admit exactly one entrant (#15763)', async () => {
+        const leasePath = createLeasePath('two-contender-abandoned-guard');
+        const guardPath = `${leasePath}${LIFECYCLE_GUARD_SUFFIX}`;
+
+        await fs.writeJson(leasePath, buildLeasePayload({
+            owner       : 'crashed-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : 2147483647,
+            token       : 'stale-token'
+        }));
+
+        // The cycle-3 reviewer interleave: both contenders observe the SAME
+        // abandoned guard; A consumes it, replaces it, and pauses inside its
+        // critical section (at the lease unlink); B then attempts its steal
+        // from the stale observation. Identity-safety requires B's steal to
+        // abort — B's unlink targets the OBSERVED owner token, which A already
+        // consumed (ENOENT), and A's replacement guard is non-empty for rmdir.
+        // Under the pathname-based rmdir this exact schedule admitted both.
+        // The crashed token is aged FAR past the threshold while both live
+        // contenders use a threshold no in-test stall can reach — only the
+        // abandoned artifact is ever legitimately stealable in this schedule.
+        const crashedOwnerFile = path.join(guardPath, 'owner-crashed');
+        await fs.ensureDir(guardPath);
+        await fs.writeFile(crashedOwnerFile, '', 'utf8');
+        const past = new Date(Date.now() - 300_000);
+        await fs.utimes(crashedOwnerFile, past, past);
+
+        // A pauses at its LEASE unlink (inside the guard, post-entry).
+        let aAtLeaseUnlink,
+            releaseA;
+        const aArrived = new Promise(resolve => aAtLeaseUnlink = resolve);
+        const aGate    = new Promise(resolve => releaseA = resolve);
+        const fsForA   = {
+            ...fs,
+            async unlink(target, ...rest) {
+                if (target === leasePath) {
+                    aAtLeaseUnlink();
+                    await aGate;
+                }
+                return fs.unlink(target, ...rest);
+            }
+        };
+
+        // B pauses at its GUARD owner-token unlink (the steal step), AFTER its
+        // stale observation — the exact reviewer schedule.
+        let bAtOwnerUnlink,
+            releaseB;
+        const bArrived = new Promise(resolve => bAtOwnerUnlink = resolve);
+        const bGate    = new Promise(resolve => releaseB = resolve);
+        const fsForB   = {
+            ...fs,
+            async unlink(target, ...rest) {
+                if (target === crashedOwnerFile) {
+                    bAtOwnerUnlink();
+                    await bGate;
+                }
+                return fs.unlink(target, ...rest);
+            }
+        };
+
+        const contenderB = acquireHeavyMaintenanceLease({
+            leasePath, owner: 'B', token: 'token-b', fsModule: fsForB, guardStaleAfterMs: 60_000
+        });
+        await bArrived; // B has observed the abandoned guard and sits pre-consumption
+
+        const contenderA = acquireHeavyMaintenanceLease({
+            leasePath, owner: 'A', token: 'token-a', fsModule: fsForA, guardStaleAfterMs: 60_000
+        });
+        await aArrived; // A consumed the abandoned guard, entered, and holds the section
+
+        releaseB();     // B's steal now fires against A's replacement guard
+        const resultB = await contenderB;
+
+        releaseA();     // A completes its takeover
+        const resultA = await contenderA;
+
+        expect(resultA).toMatchObject({acquired: true, status: 'acquired-after-stale'});
+        expect(resultB.acquired).toBe(false);
+        expect(resultB.status).toBe('held');
+        expect((await fs.readJson(leasePath)).token).toBe('token-a');
+    });
+
+    test('an evicted stalled holder defers instead of mutating the successor state (#15763)', async () => {
+        const leasePath = createLeasePath('evicted-holder');
+        const guardPath = `${leasePath}${LIFECYCLE_GUARD_SUFFIX}`;
+
+        await fs.writeJson(leasePath, buildLeasePayload({
+            owner       : 'crashed-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : 2147483647,
+            token       : 'stale-token'
+        }));
+
+        // Holder H enters and stalls inside its critical section long enough
+        // to be judged abandoned; a successor legitimately evicts it and
+        // completes a full takeover. H resumes AT its pre-mutation ownership
+        // probe: the probe reads the post-eviction state, fails, and H defers —
+        // without the probe H's unlink would delete the successor's fresh
+        // lease. (A stall ending inside the probe→syscall gap itself is the
+        // documented single-syscall residual, deliberately not modeled here.)
+        let hAtProbe,
+            releaseH,
+            hPaused = false;
+        const hArrived = new Promise(resolve => hAtProbe = resolve);
+        const hGate    = new Promise(resolve => releaseH = resolve);
+        const fsForH   = {
+            ...fs,
+            async stat(target, ...rest) {
+                if (!hPaused && typeof target === 'string'
+                    && target.startsWith(guardPath) && path.basename(target).startsWith('owner-')) {
+                    hPaused = true;
+                    hAtProbe();
+                    await hGate;
+                }
+                return fs.stat(target, ...rest);
+            }
+        };
+
+        const holder = acquireHeavyMaintenanceLease({
+            leasePath, owner: 'H', token: 'token-h', fsModule: fsForH, guardStaleAfterMs: 200
+        });
+        await hArrived;
+
+        // Age H's owner token past the threshold, then let a successor evict + take over.
+        const [hOwnerName] = (await fs.readdir(guardPath)).filter(name => name.startsWith('owner-'));
+        const past         = new Date(Date.now() - 60_000);
+        await fs.utimes(path.join(guardPath, hOwnerName), past, past);
+
+        const successor = await acquireHeavyMaintenanceLease({
+            leasePath, owner: 'S', token: 'token-s', guardStaleAfterMs: 200
+        });
+        expect(successor).toMatchObject({acquired: true});
+
+        releaseH();
+        const resultH = await holder;
+
+        expect(resultH.acquired).toBe(false);
+        expect(resultH).toMatchObject({status: 'held', guardEvicted: true});
+        expect((await fs.readJson(leasePath)).token).toBe('token-s');
+    });
+
+    test('sync steal aborts when the observed abandoned guard was replaced (#15763)', () => {
+        const leasePath = createLeasePath('sync-identity-safe-steal');
+        const guardPath = `${leasePath}${LIFECYCLE_GUARD_SUFFIX}`;
+
+        fs.writeJsonSync(leasePath, buildLeasePayload({
+            owner       : 'crashed-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : 2147483647,
+            token       : 'stale-token'
+        }));
+
+        const crashedOwnerFile = path.join(guardPath, 'owner-crashed');
+        fs.ensureDirSync(guardPath);
+        fs.writeFileSync(crashedOwnerFile, '', 'utf8');
+        const past = new Date(Date.now() - 60_000);
+        fs.utimesSync(crashedOwnerFile, past, past);
+
+        // Between S's stale observation and its consumption step, a peer
+        // completes the full recovery and now LIVES inside a replacement
+        // guard. S's unlink of the observed token hits ENOENT and the steal
+        // aborts; S must defer without touching the replacement.
+        let   swapped      = false;
+        const foreignOwner = path.join(guardPath, 'owner-foreign');
+        const racingFs     = {
+            ...fs,
+            unlinkSync(target, ...rest) {
+                if (!swapped && target === crashedOwnerFile) {
+                    swapped = true;
+                    fs.removeSync(guardPath);
+                    fs.ensureDirSync(guardPath);
+                    fs.writeFileSync(foreignOwner, '', 'utf8');
+                }
+                return fs.unlinkSync(target, ...rest);
+            }
+        };
+
+        const result = acquireHeavyMaintenanceLeaseSync({
+            leasePath, owner: 'S', token: 'token-s', fsModule: racingFs, guardStaleAfterMs: 1_000
+        });
+
+        expect(result.acquired).toBe(false);
+        expect(result.status).toBe('held');
+        expect(fs.pathExistsSync(foreignOwner)).toBe(true);
+        expect(fs.readJsonSync(leasePath).token).toBe('stale-token');
+
+        fs.removeSync(guardPath);
     });
 
     test('renewHeavyMaintenanceLease extends the owner deadline; non-owners cannot renew (#15763)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -5,6 +5,7 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
     HeavyMaintenanceLeaseService,
+    LIFECYCLE_GUARD_SUFFIX,
     acquireHeavyMaintenanceLease as _rawAcquireHeavyMaintenanceLease,
     acquireHeavyMaintenanceLeaseSync as _rawAcquireHeavyMaintenanceLeaseSync,
     buildLeasePayload,
@@ -14,6 +15,8 @@ import {
     isLeaseStale,
     releaseHeavyMaintenanceLease,
     releaseHeavyMaintenanceLeaseSync,
+    renewHeavyMaintenanceLease,
+    renewHeavyMaintenanceLeaseSync,
     shouldYieldHeavyMaintenanceLease,
     withHeavyMaintenanceLease as _rawWithHeavyMaintenanceLease
 } from '../../../../../../../ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
@@ -880,19 +883,19 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
             token       : 'stale-token'
         }));
 
-        // Contender B blocks at its takeover point (the atomic rename), which by
+        // Contender B blocks at its guard entry (the atomic mkdir), which by
         // construction is AFTER B's stale inspection — the exact interleave where
-        // the previous unconditional remove() let both contenders acquire.
+        // an unguarded takeover let both contenders act on the same stale verdict.
         let bAtTakeover,
             releaseB;
         const bArrived = new Promise(resolve => bAtTakeover = resolve);
         const bGate    = new Promise(resolve => releaseB = resolve);
         const gatedFs  = {
             ...fs,
-            async rename(...args) {
+            async mkdir(...args) {
                 bAtTakeover();
                 await bGate;
-                return fs.rename(...args);
+                return fs.mkdir(...args);
             }
         };
 
@@ -913,8 +916,8 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         expect((await fs.readJson(leasePath)).token).toBe('token-a');
     });
 
-    test('sync stale takeover restores a fresh lease it did not inspect (#15763)', () => {
-        const leasePath = createLeasePath('sync-takeover-restore');
+    test('sync recovery defers to a lease replaced after the stale observation (#15763)', () => {
+        const leasePath = createLeasePath('sync-replacement-after-observation');
 
         fs.writeJsonSync(leasePath, buildLeasePayload({
             owner       : 'crashed-owner',
@@ -923,14 +926,15 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
             token       : 'stale-token'
         }));
 
-        // Simulate the race at the atomic boundary: between this contender's stale
-        // inspection and its rename, another process replaces the lease with a
-        // FRESH one. The moved file then fails identity verification and must be
-        // restored intact instead of deleted.
+        // Replacement-after-observation: between this contender's stale
+        // inspection and its guard entry, another process replaces the lease
+        // with a FRESH one. The guarded re-inspection must see the replacement
+        // and defer — a recovery may only mutate state it re-observed INSIDE
+        // the guard, never state from the earlier unguarded observation.
         let   swapped  = false;
         const racingFs = {
             ...fs,
-            renameSync(...args) {
+            mkdirSync(...args) {
                 if (!swapped) {
                     swapped = true;
                     fs.writeJsonSync(leasePath, buildLeasePayload({
@@ -940,7 +944,7 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
                         token       : 'fresh-token'
                     }));
                 }
-                return fs.renameSync(...args);
+                return fs.mkdirSync(...args);
             }
         };
 
@@ -949,6 +953,282 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         expect(result.acquired).toBe(false);
         expect(result.status).toBe('held');
         expect(fs.readJsonSync(leasePath).token).toBe('fresh-token');
+    });
+
+    test('async recovery defers to a lease replaced after the stale observation (#15763)', async () => {
+        const leasePath = createLeasePath('async-replacement-after-observation');
+
+        await fs.writeJson(leasePath, buildLeasePayload({
+            owner       : 'crashed-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : 2147483647,
+            token       : 'stale-token'
+        }));
+
+        let   swapped  = false;
+        const racingFs = {
+            ...fs,
+            async mkdir(...args) {
+                if (!swapped) {
+                    swapped = true;
+                    await fs.writeJson(leasePath, buildLeasePayload({
+                        owner       : 'fresh-owner',
+                        staleAfterMs: TEST_LEASE_STALE_MS,
+                        pid         : process.pid,
+                        token       : 'fresh-token'
+                    }));
+                }
+                return fs.mkdir(...args);
+            }
+        };
+
+        const result = await acquireHeavyMaintenanceLease({leasePath, owner: 'reclaimer', token: 'token-r', fsModule: racingFs});
+
+        expect(result.acquired).toBe(false);
+        expect(result.status).toBe('held');
+        expect((await fs.readJson(leasePath)).token).toBe('fresh-token');
+    });
+
+    test('release cannot remove a replacement owner installed after the release began (#15763)', async () => {
+        const leasePath = createLeasePath('release-replacement');
+
+        await fs.writeJson(leasePath, buildLeasePayload({
+            owner       : 'old-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : process.pid,
+            token       : 'old-token'
+        }));
+
+        // Replacement-during-release: between the release call and its guarded
+        // validation, a reclaimer replaces the lease (the TTL-expiry
+        // interleave). Validation and removal execute inside one guarded
+        // section, so the release observes the replacement and defers — an
+        // unguarded check-then-remove deleted the replacement owner's lease.
+        let   swapped  = false;
+        const racingFs = {
+            ...fs,
+            async mkdir(...args) {
+                if (!swapped) {
+                    swapped = true;
+                    await fs.writeJson(leasePath, buildLeasePayload({
+                        owner       : 'replacement-owner',
+                        staleAfterMs: TEST_LEASE_STALE_MS,
+                        pid         : process.pid,
+                        token       : 'replacement-token'
+                    }));
+                }
+                return fs.mkdir(...args);
+            }
+        };
+
+        const result = await releaseHeavyMaintenanceLease({leasePath, token: 'old-token', fsModule: racingFs});
+
+        expect(result).toMatchObject({status: 'not-owner', released: false});
+        expect((await fs.readJson(leasePath)).token).toBe('replacement-token');
+    });
+
+    test('sync release cannot remove a replacement owner installed after the release began (#15763)', () => {
+        const leasePath = createLeasePath('sync-release-replacement');
+
+        fs.writeJsonSync(leasePath, buildLeasePayload({
+            owner       : 'old-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : process.pid,
+            token       : 'old-token'
+        }));
+
+        let   swapped  = false;
+        const racingFs = {
+            ...fs,
+            mkdirSync(...args) {
+                if (!swapped) {
+                    swapped = true;
+                    fs.writeJsonSync(leasePath, buildLeasePayload({
+                        owner       : 'replacement-owner',
+                        staleAfterMs: TEST_LEASE_STALE_MS,
+                        pid         : process.pid,
+                        token       : 'replacement-token'
+                    }));
+                }
+                return fs.mkdirSync(...args);
+            }
+        };
+
+        const result = releaseHeavyMaintenanceLeaseSync({leasePath, token: 'old-token', fsModule: racingFs});
+
+        expect(result).toMatchObject({status: 'not-owner', released: false});
+        expect(fs.readJsonSync(leasePath).token).toBe('replacement-token');
+    });
+
+    test('lifecycle guard serializes recovery against release — the outgoing owner cannot delete the reclaimer\'s lease (#15763)', async () => {
+        const leasePath = createLeasePath('guard-serialization');
+
+        await fs.writeJson(leasePath, buildLeasePayload({
+            owner       : 'stale-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : 2147483647,
+            token       : 'stale-token'
+        }));
+
+        // Reclaimer R pauses INSIDE the guard (at its unlink), holding the
+        // critical section. The stale lease's owner then calls release: an
+        // unguarded release would read the still-present stale record, match
+        // its own token, and remove whatever file exists when the remove()
+        // lands — deleting R's fresh lease. Under the guard the release can
+        // only run after R exits, observes R's lease, and defers.
+        let rAtUnlink,
+            releaseR;
+        const rArrived = new Promise(resolve => rAtUnlink = resolve);
+        const rGate    = new Promise(resolve => releaseR = resolve);
+        const gatedFs  = {
+            ...fs,
+            async unlink(...args) {
+                rAtUnlink();
+                await rGate;
+                return fs.unlink(...args);
+            }
+        };
+
+        const reclaimer = acquireHeavyMaintenanceLease({leasePath, owner: 'R', token: 'token-r', fsModule: gatedFs});
+        await rArrived;
+
+        const releaseAttempt = releaseHeavyMaintenanceLease({leasePath, token: 'stale-token'});
+
+        // Give the release a real window to run before R resumes; the guard
+        // must hold it in its retry loop for this entire interval.
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        releaseR();
+
+        const [reclaimResult, releaseResult] = await Promise.all([reclaimer, releaseAttempt]);
+
+        expect(reclaimResult).toMatchObject({acquired: true, status: 'acquired-after-stale'});
+        expect(releaseResult).toMatchObject({status: 'not-owner', released: false});
+        expect((await fs.readJson(leasePath)).token).toBe('token-r');
+    });
+
+    test('an abandoned lifecycle guard is reclaimed after guardStaleAfterMs (#15763)', async () => {
+        const leasePath = createLeasePath('abandoned-guard');
+        const guardPath = `${leasePath}${LIFECYCLE_GUARD_SUFFIX}`;
+
+        await fs.writeJson(leasePath, buildLeasePayload({
+            owner       : 'crashed-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : 2147483647,
+            token       : 'stale-token'
+        }));
+
+        // A holder crashed inside the critical section: the guard directory
+        // survives with an old mtime and no live owner behind it.
+        await fs.ensureDir(guardPath);
+        const past = new Date(Date.now() - 60_000);
+        await fs.utimes(guardPath, past, past);
+
+        const result = await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner            : 'recoverer',
+            token            : 'token-r',
+            guardStaleAfterMs: 1_000
+        });
+
+        expect(result).toMatchObject({acquired: true, status: 'acquired-after-stale'});
+        expect(await fs.pathExists(guardPath)).toBe(false);
+    });
+
+    test('a live contended lifecycle guard defers acquisition without mutating the lease (#15763)', async () => {
+        const leasePath = createLeasePath('contended-guard');
+        const guardPath = `${leasePath}${LIFECYCLE_GUARD_SUFFIX}`;
+
+        await fs.writeJson(leasePath, buildLeasePayload({
+            owner       : 'stale-owner',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            pid         : 2147483647,
+            token       : 'stale-token'
+        }));
+
+        // A FRESH guard held by a live peer for the whole retry budget: the
+        // contender must exhaust its attempts and defer — never bypass the
+        // guard to mutate the (stale) lease underneath the peer's transition.
+        await fs.ensureDir(guardPath);
+
+        const result = await acquireHeavyMaintenanceLease({leasePath, owner: 'contender', token: 'token-c'});
+
+        expect(result).toMatchObject({acquired: false, status: 'held', guardContended: true});
+        expect((await fs.readJson(leasePath)).token).toBe('stale-token');
+
+        await fs.rmdir(guardPath);
+    });
+
+    test('renewHeavyMaintenanceLease extends the owner deadline; non-owners cannot renew (#15763)', async () => {
+        const leasePath = createLeasePath('renewal');
+        const t0        = new Date('2026-07-24T08:00:00.000Z');
+
+        await acquireHeavyMaintenanceLease({leasePath, owner: 'worker', token: 'owner-token', now: t0});
+
+        const t1      = new Date(t0.getTime() + TEST_LEASE_STALE_MS - 1_000);
+        const renewal = await renewHeavyMaintenanceLease({
+            leasePath,
+            token       : 'owner-token',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            now         : t1
+        });
+
+        expect(renewal).toMatchObject({status: 'renewed', renewed: true});
+        expect(renewal.lease.token).toBe('owner-token');
+        expect(renewal.lease.renewedAt).toBe(t1.toISOString());
+        expect(renewal.lease.expiresAt).toBe(new Date(t1.getTime() + TEST_LEASE_STALE_MS).toISOString());
+
+        // Past the ORIGINAL deadline the renewed lease still holds: live
+        // expiry has been pushed forward, so no contender can reclaim.
+        const t2        = new Date(t0.getTime() + TEST_LEASE_STALE_MS + 1_000);
+        const contender = await acquireHeavyMaintenanceLease({leasePath, owner: 'contender', now: t2});
+        expect(contender).toMatchObject({status: 'held', acquired: false});
+
+        // Non-owner renewal defers and mutates nothing.
+        const foreign = await renewHeavyMaintenanceLease({
+            leasePath,
+            token       : 'foreign-token',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            now         : t2
+        });
+        expect(foreign).toMatchObject({status: 'not-owner', renewed: false});
+        expect((await fs.readJson(leasePath)).token).toBe('owner-token');
+
+        await fs.remove(leasePath);
+        await expect(renewHeavyMaintenanceLease({
+            leasePath,
+            token       : 'owner-token',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            now         : t2
+        })).resolves.toMatchObject({status: 'missing', renewed: false});
+    });
+
+    test('sync renewal mirrors async renewal semantics (#15763)', () => {
+        const leasePath = createLeasePath('renewal-sync');
+        const t0        = new Date('2026-07-24T08:00:00.000Z');
+
+        acquireHeavyMaintenanceLeaseSync({leasePath, owner: 'worker', token: 'owner-token', now: t0});
+
+        const t1      = new Date(t0.getTime() + 30_000);
+        const renewal = renewHeavyMaintenanceLeaseSync({
+            leasePath,
+            token       : 'owner-token',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            now         : t1
+        });
+
+        expect(renewal).toMatchObject({status: 'renewed', renewed: true});
+        expect(renewal.lease.expiresAt).toBe(new Date(t1.getTime() + TEST_LEASE_STALE_MS).toISOString());
+
+        expect(renewHeavyMaintenanceLeaseSync({
+            leasePath,
+            token       : 'foreign-token',
+            staleAfterMs: TEST_LEASE_STALE_MS,
+            now         : t1
+        })).toMatchObject({status: 'not-owner', renewed: false});
+
+        expect(() => renewHeavyMaintenanceLeaseSync({leasePath, token: 'owner-token', now: t1}))
+            .toThrow(/staleAfterMs.*required/);
     });
 
     test('a live owner inside its TTL cannot be reclaimed; the boundary is the documented backstop (#15763)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
@@ -2,6 +2,7 @@ import {test, expect} from '@playwright/test';
 import {
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
     KB_TENANT_REPO_SYNC_LEASE_HELD,
+    KB_TENANT_REPO_SYNC_LEASE_LOST,
     KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
     KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
@@ -16,6 +17,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         const codes = [
             KB_TENANT_REPO_SYNC_SYNC_FAILED,
             KB_TENANT_REPO_SYNC_LEASE_HELD,
+            KB_TENANT_REPO_SYNC_LEASE_LOST,
             KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
             KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
             KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
@@ -29,9 +31,10 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
 
     test('TENANT_REPO_SYNC_ERROR_CODES array contains exactly the exported codes', () => {
         expect(Array.isArray(TENANT_REPO_SYNC_ERROR_CODES)).toBe(true);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(6);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(7);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_SYNC_FAILED);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_LEASE_HELD);
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_LEASE_LOST);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED);
@@ -47,7 +50,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         expect(() => TENANT_REPO_SYNC_ERROR_CODES.push('KB_TENANT_REPO_SYNC_MUTATED')).toThrow(TypeError);
         expect(() => { TENANT_REPO_SYNC_ERROR_CODES[TENANT_REPO_SYNC_ERROR_CODES.length] = 'KB_TENANT_REPO_SYNC_MUTATED'; }).toThrow(TypeError);
         expect(() => { TENANT_REPO_SYNC_ERROR_CODES.length = 0; }).toThrow(TypeError);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(6);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(7);
         expect(TENANT_REPO_SYNC_ERROR_CODES).not.toContain('KB_TENANT_REPO_SYNC_MUTATED');
         expect(isTenantRepoSyncErrorCode('KB_TENANT_REPO_SYNC_MUTATED')).toBe(false);
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect} from '@playwright/test';
 import {
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
+    KB_TENANT_REPO_SYNC_LEASE_HELD,
     KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
     KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
@@ -14,6 +15,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
     test('all exported codes carry the canonical KB_TENANT_REPO_SYNC_ prefix', () => {
         const codes = [
             KB_TENANT_REPO_SYNC_SYNC_FAILED,
+            KB_TENANT_REPO_SYNC_LEASE_HELD,
             KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
             KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
             KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
@@ -27,8 +29,9 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
 
     test('TENANT_REPO_SYNC_ERROR_CODES array contains exactly the exported codes', () => {
         expect(Array.isArray(TENANT_REPO_SYNC_ERROR_CODES)).toBe(true);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(5);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(6);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_SYNC_FAILED);
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_LEASE_HELD);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED);
@@ -42,9 +45,9 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         // in strict mode. ES modules are strict by default, so these throw.
         expect(Object.isFrozen(TENANT_REPO_SYNC_ERROR_CODES)).toBe(true);
         expect(() => TENANT_REPO_SYNC_ERROR_CODES.push('KB_TENANT_REPO_SYNC_MUTATED')).toThrow(TypeError);
-        expect(() => { TENANT_REPO_SYNC_ERROR_CODES[5] = 'KB_TENANT_REPO_SYNC_MUTATED'; }).toThrow(TypeError);
+        expect(() => { TENANT_REPO_SYNC_ERROR_CODES[TENANT_REPO_SYNC_ERROR_CODES.length] = 'KB_TENANT_REPO_SYNC_MUTATED'; }).toThrow(TypeError);
         expect(() => { TENANT_REPO_SYNC_ERROR_CODES.length = 0; }).toThrow(TypeError);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(5);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(6);
         expect(TENANT_REPO_SYNC_ERROR_CODES).not.toContain('KB_TENANT_REPO_SYNC_MUTATED');
         expect(isTenantRepoSyncErrorCode('KB_TENANT_REPO_SYNC_MUTATED')).toBe(false);
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -29,9 +29,11 @@ import {
     TENANT_REPO_INGEST_CONTRACT_VERSION
 } from '../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
 import {deriveTenantRepoMirrorPath} from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
+import {buildLeasePayload}          from '../../../../../../../ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs';
 import {
     buildRunTaskOptions,
-    parseArgs
+    parseArgs,
+    resolveExitCode
 } from '../../../../../../../ai/scripts/maintenance/syncTenantRepos.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -544,6 +546,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         const result = await TenantRepoSyncService.runTask({
             reason           : 'periodic',
             taskStateService,
+            revisionsFilePath: revisionsFile,
             tenantReposConfig: {tenantRepos: [{tenantId: 't1', repoSlug: 'org/seeded', mirrorRoot, cloneUrl: 'https://github.com/neomjs/seeded.git'}]},
             gitMirror        : envelopeWatchingGitMirror,
             // For the persistence test, use a real-shape envelope-builder fake that
@@ -1506,33 +1509,32 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         const logLines         = [];
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/repo-a'});
 
-        const readOnlyParent = path.join(tmpDir, 'ro-parent');
-        await fs.ensureDir(readOnlyParent);
-        await fs.chmod(readOnlyParent, 0o500);
+        // Force a deep TenantRepoSyncError at the final manifest commit: a directory
+        // squats on the exact temporary-sibling path, so the atomic tmp-write fails
+        // while the strict read (no manifest yet) and the sibling lease file work.
+        const manifestDir       = path.join(tmpDir, 'manifest-dir');
+        const directoryAsTarget = path.join(manifestDir, 'revisions.json');
+        await fs.ensureDir(`${directoryAsTarget}.tmp-${process.pid}`);
 
-        try {
-            const result = await TenantRepoSyncService.runTask({
-                reason           : 'periodic-sweep:60000',
-                taskStateService,
-                writeLog         : (level, msg) => logLines.push({level, msg}),
-                tenantReposConfig: {tenantRepos: [
-                    {tenantId: 't1', repoSlug: 'org/repo-a', mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git'}
-                ]},
-                gitMirror                    : makeFakeGitMirror(),
-                envelopeBuilder              : makeFakeEnvelopeBuilder(),
-                knowledgeBaseIngestionService: makeFakeIngestionService(),
-                revisionsFilePath            : path.join(readOnlyParent, 'subdir', 'revisions.json')
-            });
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            writeLog         : (level, msg) => logLines.push({level, msg}),
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/repo-a', mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : directoryAsTarget
+        });
 
-            expect(result.status).toBe('failed');
-            expect(result.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED');
-            expect(result.details.meta?.phase).toBe('manifest-update');
-            expect(result.details.meta?.filePath).toContain('revisions.json');
-            const errLine = logLines.find(l => l.level === 'ERROR' && l.msg.includes('KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED'));
-            expect(errLine).toBeDefined();
-        } finally {
-            await fs.chmod(readOnlyParent, 0o700);
-        }
+        expect(result.status).toBe('failed');
+        expect(result.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED');
+        expect(result.details.meta?.phase).toBe('manifest-update');
+        expect(result.details.meta?.filePath).toContain('revisions.json');
+        const errLine = logLines.find(l => l.level === 'ERROR' && l.msg.includes('KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED'));
+        expect(errLine).toBeDefined();
     });
 
     test('concurrency-gate: concurrencyLimit=1 serializes per-repo work (#11942 AC2)', async () => {
@@ -2160,6 +2162,178 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(defaultCall, 'envelope builder called for repo-default').toBeDefined();
         expect(defaultCall.args.newHead).toBe('HEAD');
     });
+
+    // --- Cross-process serialization + atomic manifest commit ---
+
+    function leaseFilePath() {
+        return path.join(tmpDir, 'tenant-repo-sync-lease.json');
+    }
+
+    /**
+     * Base runTask options for the lease suite: one configured repo, tmp-dir
+     * manifest (which also derives the tmp-dir sibling lease path), immediate cadence.
+     */
+    function baseLeaseRunOptions({taskStateService, ...overrides}) {
+        return {
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            revisionsFilePath: revisionsFile,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug: 'org/lease-repo', mirrorRoot, cloneUrl: 'https://github.com/neomjs/lease-repo.git'
+            }]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            globalCadenceMs              : 0,
+            jitterRatio                  : 0,
+            seedBootstrap                : false,
+            ...overrides
+        };
+    }
+
+    test('cross-process lease: a held lease defers the sweep without repo work or manifest mutation (#15763)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            mirrorCalls      = [];
+
+        await fs.writeJson(revisionsFile, {revisions: {'t1/org/lease-repo': {
+            lastIngestedRev                   : 'sha-before',
+            lastRunAttemptAt                  : 0,
+            consecutiveFailures               : 1,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        }}});
+        const originalManifest = await fs.readFile(revisionsFile, 'utf8');
+
+        await fs.writeJson(leaseFilePath(), buildLeasePayload({
+            owner       : 'tenant-repo-sync:manual',
+            reason      : 'tenant-repo-sync',
+            pid         : process.pid,
+            staleAfterMs: 60_000,
+            token       : 'foreign-owner-token'
+        }));
+
+        const result = await TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService,
+            gitMirror: makeFakeGitMirror({captureCalls: mirrorCalls})
+        }));
+
+        expect(result.status).toBe('skipped');
+        expect(result.details).toMatchObject({
+            reasonCode: 'KB_TENANT_REPO_SYNC_LEASE_HELD',
+            leaseOwner: 'tenant-repo-sync:manual'
+        });
+        expect(mirrorCalls).toHaveLength(0);
+        expect(await fs.readFile(revisionsFile, 'utf8')).toBe(originalManifest);
+        expect(taskStateService.getTaskState('tenant-repo-sync')?.running).toBeFalsy();
+
+        // Bounded diagnostics: owner class + timestamps only — no pid, no host paths.
+        const serialized = JSON.stringify(result);
+        expect(serialized).not.toContain('"pid"');
+        expect(serialized).not.toContain(tmpDir);
+    });
+
+    test('cross-process lease: two concurrent invocations serialize — one completes, one defers (#15763)', async () => {
+        const
+            taskStateServiceA = createInMemoryTaskStateService(),
+            taskStateServiceB = createInMemoryTaskStateService();
+
+        let releaseGate;
+        const gate = new Promise(resolve => releaseGate = resolve);
+
+        const invocationA = TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService             : taskStateServiceA,
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                async summaryFactory() {
+                    await gate;
+                    return {ingested: 1, deleted: 0, errors: []};
+                }
+            })
+        }));
+
+        // Deterministic interleave: wait until invocation A provably holds the lease.
+        for (let i = 0; i < 200 && !await fs.pathExists(leaseFilePath()); i++) {
+            await new Promise(resolve => setTimeout(resolve, 5));
+        }
+        expect(await fs.pathExists(leaseFilePath())).toBe(true);
+
+        const resultB = await TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService: taskStateServiceB,
+            reason          : 'manual'
+        }));
+
+        expect(resultB.status).toBe('skipped');
+        expect(resultB.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_LEASE_HELD');
+        expect(resultB.details.leaseOwner).toBe('tenant-repo-sync:scheduler');
+
+        releaseGate();
+        const resultA = await invocationA;
+
+        expect(resultA.status).toBe('completed');
+        const persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions['t1/org/lease-repo'].lastIngestedRev).toBe('sha-head-org/lease-repo');
+        expect(await fs.pathExists(leaseFilePath())).toBe(false);
+    });
+
+    test('cross-process lease: a dead-owner lease is reclaimed and released after the run (#15763)', async () => {
+        await fs.writeJson(leaseFilePath(), buildLeasePayload({
+            owner       : 'tenant-repo-sync:manual',
+            reason      : 'tenant-repo-sync',
+            pid         : 2147483647,
+            staleAfterMs: 60_000,
+            token       : 'dead-owner-token'
+        }));
+
+        const result = await TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService: createInMemoryTaskStateService()
+        }));
+
+        expect(result.status).toBe('completed');
+        expect(await fs.pathExists(leaseFilePath())).toBe(false);
+    });
+
+    test('cross-process lease: released after a failing sweep so the next run can acquire (#15763)', async () => {
+        const failing = await TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService             : createInMemoryTaskStateService(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory() {
+                    return {ingested: 0, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_FAILED'}]};
+                }
+            })
+        }));
+
+        expect(failing.status).toBe('failed');
+        expect(await fs.pathExists(leaseFilePath())).toBe(false);
+
+        const recovered = await TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService: createInMemoryTaskStateService()
+        }));
+
+        expect(recovered.status).toBe('completed');
+    });
+
+    test('atomic manifest write: a failed write leaves the previous complete document readable (#15763)', async () => {
+        const
+            roDir  = path.join(tmpDir, 'ro-manifest'),
+            target = path.join(roDir, 'revisions.json');
+
+        await fs.ensureDir(roDir);
+        await fs.writeJson(target, {revisions: {'t1/org/keep': {lastIngestedRev: 'sha-keep'}}});
+        const original = await fs.readFile(target, 'utf8');
+
+        await fs.chmod(roDir, 0o555);
+        try {
+            await expect(TenantRepoSyncService.writePersistedRevisions({
+                filePath : target,
+                revisions: {'t1/org/keep': {lastIngestedRev: 'sha-new'}}
+            })).rejects.toMatchObject({code: 'KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED'});
+        } finally {
+            await fs.chmod(roDir, 0o755);
+        }
+
+        expect(await fs.readFile(target, 'utf8')).toBe(original);
+        expect((await fs.readdir(roDir)).filter(name => name.includes('.tmp-'))).toEqual([]);
+    });
 });
 
 test.describe('TenantRepoSyncService.resolveIngestionService — export-drift guard (#12042)', () => {
@@ -2373,5 +2547,13 @@ test.describe('syncTenantRepos manual CLI (#15748)', () => {
             onlyRepoSlugs: ['org/a', 'org/b'],
             fullReplay   : true
         });
+    });
+
+    test('resolveExitCode maps runTask results onto the documented exit-code contract (#15763)', () => {
+        expect(resolveExitCode({status: 'completed', details: {}})).toBe(0);
+        expect(resolveExitCode({status: 'skipped', details: {reasonCode: 'KB_TENANT_REPO_SYNC_LEASE_HELD'}})).toBe(4);
+        expect(resolveExitCode({status: 'failed', details: {reasonCode: 'KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED'}})).toBe(3);
+        expect(resolveExitCode({status: 'failed', details: {reasonCode: 'KB_TENANT_REPO_SYNC_SYNC_FAILED'}})).toBe(1);
+        expect(resolveExitCode({status: 'skipped', details: {reason: 'no-tenant-repos-configured'}})).toBe(1);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -29,7 +29,11 @@ import {
     TENANT_REPO_INGEST_CONTRACT_VERSION
 } from '../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
 import {deriveTenantRepoMirrorPath} from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
-import {buildLeasePayload}          from '../../../../../../../ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs';
+import {
+    LIFECYCLE_GUARD_SUFFIX,
+    acquireHeavyMaintenanceLease,
+    buildLeasePayload
+} from '../../../../../../../ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs';
 import {
     buildRunTaskOptions,
     parseArgs,
@@ -2310,6 +2314,104 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         }));
 
         expect(recovered.status).toBe('completed');
+    });
+
+    test('lease renewal keeps a live long-running owner past its base TTL — no mid-work reclaim (#15763)', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+
+        let releaseIngestion;
+        const ingestionGate = new Promise(resolve => releaseIngestion = resolve);
+
+        const invocation = TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService,
+            leaseStaleAfterMs            : 300,
+            leaseRenewalIntervalMs       : 50,
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                async summaryFactory() {
+                    await ingestionGate;
+                    return {ingested: 1, deleted: 0, errors: []};
+                }
+            })
+        }));
+
+        for (let i = 0; i < 200 && !await fs.pathExists(leaseFilePath()); i++) {
+            await new Promise(resolve => setTimeout(resolve, 5));
+        }
+        expect(await fs.pathExists(leaseFilePath())).toBe(true);
+
+        // Hold the run well past its base TTL. Without renewal the lease would
+        // be reclaimable at +300ms; the renewal loop must keep the live owner's
+        // deadline moving so the contender still observes an active hold.
+        await new Promise(resolve => setTimeout(resolve, 450));
+
+        const contender = await acquireHeavyMaintenanceLease({
+            leasePath   : leaseFilePath(),
+            owner       : 'contender',
+            staleAfterMs: 300
+        });
+        expect(contender).toMatchObject({acquired: false, status: 'held'});
+
+        releaseIngestion();
+        const result = await invocation;
+
+        expect(result.status).toBe('completed');
+        expect((await fs.readJson(revisionsFile)).revisions['t1/org/lease-repo'].lastIngestedRev).toBe('sha-head-org/lease-repo');
+        expect(await fs.pathExists(leaseFilePath())).toBe(false);
+    });
+
+    test('renewal failure aborts before protected work: failed run, no manifest, untouched backoff, replacement intact (#15763)', async () => {
+        const taskStateService = createInMemoryTaskStateService();
+
+        let releaseEnvelope;
+        const envelopeGate = new Promise(resolve => releaseEnvelope = resolve);
+        const baseEnvelope = makeFakeEnvelopeBuilder();
+
+        const invocation = TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService,
+            leaseStaleAfterMs     : 60_000,
+            leaseRenewalIntervalMs: 25,
+            envelopeBuilder       : async (...args) => {
+                await envelopeGate;
+                return baseEnvelope(...args);
+            }
+        }));
+
+        for (let i = 0; i < 200 && !await fs.pathExists(leaseFilePath()); i++) {
+            await new Promise(resolve => setTimeout(resolve, 5));
+        }
+        expect(await fs.pathExists(leaseFilePath())).toBe(true);
+
+        // A reclaimer replaces the lease while the run is paused mid-work.
+        // The replacement happens INSIDE the lifecycle guard so an in-flight
+        // renewal tick cannot interleave with this test write.
+        const guardPath = `${leaseFilePath()}${LIFECYCLE_GUARD_SUFFIX}`;
+        await fs.ensureDir(guardPath);
+        await fs.writeJson(leaseFilePath(), buildLeasePayload({
+            owner       : 'replacement-owner',
+            reason      : 'tenant-repo-sync',
+            pid         : process.pid,
+            staleAfterMs: 60_000,
+            token       : 'replacement-token'
+        }));
+        await fs.rmdir(guardPath);
+
+        // Let renewal ticks observe the loss; even under full renewal
+        // starvation the pre-ingest fence re-inspects the live file and
+        // reaches the same abort.
+        await new Promise(resolve => setTimeout(resolve, 120));
+
+        releaseEnvelope();
+        const result = await invocation;
+
+        expect(result.status).toBe('failed');
+        expect(result.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_LEASE_LOST');
+
+        // Fail-closed: no manifest was ever committed and per-repo backoff
+        // state was not manufactured for the aborted sweep.
+        expect(await fs.pathExists(revisionsFile)).toBe(false);
+
+        // The loser's token-guarded release could not remove the replacement.
+        expect((await fs.readJson(leaseFilePath())).token).toBe('replacement-token');
     });
 
     test('atomic manifest write: a failed write leaves the previous complete document readable (#15763)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -2334,6 +2334,92 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(await fs.readFile(target, 'utf8')).toBe(original);
         expect((await fs.readdir(roDir)).filter(name => name.includes('.tmp-'))).toEqual([]);
     });
+
+    test('commit-point fence: an evicted writer aborts without writing (#15763)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            foreignLease     = buildLeasePayload({
+                owner       : 'tenant-repo-sync:scheduler',
+                reason      : 'tenant-repo-sync',
+                pid         : process.pid,
+                staleAfterMs: 60_000,
+                token       : 'foreign-takeover-token'
+            });
+
+        await fs.writeJson(revisionsFile, {revisions: {'t1/org/lease-repo': {
+            lastIngestedRev                   : 'sha-before',
+            lastRunAttemptAt                  : 0,
+            consecutiveFailures               : 0,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        }}});
+        const originalManifest = await fs.readFile(revisionsFile, 'utf8');
+
+        // Simulate a TTL eviction: a new owner replaces the lease mid-sweep.
+        const takeoverMirror = {
+            ...makeFakeGitMirror(),
+            async fetch() {
+                await fs.writeJson(leaseFilePath(), foreignLease);
+            }
+        };
+
+        const result = await TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService,
+            gitMirror: takeoverMirror
+        }));
+
+        expect(result.status).toBe('failed');
+        expect(result.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_LEASE_LOST');
+        expect(await fs.readFile(revisionsFile, 'utf8')).toBe(originalManifest);
+        // Token-guarded release must not clobber the new owner's lease.
+        expect((await fs.readJson(leaseFilePath())).token).toBe('foreign-takeover-token');
+    });
+
+    test('atomic manifest write: an interrupted partial temp write never replaces the target (#15763)', async () => {
+        const target = path.join(tmpDir, 'fault-injected.json');
+        await fs.writeJson(target, {revisions: {'t1/org/keep': {lastIngestedRev: 'sha-keep'}}});
+        const original = await fs.readFile(target, 'utf8');
+
+        const shortWriteFs = {
+            ...fs,
+            async writeFile(filePath, payload, ...rest) {
+                await fs.writeFile(filePath, String(payload).slice(0, 10), ...rest);
+                const error = new Error('interrupted after a partial write');
+                error.code  = 'EIO';
+                throw error;
+            }
+        };
+
+        await expect(TenantRepoSyncService.writePersistedRevisions({
+            filePath : target,
+            revisions: {'t1/org/keep': {lastIngestedRev: 'sha-new'}},
+            fsModule : shortWriteFs
+        })).rejects.toMatchObject({code: 'KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED'});
+
+        expect(await fs.readFile(target, 'utf8')).toBe(original);
+        expect((await fs.readdir(tmpDir)).filter(name => name.includes('.tmp-'))).toEqual([]);
+    });
+
+    test('atomic manifest write: a multi-chunk payload lands complete and parseable (#15763)', async () => {
+        const target    = path.join(tmpDir, 'large-manifest.json');
+        const revisions = {};
+
+        for (let i = 0; i < 2000; i++) {
+            revisions[`t1/org/repo-${i}`] = {
+                lastIngestedRev                   : 'f'.repeat(512) + i,
+                lastRunAttemptAt                  : i,
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            };
+        }
+
+        await TenantRepoSyncService.writePersistedRevisions({filePath: target, revisions});
+
+        const persisted = await fs.readJson(target);
+        expect(Object.keys(persisted.revisions)).toHaveLength(2000);
+        expect(persisted.revisions['t1/org/repo-1999'].lastIngestedRev.endsWith('1999')).toBe(true);
+    });
 });
 
 test.describe('TenantRepoSyncService.resolveIngestionService — export-drift guard (#12042)', () => {


### PR DESCRIPTION
Resolves #15763

The tenant-repo lane's two entry paths — the orchestrator's periodic sweep and the manual `syncTenantRepos.mjs` CLI — now serialize through one dedicated cross-process lease and commit the revisions manifest atomically. The lease is a tokenized sibling file of the manifest (lock and data share one persistence/recovery boundary on the volume shipped by `#15764`), acquired inside `runTask` — the single chokepoint both paths share — via the existing heavy-maintenance lease primitives with a dedicated identity. Contention is a bounded non-failure: the periodic sweep defers with `KB_TENANT_REPO_SYNC_LEASE_HELD` and zero checkpoint/backoff mutation; the CLI exits deterministically with new code `4` plus an owner/expiry hint. Crashed owners recover instantly via pid-liveness. `writePersistedRevisions` becomes temp-sibling + fsync + rename, so a crash mid-write can no longer produce the torn manifest that the strict reader (since `#15761`) fail-closes the whole lane on.

The exclusivity contract after the cycle-3 review is **one serialized transition mechanism, identity-safe in its own recovery, plus work-level renewal**. Every read-verify-mutate transition on an existing lease record — stale/malformed recovery, token-guarded release, renewal — executes inside a short-lived lifecycle guard and acts only on state re-observed INSIDE the guard, never on an earlier observation. Guard entry is atomic-with-identity: the entrant stages a directory carrying its unique `owner-<token>` file and `rename()`s it onto the canonical guard name, which POSIX refuses when the target is non-empty — a live guard can never be replaced. Abandoned-guard recovery consumes exactly the OBSERVED artifacts: `unlink` of the specific observed owner filename (`ENOENT` ⇒ observed guard gone ⇒ abort) then `rmdir` (`ENOTEMPTY` ⇒ someone re-entered ⇒ abort) — the cycle-3 reviewer-reproduced pathname-based removal of a replacement guard is structurally impossible, and the deterministic two-contender regression proves exactly one entrant/acquirer in that schedule (async + sync). Every lease mutation inside the section re-verifies live guard ownership immediately before acting, so an evicted stalled holder DEFERS (`guardEvicted`) instead of mutating its successor's state. Plain acquisition stays an atomic exclusive create deferring via `EEXIST`. A running sweep renews its own lease every `max(5s, TTL/3)`, so a live owner never reaches its deadline mid-work; work fences before each repo's git phase, each KB ingest, and every manifest commit abort a de-owned run with `KB_TENANT_REPO_SYNC_LEASE_LOST` — checkpoints, backoff state, and the successor's lease stay untouched, and no partial sweep is committed. pid-liveness recovers crashes instantly; the TTL remains the backstop for an owner that stopped renewing. Precise residual bound: a holder stalled past `guardStaleAfterMs` (default 10s vs µs-scale guarded sections) is legitimately evictable; the pre-mutation ownership probe narrows its exposure to the probe's own single stat→syscall gap, reachable only by a holder that both stalled past the threshold and resumed inside that gap — live transitions can be neither evicted nor replaced. Manifest writes keep the full-write `writeFile` contract before fsync + rename.

Evidence: L2 (real-filesystem lease/manifest unit coverage: gated concurrent two-writer witness; two-reclaimer guard interleave; replacement-after-observation regressions, async + sync; replacement-during-release regressions, async + sync; a recovery-vs-release guard-serialization interleave; the cycle-3 two-contender abandoned-guard interleave proving exactly one entrant; the evicted-stalled-holder probe witness; sync identity-safe steal abort; abandoned-guard steal-path reclaim + interrupted-entry empty-guard replacement + live contended-guard deferral; renewal keeping a live owner past its base TTL; renewal-failure fail-closed abort; mid-sweep eviction fence witness; fault-injected partial-write regression) → L2 required (the close-target ACs are cross-process state-machine and persistence contracts). Residual: none.

## Deltas from ticket

- Immediate-busy instead of a bounded CLI wait: the ticket allowed either; immediate busy (exit `4` + stderr owner/expiry hint) is simpler, timer-free, and matches the fail-fast operator model — re-running is the retry.
- The lease path derives from the resolved revisions-manifest path (sibling file) rather than a separate config leaf: lock and data provably share one volume/recovery boundary, and every test that isolates the manifest automatically isolates the lease.
- Lease-acquire IO failures (unwritable state dir, broken volume) return the lane's structured `failed` result (`phase: lease-acquire`) instead of escaping as a raw throw.
- One pre-existing fixture retargeted: the deep-error-propagation test forced `MANIFEST_UPDATE_FAILED` via an unwritable parent directory, which now (correctly) fails earlier at lease creation; it forces the same deep error via a directory squatting on the exact temporary-sibling path — same assertions, deterministic, no chmod juggling.
- Troubleshooting gains the torn-manifest last-resort recovery line the PR #15766 review fed into this ticket (deleting the manifest is safe at full re-ingestion cost; never hand-edit it).
- Renewal cadence is a derivation from the existing TTL leaf (`max(5s, TTL/3)`), not a new config leaf; the guard staleness threshold is a primitive-internal mechanism constant with a test-seam override (`guardStaleAfterMs`), not policy. No AiConfig surface added in cycle 2.
- Lease loss mid-sweep is a run-level abort, not a per-repo failure: aborted repos keep their checkpoint/attempt/backoff state byte-identical (`status: 'aborted-lease-lost'` in the run details), because the successor now owns forward progress.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — 69 passed. Cycle-2 additions: renewal keeps a live long-running owner past its base TTL (contender still observes an active hold); renewal-failure fail-closed abort (failed run, `KB_TENANT_REPO_SYNC_LEASE_LOST`, no manifest ever committed, backoff untouched, replacement lease intact).
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs` — 32 passed. Cycle-2 additions/reworks: the two cycle-1 interleave regressions re-aimed at the guard mechanism (same semantic assertions); replacement-after-observation (async + sync); replacement-during-release (async + sync); recovery-vs-release guard serialization (the outgoing owner's release provably cannot delete the reclaimer's lease); abandoned-guard reclamation via `guardStaleAfterMs`; live contended guard defers without mutating; renewal semantics async + sync (deadline extension, non-owner deferral, missing lease, required-TTL throw).
- Adjacent importers (`manualHeavyMaintenanceScriptLeaseAdoption`, `VectorService.leaseYield`, `scheduling/tenantRepoSync`) — 39 passed; second-order sync-variant consumers (`Orchestrator.spec`, `MaintenanceBackpressureService`, `leaseMonitor`, `leaseWatchdog`, `TenantRepoSyncErrors`) — 125 passed.
- `npm run ai:lint-config-template-ssot` — OK (no config change in cycle 2); `npm run ai:lint-guides` — 0 hard findings.
- First CI run surfaced a dedicated `TenantRepoSyncErrors.spec.mjs` my targeted set had missed: its taxonomy pin hardcoded the five-code list, correctly failing on the sixth code. Spec extended (imports, prefix list, exact-count `6`, length-relative mutation probe); combined rerun of both specs — 71 passed at `86a7a4be66`.

## Post-Merge Validation

- [ ] On the next cloud rollout, run the manual CLI while the periodic lane is enabled: expect either a normal exit `0` or a clean exit-`4` busy result, the deferred side reporting `skipped` with `KB_TENANT_REPO_SYNC_LEASE_HELD` in the task outcome, and no lost revision updates across the overlap window.
- [ ] During a long tenant sweep on the deployment volume, confirm the lease file's `renewedAt`/`expiresAt` advance while the sweep runs (renewal observable in place) and that no `….lifecycle-guard` directory persists after the run.

## Commits

- `cf0198d28c` — lease serialization + atomic manifest commit (service, config leaf + parity, error code, CLI exit contract, six new tests, two guides); rebased onto post-#15773 `dev` (one imports/consts conflict resolved as predicted by the pre-review `merge-tree` check)
- `664927b5f7` — error-taxonomy spec extended for the sixth code (surfaced by full-suite CI)
- `40f245e5bb` — cycle-1 Required Actions: identity-preserving stale takeover, six-hour TTL default + toggle-table documentation, commit-point ownership fence (`KB_TENANT_REPO_SYNC_LEASE_LOST`), full-write manifest contract with an `fsModule` fault-injection seam, and six safety regressions
- `8eff5f85c9` — cycle-2 Required Actions: lifecycle-guard serialization of every recovery/release/renewal transition (rename-aside takeover deleted, async + sync parity), lease renewal during work, per-repo git-phase + pre-ingest work fences with run-level `aborted-lease-lost` semantics, ten new/reworked regressions, docs aligned to the proven contract
- `2f142a57ef` — cycle-3 carried RA: identity-safe abandoned-guard recovery (owner-token entry via staged atomic rename; steal consumes only observed artifacts; pre-mutation ownership probes with `guardEvicted` deferral; async + sync parity), the reviewer's deterministic two-contender regression + evicted-holder + sync steal-abort + empty-guard witnesses, prose aligned to the precise residual bound

## Evolution

Cycle-1 review (Emmy) falsified three safety windows at exact head: a stale-reclaim TOCTOU in the shared primitive letting two contenders both acquire, a 15-minute TTL that could evict a legitimate live sweep, and an unchecked single `fs.write()` whose partial completion could be renamed into place. All three closed in `40f245e5bb`.

Cycle-2 review (Emmy) falsified the cycle-1 takeover itself: verifying a moved record after renaming it aside cannot establish exclusivity for the unnamed interval (two participants provably held `acquired: true` with the final record belonging to one), release validated its token in a separate operation from removal (a replacement owner's lease could be deleted), and the commit fence alone did not stop a live-but-expired owner's repo work from overlapping its successor. The repair replaced verify-after-move with mutate-only-on-guarded-re-observation — one serialization point for every lifecycle transition, deleting the rename/`link()` restore machinery outright — and moved expiry from a static deadline to renewal-while-working plus fences at every protected-work boundary.

Cycle-3 review (Emmy) falsified the guard's own abandoned-state recovery with a deterministic interleave: two contenders observing one abandoned guard could remove each other's replacement (`rmdir` by pathname acts on whatever currently bears the name, not the observed directory) — the mkdir-era claim "double-entry requires a holder stalled past the threshold" was wrong about the mechanism, since the schedule needs only a stale OBSERVATION, not a stalled holder. The repair made every step of recovery consume only observed identity: entry is born carrying an owner token via staged atomic rename (a live guard is irreplaceable by construction — rename refuses non-empty targets), the steal unlinks exactly the observed token and aborts on `ENOENT`/`ENOTEMPTY`, and every lease mutation re-proves live ownership immediately before acting so even an evicted stalled holder defers. Each cycle of this review tightened the same invariant one layer down: lease record → lease lifecycle → the serializer's own lifecycle; the body now states the terminal bound precisely instead of optimistically.

Authored by Vega (Claude Fable 5, Claude Code). Session 9af3c9a5-efc2-4716-bb5c-19289e22ddcc.

