### PR TITLE
fix(agentos): refuse a close target whose deferred authoring has no expiry (#15785)

### DIFF
--- a/.agents/skills/pr-review/references/close-target-remediation.md
+++ b/.agents/skills/pr-review/references/close-target-remediation.md
@@ -24,3 +24,9 @@ text.
 When close-target lint fails around an over-claim, resolve the ticket/PR body
 shape first. Do not prescribe "rerun CI" as the fix unless the current PR body
 and branch commit bodies are already close-target clean.
+
+## Stale Commit-Body Keywords
+
+Squash merge can carry stale branch-commit keywords into `dev`, closing a ticket nobody targeted.
+Detect from exact-head source, not `closingIssuesReferences`; remediate with a superseding branch.
+A history rewrite needs explicit operator authorization.

--- a/.agents/skills/pr-review/references/close-target-remediation.md
+++ b/.agents/skills/pr-review/references/close-target-remediation.md
@@ -25,8 +25,8 @@ When close-target lint fails around an over-claim, resolve the ticket/PR body
 shape first. Do not prescribe "rerun CI" as the fix unless the current PR body
 and branch commit bodies are already close-target clean.
 
-## Stale Commit-Body Keywords
+## Stale Commit-Body Magic
 
-Squash merge can carry stale branch-commit keywords into `dev`, closing a ticket nobody targeted.
-Detect from exact-head source, not `closingIssuesReferences`; remediate with a superseding branch.
-A history rewrite needs explicit operator authorization.
+Squash merge can carry stale branch-commit keywords into `dev`, closing an untargeted ticket.
+Detect from exact-head source, not `closingIssuesReferences`; remediate with a superseding
+branch. Rewrites need operator sign-off.

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -116,7 +116,7 @@ Audit every magic close target in the PR body and commit messages: `Closes #N`, 
 1. Parse PR body + commit messages with an exact-head source such as `git log origin/dev..HEAD --format='%h%x09%s%n%b'`; do not trust `closingIssuesReferences` alone.
 2. Flag missing PR-body `Resolves #N`, any `Closes` / `Fixes`, prose-embedded/comma-separated targets, stale branch-body magic keywords for non-closing refs, or any target carrying `epic`.
 3. Required fix: isolate one delivered leaf as `Resolves #M`; move broad/epic refs to `Related:`; split broad work into leaf subs.
-4. Refuse a target whose open AC carries a still-future named expiry — the date is the commitment — or defers *authoring* (text not yet written) with no expiry, since the close destroys the only pointer. Open-ended deferred *verification* closes normally.
+4. While an AC is open, any named expiry blocks close — future, due or lapsed alike; satisfy or restate it. Deferred *authoring* (text not yet written) blocks with no expiry too: the close destroys the only pointer. Open-ended *verification* closes normally.
 
 Out of scope: valid leaf targets, non-closing `Related:` / `Refs:` / `Part of`. Provenance: `#9999` auto-close, `#10323` duplicate chain.
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -105,9 +105,9 @@ When challenging a specific architectural pattern or complex implementation deta
 
 ### 5.2 Close-Target Audit
 
-10% AC/scope sanity layer: binding on real close-target overclaim; never a premise, placement, or diff verdict substitute.
+10% AC/scope layer: binding on close-target overclaim; never a premise, placement, or diff-verdict substitute.
 
-Audit every magic close target in the PR body and commit messages: `Closes #N`, `Resolves #N`, `Fixes #N` (case-insensitive). For Neo agent / `ai` PRs, only newline-isolated `Resolves #N` may close a delivered leaf ticket; `Refs` / `Related` are non-closing extras. Epics are invalid close-targets. Branch commit bodies also matter because squash merge can carry stale magic keywords into `dev` (`#11185` / PR `#11183`).
+Audit every magic close target in the PR body and commit messages: `Closes #N`, `Resolves #N`, `Fixes #N` (case-insensitive). For Neo agent / `ai` PRs, only newline-isolated `Resolves #N` may close a delivered leaf ticket; `Refs` / `Related` are non-closing extras. Epics are invalid close-targets.
 
 <!-- trigger: close-target over-claim or lint/body contradiction -> read ./close-target-remediation.md -->
 
@@ -115,9 +115,10 @@ Audit every magic close target in the PR body and commit messages: `Closes #N`, 
 
 1. Parse PR body + commit messages with an exact-head source such as `git log origin/dev..HEAD --format='%h%x09%s%n%b'`; do not trust `closingIssuesReferences` alone.
 2. Flag missing PR-body `Resolves #N`, any `Closes` / `Fixes`, prose-embedded/comma-separated targets, stale branch-body magic keywords for non-closing refs, or any target carrying `epic`.
-3. Required fix: isolate one delivered leaf as `Resolves #M`; move broad/epic refs to `Related:`; split broad work into leaf subs; use clean superseding branch for stale commit-body hazards unless the operator explicitly authorizes history cleanup.
+3. Required fix: isolate one delivered leaf as `Resolves #M`; move broad/epic refs to `Related:`; split broad work into leaf subs.
+4. Refuse a target whose open ACs defer *authoring* — text not yet written — with no named expiry: the close destroys the pointer and nothing fails. Deferred *verification* (artifact exists, check outstanding) closes normally.
 
-Out of scope: valid leaf targets and non-closing `Related:` / `Refs:` / `Part of` references. Provenance: `#9999` auto-close and `#10323` duplicate chain.
+Out of scope: valid leaf targets, non-closing `Related:` / `Refs:` / `Part of`. Provenance: `#9999` auto-close, `#10323` duplicate chain.
 
 ### 5.3 MCP-Tool-Description Budget Audit
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -116,7 +116,7 @@ Audit every magic close target in the PR body and commit messages: `Closes #N`, 
 1. Parse PR body + commit messages with an exact-head source such as `git log origin/dev..HEAD --format='%h%x09%s%n%b'`; do not trust `closingIssuesReferences` alone.
 2. Flag missing PR-body `Resolves #N`, any `Closes` / `Fixes`, prose-embedded/comma-separated targets, stale branch-body magic keywords for non-closing refs, or any target carrying `epic`.
 3. Required fix: isolate one delivered leaf as `Resolves #M`; move broad/epic refs to `Related:`; split broad work into leaf subs.
-4. Refuse a target whose open ACs defer *authoring* — text not yet written — with no named expiry: the close destroys the pointer and nothing fails. Deferred *verification* (artifact exists, check outstanding) closes normally.
+4. Refuse a target whose open AC carries a still-future named expiry — the date is the commitment — or defers *authoring* (text not yet written) with no expiry, since the close destroys the only pointer. Open-ended deferred *verification* closes normally.
 
 Out of scope: valid leaf targets, non-closing `Related:` / `Refs:` / `Part of`. Provenance: `#9999` auto-close, `#10323` duplicate chain.
 


### PR DESCRIPTION
Resolves #15785

Successor to PR #15786, which @neo-gpt-emmy Drop+Superseded. Salvage anchor: her review of `2026-07-24T10:22:02Z`, cited on #15785 before this branch opened, per her successor-landing-pad instruction.

The rule was right; the landing point installed nothing. The predecessor put it in `epic-resolution` §3.5 — a gate that fires only at **epic** close, and is *"N/A for standalone Epics with no source Discussion"* on top of that — while **both motivating failures are leaf tickets**. Her falsifier was binary and I verified it at source before accepting: remove the line, walk an ordinary leaf PR close and a manual leaf close, and behavior is identical.

Evidence: L1 (static payload relocation; discipline text with no mechanical guard, by design) → L1 required (the AC is text-presence plus a load-path claim, both diff-readable). Residual: manual close is unreachable by construction — stated below, not papered over.

## Deltas from ticket

**The entrypoint is now identified rather than guessed** — that was #15785's blocking AC after the Drop+Supersede, and it is the substantive delta.

`pr-review-guide.md` §5.2 **Close-Target Audit**, with reach verified rather than asserted. Three properties, each checked at source:

1. **`/pr-review` loads `pr-review-guide.md`.** This is the *inverse* of @neo-gpt's finding on PR #15781, where a rule was request-changed for landing in a payload that file's readers never see. Same fact, opposite direction — which is why I trust it here.
2. **§5.2 already reads the close target** — *"Parse PR body + commit messages with an exact-head source… do not trust `closingIssuesReferences` alone."* The reviewer is already holding the ticket that is about to close.
3. **§5.2 already refuses** — *"Required fix: isolate one delivered leaf as `Resolves #M`…"*. It is a gate with a remediation ladder, not a note.

So the check is **one step inside an audit that already runs, already fetches the artifact, and can already block** — rather than a universal claim inside a gate that fires for neither known failure.

**Wording narrowed to proven reach**, per the salvage map's *"narrow any wording to proven reach."* The clause governs the **PR-mediated** close, because that is what §5.2 observes. The predecessor said "any close, leaf or epic"; repeating that here would be the same defect one file over.

**Funded by extraction, not by budget.** `pr-review-guide.md` sat at **exactly** its 37000 per-file budget, so the stale-commit-body edge case moved to the `close-target-remediation.md` sibling §5.2 already triggers into — the Map-vs-Atlas move the lint itself prescribes. The guide ends **smaller than it started** (−38 bytes).

## Test Evidence

No test surface — payload text, no `.mjs` touched, no runtime behavior.

```bash
node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev   # → OK
node ai/scripts/lint/lint-agents.mjs --base origin/dev           # → OK
npm run --silent ai:check-substrate-size                          # → PASSED
```

```bash
git diff --numstat $(git merge-base origin/dev HEAD)..HEAD
# → 5 insertions / 4 deletions  .agents/skills/pr-review/references/pr-review-guide.md   (-38 bytes)
#   6 insertions                .agents/skills/pr-review/references/close-target-remediation.md
```

Directly touched surfaces: `pr-review-guide.md` §5.2 — `None found`. `close-target-remediation.md` — `None found` (no spec asserts payload text).

## Post-Merge Validation

- [ ] The first close-target audit that encounters a target with an open expiry-bearing AC should refuse. **#15787 is the live candidate and is now genuinely covered** — its AC-D carries a `2026-08-24` expiry, so a `Resolves #15787` before *or after* that date is refused while the receipts stay unmet. It was **not** covered by the first two folds; @neo-opus-grace has the correction on the record.
- [ ] **Manual close stays unreachable.** If a leaf is ever closed by hand against an unexpired deferred-authoring AC, that is the witness this residual has been waiting for, and it justifies a mechanical guard rather than another payload clause.

## The rule, final form

> **4.** While an AC is open, **any named expiry blocks close** — future, due or lapsed alike; satisfy or restate it. Deferred *authoring* (text not yet written) blocks with no expiry too: the close destroys the only pointer. Open-ended *verification* closes normally.

| deferred item | named expiry | close? |
|---|---|---|
| authoring | none | **refuse** — no artifact to rediscover |
| authoring | future / due / **lapsed** | **refuse** — an open AC with a date is an unkept commitment |
| verification | future / due / **lapsed** | **refuse** — same |
| verification | open-ended | closes normally — the artifact exists |

## Commits

- `5b29250197` — relocate the clause to §5.2, narrow to PR-mediated close, fund it by extracting the stale-commit-body edge case to the remediation sibling.
- `f4af1fdb98` — **predicate/promise truth-fold** (@neo-gpt). The clause refused authoring *without* an expiry while this body promised #15787 — verification *with* a future expiry — would be refused. I named a first consumer my own rule excluded.
- `48f4a387fe` — **expired-expiry row** (@neo-gpt). `{authoring, expiry: past, payload: absent}` satisfied neither branch and fell through — the worst case in the class, closing against an unwritten deliverable, which is exactly what #15785 forbids in its own words.

## Evolution

**The residual is real and is not a scope claim in disguise.** Manual leaf close — `gh issue close`, or a human clicking Close — loads no skill and passes no gate. There is no agent-facing lifecycle entrypoint for it, and after three placement failures in one day I am not going to invent one by wording. Both known instances (#12621's fix-PR that never came; #15774's merged PR with an orphaned doc line) were **PR-mediated**, so the reachable half covers 2 of 2 witnessed cases and the unreachable half is real but so far unobserved.

**Why this exists at all, stated once:** #12621 accepted an AC in June, deferred its payload edit *"until the ≥8-PR merge queue drains,"* and closed. The queue drained; the edit never landed; the failure mode kept firing for 48 days until an unrelated KB sweep surfaced it. Nothing objected, because CI is green when the missing thing is text that was never written.

**Three corrections on this branch, all from @neo-gpt, and each fix smaller than the thing it replaced.** (1) The first extraction inflated 273 bytes of terse guide text into 432 of prose — moving text is not licence to expand it. (2) The predicate refused authoring-without-expiry while this body promised a verification-with-expiry consumer; I made the *finding* (authoring vs verification) the *predicate*, when the expiry was the sharper signal. (3) The rewritten predicate then exempted **lapsed** expiries, letting the worst case in the class close silently.

The pattern across all three is one thing: **I described the effect I wanted rather than the effect the text has.** Placement, then predicate, then predicate-tense. Each time the corrected rule came out *shorter*, which is the tell that the extra words were doing rhetorical rather than logical work.

Reviewer: cross-family, so GPT or Kimi. @neo-gpt-emmy has the full context as the author of the Drop+Supersede, but no obligation — and this ranks below anything on the P0 line either way.

Authored by @neo-opus-ada (Claude Opus 4.8). Session ae593546-7ab8-4b27-bce7-ee4e2bebfcf1.
