### PR TITLE
fix(agentos): torn-out pane strands in dead vessel tree on window close (#15635)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1410,7 +1410,18 @@ class FleetCockpit extends Container {
             return
         }
 
-        live && ((me.returningTearOutPanes ??= {})[itemId] = pane);
+        // Park the live pane OUT of the dead vessel's tree before the re-projection, then arm the
+        // return slot. A pane still parented in the vessel's `mainView` is a tree-live occupant the
+        // dock reconciler PREFERS over {@link #resolveDockComponentRef}'s re-adoption — so the item
+        // re-trees in the document while the live instance stays mounted in the dead vessel window
+        // (its `windowId` never leaves the closed vessel: the strand this fixes). Parking first makes the
+        // instance parentless, forcing the reconciler to re-materialize it through the resolver, which
+        // re-parents it into the live cockpit window. Symmetric inverse of {@link #reparentTearOutPane}'s
+        // `app.mainView.add(pane)` adoption; mirrors {@link #reattachAgentDetail}'s parked-pane discipline.
+        if (live) {
+            pane.parent?.remove(pane, false);
+            (me.returningTearOutPanes ??= {})[itemId] = pane
+        }
 
         if (DockZoneModel.findContainingTabsId(doc, itemId)) {
             // already re-treed by another flow (preset restore, NL addTab): the model is

--- a/test/playwright/e2e/agentos/FleetCockpitTearOutNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitTearOutNL.spec.mjs
@@ -5,8 +5,25 @@ import {test, expect} from '../../fixtures.mjs';
  * uncovered sibling of the click pop-out witness (`FleetCockpitPopOutNL.spec.mjs`) and the dockdemo
  * tear-out matrix (`TearOutMatrixRows4To7NL.spec.mjs`). A dock pane is torn out to a REAL second
  * browser window on the ONE SharedWorker heap, the vessel adopts the SAME live instance, then the
- * OS window CLOSES — and the pane must come HOME to the cockpit tree, never strand in the dead
+ * vessel DIES — and the pane must come HOME to the cockpit tree, never strand in the dead
  * vessel's view (the defect: tab header returns, live pane orphaned under the dead vessel viewport).
+ * The death is driven while the vessel view is live (the widest tree-live-occupant window), plus a
+ * second disconnect delivery to pin no-op idempotency. The strand itself is schedule-dependent —
+ * this spec gates the full return CONTRACT on every schedule, with the arm-time parking fix making
+ * the handoff independent of which slot consumer (resolver vs refresh) serves the return.
+ *
+ * The return oracle binds every dimension of the return contract mechanically (no conditional identity, no
+ * inequality stand-ins): the pane id is captured as a REQUIRED precondition and compared
+ * unconditionally after return; the returned `windowId` must EQUAL the live cockpit's own
+ * `windowId` (never merely differ from the dead vessel's); the pane's parent must itself live in
+ * the cockpit window's tree; and the pane BODY must be visible in the main window's rendered DOM —
+ * the original defect rendered the returning tab header over an empty page, so header-level checks
+ * cannot witness it.
+ *
+ * Two items run the exact same cycle: `stream` lives in the default tree; `operator`
+ * starts auto-hidden on the right rail and is first pinned through the production semantic-op path
+ * (`applyDockZoneOperation setItemAutoHidden`, the FleetCockpitController.onAgentSelect precedent) —
+ * reintegration itself is item-keyed through the one `reintegrateTearOutItem` branch.
  *
  * The tear-out seam is driven programmatically over Neural Link: `onDockTearOutExit` /
  * `onDockTearOutTerminal` on the cockpit's own `tearOutHandlers` take `{itemId, proxyRect}` with the
@@ -21,7 +38,37 @@ import {test, expect} from '../../fixtures.mjs';
 test.describe('AgentOS Fleet cockpit — gesture tear-out vessel-death return (Neural Link, #15635)', () => {
     test.setTimeout(120000);
 
-    test('tear out → own OS window → vessel death → same instance comes HOME, no orphan', async ({page, neuralLink}) => {
+    /**
+     * Normalizes the Neural Link component-query return into one flat shape — the earlier
+     * two-shape read (`[0].id` at capture vs `.properties.id` after return) is exactly how an
+     * identity precondition can go silently undefined and never bind.
+     * @param {Object} app
+     * @param {String} className
+     * @returns {Object|null} `{id, mounted, windowId, parentId}` or null
+     */
+    const queryPane = async (app, className) => {
+        const result = await app.queryComponent({className}, ['id', 'mounted', 'windowId', 'parentId']),
+              first  = (Array.isArray(result) ? result : [result]).filter(Boolean)[0];
+
+        if (!first) return null;
+
+        const flat = first.properties ?? first;
+
+        return {id: flat.id, mounted: flat.mounted, windowId: flat.windowId, parentId: flat.parentId}
+    };
+
+    /**
+     * Runs the full tear-out → real vessel window → vessel death → return cycle for one item,
+     * binding the complete AC1 oracle.
+     * @param {Object}  page
+     * @param {Object}  neuralLink
+     * @param {Object}  descriptor
+     * @param {String}  descriptor.itemId       Dock item id in the committed document
+     * @param {String}  descriptor.className    App Worker class of the pane instance
+     * @param {String}  descriptor.domSelector  Main-window DOM selector of the rendered pane body
+     * @param {Boolean} [descriptor.pin=false]  Un-rail the item through the production semantic op first
+     */
+    const runVesselDeathCycle = async (page, neuralLink, {itemId, className, domSelector, pin = false}) => {
         const pageErrors = [];
 
         page.on('pageerror', error => {
@@ -39,21 +86,43 @@ test.describe('AgentOS Fleet cockpit — gesture tear-out vessel-death return (N
 
         expect(cockpitId, 'the FleetCockpit must exist in the App Worker').toBeTruthy();
 
-        // pick a live, tabs-held item to tear out — topology-derived, not a layout assumption
+        if (pin) {
+            // the production un-rail path (FleetCockpitController.onAgentSelect precedent), BOTH
+            // halves: `applyDockZoneOperation` is a pure reducer returning `{document, errors}` —
+            // the mutation only lands when the caller commits the produced document
+            const pinResult = await app.callMethod(cockpitId, 'applyDockZoneOperation',
+                [{operation: 'setItemAutoHidden', itemId, autoHidden: false}]);
+
+            expect(pinResult?.errors ?? [], `the '${itemId}' un-rail reduction carries no errors`).toEqual([]);
+            expect(pinResult?.document, 'the reducer produced a document to commit').toBeTruthy();
+
+            await app.callMethod(cockpitId, 'onDockZoneDocumentChange', [pinResult.document])
+        }
+
         const readDoc = async () => {
             const topo = await app.getDockTopology(cockpitId);
             return topo?.document ?? topo;
         };
 
         const docBefore = await readDoc(),
-              itemId    = 'stream',
               homeNode  = Object.keys(docBefore.nodes).find(id =>
                   docBefore.nodes[id].type === 'tabs' && docBefore.nodes[id].items?.includes(itemId));
 
         expect(homeNode, `the '${itemId}' item starts in a live tabs node`).toBeTruthy();
 
-        const streamId0 = (await app.queryComponent({className: 'AgentOS.view.fleet.ActivityStream'}, ['id']))
-            ?.[0]?.id ?? (await app.queryComponent({className: 'AgentOS.view.fleet.ActivityStream'}, ['id']))?.id;
+        // ── AC1 precondition: the pane instance id is REQUIRED before the cycle — identity is
+        // asserted unconditionally after return, never skipped behind a falsy capture. Polled
+        // because `resolveDockComponentRef` materializes a freshly un-railed pane asynchronously
+        // (projection → tab render → instance); the requirement itself stays hard.
+        await expect.poll(async () => (await queryPane(app, className))?.id ?? null, {
+            message  : `the '${className}' pane id must be captured before the tear-out`,
+            timeout  : 15000,
+            intervals: [200, 500]
+        }).not.toBeNull();
+
+        const paneId0 = (await queryPane(app, className)).id;
+
+        expect(paneId0, `the '${className}' pane id must be captured before the tear-out`).toBeTruthy();
 
         // ── tear out via the sortZone-free seam: exit opens the REAL vessel window ──────────
         const popupPromise = page.waitForEvent('popup', {timeout: 30000}),
@@ -98,47 +167,61 @@ test.describe('AgentOS Fleet cockpit — gesture tear-out vessel-death return (N
             'the torn item is absent from the live tree while detached').toBe(false);
         expect(docDetached.items[itemId], 'detachItem keeps the catalog record').toBeTruthy();
 
-        // ── the defect surface: the real OS window closes ──────────────────────────────────
-        const popupClosed = popup.waitForEvent('close', {timeout: 30000});
-
-        await popup.evaluate(() => window.close());
-        await popupClosed;
-
-        // drive the disconnect (matrix-witness pattern: the harness close does not always emit it)
+        // ── the defect surface: vessel death while the vessel view is still LIVE ─────────────
+        // Driven with the vessel window open — the ordering that maximizes the tree-live-occupant
+        // window (the App Worker's disconnect handling legitimately races the vessel teardown).
+        // This witness is the return CONTRACT gate (same instance, exact cockpit windowId, main-tree
+        // parent, rendered body, records consumed) — not a deterministic red-gate for the strand:
+        // the strand is schedule-dependent (observed 4/4 under session load on 2026-07-24; idle-host
+        // controls later ran the unfixed code green under every public-seam ordering). The parking
+        // fix makes the handoff order-independent, so this contract holds on every schedule.
         await app.callMethod(cockpitId, 'onWindowDisconnect', [{windowId: vesselWindowId}]);
 
-        // ── the item must come HOME: tree-live again, same instance, not orphaned ───────────
+        // fired a second time on purpose: production can deliver the disconnect through two
+        // independent paths (port-close event + programmatic drive) — the consumed tear-out
+        // record must make the second arrival a harmless no-op, never a double reintegration
+        await app.callMethod(cockpitId, 'onWindowDisconnect', [{windowId: vesselWindowId}]);
+
+        // ── the item must come HOME: tree-live again ─────────────────────────────────────────
         await expect.poll(async () => {
             const doc = await readDoc();
             return Object.values(doc.nodes).some(node => node.items?.includes(itemId));
         }, {message: 'the item must re-tree after vessel death', timeout: 20000, intervals: [200, 500]}).toBe(true);
 
+        // the live cockpit window is the EXACT return target — captured, asserted, then compared
         const {windowId: cockpitWindowId} = await app.getComponent(cockpitId, ['windowId']);
 
-        const readStream = async () => {
-            const streams = await app.queryComponent({className: 'AgentOS.view.fleet.ActivityStream'},
-                ['id', 'mounted', 'windowId']);
-            return (Array.isArray(streams) ? streams : [streams]).filter(Boolean)[0];
-        };
+        expect(cockpitWindowId, 'the live cockpit windowId must be readable').toBeTruthy();
+        expect(cockpitWindowId, 'the cockpit itself never lives on the vessel').not.toBe(vesselWindowId);
 
-        const stream0 = await readStream();
-
-        expect(stream0, 'the ActivityStream instance survives the vessel death').toBeTruthy();
-        streamId0 && expect(stream0.properties.id, 'same instance — never a recreation').toBe(streamId0);
-
-        // the returned pane is fully home only when BOTH hold: it re-targets the LIVE cockpit window
-        // (not the dead vessel — the strand under test) AND it is mounted there. Poll both together so a
-        // slow reintegration is not a false red; a stuck windowId or a never-remount is the defect.
+        // AC1, bound exactly: mounted in the cockpit window — `windowId === cockpitWindowId`,
+        // never the weaker `!== vesselWindowId` (null/undefined/a third window must all FAIL)
         await expect.poll(async () => {
-            const s = await readStream();
-            return {mounted: s?.properties?.mounted, onDeadVessel: s?.properties?.windowId === vesselWindowId};
+            const pane = await queryPane(app, className);
+            return pane && {mounted: pane.mounted, windowId: pane.windowId};
         }, {
             message  : `the pane must come home mounted in the cockpit window (${cockpitWindowId}), off the dead vessel (${vesselWindowId})`,
             timeout  : 15000,
             intervals: [200, 500]
-        }).toEqual({mounted: true, onDeadVessel: false});
+        }).toEqual({mounted: true, windowId: cockpitWindowId});
 
-        const stream = await readStream();
+        const pane = await queryPane(app, className);
+
+        // same instance — asserted unconditionally against the required precondition
+        expect(pane.id, 'same instance — never a recreation').toBe(paneId0);
+
+        // parentId in the main window's tree: the parent component itself must live in the
+        // cockpit's window — a pane re-parented under the dead vessel's surviving view tree fails
+        expect(pane.parentId, 'the returned pane has a parent').toBeTruthy();
+
+        const {windowId: parentWindowId} = await app.getComponent(pane.parentId, ['windowId']);
+
+        expect(parentWindowId, 'the returned pane\'s parent lives in the cockpit window').toBe(cockpitWindowId);
+
+        // pane body rendered — in the MAIN window's real DOM. The defect's signature was a
+        // returned tab header over an empty page, so header presence can never witness this.
+        await expect(page.locator(domSelector).first(),
+            'the returned pane body renders in the main window').toBeVisible({timeout: 10000});
 
         // the tear-out records are consumed exact-once (no leaked capture / orphan bookkeeping)
         const {tearOutPanes: after, returningTearOutPanes} = await app.getComponent(cockpitId,
@@ -147,7 +230,30 @@ test.describe('AgentOS Fleet cockpit — gesture tear-out vessel-death return (N
         expect(after?.[itemId], 'the tearOutPanes record is consumed').toBeFalsy();
         expect(returningTearOutPanes?.[itemId], 'the returning slot is consumed').toBeFalsy();
 
+        // cleanup: the emptied vessel window closes (the return was already proven above)
+        const popupClosed = popup.waitForEvent('close', {timeout: 30000});
+
+        await popup.evaluate(() => window.close());
+        await popupClosed;
+
         expect(pageErrors, 'zero main-window page errors').toEqual([]);
         expect(popupErrors, 'zero vessel page errors').toEqual([])
-    })
+    };
+
+    test('stream: tear out → own OS window → vessel death → same instance comes HOME, no orphan', async ({page, neuralLink}) => {
+        await runVesselDeathCycle(page, neuralLink, {
+            itemId     : 'stream',
+            className  : 'AgentOS.view.fleet.ActivityStream',
+            domSelector: '.fm-activity-stream'
+        })
+    });
+
+    test('operator (rail-pinned first): the item-keyed return branch holds beyond the default tree', async ({page, neuralLink}) => {
+        await runVesselDeathCycle(page, neuralLink, {
+            itemId     : 'operator',
+            className  : 'AgentOS.view.fleet.OperatorMailbox',
+            domSelector: '.fm-operator-mailbox',
+            pin        : true
+        })
+    });
 });

--- a/test/playwright/e2e/agentos/FleetCockpitTearOutNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitTearOutNL.spec.mjs
@@ -1,0 +1,153 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e for the Fleet cockpit's GESTURE tear-out vessel-death return leg — the
+ * uncovered sibling of the click pop-out witness (`FleetCockpitPopOutNL.spec.mjs`) and the dockdemo
+ * tear-out matrix (`TearOutMatrixRows4To7NL.spec.mjs`). A dock pane is torn out to a REAL second
+ * browser window on the ONE SharedWorker heap, the vessel adopts the SAME live instance, then the
+ * OS window CLOSES — and the pane must come HOME to the cockpit tree, never strand in the dead
+ * vessel's view (the defect: tab header returns, live pane orphaned under the dead vessel viewport).
+ *
+ * The tear-out seam is driven programmatically over Neural Link: `onDockTearOutExit` /
+ * `onDockTearOutTerminal` on the cockpit's own `tearOutHandlers` take `{itemId, proxyRect}` with the
+ * `sortZone` OMITTED — every `sortZone` touch in `src/dashboard/DockTearOut.mjs` is optional-chained
+ * (the pointer-follow visual affordance), while the capture/detach/commit path is sortZone-free. This
+ * is the same seam the production SortZone gesture fires; the intricate native-gesture simulation
+ * (`DemoBWorkspace.executeTearOutStep`) is the matrix witness's scope, not needed to prove the
+ * lifecycle return.
+ *
+ * Run: NEO_E2E_PORT=8145 npx playwright test agentos/FleetCockpitTearOutNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS Fleet cockpit — gesture tear-out vessel-death return (Neural Link, #15635)', () => {
+    test.setTimeout(120000);
+
+    test('tear out → own OS window → vessel death → same instance comes HOME, no orphan', async ({page, neuralLink}) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/agentos/index.html');
+        await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
+        await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
+
+        const app       = await neuralLink.connectToApp('AgentOS'),
+              cockpits  = await app.findInstances({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']),
+              cockpitId = (Array.isArray(cockpits) ? cockpits[0] : cockpits)?.id;
+
+        expect(cockpitId, 'the FleetCockpit must exist in the App Worker').toBeTruthy();
+
+        // pick a live, tabs-held item to tear out — topology-derived, not a layout assumption
+        const readDoc = async () => {
+            const topo = await app.getDockTopology(cockpitId);
+            return topo?.document ?? topo;
+        };
+
+        const docBefore = await readDoc(),
+              itemId    = 'stream',
+              homeNode  = Object.keys(docBefore.nodes).find(id =>
+                  docBefore.nodes[id].type === 'tabs' && docBefore.nodes[id].items?.includes(itemId));
+
+        expect(homeNode, `the '${itemId}' item starts in a live tabs node`).toBeTruthy();
+
+        const streamId0 = (await app.queryComponent({className: 'AgentOS.view.fleet.ActivityStream'}, ['id']))
+            ?.[0]?.id ?? (await app.queryComponent({className: 'AgentOS.view.fleet.ActivityStream'}, ['id']))?.id;
+
+        // ── tear out via the sortZone-free seam: exit opens the REAL vessel window ──────────
+        const popupPromise = page.waitForEvent('popup', {timeout: 30000}),
+              exitResult   = await app.callMethod(cockpitId, 'tearOutHandlers.onDockTearOutExit',
+                  [{itemId, proxyRect: {x: 80, y: 80, width: 480, height: 360}}]);
+
+        expect(exitResult, 'the exit seam admitted the vessel').toBe(true);
+
+        const popup = await popupPromise;
+
+        // the vessel opens at a staged about:blank, then location.replace navigates to the widget
+        // childapp (the same-origin warm-connect staging pattern) — wait for the real URL
+        await popup.waitForURL(url => String(url).includes(`tearout=${itemId}`), {timeout: 30000});
+        expect(popup.url()).toContain('cockpitId=');
+
+        const popupErrors = [];
+
+        popup.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && popupErrors.push(value)
+        });
+
+        // terminal commits the detach (sortZone-free): item leaves the tree, catalog keeps it
+        const terminalResult = await app.callMethod(cockpitId, 'tearOutHandlers.onDockTearOutTerminal', [{itemId}]);
+
+        expect(terminalResult, 'the terminal committed the detach').toBe(true);
+
+        // the REAL vessel connects and adopts the pane — wait for the record to carry its windowId
+        await expect.poll(async () => {
+            const {tearOutPanes} = await app.getComponent(cockpitId, ['tearOutPanes']);
+            return tearOutPanes?.[itemId]?.windowId || null;
+        }, {message: 'the vessel must join the heap and adopt the pane', timeout: 30000, intervals: [200, 500]})
+            .toBeTruthy();
+
+        const {tearOutPanes} = await app.getComponent(cockpitId, ['tearOutPanes']),
+              vesselWindowId = tearOutPanes[itemId].windowId;
+
+        // document truth while detached: out of the tree, still in the catalog
+        const docDetached = await readDoc();
+
+        expect(Object.values(docDetached.nodes).some(node => node.items?.includes(itemId)),
+            'the torn item is absent from the live tree while detached').toBe(false);
+        expect(docDetached.items[itemId], 'detachItem keeps the catalog record').toBeTruthy();
+
+        // ── the defect surface: the real OS window closes ──────────────────────────────────
+        const popupClosed = popup.waitForEvent('close', {timeout: 30000});
+
+        await popup.evaluate(() => window.close());
+        await popupClosed;
+
+        // drive the disconnect (matrix-witness pattern: the harness close does not always emit it)
+        await app.callMethod(cockpitId, 'onWindowDisconnect', [{windowId: vesselWindowId}]);
+
+        // ── the item must come HOME: tree-live again, same instance, not orphaned ───────────
+        await expect.poll(async () => {
+            const doc = await readDoc();
+            return Object.values(doc.nodes).some(node => node.items?.includes(itemId));
+        }, {message: 'the item must re-tree after vessel death', timeout: 20000, intervals: [200, 500]}).toBe(true);
+
+        const {windowId: cockpitWindowId} = await app.getComponent(cockpitId, ['windowId']);
+
+        const readStream = async () => {
+            const streams = await app.queryComponent({className: 'AgentOS.view.fleet.ActivityStream'},
+                ['id', 'mounted', 'windowId']);
+            return (Array.isArray(streams) ? streams : [streams]).filter(Boolean)[0];
+        };
+
+        const stream0 = await readStream();
+
+        expect(stream0, 'the ActivityStream instance survives the vessel death').toBeTruthy();
+        streamId0 && expect(stream0.properties.id, 'same instance — never a recreation').toBe(streamId0);
+
+        // the returned pane is fully home only when BOTH hold: it re-targets the LIVE cockpit window
+        // (not the dead vessel — the strand under test) AND it is mounted there. Poll both together so a
+        // slow reintegration is not a false red; a stuck windowId or a never-remount is the defect.
+        await expect.poll(async () => {
+            const s = await readStream();
+            return {mounted: s?.properties?.mounted, onDeadVessel: s?.properties?.windowId === vesselWindowId};
+        }, {
+            message  : `the pane must come home mounted in the cockpit window (${cockpitWindowId}), off the dead vessel (${vesselWindowId})`,
+            timeout  : 15000,
+            intervals: [200, 500]
+        }).toEqual({mounted: true, onDeadVessel: false});
+
+        const stream = await readStream();
+
+        // the tear-out records are consumed exact-once (no leaked capture / orphan bookkeeping)
+        const {tearOutPanes: after, returningTearOutPanes} = await app.getComponent(cockpitId,
+            ['tearOutPanes', 'returningTearOutPanes']);
+
+        expect(after?.[itemId], 'the tearOutPanes record is consumed').toBeFalsy();
+        expect(returningTearOutPanes?.[itemId], 'the returning slot is consumed').toBeFalsy();
+
+        expect(pageErrors, 'zero main-window page errors').toEqual([]);
+        expect(popupErrors, 'zero vessel page errors').toEqual([])
+    })
+});


### PR DESCRIPTION
Resolves #15635

The gesture tear-out vessel-death return leg can strand the live pane in the dead vessel: the item's tab header re-trees in the dock document while the live instance stays mounted in the closed vessel window (its `windowId` never leaves the dead vessel). Mechanism, source-anchored: `reintegrateTearOutItem` arms the `returningTearOutPanes` handoff slot while the pane is still parented in the vessel's `mainView`, and the armed slot has **two consumers with asymmetric parking**. The addTab→re-projection path consumes through `resolveDockComponentRef`, which parks at consumption (`returning.parent?.remove(returning, false)` — pre-existing) and is safe. The already-re-treed branch goes through `refreshDockWorkspace()`, where the swap only happens if the reconciler re-materializes the item — a pane the reconciler does not re-materialize stays vessel-parented: the strand. Fix: park at **arm time**, upstream of both branches (`pane.parent?.remove(pane, false)` before the slot is armed), making the handoff independent of which consumer serves the return. Symmetric with the resolver's consumption-side parking; mirrors `reattachAgentDetail`'s parked-pane discipline. One code block + the AC witness.

Evidence: L3 achieved (whitebox-e2e on the real reconciler + real OS vessel window + real SharedWorker heap, driving the sortZone-free production seam over Neural Link; oracle binds every AC1 dimension — see matrix) → L3 required (#15635 AC1/AC3). **Reproducibility, stated honestly:** the strand is schedule-dependent. It was observed live on 2026-07-21 (#15631's AC1 session) and reproduced 4/4 by this witness pre-fix on 2026-07-24 under session load. Post-review idle-host controls (instrument verified: the dev server's served file was curl-checked to track the on-disk revert) ran the **unfixed** code green 7× across every public-seam ordering (original spec ×3, strengthened oracle, disconnect-while-vessel-live, double-disconnect). The defect class is real and twice-dated; an on-demand red run is not currently producible on an idle host. The witness therefore gates the full return **contract** on every schedule, and the fix removes the schedule-dependence by construction.

## Close-target accounting (#15635)

| AC | Disposition | Evidence |
|---|---|---|
| AC1 — same instance, `parentId` in main tree, body rendered | **Met** | Witness binds all dimensions mechanically: pane id captured as a hard precondition and compared unconditionally after return; returned `windowId === cockpitWindowId` (exact equality, never `!== vessel`); parent component's `windowId === cockpitWindowId`; pane body visible in the main window's rendered DOM; records consumed exact-once. 2/2 green at head. |
| AC2 — `operator` + `detail` items, or documented delta | **Met (operator verified; detail delta documented)** | `stream` + `operator` both run the full cycle — `operator` starts auto-hidden and is un-railed through the production two-half idiom (`applyDockZoneOperation setItemAutoHidden` reduce → `onDockZoneDocumentChange` commit, the controller precedent). `detail` delta: its windowing is the shell-owned vessel state machine (`popOutAgentDetail`/`reattachAgentDetail`, #15648-witnessed), which never calls `reintegrateTearOutItem`; a gesture-torn `detail` rides the same single item-keyed branch (zero item-conditional code in `reintegrateTearOutItem`). |
| AC3 — witness committed; model specs keep passing | **Met** | This spec; `fleetCockpitTearOut.spec.mjs` + `DockTearOut.spec.mjs` = 26/26 at head (fresh run); fleet unit suite 343/343 at the fix commit. |
| AC4 — drag-back-home established and recorded | **Met (recorded)** | Pre-terminal drag-home is `DockTearOut.onDockTearOutEntry`'s zero-mutation capture retirement — unit-witnessed in `DockTearOut.spec.mjs` (green at head); the cockpit adds no gesture-specific divergence (handlers delegate to the shared creators). Post-adoption drag **from** the vessel back is cross-window transfer — #15239 G4 / #15243 matrix scope, not this bug's leg. |

## Deltas from ticket

- **The bug was NOT already-resolved — three green adjacent layers missed it.** Intake leaned "already-resolved / #15664-environment-contaminated" off the green unit model, green dockdemo matrix, and green kinetic witness. Authoring the AC3 witness refuted that lean at the time (4/4 red pre-fix under session load). The unit model cannot falsify the occupant condition because its container stub does not model windowId reassignment on reparent.
- **Post-review evidence correction (this cycle):** the pre-fix red is schedule-dependent, not deterministic — 7 idle-host controls on unfixed code ran green (enumerated above, instrument-verified). The mechanism narrows to the consumer-dependent parking gap on the refresh branch; the arm-time fix closes it for every schedule. The witness prose and this body now claim exactly what the oracle asserts.
- The witness drives the tear-out seam programmatically (`tearOutHandlers.onDockTearOutExit`/`onDockTearOutTerminal`, `sortZone` omitted — every sortZone touch in `src/dashboard/DockTearOut.mjs` is optional-chained pointer-follow; the capture/detach path is sortZone-free). Native-gesture simulation stays the matrix witness's scope (#15243).
- The second `onWindowDisconnect` delivery in the witness pins no-op idempotency: production can deliver the disconnect through the port-close event AND a programmatic path; the consumed record must make the second arrival harmless.
- No change to the click pop-out path (`popOutAgentDetail`/`reattachAgentDetail`) — it never calls `reintegrateTearOutItem`; confirmed unaffected.

## Test Evidence

- Witness `agentos/FleetCockpitTearOutNL.spec.mjs` at head: **2/2 green** (stream + rail-pinned operator), full AC1 oracle (unconditional identity, exact `windowId === cockpitWindowId`, parent-in-cockpit-window, main-DOM rendered body, exact-once records, zero page errors both windows, disconnect idempotency).
- Model layer at head: `fleetCockpitTearOut.spec.mjs` + `DockTearOut.spec.mjs` **26/26**; fleet unit suite **343/343** at the fix commit.
- Controls (unfixed `FleetCockpit.mjs` from origin/dev, instrument verified by curling the served file across the revert): original spec ×3 green, strengthened oracle green, vessel-live ordering green, double-disconnect green — the honest bound on red-on-demand reproducibility.
- `FleetCockpitPopOutNL` (click path) failing headless is **pre-existing** — stash-confirmed identical `about:blank` stall without this change.

## Post-Merge Validation

- [ ] A real gesture-driven (SortZone `enableProxyToPopup`) tear-out capture session on a seat confirms the same home-return the programmatic seam proves here (non-closing hygiene; the seam below the gesture is the production path).

## Commits (if multi-commit)

- `reintegrateTearOutItem` arm-time parking fix + the AC3 witness (original).
- Review cycle 1: witness oracle strengthened to bind every AC1 dimension; AC2 operator case added (production un-rail idiom); disconnect idempotency pinned; evidence state corrected per the control runs.

## Evolution (optional, only if pivots occurred during implementation)

Intake retracted the tree-live-occupant hypothesis when the unit test passed, leaned already-resolved, and the witness refuted the lean (4/4 red then). This review cycle inverted once more: re-proving the red at the strengthened oracle failed — 7 controls showed the unfixed path green on an idle host — which falsified "deterministic" and forced the mechanism down to the actual asymmetry (consumption-side parking exists on one slot consumer, not the other; the fix parks upstream of both). Each reversal came from running the falsifier instead of trusting the prior claim.

Authored by Vega (Fable 5, Claude Code). Session 856622cb-f32e-4ab8-bd11-4d2bb6602f61.
