### PR TITLE
fix(ai): pass argv, not a shell string, from the file-system MCP server (#15818)

### DIFF
--- a/ai/mcp/server/file-system/services/FileSystemService.mjs
+++ b/ai/mcp/server/file-system/services/FileSystemService.mjs
@@ -1,21 +1,38 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import util from 'util';
 
-const execAsync = util.promisify(exec);
+/**
+ * `execFile`, not `exec`. `exec` spawns a shell, which would make every argument a fragment of a
+ * command string — and the only untrusted input here is a caller-supplied path. Passing argv keeps
+ * a path a path: `;`, `&&`, `$(…)` and spaces reach the child process as literal characters of one
+ * argument, so command injection is unrepresentable rather than filtered.
+ */
+const execFileAsync = util.promisify(execFile);
 
 /**
  * Validates that a requested path does not traverse outside the project root.
+ *
+ * **Containment only — this is not a shell-safety guard.** It answers "is this path inside the
+ * root", and a path can be perfectly inside the root while containing shell metacharacters. Callers
+ * must never treat its return value as safe to interpolate into a command string; use argv.
+ *
  * @param {String} absolutePath
  * @returns {String} The resolved path if safe.
  * @throws {Error} If path traversal occurs.
  */
 function ensureSandboxed(absolutePath) {
-    const rootPath = path.resolve(process.cwd());
+    const rootPath   = path.resolve(process.cwd());
     const targetPath = path.resolve(absolutePath);
 
-    if (!targetPath.startsWith(rootPath)) {
+    // Compared on a path boundary, not a string prefix: `startsWith` admitted any sibling directory
+    // whose name merely begins with the root's, so `<root>-evil/x` passed a jail meant to exclude it.
+    // `path.relative` answers the containment question directly — an escaping path is either
+    // absolute or starts with a `..` segment.
+    const relative = path.relative(rootPath, targetPath);
+
+    if (relative !== '' && (path.isAbsolute(relative) || relative.split(path.sep)[0] === '..')) {
         throw new Error(`403 Forbidden: Path traversal detected. Operation jailed to ${rootPath}`);
     }
 
@@ -55,7 +72,7 @@ class FileSystemService {
 
         try {
             // --check runs the syntax parser without executing
-            await execAsync(`node --check ${safePath}`);
+            await execFileAsync('node', ['--check', safePath]);
             return 'Syntax OK';
         } catch (error) {
             // Returning the stderr which contains the compilation error
@@ -73,7 +90,7 @@ class FileSystemService {
 
         try {
             // Run exactly that file natively using the npm script mapping or direct npx command
-            const { stdout, stderr } = await execAsync(`npx playwright test ${safePath}`);
+            const { stdout, stderr } = await execFileAsync('npx', ['playwright', 'test', safePath]);
             return `Test Passed:\n${stdout}`;
         } catch (error) {
             return `Test Failed:\n${error.stdout}\n${error.stderr || error.message}`;

--- a/ai/mcp/server/file-system/services/FileSystemService.mjs
+++ b/ai/mcp/server/file-system/services/FileSystemService.mjs
@@ -61,14 +61,29 @@ async function canonicalize(targetPath) {
  * @throws {Error} If the canonical target lies outside the root.
  */
 async function ensureSandboxed(absolutePath) {
-    const
-        rootPath   = await fs.realpath(path.resolve(process.cwd())),
-        targetPath = await canonicalize(path.resolve(absolutePath)),
-        // Compared on a path boundary, not a string prefix: `startsWith` admitted any sibling
-        // directory whose name merely begins with the root's, so `<root>-evil/x` passed a jail meant
-        // to exclude it. `path.relative` answers containment directly — an escaping path is either
-        // absolute or starts with a `..` segment.
-        relative   = path.relative(rootPath, targetPath);
+    let rootPath, targetPath;
+
+    // THREE states, not two: contained · outside · **could not establish**. A resolution failure —
+    // EACCES on an ancestor, ELOOP, a vanished parent — leaves containment UNPROVEN, and unproven
+    // must be refused, not surfaced as a raw fs error. A bare `EACCES` reads to a caller (and to an
+    // agent reading the tool result) as an I/O problem worth retrying, when the truth is that the
+    // jail could not answer. The guard therefore fails closed with its own classification rather
+    // than letting the ambiguity escape wearing a different error's name.
+    try {
+        rootPath   = await fs.realpath(path.resolve(process.cwd()));
+        targetPath = await canonicalize(path.resolve(absolutePath))
+    } catch (error) {
+        throw new Error(
+            `403 Forbidden: Canonical containment could not be established (${error?.code ?? 'unknown'}). ` +
+            `Refusing the operation — this is NOT a verdict that the path is safe.`
+        );
+    }
+
+    // Compared on a path boundary, not a string prefix: `startsWith` admitted any sibling directory
+    // whose name merely begins with the root's, so `<root>-evil/x` passed a jail meant to exclude it.
+    // `path.relative` answers containment directly — an escaping path is either absolute or starts
+    // with a `..` segment.
+    const relative = path.relative(rootPath, targetPath);
 
     if (relative !== '' && (path.isAbsolute(relative) || relative.split(path.sep)[0] === '..')) {
         throw new Error(`403 Forbidden: Path traversal detected. Operation jailed to ${rootPath}`);

--- a/ai/mcp/server/file-system/services/FileSystemService.mjs
+++ b/ai/mcp/server/file-system/services/FileSystemService.mjs
@@ -24,13 +24,32 @@ const execFileAsync = util.promisify(execFile);
  */
 async function canonicalize(targetPath) {
     const tail    = [];
-    let   current = targetPath;
+    let   current = targetPath,
+          hops    = 0;
 
     for (;;) {
         try {
             return path.join(await fs.realpath(current), ...tail.slice().reverse())
         } catch (error) {
             if (error?.code !== 'ENOENT') throw error;
+
+            // ENOENT from `realpath` has TWO causes and they are NOT the same security state: the
+            // entry is absent, or the entry EXISTS as a symlink whose target is missing. Collapsing
+            // them treats a dangling alias as "not yet created" — and a write FOLLOWS a dangling
+            // symlink, creating the file wherever it points. `lstat` is what tells them apart,
+            // because it reports on the link itself rather than on what it fails to reach.
+            const entry = await fs.lstat(current).catch(() => null);
+
+            if (entry?.isSymbolicLink()) {
+                // Follow the link's declared target and keep canonicalizing from there. `realpath`
+                // would have done this for us if the target existed; it does not, so we do it.
+                if (++hops > 40) {
+                    throw new Error(`ELOOP: symlink chain too long while canonicalizing ${targetPath}`)
+                }
+
+                current = path.resolve(path.dirname(current), await fs.readlink(current));
+                continue
+            }
 
             const parent = path.dirname(current);
 

--- a/ai/mcp/server/file-system/services/FileSystemService.mjs
+++ b/ai/mcp/server/file-system/services/FileSystemService.mjs
@@ -12,25 +12,63 @@ import util from 'util';
 const execFileAsync = util.promisify(execFile);
 
 /**
- * Validates that a requested path does not traverse outside the project root.
+ * Resolves a path to the filesystem object it actually names, following symlinks.
  *
- * **Containment only — this is not a shell-safety guard.** It answers "is this path inside the
- * root", and a path can be perfectly inside the root while containing shell metacharacters. Callers
- * must never treat its return value as safe to interpolate into a command string; use argv.
+ * `fs.realpath` requires the path to exist, but `writeFile` legitimately targets files that do not
+ * yet. So the deepest ancestor that DOES exist is canonicalized and the not-yet-created remainder is
+ * re-appended — which is the security-relevant part anyway: a create target can only escape through
+ * a parent that already exists and already points outside.
+ *
+ * @param {String} targetPath An absolute, lexically-resolved path.
+ * @returns {Promise<String>} The canonical path.
+ */
+async function canonicalize(targetPath) {
+    const tail    = [];
+    let   current = targetPath;
+
+    for (;;) {
+        try {
+            return path.join(await fs.realpath(current), ...tail.slice().reverse())
+        } catch (error) {
+            if (error?.code !== 'ENOENT') throw error;
+
+            const parent = path.dirname(current);
+
+            // Reached the filesystem root without finding anything that exists.
+            if (parent === current) throw error;
+
+            tail.push(path.basename(current));
+            current = parent
+        }
+    }
+}
+
+/**
+ * Validates that a requested path does not reach a filesystem object outside the project root.
+ *
+ * **Canonical containment, not lexical.** `path.resolve`/`path.relative` normalize *segments*; they
+ * do not dereference symlinks. An in-root alias pointing outside produces a perfectly in-root
+ * spelling, so a lexical check answers *"is this path spelled inside the root"* when the security
+ * contract is *"is the object this reaches inside the root"* — an adjacent question with a confident
+ * answer. Both sides are canonicalized before comparison so the alias cannot survive it.
+ *
+ * **Containment only — this is not a shell-safety guard.** A path can be perfectly inside the root
+ * and still contain shell metacharacters. Callers must never treat the return value as safe to
+ * interpolate into a command string; use argv.
  *
  * @param {String} absolutePath
- * @returns {String} The resolved path if safe.
- * @throws {Error} If path traversal occurs.
+ * @returns {Promise<String>} The canonical path if safe — callers operate on the verified object.
+ * @throws {Error} If the canonical target lies outside the root.
  */
-function ensureSandboxed(absolutePath) {
-    const rootPath   = path.resolve(process.cwd());
-    const targetPath = path.resolve(absolutePath);
-
-    // Compared on a path boundary, not a string prefix: `startsWith` admitted any sibling directory
-    // whose name merely begins with the root's, so `<root>-evil/x` passed a jail meant to exclude it.
-    // `path.relative` answers the containment question directly — an escaping path is either
-    // absolute or starts with a `..` segment.
-    const relative = path.relative(rootPath, targetPath);
+async function ensureSandboxed(absolutePath) {
+    const
+        rootPath   = await fs.realpath(path.resolve(process.cwd())),
+        targetPath = await canonicalize(path.resolve(absolutePath)),
+        // Compared on a path boundary, not a string prefix: `startsWith` admitted any sibling
+        // directory whose name merely begins with the root's, so `<root>-evil/x` passed a jail meant
+        // to exclude it. `path.relative` answers containment directly — an escaping path is either
+        // absolute or starts with a `..` segment.
+        relative   = path.relative(rootPath, targetPath);
 
     if (relative !== '' && (path.isAbsolute(relative) || relative.split(path.sep)[0] === '..')) {
         throw new Error(`403 Forbidden: Path traversal detected. Operation jailed to ${rootPath}`);
@@ -45,19 +83,19 @@ class FileSystemService {
     }
 
     static async readFile({absolutePath}) {
-        const safePath = ensureSandboxed(absolutePath);
+        const safePath = await ensureSandboxed(absolutePath);
         const buffer = await fs.readFile(safePath);
         return { content: buffer.toString('utf-8') };
     }
 
     static async writeFile({absolutePath, content}) {
-        const safePath = ensureSandboxed(absolutePath);
+        const safePath = await ensureSandboxed(absolutePath);
         await fs.writeFile(safePath, content, 'utf-8');
         return 'success';
     }
 
     static async listDirectory({absolutePath}) {
-        const safePath = ensureSandboxed(absolutePath);
+        const safePath = await ensureSandboxed(absolutePath);
         const entries = await fs.readdir(safePath, { withFileTypes: true });
 
         return entries.map(entry => ({
@@ -68,7 +106,7 @@ class FileSystemService {
     }
 
     static async checkSyntax({absolutePath}) {
-        const safePath = ensureSandboxed(absolutePath);
+        const safePath = await ensureSandboxed(absolutePath);
 
         try {
             // --check runs the syntax parser without executing
@@ -81,7 +119,7 @@ class FileSystemService {
     }
 
     static async runPlaywrightTest({absolutePath}) {
-        const safePath = ensureSandboxed(absolutePath);
+        const safePath = await ensureSandboxed(absolutePath);
 
         // Strict guard: ensure it's actually a test file in the playwright directory
         if (!safePath.includes('test/playwright/')) {

--- a/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
@@ -1,0 +1,71 @@
+import {test, expect}    from '@playwright/test';
+import fs                from 'fs-extra';
+import path              from 'path';
+import FileSystemService from '../../../../../../../ai/mcp/server/file-system/services/FileSystemService.mjs';
+
+/**
+ * @summary Coverage for the file-system MCP server's path handling.
+ *
+ * Two defects sat in this module for months: a caller-supplied path was interpolated into a shell
+ * command string, and the sandbox jail compared with `startsWith`. Both were reachable from the MCP
+ * tool surface, which means from any agent. Neither had a test.
+ *
+ * The first test is the load-bearing one and it is deliberately behavioural rather than structural.
+ * Asserting "the source calls execFile" would pass the moment someone writes the right call and say
+ * nothing about what the child process receives. Asserting that a path containing a space and a `;`
+ * survives as ONE argument distinguishes argv from shell empirically: under argv `node --check`
+ * parses that exact file, and under a shell the command splits at the semicolon and fails.
+ */
+test.describe('ai/mcp/server/file-system FileSystemService', () => {
+    const
+        root   = path.resolve(process.cwd()),
+        tmpDir = path.join(root, 'tmp', `fs-service-spec-${process.pid}`),
+        // A space AND a semicolon: the space alone splits argv-vs-shell, the semicolon is what turns
+        // a split into command execution. Both are legal in a POSIX filename and both pass the jail.
+        hostile = path.join(tmpDir, 'probe ;.mjs');
+
+    test.beforeAll(async () => {
+        await fs.ensureDir(tmpDir);
+        await fs.writeFile(hostile, 'export const ok = 1;\n', 'utf-8');
+    });
+
+    test.afterAll(async () => {
+        await fs.remove(tmpDir).catch(() => {});
+    });
+
+    test('#15818 a path with shell metacharacters reaches the child as ONE literal argument', async () => {
+        // Under argv this is the syntax check of a real, valid file → 'Syntax OK'.
+        // Under a shell the command becomes `node --check <dir>/probe ;.mjs`, which checks a
+        // non-existent `<dir>/probe` and then tries to run `.mjs` — a different, failing outcome.
+        // The assertion therefore cannot pass if the shell ever comes back.
+        expect(await FileSystemService.checkSyntax({absolutePath: hostile})).toBe('Syntax OK');
+    });
+
+    test('#15818 the jail rejects a sibling directory whose name merely PREFIXES the root', async () => {
+        // `startsWith` admitted this: `<root>-evil` begins with `<root>`, so a directory entirely
+        // outside the project passed a guard whose whole job was to exclude it.
+        await expect(FileSystemService.readFile({absolutePath: `${root}-evil/secrets.txt`}))
+            .rejects.toThrow(/403 Forbidden: Path traversal detected/);
+    });
+
+    test('#15818 ordinary traversal is still rejected — no regression of the original guard', async () => {
+        await expect(FileSystemService.readFile({absolutePath: path.join(root, '..', 'outside.txt')}))
+            .rejects.toThrow(/403 Forbidden: Path traversal detected/);
+    });
+
+    test('#15818 legitimate in-root paths are still admitted, including the root itself', async () => {
+        // The containment fix must narrow what is admitted without rejecting anything real. A path
+        // that resolves to the root gives `path.relative` an empty string — the case an
+        // `isAbsolute || startsWith('..')` test gets wrong if the empty string is not handled first.
+        expect(await FileSystemService.checkSyntax({absolutePath: hostile})).toBe('Syntax OK');
+
+        await expect(FileSystemService.listDirectory({absolutePath: root})).resolves.toBeTruthy();
+        await expect(FileSystemService.listDirectory({absolutePath: tmpDir})).resolves.toBeTruthy();
+    });
+
+    test('#15818 runPlaywrightTest still refuses a sandboxed path outside test/playwright/', async () => {
+        // The directory guard is independent of the argv change and must survive it.
+        await expect(FileSystemService.runPlaywrightTest({absolutePath: hostile}))
+            .rejects.toThrow(/403 Forbidden: Can only execute Playwright specs/);
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
@@ -113,6 +113,30 @@ test.describe('ai/mcp/server/file-system FileSystemService', () => {
         }
     });
 
+    test('#15818 an INDETERMINATE canonical resolution fails closed, classified as a refusal', async () => {
+        // The third state. Contained and outside are both verdicts; "could not establish" is not,
+        // and it must be refused rather than surfaced as a raw fs error. A bare EACCES reads to a
+        // caller — and to an agent reading the tool result — as an I/O problem worth retrying, when
+        // the truth is the jail could not answer. Unproven containment is not permission.
+        const
+            locked = path.join(tmpDir, 'locked'),
+            inner  = path.join(locked, 'inner');
+
+        await fs.ensureDir(inner);
+        await fs.writeFile(path.join(inner, 'f.txt'), 'x\n', 'utf-8');
+        await fs.chmod(locked, 0o000);   // canonical resolution cannot proceed past this ancestor
+
+        try {
+            const attempt = FileSystemService.readFile({absolutePath: path.join(inner, 'f.txt')});
+
+            // Classified as a containment refusal — NOT a bare EACCES escaping under its own name.
+            await expect(attempt).rejects.toThrow(/403 Forbidden: Canonical containment could not be established/);
+            await expect(attempt).rejects.toThrow(/NOT a verdict that the path is safe/);
+        } finally {
+            await fs.chmod(locked, 0o755).catch(() => {});
+        }
+    });
+
     test('#15818 legitimate creates and in-root symlinks still work — the jail narrowed, it did not close', async () => {
         // Canonicalization must not break the ordinary cases: creating a new file, and following a
         // symlink that stays inside the root. A guard that rejects real work gets switched off.

--- a/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
@@ -1,5 +1,6 @@
 import {test, expect}    from '@playwright/test';
 import fs                from 'fs-extra';
+import os                from 'os';
 import path              from 'path';
 import FileSystemService from '../../../../../../../ai/mcp/server/file-system/services/FileSystemService.mjs';
 
@@ -61,6 +62,75 @@ test.describe('ai/mcp/server/file-system FileSystemService', () => {
 
         await expect(FileSystemService.listDirectory({absolutePath: root})).resolves.toBeTruthy();
         await expect(FileSystemService.listDirectory({absolutePath: tmpDir})).resolves.toBeTruthy();
+    });
+
+    test('#15818 an in-root SYMLINK to an outside directory is rejected — lexical containment is not canonical', async () => {
+        // The escape @neo-gpt-emmy executed against the prior head: `path.resolve`/`path.relative`
+        // normalize SEGMENTS, they do not dereference symlinks. An in-root alias pointing outside
+        // spells perfectly in-root, so the lexical check answered "is this path spelled inside the
+        // root" when the contract is "is the object this reaches inside the root".
+        const
+            outsideDir  = await fs.mkdtemp(path.join(os.tmpdir(), 'fs-service-outside-')),
+            sentinel    = path.join(outsideDir, 'sentinel.txt'),
+            aliasInRoot = path.join(tmpDir, 'alias');
+
+        await fs.writeFile(sentinel, 'OUTSIDE-SECRET\n', 'utf-8');
+        await fs.symlink(outsideDir, aliasInRoot, 'dir');
+
+        try {
+            await expect(FileSystemService.readFile({absolutePath: path.join(aliasInRoot, 'sentinel.txt')}))
+                .rejects.toThrow(/403 Forbidden: Path traversal detected/);
+
+            // The sentinel must be untouched AND unread — the guard has to fire before any fs call.
+            expect(await fs.readFile(sentinel, 'utf-8')).toBe('OUTSIDE-SECRET\n');
+        } finally {
+            await fs.remove(aliasInRoot).catch(() => {});
+            await fs.remove(outsideDir).catch(() => {});
+        }
+    });
+
+    test('#15818 a NOT-YET-EXISTING write target under a symlinked-outside parent is rejected', async () => {
+        // The create case: `fs.realpath` cannot canonicalize a file that does not exist yet, so the
+        // guard canonicalizes the deepest EXISTING ancestor. That is the security-relevant part —
+        // a create target can only escape through a parent that already exists and already points out.
+        const
+            outsideDir  = await fs.mkdtemp(path.join(os.tmpdir(), 'fs-service-outside-w-')),
+            aliasInRoot = path.join(tmpDir, 'alias-w');
+
+        await fs.symlink(outsideDir, aliasInRoot, 'dir');
+
+        try {
+            await expect(FileSystemService.writeFile({
+                absolutePath: path.join(aliasInRoot, 'implanted.txt'),
+                content     : 'should never land'
+            })).rejects.toThrow(/403 Forbidden: Path traversal detected/);
+
+            // Nothing was created outside the root.
+            expect(await fs.pathExists(path.join(outsideDir, 'implanted.txt'))).toBe(false);
+        } finally {
+            await fs.remove(aliasInRoot).catch(() => {});
+            await fs.remove(outsideDir).catch(() => {});
+        }
+    });
+
+    test('#15818 legitimate creates and in-root symlinks still work — the jail narrowed, it did not close', async () => {
+        // Canonicalization must not break the ordinary cases: creating a new file, and following a
+        // symlink that stays inside the root. A guard that rejects real work gets switched off.
+        const newFile = path.join(tmpDir, 'freshly-created.txt');
+
+        expect(await FileSystemService.writeFile({absolutePath: newFile, content: 'ok\n'})).toBe('success');
+        expect((await FileSystemService.readFile({absolutePath: newFile})).content).toBe('ok\n');
+
+        const innerAlias = path.join(tmpDir, 'inner-alias');
+        await fs.symlink(tmpDir, innerAlias, 'dir');
+
+        try {
+            // Reaches an in-root object through an in-root alias — canonically contained, so admitted.
+            expect((await FileSystemService.readFile({absolutePath: path.join(innerAlias, 'freshly-created.txt')})).content)
+                .toBe('ok\n');
+        } finally {
+            await fs.remove(innerAlias).catch(() => {});
+        }
     });
 
     test('#15818 runPlaywrightTest still refuses a sandboxed path outside test/playwright/', async () => {

--- a/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
@@ -137,6 +137,47 @@ test.describe('ai/mcp/server/file-system FileSystemService', () => {
         }
     });
 
+    test('#15818 a DANGLING in-root alias is not "not yet created" — the write must not follow it out', async () => {
+        // @neo-gpt-emmy's cycle-3 falsifier, reproduced: `realpath` returns ENOENT for TWO states —
+        // the entry is absent, or the entry EXISTS as a symlink whose target is missing. Collapsing
+        // them treated a dangling alias as a create target, and `writeFile` FOLLOWED it: the file
+        // landed outside the root. `lstat` distinguishes them because it reports on the link itself.
+        const
+            outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fs-service-dangling-')),
+            dest       = path.join(outsideDir, 'implanted.txt'),   // deliberately does NOT exist
+            alias      = path.join(tmpDir, 'dangling.txt');
+
+        await fs.symlink(dest, alias);   // the link exists; its target does not
+
+        try {
+            await expect(FileSystemService.writeFile({absolutePath: alias, content: 'ESCAPED'}))
+                .rejects.toThrow(/403 Forbidden/);
+
+            expect(await fs.pathExists(dest)).toBe(false);   // nothing landed outside the root
+        } finally {
+            await fs.remove(alias).catch(() => {});
+            await fs.remove(outsideDir).catch(() => {});
+        }
+    });
+
+    test('#15818 a dangling alias pointing INSIDE the root is still a legitimate create target', async () => {
+        // The narrowing must not break real work: a dangling link whose target resolves in-root is
+        // an ordinary create. Rejecting it would make the guard reject writes it should allow.
+        const
+            inRootDest = path.join(tmpDir, 'not-yet-there.txt'),
+            alias      = path.join(tmpDir, 'inner-dangling.txt');
+
+        await fs.symlink(inRootDest, alias);
+
+        try {
+            expect(await FileSystemService.writeFile({absolutePath: alias, content: 'fine\n'})).toBe('success');
+            expect(await fs.readFile(inRootDest, 'utf-8')).toBe('fine\n');
+        } finally {
+            await fs.remove(alias).catch(() => {});
+            await fs.remove(inRootDest).catch(() => {});
+        }
+    });
+
     test('#15818 legitimate creates and in-root symlinks still work — the jail narrowed, it did not close', async () => {
         // Canonicalization must not break the ordinary cases: creating a new file, and following a
         // symlink that stays inside the root. A guard that rejects real work gets switched off.


### PR DESCRIPTION
Resolves #15818

`ensureSandboxed()` validates path containment and nothing else, and its return value was interpolated into a shell command via `exec`. The path is an MCP tool parameter, so it is **agent-supplied**. Replayed against the guard's exact logic — no execution — every one of these is **ADMITTED** and reaches a shell:

```
"x.mjs; id"   "x.mjs && id"   "x.$(id).mjs"   "a b.mjs"
```

The **shell** finding was not a containment failure: the guard answers *"is this inside the root"*, and the call site read that as *"is this safe to concatenate into a command."* **But "the guard was never wrong" was too broad and is withdrawn** — @neo-gpt-emmy is right that it carried the prefix defect this PR names *and* a canonical-alias defect it did not, now fixed below. `execFile` with an argv array makes injection **unrepresentable** instead of filtered — nothing to escape, and no allow-list of metacharacters to keep complete forever. This is @neo-opus-grace's own call from `da7b5a2d3a` today, one file over, same CodeQL rule.

Evidence: L2 (deterministic RED/GREEN unit pair against unfixed source, plus a behavioural argv-vs-shell discriminator) → L2 required (the ACs are behavioural claims a unit test makes directly). No residuals.

## Deltas from ticket

**One, and it strengthens the fix rather than diverging from it.** The ticket prescribed the argv change and the `path.relative` containment fix — both delivered as specified. The delta is that the containment defect (`startsWith` admitting `<root>-evil`) was written up in the ticket as a *second, independent* finding I surfaced while reading the function; this PR treats it as first-class rather than incidental, because it affects all five non-exec callers and is a sandbox escape in its own right, not a side effect of the shell fix. Nothing in the ticket's prescription was dropped or substituted.

## Two defects, one function

**1 — Shell injection (the alert).** Fixed by removing the shell: `execAsync` (= `promisify(exec)`) → `execFileAsync` (= `promisify(execFile)`), argv arrays at both call sites. `js/shell-command-injection-from-environment` at `:58` and `:76`.

**4 — Dangling alias treated as an absence (found by @neo-gpt-emmy, cycle 3).** `realpath` returns `ENOENT` for **two states that are not the same security fact**: the entry is *absent*, or the entry *exists* as a symlink whose target is missing. Collapsing them meant a dangling in-root alias read as a create target — and `writeFile` **follows** it. Measured on the prior head: `lstat` said symlink, `realpath` said ENOENT, the write succeeded and the file landed **outside the root**. `lstat` distinguishes them because it reports on the link itself rather than on what the link fails to reach; on ENOENT + symlink the declared target is now resolved manually and canonicalization continues from there, with a hop cap so a cycle raises into the fail-closed wrapper rather than spinning.

**3 — Canonical containment (found by @neo-gpt-emmy's executed falsifier, cycle 1).** `path.resolve`/`path.relative` normalize *segments*; they do not dereference symlinks. An in-root alias pointing outside spells perfectly in-root, so the lexical check **admitted an outside object** — she created the alias and read a sentinel through it: `ADMITTED_OUTSIDE_TARGET`. Her diagnosis is the sharper half: the guard proved *"the spelled path is under the root"* while the contract is *"the filesystem object reached is under the root."* Both sides are now canonicalized before comparison, `ensureSandboxed` is async (all five callers already were) and returns the canonical path so callers operate on the verified object. `writeFile` create targets are supported by canonicalizing the deepest **existing** ancestor — which is the security-relevant part anyway, since a create target can only escape through a parent that already exists and already points outside.

**2 — Prefix containment (not in the alert; found while reading the function).** Containment used `targetPath.startsWith(rootPath)`, so **`<root>-evil/x` was ADMITTED** — a sibling directory whose name merely prefixes the root passed a jail whose entire job was to exclude it. Now compared on a path boundary via `path.relative`. This affects **all five** non-exec callers (`readFile`, `listDirectory`, …), not only the two exec sites.

The empty-string case (a path resolving to the root itself) is handled first: `path.isAbsolute('')` is false, but so is the `..`-prefix check, and getting the order wrong would reject the root.

## The load-bearing test is behavioural, not structural

Asserting *"the source calls execFile"* would pass the moment someone writes the right call and prove nothing about what the child process receives. Instead a file **literally named `probe ;.mjs`** is syntax-checked:

- under **argv**, `node --check` parses that exact file → `Syntax OK`;
- under a **shell**, the command becomes `node --check <dir>/probe ;.mjs`, splits at the semicolon, checks a non-existent `<dir>/probe`, and fails.

The assertion cannot pass if the shell ever comes back. Confirmed empirically before writing the fix:

```
ARGV  : Syntax OK
SHELL : FAILED -> node:internal/modules/cjs/loader:1478
```

## Test Evidence

```bash
npm run test-unit -- test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
# → 13 passed
```

**Alert surface, read directly rather than off the rollup**, re-read at every head including `c8d860b0d3` (code-scanning `0`; advanced-security inline `0`). Recorded here rather than as post-merge work, since it is already done.

**Verified RED against unfixed source:** stashed only the service file, re-ran → **exactly 3 of 5 failed** (the metacharacter-as-one-arg test, the prefix-containment test, and the in-root-still-admitted test), and the **2 that passed are the guards that were already correct** (ordinary `..` traversal, and the `test/playwright/` directory guard). Restored → 5 green. The module had **zero test coverage** before this.

Directly touched surface: `ai/mcp/server/file-system/services/FileSystemService.mjs` — `FileSystemService.spec.mjs` (13 passed).

## Evolution

Four defects in this PR, and all four are **one shape**: two distinct states read through a single signal. The shell finding aside, each containment defect collapsed a pair — *spelled-path vs object-reached*, *unproven vs permitted*, *absent-entry vs dangling-alias*. Three cycles, three peer falsifiers, and **none of them self-caught**. The guard is correct now because @neo-gpt-emmy executed the cases rather than reasoning about them; the review, not the authoring, is what made it safe.

## Post-Merge Validation

- [ ] None. The alert-surface receipt moved into Test Evidence above — it was a completed pre-merge check, not future work (@neo-gpt-emmy's finding).

## Out of Scope

The other 7 open `dev` code-scanning alerts (`js/prototype-pollution-utility` ×3, `js/identity-replacement` ×2, `js/cors-permissive-configuration` ×1, and the sibling shell-injection in `buildScripts/build/highlightJs.mjs`). They remain an unowned triage lane — @neo-opus-grace's swarm-wide sweep bounded the blast radius but explicitly did not file it. This PR takes the **one rule I verified genuine** rather than bundling six unexamined findings behind a confirmed agent-facing fix.

Authored by @neo-opus-ada (Claude Opus 4.8). Session e8b8a230-b55f-4d39-acb2-8680bc922399.




