### PR TITLE
feat(testing): probe unit-suite CI wall-clock with workers 4 (#15783)

### DIFF
--- a/test/playwright/playwright.config.unit.mjs
+++ b/test/playwright/playwright.config.unit.mjs
@@ -22,7 +22,7 @@ export default defineConfig({
     fullyParallel: true,
     forbidOnly   : !!process.env.CI,
     retries      : process.env.CI ? 2 : 0,
-    workers      : process.env.CI ? 1 : undefined,
+    workers      : process.env.CI ? 4 : undefined,
     reporter     : [['json', {outputFile: path.join(__dirname, 'test-results/unit/test-results.json')}]],
     use          : {trace: 'on-first-retry'},
     projects     : [{


### PR DESCRIPTION
Resolves #15783

Measurement probe, one line: `workers: process.env.CI ? 1 : undefined` → `? 4` in [test/playwright/playwright.config.unit.mjs](test/playwright/playwright.config.unit.mjs). The CI unit job currently runs all 820 unit specs single-worker on a 4-vCPU public runner (~10-minute wall across recent runs, setup only ~25s); the line is unchanged since the config's creation (2025-10-12, `#7471`), while the isolation-by-construction substrate that makes parallelism plausible (per-process Chroma DB naming from the `#12335` fix, `UNIT_TEST_MODE` isolation per ADR 0019 B4, Playwright per-file worker processes) all landed after it. This PR exists to produce the numbers the ticket's verdict needs; it merges only through the ordinary review + human gate after the verdict, and a repeatable cross-file collision closes it unmerged in favor of naming the specific isolation defect it exposed.

Evidence: L2 achieved by this PR's own CI runs (the measurement IS the artifact: the config file is a non-docs path, so the classifier runs the full unit suite at this head; wall-clock + retry telemetry recorded on #15783 against the baseline runs cited there) → L2 required (the close-target ACs are CI-measurement contracts). Residual: the ≥2-run sample + verdict comment land on the ticket after CI completes (AC 2/3).

## Deltas from ticket

None substantive — the diff is exactly the ticket's prescribed single line.

## Test Evidence

- The probe's evidence surface is CI itself: `unit` job wall-clock + `retries: 2` telemetry at this head, ≥2 runs, recorded on #15783 next to the single-worker baselines (9:56 and 10:36 on 2026-07-24/23).
- Local single-worker runs remain unaffected (`workers: undefined` outside CI — unchanged).
- Directly touched app/feature surfaces: `None found` (test-infra config only).

## Post-Merge Validation

- [ ] First five post-merge `dev` unit runs: wall-clock stays in the measured band and no new flake class appears in retry telemetry (revert is a one-line restore if it does).

## Review note

Held for the #15783 verdict before any merge handoff: reviewer(s) should see the recorded measurements, not just the diff. Cross-family seat intentionally not requested until the data is on the ticket.

Authored by Vega (Claude Fable 5, Claude Code). Session 2cca0fff-6354-4036-bfdd-fc3320938015.
