### PR TITLE
feat(workstation): tear-out wiring — vessel shell, DockTearOut composition, journey executor + spec-proven witnesses (#15252)

### DIFF
--- a/apps/workstation/neo-config.json
+++ b/apps/workstation/neo-config.json
@@ -14,6 +14,7 @@
         "DragDrop",
         "LocalStorage",
         "Navigator",
-        "Stylesheet"
+        "Stylesheet",
+        "WindowPosition"
     ]
 }

--- a/apps/workstation/view/Viewport.mjs
+++ b/apps/workstation/view/Viewport.mjs
@@ -7,6 +7,14 @@ import Workspace    from './Workspace.mjs';
  * The viewport owns only the render root. Workstation owns the state provider, dock document,
  * stores, pane cache, and deterministic tour so the application remains independently bootable.
  *
+ * Two boot modes, resolved from the window's own search params (async — the worker reads the
+ * URL through the main-thread seam, so the workspace mounts in `onConstructed`):
+ *
+ * - default         → the dense living-data workspace (`Workspace`)
+ * - `?popout=<id>`  → an EMPTY pop-out host: this window carries no workspace of its own; the
+ *   opener's workspace reparents the live pane into this viewport (the shared-heap contract —
+ *   one App Worker, two render targets; the dockdemo vessel-shell sibling pattern).
+ *
  * @class Workstation.view.Viewport
  * @extends Neo.container.Viewport
  */
@@ -22,16 +30,33 @@ class Viewport extends BaseViewport {
          */
         cls: ['workstation-viewport'],
         /**
-         * @member {Object[]} items
-         */
-        items: [{
-            module: Workspace,
-            flex  : 1
-        }],
-        /**
          * @member {Object} layout
          */
         layout: {ntype: 'vbox', align: 'stretch'}
+    }
+
+    /**
+     * Resolves the boot mode from the window URL and mounts the workspace — or nothing:
+     * a pop-out vessel is a render target waiting for its live pane.
+     */
+    async onConstructed() {
+        super.onConstructed();
+
+        let me     = this,
+            url    = await Neo.Main.getByPath({path: 'document.URL', windowId: me.windowId}),
+            params = new URL(url).searchParams;
+
+        if (me.isDestroyed) return;
+
+        if (params.get('popout')) {
+            me.addCls('workstation-popout-host');
+            return
+        }
+
+        me.add({
+            module: Workspace,
+            flex  : 1
+        })
     }
 }
 

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -12,8 +12,11 @@ import DockPreview                              from '../../../src/dashboard/Doc
 import DockProjectionReconciler                 from '../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockService                              from '../../../src/ai/client/DockService.mjs';
 import DockZoneModel                            from '../../../src/dashboard/DockZoneModel.mjs';
+import InteractionService                       from '../../../src/ai/client/InteractionService.mjs';
 import StateProvider                            from '../../../src/state/Provider.mjs';
 import TourRunner                               from '../../../src/ai/client/TourRunner.mjs';
+import {createDockTearOutHandlers}              from '../../../src/dashboard/DockTearOut.mjs';
+import {createDockVesselEmbodiment}             from '../../../src/dashboard/DockVesselEmbodiment.mjs';
 import {workstationTourScript, initialDocument} from '../tour/denseWorkstation.mjs';
 import '../../../src/button/Base.mjs';
 import '../../../src/tab/Container.mjs';
@@ -133,10 +136,68 @@ class Workspace extends Container {
      */
     dragAffordances = null
     /**
+     * Real-pointer gesture driver for the app-owned journey executors (spec + film replays).
+     * @member {Neo.ai.client.InteractionService|null} interactionService=null
+     */
+    interactionService = null
+    /**
      * @member {Object} paneCache={}
      * @protected
      */
     paneCache = {}
+    /**
+     * The transient render embodiment for admitted tear-out vessels (live pane staged into the
+     * vessel while a hidden exact-slot placeholder holds the source indices).
+     * @member {Object|null} tearOutEmbodiment=null
+     */
+    tearOutEmbodiment = null
+    /**
+     * The tear-out gesture choreography (admission chain + commit-at-terminal routing).
+     * @member {Object|null} tearOutHandlers=null
+     */
+    tearOutHandlers = null
+    /**
+     * Connect-time admission tokens for tear-out vessels whose render stage is still settling.
+     * @member {Map} tearOutConnectAdmissions=new Map()
+     * @protected
+     */
+    tearOutConnectAdmissions = new Map()
+    /**
+     * Pre-terminal connected tear-out vessels by item id.
+     * @member {Object} tearOutConnects={}
+     * @protected
+     */
+    tearOutConnects = {}
+    /**
+     * Post-commit vessel-owned panes by item id (the detached terminal committed).
+     * @member {Object} tearOutPanes={}
+     * @protected
+     */
+    tearOutPanes = {}
+    /**
+     * Exact `{tabsNodeId, index}` placement captured at each detach commit — the return truth.
+     * @member {Object} tearOutPlacements={}
+     * @protected
+     */
+    tearOutPlacements = {}
+    /**
+     * Retirement fences: items whose vessel close is in flight (connects stay cleanup-only).
+     * @member {Set} tearOutRetirements=new Set()
+     * @protected
+     */
+    tearOutRetirements = new Set()
+    /**
+     * Product-semantic vessel owner grants by `flow:itemId`.
+     * @member {Map} vesselOwnerGrants=new Map()
+     * @protected
+     */
+    vesselOwnerGrants = new Map()
+    /**
+     * Monotonic grant generation counter.
+     * @member {Number} vesselOwnerGrantGeneration=0
+     * @protected
+     */
+    vesselOwnerGrantGeneration = 0
     /**
      * @member {Promise|null} refreshPromise=null
      * @protected
@@ -250,6 +311,33 @@ class Workspace extends Container {
             indicators: me.getReference('drop-indicators'),
             owner     : me,
             preview   : me.getReference('dock-preview')
+        });
+
+        me.interactionService = Neo.create(InteractionService, {});
+
+        me.tearOutEmbodiment = createDockVesselEmbodiment({
+            resolvePane: itemId => me.paneCache[itemId]
+                ?? (me.dockModel?.items?.[itemId] && me.resolvePane(itemId, me.dockModel.items[itemId])),
+            resolveTarget: windowId => Neo.apps[windowId]?.mainView ?? null
+        });
+
+        // The gesture tear-out choreography. The composition law (dockdemo sibling): a tear-out
+        // vessel NEVER writes shared detach bookkeeping mid-gesture — model truth is untouched
+        // until the detached terminal, so a cancelled or re-entered tear-out is zero-mutation
+        // by GUARD. Post-commit adoption uses its own bookkeeping (tearOutPanes/tearOutConnects).
+        me.tearOutHandlers = createDockTearOutHandlers({
+            applyOperation  : descriptor => me.applyTearOutOperation(descriptor),
+            closeVessel     : vessel => me.closeTearOutVessel(vessel),
+            onDocumentChange: (document, operation, vessel) => me.onTearOutDocumentChange(document, operation, vessel),
+            openVessel      : request => me.openTearOutVessel(request)
+        });
+
+        // vessel lifecycle: a granted `?popout=` window adopts the live pane on connect,
+        // and a vessel death brings its item home on disconnect
+        Neo.currentWorker.on({
+            connect   : me.onWindowConnect,
+            disconnect: me.onWindowDisconnect,
+            scope     : me
         });
 
         // The reactive afterSet fires before the dock host exists during construction —
@@ -474,8 +562,10 @@ class Workspace extends Container {
     /**
      * Defers the instance-preserving re-projection after a successful reducer commit.
      * @param {Object} document
+     * @param {Object} [options={}]
+     * @param {String[]} [options.preserveItemIds] Owner-held panes the reconciler must park.
      */
-    onDockZoneDocumentChange(document) {
+    onDockZoneDocumentChange(document, options={}) {
         let me = this;
 
         me.dockModel = document;
@@ -486,7 +576,7 @@ class Workspace extends Container {
         me.refreshPromise = (me.refreshPromise || Promise.resolve())
             .then(() => me.timeout(0))
             .then(() => {
-                if (!me.isDestroyed) return me.refreshDockWorkspace()
+                if (!me.isDestroyed) return me.refreshDockWorkspace(options)
             })
     }
 
@@ -580,9 +670,16 @@ class Workspace extends Container {
 
         return DockLayoutAdapter.project(me.dockModel, {
             applyDockZoneOperation   : me.applyDockZoneOperation.bind(me),
+            // Tear-out opt-in (§2.8): arms the window-boundary hysteresis + overdrag on every
+            // projected tabs zone; the gesture handlers below route through the tear-out machine.
+            enableDockTearOut        : true,
             onDockCrossZoneDragCancel: data => me.dragAffordances.onDragCancel(data),
             onDockCrossZoneDragMove  : data => me.dragAffordances.onDragMove(data),
             onDockCrossZoneDrop      : data => me.dragAffordances.onDrop(data),
+            onDockTearOutCancel      : data => me.tearOutHandlers.onDockTearOutCancel(data),
+            onDockTearOutEntry       : data => me.tearOutHandlers.onDockTearOutEntry(data),
+            onDockTearOutExit        : data => me.tearOutHandlers.onDockTearOutExit(data),
+            onDockTearOutTerminal    : data => me.tearOutHandlers.onDockTearOutTerminal(data),
             onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
             resolveComponentRef      : resolveComponentRef
                 || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
@@ -672,9 +769,12 @@ class Workspace extends Container {
      * {@link Neo.dashboard.DockProjectionReconciler} owns the renderer-safe staged ownership
      * transaction shared with other docking workspaces. Workstation supplies its cached-pane resolver,
      * header text, FLIP motion, retained-indicator suppression, and the heavy Overflow menu witness.
+     * @param {Object} [options={}]
+     * @param {String[]} [options.preserveItemIds=[]] Owner-held panes the reconciler must park
+     *     instead of destroy (a terminal-first tear-out vessel owns its pane before it connects).
      * @returns {Promise<void>}
      */
-    async refreshDockWorkspace() {
+    async refreshDockWorkspace({preserveItemIds=[]}={}) {
         const
             me           = this,
             host         = me.getReference('dock-host'),
@@ -709,6 +809,7 @@ class Workspace extends Container {
             host,
             nextConfig,
             placeholders,
+            preserveItemIds,
             resolveItem: itemId => me.resolvePane(itemId, me.dockModel.items[itemId]),
             onProjectionStaged({plans}) {
                 const retainedTabBars = [...plans.values()]
@@ -1078,6 +1179,989 @@ class Workspace extends Container {
     }
 
     /**
+     * @summary Mints one product-semantic vessel grant and supersedes the prior generation for
+     * the same flow/item. The token is a bearer hint only; {@link #consumeVesselOwnerGrant}
+     * additionally requires the opener-minted native route for the exact connected child.
+     * @param {String} flow Vessel flow discriminator (`tear-out`).
+     * @param {String} itemId
+     * @returns {{generation: Number, token: String}}
+     * @protected
+     */
+    createVesselOwnerGrant(flow, itemId) {
+        let grant = {
+            generation: ++this.vesselOwnerGrantGeneration,
+            token     : crypto.randomUUID()
+        };
+
+        this.vesselOwnerGrants.set(`${flow}:${itemId}`, grant);
+
+        return grant
+    }
+
+    /**
+     * @summary Consumes one exact product grant after validating the generic native route.
+     * Consumption precedes every reparent, making replay and same-name reuse inert.
+     * @param {Object} data
+     * @param {Object} data.windowData
+     * @param {String} flow
+     * @param {Number} generation
+     * @param {String} grant
+     * @param {String} itemId
+     * @param {String} windowId
+     * @returns {Boolean}
+     * @protected
+     */
+    consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId}) {
+        let me     = this,
+            key    = `${flow}:${itemId}`,
+            stored = me.vesselOwnerGrants.get(key),
+            route  = data.windowData?.nativeRoute;
+
+        if (
+            !stored || !grant || stored.token !== grant || stored.generation !== generation ||
+            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId || route.targetWindowId !== windowId
+        ) {
+            return false
+        }
+
+        me.vesselOwnerGrants.delete(key);
+
+        return true
+    }
+
+    /**
+     * @summary Revokes the current semantic grant for one flow/item admission.
+     * @param {String} flow
+     * @param {String} itemId
+     * @protected
+     */
+    revokeVesselOwnerGrant(flow, itemId) {
+        this.vesselOwnerGrants.delete(`${flow}:${itemId}`)
+    }
+
+    /**
+     * The tear-out admission seam: opens the vessel window for a mid-gesture boundary exit.
+     * Reuses the workstation viewport's `?popout=` pure-pane-host mode. The granted child
+     * immediately carries the same live pane through {@link Neo.dashboard.DockVesselEmbodiment};
+     * it owns no workspace document. Fail-closed per the admission contract: `windowOpen` returns
+     * a BOOLEAN (a blocked popup never throws), and any falsy/throwing acquisition returns `null`
+     * so the gesture degrades to its in-window fallback.
+     * @param {Object} request
+     * @param {Number} request.admissionToken
+     * @param {String} request.itemId
+     * @param {Object} request.proxyRect
+     * @returns {Promise<{admissionToken: Number, generation: Number, popupHeight: Number, popupWidth: Number, windowName: String}|null>}
+     * @protected
+     */
+    async openTearOutVessel({admissionToken, itemId, proxyRect}) {
+        let me         = this,
+            {windowId} = me,
+            windowName = `tearout-${itemId}`,
+            ownerGrant = me.createVesselOwnerGrant('tear-out', itemId);
+
+        admissionToken = Number.isFinite(admissionToken) ? admissionToken : ownerGrant.generation;
+        ownerGrant.admissionToken = admissionToken;
+
+        if (me.tearOutRetirements.has(itemId)) {
+            me.revokeVesselOwnerGrant('tear-out', itemId);
+            return null
+        }
+
+        try {
+            let winData = await Neo.Main.getWindowData({windowId}),
+                width   = Math.max(Math.round(proxyRect?.width  || 480), 320),
+                height  = Math.max(Math.round(proxyRect?.height || 360), 240),
+                left    = Math.round((proxyRect?.x ?? 120) + winData.screenLeft),
+                top     = Math.round((proxyRect?.y ?? 120) + (winData.outerHeight - winData.innerHeight) + winData.screenTop);
+
+            let opened = await Neo.Main.windowOpen({
+                nativeCapabilities: {close: true, position: true},
+                url               : `./index.html?popout=${itemId}&hostId=${me.id}`
+                    + `&vesselFlow=tear-out&vesselGrant=${ownerGrant.token}`
+                    + `&vesselGeneration=${ownerGrant.generation}`
+                    + `&vesselAdmission=${admissionToken}`,
+                windowFeatures: `height=${height},left=${left},top=${top},width=${width}`,
+                windowId,
+                windowName
+            });
+
+            if (opened === false) {
+                me.revokeVesselOwnerGrant('tear-out', itemId);
+                return null
+            }
+
+            me.tearOutVesselDims = {height, width};
+
+            return {
+                admissionToken,
+                generation : ownerGrant.generation,
+                popupHeight: height,
+                popupWidth : width,
+                windowName
+            }
+        } catch (error) {
+            me.revokeVesselOwnerGrant('tear-out', itemId);
+            return null
+        }
+    }
+
+    /**
+     * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry,
+     * cancel, or a refused model commit). The live connection and owner grant remain recoverable
+     * until the platform strictly admits the close; an explicit refusal can therefore be retried
+     * instead of orphaning a parked native generation.
+     * @param {Object} vessel
+     * @param {Number} [vessel.admissionToken]
+     * @param {Number} [vessel.generation]
+     * @param {String} vessel.itemId
+     * @param {Object} [vessel.nativeRoute] Exact opener-minted physical route when available.
+     * @param {String} vessel.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async closeTearOutVessel({admissionToken, generation, itemId, nativeRoute, windowName}) {
+        let me               = this,
+            entry            = me.resolveTearOutVessel(itemId),
+            admission        = me.tearOutConnectAdmissions.get(itemId),
+            ownerGrant       = me.vesselOwnerGrants.get(`tear-out:${itemId}`),
+            expected         = `tearout-${itemId}`,
+            exactGeneration  = entry?.generation ?? admission?.generation ?? ownerGrant?.generation,
+            exactToken       = entry?.admissionToken ?? admission?.admissionToken ?? ownerGrant?.admissionToken,
+            embodiedWindowId = entry?.windowId ?? admission?.windowId ?? me.tearOutEmbodiment.getWindowId(itemId),
+            closed           = false;
+
+        if (
+            !itemId || windowName !== expected || (entry && entry.windowName !== windowName) ||
+            (Number.isFinite(generation) && generation !== exactGeneration) ||
+            (Number.isFinite(admissionToken) && admissionToken !== exactToken)
+        ) {
+            return false
+        }
+
+        nativeRoute ??= entry?.nativeRoute ?? admission?.nativeRoute ?? (
+            admission?.windowId && Neo.manager?.Window?.get(admission.windowId)?.nativeRoute
+        );
+
+        const exactWindowId = entry?.windowId ?? admission?.windowId;
+
+        if (nativeRoute && (
+            !nativeRoute.nativeHandleKey || nativeRoute.ownerWindowId !== me.windowId ||
+            !nativeRoute.targetWindowId || nativeRoute.capabilities?.close !== true ||
+            (exactWindowId && nativeRoute.targetWindowId !== exactWindowId)
+        )) return false;
+
+        // Establish retirement before restoring any source embodiment or awaiting the platform.
+        // A refused close retains the exact route + tear-out machine slot for retry, but the
+        // content stays safely home.
+        me.tearOutRetirements.add(itemId);
+        admission && (admission.invalidated = true);
+
+        if (embodiedWindowId && me.tearOutEmbodiment.isStaged(itemId)) {
+            const sourceOwns = Boolean(DockZoneModel.findContainingTabsId(me.dockModel, itemId)),
+                  settled    = me.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({
+                      itemId, windowId: embodiedWindowId
+                  });
+
+            if (!settled) return false
+        }
+
+        try {
+            if (nativeRoute) {
+                closed = await Neo.Main.windowNativeClose({
+                    nativeHandleKey: nativeRoute.nativeHandleKey,
+                    targetWindowId : nativeRoute.targetWindowId,
+                    windowId       : me.windowId
+                }) === true
+            } else {
+                // Before connect there is no exact route to correlate yet; the active tear-out
+                // slot's unguessable semantic name is the only available authority. Once a route
+                // exists, ANY invalidity above fails closed — never downgrade to same-name close.
+                await Neo.Main.windowClose({names: [windowName], windowId: me.windowId});
+                closed = true
+            }
+        } catch (error) {
+            return false
+        }
+
+        if (!closed) return false;
+
+        delete me.tearOutConnects[itemId];
+        me.tearOutConnectAdmissions.delete(itemId);
+        me.revokeVesselOwnerGrant('tear-out', itemId);
+        me.tearOutRetirements.delete(itemId);
+
+        return true
+    }
+
+    /**
+     * @summary Resolves the exact live vessel identity for one torn item, connect- or commit-side.
+     * @param {String} itemId
+     * @returns {Object|null}
+     * @protected
+     */
+    resolveTearOutVessel(itemId) {
+        let entry = this.tearOutConnects[itemId] ?? this.tearOutPanes[itemId];
+
+        if (!entry?.windowId) return null;
+
+        const resolved = {
+            ...entry,
+            nativeRoute: entry.nativeRoute ?? Neo.manager?.Window?.get(entry.windowId)?.nativeRoute ?? null,
+            windowName : entry.windowName ?? `tearout-${itemId}`
+        };
+
+        Object.defineProperties(resolved, {
+            admissionToken: {value: entry.admissionToken},
+            generation    : {value: entry.generation}
+        });
+
+        return resolved
+    }
+
+    /**
+     * @summary The tear-out commit seam with exact-position capture riding it: the
+     * `{tabsNodeId, index}` pair is readable only BEFORE a detach commit removes the item from
+     * the tree, and a refused commit deletes its own capture — no stale placement outlives a
+     * gesture that never committed. Every non-detach descriptor passes through untouched.
+     * @param {Object} descriptor
+     * @returns {{document: Object, errors: String[]}|null}
+     * @protected
+     */
+    applyTearOutOperation(descriptor) {
+        let me       = this,
+            isDetach = descriptor?.operation === 'detachItem',
+            captured = isDetach ? DockZoneModel.captureItemPlacement(me.dockModel, descriptor.itemId) : null,
+            result;
+
+        captured && (me.tearOutPlacements[descriptor.itemId] = captured);
+
+        result = me.applyDockZoneOperation(descriptor);
+
+        isDetach && result?.errors?.length && delete me.tearOutPlacements[descriptor.itemId];
+
+        return result
+    }
+
+    /**
+     * @summary Commits a detached terminal without sacrificing the live pane to projection order.
+     * @description A connect-first vessel already carries the pane and leaves an exact-slot source
+     * placeholder for ordinary projection cleanup. A terminal-first vessel has no placeholder, so
+     * the source reconciler must preserve the pane until the granted child arrives.
+     * @param {Object} document
+     * @param {Object} operation
+     * @param {Object} vessel Exact admitted vessel identity, including its private generation.
+     * @protected
+     */
+    onTearOutDocumentChange(document, operation, vessel) {
+        let me       = this,
+            detached = operation?.operation === 'detachItem',
+            itemId   = operation?.itemId;
+
+        if (!detached) {
+            me.onDockZoneDocumentChange(document);
+            return
+        }
+
+        me.onDockZoneDocumentChange(document, {
+            preserveItemIds: me.tearOutEmbodiment.isStaged(itemId) ? [] : [itemId]
+        });
+        me.adoptTearOutPane(itemId, vessel?.generation, vessel?.admissionToken)
+    }
+
+    /**
+     * The post-commit adoption: the detached terminal committed `detachItem` (the item left the
+     * tree, catalog preserved), so the vessel now OWNS the pane. Writes the {@link #tearOutPanes}
+     * entry and — if the vessel already connected ({@link #tearOutConnects}, the long-drag order)
+     * — reparents the live pane into it immediately; otherwise {@link #onWindowConnect} adopts on
+     * arrival (the fast-terminal order).
+     * @param {String} itemId
+     * @param {Number} [generation] Exact owner-grant generation for terminal-first adoption.
+     * @param {Number} [admissionToken] Exact gesture admission for terminal-first adoption.
+     * @protected
+     */
+    adoptTearOutPane(itemId, generation, admissionToken) {
+        let me        = this,
+            connected = me.tearOutConnects[itemId];
+
+        me.tearOutPanes[itemId] = connected
+            ? {...connected}
+            : {windowName: `tearout-${itemId}`, windowId: null};
+
+        Object.defineProperties(me.tearOutPanes[itemId], {
+            admissionToken: {
+                configurable: true,
+                value       : connected?.admissionToken ?? admissionToken ?? null,
+                writable    : true
+            },
+            generation: {
+                configurable: true,
+                value       : connected?.generation ?? generation ?? null,
+                writable    : true
+            },
+            nativeRoute: {
+                configurable: true,
+                value       : connected?.nativeRoute ?? null,
+                writable    : true
+            }
+        });
+
+        if (connected) {
+            // Promotion is synchronous and single-owner: committed disconnects may only match
+            // tearOutPanes from this point onward, never the pre-terminal connect branch first.
+            delete me.tearOutConnects[itemId];
+
+            if (me.tearOutEmbodiment.isStaged(itemId)) {
+                me.tearOutEmbodiment.promote({itemId, windowId: connected.windowId})
+            } else {
+                me.reparentTearOutPane(itemId, connected)
+            }
+        }
+    }
+
+    /**
+     * Moves the LIVE cached pane into a connected tear-out vessel — pure render-target work;
+     * the model already committed at the terminal.
+     * @param {String} itemId
+     * @param {Object} target `{windowId}`
+     * @returns {Boolean}
+     * @protected
+     */
+    reparentTearOutPane(itemId, target) {
+        let me         = this,
+            {windowId} = target,
+            app        = Neo.apps[windowId],
+            pane       = me.paneCache[itemId];
+
+        if (!app || !pane || pane.isDestroyed) return false;
+
+        me.tearOutPanes[itemId] && Object.assign(me.tearOutPanes[itemId], target);
+
+        if (pane.parent !== app.mainView) {
+            pane.parent?.remove(pane, false);
+            app.mainView.add(pane)
+        }
+
+        return true
+    }
+
+    /**
+     * @summary Brings a torn-out item HOME on vessel death — the exact-position return.
+     *
+     * The stored `{tabsNodeId, index}` pair (captured at the detach terminal) is the placement
+     * truth; recovery is SEMANTIC, never geometric: a stored home node that left the tree falls
+     * back to the first surviving tabs node (append). Exact-once and idempotent: an item some
+     * other flow already re-treed is left where it is, and the placement record is consumed
+     * regardless. An item whose document no longer catalogs it, or a document with no surviving
+     * tabs node, stays catalog-only — the honest terminal, with zero mutation.
+     * @param {String} itemId
+     * @protected
+     */
+    reintegrateTearOutItem(itemId) {
+        let me         = this,
+            placement  = me.tearOutPlacements[itemId],
+            doc        = me.dockModel,
+            storedHome = placement && doc.nodes?.[placement.tabsNodeId]?.type === 'tabs' ? placement.tabsNodeId : null,
+            fallback   = storedHome || Object.entries(doc.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],
+            result;
+
+        delete me.tearOutPlacements[itemId];
+
+        if (!doc.items?.[itemId] || !fallback || DockZoneModel.findContainingTabsId(doc, itemId)) {
+            return
+        }
+
+        result = me.applyDockZoneOperation({
+            operation : 'addTab',
+            itemId,
+            tabsNodeId: fallback,
+            ...(storedHome ? {index: placement.index} : {})
+        });
+
+        result?.errors?.length === 0 && me.onDockZoneDocumentChange(result.document)
+    }
+
+    /**
+     * A popup window joined the shared heap: if it is one of OURS (the pop-out URL carries
+     * `popout=<itemId>&hostId=<this.id>` plus an exact vessel grant), reparent the LIVE cached
+     * pane into its main view. The instance moves trees; nothing is recreated.
+     * @param {Object} data `{appName, windowId, windowData}`
+     */
+    async onWindowConnect(data) {
+        let me         = this,
+            {windowId} = data,
+            app        = Neo.apps[windowId];
+
+        if (!app || me.isDestroyed) return;
+
+        let url            = await Neo.Main.getByPath({path: 'document.URL', windowId}),
+            params         = new URL(url).searchParams,
+            itemId         = params.get('popout'),
+            flow           = params.get('vesselFlow'),
+            grant          = params.get('vesselGrant'),
+            admissionValue = params.get('vesselAdmission'),
+            admissionToken = admissionValue === null ? NaN : Number(admissionValue),
+            generation     = Number(params.get('vesselGeneration'));
+
+        if (params.get('hostId') !== me.id) return;
+        if (!itemId || flow !== 'tear-out' || !Number.isFinite(admissionToken)) return;
+
+        // Geometry-ready is part of child admission: do not publish the connected vessel to any
+        // ownership branch until its Main realm has installed resize observation.
+        await Neo.main.addon.WindowPosition?.setConfigs({observeResize: true, windowId});
+
+        // Retirement authority is established before any awaited close. A connect continuation
+        // that resumes after that boundary is cleanup-only. Consume its exact grant and retain
+        // the route for a refused-close retry, but never stage content into the closing realm.
+        if (me.tearOutRetirements.has(itemId)) {
+            if (me.consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId})) {
+                const admission = {admissionToken, generation, invalidated: true, windowId};
+
+                Object.defineProperty(admission, 'nativeRoute', {value: data.windowData.nativeRoute});
+                me.tearOutConnectAdmissions.set(itemId, admission)
+            }
+            return
+        }
+
+        if (!me.consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId})) return;
+
+        // A granted tear-out embodies immediately: the same live pane moves into the vessel while
+        // a hidden exact-slot placeholder keeps source tab/card indices coherent. Model truth
+        // remains untouched until the terminal.
+        const
+            admission  = {admissionToken, generation, invalidated: false, windowId},
+            connection = {windowId};
+
+        Object.defineProperties(connection, {
+            admissionToken: {value: admissionToken},
+            generation    : {value: generation},
+            nativeRoute   : {value: data.windowData.nativeRoute}
+        });
+        Object.defineProperty(admission, 'nativeRoute', {value: data.windowData.nativeRoute});
+        me.tearOutConnectAdmissions.set(itemId, admission);
+
+        const staged = await me.tearOutEmbodiment.stage({itemId, windowId});
+
+        // A re-entry/cancel may retire the semantic vessel while the cross-window render
+        // transaction is still painting. The exact admission token is durable across a close
+        // acknowledgement clearing the transient retirement fence, so a dead generation can
+        // never resume here and publish itself after its disconnect already fired.
+        if (
+            me.tearOutConnectAdmissions.get(itemId) !== admission || admission.invalidated ||
+            me.tearOutRetirements.has(itemId)
+        ) {
+            staged && me.tearOutEmbodiment.restore({itemId, windowId});
+            return
+        }
+
+        me.tearOutConnectAdmissions.delete(itemId);
+
+        if (me.tearOutPanes[itemId]) {
+            Object.assign(me.tearOutPanes[itemId], connection);
+            Object.defineProperties(me.tearOutPanes[itemId], {
+                admissionToken: {configurable: true, value: admissionToken, writable: true},
+                generation    : {configurable: true, value: generation, writable: true},
+                nativeRoute   : {configurable: true, value: data.windowData.nativeRoute, writable: true}
+            });
+
+            if (staged) {
+                me.tearOutEmbodiment.promote({itemId, windowId})
+            } else {
+                me.reparentTearOutPane(itemId, connection)
+            }
+        } else {
+            me.tearOutConnects[itemId] = connection
+        }
+    }
+
+    /**
+     * A vessel window left the shared heap. Physical death is authoritative: clear every state
+     * owner so a successor gesture cannot inherit or be blocked by the retired generation, and
+     * bring a committed item HOME (model commit precedes every render effect; the reintegration
+     * is exact-once and idempotent).
+     * @param {Object} data `{appName, windowId}`
+     */
+    onWindowDisconnect(data) {
+        let me = this;
+
+        if (me.isDestroyed) return;
+
+        // A child can disconnect while its live-pane stage is still awaiting renderer settlement.
+        // The connect is not in tearOutConnects yet, so this private generation token is the only
+        // exact owner. Retire it now; the stage continuation observes the deleted token and cannot
+        // republish the dead window.
+        for (const [itemId, admission] of me.tearOutConnectAdmissions) {
+            if (admission.windowId === data.windowId) {
+                const
+                    committed  = Boolean(me.tearOutPanes[itemId]),
+                    windowName = `tearout-${itemId}`;
+
+                me.tearOutConnectAdmissions.delete(itemId);
+                me.tearOutRetirements.add(itemId);
+
+                if (me.tearOutEmbodiment.isStaged(itemId)) {
+                    me.tearOutEmbodiment.restore({itemId, windowId: data.windowId})
+                }
+
+                me.tearOutHandlers.onVesselRetired({
+                    admissionToken: admission.admissionToken,
+                    generation    : admission.generation,
+                    itemId,
+                    windowName
+                });
+                me.revokeVesselOwnerGrant('tear-out', itemId);
+                me.tearOutRetirements.delete(itemId);
+                delete me.tearOutPanes[itemId];
+                committed && me.reintegrateTearOutItem(itemId);
+                return
+            }
+        }
+
+        // A pre-terminal tear-out may disconnect after an exact close returned false (the native
+        // event can outrun its Boolean acknowledgement) or after the user closes the retained
+        // window manually. Clear BOTH state owners.
+        for (const [itemId, entry] of Object.entries(me.tearOutConnects)) {
+            if (entry.windowId === data.windowId) {
+                const windowName = `tearout-${itemId}`;
+
+                me.tearOutRetirements.add(itemId);
+
+                if (me.tearOutEmbodiment.isStaged(itemId)) {
+                    const sourceOwns = Boolean(DockZoneModel.findContainingTabsId(me.dockModel, itemId));
+
+                    me.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({itemId, windowId: entry.windowId})
+                }
+
+                delete me.tearOutConnects[itemId];
+                me.tearOutHandlers.onVesselRetired({
+                    admissionToken: entry.admissionToken,
+                    generation    : entry.generation,
+                    itemId,
+                    windowName
+                });
+                me.revokeVesselOwnerGrant('tear-out', itemId);
+                me.tearOutRetirements.delete(itemId);
+                return
+            }
+        }
+
+        // Tear-out vessel death after the commit: the item comes HOME. A pre-terminal disconnect
+        // has no entry in either map and needs nothing.
+        for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
+            if (entry.windowId === data.windowId) {
+                const windowName = entry.windowName ?? `tearout-${itemId}`;
+
+                delete me.tearOutPanes[itemId];
+                delete me.tearOutConnects[itemId];
+                me.tearOutRetirements.delete(itemId);
+                me.tearOutHandlers.onVesselRetired({
+                    admissionToken: entry.admissionToken,
+                    generation    : entry.generation,
+                    itemId,
+                    windowName
+                });
+                me.reintegrateTearOutItem(itemId);
+                break
+            }
+        }
+    }
+
+    /**
+     * @summary The app-owned tear-out journey executor — scene 2's real-pointer drive.
+     *
+     * Arms a tab drag, flings the proxy past the window boundary so
+     * {@link Neo.dashboard.DockTabSortZone} fires `dockTearOutExit`, the host opens a `?popout=`
+     * vessel, then — gated on that vessel's ACTUAL birth ({@link #onWindowConnect}) — survives
+     * deliberate post-birth moves and settles one of three terminals: release while detached
+     * (`dockTearOutTerminal` → the `detachItem` commit + adoption), Escape-cancel (zero-mutation
+     * vessel close), or RE-ENTRY (`reenter` — the drag walks back inside past the reattach
+     * threshold, the vessel retires MID-GESTURE with zero mutation and the in-window proxy
+     * resumes: the film's back-IN morph beat, then cancelled cleanly).
+     *
+     * The proof is OBSERVABLE-ONLY — committed document truth + vessel bookkeeping, never the
+     * machine's internal drag state. Path and pace are tunable for the film takes (D-010):
+     * `curve` bows the pointer path (0 = straight, deterministic either way), `moveSteps` and
+     * `moveDelay` set the sampling density and rhythm.
+     * @param {Object} step
+     * @param {String} step.itemId The dock item to tear out.
+     * @param {String} step.sourceNodeId The tabs node currently holding it.
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.cancel=false] Escape while detached — the zero-mutation witness.
+     * @param {Number} [options.curve=0] Perpendicular path bow as a fraction of path length.
+     * @param {Number} [options.moveDelay=16] Milliseconds between pointer samples.
+     * @param {Number} [options.moveSteps=4] Pointer samples per path leg.
+     * @param {Number} [options.postBirthMoves=2] Outward moves after birth (survival probe; floored at 2).
+     * @param {Boolean} [options.reenter=false] Walk back inside instead of releasing — the morph witness.
+     * @returns {Promise<Object>}
+     */
+    async executeTearOutStep(step, {cancel=false, curve=0, moveDelay=16, moveSteps=4, postBirthMoves=2, reenter=false}={}) {
+        let me                     = this,
+            {itemId, sourceNodeId} = step || {},
+            document               = me.dockModel,
+            node                   = document?.nodes?.[sourceNodeId],
+            button                 = null,
+            release                = null;
+
+        if (!itemId || node?.type !== 'tabs' || !node.items.includes(itemId)) {
+            return {applied: false, errors: ['tear-out step must name a live item held by a tabs node']}
+        }
+
+        let pane = me.paneCache[itemId];
+
+        if (!pane || pane.isDestroyed || !document.items?.[itemId]) {
+            return {applied: false, errors: ['source pane is not live and owned by the workspace']}
+        }
+
+        try {
+            // Drain the host-owned projection queue before reading tab chrome.
+            await me.refreshPromise;
+
+            let host          = me.getReference('dock-host'),
+                tabs          = host?.down({dockNodeId: sourceNodeId}),
+                sortZone      = tabs?.getTabBar()?.sortZone,
+                itemIndex     = node.items.indexOf(itemId),
+                WindowManager = (await import('../../../src/manager/Window.mjs')).default;
+
+            button = tabs?.getTabAtIndex(itemIndex);
+
+            let window       = WindowManager.get(button?.windowId),
+                [buttonRect] = button ? await button.getDomRect([button.id], button.windowId) : [];
+
+            if (!button || !sortZone || !buttonRect || !window?.innerRect) {
+                return {applied: false, errors: ['tear-out gesture surfaces are not ready']}
+            }
+
+            // The committed document BEFORE the gesture — the zero-mutation (cancel/reenter) and
+            // detach-commit (terminal) proofs both compare against this snapshot.
+            let documentBefore = DockZoneModel.clone(document),
+                catalogBefore  = Object.keys(documentBefore.items);
+
+            let startX  = buttonRect.x + buttonRect.width / 2,
+                startY  = buttonRect.y + buttonRect.height / 2,
+                startSX = window.innerRect.x + startX,
+                startSY = window.innerRect.y + startY,
+                opt     = (clientX, clientY, screenX, screenY, buttons) => ({
+                    bubbles: true, button: 0, buttons, cancelable: true, clientX, clientY, screenX, screenY
+                }),
+                moveTo  = (x, y) => me.interactionService.simulateEvent({events: [{
+                    delay  : moveDelay, targetId: button.id, type: 'mousemove', windowId: button.windowId,
+                    options: opt(x, y, window.innerRect.x + x, window.innerRect.y + y, 1)
+                }]});
+
+            // A stale record from a prior gesture would false-open the birth gate.
+            delete me.tearOutConnects[itemId];
+
+            // Phase 1: own the native sensor + cross the LOCAL drag arming threshold (delay+distance).
+            await me.interactionService.simulateEvent({events: [{
+                targetId: button.id, type: 'mousedown', windowId: button.windowId,
+                options : opt(startX, startY, startSX, startSY, 1)
+            }, {
+                delay  : 120, targetId: button.id, type: 'mousemove', windowId: button.windowId,
+                options: opt(startX + 8, startY + 2, startSX + 8, startSY + 2, 1)
+            }, {
+                delay  : 16, targetId: button.id, type: 'mousemove', windowId: button.windowId,
+                options: opt(startX + 16, startY + 24, startSX + 16, startSY + 24, 1)
+            }]});
+
+            // The drag arms ASYNC — gate on proxy + boundary + itemRects before any outward sample
+            // or the exit never fires (arming precedes boundary moves).
+            let armed = await me.waitForTearOutDragArmed(sortZone);
+
+            if (!armed) {
+                let cancellation = await me.cancelTearOutGesture(button, {clientX: startX, clientY: startY, screenX: startSX, screenY: startSY});
+
+                return {applied: false, errors: ['tear-out drag did not arm'], proof: {armed: false, cancellation, documentBefore}}
+            }
+
+            // The tear-out exit fires when the proxy LEAVES `boundaryContainerRect`. Target past
+            // its bottom-right corner, fully outside, so intersectionRatio collapses below the
+            // reattach threshold.
+            let b       = sortZone.boundaryContainerRect,
+                bRight  = b.right  ?? (b.x + b.width),
+                bBottom = b.bottom ?? (b.y + b.height),
+                outX    = Math.round(bRight  + 120),
+                outY    = Math.round(bBottom + 120),
+                outSX   = window.innerRect.x + outX,
+                outSY   = window.innerRect.y + outY;
+
+            release = {clientX: outX, clientY: outY, screenX: outSX, screenY: outSY};
+
+            // The deterministic pointer path: a quadratic bow through a perpendicular control
+            // point (curve=0 degenerates to the straight line). t runs 0→1 outward.
+            let pathPoint = t => {
+                let mx = startX + (outX - startX) / 2 + (outY - startY) * curve,
+                    my = startY + (outY - startY) / 2 - (outX - startX) * curve,
+                    ax = startX + (mx - startX) * t, ay = startY + (my - startY) * t,
+                    bx = mx + (outX - mx) * t,       by = my + (outY - my) * t;
+
+                return {x: Math.round(ax + (bx - ax) * t), y: Math.round(ay + (by - ay) * t)}
+            };
+
+            // Phase 2: PROGRESSIVE outward moves — each further out so intersectionRatio steps
+            // down: dragBoundaryExit → dockTearOutExit → the host acquires the vessel.
+            for (let stepIndex = 1; stepIndex <= moveSteps; stepIndex++) {
+                let p = pathPoint(stepIndex / moveSteps);
+
+                await moveTo(p.x, p.y)
+            }
+
+            // Gate on the vessel's ACTUAL birth: a `?popout=` window connecting through onWindowConnect.
+            let born = await me.waitForTearOutVessel(itemId);
+
+            if (!born) {
+                let diag         = `exitFired=${Boolean(sortZone.isWindowDragging)} lastRatio=${sortZone.lastIntersectionRatio} boundary=${JSON.stringify(b)} out=(${outX},${outY}) itemRects=${sortZone.itemRects?.length ?? 'null'}`,
+                    cancellation = await me.cancelTearOutGesture(button, release);
+
+                return {
+                    applied: false,
+                    errors : [`tear-out vessel was not born after the boundary exit — ${diag}`],
+                    proof  : {armed: true, born: false, diag, cancellation, documentBefore}
+                }
+            }
+
+            // Post-birth survival probe: deliberate OUTWARD moves must NOT reap the newborn vessel.
+            let probeMoves = Math.max(2, postBirthMoves);
+
+            for (let i = 1; i <= probeMoves; i++) {
+                await moveTo(outX, outY + i * 12)
+            }
+
+            let survivedProbe = Boolean(me.tearOutConnects[itemId]);
+
+            if (reenter) {
+                // The morph beat: walk back INSIDE until the PROXY re-enters past the reattach
+                // threshold — dockTearOutEntry retires the vessel MID-GESTURE with zero mutation
+                // and the zone resumes its in-window embodiment. Then end the resumed in-window
+                // drag with a clean cancel; the document stays byte-identical.
+                //
+                // The re-entry target is a point ~35% into the boundary rect, NOT the source
+                // button: the tear-out proxy is pane-sized and the grab corner is unknown, so a
+                // button near a window edge can never recover 60% overlap — the interior point
+                // guarantees the ratio for any grab corner.
+                let vesselWindowId = me.tearOutConnects[itemId]?.windowId ?? null,
+                    inX            = Math.round(b.x + (b.width  ?? 0) * 0.35),
+                    inY            = Math.round(b.y + (b.height ?? 0) * 0.35);
+
+                for (let stepIndex = 1; stepIndex <= moveSteps; stepIndex++) {
+                    let t = stepIndex / moveSteps;
+
+                    await moveTo(
+                        Math.round(outX + (inX - outX) * t),
+                        Math.round(outY + (inY - outY) * t)
+                    )
+                }
+
+                let retired       = await me.waitForTearOutVesselRetired(itemId),
+                    reentryDiag   = `isWindowDragging=${Boolean(sortZone.isWindowDragging)} reattachArmed=${Boolean(sortZone.reattachArmed)} lastRatio=${sortZone.lastIntersectionRatio} activeVessel=${Boolean(me.tearOutHandlers.activeVessel)} connects=${Boolean(me.tearOutConnects[itemId])} staged=${me.tearOutEmbodiment.isStaged(itemId)} boundary=${JSON.stringify(b)} in=(${inX},${inY}) vesselDims=${JSON.stringify(me.tearOutVesselDims)}`,
+                    cancellation  = await me.cancelTearOutGesture(button, {clientX: inX, clientY: inY, screenX: window.innerRect.x + inX, screenY: window.innerRect.y + inY}),
+                    documentAfter = DockZoneModel.clone(me.dockModel),
+                    windowGone    = !vesselWindowId || !WindowManager.get(vesselWindowId);
+
+                return {
+                    applied  : false,
+                    errors   : retired ? [] : [`vessel did not retire on re-entry — ${reentryDiag}`],
+                    reentered: retired,
+                    proof    : {
+                        born              : true,
+                        survivedProbe,
+                        retired,
+                        windowGone,
+                        cancellation,
+                        documentBefore,
+                        documentAfter,
+                        documentsUnchanged: JSON.stringify(documentBefore) === JSON.stringify(documentAfter),
+                        vesselWindowName  : `tearout-${itemId}`
+                    }
+                }
+            }
+
+            if (cancel) {
+                // Escape while detached → dockTearOutCancel → the host closes its vessel. The
+                // committed document must be byte-identical — the zero-mutation invariant.
+                let cancellation  = await me.cancelTearOutGesture(button, release),
+                    documentAfter = DockZoneModel.clone(me.dockModel);
+
+                return {
+                    applied  : false,
+                    cancelled: true,
+                    errors   : [],
+                    proof    : {
+                        born              : true,
+                        survivedProbe,
+                        cancellation,
+                        documentBefore,
+                        documentAfter,
+                        documentsUnchanged: JSON.stringify(documentBefore) === JSON.stringify(documentAfter),
+                        vesselWindowName  : `tearout-${itemId}`
+                    }
+                }
+            }
+
+            // Terminal: release while detached → dockTearOutTerminal → the detachItem commit +
+            // adoption (the vessel owns the pane now).
+            await me.interactionService.simulateEvent({events: [{
+                targetId: button.id, type: 'mouseup', windowId: button.windowId,
+                options : opt(outX, outY, outSX, outSY, 0)
+            }]});
+
+            let committed      = await me.waitForTearOutCommit(itemId),
+                documentAfter  = DockZoneModel.clone(me.dockModel),
+                absentFromTree = !Object.values(documentAfter.nodes).some(zoneNode => zoneNode.items?.includes(itemId)),
+                keptInCatalog  = Boolean(documentAfter.items?.[itemId]);
+
+            return {
+                applied: committed && absentFromTree && keptInCatalog,
+                errors : committed && absentFromTree && keptInCatalog ? [] : ['detachItem commit did not reach committed document truth'],
+                proof  : {
+                    born              : true,
+                    survivedProbe,
+                    committed,
+                    documentBefore,
+                    documentAfter,
+                    detachCommitted   : absentFromTree && keptInCatalog,
+                    itemAbsentFromTree: absentFromTree,
+                    itemKeptInCatalog : keptInCatalog,
+                    catalogPreserved  : catalogBefore.every(id => Boolean(documentAfter.items?.[id])),
+                    vesselWindowName  : `tearout-${itemId}`
+                }
+            }
+        } catch (error) {
+            button && await me.cancelTearOutGesture(button, release).catch(() => {});
+
+            return {applied: false, errors: [error?.message || String(error)]}
+        }
+    }
+
+    /**
+     * Polls until the base drag has ARMED — a live proxy AND the async main-thread
+     * `boundaryContainerRect` AND measured `itemRects` are all present: exactly the facts
+     * the sort zone needs before it will sample a boundary exit.
+     * @param {Neo.draggable.container.SortZone} sortZone
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=120]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async waitForTearOutDragArmed(sortZone, {attempts=120, delay=16}={}) {
+        let me    = this,
+            armed = () => Boolean(sortZone?.dragProxy && sortZone?.boundaryContainerRect && sortZone?.itemRects);
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            if (armed()) return true;
+
+            attempt < attempts && await me.timeout(delay)
+        }
+
+        return armed()
+    }
+
+    /**
+     * Gates on the tear-out vessel's ACTUAL birth: the `?popout=<itemId>` window connecting
+     * through {@link #onWindowConnect}. Polls that observable rather than any internal drag flag.
+     * @param {String} itemId
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=180]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async waitForTearOutVessel(itemId, {attempts=180, delay=16}={}) {
+        let me = this;
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            if (me.tearOutConnects[itemId] || me.tearOutPanes[itemId]) return true;
+
+            attempt < attempts && await me.timeout(delay)
+        }
+
+        return Boolean(me.tearOutConnects[itemId] || me.tearOutPanes[itemId])
+    }
+
+    /**
+     * Gates on a re-entry retirement fully settling: no connect entry, no pending admission,
+     * no staged embodiment, and the tear-out machine's slot cleared.
+     * @param {String} itemId
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=180]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async waitForTearOutVesselRetired(itemId, {attempts=180, delay=16}={}) {
+        let me      = this,
+            retired = () => Boolean(
+                !me.tearOutConnects[itemId] && !me.tearOutConnectAdmissions.has(itemId) &&
+                !me.tearOutEmbodiment.isStaged(itemId) && !me.tearOutHandlers.activeVessel
+            );
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            if (retired()) return true;
+
+            attempt < attempts && await me.timeout(delay)
+        }
+
+        return retired()
+    }
+
+    /**
+     * Gates on the committed detach reaching document truth: the item leaves every node's
+     * `items` (the vessel owns it) while the catalog entry stays.
+     * @param {String} itemId
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=180]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async waitForTearOutCommit(itemId, {attempts=180, delay=16}={}) {
+        let me       = this,
+            detached = () => {
+                let document = me.dockModel;
+
+                return !Object.values(document.nodes).some(zoneNode => zoneNode.items?.includes(itemId))
+                    && Boolean(document.items?.[itemId])
+            };
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            if (detached()) return true;
+
+            attempt < attempts && await me.timeout(delay)
+        }
+
+        return detached()
+    }
+
+    /**
+     * Cancels a live tear-out gesture: an Escape keydown (the drag-cancel signal the sort zone
+     * consumes) followed by a settling mouseup.
+     * @param {Neo.component.Base} button The dragged tab button.
+     * @param {Object} release `{clientX, clientY, screenX, screenY}` the release point.
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async cancelTearOutGesture(button, release) {
+        let me = this;
+
+        if (!button) return {escapeDispatched: false, releaseDispatched: false, settled: false};
+
+        let {clientX=0, clientY=0, screenX=0, screenY=0} = release || {},
+            escapeDispatched = await me.interactionService.dispatch({
+                id      : button.id,
+                type    : 'keydown',
+                windowId: button.windowId,
+                options : {bubbles: true, cancelable: true, code: 'Escape', key: 'Escape'}
+            }),
+            releaseDispatched = await me.interactionService.dispatch({
+                id      : button.id,
+                type    : 'mouseup',
+                windowId: button.windowId,
+                options : {bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY, screenX, screenY}
+            });
+
+        return {escapeDispatched, releaseDispatched, settled: true}
+    }
+
+    /**
      * Tears down the workspace-owned producer, tour seams, and cached pane instances.
      * @param {...*} args
      */
@@ -1089,9 +2173,17 @@ class Workspace extends Container {
             me.#feedIntervalId = null
         }
 
+        Neo.currentWorker.un({
+            connect   : me.onWindowConnect,
+            disconnect: me.onWindowDisconnect,
+            scope     : me
+        });
+
         me.tourRunner?.destroy();
         me.dockService?.destroy();
         me.dragAffordances?.destroy();
+        me.interactionService?.destroy();
+        me.tearOutEmbodiment?.destroy();
         me.cueSettlements.clear();
 
         Object.values(me.paneCache).forEach(pane => {

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1937,9 +1937,16 @@ class Workspace extends Container {
                 // button: the tear-out proxy is pane-sized and the grab corner is unknown, so a
                 // button near a window edge can never recover 60% overlap — the interior point
                 // guarantees the ratio for any grab corner.
-                let vesselWindowId = me.tearOutConnects[itemId]?.windowId ?? null,
-                    inX            = Math.round(b.x + (b.width  ?? 0) * 0.35),
-                    inY            = Math.round(b.y + (b.height ?? 0) * 0.35);
+                let vesselWindowId    = me.tearOutConnects[itemId]?.windowId ?? null,
+                    inX               = Math.round(b.x + (b.width  ?? 0) * 0.35),
+                    inY               = Math.round(b.y + (b.height ?? 0) * 0.35),
+                    boundaryEntrySeen = false,
+                    entrySeen         = false,
+                    boundaryProbe     = () => {boundaryEntrySeen = true},
+                    entryProbe        = () => {entrySeen = true};
+
+                sortZone.on('dragBoundaryEntry', boundaryProbe);
+                tabs.on('dockTearOutEntry', entryProbe);
 
                 for (let stepIndex = 1; stepIndex <= moveSteps; stepIndex++) {
                     let t = stepIndex / moveSteps;
@@ -1950,8 +1957,13 @@ class Workspace extends Container {
                     )
                 }
 
-                let retired       = await me.waitForTearOutVesselRetired(itemId),
-                    reentryDiag   = `isWindowDragging=${Boolean(sortZone.isWindowDragging)} reattachArmed=${Boolean(sortZone.reattachArmed)} lastRatio=${sortZone.lastIntersectionRatio} activeVessel=${Boolean(me.tearOutHandlers.activeVessel)} connects=${Boolean(me.tearOutConnects[itemId])} staged=${me.tearOutEmbodiment.isStaged(itemId)} boundary=${JSON.stringify(b)} in=(${inX},${inY}) vesselDims=${JSON.stringify(me.tearOutVesselDims)}`,
+                let retired     = await me.waitForTearOutVesselRetired(itemId),
+                    reentryDiag = `boundaryEntrySeen=${boundaryEntrySeen} entrySeen=${entrySeen} isWindowDragging=${Boolean(sortZone.isWindowDragging)} reattachArmed=${Boolean(sortZone.reattachArmed)} lastRatio=${sortZone.lastIntersectionRatio} placeholder=${Boolean(sortZone.dragPlaceholder)} indexMap=${JSON.stringify(sortZone.indexMap)} ownerItems=${sortZone.owner?.items?.length} itemRectsLen=${sortZone.itemRects?.length} activeVessel=${Boolean(me.tearOutHandlers.activeVessel)} connects=${Boolean(me.tearOutConnects[itemId])} staged=${me.tearOutEmbodiment.isStaged(itemId)} boundary=${JSON.stringify(b)} in=(${inX},${inY}) vesselDims=${JSON.stringify(me.tearOutVesselDims)}`;
+
+                sortZone.un('dragBoundaryEntry', boundaryProbe);
+                tabs.un('dockTearOutEntry', entryProbe);
+
+                let
                     cancellation  = await me.cancelTearOutGesture(button, {clientX: inX, clientY: inY, screenX: window.innerRect.x + inX, screenY: window.innerRect.y + inY}),
                     documentAfter = DockZoneModel.clone(me.dockModel),
                     windowGone    = !vesselWindowId || !WindowManager.get(vesselWindowId);

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -41,6 +41,18 @@ import {test, expect} from '../../fixtures.mjs';
  *   NEO_E2E_PORT=8124 npx playwright test workstation/WorkstationFiveBeatNL \
  *     -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
+// Film-take mode (NEO_FILM_TAKE=1): the SAME journey drive, recorded — per-page videos land in
+// the Playwright artifacts dir (main window + each vessel separately), and the gesture executors
+// switch from spec pacing to the production record's D-010 film pacing (slightly-quick, curved,
+// ~30fps pointer sampling). The spec's assertions stay identical: a take that cannot pass the
+// witness is not a take.
+const
+    filmTake = Boolean(process.env.NEO_FILM_TAKE),
+    filmPace = filmTake ? {curve: 0.18, moveDelay: 33, moveSteps: 24} : {};
+
+// `video` must live at file level (a describe-scoped use() would force a new worker).
+test.use({video: filmTake ? 'on' : 'off'});
+
 test.describe('Workstation — the five-beat multi-window journey', () => {
     test.setTimeout(180000);
     // The later beats need real screen estate to the right of the main window for vessels;
@@ -221,7 +233,8 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
         // Drive through the workspace-owned gesture executor — real pointer, worker-truth proof.
         const result = await app.callMethod(wsId, 'executeTearOutStep', [
-            {itemId: 'metrics', sourceNodeId: 'right-top-tabs'}
+            {itemId: 'metrics', sourceNodeId: 'right-top-tabs'},
+            filmPace
         ]);
 
         expect(result.errors).toEqual([]);
@@ -254,14 +267,12 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(pageErrors).toEqual([])
     });
 
-    // CONTRACTED pending the SortZone window-drag re-entry geometry fix: during window-drag the
-    // proxy is VESSEL-sized (popupWidth × popupHeight) while the boundary is the TAB STRIP, and
-    // checkWindowBoundary normalizes the intersection by the PROXY area — the achievable maximum
-    // is stripArea/proxyArea (measured 0.2003 on this stage, hit exactly at full strip cover),
-    // so `reattachThreshold: 0.6` is unreachable and `dockTearOutEntry` can never fire from a
-    // real pointer walk-back. The executor's `reenter` drive below is the ready witness; it
-    // activates once the entry test normalizes by the smaller rect (engine ticket filed from
-    // this finding — receipts in fivebeat-morph-run5.log, production root).
+    // CONTRACTED pending the second re-entry defect: the ratio now crosses (min-area coverage —
+    // measured 0.7898 > 0.6 armed+rising on this stage), but the SortZone entry block dereferences
+    // `dragPlaceholder.wrapperStyle` before firing, and dock tab strips are placeholder-less by
+    // design (projection-owned layout) — the crossing sample throws, `dragBoundaryEntry` never
+    // fires, the vessel never retires. Three-hop probes (`boundaryEntrySeen=false` while the
+    // ratio stored) pinned it; the executor's reenter drive stays the activation witness.
     test.fixme('scene 2 (morph) — out past the edge and BACK IN: the vessel retires mid-drag, zero mutation', async ({page, neuralLink}) => {
         const {app, pageErrors, wsId} = await boot({page, neuralLink});
 
@@ -274,7 +285,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         // resumes) — the film's back-IN morph beat, witnessed from worker truth.
         const result = await app.callMethod(wsId, 'executeTearOutStep', [
             {itemId: 'metrics', sourceNodeId: 'right-top-tabs'},
-            {reenter: true}
+            {reenter: true, ...filmPace}
         ]);
 
         expect(result.errors).toEqual([]);

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -19,12 +19,14 @@ import {test, expect} from '../../fixtures.mjs';
  *  5. «The signature»        — final topology plus the continuity readout: the same live
  *                              instances, heartbeats monotonic across every transition.
  *
- * Beats 2-4 are CONTRACTED (test.fixme) until the workstation composes the shared dashboard
- * multi-window machinery (vessel shell + workspace composition + app-owned gesture executors —
- * later commits on this branch; the underlying tear-out, conversion, arbitration, return, and
- * teardown mechanics are already shipped in src/dashboard). Each fixme names the worker-truth
- * receipts its activation must assert, so the contract is reviewable now and the legs turn on
- * without reshaping the suite.
+ * Scene 2 is LIVE (the workstation composes the shipped tear-out machinery: `?popout=` vessel
+ * shell + DockTearOut/DockVesselEmbodiment composition + the app-owned `executeTearOutStep`
+ * executor), including the back-IN morph witness — one continuous drag out and home again,
+ * zero mutation by guard. Beats 3-4 remain CONTRACTED (test.fixme) until the cross-window
+ * docking wiring lands (conversion, remote zone previews, arbitration, stack return; the
+ * mechanics are already shipped in src/dashboard). Each fixme names the worker-truth receipts
+ * its activation must assert, so the contract stays reviewable and the legs turn on without
+ * reshaping the suite.
  *
  * Determinism contract: the executable journey runs TWICE per spec run; the per-beat logs must
  * be identical across runs (structural facts only — no clock-coupled values), with a
@@ -205,17 +207,98 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(pageErrors, 'the journey must be error-free').toEqual([])
     });
 
-    // ── beats 2-4: contracted legs — activate as the workstation multi-window wiring lands ──
+    // ── beats 3-4: contracted legs — activate as the cross-window docking wiring lands ──
 
-    test.fixme('scene 2 — the tear-out: a real pointer drag births a vessel MID-GESTURE', async () => {
-        // Receipts this leg must assert when activated:
-        //  - the popup exists in Playwright's window set BEFORE pointer-up (waitForEvent('popup')
-        //    resolves while the drag is still armed — the mid-gesture birth claim);
-        //  - committed document: the torn item is ABSENT from every node's items yet PRESENT in
-        //    the catalog (the vessel owns it; no leak);
-        //  - the pane instance id is IDENTICAL before and after (object permanence into the hop);
-        //  - heartbeat monotonic across the transition;
-        //  - drive through the workspace-owned gesture executor, never raw reducer calls.
+    test('scene 2 — the tear-out: a real pointer drag births a vessel MID-GESTURE', async ({page, neuralLink}) => {
+        const {app, pageErrors, wsId} = await boot({page, neuralLink});
+
+        const
+            heartbeatBefore = await readHeartbeat(app, wsId),
+            paneIdBefore    = (await app.callMethod(wsId, 'getPaneIdentity', ['metrics'])),
+            popupPromise    = page.waitForEvent('popup', {timeout: 90000});
+
+        expect(paneIdBefore, 'the pane must be live and cached before the gesture').toBeTruthy();
+
+        // Drive through the workspace-owned gesture executor — real pointer, worker-truth proof.
+        const result = await app.callMethod(wsId, 'executeTearOutStep', [
+            {itemId: 'metrics', sourceNodeId: 'right-top-tabs'}
+        ]);
+
+        expect(result.errors).toEqual([]);
+        expect(result.proof.born,  'the vessel must be born MID-GESTURE (before pointer-up)').toBe(true);
+        expect(result.proof.survivedProbe, 'post-birth outward moves must not reap the vessel').toBe(true);
+        expect(result.applied, 'the detached release must commit detachItem').toBe(true);
+
+        // The popup is a REAL OS window in Playwright's window set — and it stays alive: it owns
+        // the pane now.
+        const popup = await popupPromise;
+
+        expect(popup.isClosed(), 'the committed vessel must remain open').toBe(false);
+
+        // Third-party truth: the committed document read fresh from the worker.
+        const documentAfter = await readDocument(app, wsId);
+
+        expect(Object.values(documentAfter.nodes).some(node => node.items?.includes('metrics')),
+            'the torn item must be ABSENT from every node').toBe(false);
+        expect(documentAfter.items.metrics, 'the torn item must stay in the catalog').toBeTruthy();
+        expect(documentAfter.nodes['right-top-tabs'].items, 'the sibling tab keeps the node alive')
+            .toEqual(['audit']);
+
+        // Object permanence: the SAME live instance crossed the window boundary.
+        const paneIdAfter = await app.callMethod(wsId, 'getPaneIdentity', ['metrics']);
+
+        expect(paneIdAfter).toBe(paneIdBefore);
+
+        // The heartbeat moved FORWARD — nothing reloaded, nothing recreated.
+        expect(await readHeartbeat(app, wsId)).toBeGreaterThan(heartbeatBefore);
+        expect(pageErrors).toEqual([])
+    });
+
+    // CONTRACTED pending the SortZone window-drag re-entry geometry fix: during window-drag the
+    // proxy is VESSEL-sized (popupWidth × popupHeight) while the boundary is the TAB STRIP, and
+    // checkWindowBoundary normalizes the intersection by the PROXY area — the achievable maximum
+    // is stripArea/proxyArea (measured 0.2003 on this stage, hit exactly at full strip cover),
+    // so `reattachThreshold: 0.6` is unreachable and `dockTearOutEntry` can never fire from a
+    // real pointer walk-back. The executor's `reenter` drive below is the ready witness; it
+    // activates once the entry test normalizes by the smaller rect (engine ticket filed from
+    // this finding — receipts in fivebeat-morph-run5.log, production root).
+    test.fixme('scene 2 (morph) — out past the edge and BACK IN: the vessel retires mid-drag, zero mutation', async ({page, neuralLink}) => {
+        const {app, pageErrors, wsId} = await boot({page, neuralLink});
+
+        const
+            heartbeatBefore = await readHeartbeat(app, wsId),
+            paneIdBefore    = await app.callMethod(wsId, 'getPaneIdentity', ['metrics']),
+            popupPromise    = page.waitForEvent('popup', {timeout: 90000});
+
+        // One continuous drag: out (vessel born) → back IN (vessel retires, the in-window proxy
+        // resumes) — the film's back-IN morph beat, witnessed from worker truth.
+        const result = await app.callMethod(wsId, 'executeTearOutStep', [
+            {itemId: 'metrics', sourceNodeId: 'right-top-tabs'},
+            {reenter: true}
+        ]);
+
+        expect(result.errors).toEqual([]);
+        expect(result.proof.born, 'the vessel must be born mid-gesture').toBe(true);
+        expect(result.reentered, 'the vessel must retire on re-entry while the pointer is down').toBe(true);
+        expect(result.proof.documentsUnchanged, 'a re-entered gesture is zero-mutation by guard').toBe(true);
+
+        // The popup existed for real — and closed itself when the gesture came home.
+        const popup = await popupPromise;
+
+        await expect.poll(() => popup.isClosed(), {
+            message: 'the retired vessel window must close',
+            timeout: 15000
+        }).toBe(true);
+
+        // Third-party truth: the committed document still holds the item in its original node.
+        const documentAfter = await readDocument(app, wsId);
+
+        expect(documentAfter.nodes['right-top-tabs'].items).toEqual(['metrics', 'audit']);
+
+        // Same instance, heartbeat monotonic — the morph never touched the living content.
+        expect(await app.callMethod(wsId, 'getPaneIdentity', ['metrics'])).toBe(paneIdBefore);
+        expect(await readHeartbeat(app, wsId)).toBeGreaterThan(heartbeatBefore);
+        expect(pageErrors).toEqual([])
     });
 
     test.fixme('scene 3 — the second window learns to dock: convert-while-dragging + exactly one preview', async () => {

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -80,6 +80,12 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         await page.waitForSelector('.workstation-tour-play',    {timeout: 30000});
         await page.waitForSelector('.neo-tab-overflow-control', {timeout: 30000});
 
+        // A film take records the physical display: the headed window must be the top of the
+        // z-order or the capture shows whatever application happens to cover it. CDP-level and
+        // deterministic — never AppleScript (two same-bundle Chrome processes make script
+        // addressing flip-flop between instances).
+        filmTake && await page.bringToFront();
+
         const app        = await neuralLink.connectToApp('Workstation'),
               workspaces = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
               wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
@@ -267,13 +273,10 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(pageErrors).toEqual([])
     });
 
-    // CONTRACTED pending the second re-entry defect: the ratio now crosses (min-area coverage —
-    // measured 0.7898 > 0.6 armed+rising on this stage), but the SortZone entry block dereferences
-    // `dragPlaceholder.wrapperStyle` before firing, and dock tab strips are placeholder-less by
-    // design (projection-owned layout) — the crossing sample throws, `dragBoundaryEntry` never
-    // fires, the vessel never retires. Three-hop probes (`boundaryEntrySeen=false` while the
-    // ratio stored) pinned it; the executor's reenter drive stays the activation witness.
-    test.fixme('scene 2 (morph) — out past the edge and BACK IN: the vessel retires mid-drag, zero mutation', async ({page, neuralLink}) => {
+    // The engine's re-entry path is whole at last: the ratio crosses (min-area coverage) AND the
+    // entry fires on placeholder-less zones (the layout restore is gated on its own marker) — one
+    // continuous drag out past the edge and home again, zero mutation by guard.
+    test('scene 2 (morph) — out past the edge and BACK IN: the vessel retires mid-drag, zero mutation', async ({page, neuralLink}) => {
         const {app, pageErrors, wsId} = await boot({page, neuralLink});
 
         const

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1,0 +1,248 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary The five-beat multi-window journey witness for the flagship workstation — the
+ * executable authority the release recording derives from. Recordings are derivatives; this
+ * journey, with worker-truth receipts per beat, is the proof that regenerates at any head.
+ *
+ * The five beats:
+ *
+ *  1. «The room is alive»    — the dense document answers a real resizeSplit, themes flip,
+ *                              and the feed heartbeat never pauses (shipped ops — live today);
+ *  2. «The tear-out»         — a tab dragged past the window edge becomes a real OS popup
+ *                              MID-GESTURE (the vessel exists while the pointer is still down);
+ *  3. «The second window learns to dock» — a pane converts to a popup while dragging, glides
+ *                              over the first popup, dock zones glow INSIDE it, and overlap
+ *                              arbitration previews EXACTLY one claim;
+ *  4. «Reintegration»        — the merged stack drags home, commits atomically, and the
+ *                              emptied vessel closes itself AFTER the commit;
+ *  5. «The signature»        — final topology plus the continuity readout: the same live
+ *                              instances, heartbeats monotonic across every transition.
+ *
+ * Beats 2-4 are CONTRACTED (test.fixme) until the workstation composes the shared dashboard
+ * multi-window machinery (vessel shell + workspace composition + app-owned gesture executors —
+ * later commits on this branch; the underlying tear-out, conversion, arbitration, return, and
+ * teardown mechanics are already shipped in src/dashboard). Each fixme names the worker-truth
+ * receipts its activation must assert, so the contract is reviewable now and the legs turn on
+ * without reshaping the suite.
+ *
+ * Determinism contract: the executable journey runs TWICE per spec run; the per-beat logs must
+ * be identical across runs (structural facts only — no clock-coupled values), with a
+ * zero-residue reload between takes. The film's recording pipeline replays exactly this drive
+ * headed, so a surface fix re-runs the spec instead of re-recording a one-shot video.
+ *
+ * Claim boundary: this spec makes NO cross-platform, default-selection, or release-portability
+ * claims — its receipts are macOS-headed only, and caption copy derived from it inherits the
+ * same bound.
+ *
+ * Headed run (the filmable form):
+ *   NEO_E2E_PORT=8124 npx playwright test workstation/WorkstationFiveBeatNL \
+ *     -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Workstation — the five-beat multi-window journey', () => {
+    test.setTimeout(180000);
+    // The later beats need real screen estate to the right of the main window for vessels;
+    // scene 1 inherits the same stage so the recorded geometry never shifts between beats.
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 800, width: 1280}
+    });
+
+    /**
+     * Boots the workstation, connects the Neural Link bridge, and wires error capture.
+     * @param {Object} fixtures `{page, neuralLink}`
+     * @returns {Promise<Object>} `{app, pageErrors, wsId}`
+     */
+    async function boot({page, neuralLink}) {
+        const pageErrors = [];
+
+        page.on('pageerror', error => {
+            let value = String(error?.stack || error?.message || error || '');
+
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-tour-play',    {timeout: 30000});
+        await page.waitForSelector('.neo-tab-overflow-control', {timeout: 30000});
+
+        const app        = await neuralLink.connectToApp('Workstation'),
+              workspaces = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'the App Worker must own one Workspace').toBeTruthy();
+
+        return {app, pageErrors, wsId}
+    }
+
+    /**
+     * Reads the committed dock document fresh from the worker — the third-party truth every
+     * beat asserts against (never an executor's own snapshot).
+     * @param {Object} app Neural Link app wrapper.
+     * @param {String} wsId
+     * @returns {Promise<Object>}
+     */
+    async function readDocument(app, wsId) {
+        return (await app.getComponent(wsId, ['dockModel'])).dockModel
+    }
+
+    /**
+     * Reads the monotonic feed heartbeat — the continuity witness the whole journey rides:
+     * a reset would prove a reload/recreate happened where the story claims none did.
+     * @param {Object} app Neural Link app wrapper.
+     * @param {String} wsId
+     * @returns {Promise<Number>}
+     */
+    async function readHeartbeat(app, wsId) {
+        return (await app.getComponent(wsId, ['feedSequence'])).feedSequence
+    }
+
+    test('scene 1 — the room is alive: two runs, identical beat logs, heartbeat never resets', async ({page, neuralLink}) => {
+        const logs       = [],
+              pageErrors = [];
+
+        for (let run = 0; run < 2; run++) {
+            const ctx     = await boot({page, neuralLink}),
+                  {app}   = ctx,
+                  {wsId}  = ctx,
+                  beatLog = [];
+
+            pageErrors.push(...ctx.pageErrors);
+
+            // ── beat 1: the dense opening stage IS the committed document ────────────────────
+            const opening = await readDocument(app, wsId);
+
+            expect(opening.nodes['scale-tabs'].items).toEqual(['scale']);
+            expect(opening.nodes['heavy-tabs'].items).toHaveLength(12);
+            expect(opening.items.graph.autoHidden).toBe(true);
+            expect(opening.items.inspector.autoHidden).toBe(true);
+
+            const heartbeatAtOpen = await readHeartbeat(app, wsId);
+
+            expect(heartbeatAtOpen, 'the feed producer must already be alive at the opening shot')
+                .toBeGreaterThan(0);
+            beatLog.push({
+                beat      : 'opening-topology',
+                heavyCount: opening.nodes['heavy-tabs'].items.length,
+                railed    : ['graph', 'inspector']
+            });
+
+            // ── beat 2: the room answers — a real resizeSplit through the app-owned tour
+            // harness. `applyDockZoneOperation` is PURE (computes {document, errors}); the
+            // commit lives on the adapter's documentChange path, and `runTourSpec` is the
+            // workspace's own spec-mode front door: fresh document, reducer op, runner-owned
+            // deterministic log — the same contract the film's recording pipeline replays. ──
+            const spec = await app.callMethod(wsId, 'runTourSpec', [{
+                schema: 'neo.tour.script.v1',
+                id    : 'five-beat-scene1',
+                title : 'scene 1 — the room answers',
+                scenes: [{
+                    id   : 's1',
+                    title: 'resize',
+                    steps: [{
+                        type      : 'op',
+                        descriptor: {operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.52, 0.48]},
+                        expect    : [{path: 'nodes.split-main.sizes.0', equals: 0.52}]
+                    }, {
+                        type  : 'topology-assert',
+                        expect: [{path: 'nodes.split-main.sizes.1', equals: 0.48}]
+                    }]
+                }]
+            }]);
+
+            expect(spec.completed, 'the spec-mode replay must complete cleanly').toBe(true);
+            expect(spec.errors).toEqual([]);
+            expect(spec.document.nodes['split-main'].sizes).toEqual([0.52, 0.48]);
+
+            await expect.poll(async () => (await readDocument(app, wsId)).nodes['split-main'].sizes, {
+                message  : 'the committed document must carry the new proportion',
+                timeout  : 10000,
+                intervals: [100, 250]
+            }).toEqual([0.52, 0.48]);
+
+            beatLog.push({beat: 'resize-commit', runnerBeats: spec.log.length, sizes: [0.52, 0.48]});
+
+            // ── beat 3: daylight changes nothing but the light — theme round-trip ────────────
+            await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-light']);
+
+            await expect.poll(async () =>
+                (await app.getComponent(wsId, ['theme'])).theme, {
+                message: 'the workspace must reach the light theme',
+                timeout: 10000
+            }).toBe('neo-theme-neo-light');
+
+            await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-dark']);
+
+            await expect.poll(async () =>
+                (await app.getComponent(wsId, ['theme'])).theme, {
+                message: 'the workspace must return to the dark theme',
+                timeout: 10000
+            }).toBe('neo-theme-neo-dark');
+
+            // The document survived both flips untouched — the skin is not the state.
+            const afterThemes = await readDocument(app, wsId);
+
+            expect(afterThemes.nodes['split-main'].sizes).toEqual([0.52, 0.48]);
+            beatLog.push({beat: 'theme-roundtrip', finalTheme: 'neo-theme-neo-dark'});
+
+            // ── continuity: the heartbeat moved FORWARD through every beat, never reset ──────
+            const heartbeatAtClose = await readHeartbeat(app, wsId);
+
+            expect(heartbeatAtClose, 'heartbeats never reset across the scene')
+                .toBeGreaterThan(heartbeatAtOpen);
+            beatLog.push({beat: 'continuity', monotonic: true});
+
+            logs.push(beatLog);
+
+            // zero-residue between takes: a fresh boot must reproduce the identical beat log
+            if (run === 0) {
+                await page.reload()
+            }
+        }
+
+        // the determinism AC: two scripted runs replay the identical structural beat log
+        expect(logs[1], 'two runs must replay the identical beat log').toEqual(logs[0]);
+        expect(pageErrors, 'the journey must be error-free').toEqual([])
+    });
+
+    // ── beats 2-4: contracted legs — activate as the workstation multi-window wiring lands ──
+
+    test.fixme('scene 2 — the tear-out: a real pointer drag births a vessel MID-GESTURE', async () => {
+        // Receipts this leg must assert when activated:
+        //  - the popup exists in Playwright's window set BEFORE pointer-up (waitForEvent('popup')
+        //    resolves while the drag is still armed — the mid-gesture birth claim);
+        //  - committed document: the torn item is ABSENT from every node's items yet PRESENT in
+        //    the catalog (the vessel owns it; no leak);
+        //  - the pane instance id is IDENTICAL before and after (object permanence into the hop);
+        //  - heartbeat monotonic across the transition;
+        //  - drive through the workspace-owned gesture executor, never raw reducer calls.
+    });
+
+    test.fixme('scene 3 — the second window learns to dock: convert-while-dragging + exactly one preview', async () => {
+        // Receipts this leg must assert when activated:
+        //  - a second pane converts to a vessel while its drag continues (park-not-close
+        //    lifecycle: the vessel is parked during the gesture, never destroyed mid-flight);
+        //  - dragged over the first popup, the TARGET popup's zones preview (remote previews
+        //    rendered inside the other window);
+        //  - with two overlapping candidates, EXACTLY ONE preview claims — deterministic
+        //    arbitration, asserted from the claim registry, not from pixels;
+        //  - release docks: two panes in one popup, both stores still streaming.
+    });
+
+    test.fixme('scene 4 — reintegration: whole stack home, commit precedes the vessel self-close', async () => {
+        // Receipts this leg must assert when activated:
+        //  - stack-handle drag home over main; main zones preview;
+        //  - the commit lands the WHOLE stack atomically (one document transaction);
+        //  - the emptied vessel closes itself AFTER the commit — and a native close resolves
+        //    provisionally: the receipt is terminal only when the runtime windowId leaves the
+        //    connected topology (dispatch success is never effect proof);
+        //  - same-instance identity + heartbeat continuity across the return.
+    });
+
+    test.fixme('scene 5 — the signature: full journey in ONE run, two-take beat-log equality', async () => {
+        // The capstone contract: all five beats consecutively, one headed run, real pointer,
+        // the per-beat worker-truth asserts above, two consecutive runs with identical beat
+        // logs, and the final continuity readout (feed counts monotonic end-to-end) as the
+        // closing shot the film records.
+    });
+});


### PR DESCRIPTION
Resolves #15907
Refs #15252 — **increment 1 of the five-beat capstone ladder: the tear-out wiring, spec-proven** (#15907 is the increment's close-target per the one-Resolves-per-ticket rule; the capstone ticket #15252 stays open for the film, blocked by #15906's cross-window increment). This PR delivers the workstation's first real multi-window capability and the executable witnesses that prove it. Reshaped from the original one-PR-vehicle plan at the operator's direction (2026-07-25): increments merge as they green; no long-lived draft.

## What ships

1. **Vessel shell:** `apps/workstation/view/Viewport.mjs` gains the `?popout=` empty-vessel-host boot mode (dockdemo sibling pattern) — one App Worker, multiple render targets.
2. **Tear-out composition:** `apps/workstation/view/Workspace.mjs` composes the shipped `createDockTearOutHandlers` + `createDockVesselEmbodiment` over workstation-owned seams: vessel owner grants (mint/consume/revoke with native-route validation), admission-token connect flow, exact-position reintegration on vessel death, `preserveItemIds` projection support, worker connect/disconnect lifecycle. `enableDockTearOut` arms the projection's tabs zones.
3. **App-owned journey executor:** `executeTearOutStep` — real-pointer drive with film tunables (quadratic curve bow, move-step pacing) and three terminals: detach-commit, Escape-cancel (zero-mutation witness), and re-enter (the morph). Three-hop event probes (`dragBoundaryEntry` on the zone, `dockTearOutEntry` on the tabs container) ship in its failure diagnostics — they bisected two engine defects and stay as permanent diagnostic surface.
4. **Witnesses:** `WorkstationFiveBeatNL.spec.mjs` — scene 1 (dense room, two-take beat-log determinism) + scene 2 commit leg (vessel born MID-GESTURE before pointer-up, `detachItem` committed, same pane instance across the hop, heartbeat monotonic) + scene 2 morph leg (out past the edge and BACK IN: vessel retires mid-drag via `dockTearOutEntry`, committed document byte-identical). Scenes 3-5 remain contracted `test.fixme` legs naming their worker-truth receipts — they activate with the stage-B increment.
5. **Film-take mode:** `NEO_FILM_TAKE=1` switches the same spec to draft-capture form (film pacing + headed-window fronting); assertions unchanged — a take that cannot pass the witness is not a take.

## Deltas from ticket

- **Increment reshape (operator-directed):** the ticket's one-PR-vehicle plan is superseded — this PR = increment 1; stage-B wiring gets its own ticket/PR; the film remains #15252's close condition.
- Two engine defects found and fixed OUTSIDE this PR while wiring it (both merged): #15895/PR #15897 (window-drag re-entry ratio normalized by vessel-sized proxy area — threshold unreachable) and #15899/PR #15901 (entry block dereferenced the placeholder before firing — dock strips are placeholder-less by design). This PR's morph witness was the discovery instrument and is now their living regression proof at the consumer grain.
- The re-entry morph beat itself was not in the ticket's original AC wording — it entered via the film's cold-open design (retention data) and proved to be the highest-value witness in the set.

## Test Evidence

- Scene-2 set at `0ce4cd2a49` (rebased onto both engine fixes): `NEO_E2E_PORT=8124 npx playwright test workstation/WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --grep "scene 2"` → **3 passed, 0 failed** (commit leg + morph leg + gl-probe).
- Full suite at the tear-out head: 3 passed / 4 contracted skips / 0 failed (scene 1 two-take determinism included; log receipts retained in the gitignored production root `test-results/dock-wow-demo/`).
- e2e specs are post-merge/author-side witnesses on this repo (not PR CI); PR CI covers lint/unit/components — all green at head.
- Directly touched surfaces: apps/workstation → this spec; src/dashboard consumers → existing unit contracts (DockTearOut.spec, DockTabSortZone.spec — untouched, green in CI).

Evidence: L3 achieved for increment-1 scope (real-pointer journey legs green at exact head, two-take determinism on scene 1) → the capstone's full L3 (five consecutive beats, one run) lands with stage B. Residual: scenes 3-5 activation [#15252, stage-B increment].

## Post-Merge Validation

- [ ] Re-run the five-beat witness at the merged head: `NEO_E2E_PORT=8124 npx playwright test workstation/WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1`
- [ ] First film-take capture at the merged head (v0 draft cut: scene 1 + tear-out + morph) — gated on the one-time capture-stage setting on the recording machine; take orchestration is proven and staged.

## Production context (the film)

This journey is the exact-head stage for the FIRST film produced with `/video-create`. Production authority (phase-gated record, claim ledger, captions, take ledger, voice promotion) lives in the gitignored production root. Narrator voice promoted (marin, operator-auditioned, fallback nova); narration records against the transcript derived from the visual cut. Publication remains operator-gated.

## Credits

Screenplay: Clio's draft v1 + her retention-data cold-open note. Take protocol + NL gotchas + capture-war doctrine: Iris (#15631). Voice pipeline: Emmy (two audition rounds, manifest discipline). Edge ruling: Emmy (#15245 scope). Engine fixes en route: reviewed by Iris ×2, merged by @tobiu. Mechanism substrate: the G1–G4 arc.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Sessions bf564554 / b8c9e338 (Memory Core).
