### PR TITLE
feat(test): fail the E2E suite loud when GPU-intent flags resolve to no GL (#15813)

### DIFF
--- a/test/playwright/e2e/gl.setup.mjs
+++ b/test/playwright/e2e/gl.setup.mjs
@@ -1,0 +1,63 @@
+import {test as setup, expect} from '@playwright/test';
+import {claimsGpuAcceleration} from './utils/gpuIntent.mjs';
+import {readGlState}           from './utils/glState.mjs';
+
+/**
+ * @summary Boot gate: the E2E suite refuses to run silently on a GPU it only *claims* to have.
+ *
+ * Days were spent investigating a suspected vessel/heap-join defect. The actual cause was a
+ * launch flag whose text stayed valid while the runtime moved out from under it — GL resolved to
+ * `none` at every window birth, Chromium's GPU-crash threshold eventually killed the whole browser
+ * mid-suite, and the "GPU-accelerated" benchmark suite had plausibly never rendered one accelerated
+ * frame. It was green the entire time, because a green suite proves the tests passed, not that they
+ * ran under the conditions they claim to measure.
+ *
+ * A source-shaped check cannot catch this class: the config's spelling never rotted, the environment
+ * rotted beneath it. So this gate observes the *effect* — once, at boot, before any benchmark
+ * attributes a number to hardware it may not be using.
+ *
+ * **Placement.** This is a setup project rather than `globalSetup`, following the `chroma-setup`
+ * precedent in `playwright.config.unit.mjs`. `e2e/globalSetup.mjs` runs as a plain node function
+ * outside any launched browser, so it structurally cannot observe the browser's GL state — the
+ * distinction that matters here is exactly the one between reading a config and running under it.
+ *
+ * @see test/playwright/e2e/utils/glState.mjs   three-state reading
+ * @see test/playwright/e2e/utils/gpuIntent.mjs the declaration this gate holds the run to
+ */
+setup('E2E boot: GPU-intent flags resolve to real GL', async ({page}) => {
+    const
+        demandsGl = claimsGpuAcceleration(),
+        gl        = await readGlState(page),
+        detail    = `state=${gl.state} renderer=${gl.renderer ?? 'n/a'} vendor=${gl.vendor ?? 'n/a'} generic=${gl.generic ?? 'n/a'} reason=${gl.reason ?? 'none'}`;
+
+    // Logged on every outcome, healthy included: a benchmark number is worth what its rendering path
+    // is worth, and the run's own log is where that has to be recoverable afterwards.
+    console.log(`[gl-probe] ${detail}`);
+
+    if (!demandsGl) {
+        console.log('[gl-probe] launch args carry no GPU-intent flag — nothing claimed, nothing demanded.');
+        return
+    }
+
+    // "Could not look" is its own outcome and still stops the run. A probe that waves the suite
+    // through when its own instrument is missing is the same defect wearing this gate's uniform:
+    // it would report the absence of evidence as evidence of health.
+    expect(gl.state, [
+        `E2E boot probe could not determine the GL state (${gl.reason}).`,
+        'This is NOT a pass — the suite claims hardware acceleration and the probe was unable to verify it.',
+        `Observed: ${detail}`,
+        'Fix the probe or the browser surface before trusting any benchmark from this run.'
+    ].join('\n')).not.toBe('unobserved');
+
+    expect(gl.state, [
+        'E2E boot probe: GPU-intent launch flags did NOT resolve to hardware GL.',
+        `Observed: ${detail}`,
+        '',
+        'This is the #15664 class — flag rot. The launch arguments still read correctly; the browser',
+        'no longer honours them, so this suite would render on nothing while reporting GPU numbers.',
+        'Chrome retired --use-gl=desktop via its ANGLE-only allowlist exactly this way.',
+        '',
+        'Check every GPU-intent flag in test/playwright/e2e/utils/gpuIntent.mjs against the current',
+        'Chrome build before assuming a hardware fault. Evidence chain: https://github.com/neomjs/neo/issues/15664'
+    ].join('\n')).toBe('accelerated')
+});

--- a/test/playwright/e2e/utils/glState.mjs
+++ b/test/playwright/e2e/utils/glState.mjs
@@ -1,0 +1,86 @@
+/**
+ * @summary Reads the live GL state of a launched browser, as three states rather than two.
+ *
+ * This module exists because of a configuration whose *text* never rotted — `--use-gl=desktop` stayed
+ * spelled correctly while Chrome's ANGLE-only allowlist quietly stopped accepting it, so GL resolved
+ * to `none` from the day the flag landed. No source-shaped instrument can see that: the config reads
+ * fine, the lint passes, the suite is green. Only the *effect* differs, so only an effect probe finds it.
+ *
+ * **Three states, not two — this is the point of the module.** A probe that answers
+ * healthy-or-degraded is itself a Face-C artifact: when `WEBGL_debug_renderer_info` is unavailable
+ * it would report the absence of evidence as evidence of health, which is the same shape as the bug
+ * it guards. `unobserved` exists so "could not look" can never be spoken as "looked and it was fine".
+ *
+ * @see test/playwright/e2e/gl.setup.mjs  the boot gate that acts on this reading
+ * @see https://github.com/neomjs/neo/issues/15664  the incident
+ * @see https://github.com/orgs/neomjs/discussions/15812  the artifact-that-cannot-fail class
+ */
+
+/**
+ * @summary Substrings that identify a software rasterizer in an unmasked renderer string.
+ *
+ * **Deliberately a deny-list, and deliberately incomplete.** An allow-list of hardware renderers
+ * would need every GPU on every platform and would fail closed on the next one shipped — a guard
+ * that breaks on new hardware gets switched off. This list is the *secondary* signal; the primary
+ * one is structural and needs no string matching at all: under `--use-gl=desktop` paired with
+ * `--disable-software-rasterizer` a WebGL context cannot be created at all, so `context: false` is
+ * the unambiguous tell. Treat additions here as refinements, never as the mechanism.
+ * @type {String[]}
+ */
+export const SOFTWARE_RENDERER_MARKERS = ['swiftshader', 'llvmpipe', 'software', 'microsoft basic render'];
+
+/**
+ * @summary Observes the browser's actual GL capability from inside the launched page.
+ *
+ * Runs in page context: creates a throwaway canvas, requests a WebGL context, and asks
+ * `WEBGL_debug_renderer_info` for the unmasked renderer. The generic `gl.getParameter(gl.RENDERER)`
+ * is captured too but is not decisive — Chrome answers `'WebKit WebGL'` regardless of what is
+ * underneath, verified on a healthy macOS seat, so it cannot separate hardware from software.
+ *
+ * @param {Object}   page                A Playwright page on any loaded document.
+ * @returns {Promise<{state: String, renderer: String|null, vendor: String|null, generic: String|null, reason: String|null}>}
+ *          `state` is one of:
+ *          - `'accelerated'` — a context exists and its unmasked renderer names no software rasterizer.
+ *          - `'degraded'`    — no WebGL context at all, or the renderer names a software rasterizer.
+ *          - `'unobserved'`  — a context exists but the renderer could not be identified, or the
+ *                              evaluation itself failed. **Never** collapse this into `'accelerated'`.
+ */
+export async function readGlState(page) {
+    let raw;
+
+    try {
+        raw = await page.evaluate(() => {
+            const
+                canvas = document.createElement('canvas'),
+                gl     = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+
+            if (!gl) return {context: false};
+
+            const ext = gl.getExtension('WEBGL_debug_renderer_info');
+
+            return {
+                context : true,
+                renderer: ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : null,
+                vendor  : ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL)   : null,
+                generic : gl.getParameter(gl.RENDERER)
+            }
+        })
+    } catch (error) {
+        // The probe failing is not the browser being healthy. Say so.
+        return {state: 'unobserved', renderer: null, vendor: null, generic: null, reason: `probe-evaluation-failed: ${error?.message ?? 'unknown'}`}
+    }
+
+    if (!raw.context) {
+        return {state: 'degraded', renderer: null, vendor: null, generic: null, reason: 'no-webgl-context'}
+    }
+
+    if (!raw.renderer) {
+        return {state: 'unobserved', renderer: null, vendor: raw.vendor, generic: raw.generic, reason: 'webgl-debug-renderer-info-unavailable'}
+    }
+
+    const software = SOFTWARE_RENDERER_MARKERS.find(marker => raw.renderer.toLowerCase().includes(marker));
+
+    return software
+        ? {state: 'degraded', renderer: raw.renderer, vendor: raw.vendor, generic: raw.generic, reason: `software-renderer: ${software}`}
+        : {state: 'accelerated', renderer: raw.renderer, vendor: raw.vendor, generic: raw.generic, reason: null}
+}

--- a/test/playwright/e2e/utils/gpuIntent.mjs
+++ b/test/playwright/e2e/utils/gpuIntent.mjs
@@ -33,6 +33,15 @@ export const GPU_INTENT_ARGS = [
 
 /**
  * @summary Everything else the E2E browser launches with — isolation, memory, throttling, sandbox.
+ *
+ * NEVER add `--use-gl=desktop` or `--disable-software-rasterizer` here. Modern Chrome's GL allowlist
+ * is ANGLE-only (metal/opengl/swiftshader), so `desktop` resolves to gl=none — the GPU process then
+ * dies at EVERY window birth, and with the software fallback disabled Chromium's crash threshold kills
+ * the whole browser mid-test in headed mode (the second popup birth crossed it deterministically:
+ * "GPU process isn't usable. Goodbye." → SIGTRAP, all SharedWorkers gone). Default ANGLE (Metal on
+ * macOS) IS the hardware path — measured on this seat, headed and headless: "ANGLE (Apple, ANGLE Metal
+ * Renderer: Apple M5 Max)". This warning is the source authority for that removal; the boot gate in
+ * `gl.setup.mjs` enforces it at runtime, but the two together are cheaper than either alone.
  * @type {String[]}
  */
 export const BASE_LAUNCH_ARGS = [

--- a/test/playwright/e2e/utils/gpuIntent.mjs
+++ b/test/playwright/e2e/utils/gpuIntent.mjs
@@ -1,0 +1,65 @@
+/**
+ * @summary The E2E browser's launch arguments, split so the GPU intent is machine-readable.
+ *
+ * This module is the single declaration. `playwright.config.e2e.mjs` spreads it into the project's
+ * `launchOptions`, and the boot probe reads it to decide whether hardware GL is something this run
+ * is *entitled to demand*. A second hand-maintained copy in the probe would drift, and drift between
+ * two statements of the same fact is how a dead GL flag stayed invisible for five months.
+ *
+ * **Why the split matters.** The probe must not demand GL unconditionally. If a future config drops
+ * every accelerator flag — a legitimate choice for a headless CI lane — a probe that still failed on
+ * software rendering would be a guard nobody could satisfy, and guards nobody can satisfy get
+ * disabled. Reading the intent from the declaration keeps the demand proportional to the claim.
+ *
+ * @see test/playwright/e2e/gl.setup.mjs  the boot probe that consumes GPU_INTENT_ARGS
+ * @see https://github.com/neomjs/neo/issues/15664  the five-month-silent dead-flag incident
+ */
+
+/**
+ * @summary Flags whose only purpose is to obtain hardware-accelerated rendering.
+ *
+ * Presence of any of these is the run asserting *"this suite renders on the GPU"* — which is exactly
+ * the claim the boot probe verifies against the live browser. Flags that merely tune an already
+ * accelerated pipeline (`--disable-frame-rate-limit`, `--force-gpu-mem-available-mb`) are NOT here:
+ * they do not by themselves claim acceleration, so they must not arm the demand.
+ * @type {String[]}
+ */
+export const GPU_INTENT_ARGS = [
+    '--ignore-gpu-blocklist',
+    '--enable-gpu-rasterization',
+    '--enable-zero-copy',
+    '--enable-accelerated-2d-canvas'
+];
+
+/**
+ * @summary Everything else the E2E browser launches with — isolation, memory, throttling, sandbox.
+ * @type {String[]}
+ */
+export const BASE_LAUNCH_ARGS = [
+    '--disable-frame-rate-limit',
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--js-flags=--max_old_space_size=8192',
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding',
+    '--disable-dev-shm-usage',
+    '--disable-ipc-flooding-protection',
+    '--force-gpu-mem-available-mb=4096',
+    '--disable-features=IsolateOrigins,site-per-process'
+];
+
+/**
+ * @summary The full argument list handed to Chrome.
+ * @type {String[]}
+ */
+export const E2E_LAUNCH_ARGS = [...GPU_INTENT_ARGS, ...BASE_LAUNCH_ARGS];
+
+/**
+ * @summary Whether a given argument list claims hardware acceleration.
+ * @param {String[]} [args=E2E_LAUNCH_ARGS]
+ * @returns {Boolean}
+ */
+export function claimsGpuAcceleration(args = E2E_LAUNCH_ARGS) {
+    return args.some(arg => GPU_INTENT_ARGS.includes(arg))
+}

--- a/test/playwright/e2e/utils/gpuIntent.mjs
+++ b/test/playwright/e2e/utils/gpuIntent.mjs
@@ -11,6 +11,17 @@
  * software rendering would be a guard nobody could satisfy, and guards nobody can satisfy get
  * disabled. Reading the intent from the declaration keeps the demand proportional to the claim.
  *
+ * **NEVER add `--use-gl=desktop` or `--disable-software-rasterizer` to ANY list in this module.**
+ * The prohibition is module-wide on purpose: `--use-gl=desktop` reads like a GPU selector and a
+ * maintainer's hand goes to `GPU_INTENT_ARGS`, so a ban scoped to one list guards the wrong surface.
+ * Modern Chrome's GL allowlist is ANGLE-only (metal/opengl/swiftshader), so `desktop` resolves to
+ * gl=none — the GPU process then dies at EVERY window birth, and with the software fallback disabled
+ * Chromium's crash threshold kills the whole browser mid-test in headed mode (the second popup birth
+ * crossed it deterministically: "GPU process isn't usable. Goodbye." → SIGTRAP, all SharedWorkers
+ * gone). Default ANGLE (Metal on macOS) IS the hardware path — measured on this seat, headed and
+ * headless: "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Max)". This is the source authority for
+ * that removal; `gl.setup.mjs` enforces it at runtime, but the two together are cheaper than either.
+ *
  * @see test/playwright/e2e/gl.setup.mjs  the boot probe that consumes GPU_INTENT_ARGS
  * @see https://github.com/neomjs/neo/issues/15664  the five-month-silent dead-flag incident
  */
@@ -33,15 +44,8 @@ export const GPU_INTENT_ARGS = [
 
 /**
  * @summary Everything else the E2E browser launches with — isolation, memory, throttling, sandbox.
- *
- * NEVER add `--use-gl=desktop` or `--disable-software-rasterizer` here. Modern Chrome's GL allowlist
- * is ANGLE-only (metal/opengl/swiftshader), so `desktop` resolves to gl=none — the GPU process then
- * dies at EVERY window birth, and with the software fallback disabled Chromium's crash threshold kills
- * the whole browser mid-test in headed mode (the second popup birth crossed it deterministically:
- * "GPU process isn't usable. Goodbye." → SIGTRAP, all SharedWorkers gone). Default ANGLE (Metal on
- * macOS) IS the hardware path — measured on this seat, headed and headless: "ANGLE (Apple, ANGLE Metal
- * Renderer: Apple M5 Max)". This warning is the source authority for that removal; the boot gate in
- * `gl.setup.mjs` enforces it at runtime, but the two together are cheaper than either alone.
+ * (The poison-flag prohibition is module-wide — see the file header — because it is not specific to
+ * this list.)
  * @type {String[]}
  */
 export const BASE_LAUNCH_ARGS = [

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -2,6 +2,7 @@ import './configTemplateResolver.mjs';
 
 import {defineConfig, devices} from '@playwright/test';
 import {resolveFreePortSync}   from './resolveFreePort.mjs';
+import {E2E_LAUNCH_ARGS}       from './e2e/utils/gpuIntent.mjs';
 
 // Per-process by default: this suite renders ITS OWN checkout (reuseExistingServer:false below), so a
 // fixed default would silently adopt a foreign dev-server squatting on 8080 — that server serves the
@@ -41,36 +42,21 @@ export default defineConfig({
     },
 
     projects: [{
-        name: 'chromium',
-        use : {
+        // Boot gate: observes that the GPU-intent flags below actually resolve to hardware
+        // GL before a single benchmark attributes a number to acceleration it may not have. Launches
+        // with the SAME args as the suite — probing a different browser would prove nothing.
+        name     : 'gl-probe',
+        testMatch: /gl\.setup\.mjs$/,
+        use      : {channel: 'chrome', launchOptions: {args: E2E_LAUNCH_ARGS}}
+    }, {
+        name        : 'chromium',
+        dependencies: ['gl-probe'],
+        use         : {
             channel      : 'chrome', // Use local Google Chrome instead of Playwright's Chromium binary
-            launchOptions: {
-                args: [
-                    // NEVER pass '--use-gl=desktop' or '--disable-software-rasterizer' here: modern Chrome's
-                    // GL allowlist is ANGLE-only (metal/opengl/swiftshader), so 'desktop' resolves to gl=none —
-                    // the GPU process then dies at EVERY window birth, and with the software fallback disabled
-                    // Chromium's crash threshold kills the whole browser mid-test in headed mode: the second
-                    // popup birth crossed it deterministically ("GPU process isn't usable. Goodbye." → SIGTRAP,
-                    // all SharedWorkers gone). Without the overrides Chrome selects its supported ANGLE
-                    // backend — measured on this seat with this flag set, headed AND headless:
-                    // "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Max)".
-                    '--ignore-gpu-blocklist',
-                    '--enable-gpu-rasterization',
-                    '--enable-zero-copy',
-                    '--enable-accelerated-2d-canvas',
-                    '--disable-frame-rate-limit',
-                    '--no-sandbox',
-                    '--disable-setuid-sandbox',
-                    '--js-flags=--max_old_space_size=8192',
-                    '--disable-background-timer-throttling',
-                    '--disable-backgrounding-occluded-windows',
-                    '--disable-renderer-backgrounding',
-                    '--disable-dev-shm-usage',
-                    '--disable-ipc-flooding-protection',
-                    '--force-gpu-mem-available-mb=4096',
-                    '--disable-features=IsolateOrigins,site-per-process'
-                ]
-            }
+            // Declared once in e2e/utils/gpuIntent.mjs so the boot probe reads the same list this
+            // launches with. A second copy here would drift, and drift between two statements of one
+            // fact is how a dead GL flag stayed invisible for five months.
+            launchOptions: {args: E2E_LAUNCH_ARGS}
         }
     }]
 });

--- a/test/playwright/unit/e2e/glState.spec.mjs
+++ b/test/playwright/unit/e2e/glState.spec.mjs
@@ -1,0 +1,109 @@
+import {expect, test}                           from '@playwright/test';
+import {claimsGpuAcceleration, GPU_INTENT_ARGS} from '../../e2e/utils/gpuIntent.mjs';
+import {readGlState, SOFTWARE_RENDERER_MARKERS} from '../../e2e/utils/glState.mjs';
+
+/**
+ * @summary Coverage for the E2E boot probe's decision core.
+ *
+ * `readGlState` takes a Playwright page and calls one `evaluate`, so the browser is an injected seam
+ * and every branch is reachable with a fake. That matters more than usual here: the `unobserved`
+ * branch cannot be produced by any launch flag — `WEBGL_debug_renderer_info` is available on every
+ * seat we run on — so without a fake it would be a branch that only exists in the source. A guard
+ * whose third state has never once been observed firing is indistinguishable from one that has two.
+ *
+ * The `accelerated` and `degraded` states are additionally proven end-to-end against a real Chrome
+ * in the PR's red/green evidence; these tests pin the classification, not the browser.
+ */
+test.describe('e2e/utils/glState', () => {
+    const fakePage = value => ({
+        evaluate: async () => {
+            if (value instanceof Error) throw value;
+            return value
+        }
+    });
+
+    test('#15813 no WebGL context at all is DEGRADED — the #15664 signature', async () => {
+        // Measured, not imagined: launching Chrome with --use-gl=desktop + --disable-software-rasterizer
+        // returns exactly {context: false}. That is the state the suite shipped in for five months.
+        const result = await readGlState(fakePage({context: false}));
+
+        expect(result.state).toBe('degraded');
+        expect(result.reason).toBe('no-webgl-context');
+        expect(result.renderer).toBeNull();
+    });
+
+    test('#15813 a hardware renderer is ACCELERATED', async () => {
+        const result = await readGlState(fakePage({
+            context : true,
+            renderer: 'ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Max, Unspecified Version)',
+            vendor  : 'Google Inc. (Apple)',
+            generic : 'WebKit WebGL'
+        }));
+
+        expect(result.state).toBe('accelerated');
+        expect(result.reason).toBeNull();
+        expect(result.renderer).toContain('Metal');
+    });
+
+    test('#15813 every software marker classifies as DEGRADED, not accelerated', async () => {
+        for (const marker of SOFTWARE_RENDERER_MARKERS) {
+            const result = await readGlState(fakePage({
+                context : true,
+                renderer: `ANGLE (Google, Vulkan 1.3 (${marker} Device))`,
+                vendor  : 'Google Inc.',
+                generic : 'WebKit WebGL'
+            }));
+
+            expect(result.state, `marker "${marker}" must classify as degraded`).toBe('degraded');
+            expect(result.reason).toContain(marker);
+        }
+    });
+
+    test('#15813 marker matching is case-insensitive — renderer strings are vendor-formatted', async () => {
+        // Renderer strings are whatever the driver prints; "SwiftShader" ships capitalised, and a
+        // case-sensitive match would have let the real-world spelling through.
+        const result = await readGlState(fakePage({
+            context : true,
+            renderer: 'ANGLE (Google, Vulkan 1.3 (SwiftShader Device))',
+            vendor  : 'Google Inc.',
+            generic : 'WebKit WebGL'
+        }));
+
+        expect(result.state).toBe('degraded');
+    });
+
+    test('#15813 a context WITHOUT a usable renderer string is UNOBSERVED, never accelerated', async () => {
+        // The branch this whole module exists for. A context exists, so the naive read is "GL works";
+        // but the renderer is unidentifiable, so software rendering cannot be ruled out. Reporting
+        // accelerated here would be the absence of evidence spoken as evidence.
+        const result = await readGlState(fakePage({
+            context : true,
+            renderer: null,
+            vendor  : null,
+            generic : 'WebKit WebGL'
+        }));
+
+        expect(result.state).toBe('unobserved');
+        expect(result.reason).toBe('webgl-debug-renderer-info-unavailable');
+        expect(result.generic).toBe('WebKit WebGL'); // still reported — the reader may want it
+    });
+
+    test('#15813 the probe FAILING is not the browser being healthy', async () => {
+        const result = await readGlState(fakePage(new Error('Target page, context or browser has been closed')));
+
+        expect(result.state).toBe('unobserved');
+        expect(result.reason).toContain('probe-evaluation-failed');
+        expect(result.reason).toContain('browser has been closed');
+    });
+
+    test('#15813 the demand is armed by the declaration, not hardcoded', async () => {
+        // A config that claims nothing must be able to demand nothing, or the gate becomes something
+        // a headless lane has to switch off — and a gate people switch off is worse than no gate.
+        expect(claimsGpuAcceleration(GPU_INTENT_ARGS)).toBe(true);
+        expect(claimsGpuAcceleration(['--no-sandbox', '--disable-dev-shm-usage'])).toBe(false);
+        expect(claimsGpuAcceleration([])).toBe(false);
+
+        // Tuning flags do not by themselves claim acceleration and must not arm the demand.
+        expect(claimsGpuAcceleration(['--disable-frame-rate-limit', '--force-gpu-mem-available-mb=4096'])).toBe(false);
+    });
+});


### PR DESCRIPTION
Resolves #15813

A launch flag whose *text* stays valid while the runtime moves out from under it is invisible to every source-shaped instrument we own. The config reads fine, the lint passes, the suite is green — and the "GPU-accelerated" benchmark suite plausibly never rendered one accelerated frame. Only the **effect** differs, so only an effect probe finds it.

Evidence: L3 (the gate run against real Chrome on live macOS seats, both directions, output below) → L3 required (the GL-state ACs are behavioural claims about a launched browser). **No closing residuals:** the final rebased head is independently verified headed and headless; see Review Closure.

## ✅ Merge order resolved

#15814 merged first and this branch was rebased onto it. The final PR diff therefore carries **zero** deletions of `--use-gl=desktop` / `--disable-software-rasterizer`; those removals remain owned by #15814. This PR moves the surviving launch arguments into `e2e/utils/gpuIntent.mjs`, whose module-level warning preserves #15814's reason at the new mutation surface.
## Deltas from ticket

**Placement decided by V-B-A, not by the ticket's first suggestion.** The ticket offered `globalSetup` *or* a fixture, flagging that globalSetup "may run before browser launch." It does more than may: `e2e/globalSetup.mjs` is a plain node function that awaits `ensureDevelopmentThemeAssets()` and nothing else — no browser exists in its scope at all. So the probe ships as a **setup project** with `dependencies: ['gl-probe']`, following the `chroma-setup` precedent already in `playwright.config.unit.mjs`. The distinction is the same one the whole ticket is about: reading a config versus running under it.

**One thing the ticket did not ask for, and I think it is the load-bearing half.** The ticket says the probe must know whether GPU intent is configured. Rather than hardcode that knowledge, `gpuIntent.mjs` is the **single declaration** the config spreads and the probe reads. A second hand-maintained copy in the probe would drift — and drift between two statements of one fact is precisely how a dead flag survives five months. A config that claims no acceleration therefore demands none, so a headless lane never has to switch the gate off; a gate people switch off is worse than no gate.

Tuning flags (`--disable-frame-rate-limit`, `--force-gpu-mem-available-mb`) are deliberately **not** GPU-intent: they tune an already-accelerated pipeline rather than claiming acceleration, so they must not arm the demand.

## Three states, not two

`unobserved` is not defensive padding — it is the ticket's AC3 and the reason this gate is not itself an instance of the class it guards. A probe answering healthy-or-degraded would report the absence of evidence as evidence of health the moment `WEBGL_debug_renderer_info` went away.

| state | when | gate |
|---|---|---|
| `accelerated` | context exists, unmasked renderer names no software rasterizer | pass, renderer logged |
| `degraded` | **no WebGL context at all**, or a software renderer | fail, naming the flag-rot class |
| `unobserved` | context exists but the renderer is unidentifiable, or the evaluation threw | fail with a **distinct** message: *"This is NOT a pass"* |

**The `unobserved` branch is verified reachable rather than merely written.** No launch flag suppresses `WEBGL_debug_renderer_info` on our seats, so end-to-end it is unreachable — which would make it a branch that exists only in the source, the exact shape being guarded against. `readGlState(page)` takes the browser as an injected seam, so a fake page reaches every branch. Both `unobserved` paths (missing extension, evaluation throws) are pinned.

The software-marker list is a **deny-list and says so in its own JSDoc**. An allow-list of hardware renderers would need every GPU on every platform and fail closed on the next one shipped. It is the *secondary* signal; the primary needs no string matching at all, because the poisoned flag pair produces no context.

## Test Evidence

**Red and green, both against real Chrome on this host, at the gate level.**

```
# poisoned args (--use-gl=desktop + --disable-software-rasterizer re-added):
[gl-probe] state=degraded renderer=n/a vendor=n/a generic=n/a reason=no-webgl-context
  Error: E2E boot probe: GPU-intent launch flags did NOT resolve to hardware GL.
  Observed: state=degraded ... reason=no-webgl-context
  This is the flag-rot class. The launch arguments still read correctly; the browser
  1 failed

# clean args (this branch):
[gl-probe] state=accelerated renderer=ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Max, Unspecified Version) vendor=Google Inc. (Apple) generic=WebKit WebGL reason=none
  1 passed (7.3s)
```

The red state is **not a reconstruction** — before #15814 merged, I measured the same `{"context": false}` by launching Chrome with `dev`'s then-current poisoned argument list. The gate-level red above then re-produced it through the real gate.

```bash
npx playwright test --config=test/playwright/playwright.config.unit.mjs test/playwright/unit/e2e/glState.spec.mjs
# → 7 passed
```

Placement of the unit spec follows `test/playwright/util/DeltaCapture.mjs` → `test/playwright/unit/vdom/DeltaCapture.spec.mjs`: a test helper covered by a unit spec placed by domain.

Directly touched surfaces: `e2e/utils/glState.mjs` + `e2e/utils/gpuIntent.mjs` — `unit/e2e/glState.spec.mjs` (7 passed, new). `e2e/gl.setup.mjs` + `playwright.config.e2e.mjs` — covered by the gate-level red/green run above; the e2e suite has no CI lane, so that run is the enforcement point.

## Post-Merge Validation

@neo-gpt's Cycle-1 and Cycle-2 reviews found two real gaps. Both are closed on final rebased head `0bda1848d9`.

- [x] **Source authority preserved.** #15814's durable poison-flag explanation is now module-wide in `gpuIntent.mjs`, covering `GPU_INTENT_ARGS`, `BASE_LAUNCH_ARGS`, and the composed list at the new mutation surface.
- [x] **Rebased onto merged #15814.** The final diff carries zero poison-flag deletions; those removals remain owned by @neo-opus-vega's PR.
- [x] **Independent exact-head seat.** @neo-gpt ran `gl-probe` at `0bda1848d9` headed and headless; both passed with `ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Max)`.
### Cost — AC1 amended, not silently missed

The ticket estimated `≤ ~1s` added boot cost. @neo-gpt measured the setup dependency at **+1.6–2.1s** across paired runs, and he is right. The estimate assumed an *in-browser* probe; the placement I chose — a setup project, which his review endorsed — pays one full browser launch, because a boot gate must fail **before** any benchmark runs and therefore cannot share the benchmark's browser. The cheaper shape could only observe after that browser is already up, too late to gate. So the cost is the price of the guarantee, #15813's AC1 is amended to the measured number with that rationale, and the `No residuals` claim is withdrawn rather than defended.

## Evolution

This is the third face of the "artifact that cannot fail" class under discussion in D#15812, and the one with the cleanest incident behind it: **the configuration's text never rotted — the environment rotted under it.** Two of us refuted our own proposed lints for that class today by measuring them; this face needed no lint, because the answer was never to recognise a correct-looking artifact. It was to observe the effect.

The gate is deliberately not switchable. An escape hatch would be a carve-out to quiet the guard, and a carve-out that quiets a guard is how a false-negative channel opens — a lesson from earlier in this same session, applied here before it could be repeated.

Authored by @neo-opus-ada (Claude Opus 4.8). Session e8b8a230-b55f-4d39-acb2-8680bc922399.


