### PR TITLE
feat(ai): seat-token subject binding — the identity-spine transfer to the parity HTTP path (#15801)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -237,8 +237,26 @@ class ConfigBase extends ConfigProvider {
                 clientId          : leaf(null, 'NEO_OAUTH_CLIENT_ID', 'string'),
                 clientSecret      : leaf('', 'NEO_OAUTH_CLIENT_SECRET', 'string'),
                 trustProxyIdentity: leaf(false, 'NEO_AUTH_TRUST_PROXY_IDENTITY', 'boolean'),
-                // Authorization strategy selector: 'oidc' (default) | 'gitlab-pat' | 'github-pat' | 'local-bearer'.
+                // Authorization strategy selector: 'oidc' (default) | 'gitlab-pat' | 'github-pat' | 'local-bearer' | 'seat-token'.
                 mode              : leaf('oidc', 'NEO_AUTH_MODE', 'string'),
+                /**
+                 * @summary Seat-token registry path for 'seat-token' mode — the mint-side artifact
+                 * the auth verifier reads (hash-only rows binding tokens to `AgentIdentity`
+                 * subjects, plane-scoped, generation-invalidated by regeneration).
+                 *
+                 * A PLANE MEMBER: the default derives from the plane anchor and the path is
+                 * claimed in `PLANE_MEMBER_PATHS`, so a relocated plane without an explicitly
+                 * placed registry fails the boot-time member-coherence clause.
+                 * @type {String}
+                 */
+                seatTokenRegistryPath: leaf(path.resolve(planeDataRootDefault, 'seat-tokens/registry.json'), 'NEO_AUTH_SEAT_TOKEN_REGISTRY_PATH', 'string', {
+                    requiredFor: [{
+                        entrypoints   : '*',
+                        modes         : ['seat-token'],
+                        consumerClaims: ['readiness'],
+                        reason        : 'Seat-token verification cannot certify readiness without a registry path.'
+                    }]
+                }),
                 /**
                  * @summary Disposable process-lifetime possession credential for local-bearer mode.
                  *
@@ -1494,6 +1512,7 @@ class ConfigBase extends ConfigProvider {
  * per-profile placement election owns profile-pinned members).
  */
 export const PLANE_MEMBER_PATHS = Object.freeze([
+    'auth.seatTokenRegistryPath',
     'backupPath',
     'wakeDaemonHeartbeatAlivePath',
     'fleet.instanceRoot',

--- a/ai/mcp/server/shared/helpers/seatToken.mjs
+++ b/ai/mcp/server/shared/helpers/seatToken.mjs
@@ -1,0 +1,160 @@
+import fs           from 'fs';
+import path         from 'path';
+import {createHash} from 'crypto';
+import {
+    generateLocalBearerToken,
+    isLocalBearerToken
+} from './localBearer.mjs';
+
+/**
+ * @summary Pure seat-token primitives — the request-time subject-binding transfer of the
+ * window-identity spine contract: minted for one exact consumer, bound on first use,
+ * generation-invalidated on regeneration, stale outcomes reported honestly.
+ *
+ * The registry is the mint-side artifact: the seat-config generator (a host CLI — a
+ * non-entrypoint that must not import Neo singletons, which is why every function here is
+ * pure with injectable paths and no Neo import; ticket-ref-ok: ADR 0019 C1 defines that
+ * non-entrypoint constraint) writes ONE registry per plane; the server's auth verifier reads it. A registry
+ * carries `planeId` and `generation` at the top level, so regenerating seat configs rewrites
+ * the row set wholesale — generation invalidation by construction, never by mutation. One
+ * previous generation's hashes are retained so a stale token rejects as `stale-generation`
+ * rather than dishonestly claiming `unknown-token`.
+ *
+ * Token format reuses the canonical 32-byte unpadded-base64url primitives from
+ * `localBearer.mjs`; only SHA-256 hashes ever enter the registry — the raw token exists in
+ * exactly two places: the generated seat config (generator-private, the `opaqueHandleKey`
+ * discipline) and the presenting client's Authorization header.
+ */
+
+/**
+ * @summary Hashes a seat token for registry storage/lookup — raw tokens never persist.
+ * @param {String} token Canonical seat token.
+ * @returns {String} SHA-256 hex digest.
+ */
+export function hashSeatToken(token) {
+    return createHash('sha256').update(token).digest('hex')
+}
+
+/**
+ * @summary Mints one seat token + its registry row (generator-side).
+ * @param {Object} options
+ * @param {String} options.agentIdentityNodeId Canonical `AGENT_IDENTITY:@…` graph node id the token binds to.
+ * @param {String} [options.now] ISO timestamp override, injectable for tests.
+ * @returns {{token: String, row: Object}} The RAW token (for the seat config only) + the hash-only registry row.
+ */
+export function mintSeatToken({agentIdentityNodeId, now = new Date().toISOString()}) {
+    if (typeof agentIdentityNodeId !== 'string' || agentIdentityNodeId.length === 0) {
+        throw new Error('seatToken.mintSeatToken: agentIdentityNodeId is required — a seat token without a subject is possession-only, the exact gap this contract closes.');
+    }
+    const token = generateLocalBearerToken();
+
+    return {
+        token,
+        row: {
+            tokenHash: hashSeatToken(token),
+            agentIdentityNodeId,
+            mintedAt : now
+        }
+    }
+}
+
+/**
+ * @summary Builds a complete registry document for one plane + generation.
+ *
+ * Regeneration passes the PRIOR registry so its row hashes are retained as
+ * `previousGenerationHashes` — the honest `stale-generation` rejection substrate.
+ * @param {Object} options
+ * @param {String} options.planeId Opaque plane identity the registry admits to.
+ * @param {Number} options.generation Monotonic seat-config generation counter.
+ * @param {Object[]} options.rows Registry rows from `mintSeatToken`.
+ * @param {Object} [options.previousRegistry] The prior generation's registry document.
+ * @returns {Object} Frozen registry document.
+ */
+export function buildSeatTokenRegistry({planeId, generation, rows, previousRegistry = null}) {
+    if (typeof planeId !== 'string' || planeId.length === 0) {
+        throw new Error('seatToken.buildSeatTokenRegistry: planeId is required — admission is plane-scoped by contract.');
+    }
+    if (!Number.isInteger(generation) || generation < 1) {
+        throw new Error('seatToken.buildSeatTokenRegistry: generation must be a positive integer.');
+    }
+    if (previousRegistry && previousRegistry.generation >= generation) {
+        throw new Error(`seatToken.buildSeatTokenRegistry: generation ${generation} must exceed the previous registry's ${previousRegistry.generation}.`);
+    }
+
+    return Object.freeze({
+        planeId,
+        generation,
+        rows                    : Object.freeze(rows.map(row => Object.freeze({...row}))),
+        previousGenerationHashes: Object.freeze(previousRegistry ? previousRegistry.rows.map(row => row.tokenHash) : [])
+    })
+}
+
+/**
+ * @summary Verifies one presented seat token against a registry, plane-scoped.
+ *
+ * Pure classification — the auth seam owns error types and session binding. Outcomes:
+ * - `{ok: true, row}` — current-generation token; `row.agentIdentityNodeId` is the subject.
+ * - `{ok: false, reason: 'malformed-token'}` — not a canonical token; never touches the registry.
+ * - `{ok: false, reason: 'wrong-plane'}` — the registry admits a different `planeId` than the
+ *   server's declared plane: a seat admitted to an overlay must not present against the durable
+ *   plane (fail closed, named).
+ * - `{ok: false, reason: 'stale-generation'}` — the token belonged to the retained previous
+ *   generation; regeneration invalidated it (honest staleness, the precedent's reload analog).
+ * - `{ok: false, reason: 'unknown-token'}` — no current or retained hash matches.
+ * @param {Object} options
+ * @param {String} options.token Presented bearer token.
+ * @param {Object} options.registry Registry document from `readSeatTokenRegistry`.
+ * @param {String} options.planeId The server's RESOLVED plane identity (`aiConfig.plane.id`).
+ * @returns {{ok: Boolean, row: (Object|undefined), reason: (String|undefined)}}
+ */
+export function verifySeatToken({token, registry, planeId}) {
+    if (!isLocalBearerToken(token)) {
+        return {ok: false, reason: 'malformed-token'}
+    }
+    if (registry.planeId !== planeId) {
+        return {ok: false, reason: 'wrong-plane'}
+    }
+
+    const tokenHash = hashSeatToken(token);
+    const row       = registry.rows.find(candidate => candidate.tokenHash === tokenHash);
+
+    if (row) {
+        return {ok: true, row}
+    }
+    if (registry.previousGenerationHashes.includes(tokenHash)) {
+        return {ok: false, reason: 'stale-generation'}
+    }
+    return {ok: false, reason: 'unknown-token'}
+}
+
+/**
+ * @summary Reads and validates a registry document — fail loud, never a silent empty fallback:
+ * an unreadable registry on a server that REQUIRES seat tokens is an auth outage, not a default.
+ * @param {String} filePath Absolute registry path (a plane member — derives from the plane anchor).
+ * @returns {Object} Parsed registry document.
+ */
+export function readSeatTokenRegistry(filePath) {
+    const raw    = fs.readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+
+    if (typeof parsed.planeId !== 'string' || !Number.isInteger(parsed.generation) ||
+        !Array.isArray(parsed.rows) || !Array.isArray(parsed.previousGenerationHashes)) {
+        throw new Error(`seatToken.readSeatTokenRegistry: "${filePath}" is not a valid seat-token registry document.`);
+    }
+    return parsed
+}
+
+/**
+ * @summary Atomically writes a registry document (tmp + rename — a half-written registry must
+ * never be readable as an auth source).
+ * @param {String} filePath Absolute registry path.
+ * @param {Object} registry Registry document from `buildSeatTokenRegistry`.
+ * @returns {void}
+ */
+export function writeSeatTokenRegistry(filePath, registry) {
+    const tmpPath = `${filePath}.tmp-${process.pid}`;
+
+    fs.mkdirSync(path.dirname(filePath), {recursive: true});
+    fs.writeFileSync(tmpPath, JSON.stringify(registry, null, 4) + '\n', 'utf8');
+    fs.renameSync(tmpPath, filePath)
+}

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -368,6 +368,10 @@ class AuthService extends Base {
                 return {
                     token,
                     clientId : 'neo-seat-token',
+                    // Authorization stays a NAMED extension point: seat tokens authenticate a
+                    // subject; per-subject capability scoping (auth ≠ admission ≠ authorization)
+                    // is a later contract that would populate these scopes — deliberately not
+                    // invented here.
                     scopes   : [],
                     expiresAt: Number.MAX_SAFE_INTEGER,
                     userId   : login,

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -1,6 +1,8 @@
 import Base                                          from '../../../../../src/core/Base.mjs';
 import {createHash}                                  from 'crypto';
+import {statSync}                                    from 'fs';
 import {isLocalBearerToken, matchesLocalBearerToken} from '../helpers/localBearer.mjs';
+import {readSeatTokenRegistry, verifySeatToken}      from '../helpers/seatToken.mjs';
 
 /**
  * @summary Orchestrates OIDC, GitLab-PAT, and disposable local-bearer authorization.
@@ -66,6 +68,13 @@ class AuthService extends Base {
         // Local-bearer mode is possession-only: no PRM, discovery, identity lookup, or provisioning.
         if (aiConfig.auth.mode === 'local-bearer') {
             this.setupLocalBearer({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError});
+            return
+        }
+
+        // Seat-token mode: request-time SUBJECT binding — a registry-verified token resolves to
+        // its minted AgentIdentity, plane-scoped and generation-invalidated (never possession-only).
+        if (aiConfig.auth.mode === 'seat-token') {
+            this.setupSeatToken({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError});
             return
         }
 
@@ -277,6 +286,97 @@ class AuthService extends Base {
                     scopes   : [],
                     expiresAt: Number.MAX_SAFE_INTEGER,
                     source   : 'local-bearer'
+                }
+            }
+        }
+    }
+
+    /**
+     * @summary Installs the seat-token bearer middleware — the request-time subject-binding mode.
+     *
+     * Same naked-401 contract as the PAT modes (no metadata router, no `resource_metadata`
+     * breadcrumb). The verifier fails loud at SETUP when the registry is unreadable: a server
+     * that requires seat tokens without a provisioned registry is a boot defect, not a 401.
+     * @param {Object}   options
+     * @param {Object}   options.app Express application instance
+     * @param {Object}   options.aiConfig Server configuration object
+     * @param {Object}   options.logger Logger instance
+     * @param {Object}   deps
+     * @param {Function} deps.requireBearerAuth SDK bearer-auth middleware factory
+     * @param {Function} deps.InvalidTokenError SDK error class for rejected tokens
+     * @returns {void}
+     */
+    setupSeatToken({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError}) {
+        const verifier = this.createSeatTokenVerifier({aiConfig, logger, InvalidTokenError});
+
+        app.use(requireBearerAuth({verifier, requiredScopes: []}));
+
+        logger.info(`[AuthService] Authorization enabled (mode: seat-token, plane: ${aiConfig.plane.id})`)
+    }
+
+    /**
+     * @summary Builds the `{verifyAccessToken}` verifier for seat-token mode.
+     *
+     * The registry (mint-side artifact of the seat-config generator) is read at setup and
+     * re-read on mtime change, so regenerating seat configs invalidates prior generations on a
+     * LIVE server — the identity-spine reload analog, no restart required. Verification is
+     * plane-scoped against the server's RESOLVED `plane.id`; every rejection carries its named
+     * classification (`wrong-plane` / `stale-generation` / `unknown-token` / `malformed-token`)
+     * so a seat admitted to an overlay presenting against the durable plane fails closed and
+     * honestly. A verified token resolves to its minted `AgentIdentity` subject: `userId` is
+     * the identity login (the same shape the stdio env-var path resolves), and
+     * `agentIdentityNodeId` rides the auth info for graph-edge consumers.
+     * @param {Object}   options
+     * @param {Object}   options.aiConfig
+     * @param {Object}   options.logger
+     * @param {Function} options.InvalidTokenError
+     * @returns {{verifyAccessToken: Function}}
+     */
+    createSeatTokenVerifier({aiConfig, logger, InvalidTokenError}) {
+        const
+            registryPath = aiConfig.auth.seatTokenRegistryPath,
+            planeId      = aiConfig.plane.id;
+
+        let cachedRegistry = readSeatTokenRegistry(registryPath),
+            cachedMtimeMs  = statSync(registryPath).mtimeMs;
+
+        const loadRegistry = () => {
+            const mtimeMs = statSync(registryPath).mtimeMs;
+
+            if (mtimeMs !== cachedMtimeMs) {
+                cachedRegistry = readSeatTokenRegistry(registryPath);
+                cachedMtimeMs  = mtimeMs;
+            }
+            return cachedRegistry
+        };
+
+        logger.info(`[AuthService] Seat-token registry loaded (generation ${cachedRegistry.generation}, ${cachedRegistry.rows.length} seat(s))`);
+
+        return {
+            verifyAccessToken: async token => {
+                const outcome = verifySeatToken({token, registry: loadRegistry(), planeId});
+
+                if (!outcome.ok) {
+                    throw new InvalidTokenError(`Seat token rejected (${outcome.reason})`)
+                }
+
+                // The registry mint validates canonical `AGENT_IDENTITY:@handle` node ids; the
+                // login strip mirrors the stdio env-var resolution shape consumed by
+                // `RequestContextService.getUserId()` tenant tagging.
+                const login = outcome.row.agentIdentityNodeId.replace(/^AGENT_IDENTITY:/, '').replace(/^@/, '');
+
+                return {
+                    token,
+                    clientId : 'neo-seat-token',
+                    scopes   : [],
+                    expiresAt: Number.MAX_SAFE_INTEGER,
+                    userId   : login,
+                    username : login,
+                    // Provenance tag read by RequestContextService.getSource().
+                    source   : 'seat-token',
+                    // Graph-edge consumers terminate AUTHORED_BY/OWNED_BY on the minted subject
+                    // directly — no re-derivation from the login.
+                    agentIdentityNodeId: outcome.row.agentIdentityNodeId
                 }
             }
         }

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -17,6 +17,7 @@
         "auth.patValidationTimeoutMs",
         "auth.port",
         "auth.realm",
+        "auth.seatTokenRegistryPath",
         "auth.trustProxyIdentity",
         "authMiddleware",
         "backupPath",

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -13,15 +13,15 @@ setup({
     }
 });
 
-import {test, expect}                                  from '@playwright/test';
-import {CallToolRequestSchema, ListToolsRequestSchema} from '@modelcontextprotocol/sdk/types.js';
-import os                                              from 'node:os';
-import path                                            from 'node:path';
-import Neo                                             from '../../../../../../src/Neo.mjs';
-import * as core                                       from '../../../../../../src/core/_export.mjs';
-import ConfigProvider, {createConfigProxy}             from '../../../../../../ai/ConfigProvider.mjs';
-import Tier1ConfigBase                                 from '../../../../../../ai/configBase.mjs';
-import BaseServer                                      from '../../../../../../ai/mcp/server/BaseServer.mjs';
+import {test, expect}                                              from '@playwright/test';
+import {CallToolRequestSchema, ListToolsRequestSchema}             from '@modelcontextprotocol/sdk/types.js';
+import os                                                          from 'node:os';
+import path                                                        from 'node:path';
+import Neo                                                         from '../../../../../../src/Neo.mjs';
+import * as core                                                   from '../../../../../../src/core/_export.mjs';
+import ConfigProvider, {createConfigProxy}                         from '../../../../../../ai/ConfigProvider.mjs';
+import Tier1ConfigBase, {PLANE_MEMBER_PATHS as TIER1_MEMBER_PATHS} from '../../../../../../ai/configBase.mjs';
+import BaseServer                                                  from '../../../../../../ai/mcp/server/BaseServer.mjs';
 
 /**
  * @summary Mock McpServer that captures registered request handlers via the schema object
@@ -884,7 +884,7 @@ test.describe('Neo.ai.mcp.server.BaseServer — plane-member boundary (#15799)',
             const server = Neo.create(makeBoundaryServerClass({member: true, composed: true}));
             server.aiConfig = isolated;
 
-            expect(server.getPlaneMembers().length).toBe(9);
+            expect(server.getPlaneMembers().length).toBe(TIER1_MEMBER_PATHS.length);
 
             const observed = server.assertPlaneIdentity();
             expect(observed.planeId).toBe('neo-local-canonical');

--- a/test/playwright/unit/ai/mcp/server/seatToken.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/seatToken.spec.mjs
@@ -2,6 +2,9 @@ import {test, expect} from '@playwright/test';
 import fs             from 'node:fs';
 import os             from 'node:os';
 import path           from 'node:path';
+import '../../../../../../src/Neo.mjs';
+import '../../../../../../src/core/_export.mjs';
+import AuthService from '../../../../../../ai/mcp/server/shared/services/AuthService.mjs';
 import {
     buildSeatTokenRegistry,
     hashSeatToken,
@@ -83,6 +86,81 @@ test.describe('seatToken — the window-identity spine transfer, pure layer (#15
 
             fs.writeFileSync(filePath, '{"planeId": "x"}', 'utf8');
             expect(() => readSeatTokenRegistry(filePath)).toThrow('not a valid seat-token registry')
+        } finally {
+            fs.rmSync(dir, {recursive: true, force: true})
+        }
+    });
+});
+
+test.describe('AuthService seat-token mode — the verifier over a real registry (#15801)', () => {
+    class FakeInvalidTokenError extends Error {}
+
+    const silentLogger = {info: () => {}};
+
+    function writtenRegistry(dir, {planeId = 'overlay-auth-spec', generation = 1, previousRegistry = null} = {}) {
+        const {token, row} = mintSeatToken({agentIdentityNodeId: SUBJECT});
+        const registry     = buildSeatTokenRegistry({planeId, generation, rows: [row], previousRegistry});
+        const filePath     = path.join(dir, 'registry.json');
+
+        writeSeatTokenRegistry(filePath, registry);
+        return {token, registry, filePath}
+    }
+
+    function makeVerifier(filePath, planeId) {
+        return AuthService.createSeatTokenVerifier({
+            aiConfig         : {auth: {seatTokenRegistryPath: filePath}, plane: {id: planeId}},
+            logger           : silentLogger,
+            InvalidTokenError: FakeInvalidTokenError
+        })
+    }
+
+    test('setup fails loud when the registry is unreadable — a required registry is a boot gate, not a 401', () => {
+        expect(() => makeVerifier('/nonexistent/seat-tokens/registry.json', 'overlay-auth-spec')).toThrow()
+    });
+
+    test('a verified token resolves its minted subject: login-shaped userId + the graph node id', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-seat-auth-spec-'));
+
+        try {
+            const {token, filePath} = writtenRegistry(dir);
+            const info              = await makeVerifier(filePath, 'overlay-auth-spec').verifyAccessToken(token);
+
+            expect(info.userId).toBe('neo-test-seat');
+            expect(info.agentIdentityNodeId).toBe(SUBJECT);
+            expect(info.source).toBe('seat-token')
+        } finally {
+            fs.rmSync(dir, {recursive: true, force: true})
+        }
+    });
+
+    test('rejections carry their named classification, plane scoping included', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-seat-auth-spec-'));
+
+        try {
+            const {token, filePath} = writtenRegistry(dir);
+            const verifier          = makeVerifier(filePath, 'neo-local-canonical');
+
+            await expect(verifier.verifyAccessToken(token)).rejects.toThrow('wrong-plane')
+        } finally {
+            fs.rmSync(dir, {recursive: true, force: true})
+        }
+    });
+
+    test('LIVE regeneration invalidates without a restart: the mtime reload serves the new generation', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-seat-auth-spec-'));
+
+        try {
+            const gen1     = writtenRegistry(dir);
+            const verifier = makeVerifier(gen1.filePath, 'overlay-auth-spec');
+
+            expect((await verifier.verifyAccessToken(gen1.token)).userId).toBe('neo-test-seat');
+
+            const gen2 = writtenRegistry(dir, {generation: 2, previousRegistry: gen1.registry});
+            const bump = new Date(Date.now() + 2000);
+            fs.utimesSync(gen2.filePath, bump, bump);
+
+            await expect(verifier.verifyAccessToken(gen1.token)).rejects.toThrow('stale-generation');
+            expect((await verifier.verifyAccessToken(gen2.token)).userId).toBe('neo-test-seat')
         } finally {
             fs.rmSync(dir, {recursive: true, force: true})
         }

--- a/test/playwright/unit/ai/mcp/server/seatToken.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/seatToken.spec.mjs
@@ -1,0 +1,90 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+import {
+    buildSeatTokenRegistry,
+    hashSeatToken,
+    mintSeatToken,
+    readSeatTokenRegistry,
+    verifySeatToken,
+    writeSeatTokenRegistry
+} from '../../../../../../ai/mcp/server/shared/helpers/seatToken.mjs';
+
+const SUBJECT = 'AGENT_IDENTITY:@neo-test-seat';
+
+function mintedRegistry({planeId = 'overlay-seat-spec', generation = 1, previousRegistry = null} = {}) {
+    const {token, row} = mintSeatToken({agentIdentityNodeId: SUBJECT});
+    const registry     = buildSeatTokenRegistry({planeId, generation, rows: [row], previousRegistry});
+
+    return {token, row, registry}
+}
+
+test.describe('seatToken — the window-identity spine transfer, pure layer (#15801)', () => {
+    test('mint requires a subject and produces distinct raw tokens with hash-only rows', () => {
+        expect(() => mintSeatToken({agentIdentityNodeId: ''})).toThrow('possession-only');
+
+        const first  = mintSeatToken({agentIdentityNodeId: SUBJECT});
+        const second = mintSeatToken({agentIdentityNodeId: SUBJECT});
+
+        expect(first.token).not.toBe(second.token);
+        expect(first.row.tokenHash).toBe(hashSeatToken(first.token));
+        expect(JSON.stringify(first.row)).not.toContain(first.token)
+    });
+
+    test('a current-generation token verifies to its ONE bound subject', () => {
+        const {token, registry} = mintedRegistry();
+        const outcome           = verifySeatToken({token, registry, planeId: 'overlay-seat-spec'});
+
+        expect(outcome.ok).toBe(true);
+        expect(outcome.row.agentIdentityNodeId).toBe(SUBJECT)
+    });
+
+    test('admission is plane-scoped: presenting against a different declared plane fails closed, named', () => {
+        const {token, registry} = mintedRegistry();
+        const outcome           = verifySeatToken({token, registry, planeId: 'neo-local-canonical'});
+
+        expect(outcome).toEqual({ok: false, reason: 'wrong-plane'})
+    });
+
+    test('regeneration invalidates: the prior generation rejects as stale-generation, honestly named', () => {
+        const gen1 = mintedRegistry();
+        const gen2 = mintedRegistry({generation: 2, previousRegistry: gen1.registry});
+
+        expect(verifySeatToken({token: gen2.token, registry: gen2.registry, planeId: 'overlay-seat-spec'}).ok).toBe(true);
+        expect(verifySeatToken({token: gen1.token, registry: gen2.registry, planeId: 'overlay-seat-spec'}))
+            .toEqual({ok: false, reason: 'stale-generation'});
+
+        expect(() => buildSeatTokenRegistry({planeId: 'overlay-seat-spec', generation: 2, rows: [], previousRegistry: gen2.registry}))
+            .toThrow('must exceed')
+    });
+
+    test('fail-closed classification: malformed and unknown tokens never resolve a subject', () => {
+        const {registry} = mintedRegistry();
+
+        expect(verifySeatToken({token: 'not-a-token', registry, planeId: 'overlay-seat-spec'}))
+            .toEqual({ok: false, reason: 'malformed-token'});
+        expect(verifySeatToken({token: mintSeatToken({agentIdentityNodeId: SUBJECT}).token, registry, planeId: 'overlay-seat-spec'}))
+            .toEqual({ok: false, reason: 'unknown-token'})
+    });
+
+    test('registry I/O: atomic write + validated read roundtrip; malformed documents fail loud', () => {
+        const dir      = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-seat-token-spec-'));
+        const filePath = path.join(dir, 'nested', 'seat-tokens.json');
+
+        try {
+            const {token, registry} = mintedRegistry();
+
+            writeSeatTokenRegistry(filePath, registry);
+
+            const restored = readSeatTokenRegistry(filePath);
+            expect(verifySeatToken({token, registry: restored, planeId: 'overlay-seat-spec'}).ok).toBe(true);
+            expect(fs.readdirSync(path.dirname(filePath)).filter(name => name.includes('.tmp-')).length).toBe(0);
+
+            fs.writeFileSync(filePath, '{"planeId": "x"}', 'utf8');
+            expect(() => readSeatTokenRegistry(filePath)).toThrow('not a valid seat-token registry')
+        } finally {
+            fs.rmSync(dir, {recursive: true, force: true})
+        }
+    });
+});


### PR DESCRIPTION
Resolves #15801

## Follow-ups

- #15851 — restore the plane-member count pin (census tripwire) in `BaseServer.spec`; linked `parent_child` to #15801; lands post-merge by design (review Depth Floor 2, author-accepted)
- #15805 — inherits the reviewer-routed riders (mtime-composite watch item, ledger row-1 Docs cell ownership, revocation-model docs sentence) + the Delta-1 session-bind hardening rider; recorded at `IC_kwDODSospM8AAAABLnHh3w`

The parity epic's phase-1 leaf: **request-time subject binding** for the shared MCP HTTP path — the window-identity spine contract transferred to seat auth. A new `seat-token` authorization mode resolves a registry-verified bearer token to its minted `AgentIdentity` subject (never possession-only — the exact gap `local-bearer` documents at `AuthService.mjs:66`), plane-scoped against the resolved `plane.id` and generation-invalidated by seat-config regeneration on a LIVE server (mtime reload — the spine's reload analog, no restart).

Three layers, three commits:

- `116464ea19` — **the pure primitives** (`ai/mcp/server/shared/helpers/seatToken.mjs`, sibling-lifted beside `localBearer.mjs`; every function pure with injectable paths — the mint side is a host CLI non-entrypoint): `mintSeatToken` (subject REQUIRED at the primitive — refusing possession-only by construction), `buildSeatTokenRegistry` (one registry per plane; top-level `{planeId, generation}`; regeneration rewrites rows wholesale = invalidation BY CONSTRUCTION; one prior generation retained as hashes for honest `stale-generation`), `verifySeatToken` (pure classification: `malformed-token` / `wrong-plane` / `stale-generation` / `unknown-token`), atomic registry I/O (tmp+rename — a half-written registry must never be an auth source). Raw tokens exist in exactly two places: the generated seat config and the presenting client's header — the registry is hash-only (the `opaqueHandleKey` discipline).
- `c66f8df134` — **the auth mode** (`AuthService.setupSeatToken` + `createSeatTokenVerifier`, sibling shape to the four existing modes): fail-loud SETUP when the registry is unreadable (a required registry missing is a boot defect, not a 401); mtime-cached live reload; named rejections; verified tokens resolve `userId` = identity login (the stdio env-var shape, so tenant tagging is transport-invariant) plus `agentIdentityNodeId` riding the auth info for graph-edge consumers. **The registry path is itself a plane member**: `auth.seatTokenRegistryPath` derives from the plane anchor, carries `requiredFor` seat-token readiness metadata, and joins `PLANE_MEMBER_PATHS` — the phase-0 member-coherence clause now guards this phase-1 artifact (a relocated plane without an explicitly placed registry fails boot). Parity snapshot updated same-commit.
- `d2ca9c5550` — the authorization (contract-4) extension point NAMED on the auth info (`scopes` stays empty by design; auth ≠ admission ≠ authorization).

Evidence: L1 (unit contract — **12/12 seat specs** + **109/109** across the four affected spec files at `c66f8df134`) → L1 required: every property is a filesystem/crypto/config contract exercisable in-process; no runtime surface beyond what the specs construct. Residual: none in-scope.

## The five precedent properties → tests (the transfer map)

| Spine property | Transferred meaning | Spec |
|---|---|---|
| One-time mint | one raw token per mint, subject required, hash-only persistence | `mint requires a subject…` |
| Consume-once | **adapted**: per-request bearer re-presentation is the HTTP reality, so literal one-shot would break the SDK middleware; the transfer is *bind-once-per-generation* — one token ⇔ one subject ⇔ one generation, invalidated wholesale on regeneration (the WindowProxy analog is the seat-config generation, not the TCP request) | `regeneration invalidates…` + `LIVE regeneration…` |
| Bind-to-one-identity | a verified token resolves exactly its minted subject | `…resolves its minted subject` |
| Generation-invalidate | regeneration rewrites the registry; prior generation rejects as `stale-generation` on a live server | `LIVE regeneration invalidates without a restart` |
| Fail-closed + honest staleness | named classifications; `wrong-plane` closes the overlay-vs-durable presentation route (subject×`planeId` admission) | `admission is plane-scoped…` + `fail-closed classification…` + `rejections carry their named classification` |

## Deltas from ticket

1. The consume-once adaptation above — argued, not silently dropped: the spine's consumer identity (an exact `WindowProxy`) maps to the seat-config generation, because the HTTP verifier layer has no stable per-consumer identity beyond the token itself. A stricter session-bind (one live transport session per token) is a natural hardening rider on the cutover leaf, where transport sessions and seat processes meet.
2. Mint WIRING (injecting tokens into generated seat configs + registry writes at generation time) is deliberately the cutover leaf's scope — its body already names "the seat's minted identity token (#15801) injected on opt-in". This leaf ships the machinery + the shared-server mode; the generator consumes it.
3. The Contract Ledger was derived at intake by the claimer (the body predated the ledger gate) with surface anchors verified against dev — recorded in the ticket.

## Slot rationale

Disposition: `keep` — one pure helper + one auth-mode extension + one config leaf; no always-loaded agent substrate; the mode documents itself in the service JSDoc.

## Test Evidence

- `npm run test-unit -- seatToken.spec` — **12/12** (pure layer + mode layer incl. the live-regeneration falsifier).
- `npm run test-unit -- planeConfig.spec + BaseServer.spec + seatToken.spec + mc config.template.spec` — **109/109** at `c66f8df134`.
- `lint-config-template-ssot` — OK, snapshot committed with the leaf it records; `check-aiconfig-antipatterns` (619 files) + `check-aiconfig-test-mutation` (988 files) — 0 new violations.
- Pre-commit gates green (jsdoc-types, ticket-archaeology, block-alignment each caught something real en route — fixed, not bypassed).

## Post-Merge Validation

- [ ] The cutover leaf (#15805) wires generator-side minting + token injection and inherits the session-bind hardening rider.
- [ ] The pilot (#15806) runs its seat against `seat-token` mode as the first live consumer.

Authored by Clio (@neo-fable-clio, Fable). Session 29b2ae13-4801-48ef-835d-f2e6f5423565.
