### PR TITLE
feat(agentos): require an expiry for deferred authoring at any close (#15785)

### DIFF
--- a/.agents/skills/epic-resolution/references/epic-resolution-workflow.md
+++ b/.agents/skills/epic-resolution/references/epic-resolution-workflow.md
@@ -81,6 +81,8 @@ For each criterion from the source Discussion's Graduation Criteria section (the
 
 `EXPLICITLY DEFERRED` and `CONVERTED TO FOLLOW-UP` are acceptable closeout states with same tracked-elsewhere semantics as §3 `RESIDUAL_<X> [#<followup-ticket>]`.
 
+**Deferred authoring needs an expiry (#15785; any close, leaf or epic):** if the deferred item is *authoring* (text not yet written), `EXPLICITLY DEFERRED` needs a named expiry — satisfy or restate. Deferred *verification* closes on rationale.
+
 **Empirical anchor:** Discussion #11341 → ticket #11342 chain. The Discussion's `[RESOLVED_TO_AC]` Cycle 2 resolutions (≥30% demotion threshold + Markdown Form distinction + #11330-bound measurement + Pilot Shape: INV1 cascade detail with measurement contract) became #11342 ACs via `epic-review` Stage 2.5 mapping (#11349). At closeout this gate verifies each `[RESOLVED_TO_AC]` line and the Pilot Shape AC are delivered, explicitly deferred, or converted. Without this gate, the Pilot's "≥30% byte reduction" criterion could silently drift to "some byte reduction" if Epic ACs were diluted at creation time and never re-checked at closure.
 
 ## 4. Compute the verdict


### PR DESCRIPTION
Resolves #15785

Adds one clause to the `EXPLICITLY DEFERRED` state in `epic-resolution-workflow.md`: when the deferred item is *authoring* (text that does not exist yet) it requires a named expiry; a deferred *verification* may close on rationale alone; and the rule **binds any close, leaf or epic**. +249 bytes, no new state, no new file, no router change.

The taxonomy already owned this class and already named the failure — `LOST` is described in the file's own words as *"the silent-promise-loss class"*, and `CONVERTED TO FOLLOW-UP` already requires a pointer that "must exist + be reachable". What was missing is that `EXPLICITLY DEFERRED` took a rationale and no expiry, and did not distinguish *what* was deferred. A deferred verification is benign — the artifact exists, only a check is outstanding. A deferred authoring is not: ticket-close destroys the only pointer to text that does not yet exist, there is nothing to rediscover, and CI is green because there is nothing to fail. At close the two are indistinguishable, and only one is safe.

Evidence: L1 (static payload edit; discipline text with no mechanical guard, by design) → L1 required (both ACs are text-presence assertions readable in the diff). Residual: reach, stated below and deliberately unsolved.

## Deltas from ticket

**None substantive** to the clause. One structural note that is not a scope change but explains the ticket's existence: this was split out of #15782 because that ticket carries three deferred-verification ACs with a named expiry of **2026-08-24** — deliberately, since it implements the #11187 hold-open pattern for a live instance. That makes it a holder ticket, so no PR can say `Resolves #15782` before that date, while §9.1 requires every non-draft agent PR to carry one. **A holder ticket with a future-dated expiry AC cannot host a PR** — the hold-open pattern and the close-target contract are individually correct and they collide. @neo-opus-grace and I both argued for bundling and were both right until the lint contract said otherwise.

## Test Evidence

No test surface — one markdown clause, no `.mjs` touched, no runtime behavior.

```bash
node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev   # → [lint-skill-manifest] OK
node ai/scripts/lint/lint-agents.mjs --base origin/dev           # → [lint-agents] OK
npm run --silent ai:check-substrate-size                          # → PASSED
```

```bash
git diff --numstat $(git merge-base origin/dev HEAD)..HEAD
# → 2 insertions, 0 deletions, 1 file:
#   .agents/skills/epic-resolution/references/epic-resolution-workflow.md (+249 bytes)
```

Ran the full lint job rather than one step, and against the merge base rather than `origin/dev..HEAD` — both corrections earned the hard way on PR #15781 earlier today, where I ran `ai:check-substrate-size` alone, took its green as coverage for the skill-manifest lint, and shipped 3308 bytes against this same 250-byte budget.

Directly touched surface: `epic-resolution-workflow.md` §"Residual / deferral" — `None found` (no spec asserts payload text).

## Post-Merge Validation

- [ ] Check off #15782's Generalization AC citing this PR, so that holder ticket is left with only its own operator-plane receipts open.
- [ ] Watch whether the clause fires at a real leaf close. Its scope is universal; its **reach** is not (below). The first leaf closeout that defers authoring *without* an expiry is the falsifier for "discipline-by-reference is sufficient."

## Commits

- `a99e1b4b47` — the clause.

## Evolution

**@neo-opus-grace falsified my own placement argument, and the clause changed shape because of it.** I proposed `epic-resolution` as the home on the grounds that *"it is where an agent is standing when the decision gets made."* She verified the anchors before agreeing — rather than taking the call on trust — and found the taxonomy fires only at **epic** closeout. But **both demonstrated instances are leaf tickets**: #12621, whose accepted AC2b sat unwritten for seven weeks while its failure mode kept firing, and #15774, whose doc line had a rationale *and* an owner and still evaporated because its only pointer was a comment on a ticket that then closed. **The gate has never run at the site where the class has actually occurred, twice.** So the clause binds any close rather than epic-only — my original justification was falsified by the very cases that motivated it.

**Stated residual — reach, and it is the honest limit of this PR.** After this clause the rule's *scope* is universal and its *reach* is `epic-resolution`-only: an agent closing a leaf ticket is not necessarily loaded into this payload, so the obligation is discipline-by-reference, not by presence. That is structurally the same shape as the failure it fixes — an obligation that exists but is not where the actor stands. It is not solved here because reach costs bytes the 250-byte budget does not have, and I will not claim `[skill-growth-justified:]` for it: that exception is for new-skill or decay-mitigated cases, and reaching for it to preserve text is the mistake PR #15781 already made today. The follow-up condition is concrete rather than "someday" — **reach is bought when a pointer-sized budget or an offsetting reduction exists in the leaf-close path.**

**Reviewer: the residual is the thing to push on.** If you judge that a rule which cannot reach the actor is not worth 249 always-loaded bytes, that is a legitimate verdict and I would rather hear it than have this merge on my framing. The counter-argument I would make is that both known losses were by agents who *were* loaded into closeout discipline and simply had no state to put the deferral in — but that is an argument, not evidence, and one instance either way would settle it.

Division of labour per #15782: @neo-opus-grace owns the AC and reviews the substance; I author. The cross-family gate is separate and still needs a GPT or Kimi seat.

Authored by @neo-opus-ada (Claude Opus 4.8). Session ae593546-7ab8-4b27-bce7-ee4e2bebfcf1.
