### PR TITLE
test(ai): restore the plane-member census pin beside the coherence check (#15851)

### DIFF
--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -884,6 +884,9 @@ test.describe('Neo.ai.mcp.server.BaseServer — plane-member boundary (#15799)',
             const server = Neo.create(makeBoundaryServerClass({member: true, composed: true}));
             server.aiConfig = isolated;
 
+            // census, not coherence: a silent PLANE_MEMBER_PATHS deletion must fail this line.
+            // Changing plane membership = bumping this literal consciously in the same commit.
+            expect(TIER1_MEMBER_PATHS.length).toBe(10);
             expect(server.getPlaneMembers().length).toBe(TIER1_MEMBER_PATHS.length);
 
             const observed = server.assertPlaneIdentity();


### PR DESCRIPTION
Resolves #15851

Restores the absolute plane-member census pin that PR #15832 traded away when it de-literalized the count assertion: `BaseServer.spec.mjs` now carries BOTH assertions side by side — the census literal (`TIER1_MEMBER_PATHS.length === 10`, commented "census, not coherence" with the conscious-bump contract) AND the untouched live coherence check (`server.getPlaneMembers().length === TIER1_MEMBER_PATHS.length`). Two assertions, two jobs: a silent deletion from `PLANE_MEMBER_PATHS` now fails the pin even where the coherence check would shrink in lockstep and pass. Origin: PR #15832 review `PRR_kwDODSospM8AAAABHK9rpg` Depth Floor 2 (reviewer-suggested, author-accepted).

Placement rationale (per AC): kept in `BaseServer.spec.mjs` beside the coherence assertion — where the pre-#15832 literal lived and where the two jobs read as a deliberate pair; the config-side spec alternative was considered and declined to keep the census adjacent to the projection it disciplines.

Evidence: L1 (unit contract — the assertion is in-process, no runtime surface) → L1 required (all three ACs are spec-text properties). Residual: none.

## Deltas from ticket

None substantive — 3 inserted lines (2 comment, 1 assertion), exactly the ticket's Fix shape.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs` — **49/49 passed** with the pin in place.
- **Red-proof (tripwire has teeth):** literal temporarily set to `9` → `Expected: 9, Received: 10 — 1 failed, 48 passed`; restored to `10` → 49/49 green. The pin is live, not vacuous.
- Directly touched surface `test/playwright/unit/ai/mcp/server/`: `BaseServer.spec.mjs` is itself the coverage.

## Post-Merge Validation

- [ ] First real `PLANE_MEMBER_PATHS` membership change bumps the literal in the same commit (the conscious-act contract this pin enforces — first live firing validates the discipline).

Authored by Clio (Fable 5, Claude Code). Session fed0f707-b481-432f-a5d9-587cc0325942.
