### PR TITLE
fix(ai): a mailbox receipt must not outrun its durable write (#15821)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1122,29 +1122,105 @@ function getArchivedAtForMessage(messageNode, deliveryEdge=null) {
     return messageNode?.properties?.archivedAt || null;
 }
 
+/**
+ * Durably persists a receipt mutation (read or archive) already applied to a per-recipient
+ * `DELIVERED_TO` edge, and reports whether the durable write actually ran.
+ *
+ * ## Why this is not gated on `autoSave`
+ *
+ * `Database#autoSave` exists to suppress **load-echo** writes: every site that clears it
+ * (`Database.mjs` delta-sync invalid-node/edge pruning, vicinity load, and the other bulk
+ * load paths) is populating the in-memory cache *from* storage, where writing back would
+ * amplify writes and pollute the delta log. A read or archive receipt is the opposite — a
+ * **user-originated** mutation that can never be a load echo — so suppressing it under that
+ * flag is a category error, not an optimisation.
+ *
+ * It is also unobservable in every reachable state: those windows are synchronous (no `await`
+ * between clearing the flag and restoring it), so a receipt call cannot execute inside one.
+ * The gate could therefore only ever fire in a state nothing reaches — which is precisely why
+ * it went unnoticed while making the receipt claim a durability it had not delivered.
+ *
+ * The `storage` guard stays: with no storage there is nowhere to write, and the caller needs
+ * to know that rather than reporting an unqualified success.
+ *
+ * @param {Object} edge `DELIVERED_TO` edge record carrying the already-applied receipt property.
+ * @returns {Promise<Boolean>} `true` when the durable write ran; `false` when there was no storage.
+ */
+async function persistReceiptEdge(edge) {
+    const db = GraphService.db;
+
+    if (!db?.storage) {
+        return false;
+    }
+
+    await db.storage.addEdges([edge]);
+    db.acknowledgeLocalMutations?.();
+
+    return true;
+}
+
+/**
+ * Builds the receipt a mailbox lifecycle tool returns, degrading it honestly when the durable
+ * write did not run.
+ *
+ * The happy-path shape is byte-identical to what callers already consume, so nothing that reads
+ * `status` breaks. When the write was skipped the receipt gains `durable: false` plus a warning
+ * instead of silently asserting a persistence that a restart would discard — the in-memory
+ * mutation is real for this process, and that is exactly as much as the receipt may claim.
+ *
+ * The stricter alternative — refusing the ack outright, or returning a retryable status — is
+ * deliberately not taken here: it would change `status` for existing consumers, and the
+ * non-durable branch is unreachable while storage is present. Surfacing beats breaking.
+ *
+ * @param {Object} receipt The success receipt (`{messageId, readAt|archivedAt, status}`).
+ * @param {Boolean} durable Whether the durable write ran.
+ * @param {String} operation Human-readable operation name for the warning text.
+ * @returns {Object} The receipt, annotated when non-durable.
+ */
+function receiptWithDurability(receipt, durable, operation) {
+    if (durable) {
+        return receipt;
+    }
+
+    const warning = `${operation} was applied in memory but NOT persisted: the graph database has no storage backing, so this state is lost on restart.`;
+
+    logger.warn(`[MailboxService] ${warning}`);
+
+    return {...receipt, durable: false, warning};
+}
+
+/**
+ * Sets the read timestamp on a per-recipient `DELIVERED_TO` edge for broadcast messages and
+ * reports whether that mutation reached durable storage.
+ *
+ * The in-memory mutation is unconditional but the durable write is not, so the boolean is
+ * load-bearing: a caller that returns a read receipt without consulting it would acknowledge a
+ * write that a restart discards.
+ *
+ * @param {Object} edge `DELIVERED_TO` edge record.
+ * @param {String} readAt ISO timestamp.
+ * @returns {Promise<Boolean>} `true` when the read state was persisted durably.
+ */
 async function setDeliveryEdgeReadAt(edge, readAt) {
     setRecordProperties(edge, {
         ...getRecordProperties(edge),
         readAt
     });
 
-    const db = GraphService.db;
-
-    if (db?.autoSave && db.storage) {
-        await db.storage.addEdges([edge]);
-        db.acknowledgeLocalMutations?.();
-    }
+    return persistReceiptEdge(edge);
 }
 
 /**
  * Sets the archive timestamp on a per-recipient DELIVERED_TO edge for broadcast
- * messages. Mirrors `setDeliveryEdgeReadAt` exactly — same write shape
- * (merge properties + addEdges + acknowledgeLocalMutations) so broadcast archive state
- * participates in the same WAL coherence guarantees as read receipts.
+ * messages. Mirrors `setDeliveryEdgeReadAt` exactly — both delegate to
+ * `persistReceiptEdge`, so broadcast archive state participates in the same durability
+ * guarantees as read receipts. That mirroring is the reason this function shares the fix:
+ * the two carried identical write shapes, so an archive receipt could report success on a
+ * skipped durable write for exactly the same reason a read receipt could.
  *
  * @param {Object} edge DELIVERED_TO edge record.
  * @param {String} archivedAt ISO timestamp.
- * @returns {Promise<void>}
+ * @returns {Promise<Boolean>} `true` when the archive state was persisted durably.
  */
 async function setDeliveryEdgeArchivedAt(edge, archivedAt) {
     setRecordProperties(edge, {
@@ -1152,12 +1228,7 @@ async function setDeliveryEdgeArchivedAt(edge, archivedAt) {
         archivedAt
     });
 
-    const db = GraphService.db;
-
-    if (db?.autoSave && db.storage) {
-        await db.storage.addEdges([edge]);
-        db.acknowledgeLocalMutations?.();
-    }
+    return persistReceiptEdge(edge);
 }
 
 function linkOptionalMailboxEdge(source, target, type, weight, properties) {
@@ -2246,9 +2317,9 @@ class MailboxService extends Base {
         if (deliveryEdge) {
             const readAt = new Date().toISOString();
 
-            await setDeliveryEdgeReadAt(deliveryEdge, readAt);
+            const durable = await setDeliveryEdgeReadAt(deliveryEdge, readAt);
 
-            return { messageId, readAt, status: 'read' };
+            return receiptWithDurability({ messageId, readAt, status: 'read' }, durable, 'mark_read');
         }
 
         // A broadcast recipient with no visible delivery edge is the one state where the projection is
@@ -2271,9 +2342,9 @@ class MailboxService extends Base {
             if (repairedEdge) {
                 const readAt = new Date().toISOString();
 
-                await setDeliveryEdgeReadAt(repairedEdge, readAt);
+                const durable = await setDeliveryEdgeReadAt(repairedEdge, readAt);
 
-                return { messageId, readAt, status: 'read' };
+                return receiptWithDurability({ messageId, readAt, status: 'read' }, durable, 'mark_read');
             }
         }
 
@@ -2352,9 +2423,9 @@ class MailboxService extends Base {
         if (deliveryEdge) {
             const archivedAt = new Date().toISOString();
 
-            await setDeliveryEdgeArchivedAt(deliveryEdge, archivedAt);
+            const durable = await setDeliveryEdgeArchivedAt(deliveryEdge, archivedAt);
 
-            return { messageId, archivedAt, status: 'archived' };
+            return receiptWithDurability({ messageId, archivedAt, status: 'archived' }, durable, 'archive_message');
         }
 
         if (isBroadcastRecipient && hasBroadcastDeliveryEdges(messageId)) {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.ReceiptDurability.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.ReceiptDurability.spec.mjs
@@ -1,0 +1,210 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'MailboxReceiptDurabilityTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import                            '../../../../../../src/manager/Instance.mjs';
+import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+
+/**
+ * A read receipt must not out-claim its durable write.
+ *
+ * `mark_read` / `archive_message` mutate the in-memory `DELIVERED_TO` edge unconditionally, then
+ * persisted only when `db.autoSave` was set — while the tool returned `status: 'read'` either way.
+ * An acknowledged write that was never persisted is a false receipt: the mark survives until the
+ * process restarts and then silently reverts to unread.
+ *
+ * These specs assert durability **against storage**, not against a spy: after the call they read
+ * the edge back through `storage.loadNodeVicinitySync` (bypassing the in-memory cache the mutation
+ * always updates), which is the only way to tell "persisted" from "looked persisted".
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('MailboxService — receipt durability cannot outrun the durable write (#15821)', () => {
+    let MailboxService, GraphService, LifecycleService, mailboxAiConfig;
+    let dbPath, originalAutoSave, originalPolicy;
+
+    const SENDER    = '@neo-opus-ada',
+          RECIPIENT = '@neo-opus-grace';
+
+    test.beforeAll(async () => {
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+
+        dbPath = path.join(tmpDir, `neo-receipt-durability-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
+
+        // A file-backed DB, not `:memory:` — the whole point is what storage holds.
+        mailboxAiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
+        mailboxAiConfig.storagePaths.graph = dbPath;
+        mailboxAiConfig.collections      ??= {};
+        mailboxAiConfig.collections.memory  = `test-memory-${Date.now()}`;
+        mailboxAiConfig.collections.session = `test-session-${Date.now()}`;
+
+        GraphService     = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        MailboxService   = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;
+        LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
+
+        mailboxAiConfig.data.mailbox ??= {};
+        originalPolicy = mailboxAiConfig.data.mailbox.defaultReplyPolicy;
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync();
+        } else {
+            await LifecycleService.ready();
+        }
+
+        originalAutoSave = GraphService.db.autoSave;
+    });
+
+    test.afterAll(async () => {
+        // Symmetric restore: `autoSave` is singleton state and Playwright interleaves files.
+        if (GraphService?.db) {
+            GraphService.db.autoSave = originalAutoSave;
+        }
+        if (mailboxAiConfig?.data?.mailbox) {
+            mailboxAiConfig.data.mailbox.defaultReplyPolicy = originalPolicy;
+        }
+        if (dbPath) {
+            for (const suffix of ['', '-wal', '-shm']) {
+                await fs.remove(`${dbPath}${suffix}`);
+            }
+        }
+    });
+
+    /** Reads the per-recipient DELIVERED_TO edge back FROM STORAGE, never from the in-memory cache. */
+    const readReceiptFromStorage = (messageId, recipient) => {
+        const vicinity = GraphService.db.storage.loadNodeVicinitySync([messageId]),
+              edges    = vicinity?.edges || [];
+
+        return edges.find(edge => {
+            const source = edge.source ?? edge?.data?.source,
+                  target = edge.target ?? edge?.data?.target,
+                  type   = edge.type   ?? edge?.data?.type;
+
+            return source === messageId && type === 'DELIVERED_TO' && target === recipient;
+        }) || null;
+    };
+
+    const propertiesOf = edge => {
+        const raw = edge?.properties ?? edge?.data?.properties;
+
+        return typeof raw === 'string' ? JSON.parse(raw) : (raw || {});
+    };
+
+    /** Sends a broadcast as SENDER so RECIPIENT gets a per-recipient DELIVERED_TO edge. */
+    const sendBroadcast = async subject => {
+        const sent = await RequestContextService.run({agentIdentityNodeId: SENDER}, () =>
+            MailboxService.addMessage({to: 'AGENT:*', subject, body: 'receipt durability fixture'}));
+
+        return sent.messageId;
+    };
+
+    /** Runs a mailbox call bound to RECIPIENT — identity is an AsyncLocalStorage scope, not a setter. */
+    const asRecipient = callback => RequestContextService.run({agentIdentityNodeId: RECIPIENT}, callback);
+
+    test('the receipt persists even with autoSave OFF — the gate was a category error', async () => {
+        // `autoSave` exists to suppress LOAD-ECHO writes (bulk paths populating the cache FROM
+        // storage). A read receipt is user-originated and can never be a load echo, so the old
+        // gate silently discarded it. This is the assertion the fix exists for.
+        const messageId = await sendBroadcast('durability: autoSave off');
+
+        GraphService.db.autoSave = false;
+
+        const receipt = await asRecipient(() => MailboxService.markRead({messageId}));
+
+        expect(receipt.status).toBe('read');
+
+        const stored = readReceiptFromStorage(messageId, RECIPIENT);
+
+        expect(stored).not.toBeNull();
+        // Read back from STORAGE: the in-memory edge always carries the readAt, so only this
+        // discriminates a persisted mark from one that a restart would drop.
+        expect(propertiesOf(stored).readAt).toBe(receipt.readAt);
+
+        GraphService.db.autoSave = originalAutoSave;
+    });
+
+    test('the happy-path receipt shape is unchanged — no consumer sees a new field', async () => {
+        // The fix must not alter what every existing caller already consumes.
+        const messageId = await sendBroadcast('durability: happy path');
+
+        GraphService.db.autoSave = true;
+
+        const receipt = await asRecipient(() => MailboxService.markRead({messageId}));
+
+        expect(Object.keys(receipt).sort()).toEqual(['messageId', 'readAt', 'status']);
+        expect(receipt).not.toHaveProperty('durable');
+        expect(receipt).not.toHaveProperty('warning');
+        expect(propertiesOf(readReceiptFromStorage(messageId, RECIPIENT)).readAt).toBe(receipt.readAt);
+    });
+
+    test('with NO storage the receipt degrades honestly instead of asserting persistence', async () => {
+        // The one state where the write genuinely cannot run. Previously indistinguishable from
+        // success; now the caller is told, so a false ack is impossible rather than merely unlikely.
+        const messageId   = await sendBroadcast('durability: no storage');
+        const realStorage = GraphService.db.storage;
+
+        try {
+            GraphService.db.storage = null;
+
+            const receipt = await asRecipient(() => MailboxService.markRead({messageId}));
+
+            expect(receipt.durable).toBe(false);
+            expect(receipt.warning).toMatch(/NOT persisted/);
+            // The in-memory mutation is real for this process, so the readAt is still returned —
+            // the receipt states exactly as much as it can back, and no more.
+            expect(receipt.readAt).toBeTruthy();
+        } finally {
+            GraphService.db.storage = realStorage;
+        }
+    });
+
+    test('archive_message carries the same fix — its write shape was identical', async () => {
+        // `setDeliveryEdgeArchivedAt` mirrors the read setter by design and documents that mirroring,
+        // so fixing only the read path would have left a documented twin defect behind.
+        const messageId = await sendBroadcast('durability: archive twin');
+
+        GraphService.db.autoSave = false;
+
+        const receipt = await asRecipient(() => MailboxService.archiveMessage({messageId}));
+
+        expect(receipt.status).toBe('archived');
+        expect(propertiesOf(readReceiptFromStorage(messageId, RECIPIENT)).archivedAt).toBe(receipt.archivedAt);
+
+        GraphService.db.autoSave = originalAutoSave;
+    });
+
+    test('archive degrades honestly with no storage too', async () => {
+        const messageId   = await sendBroadcast('durability: archive no storage');
+        const realStorage = GraphService.db.storage;
+
+        try {
+            GraphService.db.storage = null;
+
+            const receipt = await asRecipient(() => MailboxService.archiveMessage({messageId}));
+
+            expect(receipt.durable).toBe(false);
+            expect(receipt.warning).toMatch(/archive_message/);
+        } finally {
+            GraphService.db.storage = realStorage;
+        }
+    });
+});


### PR DESCRIPTION
`mark_read` returned `status: 'read'` while the durable write was skipped. `setDeliveryEdgeReadAt` mutated the in-memory `DELIVERED_TO` edge unconditionally, then gated persistence on `db?.autoSave && db.storage`. **An acknowledged write that was never persisted is a false receipt** — the mark holds until the process restarts, then silently reverts to unread.

`setDeliveryEdgeArchivedAt` carried the identical shape, and its own JSDoc promised it *"mirrors `setDeliveryEdgeReadAt` exactly"*. Fixing only the read path would have left a **documented** twin defect behind, so both now delegate to one `persistReceiptEdge` helper that keeps the mirror true by construction.

**Evidence:** reproduced end-to-end, not inferred from the source. With the old gate restored and `autoSave` forced off, the service returns `status: 'read'` while **storage still holds `readAt: null`** — and `archivedAt: undefined` on the archive twin:

| control | result |
|---|---|
| old `autoSave` gate restored, read path | RED — `Expected: "2026-07-24T16:39:00.451Z"`, `Received: null` from storage |
| old `autoSave` gate restored, archive twin | RED — `Received: undefined` from storage |
| gate removed (this PR) | 5 green |

Every durability assertion reads the edge back through `storage.loadNodeVicinitySync`, **never** the in-memory cache the mutation always updates. That read-back is the only thing that distinguishes *persisted* from *looked persisted* — a spy on `addEdges` would have passed against a store that never committed.

## Deltas from ticket

- **Why the gate was wrong, not merely unlucky.** `Database#autoSave` exists to suppress **load-echo** writes: every site that clears it (delta-sync invalid-node/edge pruning, vicinity load, the other bulk paths) is populating the in-memory cache *from* storage, where writing back amplifies writes and pollutes the delta log. A receipt is **user-originated** and can never be a load echo, so suppressing it under that flag is a **category error**. I read those semantics before touching the write path rather than assuming them — the ticket proposed "drop the gate" as one of two options, and this is the argument that decides between them. The `storage` guard stays: with no storage there is nowhere to write, and the caller needs to be told.
- **The archive twin was not in the ticket.** I found it while reading the read path. It is the same defect with the same blast radius (`archive_message` acknowledging a lost archive), and its JSDoc made the coupling explicit.
- **What this PR does NOT claim.** It does **not** explain the reported resurfacing. The ticket's trigger mechanism stays open: I weakened or falsified four candidates by static tracing (sync-window interleave · WAL-checkpoint loss · steady-state `autoSave=false` · `syncCache` reload dropping the `readAt`), and mc-server builds its graph DB without passing `autoSave`, so it **defaults `true`** and the durable write *does* run in steady state. @neo-opus-vega's heavy-`mark_read` session independently corroborates that — acks appeared durable. So: the false ack is real and now **proven reachable when `autoSave` is false**; I have **not** shown production reaches that state. This removes the possibility rather than diagnosing the incident, and deliberately leaves the mechanism to @neo-fable-clio's runtime probe (does the lost edge's *storage* row carry the `readAt` at the moment of loss). Closing #15821 on the *mechanism* would be closing on a wrong diagnosis — see the close-target reasoning below for why this still carries `Resolves` (the ticket's titled defect) and what obligation that creates. The commit trailer says `Refs` deliberately, so the commit history does not assert more than the commit delivered.
- **Recorded design choice rather than a silent one.** The ticket offered a stricter shape — refuse the ack, or return a retryable status. That would change `status` for existing callers in order to harden a branch that is unreachable while storage is present. The happy-path receipt is therefore **byte-identical** (`{messageId, readAt, status}`, pinned by an exact key-set assertion); only the no-storage branch gains `durable: false` plus a warning. Surfacing beats breaking.

## Test Evidence

`test/playwright/unit/ai/services/memory-core/MailboxService.ReceiptDurability.spec.mjs` — **5 tests, all green** (the playwright runner reports 7 including the chroma setup/teardown fixtures; the spec itself is 5).

| test | asserts |
|---|---|
| receipt persists with `autoSave` OFF | storage's `readAt` equals the returned receipt — the assertion the fix exists for |
| happy-path shape unchanged | exact key set `['messageId','readAt','status']`; no `durable`/`warning` leaks to existing consumers |
| no storage → honest degradation | `durable: false` + a warning naming non-persistence, with the readAt still returned (the in-memory mutation is real for this process) |
| archive twin carries the fix | storage's `archivedAt` equals the returned receipt under `autoSave` OFF |
| archive degrades honestly | `durable: false` + a warning naming `archive_message` |

**Regression surface:** this changes a *shared* write path, so the pre-existing suite ran too — `MailboxService.spec.mjs`, **124 passed**.

```bash
NEO_CHROMA_PORT_TEST=18545 UNIT_TEST_MODE=true npx playwright test \
  -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/services/memory-core/MailboxService.ReceiptDurability.spec.mjs
```

The suite restores `autoSave` and the reply policy symmetrically in `afterAll` and removes its own `.db`/`-wal`/`-shm` files — `autoSave` is singleton state and Playwright interleaves files even under `mode: 'serial'`.

## Post-Merge Validation

- The mechanism remains open. When the runtime probe lands, re-read whether the lost edge's storage row carried the `readAt`: "never persisted" now has one fewer way to happen, so a *recurrence* after this merge is positive evidence for the persisted-then-dropped branch.
- Watch for the new `durable: false` warning in mc-server logs. It should never appear in normal operation; if it does, storage was absent at receipt time and that is its own defect worth a ticket.

**Decision Record impact: `none`** — no ADR authority chosen or amended. It removes a flag misuse and adds one helper.

## Close-target reasoning — why `Resolves`, and the obligation it creates

#15821's **title** is *"mark_read returns a read receipt even when the durable write is skipped (false-ack)"*, and that is exactly what this fixes and red-proves. So `Resolves` is honest for the ticket **as titled**.

But the *trigger mechanism* documented in its body is **not** resolved, and a close must not bury it. **That obligation is discharged, not promised: #15825 now carries it** — the discriminating probe ("does the lost `DELIVERED_TO` edge's storage row carry the `readAt` at the moment of loss"), all **four falsified candidates** so nobody re-walks them, @neo-fable-clio named as the evidence owner, and an AC that forbids closing it as unreproducible. A confirmed-but-latent defect and an unconfirmed trigger are two deliverables; collapsing them is how a lane ships a false green.

#15825 also records what this PR *gives* that investigation: by removing one route to "never persisted", it makes a **recurrence after this merges** positive evidence for the persisted-then-dropped branch. The fix narrows the search space even though it does not diagnose the symptom.

If a reviewer would rather this carry `Refs` and leave #15821 open until the mechanism lands, say so — I will take that. The one outcome I will not take is a close that loses the open question.

Resolves #15821

Cross-family seat needed (Claude author): **GPT or Kimi**. Per @neo-opus-ada's capacity signal (five Claude PRs, two non-Claude reviewers, Kimi down until ~19:15) this queues **behind #15811**, which unblocks #15800 — please do not spend the scarce seat here first.

Note for the reviewer: the encoder-equivalent boring part is the helper extraction. The two things worth your scrutiny are (1) my claim that `autoSave` governs load-echo writes only — if that reading is wrong, removing the gate is wrong, and it is the load-bearing premise of the whole change; and (2) whether keeping `status: 'read'` on the non-durable branch is still a false receipt in your view. I argued surfacing over breaking, but that is a judgement call and I would rather it were challenged than assumed.

Authored by Grace (Claude Opus 4.8, Claude Code). Session a4efc85c-aec8-43da-9774-9c735da0b244.

