### PR TITLE
feat(ai): preflight tenant repo access (#15760)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -3,6 +3,9 @@ import path                                 from 'node:path';
 import Base                                 from '../../../../src/core/Base.mjs';
 import AiConfig                             from '../../../config.mjs';
 import {probeProviderParallelModelCapacity} from '../../../services/graph/providerReadinessHelper.mjs';
+import {
+    isTenantRepoAccessReadinessOutcome
+} from '../../../services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 
 import {
     boundUtf8Tail,
@@ -683,11 +686,12 @@ export class DeploymentStateBridgeService extends Base {
             persistedRepoState: persistedRevisions[createTenantRepoLabel(repo)] || null,
             revisionStateAvailable,
             globalCadenceMs   : scheduler.globalCadenceMs,
-            jitterRatio       : scheduler.jitterRatio
+            jitterRatio       : scheduler.jitterRatio,
+            accessReadiness   : readTenantRepoAccessReadiness(this.tenantRepoSyncService, repo, observedAt)
         }));
 
         return {
-            schemaVersion: 1,
+            schemaVersion: 2,
             recordType   : 'tenant-repo-sync-deployment-state',
             source,
             observedAt,
@@ -706,6 +710,10 @@ export class DeploymentStateBridgeService extends Base {
             checkpointRevalidation: summarizeCheckpointRevalidation({
                 repoStates,
                 stateAvailable: configEnumerationAvailable && revisionStateAvailable
+            }),
+            accessReadiness: summarizeTenantRepoAccessReadiness({
+                repoStates,
+                stateAvailable: configEnumerationAvailable
             }),
             repos : repoStates,
             errors
@@ -1063,6 +1071,114 @@ function summarizeCheckpointRevalidation({repoStates, stateAvailable}) {
 }
 
 /**
+ * @summary Reads process-local access evidence without letting inspection trigger network work.
+ * @param {Object|null} service TenantRepoSyncService-compatible source.
+ * @param {Object} repo Effective repository entry.
+ * @param {Number} observedAt Snapshot observation epoch.
+ * @returns {Object|null}
+ */
+function readTenantRepoAccessReadiness(service, repo, observedAt) {
+    if (typeof service?.getTenantRepoAccessReadiness !== 'function') {
+        return null;
+    }
+
+    try {
+        return service.getTenantRepoAccessReadiness(repo, {observedAt});
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * @summary Reduces one cached access result to its strict public allowlist.
+ * @param {Object|null} candidate Process-local readiness candidate.
+ * @param {Boolean} disabled Whether the repository is disabled.
+ * @returns {{status: String, code: String|null, checkedAt: String|null}}
+ */
+function summarizeTenantRepoAccessState(candidate, disabled) {
+    if (disabled) {
+        return {
+            status   : 'not-required',
+            code     : null,
+            checkedAt: null
+        };
+    }
+
+    const
+        status    = candidate?.status,
+        code      = typeof candidate?.code === 'string' ? candidate.code : null,
+        checkedAt = typeof candidate?.checkedAt === 'string' && Number.isFinite(Date.parse(candidate.checkedAt))
+            ? new Date(candidate.checkedAt).toISOString()
+            : null;
+
+    if (checkedAt && isTenantRepoAccessReadinessOutcome(status, code)) {
+        return {status, code, checkedAt};
+    }
+
+    return {
+        status   : 'unknown',
+        code     : null,
+        checkedAt: null
+    };
+}
+
+/**
+ * @summary Builds aggregate access-readiness counts without exposing repository identities.
+ * @param {Object} options
+ * @param {Object[]} options.repoStates Redacted per-repo diagnostic rows.
+ * @param {Boolean} options.stateAvailable Whether effective repo enumeration succeeded.
+ * @returns {Object}
+ */
+function summarizeTenantRepoAccessReadiness({repoStates, stateAvailable}) {
+    if (!stateAvailable) {
+        return {
+            status       : 'unknown',
+            requiredCount: null,
+            readyCount   : null,
+            degradedCount: null,
+            unknownCount : null,
+            checkedCount : null
+        };
+    }
+
+    const required = repoStates.filter(repo => !repo.disabled);
+    const summary  = {
+        status       : 'not-required',
+        requiredCount: required.length,
+        readyCount   : 0,
+        degradedCount: 0,
+        unknownCount : 0,
+        checkedCount : 0
+    };
+
+    for (const repo of required) {
+        const status = repo.accessReadiness.status;
+
+        if (status === 'ready') {
+            summary.readyCount++;
+        } else if (status === 'degraded') {
+            summary.degradedCount++;
+        } else {
+            summary.unknownCount++;
+        }
+
+        if (repo.accessReadiness.checkedAt) {
+            summary.checkedCount++;
+        }
+    }
+
+    if (summary.degradedCount > 0) {
+        summary.status = 'degraded';
+    } else if (summary.unknownCount > 0) {
+        summary.status = 'unknown';
+    } else if (summary.readyCount > 0) {
+        summary.status = 'ready';
+    }
+
+    return summary;
+}
+
+/**
  * @summary Projects one configured repository into a redacted scheduler and
  * checkpoint-revalidation diagnostic row.
  * @param {Object} options
@@ -1073,6 +1189,7 @@ function summarizeCheckpointRevalidation({repoStates, stateAvailable}) {
  * @param {Boolean} options.revisionStateAvailable Whether the manifest was readable.
  * @param {Number} options.globalCadenceMs Global per-repo cadence.
  * @param {Number} options.jitterRatio Deterministic jitter ratio.
+ * @param {Object|null} options.accessReadiness Process-local access evidence.
  * @returns {Object}
  */
 function summarizeTenantRepoState({
@@ -1082,7 +1199,8 @@ function summarizeTenantRepoState({
     persistedRepoState,
     revisionStateAvailable,
     globalCadenceMs,
-    jitterRatio
+    jitterRatio,
+    accessReadiness
 }) {
     const
         normalizedCheckpoint = normalizeTenantRepoCheckpointState(persistedRepoState),
@@ -1106,6 +1224,7 @@ function summarizeTenantRepoState({
         repoHash                          : hashValue(repo.repoSlug),
         configTier                        : repo.configTier || 'unreported',
         disabled,
+        accessReadiness                   : summarizeTenantRepoAccessState(accessReadiness, disabled),
         status                            : classifyTenantRepoState({disabled, due: dueState.due, persistedRepoState: normalizedCheckpoint, lastOutcome}),
         due                               : disabled ? false : dueState.due,
         nextDueAt                         : Number.isFinite(nextDueAtMs) ? new Date(nextDueAtMs).toISOString() : null,

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1,10 +1,17 @@
-import fs                    from 'fs-extra';
-import path                  from 'node:path';
-import Base                  from '../../../../src/core/Base.mjs';
-import AiConfig              from '../../../config.mjs';
-import GitMirror             from '../../../services/knowledge-base/helpers/gitMirror.mjs';
-import {buildIngestEnvelope} from '../../../services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
-import {isRepoDue}           from '../scheduling/tenantRepoSync.mjs';
+import fs                        from 'fs-extra';
+import {createHmac, randomBytes} from 'node:crypto';
+import path                      from 'node:path';
+import Base                      from '../../../../src/core/Base.mjs';
+import AiConfig                  from '../../../config.mjs';
+import GitMirror                 from '../../../services/knowledge-base/helpers/gitMirror.mjs';
+import {buildIngestEnvelope}     from '../../../services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
+import {
+    isTenantRepoAccessReadinessOutcome,
+    normalizeTenantRepoCredentialRef,
+    TenantRepoAccessCode,
+    TenantRepoAccessStatus
+} from '../../../services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
+import {isRepoDue} from '../scheduling/tenantRepoSync.mjs';
 import {
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
@@ -22,6 +29,8 @@ import {
 } from './tenantRepoCheckpointValidity.mjs';
 
 const
+    ACCESS_CONFIG_FINGERPRINT_KEY = randomBytes(32),
+    ACCESS_READINESS_MIN_TTL_MS   = 15 * 60 * 1000,
     BOUNDED_KB_ERROR_CODE_PATTERN = /^KB_[A-Z0-9_]{1,120}$/,
     PERSISTED_REVISIONS_FILE_NAME = 'tenant-repo-sync-revisions.json';
 
@@ -95,6 +104,76 @@ function getSourceErrorCode(error, outerCode) {
     }
 
     return BOUNDED_KB_ERROR_CODE_PATTERN.test(sourceCode) ? sourceCode : null;
+}
+
+/**
+ * @summary Builds an internal-only digest of the effective access configuration.
+ * @param {Object} repo Effective tenant-repo entry.
+ * @returns {String}
+ * @private
+ */
+function hashTenantRepoAccessConfig(repo) {
+    return createHmac('sha256', ACCESS_CONFIG_FINGERPRINT_KEY).update(JSON.stringify({
+        branchRef    : repo.branchRef || 'HEAD',
+        cloneUrl     : repo.cloneUrl,
+        credentialRef: normalizeTenantRepoCredentialRef(repo.credentialRef)
+    })).digest('hex');
+}
+
+/**
+ * @summary Returns the stable internal key for one effective tenant repository.
+ * @param {Object} repo Effective tenant-repo entry.
+ * @returns {String}
+ * @private
+ */
+function createTenantRepoAccessKey(repo) {
+    return `${repo.tenantId}/${repo.repoSlug}`;
+}
+
+/**
+ * @summary Returns true when a configured tenant repository is disabled.
+ * @param {Object} repo Effective tenant-repo entry.
+ * @returns {Boolean}
+ * @private
+ */
+function isTenantRepoDisabled(repo) {
+    return repo.disabled === true || repo.enabled === false;
+}
+
+/**
+ * @summary Normalizes a readiness timestamp without copying arbitrary upstream data.
+ * @param {*} value Candidate ISO timestamp.
+ * @param {String} fallback Current observation timestamp.
+ * @returns {String}
+ * @private
+ */
+function safeAccessReadinessTimestamp(value, fallback) {
+    return typeof value === 'string' && Number.isFinite(Date.parse(value))
+        ? new Date(value).toISOString()
+        : fallback;
+}
+
+/**
+ * @summary Derives a bounded evidence lifetime from the repo's normal acquisition cadence.
+ *
+ * Two cadence windows avoid an extra remote probe immediately beside every scheduled
+ * fetch. The fifteen-minute floor prevents high-frequency repos from turning readiness
+ * into a network poller.
+ *
+ * @param {Object} repo Effective tenant-repo entry.
+ * @param {Number} globalCadenceMs Global per-repo cadence fallback.
+ * @returns {Number}
+ * @private
+ */
+function getAccessReadinessMaxAgeMs(repo, globalCadenceMs) {
+    const cadenceMs = Number.isFinite(repo.cadenceMs) && repo.cadenceMs > 0
+        ? repo.cadenceMs
+        : globalCadenceMs;
+
+    return Math.max(
+        Number.isFinite(cadenceMs) && cadenceMs > 0 ? cadenceMs * 2 : 0,
+        ACCESS_READINESS_MIN_TTL_MS
+    );
 }
 
 /**
@@ -206,6 +285,16 @@ class TenantRepoSyncService extends Base {
     }
 
     /**
+     * Process-local tenant-repo capability evidence. Hidden fingerprints exist
+     * only to detect effective config or credential rotation; the public getter
+     * projects status, code, and timestamp only. Container restart deliberately
+     * clears the cache and returns readiness to unknown until bootstrap probes run.
+     * @member {Map<String, Object>} accessReadinessCache
+     * @protected
+     */
+    accessReadinessCache = new Map()
+
+    /**
      * Rejects non-positive-integer `concurrencyLimit` values. `0` would create a
      * never-acquirable semaphore; negatives and fractional values produce ambiguous
      * `active < limit` semantics (1.5 admits two slots, etc.). Invalid values fall
@@ -231,6 +320,254 @@ class TenantRepoSyncService extends Base {
     beforeSetConcurrencyGateTimeoutMs(value, oldValue) {
         if (!Number.isFinite(value) || value < 0) return oldValue ?? 30000;
         return value;
+    }
+
+    /**
+     * @summary Returns a bounded readiness result for one effective repository.
+     * @param {Object} repo Tenant and repository identity.
+     * @param {Object} [options]
+     * @param {Number} [options.observedAt=Date.now()] Observation epoch.
+     * @returns {{status: String, code: String, checkedAt: String}|null}
+     */
+    getTenantRepoAccessReadiness(repo = {}, {observedAt = Date.now()} = {}) {
+        const entry = this.accessReadinessCache.get(createTenantRepoAccessKey(repo));
+
+        if (!entry) {
+            return null;
+        }
+
+        if (!Number.isFinite(entry.expiresAt) || entry.expiresAt <= observedAt) {
+            return {
+                status   : TenantRepoAccessStatus.UNKNOWN,
+                code     : TenantRepoAccessCode.EVIDENCE_EXPIRED,
+                checkedAt: entry.checkedAt
+            };
+        }
+
+        return {
+            status   : entry.status,
+            code     : entry.code,
+            checkedAt: entry.checkedAt
+        };
+    }
+
+    /**
+     * @summary Clears volatile access evidence, mirroring a process restart.
+     * @returns {void}
+     * @protected
+     */
+    clearTenantRepoAccessReadiness() {
+        this.accessReadinessCache.clear();
+    }
+
+    /**
+     * @summary Probes every enabled effective repository at bootstrap or access-config rotation.
+     *
+     * Local credential resolution runs on every sweep so file/key replacement is observed.
+     * Remote capability work runs only when the process-local config or credential fingerprint
+     * changes. A failure remains isolated to its repository and never prevents other probes or
+     * the authoritative scheduled clone/fetch path.
+     *
+     * @param {Object} options
+     * @param {Object[]} options.repos Effective tenant repositories.
+     * @param {Object} [options.gitMirror=GitMirror] GitMirror-compatible primitive.
+     * @param {Function} [options.writeLog] Optional orchestrator logger.
+     * @param {Number} [options.globalCadenceMs] Global per-repo cadence fallback.
+     * @returns {Promise<void>}
+     */
+    async refreshTenantRepoAccessReadiness({
+        repos = [],
+        gitMirror = GitMirror,
+        writeLog,
+        globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs
+    } = {}) {
+        const enabledRepos = repos.filter(repo => !isTenantRepoDisabled(repo));
+        const activeKeys   = new Set(enabledRepos.map(createTenantRepoAccessKey));
+
+        for (const key of this.accessReadinessCache.keys()) {
+            if (!activeKeys.has(key)) {
+                this.accessReadinessCache.delete(key);
+            }
+        }
+
+        const semaphore = createConcurrencySemaphore({
+            limit: this.concurrencyLimit
+        });
+
+        await Promise.all(enabledRepos.map(async repo => {
+            await semaphore.acquire();
+
+            try {
+                await this.refreshTenantRepoAccessReadinessEntry({
+                    repo,
+                    gitMirror,
+                    writeLog,
+                    globalCadenceMs
+                });
+            } finally {
+                semaphore.release();
+            }
+        }));
+    }
+
+    /**
+     * @summary Refreshes one process-local access-readiness cache entry.
+     * @param {Object} options
+     * @param {Object} options.repo Effective tenant repository.
+     * @param {Object} options.gitMirror GitMirror-compatible primitive.
+     * @param {Function} [options.writeLog] Optional orchestrator logger.
+     * @param {Number} options.globalCadenceMs Global per-repo cadence fallback.
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async refreshTenantRepoAccessReadinessEntry({repo, gitMirror, writeLog, globalCadenceMs}) {
+        const
+            key        = createTenantRepoAccessKey(repo),
+            checkedAt  = new Date().toISOString(),
+            maxAgeMs   = getAccessReadinessMaxAgeMs(repo, globalCadenceMs),
+            nextExpiry = Date.now() + maxAgeMs;
+
+        let configFingerprint;
+
+        try {
+            configFingerprint = hashTenantRepoAccessConfig(repo);
+        } catch {
+            this.accessReadinessCache.set(key, {
+                status               : TenantRepoAccessStatus.DEGRADED,
+                code                 : TenantRepoAccessCode.CREDENTIAL_INVALID,
+                checkedAt,
+                configFingerprint    : null,
+                credentialFingerprint: null,
+                expiresAt            : nextExpiry,
+                maxAgeMs
+            });
+            return;
+        }
+
+        if (
+            typeof gitMirror?.inspectCredentialReadiness !== 'function'
+            || typeof gitMirror?.probeRemoteAccess !== 'function'
+        ) {
+            this.accessReadinessCache.set(key, {
+                status               : TenantRepoAccessStatus.UNKNOWN,
+                code                 : TenantRepoAccessCode.PROBE_UNAVAILABLE,
+                checkedAt,
+                configFingerprint,
+                credentialFingerprint: null,
+                expiresAt            : nextExpiry,
+                maxAgeMs
+            });
+            return;
+        }
+
+        let local;
+
+        try {
+            local = await gitMirror.inspectCredentialReadiness({
+                credentialRef: repo.credentialRef
+            });
+        } catch {
+            local = null;
+        }
+
+        if (
+            local?.status !== TenantRepoAccessStatus.READY
+            || typeof local.cacheFingerprint !== 'string'
+            || !local.cacheFingerprint
+        ) {
+            this.accessReadinessCache.set(key, {
+                status               : TenantRepoAccessStatus.DEGRADED,
+                code                 : TenantRepoAccessCode.CREDENTIAL_INVALID,
+                checkedAt,
+                configFingerprint,
+                credentialFingerprint: null,
+                expiresAt            : nextExpiry,
+                maxAgeMs
+            });
+            writeLog?.('WARN', `[TenantRepoSync] Access preflight degraded for ${key}: ${TenantRepoAccessCode.CREDENTIAL_INVALID}.`);
+            return;
+        }
+
+        const previous = this.accessReadinessCache.get(key);
+
+        if (
+            previous?.configFingerprint === configFingerprint
+            && previous?.credentialFingerprint === local.cacheFingerprint
+            && Number.isFinite(previous.expiresAt)
+            && previous.expiresAt > Date.now()
+        ) {
+            return;
+        }
+
+        let probe;
+
+        try {
+            probe = await gitMirror.probeRemoteAccess({
+                cloneUrl     : repo.cloneUrl,
+                credentialRef: repo.credentialRef,
+                ref          : repo.branchRef || 'HEAD'
+            });
+        } catch {
+            probe = null;
+        }
+
+        const
+            validOutcome = isTenantRepoAccessReadinessOutcome(probe?.status, probe?.code),
+            status       = validOutcome ? probe.status : TenantRepoAccessStatus.DEGRADED,
+            code         = validOutcome ? probe.code : TenantRepoAccessCode.PROBE_FAILED;
+
+        this.accessReadinessCache.set(key, {
+            status,
+            code,
+            checkedAt            : safeAccessReadinessTimestamp(probe?.checkedAt, checkedAt),
+            configFingerprint,
+            credentialFingerprint: typeof probe?.cacheFingerprint === 'string' && probe.cacheFingerprint
+                ? probe.cacheFingerprint
+                : local.cacheFingerprint,
+            expiresAt: nextExpiry,
+            maxAgeMs
+        });
+
+        if (status !== TenantRepoAccessStatus.READY) {
+            writeLog?.('WARN', `[TenantRepoSync] Access preflight degraded for ${key}: ${code}.`);
+        }
+    }
+
+    /**
+     * @summary Lets an authoritative clone/fetch result supersede cached probe evidence.
+     * @param {Object} options
+     * @param {Object} options.repo Effective tenant repository.
+     * @param {Boolean} options.ready Whether Git acquisition succeeded.
+     * @param {Error} [options.error] GitMirror failure when acquisition did not succeed.
+     * @param {Number} [options.globalCadenceMs] Global per-repo cadence fallback.
+     * @returns {void}
+     * @protected
+     */
+    recordTenantRepoAccessOutcome({
+        repo,
+        ready,
+        error,
+        globalCadenceMs = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs
+    } = {}) {
+        const
+            key       = createTenantRepoAccessKey(repo),
+            previous  = this.accessReadinessCache.get(key) || {},
+            checkedAt = new Date().toISOString(),
+            maxAgeMs  = getAccessReadinessMaxAgeMs(repo, globalCadenceMs),
+            code      = ready
+                ? TenantRepoAccessCode.READY
+                : (error?.code === 'KB_GITMIRROR_CREDENTIAL_REF_INVALID'
+                    ? TenantRepoAccessCode.CREDENTIAL_INVALID
+                    : TenantRepoAccessCode.SYNC_FAILED);
+
+        this.accessReadinessCache.set(key, {
+            ...previous,
+            status   : ready ? TenantRepoAccessStatus.READY : TenantRepoAccessStatus.DEGRADED,
+            code,
+            checkedAt,
+            expiresAt: Date.now() + maxAgeMs,
+            maxAgeMs
+        });
     }
 
     /**
@@ -393,6 +730,13 @@ class TenantRepoSyncService extends Base {
             writeLog?.('INFO', `[TenantRepoSync] No tenantRepos configured; skipping.`);
             return {status: 'skipped', details};
         }
+
+        await this.refreshTenantRepoAccessReadiness({
+            repos: allRepos,
+            gitMirror,
+            writeLog,
+            globalCadenceMs
+        });
 
         const resolvedRevisionsPath = revisionsFilePath || this.defaultRevisionsFilePath();
         const ingestionService      = knowledgeBaseIngestionService || await this.resolveIngestionService();
@@ -558,7 +902,8 @@ class TenantRepoSyncService extends Base {
                 return;
             }
 
-            let slotAcquired = false;
+            let slotAcquired    = false,
+                accessConfirmed = false;
             try {
                 await semaphore.acquire();
                 slotAcquired = true;
@@ -577,6 +922,8 @@ class TenantRepoSyncService extends Base {
                     mirrorRoot   : repo.mirrorRoot,
                     credentialRef: repo.credentialRef
                 });
+                accessConfirmed = true;
+                this.recordTenantRepoAccessOutcome({repo, ready: true, globalCadenceMs});
 
                 const envelope = await envelopeBuilder({
                     tenantId       : repo.tenantId,
@@ -645,6 +992,10 @@ class TenantRepoSyncService extends Base {
                 const sourceErrorCode = getSourceErrorCode(e, code);
                 const sourceSuffix    = sourceErrorCode ? ` source=${sourceErrorCode}` : '';
                 writeLog?.('ERROR', `[TenantRepoSync] ${repoLabel} failed: ${code}${sourceSuffix} (${e.message})`);
+
+                if (slotAcquired && !accessConfirmed) {
+                    this.recordTenantRepoAccessOutcome({repo, ready: false, error: e, globalCadenceMs});
+                }
 
                 // Increment consecutiveFailures on failure; preserve last good
                 // ingested revision so the next successful run starts from the correct base.

--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -1,30 +1,41 @@
-import {spawn} from 'child_process';
-import fs      from 'fs-extra';
-import os      from 'os';
-import path    from 'path';
+import {spawn}                    from 'child_process';
+import {createHmac, randomBytes}  from 'node:crypto';
+import {constants as fsConstants} from 'node:fs';
+import fs                         from 'fs-extra';
+import os                         from 'os';
+import path                       from 'path';
 
 import {
     assertCleanCloneUrl,
     deriveTenantRepoMirrorPath,
-    redactTenantRepoSecrets
+    normalizeTenantRepoCredentialRef,
+    redactTenantRepoSecrets,
+    TenantRepoAccessCode,
+    TenantRepoAccessStatus
+} from './tenantRepoAccessContract.mjs';
+
+export {
+    TenantRepoAccessCode,
+    TenantRepoAccessStatus
 } from './tenantRepoAccessContract.mjs';
 
 /**
  * @summary Git-backed persistent mirror primitive for server-side tenant repo ingestion.
  *
- * `GitMirror` owns only the low-level mirror lifecycle for #11788: clone-if-missing,
+ * `GitMirror` owns only the low-level mirror lifecycle: clone-if-missing,
  * fetch, ref resolution, ancestry checks, and revision diffs. It deliberately consumes
- * the #11787 clean repo-access helpers instead of deriving paths or persisting
+ * the clean repo-access helpers instead of deriving paths or persisting
  * credential material itself. Higher-level `tenant-repo-sync` cadence and
- * `ingestSourceFiles()` envelope construction remain owned by sibling subs #11790
- * and #11789.
+ * `ingestSourceFiles()` envelope construction remain owned by sibling services.
  *
  * @see https://github.com/neomjs/neo/issues/11788
  * @see https://github.com/neomjs/neo/issues/11787
  */
 
 const GIT_TERMINAL_PROMPT_DISABLED = '0';
-const ASKPASS_SCRIPT = `#!/bin/sh
+const ACCESS_PROBE_TIMEOUT_MS      = 15_000;
+const CREDENTIAL_FINGERPRINT_KEY   = randomBytes(32);
+const ASKPASS_SCRIPT               = `#!/bin/sh
 case "$1" in
     *Username*|*username*) printf '%s\\n' "\${NEO_GITMIRROR_USERNAME:-x-access-token}" ;;
     *) printf '%s\\n' "$NEO_GITMIRROR_PASSWORD" ;;
@@ -88,44 +99,36 @@ function createGitEnv(overrides = {}) {
 }
 
 /**
- * @summary Normalizes supported credential reference shapes.
+ * @summary Maps the shared tenant-repo credential grammar onto GitMirror's stable error contract.
  * @param {String|Object|null} credentialRef Durable credential reference.
  * @returns {Object|null}
  * @private
  */
-function normalizeCredentialRef(credentialRef) {
-    if (!credentialRef) {
-        return null;
+function normalizeGitCredentialRef(credentialRef) {
+    try {
+        return normalizeTenantRepoCredentialRef(credentialRef, {allowOmitted: true});
+    } catch (error) {
+        throw createGitMirrorError(
+            'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
+            'GitMirror credentialRef is invalid or unsupported',
+            {cause: error}
+        );
     }
+}
 
-    if (typeof credentialRef === 'string') {
-        if (credentialRef === 'none') {
-            return {type: 'none'};
-        }
-
-        if (credentialRef.startsWith('env:')) {
-            return {type: 'env', name: credentialRef.slice(4)};
-        }
-
-        if (credentialRef.startsWith('ssh:')) {
-            return {type: 'ssh', keyPath: credentialRef.slice(4)};
-        }
-
-        if (credentialRef.startsWith('file:')) {
-            return {type: 'file', filePath: credentialRef.slice(5)};
-        }
-
-        return {type: 'env', name: credentialRef};
-    }
-
-    if (typeof credentialRef === 'object' && !Array.isArray(credentialRef)) {
-        return credentialRef;
-    }
-
-    throw createGitMirrorError(
-        'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
-        'GitMirror credentialRef must be a string, object, or omitted for local mirrors'
-    );
+/**
+ * @summary Produces a process-local, non-persistable fingerprint for credential-change detection.
+ * @param {String} type Credential type discriminator.
+ * @param {String|Buffer} value Resolved credential material.
+ * @returns {String}
+ * @private
+ */
+function fingerprintCredential(type, value = '') {
+    return createHmac('sha256', CREDENTIAL_FINGERPRINT_KEY)
+        .update(type)
+        .update('\0')
+        .update(value)
+        .digest('hex');
 }
 
 /**
@@ -165,44 +168,50 @@ async function createAskPassCredentialEnvironment({secret, username = 'x-access-
 }
 
 /**
- * @summary Resolves transient git credential environment overrides.
+ * @summary Resolves and validates credential material without exposing it to callers.
+ *
+ * The returned fingerprint is keyed with process-local entropy. It can compare two
+ * resolutions within this process, but cannot be persisted or reused to test a secret
+ * outside the running orchestrator.
+ *
  * @param {Object} options
  * @param {String|Object|null} options.credentialRef Durable credential reference.
- * @returns {Promise<{env: Object, secretHints: String[], cleanup: Function}>}
+ * @returns {Promise<{ref: Object|null, secret: String|undefined, cacheFingerprint: String}>}
  * @private
  */
-async function resolveCredentialEnvironment({credentialRef} = {}) {
-    const ref = normalizeCredentialRef(credentialRef);
+async function resolveCredentialMaterial({credentialRef} = {}) {
+    const ref = normalizeGitCredentialRef(credentialRef);
 
     if (!ref || ref.type === 'none') {
-        return {env: {}, secretHints: [], cleanup: async () => {}};
+        return {
+            ref,
+            cacheFingerprint: fingerprintCredential('none')
+        };
     }
 
     if (ref.type === 'env') {
         const name   = ref.name;
         const secret = process.env[name];
 
-        if (!name || !secret) {
+        if (typeof secret !== 'string' || secret.trim() === '') {
             throw createGitMirrorError(
                 'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
                 'GitMirror env credentialRef could not be resolved'
             );
         }
 
-        return createAskPassCredentialEnvironment({secret, username: ref.username});
+        return {
+            ref,
+            secret,
+            cacheFingerprint: fingerprintCredential('env', secret)
+        };
     }
 
     if (ref.type === 'file') {
-        if (!ref.filePath) {
-            throw createGitMirrorError(
-                'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
-                'GitMirror file credentialRef requires filePath'
-            );
-        }
-
         let secret;
 
         try {
+            await fs.access(ref.filePath, fsConstants.R_OK);
             secret = (await fs.readFile(ref.filePath, 'utf-8')).trim();
         } catch (error) {
             throw createGitMirrorError(
@@ -219,31 +228,37 @@ async function resolveCredentialEnvironment({credentialRef} = {}) {
             );
         }
 
-        return createAskPassCredentialEnvironment({secret, username: ref.username});
+        return {
+            ref,
+            secret,
+            cacheFingerprint: fingerprintCredential('file', secret)
+        };
     }
 
     if (ref.type === 'ssh') {
-        if (!ref.keyPath) {
+        let key;
+
+        try {
+            await fs.access(ref.keyPath, fsConstants.R_OK);
+            key = await fs.readFile(ref.keyPath);
+        } catch (error) {
             throw createGitMirrorError(
                 'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
-                'GitMirror ssh credentialRef requires keyPath'
+                'GitMirror ssh credentialRef could not be resolved',
+                {cause: error}
+            );
+        }
+
+        if (key.toString('utf-8').trim() === '') {
+            throw createGitMirrorError(
+                'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
+                'GitMirror ssh credentialRef resolved to an empty key'
             );
         }
 
         return {
-            env: {
-                GIT_SSH_COMMAND: [
-                    'ssh',
-                    '-i',
-                    shellQuote(ref.keyPath),
-                    '-o',
-                    'IdentitiesOnly=yes',
-                    '-o',
-                    'StrictHostKeyChecking=accept-new'
-                ].join(' ')
-            },
-            secretHints: [],
-            cleanup    : async () => {}
+            ref,
+            cacheFingerprint: fingerprintCredential('ssh', key)
         };
     }
 
@@ -251,6 +266,40 @@ async function resolveCredentialEnvironment({credentialRef} = {}) {
         'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
         `GitMirror unsupported credentialRef type: ${ref.type}`
     );
+}
+
+/**
+ * @summary Builds transient Git environment overrides from already-validated credential material.
+ * @param {Object} material Resolved credential material.
+ * @returns {Promise<{env: Object, secretHints: String[], cleanup: Function}>}
+ * @private
+ */
+async function createCredentialEnvironment(material) {
+    const {ref, secret} = material;
+
+    if (!ref || ref.type === 'none') {
+        return {env: {}, secretHints: [], cleanup: async () => {}};
+    }
+
+    if (ref.type === 'env' || ref.type === 'file') {
+        return createAskPassCredentialEnvironment({secret, username: ref.username});
+    }
+
+    return {
+        env: {
+            GIT_SSH_COMMAND: [
+                'ssh',
+                '-i',
+                shellQuote(ref.keyPath),
+                '-o',
+                'IdentitiesOnly=yes',
+                '-o',
+                'StrictHostKeyChecking=accept-new'
+            ].join(' ')
+        },
+        secretHints: [],
+        cleanup    : async () => {}
+    };
 }
 
 /**
@@ -264,10 +313,15 @@ async function runGit(args, {
     acceptedExitCodes = [0],
     cwd,
     credentialRef,
+    credentialMaterial,
     failureCode = 'KB_GITMIRROR_GIT_FAILED',
-    failureMessage = 'GitMirror git command failed'
+    failureMessage = 'GitMirror git command failed',
+    timeoutCode = 'KB_GITMIRROR_GIT_TIMEOUT',
+    timeoutMessage = 'GitMirror git command timed out',
+    timeoutMs = 0
 } = {}) {
-    const credential = await resolveCredentialEnvironment({credentialRef});
+    const material   = credentialMaterial || await resolveCredentialMaterial({credentialRef});
+    const credential = await createCredentialEnvironment(material);
 
     try {
         const result = await new Promise((resolve, reject) => {
@@ -278,6 +332,24 @@ async function runGit(args, {
             });
             let stdout = '';
             let stderr = '';
+            let settled = false;
+            let timeoutId;
+
+            const settle = callback => value => {
+                if (settled) {
+                    return;
+                }
+
+                settled = true;
+
+                if (timeoutId) {
+                    clearTimeout(timeoutId);
+                }
+
+                callback(value);
+            };
+            const resolveOnce = settle(resolve);
+            const rejectOnce  = settle(reject);
 
             child.stdout.on('data', data => {
                 stdout += data;
@@ -287,8 +359,20 @@ async function runGit(args, {
                 stderr += data;
             });
 
-            child.on('error', reject);
-            child.on('close', exitCode => resolve({exitCode, stdout, stderr}));
+            child.on('error', rejectOnce);
+            child.on('close', exitCode => resolveOnce({exitCode, stdout, stderr}));
+
+            if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+                timeoutId = setTimeout(() => {
+                    try {
+                        child.kill('SIGKILL');
+                    } catch {}
+
+                    rejectOnce(createGitMirrorError(timeoutCode, timeoutMessage, {
+                        secretHints: credential.secretHints
+                    }));
+                }, timeoutMs);
+            }
         });
 
         if (!acceptedExitCodes.includes(result.exitCode)) {
@@ -314,6 +398,179 @@ async function runGit(args, {
         });
     } finally {
         await credential.cleanup();
+    }
+}
+
+/**
+ * @summary Classifies a redacted Git probe failure into the public access-readiness vocabulary.
+ * @param {Error} error Redacted GitMirror error.
+ * @returns {String}
+ * @private
+ */
+function classifyAccessProbeFailure(error) {
+    if (error.code === 'KB_GITMIRROR_ACCESS_PROBE_TIMEOUT') {
+        return TenantRepoAccessCode.TIMEOUT;
+    }
+
+    if (error.code === 'KB_GITMIRROR_CREDENTIAL_REF_INVALID') {
+        return TenantRepoAccessCode.CREDENTIAL_INVALID;
+    }
+
+    const stderr = String(error.stderr || '');
+
+    if (
+        /could not resolve host|temporary failure in name resolution|network is unreachable|failed to connect|connection (?:timed out|refused|reset)|ssh: connect to host/iu
+            .test(stderr)
+    ) {
+        return TenantRepoAccessCode.TRANSPORT_FAILED;
+    }
+
+    if (Number.isInteger(error.exitCode)) {
+        return TenantRepoAccessCode.DENIED_OR_NOT_FOUND;
+    }
+
+    return TenantRepoAccessCode.PROBE_FAILED;
+}
+
+/**
+ * @summary Validates local credential resolution and returns only a process-local cache fingerprint.
+ *
+ * No credential reference, path, environment-variable name, username, or secret is
+ * returned. Callers may compare `cacheFingerprint` only inside the current process;
+ * the HMAC key is random per process and deliberately unavailable.
+ *
+ * @param {Object} options
+ * @param {String|Object|null} options.credentialRef Durable credential reference.
+ * @returns {Promise<{status: String, code: String, cacheFingerprint: String|null}>}
+ */
+export async function inspectCredentialReadiness({credentialRef} = {}) {
+    try {
+        const material = await resolveCredentialMaterial({credentialRef});
+
+        return {
+            status          : TenantRepoAccessStatus.READY,
+            code            : TenantRepoAccessCode.CREDENTIAL_RESOLVED,
+            cacheFingerprint: material.cacheFingerprint
+        };
+    } catch {
+        return {
+            status          : TenantRepoAccessStatus.DEGRADED,
+            code            : TenantRepoAccessCode.CREDENTIAL_INVALID,
+            cacheFingerprint: null
+        };
+    }
+}
+
+/**
+ * @summary Performs a bounded, read-only capability probe for one repository and ref.
+ *
+ * The probe uses `git ls-remote --exit-code` through the same credential, askpass,
+ * SSH, redaction, and subprocess boundary as clone/fetch. Its output is categorical:
+ * raw Git stdout/stderr and credential metadata never cross this function.
+ *
+ * @param {Object} options
+ * @param {String} options.cloneUrl Clean repository URL.
+ * @param {String|Object|null} options.credentialRef Durable credential reference.
+ * @param {String} [options.ref='HEAD'] Configured branch, tag, or ref.
+ * @param {Number} [options.timeoutMs=15000] Positive subprocess deadline.
+ * @returns {Promise<{status: String, code: String, checkedAt: String, cacheFingerprint: String|null}>}
+ */
+export async function probeRemoteAccess({
+    cloneUrl,
+    credentialRef,
+    ref = 'HEAD',
+    timeoutMs = ACCESS_PROBE_TIMEOUT_MS
+} = {}) {
+    const checkedAt = new Date().toISOString();
+    let   cleanCloneUrl,
+          material;
+
+    try {
+        cleanCloneUrl = assertCleanCloneUrl(cloneUrl);
+    } catch {
+        return {
+            status          : TenantRepoAccessStatus.DEGRADED,
+            code            : TenantRepoAccessCode.PROBE_FAILED,
+            checkedAt,
+            cacheFingerprint: null
+        };
+    }
+
+    try {
+        material = await resolveCredentialMaterial({credentialRef});
+    } catch {
+        return {
+            status          : TenantRepoAccessStatus.DEGRADED,
+            code            : TenantRepoAccessCode.CREDENTIAL_INVALID,
+            checkedAt,
+            cacheFingerprint: null
+        };
+    }
+
+    const effectiveTimeoutMs = Number.isFinite(timeoutMs) && timeoutMs > 0
+        ? timeoutMs
+        : ACCESS_PROBE_TIMEOUT_MS;
+
+    try {
+        const
+            rawRevision = typeof ref === 'string' && /^[a-f0-9]{7,64}$/iu.test(ref),
+            args        = ['ls-remote', '--exit-code', cleanCloneUrl];
+
+        if (!rawRevision) {
+            args.push(ref);
+        }
+
+        const result = await runGit(args, {
+            acceptedExitCodes: [0, 2],
+            credentialMaterial: material,
+            failureCode      : 'KB_GITMIRROR_ACCESS_PROBE_FAILED',
+            failureMessage   : 'GitMirror repository access probe failed',
+            timeoutCode      : 'KB_GITMIRROR_ACCESS_PROBE_TIMEOUT',
+            timeoutMessage   : 'GitMirror repository access probe timed out',
+            timeoutMs        : effectiveTimeoutMs
+        });
+
+        const advertisedRefs = rawRevision && result.exitCode === 0
+            ? result.stdout
+                .split('\n')
+                .map(line => line.trim().split(/\s+/u))
+                .filter(([revision, refName]) => revision && refName)
+            : [];
+        const advertisedRevision = advertisedRefs
+            .some(([revision]) => revision.toLowerCase().startsWith(ref.toLowerCase()));
+        const advertisedNamedRef = advertisedRefs
+            .some(([, refName]) => [
+                ref,
+                `refs/heads/${ref}`,
+                `refs/tags/${ref}`
+            ].includes(refName));
+
+        if (rawRevision && !advertisedRevision && !advertisedNamedRef) {
+            return {
+                status          : TenantRepoAccessStatus.UNKNOWN,
+                code            : TenantRepoAccessCode.REF_UNVERIFIED,
+                checkedAt,
+                cacheFingerprint: material.cacheFingerprint
+            };
+        }
+
+        return {
+            status: result.exitCode === 0
+                ? TenantRepoAccessStatus.READY
+                : TenantRepoAccessStatus.DEGRADED,
+            code: result.exitCode === 0
+                ? TenantRepoAccessCode.READY
+                : TenantRepoAccessCode.REF_NOT_FOUND,
+            checkedAt,
+            cacheFingerprint: material.cacheFingerprint
+        };
+    } catch (error) {
+        return {
+            status          : TenantRepoAccessStatus.DEGRADED,
+            code            : classifyAccessProbeFailure(error),
+            checkedAt,
+            cacheFingerprint: material.cacheFingerprint
+        };
     }
 }
 
@@ -594,7 +851,9 @@ const GitMirror = {
     cloneIfMissing,
     diffRevisions,
     fetch,
+    inspectCredentialReadiness,
     isAncestor,
+    probeRemoteAccess,
     resolveHead
 };
 

--- a/ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs
@@ -11,9 +11,61 @@ import path from 'path';
  * @see https://github.com/neomjs/neo/issues/11787
  */
 
-const URL_WITH_USERINFO_RE = /^[a-z][a-z0-9+.-]*:\/\/[^/\s@]+@/iu;
-const SCP_LIKE_USERINFO_RE = /^[^/\s@:]+@[^/\s@:]+:/u;
-const SECRET_REPLACEMENT   = '[REDACTED]';
+const URL_WITH_USERINFO_RE   = /^[a-z][a-z0-9+.-]*:\/\/[^/\s@]+@/iu;
+const SCP_LIKE_USERINFO_RE   = /^[^/\s@:]+@[^/\s@:]+:/u;
+const ENV_CREDENTIAL_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+const SECRET_REPLACEMENT     = '[REDACTED]';
+
+export const TenantRepoAccessStatus = Object.freeze({
+    READY   : 'ready',
+    DEGRADED: 'degraded',
+    UNKNOWN : 'unknown'
+});
+
+export const TenantRepoAccessCode = Object.freeze({
+    CREDENTIAL_RESOLVED: 'KB_TENANT_REPO_ACCESS_CREDENTIAL_RESOLVED',
+    CREDENTIAL_INVALID : 'KB_TENANT_REPO_ACCESS_CREDENTIAL_INVALID',
+    READY              : 'KB_TENANT_REPO_ACCESS_READY',
+    TIMEOUT            : 'KB_TENANT_REPO_ACCESS_TIMEOUT',
+    TRANSPORT_FAILED   : 'KB_TENANT_REPO_ACCESS_TRANSPORT_FAILED',
+    DENIED_OR_NOT_FOUND: 'KB_TENANT_REPO_ACCESS_DENIED_OR_NOT_FOUND',
+    REF_NOT_FOUND      : 'KB_TENANT_REPO_ACCESS_REF_NOT_FOUND',
+    REF_UNVERIFIED     : 'KB_TENANT_REPO_ACCESS_REF_UNVERIFIED',
+    PROBE_FAILED       : 'KB_TENANT_REPO_ACCESS_PROBE_FAILED',
+    EVIDENCE_EXPIRED   : 'KB_TENANT_REPO_ACCESS_EVIDENCE_EXPIRED',
+    PROBE_UNAVAILABLE  : 'KB_TENANT_REPO_ACCESS_PROBE_UNAVAILABLE',
+    SYNC_FAILED        : 'KB_TENANT_REPO_ACCESS_SYNC_FAILED'
+});
+
+const TENANT_REPO_ACCESS_CODES_BY_STATUS = Object.freeze({
+    [TenantRepoAccessStatus.READY]: Object.freeze([
+        TenantRepoAccessCode.READY
+    ]),
+    [TenantRepoAccessStatus.DEGRADED]: Object.freeze([
+        TenantRepoAccessCode.CREDENTIAL_INVALID,
+        TenantRepoAccessCode.TIMEOUT,
+        TenantRepoAccessCode.TRANSPORT_FAILED,
+        TenantRepoAccessCode.DENIED_OR_NOT_FOUND,
+        TenantRepoAccessCode.REF_NOT_FOUND,
+        TenantRepoAccessCode.PROBE_FAILED,
+        TenantRepoAccessCode.SYNC_FAILED
+    ]),
+    [TenantRepoAccessStatus.UNKNOWN]: Object.freeze([
+        TenantRepoAccessCode.REF_UNVERIFIED,
+        TenantRepoAccessCode.EVIDENCE_EXPIRED,
+        TenantRepoAccessCode.PROBE_UNAVAILABLE
+    ])
+});
+
+/**
+ * @summary Checks the strict public status/code pairing for tenant-repo access evidence.
+ * @param {String} status Candidate readiness status.
+ * @param {String} code Candidate stable readiness code.
+ * @returns {Boolean}
+ */
+export function isTenantRepoAccessReadinessOutcome(status, code) {
+    return TENANT_REPO_ACCESS_CODES_BY_STATUS[status]?.includes(code) === true;
+}
 
 /**
  * @summary Creates a contract error with a stable code for callers and tests.
@@ -189,6 +241,144 @@ export function normalizeRepoSlug(repoSlug) {
 }
 
 /**
+ * @summary Normalizes the shared, reference-only credential grammar for tenant repositories.
+ *
+ * Supported string forms are `none`, `env:NAME`, `file:/path`, and `ssh:/path`.
+ * A bare environment-variable name remains supported for backward compatibility, but
+ * any string containing an unknown scheme delimiter is rejected instead of being
+ * reinterpreted as an environment-variable name.
+ *
+ * Object forms use the same four `type` values and the corresponding `name`,
+ * `filePath`, or `keyPath` property. The returned object contains only fields consumed
+ * by GitMirror, preventing unrelated config data from crossing the credential boundary.
+ *
+ * @param {String|Object|null} credentialRef Durable credential reference.
+ * @param {Object} [options]
+ * @param {Boolean} [options.allowOmitted=false] Allow `null` / `undefined` for local GitMirror callers.
+ * @returns {Object|null}
+ */
+export function normalizeTenantRepoCredentialRef(credentialRef, {allowOmitted = false} = {}) {
+    if (credentialRef === null || credentialRef === undefined) {
+        if (allowOmitted) {
+            return null;
+        }
+
+        throw createContractError(
+            'KB_TENANT_REPO_CREDENTIAL_REF_REQUIRED',
+            'Tenant repo config entries require credentialRef'
+        );
+    }
+
+    let candidate;
+
+    if (typeof credentialRef === 'string') {
+        const value = credentialRef.trim();
+
+        if (!value) {
+            throw createContractError(
+                'KB_TENANT_REPO_CREDENTIAL_REF_INVALID',
+                'Tenant repo credentialRef must be a non-empty supported reference'
+            );
+        }
+
+        if (value === 'none') {
+            return {type: 'none'};
+        }
+
+        const separatorIndex = value.indexOf(':');
+
+        if (separatorIndex === -1) {
+            candidate = {type: 'env', name: value};
+        } else {
+            const
+                type   = value.slice(0, separatorIndex),
+                target = value.slice(separatorIndex + 1).trim();
+
+            if (type === 'env') {
+                candidate = {type, name: target};
+            } else if (type === 'file') {
+                candidate = {type, filePath: target};
+            } else if (type === 'ssh') {
+                candidate = {type, keyPath: target};
+            } else {
+                throw createContractError(
+                    'KB_TENANT_REPO_CREDENTIAL_REF_INVALID',
+                    'Tenant repo credentialRef uses an unsupported scheme'
+                );
+            }
+        }
+    } else if (typeof credentialRef === 'object' && !Array.isArray(credentialRef)) {
+        candidate = credentialRef;
+    } else {
+        throw createContractError(
+            'KB_TENANT_REPO_CREDENTIAL_REF_INVALID',
+            'Tenant repo credentialRef must be a supported string or object reference'
+        );
+    }
+
+    const type = candidate.type;
+
+    if (!['none', 'env', 'file', 'ssh'].includes(type)) {
+        throw createContractError(
+            'KB_TENANT_REPO_CREDENTIAL_REF_INVALID',
+            'Tenant repo credentialRef uses an unsupported type'
+        );
+    }
+
+    const normalized = {type};
+
+    if (type === 'env') {
+        const name = typeof candidate.name === 'string' ? candidate.name.trim() : '';
+
+        if (!ENV_CREDENTIAL_NAME_RE.test(name)) {
+            throw createContractError(
+                'KB_TENANT_REPO_CREDENTIAL_REF_INVALID',
+                'Tenant repo env credentialRef requires a valid environment-variable name'
+            );
+        }
+
+        normalized.name = name;
+    } else if (type === 'file') {
+        const filePath = typeof candidate.filePath === 'string' ? candidate.filePath.trim() : '';
+
+        if (!filePath) {
+            throw createContractError(
+                'KB_TENANT_REPO_CREDENTIAL_REF_INVALID',
+                'Tenant repo file credentialRef requires filePath'
+            );
+        }
+
+        normalized.filePath = filePath;
+    } else if (type === 'ssh') {
+        const keyPath = typeof candidate.keyPath === 'string' ? candidate.keyPath.trim() : '';
+
+        if (!keyPath) {
+            throw createContractError(
+                'KB_TENANT_REPO_CREDENTIAL_REF_INVALID',
+                'Tenant repo ssh credentialRef requires keyPath'
+            );
+        }
+
+        normalized.keyPath = keyPath;
+    }
+
+    if (Object.hasOwn(candidate, 'username')) {
+        const username = typeof candidate.username === 'string' ? candidate.username.trim() : '';
+
+        if (!['env', 'file'].includes(type) || !username || /[\r\n]/u.test(username)) {
+            throw createContractError(
+                'KB_TENANT_REPO_CREDENTIAL_REF_INVALID',
+                'Tenant repo env/file credentialRef username must be a non-empty single-line string'
+            );
+        }
+
+        normalized.username = username;
+    }
+
+    return normalized;
+}
+
+/**
  * @summary Normalizes one tenant repo-access config entry and enforces the no-secret boundary.
  * @param {Object} entry Tenant repo-access config entry.
  * @param {String} [entry.branchRef] Optional git ref (branch / tag / sha) to ingest from. When
@@ -214,6 +404,8 @@ export function normalizeTenantRepoEntry(entry = {}) {
             'Tenant repo config entries require credentialRef'
         );
     }
+
+    normalizeTenantRepoCredentialRef(entry.credentialRef);
 
     if (Object.hasOwn(entry, 'branchRef') && (typeof entry.branchRef !== 'string' || entry.branchRef.trim() === '')) {
         throw createContractError(

--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -118,6 +118,12 @@ tenants:
 
 The `tenantRepos:` block is the bootstrap tier for the pull-mode polling config — `listConfiguredTenantRepos()` resolves it under the graph node → `kb-config.yaml` → `aiConfig` tiering. Graph-only tenant config nodes are included through the graph service's RLS-aware tenant-config enumeration surface; an unreadable graph tier degrades deployment diagnostics instead of silently behaving like an empty pull-mode config.
 
+`credentialRef` accepts only `none`, `env:NAME`, `file:/path`, or `ssh:/path` (plus a
+legacy bare environment-variable name). The object equivalents use `type: none|env|file|ssh`
+with `name`, `filePath`, or `keyPath`; `env` and `file` may also specify a non-empty
+`username`. An unknown scheme such as `helper:*` is rejected during effective-config
+resolution instead of being reinterpreted as an environment-variable name.
+
 The YAML is bootstrap-only — the graph node is canonical once written. Runtime resolution stays
 fail-soft: a missing, empty, unreadable, malformed, or invalid-shape file cannot block a valid graph
 or AiConfig fallback. Diagnostics remain fail-honest, however. The deployment snapshot projects

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -202,9 +202,18 @@ The orchestrator's pull-mode sync (`TenantRepoSyncService.resolveTenantReposConf
 }
 ```
 
-**Credential-bearing `cloneUrl` strings (`https://user:token@...`) are rejected at config normalization.** The `credentialRef` is a reference (env-var name, secret-store path, etc.) that `GitMirror` resolves only at the git subprocess invocation boundary (`GIT_ASKPASS` for HTTPS, `GIT_SSH_COMMAND` for SSH). The deployment graph never persists resolved credentials.
+**Credential-bearing `cloneUrl` strings (`https://user:token@...`) are rejected at config normalization.** The `credentialRef` is a reference that uses one shared grammar: `none`, `env:NAME`, `file:/path`, or `ssh:/path` (a legacy bare environment-variable name remains accepted). The same normalized grammar feeds `GitMirror`; unknown schemes such as `helper:*` fail during effective-config resolution rather than becoming delayed environment lookups. `GitMirror` resolves credential material only at its local validation or git-subprocess boundary (`GIT_ASKPASS` for HTTPS, `GIT_SSH_COMMAND` for SSH). The deployment graph never persists resolved credentials.
 
-Use `file:/run/secrets/<name>` when the deployment mounts Git credentials through Docker `secrets:` or a Kubernetes Secret volume. `GitMirror` reads and trims the file at subprocess time, then feeds the value through the same transient `GIT_ASKPASS` path as `env:` credentials; empty or missing files fail before git runs.
+Use `file:/run/secrets/<name>` when the deployment mounts Git credentials through Docker `secrets:` or a Kubernetes Secret volume. `GitMirror` reads and trims the file at resolution time, then feeds the value through the same transient `GIT_ASKPASS` path as `env:` credentials; empty, missing, or unreadable files fail before git runs. `ssh:` references likewise require a present, readable, non-empty key before Git constructs `GIT_SSH_COMMAND`.
+
+At the first orchestrator sync sweep, before per-repo cadence/jitter can defer clone/fetch,
+`TenantRepoSyncService` performs a bounded, read-only capability preflight for every enabled
+effective repo. It resolves credential material locally, then runs `git ls-remote --exit-code`
+against the clean URL and configured ref through GitMirror's existing askpass/SSH/redaction
+boundary. The process caches only a keyed credential fingerprint plus bounded status/code/time;
+config or credential rotation invalidates that entry. A normal clone/fetch remains authoritative
+and can supersede stale probe evidence. One failed preflight does not block unrelated repositories
+or suppress the normal retry path.
 
 **`branchRef` (optional)** selects which git ref to ingest from. Omitted = `'HEAD'` = the remote's default branch. Useful when the canonical product-source-of-truth branch differs from the repo's default branch — e.g., trunk-based teams using `dev` as integration line + `main` as release-tag-only. Validated as a non-empty string at config normalization; accepts any git ref name (branch, tag, sha) since it flows through `gitMirror.resolveHead()`.
 
@@ -321,6 +330,15 @@ the checkpoint aggregate unavailable; counts are likewise unavailable when repo
 enumeration or revision-state reading fails. Existing per-repo rows add only the version values and
 `checkpointStatus` beside their already-hashed identities.
 
+The same section exposes `accessReadiness`. Its aggregate is `ready` only when every enabled
+required repo has current process-local capability evidence; otherwise it is `degraded`,
+`unknown`, or `not-required`, with ready/degraded/unknown/checked counts. Each already-hashed
+repo row adds only `{status, code, checkedAt}`. A process restart clears this volatile evidence,
+and evidence expires after two effective repo-cadence windows (with a fifteen-minute floor), so
+inspection reports `unknown` until the next sync sweep re-probes. Inspection itself never launches
+Git or network work. Clone URLs, refs, credential references, env names, file/key paths,
+usernames, fingerprints, Git output, and stacks never enter the snapshot.
+
 ### Repo Freshness Status Enum
 
 | Status | Meaning | Transition |
@@ -346,6 +364,16 @@ Per-repo failures carry a stable `lastErrorCode` field on the health payload; op
 
 The `KB_TENANT_REPO_SYNC_*` prefix distinguishes these codes from sibling-subsystem error families (`KB_GITMIRROR_*`, `KB_INGEST_*`, `KB_TENANT_REPO_ACCESS_*`).
 `lastSourceErrorCode` is optional and bounded to stable `KB_*` codes only; it never carries clone URLs, credential references, tokens, raw repository identities, or git stderr.
+
+Access preflight uses the provider-neutral `KB_TENANT_REPO_ACCESS_*` family:
+`READY`, `CREDENTIAL_INVALID`, `TIMEOUT`, `TRANSPORT_FAILED`,
+`DENIED_OR_NOT_FOUND`, `REF_NOT_FOUND`, `REF_UNVERIFIED`, and the bounded fallback
+`PROBE_FAILED`. `PROBE_UNAVAILABLE` means the scheduler could not obtain the
+GitMirror preflight surface, while `SYNC_FAILED` means a later authoritative
+clone/fetch failed. A raw commit SHA that is not an advertised ref tip reports
+`REF_UNVERIFIED` rather than falsely reporting it missing; normal fetch remains
+the authority for that revision. These codes prove capability categories only; they do not
+infer PAT, deploy-token, group-token, or provider-specific scope metadata.
 
 ### Quarantine Runbook
 

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -217,6 +217,24 @@ identities, clone URLs, credentials, tokens, stacks, and raw filesystem/parser m
 
 For pull-mode deployments with configured `tenantRepos[]`, call `inspect_deployment` or `get_deployment_state_snapshot` and inspect the `tenantRepoSync` section before taking manual action. It distinguishes disabled, true no-configured-repos, not-due, running, completed, failed, and degraded/unreadable state without exposing credentials or raw logs. A degraded config-read error means the graph/YAML/default config resolver could not prove the effective `tenantRepos`; treat that differently from a real empty config. If the task is configured but has not advanced, use the stable reason code and per-repo hashed state there to decide whether to wait for the next due sweep, fix credentials/config, or run `node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <slug>` inside the orchestrator container. When `lastErrorCode` is `KB_TENANT_REPO_SYNC_SYNC_FAILED`, check `lastSourceErrorCode`: `KB_GITMIRROR_CREDENTIAL_REF_INVALID`, `KB_GITMIRROR_CLONE_FAILED`, or `KB_GITMIRROR_FETCH_FAILED` points to the credential/ref/upstream access path before generic ingestion debugging. `KB_VECTOR_EMBED_FAILED` means the repository fetch and envelope reached the ingestion layer but vector writes failed; correct the embedding path before retrying.
 
+Read `tenantRepoSync.accessReadiness` before waiting for cadence. `ready` means every enabled
+repo passed the process-local credential check and bounded remote capability probe; `degraded`
+means at least one proved failure; `unknown` means the current process has not produced valid
+evidence yet (commonly immediately after restart); `not-required` means there are no enabled
+required repos. Inspection reads cached evidence and never triggers network work.
+
+| Access code | Meaning | Operator action |
+|---|---|---|
+| `KB_TENANT_REPO_ACCESS_CREDENTIAL_INVALID` | The env secret, secret file, or SSH key is missing, empty, unreadable, or its reference shape is invalid. | Align the configured reference with the orchestrator's mounted env/file/key, then let the next sweep re-resolve it. |
+| `KB_TENANT_REPO_ACCESS_TIMEOUT` | The bounded `ls-remote` probe exceeded its deadline. | Check upstream latency, firewall/proxy behavior, and DNS; do not infer token scope from a timeout. |
+| `KB_TENANT_REPO_ACCESS_TRANSPORT_FAILED` | Git reported a network/DNS/connection-class failure. | Restore egress and name resolution from the orchestrator network. |
+| `KB_TENANT_REPO_ACCESS_DENIED_OR_NOT_FOUND` | The remote did not grant readable repository capability, or intentionally hid a missing repository behind the same response. | Verify repository membership/reach and read permission for this specific repo; do not assume one token reaches sibling groups/namespaces. |
+| `KB_TENANT_REPO_ACCESS_REF_NOT_FOUND` | The repo was readable but the configured ref was not advertised. | Correct `branchRef` or publish the intended branch/tag. |
+| `KB_TENANT_REPO_ACCESS_REF_UNVERIFIED` | A raw commit SHA was not an advertised ref tip, so `ls-remote` could prove repo access but not commit reachability. | Let the normal clone/fetch resolve the SHA; do not rewrite the ref solely from this unknown result. |
+| `KB_TENANT_REPO_ACCESS_EVIDENCE_EXPIRED` | The cached proof is older than its bounded lifetime. | Wait for the next sync sweep to re-probe; inspection does not launch network work. |
+| `KB_TENANT_REPO_ACCESS_PROBE_FAILED` / `KB_TENANT_REPO_ACCESS_PROBE_UNAVAILABLE` | The probe could not produce a certifying category. | Verify the orchestrator and GitMirror code are from one current image cohort, then inspect service health. |
+| `KB_TENANT_REPO_ACCESS_SYNC_FAILED` | A later authoritative clone/fetch failed after or without the cached probe. | Use `lastSourceErrorCode` and the normal GitMirror acquisition runbook; clone/fetch supersedes older probe evidence. |
+
 Current releases accept a tenant-repo ingest as successful only when the returned summary contains
 an array-valued, empty `errors` field. A failed attempt keeps the last known-good revision. If the
 deployment was upgraded after an older release had already advanced its checkpoint on an

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -754,6 +754,14 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                             lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
                         }
                     };
+                },
+                getTenantRepoAccessReadiness() {
+                    return {
+                        status          : 'ready',
+                        code            : 'KB_TENANT_REPO_ACCESS_READY',
+                        checkedAt       : '2024-03-09T15:59:00.000Z',
+                        cacheFingerprint: 'must-not-cross-the-bridge'
+                    };
                 }
             },
             tenantRepoSyncEnabledReader: () => true
@@ -762,6 +770,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         const tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
 
         expect(tenantRepoSync.status).toBe('not-due');
+        expect(tenantRepoSync.schemaVersion).toBe(2);
         expect(tenantRepoSync.config).toMatchObject({
             repoCount : 1,
             tierCounts: {yaml: 1}
@@ -773,11 +782,157 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             due                : false,
             lastIngestedRev    : 'abcdef123456',
             consecutiveFailures: 0,
-            checkpointStatus   : 'complete'
+            checkpointStatus   : 'complete',
+            accessReadiness    : {
+                status   : 'ready',
+                code     : 'KB_TENANT_REPO_ACCESS_READY',
+                checkedAt: '2024-03-09T15:59:00.000Z'
+            }
+        });
+        expect(tenantRepoSync.accessReadiness).toEqual({
+            status       : 'ready',
+            requiredCount: 1,
+            readyCount   : 1,
+            degradedCount: 0,
+            unknownCount : 0,
+            checkedCount : 1
         });
         expect(JSON.stringify(tenantRepoSync)).not.toContain('tenant-a');
         expect(JSON.stringify(tenantRepoSync)).not.toContain('private/repo');
         expect(JSON.stringify(tenantRepoSync)).not.toContain('TOKEN');
+        expect(JSON.stringify(tenantRepoSync)).not.toContain('must-not-cross-the-bridge');
+    });
+
+    test('collectTenantRepoSyncSnapshot projects mixed access readiness through a deep allowlist', async () => {
+        const repos = [
+            {
+                tenantId     : 'tenant-ready',
+                repoSlug     : 'private/ready',
+                cloneUrl     : 'https://git.example/private/ready.git',
+                credentialRef: 'env:READY_TOKEN'
+            },
+            {
+                tenantId     : 'tenant-denied',
+                repoSlug     : 'private/denied',
+                cloneUrl     : 'https://git.example/private/denied.git',
+                credentialRef: 'file:/run/secrets/denied-token'
+            },
+            {
+                tenantId     : 'tenant-unknown',
+                repoSlug     : 'private/unknown',
+                cloneUrl     : 'ssh://git.example/private/unknown.git',
+                credentialRef: 'ssh:/run/secrets/unknown-key'
+            },
+            {
+                tenantId     : 'tenant-disabled',
+                repoSlug     : 'private/disabled',
+                cloneUrl     : 'https://git.example/private/disabled.git',
+                credentialRef: 'env:DISABLED_TOKEN',
+                disabled     : true
+            }
+        ];
+        const service = createService({
+            taskStateService: {
+                getTaskState() {
+                    return null;
+                }
+            },
+            tenantRepoSyncService: {
+                async resolveTenantReposConfig() {
+                    return {tenantRepos: repos};
+                },
+                defaultRevisionsFilePath() {
+                    return '/state/revisions.json';
+                },
+                async readPersistedRevisions() {
+                    return {};
+                },
+                getTenantRepoAccessReadiness(repo) {
+                    if (repo.tenantId === 'tenant-ready') {
+                        return {
+                            status          : 'ready',
+                            code            : 'KB_TENANT_REPO_ACCESS_READY',
+                            checkedAt       : '2024-03-09T15:59:00.000Z',
+                            cacheFingerprint: 'secret-fingerprint',
+                            cloneUrl        : repo.cloneUrl,
+                            credentialRef   : repo.credentialRef
+                        };
+                    }
+
+                    if (repo.tenantId === 'tenant-denied') {
+                        return {
+                            status   : 'degraded',
+                            code     : 'KB_TENANT_REPO_ACCESS_DENIED_OR_NOT_FOUND',
+                            checkedAt: '2024-03-09T15:58:00.000Z',
+                            stderr   : 'fatal token secret-value',
+                            keyPath  : '/host/private/key',
+                            username : 'private-user',
+                            stack    : 'private-stack'
+                        };
+                    }
+
+                    return {
+                        status   : 'degraded',
+                        code     : 'KB_TENANT_REPO_ACCESS_TOKEN_SECRET',
+                        checkedAt: '2024-03-09T15:57:00.000Z',
+                        token    : 'secret-value'
+                    };
+                }
+            },
+            tenantRepoSyncEnabledReader: () => true
+        });
+
+        const tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(tenantRepoSync.accessReadiness).toEqual({
+            status       : 'degraded',
+            requiredCount: 3,
+            readyCount   : 1,
+            degradedCount: 1,
+            unknownCount : 1,
+            checkedCount : 2
+        });
+        expect(tenantRepoSync.repos.map(repo => repo.accessReadiness)).toEqual([
+            {
+                status   : 'ready',
+                code     : 'KB_TENANT_REPO_ACCESS_READY',
+                checkedAt: '2024-03-09T15:59:00.000Z'
+            },
+            {
+                status   : 'degraded',
+                code     : 'KB_TENANT_REPO_ACCESS_DENIED_OR_NOT_FOUND',
+                checkedAt: '2024-03-09T15:58:00.000Z'
+            },
+            {
+                status   : 'unknown',
+                code     : null,
+                checkedAt: null
+            },
+            {
+                status   : 'not-required',
+                code     : null,
+                checkedAt: null
+            }
+        ]);
+
+        const serialized = JSON.stringify(tenantRepoSync);
+
+        for (const forbidden of [
+            'tenant-ready',
+            'private/ready',
+            'git.example',
+            'READY_TOKEN',
+            '/run/secrets',
+            'secret-fingerprint',
+            'fatal token',
+            'secret-value',
+            '/host/private',
+            'private-user',
+            'private-stack',
+            'KB_TENANT_REPO_ACCESS_TOKEN_SECRET'
+        ]) {
+            expect(serialized).not.toContain(forbidden);
+        }
     });
 
     test('collectTenantRepoSyncSnapshot surfaces bounded failure outcome codes', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -60,6 +60,21 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         return {
             async cloneIfMissing(args) { captureCalls.push({op: 'cloneIfMissing', args}); },
             async fetch(args)          { captureCalls.push({op: 'fetch',         args}); },
+            async inspectCredentialReadiness() {
+                return {
+                    status          : 'ready',
+                    code            : 'KB_TENANT_REPO_ACCESS_CREDENTIAL_RESOLVED',
+                    cacheFingerprint: 'fake-credential-fingerprint'
+                };
+            },
+            async probeRemoteAccess() {
+                return {
+                    status          : 'ready',
+                    code            : 'KB_TENANT_REPO_ACCESS_READY',
+                    checkedAt       : new Date().toISOString(),
+                    cacheFingerprint: 'fake-credential-fingerprint'
+                };
+            },
             async resolveHead({ref})   { return `sha-for-${ref}`; },
             async isAncestor()         { return true; },
             async diffRevisions()      { return {addedOrChanged: [], deleted: []}; }
@@ -127,6 +142,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // concurrency tests cannot leak short timeouts / serial-limit to siblings.
         TenantRepoSyncService.concurrencyLimit         = 2;
         TenantRepoSyncService.concurrencyGateTimeoutMs = 30000;
+        TenantRepoSyncService.clearTenantRepoAccessReadiness();
     });
 
     test('skipped when no tenantRepos configured', async () => {
@@ -159,6 +175,202 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(result.status).toBe('skipped');
         expect(result.details.reasonCode).toBe('already-running');
         expect(result.details.pid).toBe(12345);
+    });
+
+    test('preflights a not-due repo at bootstrap and re-probes only after config or credential rotation', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repo             = {
+                tenantId     : 'tenant-a',
+                repoSlug     : 'private/repo',
+                mirrorRoot,
+                cloneUrl     : 'https://git.example/private/repo.git',
+                credentialRef: 'env:TENANT_REPO_TOKEN',
+                branchRef    : 'dev'
+            },
+            probeCalls = [];
+
+        let credentialFingerprint = 'credential-a';
+
+        const gitMirror = {
+            async inspectCredentialReadiness() {
+                return {
+                    status          : 'ready',
+                    code            : 'KB_TENANT_REPO_ACCESS_CREDENTIAL_RESOLVED',
+                    cacheFingerprint: credentialFingerprint
+                };
+            },
+            async probeRemoteAccess(args) {
+                probeCalls.push(args);
+                return {
+                    status          : 'ready',
+                    code            : 'KB_TENANT_REPO_ACCESS_READY',
+                    checkedAt       : '2026-07-23T20:00:00.000Z',
+                    cacheFingerprint: credentialFingerprint
+                };
+            },
+            async cloneIfMissing() {
+                throw new Error('not-due repo must not clone');
+            },
+            async fetch() {
+                throw new Error('not-due repo must not fetch');
+            }
+        };
+
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: {
+                'tenant-a/private/repo': {
+                    lastIngestedRev                   : 'abcdef1234567890',
+                    lastRunAttemptAt                  : Date.now(),
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                }
+            }
+        });
+
+        const options = {
+            reason                       : 'periodic',
+            taskStateService,
+            tenantReposConfig            : {tenantRepos: [repo]},
+            gitMirror,
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            globalCadenceMs              : 60_000,
+            jitterRatio                  : 0,
+            seedBootstrap                : false
+        };
+
+        await TenantRepoSyncService.runTask(options);
+        await TenantRepoSyncService.runTask(options);
+
+        expect(probeCalls).toHaveLength(1);
+        expect(probeCalls[0]).toMatchObject({
+            cloneUrl: 'https://git.example/private/repo.git',
+            ref     : 'dev'
+        });
+
+        expect(TenantRepoSyncService.getTenantRepoAccessReadiness(repo, {
+            observedAt: Date.now() + 24 * 60 * 60 * 1000
+        })).toMatchObject({
+            status: 'unknown',
+            code  : 'KB_TENANT_REPO_ACCESS_EVIDENCE_EXPIRED'
+        });
+
+        TenantRepoSyncService.accessReadinessCache.get('tenant-a/private/repo').expiresAt = 0;
+        await TenantRepoSyncService.runTask(options);
+        expect(probeCalls).toHaveLength(2);
+
+        credentialFingerprint = 'credential-b';
+        await TenantRepoSyncService.runTask(options);
+        expect(probeCalls).toHaveLength(3);
+
+        repo.cloneUrl = 'https://git.example/private/repo-renamed.git';
+        await TenantRepoSyncService.runTask(options);
+        expect(probeCalls).toHaveLength(4);
+
+        const publicReadiness = TenantRepoSyncService.getTenantRepoAccessReadiness(repo);
+
+        expect(publicReadiness).toEqual({
+            status   : 'ready',
+            code     : 'KB_TENANT_REPO_ACCESS_READY',
+            checkedAt: '2026-07-23T20:00:00.000Z'
+        });
+        expect(JSON.stringify(publicReadiness)).not.toContain('credential-b');
+        expect(JSON.stringify(publicReadiness)).not.toContain('TENANT_REPO_TOKEN');
+        expect(JSON.stringify(publicReadiness)).not.toContain('git.example');
+    });
+
+    test('isolates an inaccessible repo while unrelated repositories continue syncing', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            mirrorCalls      = [],
+            repos            = [
+                {
+                    tenantId     : 'tenant-a',
+                    repoSlug     : 'private/denied',
+                    mirrorRoot,
+                    cloneUrl     : 'https://git.example/private/denied.git',
+                    credentialRef: 'env:DENIED_TOKEN'
+                },
+                {
+                    tenantId     : 'tenant-b',
+                    repoSlug     : 'private/ready',
+                    mirrorRoot,
+                    cloneUrl     : 'https://git.example/private/ready.git',
+                    credentialRef: 'env:READY_TOKEN'
+                }
+            ],
+            gitMirror = {
+                async inspectCredentialReadiness({credentialRef}) {
+                    return {
+                        status          : 'ready',
+                        code            : 'KB_TENANT_REPO_ACCESS_CREDENTIAL_RESOLVED',
+                        cacheFingerprint: `fingerprint-${credentialRef}`
+                    };
+                },
+                async probeRemoteAccess({cloneUrl}) {
+                    const denied = cloneUrl.includes('/denied');
+                    return {
+                        status: denied ? 'degraded' : 'ready',
+                        code  : denied
+                            ? 'KB_TENANT_REPO_ACCESS_DENIED_OR_NOT_FOUND'
+                            : 'KB_TENANT_REPO_ACCESS_READY',
+                        checkedAt       : '2026-07-23T20:00:00.000Z',
+                        cacheFingerprint: denied ? 'denied' : 'ready'
+                    };
+                },
+                async cloneIfMissing(args) {
+                    mirrorCalls.push({op: 'cloneIfMissing', args});
+
+                    if (args.repoSlug === 'private/denied') {
+                        const error = new Error('bounded fake acquisition failure');
+                        error.code = 'KB_GITMIRROR_CLONE_FAILED';
+                        throw error;
+                    }
+                },
+                async fetch(args) {
+                    mirrorCalls.push({op: 'fetch', args});
+                },
+                async resolveHead({ref}) {
+                    return `sha-for-${ref}`;
+                },
+                async isAncestor() {
+                    return true;
+                },
+                async diffRevisions() {
+                    return {addedOrChanged: [], deleted: []};
+                }
+            };
+
+        const result = await TenantRepoSyncService.runTask({
+            reason                       : 'periodic',
+            taskStateService,
+            tenantReposConfig            : {tenantRepos: repos},
+            gitMirror,
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details.completedCount).toBe(1);
+        expect(result.details.failedCount).toBe(1);
+        expect(mirrorCalls.filter(call => call.args.repoSlug === 'private/ready'))
+            .toEqual([
+                expect.objectContaining({op: 'cloneIfMissing'}),
+                expect.objectContaining({op: 'fetch'})
+            ]);
+        expect(TenantRepoSyncService.getTenantRepoAccessReadiness(repos[0])).toMatchObject({
+            status: 'degraded',
+            code  : 'KB_TENANT_REPO_ACCESS_SYNC_FAILED'
+        });
+        expect(TenantRepoSyncService.getTenantRepoAccessReadiness(repos[1])).toMatchObject({
+            status: 'ready',
+            code  : 'KB_TENANT_REPO_ACCESS_READY'
+        });
     });
 
     test('completed: iterates configured repos and calls ingestion service', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
@@ -1,23 +1,26 @@
 import {test, expect} from '@playwright/test';
 
-import fs             from 'fs-extra';
-import os             from 'os';
-import path           from 'path';
-import {execFile}     from 'child_process';
-import {promisify}    from 'util';
+import fs          from 'fs-extra';
+import os          from 'os';
+import path        from 'path';
+import {execFile}  from 'child_process';
+import {promisify} from 'util';
 
 import GitMirror, {
     cloneIfMissing,
     diffRevisions,
     fetch,
+    inspectCredentialReadiness,
     isAncestor,
+    probeRemoteAccess,
+    TenantRepoAccessCode,
     resolveHead
 } from '../../../../../../ai/services/knowledge-base/helpers/gitMirror.mjs';
 
 const execFileAsync = promisify(execFile);
 
 /**
- * @summary Contract tests for the persistent Git mirror primitive (#11788).
+ * @summary Contract tests for the persistent Git mirror primitive.
  *
  * The tests use local fixture repositories only. Credentialed remote acquisition is
  * represented by no-leak failure assertions so the suite never depends on provider
@@ -102,6 +105,23 @@ exit 1
 
         try {
             await callback(capturePath);
+        } finally {
+            process.env.PATH = originalPath;
+        }
+    }
+
+    async function withFakeGitScript(script, callback) {
+        const originalPath = process.env.PATH;
+        const binDir       = path.join(root, 'fake-probe-bin');
+        const gitPath      = path.join(binDir, 'git');
+
+        await fs.ensureDir(binDir);
+        await fs.writeFile(gitPath, `#!/bin/sh\n${script}\n`);
+        await fs.chmod(gitPath, 0o755);
+        process.env.PATH = `${binDir}${path.delimiter}${originalPath}`;
+
+        try {
+            await callback();
         } finally {
             process.env.PATH = originalPath;
         }
@@ -199,6 +219,159 @@ exit 1
             credentialRef: 'env:NEO_GITMIRROR_MISSING_TOKEN',
             repoSlug     : 'local/other-source'
         })).rejects.toMatchObject({code: 'KB_GITMIRROR_CREDENTIAL_REF_INVALID'});
+    });
+
+    test('rejects an unsupported credentialRef scheme through the shared config grammar', async () => {
+        const source = await createSourceRepo();
+
+        await expect(cloneIfMissing({
+            ...mirrorOptions(source),
+            credentialRef: 'helper:github-app-installation'
+        })).rejects.toMatchObject({code: 'KB_GITMIRROR_CREDENTIAL_REF_INVALID'});
+    });
+
+    test('checks env, file, and SSH credential material without exposing reference metadata', async () => {
+        const tokenPath = path.join(root, 'readiness-token');
+        const keyPath   = path.join(root, 'readiness-key');
+
+        process.env.NEO_GITMIRROR_TEST_TOKEN = 'local-readiness-secret';
+        await fs.writeFile(tokenPath, 'file-readiness-secret\n');
+        await fs.writeFile(keyPath, '-----BEGIN PRIVATE KEY-----\nfixture\n-----END PRIVATE KEY-----\n');
+
+        const results = await Promise.all([
+            inspectCredentialReadiness({credentialRef: 'env:NEO_GITMIRROR_TEST_TOKEN'}),
+            inspectCredentialReadiness({credentialRef: `file:${tokenPath}`}),
+            inspectCredentialReadiness({credentialRef: `ssh:${keyPath}`})
+        ]);
+
+        for (const result of results) {
+            expect(result).toMatchObject({
+                status: 'ready',
+                code  : TenantRepoAccessCode.CREDENTIAL_RESOLVED
+            });
+            expect(result.cacheFingerprint).toMatch(/^[a-f0-9]{64}$/u);
+        }
+
+        const serialized = JSON.stringify(results);
+        expect(serialized).not.toContain('local-readiness-secret');
+        expect(serialized).not.toContain('file-readiness-secret');
+        expect(serialized).not.toContain('NEO_GITMIRROR_TEST_TOKEN');
+        expect(serialized).not.toContain(tokenPath);
+        expect(serialized).not.toContain(keyPath);
+    });
+
+    test('classifies missing or unreadable local credential material before Git runs', async () => {
+        const unreadableKeyPath = path.join(root, 'key-directory');
+
+        await fs.ensureDir(unreadableKeyPath);
+
+        await expect(inspectCredentialReadiness({
+            credentialRef: 'env:NEO_GITMIRROR_MISSING_TOKEN'
+        })).resolves.toEqual({
+            status          : 'degraded',
+            code            : TenantRepoAccessCode.CREDENTIAL_INVALID,
+            cacheFingerprint: null
+        });
+        await expect(inspectCredentialReadiness({
+            credentialRef: `file:${path.join(root, 'missing-token')}`
+        })).resolves.toMatchObject({
+            status: 'degraded',
+            code  : TenantRepoAccessCode.CREDENTIAL_INVALID
+        });
+        await expect(inspectCredentialReadiness({
+            credentialRef: `ssh:${unreadableKeyPath}`
+        })).resolves.toMatchObject({
+            status: 'degraded',
+            code  : TenantRepoAccessCode.CREDENTIAL_INVALID
+        });
+    });
+
+    test('probes a readable repository and distinguishes a missing ref', async () => {
+        const source = await createSourceRepo();
+        const head   = await git(['rev-parse', 'HEAD'], source);
+
+        await git(['branch', 'deadbee'], source);
+
+        await expect(probeRemoteAccess({
+            cloneUrl     : source,
+            credentialRef: 'none',
+            ref          : 'main'
+        })).resolves.toMatchObject({
+            status: 'ready',
+            code  : TenantRepoAccessCode.READY
+        });
+        await expect(probeRemoteAccess({
+            cloneUrl     : source,
+            credentialRef: 'none',
+            ref          : 'deadbee'
+        })).resolves.toMatchObject({
+            status: 'ready',
+            code  : TenantRepoAccessCode.READY
+        });
+        await expect(probeRemoteAccess({
+            cloneUrl     : source,
+            credentialRef: 'none',
+            ref          : 'missing-ref'
+        })).resolves.toMatchObject({
+            status: 'degraded',
+            code  : TenantRepoAccessCode.REF_NOT_FOUND
+        });
+
+        await expect(probeRemoteAccess({
+            cloneUrl     : source,
+            credentialRef: 'none',
+            ref          : head
+        })).resolves.toMatchObject({
+            status: 'ready',
+            code  : TenantRepoAccessCode.READY
+        });
+
+        await git(['branch', '-D', 'deadbee'], source);
+        await commitSecondRevision(source);
+
+        await expect(probeRemoteAccess({
+            cloneUrl     : source,
+            credentialRef: 'none',
+            ref          : head
+        })).resolves.toMatchObject({
+            status: 'unknown',
+            code  : TenantRepoAccessCode.REF_UNVERIFIED
+        });
+    });
+
+    test('classifies denied, transport, and timeout probe failures without returning Git prose', async () => {
+        const cases = [
+            {
+                script : "printf '%s\\n' 'fatal: Authentication failed for https://example.invalid/private.git' >&2\nexit 128",
+                code   : TenantRepoAccessCode.DENIED_OR_NOT_FOUND,
+                timeout: 1000
+            },
+            {
+                script : "printf '%s\\n' 'fatal: Could not resolve host: example.invalid' >&2\nexit 128",
+                code   : TenantRepoAccessCode.TRANSPORT_FAILED,
+                timeout: 1000
+            },
+            {
+                script : 'sleep 1\nexit 0',
+                code   : TenantRepoAccessCode.TIMEOUT,
+                timeout: 20
+            }
+        ];
+
+        for (const item of cases) {
+            await withFakeGitScript(item.script, async () => {
+                const result = await probeRemoteAccess({
+                    cloneUrl     : 'https://example.invalid/private.git',
+                    credentialRef: 'none',
+                    ref          : 'main',
+                    timeoutMs    : item.timeout
+                });
+
+                expect(result).toMatchObject({status: 'degraded', code: item.code});
+                expect(JSON.stringify(result)).not.toContain('Authentication failed');
+                expect(JSON.stringify(result)).not.toContain('example.invalid');
+            });
+        }
     });
 
     test('resolves file credentialRef strings through askpass and redacts the resolved secret', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/tenantRepoAccessContract.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/tenantRepoAccessContract.spec.mjs
@@ -5,17 +5,21 @@ import {
     deriveRepoSlugFromCloneUrl,
     deriveTenantRepoMirrorPath,
     hasCloneUrlUserInfo,
+    isTenantRepoAccessReadinessOutcome,
     normalizeRepoSlug,
+    normalizeTenantRepoCredentialRef,
     normalizeTenantRepoConfig,
     normalizeTenantRepoEntry,
-    redactTenantRepoSecrets
+    redactTenantRepoSecrets,
+    TenantRepoAccessCode,
+    TenantRepoAccessStatus
 } from '../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 
 /**
- * @summary Contract tests for tenant repo-access config normalization (#11787).
+ * @summary Contract tests for tenant repo-access config normalization.
  *
  * The helper is pure by design: it validates tenant-side repo identities without touching Git,
- * env vars, credential helpers, or the Knowledge Base graph. The Git mirror worker (#11788)
+ * env vars, credential helpers, or the Knowledge Base graph. The Git mirror worker
  * owns credential injection; this layer owns the no-secret persistence boundary.
  *
  * @see https://github.com/neomjs/neo/issues/11787
@@ -29,7 +33,7 @@ test.describe('TenantRepoAccessContract (#11787)', () => {
         expect(deriveRepoSlugFromCloneUrl('github.com:neomjs/neo.git')).toBe('github.com/neomjs/neo');
     });
 
-    test('normalizes tenant repo entries while preserving credentialRef as a reference only', () => {
+    test('normalizes tenant repo entries while preserving supported credentialRef values as references only', () => {
         expect(normalizeTenantRepoEntry({
             cloneUrl     : 'https://github.com/neomjs/neo.git',
             credentialRef: 'env:GITHUB_TOKEN'
@@ -39,13 +43,77 @@ test.describe('TenantRepoAccessContract (#11787)', () => {
             repoSlug     : 'github.com/neomjs/neo'
         });
 
-        expect(normalizeTenantRepoConfig({
+        expect(() => normalizeTenantRepoConfig({
             tenantRepos: [{
                 cloneUrl     : 'https://github.com/neomjs/neo.git',
                 credentialRef: 'helper:github-app-installation',
                 repoSlug     : 'github.com/neomjs/custom'
             }]
-        }).tenantRepos[0].repoSlug).toBe('github.com/neomjs/custom');
+        })).toThrow(/unsupported scheme/u);
+    });
+
+    test('shares one explicit credentialRef grammar with GitMirror', () => {
+        expect(normalizeTenantRepoCredentialRef('none')).toEqual({type: 'none'});
+        expect(normalizeTenantRepoCredentialRef('env:GITHUB_TOKEN')).toEqual({
+            type: 'env',
+            name: 'GITHUB_TOKEN'
+        });
+        expect(normalizeTenantRepoCredentialRef('GITHUB_TOKEN')).toEqual({
+            type: 'env',
+            name: 'GITHUB_TOKEN'
+        });
+        expect(normalizeTenantRepoCredentialRef('file:/run/secrets/git-token')).toEqual({
+            type    : 'file',
+            filePath: '/run/secrets/git-token'
+        });
+        expect(normalizeTenantRepoCredentialRef('ssh:/run/secrets/git-key')).toEqual({
+            type   : 'ssh',
+            keyPath: '/run/secrets/git-key'
+        });
+        expect(normalizeTenantRepoCredentialRef({
+            type    : 'file',
+            filePath: '/run/secrets/git-token',
+            username: 'deploy-token',
+            ignored : 'not-crossing-the-boundary'
+        })).toEqual({
+            type    : 'file',
+            filePath: '/run/secrets/git-token',
+            username: 'deploy-token'
+        });
+    });
+
+    test('rejects unsupported or incomplete credentialRef shapes at config resolution', () => {
+        expect(() => normalizeTenantRepoCredentialRef('helper:github-app-installation'))
+            .toThrow(/unsupported scheme/u);
+        expect(() => normalizeTenantRepoCredentialRef('env:'))
+            .toThrow(/valid environment-variable name/u);
+        expect(() => normalizeTenantRepoCredentialRef('file:'))
+            .toThrow(/requires filePath/u);
+        expect(() => normalizeTenantRepoCredentialRef({type: 'ssh', keyPath: ''}))
+            .toThrow(/requires keyPath/u);
+        expect(() => normalizeTenantRepoCredentialRef({type: 'ssh', keyPath: '/key', username: 'git'}))
+            .toThrow(/env\/file credentialRef username/u);
+        expect(() => normalizeTenantRepoCredentialRef({type: 'vault', name: 'tenant-token'}))
+            .toThrow(/unsupported type/u);
+    });
+
+    test('allowlists public access-readiness codes by status', () => {
+        expect(isTenantRepoAccessReadinessOutcome(
+            TenantRepoAccessStatus.READY,
+            TenantRepoAccessCode.READY
+        )).toBe(true);
+        expect(isTenantRepoAccessReadinessOutcome(
+            TenantRepoAccessStatus.UNKNOWN,
+            TenantRepoAccessCode.EVIDENCE_EXPIRED
+        )).toBe(true);
+        expect(isTenantRepoAccessReadinessOutcome(
+            TenantRepoAccessStatus.DEGRADED,
+            TenantRepoAccessCode.READY
+        )).toBe(false);
+        expect(isTenantRepoAccessReadinessOutcome(
+            TenantRepoAccessStatus.DEGRADED,
+            'KB_TENANT_REPO_ACCESS_TOKEN_SECRET'
+        )).toBe(false);
     });
 
     test('preserves optional branchRef when valid (#12040)', () => {


### PR DESCRIPTION
Resolves #15760

Tenant-repo ingestion now answers access readiness before cadence makes a repository due. The shared access contract explicitly normalizes `none`, env, file, and SSH credential references and rejects unsupported schemes; GitMirror resolves local credential material and runs a bounded, read-only `git ls-remote` capability probe through the same askpass/SSH/redaction boundary used by clone and fetch. The orchestrator caches only process-local fingerprints plus stable readiness outcomes, invalidates proof on config or credential rotation and evidence expiry, preserves normal clone/fetch as the final authority, and keeps failures isolated per repository. Deployment-state schema v2 projects strict status/code pairs, timestamps, aggregate counts, and hashed repo identities without launching network work during inspection or exposing credential metadata.

Related: #15763

Decision Record impact: aligned with ADR 0014's cloud scheduler topology and ADR 0019's config authority; no amendment required. Readiness remains outside `tenant-repo-sync-revisions.json`, so the adjacent lease/atomic-manifest lane retains sole ownership of durable revision state.

Evidence: L3 (real `git ls-remote` probes against disposable repositories plus deterministic failure, cache-invalidation, isolation, and deep-redaction coverage) → L3 required (bounded capability proof and deployment-readiness contracts). No residuals.

## Deltas from ticket

- Raw commit SHAs that are not advertised ref tips report `unknown` rather than a false `ref-not-found`; advertised SHAs and all-hex branch names still report ready.
- Readiness proof expires after two effective repo cadence windows with a 15-minute floor, avoiding a second network poller while preventing stale evidence from certifying deployment readiness indefinitely.
- Existing cloud-deployment operator references were updated in place; no turn-loaded instruction substrate or new rule slot was added.

## Test Evidence

- Credential grammar, env/file/SSH resolution, real Git probes, timeout/transport/denied/ref classification, scheduler bootstrap/cache invalidation, per-repo isolation, deployment aggregates, and deep redaction: `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs test/playwright/unit/ai/services/knowledge-base/tenantRepoAccessContract.spec.mjs --reporter=dot` — 178 passed after rebasing onto current `origin/dev`.
- Runtime syntax and patch hygiene: `node --check` for all four modified runtime modules plus `git diff --check` — passed.
- Cloud deployment guides: `npm run ai:lint-guides` — 0 hard errors; 28 repository-wide warnings.
- Client-neutrality scan across all changed files — no matches.
- Agent gates: `npm run agent-preflight -- --no-fix --pr-body /private/tmp/neo-pr-15760-body.md <eleven changed files>` — passed.

## Post-Merge Validation

- [ ] On the next non-production multi-repo deployment, confirm the first scheduler sweep populates `tenantRepoSync.accessReadiness` before any repo is cadence-due, inaccessible repos degrade only their own rows, and inspection performs no additional Git probe.

## Evolution

A direct falsifier showed that `git ls-remote <raw-sha>` returns exit 2 for a valid non-tip commit. The probe therefore treats unadvertised raw SHAs as unverified, while parsing the full advertised-ref set also preserves valid all-hex branch names. The final public projection uses exact status/code pair allowlists rather than accepting any string with the readiness prefix.

Authored by Euclid (GPT-5.6, Codex Desktop). Session 6f1cb766-e35c-495f-bf54-c1a6ad43197e.
