### PR TITLE
fix(build): match the B4 config root by shape, not by two literal names (#15838)

### DIFF
--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -38,16 +38,18 @@ const DB_PATH_LEAVES = '(?:storagePaths|database|collections|logPath)';
  * measured against this file's own exported pattern rather than reasoned about:
  *
  *   1. An ALIASED binding walked straight through. `mailboxAiConfig.storagePaths.graph = dbPath` was not
- *      flagged, and three spec files (14 occurrences) mutate Class-A leaves that way today.
- *   2. Far worse: the approved `aiConfig` -> `AiConfig` PascalCase normalization (1,526 occurrences across
- *      198 files) would have made this lint match NOTHING in the repo — while the sweep's own acceptance
- *      criterion read "check-aiconfig-test-mutation must stay green." Green because inert. A fail-build
- *      B4 guard would have been retired by a refactor that certified the retirement as success.
+ *      flagged, and files bound this way (`mailboxAiConfig`, `mirrorAiConfig`) mutate Class-A leaves today.
+ *   2. Far worse: a repo-wide `aiConfig` -> `AiConfig` PascalCase normalization (1,526 occurrences across
+ *      198 files) would have made a case-sensitive literal anchor match NOTHING — while the rename's own
+ *      "the mutation lint must stay green" criterion certified that inert gate as success. A fail-build
+ *      B4 guard retired by a refactor whose acceptance criteria prove the retirement.
  *
  * So any identifier ENDING in `Config` counts as a config root: `aiConfig`, `AiConfig`, `mailboxAiConfig`,
- * `Memory_Config`, and whatever the next rename produces. `aiConfigDefaults` still does not match — the
- * trailing `\b` requires `Config` to end the identifier — which preserves prior behaviour for the separate
- * TIER1 defaults module.
+ * `Memory_Config`, `$Config`, and whatever the next rename produces. The root boundary is a
+ * lookbehind/lookahead pair rather than `\b`, because `\b` cannot sit before a `$`-leading identifier and
+ * would let `$Config.…` evade a grammar that admits a leading `$`. `aiConfigDefaults` still does not match —
+ * the trailing boundary requires `Config` to END the identifier — preserving prior behaviour for the
+ * separate TIER1 defaults module.
  *
  * This deliberately accepts FALSE POSITIVES on unrelated `*Config` objects that assign a Class-A leaf.
  * That is the correct trade for a safety-critical gate: a false positive costs one escape marker plus a
@@ -57,13 +59,15 @@ const DB_PATH_LEAVES = '(?:storagePaths|database|collections|logPath)';
 const CONFIG_ROOT = '[A-Za-z_$][\\w$]*Config';
 
 export const DB_PATH_MUTATION = new RegExp(
-    `\\b${CONFIG_ROOT}\\b[\\w.$?[\\]'"\`-]*` +                                  // a config-shaped root, then any path chars (incl. `?.`)
+    // Root boundary is a lookbehind/lookahead pair, NOT `\\b`: `\\b` fails before a `$`-leading identifier
+    // (`$` is a non-word char), so `$Config.storagePaths.graph = x` evaded a grammar that advertises `$` as a
+    // valid leading char. `(?<![\\w$])` / `(?![\\w$])` anchor on "not inside another identifier", which is the
+    // real intent and closes that divergence in the fail-SAFE direction (catch it; a false positive costs one
+    // escape marker, a false negative is the orphan incident).
+    `(?<![\\w$])${CONFIG_ROOT}(?![\\w$])[\\w.$[\\]'"\`-]*` +                     // a config-shaped root, then any path chars
     `(?:\\.${DB_PATH_LEAVES}\\b|\\[\\s*['"\`]${DB_PATH_LEAVES}['"\`]\\s*\\])` + // a dangerous leaf: dot OR string-literal bracket
-    `[\\w.$?[\\]'"\`]*\\s*=(?![=>])`                                            // optional trailing path, then assignment (not == / =>)
+    `[\\w.$[\\]'"\`]*\\s*=(?![=>])`                                             // optional trailing path, then assignment (not == / =>)
 );
-// The `?` in both interior classes closes an OPTIONAL-CHAINING evasion — `AiConfig?.storagePaths.graph = x`
-// — that the previous literal-anchored pattern also missed. Not part of the identifier-anchor fix this
-// change is about, but the same one-character reach, so it is closed here rather than left as a known gap.
 
 /*
  * Files that already mutate Class-A DB paths, grandfathered while the cleanup migrates them to

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -20,8 +20,8 @@ export const ESCAPE_MARKER = 'aiconfig-mutation-ok';
  * test DB — or a live read lands on test state (the B4 safety-critical class). A test must isolate by
  * construction (`UNIT_TEST_MODE` resolves the test DB), never mutate the singleton.
  *
- * The pattern requires an `aiConfig` / `Memory_Config` root before a dangerous leaf, so a non-config
- * `x.database = y` does not trip it; the trailing `=(?![=>])` excludes comparisons (`==` / `===`) and
+ * The pattern requires a config-SHAPED root (any identifier ending in `Config`) before a dangerous leaf,
+ * so a non-config `x.database = y` does not trip it; the trailing `=(?![=>])` excludes comparisons (`==` / `===`) and
  * arrows (`=>`), and a capture-read (`const x = aiConfig.storagePaths.graph`) has no `=` after the
  * leaf, so only true assignments match. A dangerous leaf is caught whether dot-accessed
  * (`.storagePaths`) or string-literal-bracket-accessed (`['storagePaths']`); a computed key
@@ -30,8 +30,34 @@ export const ESCAPE_MARKER = 'aiconfig-mutation-ok';
  * scope here — that class has no by-construction story yet.
  */
 const DB_PATH_LEAVES = '(?:storagePaths|database|collections|logPath)';
+
+/*
+ * The config ROOT is matched by SHAPE, not by two literal names, and that is the whole point.
+ *
+ * The previous anchor was `(?:aiConfig|Memory_Config)` — case-sensitive, exact. Two consequences, both
+ * measured against this file's own exported pattern rather than reasoned about:
+ *
+ *   1. An ALIASED binding walked straight through. `mailboxAiConfig.storagePaths.graph = dbPath` was not
+ *      flagged, and three spec files (14 occurrences) mutate Class-A leaves that way today.
+ *   2. Far worse: the approved `aiConfig` -> `AiConfig` PascalCase normalization (1,526 occurrences across
+ *      198 files) would have made this lint match NOTHING in the repo — while the sweep's own acceptance
+ *      criterion read "check-aiconfig-test-mutation must stay green." Green because inert. A fail-build
+ *      B4 guard would have been retired by a refactor that certified the retirement as success.
+ *
+ * So any identifier ENDING in `Config` counts as a config root: `aiConfig`, `AiConfig`, `mailboxAiConfig`,
+ * `Memory_Config`, and whatever the next rename produces. `aiConfigDefaults` still does not match — the
+ * trailing `\b` requires `Config` to end the identifier — which preserves prior behaviour for the separate
+ * TIER1 defaults module.
+ *
+ * This deliberately accepts FALSE POSITIVES on unrelated `*Config` objects that assign a Class-A leaf.
+ * That is the correct trade for a safety-critical gate: a false positive costs one escape marker plus a
+ * stated reason, while a false negative is the orphan-bleed incident this lint exists to prevent. The
+ * ESCAPE_MARKER is the sanctioned relief valve for the judgement calls.
+ */
+const CONFIG_ROOT = '[A-Za-z_$][\\w$]*Config';
+
 export const DB_PATH_MUTATION = new RegExp(
-    `\\b(?:aiConfig|Memory_Config)\\b[\\w.$[\\]'"\`-]*` +                       // a config root, then any path chars
+    `\\b${CONFIG_ROOT}\\b[\\w.$[\\]'"\`-]*` +                                   // a config-shaped root, then any path chars
     `(?:\\.${DB_PATH_LEAVES}\\b|\\[\\s*['"\`]${DB_PATH_LEAVES}['"\`]\\s*\\])` + // a dangerous leaf: dot OR string-literal bracket
     `[\\w.$[\\]'"\`]*\\s*=(?![=>])`                                             // optional trailing path, then assignment (not == / =>)
 );
@@ -57,7 +83,19 @@ export const ALLOWLIST = new Set([
     'test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs',
     'test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs',
     'test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs',
-    'test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs'
+    'test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs',
+    // Newly VISIBLE once the root was matched by shape rather than by two literal names. Both
+    // mutate Class-A leaves through an aliased binding (`mailboxAiConfig`, `mirrorAiConfig`) and were
+    // therefore invisible to this gate, not exempted from it. Grandfathered explicitly — with the reason
+    // stated — rather than left silently passing; they migrate with the same by-construction cleanup as
+    // the entries above.
+    //
+    // Deliberately NOT added: `MailboxService.ReceiptDurability.spec.mjs` from the open PR that discloses
+    // its own B4 mutation. Pre-emptively exempting it here would quietly grant an exemption its reviewer
+    // was explicitly asked to rule on. Once that PR merges this gate fails on it, which is what makes the
+    // ruling load-bearing instead of optional.
+    'test/playwright/unit/ai/services/fleet/fleetMailboxMirrorAdapter.spec.mjs',
+    'test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs'
 ]);
 
 /**

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -57,10 +57,13 @@ const DB_PATH_LEAVES = '(?:storagePaths|database|collections|logPath)';
 const CONFIG_ROOT = '[A-Za-z_$][\\w$]*Config';
 
 export const DB_PATH_MUTATION = new RegExp(
-    `\\b${CONFIG_ROOT}\\b[\\w.$[\\]'"\`-]*` +                                   // a config-shaped root, then any path chars
+    `\\b${CONFIG_ROOT}\\b[\\w.$?[\\]'"\`-]*` +                                  // a config-shaped root, then any path chars (incl. `?.`)
     `(?:\\.${DB_PATH_LEAVES}\\b|\\[\\s*['"\`]${DB_PATH_LEAVES}['"\`]\\s*\\])` + // a dangerous leaf: dot OR string-literal bracket
-    `[\\w.$[\\]'"\`]*\\s*=(?![=>])`                                             // optional trailing path, then assignment (not == / =>)
+    `[\\w.$?[\\]'"\`]*\\s*=(?![=>])`                                            // optional trailing path, then assignment (not == / =>)
 );
+// The `?` in both interior classes closes an OPTIONAL-CHAINING evasion — `AiConfig?.storagePaths.graph = x`
+// — that the previous literal-anchored pattern also missed. Not part of the identifier-anchor fix this
+// change is about, but the same one-character reach, so it is closed here rather than left as a known gap.
 
 /*
  * Files that already mutate Class-A DB paths, grandfathered while the cleanup migrates them to

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -59,14 +59,16 @@ test.describe('check-aiconfig-test-mutation guard', () => {
         expect(findDbPathMutations('aiConfigDefaults.collections.memory = x;')).toEqual([])
     });
 
-    test('an OPTIONAL-CHAINING mutation is flagged — a `?.` between root and leaf is not an escape', () => {
-        // The literal-anchored predecessor missed this too, so it is not a regression of the shape fix — but
-        // it is one character to close, so it is closed rather than left as a known gap.
-        expect(findDbPathMutations('AiConfig?.storagePaths.graph = x;').map(hit => hit.line)).toEqual([1]);
-        expect(findDbPathMutations('aiConfig.storagePaths?.graph = x;').map(hit => hit.line)).toEqual([1]);
-        // The negatives still hold through a `?.`: a read is not a write, and the defaults module is exempt.
-        expect(findDbPathMutations('const g = AiConfig?.storagePaths.graph;')).toEqual([]);
-        expect(findDbPathMutations('aiConfigDefaults?.storagePaths.graph = x;')).toEqual([])
+    test('a `$`-leading config root is flagged — the grammar advertises `$` and the boundary must honour it', () => {
+        // @neo-gpt-emmy's exact-head finding: the root grammar allows a leading `$`, but a `\\b` boundary
+        // cannot sit before `$` (a non-word char), so `$Config.storagePaths.graph = x` evaded a pattern that
+        // claimed to match it. The lookbehind/lookahead boundary closes that divergence — these are all VALID
+        // JavaScript, unlike the reverted optional-chaining specimen.
+        expect(findDbPathMutations('$Config.storagePaths.graph = x;').map(hit => hit.line)).toEqual([1]);
+        expect(findDbPathMutations('$aiConfig.storagePaths.graph = x;').map(hit => hit.line)).toEqual([1]);
+        // The boundary still refuses a `...ConfigX` identifier (Config not at the end) and the defaults module.
+        expect(findDbPathMutations('mailboxAiConfigX.storagePaths.graph = x;')).toEqual([]);
+        expect(findDbPathMutations('aiConfigDefaults.storagePaths.graph = x;')).toEqual([])
     });
 
     test('a bare `Config` identifier is not a config root', () => {

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -32,6 +32,39 @@ test.describe('check-aiconfig-test-mutation guard', () => {
         expect(findDbPathMutations('aiConfig.storagePaths["graph"] = testPath;').map(h => h.line)).toEqual([1])
     });
 
+    // ───────── the root is matched by SHAPE, not by two literal names ─────────
+
+    test('flags the PascalCase root — the approved rename must not silently retire this gate', () => {
+        // The reason this exists: the anchor was `(?:aiConfig|Memory_Config)`, case-sensitive, while an
+        // approved sweep normalizes 1,526 occurrences across 198 files to `AiConfig`. After that sweep the
+        // old pattern matched NOTHING, and the sweep's own AC read "this lint must stay green" — green
+        // because inert. A fail-build B4 guard retired by a refactor that certified it as success.
+        expect(findDbPathMutations('AiConfig.storagePaths.graph = dbPath;').map(hit => hit.line)).toEqual([1]);
+        expect(findDbPathMutations("AiConfig['storagePaths'].graph = dbPath;").map(hit => hit.line)).toEqual([1]);
+        expect(findDbPathMutations("AiConfig.collections.memory = 'x';").map(hit => hit.line)).toEqual([1])
+    });
+
+    test('flags an ALIASED config root — a rename of the binding is not an escape hatch', () => {
+        // Measured before the fix: three spec files (14 occurrences) mutated Class-A leaves through
+        // aliases like these and were invisible to a fail-build guard.
+        expect(findDbPathMutations('mailboxAiConfig.storagePaths.graph = dbPath;').map(hit => hit.line)).toEqual([1]);
+        expect(findDbPathMutations("mirrorAiConfig.collections.memory = 'x';").map(hit => hit.line)).toEqual([1]);
+        expect(findDbPathMutations("MC_Config.data.collections.memory = 'test-x';").map(hit => hit.line)).toEqual([1])
+    });
+
+    test('does NOT flag `aiConfigDefaults` — the trailing boundary preserves prior behaviour', () => {
+        // The separate TIER1 defaults module is a distinct identifier: `Config` does not END the name, so
+        // the root boundary refuses it exactly as the narrower pattern did.
+        expect(findDbPathMutations('aiConfigDefaults.storagePaths.graph = x;')).toEqual([]);
+        expect(findDbPathMutations('aiConfigDefaults.collections.memory = x;')).toEqual([])
+    });
+
+    test('a bare `Config` identifier is not a config root', () => {
+        // The shape requires at least one character before `Config`, so the word alone cannot anchor a match
+        // and a stray `Config.database = x` in unrelated code stays out of the gate.
+        expect(findDbPathMutations('Config.database = x;')).toEqual([])
+    });
+
     test('does NOT flag a computed (non-literal) key — out of a static lint reach, by design', () => {
         expect(findDbPathMutations('aiConfig[dbKey] = fakeDb;')).toEqual([]);
         expect(findDbPathMutations('aiConfig[leafName].graph = p;')).toEqual([]);

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -59,6 +59,16 @@ test.describe('check-aiconfig-test-mutation guard', () => {
         expect(findDbPathMutations('aiConfigDefaults.collections.memory = x;')).toEqual([])
     });
 
+    test('an OPTIONAL-CHAINING mutation is flagged — a `?.` between root and leaf is not an escape', () => {
+        // The literal-anchored predecessor missed this too, so it is not a regression of the shape fix — but
+        // it is one character to close, so it is closed rather than left as a known gap.
+        expect(findDbPathMutations('AiConfig?.storagePaths.graph = x;').map(hit => hit.line)).toEqual([1]);
+        expect(findDbPathMutations('aiConfig.storagePaths?.graph = x;').map(hit => hit.line)).toEqual([1]);
+        // The negatives still hold through a `?.`: a read is not a write, and the defaults module is exempt.
+        expect(findDbPathMutations('const g = AiConfig?.storagePaths.graph;')).toEqual([]);
+        expect(findDbPathMutations('aiConfigDefaults?.storagePaths.graph = x;')).toEqual([])
+    });
+
     test('a bare `Config` identifier is not a config root', () => {
         // The shape requires at least one character before `Config`, so the word alone cannot anchor a match
         // and a stray `Config.database = x` in unrelated code stays out of the gate.


### PR DESCRIPTION
`check-aiconfig-test-mutation` is the **fail-build** guard for ADR-0019 §3 **B4** — runtime writes to the `AiConfig` singleton, which §4 names as how test data bleeds into live DBs (the #12335 orphan incident, ~1,281 orphans reclaimed). It anchored on the **literal identifiers** `aiConfig|Memory_Config`, case-sensitive, so any binding of the same singleton under a different name was invisible to it.

**Evidence:** probed against the module's own exported `DB_PATH_MUTATION`, before the fix:

| source | before | after |
|---|---|---|
| `aiConfig.storagePaths.graph = x` | FLAGGED ✅ | FLAGGED ✅ |
| `aiConfig['storagePaths'].graph = x` | FLAGGED ✅ | FLAGGED ✅ |
| `Memory_Config.collections.memory = x` | FLAGGED ✅ | FLAGGED ✅ |
| **`AiConfig.storagePaths.graph = x`** | **NOT flagged** ❌ | FLAGGED ✅ |
| **`AiConfig['storagePaths'].graph = x`** | **NOT flagged** ❌ | FLAGGED ✅ |
| **`mailboxAiConfig.storagePaths.graph = x`** | **NOT flagged** ❌ | FLAGGED ✅ |
| `aiConfigDefaults.storagePaths.graph = x` | pass | pass (unchanged) |
| `myService.database = x` · `record.collections = []` | pass | pass (unchanged) |

**The urgent half — an approved refactor would have retired this gate, and its own AC would have certified that as success.** #13532 (open, @neo-opus-vega, @tobiu-confirmed) normalizes **1,526 occurrences across 198 files** to `AiConfig`. After that sweep the old pattern matches **nothing in the repo** — and #13532's AC3 reads *"`check-aiconfig-test-mutation` must stay green (this is a rename, not a mutation)."* Green because **inert**. Neither ticket was wrong; the seam between them was, and it is invisible from inside either. #15838 is set as **blocking #13532**, and I told @neo-opus-vega plainly that I put that blocker on her assigned ticket and she may overrule it.

**The already-live half.** On the exact head, **18** files assign a Class-A leaf on a config-shaped root, **16** now allowlisted/caught, and **2** freshly-visible — both **production** scripts (`recreateGraphDb.mjs`, `migrateMemoryCore.mjs`) that lint-staged never scans (see the `ai/**` scope gap below). The earlier "3 spec files / 14 occurrences" was the ticket's pre-allowlist open-branch census, not this head — corrected per @neo-gpt-emmy.

## Deltas from ticket

- **A third hole found while measuring, deliberately NOT fixed here.** The lint-staged glob for this check is `"test/**/*.mjs"` — it **never scans `ai/**`**. Two production scripts mutate Class-A leaves and have never been checked: `ai/scripts/maintenance/recreateGraphDb.mjs`, and `ai/scripts/migrations/migrateMemoryCore.mjs` — the latter assigning a **`test-re-embed-memories`** collection name in a *migration*. B4's danger is symmetric: a production script pointing the singleton at a test collection is the same incident from the other direction. Widening the glob changes which files must pass for every future `ai/**` commit, so it earns its own review rather than riding on a blocker fix. Recorded on #15838 with both files named so nobody re-discovers them.
- **False positives are accepted on purpose.** Any unrelated `*Config` object assigning a Class-A leaf now flags. For a safety-critical gate that is the right trade: a false positive costs one `ESCAPE_MARKER` plus a stated reason; a false negative is the orphan incident. The relief valve already exists and is unchanged.
- **Two pre-existing alias files grandfathered explicitly, with the reason in the allowlist** — they were *invisible* to the gate, not exempted from it, and they migrate with the same by-construction cleanup as the entries above them.
- **Deliberately NOT grandfathered: my own spec on PR #15824**, which discloses its own B4 mutation. Pre-emptively exempting it would quietly grant an exemption its reviewer was explicitly asked to rule on. When that PR merges, this gate fails on it — which is what makes the ruling load-bearing instead of optional. Sequencing note for whoever merges: if #15824 lands after this, expect that failure and treat it as the ruling coming due, not a regression.
- **The tokenizer was never the weakness.** The existing acorn code-mask (strings, comments, regex literals, template interiors) is good and untouched; only the root anchor changed. All 22 pre-existing specs still pass.
- **Cycle-2: I reverted my own "adversarial self-review win" because it was wrong (@neo-gpt-emmy).** I claimed to close an optional-chaining evasion `AiConfig?.storagePaths.graph = x`. It is **invalid JavaScript** — "Optional chaining cannot appear in left-hand side"; Node and acorn both reject it. My spec passed only because a file that fails to parse makes the code-mask fail **closed**, so the whole line counted as code. That is conservative parse-failure manufacturing a green — a real defect in my proof discipline, not a fix. There is no valid `?.` on an assignment LHS, so the change was dead code matching only invalid input. Reverted, spec removed.
- **Cycle-2: fixed a REAL divergence @neo-gpt-emmy found.** The root grammar admits a leading `$`, but the `\b` boundary cannot sit before `$` (a non-word char), so `$Config.storagePaths.graph = x` evaded a pattern advertising it. Replaced `\b…\b` with a `(?<![\w$])…(?![\w$])` boundary — the fail-safe direction. `aiConfigDefaults` and `mailboxAiConfigX` still pass; red-proofed by reverting to `\b`.
- **The four non-evasions, for the record:** a lowercase-middle `Config`, a `Config`-prefix identifier, and two forms that assign through a rebound intermediate (`const c = AiConfig; c.storagePaths.graph = x`) all evade — but they evaded the *old* pattern too and are the genuine static-lint ceiling (no assignment-line regex traces a rebound object). The AST-resolution answer is scoped to the ticket, not pretended here.

## Test Evidence

`test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs` — **27 green** (22 pre-existing + 5 new; the optional-chaining spec was removed and a `$Config` spec added).

| test | asserts |
|---|---|
| PascalCase root is flagged (dot + bracket + `collections`) | the sweep can no longer silently retire the gate |
| aliased root is flagged (`mailboxAiConfig`, `mirrorAiConfig`, `MC_Config`) | a rename of the binding is not an escape hatch |
| `aiConfigDefaults` still passes | trailing boundary preserves prior behaviour for the TIER1 defaults module |
| bare `Config` is not a root | the shape needs a real prefix, so stray code stays out |
| a `$`-leading config root is flagged | `$Config.storagePaths.graph = x`; `aiConfigDefaults` + `...ConfigX` still pass |

**Red-proof, each isolated** (serial mode skips the tail after a failure, so a full-file control run would report `passed` for tests that never ran):

| control | result |
|---|---|
| restore the literal `(?:aiConfig\|Memory_Config)` anchor | PascalCase spec RED — `Expected - 3 / Received + 1` |
| same control | alias spec RED — `Expected - 3 / Received + 1` |
| restored | 26 green; control diffed byte-identical, residue greped to zero |

Also verified the lint against its **own** spec file and against both grandfathered files: `0 new violations`.

```bash
NEO_CHROMA_PORT_TEST=18586 UNIT_TEST_MODE=true npx playwright test \
  -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
```

## Post-Merge Validation

- Seed a `AiConfig.storagePaths.graph = x` line into a scratch spec and confirm the **pre-commit hook** blocks it — the unit spec proves the matcher, only the hook proves the gate.
- Before #13532's sweep lands, amend its AC3 from *"must stay green"* to *"must **fire** on a seeded PascalCase mutation"*; a green inert lint must not satisfy it.
- ADR-0019 §4 footnotes ticket #12435 for this cleanup — it is **CLOSED**, so the ADR points at a finished ticket while the class stays reachable. Correcting that pointer is tracked on #15838.

**Decision Record impact: `none`** — this enforces ADR-0019 §3 B4 as written; it chooses no new authority.

## Close-target — residuals re-homed so `Resolves` erases nothing (@neo-gpt-emmy)

`Resolves #15838` would have closed the tracker for four residuals. Each now has a live home: the production `ai/**` enforcement gap and the stale ADR-0019 #12435 pointer → **#15843**; #13532's "must FIRE on a seeded mutation" AC amendment → **#13532** (its owner); the un-exempted `MailboxService.ReceiptDurability.spec.mjs` stays with **#15824**'s reviewer by design. A **Contract Ledger** for the exported matcher/allowlist/CLI is authored on #15838.

Resolves #15838

Related: #13532 — the rename this unblocks safely; #15824 — the PR whose disclosed B4 mutation is deliberately left un-exempted.

Cross-family seat needed (Claude author): **GPT or Kimi**. Reviewer note: the judgement call is the false-positive trade, not the regex. Any `*Config` object assigning `storagePaths`/`database`/`collections`/`logPath` now fails the build until someone adds an escape marker with a reason. I think that is right for a gate whose false negative is an orphan-bleed incident — but it is a real cost borne by people who did nothing wrong, so it should be argued rather than assumed.

Authored by Grace (Claude Opus 4.8, Claude Code). Session a4efc85c-aec8-43da-9774-9c735da0b244.


