### PR TITLE
fix(e2e): drop dead --use-gl=desktop and software-rasterizer ban killing headed Chrome (#15664)

### DIFF
--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -51,7 +51,9 @@ export default defineConfig({
                     // the GPU process then dies at EVERY window birth, and with the software fallback disabled
                     // Chromium's crash threshold kills the whole browser mid-test in headed mode: the second
                     // popup birth crossed it deterministically ("GPU process isn't usable. Goodbye." → SIGTRAP,
-                    // all SharedWorkers gone). Default ANGLE (Metal on macOS) IS the hardware path.
+                    // all SharedWorkers gone). Without the overrides Chrome selects its supported ANGLE
+                    // backend — measured on this seat with this flag set, headed AND headless:
+                    // "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Max)".
                     '--ignore-gpu-blocklist',
                     '--enable-gpu-rasterization',
                     '--enable-zero-copy',

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -46,12 +46,16 @@ export default defineConfig({
             channel      : 'chrome', // Use local Google Chrome instead of Playwright's Chromium binary
             launchOptions: {
                 args: [
-                    '--use-gl=desktop',
+                    // NEVER pass '--use-gl=desktop' or '--disable-software-rasterizer' here: modern Chrome's
+                    // GL allowlist is ANGLE-only (metal/opengl/swiftshader), so 'desktop' resolves to gl=none —
+                    // the GPU process then dies at EVERY window birth, and with the software fallback disabled
+                    // Chromium's crash threshold kills the whole browser mid-test in headed mode: the second
+                    // popup birth crossed it deterministically ("GPU process isn't usable. Goodbye." → SIGTRAP,
+                    // all SharedWorkers gone). Default ANGLE (Metal on macOS) IS the hardware path.
                     '--ignore-gpu-blocklist',
                     '--enable-gpu-rasterization',
                     '--enable-zero-copy',
                     '--enable-accelerated-2d-canvas',
-                    '--disable-software-rasterizer',
                     '--disable-frame-rate-limit',
                     '--no-sandbox',
                     '--disable-setuid-sandbox',

--- a/test/playwright/playwright.config.matrix.mjs
+++ b/test/playwright/playwright.config.matrix.mjs
@@ -17,11 +17,10 @@ process.env.NEO_E2E_PORT = String(PORT);
  * The tear-out portability-matrix runner (see
  * `learn/guides/specificfeatures/TearOutPortabilityMatrix.md` — the evidence ledger).
  *
- * Deliberately SEPARATE from `playwright.config.e2e.mjs`: the e2e config's benchmark launch
- * flags (`--use-gl=desktop`, GPU rasterization overrides) are headless-calibrated — in HEADED
- * mode on macOS they crash Chrome's GPU process ("GPU process isn't usable"), and the matrix
- * contract requires headed real-browser runs. Beyond the crash, GL/GPU overrides would distort
- * exactly the native placement semantics this suite measures.
+ * Deliberately SEPARATE from `playwright.config.e2e.mjs`: the e2e config carries benchmark
+ * launch flags (GPU rasterization overrides) calibrated for throughput benchmarks, and any
+ * GL/GPU override would distort exactly the native placement semantics this suite measures —
+ * the matrix contract requires headed real-browser runs on platform defaults.
  *
  * Measurement-fidelity choices, stated honestly:
  * - **Headed by default** (`headless: false`): headed IS this runner's identity — headless proves


### PR DESCRIPTION
Resolves #15664

The kinetic witness's run-2 kill was never a vessel or heap-join defect — it was the e2e config launching Chrome with `--use-gl=desktop`, a legacy GL selector that modern Chrome's allowlist (ANGLE-only: `egl-angle` × metal/opengl/swiftshader) no longer contains. The request resolved to `gl=none,angle=none`, so the GPU process failed init and died again at **every window birth**; `--disable-software-rasterizer` forbade the swiftshader fallback that would have absorbed the failure; and Chromium's internal GPU-crash threshold then terminated the **entire browser** deterministically at run-2's popup birth (`GPU process isn't usable. Goodbye.` → SIGTRAP). Every SharedWorker died with the browser — that is the ticket's observed "App Worker orderly-disconnect ~1.3s after boot" (the NL bridge socket dropping) and the `ConnectionService.resolveRequest` `Target App not found` terminal. The fix deletes the two poison flags and documents the constraint in place; Chrome then selects its supported ANGLE backend — **measured on this seat with this PR's exact flag set, headed AND headless: `ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Max)`** (WebGL `UNMASKED_RENDERER_WEBGL` receipt) — i.e. the hardware-accelerated path these benchmark flags always intended (under `gl=none`, the suite's GPU-acceleration flags never delivered GPU acceleration at all).

Diagnosis chain with per-layer receipts (instrumented worker-side registration tables → main-thread span logs → on-failure renderer liveness probe → `DEBUG=pw:browser*` browser stderr) is recorded on the ticket: https://github.com/neomjs/neo/issues/15664#issuecomment-5069969520 — including the falsification of the ticket's own Hypothesis 1 (SharedWorker registration tables are pristine at run-2; the App SharedWorker does not even survive the between-runs reload boundary — each run gets a fresh worker).

Evidence: L3 achieved (live headed Chrome witness runs on the affected seat — real browser, real windows, real SharedWorkers — plus headless controls) → L3 required (#15664's observable ACs: `--headed` twice-consecutive on one port, run-2 popup navigates). No close-target residuals. CI's own ceiling is lower (no e2e lane runs there) — the live-seat receipts above are separately achieved evidence, not a sandbox artifact; cross-seat/other-OS confirmation is non-closing post-merge hygiene, not a #15664 residual.

## Deltas from ticket

- The ticket's Hypothesis 1 (SharedWorker-side registration lifecycle for closed vessels, stale vessel entry under the shared window name) was instrumented first per the pickup protocol and **falsified**: registration tables were pristine at run-2 pre-popout, and the SharedWorker heap does not survive the witness's between-runs reload at all. The heap-join and vessel state machinery are exonerated — run-0's full drill → pop-out → glide → reattach cycle walks correctly on every instrumented run.
- The fix therefore lands in `test/playwright/playwright.config.e2e.mjs` (launch flags), not in `src/`. No runtime code changed.
- `#15648` same-machinery flag from the pickup protocol: verified **not** the same root (its repro used manually-launched Chrome without these flags; it is a connect-window calibration/observability issue under load). Verdict + two sharpening facts recorded on #15648: https://github.com/neomjs/neo/issues/15648#issuecomment-5069971810

## Test Evidence

- Pre-fix repro: 4/4 deterministic headed kills at run-2 pop-out on this seat (3 instrumented rounds + 1 `DEBUG=pw:browser*` round), browser stderr FATAL captured verbatim on the ticket. Headless: passes pre-fix (matches ticket).
- Post-fix, `agentos/FleetCockpitKineticNL.spec.mjs` (the witness, `NEO_E2E_PORT` fresh, `--workers=1`):
  - headed: **2× green** (one instrumented confirmation + one clean run) — two consecutive in-spec runs with identical beat logs each time, the exact AC that previously died at run-2.
  - headless (CI mode): **green**, unchanged.
- Full e2e suite (87 spec files / 165 tests, headless, `--workers=1`) after the flag removal: **151 passed / 11 failed / 3 skipped (18.0m)**. The 11 failures are all in the popup/multi-window class (Demo B family, FleetCockpitPopOut, HarnessEndurance, FleetGridKeyboardA11y — the latter a pure `EADDRINUSE :8083` port collision on this seat). 
- **Old-config control runs (same seat, headless, immediately after):** all 10 controllable failures reproduce **test-for-test identically** on the pre-fix config — control-1: 7/7 across the agentos/benchmarks failing files (2.8m); control-2: 3/3 across the dashboard failing files (38.9s). The 11th (`FleetGridKeyboardA11y.spec.mjs:113`) is `EADDRINUSE 127.0.0.1:8083` — a live `ai/services/fleet/devFleetServer.mjs` process on this seat holds the port the spec needs; environmental by error shape and attributed to a named running process. **Zero regressions, zero rescues from the flag removal in headless.** The pre-existing headless popup-stall class (popups stuck at `about:blank`) is a distinct investigation lane, adjacent to #15648's vessel-boot observability work — unchanged by this PR in either direction.
- Diagnostic instrumentation was fully reverted before commit; the PR diff is the config change only.
- Touched surface `test/playwright` (e2e config): covered by the suite runs above. Touched app surfaces: none.

## Post-Merge Validation

*(non-closing hygiene — not #15664 residuals; its ACs are fully delivered by the live-seat evidence above)*

- [ ] Next FM capture/dogfood session on a different seat/OS runs the kinetic witness headed and green (the flags were macOS-lethal; Linux seats should verify their default ANGLE path too).
- [ ] Headed multi-window FM flows (#15648 lane) re-measure vessel boot→join latency with a working GPU (~1.3s observed on this seat) before recalibrating `detailVesselConnectWindowMs`.

## Commits (if multi-commit)

- Single commit: the flag removal + in-place constraint comment.

Authored by Vega (Fable 5, Claude Code). Session 6b95191e-b5bf-487b-9672-96a76060a92b.
