### PR TITLE
fix(deploy): pin the deployed revision in the reference pipeline (#15792)

### DIFF
--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -40,7 +40,40 @@ fi
 
 compose() { docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" "${profile_args[@]}" "$@"; }
 
-echo "[deploy] revision: $(git -C "$SCRIPT_DIR" describe --tags --always 2>/dev/null || echo unknown)"
+# Resolve the deployed revision BEFORE Docker runs (#15792). Every run pins:
+# there is deliberately no unpinned path, because this is the reference pipeline
+# and its default is what propagates to every downstream deployment.
+#
+# BOTH args are exported, not just NEO_REVISION. NEO_REVISION only feeds the OCI
+# revision LABEL; the source stage fetches ${NEO_REF}. Exporting only NEO_REVISION
+# would stamp a resolved SHA onto an image whose source stage fetched a mutable
+# channel — a label asserting a fact the artifact does not hold, and the cache
+# input would not change, so `--build` might not even re-fetch.
+NEO_SELECTOR="${NEO_REF:-dev}"
+NEO_REPO_URL="${NEO_REPO_URL:-https://github.com/neomjs/neo.git}"
+
+if [[ "$NEO_SELECTOR" =~ ^[0-9a-f]{40}$ ]]; then
+    resolved_revision="$NEO_SELECTOR"
+else
+    # A channel/tag, or an abbreviated SHA (which `git fetch` would reject anyway
+    # — see PipelineWiring.md). Resolve it to exactly one full SHA or abort.
+    matches="$(git ls-remote "$NEO_REPO_URL" "$NEO_SELECTOR" 2>/dev/null | awk '{print $1}' || true)"
+    match_count="$(printf '%s' "$matches" | grep -c . || true)"
+
+    if [ "$match_count" -ne 1 ]; then
+        echo "[deploy] FATAL: selector '${NEO_SELECTOR}' resolved to ${match_count} refs at ${NEO_REPO_URL}; expected exactly 1." >&2
+        echo "[deploy] Pass a full 40-character SHA, or a selector that names exactly one ref. Docker was NOT invoked." >&2
+        exit 1
+    fi
+    resolved_revision="$matches"
+fi
+
+export NEO_REF="$resolved_revision"
+export NEO_REVISION="$resolved_revision"
+
+echo "[deploy] selector:     $NEO_SELECTOR"
+echo "[deploy] revision:     $resolved_revision   <- built into the images"
+echo "[deploy] host-checkout: $(git -C "$SCRIPT_DIR" describe --tags --always 2>/dev/null || echo unknown)   (this host only; NOT what is deployed)"
 echo "[deploy] compose:  $COMPOSE_FILE"
 echo "[deploy] project:  $PROJECT_NAME"
 echo "[deploy] profiles: ${profile_args[*]}"

--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -53,7 +53,42 @@ NEO_SELECTOR="${NEO_REF:-dev}"
 NEO_REPO_URL="${NEO_REPO_URL:-https://github.com/neomjs/neo.git}"
 
 if [[ "$NEO_SELECTOR" =~ ^[0-9a-f]{40}$ ]]; then
-    resolved_revision="$NEO_SELECTOR"
+    # A 40-hex string is an OBJECT id — NOT necessarily a commit, and not necessarily
+    # present on the remote at all. Trusting its shape was the last hiding place of the
+    # original defect: an annotated-TAG object id is 40 hex, and the Dockerfile's
+    # `git fetch …; git checkout --detach FETCH_HEAD; git rev-parse HEAD` peels it to the
+    # commit — so the label would attest the tag object while /app/.neo-revision records
+    # the commit. A nonexistent 40-hex id would likewise sail past the fail-before-Docker
+    # contract and only break inside the build.
+    #
+    # So prove it against the remote with the SAME sequence the Dockerfile runs, and export
+    # what that sequence resolves to. `^{commit}` both asserts commit-ness and performs the
+    # peel; a tag object resolves to its commit, a tree or blob fails, and an absent id fails
+    # at fetch. Shallow + a throwaway dir keeps it cheap; the pipeline already hits the network.
+    probe_dir="$(mktemp -d)"
+    trap 'rm -rf "$probe_dir"' EXIT INT TERM
+
+    if ! git -C "$probe_dir" init --quiet >/dev/null 2>&1 \
+       || ! git -C "$probe_dir" fetch --quiet --depth=1 "$NEO_REPO_URL" "$NEO_SELECTOR" >/dev/null 2>&1; then
+        echo "[deploy] FATAL: 40-char id '${NEO_SELECTOR}' could not be fetched from ${NEO_REPO_URL}." >&2
+        echo "[deploy] It is absent, unreachable, or the remote refuses by-id fetches. Docker was NOT invoked." >&2
+        exit 1
+    fi
+
+    resolved_revision="$(git -C "$probe_dir" rev-parse --verify --quiet 'FETCH_HEAD^{commit}' 2>/dev/null || true)"
+
+    if [ -z "$resolved_revision" ]; then
+        echo "[deploy] FATAL: 40-char id '${NEO_SELECTOR}' is not a commit and has no commit to peel to." >&2
+        echo "[deploy] Pass a commit id or an annotated tag name. Docker was NOT invoked." >&2
+        exit 1
+    fi
+
+    if [ "$resolved_revision" != "$NEO_SELECTOR" ]; then
+        # The selector was a tag object (or otherwise peelable). Say so: the operator asked for
+        # one id and the images will carry another, and a silent substitution here is the exact
+        # provenance lie this ticket exists to remove.
+        echo "[deploy] note: '${NEO_SELECTOR}' peeled to commit ${resolved_revision} — the commit is what gets built and attested." >&2
+    fi
 else
     # A channel/tag, or an abbreviated SHA (which `git fetch` would reject anyway
     # — see PipelineWiring.md). Resolve it to exactly one full COMMIT id or abort.

--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -69,19 +69,27 @@ else
     # returns `refs/tags/v9.9.9^{}` (the commit). A `refs/tags/<sel>*` glob would work too
     # but can over-match (`v9.9.9-rc1`), turning one tag into a false ambiguity abort.
     ls_remote="$(git ls-remote "$NEO_REPO_URL" "$NEO_SELECTOR" "${NEO_SELECTOR}^{}" 2>/dev/null || true)"
-    peeled="$(printf '%s\n' "$ls_remote" | awk '$2 ~ /\^\{\}$/ {print $1}')"
+    # Ambiguity is decided on the NON-PEEL refs, never after peeling. A selector can match
+    # BOTH a branch and an annotated tag (`refs/heads/X` + `refs/tags/X` + `refs/tags/X^{}`)
+    # — git itself treats that as ambiguous. Preferring the peel first would collapse three
+    # lines to one and silently deploy the tag while ignoring the branch, bypassing this abort.
+    plain_refs="$(printf '%s\n' "$ls_remote" | awk '$2 != "" && $2 !~ /\^\{\}$/ {print $2}')"
+    match_count="$(printf '%s' "$plain_refs" | grep -c . || true)"
 
-    if [ -n "$peeled" ]; then
-        # Annotated tag: the peel IS the deployed commit.
-        matches="$peeled"
-    else
-        # Branch, lightweight tag, or full ref — these point at commits directly.
-        matches="$(printf '%s\n' "$ls_remote" | awk '$2 !~ /\^\{\}$/ {print $1}')"
+    if [ "$match_count" -eq 1 ]; then
+        # Exactly one ref matched. Resolve it to a COMMIT: an annotated tag contributes a
+        # `^{}` peel, everything else already points at a commit.
+        peeled="$(printf '%s\n' "$ls_remote" | awk -v r="$plain_refs" '$2 == r "^{}" {print $1}')"
+
+        if [ -n "$peeled" ]; then
+            matches="$peeled"
+        else
+            matches="$(printf '%s\n' "$ls_remote" | awk -v r="$plain_refs" '$2 == r {print $1}')"
+        fi
     fi
-    match_count="$(printf '%s' "$matches" | grep -c . || true)"
 
     if [ "$match_count" -ne 1 ]; then
-        echo "[deploy] FATAL: selector '${NEO_SELECTOR}' resolved to ${match_count} commits at ${NEO_REPO_URL}; expected exactly 1." >&2
+        echo "[deploy] FATAL: selector '${NEO_SELECTOR}' matched ${match_count} refs at ${NEO_REPO_URL}; expected exactly 1." >&2
         echo "[deploy] Pass a full 40-character commit SHA, or a selector naming exactly one ref. Docker was NOT invoked." >&2
         exit 1
     fi

--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -56,13 +56,28 @@ if [[ "$NEO_SELECTOR" =~ ^[0-9a-f]{40}$ ]]; then
     resolved_revision="$NEO_SELECTOR"
 else
     # A channel/tag, or an abbreviated SHA (which `git fetch` would reject anyway
-    # — see PipelineWiring.md). Resolve it to exactly one full SHA or abort.
-    matches="$(git ls-remote "$NEO_REPO_URL" "$NEO_SELECTOR" 2>/dev/null | awk '{print $1}' || true)"
+    # — see PipelineWiring.md). Resolve it to exactly one full COMMIT id or abort.
+    #
+    # An ANNOTATED tag advertises two lines: the tag object at `refs/tags/X` and the
+    # peeled commit at `refs/tags/X^{}`. Docker checks out the peeled commit, so the
+    # tag-object id would make NEO_REVISION disagree with /app/.neo-revision — the
+    # label attesting an object that is not the deployed source. A 40-char git object
+    # id is not necessarily a COMMIT id. Prefer the peel; never the tag object.
+    ls_remote="$(git ls-remote "$NEO_REPO_URL" "$NEO_SELECTOR" 2>/dev/null || true)"
+    peeled="$(printf '%s\n' "$ls_remote" | awk '$2 ~ /\^\{\}$/ {print $1}')"
+
+    if [ -n "$peeled" ]; then
+        # Annotated tag: the peel IS the deployed commit.
+        matches="$peeled"
+    else
+        # Branch, lightweight tag, or full ref — these point at commits directly.
+        matches="$(printf '%s\n' "$ls_remote" | awk '$2 !~ /\^\{\}$/ {print $1}')"
+    fi
     match_count="$(printf '%s' "$matches" | grep -c . || true)"
 
     if [ "$match_count" -ne 1 ]; then
-        echo "[deploy] FATAL: selector '${NEO_SELECTOR}' resolved to ${match_count} refs at ${NEO_REPO_URL}; expected exactly 1." >&2
-        echo "[deploy] Pass a full 40-character SHA, or a selector that names exactly one ref. Docker was NOT invoked." >&2
+        echo "[deploy] FATAL: selector '${NEO_SELECTOR}' resolved to ${match_count} commits at ${NEO_REPO_URL}; expected exactly 1." >&2
+        echo "[deploy] Pass a full 40-character commit SHA, or a selector naming exactly one ref. Docker was NOT invoked." >&2
         exit 1
     fi
     resolved_revision="$matches"

--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -63,7 +63,12 @@ else
     # tag-object id would make NEO_REVISION disagree with /app/.neo-revision — the
     # label attesting an object that is not the deployed source. A 40-char git object
     # id is not necessarily a COMMIT id. Prefer the peel; never the tag object.
-    ls_remote="$(git ls-remote "$NEO_REPO_URL" "$NEO_SELECTOR" 2>/dev/null || true)"
+    # BOTH patterns, and this is load-bearing: an EXACT pattern never elicits the peel.
+    # Verified against a disposable annotated-tag repo — `ls-remote <url> v9.9.9` returns
+    # only `refs/tags/v9.9.9` (the tag object); `ls-remote <url> v9.9.9 'v9.9.9^{}'` also
+    # returns `refs/tags/v9.9.9^{}` (the commit). A `refs/tags/<sel>*` glob would work too
+    # but can over-match (`v9.9.9-rc1`), turning one tag into a false ambiguity abort.
+    ls_remote="$(git ls-remote "$NEO_REPO_URL" "$NEO_SELECTOR" "${NEO_SELECTOR}^{}" 2>/dev/null || true)"
     peeled="$(printf '%s\n' "$ls_remote" | awk '$2 ~ /\^\{\}$/ {print $1}')"
 
     if [ -n "$peeled" ]; then

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -35,6 +35,15 @@ Do not redeploy on every commit. The Agent OS deployment is a stateful service; 
 
 Avoid "deploy on every push to `dev`": it couples MCP availability to ordinary development cadence.
 
+**Pass the gating signal to the deploy script — it does not infer it.** Checking out a release tag in the CI job is not enough: [`deploy-pipeline.sh`](../../../ai/examples/cloud-deployment/deploy-pipeline.sh) resolves `NEO_REF` (default `dev`), **not** the job's checked-out ref, so a tag-triggered job that omits it deploys `dev` while its workspace sits on the tag. Hand the selector over explicitly:
+
+```bash
+# tag-triggered job: deploy the tag that fired it, not the default channel
+NEO_REF="$CI_COMMIT_TAG" ai/examples/cloud-deployment/deploy-pipeline.sh
+```
+
+The script resolves that selector to a full commit id before Docker runs, and **peels annotated tags** — the tag object is never attested as the deployed revision. Substitute your CI's tag variable (`GITHUB_REF_NAME`, `CI_COMMIT_TAG`, …); for a protected-branch or manual-dispatch trigger, pass the branch or an operator-supplied SHA the same way.
+
 ## Deployed-revision provenance
 
 Release-gating chooses *which* revision to deploy. This section is how the deployment **proves** which revision it actually runs — a separate problem, and the one that lets a stale stack look healthy.

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -72,6 +72,9 @@ async function createFakeBin(plainLines, peelLine = '') {
         'if [ "$1" = "-C" ] && [ "$3" = "init" ]; then exit 0; fi',
         'if [ "$1" = "-C" ] && [ "$3" = "fetch" ]; then [ -n "$FAKE_FETCH_FAILS" ] && exit 128; exit 0; fi',
         'if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ]; then',
+        // Require the load-bearing peel expression: returning FAKE_PEEL_TO for plain FETCH_HEAD
+        // would let the annotated-tag test stay green while production reintroduced the tag-object bug.
+        '    [ "${@: -1}" != "FETCH_HEAD^{commit}" ] && exit 1',
         '    [ -z "$FAKE_PEEL_TO" ] && exit 1',
         '    printf \'%s\\n\' "$FAKE_PEEL_TO"; exit 0',
         'fi',

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -124,7 +124,7 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
 
         expect(result.code).not.toBe(0);
         expect(result.output).toContain('no-such-branch');
-        expect(result.output).toContain('resolved to 0 commits');
+        expect(result.output).toContain('matched 0 refs');
         // The whole point: an unresolvable selector must never reach a build.
         expect(await dockerInvocations(fake.dockerLog)).toBe(0)
     });
@@ -137,7 +137,7 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
             result   = runPipeline(fake, 'ambiguous');
 
         expect(result.code).not.toBe(0);
-        expect(result.output).toContain('resolved to 2 commits');
+        expect(result.output).toContain('matched 2 refs');
         expect(await dockerInvocations(fake.dockerLog)).toBe(0)
     });
 
@@ -215,6 +215,26 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         // The tag object must never be attested as the deployed revision.
         expect(log).not.toContain(TAG_OBJECT);
         expect(result.output).not.toContain(TAG_OBJECT)
+    });
+
+    test('a branch + annotated-tag collision ABORTS instead of silently picking the tag', async () => {
+        // git itself treats `refs/heads/X` + `refs/tags/X` as ambiguous. Deciding ambiguity AFTER
+        // peeling would collapse three advertised lines to one and deploy the tag while ignoring
+        // the branch — an abort bypass created by the peel preference itself.
+        const
+            BRANCH_COMMIT = 'b1b1b10000000000000000000000000000000000',
+            TAG_OBJECT    = 'c2c2c20000000000000000000000000000000000',
+            TAG_COMMIT    = 'd3d3d30000000000000000000000000000000000',
+            fake          = await createFakeBin(
+                `${BRANCH_COMMIT}\trefs/heads/collide\n${TAG_OBJECT}\trefs/tags/collide`,
+                `${TAG_COMMIT}\trefs/tags/collide^{}`
+            ),
+            result = runPipeline(fake, 'collide');
+
+        expect(result.code).not.toBe(0);
+        expect(result.output).toContain('matched 2 refs');
+        // Nothing may be deployed, and no candidate may be attested.
+        expect(await dockerInvocations(fake.dockerLog)).toBe(0)
     });
 
     test('a lightweight tag (single line, no peel) still resolves', async () => {

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect} from '@playwright/test';
-import {execFileSync} from 'node:child_process';
+import {execFileSync, spawnSync} from 'node:child_process';
 import fs             from 'node:fs/promises';
 import os             from 'node:os';
 import path           from 'node:path';
@@ -104,30 +104,34 @@ async function createFakeBin(plainLines, peelLine = '') {
  * @returns {Object} `{code, output}`.
  */
 function runPipelineWithProbe(fake, selector, {fetchFails = false, peelTo = ''} = {}) {
-    try {
-        // `2>&1` is load-bearing: the peel note is a WARNING on stderr, and execFileSync discards
-        // stderr on the success path — so without merging, an assertion about it could never pass
-        // even when the script emits it correctly. Same wrong-channel mistake as observing argv
-        // when the payload travels as env; the failure paths read `error.stderr` and are unaffected.
-        const output = execFileSync('bash', ['-c', '"$0" 2>&1', scriptPath], {
-            cwd     : repoRoot,
-            encoding: 'utf8',
-            env     : {
-                ...process.env,
-                FAKE_FETCH_FAILS: fetchFails ? '1' : '',
-                FAKE_LS_PEEL    : '',
-                FAKE_LS_PLAIN   : '',
-                FAKE_PEEL_TO    : peelTo,
-                NEO_REF         : selector,
-                PATH            : `${fake.bin}:${process.env.PATH}`
-            },
-            stdio: ['ignore', 'pipe', 'pipe']
-        });
+    // `spawnSync` rather than `execFileSync`, and NO shell. Both streams are needed on the SUCCESS
+    // path too — the peel note is a stderr WARNING, and `execFileSync` discards stderr when the
+    // command succeeds, so an assertion about it could never pass even when the script emits it
+    // correctly (the same wrong-channel mistake as observing argv when the payload travels as env).
+    // The obvious fix, `bash -c '"$0" 2>&1'`, builds a shell command out of `scriptPath` — which is
+    // derived from `process.cwd()` — and CodeQL correctly flagged that as a shell command built from
+    // an uncontrolled absolute path. `spawnSync` returns `{status, stdout, stderr}` on both paths, so
+    // it removes the shell AND the try/catch instead of sanitising an interpolation.
+    const result = spawnSync('bash', [scriptPath], {
+        cwd     : repoRoot,
+        encoding: 'utf8',
+        env     : {
+            ...process.env,
+            FAKE_FETCH_FAILS: fetchFails ? '1' : '',
+            FAKE_LS_PEEL    : '',
+            FAKE_LS_PLAIN   : '',
+            FAKE_PEEL_TO    : peelTo,
+            NEO_REF         : selector,
+            PATH            : `${fake.bin}:${process.env.PATH}`
+        },
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
 
-        return {code: 0, output}
-    } catch (error) {
-        return {code: error.status ?? 1, output: `${error.stdout ?? ''}${error.stderr ?? ''}`}
+    if (result.error) {
+        throw result.error
     }
+
+    return {code: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}`}
 }
 
 /**

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -1,0 +1,157 @@
+import {test, expect} from '@playwright/test';
+import {execFileSync} from 'node:child_process';
+import fs             from 'node:fs/promises';
+import os             from 'node:os';
+import path           from 'node:path';
+import process        from 'node:process';
+
+/**
+ * Guards the revision-pinning contract of `ai/examples/cloud-deployment/deploy-pipeline.sh`.
+ *
+ * WHY this is a unit spec and not an integration one: every assertion here is about what the script
+ * decides BEFORE Docker runs. Faking `git` and `docker` on `PATH` keeps the whole contract testable
+ * with no Docker daemon and no network — which matters because no agent sandbox has a reachable
+ * daemon, and CI's integration lane builds `ai/deploy/docker-compose.test.yml`, a different stack
+ * that never exercises this script.
+ *
+ * The load-bearing assertion is NEGATIVE: on any unresolvable selector the script must exit non-zero
+ * having never invoked Docker. A pipeline that resolves ambiguously and then builds anyway is worse
+ * than one that fails, because it produces an image whose provenance labels assert a revision nobody
+ * chose. `fakeDocker` therefore appends to a log file, and the failure cases assert that log is empty.
+ *
+ * The positive case guards the other half of the contract: BOTH `NEO_REF` and `NEO_REVISION` must reach
+ * Compose as the resolved SHA. Exporting only `NEO_REVISION` would label the image with a resolved
+ * revision while the Dockerfile's source stage still fetched `${NEO_REF}` — a label asserting a fact
+ * the artifact does not hold, and an unchanged cache input so `--build` might not even re-fetch.
+ */
+
+const
+    repoRoot   = path.resolve(process.cwd()),
+    scriptPath = path.join(repoRoot, 'ai/examples/cloud-deployment/deploy-pipeline.sh'),
+    FULL_SHA   = '6be5afc1c30000000000000000000000000000aa';
+
+/**
+ * Builds a throwaway bin dir whose `git` and `docker` shadow the real ones on `PATH`.
+ * `fake-git ls-remote` echoes `lsRemote` verbatim so a spec can stage zero, one, or many refs.
+ * `fake-docker` records every invocation, so "Docker was never called" is an assertable fact
+ * rather than an inference from the exit code.
+ * @param {String} lsRemote Raw `git ls-remote` stdout to stage (empty string = zero matches).
+ * @returns {Promise<Object>} `{bin, dockerLog}` paths.
+ */
+async function createFakeBin(lsRemote) {
+    const
+        bin       = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-deploy-pin-')),
+        dockerLog = path.join(bin, 'docker-invocations.log');
+
+    await fs.writeFile(path.join(bin, 'git'), [
+        '#!/usr/bin/env bash',
+        // Only ls-remote is contract-relevant; `describe` keeps the host-checkout log line working.
+        'if [ "$1" = "ls-remote" ]; then printf \'%s\' "$FAKE_LS_REMOTE"; exit 0; fi',
+        'if [ "$1" = "-C" ] && [ "$3" = "describe" ]; then echo "fake-describe"; exit 0; fi',
+        'exit 0'
+    ].join('\n'), {mode: 0o755});
+
+    await fs.writeFile(path.join(bin, 'docker'), [
+        '#!/usr/bin/env bash',
+        `echo "invoked: $*" >> ${JSON.stringify(dockerLog)}`,
+        'exit 0'
+    ].join('\n'), {mode: 0o755});
+
+    await fs.writeFile(dockerLog, '');
+
+    return {bin, dockerLog, lsRemote}
+}
+
+/**
+ * Runs the pipeline script with a faked `PATH`, never throwing on non-zero exit so the spec can
+ * assert on the code and the streams together.
+ * @param {Object} fake The `createFakeBin` result.
+ * @param {String} selector Value for `NEO_REF`.
+ * @returns {Object} `{code, output}`.
+ */
+function runPipeline(fake, selector) {
+    try {
+        const output = execFileSync('bash', [scriptPath], {
+            cwd     : repoRoot,
+            encoding: 'utf8',
+            env     : {
+                ...process.env,
+                FAKE_LS_REMOTE: fake.lsRemote,
+                NEO_REF       : selector,
+                PATH          : `${fake.bin}:${process.env.PATH}`
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+
+        return {code: 0, output}
+    } catch (error) {
+        return {code: error.status ?? 1, output: `${error.stdout ?? ''}${error.stderr ?? ''}`}
+    }
+}
+
+/**
+ * @param {String} dockerLog
+ * @returns {Promise<Number>} Count of recorded Docker invocations.
+ */
+async function dockerInvocations(dockerLog) {
+    const contents = await fs.readFile(dockerLog, 'utf8');
+
+    return contents.split('\n').filter(Boolean).length
+}
+
+test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
+    test('a selector matching zero refs fails closed without invoking Docker', async () => {
+        const fake   = await createFakeBin(''),
+              result = runPipeline(fake, 'no-such-branch');
+
+        expect(result.code).not.toBe(0);
+        expect(result.output).toContain('no-such-branch');
+        expect(result.output).toContain('resolved to 0 refs');
+        // The whole point: an unresolvable selector must never reach a build.
+        expect(await dockerInvocations(fake.dockerLog)).toBe(0)
+    });
+
+    test('an ambiguous selector matching many refs fails closed without invoking Docker', async () => {
+        const
+            manyRefs = `aaaa111111111111111111111111111111111111\trefs/heads/x\n` +
+                       `bbbb222222222222222222222222222222222222\trefs/heads/y`,
+            fake     = await createFakeBin(manyRefs),
+            result   = runPipeline(fake, 'ambiguous');
+
+        expect(result.code).not.toBe(0);
+        expect(result.output).toContain('resolved to 2 refs');
+        expect(await dockerInvocations(fake.dockerLog)).toBe(0)
+    });
+
+    test('an abbreviated SHA fails closed — an abbreviated ref is not a reproducible pin', async () => {
+        const fake   = await createFakeBin(''),
+              result = runPipeline(fake, FULL_SHA.slice(0, 10));
+
+        expect(result.code).not.toBe(0);
+        expect(await dockerInvocations(fake.dockerLog)).toBe(0)
+    });
+
+    test('a full 40-char SHA passes through and is reported as the deployed revision', async () => {
+        const fake   = await createFakeBin(''),
+              result = runPipeline(fake, FULL_SHA);
+
+        expect(result.code).toBe(0);
+        expect(result.output).toContain(FULL_SHA);
+        // The host checkout must be reported as explicitly NOT the deployed revision.
+        expect(result.output).toContain('host-checkout:');
+        expect(result.output).toContain('NOT what is deployed');
+        expect(await dockerInvocations(fake.dockerLog)).toBeGreaterThan(0)
+    });
+
+    test('a resolvable channel resolves to its single SHA rather than staying mutable', async () => {
+        const
+            fake   = await createFakeBin(`${FULL_SHA}\trefs/heads/dev`),
+            result = runPipeline(fake, 'dev');
+
+        expect(result.code).toBe(0);
+        // Resolved, not passed through as the channel name.
+        expect(result.output).toContain(FULL_SHA);
+        expect(result.output).toContain('selector:');
+        expect(await dockerInvocations(fake.dockerLog)).toBeGreaterThan(0)
+    })
+})

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -51,9 +51,12 @@ async function createFakeBin(lsRemote) {
         'exit 0'
     ].join('\n'), {mode: 0o755});
 
+    // Record the ENVIRONMENT, not only argv. NEO_REF / NEO_REVISION reach Compose as exported
+    // env, never as arguments — so a docker stub logging `$*` alone can never falsify
+    // "both variables reach Compose", which is the claim the pinning contract rests on.
     await fs.writeFile(path.join(bin, 'docker'), [
         '#!/usr/bin/env bash',
-        `echo "invoked: $*" >> ${JSON.stringify(dockerLog)}`,
+        `echo "invoked: $* | NEO_REF=${'$'}{NEO_REF-<unset>} NEO_REVISION=${'$'}{NEO_REVISION-<unset>}" >> ${JSON.stringify(dockerLog)}`,
         'exit 0'
     ].join('\n'), {mode: 0o755});
 
@@ -106,7 +109,7 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
 
         expect(result.code).not.toBe(0);
         expect(result.output).toContain('no-such-branch');
-        expect(result.output).toContain('resolved to 0 refs');
+        expect(result.output).toContain('resolved to 0 commits');
         // The whole point: an unresolvable selector must never reach a build.
         expect(await dockerInvocations(fake.dockerLog)).toBe(0)
     });
@@ -119,7 +122,7 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
             result   = runPipeline(fake, 'ambiguous');
 
         expect(result.code).not.toBe(0);
-        expect(result.output).toContain('resolved to 2 refs');
+        expect(result.output).toContain('resolved to 2 commits');
         expect(await dockerInvocations(fake.dockerLog)).toBe(0)
     });
 
@@ -153,5 +156,54 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         expect(result.output).toContain(FULL_SHA);
         expect(result.output).toContain('selector:');
         expect(await dockerInvocations(fake.dockerLog)).toBeGreaterThan(0)
+    });
+
+    test('BOTH NEO_REF and NEO_REVISION reach Compose as the resolved commit', async () => {
+        const
+            fake   = await createFakeBin(`${FULL_SHA}\trefs/heads/dev`),
+            result = runPipeline(fake, 'dev');
+
+        expect(result.code).toBe(0);
+
+        // The env, not argv: NEO_REVISION alone would label the image while the source stage
+        // still fetched ${NEO_REF} — a label attesting a commit the build never checked out.
+        const log = await fs.readFile(fake.dockerLog, 'utf8');
+
+        expect(log).toContain(`NEO_REF=${FULL_SHA}`);
+        expect(log).toContain(`NEO_REVISION=${FULL_SHA}`);
+        expect(log).not.toContain('NEO_REF=dev');
+        expect(log).not.toContain('NEO_REVISION=<unset>')
+    });
+
+    test('an annotated tag resolves to the PEELED COMMIT, never the tag object', async () => {
+        // An annotated tag advertises two lines. Docker checks out the peel, so stamping the
+        // tag object would make NEO_REVISION disagree with /app/.neo-revision — a 40-char git
+        // object id is not necessarily a commit id.
+        const
+            TAG_OBJECT    = '9c18ce0000000000000000000000000000000000',
+            PEELED_COMMIT = 'a312fc0000000000000000000000000000000000',
+            fake          = await createFakeBin(
+                `${TAG_OBJECT}\trefs/tags/v13.2.0\n${PEELED_COMMIT}\trefs/tags/v13.2.0^{}`
+            ),
+            result = runPipeline(fake, 'v13.2.0');
+
+        expect(result.code).toBe(0);
+
+        const log = await fs.readFile(fake.dockerLog, 'utf8');
+
+        expect(log).toContain(`NEO_REVISION=${PEELED_COMMIT}`);
+        expect(log).toContain(`NEO_REF=${PEELED_COMMIT}`);
+        // The tag object must never be attested as the deployed revision.
+        expect(log).not.toContain(TAG_OBJECT);
+        expect(result.output).not.toContain(TAG_OBJECT)
+    });
+
+    test('a lightweight tag (single line, no peel) still resolves', async () => {
+        const
+            fake   = await createFakeBin(`${FULL_SHA}\trefs/tags/lightweight`),
+            result = runPipeline(fake, 'lightweight');
+
+        expect(result.code).toBe(0);
+        expect(await fs.readFile(fake.dockerLog, 'utf8')).toContain(`NEO_REVISION=${FULL_SHA}`)
     })
 })

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -32,13 +32,22 @@ const
 
 /**
  * Builds a throwaway bin dir whose `git` and `docker` shadow the real ones on `PATH`.
- * `fake-git ls-remote` echoes `lsRemote` verbatim so a spec can stage zero, one, or many refs.
- * `fake-docker` records every invocation, so "Docker was never called" is an assertable fact
- * rather than an inference from the exit code.
- * @param {String} lsRemote Raw `git ls-remote` stdout to stage (empty string = zero matches).
+ *
+ * `fake-git ls-remote` deliberately MODELS REAL PATTERN SEMANTICS rather than echoing a fixture:
+ * an exact pattern (`v9.9.9`) advertises only the tag object, and the peeled commit
+ * (`refs/tags/v9.9.9^{}`) appears ONLY when the caller also passes the `^{}` pattern. Verified
+ * against a disposable annotated-tag repository. A fixture that hands back both lines regardless
+ * cannot fail when the script stops asking for the peel — which is precisely the defect that
+ * slipped through cycle 1: the earlier stub proved the code against input git never produces.
+ *
+ * `fake-docker` records every invocation plus the environment, so "Docker was never called" and
+ * "both variables reached Compose" are assertable facts rather than inferences.
+ *
+ * @param {String} peelLine  Peel line to advertise, or '' for none (branch / lightweight tag).
+ * @param {String} plainLines Non-peel lines always advertised (tag object, branches, or '').
  * @returns {Promise<Object>} `{bin, dockerLog}` paths.
  */
-async function createFakeBin(lsRemote) {
+async function createFakeBin(plainLines, peelLine = '') {
     const
         bin       = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-deploy-pin-')),
         dockerLog = path.join(bin, 'docker-invocations.log');
@@ -46,7 +55,12 @@ async function createFakeBin(lsRemote) {
     await fs.writeFile(path.join(bin, 'git'), [
         '#!/usr/bin/env bash',
         // Only ls-remote is contract-relevant; `describe` keeps the host-checkout log line working.
-        'if [ "$1" = "ls-remote" ]; then printf \'%s\' "$FAKE_LS_REMOTE"; exit 0; fi',
+        'if [ "$1" = "ls-remote" ]; then',
+        '    printf \'%s\' "$FAKE_LS_PLAIN"',
+        // The peel is advertised ONLY if some argument carries the ^{} pattern — real git behaviour.
+        '    for a in "$@"; do case "$a" in *"^{}") [ -n "$FAKE_LS_PEEL" ] && printf \'\\n%s\' "$FAKE_LS_PEEL";; esac; done',
+        '    exit 0',
+        'fi',
         'if [ "$1" = "-C" ] && [ "$3" = "describe" ]; then echo "fake-describe"; exit 0; fi',
         'exit 0'
     ].join('\n'), {mode: 0o755});
@@ -62,7 +76,7 @@ async function createFakeBin(lsRemote) {
 
     await fs.writeFile(dockerLog, '');
 
-    return {bin, dockerLog, lsRemote}
+    return {bin, dockerLog, plainLines, peelLine}
 }
 
 /**
@@ -79,9 +93,10 @@ function runPipeline(fake, selector) {
             encoding: 'utf8',
             env     : {
                 ...process.env,
-                FAKE_LS_REMOTE: fake.lsRemote,
-                NEO_REF       : selector,
-                PATH          : `${fake.bin}:${process.env.PATH}`
+                FAKE_LS_PEEL : fake.peelLine,
+                FAKE_LS_PLAIN: fake.plainLines,
+                NEO_REF      : selector,
+                PATH         : `${fake.bin}:${process.env.PATH}`
             },
             stdio: ['ignore', 'pipe', 'pipe']
         });
@@ -182,8 +197,12 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         const
             TAG_OBJECT    = '9c18ce0000000000000000000000000000000000',
             PEELED_COMMIT = 'a312fc0000000000000000000000000000000000',
+            // The peel is the SECOND argument, so fake-git advertises it only when the script
+            // actually asks for the `^{}` pattern. Staging both as always-advertised would make
+            // this test unable to fail — which is how the cycle-1 fixture passed a broken script.
             fake          = await createFakeBin(
-                `${TAG_OBJECT}\trefs/tags/v13.2.0\n${PEELED_COMMIT}\trefs/tags/v13.2.0^{}`
+                `${TAG_OBJECT}\trefs/tags/v13.2.0`,
+                `${PEELED_COMMIT}\trefs/tags/v13.2.0^{}`
             ),
             result = runPipeline(fake, 'v13.2.0');
 

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -62,6 +62,19 @@ async function createFakeBin(plainLines, peelLine = '') {
         '    exit 0',
         'fi',
         'if [ "$1" = "-C" ] && [ "$3" = "describe" ]; then echo "fake-describe"; exit 0; fi',
+        // The 40-hex PROBE. Previously the fast path never called git at all, so this stub was
+        // bypassed and the spec could not falsify anything about it — which is exactly how a
+        // tag-object id and a nonexistent id both reached Docker through the branch that calls
+        // itself the reproducible full-commit path. Modelled on real semantics:
+        //   fetch  fails when the id is absent    -> FAKE_FETCH_FAILS
+        //   ^{commit} yields '' for a non-commit  -> FAKE_PEEL_TO empty
+        //   ^{commit} peels a tag object          -> FAKE_PEEL_TO = the commit
+        'if [ "$1" = "-C" ] && [ "$3" = "init" ]; then exit 0; fi',
+        'if [ "$1" = "-C" ] && [ "$3" = "fetch" ]; then [ -n "$FAKE_FETCH_FAILS" ] && exit 128; exit 0; fi',
+        'if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ]; then',
+        '    [ -z "$FAKE_PEEL_TO" ] && exit 1',
+        '    printf \'%s\\n\' "$FAKE_PEEL_TO"; exit 0',
+        'fi',
         'exit 0'
     ].join('\n'), {mode: 0o755});
 
@@ -77,6 +90,41 @@ async function createFakeBin(plainLines, peelLine = '') {
     await fs.writeFile(dockerLog, '');
 
     return {bin, dockerLog, plainLines, peelLine}
+}
+
+/**
+ * Runs the pipeline with the 40-hex probe stubbed. Separate from `runPipeline` because the probe
+ * env is meaningless on the ls-remote path and passing it there would blur which branch is under test.
+ * @param {Object} fake The `createFakeBin` result.
+ * @param {String} selector 40-char id under test.
+ * @param {Object} probe `{fetchFails, peelTo}` — the remote's answers.
+ * @returns {Object} `{code, output}`.
+ */
+function runPipelineWithProbe(fake, selector, {fetchFails = false, peelTo = ''} = {}) {
+    try {
+        // `2>&1` is load-bearing: the peel note is a WARNING on stderr, and execFileSync discards
+        // stderr on the success path — so without merging, an assertion about it could never pass
+        // even when the script emits it correctly. Same wrong-channel mistake as observing argv
+        // when the payload travels as env; the failure paths read `error.stderr` and are unaffected.
+        const output = execFileSync('bash', ['-c', '"$0" 2>&1', scriptPath], {
+            cwd     : repoRoot,
+            encoding: 'utf8',
+            env     : {
+                ...process.env,
+                FAKE_FETCH_FAILS: fetchFails ? '1' : '',
+                FAKE_LS_PEEL    : '',
+                FAKE_LS_PLAIN   : '',
+                FAKE_PEEL_TO    : peelTo,
+                NEO_REF         : selector,
+                PATH            : `${fake.bin}:${process.env.PATH}`
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+
+        return {code: 0, output}
+    } catch (error) {
+        return {code: error.status ?? 1, output: `${error.stdout ?? ''}${error.stderr ?? ''}`}
+    }
 }
 
 /**
@@ -149,9 +197,11 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         expect(await dockerInvocations(fake.dockerLog)).toBe(0)
     });
 
-    test('a full 40-char SHA passes through and is reported as the deployed revision', async () => {
+    test('a full 40-char SHA is VERIFIED against the remote, not trusted for its shape', async () => {
+        // The old version of this test asserted the selector "passes through" — which asserted the
+        // defect. A 40-hex id is only the deployed revision once the remote confirms it is a commit.
         const fake   = await createFakeBin(''),
-              result = runPipeline(fake, FULL_SHA);
+              result = runPipelineWithProbe(fake, FULL_SHA, {peelTo: FULL_SHA});
 
         expect(result.code).toBe(0);
         expect(result.output).toContain(FULL_SHA);
@@ -159,6 +209,49 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         expect(result.output).toContain('host-checkout:');
         expect(result.output).toContain('NOT what is deployed');
         expect(await dockerInvocations(fake.dockerLog)).toBeGreaterThan(0)
+    });
+
+    test('a nonexistent 40-hex id fails closed without invoking Docker', async () => {
+        // Shape is not existence. The fail-before-Docker contract binds here too, and this was the
+        // one branch that skipped it entirely.
+        const fake   = await createFakeBin(''),
+              result = runPipelineWithProbe(fake, 'dead' + 'b'.repeat(36), {fetchFails: true});
+
+        expect(result.code).not.toBe(0);
+        expect(result.output).toContain('could not be fetched');
+        expect(await dockerInvocations(fake.dockerLog)).toBe(0)
+    });
+
+    test('a 40-hex ANNOTATED-TAG OBJECT id exports the PEELED COMMIT, never the tag object', async () => {
+        // The original wrong-attestation defect's last hiding place: a tag object id is also 40 hex,
+        // and the Dockerfile's `checkout --detach FETCH_HEAD; rev-parse HEAD` peels it — so trusting
+        // the shape stamps a label that /app/.neo-revision truthfully contradicts.
+        const
+            TAG_OBJECT_ID = '231f84c368e0351933e95dc51e7bd73b1e15bdff',
+            PEELED_COMMIT = '4a972d07e6eb08975b15eaf3499f16c742ad70bb',
+            fake          = await createFakeBin(''),
+            result        = runPipelineWithProbe(fake, TAG_OBJECT_ID, {peelTo: PEELED_COMMIT});
+
+        expect(result.code).toBe(0);
+
+        const log = await fs.readFile(fake.dockerLog, 'utf8');
+
+        expect(log).toContain(`NEO_REVISION=${PEELED_COMMIT}`);
+        expect(log).toContain(`NEO_REF=${PEELED_COMMIT}`);
+        // The tag object must never be attested, and the substitution must be stated out loud.
+        expect(log).not.toContain(TAG_OBJECT_ID);
+        expect(result.output).toContain('peeled to commit')
+    });
+
+    test('a 40-hex id that is not a commit (tree/blob) fails closed without invoking Docker', async () => {
+        // `^{commit}` yields nothing for a tree or blob. Reaching Docker with a non-commit would
+        // produce an image whose revision label names an object that is not source history.
+        const fake   = await createFakeBin(''),
+              result = runPipelineWithProbe(fake, 'c'.repeat(40), {peelTo: ''});
+
+        expect(result.code).not.toBe(0);
+        expect(result.output).toContain('is not a commit');
+        expect(await dockerInvocations(fake.dockerLog)).toBe(0)
     });
 
     test('a resolvable channel resolves to its single SHA rather than staying mutable', async () => {


### PR DESCRIPTION
Resolves #15792

The reference deploy pipeline could not express the exact-SHA floor it documents. `deploy-pipeline.sh` ran `compose up -d --build` with neither `NEO_REF` nor `NEO_REVISION` set, sourced no env file, and there is no `.env` in `ai/deploy/` for Compose to auto-read — so **every scripted deploy built mutable `dev` and asserted no revision**, while `PipelineWiring.md`'s manual path pins correctly. Two documented paths, divergent behaviour: the two-realities class sitting inside the deployment tooling itself.

**It also printed a confidently wrong receipt.** The script already echoed `[deploy] revision:` — using the **host checkout's** `git describe`, which has nothing to do with the revision fetched into the images. An operator reading `[deploy] revision: v13.1.0-42-gabc1234` would reasonably conclude that named the deployed code. That is worse than an absent receipt, and it sat in the reference pipeline downstream teams are told to copy.

Evidence: L2 (fake-git + fake-docker `PATH` harness, committed as a spec; 5/5 green, no Docker daemon and no network) → L3 required (a real build proving the OCI revision label materialises). Residual: the label-materialization read only [#15787].

## Deltas from ticket

- **Found while implementing: the misleading `[deploy] revision:` line.** Not in the ticket — it was discovered at the insertion point. The log now separates `revision:` *(built into the images)* from `host-checkout:` *(this host only; NOT what is deployed)*. This is the fourth instance in one day of a metadata surface asserting something the mechanism underneath doesn't guarantee, on this same subsystem.
- **The deferral shrank.** The ticket originally marked the whole verification `[deferred verification — expiry 2026-08-24]` on the grounds that no agent sandbox has a Docker daemon. @neo-gpt's author-fold on Discussion #15758 supplied the `fake-git`/`fake-docker` idea, which makes the **fail-closed contract L2-testable today**. Only the label-materialization half stays deferred. I had let an environmental limit swallow a testable contract instead of scoping the blocker to the assertions it actually blocks.
- **Placement question resolved, and my first framing of it was wrong.** I initially blocked on "the repo has no shell-test precedent" — true (zero `.sh`/`.bats` specs, no shell npm scripts) and irrelevant. The right question was "where do spawn-and-assert specs live," and **77 existing Playwright specs already spawn child processes**. Flat under `test/playwright/unit/ai/` with a PascalCase name matches the 20+ siblings there. A unit spec rather than integration because every assertion is about what the script decides *before* Docker runs.

## Test Evidence

`npm run test-unit` scoped to the new spec, run twice (before and after the block-alignment fix), with a run-scoped Chroma port so no other agent's suite is disturbed:

```
NEO_CHROMA_PORT_TEST=18212 UNIT_TEST_MODE=true npx playwright test \
  -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
→ 7 passed (3.7s)   [5 contract cases + chroma setup/teardown]
```

| Case | exit | Docker invocations |
|---|---|---|
| selector matching zero refs | non-zero | **0** |
| ambiguous selector (2 refs) | non-zero | **0** |
| abbreviated SHA | non-zero | **0** |
| full 40-char SHA | 0 | >0, revision echoed |
| resolvable channel | 0 | >0, resolved to its single SHA |

The load-bearing assertions are **negative**: `fake-docker` appends to a log, and each failure case asserts that log is empty. A pipeline that resolves ambiguously and builds anyway is worse than one that fails, because it produces an image whose provenance labels assert a revision nobody chose.

Per directly touched surface: `ai/examples/cloud-deployment/**` — `DeployPipelineRevisionPin.spec.mjs` (new, 5/5). `bash -n` clean on the script.

Pre-commit gates that corrected earlier attempts, both usefully: `check-ticket-archaeology` rejected ticket refs in durable JSDoc (they rot when the ticket closes — refs belong here in the PR body instead), and `check-block-alignment` required the import block at column 23. Spec re-run green after both.

## Post-Merge Validation

- [ ] None for this PR. The remaining label-materialization read lives on **#15787** (holder, expiry 2026-08-24, explicitly never a PR close target) alongside the other #15774 receipts. Recorded as an item so the absence is visible rather than looking like an omission.

## Commits

- `f6a250eaa5` — resolve before Docker, pin every run, export **both** args, split the log into deployed-revision vs host-checkout.
- `7465e1f5b5` — commits the fake-git/fake-docker harness as a unit spec so the fail-closed contract is a repo artifact rather than an ad-hoc run.

## Scope discipline

`NEO_REVISION` alone was never sufficient and the PR does not treat it as such: it feeds only the OCI label, while the Dockerfile's source stage fetches `${NEO_REF}`. Exporting only `NEO_REVISION` would stamp a resolved SHA onto an image built from a mutable channel *and* leave the cache input unchanged, so `--build` might not even re-fetch. Author-canonical per @neo-gpt's fold; the reasoning is in the AC so the next reader sees why "both" is load-bearing rather than belt-and-braces.

Deliberately excluded: no rollout trigger, controller, or automation (Discussion #15758 Axes 1–6 stay open — this only makes the **existing** floor performable); no change to #15774's three provenance surfaces; no cohort manifest or plane identity (gated on Discussion #15595's election).

**Decision Record impact: `none`.** A reference-script fix plus a test; no authority chosen, no runtime surface widened.

Related: #15774
Related: #15787
Related: #15782
Related: [Discussion #15758](https://github.com/orgs/neomjs/discussions/15758)

Cross-family seat needed (Claude author): GPT or Kimi. **Not routing to @neo-gpt** — he is on the P0 critical path and has taken two Claude reviews inside four minutes already, and his own author-fold shaped this PR, so a different seat is the better check. The committed L2 harness should make it cheap for a kimi seat post-reset.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 92799c10-cb3b-4c01-a2b0-fd8552c3c02e.
