### PR TITLE
fix(agentos): widen and witness the detail-vessel admission window (#15648)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -214,9 +214,15 @@ class FleetCockpit extends Container {
          * contract — an admission may fail, it may never hang. Non-reactive class-config default:
          * `Neo.overwrites`-eligible and instance-configurable (witnesses pass a short window at
          * creation).
-         * @member {Number} detailVesselConnectWindowMs=10000
+         *
+         * Calibration: a healthy heap-join measures ~1.3s born→windowed, but a loaded/cold seat
+         * legitimately exceeds 10s — twice-observed live: a 10s window flapped the same pop-out
+         * a 20s window let survive, minutes apart on one seat. 20s ≈ 15x healthy headroom — the
+         * cold-provider-beats-default class, the same widening shape as the Memory Core
+         * embed-write canary. A genuinely dead connect still rolls back at the bound.
+         * @member {Number} detailVesselConnectWindowMs=20000
          */
-        detailVesselConnectWindowMs: 10000,
+        detailVesselConnectWindowMs: 20000,
         /**
          * The cockpit-level roster host — ONE provider-owned {@link AgentOS.store.FleetRoster}
          * instance (autoLoaded from the JSON sample seed) that the grid + health bar bind; the
@@ -1588,6 +1594,8 @@ class FleetCockpit extends Container {
             me.detailVesselState       = 'failed-blocked';
             me.lastDetailVesselFailure = 'blocked';
 
+            me.warnVesselAdmissionFailure('blocked', {windowName});
+
             await me.reattachAgentDetail({windowAlreadyClosed: true});
 
             return {detached: false, errors: ['popup blocked: the vessel window did not open']}
@@ -1598,6 +1606,7 @@ class FleetCockpit extends Container {
             if (generation === me.detailVesselGeneration && me.detailVesselState === 'opening') {
                 me.detailVesselState       = 'failed-timeout';
                 me.lastDetailVesselFailure = 'timeout';
+                me.warnVesselAdmissionFailure('timeout', {boundMs: me.detailVesselConnectWindowMs, windowName});
                 me.reattachAgentDetail()
             }
         }, me.detailVesselConnectWindowMs);
@@ -1701,6 +1710,22 @@ class FleetCockpit extends Container {
         }
 
         return {errors: [], reattached: true}
+    }
+
+    /**
+     * @summary One self-describing line per silent-rollback admission edge — the flap witness.
+     *
+     * Both failure edges (`failed-blocked`, `failed-timeout`) roll the dock back so cleanly that
+     * a flap is visually identical to a user-initiated reattach. {@link #lastDetailVesselFailure}
+     * carries the state half of the observability contract; this warn carries the log half — the
+     * App-Worker console bridges into the Neural Link console stream, so harnesses and agents can
+     * distinguish an admission failure from a deliberate return without polling cockpit state.
+     * @param {String} kind The failure edge: 'blocked' or 'timeout'.
+     * @param {Object} meta Window name + bound context, so the line stands alone in a log.
+     * @protected
+     */
+    warnVesselAdmissionFailure(kind, meta) {
+        console.warn(`[FleetCockpit] detail-vessel admission failed (${kind}):`, meta)
     }
 
     /**

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -237,20 +237,33 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
     test('blocked popup: windowOpen=false takes the failed-blocked edge and rolls back commit-or-neither', async () => {
         vessel = installWindowVessel({openResult: false, popupUrl: null});
 
-        const pane   = await revealDetail(),
-              result = await cockpit.popOutAgentDetail();
+        // the silent edge carries a log witness — captured with a PAIRED restore
+        const warns    = [],
+              origWarn = console.warn;
 
-        expect(result.detached).toBe(false);
-        expect(result.errors[0]).toContain('popup blocked');
+        console.warn = (...args) => warns.push(args);
 
-        // the rollback settled the machine home; the failure trace survives it
-        expect(cockpit.detailVesselState).toBe('docked');
-        expect(cockpit.lastDetailVesselFailure).toBe('blocked');
+        try {
+            const pane   = await revealDetail(),
+                  result = await cockpit.popOutAgentDetail();
 
-        // the SAME instance is docked again at its exact home; nothing was closed (nothing opened)
-        expect(cockpit.getReference('agent-detail')).toBe(pane);
-        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'operator']);
-        expect(vessel.closeCalls).toHaveLength(0)
+            expect(result.detached).toBe(false);
+            expect(result.errors[0]).toContain('popup blocked');
+
+            // the rollback settled the machine home; the failure trace survives it
+            expect(cockpit.detailVesselState).toBe('docked');
+            expect(cockpit.lastDetailVesselFailure).toBe('blocked');
+
+            // the flap witness: the log half of the observability contract (state half above)
+            expect(warns.some(args => String(args[0]).includes('admission failed (blocked)'))).toBe(true);
+
+            // the SAME instance is docked again at its exact home; nothing was closed (nothing opened)
+            expect(cockpit.getReference('agent-detail')).toBe(pane);
+            expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'operator']);
+            expect(vessel.closeCalls).toHaveLength(0)
+        } finally {
+            console.warn = origWarn
+        }
     });
 
     test('bounded connect window: a vessel that never joins takes the failed-timeout edge and rolls back', async () => {
@@ -269,18 +282,34 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
         const pane = await revealDetail();
 
-        const result = await cockpit.popOutAgentDetail();
+        // the silent edge carries a log witness — captured with a PAIRED restore
+        const warns    = [],
+              origWarn = console.warn;
 
-        expect(result.detached).toBe(true);
-        expect(cockpit.detailVesselState).toBe('opening');
+        console.warn = (...args) => warns.push(args);
 
-        await expect.poll(() => cockpit.detailVesselState, {timeout: 2000}).toBe('docked');
+        try {
+            const result = await cockpit.popOutAgentDetail();
 
-        expect(cockpit.lastDetailVesselFailure).toBe('timeout');
-        expect(cockpit.getReference('agent-detail')).toBe(pane);
+            expect(result.detached).toBe(true);
+            expect(cockpit.detailVesselState).toBe('opening');
 
-        // the timeout rollback closes the maybe-open vessel by name
-        expect(vessel.closeCalls).toHaveLength(1)
+            await expect.poll(() => cockpit.detailVesselState, {timeout: 2000}).toBe('docked');
+
+            expect(cockpit.lastDetailVesselFailure).toBe('timeout');
+            expect(cockpit.getReference('agent-detail')).toBe(pane);
+
+            // the flap witness: self-describing, carries the bound that fired (log half; state half above)
+            const timeoutWarn = warns.find(args => String(args[0]).includes('admission failed (timeout)'));
+
+            expect(timeoutWarn, 'the timeout flap must log its witness line').toBeTruthy();
+            expect(timeoutWarn[1]).toMatchObject({boundMs: 20});
+
+            // the timeout rollback closes the maybe-open vessel by name
+            expect(vessel.closeCalls).toHaveLength(1)
+        } finally {
+            console.warn = origWarn
+        }
     });
 
     test('generation revalidation: a stale connect after reattach is inert', async () => {


### PR DESCRIPTION
Resolves #15648

The detail vessel's admission machine flapped silently on loaded seats: a legitimate cold boot exceeded the 10s connect window, the `failed-timeout` edge rolled the dock back, and the flap was visually identical to a user-initiated reattach — `popOutAgentDetail` had already answered `detached: true`, so nothing anywhere said an admission failed. Two changes, matching the ticket's options 1+3 (option 2's adaptive heartbeat deliberately deferred — see Deltas):

1. **Calibrated widening with the rationale in place:** `detailVesselConnectWindowMs` 10000 → 20000. The number is justified against the *healthy* baseline (~1.3s born→windowed on a GL-fixed seat — the pre-#15664 environment inflated every historical boot measurement) and the ticket's live evidence (the same pop-out that flapped at 10s survived at 20s, minutes apart on one seat): ~15x healthy headroom, the cold-provider-beats-default class (`#14182` precedent). The boundedness contract is untouched — a genuinely dead connect still rolls back.
2. **The flap witness:** both silent failure edges (`failed-timeout` AND `failed-blocked` — they share the silence problem) now emit one self-describing `console.warn` line via a small `@protected` helper, carrying the edge kind, window name, and the bound that fired. `lastDetailVesselFailure` already persisted the state half through the rollback; the warn is the log half — the App-Worker console bridges into the Neural Link console stream, so harnesses and agents can distinguish a flap from a deliberate return without polling cockpit state.

Evidence: L2 in CI (unit seam) + L3 live (mounted headed witness plus the ticket's same-seat 20s survival receipt) → L3 required for #15648's loaded-seat behavior. No close-target residuals; a plain-dev rerun after #15814 and another loaded-seat capture remain non-closing post-merge validation.

## Deltas from ticket

- Option 2 (adaptive extension via a childapp boot-progress heartbeat) is deliberately NOT implemented: it introduces new cross-realm signaling machinery for a case the calibrated bound + the new observability may fully absorb. If a post-merge loaded-seat observation shows 20s still flapping legitimate boots, the heartbeat becomes a follow-up with that evidence attached — filed then, not speculatively now.
- The `failed-blocked` edge got the same witness line (the ticket named only `failed-timeout`; both edges share the silent-flap problem and the same consumer).
- Intake recorded a calibration correction on the ticket: pre-#15664 boot measurements from the e2e seat were inflated by the dead-GL environment; the widened bound is justified against the healthy baseline instead.

## Test Evidence

- `test/playwright/unit/apps/agentos/view/fleet/` (touched suite's directory): **343/343 passed** (22.1s, unit config, workers=1) — including both extended failure-edge tests, which assert the witness line with a **paired console.warn capture/restore** (the `#15789` teardown discipline applied conspicuously).
- Mounted proof (touched app surface `apps/agentos` fleet cockpit): `FleetCockpitKineticNL.spec.mjs` **headed green** (18.4s, two in-spec runs, identical beat logs) on this change. Environment note for honesty: the run executed with PR #15814's e2e config fix applied to the worktree *for the run only* (then restored — this PR's diff stays clean); on plain `dev` the witness dies from #15664's environment defect regardless of this change. Once #15814 merges, the witness covers this path with no special handling.
- The timeout-vs-legit-boot distinction (AC4) rides the spec's existing injectable-window contract (`detailVesselConnectWindowMs: 20` at instance creation) — no sleeps on production bounds.

## Post-Merge Validation

- [ ] After #15814 merges: kinetic witness headed green on plain `dev` (no run-only config application).
- [ ] A real loaded-seat capture session observes either a surviving cold boot within 20s, or a `failed-timeout` witness line — either way the flap is now visible; if legitimate boots still flap, file the option-2 heartbeat follow-up with that observation attached.

## Commits (if multi-commit)

- Single commit: config calibration + witness helper + both edge call sites + spec extensions.

Authored by Vega (Fable 5, Claude Code). Session 6b95191e-b5bf-487b-9672-96a76060a92b.
