### PR TITLE
feat(ai): plane-identity paired artifact — the parity epic's phase-0 spine (#15799)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1486,4 +1486,23 @@ class ConfigBase extends ConfigProvider {
     }
 }
 
+/**
+ * @summary The plane-member paths this Tier-1 base claims — the enumerable input for the
+ * F-invariant's member-coherence clause (`assertPlaneMemberCoherence`): each entry must
+ * resolve beneath the resolved `plane.dataRoot` or be explicitly placed per profile.
+ * Deliberately excludes `orchestrator.tenantRepoMirrorRoot` (cloud-profile-pinned; the
+ * per-profile placement election owns profile-pinned members).
+ */
+export const PLANE_MEMBER_PATHS = Object.freeze([
+    'backupPath',
+    'wakeDaemonHeartbeatAlivePath',
+    'fleet.instanceRoot',
+    'engines.chroma.dataDirProd',
+    'orchestrator.dataDir',
+    'orchestrator.dbPath',
+    'orchestrator.deploymentStateBridge.snapshotPath',
+    'orchestrator.recoveryActuator.healAttemptsPath',
+    'orchestrator.recoveryActuator.recoveryRunStateDir'
+]);
+
 export default Neo.setupClass(ConfigBase);

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1,7 +1,8 @@
-import os                     from 'os';
-import path                   from 'path';
-import {fileURLToPath}        from 'url';
-import ConfigProvider, {leaf} from './ConfigProvider.mjs';
+import os                          from 'os';
+import path                        from 'path';
+import {fileURLToPath}             from 'url';
+import ConfigProvider, {leaf}      from './ConfigProvider.mjs';
+import {PLANE_DEFAULTS, PLANE_ENV} from './planeConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -46,6 +47,34 @@ class ConfigBase extends ConfigProvider {
         data: {
             neoRootDir : leaf(neoRootDir),
             projectRoot: leaf(projectRoot),
+            /**
+             * The declared plane-identity subtree — the first-class object the data-root
+             * placement election decides placement FOR. Declaration source is the pure-defaults
+             * twin `ai/planeConfig.mjs` (ticket-ref-ok: ADR 0019 §5.5 names that module shape):
+             * the leaf imports the twin's frozen literals + env names, so leaf↔twin drift is
+             * impossible by construction.
+             * Three concepts, never conflated: `id` is opaque identity (no path/checkout content);
+             * `dataRoot` is the resolved evidence every plane-member leaf derives from;
+             * `NEO_AI_CANONICAL_ROOT` (provisioning-time, `bootstrapWorktree.mjs`) names a
+             * checkout and is deliberately NOT part of this subtree.
+             * @member {Object} data.plane
+             */
+            plane: {
+                /**
+                 * Stable opaque plane identity. Overlays, cloud deployments, and ephemeral
+                 * isolation planes (Option F overlays) override via env; equality of `planeId`
+                 * is the ONLY sanctioned "same plane?" predicate — never path comparison.
+                 * @type {string}
+                 */
+                id: leaf(PLANE_DEFAULTS.planeId, PLANE_ENV.planeId, 'string'),
+                /**
+                 * The durable data root this process resolved for the declared plane — the single
+                 * anchor plane-member leaves derive from via `path.join`-style derivations, each
+                 * member keeping its own env escape.
+                 * @type {string}
+                 */
+                dataRoot: leaf(path.resolve(neoRootDir, PLANE_DEFAULTS.dataRootRelative), PLANE_ENV.dataRoot, 'string')
+            },
             /**
              * The current in-flight release version whose milestone / epic work counts as "current
              * release focus" for the Golden Path emitter. Set at cut-prep, advanced by

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -78,7 +78,7 @@ class ConfigBase extends ConfigProvider {
                  * not only on the frozen default the load guard covers.
                  * @type {string}
                  */
-                id: {default: PLANE_DEFAULTS.planeId, env: PLANE_ENV.planeId, parse: parsePlaneIdEnv},
+                id: {default: PLANE_DEFAULTS.planeId, env: PLANE_ENV.planeId, type: 'string', parse: parsePlaneIdEnv},
                 /**
                  * The durable data root this process resolved for the declared plane — the single
                  * anchor plane-member leaves derive from via `path.join`-style derivations, each

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1,14 +1,23 @@
-import os                          from 'os';
-import path                        from 'path';
-import {fileURLToPath}             from 'url';
-import ConfigProvider, {leaf}      from './ConfigProvider.mjs';
-import {PLANE_DEFAULTS, PLANE_ENV} from './planeConfig.mjs';
+import os                     from 'os';
+import path                   from 'path';
+import {fileURLToPath}        from 'url';
+import ConfigProvider, {leaf} from './ConfigProvider.mjs';
+import {
+    PLANE_DEFAULTS,
+    PLANE_ENV,
+    parsePlaneIdEnv,
+    resolvePlaneDataRoot
+} from './planeConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../');
 // Fallback to neoRootDir if cwd is root (e.g., container/daemon edge cases)
-const projectRoot           = process.cwd() === '/' ? neoRootDir : process.cwd();
+const projectRoot = process.cwd() === '/' ? neoRootDir : process.cwd();
+// The single plane-member anchor: every durable data-plane default below derives from this
+// const (env-free twin resolution — the leaf machinery owns all env binding), so no member
+// re-derives its own root and no member resolves against ambient cwd.
+const planeDataRootDefault  = resolvePlaneDataRoot({env: {}, rootDir: neoRootDir});
 const chromaUnitTestDataDir = path.join(os.tmpdir(), 'neo-chroma-unit-test');
 
 const HOUR_MS = 60 * 60 * 1000;
@@ -64,16 +73,19 @@ class ConfigBase extends ConfigProvider {
                  * Stable opaque plane identity. Overlays, cloud deployments, and ephemeral
                  * isolation planes (Option F overlays) override via env; equality of `planeId`
                  * is the ONLY sanctioned "same plane?" predicate — never path comparison.
+                 * The env layer routes through the twin's `parsePlaneIdEnv`, so a path-shaped
+                 * override fails loud at boot — the opacity invariant holds on RESOLVED values,
+                 * not only on the frozen default the load guard covers.
                  * @type {string}
                  */
-                id: leaf(PLANE_DEFAULTS.planeId, PLANE_ENV.planeId, 'string'),
+                id: {default: PLANE_DEFAULTS.planeId, env: PLANE_ENV.planeId, parse: parsePlaneIdEnv},
                 /**
                  * The durable data root this process resolved for the declared plane — the single
                  * anchor plane-member leaves derive from via `path.join`-style derivations, each
                  * member keeping its own env escape.
                  * @type {string}
                  */
-                dataRoot: leaf(path.resolve(neoRootDir, PLANE_DEFAULTS.dataRootRelative), PLANE_ENV.dataRoot, 'string')
+                dataRoot: leaf(planeDataRootDefault, PLANE_ENV.dataRoot, 'string')
             },
             /**
              * The current in-flight release version whose milestone / epic work counts as "current
@@ -88,13 +100,13 @@ class ConfigBase extends ConfigProvider {
              * Universal JSONL backup/export directory for Agent OS databases.
              * @type {string}
              */
-            backupPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/backups'), 'NEO_BACKUP_PATH', 'string'),
+            backupPath: leaf(path.resolve(planeDataRootDefault, 'backups'), 'NEO_BACKUP_PATH', 'string'),
             /**
              * Path to the wake-daemon liveness sentinel touched on every swarm-heartbeat
              * pulse. Operators / tests can isolate the path via `NEO_HEARTBEAT_ALIVE_PATH`.
              * @type {string}
              */
-            wakeDaemonHeartbeatAlivePath: leaf(path.resolve(neoRootDir, '.neo-ai-data/wake-daemon/heartbeat.alive'), 'NEO_HEARTBEAT_ALIVE_PATH', 'string'),
+            wakeDaemonHeartbeatAlivePath: leaf(path.resolve(planeDataRootDefault, 'wake-daemon/heartbeat.alive'), 'NEO_HEARTBEAT_ALIVE_PATH', 'string'),
             /**
              * Fleet Manager supervision leaves: where per-agent harness instance homes live and
              * which binary each harness family launches. The lifecycle service reads these at the
@@ -108,7 +120,7 @@ class ConfigBase extends ConfigProvider {
                  * checkouts root.
                  * @type {string}
                  */
-                instanceRoot   : leaf(path.resolve(neoRootDir, '.neo-ai-data/fleet/instances'), 'NEO_FLEET_INSTANCE_ROOT', 'string'),
+                instanceRoot   : leaf(path.resolve(planeDataRootDefault, 'fleet/instances'), 'NEO_FLEET_INSTANCE_ROOT', 'string'),
                 harnessBinaries: {
                     /**
                      * The antigravity harness binary — the app-bundle MAIN binary (a directly
@@ -535,7 +547,7 @@ class ConfigBase extends ConfigProvider {
                 chroma: {
                     // Env-bindable like its host/port siblings: a packaged harness ships the organism in a
                     // read-only(ish) resources dir and must move the persist dir to a per-user data root.
-                    dataDirProd: leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/unified'), 'NEO_CHROMA_DATA_DIR', 'string'),
+                    dataDirProd: leaf(path.resolve(planeDataRootDefault, 'chroma/unified'), 'NEO_CHROMA_DATA_DIR', 'string'),
                     dataDirTest: leaf(chromaUnitTestDataDir, 'NEO_CHROMA_DATA_DIR_TEST', 'string'),
                     hostProd   : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
                     hostTest   : leaf('localhost', 'NEO_CHROMA_HOST_TEST', 'string'),
@@ -611,25 +623,28 @@ class ConfigBase extends ConfigProvider {
                 /**
                  * Directory owning ALL orchestrator-daemon runtime state: the daemon + child-task
                  * PID files, `orchestrator.log`, `orchestrator-state.json`, and the heavy-maintenance
-                 * lease + tenant-repo-sync revision files stored beside them. Kept relative on
-                 * purpose — it resolves against the daemon's cwd (repo root under the standard
-                 * launch). Owning the default AND the `NEO_AI_ORCHESTRATOR_DIR` env binding here
+                 * lease + tenant-repo-sync revision files stored beside them. Derives from the
+                 * declared plane anchor (absolute) — the prior relative default resolved against
+                 * the daemon's ambient cwd, which is exactly the per-process root ambiguity the
+                 * plane subtree removes; cloud deployments keep overriding via env. Owning the
+                 * default AND the `NEO_AI_ORCHESTRATOR_DIR` env binding here (instead of a
+                 * module-level `process.env` read at the consumer) keeps the config-is-SSOT
+                 * contract: no consumer re-derives from env, no consumer holds a hidden default.
+                 * @type {String}
+                 */
+                dataDir: leaf(path.resolve(planeDataRootDefault, 'orchestrator-daemon'), 'NEO_AI_ORCHESTRATOR_DIR', 'string'),
+                /**
+                 * SQLite Memory Core graph database file the orchestrator opens for graph-backed
+                 * health checks and maintenance decisions. Derives from the declared plane anchor
+                 * (absolute) — the prior relative default resolved against the daemon's ambient
+                 * cwd, the per-process root ambiguity the plane subtree removes; deployments keep
+                 * overriding via env. Owning the default AND the `NEO_AI_DB_PATH` env binding here
                  * (instead of a module-level `process.env` read at the consumer) keeps the
                  * config-is-SSOT contract: no consumer re-derives from env, no consumer holds a
                  * hidden default.
                  * @type {String}
                  */
-                dataDir: leaf('.neo-ai-data/orchestrator-daemon', 'NEO_AI_ORCHESTRATOR_DIR', 'string'),
-                /**
-                 * SQLite Memory Core graph database file the orchestrator opens for graph-backed
-                 * health checks and maintenance decisions. Kept relative on purpose — it resolves
-                 * against the daemon's cwd (repo root under the standard launch). Owning the
-                 * default AND the `NEO_AI_DB_PATH` env binding here (instead of a module-level
-                 * `process.env` read at the consumer) keeps the config-is-SSOT contract: no
-                 * consumer re-derives from env, no consumer holds a hidden default.
-                 * @type {String}
-                 */
-                dbPath: leaf('.neo-ai-data/sqlite/memory-core-graph.sqlite', 'NEO_AI_DB_PATH', 'string'),
+                dbPath: leaf(path.resolve(planeDataRootDefault, 'sqlite/memory-core-graph.sqlite'), 'NEO_AI_DB_PATH', 'string'),
                 /**
                  * Deployment profile for Agent OS maintenance ownership.
                  * `local` preserves maintainer-checkout behavior; `cloud` disables local-only
@@ -645,6 +660,10 @@ class ConfigBase extends ConfigProvider {
                  * `tenantRepos[].mirrorRoot` overrides this value when present; absent
                  * per-repo overrides fall back through this Tier-1 default. Env override:
                  * `NEO_TENANT_REPO_MIRROR_ROOT`.
+                 * Deliberately NOT derived from the local plane anchor: this default names the
+                 * CLOUD profile's plane root (the lane is cloud-only), and re-anchoring it
+                 * locally would silently break containerized defaults. The per-profile
+                 * plane-placement election owns unifying profile-pinned members.
                  * @type {String}
                  */
                 tenantRepoMirrorRoot: leaf('/app/.neo-ai-data', 'NEO_TENANT_REPO_MIRROR_ROOT', 'string'),
@@ -756,7 +775,7 @@ class ConfigBase extends ConfigProvider {
                  */
                 deploymentStateBridge: {
                     enabled                     : leaf(true, 'NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED', 'boolean'),
-                    snapshotPath                : leaf(path.resolve(neoRootDir, '.neo-ai-data/deployment-state/snapshot.json'), 'NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH', 'string'),
+                    snapshotPath                : leaf(path.resolve(planeDataRootDefault, 'deployment-state/snapshot.json'), 'NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH', 'string'),
                     writeIntervalMs             : leaf(30000, 'NEO_DEPLOYMENT_STATE_BRIDGE_WRITE_INTERVAL_MS', 'number'),
                     staleAfterMs                : leaf(2 * 60 * 1000, 'NEO_DEPLOYMENT_STATE_BRIDGE_STALE_AFTER_MS', 'number'),
                     maxSnapshotBytes            : leaf(256 * 1024, 'NEO_DEPLOYMENT_STATE_BRIDGE_MAX_BYTES', 'number'),
@@ -1118,8 +1137,8 @@ class ConfigBase extends ConfigProvider {
                     blockedSupervisedTasks     : leaf([], 'NEO_RECOVERY_ACTUATOR_BLOCKED_SUPERVISED_TASKS', 'csv'),
                     blockedComposeServices     : leaf([], 'NEO_RECOVERY_ACTUATOR_BLOCKED_COMPOSE_SERVICES', 'csv'),
                     blockedDeployTargets       : leaf([], 'NEO_RECOVERY_ACTUATOR_BLOCKED_DEPLOY_TARGETS', 'csv'),
-                    healAttemptsPath           : leaf(path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/heal-attempts.json'), 'NEO_RECOVERY_ACTUATOR_HEAL_ATTEMPTS_PATH', 'string'),
-                    recoveryRunStateDir        : leaf(path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/recovery-runs'), 'NEO_RECOVERY_ACTUATOR_RUN_STATE_DIR', 'string'),
+                    healAttemptsPath           : leaf(path.resolve(planeDataRootDefault, 'orchestrator-daemon/heal-attempts.json'), 'NEO_RECOVERY_ACTUATOR_HEAL_ATTEMPTS_PATH', 'string'),
+                    recoveryRunStateDir        : leaf(path.resolve(planeDataRootDefault, 'orchestrator-daemon/recovery-runs'), 'NEO_RECOVERY_ACTUATOR_RUN_STATE_DIR', 'string'),
                     recoveryRunRetentionLimit  : leaf(100, 'NEO_RECOVERY_ACTUATOR_RUN_RETENTION_LIMIT', 'number'),
                     maxAttemptsPerWindow       : leaf(3, 'NEO_RECOVERY_ACTUATOR_MAX_ATTEMPTS_PER_WINDOW', 'number'),
                     maxAttemptsWindowMs        : leaf(HOUR_MS, 'NEO_RECOVERY_ACTUATOR_MAX_ATTEMPTS_WINDOW_MS', 'number'),

--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -3,7 +3,11 @@ import {CallToolRequestSchema, ListToolsRequestSchema} from '@modelcontextprotoc
 import path                                            from 'node:path';
 import {fileURLToPath}                                 from 'node:url';
 import Base                                            from '../../../src/core/Base.mjs';
-import {assertPlaneCoherence, resolvePlaneDataRoot}    from '../../planeConfig.mjs';
+import {
+    assertPlaneCoherence,
+    assertPlaneMemberCoherence,
+    resolvePlaneDataRoot
+} from '../../planeConfig.mjs';
 
 // The durable-root reference for the plane fail-closed check: THIS checkout's default plane
 // root (env-free twin resolution). A declared overlay resolving it — via env leakage or a
@@ -533,6 +537,18 @@ class BaseServer extends Base {
     }
 
     /**
+     * @summary The claimed plane-member entries for this server's config — `{path, resolved,
+     * default}` per member (see `collectPlaneMembers`). Member servers override to walk their
+     * config base's `PLANE_MEMBER_PATHS`; the default empty list keeps non-members and the
+     * base class free of member claims.
+     * @returns {Object[]}
+     * @protected
+     */
+    getPlaneMembers() {
+        return [];
+    }
+
+    /**
      * @summary Fail-closed plane-identity assertion on the RESOLVED config values. Placed on
      * this shared building block because every boot order — the default `boot()` and the
      * custom overrides — calls `runHealthcheckAndLogStatus()` after `loadCustomConfig()`,
@@ -557,11 +573,21 @@ class BaseServer extends Base {
                 `[${this.constructor.name}] declared plane member resolved no \`plane\` subtree — Tier-1 config not loaded?`
             );
         }
-        return assertPlaneCoherence({
+        const observed = assertPlaneCoherence({
             planeId : plane.id,
             dataRoot: plane.dataRoot,
             canonicalDataRoot
         });
+
+        // Member-coherence clause: a relocated plane root with members still on their
+        // build-time anchor defaults is a partially-moved plane — fail closed, never split
+        // storage across two roots.
+        const members = this.getPlaneMembers();
+
+        if (members.length > 0) {
+            assertPlaneMemberCoherence({dataRoot: plane.dataRoot, members});
+        }
+        return observed;
     }
 
     /**

--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -6,8 +6,10 @@ import Base                                            from '../../../src/core/B
 import {
     assertPlaneCoherence,
     assertPlaneMemberCoherence,
+    collectPlaneMembers,
     resolvePlaneDataRoot
 } from '../../planeConfig.mjs';
+import Tier1ConfigBase, {PLANE_MEMBER_PATHS as TIER1_PLANE_MEMBER_PATHS} from '../../configBase.mjs';
 
 // The durable-root reference for the plane fail-closed check: THIS checkout's default plane
 // root (env-free twin resolution). A declared overlay resolving it — via env leakage or a
@@ -538,14 +540,42 @@ class BaseServer extends Base {
 
     /**
      * @summary The claimed plane-member entries for this server's config — `{path, resolved,
-     * default}` per member (see `collectPlaneMembers`). Member servers override to walk their
-     * config base's `PLANE_MEMBER_PATHS`; the default empty list keeps non-members and the
-     * base class free of member claims.
+     * default}` per member (see `collectPlaneMembers`). Member servers override to return
+     * `collectMemberEntries(...)`; the default empty list keeps non-members and the base
+     * class free of member claims.
      * @returns {Object[]}
      * @protected
      */
     getPlaneMembers() {
         return [];
+    }
+
+    /**
+     * @summary Composes the COMPLETE claimed member set a member server opens: its
+     * server-local claims PLUS the inherited Tier-1 claims — both resolved through the
+     * SAME per-server config (`this.aiConfig`; Tier-1 leaves resolve via the Provider
+     * parent chain). A member server that asserted only its local list would leave the
+     * Tier-1 members it consumes (e.g. the Chroma persist dir) boot-orphaned — a local
+     * explicit placement must never mask stale Tier-1 members after a root relocation.
+     * @param {Object} options
+     * @param {String[]} options.localPaths The server's own claimed member paths.
+     * @param {Object} options.localDescriptorData The server config base's static `config.data`.
+     * @returns {Object[]}
+     * @protected
+     */
+    collectMemberEntries({localPaths, localDescriptorData}) {
+        return [
+            ...collectPlaneMembers({
+                memberPaths   : localPaths,
+                resolvedConfig: this.aiConfig,
+                descriptorData: localDescriptorData
+            }),
+            ...collectPlaneMembers({
+                memberPaths   : TIER1_PLANE_MEMBER_PATHS,
+                resolvedConfig: this.aiConfig,
+                descriptorData: Tier1ConfigBase.config.data
+            })
+        ];
     }
 
     /**

--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -1,6 +1,17 @@
 import {McpServer}                                     from '@modelcontextprotocol/sdk/server/mcp.js';
 import {CallToolRequestSchema, ListToolsRequestSchema} from '@modelcontextprotocol/sdk/types.js';
+import path                                            from 'node:path';
+import {fileURLToPath}                                 from 'node:url';
 import Base                                            from '../../../src/core/Base.mjs';
+import {assertPlaneCoherence, resolvePlaneDataRoot}    from '../../planeConfig.mjs';
+
+// The durable-root reference for the plane fail-closed check: THIS checkout's default plane
+// root (env-free twin resolution). A declared overlay resolving it — via env leakage or a
+// symlink layer — is the breach the boot assertion exists to stop.
+const canonicalDataRoot = resolvePlaneDataRoot({
+    env    : {},
+    rootDir: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../')
+});
 
 /**
  * @summary Common base class for all Neo MCP servers.
@@ -507,12 +518,36 @@ class BaseServer extends Base {
     }
 
     /**
-     * @summary Runs the per-server healthcheck (if any) and emits a startup-status log line.
+     * @summary Fail-closed plane-identity assertion on the RESOLVED config values. Placed on
+     * this shared building block because every boot order — the default `boot()` and the
+     * custom overrides — calls `runHealthcheckAndLogStatus()` after `loadCustomConfig()`,
+     * so the assertion also closes the custom-config-file route the leaf's env parser
+     * never sees. Config-less servers (null `aiConfig`) carry no plane by contract.
+     * @returns {Object|null} Frozen observed identity `{planeId, dataRoot}`, or `null`.
+     * @protected
+     */
+    assertPlaneIdentity() {
+        if (!this.aiConfig) return null;
+
+        const {plane} = this.aiConfig;
+
+        return assertPlaneCoherence({
+            planeId : plane.id,
+            dataRoot: plane.dataRoot,
+            canonicalDataRoot
+        });
+    }
+
+    /**
+     * @summary Asserts plane-identity coherence (fail closed before serving), then runs the
+     * per-server healthcheck (if any) and emits a startup-status log line.
      * Returns the health result for use by `afterHealthcheck` hooks.
      * @returns {Promise<Object|null>} The healthcheck result, or `null` if no health service.
      * @protected
      */
     async runHealthcheckAndLogStatus() {
+        this.assertPlaneIdentity();
+
         const healthService = this.getHealthService();
         if (!healthService?.healthcheck) {
             this.logStartupStatus(null);

--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -518,19 +518,45 @@ class BaseServer extends Base {
     }
 
     /**
+     * @summary Declares whether this server is a data-plane MEMBER — a server that opens
+     * durable plane storage (WAL, SQLite, Chroma) and must therefore prove plane-identity
+     * coherence before serving. Membership is an explicit class declaration, never inferred
+     * from config shape: API-bridge servers (github-/gitlab-workflow) and isolated test
+     * fixtures carry no plane by contract and skip the assertion; member servers override
+     * to `true` and then fail LOUD on every unresolvable state (no config, no `plane`
+     * subtree) — a member can never silently skip its own invariant.
+     * @returns {Boolean}
+     * @protected
+     */
+    isPlaneMember() {
+        return false;
+    }
+
+    /**
      * @summary Fail-closed plane-identity assertion on the RESOLVED config values. Placed on
      * this shared building block because every boot order — the default `boot()` and the
      * custom overrides — calls `runHealthcheckAndLogStatus()` after `loadCustomConfig()`,
      * so the assertion also closes the custom-config-file route the leaf's env parser
-     * never sees. Config-less servers (null `aiConfig`) carry no plane by contract.
+     * never sees. Non-members (see `isPlaneMember()`) carry no plane by contract and
+     * return `null`; declared members fail loud on any unresolvable state.
      * @returns {Object|null} Frozen observed identity `{planeId, dataRoot}`, or `null`.
      * @protected
      */
     assertPlaneIdentity() {
-        if (!this.aiConfig) return null;
+        if (!this.isPlaneMember()) return null;
 
+        if (!this.aiConfig) {
+            throw new Error(
+                `[${this.constructor.name}] declared plane member booted without aiConfig — plane identity unresolvable.`
+            );
+        }
         const {plane} = this.aiConfig;
 
+        if (!plane) {
+            throw new Error(
+                `[${this.constructor.name}] declared plane member resolved no \`plane\` subtree — Tier-1 config not loaded?`
+            );
+        }
         return assertPlaneCoherence({
             planeId : plane.id,
             dataRoot: plane.dataRoot,
@@ -569,7 +595,7 @@ class BaseServer extends Base {
      */
     async connectTransport() {
         const metadata  = this.getServerMetadata();
-        const transport = this.aiConfig === null ? 'stdio' : this.aiConfig.transport;
+        const transport = !this.aiConfig ? 'stdio' : this.aiConfig.transport;
 
         if (transport === 'sse') {
             throw new Error(

--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -1,6 +1,5 @@
 import BaseServer                       from '../BaseServer.mjs';
 import aiConfig                         from './config.mjs';
-import {collectPlaneMembers}            from '../../../planeConfig.mjs';
 import ConfigBase, {PLANE_MEMBER_PATHS} from './configBase.mjs';
 import logger                           from './logger.mjs';
 import DatabaseService                  from '../../../services/knowledge-base/DatabaseService.mjs';
@@ -44,16 +43,16 @@ class Server extends BaseServer {
     }
 
     /**
-     * @summary Walks this server's claimed plane-member paths against the resolved config —
-     * the boot-time input for the F-invariant's member-coherence clause.
+     * @summary The COMPLETE plane this server opens: its local claimed member paths PLUS the
+     * inherited Tier-1 claims, composed by `BaseServer.collectMemberEntries` — the boot-time
+     * input for the F-invariant's member-coherence clause.
      * @returns {Object[]}
      * @protected
      */
     getPlaneMembers() {
-        return collectPlaneMembers({
-            memberPaths   : PLANE_MEMBER_PATHS,
-            resolvedConfig: this.aiConfig,
-            descriptorData: ConfigBase.config.data
+        return this.collectMemberEntries({
+            localPaths         : PLANE_MEMBER_PATHS,
+            localDescriptorData: ConfigBase.config.data
         });
     }
 

--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -31,6 +31,17 @@ class Server extends BaseServer {
     logger   = logger
 
     /**
+     * @summary The Knowledge Base opens durable plane storage (the unified Chroma persist
+     * dir, shared telemetry SQLite) — a declared plane MEMBER: the boot-time plane-identity
+     * assertion fails loud rather than ever silently skipping.
+     * @returns {Boolean}
+     * @protected
+     */
+    isPlaneMember() {
+        return true;
+    }
+
+    /**
      * @summary MCP server identity for `createMcpServer()`.
      * @returns {{name: String, version: String, capabilities: Object}}
      */

--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -1,10 +1,12 @@
-import BaseServer            from '../BaseServer.mjs';
-import aiConfig              from './config.mjs';
-import logger                from './logger.mjs';
-import DatabaseService       from '../../../services/knowledge-base/DatabaseService.mjs';
-import HealthService         from '../../../services/knowledge-base/HealthService.mjs';
-import KBRecorderService     from '../../../services/knowledge-base/KBRecorderService.mjs';
-import {listTools, callTool} from './toolService.mjs';
+import BaseServer                       from '../BaseServer.mjs';
+import aiConfig                         from './config.mjs';
+import {collectPlaneMembers}            from '../../../planeConfig.mjs';
+import ConfigBase, {PLANE_MEMBER_PATHS} from './configBase.mjs';
+import logger                           from './logger.mjs';
+import DatabaseService                  from '../../../services/knowledge-base/DatabaseService.mjs';
+import HealthService                    from '../../../services/knowledge-base/HealthService.mjs';
+import KBRecorderService                from '../../../services/knowledge-base/KBRecorderService.mjs';
+import {listTools, callTool}            from './toolService.mjs';
 
 /**
  * @summary The Knowledge Base MCP Server application.
@@ -39,6 +41,20 @@ class Server extends BaseServer {
      */
     isPlaneMember() {
         return true;
+    }
+
+    /**
+     * @summary Walks this server's claimed plane-member paths against the resolved config —
+     * the boot-time input for the F-invariant's member-coherence clause.
+     * @returns {Object[]}
+     * @protected
+     */
+    getPlaneMembers() {
+        return collectPlaneMembers({
+            memberPaths   : PLANE_MEMBER_PATHS,
+            resolvedConfig: this.aiConfig,
+            descriptorData: ConfigBase.config.data
+        });
     }
 
     /**

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -2,6 +2,7 @@ import os                                        from 'os';
 import path                                      from 'path';
 import ConfigProvider, {createConfigProxy, leaf} from '../../../ConfigProvider.mjs';
 import {fileURLToPath}                           from 'url';
+import {resolvePlaneDataRoot}                    from '../../../planeConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -10,6 +11,8 @@ const __dirname  = path.dirname(__filename);
 // here: a runtime operator overlay and the tracked template must never both compete for `Neo.ai.Config`.
 const AiConfig   = createConfigProxy(Neo.ai.Config);
 const neoRootDir = path.resolve(__dirname, '../../../../');
+// The single plane-member anchor (env-free twin resolution — the leaf machinery owns env binding).
+const planeDataRoot = resolvePlaneDataRoot({env: {}, rootDir: neoRootDir});
 
 /**
  * @summary Extendable defaults and formulas for the Knowledge Base MCP server.
@@ -261,7 +264,7 @@ class ConfigBase extends ConfigProvider {
              * trail observable from the host shell. Default: `<neoRootDir>/.neo-ai-data/logs/`.
              * @type {string}
              */
-            logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs'), 'NEO_KB_LOG_PATH', 'string'),
+            logPath: leaf(path.resolve(planeDataRoot, 'logs'), 'NEO_KB_LOG_PATH', 'string'),
             /**
              * @summary Retention policy for Knowledge Base MCP diagnostic log files.
              *

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -537,4 +537,15 @@ class ConfigBase extends ConfigProvider {
         }
     }
 }
+
+/**
+ * @summary The plane-member paths this server claims — the enumerable input for the
+ * F-invariant's member-coherence clause (`assertPlaneMemberCoherence`), asserted at boot
+ * by `Server.getPlaneMembers()`. The Chroma persist dir is Tier-1-owned (`engines.chroma`)
+ * and asserted by the Tier-1 member list, not re-claimed here.
+ */
+export const PLANE_MEMBER_PATHS = Object.freeze([
+    'logPath'
+]);
+
 export default Neo.setupClass(ConfigBase);

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -825,6 +825,18 @@ components:
           format: date-time
           description: Timestamp of when the health check was performed.
           example: "2025-10-25T12:00:00Z"
+        plane:
+          type: object
+          description: OBSERVED plane identity — the id/dataRoot THIS process resolved, read from the same per-server config the boot assertion verified (the deployment manifest's observed column). Always present.
+          properties:
+            id:
+              type: string
+              description: Opaque plane identity (never a path).
+              example: "neo-local-canonical"
+            dataRoot:
+              type: string
+              description: Absolute durable data root this process resolved.
+          required: [id, dataRoot]
         runtimeFreshness:
           type: object
           description: Compact boot-vs-current runtime freshness diagnostic for detecting stale Knowledge Base MCP process attachments.

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -58,7 +58,12 @@ const serviceMapping = {
     get_class_hierarchy          : QueryService            .getClassHierarchy  .bind(QueryService),
     get_document_by_id           : DocumentService         .getDocumentById    .bind(DocumentService),
     get_mcp_tool_handbook        : toolId => toolService.getToolHandbook(toolId),
-    healthcheck                  : HealthService           .healthcheck        .bind(HealthService),
+    // Health payload + the OBSERVED plane identity (per-process emission for the deployment
+    // manifest's observed column). Read at the use site per the Provider SSOT.
+    healthcheck                  : async () => ({
+        ...await HealthService.healthcheck(),
+        plane: {id: AiConfig.plane.id, dataRoot: AiConfig.plane.dataRoot}
+    }),
     get_deployment_state_snapshot: readDeploymentInspection,
     inspect_deployment           : readDeploymentInspection,
     get_ingestion_progress       : IngestionService        .getIngestionProgress.bind(IngestionService),

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -54,15 +54,17 @@ const listTransportVisibleTools = ({cursor=0, limit} = {}) => {
 };
 
 const serviceMapping = {
-    ask_knowledge_base           : SearchService           .ask                .bind(SearchService),
-    get_class_hierarchy          : QueryService            .getClassHierarchy  .bind(QueryService),
-    get_document_by_id           : DocumentService         .getDocumentById    .bind(DocumentService),
-    get_mcp_tool_handbook        : toolId => toolService.getToolHandbook(toolId),
+    ask_knowledge_base   : SearchService           .ask                .bind(SearchService),
+    get_class_hierarchy  : QueryService            .getClassHierarchy  .bind(QueryService),
+    get_document_by_id   : DocumentService         .getDocumentById    .bind(DocumentService),
+    get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
     // Health payload + the OBSERVED plane identity (per-process emission for the deployment
-    // manifest's observed column). Read at the use site per the Provider SSOT.
+    // manifest's observed column). Read from the SAME per-server config the boot assertion
+    // verified (`Server.aiConfig` === this singleton) — never a second Provider, so a custom
+    // child overlay can never verify one identity and report another.
     healthcheck                  : async () => ({
         ...await HealthService.healthcheck(),
-        plane: {id: AiConfig.plane.id, dataRoot: AiConfig.plane.dataRoot}
+        plane: {id: kbConfig.plane.id, dataRoot: kbConfig.plane.dataRoot}
     }),
     get_deployment_state_snapshot: readDeploymentInspection,
     inspect_deployment           : readDeploymentInspection,

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -28,10 +28,12 @@ import {
     createMessageGraphProjectionProcessor,
     startMessageDrainLoop
 } from '../../../daemons/message/drainCycle.mjs';
-import {acquireMessageDrainLock}      from '../../../daemons/message/drainLock.mjs';
-import {getMissingMessageWalLeaves}   from '../../../services/memory-core/helpers/messageWalStore.mjs';
-import {TRUST_TIERS}                  from '../../../graph/identityRoots.mjs';
-import {normalizeAgentIdentityNodeId} from '../../../graph/normalizeAgentIdentityNodeId.mjs';
+import {acquireMessageDrainLock}        from '../../../daemons/message/drainLock.mjs';
+import {getMissingMessageWalLeaves}     from '../../../services/memory-core/helpers/messageWalStore.mjs';
+import {TRUST_TIERS}                    from '../../../graph/identityRoots.mjs';
+import {normalizeAgentIdentityNodeId}   from '../../../graph/normalizeAgentIdentityNodeId.mjs';
+import {collectPlaneMembers}            from '../../../planeConfig.mjs';
+import ConfigBase, {PLANE_MEMBER_PATHS} from './configBase.mjs';
 
 // Security invariant, not deployment policy: graph ids must remain namespace/path/control safe.
 const AUTH_IDENTITY_USER_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$/;
@@ -83,6 +85,20 @@ class Server extends BaseServer {
      */
     isPlaneMember() {
         return true;
+    }
+
+    /**
+     * @summary Walks this server's claimed plane-member paths against the resolved config —
+     * the boot-time input for the F-invariant's member-coherence clause.
+     * @returns {Object[]}
+     * @protected
+     */
+    getPlaneMembers() {
+        return collectPlaneMembers({
+            memberPaths   : PLANE_MEMBER_PATHS,
+            resolvedConfig: this.aiConfig,
+            descriptorData: ConfigBase.config.data
+        });
     }
 
     /**

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -75,6 +75,17 @@ class Server extends BaseServer {
     stdioIdentity = null
 
     /**
+     * @summary Memory Core opens durable plane storage (memory/message WAL, the shared
+     * SQLite graph, Chroma collections) — a declared plane MEMBER: the boot-time
+     * plane-identity assertion fails loud rather than ever silently skipping.
+     * @returns {Boolean}
+     * @protected
+     */
+    isPlaneMember() {
+        return true;
+    }
+
+    /**
      * @summary MCP server identity for `createMcpServer()`. Includes the experimental
      * `neo-wake-substrate` capability that surfaces wake events for connected clients.
      * @returns {{name: String, version: String, capabilities: Object}}

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -32,7 +32,6 @@ import {acquireMessageDrainLock}        from '../../../daemons/message/drainLock
 import {getMissingMessageWalLeaves}     from '../../../services/memory-core/helpers/messageWalStore.mjs';
 import {TRUST_TIERS}                    from '../../../graph/identityRoots.mjs';
 import {normalizeAgentIdentityNodeId}   from '../../../graph/normalizeAgentIdentityNodeId.mjs';
-import {collectPlaneMembers}            from '../../../planeConfig.mjs';
 import ConfigBase, {PLANE_MEMBER_PATHS} from './configBase.mjs';
 
 // Security invariant, not deployment policy: graph ids must remain namespace/path/control safe.
@@ -88,16 +87,16 @@ class Server extends BaseServer {
     }
 
     /**
-     * @summary Walks this server's claimed plane-member paths against the resolved config —
-     * the boot-time input for the F-invariant's member-coherence clause.
+     * @summary The COMPLETE plane this server opens: its local claimed member paths PLUS the
+     * inherited Tier-1 claims, composed by `BaseServer.collectMemberEntries` — the boot-time
+     * input for the F-invariant's member-coherence clause.
      * @returns {Object[]}
      * @protected
      */
     getPlaneMembers() {
-        return collectPlaneMembers({
-            memberPaths   : PLANE_MEMBER_PATHS,
-            resolvedConfig: this.aiConfig,
-            descriptorData: ConfigBase.config.data
+        return this.collectMemberEntries({
+            localPaths         : PLANE_MEMBER_PATHS,
+            localDescriptorData: ConfigBase.config.data
         });
     }
 

--- a/ai/mcp/server/memory-core/configBase.mjs
+++ b/ai/mcp/server/memory-core/configBase.mjs
@@ -2,6 +2,7 @@ import os                     from 'os';
 import path                   from 'path';
 import ConfigProvider, {leaf} from '../../../ConfigProvider.mjs';
 import {fileURLToPath}        from 'url';
+import {resolvePlaneDataRoot} from '../../../planeConfig.mjs';
 import {
     MEMORY_CORE_GRAPH_DB_ENV,
     TURN_PRESENCE_DEFAULTS,
@@ -21,10 +22,14 @@ function parseMemorySharingPolicy(envVarName, {env = process.env} = {}) {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
-const neoRootDir        = path.resolve(__dirname, '../../../../');
-const cwd               = neoRootDir;
-const wakeDaemonDataDir = path.resolve(process.env.NEO_AI_DAEMON_DIR || path.resolve(cwd, '.neo-ai-data/wake-daemon'));
-const DAY_MS            = 24 * 60 * 60 * 1000;
+const neoRootDir = path.resolve(__dirname, '../../../../');
+const cwd        = neoRootDir;
+// The single plane-member anchor (env-free twin resolution — the leaf machinery owns all env
+// binding): every durable data-plane default below derives from it, replacing the per-leaf
+// `path.resolve(cwd, '.neo-ai-data/…')` re-derivations and the prior module-scope
+// `process.env.NEO_AI_DAEMON_DIR` inline read.
+const planeDataRoot = resolvePlaneDataRoot({env: {}, rootDir: neoRootDir});
+const DAY_MS        = 24 * 60 * 60 * 1000;
 
 // Per-worker-unique test collection names, generated at config-load. Each playwright worker is a
 // separate process that re-evaluates this module → its own unique names, so fullyParallel workers
@@ -214,12 +219,18 @@ class ConfigBase extends ConfigProvider {
                 useTestHarness : leaf(false, 'NEO_TEST_CONFIG_TEMPLATES', 'boolean')
             },
             /**
-             * Durable wake-daemon watermarks consumed by GraphLog maintenance.
+             * Durable wake-daemon watermarks consumed by GraphLog maintenance. `dataDir` derives
+             * from the declared plane anchor; the two watermark paths consumers read
+             * (`bridgeLastSyncIdPath` / `wakeSubscriptionLiveCursorPath`) are formulas (below)
+             * deriving from the RESOLVED `dataDir` — relocating the daemon dir via
+             * `NEO_AI_DAEMON_DIR` moves the watermarks with it (children of a relocatable parent
+             * are genuinely computed values, so formulas, not static joins), while each watermark
+             * keeps its explicit override leaf.
              */
             wakeDaemon: {
-                dataDir                       : leaf(wakeDaemonDataDir, 'NEO_AI_DAEMON_DIR', 'string'),
-                bridgeLastSyncIdPath          : leaf(path.join(wakeDaemonDataDir, 'lastSyncId'), 'NEO_BRIDGE_LAST_SYNC_ID_PATH', 'string'),
-                wakeSubscriptionLiveCursorPath: leaf(path.join(wakeDaemonDataDir, 'wakeSubscriptionLiveCursor'), 'NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE', 'string')
+                dataDir                               : leaf(path.resolve(planeDataRoot, 'wake-daemon'), 'NEO_AI_DAEMON_DIR', 'string'),
+                bridgeLastSyncIdPathOverride          : leaf(null, 'NEO_BRIDGE_LAST_SYNC_ID_PATH', 'string'),
+                wakeSubscriptionLiveCursorPathOverride: leaf(null, 'NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE', 'string')
             },
             /**
              * Turn-presence interval writer configuration.
@@ -274,14 +285,14 @@ class ConfigBase extends ConfigProvider {
              */
             datasets: {
                 rlaif: {
-                    trajectories: leaf(path.resolve(cwd, '.neo-ai-data/datasets/rlaif/trajectories.jsonl'), 'NEO_RLAIF_PATH', 'string')
+                    trajectories: leaf(path.resolve(planeDataRoot, 'datasets/rlaif/trajectories.jsonl'), 'NEO_RLAIF_PATH', 'string')
                 }
             },
             /**
              * Directory for per-cycle REM run/stage JSONL state artifacts.
              * @type {string}
              */
-            remRunStateDir: leaf(path.resolve(cwd, '.neo-ai-data/rem-runs'), 'NEO_REM_RUN_STATE_DIR', 'string'),
+            remRunStateDir: leaf(path.resolve(planeDataRoot, 'rem-runs'), 'NEO_REM_RUN_STATE_DIR', 'string'),
             /**
              * Stall threshold for the REM consolidation-liveness watchdog: max age (ms) since the last
              * successful REM cycle before the watchdog records/raises a consolidation stall. Default 6h
@@ -343,7 +354,7 @@ class ConfigBase extends ConfigProvider {
                  * Production WAL segment directory. Declarative leaf; env override via `NEO_MEMORY_WAL_DIR`.
                  * @type {string}
                  */
-                dirProd        : leaf(path.resolve(cwd, '.neo-ai-data/memory-wal'), 'NEO_MEMORY_WAL_DIR', 'string'),
+                dirProd        : leaf(path.resolve(planeDataRoot, 'memory-wal'), 'NEO_MEMORY_WAL_DIR', 'string'),
                 /**
                  * Unit-test WAL directory: per-worker-unique under the OS temp root (module const above).
                  * @type {string}
@@ -378,7 +389,7 @@ class ConfigBase extends ConfigProvider {
                  * env override via `NEO_MEMORY_EMBED_DAEMON_DIR`.
                  * @type {string}
                  */
-                daemonDataDir  : leaf(path.resolve(cwd, '.neo-ai-data/embed-daemon'), 'NEO_MEMORY_EMBED_DAEMON_DIR', 'string'),
+                daemonDataDir  : leaf(path.resolve(planeDataRoot, 'embed-daemon'), 'NEO_MEMORY_EMBED_DAEMON_DIR', 'string'),
                 /**
                  * Embed-daemon drain cadence. Per-turn saves arrive minutes apart; 5s keeps
                  * semantic recall near-realtime without hot-looping the store. This cadence is
@@ -463,7 +474,7 @@ class ConfigBase extends ConfigProvider {
                  * Data directory (PID file, rotating log) for the local message WAL drain daemon.
                  * @type {string}
                  */
-                daemonDataDir : leaf(path.resolve(cwd, '.neo-ai-data/message-daemon'), 'NEO_MESSAGE_WAL_DAEMON_DIR', 'string'),
+                daemonDataDir : leaf(path.resolve(planeDataRoot, 'message-daemon'), 'NEO_MESSAGE_WAL_DAEMON_DIR', 'string'),
                 /**
                  * Message WAL drain cadence. Mirrors memory WAL cadence; the replay semantics are
                  * owned by the message drain processor, while this leaf owns host scheduling.
@@ -542,7 +553,7 @@ class ConfigBase extends ConfigProvider {
              * admitted target and never supplies a filesystem path.
              * @type {string}
              */
-            hookProjectionRoot: leaf(path.resolve(cwd, '.neo-ai-data/hook-projections'), 'NEO_HOOK_PROJECTION_ROOT', 'string'),
+            hookProjectionRoot: leaf(path.resolve(planeDataRoot, 'hook-projections'), 'NEO_HOOK_PROJECTION_ROOT', 'string'),
             /**
              * Minimum `daysIdle * max(structuralWeight, 1)` score required for Silent Threads.
              * @type {number}
@@ -621,7 +632,7 @@ class ConfigBase extends ConfigProvider {
              * synthesizer runs in that daemon).
              * @type {string}
              */
-            goldenPathRouteAttributionLedgerDirProd: leaf(path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/route-attribution'), 'NEO_GOLDEN_PATH_ROUTE_ATTRIBUTION_LEDGER_DIR', 'string'),
+            goldenPathRouteAttributionLedgerDirProd: leaf(path.resolve(planeDataRoot, 'orchestrator-daemon/route-attribution'), 'NEO_GOLDEN_PATH_ROUTE_ATTRIBUTION_LEDGER_DIR', 'string'),
             /**
              * Unit-test ledger directory — under the OS temp root so test-mode emits stay off the production
              * `.neo-ai-data` path. Declarative leaf; test-mode resolved by construction via the formula below.
@@ -722,7 +733,7 @@ class ConfigBase extends ConfigProvider {
              * `nl-server-`). Per-server file isolation, single tailable directory.
              * @type {string}
              */
-            logPath: leaf(path.resolve(cwd, '.neo-ai-data/logs'), 'NEO_MEMORY_LOG_PATH', 'string'),
+            logPath: leaf(path.resolve(planeDataRoot, 'logs'), 'NEO_MEMORY_LOG_PATH', 'string'),
             /**
              * @summary Retention policy for Memory Core MCP diagnostic log files.
              *
@@ -828,7 +839,7 @@ class ConfigBase extends ConfigProvider {
              * Target file path for the lazy backfill queue of unresolved provenance edges.
              * @type {string}
              */
-            lazyEdgesQueuePath: leaf(path.resolve(cwd, '.neo-ai-data/memory-core/lazy-edges.jsonl'), 'NEO_LAZY_EDGES_QUEUE_PATH', 'string')
+            lazyEdgesQueuePath: leaf(path.resolve(planeDataRoot, 'memory-core/lazy-edges.jsonl'), 'NEO_LAZY_EDGES_QUEUE_PATH', 'string')
         },
         /**
          * Reactive computed config values (`Neo.state.Provider` formulas — recompute when a dependency changes).
@@ -856,7 +867,12 @@ class ConfigBase extends ConfigProvider {
             // The active handoff path follows the effective unit-or-Playwright storage selector.
             'handoffFilePath': data => data.storagePaths.useTestDatabase ? data.handoffFilePathTest : data.handoffFilePathProd,
             // The active route-attribution ledger dir follows the same test-storage selector.
-            'goldenPathRouteAttributionLedgerDir': data => data.storagePaths.useTestDatabase ? data.goldenPathRouteAttributionLedgerDirTest : data.goldenPathRouteAttributionLedgerDirProd
+            'goldenPathRouteAttributionLedgerDir': data => data.storagePaths.useTestDatabase ? data.goldenPathRouteAttributionLedgerDirTest : data.goldenPathRouteAttributionLedgerDirProd,
+            // Wake-daemon watermark paths: explicit override leaf when set, else derived from the
+            // RESOLVED daemon dataDir — the cascade the prior module-scope env read provided at
+            // load time, now reactive (relocating `wakeDaemon.dataDir` moves both watermarks).
+            'wakeDaemon.bridgeLastSyncIdPath'          : data => data.wakeDaemon.bridgeLastSyncIdPathOverride ?? path.join(data.wakeDaemon.dataDir, 'lastSyncId'),
+            'wakeDaemon.wakeSubscriptionLiveCursorPath': data => data.wakeDaemon.wakeSubscriptionLiveCursorPathOverride ?? path.join(data.wakeDaemon.dataDir, 'wakeSubscriptionLiveCursor')
         }
     }
 }

--- a/ai/mcp/server/memory-core/configBase.mjs
+++ b/ai/mcp/server/memory-core/configBase.mjs
@@ -876,4 +876,24 @@ class ConfigBase extends ConfigProvider {
         }
     }
 }
+
+/**
+ * @summary The plane-member paths this server claims — the enumerable input for the
+ * F-invariant's member-coherence clause (`assertPlaneMemberCoherence`), asserted at boot
+ * by `Server.getPlaneMembers()`. Prod-side leaves on purpose: test-mode formulas select
+ * disposable paths by construction and are not plane members.
+ */
+export const PLANE_MEMBER_PATHS = Object.freeze([
+    'datasets.rlaif.trajectories',
+    'remRunStateDir',
+    'memoryWal.dirProd',
+    'memoryWal.daemonDataDir',
+    'messageWal.daemonDataDir',
+    'wakeDaemon.dataDir',
+    'hookProjectionRoot',
+    'goldenPathRouteAttributionLedgerDirProd',
+    'logPath',
+    'lazyEdgesQueuePath'
+]);
+
 export default Neo.setupClass(ConfigBase);

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2719,6 +2719,18 @@ components:
           format: date-time
           description: The ISO 8601 timestamp of when the health check was performed.
           example: "2025-10-24T10:00:00.000Z"
+        plane:
+          type: object
+          description: "OBSERVED plane identity — the id/dataRoot THIS process resolved, read from the same per-server config the boot assertion verified (the deployment manifest's observed column). Always present."
+          properties:
+            id:
+              type: string
+              description: "Opaque plane identity (never a path)."
+              example: "neo-local-canonical"
+            dataRoot:
+              type: string
+              description: "Absolute durable data root this process resolved."
+          required: [id, dataRoot]
         runtimeFreshness:
           type: object
           description: "Compact boot-vs-current Memory Core MCP runtime freshness diagnostic. Stale is diagnostic metadata, not a service outage."

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -1,6 +1,7 @@
 import path                          from 'path';
 import {fileURLToPath}               from 'url';
 import AiConfig                      from '../../../config.mjs';
+import mcConfig                      from './config.mjs';
 import ToolService                   from '../../ToolService.mjs';
 import GraphqlService                from '../../../services/github-workflow/GraphqlService.mjs';
 import PullRequestHistoryService     from '../../../services/github-workflow/PullRequestHistoryService.mjs';
@@ -161,18 +162,20 @@ const serviceMapping = {
     // NOT agent-callable: a mass-destructive op does not belong on the MCP surface, and any
     // confirmation an agent can supply is not a guard. An operator path, if ever needed,
     // routes through DestructiveOperationGuard — never through tool re-exposure.
-    get_all_summaries           : SummaryService         .listSummaries           .bind(SummaryService),
-    get_community_source_health : getCommunitySourceHealth,
-    get_context_frontier        : MemoryService          .getContextFrontier      .bind(MemoryService),
-    get_neighbors               : GraphService           .getNeighbors            .bind(GraphService),
-    get_node                    : GraphService           .getNode                 .bind(GraphService),
-    get_session_memories        : MemoryService          .listMemories            .bind(MemoryService),
+    get_all_summaries          : SummaryService         .listSummaries           .bind(SummaryService),
+    get_community_source_health: getCommunitySourceHealth,
+    get_context_frontier       : MemoryService          .getContextFrontier      .bind(MemoryService),
+    get_neighbors              : GraphService           .getNeighbors            .bind(GraphService),
+    get_node                   : GraphService           .getNode                 .bind(GraphService),
+    get_session_memories       : MemoryService          .listMemories            .bind(MemoryService),
     // Health payload + the OBSERVED plane identity: a deployment manifest's desired-vs-observed
     // comparison needs each process to REPORT what it resolved — host-side re-derivation cannot
-    // populate an observed column. Read at the use site per the Provider SSOT.
+    // populate an observed column. Read from the SAME per-server config the boot assertion
+    // verified (`Server.aiConfig` === this singleton) — never a second Provider, so a custom
+    // child overlay can never verify one identity and report another.
     healthcheck                 : async args => ({
         ...await HealthService.healthcheck(args),
-        plane: {id: AiConfig.plane.id, dataRoot: AiConfig.plane.dataRoot}
+        plane: {id: mcConfig.plane.id, dataRoot: mcConfig.plane.dataRoot}
     }),
     mutate_frontier             : MemoryService          .mutateFrontier          .bind(MemoryService),
     pre_brief_session           : MemoryService          .preBriefSession         .bind(MemoryService),

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -167,7 +167,13 @@ const serviceMapping = {
     get_neighbors               : GraphService           .getNeighbors            .bind(GraphService),
     get_node                    : GraphService           .getNode                 .bind(GraphService),
     get_session_memories        : MemoryService          .listMemories            .bind(MemoryService),
-    healthcheck                 : HealthService          .healthcheck             .bind(HealthService),
+    // Health payload + the OBSERVED plane identity: a deployment manifest's desired-vs-observed
+    // comparison needs each process to REPORT what it resolved — host-side re-derivation cannot
+    // populate an observed column. Read at the use site per the Provider SSOT.
+    healthcheck                 : async args => ({
+        ...await HealthService.healthcheck(args),
+        plane: {id: AiConfig.plane.id, dataRoot: AiConfig.plane.dataRoot}
+    }),
     mutate_frontier             : MemoryService          .mutateFrontier          .bind(MemoryService),
     pre_brief_session           : MemoryService          .preBriefSession         .bind(MemoryService),
     query_hybrid_graph          : GraphService           .queryNodeTopology       .bind(GraphService),

--- a/ai/mcp/server/neural-link/configBase.mjs
+++ b/ai/mcp/server/neural-link/configBase.mjs
@@ -2,10 +2,13 @@ import os                     from 'os';
 import path                   from 'path';
 import {fileURLToPath}        from 'url';
 import ConfigProvider, {leaf} from '../../../ConfigProvider.mjs';
+import {resolvePlaneDataRoot} from '../../../planeConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../../../../');
+// The single plane-member anchor (env-free twin resolution — the leaf machinery owns env binding).
+const planeDataRoot = resolvePlaneDataRoot({env: {}, rootDir: neoRootDir});
 
 /**
  * @summary Extendable defaults and formulas for the Neural Link MCP server.
@@ -89,7 +92,7 @@ class ConfigBase extends ConfigProvider {
              * Per-server file isolation, single tailable directory.
              * @type {string}
              */
-            logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs'), 'NEO_NL_LOG_PATH', 'string'),
+            logPath: leaf(path.resolve(planeDataRoot, 'logs'), 'NEO_NL_LOG_PATH', 'string'),
             /**
              * @summary Retention policy for Neural Link MCP diagnostic log files.
              *

--- a/ai/planeConfig.mjs
+++ b/ai/planeConfig.mjs
@@ -182,6 +182,76 @@ export function assertPlaneCoherence({planeId, dataRoot, canonicalDataRoot, cano
     return Object.freeze({planeId, dataRoot})
 }
 
+/**
+ * @summary Walks a claimed plane-member path list against a RESOLVED config plus the
+ * declaring class's static descriptor data, producing `{path, resolved, default}` entries
+ * for `assertPlaneMemberCoherence`. Fails loud on any unresolvable listed path — a claimed
+ * member that cannot be walked is a contract breach, never a skip.
+ * @param {Object} options
+ * @param {String[]} options.memberPaths Dotted member paths the config base claims.
+ * @param {Object} options.resolvedConfig The resolved config (Provider proxy) to read values from.
+ * @param {Object} options.descriptorData The declaring class's static `config.data` tree.
+ * @returns {Object[]} `{path, resolved, default}` entries.
+ */
+export function collectPlaneMembers({memberPaths, resolvedConfig, descriptorData}) {
+    // Read-then-check (never the `in` operator): resolved configs are Provider PROXIES whose
+    // reads delegate to the reactive data tree without implementing a `has` trap. An
+    // undefined terminal fails loud — a claimed member that cannot be walked is a contract
+    // breach, never a skip.
+    const dig = (obj, dotted, what) => {
+        const value = dotted.split('.').reduce((node, key) => node == null ? undefined : node[key], obj);
+
+        if (value === undefined) {
+            throw new Error(`planeConfig.collectPlaneMembers: claimed member "${dotted}" is not resolvable in the ${what} tree.`);
+        }
+        return value;
+    };
+
+    return memberPaths.map(memberPath => ({
+        path    : memberPath,
+        resolved: dig(resolvedConfig, memberPath, 'resolved'),
+        default : dig(descriptorData, memberPath, 'descriptor').default
+    }))
+}
+
+/**
+ * @summary Member-coherence clause of the F-invariant: when `plane.dataRoot` resolves away
+ * from the build-time anchor (an env/profile relocation), every claimed member must either
+ * sit beneath the RESOLVED root or be EXPLICITLY placed (resolved ≠ its declared default).
+ * A partially-moved plane — root relocated, members still on their anchor defaults — is the
+ * alternate-realities defect this epic exists to remove, so it FAILS BOOT rather than
+ * silently splitting storage across two roots.
+ * Comparison is LITERAL-prefix (`path.resolve` normalization, injectable): member coherence
+ * asks whether a member's resolved string derives from the resolved root — symlink
+ * forensics (a member reaching the root through a link layer) belong to the reconcile
+ * probe, not this boot clause; mixing realpath into one side of a string-derivation
+ * comparison flags every not-yet-created member on a symlinked seat.
+ * @param {Object} options
+ * @param {String} options.dataRoot Resolved `plane.dataRoot`.
+ * @param {Object[]} options.members `{path, resolved, default}` entries from `collectPlaneMembers`.
+ * @param {Function} [options.realpathFn] Path normalizer, injectable for tests.
+ * @returns {void}
+ */
+export function assertPlaneMemberCoherence({dataRoot, members, realpathFn = path.resolve}) {
+    const rootReal = realpathFn(dataRoot);
+
+    const strays = members.filter(member => {
+        if (member.resolved !== member.default) return false;
+
+        const resolvedReal = realpathFn(member.resolved);
+        return resolvedReal !== rootReal && !resolvedReal.startsWith(rootReal + path.sep);
+    });
+
+    if (strays.length > 0) {
+        throw new Error(
+            `planeConfig.assertPlaneMemberCoherence: plane.dataRoot resolves to "${dataRoot}" but ` +
+            `${strays.length} claimed member(s) still derive from the build-time anchor ` +
+            `(${strays.map(stray => stray.path).join(', ')}) — relocating the plane requires per-member ` +
+            'placement (member env bindings / the per-profile election); a partially-moved plane fails closed.'
+        );
+    }
+}
+
 // Module-load invariant: the twin is literals + env NAMES only — the frozen default must
 // satisfy the same opacity predicate every resolved value passes through. Fail at load,
 // not at review.

--- a/ai/planeConfig.mjs
+++ b/ai/planeConfig.mjs
@@ -8,7 +8,10 @@ import path from 'node:path';
  * Non-entrypoints (host CLI scripts, per-harness-family hook writers, host daemons) must not
  * import Neo singletons. This module carries the SAME env-var names and default literals the leaf
  * subtree declares — and the leaf subtree imports THESE constants as its declaration source, so
- * leaf↔twin drift is impossible by construction (the pairing test pins only resolver semantics).
+ * leaf↔twin drift is impossible by construction. The resolver semantics are equivalent to the
+ * leaf's env layer by construction too (for strings, truthiness and the provider's emptiness
+ * partition identically — `''` is the only falsy string), so the pairing test pins that
+ * equivalence rather than guarding a live drift channel.
  *
  * The three concepts this plane API never conflates:
  * - **identity** — the opaque `planeId` (never a path, never checkout-shaped: a checkout-shaped
@@ -37,14 +40,59 @@ export const PLANE_DEFAULTS = Object.freeze({
 });
 
 /**
- * @summary Resolves the plane identity without importing Neo singletons.
+ * @summary The opacity predicate for plane identities — ONE rule covering the frozen default
+ * (module-load guard below) and every RESOLVED value, env overrides included. A path- or
+ * checkout-shaped planeId silently pre-decides the data-root placement election, so opacity
+ * must hold on the values that vary, not only on the literal that cannot.
+ * @param {*} value
+ * @returns {Boolean}
+ */
+export function isOpaquePlaneId(value) {
+    return typeof value === 'string' && value.length > 0 &&
+        !value.includes('/') && !value.includes('\\') &&
+        !value.includes(PLANE_DEFAULTS.dataRootRelative)
+}
+
+/**
+ * @summary Env-layer parser for the `plane.id` leaf — the leaf reaches the SAME opacity
+ * predicate the twin's resolver enforces (mirrors the `parseMemorySharingPolicy` descriptor
+ * precedent: absent/empty env → `undefined`, so the declared default applies).
+ * @param {String} envVarName
+ * @param {Object} [options]
+ * @param {Object} [options.env=process.env] Environment source.
+ * @returns {String|undefined}
+ */
+export function parsePlaneIdEnv(envVarName, {env = process.env} = {}) {
+    const rawValue = env[envVarName];
+    if (rawValue === undefined || rawValue === null || rawValue === '') return;
+    if (!isOpaquePlaneId(rawValue)) {
+        throw new Error(
+            `planeConfig: ${envVarName}="${rawValue}" is not an opaque planeId — ` +
+            'no path separators or data-dir content; a path-shaped identity would pre-decide the placement election.'
+        );
+    }
+    return rawValue
+}
+
+/**
+ * @summary Resolves the plane identity without importing Neo singletons. The RESOLVED value
+ * (override or default) must satisfy the opacity invariant — fail loud, never propagate a
+ * path-shaped identity.
  * @param {Object} [options]
  * @param {Object} [options.env=process.env] Environment source.
  * @returns {String}
  */
 export function resolvePlaneId({env = process.env} = {}) {
     const override = env[PLANE_ENV.planeId];
-    return override ? override : PLANE_DEFAULTS.planeId
+    const resolved = override ? override : PLANE_DEFAULTS.planeId;
+
+    if (!isOpaquePlaneId(resolved)) {
+        throw new Error(
+            `planeConfig.resolvePlaneId: "${resolved}" is not an opaque planeId — ` +
+            'no path separators or data-dir content; a path-shaped identity would pre-decide the placement election.'
+        );
+    }
+    return resolved
 }
 
 /**
@@ -71,9 +119,9 @@ export function resolvePlaneDataRoot({env = process.env, rootDir} = {}) {
     return path.resolve(rootDir, PLANE_DEFAULTS.dataRootRelative)
 }
 
-// Module-load invariant: the twin is literals + env NAMES only. A path-shaped or
-// checkout-shaped planeId default would silently pre-decide the data-root placement
-// election — fail at load, not at review.
-if (PLANE_DEFAULTS.planeId.includes('/') || PLANE_DEFAULTS.planeId.includes(path.sep)) {
+// Module-load invariant: the twin is literals + env NAMES only — the frozen default must
+// satisfy the same opacity predicate every resolved value passes through. Fail at load,
+// not at review.
+if (!isOpaquePlaneId(PLANE_DEFAULTS.planeId)) {
     throw new Error('planeConfig: PLANE_DEFAULTS.planeId must stay opaque — no path content.');
 }

--- a/ai/planeConfig.mjs
+++ b/ai/planeConfig.mjs
@@ -1,0 +1,79 @@
+import path from 'node:path';
+
+/**
+ * @summary The plane-identity pure-defaults twin — the sanctioned non-entrypoint companion
+ * (ticket-ref-ok: ADR 0019 §5.5 names this exact module shape) to the `plane` leaf subtree
+ * in `ai/configBase.mjs`.
+ *
+ * Non-entrypoints (host CLI scripts, per-harness-family hook writers, host daemons) must not
+ * import Neo singletons. This module carries the SAME env-var names and default literals the leaf
+ * subtree declares — and the leaf subtree imports THESE constants as its declaration source, so
+ * leaf↔twin drift is impossible by construction (the pairing test pins only resolver semantics).
+ *
+ * The three concepts this plane API never conflates:
+ * - **identity** — the opaque `planeId` (never a path, never checkout-shaped: a checkout-shaped
+ *   identity would silently pre-decide the data-root placement election);
+ * - **resolved evidence** — the `dataRoot` a process actually resolved at runtime;
+ * - **checkout root** — `NEO_AI_CANONICAL_ROOT`, which names a checkout for provisioning-time
+ *   hydration (`bootstrapWorktree.mjs`) and is explicitly NOT the plane identity.
+ */
+export const PLANE_ENV = Object.freeze({
+    dataRoot: 'NEO_PLANE_DATA_ROOT',
+    planeId : 'NEO_PLANE_ID'
+});
+
+export const PLANE_DEFAULTS = Object.freeze({
+    /**
+     * Relative to the injected root; the leaf side resolves it against `neoRootDir`,
+     * non-entrypoint consumers inject their own discovered root.
+     */
+    dataRootRelative: '.neo-ai-data',
+    /**
+     * The institution's canonical local plane. Overlays, cloud deployments, and ephemeral
+     * isolation planes override via env — a stable literal, deliberately carrying no
+     * path or checkout content.
+     */
+    planeId: 'neo-local-canonical'
+});
+
+/**
+ * @summary Resolves the plane identity without importing Neo singletons.
+ * @param {Object} [options]
+ * @param {Object} [options.env=process.env] Environment source.
+ * @returns {String}
+ */
+export function resolvePlaneId({env = process.env} = {}) {
+    const override = env[PLANE_ENV.planeId];
+    return override ? override : PLANE_DEFAULTS.planeId
+}
+
+/**
+ * @summary Resolves the plane data root without importing Neo singletons.
+ * @param {Object} options
+ * @param {Object} [options.env=process.env] Environment source.
+ * @param {String} options.rootDir Discovered repository / deployment root the relative default anchors on.
+ * @returns {String}
+ */
+export function resolvePlaneDataRoot({env = process.env, rootDir} = {}) {
+    const override = env[PLANE_ENV.dataRoot];
+
+    if (override) {
+        return override
+    }
+
+    if (!rootDir) {
+        throw new Error(
+            `planeConfig.resolvePlaneDataRoot: rootDir is required when ${PLANE_ENV.dataRoot} is unset — ` +
+            'a non-entrypoint consumer must inject its discovered root rather than trusting ambient cwd.'
+        );
+    }
+
+    return path.resolve(rootDir, PLANE_DEFAULTS.dataRootRelative)
+}
+
+// Module-load invariant: the twin is literals + env NAMES only. A path-shaped or
+// checkout-shaped planeId default would silently pre-decide the data-root placement
+// election — fail at load, not at review.
+if (PLANE_DEFAULTS.planeId.includes('/') || PLANE_DEFAULTS.planeId.includes(path.sep)) {
+    throw new Error('planeConfig: PLANE_DEFAULTS.planeId must stay opaque — no path content.');
+}

--- a/ai/planeConfig.mjs
+++ b/ai/planeConfig.mjs
@@ -1,3 +1,4 @@
+import fs   from 'node:fs';
 import path from 'node:path';
 
 /**
@@ -117,6 +118,68 @@ export function resolvePlaneDataRoot({env = process.env, rootDir} = {}) {
     }
 
     return path.resolve(rootDir, PLANE_DEFAULTS.dataRootRelative)
+}
+
+/**
+ * @summary Symlink-transparent path identity: real path when the target exists, plain
+ * resolution when it does not (a not-yet-created root cannot be the durable root).
+ * @param {String} p
+ * @returns {String}
+ */
+function realpathOrResolve(p) {
+    try {
+        return fs.realpathSync(p)
+    } catch {
+        return path.resolve(p)
+    }
+}
+
+/**
+ * @summary The F-invariant boot assertion — a declared plane's resolved values must be
+ * internally consistent, and an isolated overlay must FAIL CLOSED if it can resolve the
+ * durable root (including through a symlink layer — the reconcile probe's escape class).
+ *
+ * Three clauses, in order:
+ * 1. `planeId` must be opaque — this closes the custom-config-file route the leaf's
+ *    env parser never sees.
+ * 2. `dataRoot` must be absolute — a relative root re-imports ambient-cwd resolution.
+ * 3. A NON-canonical `planeId` (a declared overlay) must not resolve — symlink-transparently —
+ *    to the canonical durable root: identity-without-isolation would mutate the durable plane.
+ *
+ * Pure and injectable (no Neo import): entrypoints assert provider-resolved values;
+ * non-entrypoints may assert twin-resolved values.
+ * @param {Object} options
+ * @param {String} options.planeId Resolved plane identity.
+ * @param {String} options.dataRoot Resolved plane data root.
+ * @param {String} [options.canonicalDataRoot] The durable root reference; clause 3 only runs when provided.
+ * @param {String} [options.canonicalPlaneId] Canonical identity; defaults to the twin literal.
+ * @param {Function} [options.realpathFn] Path-identity resolver, injectable for tests.
+ * @returns {Object} Frozen observed identity `{planeId, dataRoot}` for emission consumers.
+ */
+export function assertPlaneCoherence({planeId, dataRoot, canonicalDataRoot, canonicalPlaneId = PLANE_DEFAULTS.planeId, realpathFn = realpathOrResolve}) {
+    if (!isOpaquePlaneId(planeId)) {
+        throw new Error(
+            `planeConfig.assertPlaneCoherence: planeId "${planeId}" is not opaque — ` +
+            'no path separators or data-dir content; a path-shaped identity would pre-decide the placement election.'
+        );
+    }
+
+    if (typeof dataRoot !== 'string' || !path.isAbsolute(dataRoot)) {
+        throw new Error(
+            `planeConfig.assertPlaneCoherence: dataRoot "${dataRoot}" must be absolute — ` +
+            'a relative plane root re-imports the ambient-cwd resolution this contract retires.'
+        );
+    }
+
+    if (planeId !== canonicalPlaneId && canonicalDataRoot &&
+        realpathFn(dataRoot) === realpathFn(canonicalDataRoot)) {
+        throw new Error(
+            `planeConfig.assertPlaneCoherence: plane "${planeId}" resolves the durable root "${canonicalDataRoot}" — ` +
+            'an isolated overlay must fail closed rather than mutate the durable plane (identity without isolation).'
+        );
+    }
+
+    return Object.freeze({planeId, dataRoot})
 }
 
 // Module-load invariant: the twin is literals + env NAMES only — the frozen default must

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -249,6 +249,9 @@
         "orchestrator.wakeDispatch.coalesceWindowSeconds",
         "orchestrator.wakeDispatch.flushHardCapSeconds",
         "orchestrator.wakeDispatch.flushRefractorySeconds",
+        "plane",
+        "plane.dataRoot",
+        "plane.id",
         "projectRoot",
         "publicUrl",
         "temporalSummary",
@@ -498,9 +501,9 @@
         "turnPresence.ttlMs",
         "undigestedSessionFreshReserve",
         "wakeDaemon",
-        "wakeDaemon.bridgeLastSyncIdPath",
+        "wakeDaemon.bridgeLastSyncIdPathOverride",
         "wakeDaemon.dataDir",
-        "wakeDaemon.wakeSubscriptionLiveCursorPath"
+        "wakeDaemon.wakeSubscriptionLiveCursorPathOverride"
     ],
     "ai/mcp/server/neural-link/config.template.mjs": [
         "autoConnect",

--- a/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
+++ b/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
@@ -149,16 +149,17 @@ A3 bans resolution helpers that duplicate the leaf's env-binding *for consumers 
 
 ### 10.4 The F-invariant boot assertion
 
-`assertPlaneCoherence` (twin-side, pure, injectable): resolved `planeId` must be opaque; resolved `dataRoot` must be absolute (a relative root re-imports ambient-cwd resolution); and a NON-canonical `planeId` — a declared overlay — must not resolve, **symlink-transparently**, to the canonical durable root: identity-without-isolation would mutate the durable plane (the reconcile probe's symlink-escape class). Wired at the head of `BaseServer.runHealthcheckAndLogStatus()` — the building block every boot order calls after config load, so custom `boot()` overrides inherit it. ADR 0014's wake-lane file-freshness premise rides on plane-member paths being exactly where the declared plane says they are; this assertion is what makes that premise checkable per process.
+`assertPlaneCoherence` (twin-side, pure, injectable): resolved `planeId` must be opaque; resolved `dataRoot` must be absolute (a relative root re-imports ambient-cwd resolution); and a NON-canonical `planeId` — a declared overlay — must not resolve, **symlink-transparently**, to the canonical durable root: identity-without-isolation would mutate the durable plane (the reconcile probe's symlink-escape class). The **member-coherence clause** (`assertPlaneMemberCoherence`, §10.5) extends the invariant to the member set: a declared member server walks its claimed `PLANE_MEMBER_PATHS` at the same boot point. Wired at the head of `BaseServer.runHealthcheckAndLogStatus()` — the building block every boot order calls after config load, so custom `boot()` overrides inherit it. ADR 0014's wake-lane file-freshness premise rides on plane-member paths being exactly where the declared plane says they are; this assertion is what makes that premise checkable per process.
 
-### 10.5 Member derivation: the A9/A2 decision rule
+### 10.5 Member derivation: the A9/A2 decision rule + enforced coherence
 
-Plane-member leaf defaults derive from ONE module-scope anchor (`resolvePlaneDataRoot({env: {}, rootDir: neoRootDir})` — **env-free** twin resolution; the leaf machinery owns all env binding, so the anchor computation is not an inline env read). Two shapes, chosen by what the parent is:
+Plane-member leaf defaults derive from ONE module-scope anchor (`resolvePlaneDataRoot({env: {}, rootDir: neoRootDir})` — **env-free** twin resolution; the leaf machinery owns all env binding, so the anchor computation is not an inline env read). Because `plane.dataRoot` is itself env-relocatable while member DEFAULTS are anchor-static, the derivation rule alone cannot guarantee coherence on the relocation branch — so the contract is derivation **plus enforcement**:
 
-- **Path under a STATIC root → static derivation** (A9): `leaf(path.resolve(planeDataRoot, 'sub'), ENV, 'string')`.
-- **Child of a RELOCATABLE parent leaf → formula** (the A2 remedy): the child is genuinely computed from the parent's RESOLVED value — an explicit `*Override` leaf wins, else derive from the resolved parent, so relocating the parent moves its children (the `wakeDaemon` watermark shape).
+- **Member defaults → static derivation from the anchor** (A9): `leaf(path.resolve(planeDataRoot, 'sub'), ENV, 'string')` — one source, no per-leaf re-derivation.
+- **Enforced coherence at boot** (the member-coherence clause): each member config base exports its claimed `PLANE_MEMBER_PATHS`; at boot, every claimed member must resolve **beneath the RESOLVED `plane.dataRoot`** or be **explicitly placed** (resolved ≠ its declared default). Setting `NEO_PLANE_DATA_ROOT` alone — a relocated root with members still on their anchor defaults — is a partially-moved plane and **fails boot**: relocation is per-member placement work (member env bindings / the per-profile election), never an implicit cascade.
+- **Child of a RELOCATABLE parent leaf → formula** (the A2 remedy): a child *within* the plane whose parent leaf is itself relocatable is genuinely computed from the parent's RESOLVED value — an explicit `*Override` leaf wins, else derive from the resolved parent, so relocating the parent moves its children (the `wakeDaemon` watermark shape).
 
-Per-profile-pinned members (e.g. a cloud-only default naming the cloud plane root) stay explicit rather than force-anchored; the placement election owns per-profile unification.
+Per-profile-pinned members (e.g. a cloud-only default naming the cloud plane root) stay explicit rather than force-anchored; the placement election owns per-profile unification and the member-set completeness audit.
 
 ### 10.6 Observed identity — resolvable is not observable
 

--- a/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
+++ b/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
@@ -94,7 +94,7 @@ aiConfig.engines.chroma.database = `graph-service-test-${process.pid}-${Date.now
 4. **Tests isolate by construction** (`UNIT_TEST_MODE` → the config resolves the test DB). Never mutate the shared singleton (B4).
 5. **The C1×B5 sanctioned shape** (V-B-A'd against `dev` — most "daemon C1" sites are actually A1):
    - **Entrypoints (incl. the `ai/` daemons) import `AiConfig` and read at the use site.** The daemons already `import Neo`/`_export`/`AiConfig` and work — so a daemon re-deriving a path is **A1, not C1**. Fix: read `AiConfig.X.Y` directly.
-   - **Genuine non-entrypoint helpers** (e.g. `TaskDefinitions.mjs` — imported by the orchestrator entrypoint, with no Neo import of its own): a **pure-defaults module** — literals + env-var *names* only, **no Neo import** — carrying the same defaults the leaves declare. This is the one true C1×B5 locus.
+   - **Genuine non-entrypoint helpers** (e.g. `TaskDefinitions.mjs` — imported by the orchestrator entrypoint, with no Neo import of its own): a **pure-defaults module** — literals + env-var *names* only, **no Neo import** — carrying the same defaults the leaves declare. This is the one true C1×B5 locus. *(Amended — see §10.1: the prescribed pairing is now INVERTED — the leaf declares FROM the twin, so the "same defaults" are one literal, not two synchronized copies.)*
    - An **entrypoint-injected value object** is acceptable *only* at a narrow, explicitly-named bootstrap boundary — not license for generic pass-along plumbing. Do **not** add a read-only accessor unless it stays pure / no-Neo-import.
    - *(Folds @neo-opus-4-7's bootstrap-weight reframe: the question was never "can it import?" — the daemons prove it can — but "should a frequent lightweight helper pay full-framework bootstrap weight to read a path?")*
 6. **Overlay = thin child of deltas** over the canonical template; never parse/splice config source to reconcile (deep-merge inheritance handles it).
@@ -126,6 +126,45 @@ Before authoring or reviewing any `ai/` config work, you MUST:
 - **ADR 0005** (ADR-at-graduation), **ADR 0007** (compaction taxonomy).
 - `ai/ConfigProvider.mjs`, `src/state/Provider.mjs`, `src/state/createHierarchicalDataProxy.mjs` — the primitive.
 - `learn/agentos/AiConfigModel.md` — the **public configuration-model guide** (docs-reader audience). This ADR is the **maintainer-facing complement** (antipattern catalog + safety-critical danger + read-gate); the two cross-reference and neither replaces the other.
+
+## 10. Amendment — the plane-identity paired artifact (2026-07-24, #15799 / PR #15811)
+
+*Drafted by @neo-fable-clio under the ticket's amendment mandate (`Decision Record: amends ADR 0019`); falsification seat: the ADR author, whose PR-review `[RETROSPECTIVE]` endorsed the §10.1 inversion. Exemplar: `ai/planeConfig.mjs` (twin) + the `plane` subtree in `ai/configBase.mjs` (leaf).*
+
+### 10.1 Constructive pairing supersedes copy-pairing in §5.5
+
+§5.5 as originally written sanctions a pure-defaults twin *carrying the same defaults the leaves declare* — two synchronized copies with a test as the only drift guard. The prescribed shape is now the **inversion**: the twin is the leaf declarations' literal SOURCE — `leaf(PLANE_DEFAULTS.x, PLANE_ENV.x, 'string')` — so literal drift is impossible **by construction**, and the pairing test narrows to resolver semantics (themselves equivalent by construction for string leaves: truthiness and the provider's emptiness check partition identically — `''` is the only falsy string). Test-enforced consistency is the fallback shape, not the pattern.
+
+### 10.2 The twin's resolvers are not A3
+
+A3 bans resolution helpers that duplicate the leaf's env-binding *for consumers that have the Provider in scope*. The twin's pure resolvers serve **non-entrypoints** — consumers with no Provider to defer to (the §5.5 C1 locus) — and the LEAF consumes the twin, never the reverse. The A3 test is **direction + audience**: a helper the leaf declares FROM, serving no-Neo consumers, is sanctioned; a helper an entrypoint calls INSTEAD of reading the leaf is A3. Entrypoint-side code still reads `AiConfig.plane.*` at the use site. (Precedent: `resolveMemoryCoreGraphPath` — the same sanctioned twin shape, predating this amendment.)
+
+### 10.3 Plane identity: three concepts, never conflated
+
+- **Identity** — `plane.id`: a stable OPAQUE string; `planeId` equality is the only sanctioned "same plane?" predicate, never path comparison. Opacity is enforced on **resolved values** by one predicate (`isOpaquePlaneId`) behind three surfaces — the twin's module-load guard, `resolvePlaneId`, and the leaf's `parse` (env layer) — with the boot assertion (§10.4) closing the fourth route: a custom config file the env parser never sees. A guard that covers only the frozen default protects the one value that cannot vary.
+- **Resolved evidence** — `plane.dataRoot`: the durable root THIS process resolved; the single anchor every plane-member leaf default derives from (§10.5).
+- **Checkout root** — `NEO_AI_CANONICAL_ROOT` names a checkout for provisioning-time hydration (`bootstrapWorktree.mjs`) and is deliberately NOT plane identity: a checkout-shaped identity would silently pre-decide the data-root placement election.
+
+**Provisioning disposition:** the planeId is *declared by the deployment layer* (env → leaf, stable literal default). Both alternative branches are rejected: persisting it inside the plane is circular (the plane must be resolved to read the id whose purpose is making that resolution deterministic), and deriving it from path/checkout content re-imports the defect the opaque form exists to prevent.
+
+### 10.4 The F-invariant boot assertion
+
+`assertPlaneCoherence` (twin-side, pure, injectable): resolved `planeId` must be opaque; resolved `dataRoot` must be absolute (a relative root re-imports ambient-cwd resolution); and a NON-canonical `planeId` — a declared overlay — must not resolve, **symlink-transparently**, to the canonical durable root: identity-without-isolation would mutate the durable plane (the reconcile probe's symlink-escape class). Wired at the head of `BaseServer.runHealthcheckAndLogStatus()` — the building block every boot order calls after config load, so custom `boot()` overrides inherit it. ADR 0014's wake-lane file-freshness premise rides on plane-member paths being exactly where the declared plane says they are; this assertion is what makes that premise checkable per process.
+
+### 10.5 Member derivation: the A9/A2 decision rule
+
+Plane-member leaf defaults derive from ONE module-scope anchor (`resolvePlaneDataRoot({env: {}, rootDir: neoRootDir})` — **env-free** twin resolution; the leaf machinery owns all env binding, so the anchor computation is not an inline env read). Two shapes, chosen by what the parent is:
+
+- **Path under a STATIC root → static derivation** (A9): `leaf(path.resolve(planeDataRoot, 'sub'), ENV, 'string')`.
+- **Child of a RELOCATABLE parent leaf → formula** (the A2 remedy): the child is genuinely computed from the parent's RESOLVED value — an explicit `*Override` leaf wins, else derive from the resolved parent, so relocating the parent moves its children (the `wakeDaemon` watermark shape).
+
+Per-profile-pinned members (e.g. a cloud-only default naming the cloud plane root) stay explicit rather than force-anchored; the placement election owns per-profile unification.
+
+### 10.6 Observed identity — resolvable is not observable
+
+A deployment manifest compares desired vs OBSERVED per service, so each process REPORTS its resolved `{plane.id, plane.dataRoot}` on its healthcheck payload (a tool-layer spread reading the SSOT at the use site). Host-side re-derivation cannot populate an observed column — it degrades the comparison to desired-vs-desired, which passes trivially and detects nothing.
+
+---
 
 Origin Session ID: `3ecb40bf-bfef-40b1-8693-a8aae5afa1b7`
 

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -15,6 +15,8 @@ setup({
 
 import {test, expect}                                  from '@playwright/test';
 import {CallToolRequestSchema, ListToolsRequestSchema} from '@modelcontextprotocol/sdk/types.js';
+import os                                              from 'node:os';
+import path                                            from 'node:path';
 import Neo                                             from '../../../../../../src/Neo.mjs';
 import * as core                                       from '../../../../../../src/core/_export.mjs';
 import BaseServer                                      from '../../../../../../ai/mcp/server/BaseServer.mjs';
@@ -762,5 +764,56 @@ test.describe('Neo.ai.mcp.server.BaseServer — initAsync canonical sequence', (
 
         await server.loadCustomConfig();
         expect(loadedFrom).toBe('/tmp/custom-config.mjs');
+    });
+});
+
+/**
+ * @summary Local builder for the plane-member boundary tests — the `BareServer` isolation
+ * precedent (no-op `initAsync`, so creation never races the assertion under test).
+ */
+function makeBoundaryServerClass({member}) {
+    const id = ++_testClassCounter;
+    class BoundarySrv extends BaseServer {
+        static config = {className: `Neo.test.mcp.server.BoundarySrv${id}`}
+        // Isolated unit test — skip the boot lifecycle so each test drives the assertion directly.
+        async initAsync() { /* no-op */ }
+        getServerMetadata() { return {name: 'boundary-test'}; }
+        getToolService()    { return {listTools: () => ({tools: []}), callTool: async () => ({})}; }
+        isPlaneMember()     { return member; }
+    }
+    return Neo.setupClass(BoundarySrv);
+}
+
+test.describe('Neo.ai.mcp.server.BaseServer — plane-member boundary (#15799)', () => {
+    test('membership defaults to false — API-bridge servers and fixtures carry no plane by contract', () => {
+        const server = Neo.create(makeTestServerClass());
+
+        // A truthy per-server config WITHOUT a plane subtree: the exact shape that must
+        // skip, never throw (the gitlab-workflow smoke-fixture regression class).
+        server.aiConfig = {transport: 'stdio'};
+
+        expect(server.isPlaneMember()).toBe(false);
+        expect(server.assertPlaneIdentity()).toBeNull();
+    });
+
+    test('a declared member without aiConfig fails loud', () => {
+        const server = Neo.create(makeBoundaryServerClass({member: true}));
+
+        expect(() => server.assertPlaneIdentity()).toThrow('without aiConfig');
+    });
+
+    test('a declared member whose config resolves no plane subtree fails loud', () => {
+        const server = Neo.create(makeBoundaryServerClass({member: true}));
+        server.aiConfig = {transport: 'stdio'};
+
+        expect(() => server.assertPlaneIdentity()).toThrow('plane');
+    });
+
+    test('a declared member with a coherent plane returns the observed identity', () => {
+        const server = Neo.create(makeBoundaryServerClass({member: true}));
+        server.aiConfig = {plane: {id: 'overlay-boundary-spec', dataRoot: path.join(os.tmpdir(), 'neo-plane-boundary-spec')}};
+
+        const observed = server.assertPlaneIdentity();
+        expect(observed.planeId).toBe('overlay-boundary-spec');
     });
 });

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -771,7 +771,7 @@ test.describe('Neo.ai.mcp.server.BaseServer — initAsync canonical sequence', (
  * @summary Local builder for the plane-member boundary tests — the `BareServer` isolation
  * precedent (no-op `initAsync`, so creation never races the assertion under test).
  */
-function makeBoundaryServerClass({member}) {
+function makeBoundaryServerClass({member, members = []}) {
     const id = ++_testClassCounter;
     class BoundarySrv extends BaseServer {
         static config = {className: `Neo.test.mcp.server.BoundarySrv${id}`}
@@ -780,6 +780,7 @@ function makeBoundaryServerClass({member}) {
         getServerMetadata() { return {name: 'boundary-test'}; }
         getToolService()    { return {listTools: () => ({tools: []}), callTool: async () => ({})}; }
         isPlaneMember()     { return member; }
+        getPlaneMembers()   { return members; }
     }
     return Neo.setupClass(BoundarySrv);
 }
@@ -812,6 +813,32 @@ test.describe('Neo.ai.mcp.server.BaseServer — plane-member boundary (#15799)',
     test('a declared member with a coherent plane returns the observed identity', () => {
         const server = Neo.create(makeBoundaryServerClass({member: true}));
         server.aiConfig = {plane: {id: 'overlay-boundary-spec', dataRoot: path.join(os.tmpdir(), 'neo-plane-boundary-spec')}};
+
+        const observed = server.assertPlaneIdentity();
+        expect(observed.planeId).toBe('overlay-boundary-spec');
+    });
+
+    test('member-coherence clause: a relocated root with anchor-default members fails boot', () => {
+        const relocatedRoot = path.join(os.tmpdir(), 'neo-plane-relocated-spec');
+        const anchorPath    = path.join(os.tmpdir(), 'neo-plane-old-anchor', 'logs');
+        const server        = Neo.create(makeBoundaryServerClass({
+            member : true,
+            members: [{path: 'logPath', resolved: anchorPath, default: anchorPath}]
+        }));
+
+        server.aiConfig = {plane: {id: 'overlay-boundary-spec', dataRoot: relocatedRoot}};
+
+        expect(() => server.assertPlaneIdentity()).toThrow('fails closed');
+    });
+
+    test('member-coherence clause: explicitly placed members boot clean', () => {
+        const relocatedRoot = path.join(os.tmpdir(), 'neo-plane-relocated-spec');
+        const server        = Neo.create(makeBoundaryServerClass({
+            member : true,
+            members: [{path: 'logPath', resolved: '/vol/logs', default: path.join(os.tmpdir(), 'neo-plane-old-anchor', 'logs')}]
+        }));
+
+        server.aiConfig = {plane: {id: 'overlay-boundary-spec', dataRoot: relocatedRoot}};
 
         const observed = server.assertPlaneIdentity();
         expect(observed.planeId).toBe('overlay-boundary-spec');

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -19,6 +19,8 @@ import os                                              from 'node:os';
 import path                                            from 'node:path';
 import Neo                                             from '../../../../../../src/Neo.mjs';
 import * as core                                       from '../../../../../../src/core/_export.mjs';
+import ConfigProvider, {createConfigProxy}             from '../../../../../../ai/ConfigProvider.mjs';
+import Tier1ConfigBase                                 from '../../../../../../ai/configBase.mjs';
 import BaseServer                                      from '../../../../../../ai/mcp/server/BaseServer.mjs';
 
 /**
@@ -771,7 +773,7 @@ test.describe('Neo.ai.mcp.server.BaseServer — initAsync canonical sequence', (
  * @summary Local builder for the plane-member boundary tests — the `BareServer` isolation
  * precedent (no-op `initAsync`, so creation never races the assertion under test).
  */
-function makeBoundaryServerClass({member, members = []}) {
+function makeBoundaryServerClass({member, members = [], composed = false}) {
     const id = ++_testClassCounter;
     class BoundarySrv extends BaseServer {
         static config = {className: `Neo.test.mcp.server.BoundarySrv${id}`}
@@ -780,7 +782,10 @@ function makeBoundaryServerClass({member, members = []}) {
         getServerMetadata() { return {name: 'boundary-test'}; }
         getToolService()    { return {listTools: () => ({tools: []}), callTool: async () => ({})}; }
         isPlaneMember()     { return member; }
-        getPlaneMembers()   { return members; }
+
+        getPlaneMembers() {
+            return composed ? this.collectMemberEntries({localPaths: [], localDescriptorData: {}}) : members;
+        }
     }
     return Neo.setupClass(BoundarySrv);
 }
@@ -842,5 +847,49 @@ test.describe('Neo.ai.mcp.server.BaseServer — plane-member boundary (#15799)',
 
         const observed = server.assertPlaneIdentity();
         expect(observed.planeId).toBe('overlay-boundary-spec');
+    });
+
+    test('the COMPLETE plane: composed Tier-1 claims fail a relocated boot, naming the strays', () => {
+        // The re-review falsifier: a member server asserting only its LOCAL list would pass
+        // while the inherited Tier-1 members it consumes stay on the old anchor. The
+        // composition makes that bypass impossible.
+        process.env.NEO_PLANE_DATA_ROOT = path.join(os.tmpdir(), 'neo-relocated-composed-spec');
+
+        try {
+            const isolated = createConfigProxy(Neo.create(ConfigProvider, {
+                data    : Tier1ConfigBase.config.data,
+                formulas: Tier1ConfigBase.config.formulas
+            }));
+
+            try {
+                const server = Neo.create(makeBoundaryServerClass({member: true, composed: true}));
+                server.aiConfig = isolated;
+
+                expect(() => server.assertPlaneIdentity()).toThrow('backupPath');
+            } finally {
+                isolated.destroy()
+            }
+        } finally {
+            delete process.env.NEO_PLANE_DATA_ROOT
+        }
+    });
+
+    test('the COMPLETE plane: composition passes on an un-relocated Tier-1 provider', () => {
+        const isolated = createConfigProxy(Neo.create(ConfigProvider, {
+            data    : Tier1ConfigBase.config.data,
+            formulas: Tier1ConfigBase.config.formulas
+        }));
+
+        try {
+            const server = Neo.create(makeBoundaryServerClass({member: true, composed: true}));
+            server.aiConfig = isolated;
+
+            expect(server.getPlaneMembers().length).toBe(9);
+
+            const observed = server.assertPlaneIdentity();
+            expect(observed.planeId).toBe('neo-local-canonical');
+        } finally {
+            isolated.destroy()
+        }
     });
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -178,7 +178,10 @@ test.describe('Memory Core Config (#10010)', () => {
         process.env.NEO_BRIDGE_LAST_SYNC_ID_PATH = '/tmp/neo-bridge-last-sync-id';
         process.env.NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE = '/tmp/neo-wake-live-cursor';
 
-        const freshCfg = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+        // The watermark paths consumers read are FORMULAS deriving from the resolved
+        // `wakeDaemon.dataDir` (explicit `*Override` leaves carry these env bindings), so the
+        // isolated instance needs the formulas too — the Tier-1 `createIsolatedConfig` shape.
+        const freshCfg = createConfigProxy(Neo.create(ConfigProvider, {data: config._data, formulas: config._formulas}));
 
         try {
             expect(freshCfg.wakeDaemon.bridgeLastSyncIdPath).toBe('/tmp/neo-bridge-last-sync-id');

--- a/test/playwright/unit/ai/planeConfig.spec.mjs
+++ b/test/playwright/unit/ai/planeConfig.spec.mjs
@@ -1,10 +1,13 @@
 import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
 import path           from 'node:path';
 import Neo            from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
 import {
     PLANE_DEFAULTS,
     PLANE_ENV,
+    assertPlaneCoherence,
     isOpaquePlaneId,
     parsePlaneIdEnv,
     resolvePlaneDataRoot,
@@ -175,6 +178,68 @@ test.describe('plane-member derivation witnesses — #15791 seat-variance ground
 
         expect(KbConfigBase.config.data.logPath.default).toBe(path.resolve(anchor, 'logs'));
         expect(NlConfigBase.config.data.logPath.default).toBe(path.resolve(anchor, 'logs'))
+    });
+});
+
+test.describe('assertPlaneCoherence — the F-invariant, both branches', () => {
+    const canonical = '/durable/checkout/.neo-ai-data';
+
+    test('standard boot: canonical identity passes and returns the frozen observed identity', () => {
+        const observed = assertPlaneCoherence({planeId: PLANE_DEFAULTS.planeId, dataRoot: canonical, canonicalDataRoot: canonical});
+
+        expect(observed).toEqual({planeId: PLANE_DEFAULTS.planeId, dataRoot: canonical});
+        expect(Object.isFrozen(observed)).toBe(true)
+    });
+
+    test('isolated overlay with its OWN root boots', () => {
+        expect(assertPlaneCoherence({
+            planeId          : 'overlay-plane-a',
+            dataRoot         : '/tmp/overlay-a/.neo-ai-data',
+            canonicalDataRoot: canonical
+        }).planeId).toBe('overlay-plane-a')
+    });
+
+    test('overlay that resolves the durable root fails closed', () => {
+        expect(() => assertPlaneCoherence({
+            planeId          : 'overlay-plane-a',
+            dataRoot         : canonical,
+            canonicalDataRoot: canonical
+        })).toThrow('durable root')
+    });
+
+    test('overlay reaching the durable root THROUGH A SYMLINK fails closed — the symlink-escape class', () => {
+        const base    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-plane-f-'));
+        const durable = path.join(base, 'durable-root');
+        const link    = path.join(base, 'overlay-link');
+
+        fs.mkdirSync(durable);
+        fs.symlinkSync(durable, link);
+
+        try {
+            expect(() => assertPlaneCoherence({
+                planeId          : 'overlay-plane-a',
+                dataRoot         : link,
+                canonicalDataRoot: durable
+            })).toThrow('durable root')
+        } finally {
+            fs.rmSync(base, {recursive: true, force: true})
+        }
+    });
+
+    test('a relative dataRoot fails the internal-consistency clause', () => {
+        expect(() => assertPlaneCoherence({
+            planeId          : PLANE_DEFAULTS.planeId,
+            dataRoot         : '.neo-ai-data',
+            canonicalDataRoot: canonical
+        })).toThrow('absolute')
+    });
+
+    test('a path-shaped planeId fails at boot — closes the custom-config route the env parser cannot see', () => {
+        expect(() => assertPlaneCoherence({
+            planeId          : '../worktrees/seat-a',
+            dataRoot         : canonical,
+            canonicalDataRoot: canonical
+        })).toThrow('opaque')
     });
 });
 

--- a/test/playwright/unit/ai/planeConfig.spec.mjs
+++ b/test/playwright/unit/ai/planeConfig.spec.mjs
@@ -1,14 +1,18 @@
 import {test, expect} from '@playwright/test';
 import path           from 'node:path';
-import '../../../../src/Neo.mjs';
+import Neo            from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
 import {
     PLANE_DEFAULTS,
     PLANE_ENV,
+    isOpaquePlaneId,
+    parsePlaneIdEnv,
     resolvePlaneDataRoot,
     resolvePlaneId
 } from '../../../../ai/planeConfig.mjs';
-import ConfigBase from '../../../../ai/configBase.mjs';
+import ConfigBase   from '../../../../ai/configBase.mjs';
+import McConfigBase from '../../../../ai/mcp/server/memory-core/configBase.mjs';
+import NlConfigBase from '../../../../ai/mcp/server/neural-link/configBase.mjs';
 
 test.describe('ai/planeConfig — the plane-identity pure-defaults twin', () => {
     test('constant maps are frozen and carry env NAMES, never values', () => {
@@ -55,8 +59,9 @@ test.describe('ai/planeConfig — the plane-identity pure-defaults twin', () => 
     });
 
     test('resolver semantics match the leaf contract under a controlled env', () => {
-        // The half that CAN still drift: the twin's pure resolution vs the leaf's
-        // env-override-with-default. Same inputs, same outputs, both branches.
+        // Equivalence pin, not a drift guard: for strings, the twin's truthiness check and the
+        // provider's emptiness partition are identical ('' is the only falsy string), so this
+        // pins a constructed equivalence on both branches rather than guarding a live channel.
         const env = {[PLANE_ENV.planeId]: 'cloud-tenant-plane', [PLANE_ENV.dataRoot]: '/app/.neo-ai-data'};
 
         expect(resolvePlaneId({env})).toBe('cloud-tenant-plane');
@@ -66,5 +71,130 @@ test.describe('ai/planeConfig — the plane-identity pure-defaults twin', () => 
         expect(resolvePlaneId({env: bare})).toBe(ConfigBase.config.data.plane.id.default);
         expect(resolvePlaneDataRoot({env: bare, rootDir: ConfigBase.config.data.neoRootDir.default}))
             .toBe(ConfigBase.config.data.plane.dataRoot.default)
+    });
+});
+
+test.describe('resolved-value opacity — the invariant on the values that vary', () => {
+    const pathShapedRows = ['/abs/path/checkout', '../worktrees/seat-a', 'C:\\checkout', '.neo-ai-data'];
+
+    test('resolvePlaneId fails loud on every path-shaped override', () => {
+        for (const bad of pathShapedRows) {
+            expect(() => resolvePlaneId({env: {[PLANE_ENV.planeId]: bad}}), bad).toThrow('opaque')
+        }
+    });
+
+    test('parsePlaneIdEnv: absent/empty defer to the default; valid passes; path-shaped throws', () => {
+        expect(parsePlaneIdEnv(PLANE_ENV.planeId, {env: {}})).toBeUndefined();
+        expect(parsePlaneIdEnv(PLANE_ENV.planeId, {env: {[PLANE_ENV.planeId]: ''}})).toBeUndefined();
+        expect(parsePlaneIdEnv(PLANE_ENV.planeId, {env: {[PLANE_ENV.planeId]: 'overlay-plane-a'}})).toBe('overlay-plane-a');
+
+        for (const bad of pathShapedRows) {
+            expect(() => parsePlaneIdEnv(PLANE_ENV.planeId, {env: {[PLANE_ENV.planeId]: bad}}), bad).toThrow('opaque')
+        }
+    });
+
+    test('isOpaquePlaneId: one predicate behind the load guard, the resolver, and the env layer', () => {
+        expect(isOpaquePlaneId(PLANE_DEFAULTS.planeId)).toBe(true);
+        expect(isOpaquePlaneId('cloud-tenant-plane')).toBe(true);
+        expect(isOpaquePlaneId('')).toBe(false);
+        expect(isOpaquePlaneId(null)).toBe(false);
+
+        for (const bad of pathShapedRows) {
+            expect(isOpaquePlaneId(bad), bad).toBe(false)
+        }
+    });
+
+    test('the leaf reaches the same predicate: plane.id declares the twin parser', () => {
+        expect(ConfigBase.config.data.plane.id.parse).toBe(parsePlaneIdEnv)
+    });
+});
+
+test.describe('plane-member derivation witnesses — #15791 seat-variance ground truth', () => {
+    // ticket-ref-ok: the #15799 AC binds these witnesses to the #15791 reconcile probe as their
+    // ground truth. The probe's finding class: per-seat plane divergence arises where members
+    // re-derive their own root (ambient cwd, homedir, ad-hoc module consts). These witnesses pin
+    // every migrated member default to the ONE declared anchor — cwd-independent by construction,
+    // so the probe's divergence class cannot re-enter through defaults.
+    const anchor = ConfigBase.config.data.plane.dataRoot.default;
+
+    test('the anchor itself is the twin resolution over neoRootDir', () => {
+        expect(anchor).toBe(resolvePlaneDataRoot({env: {}, rootDir: ConfigBase.config.data.neoRootDir.default}))
+    });
+
+    test('root config members derive from the anchor', () => {
+        const {data} = ConfigBase.config;
+
+        expect(data.backupPath.default).toBe(path.resolve(anchor, 'backups'));
+        expect(data.wakeDaemonHeartbeatAlivePath.default).toBe(path.resolve(anchor, 'wake-daemon/heartbeat.alive'));
+        expect(data.fleet.instanceRoot.default).toBe(path.resolve(anchor, 'fleet/instances'));
+        expect(data.engines.chroma.dataDirProd.default).toBe(path.resolve(anchor, 'chroma/unified'));
+        expect(data.orchestrator.deploymentStateBridge.snapshotPath.default).toBe(path.resolve(anchor, 'deployment-state/snapshot.json'));
+        expect(data.orchestrator.recoveryActuator.healAttemptsPath.default).toBe(path.resolve(anchor, 'orchestrator-daemon/heal-attempts.json'));
+        expect(data.orchestrator.recoveryActuator.recoveryRunStateDir.default).toBe(path.resolve(anchor, 'orchestrator-daemon/recovery-runs'))
+    });
+
+    test('orchestrator dataDir + dbPath are anchored ABSOLUTE — ambient-cwd resolution retired', () => {
+        const {orchestrator} = ConfigBase.config.data;
+
+        expect(path.isAbsolute(orchestrator.dataDir.default)).toBe(true);
+        expect(orchestrator.dataDir.default).toBe(path.resolve(anchor, 'orchestrator-daemon'));
+        expect(path.isAbsolute(orchestrator.dbPath.default)).toBe(true);
+        expect(orchestrator.dbPath.default).toBe(path.resolve(anchor, 'sqlite/memory-core-graph.sqlite'))
+    });
+
+    test('memory-core server members derive from the same anchor', () => {
+        const {data} = McConfigBase.config;
+
+        expect(data.memoryWal.dirProd.default).toBe(path.resolve(anchor, 'memory-wal'));
+        expect(data.memoryWal.daemonDataDir.default).toBe(path.resolve(anchor, 'embed-daemon'));
+        expect(data.messageWal.daemonDataDir.default).toBe(path.resolve(anchor, 'message-daemon'));
+        expect(data.wakeDaemon.dataDir.default).toBe(path.resolve(anchor, 'wake-daemon'));
+        expect(data.hookProjectionRoot.default).toBe(path.resolve(anchor, 'hook-projections'));
+        expect(data.remRunStateDir.default).toBe(path.resolve(anchor, 'rem-runs'));
+        expect(data.datasets.rlaif.trajectories.default).toBe(path.resolve(anchor, 'datasets/rlaif/trajectories.jsonl'));
+        expect(data.goldenPathRouteAttributionLedgerDirProd.default).toBe(path.resolve(anchor, 'orchestrator-daemon/route-attribution'));
+        expect(data.logPath.default).toBe(path.resolve(anchor, 'logs'));
+        expect(data.lazyEdgesQueuePath.default).toBe(path.resolve(anchor, 'memory-core/lazy-edges.jsonl'))
+    });
+
+    test('knowledge-base + neural-link log members derive from the same anchor', async () => {
+        // The KB config base re-wraps the registered Tier-1 singleton at module scope, so the
+        // template must be fully evaluated FIRST — awaited dynamic imports serialize that order
+        // (static import order races under worker sharding and fails file-load with "Cannot
+        // create proxy" on Neo.ai.Config undefined). The module cache makes the template's
+        // registration a ONE-SHOT side effect, and config.template.spec.mjs's afterAll restore
+        // may have unregistered it in this worker — re-bind from the cached export, the same
+        // registration-restore shape that spec uses.
+        const templateModule = await import('../../../../ai/config.template.mjs');
+
+        if (!Neo.ai?.Config) {
+            Neo.ai        = Neo.ai || {};
+            Neo.ai.Config = templateModule.default;
+        }
+        const KbConfigBase = (await import('../../../../ai/mcp/server/knowledge-base/configBase.mjs')).default;
+
+        expect(KbConfigBase.config.data.logPath.default).toBe(path.resolve(anchor, 'logs'));
+        expect(NlConfigBase.config.data.logPath.default).toBe(path.resolve(anchor, 'logs'))
+    });
+});
+
+test.describe('wakeDaemon watermark formulas — reactive derivation from the resolved dataDir', () => {
+    // Pure-function tests: formulas are static config, callable with a constructed `data`
+    // snapshot — no provider instance, no singleton mutation (the B4 discipline by construction).
+    const syncIdFormula = McConfigBase.config.formulas['wakeDaemon.bridgeLastSyncIdPath'];
+    const cursorFormula = McConfigBase.config.formulas['wakeDaemon.wakeSubscriptionLiveCursorPath'];
+
+    test('derive from the RESOLVED dataDir when no override is set — relocation moves the watermarks', () => {
+        const data = {wakeDaemon: {bridgeLastSyncIdPathOverride: null, wakeSubscriptionLiveCursorPathOverride: null, dataDir: '/relocated/wake-daemon'}};
+
+        expect(syncIdFormula(data)).toBe(path.join('/relocated/wake-daemon', 'lastSyncId'));
+        expect(cursorFormula(data)).toBe(path.join('/relocated/wake-daemon', 'wakeSubscriptionLiveCursor'))
+    });
+
+    test('explicit override leaves win over the derivation', () => {
+        const data = {wakeDaemon: {bridgeLastSyncIdPathOverride: '/pins/lastSyncId', wakeSubscriptionLiveCursorPathOverride: '/pins/cursor', dataDir: '/relocated/wake-daemon'}};
+
+        expect(syncIdFormula(data)).toBe('/pins/lastSyncId');
+        expect(cursorFormula(data)).toBe('/pins/cursor')
     });
 });

--- a/test/playwright/unit/ai/planeConfig.spec.mjs
+++ b/test/playwright/unit/ai/planeConfig.spec.mjs
@@ -1,21 +1,28 @@
-import {test, expect} from '@playwright/test';
-import fs             from 'node:fs';
-import os             from 'node:os';
-import path           from 'node:path';
-import Neo            from '../../../../src/Neo.mjs';
+import {test, expect}     from '@playwright/test';
+import fs                 from 'node:fs';
+import os                 from 'node:os';
+import path               from 'node:path';
+import {fileURLToPath}    from 'node:url';
+import {load as yamlLoad} from 'js-yaml';
+import Neo                from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
+import ConfigProvider, {createConfigProxy} from '../../../../ai/ConfigProvider.mjs';
 import {
     PLANE_DEFAULTS,
     PLANE_ENV,
     assertPlaneCoherence,
+    assertPlaneMemberCoherence,
+    collectPlaneMembers,
     isOpaquePlaneId,
     parsePlaneIdEnv,
     resolvePlaneDataRoot,
     resolvePlaneId
 } from '../../../../ai/planeConfig.mjs';
-import ConfigBase   from '../../../../ai/configBase.mjs';
-import McConfigBase from '../../../../ai/mcp/server/memory-core/configBase.mjs';
-import NlConfigBase from '../../../../ai/mcp/server/neural-link/configBase.mjs';
+import ConfigBase, {PLANE_MEMBER_PATHS} from '../../../../ai/configBase.mjs';
+import McConfigBase                     from '../../../../ai/mcp/server/memory-core/configBase.mjs';
+import NlConfigBase                     from '../../../../ai/mcp/server/neural-link/configBase.mjs';
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
 
 test.describe('ai/planeConfig — the plane-identity pure-defaults twin', () => {
     test('constant maps are frozen and carry env NAMES, never values', () => {
@@ -262,4 +269,103 @@ test.describe('wakeDaemon watermark formulas — reactive derivation from the re
         expect(syncIdFormula(data)).toBe('/pins/lastSyncId');
         expect(cursorFormula(data)).toBe('/pins/cursor')
     });
+});
+
+test.describe('member coherence — a partially-moved plane fails closed', () => {
+    const anchorRoot = '/anchor/.neo-ai-data';
+
+    test('collectPlaneMembers walks resolved + descriptor trees; unresolvable claims throw', () => {
+        const entries = collectPlaneMembers({
+            memberPaths   : ['backupPath'],
+            resolvedConfig: {backupPath: path.join(anchorRoot, 'backups')},
+            descriptorData: {backupPath: {default: path.join(anchorRoot, 'backups')}}
+        });
+
+        expect(entries).toEqual([{path: 'backupPath', resolved: path.join(anchorRoot, 'backups'), default: path.join(anchorRoot, 'backups')}]);
+        expect(() => collectPlaneMembers({memberPaths: ['missing.leaf'], resolvedConfig: {}, descriptorData: {}}))
+            .toThrow('not resolvable')
+    });
+
+    test('a relocated root with members on their anchor defaults THROWS, naming the strays', () => {
+        const members = [
+            {path: 'backupPath', resolved: path.join(anchorRoot, 'backups'), default: path.join(anchorRoot, 'backups')},
+            {path: 'logPath',    resolved: '/relocated/plane/logs',          default: path.join(anchorRoot, 'logs')}
+        ];
+
+        expect(() => assertPlaneMemberCoherence({dataRoot: '/relocated/plane', members, realpathFn: p => p}))
+            .toThrow(/fails closed[\s\S]*backupPath|backupPath[\s\S]*fails closed/)
+    });
+
+    test('explicitly placed members and under-root members both pass', () => {
+        const members = [
+            // Explicitly placed: resolved differs from the declared default.
+            {path: 'memoryWal.dirProd', resolved: '/vol/wal', default: path.join(anchorRoot, 'memory-wal')},
+            // Under the resolved root.
+            {path: 'logPath', resolved: '/relocated/plane/logs', default: '/relocated/plane/logs'}
+        ];
+
+        expect(() => assertPlaneMemberCoherence({dataRoot: '/relocated/plane', members, realpathFn: p => p})).not.toThrow()
+    });
+
+    test('INTEGRATION: a Provider with ONLY NEO_PLANE_DATA_ROOT changed fails member coherence', () => {
+        process.env[PLANE_ENV.dataRoot] = path.join(os.tmpdir(), 'neo-relocated-plane-spec');
+
+        try {
+            const isolated = createConfigProxy(Neo.create(ConfigProvider, {
+                data    : ConfigBase.config.data,
+                formulas: ConfigBase.config.formulas
+            }));
+
+            try {
+                const members = collectPlaneMembers({
+                    memberPaths   : PLANE_MEMBER_PATHS,
+                    resolvedConfig: isolated,
+                    descriptorData: ConfigBase.config.data
+                });
+
+                // The relocation branch Emmy's falsifier disproved: root moved, every
+                // non-overridden claimed member still on the build-time anchor → fail closed.
+                expect(() => assertPlaneMemberCoherence({dataRoot: isolated.plane.dataRoot, members}))
+                    .toThrow('fails closed')
+            } finally {
+                isolated.destroy()
+            }
+        } finally {
+            delete process.env[PLANE_ENV.dataRoot]
+        }
+    });
+
+    test('INTEGRATION: without the relocation env, the full claimed member set passes', () => {
+        const isolated = createConfigProxy(Neo.create(ConfigProvider, {
+            data    : ConfigBase.config.data,
+            formulas: ConfigBase.config.formulas
+        }));
+
+        try {
+            const members = collectPlaneMembers({
+                memberPaths   : PLANE_MEMBER_PATHS,
+                resolvedConfig: isolated,
+                descriptorData: ConfigBase.config.data
+            });
+
+            expect(members.length).toBe(PLANE_MEMBER_PATHS.length);
+            expect(() => assertPlaneMemberCoherence({dataRoot: isolated.plane.dataRoot, members})).not.toThrow()
+        } finally {
+            isolated.destroy()
+        }
+    });
+});
+
+test.describe('healthcheck contract — the observed plane is a DECLARED schema property', () => {
+    for (const server of ['knowledge-base', 'memory-core']) {
+        test(`${server} HealthCheckResponse declares plane {id, dataRoot}`, () => {
+            const spec  = yamlLoad(fs.readFileSync(path.resolve(specDir, `../../../../ai/mcp/server/${server}/openapi.yaml`), 'utf8'));
+            const plane = spec.components.schemas.HealthCheckResponse.properties.plane;
+
+            expect(plane.type).toBe('object');
+            expect(plane.properties.id.type).toBe('string');
+            expect(plane.properties.dataRoot.type).toBe('string');
+            expect(plane.required).toEqual(['id', 'dataRoot'])
+        });
+    }
 });

--- a/test/playwright/unit/ai/planeConfig.spec.mjs
+++ b/test/playwright/unit/ai/planeConfig.spec.mjs
@@ -1,0 +1,70 @@
+import {test, expect} from '@playwright/test';
+import path           from 'node:path';
+import '../../../../src/Neo.mjs';
+import '../../../../src/core/_export.mjs';
+import {
+    PLANE_DEFAULTS,
+    PLANE_ENV,
+    resolvePlaneDataRoot,
+    resolvePlaneId
+} from '../../../../ai/planeConfig.mjs';
+import ConfigBase from '../../../../ai/configBase.mjs';
+
+test.describe('ai/planeConfig — the plane-identity pure-defaults twin', () => {
+    test('constant maps are frozen and carry env NAMES, never values', () => {
+        expect(Object.isFrozen(PLANE_ENV)).toBe(true);
+        expect(Object.isFrozen(PLANE_DEFAULTS)).toBe(true);
+        expect(PLANE_ENV.planeId).toBe('NEO_PLANE_ID');
+        expect(PLANE_ENV.dataRoot).toBe('NEO_PLANE_DATA_ROOT')
+    });
+
+    test('the default planeId is opaque — no path or checkout content', () => {
+        expect(PLANE_DEFAULTS.planeId).not.toContain('/');
+        expect(PLANE_DEFAULTS.planeId).not.toContain(path.sep);
+        expect(PLANE_DEFAULTS.planeId).not.toContain('.neo-ai-data')
+    });
+
+    test('resolvePlaneId: default without override, env override wins', () => {
+        expect(resolvePlaneId({env: {}})).toBe(PLANE_DEFAULTS.planeId);
+        expect(resolvePlaneId({env: {[PLANE_ENV.planeId]: 'overlay-plane-a'}})).toBe('overlay-plane-a')
+    });
+
+    test('resolvePlaneDataRoot: env override needs no root; injected root anchors the default', () => {
+        expect(resolvePlaneDataRoot({env: {[PLANE_ENV.dataRoot]: '/vol/plane'}})).toBe('/vol/plane');
+
+        const resolved = resolvePlaneDataRoot({env: {}, rootDir: '/tmp/seat-x'});
+        expect(resolved).toBe(path.resolve('/tmp/seat-x', PLANE_DEFAULTS.dataRootRelative))
+    });
+
+    test('resolvePlaneDataRoot fails loud without a root — ambient cwd is never trusted', () => {
+        expect(() => resolvePlaneDataRoot({env: {}})).toThrow(PLANE_ENV.dataRoot)
+    });
+
+    test('pairing: the leaf subtree declares FROM the twin — same literals, same env names', () => {
+        const {plane} = ConfigBase.config.data;
+
+        expect(plane.id.default).toBe(PLANE_DEFAULTS.planeId);
+        expect(plane.id.env).toBe(PLANE_ENV.planeId);
+        expect(plane.dataRoot.env).toBe(PLANE_ENV.dataRoot);
+        // The leaf's absolute default anchors the twin's relative literal on neoRootDir —
+        // identity of the trailing segment proves one shared literal, not two copies.
+        expect(plane.dataRoot.default.endsWith(PLANE_DEFAULTS.dataRootRelative)).toBe(true);
+        expect(plane.dataRoot.default).toBe(
+            path.resolve(ConfigBase.config.data.neoRootDir.default, PLANE_DEFAULTS.dataRootRelative)
+        )
+    });
+
+    test('resolver semantics match the leaf contract under a controlled env', () => {
+        // The half that CAN still drift: the twin's pure resolution vs the leaf's
+        // env-override-with-default. Same inputs, same outputs, both branches.
+        const env = {[PLANE_ENV.planeId]: 'cloud-tenant-plane', [PLANE_ENV.dataRoot]: '/app/.neo-ai-data'};
+
+        expect(resolvePlaneId({env})).toBe('cloud-tenant-plane');
+        expect(resolvePlaneDataRoot({env})).toBe('/app/.neo-ai-data');
+
+        const bare = {};
+        expect(resolvePlaneId({env: bare})).toBe(ConfigBase.config.data.plane.id.default);
+        expect(resolvePlaneDataRoot({env: bare, rootDir: ConfigBase.config.data.neoRootDir.default}))
+            .toBe(ConfigBase.config.data.plane.dataRoot.default)
+    });
+});


### PR DESCRIPTION
Resolves #15799

**READY — all five ticket artifacts + two review cycles closed: Opus RC1 (both RAs at `551ba6fded`) and the GPT-seat RC (all three contracts at `b4f57e8468`). Merge gate: GPT/Kimi verdict confirmation + the human merge.**

The parity epic's spine enabler: the plane-identity **paired artifact** — a pure-defaults twin (`ai/planeConfig.mjs`, the ADR 0019 §5.5 non-entrypoint shape: frozen env-name maps + frozen literals + `{env, rootDir}`-injected pure resolvers + a module-load opaqueness invariant) and the declared `plane` leaf subtree in `ai/configBase.mjs` (`id` + `dataRoot`) — with the twin as the leaf declarations' **literal source** (`leaf(PLANE_DEFAULTS.x, PLANE_ENV.x, 'string')`), so leaf↔twin drift is impossible by construction rather than test-caught. `planeId` is opaque by contract **on resolved values, not only the frozen default** (review RC1 RA2): one `isOpaquePlaneId` predicate backs the module-load guard, the twin resolver, and the leaf's env layer (`parsePlaneIdEnv` raw-descriptor parse, the `parseMemorySharingPolicy` precedent). `dataRoot` is the single anchor the plane-member leaves now actually derive from.

Evidence: L1 (unit contract — **133/133** across the four affected spec files at `b4f57e8468`: `planeConfig` + `BaseServer` + `McpServerListToolsSmoke` + mc `config.template`), incl. the boot assertion BOTH clauses both branches and the reviewer's relocation falsifier converted into a standing integration spec → L1 required. Exact-head CI running at `b4f57e8468`. Residual: none in-scope; the orchestrator-side member walk + snapshot emission ride the election as named follow-ups.

## In this draft (5 commits)

- `086cb28e08` — `ai/planeConfig.mjs` (twin) + the `plane` subtree in `ai/configBase.mjs` (leaf side), smoke-verified all four resolver behaviors pre-commit.
- `aec0836746` — `test/playwright/unit/ai/planeConfig.spec.mjs`: seven specs (frozen maps, opaqueness, both resolver branches incl. rootless fail-loud, constructive pairing, resolver-vs-leaf equality).
- `551ba6fded` — **review RC1 response + member-leaf derivations:**
  - **RA1:** config-template parity snapshot regenerated in the same commit (`config-leaf-parity.json`, 514 declared paths) — clears the red `lint` gate and the three `lintConfigTemplateSsot.spec` failures.
  - **RA2:** the opacity invariant now holds on the values that vary — `isOpaquePlaneId` extracted, `resolvePlaneId` fails loud on path-shaped overrides, `parsePlaneIdEnv` guards the leaf env layer, and the spec asserts every measured row from the review (`/abs/path/checkout`, `../worktrees/seat-a`, `C:\checkout`, `.neo-ai-data`) on all three surfaces.
  - **Member-leaf derivations (ticket artifact):** 20 plane-member defaults across four config bases now derive from ONE anchor (`resolvePlaneDataRoot({env: {}, rootDir: neoRootDir})` — the env-free twin-resolution shape `storagePaths.graphProd` established): root config (`backupPath`, `wakeDaemonHeartbeatAlivePath`, `fleet.instanceRoot`, `engines.chroma.dataDirProd`, `orchestrator.dataDir`, `orchestrator.dbPath`, `deploymentStateBridge.snapshotPath`, `recoveryActuator.healAttemptsPath` + `recoveryRunStateDir`), memory-core (WAL dir, embed/message daemon dirs, wake-daemon dir, hook projections, REM runs, RLAIF datasets, route-attribution ledger, logs, lazy-edges), KB + Neural Link (`logPath`). The memory-core module-scope inline `process.env.NEO_AI_DAEMON_DIR` read is retired; the parity lint now reports **0 inline-env leaf defaults**.
  - **wakeDaemon watermark children are now formulas** (`bridgeLastSyncIdPath`, `wakeSubscriptionLiveCursorPath`): children of a RELOCATABLE parent are genuinely computed values, so they derive reactively from the resolved `dataDir` (the `messageWal.dir` fallback-formula precedent), each keeping an explicit override leaf (`*Override`, same env names). Behavior-preserving across all four env combinations; consumers (`compactGraphLog`, `WakeSubscriptionService`) read the same dotted paths.
  - Derivation witnesses + formula pure-function tests + the #15791 seat-variance ground-truth block added to the spec (13 new tests).
- `340651c221` — **the F-invariant + observed identity (both at shared seams):**
  - `assertPlaneCoherence` (twin-side, pure, injectable): resolved planeId opaque (closing the custom-config-file route the env parser never sees) + dataRoot absolute (ambient-cwd retirement) + a declared overlay must not resolve the durable root **symlink-transparently** (the reconcile probe's escape class, `fs.realpathSync` comparison). Wired at the head of `BaseServer.runHealthcheckAndLogStatus()` — the building block every boot order calls after config load (default + mc + nl custom boots verified); mc asserts pre-transport, nl post-transport-by-design (its transport-early boot; the throw still kills the process on breach).
  - **Observed-identity emission** (the Lane-2 consumer requirement): mc + kb healthcheck TOOL payloads spread `plane: {id, dataRoot}` at the tool layer, reading the SSOT at the use site — the manifest's observed column populates per-process. Orchestrator snapshot-side emission = named follow-up riding the election's per-profile record.
  - Six new F-invariant specs incl. a REAL symlink fixture (mkdtemp + symlink → realpath equality → fail closed) — both branches per the AC. Smoke-verified the Tier-2 proxy resolves `plane.*` through the parent chain (`mc config → neo-local-canonical | <abs root>`).
- `fb0fe26cdf` — **the ADR 0019 amendment (§10 + §5.5 cross-ref):** constructive pairing prescribed (§10.1, superseding copy-pairing — the reviewer-endorsed inversion), the A3 direction+audience test (§10.2 — twin resolvers serve no-Provider consumers, leaf declares FROM the twin), the three-concept separation + identity-provisioning disposition with both rejected branches (§10.3), the F-invariant + ADR 0014 wake-lane premise binding (§10.4), the A9/A2 member-derivation decision rule (§10.5), resolvable-is-not-observable (§10.6).

## Post-review hardening (3 commits)

- `5a6e3afcc3` — cycle-2 nit: the `plane.id` raw descriptor carries `type: 'string'` for metadata uniformity (reviewer note; `parse` owns decoding either way).
- `0913209887` — CI red #1: the mc watermark env-override spec creates its isolated provider with data ONLY; the formula-served watermark paths need `formulas` too (the Tier-1 `createIsolatedConfig` shape). Spec-side fix; the reactive-derivation design stands.
- `67356811c0` — CI red #2 (a REAL wiring defect the cross-server smoke surfaced): the F-invariant assumed every truthy `aiConfig` resolves a `plane` subtree — false for API-bridge servers (github-/gitlab-workflow) and isolated fixtures. **Plane membership is now an explicit class declaration**: `BaseServer.isPlaneMember()` defaults `false` (non-members carry no plane by contract and skip); mc + kb override `true` — they open plane storage — and then fail LOUD on every unresolvable state (no config, no `plane` subtree), so a member can never silently skip its own invariant (the RC1 RA2 discipline applied at the wiring layer). Both members' `plane.*` chain-resolution smoke-verified in real boot order, not assumed. **Delta from the `340651c221` bullet above:** NL is a non-member for now (its plane coupling is the log dir + a homedir-anchored telemetry DB — the flagged-unmigrated member); the placement election's member-set completeness audit revisits. Adjacent latent fix: the `connectTransport` null-guard now covers `undefined` (`!this.aiConfig`). Four boundary specs added (`BaseServer.spec.mjs`, the BareServer isolation precedent).

## Review cycle 2 — the GPT seat's three contracts (`b4f57e8468`)

- **RA1 — member coherence is now ENFORCED, not asserted-by-derivation:** the reviewer's falsifier (only `NEO_PLANE_DATA_ROOT` set → members stay on the anchor) is now IMPOSSIBLE to ship silently: each member config base exports its claimed `PLANE_MEMBER_PATHS` (Tier-1: 9; mc: 10; kb: 1); `collectPlaneMembers` (pure, proxy-safe) walks resolved-vs-declared values; `assertPlaneMemberCoherence` fails boot when a relocated root leaves any claimed member on its anchor default (explicitly placed members pass — cloud profiles with per-member envs stay green). Wired into `assertPlaneIdentity` for member servers. The falsifier itself is a standing integration spec (isolated Tier-1 Provider + only the plane env → throws naming the strays; clean env → full member set passes). ADR §10.4/§10.5 rewritten to state derivation **plus enforcement**, removing the static-exemption contradiction the review caught.
- **RA2 — observed identity is same-source by construction:** both healthcheck wrappers now read the per-server config singleton (`Server.aiConfig` — the exact object the boot assertion verified) instead of Tier-1; a custom child overlay can no longer verify one identity and report another.
- **RA3 — the contract is declared:** `HealthCheckResponse.plane {id, dataRoot}` (required) added to both OpenAPI schemas with declaration specs; the observed-identity row added to #15799's Contract Ledger; this body's DRAFT/evidence statements refreshed at the repaired head.
- Comparison semantics note: member coherence compares LITERAL prefixes (`path.resolve`), not realpaths — the first integration run on this very seat's symlinked `.neo-ai-data` proved that mixing realpath into one side of a string-derivation comparison flags every not-yet-created member; symlink forensics stay with the reconcile probe (its own lane).

## Ticket artifacts — all five in

- [x] The leaf (plane subtree) + the twin — `086cb28e08`.
- [x] The pairing-consistency contract (constructive) — `aec0836746`, hardened at `551ba6fded`.
- [x] Member-leaf derivations (20 members, 4 config bases, one anchor) — `551ba6fded`.
- [x] The F-invariant boot assertion, both branches tested (+ observed-identity emission) — `340651c221`.
- [x] The ADR 0019 amendment — `fb0fe26cdf`.
- [x] Reconcile report (#15791 / PR #15794) consumed as ground truth — the seat-variance witness block.

## Deltas from ticket

1. Constructive pairing (recorded pre-implementation on the ticket, `IC_kwDODSospM8AAAABLi3DBA`): the twin is the leaf declarations' literal SOURCE, so the pairing test narrows to resolver semantics — and per review falsifier 1, that equivalence holds by construction for strings (truthiness and the provider's emptiness partition identically), which the spec now states instead of understating.
2. Consumer requirements from the Lane-2 owner (ticket comment, pre-implementation): (a) observed-identity emission — folded into remaining scope at the healthcheck seam; (b) identity persistence location — resolved as *declared by the deployment layer* (env→leaf with a stable opaque default); neither derived from paths nor persisted inside the plane. The amendment names all three rejected branches.
3. Two members deliberately NOT migrated, flagged rather than silently skipped: `orchestrator.tenantRepoMirrorRoot` (its default names the CLOUD profile's plane root — re-anchoring locally would break containerized defaults; the placement election owns per-profile unification) and KB/NL `memoryCoreDbPathProd` (`os.homedir()`-anchored with a DIFFERENT filename than the graph DB — a semantic question about a possibly-legacy read path, not a mechanical re-anchor; migrating it silently would change which file two servers open).
4. `orchestrator.dataDir` + `dbPath` converted relative→anchored-absolute: their "kept relative on purpose" docs described ambient-cwd resolution — exactly the per-process root ambiguity this leaf exists to remove. Consumers verified absolute-safe (`path.join(dataDir, …)` with absolute base); cloud profiles keep overriding via env (the continuity trio is unaffected).

## Slot rationale

Disposition: `keep` — two runtime files (one config-substrate, one pure module) + one spec; no always-loaded agent substrate touched; the ADR amendment (remaining scope) carries its own keep rationale as the pattern's documentation home.

## Test Evidence

- At `67356811c0`: `BaseServer.spec + McpServerListToolsSmoke.spec + planeConfig.spec` — **105/105 passed** (the smoke spec is the file that produced CI red #2).
- At `0913209887`: `config.template.spec (mc) + planeConfig.spec` — **45/45 passed**.
- At `551ba6fded`: `planeConfig.spec + lintConfigTemplateSsot.spec + config.template.spec` — **35/35 passed, twice** (composite), **20/20 isolated**.
- `lint-config-template-ssot` — OK: **0 inline-env leaf defaults**, snapshot committed in the same commit as the change it records (RA1 discipline).
- `check-aiconfig-antipatterns` (617 files) + `check-aiconfig-test-mutation` (980 files) — **0 new violations**.
- CodeQL: zero open alerts on this PR per the swarm-wide code-scanning sweep (2026-07-24 14:08Z) — re-verified against the code-scanning surface (not `statusCheckRollup`) at ready-flip.
- Pre-commit gates green (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment, parse).

## Post-Merge Validation

- [ ] The #15800 placement election consumes `plane.id` / `plane.dataRoot` as its decision subject (the DAG successor, not this PR).

Borrowed-authority note per the ticket: discharged under the graduated epic's authority; the source Discussion's ratification window (returning Kimi seats) rides on the epic record.

Authored by Clio (@neo-fable-clio, Fable). Session a856fa79-e4fb-4c5a-a498-72672f2732a4.
