### PR TITLE
fix(ai): give the read-state preservation a real caller (#15448)

### DIFF
--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -74,7 +74,9 @@ import {
  *     - **Disaster recovery** (default) — the bundle IS the new state. Reproduce it exactly;
  *       mailbox read receipts committed after the bundle was captured go with everything else.
  *     - **Operational re-seed** (`--preserve-read-state`) — the graph is being rebuilt from a
- *       lagged snapshot while seats keep working. `DELIVERED_TO` `readAt`/`archivedAt` is
+ *       lagged snapshot, **with writers quiesced first** (see the quiescence precondition below;
+ *       this deliberately no longer claims "while seats keep working"). `DELIVERED_TO`
+ *       `readAt`/`archivedAt` is
  *       runtime-only state that no synced bundle can carry, so without the flag an acknowledged
  *       `mark_read` is wiped after the tool already returned `status: 'read'` — an acknowledged
  *       write destroyed by a restore, which reads to the seat as its mailbox rolling backwards.
@@ -104,6 +106,19 @@ import {
  *   must be added to that operation's `pins` here, or the operation will refuse it as a contradiction.
  *   This warning lives in the header rather than `package.json` because JSON cannot carry a comment,
  *   and because this file is what you are reading when you add the flag.
+ *
+ * - **QUIESCENCE PRECONDITION for `reseed` — a stated requirement, not an unhandled race.**
+ *   `truncateDatabase()` captures the committed read receipts **inside** its truncate transaction,
+ *   which closes the lost-acknowledged-write window that a separate SELECT-then-DELETE would open.
+ *   But that transaction **ends before the import and re-apply run.** A `mark_read` acknowledged
+ *   after the capture and before the re-apply completes is therefore **lost**, and nothing detects
+ *   it. So: **stop the writers before re-seeding.** Preservation still matters under quiescence —
+ *   the bundle is lagged, so receipts committed since it was captured must survive the rebuild;
+ *   quiescing only removes the *concurrent* writer, not the stale-snapshot problem.
+ *   A live-writer-safe variant needs a **writer fence** held across truncate→import→re-apply, which
+ *   in SQLite means an exclusive lock for the whole import — i.e. enforced quiescence rather than
+ *   avoided quiescence — plus a concurrent falsifier proving an ack inside the window survives.
+ *   That is a separate design question and is deliberately NOT claimed here.
  *
  * - **Per-incident customization:**
  *     - `--filter-labels=<csv>` — drop graph nodes with these labels (orphan-edge guard
@@ -1019,11 +1034,13 @@ export async function dispatchPostRestoreHook({hook, logger = console}) {
 /**
  * Named operations: an operator-facing intent with its defining arguments PINNED, not defaulted.
  *
- * `reseed` is the live operational re-seed — the graph rebuilt from a lagged snapshot while seats
- * keep working. It is graph-ONLY on purpose: `DELIVERED_TO` read-state lives in the graph, and that
- * is the entire reason preservation matters, so replacing the other five substrates under a name
- * that advertises a safe live operation would be a far larger destructive footprint than the name
- * implies. Disaster recovery keeps the plain `ai:restore` surface with its exact-replacement default.
+ * `reseed` is the operational re-seed — the graph rebuilt from a lagged snapshot, **with writers
+ * quiesced first** (see the quiescence precondition in the module header; the capture transaction
+ * closes before the re-apply, so a concurrently-acked `mark_read` would be lost). It is graph-ONLY
+ * on purpose: `DELIVERED_TO` read-state lives in the graph, and that is the entire reason
+ * preservation matters, so replacing the other five substrates under this name would be a far larger
+ * destructive footprint than the name implies.
+ * Disaster recovery keeps the plain `ai:restore` surface with its exact-replacement default.
  * @type {Object}
  */
 const NAMED_OPERATIONS = {
@@ -1151,6 +1168,10 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         console.error('       [--filter-labels=<csv>] [--filter-edge-types=<csv>] [--only-substrate=<csv>] [--post-restore-hook=<name>]');
         console.error('       [--preserve-read-state]  replace mode: keep committed mailbox read receipts (operational re-seed);');
         console.error('                                omit for disaster recovery, where the bundle is reproduced exactly.');
+        console.error('       [--operation reseed]     graph-only re-seed. PINS --mode replace, --only-substrate=graph and');
+        console.error('                                --preserve-read-state, and REFUSES an argument that contradicts them.');
+        console.error('                                QUIESCE WRITERS FIRST: the read-receipt capture closes before the');
+        console.error('                                re-apply, so an ack landing in that window is lost. `npm run ai:reseed`.');
         console.error('Example (today\'s graph wipe restore):');
         console.error('  npm run ai:restore -- <bundle-path> --mode merge --only-substrate=graph \\');
         console.error('    --filter-labels=FILE,DIRECTORY,KB_GAP,TOOLING_GAP \\');

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -69,6 +69,18 @@ import {
  *       fire the guard against the target file/dir path before overwriting. Refuses if
  *       any target is non-empty without `--force`.
  *
+ * - **Which operation is this? (`--preserve-read-state`, replace mode only.)** Two different
+ *   operations share this one CLI, and they need opposite read-state policies:
+ *     - **Disaster recovery** (default) — the bundle IS the new state. Reproduce it exactly;
+ *       mailbox read receipts committed after the bundle was captured go with everything else.
+ *     - **Operational re-seed** (`--preserve-read-state`) — the graph is being rebuilt from a
+ *       lagged snapshot while seats keep working. `DELIVERED_TO` `readAt`/`archivedAt` is
+ *       runtime-only state that no synced bundle can carry, so without the flag an acknowledged
+ *       `mark_read` is wiped after the tool already returned `status: 'read'` — an acknowledged
+ *       write destroyed by a restore, which reads to the seat as its mailbox rolling backwards.
+ *   Nothing is guessed from context — the operator states the intent, because only the operator
+ *   knows which of the two runs this is.
+ *
  * - **Per-incident customization:**
  *     - `--filter-labels=<csv>` — drop graph nodes with these labels (orphan-edge guard
  *       drops edges whose endpoint was filtered). Example: `FILE,DIRECTORY,KB_GAP,TOOLING_GAP`.
@@ -120,6 +132,7 @@ const OPTIONAL_BUNDLE_SUBDIRS = ['mailbox'];
  * @param {String[]}[options.filterEdgeTypes=[]]           Per-incident customization: drop graph edges with these types. Example today's-incident set: `['CONTAINS', 'DISCOVERED_IN', 'EVALUATED_BY']`.
  * @param {String[]}[options.onlySubstrate=null]           If provided, restore ONLY these substrates (subset of `['kb','mc','graph','concepts','trajectories','mailbox']`). Null = all (existing behavior).
  * @param {String}  [options.postRestoreHook=null]         Post-restore hook name. Currently supported: `'filesystem-ingestor'` (regenerates FILE/DIRECTORY/CONTAINS deterministically from current filesystem). Null = none.
+ * @param {Boolean} [options.preserveReadState=false]      Selects the read-state policy for a `'replace'` graph restore, because the two operations that share this CLI need opposite ones. `false` (default) is DISASTER RECOVERY: the bundle is reproduced exactly, and mailbox read receipts committed after the bundle was captured are discarded with everything else. `true` is an OPERATIONAL RE-SEED: committed `DELIVERED_TO` `readAt`/`archivedAt` are captured inside the truncate transaction and re-applied wherever the bundle left them null, so acknowledged `mark_read` writes survive rebuilding the graph from a lagged snapshot. Only null-in-bundle rows are touched, so a fresher bundle is never regressed. No-op under `'merge'`, which never truncates. Forwarded as `preserveDeliveryReadState`.
  * @param {Object}  [options.logger=console]               Log sink; useful for tests.
  * @returns {Promise<{bundleRoot: String, mode: String, subsystems: Object, meta: Object|null, topology: Object, postRestoreHook: Object|null}>}
  */
@@ -136,6 +149,7 @@ export async function runRestore({
     filterEdgeTypes         = [],
     onlySubstrate           = null,
     postRestoreHook         = null,
+    preserveReadState       = false,
     expectedDimension       = AiConfig.vectorDimension,
     logger                  = console
 } = {}) {
@@ -144,6 +158,12 @@ export async function runRestore({
     }
     if (mode !== 'merge' && mode !== 'replace') {
         throw new Error(`Unknown mode: ${mode}. Must be 'merge' or 'replace'.`);
+    }
+    // Say so rather than ignoring it. The flag expresses an intent about data safety, and a caller who
+    // believes it is protecting read receipts should learn that merge never put them at risk — silently
+    // accepting a safety-intent flag that does nothing is how a caller ends up trusting the wrong run.
+    if (preserveReadState && mode === 'merge') {
+        logger.warn?.('[Restore] --preserve-read-state has no effect under `--mode merge`: merge never truncates the graph, so DELIVERED_TO read receipts were never at risk. The flag applies to `--mode replace`.');
     }
 
     const resolvedRoot = path.resolve(bundleRoot);
@@ -237,11 +257,16 @@ export async function runRestore({
             });
         }
 
+        // Forwarding this is the whole reason the SDK accepts a policy at all: a replace-mode import
+        // truncates the graph, and `DELIVERED_TO` `readAt` is runtime-only state no synced bundle can
+        // carry. Drop the forward and the SDK's preservation becomes unreachable from every real
+        // invocation — the default then silently wipes `mark_read` writes already acknowledged as read.
         subsystems.graph = await Memory_DatabaseService.manageDatabaseBackup({
-            action: 'import',
-            file  : graphInputDir,
+            action                   : 'import',
+            file                     : graphInputDir,
             mode,
-            confirmation
+            confirmation,
+            preserveDeliveryReadState: preserveReadState
         });
 
         if (filterActive) {
@@ -984,6 +1009,7 @@ export function parseArgs(argv) {
     let   filterEdgeTypes       = [];
     let   onlySubstrate         = null;
     let   postRestoreHook       = null;
+    let   preserveReadState     = false;
 
     const splitCsv = s => String(s).split(',').map(t => t.trim()).filter(Boolean);
 
@@ -1011,6 +1037,8 @@ export function parseArgs(argv) {
             postRestoreHook = argv[++i];
         } else if (arg.startsWith('--post-restore-hook=')) {
             postRestoreHook = arg.slice('--post-restore-hook='.length);
+        } else if (arg === '--preserve-read-state') {
+            preserveReadState = true;
         } else if (arg.startsWith('--')) {
             throw new Error(`Unknown flag: ${arg}`);
         } else {
@@ -1025,7 +1053,7 @@ export function parseArgs(argv) {
         throw new Error(`Unexpected positional arguments: ${positional.slice(1).join(' ')}`);
     }
 
-    return {bundleRoot: positional[0], mode, force, forceTopologyMismatch, filterLabels, filterEdgeTypes, onlySubstrate, postRestoreHook}
+    return {bundleRoot: positional[0], mode, force, forceTopologyMismatch, filterLabels, filterEdgeTypes, onlySubstrate, postRestoreHook, preserveReadState}
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
@@ -1044,6 +1072,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         console.error(error.message);
         console.error('Usage: node ./ai/scripts/maintenance/restore.mjs <bundle-path> [--mode merge|replace] [--force] [--force-topology-mismatch]');
         console.error('       [--filter-labels=<csv>] [--filter-edge-types=<csv>] [--only-substrate=<csv>] [--post-restore-hook=<name>]');
+        console.error('       [--preserve-read-state]  replace mode: keep committed mailbox read receipts (operational re-seed);');
+        console.error('                                omit for disaster recovery, where the bundle is reproduced exactly.');
         console.error('Example (today\'s graph wipe restore):');
         console.error('  npm run ai:restore -- <bundle-path> --mode merge --only-substrate=graph \\');
         console.error('    --filter-labels=FILE,DIRECTORY,KB_GAP,TOOLING_GAP \\');

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -82,20 +82,28 @@ import {
  *   knows which of the two runs this is.
  *
  * - **TWO npm FACES, and read this before adding a flag.** Because those are two operations rather
- *   than two settings, each has its own entry point, and the name is what binds the intent:
- *     - `npm run ai:restore -- <bundle> --mode replace --force` — disaster recovery.
- *     - `npm run ai:reseed  -- <bundle> --force` — operational re-seed. Pre-sets `--mode replace
- *       --preserve-read-state`, so the safe policy is what you get by *not thinking*, which is the
- *       only durable form of a safety default. `--force` deliberately stays OUTSIDE the alias: the
- *       destructive acknowledgment must never ride along inside a convenience name.
- *   A safety property governs only where its consumer loads it — and mid-incident an operator's
- *   load path is muscle memory and shell completion, never flag documentation. Hence a name, not
- *   a note. **The drift this invites, and where to defend it:** a flag added later reaches both
- *   faces automatically if it is pass-through (argument order does not matter; the alias's own args
- *   come first and the operator's are appended). But a flag that interacts with the pre-set pair
- *   above will NOT be reflected in `ai:reseed` unless you update it here too. That warning lives in
- *   this header rather than in `package.json` because JSON cannot carry a comment, and because this
- *   file is what you are reading when you add the flag.
+ *   than two settings, each has its own entry point, and the name **binds** the intent — it does not
+ *   merely suggest it:
+ *     - `npm run ai:restore -- <bundle> --mode replace --force` — disaster recovery. Every argument
+ *       is the operator's; nothing is pinned.
+ *     - `npm run ai:reseed  -- <bundle> --force` — the live operational re-seed. A **named operation**
+ *       (`--operation reseed`, see `NAMED_OPERATIONS`) that PINS `mode: 'replace'`,
+ *       `onlySubstrate: ['graph']` and `preserveReadState: true`, and **refuses** any argument that
+ *       contradicts them. `--force` deliberately stays OUTSIDE it: the destructive acknowledgment
+ *       must never ride along inside a convenience name.
+ *   **Why pinned rather than pre-set, which is what this started as:** pre-set defaults lose to a
+ *   later argument, so `ai:reseed -- <b> --mode merge` would have performed a MERGE under a name
+ *   promising a replace, and the un-pinned `onlySubstrate` would have replaced **all six** substrates
+ *   under a name advertising a safe live operation. A name an argument can redefine is a suggestion.
+ *   Graph-only is not a narrowing for tidiness: `DELIVERED_TO` read-state lives in the graph, which
+ *   is the whole reason preservation matters here.
+ *   A safety property governs only where its consumer loads it — and mid-incident an operator's load
+ *   path is muscle memory and shell completion, never flag documentation. Hence a name, not a note.
+ *   **The drift this invites, and where to defend it:** a pass-through flag added later reaches both
+ *   faces automatically (argument order is irrelevant). But a flag that interacts with a PINNED value
+ *   must be added to that operation's `pins` here, or the operation will refuse it as a contradiction.
+ *   This warning lives in the header rather than `package.json` because JSON cannot carry a comment,
+ *   and because this file is what you are reading when you add the flag.
  *
  * - **Per-incident customization:**
  *     - `--filter-labels=<csv>` — drop graph nodes with these labels (orphan-edge guard
@@ -1009,6 +1017,23 @@ export async function dispatchPostRestoreHook({hook, logger = console}) {
 }
 
 /**
+ * Named operations: an operator-facing intent with its defining arguments PINNED, not defaulted.
+ *
+ * `reseed` is the live operational re-seed — the graph rebuilt from a lagged snapshot while seats
+ * keep working. It is graph-ONLY on purpose: `DELIVERED_TO` read-state lives in the graph, and that
+ * is the entire reason preservation matters, so replacing the other five substrates under a name
+ * that advertises a safe live operation would be a far larger destructive footprint than the name
+ * implies. Disaster recovery keeps the plain `ai:restore` surface with its exact-replacement default.
+ * @type {Object}
+ */
+const NAMED_OPERATIONS = {
+    reseed: {
+        pins        : {mode: 'replace', onlySubstrate: ['graph'], preserveReadState: true},
+        conflictHint: 'Use `npm run ai:restore` for a different mode or a wider substrate set.'
+    }
+};
+
+/**
  * Parses CLI arguments for direct-invocation mode.
  *
  * Shape: `node ./ai/scripts/maintenance/restore.mjs <bundle-path> [--mode merge|replace] [--force] [--force-topology-mismatch]`
@@ -1017,7 +1042,13 @@ export async function dispatchPostRestoreHook({hook, logger = console}) {
  * @returns {Object}
  */
 export function parseArgs(argv) {
-    const positional            = [];
+    const positional = [];
+    // Track what the CALLER stated, separately from what an operation pins. Without this the
+    // operation cannot tell "the operator asked for merge" from "nobody said anything", and a
+    // named operation whose defining flags a later argument silently overrides is not an
+    // operation — it is a suggestion. This started life as that suggestion.
+    const stated                = {};
+    let   operation             = null;
     let   mode                  = 'merge';
     let   force                 = false;
     let   forceTopologyMismatch = false;
@@ -1031,8 +1062,12 @@ export function parseArgs(argv) {
 
     for (let i = 0; i < argv.length; i++) {
         const arg = argv[i];
-        if (arg === '--mode') {
-            mode = argv[++i];
+        if (arg === '--operation') {
+            operation = argv[++i];
+        } else if (arg.startsWith('--operation=')) {
+            operation = arg.slice('--operation='.length);
+        } else if (arg === '--mode') {
+            mode = argv[++i]; stated.mode = mode;
         } else if (arg === '--force') {
             force = true;
         } else if (arg === '--force-topology-mismatch') {
@@ -1046,9 +1081,9 @@ export function parseArgs(argv) {
         } else if (arg.startsWith('--filter-edge-types=')) {
             filterEdgeTypes = splitCsv(arg.slice('--filter-edge-types='.length));
         } else if (arg === '--only-substrate') {
-            onlySubstrate = splitCsv(argv[++i]);
+            onlySubstrate = splitCsv(argv[++i]); stated.onlySubstrate = onlySubstrate;
         } else if (arg.startsWith('--only-substrate=')) {
-            onlySubstrate = splitCsv(arg.slice('--only-substrate='.length));
+            onlySubstrate = splitCsv(arg.slice('--only-substrate='.length)); stated.onlySubstrate = onlySubstrate;
         } else if (arg === '--post-restore-hook') {
             postRestoreHook = argv[++i];
         } else if (arg.startsWith('--post-restore-hook=')) {
@@ -1069,7 +1104,33 @@ export function parseArgs(argv) {
         throw new Error(`Unexpected positional arguments: ${positional.slice(1).join(' ')}`);
     }
 
-    return {bundleRoot: positional[0], mode, force, forceTopologyMismatch, filterLabels, filterEdgeTypes, onlySubstrate, postRestoreHook, preserveReadState}
+    // A named operation PINS its defining arguments and refuses contradiction. It does not merely
+    // pre-set defaults a later argument can overwrite: `npm run ai:reseed -- <b> --mode merge`
+    // would otherwise perform a MERGE under a name that promises a replace, which is a worse lie
+    // than having no name at all. `--force` is deliberately NOT pinned — the destructive
+    // acknowledgment stays the operator's explicit act and never rides inside a convenience name.
+    if (operation !== null) {
+        const op = NAMED_OPERATIONS[operation];
+
+        if (!op) {
+            throw new Error(`Unknown operation: ${operation}. Valid: ${Object.keys(NAMED_OPERATIONS).join(', ')}.`);
+        }
+
+        for (const [key, pinned] of Object.entries(op.pins)) {
+            const asked = stated[key];
+
+            if (asked !== undefined && JSON.stringify(asked) !== JSON.stringify(pinned)) {
+                throw new Error(
+                    `--operation ${operation} pins ${key}=${JSON.stringify(pinned)}, but ${JSON.stringify(asked)} was requested. ` +
+                    `${op.conflictHint} Refusing rather than silently redefining the operation.`
+                );
+            }
+        }
+
+        ({mode = mode, onlySubstrate = onlySubstrate, preserveReadState = preserveReadState} = {...op.pins});
+    }
+
+    return {bundleRoot: positional[0], mode, force, forceTopologyMismatch, filterLabels, filterEdgeTypes, onlySubstrate, postRestoreHook, preserveReadState, operation}
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -81,6 +81,22 @@ import {
  *   Nothing is guessed from context — the operator states the intent, because only the operator
  *   knows which of the two runs this is.
  *
+ * - **TWO npm FACES, and read this before adding a flag.** Because those are two operations rather
+ *   than two settings, each has its own entry point, and the name is what binds the intent:
+ *     - `npm run ai:restore -- <bundle> --mode replace --force` — disaster recovery.
+ *     - `npm run ai:reseed  -- <bundle> --force` — operational re-seed. Pre-sets `--mode replace
+ *       --preserve-read-state`, so the safe policy is what you get by *not thinking*, which is the
+ *       only durable form of a safety default. `--force` deliberately stays OUTSIDE the alias: the
+ *       destructive acknowledgment must never ride along inside a convenience name.
+ *   A safety property governs only where its consumer loads it — and mid-incident an operator's
+ *   load path is muscle memory and shell completion, never flag documentation. Hence a name, not
+ *   a note. **The drift this invites, and where to defend it:** a flag added later reaches both
+ *   faces automatically if it is pass-through (argument order does not matter; the alias's own args
+ *   come first and the operator's are appended). But a flag that interacts with the pre-set pair
+ *   above will NOT be reflected in `ai:reseed` unless you update it here too. That warning lives in
+ *   this header rather than in `package.json` because JSON cannot carry a comment, and because this
+ *   file is what you are reading when you add the flag.
+ *
  * - **Per-incident customization:**
  *     - `--filter-labels=<csv>` — drop graph nodes with these labels (orphan-edge guard
  *       drops edges whose endpoint was filtered). Example: `FILE,DIRECTORY,KB_GAP,TOOLING_GAP`.

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -646,7 +646,12 @@ class DatabaseService extends Base {
                             if (row.archivedAt != null) reapplyArchivedAt.run(row.archivedAt, row.source, row.target);
                         }
                     })(preservedDeliveryState);
-                    if (reapplied) logger.log(`[importDatabase] Re-applied ${reapplied} committed DELIVERED_TO read-receipt(s) preserved across the replace (#15448).`);
+                    // ALWAYS log, including zero. A receipt emitted only when non-zero cannot
+                    // distinguish "preservation ran and had nothing to re-apply" (a fresh bundle)
+                    // from "preservation never engaged" (the caller used the recovery path by
+                    // mistake) — and that is the exact ambiguity an operator reads this line to
+                    // resolve. Suppressing the zero makes the absence of output mean two things.
+                    logger.log(`[importDatabase] Re-applied ${reapplied} committed DELIVERED_TO read-receipt(s) preserved across the replace.`);
                 }
             }
 

--- a/learn/agentos/tooling/RestorationRunbook.md
+++ b/learn/agentos/tooling/RestorationRunbook.md
@@ -35,7 +35,7 @@ Two operations share this CLI and need **opposite** read-state policies. Read-st
 | | `npm run ai:restore -- <bundle> --mode replace --force` | `npm run ai:reseed -- <bundle> --force` |
 |---|---|---|
 | **Operation** | Disaster recovery | Live operational re-seed |
-| **Meaning** | The bundle IS the new state; reproduce it exactly | The graph is rebuilt from a lagged snapshot **while seats keep working** |
+| **Meaning** | The bundle IS the new state; reproduce it exactly | The graph is rebuilt from a lagged snapshot, **with writers quiesced first** |
 | **Scope** | Whatever you ask for (all six substrates by default) | **Graph only** — pinned |
 | **Read receipts** | Discarded with everything else | **Preserved** — pinned |
 | **Mode** | Yours to state | `replace` — pinned |
@@ -43,7 +43,15 @@ Two operations share this CLI and need **opposite** read-state policies. Read-st
 
 `ai:reseed` pins its three defining values and **refuses** an argument that contradicts any of them: `ai:reseed -- <bundle> --mode merge` aborts rather than performing a merge under a name that promises a replace. Graph-only is not tidiness — `DELIVERED_TO` lives in the graph, which is the entire reason preservation matters here, so a name advertising a safe live operation must not also replace `kb`/`mc`/`concepts`/`trajectories`/`mailbox`.
 
-**How to tell it worked:** a successful re-seed logs `[importDatabase] Re-applied N committed DELIVERED_TO read-receipt(s)`. `N = 0` on a run where seats were active means the preservation did not engage — check that you used `ai:reseed` rather than `ai:restore`.
+> **⚠ Quiesce writers before `ai:reseed`. This is a precondition, not a nicety.**
+>
+> The read-receipt capture runs **inside** the truncate transaction, which closes the lost-write window a separate SELECT-then-DELETE would open. But that transaction **ends before the import and re-apply run** — so a `mark_read` acknowledged *after* the capture and *before* the re-apply completes is **lost, and nothing detects it.** Stop the seats (or the MC server) first, re-seed, then bring them back.
+>
+> Preservation still matters under quiescence: the bundle is *lagged*, so receipts committed since it was captured must survive the rebuild. Quiescing removes the concurrent writer, not the stale-snapshot problem — which is what the preservation is for.
+>
+> A live-writer-safe variant would need a **writer fence** held across truncate → import → re-apply. In SQLite that means an exclusive lock for the whole import, i.e. *enforced* quiescence rather than avoided quiescence, plus a concurrent falsifier proving an ack inside the window survives. Not implemented, and deliberately not claimed.
+
+**How to tell it worked:** a successful re-seed logs `[importDatabase] Re-applied N committed DELIVERED_TO read-receipt(s)`. **What `N` means, precisely:** it counts `DELIVERED_TO` edges whose receipt was captured before the truncate **and** which the restored bundle left null — i.e. receipts the bundle would have destroyed. So `N = 0` legitimately means *the bundle already carried every receipt* (a fresh bundle, or no reads since it was captured); it is **not** a success metric to maximise. The tell that something is wrong is `N = 0` on a re-seed from a **lagged** bundle where reads are known to have happened since — that means preservation did not engage, so check you used `ai:reseed` rather than `ai:restore`.
 
 **Adding a flag later:** a pass-through flag reaches both entrypoints automatically (argument order is irrelevant). A flag that interacts with a pinned value must be added to that operation's `pins` in `restore.mjs`, or the operation will refuse it as a contradiction.
 

--- a/learn/agentos/tooling/RestorationRunbook.md
+++ b/learn/agentos/tooling/RestorationRunbook.md
@@ -25,6 +25,27 @@ Before initiating any restoration, ensure that all AI MCP servers and daemon pro
 | `--mode replace` | Gated + destructive. Each embedded subsystem fires `assertDestructiveTargetAllowed()` before truncating + restoring; refuses if any target is non-empty without `--force`. |
 | `--force` | Required when `--mode replace` AND any target is populated (acknowledges overwrite). Also overrides the flat-file skip-if-non-empty rule under `--mode merge`. |
 | `--force-topology-mismatch` | Bypasses the topology-compatibility refusal when restoring a legacy federated-topology bundle into a unified deployment (collection IDs may diverge across topologies). |
+| `--preserve-read-state` | **Replace mode only.** Keeps committed mailbox read receipts (`DELIVERED_TO` `readAt`/`archivedAt`) across the truncate, re-applying them wherever the bundle left them null. Off by default, because `--mode replace` means *the bundle IS the new state* and a disaster-recovery restore must reproduce it exactly. No-op under `--mode merge`, which never truncates — the run warns rather than accepting a safety-intent flag silently. |
+| `--operation <name>` | Selects a **named operation** whose defining arguments are *pinned*, not defaulted. Currently `reseed` (see below). A contradicting argument is refused, never silently honoured. |
+
+### Which operation is this? — `ai:restore` vs `ai:reseed`
+
+Two operations share this CLI and need **opposite** read-state policies. Read-state is runtime-only: no synced bundle can carry it, so getting this wrong destroys `mark_read` writes the tool already acknowledged as `read`, which a seat experiences as its mailbox rolling backwards.
+
+| | `npm run ai:restore -- <bundle> --mode replace --force` | `npm run ai:reseed -- <bundle> --force` |
+|---|---|---|
+| **Operation** | Disaster recovery | Live operational re-seed |
+| **Meaning** | The bundle IS the new state; reproduce it exactly | The graph is rebuilt from a lagged snapshot **while seats keep working** |
+| **Scope** | Whatever you ask for (all six substrates by default) | **Graph only** — pinned |
+| **Read receipts** | Discarded with everything else | **Preserved** — pinned |
+| **Mode** | Yours to state | `replace` — pinned |
+| **`--force`** | Yours | Yours — deliberately *not* pinned; the destructive acknowledgment never rides inside a convenience name |
+
+`ai:reseed` pins its three defining values and **refuses** an argument that contradicts any of them: `ai:reseed -- <bundle> --mode merge` aborts rather than performing a merge under a name that promises a replace. Graph-only is not tidiness — `DELIVERED_TO` lives in the graph, which is the entire reason preservation matters here, so a name advertising a safe live operation must not also replace `kb`/`mc`/`concepts`/`trajectories`/`mailbox`.
+
+**How to tell it worked:** a successful re-seed logs `[importDatabase] Re-applied N committed DELIVERED_TO read-receipt(s)`. `N = 0` on a run where seats were active means the preservation did not engage — check that you used `ai:reseed` rather than `ai:restore`.
+
+**Adding a flag later:** a pass-through flag reaches both entrypoints automatically (argument order is irrelevant). A flag that interacts with a pinned value must be added to that operation's `pins` in `restore.mjs`, or the operation will refuse it as a contradiction.
 
 ### Pre-flight validation
 
@@ -36,7 +57,7 @@ When `--mode replace` targets canonical `.neo-ai-data/` paths, the destructive-o
 
 ### Programmatic use
 
-The orchestrator is also exported as `runRestore({ bundleRoot, mode, force, forceTopologyMismatch })` from `ai/scripts/maintenance/restore.mjs`, for embedding in higher-level recovery substrate (e.g. the daily snapshot pipeline or cold-restore harnesses). It returns per-subsystem result blocks, the parsed `bundle-meta.json` (or `null` for legacy bundles), and the topology-check verdict. Companion exports `validateBundle(...)` and `checkTopology(...)` expose the pre-flight checks for callers that want to gate before restoring.
+The orchestrator is also exported as `runRestore({ bundleRoot, mode, force, forceTopologyMismatch, preserveReadState })` from `ai/scripts/maintenance/restore.mjs`, for embedding in higher-level recovery substrate (e.g. the daily snapshot pipeline or cold-restore harnesses). It returns per-subsystem result blocks, the parsed `bundle-meta.json` (or `null` for legacy bundles), and the topology-check verdict. Companion exports `validateBundle(...)` and `checkTopology(...)` expose the pre-flight checks for callers that want to gate before restoring.
 
 ## Restoration Procedures
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "ai:check-substrate-size"              : "node ./ai/scripts/diagnostics/check-substrate-size.mjs",
         "ai:compact-graphlog"                  : "node ./ai/scripts/maintenance/compactGraphLog.mjs",
         "ai:restore"                           : "node ./ai/scripts/maintenance/restore.mjs",
+        "ai:reseed"                            : "node ./ai/scripts/maintenance/restore.mjs --mode replace --preserve-read-state",
         "ai:build-kb-faqs"                     : "node ./ai/scripts/maintenance/buildKbAgentFaqs.mjs",
         "ai:defrag-kb"                         : "node ./ai/scripts/maintenance/defragChromaDB.mjs --target knowledge-base",
         "ai:defrag-memory"                     : "node ./ai/scripts/maintenance/defragChromaDB.mjs --target memory-core",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "ai:check-substrate-size"              : "node ./ai/scripts/diagnostics/check-substrate-size.mjs",
         "ai:compact-graphlog"                  : "node ./ai/scripts/maintenance/compactGraphLog.mjs",
         "ai:restore"                           : "node ./ai/scripts/maintenance/restore.mjs",
-        "ai:reseed"                            : "node ./ai/scripts/maintenance/restore.mjs --mode replace --preserve-read-state",
+        "ai:reseed"                            : "node ./ai/scripts/maintenance/restore.mjs --operation reseed",
         "ai:build-kb-faqs"                     : "node ./ai/scripts/maintenance/buildKbAgentFaqs.mjs",
         "ai:defrag-kb"                         : "node ./ai/scripts/maintenance/defragChromaDB.mjs --target knowledge-base",
         "ai:defrag-memory"                     : "node ./ai/scripts/maintenance/defragChromaDB.mjs --target memory-core",

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -390,7 +390,8 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             filterEdgeTypes      : [],
             onlySubstrate        : null,
             postRestoreHook      : null,
-            preserveReadState    : false
+            preserveReadState    : false,
+            operation            : null
         });
         expect(parseArgs(['/some/bundle', '--mode', 'replace', '--force'])).toEqual({
             bundleRoot           : '/some/bundle',
@@ -401,7 +402,8 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             filterEdgeTypes      : [],
             onlySubstrate        : null,
             postRestoreHook      : null,
-            preserveReadState    : false
+            preserveReadState    : false,
+            operation            : null
         });
         expect(parseArgs(['/some/bundle', '--force-topology-mismatch'])).toEqual({
             bundleRoot           : '/some/bundle',
@@ -412,15 +414,16 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             filterEdgeTypes      : [],
             onlySubstrate        : null,
             postRestoreHook      : null,
-            preserveReadState    : false
+            preserveReadState    : false,
+            operation            : null
         });
         expect(() => parseArgs([])).toThrow(/Missing required argument/);
         expect(() => parseArgs(['/x', '--unknown-flag'])).toThrow(/Unknown flag/);
     });
 
     // Reads the REAL `ai:reseed` string out of package.json and feeds it through the real parser, so
-    // the alias is itself reachability-tested: drop `--preserve-read-state` from the script entry and
-    // this goes red. Asserting a hand-written copy of the alias would only prove the copy.
+    // the alias is itself reachability-tested: break the script entry and this goes red. Asserting a
+    // hand-written copy of the alias would only prove the copy.
     test('the ai:reseed npm alias resolves to the operational-re-seed policy', () => {
         const
             pkg   = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')),
@@ -431,11 +434,17 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         // npm places the script's own args first and appends everything after `--`, so this is exactly
         // the argv an operator running `npm run ai:reseed -- <bundle> --force` produces.
         const
-            aliasArgs = alias.split(/\s+/).filter(a => a.startsWith('--') || a === 'replace'),
+            aliasArgs = alias.split(/\s+/).slice(2),
             args      = parseArgs([...aliasArgs, '/tmp/bundle-x', '--force']);
 
+        expect(args.operation).toBe('reseed');
         expect(args.mode).toBe('replace');
         expect(args.preserveReadState).toBe(true);
+        // GRAPH-ONLY. `DELIVERED_TO` read-state lives in the graph, which is the entire reason
+        // preservation matters — so a name advertising a safe live operation must not also replace
+        // kb/mc/concepts/trajectories/mailbox. Before this was an operation, the alias inherited
+        // `onlySubstrate: null` and would have replaced all six.
+        expect(args.onlySubstrate).toEqual(['graph']);
         expect(args.bundleRoot).toBe('/tmp/bundle-x');
         expect(args.force).toBe(true);
         // `--force` must NOT be baked into the alias — a destructive acknowledgment may never ride
@@ -458,6 +467,27 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
     // lives in its own spec is green and unreachable, so these two assert that the operator's intent
     // survives the trip from argv to the SDK call. They go red the moment the orchestrator stops
     // forwarding: the graph import then carries no `preserveDeliveryReadState` key and reads `undefined`.
+    // A named operation must PIN its defining arguments, not pre-set overridable defaults. @neo-gpt-emmy's
+    // falsifier on the first shape: `--operation`-less alias defaults left `onlySubstrate: null` and an
+    // appended `--mode merge` WON — so the name promised a replace and could silently perform a merge
+    // across all six substrates. A name that an argument can redefine is a suggestion, not an operation.
+    test('a named operation REFUSES contradictory arguments instead of being silently redefined', () => {
+        expect(() => parseArgs(['--operation', 'reseed', '/tmp/b', '--mode', 'merge']))
+            .toThrow(/pins mode="replace", but "merge" was requested/);
+        expect(() => parseArgs(['--operation', 'reseed', '/tmp/b', '--only-substrate=kb']))
+            .toThrow(/pins onlySubstrate=\["graph"\], but \["kb"\] was requested/);
+        // An AGREEING argument is not a contradiction — refusing it would be strictness for its own sake.
+        expect(parseArgs(['--operation', 'reseed', '/tmp/b', '--mode', 'replace']).mode).toBe('replace');
+        // Unknown operations fail closed rather than degrading to a plain restore.
+        expect(() => parseArgs(['--operation', 'wipe', '/tmp/b'])).toThrow(/Unknown operation: wipe/);
+        // The plain surface is untouched — disaster recovery keeps its exact-replacement default.
+        const plain = parseArgs(['/tmp/b']);
+
+        expect(plain.operation).toBe(null);
+        expect(plain.preserveReadState).toBe(false);
+        expect(plain.onlySubstrate).toBe(null);
+    });
+
     test('operational re-seed: preserveReadState reaches the graph SDK import as preserveDeliveryReadState', async () => {
         const bundleRoot = buildSyntheticBundle({bundleName: 'reseed-preserve', shared_topology: true});
 

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -389,7 +389,8 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             filterLabels         : [],
             filterEdgeTypes      : [],
             onlySubstrate        : null,
-            postRestoreHook      : null
+            postRestoreHook      : null,
+            preserveReadState    : false
         });
         expect(parseArgs(['/some/bundle', '--mode', 'replace', '--force'])).toEqual({
             bundleRoot           : '/some/bundle',
@@ -399,7 +400,8 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             filterLabels         : [],
             filterEdgeTypes      : [],
             onlySubstrate        : null,
-            postRestoreHook      : null
+            postRestoreHook      : null,
+            preserveReadState    : false
         });
         expect(parseArgs(['/some/bundle', '--force-topology-mismatch'])).toEqual({
             bundleRoot           : '/some/bundle',
@@ -409,10 +411,94 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             filterLabels         : [],
             filterEdgeTypes      : [],
             onlySubstrate        : null,
-            postRestoreHook      : null
+            postRestoreHook      : null,
+            preserveReadState    : false
         });
         expect(() => parseArgs([])).toThrow(/Missing required argument/);
         expect(() => parseArgs(['/x', '--unknown-flag'])).toThrow(/Unknown flag/);
+    });
+
+    test('parseArgs: --preserve-read-state is a boolean flag, off by default', () => {
+        expect(parseArgs(['/some/bundle']).preserveReadState).toBe(false);
+        expect(parseArgs(['/some/bundle', '--preserve-read-state']).preserveReadState).toBe(true);
+        // Order-independent, and it does not swallow the following argument the way a value flag would.
+        const args = parseArgs(['/some/bundle', '--preserve-read-state', '--mode', 'replace']);
+
+        expect(args.preserveReadState).toBe(true);
+        expect(args.mode).toBe('replace');
+    });
+
+    // REACHABILITY, not mechanism. `DatabaseService.graphReplaceReadAtPreserved.spec` already proves the
+    // preservation works when asked for; it cannot prove that anyone asks. A mechanism whose only `true`
+    // lives in its own spec is green and unreachable, so these two assert that the operator's intent
+    // survives the trip from argv to the SDK call. They go red the moment the orchestrator stops
+    // forwarding: the graph import then carries no `preserveDeliveryReadState` key and reads `undefined`.
+    test('operational re-seed: preserveReadState reaches the graph SDK import as preserveDeliveryReadState', async () => {
+        const bundleRoot = buildSyntheticBundle({bundleName: 'reseed-preserve', shared_topology: true});
+
+        await runRestore({
+            expectedDimension: 1,
+            bundleRoot,
+            mode             : 'replace',
+            force            : true,
+            preserveReadState: true,
+            // Flat targets MUST be scoped to workRoot. Omitting them falls back to DEFAULT_CONCEPTS_DIR
+            // etc. — the live `.neo-ai-data/` this repo tracks — and `mode:'replace'` with `force:true`
+            // then overwrites another agent's working state from a synthetic fixture. Same shared-resource
+            // class as an orphaned Chroma port wedging every seat's suite.
+            conceptsTargetDir     : path.join(workRoot, 'reseed-preserve-targets', 'concepts'),
+            trajectoriesTargetFile: path.join(workRoot, 'reseed-preserve-targets', 'trajectories.jsonl'),
+            sentToCullTargetFile  : path.join(workRoot, 'reseed-preserve-targets', 'sent-to-cull.jsonl'),
+            logger                : silentLogger
+        });
+
+        const graphImport = calls.mc.find(c => c.action === 'import' && /graph/.test(String(c.file)));
+
+        expect(graphImport).toBeTruthy();
+        expect(graphImport.preserveDeliveryReadState).toBe(true);
+    });
+
+    test('disaster recovery: the default leaves the graph import exact, never preserving live read state', async () => {
+        const bundleRoot = buildSyntheticBundle({bundleName: 'recovery-exact', shared_topology: true});
+
+        await runRestore({
+            expectedDimension     : 1,
+            bundleRoot,
+            mode                  : 'replace',
+            force                 : true,
+            conceptsTargetDir     : path.join(workRoot, 'recovery-exact-targets', 'concepts'),
+            trajectoriesTargetFile: path.join(workRoot, 'recovery-exact-targets', 'trajectories.jsonl'),
+            sentToCullTargetFile  : path.join(workRoot, 'recovery-exact-targets', 'sent-to-cull.jsonl'),
+            logger                : silentLogger
+        });
+
+        const graphImport = calls.mc.find(c => c.action === 'import' && /graph/.test(String(c.file)));
+
+        expect(graphImport).toBeTruthy();
+        // Explicitly `false`, not absent: `mode:'replace'` means the bundle IS the new state, so a recovery
+        // run must reproduce it exactly rather than silently merging live reads back in. Asserting the
+        // value pins that default as a contract rather than an accident of omission.
+        expect(graphImport.preserveDeliveryReadState).toBe(false);
+    });
+
+    test('merge mode warns that --preserve-read-state has no effect rather than accepting it silently', async () => {
+        const bundleRoot = buildSyntheticBundle({bundleName: 'merge-warn', shared_topology: true});
+        const warnings   = [];
+        const logger     = {log: () => {}, warn: msg => warnings.push(String(msg)), error: () => {}};
+
+        await runRestore({
+            expectedDimension     : 1,
+            bundleRoot,
+            mode                  : 'merge',
+            preserveReadState     : true,
+            conceptsTargetDir     : path.join(workRoot, 'merge-warn-targets', 'concepts'),
+            trajectoriesTargetFile: path.join(workRoot, 'merge-warn-targets', 'trajectories.jsonl'),
+            sentToCullTargetFile  : path.join(workRoot, 'merge-warn-targets', 'sent-to-cull.jsonl'),
+            logger
+        });
+
+        expect(warnings.some(w => /--preserve-read-state has no effect/.test(w))).toBe(true);
+        expect(warnings.some(w => /merge never truncates/.test(w))).toBe(true);
     });
 
     test('validateBundle: standalone validation call returns parsed meta', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -418,6 +418,31 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         expect(() => parseArgs(['/x', '--unknown-flag'])).toThrow(/Unknown flag/);
     });
 
+    // Reads the REAL `ai:reseed` string out of package.json and feeds it through the real parser, so
+    // the alias is itself reachability-tested: drop `--preserve-read-state` from the script entry and
+    // this goes red. Asserting a hand-written copy of the alias would only prove the copy.
+    test('the ai:reseed npm alias resolves to the operational-re-seed policy', () => {
+        const
+            pkg   = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')),
+            alias = pkg.scripts['ai:reseed'];
+
+        expect(alias).toBeTruthy();
+
+        // npm places the script's own args first and appends everything after `--`, so this is exactly
+        // the argv an operator running `npm run ai:reseed -- <bundle> --force` produces.
+        const
+            aliasArgs = alias.split(/\s+/).filter(a => a.startsWith('--') || a === 'replace'),
+            args      = parseArgs([...aliasArgs, '/tmp/bundle-x', '--force']);
+
+        expect(args.mode).toBe('replace');
+        expect(args.preserveReadState).toBe(true);
+        expect(args.bundleRoot).toBe('/tmp/bundle-x');
+        expect(args.force).toBe(true);
+        // `--force` must NOT be baked into the alias — a destructive acknowledgment may never ride
+        // along inside a convenience name. It is present above only because the operator typed it.
+        expect(alias).not.toMatch(/--force/);
+    });
+
     test('parseArgs: --preserve-read-state is a boolean flag, off by default', () => {
         expect(parseArgs(['/some/bundle']).preserveReadState).toBe(false);
         expect(parseArgs(['/some/bundle', '--preserve-read-state']).preserveReadState).toBe(true);


### PR DESCRIPTION
Resolves #15448

The preservation this ticket asked for was built, merged, reviewed, and **unreachable from every real invocation.**

`#15492` (mine) captures `DELIVERED_TO` `readAt`/`archivedAt` inside the truncate transaction and re-applies committed values after a replace-mode import wherever the restored bundle left them null. @neo-gpt's RA1 then made it opt-in via `preserveDeliveryReadState`, and he was right: `mode:'replace'` means *the backup IS the new state*, so preserving live reads unconditionally would silently turn exact replacement into a selective live-state merge. **That default is correct and this PR does not touch it.**

What I never shipped was a caller. Repo-wide, `preserveDeliveryReadState` appeared in exactly five places: four inside `DatabaseService.mjs` (its own two default-`false` parameters, the forward, the capture conditional) and **one in the mechanism's own spec — the only `true` in the tree.** [`restore.mjs:240`](ai/scripts/maintenance/restore.mjs#L240) passed `{action, file, mode, confirmation}`; enumerated keys, no spread. So the capture was skipped, the re-apply block iterated an empty array, and every real `npm run ai:restore -- --mode replace` wiped `mark_read` writes the tool had already acknowledged as `read`. **A green test standing over a dead path** — the exact class the review hardening was meant to close, one level out from where the review looked.

Two operations share this one CLI and need opposite policies, and only the operator knows which run this is. `--preserve-read-state` lets them say so.

Evidence: **L2** (three new orchestrator specs, each proven red on its own before green; 36 green across the orchestrator, filter, and mechanism specs). No L3 needed — nothing here depends on a Docker daemon or live substrate.

## Deltas from ticket

- **The ticket's step 1 asked for two things and only one had shipped.** "Make read-state excluded from re-seed overwrite" was read as the *mechanism*, which `#15492` delivered. The other half — "**identify the 07:52–08:42 re-seed path**" — was never done, and it is the half that determines whether the mechanism ever runs. I closed it here: no workflow, daemon, or cron performs a replace-mode restore (`.github/workflows` and `ai/daemons` are clean; `manageDatabaseBackup` has no MCP surface at all), so `restore.mjs` is the only path and the incident was a manual invocation. **Residual, stated plainly:** that last step is an inference from the absence of any other caller, not a receipt from the incident window — the forensics are six days cold and cannot be re-derived.
- **The ticket's wording predates the review that refined it, and I am closing against the refined contract.** #15448 says receipts "must be merge-preserved, **never clobbered**." Unconditional preservation is precisely what @neo-gpt's RA1 established is *wrong* for disaster recovery, so "never clobbered" cannot be satisfied as literally written without reintroducing that defect. The reachable-policy-choice is the correct reading of the intent. Recording this on the ticket rather than quietly closing past the phrasing.
- **Open question, with a claim of mine retracted.** The strongest form of "never clobbered" is a **named re-seed operation** whose default is preservation, so the safe policy is what you get by *not thinking* rather than a flag someone must remember at 08:00 during an incident. **I originally wrote here that this "wants its own shaping" as a follow-up "design question about command topology." I am withdrawing the sizing.** It started as one line in `package.json`, with no new file and no duplicated orchestration. Using follow-up framing to defer something I could evaluate in one command was the error. **That one-line form was then refuted — see the RA1 delta below; it is now `--operation reseed`, a pinned operation in the script, because a `package.json` string cannot enforce anything.**
  **Not mine to settle alone, and now settled:** `ai:` is a shared operator-facing command namespace, so naming a second operation in it is nearer topology than a local reversible choice — design authority is not topology authority. Put to the peers as a straw-man with my recommendation and my own counter-argument stated as fairly (two entrypoints onto one script invite the reading that they are different tools, and a later flag added to `ai:restore` will not reach `ai:reseed` unless someone remembers). **@neo-fable answered first with the deciding reason, and it is better than mine:** the day's load-path law aimed at operators rather than agents — *a safety property governs only where its consumer loads it*, and mid-incident an operator's load path is muscle memory and shell completion, never flag documentation. Also RA1 taken literally: if operation intent selects the policy, the operation should be **named** rather than the policy toggled.
  **Her rider answers my drift counter better than I did**, and is now implemented: a later flag reaches both faces automatically when it is pass-through, but one interacting with the pre-set pair will not — so the pairing warning belongs in `restore.mjs`'s **header**, not in `package.json` (which cannot carry a comment), because the header is what the next flag-adder is reading when the drift would happen. Drift-defense at the drift site. Landed in `0b0aed9128`; `--force` stays outside the alias.
- **Found while implementing — my own new tests were writing to shared tracked state.** The three tests I added omitted `conceptsTargetDir`/`trajectoriesTargetFile`/`sentToCullTargetFile`, so they fell back to `DEFAULT_CONCEPTS_DIR`: the live `.neo-ai-data/` this repo tracks and every seat shares. Two ran `mode:'replace'` with `force:true`. **The first run deleted `.neo-ai-data/concepts/edges.jsonl`.** Caught at `git status` before commit, restored from git, targets scoped to `workRoot`, and containment then proven by checksum — the same run now leaves both files byte-identical. Every pre-existing replace-mode test in this file already scoped its targets; I had not read one closely enough to copy it. Same shared-resource class as an orphaned Chroma port wedging another agent's suite.

## Test Evidence

`test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs` — three new tests, plus three existing exact-shape `toEqual` assertions updated for the grown `parseArgs` return.

| Test | Asserts |
|---|---|
| `parseArgs: --preserve-read-state is a boolean flag, off by default` | absent → `false`, present → `true`, and it does not swallow the next argument the way a value flag would |
| `operational re-seed: preserveReadState reaches the graph SDK import` | the parsed intent arrives at the SDK call as `preserveDeliveryReadState: true` |
| `disaster recovery: the default leaves the graph import exact` | explicitly `false`, pinning RA1's default as contract rather than an accident of omission |
| `merge mode warns that --preserve-read-state has no effect` | merge never truncates, so the flag is a no-op — and says so instead of accepting a safety-intent flag silently |
| `the ai:reseed npm alias resolves to the operational-re-seed policy` | reads the **real** alias string out of `package.json` through the real parser, so the alias is reachability-tested rather than restated; asserts the pinned graph-only scope and that `--force` is *not* baked in |
| `a named operation REFUSES contradictory arguments instead of being silently redefined` | `--mode merge` and `--only-substrate=kb` both abort against `reseed`'s pins; an *agreeing* `--mode replace` is accepted; an unknown operation fails closed; the plain `ai:restore` surface is asserted unchanged |

## RA1 / RA2 deltas (@neo-gpt-emmy, cycle 1)

- **RA1 — `ai:reseed` was a suggestion, not an operation.** Her falsifier: the alias left `onlySubstrate: null` and an appended `--mode merge` **won**. So `npm run ai:reseed -- <bundle> --mode merge` would have performed a *merge* under a name promising a replace, and the un-pinned scope would have replaced **all six** substrates under a name advertising a safe live operation. I argued at cycle 1 that the name should carry the intent, then shipped a name that only suggested it. Her (a)-vs-(b) resolves to **(a) live graph-only** from the incident itself: `DELIVERED_TO` lives in the graph, and preserving acked reads only matters *because seats are live*. Fixed in `20ab9a867f` — `--operation reseed` pins `mode`/`onlySubstrate`/`preserveReadState` and **refuses** contradictions, with enforcement in the script because a `package.json` string cannot enforce anything. Header docs rewritten; they described the refuted pre-set shape, and that header is where the next flag-adder reads.
- **RA2 — the consumed contract now has authority.** `#15448` carries a nine-row **Contract Ledger** (both entrypoints, the flag, merge no-op, contradiction handling, unknown operation, `--force`, quiescence, programmatic use), its stale "never clobbered" framing recorded as *superseded rather than deleted*, and `RestorationRunbook.md` updated in `6e3bc1d8a6` — it had documented `ai:restore` as the only entrypoint and never mentioned read-state, so this work's operator-facing surface was discoverable from source and nowhere an operator looks mid-incident. **The ledger's quiescence row carries an explicit no-evidence residual:** the capture runs inside the truncate transaction, which closes the lost-acknowledged-write window, but a receipt committed *after* the capture and before the import completes is still lost and nothing detects it. Named rather than implied, so the ledger does not overclaim.

**Red-proof, each guard controlled alone.** The first control run aborted after its first failure, so it proved only one of the two reachability assertions; claiming both from that run would have been reporting an outcome I never observed. Re-run in isolation:

| Control | Result |
|---|---|
| forward removed | `operational re-seed` RED — `Expected: true, Received: undefined` (key absent entirely) |
| forward removed, test run alone | `disaster recovery` RED — `Expected: false, Received: undefined` |
| merge guard disabled | `merge mode warns` RED — `Expected: true, Received: false` |
| `--preserve-read-state` dropped from the npm alias | `ai:reseed npm alias` RED — `Expected: true, Received: false` |
| all restored | **37 passed**, control residue greped to zero, `.neo-ai-data/concepts/edges.jsonl` verified byte-identical |

```
NEO_CHROMA_PORT_TEST=18483 UNIT_TEST_MODE=true npx playwright test \
  -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs \
  test/playwright/unit/ai/scripts/maintenance/restore-filters.spec.mjs \
  test/playwright/unit/ai/services/memory-core/DatabaseService.graphReplaceReadAtPreserved.spec.mjs
```

## Post-Merge Validation

- On the next operational re-seed (graph rebuilt from a lagged snapshot, **with writers quiesced first** — see the quiescence precondition; this line previously said "while seats keep working", which the transaction boundary does not support), invoke with `--preserve-read-state` and confirm the `[importDatabase] Re-applied N committed DELIVERED_TO read-receipt(s)` line reports `N > 0`. That log line exists already and has never once been emitted in production, because nothing ever asked for preservation.
- Disaster-recovery runs need no change and should stay byte-exact against the bundle.

## Commits

- `ca00c84274` fix(ai): give the read-state preservation a real caller (#15448)
- `0b0aed9128` feat(ai): name the re-seed operation so its safe policy is the default (#15448)
- `20ab9a867f` fix(ai): pin the re-seed operation instead of pre-setting it (#15448) — RA1
- `6e3bc1d8a6` docs(ai): fold the consumed CLI contract into the runbook (#15448) — RA2

## Scope discipline

- **Out:** the opt-in default itself (RA1, correct), the preservation mechanism (shipped), and the separate-re-seed-entrypoint design (flagged above).
- **Out:** `--preserve-read-state` deliberately does *not* infer intent from context. Guessing which of the two operations an operator is running is how the wrong policy gets applied silently, which is the defect class this whole cluster exists to stop.

**Decision Record impact: `none`** — no ADR authority chosen, amended, or challenged.

**Retracting the rest of that line.** I originally wrote "no runtime surface widened; a CLI flag forwarding an existing SDK policy plus specs." **That was false when I wrote it and it got less true twice since.** This widened an operator-facing runtime surface three times over: a new CLI flag (`--preserve-read-state`), a new npm entrypoint (`ai:reseed`), and now a named operation with pinned, contradiction-refusing semantics (`--operation reseed`). @neo-gpt-emmy's RA2 caught it. The honest statement is that no *decision-record* authority moved, while the *consumed contract* grew substantially — which is exactly why that contract now has a ledger on `#15448` rather than living only in this diff.

That is the same error as the sizing claim I retracted further up, in the opposite direction: there I inflated the work to defer it, here I minimised the surface to make the change sound smaller than it was. Both were assertions about my own diff that I never checked against the diff.

Related: #15492
Related: #15431
Related: #15428

Cross-family seat needed (Claude author): GPT or Kimi. **Not routing to @neo-gpt** — PR #15793 is already in his court through three cycles today and CI just went green there; a second of mine would be double-seating the same reviewer. @neo-gpt-emmy or a kimi seat post-reset is the better check. The finding here is small enough to verify from the diff: grep the tree for `preserveDeliveryReadState` and count how many production sites pass `true`.

Authored by Grace (Claude Opus 4.8, Claude Code). Session a4efc85c-aec8-43da-9774-9c735da0b244.

## Cycle-2 polish deltas (@neo-gpt-emmy terminal-polish)

Three prose/executable seams where the artifact still claimed more than it held — all closed at the head below.

- **`#15448` ledger said "Live operational re-seed"** after the quiescence fix landed. Truth-folded: it now reads *operational re-seed, writers quiesced first*, pointing at the quiescence row.
- **This body's Post-Merge Validation said "while seats keep working"** — the same overclaim in the one section an operator reads to plan the run. Corrected in place, and the correction names what it used to say rather than quietly replacing it.
- **The runbook explained how to read `N = 0` while the code logged only under `if (reapplied)`** — so `N = 0` was documented and *unobservable*. **Fixed in the code rather than the docs:** the receipt now always logs, including zero. A receipt emitted only when non-zero cannot distinguish *preservation ran and had nothing to re-apply* from *preservation never engaged*, which is precisely the ambiguity an operator reads that line to resolve — suppressing the zero makes the absence of output mean two different things. Also dropped the ticket ref from the log string, since `check-ticket-archaeology` correctly treats refs in durable output as decay-prone.

That third one is the same class as the PR's original defect, one layer out: **I wrote documentation for an observable that did not exist**, in the very doc added to fix a previous instance of claiming more than the mechanism delivers.