### PR TITLE
feat(skills): derive tech-debt-radar taxonomy from living canon (#15770)

### DIFF
--- a/.agents/skills/tech-debt-radar/references/tech-debt-radar-guide.md
+++ b/.agents/skills/tech-debt-radar/references/tech-debt-radar-guide.md
@@ -8,12 +8,12 @@ Run this meta-analysis with frontier-tier capability — it synthesizes document
 
 ## 2. Pre-Flight: Derive the Canon (never copy it)
 
-A copied canon decays by construction and eventually inverts — the radar then flags sanctioned shapes as debt. At sweep time, load the debt taxonomy FROM the living authorities:
+A copied canon decays by construction and eventually inverts — the radar then flags sanctioned shapes as debt. At sweep time, load the debt taxonomy FROM the living authorities, and keep three classes separate: **authority** (what the canon prescribes), **observation** (what the tree currently is), and **hypothesis** (candidate findings awaiting an owning lane):
 
-1. `learn/benefits/ArchitectureOverview.md` — the structural baseline (Body/Brain topology).
-2. `learn/agentos/decisions/` — the ADR index IS the pattern canon. Minimum reads: ADR 0019 (the `ai/`-config antipattern catalog) for config debt; ADR 0008 for skill-shape debt.
-3. `npm run --silent ai:structure-map -- --files --loc` — the mechanical what-belongs-where and size truth.
-4. The `pr-review` guide's anti-pattern tables and `AGENTS.md` §edge_case_triggers (the `apps/**` data-path/style gate, `core.Base` as the quality bar).
+1. `learn/benefits/ArchitectureOverview.md` — the structural baseline (Body/Brain topology). *Authority.*
+2. `learn/agentos/decisions/` — the ADR index IS the pattern canon. Minimum reads: ADR 0019 (the `ai/`-config antipattern catalog) for config debt; ADR 0008 for skill-shape debt. *Authority.*
+3. `npm run --silent ai:structure-map -- --files --loc` — current-tree measurement: where things ARE and how large. *Observation only — no intended-placement policy; observed placement is never its own authority.*
+4. The `pr-review` guide's anti-pattern tables and `AGENTS.md` §edge_case_triggers (the `apps/**` data-path/style gate, `core.Base` as the quality bar). *Authority.*
 
 A conflict between this guide and those authorities is a bug in THIS guide — the authorities win. Freshness trigger: a pattern-canon ADR graduation invalidates this pointer list; revalidate it then.
 
@@ -26,17 +26,17 @@ Use `ask_knowledge_base` against the backlog (`resources/content/issues/`): aban
 Heavily use `query_raw_memories` and `query_summaries` for "abandoned loops" (an agent attempted X and rolled back; failed test hypotheses) — past thought-logs carry the *why* behind accrued debt.
 
 ### C. Codebase Vertical Slicing
-Dive where A/B point. Classify anomalies strictly against the §2 catalogs, never against this guide's own taste — this guide's previous inline examples were canon-inverted by later ADRs, which is exactly why §2 derives instead of stating.
+Dive where A/B point. Classify anomalies strictly against the §2 catalogs, never against this guide's own taste — the previous inline examples were canon-inverted by later ADRs; that is why §2 derives instead of stating.
 
 ### D. Brain-Structural Debt (measure → report → route; never prescribe)
-The Brain (`ai/`) now outweighs the Body in modules and LOC without the Body's structural discipline. Mechanical probes:
+Across the two executable roots — `ai/` (Brain) vs `src/` (Body) — the Brain currently outweighs the Body in modules and LOC without its structural discipline: re-measure each sweep, never treat as frozen fact. Probes (*observation* producing *hypotheses*):
 
-- structure-map LOC outliers benchmarked against the Body's ceiling;
+- structure-map LOC outliers, using the Body's densest exemplary files as the comparison scale;
 - folder-shape consistency across `ai/daemons/*` (factored vs monolith vs ad-hoc flat);
-- concept↔code-home coherence: every `learn/agentos/*.md` concept guide should map to a legible code home (calibration specimen: the Dream Pipeline guide vs its implementation smeared across 25+ files in five technical-layer buckets).
+- concept↔code-home coherence: a `learn/agentos/*.md` concept guide with no legible code home is a reportable CANDIDATE, calibrated against the Dream Pipeline specimen (a first-class guide smeared across 25+ files in five technical-layer buckets) — not a universal one-guide-one-home rule.
 
 **Two-layer rule:** findings in this class are REPORTS routed to the #14304 / D#14302 canon lane — a canon-hole is itself a reportable finding. Prescribing target module shapes or file moves pre-SSOT is out of scope by #14304's own deferred gates.
 
 ## 4. Remediation Routing
 
-Findings become tickets through `/ticket-create` — duplicate sweep, Fat Ticket, six-stage challenge chain; no bypass. Labels per the live taxonomy: `ai` + one primary (`bug`/`enhancement`) + `refactoring` as the secondary. Cite provenance (Memory Core sessions, historical PRs) so the fixing agent understands the exact architectural ROI. Brain-structural findings route per §3.D, never to unilateral restructure tickets.
+Findings become tickets through `/ticket-create` — duplicate sweep, Fat Ticket, six-stage challenge chain, and its live label rules (that skill owns the label taxonomy); no bypass. Cite provenance (Memory Core sessions, historical PRs) so the fixing agent understands the exact architectural ROI. Brain-structural findings route per §3.D, never to unilateral restructure tickets.

--- a/.agents/skills/tech-debt-radar/references/tech-debt-radar-guide.md
+++ b/.agents/skills/tech-debt-radar/references/tech-debt-radar-guide.md
@@ -1,41 +1,42 @@
 # Tech Debt Radar Guide
 
-This document outlines the authoritative protocol for proactive architectural sweeping and technical debt discovery natively within the Agent OS. This capability mitigates ambient architectural rot that accumulates outside the active scope of feature development.
+The radar is a **sensor, not a judge**: it measures ambient architectural debt against the repo's LIVING canon and routes findings to the lanes that own them. Its unduplicated substance is the sweep method below — the debt taxonomy itself is never stored here.
 
-## 1. Execution Strictures (Model Tiering)
+## 1. Execution Posture
 
-This meta-analysis MUST be executed strictly by **Frontier Models** (e.g., Gemini 3.1 Pro / Claude Opus 4.6). The cognitive load required to synthesize historical documentation, graph topology, episodic memory, and active codebase layout exceeds the capacities of tactical open-weight Swarm SMLs. If you are an SML sub-agent, you must halt execution and escalate.
+Run this meta-analysis with frontier-tier capability — it synthesizes documentation, graph topology, episodic memory, and code layout at once. Tactical SML sub-agents halt and escalate. Capability class, not model names: pinned rosters decay by construction.
 
-## 2. Pre-Flight: Eradicating "Unknown Unknowns"
+## 2. Pre-Flight: Derive the Canon (never copy it)
 
-A fresh Agent instance possesses zero intuition about the high-level framework topology. Before diving into semantic sweeps, you MUST establish a mental map to prevent hallucinated debt.
+A copied canon decays by construction and eventually inverts — the radar then flags sanctioned shapes as debt. At sweep time, load the debt taxonomy FROM the living authorities:
 
-**Mandatory Action:** You MUST use the `view_file` tool to read `learn/benefits/ArchitectureOverview.md`. This establishes the structural baseline (Runtime Engine vs. Agent OS, VDOM physics, etc.) required to accurately classify architectural deviations. 
+1. `learn/benefits/ArchitectureOverview.md` — the structural baseline (Body/Brain topology).
+2. `learn/agentos/decisions/` — the ADR index IS the pattern canon. Minimum reads: ADR 0019 (the `ai/`-config antipattern catalog) for config debt; ADR 0008 for skill-shape debt.
+3. `npm run --silent ai:structure-map -- --files --loc` — the mechanical what-belongs-where and size truth.
+4. The `pr-review` guide's anti-pattern tables and `AGENTS.md` §edge_case_triggers (the `apps/**` data-path/style gate, `core.Base` as the quality bar).
+
+A conflict between this guide and those authorities is a bug in THIS guide — the authorities win. Freshness trigger: a pattern-canon ADR graduation invalidates this pointer list; revalidate it then.
 
 ## 3. The Multi-Vectored Sweep
 
-Debt discovery requires traversing semantic artifacts that `grep` cannot understand. Execute the following vectors:
-
 ### A. Ambient Artifact Traversal
-The framework stores historical context in decentralized markdown files. You MUST use the `ask_knowledge_base` tool to query against the backlog, focusing on abandoned concepts, incomplete migrations, or trailing architectural directives.
-- Your target domain encompasses `resources/content/issues/` (active backlog + historical tickets and epics).
-- Example strategies: "Identify partially completed feature migrations," "List architectural patterns mentioned in closed tickets that conflict with current Engine logic."
+Use `ask_knowledge_base` against the backlog (`resources/content/issues/`): abandoned concepts, incomplete migrations, trailing architectural directives.
 
 ### B. Episodic Memory Mining
-Code and markdown only tell half the story. The *why* is stored in Agent episodic memory.
-- You MUST heavily utilize `query_raw_memories` and `query_summaries` against the Memory Core.
-- Focus on finding "abandoned loops" (e.g., "Find instances where an agent attempted to refactor X but rolled back," "Locate failed Playwright hypotheses regarding Y").
-- Scanning past agent internal thought processes provides the rich monologue detailing why specific debt accrued.
+Heavily use `query_raw_memories` and `query_summaries` for "abandoned loops" (an agent attempted X and rolled back; failed test hypotheses) — past thought-logs carry the *why* behind accrued debt.
 
 ### C. Codebase Vertical Slicing
-Based on the clues surfaced from artifacts and memory, actively dive into the codebase. 
-- Target explicit topological layers (e.g., `.agents/skills`, `ai/mcp/`, `src/vdom/`).
-- Seek structural anomalies: orphan test directories, legacy Configuration objects (e.g., deeply nested daemon configs instead of top-level paths), deprecated JSDoc tags, or `&&` logic that should be optional chaining `?.`.
+Dive where A/B point. Classify anomalies strictly against the §2 catalogs, never against this guide's own taste — this guide's previous inline examples were canon-inverted by later ADRs, which is exactly why §2 derives instead of stating.
 
-## 4. Proactive Remediation
+### D. Brain-Structural Debt (measure → report → route; never prescribe)
+The Brain (`ai/`) now outweighs the Body in modules and LOC without the Body's structural discipline. Mechanical probes:
 
-Once you have cataloged depreciated logic clusters, you MUST generate highly actionable, granular cleanup tickets for the swarm backlog. 
+- structure-map LOC outliers benchmarked against the Body's ceiling;
+- folder-shape consistency across `ai/daemons/*` (factored vs monolith vs ad-hoc flat);
+- concept↔code-home coherence: every `learn/agentos/*.md` concept guide should map to a legible code home (calibration specimen: the Dream Pipeline guide vs its implementation smeared across 25+ files in five technical-layer buckets).
 
-1. **Ticket Intake Bypass:** Because you are generating the initiative (not responding to one), you are bypassing the standard `ticket-intake` constraint, but you MUST still use the "Fat Ticket" protocol. 
-2. **Contextual Rigor:** The generated GitHub Issues MUST document the history of why the debt exists (citing the Memory Core or historical PRs) so the tactical SML agent dispatched to fix it understands the exact architectural ROI.
-3. **Use the `create_issue` tool** to submit these directly to the repository queue, properly labeling them with `enhancement` or `refactor(ai)`.
+**Two-layer rule:** findings in this class are REPORTS routed to the #14304 / D#14302 canon lane — a canon-hole is itself a reportable finding. Prescribing target module shapes or file moves pre-SSOT is out of scope by #14304's own deferred gates.
+
+## 4. Remediation Routing
+
+Findings become tickets through `/ticket-create` — duplicate sweep, Fat Ticket, six-stage challenge chain; no bypass. Labels per the live taxonomy: `ai` + one primary (`bug`/`enhancement`) + `refactoring` as the secondary. Cite provenance (Memory Core sessions, historical PRs) so the fixing agent understands the exact architectural ROI. Brain-structural findings route per §3.D, never to unilateral restructure tickets.


### PR DESCRIPTION
Resolves #15770

The tech-debt-radar guide no longer stores a copy of the pattern canon — it derives its debt taxonomy from the living authorities at sweep time, and (per the cycle-1 review) keeps three classes explicitly separate: **authority** (what the canon prescribes), **observation** (what the tree currently is), and **hypothesis** (candidates awaiting an owning lane). §2 pre-flight loads: the ArchitectureOverview baseline and the `learn/agentos/decisions/` ADR index (minimum ADR 0019 for `ai/`-config debt, ADR 0008 for skill-shape debt) as *authority*; `npm run --silent ai:structure-map -- --files --loc` as *observation only* — current-tree measurement of where things ARE and how large, explicitly never "what belongs where" (observed placement is never its own authority); and the pr-review anti-pattern tables + the AGENTS.md `apps/**` gate as *authority* — with an authorities-win conflict rule and a freshness trigger (pattern-canon ADR graduations invalidate the pointer list). The two canon-inverted §3.C examples (defensive `?.` as a *goal*; nested daemon configs as *debt* — both inverted by ADR 0019) are gone; the multi-vector sweep method (KB traversal, Memory Core mining, vertical slicing) is preserved. New §3.D adds the Brain-structural sweep dimension across the two named executable roots (`ai/` vs `src/`, re-measured each sweep, never frozen as fact) with its mechanical probe recipe — structure-map LOC outliers scaled against the Body's densest exemplary files, `ai/daemons/*` folder-shape consistency, and concept-guide↔code-home coherence as a reportable CANDIDATE calibrated by the Dream Pipeline specimen (not a universal one-guide-one-home rule) — under the two-layer rule: observation producing hypotheses, routed to the #14304 / D#14302 canon lane, never prescribing module shapes or file moves pre-SSOT. §4 remediation routes through `/ticket-create`, which owns the volatile label taxonomy (no copied label rules remain) — the stale "intake bypass" framing is deleted. §1 is roster-neutral capability language; no model names remain anywhere in the skill.

Evidence: L2 (documentation-substrate change; mechanical gates runnable pre-merge: byte budget, manifest lint, guides lint, model-name scan) → L2 required (all close-target ACs are guide-content and byte-budget contracts verifiable in-sandbox). Residual: none.

## Slot Rationale (substrate-mutation gate, per pull-request-workflow §1.1)

- Modified section: the entire payload `references/tech-debt-radar-guide.md` — disposition **`rewrite`** (canon-inverted content replaced by derive-at-sweep-time pointers; one new pointer-shaped sweep dimension). Trigger-frequency: edge-case (loads only when the radar skill fires) × failure-severity: high when it does fire (an inverted radar files wrong-shape tickets) × enforceability: partially mechanical (byte budgets + manifest lint + model-name grep; taxonomy-derivation is DISCIPLINE-ONLY).
- Always-loaded surface (SKILL.md router): **byte-identical** — 786 B before and after; disposition `keep`, untouched.
- Decay mitigation: the root cause (copied canon) is removed structurally — the guide now names its own revalidation trigger (§2), so the substrate self-describes when it next needs review.

## /turn-memory-pre-flight Load-Effect Audit

- Map (always-loaded): `.agents/skills/tech-debt-radar/SKILL.md` — unchanged, 786 B, frontmatter description already roster-neutral.
- Atlas (conditionally loaded): `references/tech-debt-radar-guide.md` — 3,585 B → 4,076 B (+491 B; total skill 4,371 B → 4,862 B). The initial cycle landed at net −8 B; the cycle-1 review's required authority/observation/hypothesis separation added the delta, carried through AC 6's second branch (explicit decay-mitigation rationale: the separation prevents the observed-placement-becomes-canon inversion) + the manifest lint's `[skill-growth-justified: …]` commit tag (the commit message's +404 B estimate was mid-trim; +491 B is exact).
- Net always-loaded delta: **0 bytes**. Rule bodies live entirely in the conditional payload.

## Deltas from ticket

- Cycle-1 review (Euclid) falsified the ticket's own "mechanical what-belongs-where truth" framing of `ai:structure-map`: the generator enumerates the present tree and accepts no intended-policy input. Guide, ticket body, and ledger now classify it as observation; the authority/observation/hypothesis separation is stated in §2 and §3.D. The label taxonomy copy was dropped for the same volatile-canon reason. Net payload growth vs `dev` is +491 B (exact; the commit-message tag's +404 B was a mid-trim estimate), justified per the manifest lint's decay-mitigation path (`[skill-growth-justified: …]`) — the separation prevents the observed-placement-becomes-canon inversion; always-loaded delta stays 0 B.

- The optional freshness line (Fix item 7) is included in §2 rather than as a separate section — one sentence, no extra heading, keeps the byte budget.
- The guide keeps a one-line historical note in §3.C ("previous inline examples were canon-inverted by later ADRs") as the rationale for the derivation rule — a lesson pointer, not a copied list.

## Test Evidence

- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` — OK (per-file payload budget + net-delta caps + reference integrity).
- `node ai/scripts/lint/lint-guides.mjs` — 0 hard findings.
- `wc -c` byte budget: router 786 B (unchanged) + guide 4,076 B = 4,862 B vs 4,371 B baseline (AC 6, second branch: review-required separation carries the decay-mitigation rationale; `lint-skill-manifest --base origin/dev` OK with the justification tag).
- `grep -riE "gemini|claude|opus|gpt-|sonnet" .agents/skills/tech-debt-radar/` — zero matches (AC 5).
- Skill substrate has no runtime test surface; the mechanical gates above are the applicable evidence class. Directly touched app/feature surfaces: `None found` (documentation-only diff).

## Post-Merge Validation

- [ ] Next radar invocation (any agent): confirm the §2 derivation step produces a current taxonomy (ADR 0019 catalog + structure-map) and that findings in the Brain-structural class route to #14304/D#14302 instead of new restructure tickets.

## Evolution

None substantive — single-commit rewrite per the ticket's Fix list; the ticket itself carried the design (authored yesterday with two operator directives folded in).

Authored by Vega (Claude Fable 5, Claude Code). Session 2cca0fff-6354-4036-bfdd-fc3320938015.

