### PR TITLE
feat(form): add pluggable FileUpload transport (#15636)

### DIFF
--- a/src/form/field/FileUpload.mjs
+++ b/src/form/field/FileUpload.mjs
@@ -1,13 +1,16 @@
-import Field    from './Base.mjs';
-import NeoArray from '../../util/Array.mjs';
+import Field           from './Base.mjs';
+import Transport       from './fileUpload/Transport.mjs';
+import XhrTransport    from './fileUpload/Xhr.mjs';
+import NeoArray        from '../../util/Array.mjs';
+import ClassSystemUtil from '../../util/ClassSystem.mjs';
 
 const
-    sizeRE           = /^(\d+)(kb|mb|gb)?$/i,
-    sizeMultiplier   = {
-        unit : 1,
-        kb   : 1000,
-        mb   : 1000000,
-        gb   : 1000000000
+    sizeRE         = /^(\d+)(kb|mb|gb)?$/i,
+    sizeMultiplier = {
+        unit: 1,
+        kb  : 1000,
+        mb  : 1000000,
+        gb  : 1000000000
     },
     httpSuccessCodes = {
         2 : 1,
@@ -18,8 +21,9 @@ const
  * An accessible file uploading widget which automatically commences an upload as soon as
  * a file is selected using the UI.
  *
- * The URL to which the file must be uploaded is specified in the {@link config#uploadUrl} property.
- * This service must return a JSON status response in the following form for successful uploads:
+ * Byte movement is delegated to {@link config#uploadTransport}. The default
+ * {@link Neo.form.field.fileUpload.Xhr} transport uses the URL specified in
+ * {@link config#uploadUrl} and expects a JSON response in the following form for successful uploads:
  *
  * ```json
  * {
@@ -84,6 +88,14 @@ const
  * @extends Neo.form.field.Base
  */
 class FileUpload extends Field {
+    /**
+     * Whether the current upload transport was created from this field's class/config value.
+     * Passed-in instances remain externally owned.
+     * @member {Boolean} #ownsUploadTransport=false
+     * @private
+     */
+    #ownsUploadTransport = false
+
     static config = {
         /**
          * @member {String} className='Neo.form.field.FileUpload'
@@ -183,6 +195,18 @@ class FileUpload extends Field {
          * @member {String|null} uploadUrl=null
          */
         uploadUrl: null,
+
+        /**
+         * Transport class, config, or instance responsible for upload, abort, delete, and status
+         * request mechanics.
+         *
+         * Class/config values are instantiated, hosted, and destroyed by this field. A passed-in
+         * {@link Neo.form.field.fileUpload.Transport} instance remains caller-owned and is detached
+         * when replaced or when the field is destroyed.
+         * @member {Neo.form.field.fileUpload.Transport|Object|Function} uploadTransport_=Neo.form.field.fileUpload.Xhr
+         * @reactive
+         */
+        uploadTransport_: XhrTransport,
 
         /**
          * The name of the JSON property in which the document id is returned in the upload response
@@ -313,24 +337,32 @@ class FileUpload extends Field {
         error_ : null,
 
         // UI strings which can be overridden for other languages
-        chooseFile           : 'Choose file',
-        documentText         : 'Document',
-        invalidFileFormat    : 'invalid file format',
-        pleaseUseTheseTypes  : 'Please use these file types {allowedFileTypes}',
-        fileSizeMoreThan     : 'File size exceeds {allowedFileSize}',
-        uploadError          : 'Please try again',
-        documentDeleteError  : 'Document delete service error',
-        isNoLongerAvailable  : 'is no longer available',
-        documentStatusError  : 'Document status service error',
-        uploadFailed         : 'Upload failed',
-        scanning             : 'Scanning',
-        uploading            : 'Uploading...',
-        malwareFoundInFile   : 'Malware found in file',
-        pleaseCheck          : 'Please check the file and try again',
-        successfullyUploaded : 'Successfully uploaded',
-        fileWasDeleted       : 'File was deleted',
-        fileIsInAnErrorState : 'File is in an error state'
+        chooseFile          : 'Choose file',
+        documentText        : 'Document',
+        invalidFileFormat   : 'invalid file format',
+        pleaseUseTheseTypes : 'Please use these file types {allowedFileTypes}',
+        fileSizeMoreThan    : 'File size exceeds {allowedFileSize}',
+        uploadError         : 'Please try again',
+        documentDeleteError : 'Document delete service error',
+        isNoLongerAvailable : 'is no longer available',
+        documentStatusError : 'Document status service error',
+        uploadFailed        : 'Upload failed',
+        scanning            : 'Scanning',
+        uploading           : 'Uploading...',
+        malwareFoundInFile  : 'Malware found in file',
+        pleaseCheck         : 'Please check the file and try again',
+        successfullyUploaded: 'Successfully uploaded',
+        fileWasDeleted      : 'File was deleted',
+        fileIsInAnErrorState: 'File is in an error state'
     }
+
+    /**
+     * Fires before the default HTTP transport sends any configured request. Listeners may add or
+     * replace entries on the request-local headers object.
+     * @event beforeRequest
+     * @param {Object} event
+     * @param {Object} event.headers A copy of {@link #property-headers} for this request.
+     */
 
     /**
      * @param {Object} config
@@ -379,11 +411,11 @@ class FileUpload extends Field {
         me.cls = cls;
 
         me.vdom.cn[3] = {
-            id    : `${me.id}-input`,
-            cls   : 'neo-file-upload-input',
-            tag   : 'input',
-            type  : 'file',
-            value : ''
+            id   : `${me.id}-input`,
+            cls  : 'neo-file-upload-input',
+            tag  : 'input',
+            type : 'file',
+            value: ''
         };
         me.state = 'ready';
         me.error = '';
@@ -438,11 +470,7 @@ class FileUpload extends Field {
 
     async upload(file) {
         const
-            me         = this,
-            xhr        = me.xhr = new XMLHttpRequest(),
-            { upload } = xhr,
-            fileData   = new FormData(),
-            headers    = { ...me.headers };
+            me = this;
 
         // Show the action button
         me.file  = file;
@@ -460,33 +488,24 @@ class FileUpload extends Field {
         // When it is NaN, the error display does not attempt to show progress.
         me.progress = NaN;
 
-        fileData.append("file", file);
+        let response;
 
-        // React to upload state changes
-        upload.addEventListener('progress', me.onUploadProgress.bind(me));
-        upload.addEventListener('error',    me.onUploadError.bind(me));
-        upload.addEventListener('abort',    me.onUploadAbort.bind(me));
-        xhr.addEventListener('loadend',     me.onUploadDone.bind(me));
+        try {
+            response = await me.uploadTransport.upload({
+                file,
+                onProgress: event => me.onUploadProgress(event)
+            })
+        } catch (error) {
+            if (error.name === 'AbortError') {
+                me.onUploadAbort(error)
+            } else {
+                me.onUploadError(error)
+            }
 
-        xhr.open("POST", me.uploadUrl, true);
-
-        /**
-         * This event fires before every HTTP request is sent to the server via any of the configured URLs.
-         *
-         * @event beforeRequest
-         * @param {Object} event The event
-         * @param {Object} event.headers An object containing the configured {@link #property-headers}
-         * for this widget, into which new headers may be injected.
-         * @returns {Object}
-         */
-        me.fire('beforeRequest', {
-            headers
-        });
-        for (const header in headers) {
-            xhr.setRequestHeader(header, headers[header]);
+            return
         }
 
-        xhr.send(fileData);
+        me.onUploadDone(response)
     }
 
     /**
@@ -494,7 +513,10 @@ class FileUpload extends Field {
      * @param {Boolean} [silent=false]
      */
     destroy(updateParentVdom, silent) {
-        this.abortUpload();
+        const me = this;
+
+        me.releaseUploadTransport(me.uploadTransport);
+
         super.destroy(updateParentVdom, silent)
     }
 
@@ -520,7 +542,6 @@ class FileUpload extends Field {
             return
         }
 
-        this.xhr = null;
         this.clear()
     }
 
@@ -529,49 +550,42 @@ class FileUpload extends Field {
             return
         }
 
-        this.xhr = null;
         this.state = 'upload-failed';
         this.error = `${this.uploadError}`
     }
 
-    onUploadDone({ loaded, target : xhr }) {
+    /**
+     * Maps a transport-normalized upload response onto the field state.
+     * @param {Object|null} response
+     */
+    onUploadDone(response) {
         if (this.isDestroyed) {
             return
         }
 
         const me = this;
 
-        me.xhr = null;
+        if (response) {
+            if (response.success) {
+                me.documentId = response[me.documentIdParameter];
 
-        // Successful network request.
-        // Check the resulting JSON packet for details and any error.
-        if (httpSuccessCodes[String(xhr.status)[0]]) {
-            if (loaded !== 0) {
-                const response = JSON.parse(xhr.response);
+                // The status check phase is optional.
+                // If no URL specified, the file is taken to be downloadable.
+                if (me.documentStatusUrl) {
+                    me.state = 'processing';
 
-                if (response.success) {
-                    me.documentId = response[me.documentIdParameter];
-
-                    // The status check phase is optional.
-                    // If no URL specified, the file is taken to be downloadable.
-                    if (me.documentStatusUrl) {
-                        me.state = 'processing';
-
-                        // Start polling the server to see when the scan has a result;
-                        me.checkDocumentStatus();
-                    }
-                    else {
-                        me.state = 'downloadable';
-                    }
+                    // Start polling the server to see when the scan has a result;
+                    me.checkDocumentStatus();
                 }
                 else {
-                    me.error = response.message;
-                    me.state = 'upload-failed';
+                    me.state = 'downloadable';
                 }
             }
+            else {
+                me.error = response.message;
+                me.state = 'upload-failed';
+            }
         }
-        // Failed network requests are handled in onUploadError
-        // so no else condition necessary here
     }
 
     onActionButtonClick() {
@@ -617,23 +631,14 @@ class FileUpload extends Field {
     }
 
     abortUpload() {
-        this.xhr?.abort();
+        this.uploadTransport?.abort();
     }
 
     async deleteDocument() {
-        const
-            me          = this,
-            { headers } = me;
-
-        me.fire('beforeRequest', {
-            headers
-        });
+        const me = this;
 
         // We ask the server to delete using our this.documentId
-        const statusResponse = await me.trap(fetch(me.documentDeleteUrl, {
-            method : me.documentDeleteMethod,
-            headers
-        }));
+        const statusResponse = await me.trap(me.uploadTransport.deleteDocument(me.documentId));
 
         // Success
         if (httpSuccessCodes[String(statusResponse.status)[0]]) {
@@ -646,18 +651,10 @@ class FileUpload extends Field {
     }
 
     async checkDocumentStatus() {
-        const
-            me          = this,
-            { headers } = me;
+        const me = this;
 
         if (me.state === 'processing') {
-            me.fire('beforeRequest', {
-                headers
-            });
-
-            const statusResponse = await me.trap(fetch(me.documentStatusUrl, {
-                headers
-            }));
+            const statusResponse = await me.trap(me.uploadTransport.checkDocumentStatus(me.documentId));
 
             // Success
             if (httpSuccessCodes[String(statusResponse.status)[0]]) {
@@ -816,6 +813,67 @@ class FileUpload extends Field {
 
     beforeGetHeaders(headers) {
         return { ...(headers || {}) }
+    }
+
+    /**
+     * Normalizes a transport class/config/instance and reconciles ownership on replacement.
+     * @param {Neo.form.field.fileUpload.Transport|Object|Function|null} value
+     * @param {Neo.form.field.fileUpload.Transport|null} oldValue
+     * @returns {Neo.form.field.fileUpload.Transport}
+     * @protected
+     */
+    beforeSetUploadTransport(value, oldValue) {
+        const me = this;
+
+        if (value === oldValue) {
+            return value
+        }
+
+        const
+            isExternalInstance = Neo.typeOf(value) === 'NeoInstance',
+            transport          = ClassSystemUtil.beforeSetInstance(value, XhrTransport, {
+                field: me
+            });
+
+        if (!(transport instanceof Transport)) {
+            !isExternalInstance && transport?.destroy?.();
+
+            throw new TypeError('FileUpload uploadTransport must extend Neo.form.field.fileUpload.Transport.')
+        }
+
+        if (isExternalInstance && transport.field && transport.field !== me) {
+            throw new Error('FileUpload uploadTransport instance is already attached to another field.')
+        }
+
+        oldValue && me.releaseUploadTransport(oldValue);
+
+        transport.field = me;
+        me.#ownsUploadTransport = !isExternalInstance;
+
+        return transport
+    }
+
+    /**
+     * Releases one hosted transport according to its ownership provenance.
+     * @param {Neo.form.field.fileUpload.Transport|null} transport
+     * @private
+     */
+    releaseUploadTransport(transport) {
+        if (!transport) {
+            return
+        }
+
+        if (this.#ownsUploadTransport) {
+            transport.destroy()
+        } else {
+            transport.abort();
+
+            if (transport.field === this) {
+                transport.field = null
+            }
+        }
+
+        this.#ownsUploadTransport = false
     }
 
     beforeGetDocumentStatusUrl(documentStatusUrl) {

--- a/src/form/field/fileUpload/Transport.mjs
+++ b/src/form/field/fileUpload/Transport.mjs
@@ -1,0 +1,87 @@
+import Base from '../../../core/Base.mjs';
+
+/**
+ * Transport contract for {@link Neo.form.field.FileUpload}.
+ *
+ * A transport owns byte movement and remote document operations. The field remains responsible for
+ * file validation, visual state, progress rendering, and mapping remote results onto its state model.
+ *
+ * @class Neo.form.field.fileUpload.Transport
+ * @extends Neo.core.Base
+ * @abstract
+ */
+class Transport extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.form.field.fileUpload.Transport'
+         * @protected
+         */
+        className: 'Neo.form.field.fileUpload.Transport',
+
+        /**
+         * The FileUpload field currently hosting this transport.
+         *
+         * A field-created transport is owned and destroyed by that field. A passed-in transport instance
+         * remains caller-owned; the field only attaches this reference while it hosts the instance.
+         * @member {Neo.form.field.FileUpload|null} field=null
+         * @protected
+         */
+        field: null
+    }
+
+    /**
+     * Starts one upload.
+     *
+     * The resolved object is the transport-normalized upload response. It must contain the field's
+     * configured document-id property when `success` is true.
+     * @param {Object} options
+     * @param {File|Blob|Object} options.file
+     * @param {Function} options.onProgress Called with `{loaded, total}` while bytes move.
+     * @returns {Promise<Object|null>}
+     * @abstract
+     */
+    async upload({file, onProgress}) {
+        throw new Error(`${this.className} must implement upload({file, onProgress}).`)
+    }
+
+    /**
+     * Aborts the active upload, if any.
+     * @returns {void}
+     */
+    abort() {}
+
+    /**
+     * Deletes one uploaded document.
+     * @param {String|Number} documentId
+     * @returns {Promise<Object>}
+     * @abstract
+     */
+    async deleteDocument(documentId) {
+        throw new Error(`${this.className} must implement deleteDocument(documentId).`)
+    }
+
+    /**
+     * Reads the remote processing status for one uploaded document.
+     *
+     * Transports without a processing phase may leave this unimplemented while the field's
+     * `documentStatusUrl` remains unconfigured.
+     * @param {String|Number} documentId
+     * @returns {Promise<Object>}
+     * @abstract
+     */
+    async checkDocumentStatus(documentId) {
+        throw new Error(`${this.className} must implement checkDocumentStatus(documentId).`)
+    }
+
+    /**
+     * Detaches the hosting field before this transport is destroyed.
+     */
+    destroy() {
+        this.abort();
+        this.field = null;
+
+        super.destroy()
+    }
+}
+
+export default Neo.setupClass(Transport);

--- a/src/form/field/fileUpload/Xhr.mjs
+++ b/src/form/field/fileUpload/Xhr.mjs
@@ -1,0 +1,173 @@
+import Transport from './Transport.mjs';
+
+const httpSuccessCodes = {
+    2: 1,
+    4: 1
+};
+
+/**
+ * Default HTTP transport for {@link Neo.form.field.FileUpload}.
+ *
+ * Uploads use `XMLHttpRequest` so byte progress and abort stay observable. Delete and status requests
+ * use `fetch`. The hosting field supplies URLs, methods, headers, and the `beforeRequest` event; this
+ * class is the only FileUpload layer coupled to those browser request APIs.
+ *
+ * @class Neo.form.field.fileUpload.Xhr
+ * @extends Neo.form.field.fileUpload.Transport
+ */
+class Xhr extends Transport {
+    static config = {
+        /**
+         * @member {String} className='Neo.form.field.fileUpload.Xhr'
+         * @protected
+         */
+        className: 'Neo.form.field.fileUpload.Xhr'
+    }
+
+    /**
+     * The active upload request.
+     * @member {XMLHttpRequest|null} xhr=null
+     * @private
+     */
+    #xhr = null
+
+    /**
+     * Returns a request-local header object after the field's injection hook has run.
+     * @returns {Object}
+     * @private
+     */
+    getRequestHeaders() {
+        const
+            {field} = this,
+            headers = {...field.headers};
+
+        field.fire('beforeRequest', {headers});
+
+        return headers
+    }
+
+    /**
+     * Resolves one document URL against the operation's explicit document id.
+     * @param {String|Function|null} urlPattern
+     * @param {String|Number} documentId
+     * @returns {String|null}
+     * @private
+     */
+    resolveDocumentUrl(urlPattern, documentId) {
+        const {field} = this;
+
+        return typeof urlPattern === 'function'
+            ? urlPattern.call(field, field)
+            : field.createUrl(urlPattern, {
+                [field.documentIdParameter]: documentId
+            })
+    }
+
+    /**
+     * Starts an XHR multipart upload.
+     * @param {Object} options
+     * @param {File|Blob|Object} options.file
+     * @param {Function} options.onProgress
+     * @returns {Promise<Object|null>}
+     */
+    upload({file, onProgress}) {
+        const
+            me       = this,
+            {field}  = me,
+            xhr      = me.#xhr = new XMLHttpRequest(),
+            {upload} = xhr,
+            fileData = new FormData(),
+            headers  = me.getRequestHeaders();
+
+        fileData.append('file', file);
+
+        return new Promise((resolve, reject) => {
+            let settled = false;
+
+            const settle = (callback, value) => {
+                if (!settled) {
+                    settled = true;
+                    callback(value)
+                }
+            };
+
+            upload.addEventListener('progress', event => onProgress?.(event));
+            upload.addEventListener('error', () => settle(reject, new Error('File upload request failed.')));
+            upload.addEventListener('abort', () => {
+                const error = new Error('File upload request was aborted.');
+
+                error.name = 'AbortError';
+                settle(reject, error)
+            });
+
+            xhr.addEventListener('loadend', ({loaded}) => {
+                if (!settled) {
+                    let response = null;
+
+                    if (httpSuccessCodes[String(xhr.status)[0]] && loaded !== 0) {
+                        try {
+                            response = JSON.parse(xhr.response)
+                        } catch (error) {
+                            settle(reject, error);
+                            return
+                        }
+                    }
+
+                    settle(resolve, response)
+                }
+            });
+
+            xhr.open('POST', field.uploadUrl, true);
+
+            for (const header in headers) {
+                xhr.setRequestHeader(header, headers[header]);
+            }
+
+            xhr.send(fileData)
+        }).finally(() => {
+            if (me.#xhr === xhr) {
+                me.#xhr = null
+            }
+        })
+    }
+
+    /**
+     * Aborts the active XHR upload.
+     */
+    abort() {
+        this.#xhr?.abort()
+    }
+
+    /**
+     * Requests deletion using the field's resolved URL and configured method.
+     * @param {String|Number} documentId
+     * @returns {Promise<Response>}
+     */
+    deleteDocument(documentId) {
+        const
+            {field} = this,
+            headers = this.getRequestHeaders(),
+            url     = this.resolveDocumentUrl(field._documentDeleteUrl, documentId);
+
+        return fetch(url, {
+            method: field.documentDeleteMethod,
+            headers
+        })
+    }
+
+    /**
+     * Requests the current processing status using the field's resolved URL.
+     * @param {String|Number} documentId
+     * @returns {Promise<Response>}
+     */
+    checkDocumentStatus(documentId) {
+        const
+            {field} = this,
+            headers = this.getRequestHeaders(),
+            url     = this.resolveDocumentUrl(field._documentStatusUrl, documentId);
+
+        return fetch(url, {headers})
+    }
+}
+
+export default Neo.setupClass(Xhr);

--- a/test/playwright/unit/form/field/FileUpload.spec.mjs
+++ b/test/playwright/unit/form/field/FileUpload.spec.mjs
@@ -6,6 +6,126 @@ import Neo            from '../../../../../src/Neo.mjs';
 import * as core      from '../../../../../src/core/_export.mjs';
 import {test, expect} from '@playwright/test';
 import FileUpload     from '../../../../../src/form/field/FileUpload.mjs';
+import Transport      from '../../../../../src/form/field/fileUpload/Transport.mjs';
+import Xhr            from '../../../../../src/form/field/fileUpload/Xhr.mjs';
+
+class TestTransport extends Transport {
+    static config = {
+        className: 'Test.form.field.fileUpload.Transport'
+    }
+
+    aborted = false
+    deletedDocumentIds = []
+    pendingReject = null
+    statusDocumentIds = []
+    uploadCalls = []
+
+    upload({file, onProgress}) {
+        this.uploadCalls.push(file);
+        onProgress({loaded: 5, total: 10});
+
+        if (file.pending) {
+            return new Promise((resolve, reject) => {
+                this.pendingReject = reject
+            })
+        }
+
+        return Promise.resolve({success: true, documentId: 17})
+    }
+
+    abort() {
+        this.aborted = true;
+
+        if (this.pendingReject) {
+            const error = new Error('Test upload aborted.');
+
+            error.name = 'AbortError';
+            this.pendingReject(error);
+            this.pendingReject = null
+        }
+    }
+
+    async deleteDocument(documentId) {
+        this.deletedDocumentIds.push(documentId);
+
+        return {status: 200, statusText: 'OK'}
+    }
+
+    async checkDocumentStatus(documentId) {
+        this.statusDocumentIds.push(documentId);
+
+        return {
+            status    : 200,
+            statusText: 'OK',
+            json      : async () => ({status: 'AVAILABLE'})
+        }
+    }
+}
+
+Neo.setupClass(TestTransport);
+
+class FakeEventTarget {
+    listeners = {}
+
+    addEventListener(name, listener) {
+        (this.listeners[name] || (this.listeners[name] = [])).push(listener)
+    }
+
+    emit(name, event) {
+        this.listeners[name]?.forEach(listener => listener(event))
+    }
+}
+
+class FakeXMLHttpRequest extends FakeEventTarget {
+    static autoComplete = true
+    static emitNetworkError = false
+    static instances = []
+    static response = {success: true, documentId: 42}
+    static status = 200
+
+    headers = {}
+    response = ''
+    status = 0
+    upload = new FakeEventTarget()
+
+    constructor() {
+        super();
+        FakeXMLHttpRequest.instances.push(this)
+    }
+
+    abort() {
+        this.aborted = true;
+        this.upload.emit('abort', {});
+        this.emit('loadend', {loaded: 0, target: this})
+    }
+
+    open(method, url, async) {
+        this.openArgs = {method, url, async}
+    }
+
+    send(body) {
+        this.body = body;
+
+        if (FakeXMLHttpRequest.autoComplete) {
+            queueMicrotask(() => {
+                if (FakeXMLHttpRequest.emitNetworkError) {
+                    this.upload.emit('error', {});
+                    this.emit('loadend', {loaded: 0, target: this});
+                    return
+                }
+
+                this.upload.emit('progress', {loaded: 5, total: 10});
+                this.status = FakeXMLHttpRequest.status;
+                this.response = JSON.stringify(FakeXMLHttpRequest.response);
+                this.emit('loadend', {loaded: 10, target: this})
+            })
+        }
+    }
+
+    setRequestHeader(name, value) {
+        this.headers[name] = value
+    }
+}
 
 test.describe('FileUpload documented-optional URL configs', () => {
     test('null URL configs pass through the beforeGet hooks without throwing', () => {
@@ -60,13 +180,7 @@ test.describe('FileUpload documented-optional URL configs', () => {
             uploadUrl: '/upload'
         });
 
-        expect(() => instance.onUploadDone({
-            loaded: 100,
-            target: {
-                status  : 200,
-                response: JSON.stringify({success: true, documentId: 42})
-            }
-        })).not.toThrow();
+        expect(() => instance.onUploadDone({success: true, documentId: 42})).not.toThrow();
 
         expect(instance.documentId).toBe(42);
         expect(instance.state).toBe('downloadable');
@@ -110,5 +224,289 @@ test.describe('FileUpload documented-optional URL configs', () => {
         expect(instance.downloadUrl).toBe('/download/static');
 
         instance.destroy()
+    });
+});
+
+test.describe('FileUpload transport seam', () => {
+    test('class transports are field-owned while passed instances remain caller-owned', () => {
+        const
+            ownedField     = Neo.create(FileUpload, {
+                appName        : 'TestApp',
+                uploadTransport: TestTransport,
+                uploadUrl      : '/unused'
+            }),
+            ownedTransport = ownedField.uploadTransport;
+
+        expect(ownedTransport).toBeInstanceOf(TestTransport);
+        expect(ownedTransport.field).toBe(ownedField);
+
+        ownedField.destroy();
+
+        expect(ownedTransport.isDestroyed).toBe(true);
+
+        const
+            externalTransport = Neo.create(TestTransport),
+            externalField     = Neo.create(FileUpload, {
+                appName        : 'TestApp',
+                uploadTransport: externalTransport,
+                uploadUrl      : '/unused'
+            });
+
+        externalField.destroy();
+
+        expect(externalTransport.isDestroyed).not.toBe(true);
+        expect(externalTransport.field).toBeNull();
+
+        externalTransport.destroy()
+    });
+
+    test('reactive transport replacement aborts the old host and preserves ownership provenance', () => {
+        const
+            field             = Neo.create(FileUpload, {
+                appName        : 'TestApp',
+                uploadTransport: TestTransport,
+                uploadUrl      : '/unused'
+            }),
+            ownedTransport    = field.uploadTransport,
+            externalTransport = Neo.create(TestTransport);
+
+        field.uploadTransport = externalTransport;
+
+        expect(ownedTransport.isDestroyed).toBe(true);
+        expect(externalTransport.field).toBe(field);
+
+        field.uploadTransport = TestTransport;
+
+        expect(externalTransport.aborted).toBe(true);
+        expect(externalTransport.isDestroyed).not.toBe(true);
+        expect(externalTransport.field).toBeNull();
+        expect(field.uploadTransport).toBeInstanceOf(TestTransport);
+
+        const replacementTransport = field.uploadTransport;
+
+        field.destroy();
+
+        expect(replacementTransport.isDestroyed).toBe(true);
+
+        externalTransport.destroy()
+    });
+
+    test('a non-XHR transport drives progress, completion, abort, delete, and status', async () => {
+        const field = Neo.create(FileUpload, {
+            appName        : 'TestApp',
+            uploadTransport: TestTransport,
+            uploadUrl      : '/unused'
+        });
+
+        field.timeout = () => Promise.resolve();
+
+        await field.upload({name: 'complete.txt', size: 10});
+
+        const {uploadTransport} = field;
+
+        expect(uploadTransport.uploadCalls).toHaveLength(1);
+        expect(field.progress).toBe(0.5);
+        expect(field.uploadSize).toBe(5);
+        expect(field.documentId).toBe(17);
+        expect(field.state).toBe('downloadable');
+
+        field.documentStatusUrl = '/status/{documentId}';
+        field.state = 'processing';
+        await field.checkDocumentStatus();
+
+        expect(uploadTransport.statusDocumentIds).toEqual([17]);
+        expect(field.state).toBe('not-downloadable');
+
+        await field.deleteDocument();
+
+        expect(uploadTransport.deletedDocumentIds).toEqual([17]);
+        expect(field.state).toBe('ready');
+
+        const pendingUpload = field.upload({name: 'pending.txt', pending: true, size: 10});
+
+        await expect.poll(() => Boolean(uploadTransport.pendingReject)).toBe(true);
+        field.abortUpload();
+        await pendingUpload;
+
+        expect(uploadTransport.aborted).toBe(true);
+        expect(field.state).toBe('ready');
+
+        field.destroy()
+    });
+});
+
+test.describe('FileUpload default XHR transport', () => {
+    let originalFetch, originalFormData, originalXMLHttpRequest;
+
+    test.beforeEach(() => {
+        originalFetch = globalThis.fetch;
+        originalFormData = globalThis.FormData;
+        originalXMLHttpRequest = globalThis.XMLHttpRequest;
+
+        FakeXMLHttpRequest.autoComplete = true;
+        FakeXMLHttpRequest.emitNetworkError = false;
+        FakeXMLHttpRequest.instances = [];
+        FakeXMLHttpRequest.response = {success: true, documentId: 42};
+        FakeXMLHttpRequest.status = 200;
+        globalThis.XMLHttpRequest = FakeXMLHttpRequest
+    });
+
+    test.afterEach(() => {
+        globalThis.fetch = originalFetch;
+        globalThis.FormData = originalFormData;
+        globalThis.XMLHttpRequest = originalXMLHttpRequest
+    });
+
+    test('preserves upload, header injection, progress, status, and delete behavior', async () => {
+        const fetchCalls = [];
+
+        globalThis.fetch = async (url, options) => {
+            fetchCalls.push({url, options});
+
+            return url.startsWith('/status/')
+                ? {status: 200, statusText: 'OK', json: async () => ({status: 'AVAILABLE'})}
+                : {status: 200, statusText: 'OK'}
+        };
+
+        const field = Neo.create(FileUpload, {
+            appName          : 'TestApp',
+            documentDeleteUrl: '/delete/{documentId}',
+            documentStatusUrl: '/status/{documentId}',
+            headers          : {'X-Base': 'base'},
+            uploadUrl        : '/upload'
+        });
+
+        field.timeout = () => Promise.resolve();
+        field.on('beforeRequest', ({headers}) => {
+            headers['X-Injected'] = 'yes'
+        });
+
+        const file = new Blob(['x']);
+
+        Object.defineProperty(file, 'name', {value: 'xhr.txt'});
+
+        await field.upload(file);
+        await expect.poll(() => field.state).toBe('not-downloadable');
+
+        const xhr = FakeXMLHttpRequest.instances[0];
+
+        expect(field.uploadTransport).toBeInstanceOf(Xhr);
+        expect(xhr.openArgs).toEqual({method: 'POST', url: '/upload', async: true});
+        expect(xhr.headers).toEqual({'X-Base': 'base', 'X-Injected': 'yes'});
+        expect(field.progress).toBe(0.5);
+        expect(field.documentId).toBe(42);
+        expect(fetchCalls[0]).toEqual({
+            url    : '/status/42',
+            options: {headers: {'X-Base': 'base', 'X-Injected': 'yes'}}
+        });
+
+        await field.deleteDocument();
+
+        expect(fetchCalls[1]).toEqual({
+            url    : '/delete/42',
+            options: {
+                method : 'DELETE',
+                headers: {'X-Base': 'base', 'X-Injected': 'yes'}
+            }
+        });
+        expect(field.state).toBe('ready');
+
+        field.destroy()
+    });
+
+    test('delegates abort to the active XMLHttpRequest', async () => {
+        FakeXMLHttpRequest.autoComplete = false;
+
+        const field = Neo.create(FileUpload, {
+            appName  : 'TestApp',
+            uploadUrl: '/upload'
+        });
+
+        field.timeout = () => Promise.resolve();
+
+        const file = new Blob(['x']);
+
+        Object.defineProperty(file, 'name', {value: 'abort.txt'});
+
+        const uploadPromise = field.upload(file);
+
+        await expect.poll(() => FakeXMLHttpRequest.instances.length).toBe(1);
+        field.abortUpload();
+        await uploadPromise;
+
+        expect(FakeXMLHttpRequest.instances[0].aborted).toBe(true);
+        expect(field.state).toBe('ready');
+
+        field.destroy()
+    });
+
+    test('preserves server-declared and network upload failure states', async () => {
+        FakeXMLHttpRequest.status = 400;
+        FakeXMLHttpRequest.response = {success: false, message: 'Rejected by service'};
+
+        let field = Neo.create(FileUpload, {
+            appName  : 'TestApp',
+            uploadUrl: '/upload'
+        });
+
+        field.timeout = () => Promise.resolve();
+
+        let file = new Blob(['x']);
+
+        Object.defineProperty(file, 'name', {value: 'rejected.txt'});
+
+        await field.upload(file);
+
+        expect(field.state).toBe('upload-failed');
+        expect(field.error).toBe('Rejected by service');
+
+        field.destroy();
+
+        FakeXMLHttpRequest.emitNetworkError = true;
+
+        field = Neo.create(FileUpload, {
+            appName  : 'TestApp',
+            uploadUrl: '/upload'
+        });
+        field.timeout = () => Promise.resolve();
+        file = new Blob(['x']);
+
+        Object.defineProperty(file, 'name', {value: 'network.txt'});
+
+        await field.upload(file);
+
+        expect(field.state).toBe('upload-failed');
+        expect(field.error).toBe(field.uploadError);
+
+        field.destroy()
+    });
+
+    test('preserves non-success delete and status mappings', async () => {
+        globalThis.fetch = async () => ({
+            status    : 503,
+            statusText: 'Unavailable'
+        });
+
+        const field = Neo.create(FileUpload, {
+            appName          : 'TestApp',
+            documentDeleteUrl: '/delete/{documentId}',
+            documentStatusUrl: '/status/{documentId}',
+            uploadUrl        : '/upload'
+        });
+
+        field.documentId = 42;
+        field.state = 'processing';
+        await field.checkDocumentStatus();
+
+        expect(field.state).toBe('deleted');
+        expect(field.error).toBe(`${field.documentStatusError}: Unavailable`);
+
+        field.state = 'not-downloadable';
+        await field.deleteDocument();
+
+        expect(field.state).toBe('not-downloadable');
+        expect(field.error).toBe(`${field.documentDeleteError}: Unavailable`);
+
+        field.destroy()
     });
 });


### PR DESCRIPTION
Resolves #15636

`Neo.form.field.FileUpload` now delegates byte movement and remote document operations through a pluggable transport contract. The default `Neo.form.field.fileUpload.Xhr` transport preserves the existing multipart upload, progress, abort, header-injection, delete, and status-polling behavior, while non-HTTP transports can reuse the field's validation, UI, and state machine without reimplementing them.

Evidence: L2 (16 focused unit tests cover the transport seam and preserved XHR behavior; exact-head unit, component, integration, lint, and CodeQL CI are green) → L2 required (transport delegation and default-behavior ACs). No close-target residuals. The local browser component suite was environment-blocked before test execution by macOS Mach-port permission denial and watcher file-descriptor exhaustion; GitHub's current-head component job supplies that missing environment witness.

## Deltas from ticket

- Class and config transport values are field-owned and destroyed with the field; passed instances remain caller-owned and are detached on replacement or destruction.
- A transport instance already hosted by another field is rejected, preventing shared mutable host state.
- Existing document URL token substitution and function-valued URL behavior remain authoritative on the field, preserving the follow-up lanes tracked separately by `#15642` and `#15707`.

## Test Evidence

- FileUpload transport, async-destruction, and ID-sync unit surfaces: `npm run test-unit -- test/playwright/unit/form/field/FileUpload.spec.mjs test/playwright/unit/form/field/FileUploadAsync.spec.mjs test/playwright/unit/form/field/IdSync.spec.mjs` — 16/16 passed.
- Source syntax: `node --check` for `FileUpload.mjs`, `Transport.mjs`, `Xhr.mjs`, and `FileUpload.spec.mjs` — passed.
- Repository gates: `npm run agent-preflight -- --no-fix` and `git diff --cached --check` — passed; only the pre-existing non-blocking AiConfig overlay warning was reported.
- JSDoc types: `node ./buildScripts/util/check-jsdoc-types.mjs` — 1,883 files checked, 0 unparseable.
- Browser component surface: `npm run test-components` — no product result; Chromium could not launch in this sandbox (`MachPortRendezvousServer ... Permission denied`) and webpack watchers reported `EMFILE` before test bodies ran.
- GitHub CI at `2303545d4008b8751fec0562cfde8b18fea0fec8`: unit, components, integration-unified, PR/JSDoc/AiConfig/ticket lints, CodeQL analyze, CodeQL extraction guard, and direct CodeQL check — passed.

## Post-Merge Validation

None — no close-target evidence is deferred until after merge.

## Evolution

The extracted transport receives an explicit document ID for delete and status operations, while the default XHR adapter resolves the field's raw URL config at request time. This keeps transport calls deterministic without duplicating or bypassing the field's established URL-token contract.

Decision Record impact: none — this is a Body-side component seam and does not alter an accepted ADR.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019f92b3-6003-78f0-a442-eede5259532f.
