### PR TITLE
fix(deploy): pin and declare the deployed Neo revision (#15774)

### DIFF
--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -78,19 +78,35 @@ ARG TARGET_SERVER
 ARG SERVICE_ENTRYPOINT=ai/mcp/server/${TARGET_SERVER}/mcp-server.mjs
 ENV SERVER_ENTRYPOINT=${SERVICE_ENTRYPOINT}
 
-# Deployment provenance (#15774). Two facts, deliberately kept separate:
-#   `org.opencontainers.image.revision` records the REQUESTED ref — exact whenever the
-#   caller pins a tag/SHA, which is what a reproducible rollout requires. A mutable
-#   channel (the `dev` default) must never be treated as a deployed identity, so the
-#   RESOLVED commit is stamped independently into /app/.neo-revision by the source
-#   stage. Requested-vs-resolved is the desired-vs-observed pair; they diverge exactly
-#   when a channel was requested instead of a pin.
+# Deployment provenance (#15774). THREE facts, each on a surface that cannot lie:
+#
+#   1. `org.neomjs.image.requested-ref` — the REQUESTED selector (policy input). May be
+#      a mutable channel; that is legitimate for a request and meaningless as identity.
+#      Vendor-namespaced on purpose: no OCI standard key means "what was asked for".
+#   2. `org.opencontainers.image.revision` — the PACKAGED source-control revision, per
+#      the OCI image-spec contract. Caller-supplied and EMPTY BY DEFAULT, because a
+#      LABEL can only read a build ARG and Docker cannot populate a later-stage ARG
+#      from a file written in an earlier stage. Empty means "not asserted"; it must
+#      never contain a channel name. To get a spec-correct value, resolve the channel
+#      to a full SHA first and pass NEO_REVISION — which is exactly the resolve-once
+#      contract the rollout-authority design calls for.
+#   3. /app/.neo-revision — the build-time RESOLVED commit, written by the source stage.
+#      The only surface that is always populated and always true, so it is the primary
+#      provenance fact; the label above is its machine-readable echo when the caller
+#      resolved properly.
+#
+# Do NOT pass NEO_REVISION for a `NEO_SOURCE=local` build: nothing upstream was
+# packaged, /app/.neo-revision says `local-build`, and an OCI revision claim there
+# would be a fabrication.
+#
 # These ARGs are re-declared here because pre-`FROM` ARGs do not reach build stages;
 # they sit after the expensive COPY/apk layers so a changed ref does not invalidate
-# them. Both inherit the global defaults declared at the top of this file.
+# them. NEO_REF and NEO_REPO_URL inherit the global defaults declared at the top.
 ARG NEO_REF
 ARG NEO_REPO_URL
-LABEL org.opencontainers.image.revision="${NEO_REF}"
+ARG NEO_REVISION=
+LABEL org.neomjs.image.requested-ref="${NEO_REF}"
+LABEL org.opencontainers.image.revision="${NEO_REVISION}"
 LABEL org.opencontainers.image.source="${NEO_REPO_URL}"
 
 CMD ["sh", "-c", "node ${SERVER_ENTRYPOINT}"]

--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -20,11 +20,17 @@ WORKDIR /neo
 # branch, a tag, OR a full commit SHA (the reproducible pin). GitHub serves reachable SHAs.
 RUN git init -q && git remote add origin "${NEO_REPO_URL}" \
     && git fetch --depth 1 origin "${NEO_REF}" \
-    && git checkout -q --detach FETCH_HEAD
+    && git checkout -q --detach FETCH_HEAD \
+    && git rev-parse HEAD > /neo/.neo-revision
 
 FROM node:24-alpine AS source-local
 WORKDIR /neo
 COPY . .
+# `local` mode is a dev-iteration escape hatch: this stage has no `git` binary, and
+# inferring a revision from a working tree would fabricate provenance. Stamp an
+# explicit non-SHA marker so /app/.neo-revision is never absent and never mistaken
+# for a real commit.
+RUN echo 'local-build' > /neo/.neo-revision
 
 # Select the source stage from the NEO_SOURCE build arg. In 'git' mode the source-local
 # stage is never built, so no local build context is required (the portability fix).
@@ -71,5 +77,20 @@ ENV NEO_TRANSPORT=streamable-http
 ARG TARGET_SERVER
 ARG SERVICE_ENTRYPOINT=ai/mcp/server/${TARGET_SERVER}/mcp-server.mjs
 ENV SERVER_ENTRYPOINT=${SERVICE_ENTRYPOINT}
+
+# Deployment provenance (#15774). Two facts, deliberately kept separate:
+#   `org.opencontainers.image.revision` records the REQUESTED ref — exact whenever the
+#   caller pins a tag/SHA, which is what a reproducible rollout requires. A mutable
+#   channel (the `dev` default) must never be treated as a deployed identity, so the
+#   RESOLVED commit is stamped independently into /app/.neo-revision by the source
+#   stage. Requested-vs-resolved is the desired-vs-observed pair; they diverge exactly
+#   when a channel was requested instead of a pin.
+# These ARGs are re-declared here because pre-`FROM` ARGs do not reach build stages;
+# they sit after the expensive COPY/apk layers so a changed ref does not invalidate
+# them. Both inherit the global defaults declared at the top of this file.
+ARG NEO_REF
+ARG NEO_REPO_URL
+LABEL org.opencontainers.image.revision="${NEO_REF}"
+LABEL org.opencontainers.image.source="${NEO_REPO_URL}"
 
 CMD ["sh", "-c", "node ${SERVER_ENTRYPOINT}"]

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -52,6 +52,11 @@ services:
       dockerfile: Dockerfile
       args:
         TARGET_SERVER: knowledge-base
+        # Pin the deployed revision declaratively (#15774): export NEO_REF=<full-sha>
+        # for a reproducible rollout. The `:-dev` default is load-bearing — a bare
+        # `${NEO_REF}` passes an EMPTY string when unset, which would override the
+        # Dockerfile's `ARG NEO_REF=dev` and break `git fetch origin ""`.
+        NEO_REF: ${NEO_REF:-dev}
     environment:
       - NEO_TRANSPORT=streamable-http
       - NEO_AUTO_SYNC=false
@@ -109,6 +114,8 @@ services:
       dockerfile: Dockerfile
       args:
         TARGET_SERVER: memory-core
+        # Cohort invariant (#15774): every Neo service builds from the SAME ref.
+        NEO_REF: ${NEO_REF:-dev}
     environment:
       - NEO_TRANSPORT=streamable-http
       - NEO_MC_PRIMARY=false
@@ -186,6 +193,8 @@ services:
       dockerfile: Dockerfile
       args:
         SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
+        # Cohort invariant (#15774): every Neo service builds from the SAME ref.
+        NEO_REF: ${NEO_REF:-dev}
     environment:
       - NEO_AI_DEPLOYMENT_MODE=cloud
       - NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED=false

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -57,6 +57,7 @@ services:
         # `${NEO_REF}` passes an EMPTY string when unset, which would override the
         # Dockerfile's `ARG NEO_REF=dev` and break `git fetch origin ""`.
         NEO_REF: ${NEO_REF:-dev}
+        NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_TRANSPORT=streamable-http
       - NEO_AUTO_SYNC=false
@@ -116,6 +117,7 @@ services:
         TARGET_SERVER: memory-core
         # Cohort invariant (#15774): every Neo service builds from the SAME ref.
         NEO_REF: ${NEO_REF:-dev}
+        NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_TRANSPORT=streamable-http
       - NEO_MC_PRIMARY=false
@@ -195,6 +197,7 @@ services:
         SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
         # Cohort invariant (#15774): every Neo service builds from the SAME ref.
         NEO_REF: ${NEO_REF:-dev}
+        NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_AI_DEPLOYMENT_MODE=cloud
       - NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED=false

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -35,6 +35,41 @@ Do not redeploy on every commit. The Agent OS deployment is a stateful service; 
 
 Avoid "deploy on every push to `dev`": it couples MCP availability to ordinary development cadence.
 
+## Deployed-revision provenance
+
+Release-gating chooses *which* revision to deploy. This section is how the deployment **proves** which revision it actually runs — a separate problem, and the one that lets a stale stack look healthy.
+
+**Pin the revision declaratively.** Every Neo service in [`ai/deploy/docker-compose.yml`](../../../ai/deploy/docker-compose.yml) forwards a `NEO_REF` build argument, so one environment variable pins the whole cohort:
+
+```bash
+export NEO_REF=<full-git-sha>
+docker compose -f ai/deploy/docker-compose.yml [--profile …] build
+```
+
+Left unset, `NEO_REF` defaults to `dev` — the pre-existing behaviour. Prefer a full SHA over a branch name: Docker does **not** automatically invalidate a `RUN` layer when remote content changes, so re-running `build` against a mutable branch does not mechanically prove the branch was re-fetched. A changing build argument gives the cache a changing input *and* gives the deployment a verifiable identity.
+
+Confirm what compose will pass before building — the whole cohort must agree:
+
+```bash
+docker compose -f ai/deploy/docker-compose.yml --profile cloud config | grep NEO_REF
+```
+
+**Verify what the images report.** Each image records two deliberately distinct facts:
+
+| Fact | Where | Meaning |
+|---|---|---|
+| Requested ref | `org.opencontainers.image.revision` label | what the build was *asked* for — exact when you pinned a SHA, the mutable channel name when you did not |
+| Resolved commit | `/app/.neo-revision` | the commit the build actually checked out |
+
+```bash
+docker inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' <image>
+docker compose -f ai/deploy/docker-compose.yml exec mc-server cat /app/.neo-revision
+```
+
+Read them together. When you pinned a SHA they agree, and either one is the deployed identity. When you requested a channel they diverge, and only the resolved commit answers "what is running" — the label merely records that no pin was given. A `local-build` marker means the image came from `NEO_SOURCE=local` (the dev-iteration escape hatch) and carries no upstream provenance at all.
+
+Two honest bounds. First, a missing label or missing `/app/.neo-revision` means the image predates this contract — treat it as unknown-revision, not as current. Second, these are container-local reads: they answer "which revision" but they are served from inside the deployed set, so they cannot by themselves distinguish *a failed rollout* from *a succeeded rollout whose reporter died*. Durable out-of-cohort receipts are open design work, tracked on [Discussion #15758](https://github.com/orgs/neomjs/discussions/15758).
+
 ## Redeploy-safe persistence
 
 This is the load-bearing rule. A pipeline-driven redeploy **recreates containers**; it must **not destroy persistent state**. Sub C ([#11724](https://github.com/neomjs/neo/issues/11724)) already made the deployment redeploy-safe — the pipeline's job is to not undo it.

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -39,42 +39,47 @@ Avoid "deploy on every push to `dev`": it couples MCP availability to ordinary d
 
 Release-gating chooses *which* revision to deploy. This section is how the deployment **proves** which revision it actually runs — a separate problem, and the one that lets a stale stack look healthy.
 
-**Pin the revision declaratively.** Every Neo service in [`ai/deploy/docker-compose.yml`](../../../ai/deploy/docker-compose.yml) forwards a `NEO_REF` build argument, so one environment variable pins the whole cohort:
+**Resolve the channel, then pin.** Every Neo service in [`ai/deploy/docker-compose.yml`](../../../ai/deploy/docker-compose.yml) forwards two build arguments: `NEO_REF` (what you are *asking for*) and `NEO_REVISION` (the *resolved* commit). Resolve once, pass both, build once:
 
 ```bash
-export NEO_REF=<full-git-sha>
+export NEO_REF=$(git ls-remote https://github.com/neomjs/neo.git dev | cut -f1)
+export NEO_REVISION="$NEO_REF"
 docker compose -f ai/deploy/docker-compose.yml [--profile …] build
 ```
 
-Left unset, `NEO_REF` defaults to `dev` — the pre-existing behaviour. Prefer a full SHA over a branch name: Docker does **not** automatically invalidate a `RUN` layer when remote content changes, so re-running `build` against a mutable branch does not mechanically prove the branch was re-fetched. A changing build argument gives the cache a changing input *and* gives the deployment a verifiable identity.
+Left unset, `NEO_REF` defaults to `dev` and `NEO_REVISION` stays empty — the pre-existing behaviour, with no revision asserted.
+
+Prefer a resolved SHA over a branch name for two independent reasons. Docker does **not** automatically invalidate a `RUN` layer when remote content changes, so re-running `build` against a mutable branch does not mechanically prove the branch was re-fetched — a changing build argument gives the cache a changing input. And a mutable channel is *policy input*, never a build identity: resolving it yourself, once, before the build is the only way the image can honestly state what it contains.
 
 Confirm what compose will pass before building — the whole cohort must agree:
 
 ```bash
-docker compose -f ai/deploy/docker-compose.yml --profile cloud config | grep NEO_REF
+docker compose -f ai/deploy/docker-compose.yml --profile cloud config | grep -E 'NEO_REF|NEO_REVISION'
 ```
 
-**Verify what the images report.** Each image records two deliberately distinct facts:
+**Verify what the images report.** Provenance lives on three surfaces, each of which can only state a fact it actually holds. They are not interchangeable:
 
-| Fact | Where | Meaning |
+| Fact | Surface | Contract |
 |---|---|---|
-| Requested ref | `org.opencontainers.image.revision` label | what the build was *asked* for — exact when you pinned a SHA, the mutable channel name when you did not |
-| Resolved commit | `/app/.neo-revision` | the commit the build actually checked out |
+| Requested selector | `org.neomjs.image.requested-ref` label | Policy input — what the build was *asked* for. Legitimately a mutable channel. Vendor-namespaced because no OCI standard key means "what was asked for". |
+| Packaged revision | `org.opencontainers.image.revision` label | The OCI-specified source-control revision of the packaged software. Caller-supplied via `NEO_REVISION`; **empty when not supplied**, which reads as *not asserted*. It must never contain a channel name. |
+| Resolved commit | `/app/.neo-revision` | The commit the build actually checked out, written at build time. Always populated, always true — so this is the **primary** provenance fact; the label above is its machine-readable echo when the caller resolved properly. |
 
 ```bash
+docker inspect --format '{{index .Config.Labels "org.neomjs.image.requested-ref"}}' <image>
 docker inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' <image>
 docker compose -f ai/deploy/docker-compose.yml exec mc-server cat /app/.neo-revision
 ```
 
-Read them together — the *direction* of any disagreement is what carries the diagnosis:
+Read the requested selector against the resolved commit — the *direction* of any disagreement carries the diagnosis:
 
-| Requested (label) | Resolved (file) | Reading |
+| Requested | Resolved (file) | Reading |
 |---|---|---|
-| a channel, e.g. `dev` | some commit | Expected. The label only records that no pin was given; the resolved commit is the sole identity. |
-| a pinned SHA | the same SHA | The pin held. Either fact is the deployed identity. |
-| a pinned SHA | a **different** SHA | **Build-integrity failure.** Not an oddity — the build did not produce what was asked for. Do not promote this image; rebuild and investigate. |
+| a channel, e.g. `dev` | some commit | Expected. No pin was given, so the resolved commit is the sole identity — and `org.opencontainers.image.revision` will be empty, correctly asserting nothing. |
+| a pinned SHA | the same SHA | The pin held. Promote this image. |
+| a pinned SHA | a **different** SHA | **Build-integrity failure.** Not an oddity — the build did not produce what was asked for. Do not promote; rebuild and investigate. |
 
-A `local-build` marker means the image came from `NEO_SOURCE=local` (the dev-iteration escape hatch) and carries no upstream provenance at all — never promote one.
+Two rules that follow from the table. A **non-empty** `org.opencontainers.image.revision` that disagrees with `/app/.neo-revision` is the same build-integrity failure, detectable without the requested selector at all. And a **`local-build`** marker means the image came from `NEO_SOURCE=local` (the dev-iteration escape hatch): nothing upstream was packaged, so `NEO_REVISION` must not be passed for such a build and the image must never be promoted.
 
 Two honest bounds. First, a missing label or missing `/app/.neo-revision` means the image predates this contract — treat it as unknown-revision, not as current. Second, these are container-local reads: they answer "which revision" but they are served from inside the deployed set, so they cannot by themselves distinguish *a failed rollout* from *a succeeded rollout whose reporter died*. Durable out-of-cohort receipts are open design work, tracked on [Discussion #15758](https://github.com/orgs/neomjs/discussions/15758).
 

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -66,7 +66,15 @@ docker inspect --format '{{index .Config.Labels "org.opencontainers.image.revisi
 docker compose -f ai/deploy/docker-compose.yml exec mc-server cat /app/.neo-revision
 ```
 
-Read them together. When you pinned a SHA they agree, and either one is the deployed identity. When you requested a channel they diverge, and only the resolved commit answers "what is running" — the label merely records that no pin was given. A `local-build` marker means the image came from `NEO_SOURCE=local` (the dev-iteration escape hatch) and carries no upstream provenance at all.
+Read them together — the *direction* of any disagreement is what carries the diagnosis:
+
+| Requested (label) | Resolved (file) | Reading |
+|---|---|---|
+| a channel, e.g. `dev` | some commit | Expected. The label only records that no pin was given; the resolved commit is the sole identity. |
+| a pinned SHA | the same SHA | The pin held. Either fact is the deployed identity. |
+| a pinned SHA | a **different** SHA | **Build-integrity failure.** Not an oddity — the build did not produce what was asked for. Do not promote this image; rebuild and investigate. |
+
+A `local-build` marker means the image came from `NEO_SOURCE=local` (the dev-iteration escape hatch) and carries no upstream provenance at all — never promote one.
 
 Two honest bounds. First, a missing label or missing `/app/.neo-revision` means the image predates this contract — treat it as unknown-revision, not as current. Second, these are container-local reads: they answer "which revision" but they are served from inside the deployed set, so they cannot by themselves distinguish *a failed rollout* from *a succeeded rollout whose reporter died*. Durable out-of-cohort receipts are open design work, tracked on [Discussion #15758](https://github.com/orgs/neomjs/discussions/15758).
 


### PR DESCRIPTION
Resolves #15774

The deployment path could not pin the Neo revision and the built images could not declare it — so Discussion #15758's Option E floor (manual exact-SHA + stronger receipts), which is what the current cloud-deployment P0 is contracted on, was not expressible. This closes both ends: `NEO_REF` now flows through the declarative Compose path into all three Neo builds, and each image records its provenance on labels plus a resolved-commit file.

Provenance now lives on **three** non-overlapping surfaces, each stating only a fact it actually holds: `org.neomjs.image.requested-ref` (the requested selector — policy input, legitimately a channel), `org.opencontainers.image.revision` (the packaged revision, from a caller-supplied `NEO_REVISION`, **empty when not asserted**), and `/app/.neo-revision` (the build-time resolved commit — always populated, always true, therefore the primary fact).

**Cycle 1 corrected the original design here, and the correction matters.** I had put the *requested* ref in `org.opencontainers.image.revision`, whose OCI-specified meaning is the revision of the *packaged* software — so the artifact could contradict itself, most visibly when a `NEO_SOURCE=local` build labelled itself `dev` while its own file said `local-build`. Caught by @neo-gpt-emmy. Details in the author response below.

Evidence: L3 (real `docker compose` renderer probed at head `2d90c692fe` for four cases — nothing set, resolved pin, `NEO_REF` set-empty, `NEO_REVISION` set-empty — across all three services; `ai:lint-guides` + `check-agentos-theme` green) → L3 required (AC5 both label values via `docker inspect`, AC6 `/app/.neo-revision` content, AC7 the `NEO_SOURCE=local` marker plus an empty revision label — each needs a real image build). Residual: AC5, AC6, AC7, AC9 [#15774].

**Reviewer, read this before approving.** No Docker daemon is reachable from my sandbox — the CLI is present (v29.5.2) but `/var/run/docker.sock` does not exist, so `compose config` (client-side) ran and `docker build` could not. @neo-fable-clio independently probed the host and confirmed colima is stopped, then routed the build receipt operator-side. **CI does not close the gap either:** the integration lane builds from `ai/deploy/docker-compose.test.yml`, which does not use this Dockerfile, so a green CI run here is evidence that nothing regressed — *not* evidence that the labels or the revision file materialise. AC5/AC6/AC7/AC9 are annotated `[L3-deferred — operator handoff needed]` on #15774 with that deferral basis recorded. Please do not read CI green as covering them.

What I could do instead of guessing on the riskiest design point: the final-stage `ARG NEO_REF` relies on a pre-`FROM` global ARG being inherited by a stage that re-declares it bare (`NEO_REVISION` sidesteps this entirely — it is declared with its own empty default in the final stage). That exact mechanism is **already load-bearing in this same file in production** — `ARG NEO_REF=dev` at `Dockerfile:11` is re-declared bare at `Dockerfile:16` inside `source-git`, which is the shipped source-acquisition path from #12150. My final-stage re-declaration is the identical pattern, so the inheritance is proven by the file's own working behaviour rather than by my reading of the spec.

## Deltas from ticket

None substantive. Two implementation details worth surfacing:

- **`${NEO_REF:-dev}` also absorbs the set-but-empty case,** not just unset. I originally reasoned about the default as unset-protection only; Docker's `:-` form treats empty and unset identically, so an exported-but-blank `NEO_REF` also falls back to `dev` instead of passing `""` into `git fetch`. Verified as a third case rather than assumed.
- **The provenance `ARG`/`LABEL` block sits after the `apk add` and `COPY --from=builder` layers** rather than near the top of the final stage. Placing it early would invalidate those expensive layers on every ref change for no benefit; the source-dependent `COPY` already busts when the ref changes.
- **Added after filing: the pinned-mismatch row.** The ticket framed requested-vs-resolved as "they diverge under a channel request." That misses the sharper case — a mismatch under a *pinned* ref is a **build-integrity failure**, not an oddity, and that image must not be promoted. `#15775` (an independent duplicate, now closed) named the directionality better than this ticket did; folded in as the three-row reading table before review, credited to @neo-fable-clio. See #15774's convergence comment.

## Test Evidence

`docker compose --profile cloud config`, run from `ai/deploy/` at head `2d90c692fe` — all three Neo services in every case:

| Case | `NEO_REF` renders | `NEO_REVISION` renders |
|---|---|---|
| nothing set | `dev` ×3 | `""` ×3 — no revision asserted |
| resolved pin (both exported) | that SHA ×3 | that SHA ×3 |
| `NEO_REF=` (set, empty) | `dev` ×3 | `""` ×3 |
| `NEO_REVISION=` (set, empty) | `dev` ×3 | `""` ×3 — stays empty, never degrades to a channel name |

The unset row is the no-op proof: any existing deployment that does not set `NEO_REF` builds exactly as before. The pinned row is the cohort proof: one variable moves all three together. The empty row is the footgun proof.

Static verification of the bounded blast radius:

- `ai/deploy/docker-compose.yml` is the only compose file that builds from `ai/deploy/Dockerfile` — `docker-compose.dev.yml` and `docker-compose.test.yml` do not, so no test or dev topology is touched.
- `grep -c LABEL ai/deploy/Dockerfile` → `0` on `dev`, `3` at this head.
- `source-local` only builds under `NEO_SOURCE=local`; in the default `git` mode that stage is outside the dependency graph, so the marker `RUN` never executes.

Lint/guard surfaces for the touched paths:

- `npm run ai:lint-guides` → `34 guide(s) scanned — 0 hard, 28 warning(s). OK`. All 28 warnings are pre-existing on other files (`StrategicWorkflows.md`, `SwarmIntelligence.md`, `rem-state-model.md`, `v13-path.md`, `benefits/Introduction.md`); `PipelineWiring.md` produces none.
- `npm run check-agentos-theme` → parity + token-only + completeness + text-safe ink all pass.
- Pre-commit `check-whitespace` passed on all three staged files.

Per directly touched surface: `ai/deploy/**` — `None found` (no spec covers the deploy build path; the integration suite exercises `docker-compose.test.yml`, a different stack). `learn/agentos/**` — covered by `ai:lint-guides` above.

Substrate note: `PipelineWiring.md` is an operator reference doc under `learn/agentos/**`, not turn- or skill-loaded substrate, so §1.1's slot-rationale section does not apply; the added section carries its own in-doc rationale and honest bounds.

## Post-Merge Validation

- [ ] AC5 — `docker compose build` with `NEO_REF`+`NEO_REVISION=<sha>` labels `org.opencontainers.image.revision` with that SHA; the same build with `NEO_REVISION` unset leaves it **empty** (never a channel name), while `org.neomjs.image.requested-ref` carries the selector.
- [ ] AC6 — `docker compose exec mc-server cat /app/.neo-revision` returns the resolved commit.
- [ ] AC7 — a `NEO_SOURCE=local` build succeeds, stamps `local-build` (never empty, never a fabricated SHA), and leaves `org.opencontainers.image.revision` empty.
- [ ] AC9 — operator-side rebuild of the live tenant deployment reports a revision label matching the deployed SHA. Operator-owned: it needs the deployment plane.

## Commits

- `25761f41e7` — `NEO_REF` through the three Compose build args, OCI revision/source labels, resolved-commit stamp, and the `PipelineWiring.md` provenance section.
- `5d81b692e1` — names the pinned-mismatch case as a build-integrity failure (three-row reading table); docs-only, lint re-run green.
- `2d90c692fe` — **cycle-1 RA1**: stops overloading `org.opencontainers.image.revision`; adds the vendor `requested-ref` label + the caller-supplied `NEO_REVISION` arg (empty-default) across all three builds; docs rewritten to the three-surface contract. #15774's Contract Ledger, ACs, and Avoided Traps amended in the same pass.

## Scope discipline

Deliberately excluded, so the prerequisite does not smuggle in open design decisions:

- **No Neo diagnostic is taught to read the label.** `summarizeInspect` (`ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs:732-747`) drops image IDs, repo digests, and labels, so the stamped label will not surface in the deployment snapshot yet. Discussion #15758 **OQ4** explicitly owns which read-only diagnostic exposes provenance, and the verification path above needs no Neo surface change.
- No cohort manifest or desired/observed reconciliation (divergence-window material).
- No out-of-cohort evidence sink — the receipt *reader* living inside the update cohort is a separate structural problem I raised as Option H on that Discussion.
- No rollout trigger, controller, request surface, or recovery semantics (OQ1 / OQ5 / OQ7).

**Decision Record impact: `none`.** Build-arg plumbing and artifact metadata only; no rollout authority is chosen, no request surface added, no runtime access widened. ADR-0014, ADR-0019, and ADR-0026 authority are untouched, and every row of #15758's matrix — including the do-nothing-automated row E — depends on this plumbing existing.

Cycle-1 review by @neo-gpt-emmy (`PRR_kwDODSospM8AAAABHGOHEA`) requested changes on two bounded items; both are addressed at head `2d90c692fe` and re-review is requested. Her patch-blind snapshot predicted the correct label semantics before reading the diff, which is why the defect surfaced in one cycle instead of after a deployment.

Related: #12150
Related: #11733
Related: [Discussion #15758](https://github.com/orgs/neomjs/discussions/15758)

Authored by Grace (Claude Opus 4.8, Claude Code). Session 92799c10-cb3b-4c01-a2b0-fd8552c3c02e.
