### PR TITLE
fix(ci): the lint annotation must carry the answer, not cite a missing comment (#15828)

### DIFF
--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -225,4 +225,20 @@ jobs:
               });
             }
 
-            core.setFailed(`Agent PR body missing required template anchors. See follow-up comment on PR #${pr.number}.`);
+            // The annotation must carry the ANSWER, not a pointer to one. The follow-up comment is
+            // posted only on `opened` (above), but an anchor almost always breaks on `edited` —
+            // that IS the event where someone rewrote a heading. Citing a comment that was never
+            // written made the failure undiagnosable exactly when it mattered: three authors across
+            // two model families each had to open this file to learn which anchor was missing.
+            // `missingVisible`/`missingInvisible` are already computed; they just never reached here.
+            const missingAll = [...missingVisible, ...missingInvisible];
+
+            core.setFailed([
+              `Agent PR body missing required template anchors: ${missingAll.map(a => `\`${a}\``).join(', ')}.`,
+              ``,
+              `These are matched as LITERAL substrings — casing, prefixes and suffixes all break them.`,
+              `Put improvements in the body text under a heading, never in the heading itself.`,
+              context.payload.action === 'opened'
+                ? `A follow-up comment on PR #${pr.number} carries the full guidance.`
+                : `(No follow-up comment is posted on \`${context.payload.action}\` events — this annotation is the diagnostic.)`
+            ].join('\n'));


### PR DESCRIPTION
Resolves #15828

`agent-pr-body-lint` runs on `[opened, edited, synchronize, ready_for_review]` but posts its diagnostic comment on **exactly one** of them — while the failure always said *"See follow-up comment on PR #N"*.

**So on every edit it failed pointing at a comment that was never written.** That is precisely when the diagnostic matters: an anchor breaks *because someone edited the body*, which is an `edited` event by construction. The one path where the comment does exist — `opened` — is the one where the author has the template freshest in mind.

Evidence: L2 (embedded-script parse check plus the failure text replayed against a body missing two anchors, across all three event types) → L2 required (the AC is a behavioural claim about an annotation's contents). No residuals.

## Deltas from ticket

None. The ticket scoped the annotation fix and explicitly excluded both tempting over-reaches; the diff holds that line.

## Why this is worth a PR rather than a note

**Three instances today, two agents, two model families, one anchor:**

| # | who | edit | result |
|---|---|---|---|
| 1 | @neo-opus-ada | `## Post-Merge Validation` → lowercase | FAILED |
| 2 | @neo-opus-ada, PR #15816 | → `## Residual / Post-Merge Validation` | FAILED |
| 3 | @neo-gpt, PR #15816 | → `## Review Closure` (reviewer polish) | FAILED |

Every word survived each edit; the substring did not. **All three authors had to open the workflow file to learn which anchor was missing** — the information was computed and thrown away.

Instance 2 happened with the rule already banked, because that note was written around instance 1's *casing* and a *prefix* did not read as the same rule. Instance 3 was a reviewer polishing someone else's body. This is not one person being careless.

## The change

`missingVisible` / `missingInvisible` were already in scope at the failure site and never reached the annotation. Now they do, with the literal-substring rule stated inline, and the message **tells the truth about whether a comment exists for this event** instead of asserting one does.

## Deliberately not done

- **Commenting on every `synchronize`.** A comment per push is noise that gets muted — which is how a real signal stops being read. The annotation is the right surface for the recurring case.
- **Relaxing the matcher** to tolerate "better prose". The anchors are a graph-ingestion contract. **Strict matching is correct; an undiagnosable failure is not.** Loosening it would trade a visible failure for silent contract erosion.

## Test Evidence

```bash
# embedded script still parses (extracted from the YAML, 231 lines)
node --check /tmp/lintscript.mjs   # → EMBEDDED JS OK
```

Failure text replayed against a body missing `## Post-Merge Validation` and `Authored by `, for each event type:

```
--- action=edited ---
Agent PR body missing required template anchors: `## Post-Merge Validation`, `Authored by `.

These are matched as LITERAL substrings — casing, prefixes and suffixes all break them.
Put improvements in the body text under a heading, never in the heading itself.
(No follow-up comment is posted on `edited` events — this annotation is the diagnostic.)
```

`opened` produces the same anchor list and the comment reference; `synchronize` matches `edited`. The anchors are **named** in all three.

Directly touched surface: `.github/workflows/agent-pr-body-lint.yml` — validated by parse check and replayed failure text; a workflow's own behaviour is not unit-testable in this repo, and its live proof is that the next broken anchor names itself.

## Post-Merge Validation

- [ ] The next PR whose body edit breaks an anchor shows that anchor in the check annotation. Given three instances today, this will be exercised without being sought.

## Evolution

This is the day's class one layer out: the annotation answered *"did the lint fail?"* when the reader's question was *"which anchor?"*, and confidently cited evidence that did not exist. An instrument pointing at a receipt it never wrote.

It is also friction→gold with the friction measured rather than asserted — three same-day instances across two families, surfaced only because @neo-gpt stated plainly that his own polish caused one instead of quietly fixing it. One instance is carelessness; three across two families is substrate.

Authored by @neo-opus-ada (Claude Opus 4.8). Session e8b8a230-b55f-4d39-acb2-8680bc922399.
