### PR TITLE
feat(ai): re-runnable plane-placement census for the #15800 cost table (#15835)

### DIFF
--- a/ai/scripts/diagnostics/planePlacementCensus.mjs
+++ b/ai/scripts/diagnostics/planePlacementCensus.mjs
@@ -89,10 +89,24 @@ export const PLANE_DIR_NAME = '.neo-ai-data';
 export const OPENER_SEARCH_TREES = ['ai', 'buildScripts', 'src', 'apps'];
 
 /**
- * Matches an expression that resolves a plane path — either a config read or a literal plane reference.
+ * Matches an expression that resolves a plane path.
+ *
+ * Three shapes, because the plane is reached three ways and an earlier version saw only the first:
+ *   1. `storagePaths.<leaf>` — the DB-path subtree.
+ *   2. A `*Path` / `*Dir` leaf read off the config singleton (`AiConfig.backupPath`, `aiConfig.logPath`,
+ *      `…wakeDaemonHeartbeatAlivePath`, `…hierarchyPath`, …). `configBase.mjs` declares a whole family of
+ *      these and matching only `storagePaths` silently dropped every module that reached the plane through
+ *      another one — the miss @neo-gpt-emmy found on `SwarmHeartbeatService`.
+ *   3. A literal `.neo-ai-data` / `NEO_AI_DATA` / `aiDataRoot` reference.
+ *
+ * This is a SHAPE proxy for the config contract, not the contract itself: it recognises the *form* of a
+ * config plane-path read without importing the singleton into a diagnostic. A leaf whose name does not end
+ * in `Path`/`Dir` would still be missed — the durable fix is to reconcile against the config module's
+ * declared plane-member set rather than a name shape, and this JSDoc states that limit rather than
+ * implying completeness.
  * @type {RegExp}
  */
-export const PLANE_PATH_SOURCE = /storagePaths\.|\.neo-ai-data|NEO_AI_DATA|aiDataRoot/;
+export const PLANE_PATH_SOURCE = /storagePaths\.|\b[Aa]iConfig\.[A-Za-z]*(?:Path|Dir)\b|\.neo-ai-data|NEO_AI_DATA|aiDataRoot/;
 
 /**
  * Matches a filesystem operation. Deliberately broad: the axis is "does this module open the plane",
@@ -145,10 +159,22 @@ export function stripComments(source) {
 }
 
 /**
- * Lists git-tracked `.mjs` files under the census trees, excluding tests.
+ * This diagnostic's own repo-relative path, so the census can exclude itself from its own domain.
+ *
+ * A committed measurement instrument that counts itself changes the baseline it exists to reproduce: this
+ * file matches its own opener rule (it reads `.neo-ai-data` paths and calls `fs`), so before this exclusion
+ * the totals shifted by one the moment the script was committed. The observation domain has to be explicit,
+ * not silently one-off.
+ * @type {String}
+ */
+export const CENSUS_SELF_PATH = 'ai/scripts/diagnostics/planePlacementCensus.mjs';
+
+/**
+ * Lists git-tracked `.mjs` files under the census trees, excluding tests AND the census itself.
  *
  * Uses `git ls-files` rather than a directory walk so untracked scratch files and build output can never
- * enter a cost row.
+ * enter a cost row. The census excludes itself by construction — the instrument is not part of the
+ * deployment surface it measures, and counting it made the total move on commit.
  *
  * @param {Object} [options]
  * @param {String} [options.projectRoot=PROJECT_ROOT] Repo root.
@@ -158,12 +184,19 @@ export function listCensusFiles({projectRoot = PROJECT_ROOT} = {}) {
     const output = execFileSync('git', ['ls-files', ...OPENER_SEARCH_TREES], {cwd: projectRoot, encoding: 'utf8'});
 
     return output.split('\n').filter(file =>
-        file.endsWith('.mjs') && !file.includes('/test') && !file.endsWith('.spec.mjs')
+        file.endsWith('.mjs') && !file.includes('/test') && !file.endsWith('.spec.mjs') && file !== CENSUS_SELF_PATH
     );
 }
 
 /**
- * Counts modules whose executable code both resolves a plane path and performs a filesystem operation.
+ * Counts modules whose executable code CO-OCCURS a plane-path expression with a filesystem operation.
+ *
+ * **Co-occurrence, not data flow — and the distinction is deliberate.** This proves "this module names a
+ * plane path AND calls `fs` somewhere", not "this module calls `fs` ON that plane path". A line-regex
+ * cannot establish the latter (it would need to trace the path value to the `fs` call), so the claim is
+ * kept to what the evidence supports. The consequence is a small over-count — a module that reads an
+ * unrelated file and separately mentions a plane path in dead-ish code counts — which is the honest
+ * failure direction for a cost CEILING: it never under-reports the openers a branch must pay for.
  *
  * Three buckets, not two. Anything neither clearly host-invoked nor clearly server-loaded lands in
  * `unclassified` rather than being folded into whichever side makes the total tidy — a cost row is only as
@@ -214,14 +247,19 @@ export function censusPlaneOpeners({projectRoot = PROJECT_ROOT} = {}) {
 /**
  * Audits whether a seat's plane entries are containable by a bind-mount of that seat's plane root.
  *
- * `escapes` is the load-bearing number: an entry resolving outside its own plane root is not contained by
- * a bind-mount of that root, so inside a container it dangles unless the canonical root is also mounted at
- * the identical absolute host path. `dangling` is reported separately because an entry can escape and still
- * resolve perfectly **on the host** — which is exactly why the class stays invisible until containerisation.
+ * `escapes` and `dangling` are INDEPENDENT flags, not a fallthrough. An entry resolving outside its own
+ * plane root is not contained by a bind-mount of that root; an entry whose target does not exist is
+ * dangling. A single symlink can be BOTH — a dangling link that points outside the root — and an earlier
+ * version reported only the dangling half, because it derived the escape target from `realpathSync`, which
+ * throws on a dangling link and skipped the escape check. Escape is now decided from the LITERAL target
+ * (`readlinkSync`), which exists whether or not the target resolves, so the two facts are orthogonal.
+ *
+ * That escapes is the load-bearing number for containerisation is unchanged: a link resolving perfectly on
+ * the host still escapes a bind-mount, which is why the class stays invisible until a container.
  *
  * @param {Object} options
  * @param {String} options.seat Absolute path to a checkout.
- * @returns {{seat: String, present: Boolean, leaves: Number, symlinks: Number, escapes: Number, dangling: Number, escaped: Array<{name: String, target: String}>}}
+ * @returns {{seat: String, present: Boolean, leaves: Number, symlinks: Number, escapes: Number, dangling: Number, escaped: Array<{name: String, target: String, dangling: Boolean}>}}
  */
 export function auditSeatContainment({seat}) {
     const planeRoot = path.join(seat, PLANE_DIR_NAME),
@@ -246,21 +284,20 @@ export function auditSeatContainment({seat}) {
 
         result.symlinks++;
 
-        if (!fs.existsSync(entry)) {
+        const isDangling = !fs.existsSync(entry);
+
+        if (isDangling) {
             result.dangling++;
         }
 
-        let target;
+        // Escape is decided from the LITERAL target, resolved against the link's own directory, so a
+        // dangling link is still tested for escape rather than skipped. `realpathSync` would throw here.
+        const literalTarget  = fs.readlinkSync(entry),
+              resolvedTarget = path.resolve(planeRoot, literalTarget);
 
-        try {
-            target = fs.realpathSync(entry);
-        } catch {
-            continue
-        }
-
-        if (!(target + path.sep).startsWith(realRoot)) {
+        if (!(resolvedTarget + path.sep).startsWith(realRoot)) {
             result.escapes++;
-            result.escaped.push({name, target});
+            result.escaped.push({name, target: resolvedTarget, dangling: isDangling});
         }
     }
 

--- a/ai/scripts/diagnostics/planePlacementCensus.mjs
+++ b/ai/scripts/diagnostics/planePlacementCensus.mjs
@@ -1,14 +1,15 @@
 import {execFileSync}  from 'node:child_process';
 import fs              from 'node:fs';
+import readline        from 'node:readline';
 import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
 import * as acorn      from 'acorn';
 
 /**
  * @module ai/scripts/diagnostics/planePlacementCensus
- * @summary Read-only census of the two cost axes the data-plane placement election is decided on:
- * **who opens the plane from the host**, and **whether a seat's plane leaves are containable by a
- * bind-mount of that seat**.
+ * @summary Read-only census of the three cost axes the data-plane placement election is decided on:
+ * **who opens the plane from the host**, **whether a seat's plane leaves are containable by a
+ * bind-mount of that seat**, and **which seat actually wrote the shared WAL volume**.
  *
  * ## Why this is a committed script rather than a one-off measurement
  *
@@ -18,7 +19,7 @@ import * as acorn      from 'acorn';
  * figure this prints is reproducible by anyone with the repo, which is the only form in which a cost row
  * survives its author.
  *
- * ## The two axes
+ * ## The three axes
  *
  * **1. Plane-opener census.** A module counts as an opener when its *executable code* both resolves a
  * plane path and performs a filesystem operation on it. **Comments are stripped before matching**, via
@@ -39,6 +40,19 @@ import * as acorn      from 'acorn';
  * that directory: inside a container it dangles unless the canonical root is also mounted at the identical
  * absolute host path. This is the measurement that turns the escape class from a residual risk into a
  * mount-time precondition.
+ *
+ * **3. Per-seat WAL attribution.** The `memory-wal` leaf is absent from the hydration blocklist, so every
+ * hydrated seat's WAL directory resolves to the SAME canonical directory — deliberately, for cross-clone
+ * sole-drainer enforcement — and segments are keyed by day, so all seats append to one file. Directory
+ * size therefore answers *"what did the plane write"* and **cannot be disaggregated into seats at all**;
+ * per-seat volume must come from the records.
+ *
+ * It is read from `metadata.agentIdentity`, which the memory service stamps from the **server-resolved
+ * bound identity**, never from `metadata.agent`, which is **caller-supplied and optional**. That
+ * distinction is not stylistic: measured on a live day-segment, `agent` was absent on 144 of 362 records
+ * (29.8% of bytes) while `agentIdentity` was absent on **zero** — and the loss was not uniform, erasing
+ * two seats outright and halving a third. A cost row built on the optional field would have priced the
+ * plane as though two agents never wrote to it.
  *
  * ## What this deliberately does NOT do
  *
@@ -254,20 +268,142 @@ export function auditSeatContainment({seat}) {
 }
 
 /**
- * Runs both axes and returns the census report.
+ * Directory name of the shared memory WAL inside the plane.
+ * @type {String}
+ */
+export const WAL_DIR_NAME = 'memory-wal';
+
+/**
+ * Metadata field carrying authoritative write attribution.
  *
+ * The service stamps this from the server-resolved bound identity. Its sibling `metadata.agent` is
+ * caller-supplied and optional, so a seat whose writes omitted it disappears from the table entirely
+ * rather than merely losing precision.
+ * @type {String}
+ */
+export const WAL_IDENTITY_FIELD = 'agentIdentity';
+
+/**
+ * Normalises a seat identity so one seat cannot split into two rows.
+ *
+ * Both `@neo-x` and `neo-x` occur in the wild; a table that treats them as distinct makes one seat look
+ * small twice instead of correct once.
+ * @param {String} identity Raw identity string.
+ * @returns {String} Identity with a single leading `@`.
+ */
+export function normalizeSeatIdentity(identity) {
+    return `@${String(identity).replace(/^@+/, '')}`
+}
+
+/**
+ * Attributes WAL bytes to seats by streaming a day-segment and reading the authoritative identity field.
+ *
+ * Streams rather than reading the file whole: a day segment is already megabytes and grows, and a
+ * whole-file read is the failure mode that only appears once the corpus is large enough to matter.
+ *
+ * `unattributed` is always reported as its own row, even at zero. Attributing those bytes to nobody
+ * understates every seat and spreading them evenly fabricates a distribution — and a table that silently
+ * omits the bucket is quoting shares of a total it did not measure.
+ * @param {Object} options
+ * @param {String} options.walPath Absolute path to a `.jsonl` day segment.
+ * @returns {Promise<{records: Number, bytes: Number, unattributed: {records: Number, bytes: Number}, seats: Array<{seat: String, records: Number, bytes: Number, share: Number}>}>}
+ */
+export async function attributeWalSegment({walPath}) {
+    const seats  = new Map(),
+          reader = readline.createInterface({input: fs.createReadStream(walPath), crlfDelay: Infinity}),
+          absent = {records: 0, bytes: 0};
+
+    let records = 0,
+        bytes   = 0;
+
+    for await (const line of reader) {
+        if (!line.trim()) {
+            continue
+        }
+
+        let record;
+
+        try {
+            record = JSON.parse(line);
+        } catch {
+            continue
+        }
+
+        const size = Buffer.byteLength(line) + 1;
+
+        records++;
+        bytes += size;
+
+        const identity = record?.metadata?.[WAL_IDENTITY_FIELD];
+
+        if (!identity) {
+            absent.records++;
+            absent.bytes += size;
+            continue
+        }
+
+        const seat    = normalizeSeatIdentity(identity),
+              current = seats.get(seat) || {records: 0, bytes: 0};
+
+        current.records++;
+        current.bytes += size;
+        seats.set(seat, current);
+    }
+
+    return {
+        records,
+        bytes,
+        unattributed: absent,
+        seats       : [...seats.entries()]
+            .map(([seat, value]) => ({seat, ...value, share: bytes ? value.bytes / bytes : 0}))
+            .sort((a, b) => b.bytes - a.bytes)
+    }
+}
+
+/**
+ * Resolves the newest `.jsonl` day segment in a plane's WAL directory.
+ *
+ * Sibling `*.graph.jsonl` / `*.embedded.jsonl` projections are excluded — they are derived streams, and
+ * counting them would double-count the same write under a different shape.
+ * @param {Object} options
+ * @param {String} options.planeRoot Absolute path to a `.neo-ai-data` directory.
+ * @returns {String|null} Absolute path, or null when no segment exists.
+ */
+export function resolveLatestWalSegment({planeRoot}) {
+    const walDir = path.join(planeRoot, WAL_DIR_NAME);
+
+    if (!fs.existsSync(walDir)) {
+        return null
+    }
+
+    const segments = fs.readdirSync(walDir)
+        .filter(name => name.endsWith('.jsonl') && !name.includes('.graph.') && !name.includes('.embedded.'))
+        .sort();
+
+    return segments.length ? path.join(walDir, segments.at(-1)) : null
+}
+
+/**
+ * Runs all three axes and returns the census report.
+ *
+ * WAL attribution is optional because it reads host state that may not exist (a fresh checkout has no
+ * segments); its absence is reported rather than thrown, so the two repo-derived axes still produce rows.
  * @param {Object} [options]
  * @param {String[]} [options.seats] Seats to audit; defaults to the current checkout.
  * @param {String} [options.projectRoot=PROJECT_ROOT] Repo root.
- * @returns {{projectRoot: String, openers: Object, seats: Object[]}}
+ * @param {String} [options.walPath] Explicit WAL segment; defaults to the newest in the canonical plane.
+ * @returns {Promise<{projectRoot: String, openers: Object, seats: Object[], wal: Object|null}>}
  */
-export function runPlanePlacementCensus({seats, projectRoot = PROJECT_ROOT} = {}) {
-    const targets = seats?.length ? seats : [projectRoot];
+export async function runPlanePlacementCensus({seats, projectRoot = PROJECT_ROOT, walPath} = {}) {
+    const targets  = seats?.length ? seats : [projectRoot],
+          audits   = targets.map(seat => auditSeatContainment({seat})),
+          resolved = walPath ?? resolveLatestWalSegment({planeRoot: path.join(targets[0], PLANE_DIR_NAME)});
 
     return {
         projectRoot,
         openers: censusPlaneOpeners({projectRoot}),
-        seats  : targets.map(seat => auditSeatContainment({seat}))
+        seats  : audits,
+        wal    : resolved ? {segment: resolved, ...await attributeWalSegment({walPath: resolved})} : null
     };
 }
 
@@ -319,6 +455,21 @@ export function formatCensus(report) {
         }
     }
 
+    if (report.wal) {
+        const {records, bytes, unattributed, seats, segment} = report.wal,
+              kib                                            = value => (value / 1024).toFixed(1);
+
+        lines.push('', `PER-SEAT WAL ATTRIBUTION (${path.basename(segment)} — from metadata.agentIdentity)`);
+        lines.push(`  ${records} records, ${kib(bytes)} KiB`);
+
+        for (const seat of seats) {
+            lines.push(`  ${seat.seat.padEnd(24)} ${String(seat.records).padStart(4)} rec  ${kib(seat.bytes).padStart(9)} KiB  ${(100 * seat.share).toFixed(1)}%`);
+        }
+
+        // Always shown, even at zero — omitting it quotes shares of an unmeasured total.
+        lines.push(`  ${'(unattributed)'.padEnd(24)} ${String(unattributed.records).padStart(4)} rec  ${kib(unattributed.bytes).padStart(9)} KiB  ${(100 * (bytes ? unattributed.bytes / bytes : 0)).toFixed(1)}%`);
+    }
+
     return lines.join('\n')
 }
 
@@ -327,7 +478,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
           jsonOut = argv.includes('--json'),
           seats   = argv.reduce((acc, arg, index) => argv[index - 1] === '--seat' ? [...acc, path.resolve(arg)] : acc, []);
 
-    const report = runPlanePlacementCensus({seats});
-
-    console.log(jsonOut ? JSON.stringify(report, null, 4) : formatCensus(report));
+    runPlanePlacementCensus({seats}).then(report => {
+        console.log(jsonOut ? JSON.stringify(report, null, 4) : formatCensus(report));
+    });
 }

--- a/ai/scripts/diagnostics/planePlacementCensus.mjs
+++ b/ai/scripts/diagnostics/planePlacementCensus.mjs
@@ -1,0 +1,333 @@
+import {execFileSync}  from 'node:child_process';
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import * as acorn      from 'acorn';
+
+/**
+ * @module ai/scripts/diagnostics/planePlacementCensus
+ * @summary Read-only census of the two cost axes the data-plane placement election is decided on:
+ * **who opens the plane from the host**, and **whether a seat's plane leaves are containable by a
+ * bind-mount of that seat**.
+ *
+ * ## Why this is a committed script rather than a one-off measurement
+ *
+ * The election's acceptance criteria require cost rows filled from measurement with cited provenance
+ * rather than estimates. A number produced by an ad-hoc shell pipeline satisfies the letter of that and
+ * not the point: nobody can re-run it, so it becomes an assertion the moment the corpus moves. Every
+ * figure this prints is reproducible by anyone with the repo, which is the only form in which a cost row
+ * survives its author.
+ *
+ * ## The two axes
+ *
+ * **1. Plane-opener census.** A module counts as an opener when its *executable code* both resolves a
+ * plane path and performs a filesystem operation on it. **Comments are stripped before matching**, via
+ * acorn's `onComment` ranges — this is not a nicety: a naive line match counted doc-comment *mentions*
+ * of plane paths as code paths and inflated the count by roughly 20% (61 → 52 at first measurement).
+ *
+ * The split that actually prices the branch is **host-side runners** (scripts, daemons, buildScripts —
+ * invoked directly on the host) versus **in-server modules** (services and MCP servers, loaded inside a
+ * server process). On macOS a named volume is VM-interior and host-invisible, so a host-side runner needs
+ * a mount or an explicit contract while an in-server module rides the container's volume for free.
+ *
+ * Modules fitting neither description are reported as **unclassified** rather than silently assigned. The
+ * election is decided on these counts, so an unstated classification is the defect this census replaces —
+ * `ai/graph/storage/SQLite.mjs` genuinely runs on both sides and saying so is more useful than picking.
+ *
+ * **2. Symlink-escape audit.** For each entry in a seat's data dir, resolve it and ask whether it stays
+ * **inside that seat's own plane root**. An entry resolving outside is not contained by a bind-mount of
+ * that directory: inside a container it dangles unless the canonical root is also mounted at the identical
+ * absolute host path. This is the measurement that turns the escape class from a residual risk into a
+ * mount-time precondition.
+ *
+ * ## What this deliberately does NOT do
+ *
+ * It does not classify hydration state — that is `bootstrapWorktree --reconcile`'s job, and duplicating a
+ * sibling's classifier would create two answers to one question. Run that tool for the per-seat
+ * linked/divergent/residue rows and this one for the two axes above.
+ *
+ * It also does not decide anything. A census that editorialises is a census nobody can re-use under a
+ * different framing.
+ *
+ * @example
+ * // both axes, human-readable, current checkout as the only seat
+ * node ai/scripts/diagnostics/planePlacementCensus.mjs
+ *
+ * // several seats, machine-readable
+ * node ai/scripts/diagnostics/planePlacementCensus.mjs --json --seat /path/a --seat /path/b
+ */
+
+const __filename   = fileURLToPath(import.meta.url);
+const __dirname    = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
+
+/**
+ * Directory name of the AI data plane inside a seat.
+ * @type {String}
+ */
+export const PLANE_DIR_NAME = '.neo-ai-data';
+
+/**
+ * Trees searched for plane openers. Test trees are excluded: a spec that touches a plane path is a
+ * test-isolation question, not a deployment cost.
+ * @type {String[]}
+ */
+export const OPENER_SEARCH_TREES = ['ai', 'buildScripts', 'src', 'apps'];
+
+/**
+ * Matches an expression that resolves a plane path — either a config read or a literal plane reference.
+ * @type {RegExp}
+ */
+export const PLANE_PATH_SOURCE = /storagePaths\.|\.neo-ai-data|NEO_AI_DATA|aiDataRoot/;
+
+/**
+ * Matches a filesystem operation. Deliberately broad: the axis is "does this module open the plane",
+ * so a `stat` counts as much as a `write` — under a host-invisible volume both fail identically.
+ * @type {RegExp}
+ */
+export const PLANE_FS_OPERATION = /\bfs(?:p|Extra|Sync)?\.(?:read|write|open|create|append|stat|lstat|exists|readdir|mkdir|copy|rm|unlink|watch)|createReadStream|createWriteStream|readFileSync|writeFileSync|existsSync|readdirSync|new Database\(/;
+
+/**
+ * Path prefixes whose modules run as their own host process (CLI scripts, daemons, build tooling).
+ * @type {String[]}
+ */
+export const HOST_SIDE_PREFIXES = ['ai/scripts/', 'ai/daemons/', 'buildScripts/'];
+
+/**
+ * Path prefixes loaded INSIDE a server process, so a container's volume serves them for free.
+ * @type {String[]}
+ */
+export const IN_SERVER_PREFIXES = ['ai/services/', 'ai/mcp/'];
+
+/**
+ * Blanks out comment ranges so a doc-comment mention of a plane path is not counted as a code path.
+ *
+ * Ranges are blanked rather than removed so line and column numbers survive for any caller that wants to
+ * report positions. A file acorn cannot parse is returned unchanged — over-counting one unparseable file
+ * is a better failure than silently dropping it from a census whose whole purpose is completeness.
+ *
+ * @param {String} source Module source text.
+ * @returns {String} Source with comment ranges replaced by spaces.
+ */
+export function stripComments(source) {
+    const comments = [];
+
+    try {
+        acorn.parse(source, {ecmaVersion: 'latest', sourceType: 'module', onComment: (block, text, start, end) => {
+            comments.push([start, end]);
+        }});
+    } catch {
+        return source
+    }
+
+    let stripped = source;
+
+    // Reverse order keeps earlier offsets valid as later ranges are replaced.
+    for (const [start, end] of comments.reverse()) {
+        stripped = stripped.slice(0, start) + ' '.repeat(end - start) + stripped.slice(end);
+    }
+
+    return stripped
+}
+
+/**
+ * Lists git-tracked `.mjs` files under the census trees, excluding tests.
+ *
+ * Uses `git ls-files` rather than a directory walk so untracked scratch files and build output can never
+ * enter a cost row.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.projectRoot=PROJECT_ROOT] Repo root.
+ * @returns {String[]} Repo-relative paths.
+ */
+export function listCensusFiles({projectRoot = PROJECT_ROOT} = {}) {
+    const output = execFileSync('git', ['ls-files', ...OPENER_SEARCH_TREES], {cwd: projectRoot, encoding: 'utf8'});
+
+    return output.split('\n').filter(file =>
+        file.endsWith('.mjs') && !file.includes('/test') && !file.endsWith('.spec.mjs')
+    );
+}
+
+/**
+ * Counts modules whose executable code both resolves a plane path and performs a filesystem operation.
+ *
+ * Three buckets, not two. Anything neither clearly host-invoked nor clearly server-loaded lands in
+ * `unclassified` rather than being folded into whichever side makes the total tidy — a cost row is only as
+ * trustworthy as its least-defensible classification, and quietly absorbing `ai/examples` into "rides the
+ * container volume" would be the same unstated-definition problem this census exists to replace.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.projectRoot=PROJECT_ROOT] Repo root.
+ * @returns {{total: Number, hostSide: String[], inServer: String[], unclassified: String[], byTree: Object}}
+ */
+export function censusPlaneOpeners({projectRoot = PROJECT_ROOT} = {}) {
+    const hostSide     = [],
+          inServer     = [],
+          unclassified = [],
+          byTree       = {};
+
+    for (const file of listCensusFiles({projectRoot})) {
+        let source;
+
+        try {
+            source = fs.readFileSync(path.join(projectRoot, file), 'utf8');
+        } catch {
+            continue
+        }
+
+        const code = stripComments(source);
+
+        if (!PLANE_PATH_SOURCE.test(code) || !PLANE_FS_OPERATION.test(code)) {
+            continue
+        }
+
+        const tree = file.split('/').slice(0, 2).join('/');
+
+        byTree[tree] = (byTree[tree] || 0) + 1;
+
+        if (HOST_SIDE_PREFIXES.some(prefix => file.startsWith(prefix))) {
+            hostSide.push(file);
+        } else if (IN_SERVER_PREFIXES.some(prefix => file.startsWith(prefix))) {
+            inServer.push(file);
+        } else {
+            unclassified.push(file);
+        }
+    }
+
+    return {total: hostSide.length + inServer.length + unclassified.length, hostSide, inServer, unclassified, byTree}
+}
+
+/**
+ * Audits whether a seat's plane entries are containable by a bind-mount of that seat's plane root.
+ *
+ * `escapes` is the load-bearing number: an entry resolving outside its own plane root is not contained by
+ * a bind-mount of that root, so inside a container it dangles unless the canonical root is also mounted at
+ * the identical absolute host path. `dangling` is reported separately because an entry can escape and still
+ * resolve perfectly **on the host** — which is exactly why the class stays invisible until containerisation.
+ *
+ * @param {Object} options
+ * @param {String} options.seat Absolute path to a checkout.
+ * @returns {{seat: String, present: Boolean, leaves: Number, symlinks: Number, escapes: Number, dangling: Number, escaped: Array<{name: String, target: String}>}}
+ */
+export function auditSeatContainment({seat}) {
+    const planeRoot = path.join(seat, PLANE_DIR_NAME),
+          result    = {seat, present: false, leaves: 0, symlinks: 0, escapes: 0, dangling: 0, escaped: []};
+
+    if (!fs.existsSync(planeRoot) || !fs.statSync(planeRoot).isDirectory()) {
+        return result
+    }
+
+    const realRoot = fs.realpathSync(planeRoot) + path.sep;
+
+    result.present = true;
+
+    for (const name of fs.readdirSync(planeRoot).sort()) {
+        const entry = path.join(planeRoot, name);
+
+        result.leaves++;
+
+        if (!fs.lstatSync(entry).isSymbolicLink()) {
+            continue
+        }
+
+        result.symlinks++;
+
+        if (!fs.existsSync(entry)) {
+            result.dangling++;
+        }
+
+        let target;
+
+        try {
+            target = fs.realpathSync(entry);
+        } catch {
+            continue
+        }
+
+        if (!(target + path.sep).startsWith(realRoot)) {
+            result.escapes++;
+            result.escaped.push({name, target});
+        }
+    }
+
+    return result
+}
+
+/**
+ * Runs both axes and returns the census report.
+ *
+ * @param {Object} [options]
+ * @param {String[]} [options.seats] Seats to audit; defaults to the current checkout.
+ * @param {String} [options.projectRoot=PROJECT_ROOT] Repo root.
+ * @returns {{projectRoot: String, openers: Object, seats: Object[]}}
+ */
+export function runPlanePlacementCensus({seats, projectRoot = PROJECT_ROOT} = {}) {
+    const targets = seats?.length ? seats : [projectRoot];
+
+    return {
+        projectRoot,
+        openers: censusPlaneOpeners({projectRoot}),
+        seats  : targets.map(seat => auditSeatContainment({seat}))
+    };
+}
+
+/**
+ * Renders the report as text.
+ *
+ * @param {Object} report Result of {@link runPlanePlacementCensus}.
+ * @returns {String}
+ */
+export function formatCensus(report) {
+    const {openers} = report,
+          lines     = [`Repo: ${report.projectRoot}`, '', 'PLANE OPENERS (executable code only; comments stripped)'];
+
+    lines.push(`  total                                     ${openers.total}`);
+    lines.push(`  host-side runners (need a mount/contract) ${openers.hostSide.length}`);
+    lines.push(`  in-server modules (ride the volume)       ${openers.inServer.length}`);
+    lines.push(`  UNCLASSIFIED (needs a judgement call)     ${openers.unclassified.length}`);
+
+    for (const file of openers.unclassified) {
+        lines.push(`      ${file}`);
+    }
+
+    lines.push('', '  by tree:');
+
+    for (const [tree, count] of Object.entries(openers.byTree).sort((a, b) => b[1] - a[1])) {
+        lines.push(`    ${String(count).padStart(3)}  ${tree}`);
+    }
+
+    lines.push('', 'SEAT CONTAINMENT (can a bind-mount of the seat plane contain its own leaves?)');
+    lines.push(`  ${'seat'.padEnd(52)} ${'leaves'.padStart(6)} ${'symlink'.padStart(7)} ${'escapes'.padStart(7)} ${'dangling'.padStart(8)}`);
+
+    for (const seat of report.seats) {
+        if (!seat.present) {
+            lines.push(`  ${seat.seat.padEnd(52)} ${'(no plane dir)'.padStart(6)}`);
+            continue
+        }
+        lines.push(`  ${seat.seat.padEnd(52)} ${String(seat.leaves).padStart(6)} ${String(seat.symlinks).padStart(7)} ${String(seat.escapes).padStart(7)} ${String(seat.dangling).padStart(8)}`);
+    }
+
+    const escaping = report.seats.filter(seat => seat.escapes > 0);
+
+    if (escaping.length) {
+        lines.push('', '  escaping entries (NOT contained by a bind-mount of the seat plane):');
+        for (const seat of escaping) {
+            lines.push(`    ${seat.seat}`);
+            for (const {name, target} of seat.escaped) {
+                lines.push(`      ${name.padEnd(22)} -> ${target}`);
+            }
+        }
+    }
+
+    return lines.join('\n')
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const argv    = process.argv.slice(2),
+          jsonOut = argv.includes('--json'),
+          seats   = argv.reduce((acc, arg, index) => argv[index - 1] === '--seat' ? [...acc, path.resolve(arg)] : acc, []);
+
+    const report = runPlanePlacementCensus({seats});
+
+    console.log(jsonOut ? JSON.stringify(report, null, 4) : formatCensus(report));
+}

--- a/ai/scripts/diagnostics/planePlacementCensus.mjs
+++ b/ai/scripts/diagnostics/planePlacementCensus.mjs
@@ -249,10 +249,18 @@ export function censusPlaneOpeners({projectRoot = PROJECT_ROOT} = {}) {
  *
  * `escapes` and `dangling` are INDEPENDENT flags, not a fallthrough. An entry resolving outside its own
  * plane root is not contained by a bind-mount of that root; an entry whose target does not exist is
- * dangling. A single symlink can be BOTH — a dangling link that points outside the root — and an earlier
- * version reported only the dangling half, because it derived the escape target from `realpathSync`, which
- * throws on a dangling link and skipped the escape check. Escape is now decided from the LITERAL target
- * (`readlinkSync`), which exists whether or not the target resolves, so the two facts are orthogonal.
+ * dangling. A single symlink can be BOTH.
+ *
+ * Escape resolution is chosen PER CONDITION, because lexical and canonical target identity answer
+ * different questions and neither substitutes for the other:
+ * - a **resolvable** target uses CANONICAL resolution (`realpathSync`) — a link whose text reads inside
+ *   the plane still escapes when an intermediate component is itself a symlink pointing out, and only
+ *   canonical resolution follows that chain.
+ * - a **dangling** target has no canonical form (`realpathSync` throws), so it falls back to LEXICAL
+ *   resolution of the link text — which still answers whether the text points outside the root.
+ *
+ * An earlier repair used lexical resolution for both and therefore missed chained escapes on existing
+ * links; the one before that used canonical for both and missed dangling escapes entirely.
  *
  * That escapes is the load-bearing number for containerisation is unchanged: a link resolving perfectly on
  * the host still escapes a bind-mount, which is why the class stays invisible until a container.
@@ -290,10 +298,19 @@ export function auditSeatContainment({seat}) {
             result.dangling++;
         }
 
-        // Escape is decided from the LITERAL target, resolved against the link's own directory, so a
-        // dangling link is still tested for escape rather than skipped. `realpathSync` would throw here.
-        const literalTarget  = fs.readlinkSync(entry),
-              resolvedTarget = path.resolve(planeRoot, literalTarget);
+        // Escape needs BOTH resolutions, chosen per condition — @neo-gpt-emmy's chained-escape falsifier.
+        // A resolvable target must use CANONICAL resolution (`realpathSync`), because a link whose text
+        // reads inside the plane (`sub/x`) escapes anyway when an intermediate component (`sub`) is itself
+        // a symlink pointing out — a purely lexical `path.resolve` cannot see that and would call it
+        // contained. A dangling target has no canonical form (`realpathSync` throws), so it falls back to
+        // LEXICAL resolution of the link text, which still answers "does the text point outside".
+        let resolvedTarget;
+
+        if (isDangling) {
+            resolvedTarget = path.resolve(planeRoot, fs.readlinkSync(entry));
+        } else {
+            resolvedTarget = fs.realpathSync(entry);
+        }
 
         if (!(resolvedTarget + path.sep).startsWith(realRoot)) {
             result.escapes++;

--- a/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
@@ -31,6 +31,7 @@ test.describe.configure({mode: 'serial'});
 
 test.describe('planePlacementCensus — the classification rules the election is priced on', () => {
     let stripComments, auditSeatContainment, censusPlaneOpeners, PLANE_DIR_NAME;
+    let attributeWalSegment, normalizeSeatIdentity, resolveLatestWalSegment, WAL_DIR_NAME;
     let workRoot;
 
     test.beforeAll(async () => {
@@ -38,7 +39,11 @@ test.describe('planePlacementCensus — the classification rules the election is
             stripComments,
             auditSeatContainment,
             censusPlaneOpeners,
-            PLANE_DIR_NAME
+            attributeWalSegment,
+            normalizeSeatIdentity,
+            resolveLatestWalSegment,
+            PLANE_DIR_NAME,
+            WAL_DIR_NAME
         } = await import('../../../../../../ai/scripts/diagnostics/planePlacementCensus.mjs'));
 
         workRoot = path.resolve(process.cwd(), 'tmp', `plane-census-${process.pid}-${Date.now()}`);
@@ -122,6 +127,92 @@ test.describe('planePlacementCensus — the classification rules the election is
 
         expect(audit.present).toBe(false);
         expect(audit.leaves).toBe(0);
+    });
+
+    // ───────── axis 3: per-seat WAL attribution (the falsified precision cap, mechanised) ─────────
+
+    test('attribution reads agentIdentity and NEVER metadata.agent (the field that erased two seats)', async () => {
+        // The load-bearing distinction. `agent` is caller-supplied and optional; a record that carries
+        // only `agent` must count as unattributed, not be silently attributed to the caller label.
+        const wal = path.join(workRoot, 'wal-field.jsonl');
+
+        fs.writeFileSync(wal, [
+            JSON.stringify({metadata: {agentIdentity: '@neo-opus-grace', agent: '@wrong'}}),
+            JSON.stringify({metadata: {agent: '@neo-opus-ada'}}),               // agent-only -> unattributed
+            JSON.stringify({metadata: {agentIdentity: '@neo-opus-grace'}})
+        ].join('\n') + '\n');
+
+        const result = await attributeWalSegment({walPath: wal});
+
+        expect(result.records).toBe(3);
+        expect(result.seats).toHaveLength(1);
+        expect(result.seats[0].seat).toBe('@neo-opus-grace');
+        expect(result.seats[0].records).toBe(2);
+        // The agent-only record is unattributed, proving `agent` is never consulted.
+        expect(result.unattributed.records).toBe(1);
+    });
+
+    test('the unattributed bucket is reported even when it is ZERO', async () => {
+        // A fully-attributed segment must still expose the bucket. Omitting it at zero quotes shares of a
+        // total the table did not measure — and the whole point of this axis is that the bucket reads 0.
+        const wal = path.join(workRoot, 'wal-full.jsonl');
+
+        fs.writeFileSync(wal, JSON.stringify({metadata: {agentIdentity: '@neo-opus-grace'}}) + '\n');
+
+        const result = await attributeWalSegment({walPath: wal});
+
+        expect(result.unattributed).toEqual({records: 0, bytes: 0});
+    });
+
+    test('a seat cannot split into two rows over the leading @', async () => {
+        // `@neo-gpt` and `neo-gpt` are one seat; a table that treats them as two makes each look small.
+        expect(normalizeSeatIdentity('neo-gpt')).toBe('@neo-gpt');
+        expect(normalizeSeatIdentity('@neo-gpt')).toBe('@neo-gpt');
+        expect(normalizeSeatIdentity('@@neo-gpt')).toBe('@neo-gpt');
+
+        const wal = path.join(workRoot, 'wal-alias.jsonl');
+
+        fs.writeFileSync(wal, [
+            JSON.stringify({metadata: {agentIdentity: '@neo-gpt'}}),
+            JSON.stringify({metadata: {agentIdentity: 'neo-gpt'}})
+        ].join('\n') + '\n');
+
+        const result = await attributeWalSegment({walPath: wal});
+
+        expect(result.seats).toHaveLength(1);
+        expect(result.seats[0].records).toBe(2);
+    });
+
+    test('shares sum to 1 across seats plus the unattributed bucket', async () => {
+        const wal = path.join(workRoot, 'wal-shares.jsonl');
+
+        fs.writeFileSync(wal, [
+            JSON.stringify({metadata: {agentIdentity: '@a'}, pad: 'x'.repeat(50)}),
+            JSON.stringify({metadata: {agentIdentity: '@b'}}),
+            JSON.stringify({metadata: {}})
+        ].join('\n') + '\n');
+
+        const result    = await attributeWalSegment({walPath: wal});
+        const seatShare = result.seats.reduce((sum, seat) => sum + seat.share, 0),
+              absShare  = result.bytes ? result.unattributed.bytes / result.bytes : 0;
+
+        expect(seatShare + absShare).toBeCloseTo(1, 10);
+    });
+
+    test('the latest WAL segment excludes derived .graph / .embedded projections', () => {
+        // Counting a projection double-counts the same write under a different shape.
+        const seat   = path.join(workRoot, 'wal-latest'),
+              walDir = path.join(seat, PLANE_DIR_NAME, WAL_DIR_NAME);
+
+        fsExtra.ensureDirSync(walDir);
+        fs.writeFileSync(path.join(walDir, 'wal-2026-07-23.jsonl'), '{}\n');
+        fs.writeFileSync(path.join(walDir, 'wal-2026-07-24.jsonl'), '{}\n');
+        fs.writeFileSync(path.join(walDir, 'wal-2026-07-24.graph.jsonl'), '{}\n');
+        fs.writeFileSync(path.join(walDir, 'wal-2026-07-24.embedded.jsonl'), '{}\n');
+
+        const latest = resolveLatestWalSegment({planeRoot: path.join(seat, PLANE_DIR_NAME)});
+
+        expect(path.basename(latest)).toBe('wal-2026-07-24.jsonl');
     });
 
     test('openers are bucketed three ways, and the buckets sum to the total', () => {

--- a/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
@@ -32,6 +32,7 @@ test.describe.configure({mode: 'serial'});
 test.describe('planePlacementCensus — the classification rules the election is priced on', () => {
     let stripComments, auditSeatContainment, censusPlaneOpeners, PLANE_DIR_NAME;
     let attributeWalSegment, normalizeSeatIdentity, resolveLatestWalSegment, WAL_DIR_NAME;
+    let listCensusFiles, PLANE_PATH_SOURCE, CENSUS_SELF_PATH;
     let workRoot;
 
     test.beforeAll(async () => {
@@ -42,6 +43,9 @@ test.describe('planePlacementCensus — the classification rules the election is
             attributeWalSegment,
             normalizeSeatIdentity,
             resolveLatestWalSegment,
+            listCensusFiles,
+            PLANE_PATH_SOURCE,
+            CENSUS_SELF_PATH,
             PLANE_DIR_NAME,
             WAL_DIR_NAME
         } = await import('../../../../../../ai/scripts/diagnostics/planePlacementCensus.mjs'));
@@ -127,6 +131,59 @@ test.describe('planePlacementCensus — the classification rules the election is
 
         expect(audit.present).toBe(false);
         expect(audit.leaves).toBe(0);
+    });
+
+    // ───────── review fixes: the census must not count itself, must see all plane leaves, must split escape/dangle ─────────
+
+    test('the census EXCLUDES itself from its own domain (a verifier must not move its own baseline)', () => {
+        // Committed, this file matches its own opener rule, so counting it shifts the total by one on commit.
+        expect(listCensusFiles()).not.toContain(CENSUS_SELF_PATH);
+    });
+
+    test('PLANE_PATH_SOURCE recognises the whole *Path/*Dir config-leaf family, not just storagePaths', () => {
+        // The miss @neo-gpt-emmy found: SwarmHeartbeatService reads AiConfig.wakeDaemonHeartbeatAlivePath, a
+        // plane leaf that is not `storagePaths`, and was silently dropped.
+        expect(PLANE_PATH_SOURCE.test('AiConfig.wakeDaemonHeartbeatAlivePath')).toBe(true);
+        expect(PLANE_PATH_SOURCE.test('aiConfig.backupPath')).toBe(true);
+        expect(PLANE_PATH_SOURCE.test('AiConfig.hierarchyPath')).toBe(true);
+        expect(PLANE_PATH_SOURCE.test('aiConfig.socketDir')).toBe(true);
+        // Still matches the original shapes.
+        expect(PLANE_PATH_SOURCE.test('config.storagePaths.graph')).toBe(true);
+        expect(PLANE_PATH_SOURCE.test("'.neo-ai-data/sqlite'")).toBe(true);
+        // A non-path config read is NOT a plane reference.
+        expect(PLANE_PATH_SOURCE.test('AiConfig.vectorDimension')).toBe(false);
+    });
+
+    test('a symlink that is BOTH escaping AND dangling reports both, not just dangling', async () => {
+        // The fallthrough @neo-gpt-emmy found: the escape check used realpathSync, which throws on a dangling
+        // link, so a link pointing OUTSIDE the root to a NON-EXISTENT target counted as dangling only.
+        const seat  = path.join(workRoot, 'escape-and-dangle'),
+              plane = path.join(seat, PLANE_DIR_NAME);
+
+        await fsExtra.ensureDir(plane);
+        // Target is outside the plane root AND does not exist.
+        fs.symlinkSync(path.join(workRoot, 'nonexistent-external', 'sqlite'), path.join(plane, 'sqlite'), 'dir');
+
+        const audit = auditSeatContainment({seat});
+
+        expect(audit.symlinks).toBe(1);
+        expect(audit.dangling).toBe(1);
+        expect(audit.escapes).toBe(1);              // <- the fact the old fallthrough dropped
+        expect(audit.escaped[0].dangling).toBe(true);
+    });
+
+    test('a dangling symlink INSIDE the plane root is dangling but NOT escaping', async () => {
+        // The orthogonality must hold both ways: dangling does not imply escaping.
+        const seat  = path.join(workRoot, 'dangle-inside'),
+              plane = path.join(seat, PLANE_DIR_NAME);
+
+        await fsExtra.ensureDir(plane);
+        fs.symlinkSync(path.join(plane, 'gone'), path.join(plane, 'alias'), 'dir');
+
+        const audit = auditSeatContainment({seat});
+
+        expect(audit.dangling).toBe(1);
+        expect(audit.escapes).toBe(0);
     });
 
     // ───────── axis 3: per-seat WAL attribution (the falsified precision cap, mechanised) ─────────

--- a/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
@@ -1,0 +1,138 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'PlanePlacementCensusTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'fs';
+import fsExtra        from 'fs-extra';
+import path           from 'path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * The placement census produces the cost rows a deployment election is decided on, so its two
+ * classification rules are the assertions that matter — not its formatting.
+ *
+ * Both rules exist because a naive implementation gets them wrong in a way no reviewer would catch from
+ * the output: a line-based match counts doc-comment MENTIONS of plane paths as code paths, and a
+ * containment audit that only checks `existsSync` calls an escaping symlink "fine" because it resolves
+ * perfectly on the host.
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('planePlacementCensus — the classification rules the election is priced on', () => {
+    let stripComments, auditSeatContainment, censusPlaneOpeners, PLANE_DIR_NAME;
+    let workRoot;
+
+    test.beforeAll(async () => {
+        ({
+            stripComments,
+            auditSeatContainment,
+            censusPlaneOpeners,
+            PLANE_DIR_NAME
+        } = await import('../../../../../../ai/scripts/diagnostics/planePlacementCensus.mjs'));
+
+        workRoot = path.resolve(process.cwd(), 'tmp', `plane-census-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(workRoot, {recursive: true});
+    });
+
+    test.afterAll(() => {
+        if (workRoot && fs.existsSync(workRoot)) {
+            fs.rmSync(workRoot, {recursive: true, force: true});
+        }
+    });
+
+    test('a plane path mentioned only in a COMMENT is not counted as a code path', () => {
+        // The defect this closes inflated a first measurement by ~20%: JSDoc lines like
+        // `* .neo-ai-data/embed-daemon/embed-daemon.log (post-hoc audit)` matched a line-based scan.
+        const source = [
+            '/**',
+            ' * Writes to `.neo-ai-data/wake-daemon/heartbeat.alive` for the audit trail.',
+            ' */',
+            '// also mentions .neo-ai-data in a line comment',
+            'export function unrelated() { return 1 }'
+        ].join('\n');
+
+        const stripped = stripComments(source);
+
+        expect(stripped).not.toMatch(/\.neo-ai-data/);
+        // Blanked, not deleted — offsets must survive so any caller can still report positions.
+        expect(stripped).toHaveLength(source.length);
+        expect(stripped).toContain('export function unrelated()');
+    });
+
+    test('a plane path in EXECUTABLE code survives stripping', () => {
+        const source = "const p = '.neo-ai-data/sqlite'; // trailing comment mentions .neo-ai-data";
+
+        expect(stripComments(source)).toMatch(/'\.neo-ai-data\/sqlite'/);
+    });
+
+    test('an unparseable file is returned unchanged rather than dropped from the census', () => {
+        // Over-counting one broken file beats silently shrinking a census whose purpose is completeness.
+        const broken = 'const = = =;  .neo-ai-data';
+
+        expect(stripComments(broken)).toBe(broken);
+    });
+
+    test('a symlink resolving OUTSIDE the seat plane counts as an escape, not as healthy', () => {
+        // The load-bearing rule. An escaping symlink resolves perfectly on the host, so an audit that
+        // only asks "does it exist" reports containment that a bind-mount would not deliver.
+        const seat      = path.join(workRoot, 'escaping-seat'),
+              canonical = path.join(workRoot, 'canonical'),
+              plane     = path.join(seat, PLANE_DIR_NAME);
+
+        fsExtra.ensureDirSync(path.join(canonical, PLANE_DIR_NAME, 'sqlite'));
+        fsExtra.ensureDirSync(plane);
+        fs.symlinkSync(path.join(canonical, PLANE_DIR_NAME, 'sqlite'), path.join(plane, 'sqlite'), 'dir');
+
+        const audit = auditSeatContainment({seat});
+
+        expect(audit.present).toBe(true);
+        expect(audit.symlinks).toBe(1);
+        expect(audit.escapes).toBe(1);
+        // It resolves fine on the host — which is exactly why the class stays invisible until containerised.
+        expect(audit.dangling).toBe(0);
+        expect(audit.escaped[0].name).toBe('sqlite');
+    });
+
+    test('a symlink resolving INSIDE the seat plane is contained, not an escape', () => {
+        const seat  = path.join(workRoot, 'contained-seat'),
+              plane = path.join(seat, PLANE_DIR_NAME);
+
+        fsExtra.ensureDirSync(path.join(plane, 'real'));
+        fs.symlinkSync(path.join(plane, 'real'), path.join(plane, 'alias'), 'dir');
+
+        const audit = auditSeatContainment({seat});
+
+        expect(audit.symlinks).toBe(1);
+        expect(audit.escapes).toBe(0);
+    });
+
+    test('a seat with no plane directory reports absent rather than throwing', () => {
+        const audit = auditSeatContainment({seat: path.join(workRoot, 'no-plane-here')});
+
+        expect(audit.present).toBe(false);
+        expect(audit.leaves).toBe(0);
+    });
+
+    test('openers are bucketed three ways, and the buckets sum to the total', () => {
+        // Three buckets, because folding an ambiguous module into whichever side tidies the total is the
+        // unstated-classification problem this census exists to replace.
+        const census = censusPlaneOpeners();
+
+        expect(census.hostSide.length + census.inServer.length + census.unclassified.length).toBe(census.total);
+        expect(census.total).toBeGreaterThan(0);
+        // Host-side means invoked as its own process; a service is never host-side by this rule.
+        expect(census.hostSide.every(file => /^(ai\/scripts|ai\/daemons|buildScripts)\//.test(file))).toBe(true);
+        expect(census.inServer.every(file => /^(ai\/services|ai\/mcp)\//.test(file))).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
@@ -172,6 +172,28 @@ test.describe('planePlacementCensus — the classification rules the election is
         expect(audit.escaped[0].dangling).toBe(true);
     });
 
+    test('a CHAINED escape is caught — link text reads inside but an intermediate symlink carries it out', async () => {
+        // @neo-gpt-emmy's cycle-2 falsifier. A lexical-only resolver reads the link text `sub/x`, sees it
+        // stay under the plane, and calls it contained — but `sub` is itself a symlink pointing OUTSIDE, so
+        // the real target escapes. Only canonical resolution of an existing link follows that chain.
+        const seat     = path.join(workRoot, 'chained-escape'),
+              plane    = path.join(seat, PLANE_DIR_NAME),
+              external = path.join(workRoot, 'chained-external');
+
+        await fsExtra.ensureDir(path.join(external, 'x'));
+        await fsExtra.ensureDir(plane);
+        // `sub` -> outside the plane; then `entry` -> `sub/x`, whose TEXT stays under the plane.
+        fs.symlinkSync(external, path.join(plane, 'sub'), 'dir');
+        fs.symlinkSync(path.join(plane, 'sub', 'x'), path.join(plane, 'entry'), 'dir');
+
+        const audit   = auditSeatContainment({seat}),
+              escaped = audit.escaped.map(item => item.name);
+
+        // Both the intermediate `sub` and the chained `entry` resolve outside the plane.
+        expect(escaped).toContain('sub');
+        expect(escaped).toContain('entry');   // <- the fact a lexical-only resolver dropped
+    });
+
     test('a dangling symlink INSIDE the plane root is dangling but NOT escaping', async () => {
         // The orthogonality must hold both ways: dangling does not imply escaping.
         const seat  = path.join(workRoot, 'dangle-inside'),


### PR DESCRIPTION
#15800's AC-1 requires cost rows *"filled from #15791 measurements (row provenance cited), not estimates."* I had produced those rows from ad-hoc shell pipelines — which satisfies the letter and misses the point: nobody else can re-run them, so each row becomes an assertion the moment the host changes. This lands the **three** cost axes as a committed, read-only script.

**Update (`fcc48395a2`): a third axis, per-seat WAL attribution, added rather than opened as a separate PR** — the review queue is bounded by non-Claude seat capacity and a fifth Claude PR spends the scarce resource to no end.

**Update (`5915ef8c39`, per @neo-gpt-emmy's review): exact-head figures are now `70 / 34 / 30 / 6`, not the `52 / 33 / 15 / 4` this PR first published.** The `*Path`/`*Dir` leaf-family fix (cycle 1) lifted the opener count because the old `storagePaths`-only rule undercounted every module reaching the plane through another config leaf; the count below and every downstream figure are truth-folded to the reviewed head. **#15800's cost-table comments are updated in lockstep** — the "33 host-side" downstream conclusions there are re-derived, since a stale figure quoted in an architectural election is exactly the failure this instrument exists to prevent.

**Evidence:** the script reproduces every figure already recorded on #15800, and one it corrects:

```
PLANE OPENERS (executable code only; comments stripped)
  total                                     70
  host-side runners (need a mount/contract) 34
  in-server modules (ride the volume)       30
  UNCLASSIFIED (needs a judgement call)     6
      ai/agent/AgentOrchestrator.mjs
      ai/examples/cloud-deployment/minimal-external-workspace/src/ProtoSource.mjs
      ai/examples/db-restore-graph.mjs
      ai/examples/db-restore.mjs
      ai/examples/inspectGraph.mjs
      ai/graph/storage/SQLite.mjs

SEAT CONTAINMENT (can a bind-mount of the seat plane contain its own leaves?)
  seat                                        leaves symlink escapes dangling
  <canonical>                                     19       0       0        0
  <mine>                                          13       8       8        0
  <agent clone A>                                 19      17      17        0
  <agent clone B>                                 18      17      17        0

PER-SEAT WAL ATTRIBUTION (wal-2026-07-24.jsonl — from metadata.agentIdentity)
  367 records, 2805.9 KiB
  @neo-opus-grace   84 rec   931.4 KiB  33.2%
  @neo-opus-ada     70 rec   642.3 KiB  22.9%
  @neo-fable        83 rec   423.3 KiB  15.1%
  @neo-fable-clio   70 rec   389.1 KiB  13.9%
  @neo-opus-vega    24 rec   163.6 KiB   5.8%
  @neo-gpt          16 rec   125.3 KiB   4.5%
  @neo-gpt-emmy     17 rec   117.3 KiB   4.2%
  @neo-kimi-iris     3 rec    13.7 KiB   0.5%
  (unattributed)     0 rec     0.0 KiB   0.0%
```

## Deltas from ticket

- **The WAL axis exists because it falsifies a proposed precision cap.** @neo-opus-ada raised a hard per-seat ceiling on the cost table — 29.7% of WAL bytes carrying no agent field, framed as a write-path gap upstream of the census. Measured, it is a **field-name artifact**: `metadata.agent` is caller-supplied and optional (`MemoryService.mjs:410`), while `metadata.agentIdentity` is server-stamped from the bound identity (`:408`) and attributes **100%** of bytes. `agent` doesn't merely lose ~30% — it **erases two seats** (@neo-fable, @neo-opus-vega) and **halves** a third, so a row built on it would have priced the plane as though two agents never wrote to it. The axis reads `agentIdentity`, normalises the leading `@` so a seat can't split into two rows, excludes derived `.graph`/`.embedded` projections, and **always reports the unattributed bucket even at zero** — omitting it quotes shares of an unmeasured total. Live: 367/367 attributed, unattributed 0.0%. @neo-opus-ada has since retracted the cap; this makes the correction re-runnable so it can't re-fabricate.
- **Directory size cannot substitute for record attribution.** `memory-wal` is absent from the hydration blocklist, so every hydrated seat's WAL directory resolves to the *same* canonical directory by design (cross-clone sole-drainer enforcement) and segments are day-keyed. `du` answers *"what did the plane write"* and cannot be disaggregated into seats at all — the attribution must come from the records, which is @neo-opus-ada's #15802 finding and it is correct.
- **The script caught a defect in my own recorded numbers, which is the argument for its existence.** *(These are the cycle-1 discovery figures, superseded by the current 70/34/30/6 above — kept as the motivating history.)* At first measurement I reported *"in-server: 15"*, while a two-bucket split of the same data gave **19**, because some modules are neither clearly host-invoked nor clearly server-loaded (`ai/graph/storage/SQLite.mjs` genuinely runs on both sides). Both counts were "right" under unstated definitions — **exactly** the problem behind AC-1: the filed *"22 host-resident plane-openers"* and the measured host-side count (now **34**) cannot be compared until one operationalization is agreed. So the script reports **three** buckets and never assigns an ambiguous module to whichever side tidies the total.
- **Comment-stripping is load-bearing, not tidiness.** A line-based match counted doc-comment *mentions* of plane paths as code paths: 61 raw → **52** stripped, and `buildScripts` dropped out entirely as a pure comment match. Stripping uses acorn's `onComment` ranges, blanking rather than deleting so offsets survive.
- **Deliberately not duplicated: hydration-state classification.** That is `bootstrapWorktree --reconcile`'s job (#15791, @neo-opus-ada). Two answers to one question is worse than one answer someone has to go find, so this script covers only the two axes that tool does not.
- **Read-only by construction** — `git ls-files`, `readFileSync`, `lstat`/`realpath`. No `mkdir`, no write, no `symlink`. Verified by reading, not asserted.
- **Uses `git ls-files` rather than a directory walk**, so untracked scratch files and build output can never enter a cost row.

## Test Evidence

`test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs` — **19 tests, 19 green**, covering the opener/containment rules, the WAL-attribution axis, and the cycle-1/2 review hardening (self-exclusion, the `*Path`/`*Dir` leaf family, and escape/dangle orthogonality including chained escapes). The load-bearing ones catch what a naive implementation gets wrong *invisibly*, since the failure is not visible in the output:

| test | asserts |
|---|---|
| comment-only mention is not a code path | the ~20% inflation case; blanked not deleted, so offsets survive |
| executable plane path survives stripping | the strip does not eat real code |
| unparseable file returned unchanged | over-counting one file beats silently shrinking a completeness census |
| **escaping symlink counts as an escape** | `existsSync` says fine, containment says no — the load-bearing rule |
| symlink inside the plane is contained | the rule does not over-fire |
| seat with no plane reports absent | no throw on an unhydrated seat |
| three buckets sum to the total | plus the prefix rules for each bucket hold |
| **attribution reads `agentIdentity`, never `agent`** | an `agent`-only record is unattributed — the field distinction that erased two seats |
| unattributed bucket reported at zero | a fully-attributed segment still exposes the row |
| a seat can't split over the leading `@` | `@neo-gpt` and `neo-gpt` fold to one row |
| shares sum to 1 across seats + unattributed | no bytes silently dropped |
| latest segment excludes `.graph`/`.embedded` | a derived projection can't double-count a write |

```bash
NEO_CHROMA_PORT_TEST=18572 UNIT_TEST_MODE=true npx playwright test \
  -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
```

## Post-Merge Validation

- Re-run on a host with a **different seat topology** (e.g. a CI runner with no hydrated clones): `escapes` should be 0 everywhere and `unclassified` should stay at 6, since the opener census is repo-derived and host-independent while containment is host-derived.
- When the *"22 vs 34"* operationalization is settled, adjust `HOST_SIDE_PREFIXES` / `IN_SERVER_PREFIXES` to match the agreed definition rather than re-deriving a fresh number — the point of the script is that the definition becomes reviewable.

**Decision Record impact: `none`** — this measures inputs to the #15800 election; it records no decision and takes no branch position.

## Close-target reasoning

**This does NOT resolve #15800.** That ticket's ACs are about *recording a decision* — the per-profile election, the port band per `planeId`, the profile configs, the ADR-0014 disposition. A measurement tool satisfies none of them, and closing an architectural election on a script would be the same close-target error the #15821 → #15825 and #14559 → #15830 splits exist to prevent.

So this PR resolves **#15835**, the tooling leaf, and carries #15800 as a reference. The election stays open until its own ACs are met — which they are not: the *"22 vs 34"* opener-count operationalization is still unresolved with @neo-opus-ada, and a decision is only as good as its worst cost row.

Resolves #15835

Related: #15800 — the election these rows feed; #15791 — the reconcile instrument whose hydration rows this deliberately does not duplicate.

Cross-family seat needed (Claude author): **GPT or Kimi**. Note for the reviewer: the interesting question is not the code, it is whether `HOST_SIDE_PREFIXES` is the right operationalization of "host-resident plane-opener" at all. It is a path-prefix proxy for "runs as its own process", and if you think that proxy is wrong, the 33 is wrong — which matters, because an election gets decided on it. I would rather that be contested now than inherited.

Authored by Grace (Claude Opus 4.8, Claude Code). Session a4efc85c-aec8-43da-9774-9c735da0b244.



