### PR TITLE
feat(ai): packed fp16 vector encoding for the KB release artifact (#14559)

### DIFF
--- a/ai/scripts/maintenance/downloadKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/downloadKnowledgeBase.mjs
@@ -1,17 +1,17 @@
-import {execFile}       from 'child_process';
-import fs               from 'fs-extra';
-import os               from 'os';
-import path             from 'path';
-import {promisify}      from 'util';
-import {fileURLToPath}  from 'url';
+import {execFile}      from 'child_process';
+import fs              from 'fs-extra';
+import os              from 'os';
+import path            from 'path';
+import {promisify}     from 'util';
+import {fileURLToPath} from 'url';
 
 // Neo namespace bootstrap (entry-point invariant). `Neo` + `core/_export` populate
 // `globalThis.Neo` so that `ai/services.mjs` → Compare.mjs `Neo.gatekeep` resolves.
-import Neo              from '../../../src/Neo.mjs';
-import * as core        from '../../../src/core/_export.mjs';
+import Neo       from '../../../src/Neo.mjs';
+import * as core from '../../../src/core/_export.mjs';
 
-import AiConfig         from '../../config.mjs';
-import kbConfig         from '../../mcp/server/knowledge-base/config.mjs';
+import AiConfig from '../../config.mjs';
+import kbConfig from '../../mcp/server/knowledge-base/config.mjs';
 
 import {
     KB_ChromaManager,
@@ -22,7 +22,8 @@ import {
 import {
     ARTIFACT_BASENAME,
     ARTIFACT_META_FILENAME,
-    assertCollectionScopedArtifact
+    assertCollectionScopedArtifact,
+    rehydrateArtifactFromV2
 } from './knowledgeBaseArtifact.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -42,6 +43,12 @@ const execFileAsync = promisify(execFile);
  *   The data directory is never directory-restored; Memory Core collections are never touched.
  * - **Defense-in-depth:** `assertCollectionScopedArtifact` runs on the unzipped contents before
  *   import, so a malformed artifact carrying Memory Core data or a `sqlite/` payload is rejected.
+ * - **Schema v1 + v2:** a v2 artifact carries its embeddings in a packed `fp16` sidecar rather than
+ *   as decimal text inside the JSONL; `rehydrateArtifactFromV2` re-attaches them before the import,
+ *   so the SDK boundary keeps consuming one JSONL shape. A v1 artifact has no sidecar and the step
+ *   is a no-op — older release assets stay importable. Vectors are re-attached **by index**, which
+ *   is only safe while the record order is proven, so the metadata's order digest is verified first
+ *   and a mismatch aborts instead of ingesting misaligned embeddings.
  * - **Embedding-provenance check:** the artifact's `embeddingProvider`/`dimension` metadata is
  *   compared to the consumer's config; a mismatch warns (recall would silently degrade against
  *   the shipped raw vectors) without aborting npm install.
@@ -173,6 +180,17 @@ export async function downloadKnowledgeBase({
 
         await warnOnEmbeddingMismatch({extractDir, embeddingConfig, logger});
 
+        // Schema v2 ships embeddings as a packed fp16 sidecar instead of decimal text in the JSONL.
+        // Re-attach them before the import so the SDK still consumes a v1-shaped JSONL — a v1
+        // artifact carries no sidecar and this is a no-op, which is what keeps older release assets
+        // importable. A digest/shape mismatch throws, so the catch below skips the import entirely
+        // rather than ingesting vectors paired to the wrong records.
+        const rehydration = await rehydrateArtifactFromV2({artifactDir: extractDir});
+
+        if (rehydration.rehydrated) {
+            logger.log(`🗜️  Re-attached ${rehydration.recordCount} packed fp16 embeddings (artifact schema v2).`);
+        }
+
         // Collection-scoped, merge-only import. Never directory-restores .neo-ai-data;
         // never touches a Memory Core collection.
         logger.log('📥 Importing Knowledge Base collection (merge mode)...');
@@ -211,9 +229,9 @@ async function warnOnEmbeddingMismatch({extractDir, embeddingConfig, logger}) {
         return;
     }
 
-    const meta              = await fs.readJson(metaPath);
-    const localProvider     = embeddingConfig.embeddingProvider;
-    const localDimension    = embeddingConfig.vectorDimension;
+    const meta           = await fs.readJson(metaPath);
+    const localProvider  = embeddingConfig.embeddingProvider;
+    const localDimension = embeddingConfig.vectorDimension;
 
     if (meta.embeddingProvider !== localProvider || meta.dimension !== localDimension) {
         logger.warn(

--- a/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
+++ b/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
@@ -391,8 +391,15 @@ export async function rehydrateArtifactFromV2({artifactDir, fsModule = fs}) {
         throw new Error(`Artifact declares vectorEncoding '${vectorEncoding}'; this consumer decodes 'fp16' only.`);
     }
 
-    if (!dimension || !recordCount) {
-        throw new Error(`Artifact metadata is missing 'dimension' or 'recordCount'; cannot decode '${ARTIFACT_VECTORS_FILENAME}'.`);
+    // Strict numerics, not truthiness: `dimension: "3"` is truthy and would multiply into a correct-looking
+    // byte length via string coercion, so a JSON-typed field slip would pass the geometry check it exists to fail.
+    for (const [field, value] of [['dimension', dimension], ['recordCount', recordCount]]) {
+        if (!Number.isInteger(value) || value <= 0) {
+            throw new Error(
+                `Artifact metadata field '${field}' must be a positive integer, got ${JSON.stringify(value)} ` +
+                `(${typeof value}). Refusing to derive the sidecar geometry from a coerced value.`
+            );
+        }
     }
 
     if (!vectorDigest) {
@@ -402,10 +409,19 @@ export async function rehydrateArtifactFromV2({artifactDir, fsModule = fs}) {
         );
     }
 
-    const declaredOrder = byteOrder ?? ARTIFACT_VECTOR_BYTE_ORDER;
+    // Required, never defaulted. Defaulting an absent stamp re-creates the failure this whole gate exists to
+    // prevent: it lets the consumer ASSUME the order it happens to run on, which is exactly what a
+    // producer on a differently-ordered host would violate silently. The Contract Ledger says required,
+    // so the code must too — a ledger the implementation contradicts is worse than no ledger.
+    if (!byteOrder) {
+        throw new Error(
+            `Artifact declares schema version ${declaredVersion} without a 'byteOrder'. ` +
+            `The wire order is mandatory for v2 — an absent stamp cannot be assumed to match this host.`
+        );
+    }
 
-    if (declaredOrder !== ARTIFACT_VECTOR_BYTE_ORDER) {
-        throw new Error(`Artifact declares byteOrder '${declaredOrder}'; the wire contract is '${ARTIFACT_VECTOR_BYTE_ORDER}'.`);
+    if (byteOrder !== ARTIFACT_VECTOR_BYTE_ORDER) {
+        throw new Error(`Artifact declares byteOrder '${byteOrder}'; the wire contract is '${ARTIFACT_VECTOR_BYTE_ORDER}'.`);
     }
 
     const jsonlPath   = await resolveSingleArtifactJsonl({artifactDir, fsModule}),

--- a/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
+++ b/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
@@ -1,5 +1,9 @@
-import fs   from 'fs-extra';
-import path from 'path';
+import fs       from 'fs-extra';
+import path     from 'path';
+import readline from 'readline';
+// `fs-extra`'s `open` resolves to a numeric descriptor; the positional per-row read needs a real
+// `FileHandle`, so the promises API is imported explicitly rather than assumed to be the same thing.
+import {open as openFileHandle} from 'node:fs/promises';
 
 /**
  * @module ai/scripts/maintenance/knowledgeBaseArtifact
@@ -69,6 +73,39 @@ export const ARTIFACT_VECTORS_FILENAME = 'kb-vectors-fp16.bin';
  * @type {Number}
  */
 export const ARTIFACT_SCHEMA_VERSION = 2;
+
+/**
+ * Canonical wire byte order for the packed sidecar. `Float16Array` writes in the **agent's** native
+ * order, which ECMAScript leaves at the implementation's `[[LittleEndian]]` setting — and Node ships
+ * a big-endian s390x build, so producer and consumer are not guaranteed to agree. The wire is
+ * therefore pinned little-endian and the metadata states it, so a big-endian host byte-swaps on both
+ * sides instead of silently reading every vector as noise.
+ * @type {String}
+ */
+export const ARTIFACT_VECTOR_BYTE_ORDER = 'little-endian';
+
+/**
+ * Whether this host is little-endian. Derived once from a real two-byte probe rather than assumed,
+ * because the whole point of pinning the wire order is not trusting the platform to be the common one.
+ * @type {Boolean}
+ */
+export const HOST_IS_LITTLE_ENDIAN = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+
+/**
+ * Byte-swaps a packed fp16 buffer in place when the host order differs from the wire order.
+ *
+ * A no-op on the overwhelmingly common little-endian host, which is exactly why it must exist: the
+ * one platform where it matters is the one nobody tests on.
+ * @param {Buffer} buffer Packed fp16 bytes, mutated in place.
+ * @returns {Buffer} The same buffer, in wire order.
+ */
+export function toWireByteOrder(buffer) {
+    if (HOST_IS_LITTLE_ENDIAN) {
+        return buffer
+    }
+
+    return buffer.swap16()
+}
 
 /**
  * Order-binding digest over the record-id sequence.
@@ -146,59 +183,163 @@ export function unpackVectorsFp16({buffer, recordCount, dimension}) {
 }
 
 /**
+ * Resolves the single KB JSONL inside an artifact directory, refusing anything but exactly one.
+ *
+ * v2 re-attaches vectors to rows positionally against ONE row-set, so "pick the first match" is not a
+ * tie-break — it is a silent choice of which file the sidecar is presumed to describe. The upload side
+ * already refuses an ambiguous staging dir; the consumer must refuse it too, or a second KB-prefixed
+ * JSONL slipped into a public asset decides the pairing.
+ * @param {Object} options
+ * @param {String} options.artifactDir Artifact directory.
+ * @param {Object} [options.fsModule=fs] Filesystem seam (tests).
+ * @returns {Promise<String>} Absolute path to the one KB JSONL.
+ */
+export async function resolveSingleArtifactJsonl({artifactDir, fsModule = fs}) {
+    const matches = (await fsModule.readdir(artifactDir))
+        .filter(entry => entry.startsWith(KB_BACKUP_FILE_PREFIX) && entry.endsWith('.jsonl'));
+
+    if (matches.length !== 1) {
+        throw new Error(
+            `Expected exactly one '${KB_BACKUP_FILE_PREFIX}*.jsonl' in ${artifactDir}, found ${matches.length}. ` +
+            `Refusing to guess which row-set the packed vectors describe.`
+        );
+    }
+
+    return path.join(artifactDir, matches[0]);
+}
+
+/**
+ * Streams a JSONL file line by line, invoking `onRecord` per parsed record.
+ *
+ * Whole-file `readFile(path, 'utf8')` is not an option at this scale and never was: the current v1
+ * export is ~2.81 GiB, and Node's `buffer.constants.MAX_STRING_LENGTH` is 536,870,888 — 5.62× smaller —
+ * so the naive read throws `ERR_STRING_TOO_LONG` on the real corpus while passing every small fixture.
+ * @param {Object} options
+ * @param {String} options.jsonlPath Absolute path to the JSONL.
+ * @param {Function} options.onRecord `async (record, index) => void`.
+ * @returns {Promise<Number>} Records seen.
+ */
+async function streamJsonlRecords({jsonlPath, onRecord}) {
+    const reader = readline.createInterface({
+        input    : fs.createReadStream(jsonlPath),
+        crlfDelay: Infinity
+    });
+
+    let index = 0;
+
+    for await (const line of reader) {
+        if (!line.trim()) {
+            continue
+        }
+
+        await onRecord(JSON.parse(line), index++);
+    }
+
+    return index
+}
+
+/**
+ * Writes `chunk` to a stream, honouring backpressure.
+ *
+ * Ignoring the `write()` return value is what turns a streaming rewrite back into an unbounded one —
+ * the queue grows in memory instead of the string doing it.
+ * @param {Object} stream Writable stream.
+ * @param {String|Buffer} chunk Data to write.
+ * @returns {Promise<void>}
+ */
+function writeWithBackpressure(stream, chunk) {
+    if (stream.write(chunk)) {
+        return Promise.resolve()
+    }
+
+    return new Promise(resolve => stream.once('drain', resolve))
+}
+
+/**
  * Converts a staged v1 artifact directory in place to schema v2: embeddings move out of the JSONL
  * into the packed sidecar, and the JSONL keeps everything else.
  *
  * Runs on the staging dir AFTER the SDK export, so the export path itself is untouched — the SDK
  * keeps emitting its canonical v1 JSONL and this is a pure post-processing step.
+ *
+ * **Bounded memory by construction.** Rows stream in, each row's vector is encoded and appended to the
+ * sidecar immediately, and the stripped row is appended to a sibling temp file that atomically replaces
+ * the original. Peak retention is one row plus the id list for the order digest — O(dimension + rows),
+ * never O(corpus bytes). The previous whole-file implementation could not run on the current corpus at
+ * all (`ERR_STRING_TOO_LONG`), and no small fixture could reveal that.
  * @param {Object} options
  * @param {String} options.artifactDir Staged artifact directory.
  * @param {String} options.jsonlPath Absolute path to the staged KB JSONL.
  * @param {Number} options.dimension Expected vector length.
  * @param {Object} [options.fsModule=fs] Filesystem seam (tests).
- * @returns {Promise<{recordCount: Number, dimension: Number, vectorDigest: String, vectorBytes: Number}>}
+ * @returns {Promise<{recordCount: Number, dimension: Number, vectorDigest: String, vectorBytes: Number, byteOrder: String}>}
  */
 export async function packArtifactToV2({artifactDir, jsonlPath, dimension, fsModule = fs}) {
-    const lines    = (await fsModule.readFile(jsonlPath, 'utf8')).split('\n').filter(line => line.trim()),
-          vectors  = [],
-          ids      = [],
-          stripped = [];
+    const vectorsPath = path.join(artifactDir, ARTIFACT_VECTORS_FILENAME),
+          strippedTmp = `${jsonlPath}.v2.tmp`,
+          ids         = [],
+          vectorSink  = fs.createWriteStream(vectorsPath),
+          jsonlSink   = fs.createWriteStream(strippedTmp);
 
-    for (const line of lines) {
-        const record = JSON.parse(line);
+    let vectorBytes = 0;
 
-        if (!Array.isArray(record.embedding)) {
-            throw new Error(`Record '${record.id}' has no embedding array — refusing to pack a partially-vectorised artifact.`);
-        }
+    try {
+        await streamJsonlRecords({
+            jsonlPath,
+            onRecord: async (record, index) => {
+                if (!Array.isArray(record.embedding)) {
+                    throw new Error(`Record '${record.id}' has no embedding array — refusing to pack a partially-vectorised artifact.`);
+                }
+                if (record.embedding.length !== dimension) {
+                    throw new Error(
+                        `Vector at row ${index} has length ${record.embedding.length}, expected ${dimension}. ` +
+                        `Refusing to pack: a mis-sized row shifts every vector after it.`
+                    );
+                }
 
-        ids.push(record.id);
-        vectors.push(record.embedding);
+                ids.push(record.id);
 
-        const {embedding, ...rest} = record;
-        stripped.push(JSON.stringify(rest));
+                const row = toWireByteOrder(packVectorsFp16([record.embedding], dimension));
+
+                vectorBytes += row.byteLength;
+                await writeWithBackpressure(vectorSink, row);
+
+                const {embedding, ...rest} = record;
+
+                await writeWithBackpressure(jsonlSink, JSON.stringify(rest) + '\n');
+            }
+        });
+    } finally {
+        await Promise.all([
+            new Promise(resolve => vectorSink.end(resolve)),
+            new Promise(resolve => jsonlSink.end(resolve))
+        ]);
     }
 
-    const packed = packVectorsFp16(vectors, dimension);
-
-    await fsModule.writeFile(path.join(artifactDir, ARTIFACT_VECTORS_FILENAME), packed);
-    await fsModule.writeFile(jsonlPath, stripped.join('\n') + '\n');
+    // Replace only after both streams closed cleanly, so a mid-pack failure leaves the v1 JSONL intact.
+    await fsModule.move(strippedTmp, jsonlPath, {overwrite: true});
 
     return {
         recordCount : ids.length,
         dimension,
         vectorDigest: recordOrderDigest(ids),
-        vectorBytes : packed.byteLength
+        vectorBytes,
+        byteOrder   : ARTIFACT_VECTOR_BYTE_ORDER
     };
 }
 
 /**
  * Restores a v2 artifact directory to v1 shape (embeddings inline in the JSONL) so the KB import SDK
- * consumes it unchanged. A v1 artifact is a no-op, which is what keeps older assets importable.
+ * consumes it unchanged. A genuine v1 artifact is a no-op, which is what keeps older assets importable.
  *
- * Fails loud rather than importing misaligned vectors: the sidecar's byte length must match the
- * metadata, and the JSONL's id ORDER must reproduce the stamped digest. Positional re-attachment is
- * only safe while that order is proven — a permutation would pair every row with the wrong vector at
- * exactly the right buffer size.
+ * **Fails closed on the STAMPED contract, not on sidecar presence.** Schema state is read from the
+ * metadata: a v2 artifact whose sidecar is missing is an error, never a silent v1 import that would
+ * ingest every record with no embedding at all. Unknown versions, a non-`fp16` encoding, an absent
+ * digest, a foreign byte order, a row-count mismatch, or a reordered JSONL all abort — positional
+ * re-attachment is only safe while every one of those is proven.
+ *
+ * Bounded memory: rows stream and each vector is read from the sidecar at its own offset, so peak
+ * retention is one row rather than the whole corpus.
  * @param {Object} options
  * @param {String} options.artifactDir Unzipped artifact directory.
  * @param {Object} [options.fsModule=fs] Filesystem seam (tests).
@@ -206,54 +347,121 @@ export async function packArtifactToV2({artifactDir, jsonlPath, dimension, fsMod
  */
 export async function rehydrateArtifactFromV2({artifactDir, fsModule = fs}) {
     const metaPath    = path.join(artifactDir, ARTIFACT_META_FILENAME),
-          vectorsPath = path.join(artifactDir, ARTIFACT_VECTORS_FILENAME);
+          vectorsPath = path.join(artifactDir, ARTIFACT_VECTORS_FILENAME),
+          hasSidecar  = await fsModule.pathExists(vectorsPath),
+          hasMeta     = await fsModule.pathExists(metaPath);
 
-    if (!await fsModule.pathExists(vectorsPath)) {
+    if (!hasMeta) {
+        if (hasSidecar) {
+            throw new Error(`Artifact carries '${ARTIFACT_VECTORS_FILENAME}' but no '${ARTIFACT_META_FILENAME}' — the sidecar is undecodable without its stamped record count, dimension and digest.`);
+        }
+        // No metadata and no sidecar: a pre-provenance v1 asset. Nothing to re-attach.
         return {rehydrated: false, recordCount: 0}
     }
 
-    if (!await fsModule.pathExists(metaPath)) {
-        throw new Error(`Artifact carries '${ARTIFACT_VECTORS_FILENAME}' but no '${ARTIFACT_META_FILENAME}' — the sidecar is undecodable without its record count and dimension.`);
+    const meta                                                                               = JSON.parse(await fsModule.readFile(metaPath, 'utf8')),
+          {artifactVersion, vectorEncoding, dimension, recordCount, vectorDigest, byteOrder} = meta;
+
+    // Schema state comes from the STAMP. Deriving it from sidecar presence is what let a v2 artifact
+    // with a lost sidecar import as vectorless v1 — the failure a consumer can least afford to guess at.
+    const declaredVersion = artifactVersion ?? 1;
+
+    if (declaredVersion === 1) {
+        if (hasSidecar) {
+            throw new Error(`Artifact declares artifactVersion 1 but carries '${ARTIFACT_VECTORS_FILENAME}'. Refusing a contradictory artifact rather than choosing which half to believe.`);
+        }
+        return {rehydrated: false, recordCount: 0}
     }
 
-    const meta                                   = JSON.parse(await fsModule.readFile(metaPath, 'utf8'));
-    const {dimension, recordCount, vectorDigest} = meta;
+    if (declaredVersion !== ARTIFACT_SCHEMA_VERSION) {
+        throw new Error(
+            `Artifact declares schema version ${declaredVersion}; this consumer understands ${ARTIFACT_SCHEMA_VERSION}. ` +
+            `Refusing to half-decode a format written by a newer producer — upgrade rather than guess.`
+        );
+    }
+
+    if (!hasSidecar) {
+        throw new Error(
+            `Artifact declares schema version ${declaredVersion} but '${ARTIFACT_VECTORS_FILENAME}' is missing. ` +
+            `Importing would silently ingest every record with NO embedding; refusing.`
+        );
+    }
+
+    if (vectorEncoding !== 'fp16') {
+        throw new Error(`Artifact declares vectorEncoding '${vectorEncoding}'; this consumer decodes 'fp16' only.`);
+    }
 
     if (!dimension || !recordCount) {
         throw new Error(`Artifact metadata is missing 'dimension' or 'recordCount'; cannot decode '${ARTIFACT_VECTORS_FILENAME}'.`);
     }
 
-    const entries   = await fsModule.readdir(artifactDir),
-          jsonlName = entries.find(entry => entry.startsWith(KB_BACKUP_FILE_PREFIX) && entry.endsWith('.jsonl'));
-
-    if (!jsonlName) {
-        throw new Error(`Artifact carries '${ARTIFACT_VECTORS_FILENAME}' but no '${KB_BACKUP_FILE_PREFIX}*.jsonl' to re-attach the vectors to.`);
+    if (!vectorDigest) {
+        throw new Error(
+            `Artifact declares schema version ${declaredVersion} without a 'vectorDigest'. ` +
+            `The digest is the only thing that proves the row order the positional pairing assumes — it is mandatory, not optional.`
+        );
     }
 
-    const jsonlPath = path.join(artifactDir, jsonlName),
-          records   = (await fsModule.readFile(jsonlPath, 'utf8')).split('\n').filter(line => line.trim()).map(line => JSON.parse(line)),
-          ids       = records.map(record => record.id);
+    const declaredOrder = byteOrder ?? ARTIFACT_VECTOR_BYTE_ORDER;
 
-    if (records.length !== recordCount) {
-        throw new Error(`Artifact JSONL holds ${records.length} records but metadata claims ${recordCount}. Refusing to re-attach vectors positionally.`);
+    if (declaredOrder !== ARTIFACT_VECTOR_BYTE_ORDER) {
+        throw new Error(`Artifact declares byteOrder '${declaredOrder}'; the wire contract is '${ARTIFACT_VECTOR_BYTE_ORDER}'.`);
     }
 
-    if (vectorDigest && recordOrderDigest(ids) !== vectorDigest) {
+    const jsonlPath   = await resolveSingleArtifactJsonl({artifactDir, fsModule}),
+          rowBytes    = dimension * 2,
+          expectedLen = recordCount * rowBytes,
+          actualLen   = (await fsModule.stat(vectorsPath)).size;
+
+    if (actualLen !== expectedLen) {
+        throw new Error(
+            `Packed vector sidecar is ${actualLen} bytes, expected ${expectedLen} ` +
+            `(${recordCount} records × ${dimension} dims × 2). Artifact is truncated or its metadata is wrong.`
+        );
+    }
+
+    // Order is proven BEFORE any vector is attached: a permutation pairs every row with the wrong
+    // embedding at exactly the right buffer size, so a length check cannot see it.
+    const ids = [];
+
+    await streamJsonlRecords({jsonlPath, onRecord: record => { ids.push(record.id) }});
+
+    if (ids.length !== recordCount) {
+        throw new Error(`Artifact JSONL holds ${ids.length} records but metadata claims ${recordCount}. Refusing to re-attach vectors positionally.`);
+    }
+
+    if (recordOrderDigest(ids) !== vectorDigest) {
         throw new Error(
             `Artifact record order does not match the stamped vector digest (${vectorDigest}). ` +
             `The JSONL was reordered or rewritten after packing — re-attaching by index would pair every record with the wrong embedding.`
         );
     }
 
-    const vectors = unpackVectorsFp16({
-        buffer: await fsModule.readFile(vectorsPath),
-        recordCount,
-        dimension
-    });
+    const rehydratedTmp = `${jsonlPath}.v1.tmp`,
+          sink          = fs.createWriteStream(rehydratedTmp),
+          handle        = await openFileHandle(vectorsPath, 'r'),
+          rowBuffer     = Buffer.allocUnsafe(rowBytes);
 
-    const rehydrated = records.map((record, row) => JSON.stringify({...record, embedding: Array.from(vectors[row])}));
+    try {
+        await streamJsonlRecords({
+            jsonlPath,
+            onRecord: async (record, index) => {
+                await handle.read(rowBuffer, 0, rowBytes, index * rowBytes);
 
-    await fsModule.writeFile(jsonlPath, rehydrated.join('\n') + '\n');
+                // Swap a COPY: the shared row buffer is reused every iteration, and swapping in place
+                // would corrupt the next read's view on a big-endian host.
+                const wire   = toWireByteOrder(Buffer.from(rowBuffer)),
+                      vector = new Float16Array(wire.buffer, wire.byteOffset, dimension);
+
+                await writeWithBackpressure(sink, JSON.stringify({...record, embedding: Array.from(vector)}) + '\n');
+            }
+        });
+    } finally {
+        await handle.close();
+        await new Promise(resolve => sink.end(resolve));
+    }
+
+    await fsModule.move(rehydratedTmp, jsonlPath, {overwrite: true});
     // The SDK import only reads `.jsonl`, but leaving the sidecar behind would let a re-run
     // double-rehydrate an already-inline JSONL. Removing it makes the operation idempotent.
     await fsModule.remove(vectorsPath);

--- a/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
+++ b/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
@@ -49,6 +49,103 @@ export const ARTIFACT_META_FILENAME = 'kb-artifact-meta.json';
 export const MEMORY_CORE_COLLECTION_PREFIXES = ['neo-agent-memory', 'neo-agent-sessions', 'neo-native-graph'];
 
 /**
+ * Packed-vector sidecar filename for artifact schema v2. A flat row-major `Float16` buffer of
+ * `recordCount × dimension` values; the JSONL rows carry everything EXCEPT `embedding`.
+ *
+ * Why binary: ~97% of a v1 artifact is embeddings serialized as decimal TEXT. The vectors
+ * themselves are not the waste — the encoding is. `fp16` was chosen over `fp32` on measurement,
+ * not arithmetic: on a corpus-wide 10% sample (5,492 vectors, dim 4096) fp16 round-trip scored
+ * recall@10 100.000% and recall@50 99.983% against fp32, with top-1 identical at both depths.
+ *
+ * The raw-vectors / no-re-embed invariant is UNCHANGED: the vectors still ship in full, just not
+ * as decimal text, so an adopter never re-embeds the corpus on boot.
+ * @type {String}
+ */
+export const ARTIFACT_VECTORS_FILENAME = 'kb-vectors-fp16.bin';
+
+/**
+ * Artifact schema version this build/consume pair emits and understands. v1 = embeddings inline in
+ * the JSONL as decimal text; v2 = JSONL without `embedding` + the packed `fp16` sidecar.
+ * @type {Number}
+ */
+export const ARTIFACT_SCHEMA_VERSION = 2;
+
+/**
+ * Order-binding digest over the record-id sequence.
+ *
+ * v2 re-attaches vectors to rows **by index**, so a reordered JSONL would pair every row with the
+ * wrong vector — a silent corruption that no byte-length check can see (the buffer stays exactly
+ * the right size). This digest makes that failure LOUD: the build side stamps it into the metadata
+ * and the consume side recomputes it from the JSONL it actually received. A mismatch means the
+ * pairing is untrustworthy and the import must abort rather than ingest misaligned embeddings.
+ *
+ * FNV-1a over the newline-joined ids: order-sensitive by construction, no crypto dependency, and
+ * the whole point is detecting permutation rather than resisting an adversary.
+ * @param {String[]} ids Record ids in JSONL row order.
+ * @returns {String} Hex digest.
+ */
+export function recordOrderDigest(ids) {
+    let hash = 0x811c9dc5;
+
+    for (const chunk of ids.join('\n')) {
+        hash ^= chunk.codePointAt(0);
+        hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+
+    return hash.toString(16).padStart(8, '0');
+}
+
+/**
+ * Encodes vectors to the packed `fp16` sidecar buffer.
+ * @param {Array<Array<Number>|Float32Array>} vectors Row-major vectors, all of length `dimension`.
+ * @param {Number} dimension Expected vector length; a row of any other length is a hard error
+ *        because a short row would silently shift every subsequent vector.
+ * @returns {Buffer}
+ */
+export function packVectorsFp16(vectors, dimension) {
+    const packed = new Float16Array(vectors.length * dimension);
+
+    vectors.forEach((vector, row) => {
+        if (vector.length !== dimension) {
+            throw new Error(
+                `Vector at row ${row} has length ${vector.length}, expected ${dimension}. ` +
+                `Refusing to pack: a mis-sized row shifts every vector after it.`
+            );
+        }
+        packed.set(vector, row * dimension);
+    });
+
+    return Buffer.from(packed.buffer, packed.byteOffset, packed.byteLength);
+}
+
+/**
+ * Decodes the packed sidecar back to per-row vectors, failing loud on any shape or order mismatch.
+ * @param {Object} options
+ * @param {Buffer} options.buffer Packed sidecar contents.
+ * @param {Number} options.recordCount Expected row count (from the artifact metadata).
+ * @param {Number} options.dimension Expected vector length (from the artifact metadata).
+ * @returns {Float32Array[]} One vector per row, in row order.
+ */
+export function unpackVectorsFp16({buffer, recordCount, dimension}) {
+    const expectedBytes = recordCount * dimension * 2;
+
+    if (buffer.byteLength !== expectedBytes) {
+        throw new Error(
+            `Packed vector sidecar is ${buffer.byteLength} bytes, expected ${expectedBytes} ` +
+            `(${recordCount} records × ${dimension} dims × 2). Artifact is truncated or its metadata is wrong.`
+        );
+    }
+
+    // Copy rather than view: the source Buffer may be a slice of a pooled allocation, and a view
+    // would keep the whole pool alive while also exposing neighbouring bytes on a length mistake.
+    const view = new Float16Array(buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength));
+
+    return Array.from({length: recordCount}, (_, row) =>
+        Float32Array.from(view.subarray(row * dimension, (row + 1) * dimension))
+    );
+}
+
+/**
  * Asserts a staged (or unzipped) artifact directory is collection-scoped to the public
  * Knowledge Base collection. Throws on the first sign of a Memory Core leak so the failure is
  * loud at build time and at ingest time.
@@ -90,8 +187,12 @@ export async function assertCollectionScopedArtifact({artifactDir, fsModule = fs
                 throw new Error(`Artifact scope violation: unexpected JSONL export '${entry}'. Only '${KB_BACKUP_FILE_PREFIX}*.jsonl' (the Knowledge Base collection) is permitted.`);
             }
             jsonlFiles.push(entry);
-        } else if (entry !== ARTIFACT_META_FILENAME) {
-            throw new Error(`Artifact scope violation: unexpected entry '${entry}'. Permitted: '${KB_BACKUP_FILE_PREFIX}*.jsonl' and '${ARTIFACT_META_FILENAME}'.`);
+        } else if (entry !== ARTIFACT_META_FILENAME && entry !== ARTIFACT_VECTORS_FILENAME) {
+            // Schema v2 adds EXACTLY ONE permitted binary — an exact-match allowlist entry, never a
+            // pattern. This guard is the privacy invariant that keeps Memory Core exports and sqlite
+            // payloads out of a public release asset, so widening it to `*.bin` (or anything
+            // pattern-shaped) would trade the whole guarantee for one file's convenience.
+            throw new Error(`Artifact scope violation: unexpected entry '${entry}'. Permitted: '${KB_BACKUP_FILE_PREFIX}*.jsonl', '${ARTIFACT_META_FILENAME}' and '${ARTIFACT_VECTORS_FILENAME}'.`);
         }
     }
 

--- a/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
+++ b/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
@@ -146,6 +146,122 @@ export function unpackVectorsFp16({buffer, recordCount, dimension}) {
 }
 
 /**
+ * Converts a staged v1 artifact directory in place to schema v2: embeddings move out of the JSONL
+ * into the packed sidecar, and the JSONL keeps everything else.
+ *
+ * Runs on the staging dir AFTER the SDK export, so the export path itself is untouched — the SDK
+ * keeps emitting its canonical v1 JSONL and this is a pure post-processing step.
+ * @param {Object} options
+ * @param {String} options.artifactDir Staged artifact directory.
+ * @param {String} options.jsonlPath Absolute path to the staged KB JSONL.
+ * @param {Number} options.dimension Expected vector length.
+ * @param {Object} [options.fsModule=fs] Filesystem seam (tests).
+ * @returns {Promise<{recordCount: Number, dimension: Number, vectorDigest: String, vectorBytes: Number}>}
+ */
+export async function packArtifactToV2({artifactDir, jsonlPath, dimension, fsModule = fs}) {
+    const lines    = (await fsModule.readFile(jsonlPath, 'utf8')).split('\n').filter(line => line.trim()),
+          vectors  = [],
+          ids      = [],
+          stripped = [];
+
+    for (const line of lines) {
+        const record = JSON.parse(line);
+
+        if (!Array.isArray(record.embedding)) {
+            throw new Error(`Record '${record.id}' has no embedding array — refusing to pack a partially-vectorised artifact.`);
+        }
+
+        ids.push(record.id);
+        vectors.push(record.embedding);
+
+        const {embedding, ...rest} = record;
+        stripped.push(JSON.stringify(rest));
+    }
+
+    const packed = packVectorsFp16(vectors, dimension);
+
+    await fsModule.writeFile(path.join(artifactDir, ARTIFACT_VECTORS_FILENAME), packed);
+    await fsModule.writeFile(jsonlPath, stripped.join('\n') + '\n');
+
+    return {
+        recordCount : ids.length,
+        dimension,
+        vectorDigest: recordOrderDigest(ids),
+        vectorBytes : packed.byteLength
+    };
+}
+
+/**
+ * Restores a v2 artifact directory to v1 shape (embeddings inline in the JSONL) so the KB import SDK
+ * consumes it unchanged. A v1 artifact is a no-op, which is what keeps older assets importable.
+ *
+ * Fails loud rather than importing misaligned vectors: the sidecar's byte length must match the
+ * metadata, and the JSONL's id ORDER must reproduce the stamped digest. Positional re-attachment is
+ * only safe while that order is proven — a permutation would pair every row with the wrong vector at
+ * exactly the right buffer size.
+ * @param {Object} options
+ * @param {String} options.artifactDir Unzipped artifact directory.
+ * @param {Object} [options.fsModule=fs] Filesystem seam (tests).
+ * @returns {Promise<{rehydrated: Boolean, recordCount: Number}>}
+ */
+export async function rehydrateArtifactFromV2({artifactDir, fsModule = fs}) {
+    const metaPath    = path.join(artifactDir, ARTIFACT_META_FILENAME),
+          vectorsPath = path.join(artifactDir, ARTIFACT_VECTORS_FILENAME);
+
+    if (!await fsModule.pathExists(vectorsPath)) {
+        return {rehydrated: false, recordCount: 0}
+    }
+
+    if (!await fsModule.pathExists(metaPath)) {
+        throw new Error(`Artifact carries '${ARTIFACT_VECTORS_FILENAME}' but no '${ARTIFACT_META_FILENAME}' — the sidecar is undecodable without its record count and dimension.`);
+    }
+
+    const meta                                   = JSON.parse(await fsModule.readFile(metaPath, 'utf8'));
+    const {dimension, recordCount, vectorDigest} = meta;
+
+    if (!dimension || !recordCount) {
+        throw new Error(`Artifact metadata is missing 'dimension' or 'recordCount'; cannot decode '${ARTIFACT_VECTORS_FILENAME}'.`);
+    }
+
+    const entries   = await fsModule.readdir(artifactDir),
+          jsonlName = entries.find(entry => entry.startsWith(KB_BACKUP_FILE_PREFIX) && entry.endsWith('.jsonl'));
+
+    if (!jsonlName) {
+        throw new Error(`Artifact carries '${ARTIFACT_VECTORS_FILENAME}' but no '${KB_BACKUP_FILE_PREFIX}*.jsonl' to re-attach the vectors to.`);
+    }
+
+    const jsonlPath = path.join(artifactDir, jsonlName),
+          records   = (await fsModule.readFile(jsonlPath, 'utf8')).split('\n').filter(line => line.trim()).map(line => JSON.parse(line)),
+          ids       = records.map(record => record.id);
+
+    if (records.length !== recordCount) {
+        throw new Error(`Artifact JSONL holds ${records.length} records but metadata claims ${recordCount}. Refusing to re-attach vectors positionally.`);
+    }
+
+    if (vectorDigest && recordOrderDigest(ids) !== vectorDigest) {
+        throw new Error(
+            `Artifact record order does not match the stamped vector digest (${vectorDigest}). ` +
+            `The JSONL was reordered or rewritten after packing — re-attaching by index would pair every record with the wrong embedding.`
+        );
+    }
+
+    const vectors = unpackVectorsFp16({
+        buffer: await fsModule.readFile(vectorsPath),
+        recordCount,
+        dimension
+    });
+
+    const rehydrated = records.map((record, row) => JSON.stringify({...record, embedding: Array.from(vectors[row])}));
+
+    await fsModule.writeFile(jsonlPath, rehydrated.join('\n') + '\n');
+    // The SDK import only reads `.jsonl`, but leaving the sidecar behind would let a re-run
+    // double-rehydrate an already-inline JSONL. Removing it makes the operation idempotent.
+    await fsModule.remove(vectorsPath);
+
+    return {rehydrated: true, recordCount};
+}
+
+/**
  * Asserts a staged (or unzipped) artifact directory is collection-scoped to the public
  * Knowledge Base collection. Throws on the first sign of a Memory Core leak so the failure is
  * loud at build time and at ingest time.
@@ -167,7 +283,7 @@ export async function assertCollectionScopedArtifact({artifactDir, fsModule = fs
         throw new Error(`Artifact directory not found: ${artifactDir}`);
     }
 
-    const entries = await fsModule.readdir(artifactDir);
+    const entries    = await fsModule.readdir(artifactDir);
     const jsonlFiles = [];
 
     for (const entry of entries) {

--- a/ai/scripts/maintenance/uploadKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/uploadKnowledgeBase.mjs
@@ -201,8 +201,11 @@ export async function uploadKnowledgeBase({
             recordCount,
             vectorEncoding : 'fp16',
             vectorDigest   : packed.vectorDigest,
-            neoVersion     : resolvedTag,
-            createdAt      : new Date().toISOString()
+            // Stamped, not assumed: `Float16Array` writes in the agent's native order and Node ships a
+            // big-endian build, so the consumer must be told what order it is reading.
+            byteOrder : packed.byteOrder,
+            neoVersion: resolvedTag,
+            createdAt : new Date().toISOString()
         };
         await fs.writeJson(path.join(stageDir, ARTIFACT_META_FILENAME), meta, {spaces: 2});
 

--- a/ai/scripts/maintenance/uploadKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/uploadKnowledgeBase.mjs
@@ -1,18 +1,18 @@
-import {execFile}       from 'child_process';
-import fs               from 'fs-extra';
-import os               from 'os';
-import path             from 'path';
-import readline         from 'readline';
-import {promisify}      from 'util';
-import {fileURLToPath}  from 'url';
+import {execFile}      from 'child_process';
+import fs              from 'fs-extra';
+import os              from 'os';
+import path            from 'path';
+import readline        from 'readline';
+import {promisify}     from 'util';
+import {fileURLToPath} from 'url';
 
 // Neo namespace bootstrap (entry-point invariant). `Neo` + `core/_export` populate
 // `globalThis.Neo` so that `ai/services.mjs` → Compare.mjs `Neo.gatekeep` resolves.
-import Neo              from '../../../src/Neo.mjs';
-import * as core        from '../../../src/core/_export.mjs';
+import Neo       from '../../../src/Neo.mjs';
+import * as core from '../../../src/core/_export.mjs';
 
-import AiConfig         from '../../config.mjs';
-import kbConfig         from '../../mcp/server/knowledge-base/config.mjs';
+import AiConfig from '../../config.mjs';
+import kbConfig from '../../mcp/server/knowledge-base/config.mjs';
 
 import {
     KB_DatabaseService,
@@ -23,8 +23,11 @@ import {
     ARTIFACT_BASENAME,
     KB_BACKUP_FILE_PREFIX,
     ARTIFACT_META_FILENAME,
+    ARTIFACT_SCHEMA_VERSION,
+    ARTIFACT_VECTORS_FILENAME,
     MEMORY_CORE_COLLECTION_PREFIXES,
-    assertCollectionScopedArtifact
+    assertCollectionScopedArtifact,
+    packArtifactToV2
 } from './knowledgeBaseArtifact.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -44,12 +47,16 @@ const execFileAsync = promisify(execFile);
  * mailbox. A defense-in-depth assertion (`assertCollectionScopedArtifact`) fails the upload
  * if any Memory Core collection or a `sqlite/` payload leaks into the staged artifact.
  *
- * ## Artifact shape
+ * ## Artifact shape (schema v2)
  *
- * The artifact is a zip of a staging directory containing exactly two entries:
- * - `knowledge-base-backup-<ISO-timestamp>.jsonl` — the collection export (raw vectors round-trip).
+ * The artifact is a zip of a staging directory containing exactly three entries:
+ * - `knowledge-base-backup-<ISO-timestamp>.jsonl` — the collection export, **without** `embedding`.
+ * - `kb-vectors-fp16.bin` — the embeddings as a packed row-major `fp16` buffer, paired to the JSONL
+ *   rows by index. ~97% of a v1 artifact was embeddings serialized as decimal TEXT; the vectors
+ *   still ship in full, so the raw-vectors / no-re-embed guarantee is unchanged.
  * - `kb-artifact-meta.json` — `embeddingProvider` + `dimension` provenance so a download-side
- *   recall mismatch (model/dimension drift against the shipped raw vectors) is detectable.
+ *   recall mismatch (model/dimension drift against the shipped raw vectors) is detectable, plus the
+ *   `recordCount` + order digest the consumer needs to decode the sidecar safely.
  *
  * ## Pipeline position
  *
@@ -136,8 +143,8 @@ export async function uploadKnowledgeBase({
     const dimension         = embeddingConfig.vectorDimension;
     const artifactName      = ARTIFACT_BASENAME;
 
-    const stageDir    = path.join(stageRoot, `neo-kb-artifact-${process.pid}-${Date.now()}`);
-    const artifactDir = path.dirname(path.resolve(PROJECT_ROOT, artifactName));
+    const stageDir     = path.join(stageRoot, `neo-kb-artifact-${process.pid}-${Date.now()}`);
+    const artifactDir  = path.dirname(path.resolve(PROJECT_ROOT, artifactName));
     const artifactPath = path.resolve(PROJECT_ROOT, artifactName);
 
     await fs.ensureDir(stageDir);
@@ -168,35 +175,47 @@ export async function uploadKnowledgeBase({
             );
         }
 
-        const jsonlPath    = path.join(stageDir, stagedJsonl[0]);
-        const recordCount  = await countJsonlRecords(jsonlPath);
+        const jsonlPath   = path.join(stageDir, stagedJsonl[0]);
+        const recordCount = await countJsonlRecords(jsonlPath);
 
         if (recordCount === 0) {
             throw new Error(`Knowledge Base collection '${collectionName}' exported 0 records. Run 'npm run ai:sync-kb' before releasing.`);
         }
 
-        // 3. Stamp embedding provenance so a download-side model/dimension drift is detectable.
+        // 3. Move embeddings out of the JSONL into the packed fp16 sidecar (schema v2). ~97% of a v1
+        // artifact was embeddings as decimal TEXT; the vectors still ship in full, so the
+        // raw-vectors / no-re-embed guarantee is unchanged. fp16 over fp32 was decided on a
+        // corpus-wide recall measurement, not on arithmetic — see the originating ticket.
+        logger.log('🗜️  Packing embeddings into the fp16 sidecar (schema v2)...');
+        const packed = await packArtifactToV2({artifactDir: stageDir, jsonlPath, dimension});
+        logger.log(`✅ Packed ${packed.recordCount} × ${packed.dimension} vectors into ${(packed.vectorBytes / 1048576).toFixed(1)} MB.`);
+
+        // 4. Stamp embedding provenance so a download-side model/dimension drift is detectable.
+        // `vectorDigest` binds the JSONL's record ORDER: v2 re-attaches vectors positionally, so a
+        // reordered JSONL would pair every row with the wrong embedding at exactly the right size.
         const meta = {
-            artifactVersion  : 1,
-            collection       : collectionName,
+            artifactVersion: ARTIFACT_SCHEMA_VERSION,
+            collection     : collectionName,
             embeddingProvider,
             dimension,
             recordCount,
-            neoVersion       : resolvedTag,
-            createdAt        : new Date().toISOString()
+            vectorEncoding : 'fp16',
+            vectorDigest   : packed.vectorDigest,
+            neoVersion     : resolvedTag,
+            createdAt      : new Date().toISOString()
         };
         await fs.writeJson(path.join(stageDir, ARTIFACT_META_FILENAME), meta, {spaces: 2});
 
-        // 4. Defense-in-depth: prove the staged artifact is collection-scoped (no MC, no sqlite/).
+        // 5. Defense-in-depth: prove the staged artifact is collection-scoped (no MC, no sqlite/).
         await assertCollectionScopedArtifact({artifactDir: stageDir});
         logger.log(`✅ Artifact is collection-scoped: ${recordCount} '${collectionName}' chunks, no Memory Core collections, no sqlite/.`);
 
-        // 5. Zip the staging dir CONTENTS (flat) into the canonical artifact, then upload.
+        // 6. Zip the staging dir CONTENTS (flat) into the canonical artifact, then upload.
         await fs.ensureDir(artifactDir);
         await fs.remove(artifactPath);
         logger.log(`📦 Packaging ${artifactName}...`);
         // `-j` flattens — the zip holds the JSONL + meta at its root, never a `.neo-ai-data` tree.
-        await execFileAsync('zip', ['-j', '-q', artifactPath, jsonlPath, path.join(stageDir, ARTIFACT_META_FILENAME)]);
+        await execFileAsync('zip', ['-j', '-q', artifactPath, jsonlPath, path.join(stageDir, ARTIFACT_META_FILENAME), path.join(stageDir, ARTIFACT_VECTORS_FILENAME)]);
 
         const stats = await fs.stat(artifactPath);
         logger.log(`✅ Packaged: ${artifactName} (${(stats.size / 1024 / 1024).toFixed(2)} MB)`);

--- a/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
@@ -660,6 +660,39 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
         expect(packed.byteOrder).toBe(ARTIFACT_VECTOR_BYTE_ORDER);
     });
 
+    test('the sidecar holds CANONICAL little-endian bytes for known fp16 values', async () => {
+        // A same-host round-trip cannot see a byte-order defect: producer and consumer are wrong together
+        // and agree. Only a known-value byte assertion pins the wire. 1 = 0x3C00, -2 = 0xC000,
+        // 0.5 = 0x3800; little-endian puts the low byte first, so the file must read 00 3c 00 c0 00 38.
+        const dir   = path.join(workRoot, 'canonical-bytes'),
+              jsonl = path.join(dir, `${KB_BACKUP_FILE_PREFIX}bytes.jsonl`);
+
+        await fsExtra.ensureDir(dir);
+        fs.writeFileSync(jsonl, JSON.stringify({id: 'kb-1', embedding: [1, -2, 0.5], metadata: {}}) + '\n');
+
+        await packArtifactToV2({artifactDir: dir, jsonlPath: jsonl, dimension: 3});
+
+        expect(fs.readFileSync(path.join(dir, ARTIFACT_VECTORS_FILENAME)).toString('hex')).toBe('003c00c00038');
+    });
+
+    test('a v2 artifact with NO byteOrder stamp is refused, not assumed to match this host', async () => {
+        // Defaulting an absent stamp re-creates the exact failure the gate exists to prevent — the consumer
+        // assumes the order it happens to run on. The Contract Ledger says required; so must the code.
+        const {dir} = await stageV2({label: 'absent-order', metaOverrides: {byteOrder: undefined}});
+
+        await expect(rehydrateArtifactFromV2({artifactDir: dir}))
+            .rejects.toThrow(/without a 'byteOrder'/);
+    });
+
+    test('a STRING dimension is refused — truthiness is not a geometry check', async () => {
+        // `dimension: "3"` is truthy and coerces through the multiplication, so the byte-length check would
+        // pass on a JSON-typed field slip. Strict integers close it.
+        const {dir} = await stageV2({label: 'string-dim', metaOverrides: {dimension: `${FIXTURE_DIMENSION}`}});
+
+        await expect(rehydrateArtifactFromV2({artifactDir: dir}))
+            .rejects.toThrow(/'dimension' must be a positive integer, got "4" \(string\)/);
+    });
+
     test('pack streams: peak RSS stays bounded well below the JSONL it rewrites', async () => {
         // The defect this closes could not be seen by any small fixture: the old implementation read the
         // whole JSONL into ONE utf-8 string, and the real 2.81 GiB export is 5.62x Node's

--- a/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
@@ -29,6 +29,7 @@ test.describe.configure({mode: 'serial'});
 
 test.describe('Knowledge Base release artifact — collection-scoped contract (#12157)', () => {
     let assertCollectionScopedArtifact, ARTIFACT_BASENAME, ARTIFACT_META_FILENAME, KB_BACKUP_FILE_PREFIX;
+    let ARTIFACT_VECTORS_FILENAME, ARTIFACT_SCHEMA_VERSION, packVectorsFp16, unpackVectorsFp16, recordOrderDigest;
     let uploadKnowledgeBase, downloadKnowledgeBase;
     let workRoot;
 
@@ -60,7 +61,12 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
             assertCollectionScopedArtifact,
             ARTIFACT_BASENAME,
             ARTIFACT_META_FILENAME,
-            KB_BACKUP_FILE_PREFIX
+            KB_BACKUP_FILE_PREFIX,
+            ARTIFACT_VECTORS_FILENAME,
+            ARTIFACT_SCHEMA_VERSION,
+            packVectorsFp16,
+            unpackVectorsFp16,
+            recordOrderDigest
         } = await import('../../../../../../ai/scripts/maintenance/knowledgeBaseArtifact.mjs'));
 
         ({uploadKnowledgeBase}   = await import('../../../../../../ai/scripts/maintenance/uploadKnowledgeBase.mjs'));
@@ -90,6 +96,70 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
 
         const result = await assertCollectionScopedArtifact({artifactDir: dir});
         expect(result.jsonlFiles).toEqual([`${KB_BACKUP_FILE_PREFIX}2026-01-01.jsonl`]);
+    });
+
+    // ───────── schema v2: packed fp16 vectors ─────────
+
+    test('the packed-vector sidecar is permitted — and the allowlist stayed EXACT, not pattern-shaped', async () => {
+        const dir = path.join(workRoot, 'v2-clean');
+        await fsExtra.ensureDir(dir);
+        fs.writeFileSync(path.join(dir, `${KB_BACKUP_FILE_PREFIX}2026-01-01.jsonl`), '{"id":"kb-1"}\n');
+        fs.writeFileSync(path.join(dir, ARTIFACT_META_FILENAME), '{"collection":"neo-knowledge-base"}');
+        fs.writeFileSync(path.join(dir, ARTIFACT_VECTORS_FILENAME), Buffer.alloc(4));
+
+        await expect(assertCollectionScopedArtifact({artifactDir: dir})).resolves.toBeTruthy();
+
+        // The guard is the privacy invariant keeping Memory Core exports out of a PUBLIC asset.
+        // Widening it to `*.bin` would trade that guarantee for one file's convenience, so a
+        // differently-named binary must still be refused.
+        fs.writeFileSync(path.join(dir, 'kb-vectors-fp32.bin'), Buffer.alloc(4));
+        await expect(assertCollectionScopedArtifact({artifactDir: dir}))
+            .rejects.toThrow(/unexpected entry 'kb-vectors-fp32\.bin'/);
+    });
+
+    test('fp16 pack/unpack round-trips vectors row-for-row', () => {
+        const dimension = 4,
+              vectors   = [[0.5, -0.25, 0.125, 0], [1, 0.5, 0.25, -1]],
+              packed    = packVectorsFp16(vectors, dimension);
+
+        // 2 rows × 4 dims × 2 bytes — the size the metadata-driven decode asserts against.
+        expect(packed.byteLength).toBe(2 * dimension * 2);
+
+        const out = unpackVectorsFp16({buffer: packed, recordCount: 2, dimension});
+
+        expect(out).toHaveLength(2);
+        // These values are all exactly representable in fp16, so the round-trip is bit-exact here.
+        // The lossy general case is covered by a corpus-wide recall measurement recorded on the
+        // originating ticket (100% recall@10, 99.983% recall@50 against fp32), not by this spec.
+        expect(Array.from(out[0])).toEqual(vectors[0]);
+        expect(Array.from(out[1])).toEqual(vectors[1]);
+    });
+
+    test('a mis-sized row is refused at pack time rather than shifting every later vector', () => {
+        expect(() => packVectorsFp16([[1, 2, 3, 4], [1, 2, 3]], 4))
+            .toThrow(/row 1 has length 3, expected 4/);
+    });
+
+    test('a truncated sidecar fails loud instead of decoding garbage', () => {
+        const packed = packVectorsFp16([[1, 2], [3, 4]], 2);
+
+        expect(() => unpackVectorsFp16({buffer: packed.subarray(0, 6), recordCount: 2, dimension: 2}))
+            .toThrow(/is 6 bytes, expected 8/);
+    });
+
+    test('the order digest detects a REORDERED jsonl — the failure no byte-length check can see', () => {
+        const ids = ['a', 'b', 'c'];
+
+        // Same ids, same count, same buffer size — only the pairing changed. v2 re-attaches vectors
+        // by INDEX, so a permutation silently mates every row with the wrong embedding.
+        expect(recordOrderDigest(ids)).toBe(recordOrderDigest(['a', 'b', 'c']));
+        expect(recordOrderDigest(ids)).not.toBe(recordOrderDigest(['a', 'c', 'b']));
+        expect(recordOrderDigest(ids)).not.toBe(recordOrderDigest(['a', 'b']));
+    });
+
+    test('schema version is pinned so a v1 consumer cannot silently read a v2 artifact', () => {
+        expect(ARTIFACT_SCHEMA_VERSION).toBe(2);
+        expect(ARTIFACT_VECTORS_FILENAME).toBe('kb-vectors-fp16.bin');
     });
 
     test('rejects a Memory Core memory collection leak', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
@@ -40,6 +40,7 @@ test.describe.configure({mode: 'serial'});
 test.describe('Knowledge Base release artifact — collection-scoped contract (#12157)', () => {
     let assertCollectionScopedArtifact, ARTIFACT_BASENAME, ARTIFACT_META_FILENAME, KB_BACKUP_FILE_PREFIX;
     let ARTIFACT_VECTORS_FILENAME, ARTIFACT_SCHEMA_VERSION, packVectorsFp16, unpackVectorsFp16, recordOrderDigest;
+    let packArtifactToV2, rehydrateArtifactFromV2, resolveSingleArtifactJsonl, ARTIFACT_VECTOR_BYTE_ORDER;
     let uploadKnowledgeBase, downloadKnowledgeBase;
     let workRoot;
 
@@ -156,7 +157,11 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
             ARTIFACT_SCHEMA_VERSION,
             packVectorsFp16,
             unpackVectorsFp16,
-            recordOrderDigest
+            recordOrderDigest,
+            packArtifactToV2,
+            rehydrateArtifactFromV2,
+            resolveSingleArtifactJsonl,
+            ARTIFACT_VECTOR_BYTE_ORDER
         } = await import('../../../../../../ai/scripts/maintenance/knowledgeBaseArtifact.mjs'));
 
         ({uploadKnowledgeBase}   = await import('../../../../../../ai/scripts/maintenance/uploadKnowledgeBase.mjs'));
@@ -553,6 +558,131 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
         expect(result.status).toBe('imported');
         // Untouched: the v1 embeddings reach the importer exactly as published.
         expect(observed[0].embedding).toEqual(fixtureVector(1));
+    });
+
+
+    // ───────── the v2 consume gate must fail CLOSED on the STAMPED contract ─────────
+
+    /**
+     * Stages a v2 artifact whose metadata can be overridden per test, so each guard is exercised
+     * against an otherwise-valid artifact rather than a differently-broken one.
+     */
+    const stageV2 = async ({label, metaOverrides = {}, dropSidecar = false, extraJsonl = false}) => {
+        const dir   = path.join(workRoot, `gate-${label}`),
+              jsonl = path.join(dir, `${KB_BACKUP_FILE_PREFIX}${label}.jsonl`);
+
+        await fsExtra.ensureDir(dir);
+        fs.writeFileSync(jsonl, jsonlFixture(['kb-1', 'kb-2']));
+
+        const packed = await packArtifactToV2({artifactDir: dir, jsonlPath: jsonl, dimension: FIXTURE_DIMENSION});
+
+        fs.writeFileSync(path.join(dir, ARTIFACT_META_FILENAME), JSON.stringify({
+            artifactVersion: ARTIFACT_SCHEMA_VERSION,
+            dimension      : FIXTURE_DIMENSION,
+            recordCount    : packed.recordCount,
+            vectorEncoding : 'fp16',
+            vectorDigest   : packed.vectorDigest,
+            byteOrder      : packed.byteOrder,
+            ...metaOverrides
+        }));
+
+        if (dropSidecar) {
+            fs.rmSync(path.join(dir, ARTIFACT_VECTORS_FILENAME), {force: true});
+        }
+        if (extraJsonl) {
+            fs.writeFileSync(path.join(dir, `${KB_BACKUP_FILE_PREFIX}${label}-second.jsonl`), jsonlFixture(['kb-9']));
+        }
+
+        return {dir, jsonl, packed}
+    };
+
+    test('a v2 artifact with a MISSING sidecar throws — it never imports as vectorless v1', async () => {
+        // The finding this closes: schema state was inferred from sidecar PRESENCE, so a v2 artifact
+        // that lost its sidecar returned {rehydrated:false} and the import proceeded with every record
+        // carrying NO embedding — silent, total vector loss reported as success.
+        const {dir} = await stageV2({label: 'missing-sidecar', dropSidecar: true});
+
+        await expect(rehydrateArtifactFromV2({artifactDir: dir}))
+            .rejects.toThrow(/declares schema version 2 but .* is missing[\s\S]*NO embedding/);
+    });
+
+    test('a v1 stamp carrying a sidecar throws rather than choosing which half to believe', async () => {
+        const {dir} = await stageV2({label: 'contradiction', metaOverrides: {artifactVersion: 1}});
+
+        await expect(rehydrateArtifactFromV2({artifactDir: dir}))
+            .rejects.toThrow(/declares artifactVersion 1 but carries/);
+    });
+
+    test('an artifact from a NEWER producer throws instead of half-decoding', async () => {
+        const {dir} = await stageV2({label: 'future-version', metaOverrides: {artifactVersion: ARTIFACT_SCHEMA_VERSION + 1}});
+
+        await expect(rehydrateArtifactFromV2({artifactDir: dir}))
+            .rejects.toThrow(/declares schema version 3; this consumer understands 2/);
+    });
+
+    test('a foreign vectorEncoding is refused, not decoded as fp16 anyway', async () => {
+        const {dir} = await stageV2({label: 'encoding', metaOverrides: {vectorEncoding: 'fp32'}});
+
+        await expect(rehydrateArtifactFromV2({artifactDir: dir}))
+            .rejects.toThrow(/vectorEncoding 'fp32'/);
+    });
+
+    test('a v2 artifact WITHOUT a digest is refused — the digest is mandatory, not optional', async () => {
+        // Previously `if (vectorDigest && …)`, so omitting it skipped the order proof entirely: the one
+        // check that catches a permutation was disabled by leaving a field out.
+        const {dir} = await stageV2({label: 'no-digest', metaOverrides: {vectorDigest: undefined}});
+
+        await expect(rehydrateArtifactFromV2({artifactDir: dir}))
+            .rejects.toThrow(/without a 'vectorDigest'/);
+    });
+
+    test('a foreign wire byte order is refused rather than read as noise', async () => {
+        const {dir} = await stageV2({label: 'byte-order', metaOverrides: {byteOrder: 'big-endian'}});
+
+        await expect(rehydrateArtifactFromV2({artifactDir: dir}))
+            .rejects.toThrow(/byteOrder 'big-endian'/);
+    });
+
+    test('TWO KB JSONLs are refused — the row-set the sidecar describes must be singular', async () => {
+        // Positional pairing against "whichever file matched first" is a silent choice, not a tie-break.
+        const {dir} = await stageV2({label: 'two-jsonl', extraJsonl: true});
+
+        await expect(rehydrateArtifactFromV2({artifactDir: dir}))
+            .rejects.toThrow(/Expected exactly one .* found 2/);
+        await expect(resolveSingleArtifactJsonl({artifactDir: dir}))
+            .rejects.toThrow(/Refusing to guess which row-set/);
+    });
+
+    test('the wire byte order is pinned little-endian and stamped by the packer', async () => {
+        const {packed} = await stageV2({label: 'order-stamp'});
+
+        expect(ARTIFACT_VECTOR_BYTE_ORDER).toBe('little-endian');
+        expect(packed.byteOrder).toBe(ARTIFACT_VECTOR_BYTE_ORDER);
+    });
+
+    test('pack streams: peak RSS stays bounded well below the JSONL it rewrites', async () => {
+        // The defect this closes could not be seen by any small fixture: the old implementation read the
+        // whole JSONL into ONE utf-8 string, and the real 2.81 GiB export is 5.62x Node's
+        // MAX_STRING_LENGTH (536,870,888) — so the shipped path threw ERR_STRING_TOO_LONG on the corpus
+        // it was written for while passing every 3-row test. This asserts the SHAPE (bounded retention)
+        // rather than re-running the corpus; the full-corpus receipt lives on the PR.
+        const dir   = path.join(workRoot, 'stream-bound'),
+              jsonl = path.join(dir, `${KB_BACKUP_FILE_PREFIX}stream.jsonl`),
+              ids   = Array.from({length: 4000}, (_, i) => `kb-${i}`);
+
+        await fsExtra.ensureDir(dir);
+        fs.writeFileSync(jsonl, jsonlFixture(ids));
+
+        const jsonlBytes = fs.statSync(jsonl).size,
+              before     = process.memoryUsage().rss;
+
+        const packed = await packArtifactToV2({artifactDir: dir, jsonlPath: jsonl, dimension: FIXTURE_DIMENSION});
+
+        expect(packed.recordCount).toBe(4000);
+        // Sidecar size is exact arithmetic, so a streaming bug that dropped or duplicated a row shows here.
+        expect(fs.statSync(path.join(dir, ARTIFACT_VECTORS_FILENAME)).size).toBe(4000 * FIXTURE_DIMENSION * 2);
+        // Growth must not scale with the file: a whole-file read would retain at least its own bytes.
+        expect(process.memoryUsage().rss - before).toBeLessThan(jsonlBytes * 4);
     });
 
     test('a REORDERED v2 JSONL aborts the real download BEFORE any import runs', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
@@ -22,6 +22,16 @@ import fs             from 'fs';
 import fsExtra        from 'fs-extra';
 import os             from 'os';
 import path           from 'path';
+import {execFile}     from 'child_process';
+import {promisify}    from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/** Extracts a real release zip so an assertion can read the bytes an adopter actually receives. */
+const unzipTo = (zipPath, targetDir) => execFileAsync('unzip', ['-o', '-q', zipPath, '-d', targetDir]);
+
+/** Rebuilds a flat release zip from explicit member paths (mirrors the upload script's `zip -j`). */
+const zipFlat = (zipPath, members) => execFileAsync('zip', ['-j', '-q', zipPath, ...members]);
 
 // Serial mode: upload/download specs swap real KB SDK singleton methods via seams indirectly;
 // keep file-local ordering deterministic for local multi-worker runs. CI uses workers:1.
@@ -36,7 +46,7 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
     const silentLogger = {log: () => {}, warn: () => {}, error: () => {}};
 
     /** A KB SDK seam that records its calls and returns a configurable shape. */
-    const makeDatabaseServiceSeam = ({onExport, importResult} = {}) => {
+    const makeDatabaseServiceSeam = ({onExport, onImport, importResult} = {}) => {
         const calls = [];
         return {
             calls,
@@ -47,6 +57,10 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
                     return {message: 'export ok'};
                 }
                 if (action === 'import') {
+                    // `onImport` observes the extract dir AS THE SDK SEES IT. The workflow deletes that
+                    // dir in its finally block, so this is the only point where the bytes the real
+                    // importer would consume can be asserted on.
+                    await onImport?.({action, ...rest});
                     return importResult ?? {message: 'import ok', imported: 0, mode: rest.mode};
                 }
                 throw new Error(`unexpected action ${action}`);
@@ -55,6 +69,82 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
     };
 
     const readyLifecycleSeam = () => ({ready: async () => {}});
+
+    /**
+     * Fixture vector width. Deliberately tiny — the real corpus is dim 4096, but the wiring under test
+     * is dimension-agnostic and a 4096-wide fixture would only make the spec slow and unreadable.
+     */
+    const FIXTURE_DIMENSION = 4;
+
+    /** fp16-exact values, so a round-trip assertion can be exact rather than tolerance-based. */
+    const fixtureVector = seed => [seed, seed + 0.5, -seed, 0.25];
+
+    /** A v1-shaped KB export: one record per line, embeddings inline as decimal text. */
+    const jsonlFixture = ids => ids
+        .map((id, index) => JSON.stringify({
+            id,
+            embedding: fixtureVector(index + 1),
+            metadata : {content: `content-${id}`},
+            document : null
+        }))
+        .join('\n') + '\n';
+
+    /** Reads the KB JSONL out of an artifact directory as parsed records. */
+    const readArtifactRecords = artifactDir => {
+        const name = fs.readdirSync(artifactDir).find(entry => entry.startsWith(KB_BACKUP_FILE_PREFIX) && entry.endsWith('.jsonl'));
+
+        return fs.readFileSync(path.join(artifactDir, name), 'utf8').split('\n').filter(Boolean).map(line => JSON.parse(line));
+    };
+
+    /**
+     * Builds a REAL release zip through `uploadKnowledgeBase` and returns its bytes plus a fetch seam
+     * serving them. Exercising the actual build path means the download assertions cannot pass against
+     * a hand-stubbed extract dir that the shipped pipeline would never produce.
+     */
+    const buildServedArtifact = async ({label, ids, dimension = FIXTURE_DIMENSION, mutateStage}) => {
+        const stageRoot   = path.join(workRoot, `${label}-stage`),
+              releaseRoot = path.join(workRoot, `${label}-release`);
+
+        await fsExtra.ensureDir(stageRoot);
+        await fsExtra.ensureDir(releaseRoot);
+
+        const built = await uploadKnowledgeBase({
+            tagName        : '99.0.0',
+            databaseService: makeDatabaseServiceSeam({
+                onExport: async ({backupPath}) => {
+                    fs.writeFileSync(path.join(backupPath, `${KB_BACKUP_FILE_PREFIX}${label}.jsonl`), jsonlFixture(ids));
+                }
+            }),
+            lifecycleService   : readyLifecycleSeam(),
+            embeddingConfig    : {embeddingProvider: 'openAiCompatible', vectorDimension: dimension},
+            knowledgeBaseConfig: {collectionName: 'neo-knowledge-base'},
+            runGh              : async () => {},
+            skipReleaseCheck   : true,
+            skipUpload         : true,
+            stageRoot,
+            logger             : silentLogger
+        });
+
+        // `skipUpload` retains the artifact at the repo root (the upload path cleans itself), so move it
+        // to the test's own tree immediately — a spec must not leave an untracked release asset behind.
+        const servedZip = path.join(releaseRoot, ARTIFACT_BASENAME);
+        fs.copyFileSync(built.artifactPath, servedZip);
+        fs.rmSync(built.artifactPath, {force: true});
+
+        await mutateStage?.({servedZip, releaseRoot});
+
+        const zipBytes = fs.readFileSync(servedZip);
+
+        return {
+            built,
+            servedZip,
+            fetchImpl: async () => ({
+                ok         : true,
+                status     : 200,
+                arrayBuffer: async () => zipBytes.buffer.slice(zipBytes.byteOffset, zipBytes.byteOffset + zipBytes.byteLength)
+            })
+        }
+    };
 
     test.beforeAll(async () => {
         ({
@@ -226,10 +316,12 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
         const stageRoot = path.join(workRoot, 'upload-stage-clean');
         await fsExtra.ensureDir(stageRoot);
 
-        // Export seam writes a single KB JSONL into the staging dir the SDK was handed.
+        // Export seam writes a single KB JSONL into the staging dir the SDK was handed. Records carry
+        // `dimension`-length embeddings because the v2 pack step refuses a partially-vectorised
+        // artifact — shipping rows whose vectors are missing is the failure it exists to catch.
         const databaseService = makeDatabaseServiceSeam({
             onExport: async ({backupPath}) => {
-                fs.writeFileSync(path.join(backupPath, `${KB_BACKUP_FILE_PREFIX}2026-05-29.jsonl`), '{"id":"kb-1"}\n{"id":"kb-2"}\n');
+                fs.writeFileSync(path.join(backupPath, `${KB_BACKUP_FILE_PREFIX}2026-05-29.jsonl`), jsonlFixture(['kb-1', 'kb-2']));
             }
         });
 
@@ -238,7 +330,7 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
             tagName            : '99.0.0',
             databaseService,
             lifecycleService   : readyLifecycleSeam(),
-            embeddingConfig    : {embeddingProvider: 'openAiCompatible', vectorDimension: 4096},
+            embeddingConfig    : {embeddingProvider: 'openAiCompatible', vectorDimension: FIXTURE_DIMENSION},
             knowledgeBaseConfig: {collectionName: 'neo-knowledge-base'},
             runGh              : async (args) => { ghCalls.push(args); },
             stageRoot,
@@ -247,7 +339,7 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
 
         expect(result.recordCount).toBe(2);
         expect(result.embeddingProvider).toBe('openAiCompatible');
-        expect(result.dimension).toBe(4096);
+        expect(result.dimension).toBe(FIXTURE_DIMENSION);
         expect(result.artifactName).toBe('chroma-neo-knowledge-base.zip');
 
         // Export was requested; upload was attempted (release-check + upload gh calls).
@@ -325,37 +417,8 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
 
     test('download imports collection-scoped (merge) when the artifact round-trips a real zip', async () => {
         // Build a real artifact via uploadKnowledgeBase(skipUpload) so the download path exercises
-        // the REAL zip → unzip → assert → import chain, not a stubbed extract dir.
-        const stageRoot   = path.join(workRoot, 'roundtrip-stage');
-        const releaseRoot = path.join(workRoot, 'roundtrip-release');
-        await fsExtra.ensureDir(stageRoot);
-        await fsExtra.ensureDir(releaseRoot);
-
-        const uploadDbSeam = makeDatabaseServiceSeam({
-            onExport: async ({backupPath}) => {
-                fs.writeFileSync(path.join(backupPath, `${KB_BACKUP_FILE_PREFIX}rt.jsonl`), '{"id":"kb-1","embedding":[0.1],"metadata":{"content":"x"},"document":null}\n');
-            }
-        });
-
-        const built = await uploadKnowledgeBase({
-            tagName            : '99.0.0',
-            databaseService    : uploadDbSeam,
-            lifecycleService   : readyLifecycleSeam(),
-            embeddingConfig    : {embeddingProvider: 'openAiCompatible', vectorDimension: 4096},
-            knowledgeBaseConfig: {collectionName: 'neo-knowledge-base'},
-            runGh              : async () => {},
-            skipReleaseCheck   : true,
-            skipUpload         : true,
-            stageRoot,
-            logger             : silentLogger
-        });
-
-        // Move the built artifact to a stable path the fake fetch can serve as bytes, then
-        // clear the repo-root original (skipUpload retains it; the upload-only path cleans itself).
-        const servedZip = path.join(releaseRoot, ARTIFACT_BASENAME);
-        fs.copyFileSync(built.artifactPath, servedZip);
-        fs.rmSync(built.artifactPath, {force: true});
-        const zipBytes = fs.readFileSync(servedZip);
+        // the REAL zip → unzip → assert → rehydrate → import chain, not a stubbed extract dir.
+        const {fetchImpl} = await buildServedArtifact({label: 'roundtrip', ids: ['kb-1']});
 
         const downloadDbSeam = makeDatabaseServiceSeam({importResult: {message: 'ok', imported: 1, mode: 'merge'}});
 
@@ -364,8 +427,8 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
             chromaManager   : {getKnowledgeBaseCollection: async () => ({count: async () => 0})},
             databaseService : downloadDbSeam,
             lifecycleService: readyLifecycleSeam(),
-            embeddingConfig : {embeddingProvider: 'openAiCompatible', vectorDimension: 4096},
-            fetchImpl       : async () => ({ok: true, status: 200, arrayBuffer: async () => zipBytes.buffer.slice(zipBytes.byteOffset, zipBytes.byteOffset + zipBytes.byteLength)}),
+            embeddingConfig : {embeddingProvider: 'openAiCompatible', vectorDimension: FIXTURE_DIMENSION},
+            fetchImpl,
             workRoot        : path.join(workRoot, 'dl-roundtrip'),
             logger          : silentLogger
         });
@@ -381,5 +444,158 @@ test.describe('Knowledge Base release artifact — collection-scoped contract (#
         expect(path.basename(importCall.file)).toBe('extract');
         expect(importCall.file.endsWith('.zip')).toBe(false);
         expect(importCall.file).not.toContain('.neo-ai-data');
+    });
+
+    // ───────── schema v2 wiring: the build side EMITS it, the consume side DECODES it ─────────
+
+    test('the shipped zip carries the fp16 sidecar and a JSONL stripped of embeddings', async () => {
+        const {servedZip} = await buildServedArtifact({label: 'emit-v2', ids: ['kb-1', 'kb-2', 'kb-3']});
+        const unpackDir   = path.join(workRoot, 'emit-v2-unpacked');
+
+        await fsExtra.ensureDir(unpackDir);
+        await unzipTo(servedZip, unpackDir);
+
+        // Three entries, and the vectors are the BINARY one — not decimal text inside the JSONL.
+        const entries = fs.readdirSync(unpackDir).sort();
+        expect(entries).toContain(ARTIFACT_VECTORS_FILENAME);
+        expect(entries).toContain(ARTIFACT_META_FILENAME);
+        expect(entries.filter(entry => entry.endsWith('.jsonl'))).toHaveLength(1);
+
+        const records = readArtifactRecords(unpackDir);
+        expect(records).toHaveLength(3);
+        // The whole point of v2: no row carries `embedding` as text any more…
+        records.forEach(record => expect(record).not.toHaveProperty('embedding'));
+        // …but nothing else was dropped, so the import still gets full records.
+        expect(records[0].metadata.content).toBe('content-kb-1');
+
+        // …and the sidecar is exactly rows × dims × 2 bytes, the size the consumer asserts against.
+        expect(fs.statSync(path.join(unpackDir, ARTIFACT_VECTORS_FILENAME)).size).toBe(3 * FIXTURE_DIMENSION * 2);
+
+        const meta = JSON.parse(fs.readFileSync(path.join(unpackDir, ARTIFACT_META_FILENAME), 'utf8'));
+        expect(meta.artifactVersion).toBe(ARTIFACT_SCHEMA_VERSION);
+        expect(meta.vectorEncoding).toBe('fp16');
+        expect(meta.recordCount).toBe(3);
+        // The order digest must be stamped, or the consumer cannot prove the positional pairing.
+        expect(meta.vectorDigest).toBe(recordOrderDigest(['kb-1', 'kb-2', 'kb-3']));
+    });
+
+    test('the consumer re-attaches the packed vectors BEFORE the import sees the JSONL', async () => {
+        const {fetchImpl} = await buildServedArtifact({label: 'decode-v2', ids: ['kb-1', 'kb-2']});
+
+        let observed;
+        const downloadDbSeam = makeDatabaseServiceSeam({
+            importResult: {message: 'ok', imported: 2, mode: 'merge'},
+            onImport    : async ({file}) => {
+                observed = {records: readArtifactRecords(file), entries: fs.readdirSync(file)};
+            }
+        });
+
+        const result = await downloadKnowledgeBase({
+            tagName         : '99.0.0',
+            chromaManager   : {getKnowledgeBaseCollection: async () => ({count: async () => 0})},
+            databaseService : downloadDbSeam,
+            lifecycleService: readyLifecycleSeam(),
+            embeddingConfig : {embeddingProvider: 'openAiCompatible', vectorDimension: FIXTURE_DIMENSION},
+            fetchImpl,
+            workRoot        : path.join(workRoot, 'dl-decode-v2'),
+            logger          : silentLogger
+        });
+
+        expect(result.status).toBe('imported');
+
+        // This is the load-bearing assertion of the whole wiring: the importer receives rows with
+        // embeddings INLINE, so the SDK boundary keeps consuming one JSONL shape and no adopter
+        // re-embeds the corpus on boot. The fixture values are fp16-exact, so this is exact.
+        expect(observed.records.map(record => record.embedding)).toEqual([fixtureVector(1), fixtureVector(2)]);
+        expect(observed.records[1].metadata.content).toBe('content-kb-2');
+
+        // The sidecar is consumed, not left behind — a retained sidecar would let a re-run
+        // double-rehydrate an already-inline JSONL.
+        expect(observed.entries).not.toContain(ARTIFACT_VECTORS_FILENAME);
+    });
+
+    test('a v1 artifact (embeddings inline, no sidecar) still imports unchanged', async () => {
+        // Backward compatibility is the reason the rehydrate step is a no-op rather than a hard v2
+        // requirement: releases published before schema v2 must keep installing.
+        const v1Dir = path.join(workRoot, 'v1-artifact');
+        const v1Zip = path.join(workRoot, 'v1-release', ARTIFACT_BASENAME);
+
+        await fsExtra.ensureDir(v1Dir);
+        await fsExtra.ensureDir(path.dirname(v1Zip));
+
+        fs.writeFileSync(path.join(v1Dir, `${KB_BACKUP_FILE_PREFIX}v1.jsonl`), jsonlFixture(['kb-1']));
+        fs.writeFileSync(path.join(v1Dir, ARTIFACT_META_FILENAME), JSON.stringify({
+            artifactVersion: 1, collection: 'neo-knowledge-base', embeddingProvider: 'openAiCompatible',
+            dimension      : FIXTURE_DIMENSION, recordCount: 1
+        }));
+
+        await zipFlat(v1Zip, [path.join(v1Dir, `${KB_BACKUP_FILE_PREFIX}v1.jsonl`), path.join(v1Dir, ARTIFACT_META_FILENAME)]);
+
+        const zipBytes = fs.readFileSync(v1Zip);
+
+        let observed;
+        const downloadDbSeam = makeDatabaseServiceSeam({
+            importResult: {message: 'ok', imported: 1, mode: 'merge'},
+            onImport    : async ({file}) => { observed = readArtifactRecords(file); }
+        });
+
+        const result = await downloadKnowledgeBase({
+            tagName         : '99.0.0',
+            chromaManager   : {getKnowledgeBaseCollection: async () => ({count: async () => 0})},
+            databaseService : downloadDbSeam,
+            lifecycleService: readyLifecycleSeam(),
+            embeddingConfig : {embeddingProvider: 'openAiCompatible', vectorDimension: FIXTURE_DIMENSION},
+            fetchImpl       : async () => ({ok: true, status: 200, arrayBuffer: async () => zipBytes.buffer.slice(zipBytes.byteOffset, zipBytes.byteOffset + zipBytes.byteLength)}),
+            workRoot        : path.join(workRoot, 'dl-v1'),
+            logger          : silentLogger
+        });
+
+        expect(result.status).toBe('imported');
+        // Untouched: the v1 embeddings reach the importer exactly as published.
+        expect(observed[0].embedding).toEqual(fixtureVector(1));
+    });
+
+    test('a REORDERED v2 JSONL aborts the real download BEFORE any import runs', async () => {
+        // The digest guard is only worth anything if it is reachable through the shipped path. This
+        // permutes the JSONL inside a real zip: same ids, same record count, and a sidecar of exactly
+        // the right byte length — the corruption no shape check can see.
+        const {fetchImpl} = await buildServedArtifact({
+            label      : 'reordered',
+            ids        : ['kb-1', 'kb-2', 'kb-3'],
+            mutateStage: async ({servedZip, releaseRoot}) => {
+                const tamperDir = path.join(releaseRoot, 'tamper');
+
+                await fsExtra.ensureDir(tamperDir);
+                await unzipTo(servedZip, tamperDir);
+
+                const jsonlName = fs.readdirSync(tamperDir).find(entry => entry.endsWith('.jsonl')),
+                      jsonlPath = path.join(tamperDir, jsonlName),
+                      lines     = fs.readFileSync(jsonlPath, 'utf8').split('\n').filter(Boolean);
+
+                fs.writeFileSync(jsonlPath, [lines[0], lines[2], lines[1]].join('\n') + '\n');
+                fs.rmSync(servedZip, {force: true});
+
+                await zipFlat(servedZip, [jsonlPath, path.join(tamperDir, ARTIFACT_META_FILENAME), path.join(tamperDir, ARTIFACT_VECTORS_FILENAME)]);
+            }
+        });
+
+        const downloadDbSeam = makeDatabaseServiceSeam({importResult: {message: 'ok', imported: 3, mode: 'merge'}});
+
+        const result = await downloadKnowledgeBase({
+            tagName         : '99.0.0',
+            chromaManager   : {getKnowledgeBaseCollection: async () => ({count: async () => 0})},
+            databaseService : downloadDbSeam,
+            lifecycleService: readyLifecycleSeam(),
+            embeddingConfig : {embeddingProvider: 'openAiCompatible', vectorDimension: FIXTURE_DIMENSION},
+            fetchImpl,
+            workRoot        : path.join(workRoot, 'dl-reordered'),
+            logger          : silentLogger
+        });
+
+        // Soft-fail (npm install must never break) but the import NEVER ran — the alternative is
+        // ingesting 3 records each paired with another record's embedding.
+        expect(result.status).toBe('error');
+        expect(result.reason).toMatch(/does not match the stamped vector digest/);
+        expect(downloadDbSeam.calls.filter(call => call.action === 'import')).toHaveLength(0);
     });
 });


### PR DESCRIPTION
The KB release artifact was **~95% embeddings serialized as decimal TEXT** — the waste is the encoding, not the vectors. This lands schema v2 across the upload/download boundary: `uploadKnowledgeBase` emits JSONL-without-`embedding` plus a packed `fp16` sidecar, `downloadKnowledgeBase` re-attaches it before the import. The **raw-vectors / no-re-embed invariant is untouched** — adopters still receive full vectors, just not as text, so nobody re-embeds 55k×4096 on boot.

**Evidence:** the **full current corpus** packed and rehydrated through the shipped paths, non-destructively on a copy of the 2026-07-23 export (the backup was never written, nothing re-embedded):

| stage | rows | time | peak RSS |
|---|---|---|---|
| pack | 54,912 | 12.6s | **253.2 MB** (input 2875.3 MB) |
| rehydrate | 54,912 | 20.5s | **300.3 MB** |

| | v1 | v2 | ratio |
|---|---|---|---|
| **full corpus, raw** (measured) | 2875.3 MB | **573.4 MB** (144.4 jsonl + 429.0 sidecar) | **5.01×** |
| sample, zipped (measured, 2,034 rows) | 41.8 MB | 16.2 MB | 2.58× |

The sample's 5.01× raw ratio reproduced **exactly** at full scale. The zipped ratio remains sample-based: zipping the full corpus is a release-pipeline step, not a review gate.

⚠️ **A cost this receipt exposed, disclosed rather than buried: the rehydrated JSONL is 4410.1 MB against the v1 original's 2875.3 MB — 53% larger.** fp16 → float32 → decimal yields longer numerals than the source text. So v2 trades a **5× smaller download** for a **1.53× larger import-time working file**. A shortest-round-tripping-decimal emit would recover most of it (fp16 needs ~4 significant digits) but is a new precision claim with its own measurement obligation, so it is deliberately not in this PR. **The residual has a durable landing pad: #15830** — filed narrowly for exactly this measurement, so the magic close of #14559 does not bury it.

**fp16 over fp32 was decided on measurement, not arithmetic.** The ticket deliberately left this open (*"worth a quick measurement before committing"*) and hedged toward lossless fp32. Measured against real KB embeddings using a corpus-wide every-10th sample (5,492 vectors, 120 queries spread evenly):

| | recall (fp16 vs fp32) | top-1 identical |
|---|---|---|
| **k=10** | **100.000%** | 100% |
| **k=50** | **99.983%** | 100% |

99.983% at k=50 is ≈**one** differing neighbour across 6,000 neighbour slots — a single near-tie at the tail of a 50-deep list. That is not a recall-vs-size trade-off; it is quantisation noise below what anything downstream can observe. So fp16 takes the full ≈2.6× where fp32 buys only ~1.4×, and the ticket's hedge is retired with data.

*(First pass used a contiguous head-slice and I flagged it as likely correlated; the confirmation run switched to systematic sampling specifically to retire my own caveat rather than restate it.)*

## Deltas from ticket

- **Cycle-1 repair (@neo-gpt-emmy, `CHANGES_REQUESTED` → `8c7283e9b9`).** Four findings, all correct. (1) **Both v2 paths read the whole JSONL as one utf-8 string** — the real export is **5.62× Node's `MAX_STRING_LENGTH`**, so the shipped path threw `ERR_STRING_TOO_LONG` on the corpus it was written for while passing every 3-row fixture. I had measured that corpus with a *streaming* probe in the same session and then shipped a whole-file implementation. Both paths now stream with O(row) retention. (2) **The consume gate failed OPEN**: schema state came from sidecar *presence*, so a v2 artifact that lost its sidecar imported with every record carrying **no embedding** — total vector loss reported as success. State now comes from `artifactVersion`, and six mismatch states abort. (3) **Row-set identity was not singular** — rehydrate took the first matching JSONL, which under positional pairing is a silent choice, not a tie-break. (4) **Wire byte order** is now pinned little-endian and stamped, since `Float16Array` writes native order and Node ships a big-endian s390x build.

- **Three of the ticket's figures were stale and the measurement corrects them — two of them were mine.** The corpus is **54,912 records, not 49,283** (~11% growth since 2026-07-03). Embeddings are **94.9%** of the raw JSONL, not the ~97% I repeated. The v1 zip is **~1129 MB**, not the filed 1010 MB. Caught only because the probe printed its own denominators instead of trusting the filed ones. The zipped ratio (2.58×) remains sample-measured; the **raw** ratio is now full-corpus measured at 5.01×.
- **The ticket's deferred sharding item moves further away rather than being left.** Sharding was filed as a safety net past 2 GiB; at the **measured** 573.4 MB raw artifact that threshold is now ~3.7× off (I previously wrote ~4.5× off a projected 438 MB — the full-corpus measurement supersedes it). The other deferred secondary — *baseline scope* ("does the shipped KB need the whole dev-conversation corpus?") — is a product decision this PR does not touch and does not foreclose.
- **Found while implementing: the artifact-scope guard would have rejected the sidecar.** `assertCollectionScopedArtifact` refuses any non-`.jsonl` entry except the meta file — so v2 *cannot* ship without touching it. That guard is the **privacy invariant** keeping Memory Core exports and `sqlite/` payloads out of a **public** release asset, so it gains exactly **one exact-match allowlist entry**, never a pattern. A `*.bin` rule would trade the whole guarantee for one file's convenience, and a spec pins that: `kb-vectors-fp32.bin` must still be refused.
- **Found while implementing: index-based re-attachment makes silent corruption possible.** v2 pairs rows to vectors *positionally*, so a reordered JSONL mates every row with the wrong embedding **while the buffer stays exactly the right size** — a length check cannot see it. `recordOrderDigest` makes it loud: the build side stamps the id-order digest, the consume side recomputes it from the JSONL it actually received, and a permutation aborts rather than ingesting misaligned vectors. This was not in the ticket; it is the same silent-misalignment class that produced two other defects on `dev` today, so I would not ship the format without it.
- **Found while wiring: three pre-existing `#12157` fixtures were wrong.** They staged records with **no `embedding`**, or a **1-dim** embedding against `vectorDimension: 4096`. The pack step refuses a partially-vectorised artifact by design, so I corrected the fixtures rather than loosening the guard — and gave them a tiny `FIXTURE_DIMENSION` so a spec reads in one screen.
- **Found while wiring: `skipUpload` retains the built zip at the repo root, which is not gitignored.** Every spec that builds a real artifact now moves it into its own tree immediately. Worth knowing before the next test touches this seam; the seam had no caller until this PR.

## Test Evidence

`test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs` — **37/37 green** at exact head (35 spec cases plus Brain setup/teardown).

| test | asserts |
|---|---|
| sidecar permitted, allowlist stayed EXACT | the one filename passes **and** `kb-vectors-fp32.bin` is still refused |
| fp16 pack/unpack round-trips row-for-row | 2×4 round-trip bit-exact on fp16-representable values; byte length = rows×dims×2 |
| mis-sized row refused at pack time | a short row throws rather than shifting every later vector |
| truncated sidecar fails loud | 6 bytes where 8 expected → explicit error, not garbage decode |
| order digest detects a REORDERED jsonl | `[a,b,c]` vs `[a,c,b]` differ; `[a,b]` differs — the failure no length check sees |
| schema version pinned | v1 consumers cannot silently read a v2 artifact |
| **shipped zip carries the sidecar, JSONL stripped** | 3 entries; no row has `embedding`; sidecar is exactly rows×dims×2; meta stamps `artifactVersion`/`vectorEncoding`/digest |
| **consumer re-attaches BEFORE the import sees the JSONL** | the importer receives embeddings **inline**, exact per-value; the sidecar is consumed, not left to double-rehydrate on a re-run |
| **a v1 artifact still imports unchanged** | no sidecar → no-op → published releases stay importable |
| **a REORDERED v2 artifact aborts the real download** | soft-fail (npm install never breaks) **and zero import calls** |
| **v2 stamp + MISSING sidecar throws** | never a silent vectorless import — the reviewer falsifier that found it |
| **v1 stamp + sidecar present throws** | a contradictory artifact is refused, not half-believed |
| **a newer producer version throws** | no half-decoding a format written after this consumer |
| **non-`fp16` encoding throws** | not decoded as fp16 regardless |
| **absent `vectorDigest` throws** | the digest is mandatory; omitting it used to disable the permutation check |
| **foreign `byteOrder` throws** | not read as noise on a mismatched host |
| **two KB JSONLs throw** | row-set identity is singular — positional pairing may not pick a file |
| **wire order pinned + stamped** | `little-endian`, asserted against the packer's stamp |
| **canonical fp16 bytes pinned** | `[1, -2, 0.5]` emits the literal little-endian sidecar `003c00c00038` |
| **missing `byteOrder` refused** | v2 cannot default an absent wire-order stamp to the current host |
| **strict geometry** | string-valued `dimension` is rejected instead of coercing through byte arithmetic |
| **pack streams with bounded retention** | 4,000-row fixture: exact sidecar arithmetic, RSS growth ≪ file size |

**Red-proof, each half of the wiring controlled ALONE:**

| control | result |
|---|---|
| download rehydrate disabled | reorder test RED — status `"imported"`, expected `"error"`: without that call every record pairs with another record's vector |
| sidecar dropped from the zip | emit test RED — zip holds only `["kb-artifact-meta.json", "…jsonl"]` |
| jsonl strip disabled (the size win itself) | emit test RED — rows still carry `embedding: [1, 1.5, -1, 0.25]` |
| allowlist widened to `*.bin` | scope test RED — *"promise resolved instead of rejected"* |
| digest made order-insensitive (sort ids) | reorder test RED — `Expected: not "d5eb74f7"` |
| row-length check dropped | mis-sized-row test RED — *"function did not throw"* |
| all restored | **25 passed**; controls diffed byte-identical to the originals, residue greped to zero |

Each control was re-run **in isolation**: `describe.configure({mode: 'serial'})` skips the tail after the first failure, so a full-file control run reports `passed` for tests that never executed. My first control run showed exactly one failure where two were expected — the second test had been skipped, not passed.

```bash
NEO_CHROMA_PORT_TEST=18536 UNIT_TEST_MODE=true npx playwright test \
  -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/scripts/maintenance/knowledgeBaseArtifact.spec.mjs
```

## Scope discipline

- **In:** the format primitives, the v2 emit in `uploadKnowledgeBase`, the v2 decode in `downloadKnowledgeBase`, the narrow scope-guard extension, specs.
- **Deliberately not done:** sharding and baseline-scope, both filed as *"Secondary (defer)"* on the ticket itself. Neither is made worse here; sharding's trigger recedes ~3.7×.
- **NOT committed:** the two probe scripts (recall + size). A decision probe is not substrate. The size probe's guarantee is instead pinned by the spec assertion that the sidecar is exactly `rows × dims × 2` bytes.

## Post-Merge Validation

- The first real release cut after this lands publishes a v2 asset. Confirm the published zip is in the sample-projected ~438 MB band (not ~1129 MB) and that its meta reads `artifactVersion: 2`, `vectorEncoding: "fp16"`.
- Confirm a **fresh** `npm install` against a v1 release asset still imports — the no-op path is spec-covered, but the shipped 404/soft-fail path is worth one live confirmation.

**Decision Record impact: `none`** — no ADR authority chosen or amended; an artifact format change plus one allowlist entry.

Resolves #14559

Related: #12157 — the collection-scoped artifact contract this builds on; three of its spec fixtures are corrected here.

Cross-family seat needed (Claude author): **GPT or Kimi**. Note for the reviewer: the encoder is the boring part. The two things worth your attention are the *scope-guard narrowness* and the *order digest* — both exist because the obvious implementation would have been silently wrong — and, if you want the sharpest question, whether a linear scale from a 3.7% sample is a fair basis for the ~438 MB projection.

Authored by Grace (Claude Opus 4.8, Claude Code). Session a4efc85c-aec8-43da-9774-9c735da0b244.

