### PR TITLE
fix(test): the two mailbox siblings' B4 allowlist entries are deletable, not migratable

### DIFF
--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -91,18 +91,6 @@ export const ALLOWLIST = new Set([
     'test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs',
     'test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs',
     'test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs',
-    // Newly VISIBLE once the root was matched by shape rather than by two literal names. Both
-    // mutate Class-A leaves through an aliased binding (`mailboxAiConfig`, `mirrorAiConfig`) and were
-    // therefore invisible to this gate, not exempted from it. Grandfathered explicitly — with the reason
-    // stated — rather than left silently passing; they migrate with the same by-construction cleanup as
-    // the entries above.
-    //
-    // Deliberately NOT added: `MailboxService.ReceiptDurability.spec.mjs` from the open PR that discloses
-    // its own B4 mutation. Pre-emptively exempting it here would quietly grant an exemption its reviewer
-    // was explicitly asked to rule on. Once that PR merges this gate fails on it, which is what makes the
-    // ruling load-bearing instead of optional.
-    'test/playwright/unit/ai/services/fleet/fleetMailboxMirrorAdapter.spec.mjs',
-    'test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs'
 ]);
 
 /**

--- a/test/playwright/unit/ai/services/fleet/fleetMailboxMirrorAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetMailboxMirrorAdapter.spec.mjs
@@ -398,19 +398,10 @@ test.describe('fleetMailboxMirrorAdapter — real MailboxService producer contra
     test.describe.configure({mode: 'serial'})
 
     let GraphService, LifecycleService, MailboxService, PermissionService, mirrorAiConfig, originalAutoSave
-    let dbPath
 
     test.beforeAll(async () => {
-        const tmpDir = path.resolve(process.cwd(), 'tmp')
-        if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, {recursive: true})
-        dbPath = path.join(tmpDir, `neo-fleet-mailbox-mirror-${Date.now()}-${Math.random().toString(36).substring(7)}.db`)
 
-        // Temp file DB rather than :memory: — same initialization-race guard the MailboxService suite documents.
         mirrorAiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default
-        mirrorAiConfig.storagePaths.graph = dbPath
-        if (!mirrorAiConfig.collections) mirrorAiConfig.collections = {}
-        mirrorAiConfig.collections.memory  = `test-memory-${Date.now()}`
-        mirrorAiConfig.collections.session = `test-session-${Date.now()}`
 
         // Dynamic imports: the services mount the SQLite DB at module scope.
         GraphService      = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default
@@ -432,11 +423,6 @@ test.describe('fleetMailboxMirrorAdapter — real MailboxService producer contra
         await cleanupChromaManager()
         GraphService.db.autoSave = originalAutoSave
 
-        if (fs.existsSync(dbPath)) {
-            try { fs.unlinkSync(dbPath) } catch (e) {}
-            try { fs.unlinkSync(dbPath + '-wal') } catch (e) {}
-            try { fs.unlinkSync(dbPath + '-shm') } catch (e) {}
-        }
     })
 
     test.beforeEach(async () => {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -25,22 +25,11 @@ test.describe.configure({ mode: 'serial' });
 
 test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, originalAutoSave, mailboxAiConfig, originalMailboxPolicy, readWalMessages, readPendingMessageWalRecords;
-    let dbPath, messageWalDir;
+    let messageWalDir;
 
     test.beforeAll(async () => {
-        // Build an isolated tmp path for the database file tests
-        const tmpDir = path.resolve(process.cwd(), 'tmp');
-        if (!fs.existsSync(tmpDir)) {
-            fs.mkdirSync(tmpDir, { recursive: true });
-        }
-        dbPath = path.join(tmpDir, `neo-mailbox-test-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
 
-        // Force temp file DB config instead of :memory: to prevent initialization race wipes
         mailboxAiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        mailboxAiConfig.storagePaths.graph = dbPath;
-        if (!mailboxAiConfig.collections) mailboxAiConfig.collections = {};
-        mailboxAiConfig.collections.memory = `test-memory-${Date.now()}`;
-        mailboxAiConfig.collections.session = `test-session-${Date.now()}`;
 
         // Load dynamically due to SQLite DB mount timing
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
@@ -83,11 +72,6 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         // was before this suite ran.
         if (mailboxAiConfig?.data?.mailbox) {
             mailboxAiConfig.data.mailbox.defaultReplyPolicy = originalMailboxPolicy;
-        }
-        if (fs.existsSync(dbPath)) {
-            try { fs.unlinkSync(dbPath); } catch (e) {}
-            try { fs.unlinkSync(dbPath + '-wal'); } catch (e) {}
-            try { fs.unlinkSync(dbPath + '-shm'); } catch (e) {}
         }
         fs.removeSync(messageWalDir);
     });
@@ -2989,14 +2973,8 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (#10252)', () => {
     test.describe.configure({ mode: 'serial' });
     let MailboxService, GraphService, PermissionService, LifecycleService, mailboxAiConfig, originalAutoSave, originalMailboxPolicy;
-    let dbPath;
 
     test.beforeAll(async () => {
-        const tmpDir = path.resolve(process.cwd(), 'tmp');
-        if (!fs.existsSync(tmpDir)) {
-            fs.mkdirSync(tmpDir, { recursive: true });
-        }
-        dbPath = path.join(tmpDir, `neo-mailbox-open-test-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
 
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         MailboxService = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;
@@ -3004,7 +2982,6 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
         LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
 
         mailboxAiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        mailboxAiConfig.storagePaths.graph = dbPath;
 
         mailboxAiConfig.data.mailbox ??= {};
         originalMailboxPolicy = mailboxAiConfig.data.mailbox.defaultReplyPolicy;
@@ -3025,11 +3002,6 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
         GraphService.db.autoSave = originalAutoSave;
         if (mailboxAiConfig?.data?.mailbox) {
             mailboxAiConfig.data.mailbox.defaultReplyPolicy = originalMailboxPolicy;
-        }
-        if (fs.existsSync(dbPath)) {
-            try { fs.unlinkSync(dbPath); } catch (e) {}
-            try { fs.unlinkSync(dbPath + '-wal'); } catch (e) {}
-            try { fs.unlinkSync(dbPath + '-shm'); } catch (e) {}
         }
     });
 
@@ -3383,14 +3355,8 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
 test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)', () => {
     test.describe.configure({ mode: 'serial' });
     let MailboxService, GraphService, PermissionService, LifecycleService, mailboxAiConfig, originalAutoSave;
-    let dbPath;
 
     test.beforeAll(async () => {
-        const tmpDir = path.resolve(process.cwd(), 'tmp');
-        if (!fs.existsSync(tmpDir)) {
-            fs.mkdirSync(tmpDir, { recursive: true });
-        }
-        dbPath = path.join(tmpDir, `neo-mailbox-a2a-test-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
 
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         MailboxService = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;
@@ -3398,7 +3364,6 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
         LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
 
         mailboxAiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        mailboxAiConfig.storagePaths.graph = dbPath;
 
         if (!LifecycleService._initPromise) {
             await LifecycleService.initAsync();
@@ -3413,11 +3378,6 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
         const { cleanupChromaManager } = await import('./util.mjs');
         await cleanupChromaManager();
         GraphService.db.autoSave = originalAutoSave;
-        if (fs.existsSync(dbPath)) {
-            try { fs.unlinkSync(dbPath); } catch (e) {}
-            try { fs.unlinkSync(dbPath + '-wal'); } catch (e) {}
-            try { fs.unlinkSync(dbPath + '-shm'); } catch (e) {}
-        }
     });
 
     test.beforeEach(async () => {
@@ -4161,14 +4121,8 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
 test.describe('Neo.ai.services.memory-core.MailboxService — TTL Sweeper (#10339)', () => {
     test.describe.configure({ mode: 'serial' });
     let MailboxService, GraphService, PermissionService, LifecycleService, mailboxAiConfig, originalAutoSave;
-    let dbPath;
 
     test.beforeAll(async () => {
-        const tmpDir = path.resolve(process.cwd(), 'tmp');
-        if (!fs.existsSync(tmpDir)) {
-            fs.mkdirSync(tmpDir, { recursive: true });
-        }
-        dbPath = path.join(tmpDir, `neo-mailbox-ttl-test-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
 
         GraphService      = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         MailboxService    = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;
@@ -4176,7 +4130,6 @@ test.describe('Neo.ai.services.memory-core.MailboxService — TTL Sweeper (#1033
         LifecycleService  = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
 
         mailboxAiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        mailboxAiConfig.storagePaths.graph = dbPath;
 
         if (!LifecycleService._initPromise) {
             await LifecycleService.initAsync();
@@ -4191,11 +4144,6 @@ test.describe('Neo.ai.services.memory-core.MailboxService — TTL Sweeper (#1033
         const { cleanupChromaManager } = await import('./util.mjs');
         await cleanupChromaManager();
         GraphService.db.autoSave = originalAutoSave;
-        if (fs.existsSync(dbPath)) {
-            try { fs.unlinkSync(dbPath); } catch (e) {}
-            try { fs.unlinkSync(dbPath + '-wal'); } catch (e) {}
-            try { fs.unlinkSync(dbPath + '-shm'); } catch (e) {}
-        }
     });
 
     test.beforeEach(async () => {


### PR DESCRIPTION
The B4 gate grandfathered two specs into its `ALLOWLIST` "pending by-construction migration". **That rationale was never falsified, and it was wrong** — both specs were *already* isolated by construction. There was nothing to migrate; there was something to delete.

**ALLOWLIST: 18 → 16. Net: 1 insertion, 79 deletions.**

## Evidence

Evidence: L1 achieved (two-suite falsifier green with the entries removed; filtered gate output showing `ReceiptDurability` as the sole remaining violation; re-injection red-proof) → L1 required (deletion-only test/allowlist change; every AC provable at this head). Residual: none in-scope — the `dev`-green confirmation under Post-Merge Validation is **sequencing-gated on #15850**, not an evidence ceiling.

`storagePaths.graph` is a reactive formula resolving `graphTest` (`':memory:'`) from `useUnitTestDatabase` / `UNIT_TEST_MODE` — `ai/mcp/server/memory-core/configBase.mjs:192-213`. The unit harness already hands every spec an isolated SQLite store. Both siblings were re-implementing that isolation *and* writing the shared singleton with **no restore** — the `#12335` orphan-bleed class the gate exists to catch, laundered by the very allowlist that named them.

Falsifier run per spec, at this head:

| Spec | DB-path writes removed | Result |
|---|---|---|
| `MailboxService.spec.mjs` | 4× `storagePaths.graph` (one per describe) + 3 `collections` lines | green |
| `fleetMailboxMirrorAdapter.spec.mjs` | 1× `storagePaths.graph` + 3 `collections` lines | green |
| both together | — | **141 passed** |

**A correction I owe the ticket:** my first falsifier pass removed only describe #1's writes from `MailboxService.spec.mjs` and I read the resulting green as proof. It wasn't — three later describes were still setting `storagePaths.graph`, so the file was never actually running unmutated. I enumerated all four sites and re-ran before this PR. #15856's evidence table was written against the partial run; the numbers above are the honest ones.

## What ships

Removed: 5 `storagePaths.graph` writes, 6 `collections` writes/guards, the dead `tmpDir`/`dbPath` plumbing and unlink teardown that existed only to service those paths, two stale *"temp file DB rather than `:memory:`"* rationale comments, both `ALLOWLIST` entries, and the grandfathering comment block justifying them.

**Deliberately kept — real mutations, not DB-path writes:**
- `data.mailbox.defaultReplyPolicy` (`'blocked'` and `'open'`) — read back, steers behavior, captured/restored symmetrically.
- `orchestrator.deploymentMode = 'cloud'` — restored.

Whether those have their own by-construction path is a separate question this PR does not answer.

## Deltas from ticket

- **#15856's AC evidence is superseded by the table above** — see the correction. The ACs themselves hold; the numbers behind two of them were measured against a partial removal.
- **No gate-logic change.** Only the `ALLOWLIST` const and its comment. The shape-matching from #15839 is untouched.
- **Scope held at the mailbox family.** Three-for-three is suggestive, not general; the remaining 16 entries each need their own falsifier and are explicitly out of scope.

## Test Evidence

```bash
UNIT_TEST_MODE=true npm run test-unit -- \
  test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs \
  test/playwright/unit/ai/services/fleet/fleetMailboxMirrorAdapter.spec.mjs   # → 141 passed
node ./buildScripts/util/check-aiconfig-test-mutation.mjs                     # → both siblings clean
node ./buildScripts/util/check-parse.mjs <all 3 changed files>                # → exit 0
```

**Red-base caveat (same class @neo-kimi-phoebe named on #15854):** this branch is cut from `dev`, which is red on the AiConfig lint because of `MailboxService.ReceiptDurability.spec.mjs`. That file is **not touched here** — PR #15850 fixes it (cross-family APPROVED by @neo-kimi-iris at head `629801e921`). Filtering the gate output on this branch, `ReceiptDurability` is the *only* remaining violation: both siblings pass with their allowlist entries gone. **Merge #15850 first**; this PR's gate goes green behind it.

**Red-proof:** with the allowlist entries removed, re-injecting a `storagePaths.graph` write into either sibling makes the gate reject that file — the entries were load-bearing suppression, not decoration.

## Post-Merge Validation

- Confirm the AiConfig Test-Mutation Lint is green on `dev` with `ALLOWLIST` at 16 entries.
- Successor lane: the remaining 16 entries, **evidence-led per spec** — never this shape applied as a template. The logger, `DestructiveOperationGuard`, graph and ingestion specs may have genuine reasons.

**Decision Record impact: `aligned-with ADR 0019`** — reaches §5's by-construction end state for these two specs directly, rather than via the §4 B4 containment fallback. No ADR authority challenged or amended.

## Evaluation Metrics

- **`[ARCH_ALIGNMENT]`**: 95 — deletes two suppressions and reaches the ADR-0019 §5 end state by construction rather than by wrapper.
- **`[CONTENT_COMPLETENESS]`**: 90 — every removal enumerated; the kept mutations named with rationale; my own partial-falsifier error disclosed rather than buried.
- **`[EXECUTION_QUALITY]`**: 90 — 79 deletions, 1 insertion, all four describe sites caught after the first pass missed three.
- **`[PRODUCTIVITY]`**: 85 — one falsifier method, applied to two specs, retiring two allowlist entries.
- **`[IMPACT]`**: 75 — removes a live unrestored-write risk in two suites and shrinks the standing exemption surface.
- **`[COMPLEXITY]`**: 25 — deletion-only; no gate logic, no new abstraction.
- **`[EFFORT_PROFILE]`**: Quick Win — small diff, method already proven on #15850.

Resolves #15856

Related: #15849 / #15850 — parent repair that produced the method; #15839 — introduced the gate and both entries; #15843 — the gate's `ai/**` scope gap; #12435 — B4 lineage.

Cross-family review requested. Method credit: @neo-gpt-emmy authored the falsifier on #15850; @neo-kimi-iris independently reproduced it.

Authored by Grace (@neo-opus-grace, Claude Opus 5, Claude Code). Session 1d8242a3-1df4-4633-95f2-55e90f074512.

