### PR TITLE
feat(agentos): add evidence-first video workflow (#15795)

### DIFF
--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -422,6 +422,17 @@
         "learn/guides/fundamentals/CodebaseOverview.md"
       ]
     },
+    "video-create": {
+      "name": "video-create",
+      "description": "Evidence-first end-to-end video production workflow for narrated product films, demos, and campaign media. Triggers: planning, producing, revising, or delivering a video where claims, app choreography, voice, capture, composition, QA, publication, and artifact lineage must stay bound. ANTI-trigger: isolated image generation, standalone media conversion, or app testing with no film deliverable.",
+      "routerByteBudget": 12,
+      "payloadBudget": 80000,
+      "claudeSymlinkRequired": true,
+      "downstreamDocsTargets": [
+        "learn/agentos/ProgressiveDisclosureSkills.md",
+        "learn/guides/fundamentals/CodebaseOverview.md"
+      ]
+    },
     "whitebox-e2e": {
       "name": "whitebox-e2e",
       "description": "Standardized guide and protocol for authoring robust Whitebox End-to-End tests using the Neural Link Playwright fixture. CRITICAL: Neo.mjs uses Playwright in a highly custom way. Standard Playwright patterns will fail. Triggers: Use this skill before writing, modifying, or executing Playwright End-to-End tests, or if the user asks you to write an E2E test, add end-to-end coverage, or test a component holistically.",

--- a/.agents/skills/video-create/SKILL.md
+++ b/.agents/skills/video-create/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: video-create
+description: "Evidence-first end-to-end video production workflow for narrated product films, demos, and campaign media. Triggers: planning, producing, revising, or delivering a video where claims, app choreography, voice, capture, composition, QA, publication, and artifact lineage must stay bound. ANTI-trigger: isolated image generation, standalone media conversion, or app testing with no film deliverable."
+---
+
+# Video Create
+
+For an end-to-end film, first read and strictly follow `references/video-create-workflow.md`, then copy `assets/video-project-record-template.md` into an owner-private, gitignored production root as the production authority.
+
+Read `references/native-display-capture.md` only when a claim requires popup/multi-page or native-desktop evidence; page-only capture does not load it.
+
+Keep mechanics with their owning skill, app, provider, or platform. This skill owns phase order, receipts, evidence-class admission, invalidation/resume, and artifact promotion—not a provider adapter, compositor, capture tool, schema, or universal scene runner.

--- a/.agents/skills/video-create/assets/video-project-record-template.md
+++ b/.agents/skills/video-create/assets/video-project-record-template.md
@@ -1,0 +1,250 @@
+# Video Project Record
+
+> Copy this file for one production. It is a human-readable, format-neutral authority—not a canonical machine schema. Append decisions and receipts; do not erase prior attempts or maintain a competing production log.
+
+## Record header
+
+| Field | Value |
+|---|---|
+| Project ID | `<stable-project-id>` |
+| Working title | `<title>` |
+| Record revision | `1 (guidance template)` |
+| Created / updated | `<UTC timestamps>` |
+| Production owner | `<identity>` |
+| Decision owner | `<identity>` |
+| Status | `PLANNING / IN_PRODUCTION / QA / DELIVERY_READY / PUBLISHED / ARCHIVED / CANCELED` |
+| Source ticket/discussion | `<URLs>` |
+| Owner-private production root | `<gitignored private reference>` |
+| Raw-media permissions receipt | `<safe mode/access check>` |
+| Confidential detail location | `<private reference or NOT_APPLICABLE; never paste secrets/private content>` |
+
+Use `NOT_YET_OBSERVED`, `NOT_APPLICABLE — <reason>`, `BLOCKED — <authority>`, and `UNKNOWN — <falsifier>` instead of empty cells.
+
+## Brief and authority
+
+| Field | Decision / receipt |
+|---|---|
+| Audience | `<who>` |
+| Intended viewer action | `<what happens next>` |
+| Success condition | `<observable outcome>` |
+| Delivery profiles | `<platform/profile identifiers>` |
+| Duration range | `<project-specific range>` |
+| Accessibility target | `<caption/transcript/non-visual requirements>` |
+| Story/identity authority | `<path/URL + freshness timestamp>` |
+| Retention policy | `<accepted/non-accepted media policy>` |
+| Disclosure requirements | `<voice/generated-media/sponsor/etc.>` |
+
+### External-action authority
+
+| Action | Authority owner | Status | Scope / limit | Receipt |
+|---|---|---|---|---|
+| Spend | `<identity>` | `GRANTED / BLOCKED / NOT_APPLICABLE` | `<amount/provider surface>` | `<safe reference>` |
+| Data egress | `<identity>` | `GRANTED / BLOCKED / NOT_APPLICABLE` | `<data class/destination>` | `<safe reference>` |
+| Voice/persona use | `<identity>` | `GRANTED / BLOCKED / NOT_APPLICABLE` | `<scope>` | `<safe reference>` |
+| Publication | `<identity>` | `GRANTED / BLOCKED` | `<platform/visibility>` | `<safe reference>` |
+
+Credential values never enter this record. Record only the approved store/environment reference and presence check.
+
+## Story contract
+
+| Field | Value |
+|---|---|
+| Story ID | `S-01` |
+| Thesis | `<bounded thesis>` |
+| Audience promise | `<what the film proves or enables>` |
+| Canonical transcript location/hash | `<section below or exact external reference + hash>` |
+| Beat-map revision/hash | `<revision + hash>` |
+
+### Claim ledger
+
+| Claim ID | Exact bounded claim | Primary source + freshness | Required evidence class | Beat IDs | Status | Falsifier / note |
+|---|---|---|---|---|---|---|
+| `C-01` | `<claim>` | `<source>` | `page / popup/multi-page / native-desktop / non-visual` | `B-01` | `PROPOSED / VERIFIED / NARROWED / DROPPED` | `<tool/result that could falsify>` |
+
+### Transcript and beat map
+
+| Beat ID | Claim IDs | Narration / silence | Intended semantic state | Evidence class | Runnable/cue ref | Timing floor / transition | Overlay/caption intent |
+|---|---|---|---|---|---|---|---|
+| `B-01` | `C-01` | `<text or SILENCE>` | `<state>` | `<class>` | `<ref or MANUAL>` | `<project-specific>` | `<intent>` |
+
+### Timing calibration
+
+| Calibration run | Narration/source | Pace | Result | Decision |
+|---|---|---|---|---|
+| `T-01` | `<hash/ref>` | `CONVERSATIONAL` | `<durations/readability>` | `<accepted adjustment>` |
+| `T-02` | `<hash/ref>` | `INSTITUTIONAL/DELIBERATE` | `<durations/readability>` | `<accepted adjustment>` |
+
+## App-owned runnable contract
+
+| Field | Value |
+|---|---|
+| Repository / exact head | `<repo + full SHA>` |
+| App route / build profile | `<route/profile>` |
+| Fixture / reset method | `<ref>` |
+| Host method/export | `<path + symbol>` |
+| Script schema/version | `<e.g. neo.tour.script.v1 or NOT_APPLICABLE>` |
+| Requested / supported / effective mode | `<values or NOT_APPLICABLE>` |
+| Normalized cue-log ref/hash | `<ref>` |
+| Paired spec/profile cue-log parity | `<equal after pacing timestamps excluded / NOT_APPLICABLE + reason>` |
+| Owning unit/E2E spec | `<path + exact result>` |
+| Semantic capability needs | `<needs, not remembered operation names>` |
+| Neural Link server/OpenAPI/harness projection | `<server authority + digest/version + active harness/client/adapter identity/version/schema projection or NOT_APPLICABLE>` |
+| Raw `tools/list` / runtime freshness receipt | `<safe ref>` |
+| Need → operation mapping + transport smoke | `<safe ref>` |
+| Exact-head smoke receipt | `<command/tool + result + timestamp>` |
+
+Do not copy or fork app choreography into this record. Bind the app-owned runnable contract by exact references and receipts.
+
+## Voice and audio
+
+### Current authority check
+
+| Field | Value |
+|---|---|
+| Provider product surface | `<current product/API surface or OPERATOR_RECORDING>` |
+| Primary documentation checked | `<official URL + timestamp>` |
+| Model / voice | `<project choice; no global default>` |
+| Input/output limits and format | `<current observed constraints>` |
+| Required disclosure | `<text/location>` |
+| Consent / rights / persona state | `<BEARER_ASSENTED / OPERATOR_APPROVED / REJECTED / NOT_YET_OBSERVED + authority; never conflate states>` |
+| Generated narration disclosure | `<in-film + metadata placement or NOT_APPLICABLE>` |
+| Spend / egress receipt | `<external-action row>` |
+| Transcript hash | `<hash>` |
+| Instructions hash | `<hash>` |
+| Pronunciation guidance hash | `<hash or NOT_APPLICABLE>` |
+| Generated/recorded at | `<UTC timestamp>` |
+
+### Auditions and immutable attempts
+
+| Attempt ID | Parent IDs | Anonymized candidate/config | Generic/no-persona included? | Request/recording receipt | Output hash | Intelligibility/pacing/pronunciation/fit | State | Decision |
+|---|---|---|---|---|---|---|---|---|
+| `A-VOICE-001` | `<parents>` | `<candidate>` | `YES / NO — reason` | `<safe ref>` | `<hash>` | `<observations>` | `WORKING / ACCEPTED / QUARANTINED / PURGED` | `<reason + authority>` |
+
+## Stage and capture
+
+### Stage receipt
+
+| Field | Value |
+|---|---|
+| Exact source head | `<full SHA>` |
+| Runtime/build identity | `<identity>` |
+| Route / fixture / reset | `<refs>` |
+| Viewport/display/theme/locale | `<values>` |
+| Intended window topology | `<description>` |
+| Semantic start-state receipt | `<tool/result>` |
+| In-frame application-data privacy receipt | `<fixtures/names/avatars/paths/logs/notifications reviewed>` |
+| Runnable smoke receipt | `<tool/result>` |
+| Stage accepted at | `<timestamp + identity>` |
+
+### Capture attempts
+
+| Take ID | Beat IDs | Evidence class | Target fingerprint / stage receipt | Audio/cursor/chrome policy | Source artifact path/ref | Hash | Whole-media review | State / reason |
+|---|---|---|---|---|---|---|---|---|
+| `A-TAKE-001` | `B-01` | `<class>` | `<safe ref>` | `<policy>` | `<ref>` | `<hash>` | `<review receipt or NOT_YET_OBSERVED>` | `WORKING / ACCEPTED / QUARANTINED / PURGED` |
+
+For native capture, link the before/after topology, recorder revalidation, frame-zero, and terminal-effect receipts from `../references/native-display-capture.md`.
+
+## Composition and renders
+
+### Derived render data
+
+| Render ID | Ordered source asset IDs/hashes | Trims/timing/overlays/captions/audio decisions | Editor/renderer + version | Output profile | Parent decision hash |
+|---|---|---|---|---|---|
+| `A-RENDER-001` | `<ordered refs>` | `<format-neutral decisions>` | `<tool/version>` | `<profile>` | `<hash>` |
+
+### Render attempts
+
+| Attempt ID | Parent render/source IDs | Output ref | Hash | Technical probe | State | Supersedes / reason |
+|---|---|---|---|---|---|---|
+| `A-VIDEO-001` | `<parents>` | `<ref>` | `<hash>` | `<receipt>` | `WORKING / ACCEPTED / QUARANTINED / PURGED` | `<ref/reason>` |
+
+Never overwrite an attempt. A correction is a successor row with explicit parents.
+
+## QA matrix
+
+Candidate under review: `<asset ID + exact hash>`
+
+| Dimension | Reviewer/tool | Whole artifact? | Result | Receipt / findings |
+|---|---|---|---|---|
+| Technical decode/profile | `<identity/tool>` | `YES` | `PASS / FAIL / BLOCKED` | `<receipt>` |
+| Visual | `<identity>` | `YES` | `PASS / FAIL / BLOCKED` | `<receipt>` |
+| Audio | `<identity>` | `YES` | `PASS / FAIL / BLOCKED` | `<receipt>` |
+| Cold-listener comprehension | `<identity>` | `YES` | `PASS / FAIL / BLOCKED` | `<receipt>` |
+| Claim/evidence mapping | `<identity>` | `YES` | `PASS / FAIL / BLOCKED` | `<claim IDs + findings>` |
+| Rights/privacy/disclosure | `<identity>` | `YES` | `PASS / FAIL / BLOCKED` | `<receipt>` |
+| Accessibility/captions | `<identity>` | `YES` | `PASS / FAIL / BLOCKED` | `<receipt>` |
+| Platform profile | `<identity/tool>` | `YES` | `PASS / FAIL / BLOCKED` | `<current requirements check>` |
+
+Sampling/probes may be listed as aids, but only a whole-artifact review can mark the corresponding row `YES`.
+
+### First-film state-transition audit
+
+Required for the first completed film using `/video-create`; retain for later films when useful.
+
+- [ ] Every attempt has one current recorded state.
+- [ ] Every `ACCEPTED` promotion names reviewer, authority, timestamp, exact hash, and parents.
+- [ ] Every quarantine/purge names a safe reason and retention/deletion receipt.
+- [ ] No file was overwritten to simulate a transition.
+- [ ] Revoked/superseded assets invalidate every affected descendant.
+- [ ] The published artifact and metadata bind to the accepted hashes.
+
+## Delivery bundle
+
+| Bundle field | Asset/ref | Exact hash / identity |
+|---|---|---|
+| Accepted video | `<asset ID>` | `<hash>` |
+| Captions | `<asset ID/ref>` | `<hash>` |
+| Transcript | `<asset ID/ref>` | `<hash>` |
+| Poster/thumbnail | `<asset ID/ref>` | `<hash>` |
+| Title/description/disclosure metadata | `<ref>` | `<hash>` |
+| Visibility/audience | `<value>` | `<authority receipt>` |
+| Platform profile check | `<ref>` | `<timestamp/version>` |
+
+### Publication receipt
+
+| Field | Value |
+|---|---|
+| Operator publication authority | `<receipt>` |
+| Platform identity | `<stable platform/artifact ID>` |
+| Canonical link | `<URL>` |
+| Published at | `<UTC timestamp>` |
+| Upload receipt | `<safe ref>` |
+| Read-back artifact/metadata proof | `<tool/result + exact visible identity>` |
+| Blog/campaign handoff | `<claim/evidence IDs + bundle receipt or NOT_APPLICABLE>` |
+
+## Asset lineage and retention
+
+| Asset ID | Kind | Parent IDs/hashes | Created at/by | Provenance visibility | Current state | State receipt | Retention location/expiry |
+|---|---|---|---|---|---|---|---|
+| `<ID>` | `<voice/take/render/video/caption/poster/metadata>` | `<parents>` | `<timestamp/identity>` | `PUBLIC_BOUNDED / PRIVATE` | `WORKING / ACCEPTED / QUARANTINED / PURGED` | `<append-only receipt>` | `<safe ref/policy>` |
+
+Unsafe or rights-uncleared media is purge-only. Put its sanitized deletion receipt (attempt ID, incident class, sanitized scope hash, timestamps, authorizer, destruction confirmation) in the private authority location; do not preserve revealing previews, text, paths, account data, identifiers, or descriptions here.
+
+Public provenance may expose bounded source/artifact hashes, provider/model/voice identity, disclosure, and public platform ID. Request IDs, consent artifacts, account/project references, raw errors, absolute paths, credential references, and purge detail remain private.
+
+## Invalidation and resume log
+
+| Event ID / time | Trigger | Affected claim/beat/asset IDs | Last-good receipt | Invalidated gates | Resume point | Decision owner |
+|---|---|---|---|---|---|---|
+| `INV-001` | `<change/drift/failure>` | `<IDs>` | `<ref>` | `<gates>` | `<earliest required phase>` | `<identity>` |
+
+## Decisions, bypasses, and drift
+
+| Decision ID / time | Question | Options/evidence | Decision | Authority | Revalidation trigger |
+|---|---|---|---|---|---|
+| `D-001` | `<question>` | `<evidence>` | `<decision>` | `<identity>` | `<trigger>` |
+
+Record every bypass. Two bypasses of the same gate trigger an early skill re-audit.
+
+## Final disposition
+
+| Field | Value |
+|---|---|
+| Final state | `PUBLISHED / ARCHIVED / CANCELED / NO_FILM` |
+| Accepted bundle hash | `<hash or NOT_APPLICABLE>` |
+| Claim ledger final review | `<receipt>` |
+| QA final review | `<receipt>` |
+| Publication/archive binding | `<receipt>` |
+| Non-accepted asset disposition complete | `YES / NO — reason` |
+| Closed by / at | `<identity + UTC timestamp>` |
+| Skill re-audit counter | `<completed-film ordinal; bypass/drift notes>` |

--- a/.agents/skills/video-create/references/native-display-capture.md
+++ b/.agents/skills/video-create/references/native-display-capture.md
@@ -1,0 +1,119 @@
+# Native Display Capture
+
+Load this reference only when the film needs `popup/multi-page` or `native-desktop` evidence. It hardens target selection, privacy, whole-media review, and topology receipts without prescribing a recorder or operating system.
+
+## 1. Admission
+
+State the claim first. Then choose the least powerful evidence class that can prove it:
+
+- use `page` capture for one page's rendered state;
+- use `popup/multi-page` when separately observed browser pages are material;
+- use `native-desktop` only when OS-window existence, placement, focus, movement, reattachment, or other physical behavior is itself part of the claim.
+
+If the required class cannot be safely staged and verified, narrow the claim. Never use narration to promote page evidence into native proof.
+
+## 2. Dedicated stage
+
+Prepare a dedicated capture stage before opening the recorder:
+
+- close unrelated applications/windows or move them outside the admitted capture region;
+- disable or account for notifications, overlays, password managers, clipboard panels, recent-item surfaces, and personal chrome;
+- use public-safe sample fixtures and accounts by default; live-data capture requires explicit data-scope clearance;
+- inspect the application itself for private names, avatars, paths, logs, tokens, conversations, and historical data that would remain in-frame;
+- verify microphone/system-audio sources and exclude unintended audio;
+- set deterministic display scale, resolution, theme, locale, cursor, and window geometry where the claim depends on them;
+- record the exact source head, app route, semantic start state, and topology receipt.
+
+For full-display recording, prefer an isolated non-main display dedicated to the take. If the current platform cannot prove an exact-window or isolated-display target, fail closed or narrow the claim.
+
+Do not put secrets, credential values, private paths, private conversation content, or sensitive incident detail into the project record. Record only safe references and decision receipts.
+
+## 3. Short-lived target fingerprint
+
+Create a fresh observational fingerprint for the intended target immediately before selection. It may include:
+
+- application/process identity as exposed by the recorder;
+- visible title, bounds, display, and expected nearby windows;
+- current semantic/runtime `windowId` and capability projection when available;
+- a topology snapshot and timestamp;
+- a safe screenshot or digest of the clean frame.
+
+The fingerprint is not durable routing authority. ADR 0029 §2.8.5 keeps semantic names, URLs, titles, timing, and runtime IDs from becoming physical-handle authority. Treat the fingerprint only as a short-lived selection/revalidation receipt.
+
+## 4. Recorder revalidation and frame zero
+
+After selecting the capture source and immediately before recording:
+
+1. compare the recorder's selected-source preview with the fresh fingerprint;
+2. confirm window/display bounds and audio sources;
+3. confirm the app's semantic start state through its owning inspection surface;
+4. ensure no unrelated window overlaps or can enter the retained region;
+5. start a new immutable attempt.
+
+At frame zero, verify that the retained stream actually shows the intended target, crop, scale, pointer/chrome policy, and clean stage. A correct selector label with a wrong preview fails closed.
+
+When the capture API or operating system requires user selection/permission, that user action is part of admission. Do not bypass it or infer a target from stale state.
+
+## 5. Semantic and physical receipts
+
+Native footage and application truth are complementary:
+
+- the recorder proves what was visibly retained;
+- `/neural-link` or the app's current semantic surface proves worker/application state;
+- app-owned runner/spec receipts prove the choreography contract;
+- `get_window_topology` or its current successor proves connected runtime topology.
+
+Bind each receipt to the exact take ID, source head, timestamp range, and evidence claim. If the Neural Link server/OpenAPI/harness projection changed, rerun capability discovery and the smoke proof before capture.
+
+For a claim about physical close, ADR 0029 §2.8.5 is explicit: a native `close()` return is provisional. The receipt becomes terminal only after the connected runtime `windowId` disappears from topology. For focus/position or other physical effects, record the corresponding before/after observation and semantic state; never treat dispatch success as effect proof.
+
+Independently opened, cross-origin, stale, or uncorrelated windows can remain observable, but physical control fails closed.
+
+## 6. Platform recipe boundary
+
+Portable evidence semantics are mandatory; recorder commands and selectors are not. Use a platform-specific recipe only when the current film can establish:
+
+- the recorder and platform/version in use;
+- the exact target-selection surface;
+- a fresh target fingerprint and immediate preview revalidation;
+- a safe stop/purge path;
+- a falsifiable receipt from that platform.
+
+The completed Build Week film is evidence for one macOS display-scoped workflow, not a universal operating-system recipe. Add another platform recipe only after a real film on that platform produces a reproducible receipt.
+
+## 7. During capture
+
+- Keep the stage bounded to the admitted region and sources.
+- Do not replace or overwrite a prior attempt.
+- If an unrelated notification/window/audio source enters the stream, stop the take and mark it for purge review.
+- If semantic state diverges from the script, stop or mark the exact divergence; do not edit around an unrecorded state failure.
+- If a window reconnects/reloads or its target fingerprint changes, invalidate the current target admission and reacquire it.
+
+## 8. Whole retained-media review
+
+Review the exact retained candidate from start to finish before it can become a render parent. The review covers:
+
+- every visual frame at a scale that makes text and transient overlays inspectable;
+- every audio stream, including silence and transitions;
+- all selected tracks/streams and container metadata;
+- the first and final frames;
+- crop, pointer, window bounds, notifications, titles, private data, and continuity;
+- correlation with semantic and topology receipts.
+
+Sampling aids—contact sheets, OCR, scene detection, waveform/silence scans, metadata probes—help locate risk. They cannot certify material that was not watched/listened to.
+
+Record reviewer identity, timestamp, exact hash, streams reviewed, and disposition.
+
+Cropping or masking a derivative does not sanitize a retained raw recording. Review and disposition the raw parent independently.
+
+## 9. Retention and provenance disposition
+
+- `ACCEPTED`: full review passed and the take may become a render parent.
+- `QUARANTINED`: safe to retain privately while rejected or awaiting a named decision.
+- `PURGED`: remove the media when privacy, rights, target identity, or retention safety is uncertain.
+
+Unsafe or rights-uncleared native media is purge-only. Keep a private sanitized deletion receipt with attempt ID, broad reason category, authorizer, and verification; do not preserve a revealing thumbnail, transcript, or description as evidence of deletion.
+
+If an accepted take is later found unsafe, revoke it in the project record, invalidate every descendant render/delivery, and purge or quarantine those descendants according to the same rule.
+
+Public receipts may contain bounded source/artifact hashes, evidence class, disclosure, and public platform identity. Keep request IDs, consent records, account/project references, raw errors, absolute paths, credential references, and purge detail private.

--- a/.agents/skills/video-create/references/video-create-workflow.md
+++ b/.agents/skills/video-create/references/video-create-workflow.md
@@ -1,0 +1,262 @@
+# Video Create Workflow
+
+This workflow turns a film brief into a hash-bound delivery without letting the story outrun the evidence. It is an orchestration protocol, not a media toolkit. Current provider, application, capture, editing, and publishing mechanics stay with their owning surfaces.
+
+Start by copying `../assets/video-project-record-template.md`. That record is the production authority for the film. Append receipts and decisions; do not maintain a second handwritten production log.
+
+## 1. The ownership boundary
+
+`/video-create` owns:
+
+- ordered phase gates;
+- stable story, claim, beat, attempt, and asset references;
+- evidence-class admission;
+- immutable media-attempt lineage;
+- invalidation and resume decisions;
+- QA and final artifact promotion;
+- delivery and retention receipts;
+- public/private provenance separation.
+
+It consumes, without duplicating:
+
+- `/neo-identity-update` and ADR 0018 for identity-bearing claims and framing;
+- `/neural-link` for semantic live-application inspection or interaction;
+- `/whitebox-e2e` and `/unit-test` for app-owned runnable/test evidence;
+- `/imagegen` for generated still-image mechanics;
+- `/blog-post` for hero/campaign eligibility, narrative policy, and publication-profile decisions;
+- the participating app's own runnable choreography contract;
+- current provider and platform documentation at the time of use.
+
+Do not add a provider adapter, compositor starter, capture executable, typed canonical schema, external-editor timeline authority, or generalized scene runner while following this workflow. Two stable consumers plus a graduated Decision Record are the minimum reopening evidence for an executable abstraction.
+
+## 2. Evidence classes do not promote by prose
+
+Declare the minimum evidence class for every visual claim before scripting:
+
+| Evidence class | Can establish | Cannot establish by itself |
+|---|---|---|
+| `page` | One browser page's rendered and semantic state | A second page, popup, browser chrome, or native OS-window topology |
+| `popup/multi-page` | Relationships among separately observed browser pages/popups | Native placement, physical window identity, or OS-level behavior |
+| `native-desktop` | Visible native-window/desktop behavior when paired with semantic receipts | Hidden application truth that was never inspected |
+
+A higher-class recording does not remove the semantic-state requirement. A lower-class take cannot be relabeled after capture. Narrow the claim or recapture at the admitted class.
+
+For popup/multi-page or native-desktop evidence, read `native-display-capture.md` before staging or recording.
+
+## 3. Phase gates
+
+Every phase ends with an append-only receipt in the project record. If a gate fails, stop there; do not infer downstream success.
+
+### Phase 0 — Brief and authority
+
+Record:
+
+- audience, intended action, delivery profile, duration range, accessibility target, and success condition;
+- the story/identity authority and freshness timestamp;
+- the operator decision owner;
+- explicit authority for spend, data egress, and publication;
+- an owner-private, gitignored production root plus a permissions receipt for raw media;
+- retention and disclosure requirements;
+- secrets only as credential-store/environment references, never values.
+
+If spend, egress, consent, rights, or publication authority is missing, the corresponding external action remains blocked. Planning and local reversible work may continue independently.
+
+### Phase 1 — Claim ledger and story contract
+
+Give every public claim a stable ID. For each claim, record:
+
+- exact wording or bounded proposition;
+- primary source and freshness;
+- required evidence class;
+- planned beat IDs;
+- status: `PROPOSED`, `VERIFIED`, `NARROWED`, or `DROPPED`;
+- the falsifier that could still invalidate it.
+
+Identity-bearing language consumes the current facts/framing/actions authority. A source's prestige is not a receipt; run the tool or inspect the artifact that could falsify the claim.
+
+Build the story and beat map from verified or explicitly provisional claims. Do not start from available footage and reverse-invent the thesis.
+
+Every narrated claim must map to a verified receipt or be narrowed/cut before acceptance.
+
+### Phase 2 — Transcript, beat map, and timing
+
+Bind transcript paragraphs to stable beat and claim IDs. Each beat names:
+
+- narration or silence;
+- intended semantic application state;
+- visual evidence class;
+- app-owned runnable/cue reference, if any;
+- overlay/caption intent;
+- timing floor and transition allowance.
+
+Timing is project-configurable. Calibrate against actual narration and two representative runs: one conversational/talking pace and one deliberately institutional/respectful pace. The completed Build Week film is historical calibration, not a global duration or pacing default.
+
+Changing a claim, transcript, or beat ID triggers the invalidation rules in §5; do not patch timings silently.
+
+### Phase 3 — Voice and audio authority
+
+Before any external voice operation:
+
+1. Check current primary provider documentation for product surface, model/voice availability, input limits, output format, disclosures, and terms relevant to the intended use.
+2. Record consent, rights, and persona state. Never imply a named person's voice or assent without authority. Bearer assent, operator approval, and `NOT_YET_OBSERVED` are different states; one cannot stand in for another.
+3. Compare multiple viable auditions, or record why only one/no candidate is available. For a named peer persona, anonymize the comparison and include a generic/no-persona option before asking the bearer. Evaluate intelligibility, pacing, pronunciation, emotional fit, and disclosure needs.
+4. Record provider product, model/voice, instructions hash, transcript hash, pronunciation guidance hash, request/receipt reference, generation timestamp, cost/egress authority, parent asset, and output hash.
+5. Keep every generated or recorded attempt immutable. Accept one attempt by appending a promotion receipt; never overwrite a prior attempt.
+6. Disclose generated narration in the film and delivery metadata wherever the current authority requires it.
+
+Selective regeneration creates new attempts only for affected segments, retains every parent hash, and invalidates descendant renders explicitly.
+
+No provider, model, voice, or instruction string becomes a global default. A generic narrator, operator narration, captions-only delivery, or no-film disposition remains valid when authority or quality is insufficient. If a named persona's bearer cannot audition, record that state and fall back; operator approval must not be represented as bearer assent.
+
+### Phase 4 — Exact-head application stage
+
+For application footage, bind the stage to:
+
+- repository and exact commit/head;
+- application route and build/runtime profile;
+- seed/data fixture and reset method;
+- viewport/window topology;
+- app-owned runnable method/export and any script schema version;
+- requested, supported, and effective runner mode;
+- current Neural Link server authority, OpenAPI/tool projection, and active harness projection identity when Neural Link supplies evidence;
+- smoke receipt proving the runnable contract still reaches the intended state.
+
+When Neural Link supplies evidence, name semantic needs rather than remembered operation names. Discover the raw live `tools/list`, verify runtime freshness plus server/OpenAPI digest and harness/client/adapter identity/version/schema projection, resolve each need to the current operation, smoke the exact transport/schema, and record the result. An operation name alone is not a current capability receipt.
+
+`neo.tour.script.v1` and `TourRunner` are eligible only when the participating app exposes a real runnable contract and current tests/receipts establish it. At the same source head and semantic baseline, admit an applicable capture only when its normalized cue log matches the paired spec/profile receipt with pacing timestamps excluded. Out-of-contract native choreography carries its own cue-linked receipt. The film record must not fork the schema, coerce transport payloads, or turn app choreography into a universal film scene engine.
+
+If the app has no stable runner, use a project-local/app-owned adapter or manual choreography with explicit steps. The absence of general machinery is not permission to invent it in the skill.
+
+Do not add a production product control solely to make filming easier. Dedicated demo hosts or app-owned test/choreography surfaces own film-specific driving.
+
+A page reload, application restart, bridge reconnect, or harness/client reprojection invalidates every live-session receipt. Reconnect and repeat semantic/capability preflight before capture resumes.
+
+### Phase 5 — Capture
+
+Before each take:
+
+- reset to the bound exact-head stage;
+- verify semantic start state;
+- verify that in-frame application data, names, avatars, paths, logs, and notifications are public-safe for the intended visibility; sample-data hosts are the default, and live-data capture requires explicit data-scope clearance;
+- confirm the admitted evidence class;
+- confirm the capture target and privacy/rights boundary;
+- allocate a new immutable attempt ID and path;
+- record audio/cursor/chrome/notification choices.
+
+After each retained take:
+
+- hash the artifact;
+- record source/head, stage receipt, time range, and parent inputs;
+- review the full retained visual and audio streams plus container/metadata identity;
+- append `ACCEPTED`, `QUARANTINED`, or `PURGED` disposition.
+
+Contact sheets, OCR, silence scans, waveform probes, and sampled frames can guide review. They never certify the unseen remainder.
+
+### Phase 6 — Composition and derived render data
+
+Keep derived render data in the project record or in an external editor file referenced by exact hash; it is not an independent story authority. Record:
+
+- ordered source asset IDs and hashes;
+- trims, timing offsets, overlays, captions, disclosure cards, transitions, and audio mix decisions;
+- renderer/editor identity and version;
+- output settings and parent lineage;
+- render attempt ID and hash.
+
+Rendered outputs are immutable attempts. Corrections create a successor render with explicit parents and a reason; they do not replace the prior file in place.
+
+Generated still, cover, and poster candidates are immutable attempts too. `/imagegen` retains generation mechanics; the film record retains source/prompt/instruction hashes, parents, output hash, and disposition.
+
+Cropping, masking, or omitting a derivative does not sanitize a retained unsafe raw parent. The raw asset keeps its own review and retention disposition.
+
+### Phase 7 — QA
+
+Run all applicable dimensions against the full candidate:
+
+| Dimension | Required question |
+|---|---|
+| Technical | Does the entire file decode, and do duration, dimensions, frame rate, codecs, channels, loudness, and clipping match the delivery profile? |
+| Visual | Is every retained frame free of unintended UI, private data, stale state, unreadable text, crop defects, and continuity errors? |
+| Audio | Is speech intelligible to a cold listener and synchronized, with correct pronunciation, clean transitions, and no unintended audio? |
+| Claims | Does every spoken, shown, captioned, and metadata claim map to a verified claim ID and sufficient evidence class? |
+| Rights/privacy | Are voices, images, names, data, notifications, and background material authorized for the intended visibility? |
+| Accessibility | Are captions/transcript complete, synchronized, readable, and meaning-preserving; are essential visual facts also available non-visually? |
+| Platform | Does the exact candidate meet the current upload, thumbnail/poster, caption, disclosure, metadata, and visibility requirements? |
+
+Automated probes are assistants, not whole-media certification. Record who/what completed the whole retained-media review and the exact candidate hash reviewed.
+
+The first film produced with this skill must audit every asset state transition and verify append-only lineage plus hash-bound publication.
+
+Target binding, hashes, cue-log equality, stream/metadata probes, and timing arithmetic are mechanical checks. Evidence sufficiency, whole-media privacy/audio review, bearer assent, visual meaning, and final aesthetics remain human/peer judgment gates.
+
+### Phase 8 — Delivery
+
+Publication is an external action and requires explicit operator authority even when upload credentials exist.
+
+Freeze a delivery bundle:
+
+- accepted video hash;
+- captions/transcript hash;
+- poster/thumbnail hash;
+- title/description/disclosure metadata hash;
+- visibility/audience;
+- current platform profile and limits check;
+- publication owner and approval receipt.
+
+After publication, record the platform identity, canonical link, publication timestamp, and read-back proof that the visible artifact/metadata match the frozen bundle. A successful upload response alone is not completion. Publication remains blocked when the target cannot yield a stable asset identity plus a verified link receipt.
+
+For blog/campaign integration, hand the accepted bundle and shared claim/evidence IDs to `/blog-post`. `/blog-post` retains the decision whether the profile requires, permits, or refuses companion video; neither medium becomes the other's content SSOT.
+
+### Phase 9 — Archive, quarantine, and purge
+
+Every attempt ends in one of these record dispositions:
+
+- `ACCEPTED` — retained and eligible as a parent/public artifact;
+- `QUARANTINED` — safe to retain privately but rejected or awaiting a named decision;
+- `PURGED` — deleted because retention is unsafe, unauthorized, or unnecessary.
+
+Unsafe or rights-uncleared media is purge-only. Keep only a private sanitized receipt containing the attempt ID, time, reason category, sanitized scope hash, authorizer, and deletion verification—never the sensitive content or a revealing description.
+
+Archive the accepted bundle, project record, source hashes, QA receipts, and public identity together. Apply the declared retention policy to non-accepted attempts.
+
+Public provenance may expose bounded source/artifact hashes, provider/model/voice identity, disclosure, and public platform ID. Request IDs, consent artifacts, account/project references, raw errors, absolute paths, credential references, and purge detail remain in the private authority location.
+
+## 4. Promotion rules
+
+An asset can be promoted only when:
+
+1. its parent lineage and hash are recorded;
+2. its evidence class and authority match the claims it carries;
+3. all required QA dimensions pass on that exact hash;
+4. rights/privacy/disclosure decisions are explicit;
+5. any external action has current operator authority.
+
+Promotion is an appended decision, not a rename that erases history. If an accepted artifact later fails, append a revocation/supersession receipt and create a successor attempt.
+
+## 5. Invalidation and resume
+
+Resume from the earliest invalidated gate, not from the latest available file.
+
+| Change observed | Invalidate at minimum |
+|---|---|
+| Story authority or claim wording/source changes | Claim verification, affected beats, narration, capture, render, QA, delivery |
+| Transcript/pronunciation changes | Voice attempts, timing, affected renders, audio/claim QA, delivery |
+| Source head, fixture, route, runnable contract, tool projection, or topology changes | Stage smoke, affected capture, renders, QA, delivery |
+| Page/app/bridge restart, reload, reconnect, or harness reprojection | All live-session semantic/capability receipts, affected capture, renders, QA, delivery |
+| Voice/provider/model terms or capability drift | Provider check, voice authority, affected audio/render, disclosure/platform QA |
+| Capture target/evidence class changes | Capture admission, retained-media review, affected renders, claim QA |
+| Edit decision, overlay, captions, metadata, or renderer changes | New render, affected QA, delivery binding |
+| Platform profile/visibility/link changes | Platform check, operator publication authority as applicable, delivery read-back |
+| Rights/privacy decision changes | All affected assets; quarantine or purge immediately where required |
+
+Append an invalidation entry naming the trigger, affected IDs, last-good receipt, and chosen resume point. `NOT_YET_OBSERVED` stays explicit; absence is not a pass.
+
+## 6. Completion and decay
+
+The workflow completes only when the project record binds the public or archived disposition to exact hashes and receipts. A canceled/no-film decision is complete when its authority and retained/purged asset disposition are recorded.
+
+Re-audit this skill at the third completed film or first merge anniversary, whichever comes first. Re-audit earlier after two bypasses of the same gate or material provider/platform drift. At re-audit:
+
+- promote a stable two-consumer contract only through the Decision Record gate;
+- compress unused template sections into guidance;
+- retire rules that no longer prevent observed failure;
+- keep volatile provider/platform mechanics outside this substrate.

--- a/.claude/skills/video-create
+++ b/.claude/skills/video-create
@@ -1,0 +1,1 @@
+../../.agents/skills/video-create

--- a/learn/agentos/ProgressiveDisclosureSkills.md
+++ b/learn/agentos/ProgressiveDisclosureSkills.md
@@ -108,6 +108,7 @@ Beyond lifecycle governance, specialized contexts exist for live action:
 - **`self-repair`:** A strict diagnostic protocol ensuring infrastructure verification across MCP services, Unit Testing, and Historical Forensics using Memory Core states to resolve system lockups.
 - **`debugging-antigravity`:** Antigravity 2.x MCP-authority selection, process-duplication forensics, UI-profile boundary checks, and evidence-first sqlite workspace recovery.
 - **`ideation-sandbox`:** A creative workflow ensuring brainstorming occurs politely in GitHub Discussions rather than polluting the active Issue queue. Also acts as an auto-fire trigger for high-blast-radius proposals.
+- **`video-create`:** An evidence-first film-production workflow binding claims, app-owned choreography, voice, capture class, immutable media lineage, whole-artifact QA, delivery, and retention without duplicating provider or editing mechanics.
 - **`context-recovery`:** A post-compaction recovery workflow that reconstructs active lane state from Memory Core recency, semantic recall, session rollups, and A2A before the agent resumes or asks for operator recap.
 - **`lane-intent`:** A narrow, non-authoritative, 2-hour TTL-bound pre-V-B-A signal for collision-prone / high-blast / long-V-B-A lanes (deep `/memory-mining`, `/tech-debt-radar`, multi-turn architectural V-B-A). Distinct from authoritative `[lane-claim]` (post-V-B-A); read before broadcasting `[lane-intent]` to confirm scope-trigger qualifies.
 - **`neo-identity-update`:** The protocol for updating Neo's identity (what Neo *is*) coherently across all ~30+ surfaces that encode it — README, VISION, learn/benefits, package.json, GitHub metadata, portal app, and the build-generated SEO files. Splits FACTS (single-source-derive), FRAMING (audience-segmented against a canonical apex), and ACTIONS / CTAs (governed next-step surfaces). Foundation: ADR 0018.
@@ -148,6 +149,7 @@ ensuring the YAML frontmatter and folder consistency are perfectly formed.
 | `context-recovery` | Tactical | Post-compaction lane reconstruction from Memory Core recency, semantic recall, session rollups, and A2A |
 | `whitebox-e2e` | Tactical | Neural Link pre-flight workflow for authoring custom Playwright E2E tests |
 | `ideation-sandbox` | Creative | GitHub Discussion brainstorming |
+| `video-create` | Creative | Evidence-first end-to-end film workflow with claim/evidence binding, immutable lineage, QA, delivery, and retention gates |
 | `lead-role` | Coordination | Suspends Auto Mode bias; mandates dialogue-first convergence for delegated lead tasks (Mailbox Check Protocol supported) |
 | `peer-role` | Coordination | Suspends Auto Mode bias; mandates evidence-backed convergence-pressure mindset for peer reviews |
 | `peer-naming` | Coordination | Social Name ritual (#11240 Layer 4): peer-sketched → criterion-audited → bearer-assented → peer-unvetoed → operator-confirmed; name ≠ handle |

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -442,7 +442,7 @@ Offline cognitive maintenance runs as **Node.js scripts**, not MCP protocol oper
 
 ---
 
-### Swarm Skills & Workflows (`/.agents/skills/` - 32 skills)
+### Swarm Skills & Workflows (`/.agents/skills/` - 38 skills)
 
 Formalized Anthropic Progressive Disclosure Skills natively used by the swarm. Listed in execution-lifecycle order, then tactical, creative, and meta. See [`learn/agentos/ProgressiveDisclosureSkills.md`](../../agentos/ProgressiveDisclosureSkills.md) for the full protocol reference and lifecycle flow diagram. Canonical skill-anatomy authority: [ADR 0008: SKILL.md Anatomy and Authoring Contract](../../agentos/decisions/0008-skill-anatomy-and-authoring-contract.md).
 
@@ -477,6 +477,7 @@ Formalized Anthropic Progressive Disclosure Skills natively used by the swarm. L
 
 **Creative:**
 - `ideation-sandbox`: Safe brainstorming pipelines mapped directly into GitHub Discussions (diverts early-stage proposals away from the active Issue queue, and acts as a step-back trigger for high-blast-radius proposals).
+- `video-create`: Evidence-first end-to-end film production — binds claims, app-owned choreography, voice, capture evidence class, immutable media lineage, whole-artifact QA, delivery, and retention while leaving volatile provider/editor mechanics with their owners.
 
 **Coordination:**
 - `lane-intent`: Narrow, non-authoritative, 2h TTL-bound pre-V-B-A signal for collision-prone / long-V-B-A lanes (deep `/memory-mining`, `/tech-debt-radar`, multi-turn architectural V-B-A). Distinct from authoritative `[lane-claim]` (post-V-B-A).


### PR DESCRIPTION
Resolves #15795

Adds the graduated `/video-create` capability as a deliberately non-executable Progressive Disclosure package: a 12-line trigger Map, an evidence-first production Atlas, a conditional native-display capture hardening reference, and one copyable format-neutral project record. The workflow binds claims, app-owned choreography, voice authority, evidence class, immutable asset lineage, whole-artifact QA, publication identity, and retention without absorbing provider, recorder, editor, Neural Link, TourRunner, image-generation, or blog-policy mechanics.

Evidence: L1 (static Map/Atlas/template contract, manifest/symlink/docs parity, reference-integrity and guide lint) → L1 required (workflow substrate; no runtime-effect acceptance criterion). No residuals.

## Deltas from ticket

None substantive. The diff keeps the exact four-file package and all named exclusions. During exact-anchor review it made the frozen invariants explicit where the ticket summarized them: anonymized persona audition with a generic/no-persona option, cold-listener comprehension, owner-private/gitignored production storage, restart/reprojection invalidation, raw `tools/list` plus server/OpenAPI/harness projection receipts, normalized cue-log take admission, live-data clearance, and stable platform identity plus verified link.

## Contract Ledger

| Target surface | Authority | Delivered behavior | Fallback / boundary | Evidence |
|---|---|---|---|---|
| `/video-create` Map | ADR 0008 + `/create-skill` | Exact frontmatter plus a 12-line trigger/router | Narrow tasks stay with their owning skill/tool | Manifest structural lint; 1,099-byte router |
| Production Atlas | Frozen D#15673 + #15795 | Brief/authority → claims → story/timing → voice → exact-head stage → capture → composition → QA → delivery → archive, with invalidation/resume | Stop at the first missing receipt; narrow the claim/evidence class | Static criteria mapping; reference-integrity lint |
| Native-display capture | ADR 0029 §2.8.5 + D#15673 | Dedicated target-bound stage, immediate recorder revalidation, frame-zero check, semantic/topology receipts, whole-retained-media review, purge-only unsafe disposition | Use page/popup evidence or narrow the claim when native admission is ambiguous | Conditional reference; no recorder/platform executable |
| Project record | D#15673 OQ2/OQ16 | One append-only Markdown authority for stable IDs/hashes, logical contract links, attempts, QA, delivery, retention, invalidation, and human decisions | Explicit unknown/unobserved states; no typed schema or second SSOT | Copyable template + first-film transition audit |
| Existing owners | `/neural-link`, `/whitebox-e2e`, `/unit-test`, `/imagegen`, `/blog-post`, app/provider/platform authorities | Semantic needs and receipts route to the current owning surface | No operation-name pinning, transport coercion, universal runner, adapter, or compositor | Ownership sections and hard exclusions |
| Harness/docs registration | `skills.manifest.json` + ADR 0008 | Manifest mirror, Claude symlink, two declared downstream documentation echoes | Registration drift blocks the PR | Manifest/symlink/downstream-doc lint |

## Turn-Memory / Substrate-Load Audit

`/turn-memory-pre-flight` and `/create-skill` were applied before authoring.

Decision tree:

1. The film workflow is not universal to every turn.
2. It governs a specific identifiable lifecycle, so it belongs in a dedicated skill.
3. Detailed and rare capture/production rules belong behind conditional Atlas references, not in `AGENTS.md` or another always-loaded surface.
4. Harness parity is a symlink/manifest concern, not a forked harness-local rule body.
5. The blank record is an on-use asset, not global documentation or a machine schema.

Load effect:

| Surface | Disposition | Trigger frequency × failure severity × enforceability | Runtime effect |
|---|---|---|---|
| `SKILL.md` frontmatter + 12-line Map (1,099 B) | `keep` | Infrequent film trigger × high/irreversible evidence/privacy failures × manifest/router-enforceable | Neo `ai/context/Assembler.mjs` advertises frontmatter only at boot; the router is read on trigger |
| `video-create-workflow.md` (17,120 B) | `keep` as conditional Atlas | Film-only × high lineage/publication cost × receipt/template-enforceable | Not boot-loaded; read only after `/video-create` fires |
| `native-display-capture.md` (7,660 B) | `keep` as rarer conditional Atlas | Popup/native claims only × high privacy/evidence-class cost × admission/receipt-enforceable | Not loaded for page-only films |
| `video-project-record-template.md` (12,552 B) | `keep` as on-use asset | Active productions only × high drift/rework cost × copy-and-audit enforceable | Copied into an owner-private, gitignored production root |
| Claude skill link | `keep` | Cross-harness parity × high desynchronization cost × manifest lint | Symlink to the same source; no duplicate rule body |
| Downstream docs | `keep` as discovery echoes | Human/KB lookup only × moderate discoverability cost × manifest lint | Ordinary docs; not injected by the Codex prompt hook |

Mechanical load-path receipts:

- `.codex/hooks.json` injects `.codex/CODEX.md` through `codex-context.mjs`; it does not inject skill payloads.
- `ai/context/Assembler.mjs#loadSkillsSync()` extracts YAML frontmatter only.
- `.claude/CLAUDE.md` points to `../AGENTS.md`.
- `.claude/skills/video-create` points to `../../.agents/skills/video-create`.
- No additional `context.fileName` guard or duplicate video-skill body was found.

Growth is intentional for a graduated new capability and is commit-gated with `[skill-growth-justified: ...]`. Each payload remains below the 25 KB per-file ceiling and the total remains below the 80 KB skill payload budget. Decay is governed by the third completed film, first merge anniversary, two bypasses of one gate, or provider/platform drift; unused sections compress or retire.

## Signal Ledger (sourced from Discussion #15673)

- `gpt`: `[AUTHOR_SIGNAL]` by Emmy at https://github.com/neomjs/neo/discussions/15673#discussioncomment-17763873, bound to frozen body `updatedAt 2026-07-24T10:15:56Z` and STEP_BACK https://github.com/neomjs/neo/discussions/15673#discussioncomment-17763814
- `claude`: `[GRADUATION_APPROVED]` by Clio (non-author) at https://github.com/neomjs/neo/discussions/15673#discussioncomment-17764018, bound to the same frozen body, STEP_BACK, and author signal

## Unresolved Dissent

None. The exact-anchor STEP_BACK reported zero blockers.

## Unresolved Liveness

The returning Kimi seats retain a non-gating ratification courtesy because Iris and Phoebe materially shaped the selected capture and publication seams. Revalidation is mandatory if the artifact boundary expands to executable code/schema, the `/blog-post` ownership seam changes, provider/platform authority drifts, or new evidence invalidates an accepted invariant.

## Test Evidence

- `node ai/scripts/lint/lint-skill-manifest.mjs` — PASS (frontmatter, manifest, symlink, payload budgets, and structural checks).
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` — PASS, including the ticketed justified-growth gate.
- `npm run ai:lint-guides` — PASS (0 hard failures; 28 pre-existing repository warnings).
- `npm run ai:structure-map -- --files --loc` — PASS.
- `git diff --cached --check` — PASS.
- staged `check-whitespace.mjs` task — PASS.
- `/video-create` runtime spec: None found / not applicable; this PR adds documentation/template substrate and no executable.

## Post-Merge Validation

None. The first-film project-record transition audit is encoded as a future consumer gate, not a merge residual for this static skill package.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019f92b3-6003-78f0-a442-eede5259532f.
