### PR TITLE
feat(ai): per-seat data-root reconcile — non-mutating mode + served-checkout port probe (#15791)

### DIFF
--- a/ai/scripts/diagnostics/probePortClaims.mjs
+++ b/ai/scripts/diagnostics/probePortClaims.mjs
@@ -1,16 +1,19 @@
 /**
- * @summary Read-only probe: which TCP listeners this host is running, and which checkout each SERVES.
+ * @summary Read-only probe: which TCP listeners this host is running, and which directory each RESOLVES PATHS AGAINST.
  *
  * The fourth axis of a per-seat data-root reconcile. The other three (leaves, symlink targets,
  * resolved roots) are derived from the hydration contract by `symlinkDataDir({dryRun: true})`;
  * host port claims have no declaration to derive from, so they must be observed.
  *
- * **Why served identity rather than occupancy.** "Port 8080 is busy" is not the useful fact.
+ * **Why serving directory rather than occupancy.** "Port 8080 is busy" is not the useful fact.
  * A test runner that trusted *any* listener on a port once executed a different checkout's tree
  * and produced false greens as well as false reds — two victims in one day. The question a
- * multi-seat host has to answer is *whose* process is on the port, and the honest answer is the
- * serving process's working directory: on a host where several checkouts run side by side, the
- * cwd is what says which one you would actually be talking to.
+ * multi-seat host has to answer is *whose* process is on the port, and the honest answer this
+ * probe can actually evidence is the serving process's working directory.
+ *
+ * That is deliberately a weaker claim than "which checkout". The probe never validates a cwd as a
+ * repository root, so it reports cwds and says so; asserting checkout identity would put a claim
+ * on the output that nothing in the measurement supports.
  *
  * That also makes this probe a direct read of the same property the data-root election turns on.
  * Path leaves resolve relative to the invoking process's cwd, so a listener's cwd is the plane
@@ -83,7 +86,7 @@ export function resolveProcessCwd(pid) {
 }
 
 /**
- * @summary Enumerates TCP listeners with the checkout each one serves.
+ * @summary Enumerates TCP listeners with the working directory each one serves from.
  *
  * Parses `lsof -F pcn`, whose records are line-oriented: `p<pid>` opens a process block, `c<cmd>`
  * names it, and each following `n<name>` is one of that process's sockets. State is carried across
@@ -145,16 +148,21 @@ export function parseListenerRecords(raw, cwdResolver) {
 }
 
 /**
- * @summary Groups listeners by the checkout they serve, so one host's plane split is readable.
+ * @summary Groups listeners by the cwd they serve from, so one host's plane split is readable.
  *
- * `/` and `unknown` are grouped like any other key but are NOT checkouts — a daemon rooted at `/`
- * says nothing about a plane. Callers counting distinct checkouts must use {@link servedCheckouts},
- * which excludes them; counting raw keys over-reports, since a stock macOS host always carries `/`.
+ * **These keys are working directories, not verified checkouts.** The probe never confirms that a
+ * cwd is a repository root — it reports what `lsof` says the process resolves paths against, which
+ * is the property the data-plane election actually turns on. Naming the key `cwd` keeps the claim
+ * the size of the evidence; calling it a checkout would assert an identity nothing here checked.
+ *
+ * `/` and `unknown` group like any other key but are never *serving* cwds — a daemon rooted at `/`
+ * says nothing about a plane. Callers counting distinct planes must use {@link servedCwds}, which
+ * excludes them; counting raw keys over-reports, since a stock macOS host always carries `/`.
  *
  * @param {Array<Object>} rows Listener rows from {@link probePortClaims}`.rows`.
  * @returns {Object<String, Number[]>} cwd → ascending ports served from it.
  */
-export function groupByServedCheckout(rows) {
+export function groupByCwd(rows) {
     const grouped = {};
 
     for (const {cwd, port} of rows) {
@@ -167,11 +175,11 @@ export function groupByServedCheckout(rows) {
 }
 
 /**
- * @summary The keys of {@link groupByServedCheckout} that actually denote a checkout.
+ * @summary The keys of {@link groupByCwd} that denote a real serving directory.
  * @param {Object<String, Number[]>} grouped
- * @returns {String[]} Paths excluding `/` and `unknown`.
+ * @returns {String[]} Paths excluding `/` and `unknown` — still cwds, still unvalidated as roots.
  */
-export function servedCheckouts(grouped) {
+export function servedCwds(grouped) {
     return Object.keys(grouped).filter(key => key !== UNKNOWN && key !== '/');
 }
 
@@ -179,7 +187,7 @@ function main() {
     const {observed, reason, rows} = probePortClaims();
 
     if (process.argv.includes('--json')) {
-        console.log(JSON.stringify({observed, reason, rows, byCheckout: groupByServedCheckout(rows)}, null, 4));
+        console.log(JSON.stringify({observed, reason, rows, byCwd: groupByCwd(rows)}, null, 4));
         return;
     }
 
@@ -198,13 +206,13 @@ function main() {
         console.log(`  ${String(port).padStart(5)}  ${command.padEnd(16)} pid ${pid.padEnd(8)} ${cwd}`);
     }
 
-    const byCheckout = groupByServedCheckout(rows),
-          checkouts  = servedCheckouts(byCheckout);
+    const byCwd = groupByCwd(rows),
+          cwds  = servedCwds(byCwd);
 
-    if (checkouts.length > 1) {
-        console.log(`\n${checkouts.length} distinct checkouts are serving ports on this host:`);
-        for (const checkout of checkouts) console.log(`  ${checkout} → ${byCheckout[checkout].join(', ')}`);
-        console.log('\nPorts alone do not identify a seat here — the same port number means a different plane per checkout.');
+    if (cwds.length > 1) {
+        console.log(`\n${cwds.length} distinct working directories are serving ports on this host:`);
+        for (const cwd of cwds) console.log(`  ${cwd} → ${byCwd[cwd].join(', ')}`);
+        console.log('\nPorts alone do not identify a seat here — the same port number resolves paths against a different directory per listener.');
     }
 }
 

--- a/ai/scripts/diagnostics/probePortClaims.mjs
+++ b/ai/scripts/diagnostics/probePortClaims.mjs
@@ -1,0 +1,175 @@
+/**
+ * @summary Read-only probe: which TCP listeners this host is running, and which checkout each SERVES.
+ *
+ * The fourth axis of a per-seat data-root reconcile. The other three (leaves, symlink targets,
+ * resolved roots) are derived from the hydration contract by `symlinkDataDir({dryRun: true})`;
+ * host port claims have no declaration to derive from, so they must be observed.
+ *
+ * **Why served identity rather than occupancy.** "Port 8080 is busy" is not the useful fact.
+ * A test runner that trusted *any* listener on a port once executed a different checkout's tree
+ * and produced false greens as well as false reds — two victims in one day. The question a
+ * multi-seat host has to answer is *whose* process is on the port, and the honest answer is the
+ * serving process's working directory: on a host where several checkouts run side by side, the
+ * cwd is what says which one you would actually be talking to.
+ *
+ * That also makes this probe a direct read of the same property the data-root election turns on.
+ * Path leaves resolve relative to the invoking process's cwd, so a listener's cwd is the plane
+ * it writes to. Two seats claiming adjacent ports from different checkouts is not a port conflict;
+ * it is two planes wearing one host's port namespace.
+ *
+ * **Read-only by construction.** `lsof` only; the script never connects to a port, never sends a
+ * request, never signals a process. A fingerprint that required an HTTP round-trip would make the
+ * diagnostic itself a client of the thing it is diagnosing.
+ *
+ * Platforms: macOS + Linux. `lsof -F` is chosen over `netstat`/`ss` for the same reason the
+ * sibling MCP-concurrency probe chose it — it ships by default on both targets and emits a
+ * deterministic machine-parseable format.
+ *
+ * Usage:
+ *   node ai/scripts/diagnostics/probePortClaims.mjs           # human-readable table
+ *   node ai/scripts/diagnostics/probePortClaims.mjs --json    # machine-readable
+ *
+ * @see ai/scripts/diagnostics/diagnoseMcpConcurrency.mjs  sibling probe; `lsof -F` idiom
+ * @see ai/scripts/migrations/bootstrapWorktree.mjs        symlinkDataDir dryRun — axes 1-3
+ */
+
+import {execFileSync} from 'child_process';
+
+const UNKNOWN = 'unknown';
+
+/**
+ * @summary Runs lsof, returning '' rather than throwing when it is absent or finds nothing.
+ *
+ * lsof exits non-zero on "no matching processes", which is a legitimate empty result rather than
+ * a failure — a host with no listeners is a valid observation, not an error.
+ *
+ * @param {String[]} args
+ * @returns {String} Raw stdout, or '' when lsof is unavailable or matched nothing.
+ */
+function lsof(args) {
+    try {
+        return execFileSync('lsof', args, {encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore']});
+    } catch (e) {
+        // Non-zero with output still carries the matches; only a truly empty result is empty.
+        return e?.stdout || '';
+    }
+}
+
+/**
+ * @summary Resolves a pid's current working directory — the checkout it would resolve paths against.
+ * @param {String} pid
+ * @returns {String} Absolute cwd, or `'unknown'` when the process is not inspectable (foreign uid).
+ */
+export function resolveProcessCwd(pid) {
+    const raw = lsof(['-a', '-p', pid, '-d', 'cwd', '-F', 'n']);
+
+    for (const line of raw.split('\n')) {
+        if (line.startsWith('n')) return line.slice(1);
+    }
+
+    return UNKNOWN;
+}
+
+/**
+ * @summary Enumerates TCP listeners with the checkout each one serves.
+ *
+ * Parses `lsof -F pcn`, whose records are line-oriented: `p<pid>` opens a process block, `c<cmd>`
+ * names it, and each following `n<name>` is one of that process's sockets. State is carried across
+ * lines by design of the format, which is why this is a fold rather than a per-line map.
+ *
+ * @returns {Array<{port: Number, pid: String, command: String, cwd: String}>} One row per listening
+ *          socket, sorted by port. `cwd` is `'unknown'` when the owning process is not inspectable.
+ */
+export function probePortClaims() {
+    return parseListenerRecords(lsof(['-nP', '-iTCP', '-sTCP:LISTEN', '-F', 'pcn']), resolveProcessCwd);
+}
+
+/**
+ * @summary Pure parser for `lsof -F pcn` output — the decision core, with the shell seam injected.
+ *
+ * Split out from {@link probePortClaims} so the parsing contract is testable without a host that
+ * happens to have the right listeners running. The probe is only useful if its record-folding is
+ * right, and a test that needs real sockets to prove that would be untestable in CI by construction.
+ *
+ * @param {String}   raw         Raw `lsof -F pcn` stdout.
+ * @param {Function} cwdResolver `pid => cwd`, called at most once per pid.
+ * @returns {Array<{port: Number, pid: String, command: String, cwd: String}>} Sorted by port.
+ */
+export function parseListenerRecords(raw, cwdResolver) {
+    const
+        rows = [],
+        cwds = new Map();
+
+    let pid = null, command = null;
+
+    for (const line of raw.split('\n')) {
+        if (line.startsWith('p')) {
+            pid     = line.slice(1);
+            command = null;
+            continue;
+        }
+
+        if (line.startsWith('c')) {
+            command = line.slice(1);
+            continue;
+        }
+
+        if (!line.startsWith('n') || !pid) continue;
+
+        const match = line.slice(1).match(/:(\d+)$/);
+        if (!match) continue;
+
+        if (!cwds.has(pid)) cwds.set(pid, cwdResolver(pid));
+
+        rows.push({port: Number(match[1]), pid, command: command || UNKNOWN, cwd: cwds.get(pid)});
+    }
+
+    return rows.sort((a, b) => a.port - b.port);
+}
+
+/**
+ * @summary Groups listeners by the checkout they serve, so one host's plane split is readable at a glance.
+ * @param {Array<Object>} [rows=probePortClaims()]
+ * @returns {Object<String, Number[]>} cwd → ascending ports served from it.
+ */
+export function groupByServedCheckout(rows = probePortClaims()) {
+    const grouped = {};
+
+    for (const {cwd, port} of rows) {
+        (grouped[cwd] ||= []).push(port);
+    }
+
+    for (const ports of Object.values(grouped)) ports.sort((a, b) => a - b);
+
+    return grouped;
+}
+
+function main() {
+    const rows = probePortClaims();
+
+    if (process.argv.includes('--json')) {
+        console.log(JSON.stringify({rows, byCheckout: groupByServedCheckout(rows)}, null, 4));
+        return;
+    }
+
+    if (!rows.length) {
+        console.log('No TCP listeners observed (or lsof unavailable).');
+        return;
+    }
+
+    console.log(`${rows.length} listening socket(s):\n`);
+    for (const {port, pid, command, cwd} of rows) {
+        console.log(`  ${String(port).padStart(5)}  ${command.padEnd(16)} pid ${pid.padEnd(8)} ${cwd}`);
+    }
+
+    const byCheckout = groupByServedCheckout(rows),
+          checkouts  = Object.keys(byCheckout).filter(key => key !== UNKNOWN);
+
+    if (checkouts.length > 1) {
+        console.log(`\n${checkouts.length} distinct checkouts are serving ports on this host:`);
+        for (const checkout of checkouts) console.log(`  ${checkout} → ${byCheckout[checkout].join(', ')}`);
+        console.log('\nPorts alone do not identify a seat here — the same port number means a different plane per checkout.');
+    }
+}
+
+if (process.argv[1]?.endsWith('probePortClaims.mjs')) main();

--- a/ai/scripts/diagnostics/probePortClaims.mjs
+++ b/ai/scripts/diagnostics/probePortClaims.mjs
@@ -38,20 +38,30 @@ import {execFileSync} from 'child_process';
 const UNKNOWN = 'unknown';
 
 /**
- * @summary Runs lsof, returning '' rather than throwing when it is absent or finds nothing.
+ * @summary Runs lsof, separating "looked and saw nothing" from "could not look".
  *
  * lsof exits non-zero on "no matching processes", which is a legitimate empty result rather than
  * a failure — a host with no listeners is a valid observation, not an error.
  *
+ * **"Could not observe" is never reported as "observed nothing."** `lsof` absent, a permission
+ * refusal and a genuinely quiet host are three different facts; collapsing them into `[]` would
+ * make the probe unable to fail, and an instrument that cannot fail cannot be evidence.
+ *
  * @param {String[]} args
- * @returns {String} Raw stdout, or '' when lsof is unavailable or matched nothing.
+ * @returns {{ok: Boolean, stdout: String, reason: String|null}} `ok:false` carries why.
  */
 function lsof(args) {
     try {
-        return execFileSync('lsof', args, {encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore']});
+        return {ok: true, stdout: execFileSync('lsof', args, {encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore']}), reason: null};
     } catch (e) {
-        // Non-zero with output still carries the matches; only a truly empty result is empty.
-        return e?.stdout || '';
+        // lsof exits non-zero on "no matching processes" while still emitting the matches it found,
+        // so stdout presence — not exit code — is what distinguishes a real result from a failure.
+        if (e?.stdout) return {ok: true, stdout: e.stdout, reason: null};
+
+        if (e?.code === 'ENOENT') return {ok: false, stdout: '', reason: 'lsof-unavailable'};
+        if (e?.status === 1)      return {ok: true,  stdout: '', reason: null};
+
+        return {ok: false, stdout: '', reason: `lsof-failed: ${e?.code ?? e?.status ?? 'unknown'}`};
     }
 }
 
@@ -61,9 +71,11 @@ function lsof(args) {
  * @returns {String} Absolute cwd, or `'unknown'` when the process is not inspectable (foreign uid).
  */
 export function resolveProcessCwd(pid) {
-    const raw = lsof(['-a', '-p', pid, '-d', 'cwd', '-F', 'n']);
+    const {ok, stdout} = lsof(['-a', '-p', pid, '-d', 'cwd', '-F', 'n']);
 
-    for (const line of raw.split('\n')) {
+    if (!ok) return UNKNOWN;
+
+    for (const line of stdout.split('\n')) {
         if (line.startsWith('n')) return line.slice(1);
     }
 
@@ -77,11 +89,16 @@ export function resolveProcessCwd(pid) {
  * names it, and each following `n<name>` is one of that process's sockets. State is carried across
  * lines by design of the format, which is why this is a fold rather than a per-line map.
  *
- * @returns {Array<{port: Number, pid: String, command: String, cwd: String}>} One row per listening
- *          socket, sorted by port. `cwd` is `'unknown'` when the owning process is not inspectable.
+ * @returns {{observed: Boolean, reason: String|null, rows: Array<{port: Number, pid: String, command: String, cwd: String}>}}
+ *          `observed:false` means the probe could not look — never that it looked and found nothing.
+ *          `rows` is sorted by port; `cwd` is `'unknown'` when the owning process is not inspectable.
  */
 export function probePortClaims() {
-    return parseListenerRecords(lsof(['-nP', '-iTCP', '-sTCP:LISTEN', '-F', 'pcn']), resolveProcessCwd);
+    const {ok, stdout, reason} = lsof(['-nP', '-iTCP', '-sTCP:LISTEN', '-F', 'pcn']);
+
+    if (!ok) return {observed: false, reason, rows: []};
+
+    return {observed: true, reason: null, rows: parseListenerRecords(stdout, resolveProcessCwd)};
 }
 
 /**
@@ -128,11 +145,16 @@ export function parseListenerRecords(raw, cwdResolver) {
 }
 
 /**
- * @summary Groups listeners by the checkout they serve, so one host's plane split is readable at a glance.
- * @param {Array<Object>} [rows=probePortClaims()]
+ * @summary Groups listeners by the checkout they serve, so one host's plane split is readable.
+ *
+ * `/` and `unknown` are grouped like any other key but are NOT checkouts — a daemon rooted at `/`
+ * says nothing about a plane. Callers counting distinct checkouts must use {@link servedCheckouts},
+ * which excludes them; counting raw keys over-reports, since a stock macOS host always carries `/`.
+ *
+ * @param {Array<Object>} rows Listener rows from {@link probePortClaims}`.rows`.
  * @returns {Object<String, Number[]>} cwd → ascending ports served from it.
  */
-export function groupByServedCheckout(rows = probePortClaims()) {
+export function groupByServedCheckout(rows) {
     const grouped = {};
 
     for (const {cwd, port} of rows) {
@@ -144,16 +166,30 @@ export function groupByServedCheckout(rows = probePortClaims()) {
     return grouped;
 }
 
+/**
+ * @summary The keys of {@link groupByServedCheckout} that actually denote a checkout.
+ * @param {Object<String, Number[]>} grouped
+ * @returns {String[]} Paths excluding `/` and `unknown`.
+ */
+export function servedCheckouts(grouped) {
+    return Object.keys(grouped).filter(key => key !== UNKNOWN && key !== '/');
+}
+
 function main() {
-    const rows = probePortClaims();
+    const {observed, reason, rows} = probePortClaims();
 
     if (process.argv.includes('--json')) {
-        console.log(JSON.stringify({rows, byCheckout: groupByServedCheckout(rows)}, null, 4));
+        console.log(JSON.stringify({observed, reason, rows, byCheckout: groupByServedCheckout(rows)}, null, 4));
+        return;
+    }
+
+    if (!observed) {
+        console.log(`Could not observe port claims (${reason}). This is NOT "no listeners".`);
         return;
     }
 
     if (!rows.length) {
-        console.log('No TCP listeners observed (or lsof unavailable).');
+        console.log('Observed successfully: this host has no TCP listeners.');
         return;
     }
 
@@ -163,7 +199,7 @@ function main() {
     }
 
     const byCheckout = groupByServedCheckout(rows),
-          checkouts  = Object.keys(byCheckout).filter(key => key !== UNKNOWN);
+          checkouts  = servedCheckouts(byCheckout);
 
     if (checkouts.length > 1) {
         console.log(`\n${checkouts.length} distinct checkouts are serving ports on this host:`);

--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -432,18 +432,39 @@ async function exists(p) {
  *                                        are always excluded from this generic pass and materialized
  *                                        separately, even when callers inject a narrower blocklist.
  * @param {boolean}  [options.force=false] If true, clobber an existing non-symlink dir/file at a non-blocklisted child (never touches blocklisted children).
+ * @param {boolean}  [options.dryRun=false] Reconcile mode: classify every child WITHOUT mutating —
+ *                                        no `mkdir`, no `rm`, no `symlink`. Divergences that would `throw` in the
+ *                                        mutating path are recorded in `divergent` instead, so one deviant seat
+ *                                        cannot abort a multi-seat sweep before the rest are classified. The
+ *                                        classification is byte-identical to what the mutating pass would decide;
+ *                                        only the writes are withheld.
  * @param {Function} [options.log=console.log] Logger fn for action diagnostics.
- * @returns {Promise<{linked: string[], alreadyLinked: string[], clobbered: string[], skippedNoSource: string[], mainCheckout: boolean}>} Per-item action map.
- * @throws {Error} When a non-blocklisted child's dst is a non-symlink dir/file and `force` is false. The error message names the offending child.
+ * @returns {Promise<{linked: string[], alreadyLinked: string[], clobbered: string[], skippedNoSource: string[], blocklisted: string[], divergent: Array<{name: string, reason: string, found: string}>, resolved: Object<string,string>, mainCheckout: boolean}>}
+ *          Per-item action map. `blocklisted` + `divergent` + `resolved` make the map **exhaustive**: every child of
+ *          canonical's `.neo-ai-data/` lands in exactly one bucket, which is what lets a reconcile assert that a seat
+ *          carries no unexplained residue — residue means the blocklist is incomplete — rather than merely describe it.
+ * @throws {Error} When a non-blocklisted child's dst is a non-symlink dir/file and `force` is false, or when an
+ *                 existing symlink points outside the canonical checkout. **Never throws under `dryRun`** — both
+ *                 conditions are recorded in `divergent` instead. The error message names the offending child.
  */
 export async function symlinkDataDir({
     mainCheckout,
     projectRoot,
     blocklist = DATA_SUBDIRS_BLOCKLIST,
     force     = false,
+    dryRun    = false,
     log       = console.log
 }) {
-    const result = {linked: [], alreadyLinked: [], clobbered: [], skippedNoSource: [], mainCheckout: false};
+    const result = {
+        linked         : [],
+        alreadyLinked  : [],
+        clobbered      : [],
+        skippedNoSource: [],
+        blocklisted    : [],
+        divergent      : [],
+        resolved       : {},
+        mainCheckout   : false
+    };
 
     if (path.resolve(projectRoot) === path.resolve(mainCheckout)) {
         log(`symlink skip (main checkout): no per-item action`);
@@ -456,7 +477,7 @@ export async function symlinkDataDir({
     // Ensure the parent .neo-ai-data/ exists as a regular dir; we never symlink the parent.
     // This preserves the git-tracked concepts/ subdir already present in the worktree.
     const parentDst = path.join(projectRoot, '.neo-ai-data');
-    await fs.mkdir(parentDst, {recursive: true});
+    if (!dryRun) await fs.mkdir(parentDst, {recursive: true});
 
     // Blocklist, not allowlist: enumerate EVERY child of canonical's .neo-ai-data and link all
     // except the blocklist. A new substrate child is unified automatically, removing the
@@ -479,6 +500,7 @@ export async function symlinkDataDir({
 
         if (blocklistSet.has(name) || readAliasSet.has(name) || readAliasSourceSet.has(name)) {
             log(`symlink skip (blocklisted): ${name}`);
+            result.blocklisted.push(name);
             continue;
         }
 
@@ -494,6 +516,15 @@ export async function symlinkDataDir({
                 existingReal   = await fs.realpath(resolvedTarget).catch(() => resolvedTarget);
 
             if (existingReal !== canonicalReal) {
+                // Reconcile mode records the divergence and keeps classifying; the mutating path still
+                // refuses, because adopting another checkout's state is exactly what must never happen
+                // silently. Recording beats throwing here ONLY because nothing is being written.
+                if (dryRun) {
+                    log(`reconcile divergent (foreign symlink target): ${name} → ${existingReal}`);
+                    result.divergent.push({name, reason: 'foreign-symlink-target', found: existingReal});
+                    result.resolved[name] = existingReal;
+                    continue;
+                }
                 throw new Error(
                     `Refusing unexpected symlink target at ${dst}: expected ${src}, found ${resolvedTarget}. ` +
                     `Managed hydration never adopts another checkout's state implicitly.`
@@ -501,6 +532,7 @@ export async function symlinkDataDir({
             }
             log(`symlink skip (already linked): ${name}`);
             result.alreadyLinked.push(name);
+            result.resolved[name] = existingReal;
             continue;
         }
 
@@ -515,19 +547,27 @@ export async function symlinkDataDir({
         if (lstat) {
             // A real (non-symlink) dir or file already at dst would be shadowed by the link.
             if (!force) {
+                // Same rule as the foreign-target branch: reconcile records, hydration refuses.
+                if (dryRun) {
+                    log(`reconcile divergent (clone-local data, would need --force): ${name}`);
+                    result.divergent.push({name, reason: 'clone-local-non-symlink', found: dst});
+                    result.resolved[name] = await fs.realpath(dst).catch(() => dst);
+                    continue;
+                }
                 throw new Error(
                     `Refusing to replace non-symlink ${dst}; pass force=true (CLI --force) to opt in. ` +
                     `This path contains local data that would be lost.`
                 );
             }
             log(`symlink clobber (force=true): removing ${name}`);
-            await fs.rm(dst, {recursive: true, force: true});
+            if (!dryRun) await fs.rm(dst, {recursive: true, force: true});
             result.clobbered.push(name);
         }
 
-        await fs.symlink(src, dst, entry.isDirectory() ? 'dir' : 'file');
-        log(`symlinked: ${name} → ${src}`);
+        if (!dryRun) await fs.symlink(src, dst, entry.isDirectory() ? 'dir' : 'file');
+        log(`${dryRun ? 'would symlink' : 'symlinked'}: ${name} → ${src}`);
         result.linked.push(name);
+        result.resolved[name] = await fs.realpath(src).catch(() => src);
     }
 
     return result;

--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -84,7 +84,9 @@
  *                                                    # remove clean non-current .claude/worktrees
  *                                                    # checkouts via git, then hydrate current
  * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --dry-run
- * node ai/scripts/migrations/bootstrapWorktree.mjs --reconcile [--json]  # read-only per-seat plane + port report
+ * node ai/scripts/migrations/bootstrapWorktree.mjs --reconcile [--json]  # read-only plane + port report for THIS seat
+ * node ai/scripts/migrations/bootstrapWorktree.mjs --reconcile --seat <path> --seat <path>  # ...for named seats
+ * node ai/scripts/migrations/bootstrapWorktree.mjs --link-data --dry-run  # same read-only path, obvious spelling
  *                                                    # report the same keep/remove plan
  *                                                    # without mutating disk
  * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --include-dirty
@@ -436,17 +438,23 @@ async function exists(p) {
  * @param {boolean}  [options.dryRun=false] Reconcile mode: classify every child WITHOUT mutating —
  *                                        no `mkdir`, no `rm`, no `symlink`. Divergences that would `throw` in the
  *                                        mutating path are recorded in `divergent` instead, so one deviant seat
- *                                        cannot abort a multi-seat sweep before the rest are classified. The
- *                                        classification is byte-identical to what the mutating pass would decide;
- *                                        only the writes are withheld.
+ *                                        cannot abort a multi-seat sweep before the rest are classified.
+ *                                        **Classification under `dryRun` is force-invariant**: `force` describes what
+ *                                        a later hydration may destroy, not what the seat holds now, so it cannot move
+ *                                        a leaf out of `divergent` and cannot change the residue count.
  * @param {Function} [options.log=console.log] Logger fn for action diagnostics.
- * @returns {Promise<{linked: string[], alreadyLinked: string[], clobbered: string[], skippedNoSource: string[], blocklisted: string[], divergent: Array<{name: string, reason: string, found: string}>, seatOnly: string[], resolved: Object<string,string>, mainCheckout: boolean}>}
+ * @returns {Promise<{linked: string[], alreadyLinked: string[], clobbered: string[], skippedNoSource: string[], blocklisted: string[], divergent: Array<{name: string, reason: string, found: string}>, seatOnly: string[], resolved: Object<string,string>, mainCheckout: boolean, observed: {canonical: {ok: boolean, reason: string|null}, seat: {ok: boolean, reason: string|null}}}>}
  *          Per-item action map. Under `dryRun` it is **exhaustive over the union of canonical and seat children**:
- *          every name lands in an outcome bucket, including `seatOnly` leaves canonical does not know about, which is
- *          what lets a reconcile assert a seat carries no unexplained residue rather than merely describe it.
- *          `clobbered` is not a separate outcome — it records that a `linked` item had to displace local data first,
- *          so a force-clobbered leaf legitimately appears in both. Uniqueness holds over the outcome buckets, not
- *          over every array.
+ *          every name lands in exactly one bucket — including `seatOnly` leaves canonical does not know about — which
+ *          is what lets a reconcile assert a seat carries no unexplained residue rather than merely describe it.
+ *          `clobbered` is a mutating-path-only bucket and is always empty under `dryRun`, so the one-bucket property
+ *          holds there without exception. On the mutating path a force-clobbered leaf appears in both `clobbered` and
+ *          `linked`, because displacing local data and linking are two actions that both happened.
+ *          `resolved[name]` carries each observed leaf's realpath — canonical's for a link, the seat's for a
+ *          blocklisted or seat-only leaf — and is `null` only when the path could not be resolved at all.
+ *          `observed` reports whether each side was enumerable at all. **Zero residue is only meaningful when
+ *          both sides are `ok`**; an absent canonical or an unreadable seat produces empty buckets that mean
+ *          "could not compare", never "nothing to report". Callers must gate any clean verdict on it.
  * @throws {Error} When a non-blocklisted child's dst is a non-symlink dir/file and `force` is false, or when an
  *                 existing symlink points outside the canonical checkout. **Never throws under `dryRun`** — both
  *                 conditions are recorded in `divergent` instead. The error message names the offending child.
@@ -468,7 +476,11 @@ export async function symlinkDataDir({
         divergent      : [],
         seatOnly       : [],
         resolved       : {},
-        mainCheckout   : false
+        mainCheckout   : false,
+        // Whether each side was actually enumerable. A reconcile that cannot read a side has not
+        // found zero residue there — it has found nothing, and the consumer must be able to tell
+        // those apart without inferring it from empty arrays.
+        observed       : {canonical: {ok: true, reason: null}, seat: {ok: true, reason: null}}
     };
 
     if (path.resolve(projectRoot) === path.resolve(mainCheckout)) {
@@ -491,13 +503,20 @@ export async function symlinkDataDir({
         blocklistSet       = new Set(blocklist),
         readAliasSet       = new Set(CANONICAL_DATA_READ_ALIASES.map(entry => entry.alias)),
         readAliasSourceSet = new Set(CANONICAL_DATA_READ_ALIASES.map(entry => entry.source));
-    let entries;
+    let entries = [];
     try {
         entries = await fs.readdir(canonicalDataDir, {withFileTypes: true});
     } catch (e) {
-        // Fresh canonical with no .neo-ai-data yet — nothing to link.
-        if (e?.code === 'ENOENT') return result;
-        throw e;
+        if (e?.code !== 'ENOENT') throw e;
+
+        // A canonical with no `.neo-ai-data` is "nothing to link" for hydration and "could not
+        // compare" for a reconcile — the same filesystem fact, two different verdicts. Returning
+        // the empty result to both made a seat full of residue report zero: clean by absence of
+        // evidence. The reconcile therefore records the unavailability and keeps enumerating the
+        // seat, which does not depend on canonical to be readable.
+        result.observed.canonical = {ok: false, reason: 'canonical-data-dir-absent'};
+        log(`reconcile canonical unavailable: ${canonicalDataDir} does not exist`);
+        if (!dryRun) return result;
     }
 
     // Reconcile enumerates the UNION of canonical and seat children. Iterating canonical alone
@@ -507,7 +526,22 @@ export async function symlinkDataDir({
     if (dryRun) {
         const canonicalNames = new Set(entries.map(entry => entry.name));
 
-        for (const name of await fs.readdir(parentDst).catch(() => [])) {
+        let seatNames = [];
+        try {
+            seatNames = await fs.readdir(parentDst);
+        } catch (e) {
+            // An ABSENT seat dir is a real observation: an unhydrated seat holds nothing, so zero
+            // residue is the truth. An UNREADABLE one is not — permissions hide exactly the leaves
+            // the falsifier exists to find, so it must not be allowed to look like emptiness.
+            if (e?.code === 'ENOENT') {
+                result.observed.seat = {ok: true, reason: 'seat-data-dir-absent'};
+            } else {
+                result.observed.seat = {ok: false, reason: `seat-data-dir-unreadable: ${e?.code ?? 'unknown'}`};
+                log(`reconcile seat unreadable: ${parentDst} (${e?.code ?? 'unknown'})`);
+            }
+        }
+
+        for (const name of seatNames) {
             if (canonicalNames.has(name) || blocklistSet.has(name) || readAliasSet.has(name) || readAliasSourceSet.has(name)) continue;
 
             const seatPath = path.join(parentDst, name);
@@ -523,6 +557,11 @@ export async function symlinkDataDir({
         if (blocklistSet.has(name) || readAliasSet.has(name) || readAliasSourceSet.has(name)) {
             log(`symlink skip (blocklisted): ${name}`);
             result.blocklisted.push(name);
+            // A blocklisted child is deliberately seat-local, which makes WHERE it lives the one
+            // fact a reconcile actually needs about it — "we skipped it" is not an observation.
+            // The seat path is the subject here, not canonical's: the whole point of the blocklist
+            // is that these two are supposed to differ.
+            result.resolved[name] = await fs.realpath(path.join(parentDst, name)).catch(() => null);
             continue;
         }
 
@@ -568,21 +607,28 @@ export async function symlinkDataDir({
 
         if (lstat) {
             // A real (non-symlink) dir or file already at dst would be shadowed by the link.
+
+            // Reconcile classification is FORCE-INVARIANT, and that is the load-bearing property.
+            // `force` states what a later hydration would be permitted to destroy; it says nothing
+            // about what is on the seat right now. Letting it move this leaf out of `divergent`
+            // made `--force --reconcile` report residue: 0 on the exact seat where `--reconcile`
+            // alone reported residue: 1 — same filesystem, same untouched file, opposite verdict.
+            // A diagnostic whose falsifier can be silenced by a mutation-intent flag is not one.
+            if (dryRun) {
+                log(`reconcile divergent (clone-local data, would need --force): ${name}`);
+                result.divergent.push({name, reason: 'clone-local-non-symlink', found: dst});
+                result.resolved[name] = await fs.realpath(dst).catch(() => dst);
+                continue;
+            }
+
             if (!force) {
-                // Same rule as the foreign-target branch: reconcile records, hydration refuses.
-                if (dryRun) {
-                    log(`reconcile divergent (clone-local data, would need --force): ${name}`);
-                    result.divergent.push({name, reason: 'clone-local-non-symlink', found: dst});
-                    result.resolved[name] = await fs.realpath(dst).catch(() => dst);
-                    continue;
-                }
                 throw new Error(
                     `Refusing to replace non-symlink ${dst}; pass force=true (CLI --force) to opt in. ` +
                     `This path contains local data that would be lost.`
                 );
             }
             log(`symlink clobber (force=true): removing ${name}`);
-            if (!dryRun) await fs.rm(dst, {recursive: true, force: true});
+            await fs.rm(dst, {recursive: true, force: true}); // dryRun already returned above
             result.clobbered.push(name);
         }
 
@@ -1270,8 +1316,18 @@ if (isMain) {
     const pruneStale = args.has('--prune-stale') || argv.includes('--mode=prune-stale') ||
         (argv.includes('--mode') && argv[argv.indexOf('--mode') + 1] === 'prune-stale');
     const dryRun        = args.has('--dry-run');
-    const reconcile     = args.has('--reconcile');
     const jsonOut       = args.has('--json');
+
+    // `--link-data --dry-run` is the spelling an operator reaches for first, so it MUST be the
+    // read-only path rather than a flag the link stage quietly ignores while it writes.
+    const reconcile = args.has('--reconcile') || (linkData && dryRun);
+
+    // Repeatable `--seat <path>`: classify seats other than the one this script lives in.
+    // Without it the reconcile can only ever describe its own checkout, which makes the
+    // multi-seat question — do two seats resolve the same plane? — unaskable from one process.
+    const seats = argv.reduce((acc, arg, i) => (
+        arg === '--seat' && argv[i + 1] ? [...acc, path.resolve(argv[i + 1])] : acc
+    ), []);
     const includeDirty  = args.has('--include-dirty');
     const scheduleLocal = args.has('--schedule-local');
     const intervalMs    = getNumberFlag(argv, '--interval-ms', 6 * 60 * 60 * 1000);
@@ -1299,46 +1355,71 @@ if (isMain) {
         // claims observed by the sibling probe — because a caller that has to run two commands and
         // staple the output together is not a report, it is a suggestion.
         if (reconcile) {
-            const {probePortClaims, groupByServedCheckout, servedCheckouts} =
+            const {probePortClaims, groupByCwd, servedCwds} =
                 await import('../diagnostics/probePortClaims.mjs');
 
             const
-                plane  = await symlinkDataDir({mainCheckout, projectRoot, dryRun: true, log: () => {}}),
-                ports  = probePortClaims(),
-                report = {
-                    seat      : projectRoot,
-                    canonical : mainCheckout,
-                    plane,
+                targets = seats.length ? seats : [projectRoot],
+                ports   = probePortClaims(),
+                grouped = groupByCwd(ports.rows),
+                report  = {
+                    canonical: mainCheckout,
+                    // Port claims are a property of the HOST, not of any one seat, so they sit
+                    // once at the top. Repeating them per seat would imply each seat owns the
+                    // listeners it happens to be reported next to.
                     portClaims: {
-                        observed  : ports.observed,
-                        reason    : ports.reason,
-                        rows      : ports.rows,
-                        byCheckout: groupByServedCheckout(ports.rows),
-                        checkouts : servedCheckouts(groupByServedCheckout(ports.rows))
-                    }
+                        observed: ports.observed,
+                        reason  : ports.reason,
+                        rows    : ports.rows,
+                        byCwd   : grouped,
+                        cwds    : servedCwds(grouped)
+                    },
+                    seats: []
                 };
+
+            for (const seat of targets) {
+                report.seats.push({
+                    seat,
+                    plane: await symlinkDataDir({mainCheckout, projectRoot: seat, dryRun: true, log: () => {}})
+                });
+            }
 
             if (jsonOut) {
                 console.log(JSON.stringify(report, null, 4));
             } else {
-                console.log(`Seat:      ${report.seat}`);
                 console.log(`Canonical: ${report.canonical}\n`);
-                for (const bucket of ['linked', 'alreadyLinked', 'blocklisted', 'skippedNoSource', 'seatOnly']) {
-                    console.log(`  ${bucket.padEnd(16)} ${plane[bucket].length}`);
-                }
-                console.log(`  ${'divergent'.padEnd(16)} ${plane.divergent.length}`);
-                for (const {name, reason} of plane.divergent) console.log(`      ! ${name} — ${reason}`);
 
-                // Residue is the falsifier's input, not its verdict. Non-zero residue has at least
-                // two readings — the blocklist is incomplete, or this seat was never hydrated with
-                // --link-data — and the report must not pick one. Naming the observation and
-                // leaving the interpretation to the reader is the whole point of a ground-truth
-                // artifact; a diagnostic that concludes is a diagnostic you have to re-derive.
-                const residue = plane.divergent.length + plane.seatOnly.length;
-                console.log(`\n  residue: ${residue}${residue ? ' — unreconciled against the declaration (incomplete blocklist OR unhydrated seat)' : ' (clean)'}`);
+                for (const {seat, plane} of report.seats) {
+                    console.log(`Seat: ${seat}`);
+                    for (const bucket of ['linked', 'alreadyLinked', 'blocklisted', 'skippedNoSource', 'seatOnly']) {
+                        console.log(`  ${bucket.padEnd(16)} ${plane[bucket].length}`);
+                    }
+                    console.log(`  ${'divergent'.padEnd(16)} ${plane.divergent.length}`);
+                    for (const {name, reason} of plane.divergent) console.log(`      ! ${name} — ${reason}`);
+
+                    // Residue is the falsifier's input, not its verdict. Non-zero residue has at least
+                    // two readings — the blocklist is incomplete, or this seat was never hydrated with
+                    // --link-data — and the report must not pick one. Naming the observation and
+                    // leaving the interpretation to the reader is the whole point of a ground-truth
+                    // artifact; a diagnostic that concludes is a diagnostic you have to re-derive.
+                    //
+                    // `(clean)` is spoken ONLY when both sides were enumerable. Zero residue off an
+                    // unreadable side is the absence of evidence wearing the words of evidence.
+                    const
+                        residue    = plane.divergent.length + plane.seatOnly.length,
+                        unobserved = Object.entries(plane.observed).filter(([, state]) => !state.ok);
+
+                    console.log(`  residue: ${residue}${
+                        residue     ? ' — unreconciled against the declaration (incomplete blocklist OR unhydrated seat)' :
+                        unobserved.length
+                            ? ` — NOT CLEAN, NOT COMPARED (${unobserved.map(([side, state]) => `${side}: ${state.reason}`).join('; ')})`
+                            : ' (clean)'
+                    }\n`);
+                }
+
                 console.log(report.portClaims.observed
-                    ? `  ports:   ${report.portClaims.rows.length} listener(s), ${report.portClaims.checkouts.length} checkout(s)`
-                    : `  ports:   NOT OBSERVED (${report.portClaims.reason}) — this is not "no listeners"`);
+                    ? `Ports: ${report.portClaims.rows.length} listener(s) across ${report.portClaims.cwds.length} serving cwd(s)`
+                    : `Ports: NOT OBSERVED (${report.portClaims.reason}) — this is not "no listeners"`);
             }
             process.exit(0);
         }

--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -84,6 +84,7 @@
  *                                                    # remove clean non-current .claude/worktrees
  *                                                    # checkouts via git, then hydrate current
  * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --dry-run
+ * node ai/scripts/migrations/bootstrapWorktree.mjs --reconcile [--json]  # read-only per-seat plane + port report
  *                                                    # report the same keep/remove plan
  *                                                    # without mutating disk
  * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --include-dirty
@@ -439,10 +440,13 @@ async function exists(p) {
  *                                        classification is byte-identical to what the mutating pass would decide;
  *                                        only the writes are withheld.
  * @param {Function} [options.log=console.log] Logger fn for action diagnostics.
- * @returns {Promise<{linked: string[], alreadyLinked: string[], clobbered: string[], skippedNoSource: string[], blocklisted: string[], divergent: Array<{name: string, reason: string, found: string}>, resolved: Object<string,string>, mainCheckout: boolean}>}
- *          Per-item action map. `blocklisted` + `divergent` + `resolved` make the map **exhaustive**: every child of
- *          canonical's `.neo-ai-data/` lands in exactly one bucket, which is what lets a reconcile assert that a seat
- *          carries no unexplained residue — residue means the blocklist is incomplete — rather than merely describe it.
+ * @returns {Promise<{linked: string[], alreadyLinked: string[], clobbered: string[], skippedNoSource: string[], blocklisted: string[], divergent: Array<{name: string, reason: string, found: string}>, seatOnly: string[], resolved: Object<string,string>, mainCheckout: boolean}>}
+ *          Per-item action map. Under `dryRun` it is **exhaustive over the union of canonical and seat children**:
+ *          every name lands in an outcome bucket, including `seatOnly` leaves canonical does not know about, which is
+ *          what lets a reconcile assert a seat carries no unexplained residue rather than merely describe it.
+ *          `clobbered` is not a separate outcome — it records that a `linked` item had to displace local data first,
+ *          so a force-clobbered leaf legitimately appears in both. Uniqueness holds over the outcome buckets, not
+ *          over every array.
  * @throws {Error} When a non-blocklisted child's dst is a non-symlink dir/file and `force` is false, or when an
  *                 existing symlink points outside the canonical checkout. **Never throws under `dryRun`** — both
  *                 conditions are recorded in `divergent` instead. The error message names the offending child.
@@ -462,6 +466,7 @@ export async function symlinkDataDir({
         skippedNoSource: [],
         blocklisted    : [],
         divergent      : [],
+        seatOnly       : [],
         resolved       : {},
         mainCheckout   : false
     };
@@ -493,6 +498,23 @@ export async function symlinkDataDir({
         // Fresh canonical with no .neo-ai-data yet — nothing to link.
         if (e?.code === 'ENOENT') return result;
         throw e;
+    }
+
+    // Reconcile enumerates the UNION of canonical and seat children. Iterating canonical alone
+    // cannot see a leaf that exists only on the seat, so "no unexplained residue" would be
+    // unprovable rather than merely unproven — the residue the falsifier looks for is exactly
+    // the kind canonical does not know about.
+    if (dryRun) {
+        const canonicalNames = new Set(entries.map(entry => entry.name));
+
+        for (const name of await fs.readdir(parentDst).catch(() => [])) {
+            if (canonicalNames.has(name) || blocklistSet.has(name) || readAliasSet.has(name) || readAliasSourceSet.has(name)) continue;
+
+            const seatPath = path.join(parentDst, name);
+            log(`reconcile seat-only (absent from canonical): ${name}`);
+            result.seatOnly.push(name);
+            result.resolved[name] = await fs.realpath(seatPath).catch(() => seatPath);
+        }
     }
 
     for (const entry of entries) {
@@ -1248,6 +1270,8 @@ if (isMain) {
     const pruneStale = args.has('--prune-stale') || argv.includes('--mode=prune-stale') ||
         (argv.includes('--mode') && argv[argv.indexOf('--mode') + 1] === 'prune-stale');
     const dryRun        = args.has('--dry-run');
+    const reconcile     = args.has('--reconcile');
+    const jsonOut       = args.has('--json');
     const includeDirty  = args.has('--include-dirty');
     const scheduleLocal = args.has('--schedule-local');
     const intervalMs    = getNumberFlag(argv, '--interval-ms', 6 * 60 * 60 * 1000);
@@ -1269,6 +1293,55 @@ if (isMain) {
             process.exit(1);
         }
         if (explicitRoot) console.log(`✓ Canonical checkout (explicit): ${mainCheckout}`);
+
+        // --reconcile: the read-only per-seat report. Combines both axes in one artifact — the
+        // symlink/root classification derived from the hydration declaration, and the host port
+        // claims observed by the sibling probe — because a caller that has to run two commands and
+        // staple the output together is not a report, it is a suggestion.
+        if (reconcile) {
+            const {probePortClaims, groupByServedCheckout, servedCheckouts} =
+                await import('../diagnostics/probePortClaims.mjs');
+
+            const
+                plane  = await symlinkDataDir({mainCheckout, projectRoot, dryRun: true, log: () => {}}),
+                ports  = probePortClaims(),
+                report = {
+                    seat      : projectRoot,
+                    canonical : mainCheckout,
+                    plane,
+                    portClaims: {
+                        observed  : ports.observed,
+                        reason    : ports.reason,
+                        rows      : ports.rows,
+                        byCheckout: groupByServedCheckout(ports.rows),
+                        checkouts : servedCheckouts(groupByServedCheckout(ports.rows))
+                    }
+                };
+
+            if (jsonOut) {
+                console.log(JSON.stringify(report, null, 4));
+            } else {
+                console.log(`Seat:      ${report.seat}`);
+                console.log(`Canonical: ${report.canonical}\n`);
+                for (const bucket of ['linked', 'alreadyLinked', 'blocklisted', 'skippedNoSource', 'seatOnly']) {
+                    console.log(`  ${bucket.padEnd(16)} ${plane[bucket].length}`);
+                }
+                console.log(`  ${'divergent'.padEnd(16)} ${plane.divergent.length}`);
+                for (const {name, reason} of plane.divergent) console.log(`      ! ${name} — ${reason}`);
+
+                // Residue is the falsifier's input, not its verdict. Non-zero residue has at least
+                // two readings — the blocklist is incomplete, or this seat was never hydrated with
+                // --link-data — and the report must not pick one. Naming the observation and
+                // leaving the interpretation to the reader is the whole point of a ground-truth
+                // artifact; a diagnostic that concludes is a diagnostic you have to re-derive.
+                const residue = plane.divergent.length + plane.seatOnly.length;
+                console.log(`\n  residue: ${residue}${residue ? ' — unreconciled against the declaration (incomplete blocklist OR unhydrated seat)' : ' (clean)'}`);
+                console.log(report.portClaims.observed
+                    ? `  ports:   ${report.portClaims.rows.length} listener(s), ${report.portClaims.checkouts.length} checkout(s)`
+                    : `  ports:   NOT OBSERVED (${report.portClaims.reason}) — this is not "no listeners"`);
+            }
+            process.exit(0);
+        }
 
         if (pruneStale) {
             if (scheduleLocal) {

--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -542,12 +542,24 @@ export async function symlinkDataDir({
         }
 
         for (const name of seatNames) {
-            if (canonicalNames.has(name) || blocklistSet.has(name) || readAliasSet.has(name) || readAliasSourceSet.has(name)) continue;
+            if (canonicalNames.has(name)) continue; // the canonical loop below owns every shared name
 
-            const seatPath = path.join(parentDst, name);
-            log(`reconcile seat-only (absent from canonical): ${name}`);
-            result.seatOnly.push(name);
-            result.resolved[name] = await fs.realpath(seatPath).catch(() => seatPath);
+            // A declared-local leaf is classified here too, not skipped. Skipping it meant only
+            // canonical's children could ever populate `blocklisted` — and a blocklisted child
+            // existing ONLY on the seat is not an edge case, it is the whole point of the blocklist.
+            // Such a leaf vanished from an "exhaustive" report while both sides read as observed,
+            // which is the worst version of this: nothing looked wrong.
+            const declaredLocal = blocklistSet.has(name) || readAliasSet.has(name) || readAliasSourceSet.has(name);
+
+            if (declaredLocal) {
+                log(`reconcile seat-local (declared, absent from canonical): ${name}`);
+                result.blocklisted.push(name);
+            } else {
+                log(`reconcile seat-only (absent from canonical): ${name}`);
+                result.seatOnly.push(name);
+            }
+
+            result.resolved[name] = await fs.realpath(path.join(parentDst, name)).catch(() => null);
         }
     }
 

--- a/test/playwright/unit/ai/scripts/diagnostics/probePortClaims.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/probePortClaims.spec.mjs
@@ -1,11 +1,14 @@
 import {expect, test}                                from '@playwright/test';
-import {groupByServedCheckout, parseListenerRecords,
-        servedCheckouts}                             from '../../../../../../ai/scripts/diagnostics/probePortClaims.mjs';
+import {groupByCwd, parseListenerRecords,
+        servedCwds}                                  from '../../../../../../ai/scripts/diagnostics/probePortClaims.mjs';
 
 /**
- * The probe answers the fourth axis of a per-seat data-root reconcile: which checkout SERVES each
- * port. Occupancy is not identity — a runner that trusted any listener on a port once executed a
- * different checkout's tree and produced false greens as well as false reds.
+ * The probe answers the fourth axis of a per-seat data-root reconcile: which directory each port's
+ * listener RESOLVES PATHS AGAINST. Occupancy is not identity — a runner that trusted any listener
+ * on a port once executed a different checkout's tree and produced false greens as well as reds.
+ *
+ * The probe reports cwds, not verified checkouts, and these tests hold it to that weaker claim:
+ * nothing here validates a path as a repository root, so nothing may assert one.
  *
  * The parser is tested against fixture `lsof -F pcn` output rather than live sockets: a test that
  * needed real listeners to prove the record-folding is right would be unrunnable in CI, which is
@@ -73,29 +76,43 @@ test.describe('ai/scripts/diagnostics/probePortClaims', () => {
         expect(rows[0].port).toBe(7000);
     });
 
-    test('groups by served checkout — the same port number is a DIFFERENT plane per checkout', () => {
-        const grouped = groupByServedCheckout(parseListenerRecords(fixture, resolver));
+    test('groups by serving cwd — the same port number is a DIFFERENT plane per directory', () => {
+        const grouped = groupByCwd(parseListenerRecords(fixture, resolver));
 
         expect(grouped['/seats/seat-a/neo']).toEqual([8081, 8083]);
         expect(grouped['/canonical/neo']).toEqual([8080]);
 
         // The finding this exists to surface: more than one checkout serving one host's namespace.
-        expect(servedCheckouts(grouped).length).toBeGreaterThan(1);
+        expect(servedCwds(grouped).length).toBeGreaterThan(1);
     });
 
-    test('a root-owned daemon is NOT counted as a checkout', () => {
+    test('a root-owned daemon is NOT counted as a serving cwd', () => {
         // A stock macOS host always has something rooted at `/` (ControlCenter, etc). Counting raw
-        // group keys would report a checkout that does not exist, inflating the very finding this
+        // group keys would report a plane that does not exist, inflating the very finding this
         // probe is meant to establish — an over-count is as wrong as a miss.
-        const grouped = groupByServedCheckout(parseListenerRecords(fixture, resolver));
+        const grouped = groupByCwd(parseListenerRecords(fixture, resolver));
 
         expect(grouped['/']).toEqual([5000]);
-        expect(servedCheckouts(grouped)).not.toContain('/');
-        expect(servedCheckouts(grouped)).not.toContain('unknown');
+        expect(servedCwds(grouped)).not.toContain('/');
+        expect(servedCwds(grouped)).not.toContain('unknown');
     });
 
     test('empty lsof output is a valid observation, not an error', () => {
         // A host with no listeners must return [], never throw — lsof exits non-zero on no-match.
         expect(parseListenerRecords('', () => 'unknown')).toEqual([]);
+    });
+
+    test('a non-repository cwd is reported as-is, never dropped and never called a checkout', () => {
+        // The probe validates nothing about a cwd, so a listener serving from `/usr/local/var` or a
+        // user's home has to survive the grouping intact. Filtering "non-repo-looking" paths would
+        // be the probe inventing an identity check it never ran; the honest output is the cwd.
+        const
+            raw     = 'p9001\ncpostgres\nn*:5432\np9002\ncnode\nn*:9229',
+            cwds    = {9001: '/usr/local/var/postgres', 9002: '/Users/someone'},
+            grouped = groupByCwd(parseListenerRecords(raw, pid => cwds[pid]));
+
+        expect(grouped['/usr/local/var/postgres']).toEqual([5432]);
+        expect(grouped['/Users/someone']).toEqual([9229]);
+        expect(servedCwds(grouped).sort()).toEqual(['/Users/someone', '/usr/local/var/postgres']);
     });
 });

--- a/test/playwright/unit/ai/scripts/diagnostics/probePortClaims.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/probePortClaims.spec.mjs
@@ -1,0 +1,89 @@
+import {expect, test}                                from '@playwright/test';
+import {groupByServedCheckout, parseListenerRecords} from '../../../../../../ai/scripts/diagnostics/probePortClaims.mjs';
+
+/**
+ * The probe answers the fourth axis of a per-seat data-root reconcile: which checkout SERVES each
+ * port. Occupancy is not identity — a runner that trusted any listener on a port once executed a
+ * different checkout's tree and produced false greens as well as false reds.
+ *
+ * The parser is tested against fixture `lsof -F pcn` output rather than live sockets: a test that
+ * needed real listeners to prove the record-folding is right would be unrunnable in CI, which is
+ * the reason the shell seam is injected rather than called.
+ */
+test.describe('ai/scripts/diagnostics/probePortClaims', () => {
+    // `lsof -F pcn` is line-oriented and stateful: p<pid> opens a process block, c<cmd> names it,
+    // and each following n<name> is one of THAT process's sockets.
+    const fixture = [
+        'p1363',
+        'cnode',
+        'n*:8081',
+        'n*:8083',
+        'p47541',
+        'cnode',
+        'n127.0.0.1:8080',
+        'p719',
+        'cControlCenter',
+        'n*:5000'
+    ].join('\n');
+
+    const cwds = {
+        1363 : '/seats/seat-a/neo',
+        47541: '/canonical/neo',
+        719  : '/'
+    };
+
+    const resolver = pid => cwds[pid] ?? 'unknown';
+
+    test('folds multi-socket process blocks — every port carries its OWN process cwd', () => {
+        const rows = parseListenerRecords(fixture, resolver);
+
+        expect(rows).toHaveLength(4);
+        expect(rows.map(row => row.port)).toEqual([5000, 8080, 8081, 8083]);
+
+        // Both of pid 1363's sockets inherit that pid's cwd — the state must carry across n-lines.
+        expect(rows.filter(row => row.pid === '1363').map(row => row.cwd))
+            .toEqual(['/seats/seat-a/neo', '/seats/seat-a/neo']);
+    });
+
+    test('resolves each pid at most once', () => {
+        const seen = [];
+        parseListenerRecords(fixture, pid => {
+            seen.push(pid);
+            return cwds[pid] ?? 'unknown';
+        });
+
+        // pid 1363 owns two sockets but must be resolved once — the probe reads /proc-equivalents,
+        // and re-reading per socket would scale with sockets rather than processes.
+        expect(seen).toEqual(['1363', '47541', '719']);
+    });
+
+    test('reports unknown rather than guessing when a process is not inspectable', () => {
+        // A foreign-uid process yields no cwd line; the honest answer is `unknown`, never a
+        // plausible-looking default. A wrong checkout attribution is worse than an absent one.
+        const rows = parseListenerRecords('p999\ncsomething\nn*:9999', () => 'unknown');
+
+        expect(rows[0].cwd).toBe('unknown');
+    });
+
+    test('ignores non-socket n-lines and records without a parsable port', () => {
+        const rows = parseListenerRecords('p1\ncnode\nn/some/path\nn*:7000', () => '/x');
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0].port).toBe(7000);
+    });
+
+    test('groups by served checkout — the same port number is a DIFFERENT plane per checkout', () => {
+        const grouped = groupByServedCheckout(parseListenerRecords(fixture, resolver));
+
+        expect(grouped['/seats/seat-a/neo']).toEqual([8081, 8083]);
+        expect(grouped['/canonical/neo']).toEqual([8080]);
+
+        // The finding this exists to surface: more than one checkout serving one host's namespace.
+        expect(Object.keys(grouped).filter(key => key !== 'unknown').length).toBeGreaterThan(1);
+    });
+
+    test('empty lsof output is a valid observation, not an error', () => {
+        // A host with no listeners must return [], never throw — lsof exits non-zero on no-match.
+        expect(parseListenerRecords('', () => 'unknown')).toEqual([]);
+    });
+});

--- a/test/playwright/unit/ai/scripts/diagnostics/probePortClaims.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/probePortClaims.spec.mjs
@@ -1,5 +1,6 @@
 import {expect, test}                                from '@playwright/test';
-import {groupByServedCheckout, parseListenerRecords} from '../../../../../../ai/scripts/diagnostics/probePortClaims.mjs';
+import {groupByServedCheckout, parseListenerRecords,
+        servedCheckouts}                             from '../../../../../../ai/scripts/diagnostics/probePortClaims.mjs';
 
 /**
  * The probe answers the fourth axis of a per-seat data-root reconcile: which checkout SERVES each
@@ -79,7 +80,18 @@ test.describe('ai/scripts/diagnostics/probePortClaims', () => {
         expect(grouped['/canonical/neo']).toEqual([8080]);
 
         // The finding this exists to surface: more than one checkout serving one host's namespace.
-        expect(Object.keys(grouped).filter(key => key !== 'unknown').length).toBeGreaterThan(1);
+        expect(servedCheckouts(grouped).length).toBeGreaterThan(1);
+    });
+
+    test('a root-owned daemon is NOT counted as a checkout', () => {
+        // A stock macOS host always has something rooted at `/` (ControlCenter, etc). Counting raw
+        // group keys would report a checkout that does not exist, inflating the very finding this
+        // probe is meant to establish — an over-count is as wrong as a miss.
+        const grouped = groupByServedCheckout(parseListenerRecords(fixture, resolver));
+
+        expect(grouped['/']).toEqual([5000]);
+        expect(servedCheckouts(grouped)).not.toContain('/');
+        expect(servedCheckouts(grouped)).not.toContain('unknown');
     });
 
     test('empty lsof output is a valid observation, not an error', () => {

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -725,6 +725,113 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(result.mainCheckout).toBe(false);
         });
 
+        test('#15791 dryRun classifies every child WITHOUT mutating anything', async () => {
+            await seedMainSubdirs();
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                dryRun      : true,
+                log         : () => {}
+            });
+
+            // Classification is identical to what the mutating pass would decide...
+            expect(result.linked.sort()).toEqual([...fixtureSubdirs].sort());
+
+            // ...but nothing was written: no parent dir, no links.
+            expect(await fs.pathExists(path.join(fakeWorktree, dataDir))).toBe(false);
+
+            for (const subdir of fixtureSubdirs) {
+                expect(result.resolved[subdir]).toBe(
+                    await fs.realpath(path.join(fakeMainCheckout, dataDir, subdir))
+                );
+            }
+        });
+
+        test('#15791 dryRun records a foreign symlink target as divergent instead of throwing', async () => {
+            // The mutating path refuses (see the sibling test above) because adopting another
+            // checkout's state silently is the failure. A reconcile must RECORD it instead —
+            // one deviant seat cannot be allowed to abort a multi-seat sweep.
+            await seedMainSubdirs(['sqlite']);
+
+            const
+                foreign = path.join(path.dirname(fakeMainCheckout), 'foreign-checkout', dataDir, 'sqlite'),
+                dst     = path.join(fakeWorktree, dataDir, 'sqlite');
+
+            await fs.ensureDir(foreign);
+            await fs.ensureDir(path.dirname(dst));
+            await fs.symlink(foreign, dst, 'dir');
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                dryRun      : true,
+                log         : () => {}
+            });
+
+            expect(result.divergent).toHaveLength(1);
+            expect(result.divergent[0].name).toBe('sqlite');
+            expect(result.divergent[0].reason).toBe('foreign-symlink-target');
+            expect(result.divergent[0].found).toBe(await fs.realpath(foreign));
+            expect(result.alreadyLinked).not.toContain('sqlite');
+
+            // The divergent link is untouched — reconcile observes, never repairs.
+            expect(path.resolve(path.dirname(dst), await fs.readlink(dst))).toBe(foreign);
+        });
+
+        test('#15791 dryRun records clone-local data as divergent instead of throwing', async () => {
+            await seedMainSubdirs();
+
+            const worktreeSubdir = path.join(fakeWorktree, dataDir, 'sqlite');
+            await fs.ensureDir(worktreeSubdir);
+            await fs.writeFile(path.join(worktreeSubdir, 'local-only.txt'), 'worktree-specific\n', 'utf-8');
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                dryRun      : true,
+                log         : () => {}
+            });
+
+            expect(result.divergent.map(entry => entry.name)).toContain('sqlite');
+            expect(result.divergent.find(entry => entry.name === 'sqlite').reason).toBe('clone-local-non-symlink');
+
+            // The local data is still there — a reconcile never destroys what it reports.
+            expect(await fs.readFile(path.join(worktreeSubdir, 'local-only.txt'), 'utf-8'))
+                .toBe('worktree-specific\n');
+        });
+
+        test('#15791 dryRun leaves NO unexplained residue — every canonical child lands in exactly one bucket', async () => {
+            // This is @neo-opus-grace's falsifier made executable: the reconcile is only
+            // decision-grade for OQ10 if it can come back negative. Residue on any seat means
+            // DATA_SUBDIRS_BLOCKLIST is incomplete — regardless of whether the residue has a story.
+            await seedMainSubdirs();
+            await fs.ensureDir(path.join(fakeMainCheckout, dataDir, 'concepts'));         // blocklisted
+            await fs.ensureDir(path.join(fakeMainCheckout, dataDir, 'orchestrator-daemon')); // blocklisted
+
+            const
+                canonicalChildren = await fs.readdir(path.join(fakeMainCheckout, dataDir)),
+                result            = await symlinkDataDir({
+                    mainCheckout: fakeMainCheckout,
+                    projectRoot : fakeWorktree,
+                    dryRun      : true,
+                    log         : () => {}
+                }),
+                classified        = [
+                    ...result.linked,
+                    ...result.alreadyLinked,
+                    ...result.clobbered,
+                    ...result.skippedNoSource,
+                    ...result.blocklisted,
+                    ...result.divergent.map(entry => entry.name)
+                ];
+
+            expect(classified.sort()).toEqual([...canonicalChildren].sort());
+
+            // Exactly one bucket each — a name in two buckets is as bad as a name in none.
+            expect(new Set(classified).size).toBe(classified.length);
+        });
+
         test('NEVER touches concepts/ even when present in main checkout and force=true', async () => {
             // Seed both the allowlisted subdirs AND a concepts/ in main and a regular
             // (tracked-style) concepts/ in the worktree with unique content.

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -18,7 +18,9 @@ import Neo             from '../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 import fs              from 'fs-extra';
+import os              from 'os';
 import path            from 'path';
+import {execFile}      from 'child_process';
 
 /**
  * @summary Coverage for the worktree bootstrap script.
@@ -802,9 +804,9 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
         });
 
         test('#15791 dryRun leaves NO unexplained residue — every canonical child lands in exactly one bucket', async () => {
-            // This is @neo-opus-grace's falsifier made executable: the reconcile is only
-            // decision-grade for OQ10 if it can come back negative. Residue on any seat means
-            // DATA_SUBDIRS_BLOCKLIST is incomplete — regardless of whether the residue has a story.
+            // The reconcile is only decision-grade if it can come back negative. Residue on any
+            // seat means DATA_SUBDIRS_BLOCKLIST is incomplete — regardless of whether the residue
+            // has a story a reader finds reassuring.
             await seedMainSubdirs();
             await fs.ensureDir(path.join(fakeMainCheckout, dataDir, 'concepts'));         // blocklisted
             await fs.ensureDir(path.join(fakeMainCheckout, dataDir, 'orchestrator-daemon')); // blocklisted
@@ -828,9 +830,8 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
 
             expect(classified.sort()).toEqual([...canonicalChildren].sort());
 
-            // One OUTCOME bucket each. `clobbered` is deliberately excluded from the union: it is
-            // not an outcome but a note that a `linked` item displaced local data first, so a
-            // force-clobbered leaf legitimately appears in both arrays.
+            // One bucket each, with no exceptions to state: `clobbered` is a mutating-path bucket
+            // and is always empty under dryRun, so the union above is the whole classification.
             expect(new Set(classified).size).toBe(classified.length);
         });
 
@@ -852,25 +853,111 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(result.linked).toContain('sqlite');
         });
 
-        test('#15791 force-clobber under dryRun reports the would-be clobber without losing the link', async () => {
+        test('#15791 dryRun classification is FORCE-INVARIANT — --force cannot silence the residue', async () => {
+            // The defect this pins: `force` moved a clone-local leaf out of `divergent` into
+            // clobbered+linked, so the same seat with the same untouched file reported residue 1
+            // without --force and residue 0 with it. A falsifier a flag can switch off is not one.
+            // `force` describes what a later hydration may destroy; it observes nothing.
             await seedMainSubdirs(['sqlite']);
             const local = path.join(fakeWorktree, dataDir, 'sqlite');
             await fs.ensureDir(local);
             await fs.writeFile(path.join(local, 'local.txt'), 'seat-local\n', 'utf-8');
 
+            const runs = [];
+            for (const force of [false, true]) {
+                runs.push(await symlinkDataDir({
+                    mainCheckout: fakeMainCheckout,
+                    projectRoot : fakeWorktree,
+                    dryRun      : true,
+                    force,
+                    log         : () => {}
+                }));
+            }
+
+            for (const result of runs) {
+                expect(result.divergent.map(entry => entry.name)).toContain('sqlite');
+                expect(result.divergent.find(entry => entry.name === 'sqlite').reason).toBe('clone-local-non-symlink');
+                expect(result.clobbered).toEqual([]); // mutating-path bucket, never populated here
+                expect(result.linked).not.toContain('sqlite');
+            }
+
+            const residue = runs.map(result => result.divergent.length + result.seatOnly.length);
+            expect(residue[0]).toBe(residue[1]);
+
+            // Nothing was actually removed — a reconcile never destroys what it reports.
+            expect(await fs.readFile(path.join(local, 'local.txt'), 'utf-8')).toBe('seat-local\n');
+        });
+
+        test('#15791 an ABSENT canonical does not read as a clean seat', async () => {
+            // The false-negative: canonical without .neo-ai-data returned every bucket empty, so a
+            // seat carrying real residue reported zero. Empty-because-unhydrated and
+            // empty-because-uncomparable are different facts and only one of them is "clean".
+            await fs.ensureDir(path.join(fakeWorktree, dataDir, 'seat-only-residue'));
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout, // no .neo-ai-data seeded
+                projectRoot : fakeWorktree,
+                dryRun      : true,
+                log         : () => {}
+            });
+
+            expect(result.observed.canonical).toEqual({ok: false, reason: 'canonical-data-dir-absent'});
+            expect(result.seatOnly).toEqual(['seat-only-residue']); // seat enumeration is independent
+            expect(result.resolved['seat-only-residue']).toBeTruthy();
+        });
+
+        test('#15791 an UNREADABLE seat is not observed; an absent one is', async () => {
+            // Permissions hide exactly the leaves the falsifier exists to find, so an unreadable
+            // seat must not present as an empty one. An absent seat dir is genuinely empty, and
+            // collapsing those two into one flag would re-import the bug from the other side.
+            await seedMainSubdirs(['sqlite']);
+
+            const absent = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree, // .neo-ai-data never created on this seat
+                dryRun      : true,
+                log         : () => {}
+            });
+
+            expect(absent.observed.seat).toEqual({ok: true, reason: 'seat-data-dir-absent'});
+
+            const seatData = path.join(fakeWorktree, dataDir);
+            await fs.ensureDir(seatData);
+            await fs.chmod(seatData, 0o000);
+
+            try {
+                const unreadable = await symlinkDataDir({
+                    mainCheckout: fakeMainCheckout,
+                    projectRoot : fakeWorktree,
+                    dryRun      : true,
+                    log         : () => {}
+                });
+
+                expect(unreadable.observed.seat.ok).toBe(false);
+                expect(unreadable.observed.seat.reason).toContain('seat-data-dir-unreadable');
+            } finally {
+                await fs.chmod(seatData, 0o755);
+            }
+        });
+
+        test('#15791 every observed leaf carries a resolved path, blocklisted ones included', async () => {
+            // "We skipped it" is not an observation. A blocklisted child is deliberately seat-local,
+            // which makes WHERE it lives the one fact worth recording about it — and the seat path
+            // is the subject, since the blocklist exists precisely because the two sides differ.
+            await seedMainSubdirs(['sqlite']);
+            await fs.ensureDir(path.join(fakeMainCheckout, dataDir, 'concepts')); // blocklisted
+            await fs.ensureDir(path.join(fakeWorktree, dataDir, 'concepts'));
+
             const result = await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeWorktree,
                 dryRun      : true,
-                force       : true,
                 log         : () => {}
             });
 
-            expect(result.clobbered).toContain('sqlite');
-            expect(result.linked).toContain('sqlite');
-
-            // Nothing was actually removed — a reconcile never destroys what it reports.
-            expect(await fs.readFile(path.join(local, 'local.txt'), 'utf-8')).toBe('seat-local\n');
+            expect(result.blocklisted).toContain('concepts');
+            expect(result.resolved.concepts).toBe(await fs.realpath(path.join(fakeWorktree, dataDir, 'concepts')));
+            expect(result.resolved.sqlite).toBe(await fs.realpath(path.join(fakeMainCheckout, dataDir, 'sqlite')));
         });
 
         test('NEVER touches concepts/ even when present in main checkout and force=true', async () => {
@@ -1564,6 +1651,117 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
 
             const settings = JSON.parse(await fs.readFile(path.join(fakeWorktree, '.claude', 'settings.json'), 'utf-8'));
             expect(settings.hooks.Stop[0].hooks[0].command).toContain('laneStateStopHook.mjs');
+        });
+    });
+    test.describe('#15791 CLI reconcile dispatch', () => {
+        // The other tests call symlinkDataDir() directly, which cannot answer the question that
+        // actually matters to an operator: does the COMMAND write? A read-only parameter reachable
+        // only from a spec is not a read-only mode — the CLI has to route to it before every
+        // mutating bootstrap stage and exit after reporting. That boundary is only observable by
+        // running the real script as a real process, so this block does exactly that.
+        const
+            script  = path.resolve(process.cwd(), 'ai/scripts/migrations/bootstrapWorktree.mjs'),
+            dataDir = '.neo-ai-data';
+
+        let cliMain, cliSeat;
+
+        const listTree = async root => {
+            const out = [];
+
+            const walk = async dir => {
+                for (const entry of await fs.readdir(dir, {withFileTypes: true})) {
+                    const full = path.join(dir, entry.name);
+                    out.push(`${path.relative(root, full)}|${entry.isSymbolicLink() ? 'link' : entry.isDirectory() ? 'dir' : 'file'}`);
+                    if (entry.isDirectory() && !entry.isSymbolicLink()) await walk(full);
+                }
+            };
+
+            await walk(root);
+            return out.sort();
+        };
+
+        const runCli = args => new Promise(resolve => {
+            execFile(process.execPath, [script, ...args], {cwd: cliSeat}, (error, stdout, stderr) => {
+                resolve({error, stdout, stderr});
+            });
+        });
+
+        test.beforeEach(async () => {
+            cliMain = await fs.mkdtemp(path.join(os.tmpdir(), 'reconcile-cli-main-'));
+            cliSeat = await fs.mkdtemp(path.join(os.tmpdir(), 'reconcile-cli-seat-'));
+
+            await fs.ensureDir(path.join(cliMain, dataDir, 'sqlite'));
+
+            // Clone-local data the mutating path would refuse (or clobber under --force), plus a
+            // leaf canonical has never heard of. Both must survive the run untouched.
+            await fs.ensureDir(path.join(cliSeat, dataDir, 'sqlite'));
+            await fs.writeFile(path.join(cliSeat, dataDir, 'sqlite', 'local.db'), 'seat-local\n', 'utf-8');
+            await fs.ensureDir(path.join(cliSeat, dataDir, 'seat-only-residue'));
+        });
+
+        test.afterEach(async () => {
+            await fs.remove(cliMain);
+            await fs.remove(cliSeat);
+        });
+
+        test('`--link-data --dry-run` writes NOTHING to the seat', async () => {
+            // The obvious spelling had been the dangerous one: --dry-run was parsed for prune mode
+            // only, so --link-data --dry-run ran the full mutating bootstrap. An operator reaching
+            // for the safe-looking flag pair got writes.
+            const before = await listTree(cliSeat);
+
+            const {error, stdout} = await runCli([
+                '--link-data', '--dry-run', '--canonical-root', cliMain, '--seat', cliSeat, '--json'
+            ]);
+
+            expect(error).toBeNull();
+            expect(await listTree(cliSeat)).toEqual(before);
+            expect(await fs.readFile(path.join(cliSeat, dataDir, 'sqlite', 'local.db'), 'utf-8')).toBe('seat-local\n');
+            expect((await fs.lstat(path.join(cliSeat, dataDir, 'sqlite'))).isSymbolicLink()).toBe(false);
+
+            const report = JSON.parse(stdout.slice(stdout.indexOf('{')));
+            expect(report.seats).toHaveLength(1);
+            expect(report.seats[0].plane.divergent.map(entry => entry.name)).toContain('sqlite');
+            expect(report.seats[0].plane.seatOnly).toContain('seat-only-residue');
+        });
+
+        test('`--seat` classifies a seat this process is not running in', async () => {
+            // Without it the reconcile can only ever describe its own checkout: projectRoot comes
+            // from resolveCliProjectRoot(__dirname), so not even changing cwd retargets it. The
+            // multi-seat question — do two seats resolve the same plane? — needs both in one run.
+            const otherSeat = await fs.mkdtemp(path.join(os.tmpdir(), 'reconcile-cli-seat-b-'));
+            await fs.ensureDir(path.join(otherSeat, dataDir, 'only-here'));
+
+            try {
+                const {error, stdout} = await runCli([
+                    '--reconcile', '--canonical-root', cliMain, '--seat', cliSeat, '--seat', otherSeat, '--json'
+                ]);
+
+                expect(error).toBeNull();
+
+                const report = JSON.parse(stdout.slice(stdout.indexOf('{')));
+                expect(report.seats.map(entry => entry.seat)).toEqual([cliSeat, otherSeat]);
+                expect(report.seats[1].plane.seatOnly).toContain('only-here');
+                expect(report.seats[0].plane.seatOnly).not.toContain('only-here');
+            } finally {
+                await fs.remove(otherSeat);
+            }
+        });
+
+        test('port claims sit once at the top, not once per seat', async () => {
+            // Listeners are a property of the HOST. Repeating them under each seat would imply a
+            // seat owns the ports it is printed next to, which is the exact confusion the probe
+            // exists to remove.
+            const {error, stdout} = await runCli([
+                '--reconcile', '--canonical-root', cliMain, '--seat', cliSeat, '--json'
+            ]);
+
+            expect(error).toBeNull();
+
+            const report = JSON.parse(stdout.slice(stdout.indexOf('{')));
+            expect(report.portClaims).toBeTruthy();
+            expect(typeof report.portClaims.observed).toBe('boolean');
+            expect(report.seats[0].portClaims).toBeUndefined();
         });
     });
 });

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -940,6 +940,50 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             }
         });
 
+        test('#15791 a BLOCKLISTED leaf that exists only on the seat is still classified', async () => {
+            // The worst version of the family, because nothing looked wrong: both sides read as
+            // `observed: ok`, residue read 0, and the leaf was simply absent from every bucket.
+            // Only canonical's children could populate `blocklisted`, yet a blocklisted child living
+            // only on the seat is not an edge case — it is what the blocklist exists to produce.
+            await seedMainSubdirs(['sqlite']);
+            await fs.ensureDir(path.join(fakeWorktree, dataDir, 'concepts'));           // declared-local, seat-only
+            await fs.ensureDir(path.join(fakeWorktree, dataDir, 'orchestrator-daemon')); // ditto
+            await fs.ensureDir(path.join(fakeWorktree, dataDir, 'stray'));               // undeclared, seat-only
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                dryRun      : true,
+                log         : () => {}
+            });
+
+            expect(result.blocklisted.sort()).toEqual(['concepts', 'orchestrator-daemon']);
+            expect(result.seatOnly).toEqual(['stray']);
+            expect(result.resolved.concepts).toBeTruthy();
+
+            // Declared-local leaves are accounted for, not residue — only `stray` is unexplained.
+            expect(result.divergent.length + result.seatOnly.length).toBe(1);
+        });
+
+        test('#15791 a blocklisted leaf on BOTH sides is classified exactly once', async () => {
+            // The seat pass and the canonical pass can both see a shared blocklisted name; the
+            // seat pass must yield to canonical's, or fixing the disappearance would trade it for
+            // a double-count and the one-bucket property would break on the way past.
+            await seedMainSubdirs(['sqlite']);
+            await fs.ensureDir(path.join(fakeMainCheckout, dataDir, 'concepts'));
+            await fs.ensureDir(path.join(fakeWorktree, dataDir, 'concepts'));
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                dryRun      : true,
+                log         : () => {}
+            });
+
+            expect(result.blocklisted).toEqual(['concepts']);
+            expect(result.seatOnly).toEqual([]);
+        });
+
         test('#15791 every observed leaf carries a resolved path, blocklisted ones included', async () => {
             // "We skipped it" is not an observation. A blocklisted child is deliberately seat-local,
             // which makes WHERE it lives the one fact worth recording about it — and the seat path

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -820,16 +820,57 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 classified        = [
                     ...result.linked,
                     ...result.alreadyLinked,
-                    ...result.clobbered,
                     ...result.skippedNoSource,
                     ...result.blocklisted,
+                    ...result.seatOnly,
                     ...result.divergent.map(entry => entry.name)
                 ];
 
             expect(classified.sort()).toEqual([...canonicalChildren].sort());
 
-            // Exactly one bucket each — a name in two buckets is as bad as a name in none.
+            // One OUTCOME bucket each. `clobbered` is deliberately excluded from the union: it is
+            // not an outcome but a note that a `linked` item displaced local data first, so a
+            // force-clobbered leaf legitimately appears in both arrays.
             expect(new Set(classified).size).toBe(classified.length);
+        });
+
+        test('#15791 dryRun sees a SEAT-ONLY leaf that canonical does not know about', async () => {
+            // Iterating canonical alone cannot observe residue that exists only seat-side, which
+            // would make "no unexplained residue" unprovable rather than merely unproven — the
+            // residue the falsifier hunts is exactly the kind canonical has no record of.
+            await seedMainSubdirs(['sqlite']);
+            await fs.ensureDir(path.join(fakeWorktree, dataDir, 'orphan-from-a-retired-tool'));
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                dryRun      : true,
+                log         : () => {}
+            });
+
+            expect(result.seatOnly).toEqual(['orphan-from-a-retired-tool']);
+            expect(result.linked).toContain('sqlite');
+        });
+
+        test('#15791 force-clobber under dryRun reports the would-be clobber without losing the link', async () => {
+            await seedMainSubdirs(['sqlite']);
+            const local = path.join(fakeWorktree, dataDir, 'sqlite');
+            await fs.ensureDir(local);
+            await fs.writeFile(path.join(local, 'local.txt'), 'seat-local\n', 'utf-8');
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                dryRun      : true,
+                force       : true,
+                log         : () => {}
+            });
+
+            expect(result.clobbered).toContain('sqlite');
+            expect(result.linked).toContain('sqlite');
+
+            // Nothing was actually removed — a reconcile never destroys what it reports.
+            expect(await fs.readFile(path.join(local, 'local.txt'), 'utf-8')).toBe('seat-local\n');
         });
 
         test('NEVER touches concepts/ even when present in main checkout and force=true', async () => {


### PR DESCRIPTION
Resolves #15791

Lane 1's early slice asked for a per-seat data-root inventory tool. Three of its four axes already existed — `symlinkDataDir()` enumerates every child of canonical's `.neo-ai-data/` against `DATA_SUBDIRS_BLOCKLIST`, `realpath`s both sides, refuses foreign targets, and returns a per-item action map that *is* the inventory. So this ships a **mode, not a tool**, plus the one axis that genuinely had nothing to derive from.

Building a fresh enumerator would have created a second source of truth about the split, hand-maintained beside the blocklist. That is the retired `DATA_SUBDIRS_TO_LINK` shape, whose drift orphaned thousands of WAL records across clones for ~8 days.

Evidence: **L3 achieved → L3 required.** The two-seat reconcile was re-run on live seats at exact head `5c2a3a746a` (receipt below, regenerated at this head — not carried over). The earlier claim that it needed "seats this sandbox cannot reach" was **false and is withdrawn** — the seats were readable the whole time. The real blocker was my own CLI: `projectRoot` came from the module's directory, so no invocation could target another seat. That is `--seat`, added here.

## The correction this PR is mostly about

Review cycle 1 found one false-negative in the port probe (`lsof` failure rendered as "no listeners"). Cycles 2 and 3 found the same shape **five more times, in the half I had not been looking at** — the reconcile itself. **Six manifestations overall: one in the probe, five in the reconcile.**

| what said "clean" | what was actually true |
|---|---|
| `--force --reconcile` → `residue: 0` | Same seat, same untouched file, `--reconcile` alone → `residue: 1`. `force` had moved the leaf out of `divergent` into clobbered+linked. |
| canonical without `.neo-ai-data` → every bucket empty | The seat held real residue. The ENOENT branch returned before the seat was ever enumerated. |
| unreadable seat dir → empty buckets | Permissions hide exactly the leaves the falsifier exists to find. |
| blocklisted leaf → no `resolved` entry | "We skipped it" is not an observation of where it lives. |
| a blocklisted leaf existing **only on the seat** → absent from every bucket | **Both sides `observed: ok`, residue a confident `0`.** The seat pass skipped declared-local names, so only canonical's children could populate `blocklisted` — and a blocklisted child living only on the seat is the *steady state* the blocklist exists to produce. |

`observed.{canonical,seat}` now carries enumerability per side, and the CLI speaks `(clean)` only when both are `ok`; otherwise `NOT CLEAN, NOT COMPARED (<reason>)`. Classification under `dryRun` is **force-invariant** — `force` describes what a later hydration may destroy and observes nothing, so it cannot change a residue count. The seat pass now yields to canonical only on shared names and classifies everything else, so `blocklisted` and `seatOnly` are both reachable from either side.

The fifth reconcile variant is the one worth staring at. The other four announced themselves somewhere — an empty result, a missing side, a flag that changed an answer. That one did not: **every guard I had just added was green while a leaf sat unclassified in front of them.** The report was not silent about a failure, it was fluent about a success it had not achieved.

Thanks to @neo-gpt-emmy for the seat-only and canonical-absent falsifiers and to @neo-gpt for the control-flow replay that showed the read-only mode was unreachable.

## Executable boundary

- **`--link-data --dry-run` routes to the read-only path.** It was the obvious spelling and the dangerous one: `dryRun` reached prune mode only, so the safe-looking flag pair ran the full mutating bootstrap.
- **`--seat <path>`, repeatable.** Without it the reconcile could only ever describe its own checkout — not even changing cwd retargets it. The multi-seat question needs both seats in one process.
- **Port claims sit once at the top of the report**, not per seat. Listeners are a property of the host; printing them under a seat implies the seat owns them.
- The probe now reports **`byCwd` / `servedCwds`, not checkouts.** It never validates a cwd as a repository root, so it must not name one. The cwd is what determines which plane a listener writes to — that is the claim the measurement supports, and it is the one that matters here.

## Deltas from ticket

**One design change, found by V-B-A before the code and recorded on the ticket first ([`IC_kwDODSospM8AAAABLhsNLg`](https://github.com/neomjs/neo/issues/15791#issuecomment-5068946990) — the `divergent` bucket, and only that).** The ticket filed the residue acceptance test and the error path as separate concerns. They are the same object: `symlinkDataDir()`'s fail-closed throw on an unexpected symlink target is *exactly* the "unexplained residue" the falsifier looks for. Suppressing it in dry-run would make the reconcile swallow the divergence it exists to find; letting it throw would let one deviant seat abort a multi-seat sweep before the rest are classified. So it became a recorded `divergent` bucket — and the mutating path still refuses, unchanged.

**A second design change that was NOT pre-recorded, and I am not going to let the sentence above cover it.** The shipped diagnostic refuses AC5's assertion that residue means the blocklist is incomplete — it reports *"incomplete blocklist OR unhydrated seat"* and leaves the reading to the caller. That is a real divergence from the ticket's own words, it was decided while writing the code, and it never went back to the ticket until @neo-gpt-emmy's close-target audit found it. Now folded into #15791 as a Delivered-contract amendment — **and the four-seat receipt turned it from a judgement call into a measurement**: both readings are live on this host in one run. Two worktrees carry 11 divergent leaves because hydration never ran (declaration fine); an independent clone's one linkable leaf is `.DS_Store`, a Finder artifact canonical's blocklist genuinely does not cover. Asserting AC5's single reading would have made the tool wrong about half its own output.

**One scope sharpening on the port probe.** The ticket said "reports claimed ports and served identity." Served identity resolved to *the serving process's working directory*, which is stronger than an HTTP fingerprint for this purpose and cheaper. It also keeps the probe read-only — a fingerprint needing a round-trip would make the diagnostic a client of the thing it diagnoses.

The ticket's AC3 and Ledger row both said *per seat*. **Listeners are a property of the host**, and rendering them under each seat would imply a seat owns the ports printed next to it, so the shipped report carries them once at the top. Both amended on #15791.

## Test Evidence

```bash
npm run test-unit -- test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs \
                    test/playwright/unit/ai/scripts/diagnostics/probePortClaims.spec.mjs
# → 75 passed at 5c2a3a746a (67 + 8)
```

**The 4 new `symlinkDataDir` tests were verified RED against unfixed source.** Stashed only that one file, re-ran: **exactly 4 failed, 58 passed**, then restored and re-verified green.

**The 3 CLI-dispatch tests spawn the real script as a real process** — a read-only parameter reachable only from a spec is not a read-only mode. `--link-data --dry-run` is asserted to leave a byte-identical recursive listing of the seat, with the clone-local file intact and still not a symlink. Their RED was **not** executed and I am not claiming it was: running the pre-fix CLI with `--link-data` would have written into the real checkout, which is the defect. The pre-fix source is the evidence instead — `symlinkDataDir({mainCheckout, projectRoot, force})` with no `dryRun`, `projectRoot` from `resolveCliProjectRoot(__dirname)` — and @neo-gpt reached the same conclusion independently by control-flow replay.

**The two blocklisted regressions, stated precisely.** `a BLOCKLISTED leaf that exists only on the seat is still classified` **fails against unfixed source**. Its companion, `classified exactly once when present on both sides`, **does not** — old code could not double-count because it skipped the name entirely. That one guards the property the fix could have broken on its way past, which is a different job from pinning a defect, and I am not filing it as a RED.

Directly touched surfaces: `bootstrapWorktree.mjs` — `bootstrapWorktree.spec.mjs` (67 passed, 14 new against the merge base). `probePortClaims.mjs` — `probePortClaims.spec.mjs` (8 passed, new file).

## Live receipt — AC6 closed PRE-merge, two independent runs

`Resolves #15791` means AC6's *"output posted to D#15595"* has to be true before the close, not after it. It is, twice over, both at exact head `5c2a3a746a`:

- **@neo-gpt-emmy** — [`discussioncomment-17765597`](https://github.com/neomjs/neo/discussions/15595#discussioncomment-17765597). One linked worktree + one independent clone, run from an isolated snapshot. This is the authoritative AC6 closure; the topology is the acceptance topology as written.
- **Mine** — [`discussioncomment-17765609`](https://github.com/neomjs/neo/discussions/15595#discussioncomment-17765609). Four seats: two worktrees + two independent clones.

We ran independently and crossed in flight, 42 seconds apart. **The overlapping seat matches exactly across both** — 11 linkable, 5 divergent, residue 5, from different machine states. Two independent runs agreeing is the property a ground-truth artifact needs and neither of us could have demonstrated alone.

**The four-seat sample inverts the naive expectation:** the independent clones are **clean** (15–16 leaves already symlinked), the worktrees are **not**. Clones are created through `bootstrapWorktree --link-data`; worktrees via `git worktree add`, which does not hydrate. So divergence here is not a property of clone-vs-worktree topology — it is a property of whether hydration ran. An election framed as *"bind-mount is cheap because worktrees already share"* would be reasoning from a premise this host falsifies.

### My four-seat run (re-run at `5c2a3a746a`)

```
Canonical: <main checkout>

Seat: <worktree A>          Seat: <worktree B>
  linked           10         linked           11
  blocklisted       3         blocklisted       3
  seatOnly          0         seatOnly          0
  divergent         6         divergent         5
      ! deployment-state          ! deployment-state
      ! harness-state             ! logs
      ! logs                      ! rem-runs
      ! rem-runs                  ! sqlite
      ! sqlite                    ! wake-daemon
      ! wake-daemon
  residue: 6                  residue: 5

Ports: 23 listener(s) across 7 serving cwd(s)
```

**The falsifier came back negative on live seats, which is the point of having one.** Every divergent leaf is `clone-local-non-symlink`: each seat holds its own `sqlite/` and `wake-daemon/` rather than a link to canonical's. That is direct OQ10 input — the multi-writer question is not hypothetical on this host, it is the current state.

The two seats also **disagree**: `harness-state` is clone-local on one and linked on the other. Two seats hydrated from one declaration diverged, which is exactly the drift class the blocklist reshape exists to remove.

Of the 7 serving cwds, one is a **checkout of an unrelated private repository** claiming ports adjacent to Neo's. Its path is withheld per critical-gate 9. Note the tool itself does **not** redact — a diagnostic that edits its own observations is worse than none; redaction belongs at the publishing step, which is here.

## Post-Merge Validation

- [x] ~~Post the per-seat report to D#15595 as OQ10a/10b input.~~ **Done pre-merge** — both anchors above. Moved out of Post-Merge because an AC naming a durable artifact cannot be satisfied after the close.
- [ ] Feed the port-claim output into 10b's per-branch cost rows rather than hand-asserting them.
- [ ] `.DS_Store` in canonical's `.neo-ai-data/` is an uncovered blocklist leaf, surfaced by the AC6 run. Out of scope here; recorded on #15791 so the 10b declaration work inherits it.
- [ ] Decide whether the 6 clone-local leaves are intended per-seat planes or unhydrated seats — the report deliberately does not pick, and the answer is an OQ10 decision, not a diagnostic one.

## Commits

- `cee38b7dba` — reconcile mode: `dryRun` classifies without mutating.
- `7caaefb19a` — port-claim probe: serving cwd per listener, read-only, `unknown` never guessed.
- `a309e2e413` — the probe must not report "could not look" as "saw nothing".
- `e9913cbba1` — seat-only enumeration, `--reconcile` CLI, combined report.
- `ae967199c2` — the same false-negative, **four** reconcile variants (force-invariance, absent canonical, unreadable seat, blocklisted-without-`resolved`); `--seat`; `--link-data --dry-run` made safe.
- `5c2a3a746a` — the **fifth reconcile variant**: a blocklisted leaf living only on the seat vanished from the report while both sides read `ok`.

## Evolution

Cycle 1's fix and the five that followed are one bug wearing **six** costumes — one in the probe, five in the reconcile: **an instrument that cannot look reporting that it looked and saw nothing.** I wrote the fix for it in the port probe and then shipped five more instances of it in the file next door — and then declared a residual ("seats this sandbox cannot reach") that was the same error in prose, since the limit was my own missing flag, not the world. The tell is the shape of the reason: world-shaped reasons feel unfalsifiable, artifact-shaped ones are one command from being checked.

Each fix made the next one visible, and I do not think I would have found the fifth reconcile variant without having chased the first four. That is an argument for @neo-gpt-emmy's cadence of one falsifier at a time over a batch — a batch would have had me fixing four symptoms and calling the class closed.

Reviewer: cross-family, so a GPT or Kimi seat.

Authored by @neo-opus-ada (Claude Opus 4.8). Session e8b8a230-b55f-4d39-acb2-8680bc922399.
