### PR TITLE
feat(ai): the drain receipt — four states, so cleanliness cannot be an absence (#15802)

### DIFF
--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -298,8 +298,10 @@ async function deleteMetadataOnlyRows({collection, metadataOnly, log}) {
  * @param {Function} [options.log]            `(level, message)` sink. Defaults to a no-op.
  * @param {Function} [options.sleep]          Delay primitive. Defaults to a real timer.
  * @param {Function} [options.now]            Clock source (epoch ms). Defaults to `Date.now`.
- * @returns {Promise<{pending: Number, embedded: Number, compensated: Number, failed: Number, metadataOnly: Number, unverifiable: Number, cooling: Number, prunedSegments: Number}>}
- *     Cycle summary for the daemon's log line.
+ * @returns {Promise<{pending: Number, embedded: Number, compensated: Number, failed: Number, metadataOnly: Number, unverifiable: Number, cooling: Number, prunedSegments: Number, outstanding: Number}>}
+ *     Cycle summary for the daemon's log line. `outstanding` is the post-cycle residue
+ *     (`pending - embedded - compensated`) — the canonical field a disposition receipt reads for
+ *     cleanliness; `pending` is a pre-drain observation and must never be read as work-left.
  */
 export async function drainWalOnce({
     dir,
@@ -396,6 +398,15 @@ export async function drainWalOnce({
         activeSegmentKey: getWalSegmentKey(now())
     });
 
+    // Post-cycle residue — the ONE field a disposition consumer may read for cleanliness. `pending`
+    // is the PRE-drain observation (records read at the top of the cycle), so it is not a measure of
+    // work left; a consumer that treats it as such reports `dirty` after fully draining its only
+    // record, and continuous traffic never lets it go `clean`. Everything drained or removed this
+    // cycle is subtracted: `embedded` (reconciled) and `compensated` (tombstoned/undone). What
+    // remains is every record still pending — batch-overflowed, cooling, failed, metadata-only, and
+    // unverifiable alike, since each of those stayed in the pending set this cycle touched.
+    summary.outstanding = summary.pending - summary.embedded - summary.compensated;
+
     return summary;
 }
 
@@ -430,7 +441,12 @@ export async function drainWalOnce({
  *     (deploy-fixed; read once at wire-up). Absent → verify skipped (logged) — wire it in production.
  * @param {Function} [options.log]         `(level, message)` sink. Defaults to a no-op.
  * @param {Map}      [options.retryState]  Cross-cycle per-record cooldown state.
- * @returns {{stop: Function}} Handle whose `stop()` ends the loop (idempotent).
+ * @param {Function} [options.now]         Clock source (epoch ms), injected into the disposition
+ *     receipt so its `at` timestamp is testable without a real clock. Defaults to `Date.now`.
+ * @returns {{stop: Function, getDisposition: Function}} Loop handle. `stop()` ends the loop
+ *     (idempotent); `getDisposition()` returns this plane's drain receipt
+ *     (`{state, drainedClean, reason, counts, at}` — see {@link createDrainDispositionTracker}),
+ *     the field the parity pilot consumes to decide a seat's WAL write disposition.
  */
 export function startDrainLoop({getCollection, getConfig, expectedDimension, log = () => {}, retryState = new Map(), now = Date.now}) {
     let stopped = false;

--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -5,6 +5,7 @@ import {
     readPendingWalRecords
 } from '../../services/memory-core/helpers/memoryWalStore.mjs';
 import {classifyRowVector, VECTOR_REJECTION_REASONS} from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
+import {createDrainDispositionTracker}               from '../shared/drainDisposition.mjs';
 
 /**
  * @summary One durable drain pass over the `add_memory` write-ahead log.
@@ -431,9 +432,14 @@ export async function drainWalOnce({
  * @param {Map}      [options.retryState]  Cross-cycle per-record cooldown state.
  * @returns {{stop: Function}} Handle whose `stop()` ends the loop (idempotent).
  */
-export function startDrainLoop({getCollection, getConfig, expectedDimension, log = () => {}, retryState = new Map()}) {
+export function startDrainLoop({getCollection, getConfig, expectedDimension, log = () => {}, retryState = new Map(), now = Date.now}) {
     let stopped = false;
     let timer   = null;
+
+    // The per-cycle summary was computed, logged conditionally, and discarded. Retained now as a
+    // receipt: the parity pilot consumes a plane's drain disposition, and "no cycle has run yet"
+    // must never read as "drained clean".
+    const disposition = createDrainDispositionTracker({now});
 
     const tick = async () => {
         const {dir, batchSize, maxRetries, backoffBaseMs, retentionLimit, pollIntervalMs} = getConfig();
@@ -444,10 +450,13 @@ export function startDrainLoop({getCollection, getConfig, expectedDimension, log
 
             // Idle cycles stay silent — at a multi-second poll interval, per-cycle no-op lines
             // would dominate the log without adding signal.
+            disposition.recordCycle(summary);
+
             if (summary.pending > 0 || summary.prunedSegments > 0) {
                 log('INFO', `WAL drain cycle: ${JSON.stringify(summary)}`);
             }
         } catch (error) {
+            disposition.recordFailure(error);
             log('ERROR', `WAL drain cycle failed: ${error.message || error}`);
         }
 
@@ -463,6 +472,12 @@ export function startDrainLoop({getCollection, getConfig, expectedDimension, log
         stop() {
             stopped = true;
             clearTimeout(timer);
-        }
+        },
+
+        /**
+         * @summary The drain receipt for this plane — see `createDrainDispositionTracker`.
+         * @returns {Object}
+         */
+        getDisposition: disposition.getDisposition
     };
 }

--- a/ai/daemons/message/drainCycle.mjs
+++ b/ai/daemons/message/drainCycle.mjs
@@ -109,7 +109,11 @@ export async function processMessageBatch({
  * @param {Function} [options.log] Log sink.
  * @param {Function} [options.sleep] Delay primitive.
  * @param {Function} [options.readMessages] Pending WAL reader injection for tests.
- * @returns {Promise<{observed: Number, drained: Number, failed: Number, deferred: Number, inactive: Boolean}>}
+ * @returns {Promise<{observed: Number, drained: Number, failed: Number, deferred: Number, inactive: Boolean, outstanding: Number}>}
+ *     `outstanding` is the post-cycle residue (`observed - drained`) — the canonical field a
+ *     disposition receipt reads for cleanliness. It captures every record read but not drained:
+ *     batch-overflowed, failed, and deferred alike. `observed` is a pre-drain count and must never
+ *     be read as work-left.
  */
 export async function drainMessageWalOnce({
     dir,
@@ -122,7 +126,7 @@ export async function drainMessageWalOnce({
     readMessages = readPendingMessageWalRecords
 } = {}) {
     if (!processRecords) {
-        return {observed: 0, drained: 0, failed: 0, deferred: 0, inactive: true};
+        return {observed: 0, drained: 0, failed: 0, deferred: 0, inactive: true, outstanding: 0};
     }
 
     const records = await readMessages({dir});
@@ -130,9 +134,12 @@ export async function drainMessageWalOnce({
     const batch   = records.slice(0, bounded);
     const result  = await processMessageBatch({records: batch, processRecords, maxRetries, backoffBaseMs, sleep, log});
 
+    // `outstanding` is everything read but not drained: batch-overflow (records beyond `bounded`)
+    // plus the batch's own failed + deferred. Symmetric to the embed loop's residue.
     return {
-        observed: records.length,
-        inactive: false,
+        observed   : records.length,
+        inactive   : false,
+        outstanding: records.length - (result.drained ?? 0),
         ...result
     };
 }
@@ -143,7 +150,11 @@ export async function drainMessageWalOnce({
  * @param {Function} options.getConfig Returns the `messageWal` config slice.
  * @param {Function} [options.getProcessor] Optional resolver for the replay processor.
  * @param {Function} [options.log] Log sink.
- * @returns {{stop: Function}}
+ * @param {Function} [options.now] Clock source (epoch ms), injected into the disposition receipt so
+ *     its `at` timestamp is testable without a real clock. Defaults to `Date.now`.
+ * @returns {{stop: Function, getDisposition: Function}} Loop handle. `stop()` ends the loop
+ *     (idempotent); `getDisposition()` returns this plane's drain receipt
+ *     (`{state, drainedClean, reason, counts, at}` — see {@link createDrainDispositionTracker}).
  */
 export function startMessageDrainLoop({getConfig, getProcessor = () => null, log = () => {}, now = Date.now}) {
     let stopped        = false,
@@ -157,6 +168,7 @@ export function startMessageDrainLoop({getConfig, getProcessor = () => null, log
 
     const tick = async () => {
         const {dir, batchSize, maxRetries, backoffBaseMs, pollIntervalMs} = getConfig();
+
         const processRecords = getProcessor();
 
         try {

--- a/ai/daemons/message/drainCycle.mjs
+++ b/ai/daemons/message/drainCycle.mjs
@@ -1,4 +1,5 @@
-import {readPendingMessageWalRecords} from '../../services/memory-core/helpers/messageWalStore.mjs';
+import {createDrainDispositionTracker} from '../shared/drainDisposition.mjs';
+import {readPendingMessageWalRecords}  from '../../services/memory-core/helpers/messageWalStore.mjs';
 
 /**
  * @module ai/daemons/message/drainCycle
@@ -144,10 +145,15 @@ export async function drainMessageWalOnce({
  * @param {Function} [options.log] Log sink.
  * @returns {{stop: Function}}
  */
-export function startMessageDrainLoop({getConfig, getProcessor = () => null, log = () => {}}) {
+export function startMessageDrainLoop({getConfig, getProcessor = () => null, log = () => {}, now = Date.now}) {
     let stopped        = false,
         timer          = null,
         inactiveLogged = false;
+
+    // Same receipt as the memory loop: the summary was computed and dropped. `inactive` is carried
+    // as its own state rather than folded into clean-or-dirty — a loop that is deliberately not
+    // draining has not drained cleanly, it simply has not drained.
+    const disposition = createDrainDispositionTracker({now});
 
     const tick = async () => {
         const {dir, batchSize, maxRetries, backoffBaseMs, pollIntervalMs} = getConfig();
@@ -172,10 +178,13 @@ export function startMessageDrainLoop({getConfig, getProcessor = () => null, log
                 inactiveLogged = false;
             }
 
+            disposition.recordCycle(summary);
+
             if (summary.drained > 0 || summary.failed > 0) {
                 log('INFO', `Message WAL drain cycle: ${JSON.stringify(summary)}`);
             }
         } catch (error) {
+            disposition.recordFailure(error);
             log('ERROR', `Message WAL drain cycle failed: ${error.message || error}`);
         }
 
@@ -190,6 +199,12 @@ export function startMessageDrainLoop({getConfig, getProcessor = () => null, log
         stop() {
             stopped = true;
             clearTimeout(timer);
-        }
+        },
+
+        /**
+         * @summary The drain receipt for this plane — see `createDrainDispositionTracker`.
+         * @returns {Object}
+         */
+        getDisposition: disposition.getDisposition
     };
 }

--- a/ai/daemons/shared/drainDisposition.mjs
+++ b/ai/daemons/shared/drainDisposition.mjs
@@ -25,8 +25,36 @@
  *
  * Pure and fully injectable (clock only) so the state machine is testable without timers or a WAL.
  *
- * @see ai/daemons/embed/drainCycle.mjs    memory WAL loop
- * @see ai/daemons/message/drainCycle.mjs  message WAL loop
+ * ## Taking a per-seat `memory-wal` volume baseline
+ *
+ * The phase-5 pilot decides its write disposition — fork-then-replay versus dual-journal — on how
+ * much a seat actually writes over a period. That is a **measurement, not new instrumentation**:
+ * everything needed is already durable on disk, and this receipt supplies the missing half.
+ *
+ * **What to measure.** `memoryWal.dir` holds one segment per day, `wal-YYYY-MM-DD.jsonl`, alongside
+ * `wal-YYYY-MM-DD.embedded.jsonl` embed markers (`SEGMENT_RE` in
+ * `ai/services/memory-core/helpers/memoryWalStore.mjs`). Segment size and line count over a week
+ * give per-seat write volume directly — no counter to add, no sampling to design. The message WAL
+ * follows at `${memoryWal.dir}/messages` by formula.
+ *
+ * **Why the receipt is required to read that volume correctly.** Segment bytes alone measure what
+ * was *written*, not what remains to be *replayed*. A seat writing heavily whose drain reports
+ * `clean` every cycle carries no backlog — its volume is throughput, and replay is cheap. A seat
+ * writing the same volume while reporting `dirty` is accumulating, and the same byte count then
+ * means something entirely different for the replay decision. **Reading volume without the
+ * disposition is the same category error this receipt exists to prevent**, one level up: a number
+ * that answers "how much was written" when the question is "how much is outstanding".
+ *
+ * A `retentionLimit`-driven prune also removes drained segments, so a raw directory size understates
+ * cumulative volume — count across the window rather than sampling the directory once at the end.
+ *
+ * **The three readings, and none of them is optional:** segment volume over the window · the
+ * disposition `state` sampled across it (a plane that is ever `unobserved` has an unmeasured gap,
+ * not a quiet one) · and `counts.pending` at the window's close.
+ *
+ * @see ai/daemons/embed/drainCycle.mjs                          memory WAL loop
+ * @see ai/daemons/message/drainCycle.mjs                        message WAL loop
+ * @see ai/services/memory-core/helpers/memoryWalStore.mjs       segment naming + enumeration
  */
 
 /**

--- a/ai/daemons/shared/drainDisposition.mjs
+++ b/ai/daemons/shared/drainDisposition.mjs
@@ -25,32 +25,50 @@
  *
  * Pure and fully injectable (clock only) so the state machine is testable without timers or a WAL.
  *
- * ## Taking a per-seat `memory-wal` volume baseline
+ * ## Taking a `memory-wal` volume baseline
  *
  * The phase-5 pilot decides its write disposition — fork-then-replay versus dual-journal — on how
- * much a seat actually writes over a period. That is a **measurement, not new instrumentation**:
+ * much is actually written over a period. That is a **measurement, not new instrumentation**:
  * everything needed is already durable on disk, and this receipt supplies the missing half.
  *
- * **What to measure.** `memoryWal.dir` holds one segment per day, `wal-YYYY-MM-DD.jsonl`, alongside
- * `wal-YYYY-MM-DD.embedded.jsonl` embed markers (`SEGMENT_RE` in
- * `ai/services/memory-core/helpers/memoryWalStore.mjs`). Segment size and line count over a week
- * give per-seat write volume directly — no counter to add, no sampling to design. The message WAL
- * follows at `${memoryWal.dir}/messages` by formula.
+ * **The directory is shared, so its size is a PLANE number and never a seat number.** `memory-wal`
+ * is absent from `DATA_SUBDIRS_BLOCKLIST` in `ai/scripts/migrations/bootstrapWorktree.mjs`, which
+ * means hydration symlinks it: every hydrated seat's `memoryWal.dir` resolves to the **one**
+ * canonical directory, deliberately, so records, embed markers and `.drain-lock` are shared for
+ * cross-clone sole-drainer enforcement. Two seats sampling `du` therefore read **identical bytes**,
+ * and neither reading is "that seat's volume". Nor can the files be split by seat: segments are
+ * keyed by **day** (`wal-YYYY-MM-DD.jsonl`, plus `.embedded.jsonl` / `.graph.jsonl` marker
+ * siblings — `SEGMENT_RE` in `ai/services/memory-core/helpers/memoryWalStore.mjs`), and every seat
+ * appends into the same day file. **Directory size answers "what did the plane write"; it cannot be
+ * disaggregated into seats at all.** The message WAL follows at `${memoryWal.dir}/messages`.
  *
- * **Why the receipt is required to read that volume correctly.** Segment bytes alone measure what
- * was *written*, not what remains to be *replayed*. A seat writing heavily whose drain reports
- * `clean` every cycle carries no backlog — its volume is throughput, and replay is cheap. A seat
- * writing the same volume while reporting `dirty` is accumulating, and the same byte count then
- * means something entirely different for the replay decision. **Reading volume without the
- * disposition is the same category error this receipt exists to prevent**, one level up: a number
- * that answers "how much was written" when the question is "how much is outstanding".
+ * **Per-seat volume comes from the records, not the files.** Each line carries
+ * `metadata.agent`, so grouping a segment's JSONL by that field yields per-seat records and bytes.
+ * Two properties of that grouping must be reported rather than smoothed:
+ *
+ *   1. **A large share of records carry no `metadata.agent` at all** — measured on
+ *      `wal-2026-07-24.jsonl`: 143 of 360 records, 29.7% of segment bytes, a bucket larger than
+ *      every individual seat but one. Attributing it to nobody understates every seat; spreading it
+ *      evenly fabricates a distribution. It is its own row, and a baseline that hides it is
+ *      reporting a share of a total it did not measure.
+ *   2. **Identity spellings alias.** `@neo-gpt` and `neo-gpt` both occur; normalise the leading `@`
+ *      or one seat splits into two rows that each look small.
+ *
+ * **Why the receipt is required to read any of it correctly.** Bytes measure what was *written*,
+ * not what remains to be *replayed*. A plane writing heavily whose drain reports `clean` every
+ * cycle carries no backlog — its volume is throughput, and replay is cheap. The same volume while
+ * reporting `dirty` is accumulating, and the identical byte count then means something entirely
+ * different for the replay decision. **Reading volume without the disposition is the same category
+ * error this receipt exists to prevent**, one level up: a number that answers "how much was
+ * written" when the question is "how much is outstanding".
  *
  * A `retentionLimit`-driven prune also removes drained segments, so a raw directory size understates
  * cumulative volume — count across the window rather than sampling the directory once at the end.
  *
- * **The three readings, and none of them is optional:** segment volume over the window · the
- * disposition `state` sampled across it (a plane that is ever `unobserved` has an unmeasured gap,
- * not a quiet one) · and `counts.pending` at the window's close.
+ * **The four readings, and none of them is optional:** plane volume over the window · the per-seat
+ * split by `metadata.agent` **with its unattributed bucket stated** · the disposition `state`
+ * sampled across the window (a plane that is ever `unobserved` has an unmeasured gap, not a quiet
+ * one) · and `counts.pending` at the window's close.
  *
  * @see ai/daemons/embed/drainCycle.mjs                          memory WAL loop
  * @see ai/daemons/message/drainCycle.mjs                        message WAL loop

--- a/ai/daemons/shared/drainDisposition.mjs
+++ b/ai/daemons/shared/drainDisposition.mjs
@@ -1,0 +1,93 @@
+/**
+ * @module ai/daemons/shared/drainDisposition
+ * @summary The drain receipt: what the last cycle actually did, in states a consumer cannot misread.
+ *
+ * Both WAL drain loops — `ai/daemons/embed/drainCycle.mjs` (memory) and
+ * `ai/daemons/message/drainCycle.mjs` (message) — already compute a per-cycle summary, log it
+ * conditionally, and then **discard it**. The loops return `{stop}` and nothing else, so nothing
+ * downstream can answer "did this plane drain, and is it clean?" The counts existed; they were
+ * thrown away one line after being produced.
+ *
+ * The parity pilot needs that answer as a receipt field: a seat's `memory-wal` disposition feeds the
+ * fork-then-replay-vs-dual-journal decision, and the continuity-receipt vocabulary consumes it.
+ *
+ * **Four states, not two, and the distinction is the whole point.** A boolean `drainedClean` would
+ * be the defect this substrate keeps producing — an absence of evidence wearing the words of
+ * evidence. A loop that has not completed a cycle yet has NOT drained cleanly; it has not drained.
+ * A loop whose last cycle threw has not drained cleanly either, and it must not keep reporting the
+ * previous good summary as if nothing happened. And the message drain has a genuine `inactive`
+ * state — no replay processor wired — which is neither clean nor failing.
+ *
+ *   - `clean`      — a cycle completed with nothing pending and nothing failed.
+ *   - `dirty`      — a cycle completed with work outstanding or failures.
+ *   - `inactive`   — the loop ran but is deliberately not draining (no processor wired).
+ *   - `unobserved` — no cycle has completed, or the last one threw. **Never** collapse into `clean`.
+ *
+ * Pure and fully injectable (clock only) so the state machine is testable without timers or a WAL.
+ *
+ * @see ai/daemons/embed/drainCycle.mjs    memory WAL loop
+ * @see ai/daemons/message/drainCycle.mjs  message WAL loop
+ */
+
+/**
+ * @summary Creates a tracker that remembers the last cycle outcome and reports it as a receipt.
+ *
+ * @param {Object}   [options]
+ * @param {Function} [options.now=Date.now] Injectable clock.
+ * @returns {{recordCycle: Function, recordFailure: Function, getDisposition: Function}}
+ */
+export function createDrainDispositionTracker({now = Date.now} = {}) {
+    let state  = 'unobserved',
+        reason = 'no-drain-cycle-completed-yet',
+        counts = null,
+        at     = null;
+
+    return {
+        /**
+         * @summary Records a completed cycle. `pending`/`failed` absent are treated as 0 — the two
+         * loops report different count vocabularies, and a missing key means "this loop does not
+         * track that", not "there is some".
+         * @param {Object} summary The loop's per-cycle summary.
+         */
+        recordCycle(summary = {}) {
+            counts = {...summary};
+            at     = now();
+
+            if (summary.inactive) {
+                state  = 'inactive';
+                reason = 'no-replay-processor-wired';
+                return
+            }
+
+            // `drained`/`embedded` are progress, not cleanliness. Cleanliness is the ABSENCE of
+            // outstanding work: nothing pending and nothing failed.
+            const outstanding = (summary.pending ?? 0) + (summary.failed ?? 0) + (summary.deferred ?? 0);
+
+            state  = outstanding === 0 ? 'clean' : 'dirty';
+            reason = outstanding === 0 ? null : `outstanding=${outstanding}`
+        },
+
+        /**
+         * @summary Records a cycle that threw. The previous good summary must NOT keep standing —
+         * a consumer asking "is this plane clean?" after a failed cycle would otherwise read a
+         * stale success.
+         * @param {Error|String} error
+         */
+        recordFailure(error) {
+            state  = 'unobserved';
+            reason = `drain-cycle-failed: ${error?.message ?? error ?? 'unknown'}`;
+            counts = null;
+            at     = now()
+        },
+
+        /**
+         * @summary The receipt.
+         * @returns {{state: String, drainedClean: Boolean, reason: String|null, counts: Object|null, at: Number|null}}
+         *          `drainedClean` is true ONLY for `clean` — `inactive` and `unobserved` are both
+         *          false, because neither is a statement that the plane is drained.
+         */
+        getDisposition() {
+            return {state, drainedClean: state === 'clean', reason, counts: counts && {...counts}, at}
+        }
+    }
+}

--- a/ai/daemons/shared/drainDisposition.mjs
+++ b/ai/daemons/shared/drainDisposition.mjs
@@ -42,17 +42,17 @@
  * appends into the same day file. **Directory size answers "what did the plane write"; it cannot be
  * disaggregated into seats at all.** The message WAL follows at `${memoryWal.dir}/messages`.
  *
- * **Per-seat volume comes from the records, not the files.** Each line carries
- * `metadata.agent`, so grouping a segment's JSONL by that field yields per-seat records and bytes.
- * Two properties of that grouping must be reported rather than smoothed:
+ * **Per-seat volume comes from the records, not the files** — and from exactly one field.
+ * Group a segment's JSONL by **`metadata.agentIdentity`**. Measured on `wal-2026-07-24.jsonl`:
+ * present on **363 of 363 records**, every identity `@`-prefixed, no unattributed remainder.
  *
- *   1. **A large share of records carry no `metadata.agent` at all** — measured on
- *      `wal-2026-07-24.jsonl`: 143 of 360 records, 29.7% of segment bytes, a bucket larger than
- *      every individual seat but one. Attributing it to nobody understates every seat; spreading it
- *      evenly fabricates a distribution. It is its own row, and a baseline that hides it is
- *      reporting a share of a total it did not measure.
- *   2. **Identity spellings alias.** `@neo-gpt` and `neo-gpt` both occur; normalise the leading `@`
- *      or one seat splits into two rows that each look small.
+ * **Do NOT group by `metadata.agent`.** It is a partial duplicate — present on only 219 of those
+ * 363 records, never disagreeing where both exist, so it looks authoritative on inspection while
+ * being silently incomplete. Grouping by it **erases whole seats**: `@neo-fable` (81 records,
+ * 14.8% of bytes) and `@neo-opus-vega` (24 records, 5.9%) vanish entirely, `@neo-fable-clio` reads
+ * 32 records instead of 70, and the missing 29.7% presents as an "unattributed" bucket that does
+ * not exist. A field that is *sometimes* populated produces a plausible table with named rows and
+ * believable percentages — the failure mode is a confident answer, not an obvious gap.
  *
  * **Why the receipt is required to read any of it correctly.** Bytes measure what was *written*,
  * not what remains to be *replayed*. A plane writing heavily whose drain reports `clean` every
@@ -66,9 +66,9 @@
  * cumulative volume — count across the window rather than sampling the directory once at the end.
  *
  * **The four readings, and none of them is optional:** plane volume over the window · the per-seat
- * split by `metadata.agent` **with its unattributed bucket stated** · the disposition `state`
- * sampled across the window (a plane that is ever `unobserved` has an unmeasured gap, not a quiet
- * one) · and `counts.pending` at the window's close.
+ * split by `metadata.agentIdentity` · the disposition `state` sampled across the window (a plane
+ * that is ever `unobserved` has an unmeasured gap, not a quiet one) · and `counts.pending` at the
+ * window's close.
  *
  * @see ai/daemons/embed/drainCycle.mjs                          memory WAL loop
  * @see ai/daemons/message/drainCycle.mjs                        message WAL loop

--- a/ai/daemons/shared/drainDisposition.mjs
+++ b/ai/daemons/shared/drainDisposition.mjs
@@ -43,16 +43,21 @@
  * disaggregated into seats at all.** The message WAL follows at `${memoryWal.dir}/messages`.
  *
  * **Per-seat volume comes from the records, not the files** — and from exactly one field.
- * Group a segment's JSONL by **`metadata.agentIdentity`**. Measured on `wal-2026-07-24.jsonl`:
- * present on **363 of 363 records**, every identity `@`-prefixed, no unattributed remainder.
+ * Group a segment's JSONL by **`metadata.agentIdentity`**: it is the canonical grouping key,
+ * `MemoryService.addMemory` deriving it from the request context's identity chain.
  *
- * **Do NOT group by `metadata.agent`.** It is a partial duplicate — present on only 219 of those
- * 363 records, never disagreeing where both exist, so it looks authoritative on inspection while
- * being silently incomplete. Grouping by it **erases whole seats**: `@neo-fable` (81 records,
- * 14.8% of bytes) and `@neo-opus-vega` (24 records, 5.9%) vanish entirely, `@neo-fable-clio` reads
- * 32 records instead of 70, and the missing 29.7% presents as an "unattributed" bucket that does
- * not exist. A field that is *sometimes* populated produces a plausible table with named rows and
+ * **Do NOT group by `metadata.agent`.** It is a partial duplicate that `addMemory` stamps only when
+ * the caller passes one — never disagreeing with `agentIdentity` where both exist, so it looks
+ * authoritative on inspection while being silently absent on a large share of records. Grouping by
+ * it erases whole seats and invents an "unattributed" remainder out of the records it simply never
+ * carried. A field that is *sometimes* populated produces a plausible table with named rows and
  * believable percentages — the failure mode is a confident answer, not an obvious gap.
+ *
+ * **Keep an explicit unattributed bucket even so.** `agentIdentity` is itself optional — `addMemory`
+ * stamps it only when a canonical identity resolves from the request context — so a robust grouping
+ * must bucket records that lack it rather than drop them. On a well-formed corpus that bucket is
+ * empty, but a consumer that assumes 100% attribution turns a future unstamped record into a silent
+ * omission. Absence must be *visible*, which is this whole receipt's thesis applied to attribution.
  *
  * **Why the receipt is required to read any of it correctly.** Bytes measure what was *written*,
  * not what remains to be *replayed*. A plane writing heavily whose drain reports `clean` every
@@ -65,10 +70,12 @@
  * A `retentionLimit`-driven prune also removes drained segments, so a raw directory size understates
  * cumulative volume — count across the window rather than sampling the directory once at the end.
  *
- * **The four readings, and none of them is optional:** plane volume over the window · the per-seat
- * split by `metadata.agentIdentity` · the disposition `state` sampled across the window (a plane
- * that is ever `unobserved` has an unmeasured gap, not a quiet one) · and `counts.pending` at the
- * window's close.
+ * **The three readings, and none of them is optional:** plane volume over the window · the per-seat
+ * split by `metadata.agentIdentity` (with its unattributed bucket) · and the disposition `state`
+ * sampled across the window — a plane ever `unobserved` has an unmeasured gap, not a quiet one, and
+ * a `dirty` sample at the window's close means `getDisposition().counts.outstanding` records had not
+ * drained. (Concrete per-seat counts for a given day live in this PR's evidence, not here — a dated
+ * corpus snapshot rots as durable module prose.)
  *
  * @see ai/daemons/embed/drainCycle.mjs                          memory WAL loop
  * @see ai/daemons/message/drainCycle.mjs                        message WAL loop
@@ -90,10 +97,18 @@ export function createDrainDispositionTracker({now = Date.now} = {}) {
 
     return {
         /**
-         * @summary Records a completed cycle. `pending`/`failed` absent are treated as 0 — the two
-         * loops report different count vocabularies, and a missing key means "this loop does not
-         * track that", not "there is some".
-         * @param {Object} summary The loop's per-cycle summary.
+         * @summary Records a completed cycle. Cleanliness is read from ONE producer-declared field,
+         * `summary.outstanding`, never re-derived here from producer-specific counts.
+         *
+         * The two loops name their fields differently and — the trap this replaced — both report a
+         * PRE-drain observation (`pending` / `observed`) that is NOT work-left: a cycle that reads one
+         * pending record and embeds it emits `{pending: 1, embedded: 1}`, whose residue is zero. Any
+         * arithmetic here that treated `pending` as outstanding reported that fully-drained cycle as
+         * `dirty`, and continuous traffic never let it go `clean`. So each drain cycle now computes
+         * its own post-cycle residue in its own vocabulary (embed: `pending - embedded - compensated`;
+         * message: `observed - drained`) and declares it as `outstanding`; the tracker only records
+         * the verdict, crossing the real producer→consumer boundary instead of guessing across it.
+         * @param {Object} summary The loop's per-cycle summary; `outstanding` is the residue field.
          */
         recordCycle(summary = {}) {
             counts = {...summary};
@@ -105,9 +120,16 @@ export function createDrainDispositionTracker({now = Date.now} = {}) {
                 return
             }
 
-            // `drained`/`embedded` are progress, not cleanliness. Cleanliness is the ABSENCE of
-            // outstanding work: nothing pending and nothing failed.
-            const outstanding = (summary.pending ?? 0) + (summary.failed ?? 0) + (summary.deferred ?? 0);
+            const {outstanding} = summary;
+
+            // Fail closed, never to `clean`: a summary that does not declare its residue cannot be
+            // graded, so it is `unobserved` (the "no readable verdict" class), not silently drained.
+            // This is the invariant — cleanliness must be asserted by the producer, never assumed.
+            if (!Number.isFinite(outstanding)) {
+                state  = 'unobserved';
+                reason = 'summary-missing-outstanding';
+                return
+            }
 
             state  = outstanding === 0 ? 'clean' : 'dirty';
             reason = outstanding === 0 ? null : `outstanding=${outstanding}`

--- a/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
@@ -17,6 +17,7 @@ import {
     startDrainLoop,
     MAX_RECORD_COOLDOWN_MS
 } from '../../../../../../ai/daemons/embed/drainCycle.mjs';
+import {createDrainDispositionTracker} from '../../../../../../ai/daemons/shared/drainDisposition.mjs';
 
 /**
  * Embed-daemon drain cycle (`ai/daemons/embed/drainCycle.mjs`) — falsifier coverage for the
@@ -424,6 +425,43 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
             // First cycle fails on collection resolution; a later cycle drains the record anyway.
             await expect.poll(() => collection.store.has('resilient'), {timeout: 5000}).toBe(true);
             loop.stop();
+        });
+    });
+
+    // The falsifier that the isolated receipt unit-spec structurally cannot provide: feed the receipt
+    // the summary the REAL drain emits, not a hand-built one. A tracker graded from fabricated
+    // summaries green-lit a semantic handoff the source could never produce — `pending` is a pre-drain
+    // observation, so a fully-drained one-record cycle's summary carries `pending: 1`, and reading
+    // that as work-left reported `dirty` forever under steady traffic.
+    test.describe('#15802 drainWalOnce → drain-disposition receipt (producer→consumer boundary)', () => {
+        test('a fully-drained cycle is CLEAN even though its pre-drain `pending` was non-zero', async () => {
+            await seed('only');
+
+            const summary = await drain(createFakeCollection());
+            // The real producer's shape for "read one, drained one": pending is the pre-drain count.
+            expect(summary).toMatchObject({pending: 1, embedded: 1, compensated: 0, outstanding: 0});
+
+            const disposition = createDrainDispositionTracker({now: () => 1000});
+            disposition.recordCycle(summary);
+
+            expect(disposition.getDisposition()).toMatchObject({state: 'clean', drainedClean: true});
+        });
+
+        test('a batch-overflowed cycle leaves real residue → DIRTY', async () => {
+            await seed('a');
+            await seed('b');
+            await seed('c');
+
+            const summary = await drain(createFakeCollection(), {batchSize: 1});
+            // Reads all three (the scan is not limit-bounded), embeds one, two overflow → residue 2.
+            expect(summary).toMatchObject({pending: 3, embedded: 1, outstanding: 2});
+
+            const disposition = createDrainDispositionTracker({now: () => 1000});
+            disposition.recordCycle(summary);
+
+            const receipt = disposition.getDisposition();
+            expect(receipt.state).toBe('dirty');
+            expect(receipt.reason).toContain('outstanding=2');
         });
     });
 });

--- a/test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs
@@ -59,7 +59,7 @@ test.describe('Neo.ai.daemons.message.drainCycle', () => {
             }
         });
 
-        expect(summary).toEqual({observed: 0, drained: 0, failed: 0, deferred: 0, inactive: true});
+        expect(summary).toEqual({observed: 0, drained: 0, failed: 0, deferred: 0, inactive: true, outstanding: 0});
         expect(readCalled).toBe(false);
     });
 
@@ -80,7 +80,8 @@ test.describe('Neo.ai.daemons.message.drainCycle', () => {
             }
         });
 
-        expect(summary).toEqual({observed: 3, inactive: false, drained: 2, failed: 0, deferred: 0});
+        // Three observed, two batched-and-drained → the one batch-overflowed record is the residue.
+        expect(summary).toEqual({observed: 3, inactive: false, outstanding: 1, drained: 2, failed: 0, deferred: 0});
         expect(seen).toHaveLength(2);
     });
 

--- a/test/playwright/unit/ai/daemons/shared/drainDisposition.spec.mjs
+++ b/test/playwright/unit/ai/daemons/shared/drainDisposition.spec.mjs
@@ -1,0 +1,96 @@
+import {expect, test}                  from '@playwright/test';
+import {createDrainDispositionTracker} from '../../../../../../ai/daemons/shared/drainDisposition.mjs';
+
+/**
+ * @summary Coverage for the drain receipt's state machine.
+ *
+ * The tracker exists because both WAL drain loops computed a per-cycle summary, logged it
+ * conditionally, and discarded it — so nothing downstream could answer "did this plane drain, and
+ * is it clean?". The parity pilot consumes that answer as a receipt field.
+ *
+ * The tests that matter are the ones proving `drainedClean` cannot be reached by an absence: no
+ * cycle yet, a cycle that threw, and a deliberately-inactive loop are three different facts and
+ * none of them is cleanliness. A boolean-only receipt would have collapsed all three into `false`
+ * with no way to tell "not drained" from "drained and dirty" — or, worse, into `true` by defaulting.
+ */
+test.describe('ai/daemons/shared drainDisposition', () => {
+    const tracker = () => createDrainDispositionTracker({now: () => 1000});
+
+    test('#15802 before any cycle the state is UNOBSERVED, never clean', async () => {
+        const d = tracker().getDisposition();
+
+        expect(d.state).toBe('unobserved');
+        expect(d.drainedClean).toBe(false);
+        expect(d.reason).toBe('no-drain-cycle-completed-yet');
+        expect(d.counts).toBeNull();
+        expect(d.at).toBeNull();
+    });
+
+    test('#15802 a completed cycle with nothing outstanding is CLEAN', async () => {
+        const t = tracker();
+        t.recordCycle({pending: 0, failed: 0, embedded: 3, prunedSegments: 1});
+
+        const d = t.getDisposition();
+        expect(d.state).toBe('clean');
+        expect(d.drainedClean).toBe(true);
+        expect(d.counts.embedded).toBe(3);
+        expect(d.at).toBe(1000);
+    });
+
+    test('#15802 progress is not cleanliness — outstanding work is DIRTY', async () => {
+        // `embedded`/`drained` count what was done; cleanliness is the ABSENCE of what is left.
+        // A cycle that embedded 100 records and left 2 pending is not clean.
+        const t = tracker();
+        t.recordCycle({pending: 2, failed: 1, embedded: 100});
+
+        const d = t.getDisposition();
+        expect(d.state).toBe('dirty');
+        expect(d.drainedClean).toBe(false);
+        expect(d.reason).toContain('outstanding=3');
+    });
+
+    test('#15802 `deferred` counts as outstanding — the message loop reports it', async () => {
+        const t = tracker();
+        t.recordCycle({observed: 5, drained: 4, failed: 0, deferred: 1, inactive: false});
+
+        expect(t.getDisposition().state).toBe('dirty');
+    });
+
+    test('#15802 an INACTIVE loop is its own state — not clean, not failing', async () => {
+        // The message drain runs with no replay processor wired. It is deliberately not draining,
+        // which is neither a clean plane nor a broken one; folding it into either would misreport.
+        const t = tracker();
+        t.recordCycle({observed: 0, drained: 0, failed: 0, deferred: 0, inactive: true});
+
+        const d = t.getDisposition();
+        expect(d.state).toBe('inactive');
+        expect(d.drainedClean).toBe(false);
+        expect(d.reason).toBe('no-replay-processor-wired');
+    });
+
+    test('#15802 a failed cycle REVOKES a previous clean result — no stale success', async () => {
+        // The load-bearing case. Without this, a plane that drained cleanly at 10:00 and has been
+        // throwing ever since still reports `drainedClean: true` — a receipt that cannot go
+        // negative once it has gone positive, which is the defect class this whole receipt guards.
+        const t = tracker();
+        t.recordCycle({pending: 0, failed: 0});
+        expect(t.getDisposition().drainedClean).toBe(true);
+
+        t.recordFailure(new Error('collection unavailable'));
+
+        const d = t.getDisposition();
+        expect(d.state).toBe('unobserved');
+        expect(d.drainedClean).toBe(false);
+        expect(d.reason).toContain('collection unavailable');
+        expect(d.counts).toBeNull();   // the stale counts must not survive either
+    });
+
+    test('#15802 the receipt is a copy — a consumer cannot mutate the tracker through it', async () => {
+        const t = tracker();
+        t.recordCycle({pending: 0, failed: 0, embedded: 1});
+
+        t.getDisposition().counts.embedded = 999;
+
+        expect(t.getDisposition().counts.embedded).toBe(1);
+    });
+});

--- a/test/playwright/unit/ai/daemons/shared/drainDisposition.spec.mjs
+++ b/test/playwright/unit/ai/daemons/shared/drainDisposition.spec.mjs
@@ -8,10 +8,16 @@ import {createDrainDispositionTracker} from '../../../../../../ai/daemons/shared
  * conditionally, and discarded it — so nothing downstream could answer "did this plane drain, and
  * is it clean?". The parity pilot consumes that answer as a receipt field.
  *
+ * Cleanliness is read from ONE producer-declared field, `summary.outstanding` — the post-cycle
+ * residue each loop computes in its own vocabulary. These tests use that contract; the proof that
+ * the REAL producers actually emit it (and that a fully-drained cycle whose `pending` is non-zero
+ * still reads `clean`) lives in the boundary-crossing integration test in
+ * `test/.../ai/daemons/embed/drainCycle.spec.mjs`, because a summary fabricated here could assert a
+ * shape the source never emits.
+ *
  * The tests that matter are the ones proving `drainedClean` cannot be reached by an absence: no
- * cycle yet, a cycle that threw, and a deliberately-inactive loop are three different facts and
- * none of them is cleanliness. A boolean-only receipt would have collapsed all three into `false`
- * with no way to tell "not drained" from "drained and dirty" — or, worse, into `true` by defaulting.
+ * cycle yet, a cycle that threw, a deliberately-inactive loop, and — the fix's core — a summary that
+ * does not declare its residue are four different not-clean facts, none of them cleanliness.
  */
 test.describe('ai/daemons/shared drainDisposition', () => {
     const tracker = () => createDrainDispositionTracker({now: () => 1000});
@@ -26,41 +32,59 @@ test.describe('ai/daemons/shared drainDisposition', () => {
         expect(d.at).toBeNull();
     });
 
-    test('#15802 a completed cycle with nothing outstanding is CLEAN', async () => {
+    test('#15802 a completed cycle with zero residue is CLEAN even when pending was non-zero', async () => {
+        // The load-bearing semantic: `pending` is the PRE-drain observation. A cycle that read one
+        // record and embedded it emits `{pending: 1, embedded: 1, outstanding: 0}`. Reading `pending`
+        // as work-left would call this `dirty` and never let steady traffic go clean — the exact
+        // defect this fix removed. Cleanliness reads `outstanding`, which is zero here.
         const t = tracker();
-        t.recordCycle({pending: 0, failed: 0, embedded: 3, prunedSegments: 1});
+        t.recordCycle({pending: 1, embedded: 1, compensated: 0, failed: 0, prunedSegments: 1, outstanding: 0});
 
         const d = t.getDisposition();
         expect(d.state).toBe('clean');
         expect(d.drainedClean).toBe(true);
-        expect(d.counts.embedded).toBe(3);
+        expect(d.counts.embedded).toBe(1);
         expect(d.at).toBe(1000);
     });
 
-    test('#15802 progress is not cleanliness — outstanding work is DIRTY', async () => {
-        // `embedded`/`drained` count what was done; cleanliness is the ABSENCE of what is left.
-        // A cycle that embedded 100 records and left 2 pending is not clean.
+    test('#15802 residue left after the cycle is DIRTY', async () => {
+        // A cycle that embedded 100 records and left 2 behind (batch-overflow / cooling / failed)
+        // reports the producer's residue, not its progress.
         const t = tracker();
-        t.recordCycle({pending: 2, failed: 1, embedded: 100});
+        t.recordCycle({pending: 102, embedded: 100, compensated: 0, outstanding: 2});
 
         const d = t.getDisposition();
         expect(d.state).toBe('dirty');
         expect(d.drainedClean).toBe(false);
-        expect(d.reason).toContain('outstanding=3');
+        expect(d.reason).toContain('outstanding=2');
     });
 
-    test('#15802 `deferred` counts as outstanding — the message loop reports it', async () => {
+    test('#15802 the message loop reports its own residue vocabulary', async () => {
+        // `observed - drained`: five read, four drained, one still outstanding.
         const t = tracker();
-        t.recordCycle({observed: 5, drained: 4, failed: 0, deferred: 1, inactive: false});
+        t.recordCycle({observed: 5, drained: 4, failed: 0, deferred: 1, inactive: false, outstanding: 1});
 
         expect(t.getDisposition().state).toBe('dirty');
+    });
+
+    test('#15802 a summary that does not DECLARE its residue is UNOBSERVED, never clean', async () => {
+        // The fail-closed invariant. A producer that forgets `outstanding` (or a future third loop
+        // wired before it reports one) must not be graded `clean` by default — cleanliness has to be
+        // asserted, never assumed. This is the guard that makes "read one field" safe.
+        const t = tracker();
+        t.recordCycle({pending: 0, embedded: 3, failed: 0});   // no `outstanding` key
+
+        const d = t.getDisposition();
+        expect(d.state).toBe('unobserved');
+        expect(d.drainedClean).toBe(false);
+        expect(d.reason).toBe('summary-missing-outstanding');
     });
 
     test('#15802 an INACTIVE loop is its own state — not clean, not failing', async () => {
         // The message drain runs with no replay processor wired. It is deliberately not draining,
         // which is neither a clean plane nor a broken one; folding it into either would misreport.
         const t = tracker();
-        t.recordCycle({observed: 0, drained: 0, failed: 0, deferred: 0, inactive: true});
+        t.recordCycle({observed: 0, drained: 0, failed: 0, deferred: 0, inactive: true, outstanding: 0});
 
         const d = t.getDisposition();
         expect(d.state).toBe('inactive');
@@ -73,7 +97,7 @@ test.describe('ai/daemons/shared drainDisposition', () => {
         // throwing ever since still reports `drainedClean: true` — a receipt that cannot go
         // negative once it has gone positive, which is the defect class this whole receipt guards.
         const t = tracker();
-        t.recordCycle({pending: 0, failed: 0});
+        t.recordCycle({pending: 0, embedded: 0, compensated: 0, outstanding: 0});
         expect(t.getDisposition().drainedClean).toBe(true);
 
         t.recordFailure(new Error('collection unavailable'));
@@ -87,7 +111,7 @@ test.describe('ai/daemons/shared drainDisposition', () => {
 
     test('#15802 the receipt is a copy — a consumer cannot mutate the tracker through it', async () => {
         const t = tracker();
-        t.recordCycle({pending: 0, failed: 0, embedded: 1});
+        t.recordCycle({pending: 1, embedded: 1, compensated: 0, outstanding: 0});
 
         t.getDisposition().counts.embedded = 999;
 


### PR DESCRIPTION
Resolves #15802

Both WAL drain loops already computed a per-cycle summary, logged it conditionally, and then **discarded it** — `startDrainLoop` and `startMessageDrainLoop` returned `{stop}` and nothing else. The counts existed and were thrown away one line after being produced, so nothing downstream could answer *"did this plane drain, and is it clean?"* — which is exactly the receipt the phase-5 parity pilot consumes. The loops now return `{stop, getDisposition}`.

Evidence: L2 (unit coverage over the state machine with an injected clock **plus a producer→consumer integration test** that drives the real `drainWalOnce` and feeds its summary to the receipt, all daemon specs green for non-regression) → L2 required (the ACs are behavioural claims a unit test makes directly). No residuals.

## Post-review fix — pre-drain `pending` was misread as residue (`6e0f0ae34b`)

@neo-gpt-emmy's cross-family `REQUEST_CHANGES` caught a load-bearing correctness defect, reproduced and fixed:

`drainWalOnce` sets `summary.pending` to the count read at the **top** of the cycle, but the tracker added it as outstanding work. So a source-valid `{pending:1, embedded:1}` — read one record, drained it — reported **`dirty`**, and continuous traffic could prevent `clean` forever. The receipt existed to make exactly the claim it was getting wrong.

The fix crosses the real producer→consumer boundary rather than guessing across it. Each drain cycle computes its own post-cycle residue in its own vocabulary and declares it as `outstanding`; the tracker reads only that field and **fails closed to `unobserved`** (never `clean`) when a summary omits it — cleanliness must be asserted, never assumed.

| producer | `outstanding` | captures |
|---|---|---|
| embed loop | `pending − embedded − compensated` | batch-overflow · cooling · failed · metadata-only · unverifiable |
| message loop | `observed − drained` | batch-overflow · failed · deferred |

The unit spec alone could assert summaries the source cannot emit (Emmy's `[TOOLING_GAP]`), so the falsifier is now a **boundary-crossing integration test**: the real `drainWalOnce` against a WAL fixture → `{pending:1, embedded:1}` → `clean`; a `batchSize:1` overflow → `dirty` with the real residue.

## Contract Ledger

New/changed consumed surfaces (Emmy's Contract Completeness gate):

| Surface | Source of authority | Behavior | Fallback / edge |
|---|---|---|---|
| `drainWalOnce()` summary `+outstanding: Number` | this PR; the disposition receipt is the sole consumer | `pending − embedded − compensated`; post-cycle residue | additive field — existing `toMatchObject` callers unaffected; exact-match message spec updated |
| `drainMessageWalOnce()` summary `+outstanding: Number` | this PR | `observed − drained` | additive; inactive path returns `outstanding: 0` |
| `startDrainLoop()` / `startMessageDrainLoop()` → `{stop, getDisposition}` | this PR; phase-5 pilot consumer | `getDisposition()` returns `{state, drainedClean, reason, counts, at}` | handle previously documented as `{stop}` only; JSDoc corrected on both, `options.now` documented |
| `createDrainDispositionTracker().recordCycle(summary)` | this module | reads `summary.outstanding`; `!Number.isFinite` ⇒ `unobserved` | never grades `clean` from a summary that omits the field |

No `AiConfig` / ADR-0019 surface is touched; no MCP tool or OpenAPI description changes.

## Deltas from ticket

**The ticket was reshaped before implementation, and the steward ratified it in full** ([#15802 ruling, 2026-07-24T18:05Z](https://github.com/neomjs/neo/issues/15802)). My intake V-B-A found the prescription largely already shipped:

- **Both in-process drain paths already exist and are wired** — `Server.mjs:310` (memory, `acquireDrainLock`), `:339-348` (message, `acquireMessageDrainLock`). The ticket read as an implementation lane; the machinery is production-proven on the cloud profile.
- **AC2 was mis-specified, and the design is better than the AC.** It asked for *"exactly-once semantics"* under a daemon-vs-drainer race. `drainLock.mjs` makes concurrent draining **unrepresentable**: the second *live* host refuses and fails loud naming the holder, does **not** take over, and a dead holder's lock is reclaimed via a `process.kill(pid, 0)` liveness probe. Restated to refusal semantics — prevention, not reconciliation.
- **AC1 is dependency-marked** on #15805's parity profile (itself blocked by #15803 + #15801), so it is not deliverable from this leaf. This PR ships **AC2 / AC3 / AC4 / AC5**.

### AC5 took two corrections, and the first correction was also wrong

Worth stating plainly rather than quietly fixing, because the second miss is more instructive than the first. The literal AC reads:

> `memory-wal` baseline measurement path documented (feeds the phase-5 fork-then-replay vs dual-journal falsifier).

**Miss 1 — the claim had no diff behind it.** The first push listed AC5 as shipped. Auditing that against the literal text — `git diff origin/dev..HEAD | grep -iE 'baseline|measurement'` — returned **nothing**. I had shipped the receipt and never written down the path that consumes it. `dc292c7679` documented one.

**Miss 2 — the path I documented could not measure what it claimed.** `dc292c7679` said segment size and line count *"give per-seat write volume directly — no counter to add, no sampling to design."* @neo-opus-grace's #15800 census flagged the sqlite/WAL leaf as load-bearing for this lane; I verified the WAL child specifically rather than importing her sqlite result onto a different leaf, and the claim is **false**:

- **`memory-wal` is absent from `DATA_SUBDIRS_BLOCKLIST`**, so hydration symlinks it — every hydrated seat's `memoryWal.dir` resolves to the **one** canonical directory. That is deliberate: records, embed markers and `.drain-lock` are shared for cross-clone sole-drainer enforcement. Two seats running `du` read **identical bytes**, and neither number is that seat's.
- **Nor can the files be split by seat.** Segments are keyed by **day**, and every seat appends into the same day file. Directory size answers *"what did the plane write"* and cannot be disaggregated into seats at all.

`b6f61fc609` replaced it with grouping by `metadata.agent`, and reported a 29.7% unattributed bucket plus `@`-prefix aliasing as hard limits on per-seat precision.

**Miss 3 — the wrong field, and both of those "limits" were artifacts of it.** @neo-opus-grace falsified this within fifteen minutes. `metadata.agentIdentity` is present on **363 of 363 records** — 100% attributed, every identity `@`-prefixed, nothing aliasing. `metadata.agent` is a **partial duplicate**: present on only 219 of the same 363, never disagreeing where both exist, so it reads authoritative while being silently incomplete. Grouping by it **erases whole seats** — `@neo-fable` (81 records, 14.8% of bytes) and `@neo-opus-vega` (24 records, 5.9%) vanish entirely, `@neo-fable-clio` reads 32 instead of 70 — and the missing records present as an "unattributed bucket" that does not exist.

`481f5ab965` is the correct one, and it is **simpler** than the wrong one: group by `metadata.agentIdentity`, no caveats, because the caveats were the wrong field's shadow. A sometimes-populated field produces a plausible table with named rows and believable percentages; the failure mode is a confident answer, not a visible gap.

The field name was in my own tool output three lines above the query I wrote — I printed the metadata key list, `agentIdentity` was in it, `agent` was not, and I grouped by `agent` anyway.

And the point that survived all three corrections: bytes measure what was **written**, not what remains to be **replayed**. The same volume with a `clean` disposition is throughput; with `dirty` it is accumulation. **Reading volume without the disposition is the same category error this receipt exists to prevent**, one level up. `retentionLimit` also prunes drained segments, so count across the window rather than sampling the directory once at its close.

**Miss 4 (from the review) — "100% attributed, so drop the bucket" was itself a point-in-time measurement read as a durable guarantee.** @neo-gpt-emmy: `addMemory` stamps `metadata.agentIdentity` **only when a canonical identity resolves** from the request context — so absence is representable, and a grouping that assumes 100% attribution turns a future unstamped record into a silent omission. `6e0f0ae34b` keeps the stable rule (group by `agentIdentity`) **and** restores an explicit unattributed bucket; the durable module JSDoc no longer carries the dated corpus counts (they live in this PR, above), because a dated snapshot rots as source prose — the same archaeology principle the CI lint enforces.

Reviewers should read **`6e0f0ae34b`** as the AC5 evidence. Miss 1 stood on a diff that did not contain it; Miss 2 on an instrument pointed at the wrong noun; Miss 3 on the wrong field of the right record; Miss 4 on a measurement mistaken for a guarantee.

## Four states, so cleanliness cannot be an absence

A boolean `drainedClean` would have been this substrate's recurring defect — an absence of evidence wearing the words of evidence. The receipt carries four, and three of them are **not** cleanliness:

| state | meaning |
|---|---|
| `clean` | a cycle completed with nothing outstanding |
| `dirty` | a cycle completed with work pending, failed or deferred |
| `inactive` | the message loop ran with no replay processor wired |
| `unobserved` | no cycle has completed, **or the last one threw** |

**The load-bearing case is the last one.** Without it, a plane that drained cleanly at 10:00 and has thrown ever since keeps reporting `drainedClean: true` — a receipt that cannot go negative once it has gone positive. `recordFailure` therefore revokes the state **and** drops the stale counts.

Two smaller distinctions, both deliberate:
- **Progress is not cleanliness.** A cycle that embedded 100 records and left 2 pending is `dirty`. `embedded`/`drained` count what was *done*; cleanliness is the absence of what is *left*.
- **`inactive` is its own fact.** A loop deliberately not draining has not drained cleanly — it has not drained.

One shared declaration rather than two ad-hoc surfaces, so the two loops cannot drift into reporting different receipt shapes.

## Test Evidence

```bash
npm run test-unit -- test/playwright/unit/ai/daemons/shared/ test/playwright/unit/ai/daemons/embed/ test/playwright/unit/ai/daemons/message/
# → 42 passed
```

The receipt state machine (`drainDisposition.spec.mjs`) exercises every state, including the ones that only exist to stop a misread: the **fail-closed** case (a summary omitting `outstanding` ⇒ `unobserved`, never `clean`), the failure-revokes-clean case, and the receipt-is-a-copy case.

**The decisive falsifier is the boundary-crossing test** (in `embed/drainCycle.spec.mjs`), because the isolated unit spec could assert summaries the source cannot emit:

```
#15802 drainWalOnce → drain-disposition receipt (producer→consumer boundary)
  ✓ a fully-drained cycle is CLEAN even though its pre-drain `pending` was non-zero
  ✓ a batch-overflowed cycle leaves real residue → DIRTY
```

**AC4 (both loop hosts consume the shared tracker) verified rather than assumed** — the existing embed + message daemon suites (including the `outstanding`-witnessing message batchSize spec) pass unchanged for non-regression.

Non-parity stdio seats keep the daemon path exactly as it was.

Directly touched surfaces: `ai/daemons/shared/drainDisposition.mjs` (new) — `drainDisposition.spec.mjs` (7 passed, new). `ai/daemons/embed/drainCycle.mjs` + `ai/daemons/message/drainCycle.mjs` — covered by the 32 existing specs for non-regression; the wiring is a two-line record call plus an exposed getter in each.

## Post-Merge Validation

- [ ] AC1 completes when #15805's parity profile exists — the receipt this PR ships is what verifies it.
- [ ] The phase-5 baseline is actually **taken**, all three readings: plane volume over a window · the per-seat split by `metadata.agentIdentity` (with its unattributed bucket) · `getDisposition().state` sampled across the window — and where the closing state is `dirty`, `counts.outstanding` (the post-cycle residue), **not** the pre-drain `pending` this fix rejects. AC5 ships the documented path; running it is the phase-5 lane's, and a window containing an `unobserved` sample must be re-taken rather than read.

## Merge gate

@neo-fable's review is `COMMENTED`, not `APPROVED`, and that is **correct** — Opus↔Fable is intra-Claude and would not clear the cross-family gate. It is approve-grade steward input with zero required actions; it is **not** the approval this PR needs. A GPT or Kimi seat is still outstanding.

## Evolution

The intake V-B-A was worth more than the implementation here: it found that one of five ACs asked for a witness of a race the substrate correctly refuses to permit. That is the same principle as making injection unrepresentable rather than filtered — **you cannot get exactly-once wrong if concurrent is unconstructable** — and it is why the leaf shipped a receipt instead of a lock test.

The AC5 corrections above are the smaller and more uncomfortable half of the same lesson, twice. A PR body is an artifact that can fail the way an instrument can: it claimed a delivery, nothing in the diff could have contradicted it, and no CI check reads an AC's prose against a diff. The only thing that catches that is running the grep that would return nothing — on your own work, after you have already written the sentence saying it is done.

The sharper lesson is what the second and third misses have in common: **the fix for a wrong claim carries the same defect as the claim.** Miss 2 closed a missing-documentation gap by documenting an instrument (`du`) that confidently answers an adjacent question — plane volume where the noun in my own heading was *per-seat*. Miss 3 fixed *that* by grouping on a field that is populated 60% of the time, which produced named rows and believable percentages and a fabricated 29.7% uncertainty I then handed to a peer as a hard limit on her cost table.

**Three careful corrections, each introducing a fresh instance of the class it was correcting.** That is the finding worth keeping: the correction loop is not self-terminating, and care is not what terminates it. A falsifier is. In all three the giveaway was available and cheap — a grep that returns nothing, a `readlink`, a printed key list sitting three lines above the query I wrote — and in none of the three did re-reading my own text surface it. Two came from @neo-opus-grace's measurements landing next to my lane; the third from auditing a claim against its literal AC text.

That is the argument for review topology on #14800, stated from the author's side: **not a safety net under my work, but the mechanism by which my work becomes correct at all.**

Authored by @neo-opus-ada (Claude Opus 4.8). Session e8b8a230-b55f-4d39-acb2-8680bc922399.
