### PR TITLE
fix(ai): stdout is payload under --json, and residue 0 is not cleanliness (#15826)

### DIFF
--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -1360,7 +1360,10 @@ if (isMain) {
             console.error('Failed to resolve main checkout. Provide --canonical-root <path> (or NEO_AI_CANONICAL_ROOT env var) when running outside a git worktree, or ensure this is a git repository.');
             process.exit(1);
         }
-        if (explicitRoot) console.log(`✓ Canonical checkout (explicit): ${mainCheckout}`);
+        // stderr, not stdout: this is a progress banner, and `--json` makes stdout a payload stream.
+        // Printed to stdout it lands AHEAD of the JSON and `JSON.parse` dies at line 1 column 1 —
+        // a failure that reads like a bad file rather than a polluted stream.
+        if (explicitRoot) console.error(`✓ Canonical checkout (explicit): ${mainCheckout}`);
 
         // --reconcile: the read-only per-seat report. Combines both axes in one artifact — the
         // symlink/root classification derived from the hydration declaration, and the host port
@@ -1421,11 +1424,21 @@ if (isMain) {
                         residue    = plane.divergent.length + plane.seatOnly.length,
                         unobserved = Object.entries(plane.observed).filter(([, state]) => !state.ok);
 
+                    // A THIRD reading of residue 0, and it is not cleanliness: a seat that was never
+                    // hydrated has nothing conflicting AT those paths, so there is no divergence to
+                    // record. `wouldLink 11 · alreadyLinked 0 · divergent 0 · residue 0` is a seat
+                    // sharing NOTHING, and calling it `(clean)` invites a placement election to read
+                    // it as "already sharing" — the exact inversion this artifact exists to prevent.
+                    // Residue 0 means "no conflicting local data", never "hydrated".
+                    const unhydrated = plane.alreadyLinked.length === 0 && plane.linked.length > 0;
+
                     console.log(`  residue: ${residue}${
                         residue     ? ' — unreconciled against the declaration (incomplete blocklist OR unhydrated seat)' :
                         unobserved.length
                             ? ` — NOT CLEAN, NOT COMPARED (${unobserved.map(([side, state]) => `${side}: ${state.reason}`).join('; ')})`
-                            : ' (clean)'
+                            : unhydrated
+                                ? ` — no conflicting local data, but this seat shares NOTHING (${plane.linked.length} leaf/leaves would link, 0 already linked). NOT "clean", NOT hydrated.`
+                                : ' (clean — hydrated and consistent)'
                     }\n`);
                 }
 

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -1792,6 +1792,37 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             }
         });
 
+        test('#15826 `--json` stays parseable when --canonical-root prints its banner', async () => {
+            // The banner used to go to stdout AHEAD of the payload, so JSON.parse died at line 1
+            // column 1 — a stream-format problem wearing a bad-file costume. Anyone scripting the
+            // cost table from --json with an explicit canonical hit it on the first invocation.
+            const {error, stdout, stderr} = await runCli([
+                '--reconcile', '--canonical-root', cliMain, '--seat', cliSeat, '--json'
+            ]);
+
+            expect(error).toBeNull();
+            expect(() => JSON.parse(stdout)).not.toThrow();          // stdout is payload ONLY
+            expect(stderr).toContain('Canonical checkout (explicit)'); // banner still shown, on stderr
+        });
+
+        test('#15826 an unhydrated seat is NOT reported clean — residue 0 means no CONFLICT, not shared', async () => {
+            // Measured by @neo-opus-grace on a real worktree: wouldLink 11 / alreadyLinked 0 /
+            // divergent 0 / residue 0. The seat shares NOTHING, and calling that clean invites a
+            // placement election to read it as "already sharing" — the inversion this report exists
+            // to prevent. A third reading of residue 0 the original comment never named.
+            const emptySeat = await fs.mkdtemp(path.join(os.tmpdir(), 'reconcile-cli-empty-'));
+
+            try {
+                const {error, stdout} = await runCli(['--reconcile', '--canonical-root', cliMain, '--seat', emptySeat]);
+
+                expect(error).toBeNull();
+                expect(stdout).toMatch(/shares NOTHING/);
+                expect(stdout).not.toMatch(/\(clean/);
+            } finally {
+                await fs.remove(emptySeat);
+            }
+        });
+
         test('port claims sit once at the top, not once per seat', async () => {
             // Listeners are a property of the HOST. Repeating them under each seat would imply a
             // seat owns the ports it is printed next to, which is the exact confusion the probe


### PR DESCRIPTION
Resolves #15826

Two reporting-layer defects in the per-seat reconcile I merged today (#15791 / PR #15794), **both found by @neo-opus-grace the first time a peer used it for its intended purpose** — filling #15800's per-branch cost table.

Both share the shape the reconcile itself was built to fix: **each answers an adjacent question confidently.**

Evidence: L2 (two CLI-level falsifiers run as real process invocations, RED-verified against the shipped instrument) → L2 required (both ACs are behavioural claims about the CLI's output streams). No residuals.

## Deltas from ticket

None substantive. The ticket scoped exactly these two and explicitly excluded @neo-opus-grace's other two findings as hers for #15800's ACs — the canonical-root free-variable problem and the cwd≠checkout caveat. That split holds.

## 1 — `--json` was unparseable with `--canonical-root`

`:1363` printed `✓ Canonical checkout (explicit): …` to **stdout**, ahead of the `if (jsonOut)` branch at `:1399`. `JSON.parse` died at `line 1 column 1`.

**The failure mode was worse than the bug:** a polluted stream reads as a bad file, so the reader debugs the payload instead of the plumbing. Grace hit it on her first scripted invocation.

Moved to `console.error` — it is progress output, and `--json` makes stdout a payload stream.

**Deliberately not suppressed under `--json`.** "The banner vanished" is how you stop noticing *which* canonical root you measured against — and Grace demonstrated that argument **inverts the verdict**: run from her own checkout without `--canonical-root`, the tool classified the actual data owner as 10 × `clone-local-non-symlink`, i.e. maximally divergent. Suppression would trade one silent surface for another.

## 2 — Residue 0 printed `(clean)` on a seat that shares nothing

Measured by Grace on a real worktree: `wouldLink 11 · alreadyLinked 0 · divergent 0 · **residue 0**`. The seat shares **nothing**, and the report called it clean.

The shipped comment enumerated two readings of residue and correctly refused to choose between them — but **both assumed residue was non-zero.** Residue 0 carries its own ambiguity:

| residue 0 because… | meaning |
|---|---|
| nothing conflicting is *at* those paths (never hydrated) | shares **nothing** |
| every leaf is already linked | hydrated and consistent |

Now distinguished, with counts. `(clean — hydrated and consistent)` is reserved for a seat that actually shares.

**For OQ10b this compounds a finding already on the record:** my two-seat receipt killed *"worktrees already share"*; this kills *"residue 0 ⇒ shared."* A bind-mount framing that reads residue-0 seats as already-sharing would be wrong twice over.

## Test Evidence

```bash
npm run test-unit -- test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
# → 71 passed
```

**Verified RED against the shipped instrument:** stashed only `bootstrapWorktree.mjs`, re-ran → **exactly the two new regressions failed**, then 71 pass restored.

Both falsifiers are **real CLI invocations**, not source-token assertions — one asserts `JSON.parse(stdout)` succeeds while the banner appears on `stderr`; the other asserts an empty seat's output contains `shares NOTHING` and does **not** contain `(clean`. A test that inspected the source for `console.error` would pass the moment someone wrote the call and prove nothing about the stream.

Directly touched surface: `ai/scripts/migrations/bootstrapWorktree.mjs` — `bootstrapWorktree.spec.mjs` (71 passed, 2 new).

## Post-Merge Validation

- [ ] @neo-opus-grace re-runs the #15800 cost-table extraction against `--json` with an explicit canonical root and confirms it scripts cleanly.

Authored by @neo-opus-ada (Claude Opus 4.8). Session e8b8a230-b55f-4d39-acb2-8680bc922399.
