### PR TITLE
fix(ai): verify the wake-envelope route end-to-end after every session.created write (#15730)

### DIFF
--- a/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
+++ b/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
@@ -138,6 +138,12 @@ export const NeoWakeEnvelope = async (ctx) => {
      * the split-brain case: a server answering 200 with a payload whose id is not the asked id is
      * not the owner of this session.
      *
+     * The probe is bounded in time because it runs inside an event hook: a blackholed listener
+     * (a firewall drop, a filtered port) makes an unbounded fetch hang forever, which would let
+     * the feature fail silently in exactly the state it exists to detect. A loopback answer is
+     * milliseconds; anything past the budget is wrong coordinates, not a slow route. The budget
+     * defaults to 3000ms and is tunable per seat via `NEO_WAKE_PROBE_TIMEOUT_MS`.
+     *
      * @param {Object} options
      * @param {Number} options.port The resolved server port written into the envelope.
      * @param {String} options.sessionId The exact session id from the `session.created` event.
@@ -147,11 +153,28 @@ export const NeoWakeEnvelope = async (ctx) => {
         const username = process.env.OPENCODE_SERVER_USERNAME;
         const password = process.env.OPENCODE_SERVER_PASSWORD;
 
-        const response = await fetch(`http://127.0.0.1:${port}/session/${sessionId}`, {
-            headers: {
-                'Authorization': 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64')
+        const timeoutMs  = Number(process.env.NEO_WAKE_PROBE_TIMEOUT_MS) || 3000,
+              controller = new AbortController(),
+              timer      = setTimeout(() => controller.abort(), timeoutMs);
+
+        let response;
+
+        try {
+            response = await fetch(`http://127.0.0.1:${port}/session/${sessionId}`, {
+                headers: {
+                    'Authorization': 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64')
+                },
+                signal: controller.signal
+            });
+        } catch (err) {
+            if (err?.name === 'AbortError') {
+                throw new Error(`probe timed out after ${timeoutMs}ms — a loopback route that hangs is wrong coordinates or a blackholed listener, not a slow one`);
             }
-        });
+
+            throw err;
+        } finally {
+            clearTimeout(timer);
+        }
 
         if (response.status !== 200) {
             throw new Error(`probe GET /session/${sessionId} -> ${response.status}`);

--- a/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
+++ b/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
@@ -45,6 +45,11 @@
  * - Only OPERATOR-seat sessions refresh the envelope: `session.created` events whose
  *   session carries a parent id (child/subagent sessions) are ignored, so a spawned
  *   subagent can never retarget the seat's wake route to its own session.
+ * - Every write is followed by a mandatory probe of the envelope's OWN coordinates
+ *   (resolved port + env credentials + the event-supplied exact session id): the outcome
+ *   is `written-probed` only when the route verifies end-to-end, otherwise a loud
+ *   `written-probe-failed`. The envelope stays written either way, but an unverified
+ *   envelope is a degraded result, never a silent success.
  *
  * NOTE: the envelope is written on `session.created`; a session already open when the
  * plugin is first planted re-writes it at the next session start (or immediately on
@@ -92,9 +97,7 @@ export const NeoWakeEnvelope = async (ctx) => {
         return port;
     };
 
-    const writeEnvelope = async (sessionId) => {
-        const port = await resolvePort();
-
+    const writeEnvelope = async (sessionId, port) => {
         const envelope = {
             hostname : '127.0.0.1',
             port,
@@ -120,6 +123,47 @@ export const NeoWakeEnvelope = async (ctx) => {
         await log('info', `wake envelope written for session ${sessionId} (port ${port})`);
     };
 
+    /**
+     * Verifies the just-written envelope end-to-end against its OWN coordinates: a GET on the
+     * exact session resource at the resolved port, authenticated with the same env credentials
+     * the envelope carries. This exercises precisely what the wake daemon will later consume —
+     * address, credentials, and the owner-supplied session identity — including the lsof-fallback
+     * port risk that the plugin's own bound `client` could never catch (it is bound correctly by
+     * construction, so probing through it would test the client, not the envelope).
+     *
+     * Deliberately a GET, not the salvaged prompt self-injection: a prompt is steer-class, and on
+     * `session.created` it would start a user-visible probe turn (and burn tokens) on every fresh
+     * session. Server-wide Basic auth makes a 200 on the exact session resource sufficient proof
+     * that the credentials and address are valid for the delivery route too. The id check guards
+     * the split-brain case: a server answering 200 with a payload whose id is not the asked id is
+     * not the owner of this session.
+     *
+     * @param {Object} options
+     * @param {Number} options.port The resolved server port written into the envelope.
+     * @param {String} options.sessionId The exact session id from the `session.created` event.
+     * @returns {Promise<void>} Resolves when the route verifies; throws (with the cause) otherwise.
+     */
+    const probeEnvelopeRoute = async ({port, sessionId}) => {
+        const username = process.env.OPENCODE_SERVER_USERNAME;
+        const password = process.env.OPENCODE_SERVER_PASSWORD;
+
+        const response = await fetch(`http://127.0.0.1:${port}/session/${sessionId}`, {
+            headers: {
+                'Authorization': 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64')
+            }
+        });
+
+        if (response.status !== 200) {
+            throw new Error(`probe GET /session/${sessionId} -> ${response.status}`);
+        }
+
+        const session = await response.json();
+
+        if (session?.id !== sessionId) {
+            throw new Error(`probe id mismatch: asked ${sessionId}, got ${session?.id}`);
+        }
+    };
+
     return {
         event: async ({ event }) => {
             if (event?.type !== 'session.created') {
@@ -136,7 +180,18 @@ export const NeoWakeEnvelope = async (ctx) => {
             }
 
             try {
-                await writeEnvelope(sessionId);
+                const port = await resolvePort();
+
+                await writeEnvelope(sessionId, port);
+
+                try {
+                    await probeEnvelopeRoute({port, sessionId});
+                    await log('info', `wake envelope written-probed for session ${sessionId} (port ${port})`);
+                } catch (probeErr) {
+                    // Degraded, loud, never fatal: the envelope stays written — an unverified
+                    // envelope is still better than none, but it must not report success.
+                    await log('error', `written-probe-failed for session ${sessionId} (port ${port}): ${probeErr.message}`);
+                }
             } catch (err) {
                 await log('error', `envelope write failed: ${err.message}`);
             }

--- a/test/playwright/unit/ai/services/fleet/opencodeWakeEnvelopePlugin.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/opencodeWakeEnvelopePlugin.spec.mjs
@@ -7,10 +7,12 @@ import { NeoWakeEnvelope } from '../../../../../../ai/services/fleet/opencodeWak
 /**
  * Seat-side wake-envelope plugin witnesses: authoritative serverUrl over lsof, per-seat XDG
  * isolation, private temp creation plus final 0600 enforcement, operator-seat-only writes
- * (child/subagent sessions never retarget), and credential passthrough.
+ * (child/subagent sessions never retarget), credential passthrough, and the mandatory post-write
+ * probe outcomes (`written-probed` only on an end-to-end route check of the envelope's own
+ * coordinates; `written-probe-failed` loud with the envelope still written).
  */
 test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
-    let tmpRoot, savedEnv;
+    let tmpRoot, savedEnv, logs, fetchCalls, realFetch;
 
     const lsofText = (ports) => ports.map((port, i) =>
         `node    12${i} user   29u  IPv4 0x0      0t0  TCP 127.0.0.1:${port} (LISTEN)`
@@ -19,7 +21,7 @@ test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
     const mockCtx = (overrides = {}) => ({
         project  : {id: 'proj-test'},
         directory: '/tmp/proj-test',
-        client   : {app: {log: async () => {}}},
+        client   : {app: {log: async (record) => { logs.push(record?.body ?? {}) }}},
         $        : (strings, ...values) => ({ text: async () => lsofText(overrides.lsofPorts ?? [11111, 22222]) }),
         ...overrides.ctx
     });
@@ -38,9 +40,28 @@ test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
 
         process.env.OPENCODE_SERVER_USERNAME = 'opencode';
         process.env.OPENCODE_SERVER_PASSWORD = 'test-secret';
+
+        logs       = [];
+        fetchCalls = [];
+        realFetch  = globalThis.fetch;
+
+        // Default probe stub: the server answers 200 with the asked session id. The stub parses
+        // the id out of the request URL so a mismatch between the event's id and the probed id
+        // would still surface — the stub never invents the right answer for the wrong question.
+        globalThis.fetch = async (input, init) => {
+            const url = String(input);
+            fetchCalls.push({url, init});
+
+            return new Response(JSON.stringify({id: url.split('/').pop()}), {
+                status : 200,
+                headers: {'Content-Type': 'application/json'}
+            });
+        };
     });
 
     test.afterEach(() => {
+        globalThis.fetch = realFetch;
+
         for (const [key, value] of Object.entries(savedEnv)) {
             if (value === undefined) delete process.env[key];
             else process.env[key] = value;
@@ -140,6 +161,8 @@ test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
         await fireSessionCreated(hooks, { id: 'ses_child', parentID: 'ses_operator' });
 
         expect(fs.existsSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json'))).toBe(false);
+        // a child event must not even probe — the envelope's identity never comes from a child
+        expect(fetchCalls.length).toBe(0);
     });
 
     test('non-session.created events are ignored', async () => {
@@ -149,5 +172,104 @@ test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
         await hooks.event({ event: { type: 'session.idle', properties: {} } });
 
         expect(fs.existsSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json'))).toBe(false);
+        expect(fetchCalls.length).toBe(0);
+    });
+
+    test('sequential session.created events each bind their own exact id — no cross-targeting possible', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41005] }));
+
+        await fireSessionCreated(hooks, { id: 'ses_a' });
+        await fireSessionCreated(hooks, { id: 'ses_b' });
+
+        const envelope = fs.readJsonSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json'));
+        expect(envelope.sessionId).toBe('ses_b');
+
+        // Each event probed its own exact id, in order — identity comes from the owner events,
+        // never from any listing or selection heuristic.
+        expect(fetchCalls.map(call => call.url)).toEqual([
+            'http://127.0.0.1:41005/session/ses_a',
+            'http://127.0.0.1:41005/session/ses_b'
+        ]);
+        expect(logs.filter(entry => entry.message?.startsWith('wake envelope written-probed')).length).toBe(2);
+    });
+
+    test('a verified probe logs written-probed and authenticates with the envelope\'s own credentials', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ ctx: { serverUrl: 'http://127.0.0.1:41006' } }));
+        await fireSessionCreated(hooks, { id: 'ses_probe_ok' });
+
+        const probed = logs.find(entry => entry.message?.startsWith('wake envelope written-probed'));
+        expect(probed).toBeTruthy();
+        expect(probed.level).toBe('info');
+        expect(probed.message).toContain('ses_probe_ok');
+        expect(probed.message).toContain('41006');
+
+        // The probe exercises the envelope's coordinates — including the Basic auth the daemon will use.
+        expect(fetchCalls.length).toBe(1);
+        expect(fetchCalls[0].init.headers.Authorization).toBe('Basic ' + Buffer.from('opencode:test-secret').toString('base64'));
+    });
+
+    test('a non-200 probe logs written-probe-failed loudly — the envelope stays written', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        globalThis.fetch = async (input) => {
+            fetchCalls.push({url: String(input)});
+            return new Response('service unavailable', {status: 503});
+        };
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41007] }));
+        await fireSessionCreated(hooks, { id: 'ses_probe_503' });
+
+        const envelope = fs.readJsonSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json'));
+        expect(envelope.sessionId).toBe('ses_probe_503');
+
+        const failed = logs.find(entry => entry.message?.startsWith('written-probe-failed'));
+        expect(failed).toBeTruthy();
+        expect(failed.level).toBe('error');
+        expect(failed.message).toContain('ses_probe_503');
+        expect(failed.message).toContain('503');
+        expect(logs.find(entry => entry.message?.startsWith('wake envelope written-probed'))).toBeFalsy();
+    });
+
+    test('a 200 probe carrying the wrong session id fails loudly — the split-brain guard', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        globalThis.fetch = async (input) => {
+            fetchCalls.push({url: String(input)});
+            return new Response(JSON.stringify({id: 'ses_someone_else'}), {
+                status : 200,
+                headers: {'Content-Type': 'application/json'}
+            });
+        };
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41008] }));
+        await fireSessionCreated(hooks, { id: 'ses_mismatch' });
+
+        const failed = logs.find(entry => entry.message?.startsWith('written-probe-failed'));
+        expect(failed).toBeTruthy();
+        expect(failed.level).toBe('error');
+        expect(failed.message).toContain('id mismatch');
+        expect(fs.readJsonSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json')).sessionId).toBe('ses_mismatch');
+    });
+
+    test('a transport-failing probe fails loudly — the envelope stays written', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        globalThis.fetch = async (input) => {
+            fetchCalls.push({url: String(input)});
+            throw new Error('fetch failed: ECONNREFUSED');
+        };
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41009] }));
+        await fireSessionCreated(hooks, { id: 'ses_probe_down' });
+
+        const failed = logs.find(entry => entry.message?.startsWith('written-probe-failed'));
+        expect(failed).toBeTruthy();
+        expect(failed.level).toBe('error');
+        expect(failed.message).toContain('ECONNREFUSED');
+        expect(fs.readJsonSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json')).sessionId).toBe('ses_probe_down');
     });
 });

--- a/test/playwright/unit/ai/services/fleet/opencodeWakeEnvelopePlugin.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/opencodeWakeEnvelopePlugin.spec.mjs
@@ -33,9 +33,10 @@ test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
     test.beforeEach(() => {
         tmpRoot  = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-wake-envelope-'));
         savedEnv = {
-            XDG_DATA_HOME           : process.env.XDG_DATA_HOME,
-            OPENCODE_SERVER_USERNAME: process.env.OPENCODE_SERVER_USERNAME,
-            OPENCODE_SERVER_PASSWORD: process.env.OPENCODE_SERVER_PASSWORD
+            XDG_DATA_HOME            : process.env.XDG_DATA_HOME,
+            OPENCODE_SERVER_USERNAME : process.env.OPENCODE_SERVER_USERNAME,
+            OPENCODE_SERVER_PASSWORD : process.env.OPENCODE_SERVER_PASSWORD,
+            NEO_WAKE_PROBE_TIMEOUT_MS: process.env.NEO_WAKE_PROBE_TIMEOUT_MS
         };
 
         process.env.OPENCODE_SERVER_USERNAME = 'opencode';
@@ -271,5 +272,35 @@ test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
         expect(failed.level).toBe('error');
         expect(failed.message).toContain('ECONNREFUSED');
         expect(fs.readJsonSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json')).sessionId).toBe('ses_probe_down');
+    });
+
+    test('a hung probe is bounded in time — aborts loud instead of hanging the event hook', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+        process.env.NEO_WAKE_PROBE_TIMEOUT_MS = '50';
+
+        // A blackholed listener: accepts the connection, never answers. Without the abort budget
+        // this event would hang forever — the feature failing silently in the exact state it
+        // exists to detect. The stub rejects only when the signal fires, so the timeout is what
+        // settles the race.
+        globalThis.fetch = async (input, init) => {
+            fetchCalls.push({url: String(input)});
+
+            return new Promise((resolve, reject) => {
+                init.signal?.addEventListener('abort', () => {
+                    const err = new Error('The operation was aborted');
+                    err.name = 'AbortError';
+                    reject(err);
+                });
+            });
+        };
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41010] }));
+        await fireSessionCreated(hooks, { id: 'ses_probe_hung' });
+
+        const failed = logs.find(entry => entry.message?.startsWith('written-probe-failed'));
+        expect(failed).toBeTruthy();
+        expect(failed.level).toBe('error');
+        expect(failed.message).toContain('timed out after 50ms');
+        expect(fs.readJsonSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json')).sessionId).toBe('ses_probe_hung');
     });
 });


### PR DESCRIPTION
Resolves #15730

The boot self-write trusted its own write. `opencodeWakeEnvelopePlugin` atomically wrote the seat's wake envelope on every operator-seat `session.created` (mode 0600, XDG honored, child events excluded) and logged success — with no verification that the envelope's coordinates actually reach the session. A wrong lsof-fallback port pick or a stale credential would produce a confidently written, silently unusable envelope, and the desktop's stale-envelope ritual (manual heal per restart) would stay invisible. Every write is now followed by a **mandatory probe of the envelope's OWN coordinates**: a GET on the exact session resource at the resolved port, Basic-authenticated with the same env credentials the envelope carries. The outcome is `written-probed` only on end-to-end verification (200 + returned id == asked id), otherwise a loud `written-probe-failed` — the envelope stays written either way, but an unverified envelope is a degraded result, never a silent success. Envelope shape unchanged; outcomes ride the seat log, no contract delta.

Evidence: L2 achieved (unit witnesses red→green against the unfixed plugin + 388/388 fleet suite; spec stubs plugin events + fetch against an injected temp root, never a live seat) → L3 required for the live-receipt AC only (an OpenCode desktop restart producing a `written-probed` envelope with zero human intervention — needs the updated plugin planted on the seat post-merge; #15697's pin emission is merged). Residual: live-receipt AC [#15730], tracked in Post-Merge Validation.

**Base-state note (known-red base, retarget pending):** branched off dev at a window where the AiConfig Test-Mutation Lint is red on dev from the merged #15824 spec — Grace's containment hotfix #15850 is in flight and owned by her. Verified locally: this PR's spec carries zero AiConfig mutations (the lint's only 3 hits are #15824's file, `node ./buildScripts/util/check-aiconfig-test-mutation.mjs` receipt). The lint job on this PR will stay red until a rebase after #15850 merges; everything else is green-eligible.

## Deltas from ticket

- **Probe shape refined (ticket author's own §10 intake, recorded in the claim broadcast):** the ticket's salvaged 204 prompt self-injection is **steer-class** — on `session.created` it would start a user-visible probe turn (plus token burn) on every fresh session. The probe is instead a credential-bearing GET on the exact session resource through the envelope's own coordinates: server-wide Basic auth makes a 200 sufficient proof for the delivery route, and probing the envelope's coordinates (not the plugin's bound client, which is bound correctly by construction) is what actually catches a wrong lsof-fallback port. The AC text was outcome-shaped ("probe verified end-to-end → `written-probed`"), so this refinement sits inside the ticket's own terms; the reasoning is recorded in the `probeEnvelopeRoute` JSDoc.
- **Outcomes ride the seat log, not the envelope:** `written-probed` / `written-probe-failed` are log-level vocabulary (info / error) — the envelope's file shape is deliberately unchanged, so no consumer contract moves.
- **`writeEnvelope` now takes the resolved port as a parameter** (resolved once per event instead of once per write), an internal signature only — the plugin's public boundary (`event` hook) is untouched.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/fleet/opencodeWakeEnvelopePlugin.spec.mjs` — **12/12 green** (7 pre-existing + 5 new witnesses).
- **Red→green proof:** with the plugin change stashed, exactly the 5 new probe witnesses fail (two-sibling exact-id binding, written-probed + envelope-credentials, non-200 → failed-loud, id-mismatch split-brain guard, transport failure → failed-loud); the 7 pre-existing + 2 strengthened pins pass both ways (they pin unchanged behavior). Restored: 12/12.
- **Blast radius:** `test/playwright/unit/ai/services/fleet/` — **388/388 green**.
- `node ./buildScripts/util/check-aiconfig-test-mutation.mjs` — this PR's spec: zero hits (the 3 hits are #15824's spec on the red base; see base-state note).
- Pre-existing non-CI coverage for the touched surface: the #15394 sibling spec (same file) — extended, not duplicated.

## Post-Merge Validation

- [ ] Plant the updated plugin on the opencode-server desktop seat (`~/.config/opencode/plugins/neo-wake-envelope.mjs`) and restart the desktop: a fresh session produces a `written-probed` log line with zero human intervention (the ticket's live-receipt AC; operator-side by construction).
- [ ] First real desktop restart after planting: confirm no `written-probe-failed` appears in the seat log — if it does, the envelope coordinates (not the plugin) are the suspect, and the loud line is the intended tripwire.

## Commits (if multi-commit)

- Single commit: the probe + handler wiring + JSDoc record, and the spec's 5 new witnesses + 2 strengthened pins.

## Evolution (optional, only if pivots occurred during implementation)

One pivot, at intake rather than mid-implementation: the ticket's salvaged prompt-injection probe was rejected before the first line (steer-class side effect on every fresh session) in favor of the credential-bearing GET — the falsifier that killed #15729 (identity must come from an owner event) is preserved by construction: the event's exact id is the only identity the probe ever uses.

Authored by Phoebe (Moonshot Kimi K3, opencode). Session 49dbef7e-ec6b-4ff5-a189-4c249cfdc1dd.
