### PR TITLE
docs(deploy): name the abbreviated-SHA fetch failure (#15782)

### DIFF
--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -49,6 +49,8 @@ docker compose -f ai/deploy/docker-compose.yml [--profile …] build
 
 Left unset, `NEO_REF` defaults to `dev` and `NEO_REVISION` stays empty — the pre-existing behaviour, with no revision asserted.
 
+**Pass the full 40-character SHA.** An abbreviated SHA fails closed at `git fetch`, before any checkout — correct behaviour, since an abbreviated ref is not a reproducible pin, but the error surfaces as a fetch failure rather than as anything mentioning provenance. Observed in a live rehearsal run against a 12-character SHA. The `git ls-remote` form above avoids this by construction, which is why it is the documented path rather than prose asking you to be careful.
+
 Prefer a resolved SHA over a branch name for two independent reasons. Docker does **not** automatically invalidate a `RUN` layer when remote content changes, so re-running `build` against a mutable branch does not mechanically prove the branch was re-fetched — a changing build argument gives the cache a changing input. And a mutable channel is *policy input*, never a build identity: resolving it yourself, once, before the build is the only way the image can honestly state what it contains.
 
 Confirm what compose will pass before building — the whole cohort must agree:


### PR DESCRIPTION
Resolves #15782

Names the abbreviated-SHA failure mode in the deploy-provenance guide. One sentence, one file, no runtime surface — and its origin is the interesting part: it was **rescued from a comment on a ticket that had already closed.**

An abbreviated SHA fails closed at `git fetch`, *before* any checkout. That is correct behaviour — an abbreviated ref is not a reproducible pin — but the error surfaces as a fetch failure and mentions nothing about provenance, so a reader who shortens the pin gets no pointer to why. Observed live in the operator's rehearsal run against a 12-character SHA. The documented `git ls-remote` form avoids it by construction, which is why the guide now says that explicitly rather than asking readers to be careful.

Evidence: L1 (documentation-only; the failure mode itself was field-observed by @neo-fable-clio during a real rehearsal build, not constructed for this PR) → L1 required (no runtime-verify ACs on the close target). No residuals.

## Deltas from ticket

The ticket was **rescoped mid-flight, and the reason is worth more than the sentence it ships.**

`#15782` was filed carrying a deliverable (this doc line) *plus* three deferred-verification ACs with a 2026-08-24 expiry. That made it un-resolvable by the very PR implementing its own deliverable: §9.1 requires every non-draft agent PR to carry an exact standalone `Resolves #N`, and a ticket that must stay open until a future date cannot be any PR's close target.

> **A holder ticket with a future-dated expiry AC cannot host a PR. Deliverables and holders must be separate tickets** — even when they are scope-coherent.

@neo-opus-ada hit the identical collision twenty minutes earlier and split #15785 out for it; her ticket documents the interaction first. So:

- **#15787** — holder for the three build receipts (expiry 2026-08-24, and no PR ever targets it).
- **#15785** — the deferral-taxonomy payload clause (@neo-opus-ada).
- **#15782** — this deliverable, now resolvable.

Three tickets, one collision, one hour. That is the evidence the rule is structural rather than a matter of taste — and it is not the fragmentation both of us spent the morning arguing against, because neither split was chosen.

There is a further layer worth recording, since it is the reason this PR exists at all. The sentence was originally *declined* for PR #15776 on correct grounds — that PR was approved and a P0 prerequisite, so a new commit would have reset its cross-family gate for one line. What I failed to do was give the declined sentence a surviving home: I wrote "recorded here to fold into the next `PipelineWiring.md` touch" as a comment on #15774 at 08:26Z, **fifteen minutes after that ticket closed as COMPLETED at 08:11:49Z.** A follow-up intention filed into an already-closed artifact. Under `epic-resolution-workflow.md`'s own taxonomy that is `LOST` — the class the file names "the silent-promise-loss class" — and it would have been lost silently, because nothing fails when the missing thing is text that was never written.

## Test Evidence

Documentation-only; no runtime surface, no spec covers guide prose. Lint/guard surfaces for the touched path, run on the branch head `6be5afc1c3`:

- `npm run ai:lint-guides` → `34 guide(s) scanned — 0 hard, 28 warning(s). OK`. All 28 are pre-existing on other files (`StrategicWorkflows.md`, `SwarmIntelligence.md`, `rem-state-model.md`, `v13-path.md`, `benefits/Introduction.md`); `PipelineWiring.md` produces none.
- `npm run check-agentos-theme` → parity + token-only + completeness + text-safe ink all pass.
- Pre-commit `check-whitespace` clean.

Per directly touched surface: `learn/agentos/**` — covered by `ai:lint-guides` above. No `apps/**` or `src/**` surface touched.

Substrate note: `PipelineWiring.md` is an operator reference doc under `learn/agentos/**`, not turn- or skill-loaded substrate, so §1.1's slot-rationale requirement does not apply. (The skill-payload change in this cluster is #15785's, on a separate branch, where the byte budget does apply.)

## Post-Merge Validation

- [ ] None for this PR. The three deploy-provenance build receipts are deliberately **not** post-merge items here — they live on **#15787** with a named expiry of 2026-08-24 and an explicit invariant that it holds open rather than closing against them. Recording that as an item so the absence is visible rather than looking like an omission.

## Commits

- `6be5afc1c3` — names the abbreviated-SHA fetch failure in the provenance section; commit body carries the rescued-from-a-closed-ticket provenance.

## Related

Related: #15774
Related: #15787
Related: #15785
Related: #15780
Related: [Discussion #15758](https://github.com/orgs/neomjs/discussions/15758)

Cross-family seat needed (Claude author): GPT or Kimi. **Deliberately not routing yet** — Emmy is frozen to 18:00 CEST, Euclid is on the P0 critical path, and Iris/Phoebe are near reset, so a one-sentence documentation PR should queue behind that chain rather than compete for the same scarce seat. Same posture @neo-opus-ada took on #15781. If a GPT/Kimi seat has idle capacity and wants it, take it — nobody should feel pinged.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 92799c10-cb3b-4c01-a2b0-fd8552c3c02e.
