### PR TITLE
fix(claude): align stop-hook boilerplate with implemented key classes (#15778)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -248,7 +248,7 @@ Declaring a lane is NOT driving it. Do the next concrete action NOW:
 Teeth-test: does this advance a NAMED lane right now? If you can't name the lane, it isn't driving.
 Collaboration (review · ideation · A2A) counts ONLY when it advances a named lane AND ends with a return to your own lane or an explicit lane-swap — it is an interruption, not a replacement for your own PRs.
 Passive waiting (a merge · a review · CI) is parked, not driven — take another lane.
-Stop key: ship ONE material artifact — a PR opened, a formal review submitted, or an own-PR RC-response cycle — since your last accepted stop; artifact-less autonomous turns do not stop (transcript-verified, never prose).
+Stop key: ship ONE material artifact since your last accepted stop — a PR opened (a STANDALONE \`gh pr create\`; piped/chained/compound invocations never mint the key) or a formal review submitted (\`manage_pr_review\` create). Artifact-less autonomous turns do not stop (transcript-verified, never prose); an own-PR RC-response cycle is real work but not yet a key class.
 ${STOP_HOOK_TURN_OPTIONS_HINT}
 
 ${LANE_STATE_SCHEMA_HINT}`;


### PR DESCRIPTION
Resolves #15778

One-sentence alignment of the stop-hook's refuse-boilerplate with the material-artifact contract its collector actually implements. The old Stop-key sentence promised three minting classes; `ai/scripts/lifecycle/materialArtifactKey.mjs` freezes two (`pr-opened`, `formal-review`) and documents the own-PR RC-response cycle as a deliberate v1 deferral (line 16). The new sentence lists exactly the implemented classes, adds the one-clause standalone-invocation hint for `pr-opened` (piped/chained/compound `gh pr create` never mints — fail-closed by the collector's documented design), and names the RC-response cycle as real work that is not yet a key class. String-only: no collector, evaluator, or hook-logic change. This closes the invisible-refusal loop where an agent ships a promised artifact class in good faith, emits a valid terminal, and is refused with no visible reason — the live two-refusal specimen is documented on the ticket.

Evidence: L2 (string constant in agent-harness hook substrate; full hook + collector unit suites runnable in-sandbox) → L2 required (the AC surface is refusal-prose content and unchanged behavior). Residual: none.

## Deltas from ticket

None substantive — the shipped sentence follows the ticket's Fix item 1 with the "(planned, not yet a key)" option folded in as "not yet a key class".

## Test Evidence

- `hooks/laneStateStopHook.spec.mjs` + `ai/scripts/lifecycle/materialArtifactKey.spec.mjs` — 105 passed at `338df8b68f` (no spec pins the old prose; logic contracts untouched).
- `node --check .claude/hooks/laneStateStopHook.mjs` — OK (escaped backticks inside the template literal).
- Directly touched app/feature surfaces: `None found` (agent-harness hook prose only).

## Post-Merge Validation

- [ ] Next legitimate refusal in a live session shows the new Stop-key sentence; next standalone `gh pr create` in an autonomous continuation mints `pr-opened` and the stop is accepted with a `MATERIAL-ALLOW` audit line.

## Review note

Micro-change exception candidate per `pull-request-workflow.md §6.1`: 1 line changed, refusal-prose only, no runtime-behavior delta — stating it here rather than claiming a merge bypass; any peer veto stands.

Authored by Vega (Claude Fable 5, Claude Code). Session 2cca0fff-6354-4036-bfdd-fc3320938015.
