### PR TITLE
fix(test): restore Neo.applyDeltas so SortZone stops running in other specs (#15789)

### DIFF
--- a/test/playwright/unit/component/WrapperLifecycle.spec.mjs
+++ b/test/playwright/unit/component/WrapperLifecycle.spec.mjs
@@ -26,7 +26,13 @@ import VdomHelper     from '../../../../src/vdom/Helper.mjs';
 import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
 
 // Mock applyDeltas to prevent errors during mount
+const realApplyDeltas = Neo.applyDeltas; // patched at import; restored in afterAll below
+
 Neo.applyDeltas = async () => {};
+
+test.afterAll(() => {
+    Neo.applyDeltas = realApplyDeltas;
+});
 
 class WrapperComponent extends Component {
     static config = {
@@ -60,10 +66,10 @@ test.describe('Wrapper Node & Reverse Map Lifecycle', () => {
         await child.initVnode();
 
         const wrapperId = child.id + '__wrapper';
-        
+
         // Check Wrapper Node Registration
         expect(ComponentManager.wrapperNodes.get(wrapperId)).toBe(child);
-        
+
         // Check Child Map
         const siblings = ComponentManager.getDirectChildren(parent.id);
         expect(siblings.length).toBe(1);
@@ -85,7 +91,7 @@ test.describe('Wrapper Node & Reverse Map Lifecycle', () => {
 
         const oldWrapperId = 'old-id__wrapper';
         expect(ComponentManager.wrapperNodes.get(oldWrapperId)).toBe(child);
-        
+
         const childrenBefore = ComponentManager.getDirectChildren(parent.id).map(c => c.id);
         expect(childrenBefore).toContain('old-id');
 
@@ -95,7 +101,7 @@ test.describe('Wrapper Node & Reverse Map Lifecycle', () => {
 
         // Verify Child Map Cleanup
         const childrenAfter = ComponentManager.getDirectChildren(parent.id).map(c => c.id);
-        
+
         expect(childrenAfter).toContain('new-id');
         expect(childrenAfter).not.toContain('old-id');
 
@@ -105,7 +111,7 @@ test.describe('Wrapper Node & Reverse Map Lifecycle', () => {
         // unregister('old-id') also checks component.vdom.id.
         // If component.vdom.id is still 'old-id__wrapper', it should be deleted.
         // However, we need to ensure unregister logic uses the correct ID.
-        
+
         expect(ComponentManager.wrapperNodes.has(oldWrapperId)).toBe(false);
 
         parent.destroy();

--- a/test/playwright/unit/draggable/container/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/container/SortZone.spec.mjs
@@ -22,6 +22,10 @@ import SortZone        from '../../../../../src/draggable/container/SortZone.mjs
 test.describe.serial('Neo.draggable.container.SortZone', () => {
     let container, sortZone;
 
+    const
+        realApplyDeltas = Neo.applyDeltas,
+        realGetDomRect  = Container.prototype.getDomRect;
+
     test.beforeEach(() => {
         // Mock Neo.main.addon.DragDrop
         Neo.ns('Neo.main.addon.DragDrop', true);
@@ -71,6 +75,11 @@ test.describe.serial('Neo.draggable.container.SortZone', () => {
     test.afterEach(() => {
         sortZone?.destroy();
         container?.destroy();
+
+        // The prototype patch leaks exactly as far as the namespace one does: Playwright reuses the
+        // worker, so a later spec's real getDomRect would stay replaced by this file's dummy rects.
+        Neo.applyDeltas               = realApplyDeltas;
+        Container.prototype.getDomRect = realGetDomRect;
     });
 
     test('Initializes correctly with mixed content', async () => {

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -17,7 +17,7 @@ import InstanceManager from '../../../../../src/manager/Instance.mjs';
  * @summary Tests for Neo.draggable.dashboard.SortZone directional thresholds
  */
 test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () => {
-    let DashboardContainer, DashboardSortZone, Rectangle, realDragCoordinatorOnDragEnd,
+    let DashboardContainer, DashboardSortZone, Rectangle, realApplyDeltas, realDragCoordinatorOnDragEnd,
         realDragCoordinatorOnWindowPositionChange, sortZone;
 
     test.beforeAll(async () => {
@@ -32,6 +32,12 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
 
         realDragCoordinatorOnDragEnd = Object.getPrototypeOf(Neo.manager.DragCoordinator).onDragEnd;
         realDragCoordinatorOnWindowPositionChange = Object.getPrototypeOf(Neo.manager.DragCoordinator).onWindowPositionChange;
+
+        // Captured once, before any test overrides it — two tests below replace `Neo.applyDeltas`
+        // with closures over their own `appliedDeltas`. Playwright reuses a worker across spec
+        // files, so an unrestored override runs THIS file's fixture against a later spec's
+        // components — the tell is a SortZone stack frame surfacing inside an unrelated spec.
+        realApplyDeltas = Neo.applyDeltas;
     });
 
     test.beforeEach(() => {
@@ -81,6 +87,11 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
             Neo.manager.Window.items = [];
             Neo.manager.Window.map   = new Map()
         }
+
+        // Same principle as the DragCoordinator stubs above: an override that survives its suite
+        // is indistinguishable from the method simply not working — except this one is worse,
+        // because it does not no-op, it runs dead fixture state against whoever comes next.
+        Neo.applyDeltas = realApplyDeltas;
 
         sortZone?.destroy();
     });

--- a/test/playwright/unit/functional/Button.spec.mjs
+++ b/test/playwright/unit/functional/Button.spec.mjs
@@ -30,6 +30,8 @@ test.describe('functional/Button', () => {
     let button, vnode;
     let testRun = 0;
 
+    const realApplyDeltas = Neo.applyDeltas;
+
     test.beforeEach(async () => {
         testRun++;
 
@@ -51,6 +53,8 @@ test.describe('functional/Button', () => {
         button?.destroy();
         button = null;
         vnode  = null;
+
+        Neo.applyDeltas = realApplyDeltas;
     });
 
     test('should create initial vnode correctly', async () => {

--- a/test/playwright/unit/vdom/AsymmetricMerging.spec.mjs
+++ b/test/playwright/unit/vdom/AsymmetricMerging.spec.mjs
@@ -22,7 +22,13 @@ import VdomHelper     from '../../../../src/vdom/Helper.mjs';
 import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
 
 // Mock applyDeltas to prevent errors during mount
+const realApplyDeltas = Neo.applyDeltas; // patched at import; restored in afterAll below
+
 Neo.applyDeltas = async () => {};
+
+test.afterAll(() => {
+    Neo.applyDeltas = realApplyDeltas;
+});
 
 class MockComponent extends Component {
     static config = {
@@ -68,8 +74,8 @@ class MockContainer extends Container {
 MockContainer = Neo.setupClass(MockContainer);
 
 /**
- * @summary Verification of Asymmetric VDOM Merging logic (Ticket #8827).
- * 
+ * @summary Verification of Asymmetric VDOM Merging logic.
+ *
  * Verifies that:
  * 1. Parent updates only aggregate dirty children (Selective Merging).
  * 2. Merged children's update promises are correctly resolved.
@@ -116,14 +122,14 @@ test.describe('Asymmetric VDOM Merging', () => {
         container.setSilent({style: {color: 'blue'}});
         c1.setSilent({text: 'C1 Updated'});
         c3.setSilent({text: 'C3 Updated'});
-        
+
         // Trigger update via Parent
         const {deltas} = await container.promiseUpdate();
 
         // Verify Deltas
         // Expect: Parent, C1, C3. C2 should be missing or clean.
         // Deltas structure depends on VdomHelper/mock. Assuming array of objects with id.
-        
+
         const parentDelta = deltas.find(d => d.id === container.id);
         const c1Delta     = deltas.find(d => d.id === c1.id);
         const c2Delta     = deltas.find(d => d.id === c2.id);
@@ -132,7 +138,7 @@ test.describe('Asymmetric VDOM Merging', () => {
         expect(parentDelta).toBeTruthy();
         expect(c1Delta).toBeTruthy();
         expect(c3Delta).toBeTruthy();
-        
+
         // C2 should NOT be in the deltas if selective merging works
         expect(c2Delta).toBeUndefined();
     });
@@ -158,12 +164,12 @@ test.describe('Asymmetric VDOM Merging', () => {
         container.style = {color: 'red'};
 
         let resolved = false;
-        
+
         // Child update
         const p = child.promiseUpdate().then(() => {
             resolved = true;
         });
-        
+
         child.text = 'Child Updated';
 
         // Should not be resolved yet
@@ -256,17 +262,17 @@ test.describe('Asymmetric VDOM Merging', () => {
 
     /**
      * Scenario 5: Leapfrog Merging (Grandparent -> Clean Parent -> Dirty Grandchild)
-     * 
+     *
      * Tests the ability of the framework to merge a deep descendant's update into an ancestor
      * even if the intermediate components are clean (skipped).
-     * 
+     *
      * Critical for TreeBuilder: If the intermediate Parent is clean and we are at Depth 1,
-     * standard logic might prune the Parent branch (`neoIgnore: true`), causing the 
+     * standard logic might prune the Parent branch (`neoIgnore: true`), causing the
      * Grandchild update to be lost.
-     * 
+     *
      * This test validates if `VDomUpdate`/`TreeBuilder` correctly handles this "gap"
      * by identifying the "Bridge Path" and expanding the clean Parent.
-     * 
+     *
      * It also verifies "Sparse Tree Generation": A clean sibling of the Parent ("Uncle")
      * should be pruned (ignored) if it is not on the bridge path.
      */
@@ -306,7 +312,7 @@ test.describe('Asymmetric VDOM Merging', () => {
         // - Parent (Distance 1) is a Bridge -> Must be expanded.
         // - Uncle (Distance 1) is NOT a Bridge -> Should be pruned.
         container.updateDepth = 2;
-        
+
         grandChild.setSilent({text: 'Leapfrog Update'});
 
         // 3. Trigger Grandparent
@@ -315,7 +321,7 @@ test.describe('Asymmetric VDOM Merging', () => {
         // 4. Verify Grandchild Update (Positive Case)
         // The Grandchild update MUST be present. This proves the Bridge Parent was expanded.
         const gcDelta = deltas.find(d => d.id === grandChild.id);
-        
+
         expect(gcDelta).toBeTruthy();
         expect(gcDelta.textContent).toBe('Leapfrog Update');
 
@@ -358,7 +364,7 @@ test.describe('Asymmetric VDOM Merging', () => {
         // 4. Verify
         // Should have an 'insertNode' action
         const insertDelta = deltas.find(d => d.action === 'insertNode');
-        
+
         expect(insertDelta).toBeTruthy();
         expect(insertDelta.vnode.id).toBe(newChild.vdom.id);
     });

--- a/test/playwright/unit/vdom/HiddenChildren.spec.mjs
+++ b/test/playwright/unit/vdom/HiddenChildren.spec.mjs
@@ -24,7 +24,13 @@ import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs
 import InstanceManager from '../../../../src/manager/Instance.mjs';
 
 // Mock applyDeltas to prevent errors during mount
+const realApplyDeltas = Neo.applyDeltas; // patched at import; restored in afterAll below
+
 Neo.applyDeltas = async () => {};
+
+test.afterAll(() => {
+    Neo.applyDeltas = realApplyDeltas;
+});
 
 class ChildComponent extends Component {
     static config = {

--- a/test/playwright/unit/vdom/ParentIdChange.spec.mjs
+++ b/test/playwright/unit/vdom/ParentIdChange.spec.mjs
@@ -7,7 +7,7 @@
  * 2. Components are moved correctly when `parentId` changes.
  * 3. Components are removed from the `childMap` upon destruction (unregister).
  *
- * This reverse map optimization (Issue #8872) allows for O(1) retrieval of direct children
+ * This reverse map optimization allows for O(1) retrieval of direct children
  * via `ComponentManager.getDirectChildren(parentId)`, eliminating the need for O(N) linear scans.
  *
  * @see Neo.manager.Component
@@ -38,7 +38,13 @@ import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs
 import InstanceManager from '../../../../src/manager/Instance.mjs';
 
 // Mock applyDeltas to prevent errors during mount
+const realApplyDeltas = Neo.applyDeltas; // patched at import; restored in afterAll below
+
 Neo.applyDeltas = async () => {};
+
+test.afterAll(() => {
+    Neo.applyDeltas = realApplyDeltas;
+});
 
 class ChildComponent extends Component {
     static config = {
@@ -60,7 +66,7 @@ test.describe('Issue 8872: ComponentManager Reverse Map', () => {
     test('childMap should update on parentId change', async () => {
         const parent1 = Neo.create(ParentComponent, { appName });
         const parent2 = Neo.create(ParentComponent, { appName });
-        
+
         const child = Neo.create(ChildComponent, {
             appName,
             parentId: parent1.id
@@ -87,7 +93,7 @@ test.describe('Issue 8872: ComponentManager Reverse Map', () => {
 
         // Unregister
         child.destroy();
-        
+
         children2 = ComponentManager.getDirectChildren(parent2.id);
         expect(children2.length).toBe(0);
 

--- a/test/playwright/unit/vdom/RaceCondition.spec.mjs
+++ b/test/playwright/unit/vdom/RaceCondition.spec.mjs
@@ -43,7 +43,7 @@ class RaceContainer extends Container {
 RaceContainer = Neo.setupClass(RaceContainer);
 
 /**
- * @summary Regression tests for VDOM Update Race Conditions (Ticket #8814).
+ * @summary Regression tests for VDOM update race conditions.
  *
  * These tests reproduce scenarios where concurrent updates between Parent and Child components
  * previously led to duplicate DOM nodes or state inconsistencies.
@@ -55,11 +55,19 @@ RaceContainer = Neo.setupClass(RaceContainer);
  * 4. Reverse Race: Parent starts update *after* child, risking overwrite.
  */
 test.describe('VdomLifecycle Race Condition', () => {
+    // Four tests below replace Neo.applyDeltas with closures over their OWN capturedDeltas array.
+    // Playwright reuses a worker across spec files, so an unrestored override runs this file's
+    // fixture against a later spec's components — the tell is a stack frame from here surfacing
+    // in an unrelated suite. Captured once here, restored after every test.
+    const realApplyDeltas = Neo.applyDeltas;
+
     let testIdCounter = 0;
     const getUniqueId = (prefix) => `${prefix}-${Date.now()}-${testIdCounter++}`;
     let createdComponentIds = [];
 
     test.afterEach(() => {
+        Neo.applyDeltas = realApplyDeltas;
+
         createdComponentIds.forEach(id => {
             const cmp = Neo.getComponent(id);
             if (cmp) {
@@ -249,10 +257,10 @@ test.describe('VdomLifecycle Race Condition', () => {
         // Ensure visible
         child1.hidden = false;
         await container.promiseUpdate();
-        
+
         // Wait for any potential late-arriving deltas or queued updates to clear
         await new Promise(resolve => setTimeout(resolve, 50));
-        
+
         capturedDeltas.length = 0;
 
         // Parent updates its own property (e.g. style) - Depth 1

--- a/test/playwright/unit/vdom/SparseUpdates.spec.mjs
+++ b/test/playwright/unit/vdom/SparseUpdates.spec.mjs
@@ -23,7 +23,13 @@ import VdomHelper     from '../../../../src/vdom/Helper.mjs';
 import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
 
 // Mock applyDeltas to prevent errors during mount
+const realApplyDeltas = Neo.applyDeltas; // patched at import; restored in afterAll below
+
 Neo.applyDeltas = async () => {};
+
+test.afterAll(() => {
+    Neo.applyDeltas = realApplyDeltas;
+});
 
 class SparseMockComponent extends Component {
     static config = {

--- a/test/playwright/unit/vdom/UpdateWedge.spec.mjs
+++ b/test/playwright/unit/vdom/UpdateWedge.spec.mjs
@@ -63,10 +63,12 @@ test.describe('VdomLifecycle update wedge (#12946)', () => {
 
     const originalUpdateBatch = VdomHelper.updateBatch;
     const originalCreate      = VdomHelper.create;
+    const realApplyDeltas     = Neo.applyDeltas;
 
     test.afterEach(() => {
         VdomHelper.updateBatch = originalUpdateBatch;
         VdomHelper.create      = originalCreate;
+        Neo.applyDeltas        = realApplyDeltas;
 
         createdComponentIds.forEach(id => {
             Neo.getComponent(id)?.destroy();

--- a/test/playwright/unit/vdom/VdomLifecycle.spec.mjs
+++ b/test/playwright/unit/vdom/VdomLifecycle.spec.mjs
@@ -21,7 +21,16 @@ import VdomHelper     from '../../../../src/vdom/Helper.mjs';
 import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
 
 // Mock applyDeltas to prevent errors during mount
+// Captured before the patch below, which lands at IMPORT time — there is no hook boundary early
+// enough to capture from. Playwright reuses a worker across spec files, so an unrestored no-op does
+// not crash a later spec; it silences the delta channel and lets that spec's assertions pass empty.
+const realApplyDeltas = Neo.applyDeltas;
+
 Neo.applyDeltas = async () => {};
+
+test.afterAll(() => {
+    Neo.applyDeltas = realApplyDeltas;
+});
 
 class MockComponent extends Component {
     static config = {
@@ -35,7 +44,7 @@ MockComponent = Neo.setupClass(MockComponent);
 
 /**
  * @summary Verifies the state consistency of the VdomLifecycle mixin.
- * 
+ *
  * Focuses on critical state flags like `mounted` and properties like `vnode`
  * during lifecycle events such as initialization, mounting, and hiding (removeDom).
  * Ensuring these states are correct is essential for the reliability of the
@@ -46,7 +55,7 @@ test.describe('VdomLifecycle State', () => {
     /**
      * Verifies that `initVnode` correctly initializes the component state even if
      * the component is configured to be hidden (`removeDom`) initially.
-     * 
+     *
      * Expected behavior:
      * 1. `mounted` should be true because `initVnode(true)` was called.
      * 2. `vnode` should be populated (not null) because `initVnode` forces creation by clearing `removeDom`.
@@ -70,7 +79,7 @@ test.describe('VdomLifecycle State', () => {
     /**
      * Verifies that the `vnode` property persists when a visible component is hidden
      * using `hideMode: 'removeDom'`.
-     * 
+     *
      * This persistence is critical for race condition handling: logic that checks
      * `component.vnode` relies on it being truthy even if the component is temporarily unmounted.
      */
@@ -81,19 +90,19 @@ test.describe('VdomLifecycle State', () => {
         });
 
         await comp.initVnode(true);
-        
+
         expect(comp.mounted).toBe(true);
         expect(comp.vnode).not.toBeNull();
 
         // Hide the component (triggers removeDom logic)
         comp.hidden = true;
-        
+
         // Wait for update cycle to complete
         await new Promise(resolve => setTimeout(resolve, 50));
 
         // Ensure vnode reference is not cleared upon unmounting
-        expect(comp.mounted).toBe(false); 
-        expect(comp.vnode).not.toBeNull(); 
+        expect(comp.mounted).toBe(false);
+        expect(comp.vnode).not.toBeNull();
 
         comp.destroy();
     });


### PR DESCRIPTION
Resolves #15789

Two tests in `draggable/dashboard/SortZone.spec.mjs` replace `Neo.applyDeltas` with closures over their own `appliedDeltas` array and never give it back. Playwright reuses a worker across spec files, so the override outlives the suite and runs **this file's fixture against whatever comes next** — the foreign SortZone frame @neo-opus-vega captured inside `GalleryInternalId`'s trace.

Original captured once in `beforeAll`, **before any test overrides it**, and restored in `afterEach`. That covers both existing override sites and any future one; per-site `try/finally` would not.

**`97f658fa6a` closes AC2 for the `Neo.applyDeltas` class across the whole unit tree** — 9 further leakers beyond SortZone and RaceCondition. Six patch at **module scope**, where the assignment lands at import and no hook boundary is early enough to capture from, so they capture inline and restore in `test.afterAll`.

I had called those nine "stateless no-ops" as if that made them safe. It does not — it makes them worse. A closure over dead fixture state throws or returns wrong in the victim; `Neo.applyDeltas = async () => {}` **silences the delta channel**, so the victim's delta assertions pass against nothing. Nothing goes red and the culprit file is not even in the run.

`draggable/container/SortZone.spec.mjs` also restores `Container.prototype.getDomRect` — a prototype patch leaks exactly as far as a namespace one.

**No per-file RED for those nine, and I am not implying one.** The victim pairing is order-dependent; the mechanism is already proven by this ticket's originating trace. Nine synthetic pairings would cost more than they would tell us. The RED/GREEN pair for the SortZone case stands as authored.

### Close-target: verified against AC2, twice, after getting it wrong once

AC2 asks for a `test/playwright/unit/**` sweep **recorded on the ticket**, fixing further instances in place. I published one sweep off a line-level parser and it was wrong in both directions — it read `Neo.get = origGet; Neo.getComponent = origGetComponent` as one statement (over-reporting 3 files that restore correctly) and matched only top-level `Neo.<prop>`, missing 20+ `Neo.Main.*` / `Neo.main.addon.*` / `Neo.manager.*` patches. Corrected sweep and retraction: [issuecomment-5069714806](https://github.com/neomjs/neo/issues/15789#issuecomment-5069714806).

The corrected result: **the `Neo.applyDeltas` class is clean tree-wide** — that is the incident class and this ticket's subject, so `Resolves` holds. The remaining groups are a **different surface** (main-thread bridge and addon namespaces), surfaced only because the sweep went deeper than the incident, and recorded on the ticket for a successor rather than absorbed into a PR that was reviewed as a two-file fix.

The recurrence is the real defect: hand-fixes fix the files that exist and nothing about the next spec.

**I proposed a lint for that and have since withdrawn it, after measuring it ([issuecomment-5069911589](https://github.com/neomjs/neo/issues/15789#issuecomment-5069911589)).** It fails at **36% false positives** and is blind to `Object.assign(Neo.Main, previous)` and `delete Neo.main` — the codebase's own idioms for restoring a multi-key namespace patch, and therefore precisely the case the lint existed to protect. One flagged file, `DockTabSortZone.spec.mjs:547`, restores conditionally (`if (hadDragDrop) { … } else { delete … }`) more carefully than the fix in this PR does, and my lint would have failed it. @neo-opus-grace measured a structurally identical proposal on the mechanism side and it came back 1 true / 5 false; two independent lints, two subsystems, the same structural refutation. Real detection needs dataflow, not pattern-matching, and the architectural question routes to her Discussion rather than a ticket.

**Live remainder: 21 groups across 10 files** — third and current revision of that sweep, measured at `97f658fa6a` with `Object.assign` and `delete` counted as restores. The two superseded numbers (19/16 line-level, 33/13 assignment-only) are labelled as retracted on the ticket so nobody has to reconstruct which is live. It is a floor, not a number I would defend precisely.

Evidence: L2 (deterministic RED/GREEN pair against unfixed source for the SortZone case, leaker and victim forced into one worker; 187 specs green across the touched trees) → L2 required (the AC is a behavioural claim about cross-spec bleed).

## Deltas from ticket

**The sweep found 11 files, not 1 — and the gradient changes what the right fix is.** Run before implementing rather than after, and recorded in full on the ticket (`issuecomment-5069099389`):

- **Confirmed harmful (this file):** the override **captures local fixture state**, so a leak *executes dead fixture* against a victim's components.
- **False-green risk (10 files):** `component/WrapperLifecycle`, `draggable/container/SortZone`, `functional/Button`, and the `vdom/*` cluster install **stateless** overrides. Leaked, they do not crash a victim — they make a later spec's deltas **silently not apply**, so VDOM assertions can pass against work that never happened. Quieter, and arguably worse.
- **Verified rather than inferred:** each of those files *has* a `test.afterEach`; every one of them destroys components and **none restores `Neo.applyDeltas`**. The suite has no convention for restoring a global `Neo.*` patch.

**Deliberately not swept in:** `Neo.get`, `Neo.apps`, `Neo.worker`, `Neo.ai`, `Neo.insideWorker`, `Neo.Main`, `Neo.Xhr`, `Neo.windowConfigs`. Different properties, different blast radii, several already restore correctly — my detector flags *"no restore matching a known idiom"*, which is not *"leaks"*. That is scope creep on someone else's ticket.

**One open scope question handed back rather than decided here:** eleven hand-maintained restores fix eleven known instances and nothing about the twelfth. The house rule the ticket cites — fixture-scoped seams, injected services — suggests a shared helper. A lint was the obvious candidate and is now empirically off the table (above).

## Test Evidence

**The falsifier is deterministic, not a flake** — forcing the leaker and the victim into one worker makes the bleed reproducible on demand:

```bash
npm run test-unit -- test/playwright/unit/draggable/dashboard/SortZone.spec.mjs \
                     test/playwright/unit/selection/GalleryInternalId.spec.mjs --workers=1
```

| source | result |
|---|---|
| unfixed `origin/dev` | **1 failed** — stack frame at `SortZone.spec.mjs:281` |
| with `9dec1a899d` | **12 passed** |

```bash
npm run test-unit -- test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
# → 9 passed (the file's own suite, unchanged)
```

**Two findings that upgrade the original diagnosis.** The bleed is not only a parallelism flake — forced ordering makes it deterministic, so it is regression-testable. And it bites **within the file**: the failing run shows the override from one SortZone test breaking an *earlier* one. Restoring per-test fixes both directions.

Directly touched surface: `draggable/dashboard/SortZone.spec.mjs` — its own suite, 9 passed.

## Post-Merge Validation

- [ ] Confirm `GalleryInternalId` no longer retry-heals under the `workers: 4` lane once #15783's decision lands — that was the original symptom and it should simply stop occurring.
- [ ] Resolve the convention question on #15789 for the 21-group remainder. **Not a lint** — that proposal is measured and withdrawn. The shape the counter-examples pointed at: a spec that patches a `Neo.*` namespace and has **no symmetric teardown of any form** — per-file rather than per-identifier, survives every restore idiom, and may be reviewable where it is not lintable.

## Commits

- `9dec1a899d` — capture in `beforeAll`, restore in `afterEach`.

## Evolution

The file already carried the principle in its own `afterEach` comment — *"a stub that survives its suite is indistinguishable from the method simply not working."* Someone fixed the DragCoordinator half of exactly this bug and `Neo.applyDeltas` survived the same cleanup, one screen away. That is worth noting for the convention question: a per-file fix is exactly what left this behind last time.

This override is also worse than the stubs sitting beside it. Those no-op a victim; this one runs dead fixture state against live components, which is why it produced a stack frame rather than a silent wrong answer — and why it was findable at all.

Reviewer: cross-family, so GPT or Kimi. Test-only change, no `src/` touched. Ranks below anything on the P0 line.

Authored by @neo-opus-ada (Claude Opus 4.8). Session ae593546-7ab8-4b27-bce7-ee4e2bebfcf1.


