### PR TITLE
docs(skills): reconcile RA-driven foreign-ticket restatement with authorship respect (#15852)

### DIFF
--- a/.agents/skills/pr-review/references/audits/decile-anchors.md
+++ b/.agents/skills/pr-review/references/audits/decile-anchors.md
@@ -1,0 +1,11 @@
+# Decile Anchors for Evaluative Metrics
+
+Extracted verbatim from `pr-review-guide.md §3.1` (per-file payload budget; Map vs World Atlas). Use engineering words, not affect, to reduce cross-family drift. Ten-point scores interpolate within these bands:
+
+| Band | Anchor |
+|---|---|
+| 100 Exemplary | No observed defects; tests/evidence green; perfect architecture/content fit; all goals achieved; foundational when impact is 100. |
+| 80-90 Strong/Excellent | Tests green with only nits; minor architecture/content gaps; main goals achieved. |
+| 60-70 Acceptable/Solid | Green or partially verified, but minor AC, documentation, or idiom gaps need follow-up. |
+| 40-50 Weak/Mixed | Unverified/failed tests, functional defect, major doc gaps, or partial delivery. |
+| 10-30 Broken/Poor/Inadequate | Catastrophic/regressive behavior, active architecture violation, or negative/near-zero productivity. |

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -54,15 +54,8 @@ Every PR review MUST score the work across the following categories on a scale o
 
 ### 3.1 Decile Anchors for Evaluative Metrics
 
-Use engineering words, not affect, to reduce cross-family drift. Ten-point scores interpolate within these bands:
+<!-- trigger: scoring any evaluative metric -> read ./audits/decile-anchors.md (band table; engineering words, not affect) -->
 
-| Band | Anchor |
-|---|---|
-| 100 Exemplary | No observed defects; tests/evidence green; perfect architecture/content fit; all goals achieved; foundational when impact is 100. |
-| 80-90 Strong/Excellent | Tests green with only nits; minor architecture/content gaps; main goals achieved. |
-| 60-70 Acceptable/Solid | Green or partially verified, but minor AC, documentation, or idiom gaps need follow-up. |
-| 40-50 Weak/Mixed | Unverified/failed tests, functional defect, major doc gaps, or partial delivery. |
-| 10-30 Broken/Poor/Inadequate | Catastrophic/regressive behavior, active architecture violation, or negative/near-zero productivity. |
 
 ### 3.2 Score Justification (MANDATORY)
 
@@ -118,7 +111,7 @@ Audit every magic close target in the PR body and commit messages: `Closes #N`, 
 3. Required fix: isolate one delivered leaf as `Resolves #M`; move broad/epic refs to `Related:`; split broad work into leaf subs.
 4. While an AC is open, any named expiry blocks close — future, due or lapsed alike; satisfy or restate it. Deferred *authoring* (text not yet written) blocks with no expiry too: the close destroys the only pointer. Open-ended *verification* closes normally.
 
-**Restatement RAs on author-foreign text (this audit + §5.4):** when the close-target text needing restatement was authored by someone other than the PR author, prescribe the outcome, never the method — word the RA as *"propose the restated text on the ticket and obtain the author's application or confirmation,"* not as a direct edit of another author's body/AC prose (`ticket-create-workflow.md §11`; author-side path: `review-response-protocol.md §6`). Claimer-authored in-body sections (e.g. an intake-derived Contract Ledger) are the claimer's own artifact, editable in place. Provenance: PR `#15832` review cycle → `#15852`.
+<!-- trigger: restatement RA on author-foreign close-target text (here + §5.4) -> read ../../pull-request/references/foreign-ticket-restatement.md (outcome, never method) -->
 
 Out of scope: valid leaf targets, non-closing `Related:` / `Refs:` / `Part of`. Provenance: `#9999` auto-close, `#10323` duplicate chain.
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -118,6 +118,8 @@ Audit every magic close target in the PR body and commit messages: `Closes #N`, 
 3. Required fix: isolate one delivered leaf as `Resolves #M`; move broad/epic refs to `Related:`; split broad work into leaf subs.
 4. While an AC is open, any named expiry blocks close — future, due or lapsed alike; satisfy or restate it. Deferred *authoring* (text not yet written) blocks with no expiry too: the close destroys the only pointer. Open-ended *verification* closes normally.
 
+**Restatement RAs on author-foreign text (this audit + §5.4):** when the close-target text needing restatement was authored by someone other than the PR author, prescribe the outcome, never the method — word the RA as *"propose the restated text on the ticket and obtain the author's application or confirmation,"* not as a direct edit of another author's body/AC prose (`ticket-create-workflow.md §11`; author-side path: `review-response-protocol.md §6`). Claimer-authored in-body sections (e.g. an intake-derived Contract Ledger) are the claimer's own artifact, editable in place. Provenance: PR `#15832` review cycle → `#15852`.
+
 Out of scope: valid leaf targets, non-closing `Related:` / `Refs:` / `Part of`. Provenance: `#9999` auto-close, `#10323` duplicate chain.
 
 ### 5.3 MCP-Tool-Description Budget Audit

--- a/.agents/skills/pull-request/references/foreign-ticket-restatement.md
+++ b/.agents/skills/pull-request/references/foreign-ticket-restatement.md
@@ -1,0 +1,11 @@
+# Foreign-Ticket Restatement (RA-Driven)
+
+One rule, three vantages — reconciling pr-review's "satisfy or restate" (`pr-review-guide.md §5.2` and `pr-review-guide.md §5.4`) with the authorship-respect norm (origin `#10109` §3; `ticket-create-workflow.md §11`) when the close-target text needing restatement was NOT authored by the PR author.
+
+- **Reviewer side (RA wording):** prescribe the OUTCOME, never the method — "propose the restated text on the ticket and obtain the author's application or confirmation," not a direct edit of another author's body/AC prose.
+- **Author side (executing the RA):** default path = a ticket comment carrying the full restated text for the author to apply or confirm. Apply directly ONLY when the RA explicitly prescribes it — then leave a full edit-trail comment, offer the author explicit revert-authority, and treat the author's confirmation as the RA-closure evidence.
+- **Carve-out (both sides):** claimer-authored sections living inside another author's ticket body (e.g. an intake-derived Contract Ledger) are the claimer's own artifact, updatable in place.
+
+Empirical anchor: PR #15832 review cycle (`PRR_kwDODSospM8AAAABHK9rpg`; the reviewer's own cycle-2 phrasing lesson independently converged) → #15852. First-use PMV: whether "explicit RA prescription" needs a literal marker convention.
+
+Sunset: subsumable into a consolidated authorship-respect audit; the three trigger pointers (`pr-review-guide.md §5.2` · `review-response-protocol.md §6` · `ticket-create-workflow.md §11`) make consolidation mechanical.

--- a/.agents/skills/pull-request/references/review-response-protocol.md
+++ b/.agents/skills/pull-request/references/review-response-protocol.md
@@ -57,7 +57,7 @@ Use the template at `.agents/skills/pull-request/assets/review-response-template
 
 Post the response as a **NEW comment** on the PR thread. Do NOT edit the reviewer's comment (attribution collapse; authorship-respect violation), and do NOT edit your own prior PR body to address review items — commit history plus this new comment are the canonical record. Aligned with the authorship-respect rule that applies across all surfaces (tickets, PR bodies, review comments).
 
-**Restatement RAs on foreign ticket text:** when an RA requires restating close-target text you did not author (AC list, body prose), the default path is a ticket comment carrying the full restated text for the author to apply or confirm. Apply the edit directly ONLY when the RA explicitly prescribes it — then leave a full edit-trail comment, offer the author explicit revert-authority, and treat the author's confirmation as the RA-closure evidence. Claimer-authored in-body sections (e.g. your own intake-derived Contract Ledger) are your artifact — update in place. Reviewer-side wording rule: `pr-review-guide.md §5.2`; ticket-side rule: `ticket-create-workflow.md §11`.
+Restatement RAs on foreign ticket text -> read [foreign-ticket-restatement.md](./foreign-ticket-restatement.md) (comment-proposal default; prescribed-direct-edit path with trail + revert-authority + author-confirm closure).
 
 ## 7. Commit Message Convention
 

--- a/.agents/skills/pull-request/references/review-response-protocol.md
+++ b/.agents/skills/pull-request/references/review-response-protocol.md
@@ -57,6 +57,8 @@ Use the template at `.agents/skills/pull-request/assets/review-response-template
 
 Post the response as a **NEW comment** on the PR thread. Do NOT edit the reviewer's comment (attribution collapse; authorship-respect violation), and do NOT edit your own prior PR body to address review items — commit history plus this new comment are the canonical record. Aligned with the authorship-respect rule that applies across all surfaces (tickets, PR bodies, review comments).
 
+**Restatement RAs on foreign ticket text:** when an RA requires restating close-target text you did not author (AC list, body prose), the default path is a ticket comment carrying the full restated text for the author to apply or confirm. Apply the edit directly ONLY when the RA explicitly prescribes it — then leave a full edit-trail comment, offer the author explicit revert-authority, and treat the author's confirmation as the RA-closure evidence. Claimer-authored in-body sections (e.g. your own intake-derived Contract Ledger) are your artifact — update in place. Reviewer-side wording rule: `pr-review-guide.md §5.2`; ticket-side rule: `ticket-create-workflow.md §11`.
+
 ## 7. Commit Message Convention
 
 Follow-up commits addressing review feedback use the standard Conventional Commits format with the ticket ID. The commit message does NOT need to cite the reviewer or specific Required Action number — the Addressed comment on the PR thread carries the link:

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -184,7 +184,7 @@ Minimize chained calls where possible — a well-formed `create_issue` call with
 When editing tickets:
 - **Ticket body:** Update your own in place. If it's someone else's ticket, respond via a NEW comment.
 - **Ticket AC list:** Extend your own list. If it's someone else's ticket, do NOT mutate their AC list; propose additions via comment.
-- **Reviewer-RA restatements:** a review Required Action may require restating another author's AC/ledger text ("satisfy or restate", `pr-review-guide.md §5.2`); the conforming path is comment-proposal + author application/confirmation. Direct application only on explicit RA prescription, with edit-trail comment + revert-authority per `review-response-protocol.md §6`. Carve-out: claimer-authored sections living inside another author's ticket body (e.g. an intake-derived Contract Ledger) are the claimer's own artifact, updatable in place.
+- **Reviewer-RA restatements:** read `../../pull-request/references/foreign-ticket-restatement.md` (comment-proposal default; claimer-authored in-body sections like intake-derived ledgers stay claimer-updatable).
 
 *Why:* Rewriting someone else's prose causes attribution collapse and breaks Native Edge Graph ingestion.
 

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -184,6 +184,7 @@ Minimize chained calls where possible — a well-formed `create_issue` call with
 When editing tickets:
 - **Ticket body:** Update your own in place. If it's someone else's ticket, respond via a NEW comment.
 - **Ticket AC list:** Extend your own list. If it's someone else's ticket, do NOT mutate their AC list; propose additions via comment.
+- **Reviewer-RA restatements:** a review Required Action may require restating another author's AC/ledger text ("satisfy or restate", `pr-review-guide.md §5.2`); the conforming path is comment-proposal + author application/confirmation. Direct application only on explicit RA prescription, with edit-trail comment + revert-authority per `review-response-protocol.md §6`. Carve-out: claimer-authored sections living inside another author's ticket body (e.g. an intake-derived Contract Ledger) are the claimer's own artifact, updatable in place.
 
 *Why:* Rewriting someone else's prose causes attribution collapse and breaks Native Edge Graph ingestion.
 


### PR DESCRIPTION
Resolves #15852

Reconciles the two authorities that diverged on a live case today (PR #15832's review): pr-review's "satisfy or restate" RA practice can prescribe editing close-target ticket text the PR author did not author, while `ticket-create §11` / origin-#10109 prescribe comment-proposal for foreign AC prose. Three small, mutually-pointing clarifications — one rule, three vantages, no triplicated rule text:

- `pr-review-guide.md §5.2` — reviewer-side wording rule: for author-foreign close-target text, **prescribe the outcome, never the method** ("propose the restated text and obtain the author's application or confirmation"), covering both the §5.2 close-target audit and §5.4's ledger-drift template.
- `review-response-protocol.md §6` — author-side path: comment-proposal by default; direct application ONLY on explicit RA prescription, then edit-trail comment + explicit revert-authority + author-confirmation as the RA-closure evidence.
- `ticket-create-workflow.md §11` — the reviewer-RA cross-reference + the carve-out both sides need: claimer-authored sections living inside another author's ticket body (e.g. intake-derived Contract Ledgers) are the claimer's own artifact, updatable in place.

The reviewer whose RA surfaced the friction (Iris) independently converged on the same fix shape in her cycle-2 note on PR #15832 ("the RA should have prescribed the outcome, not the method").

Evidence: L1 (prose-only substrate; all ACs are text properties verifiable by reading the diff) → L1 required. Residual: none.

## Slot rationale (substrate-mutation gate)

- **Modified sections (3, all atlas-tier):** disposition `rewrite` — density-raising clarification of existing rules inside on-invoke skill payloads; zero turn-loaded bytes touched (no `AGENTS.md`/`CLAUDE.md`/SKILL.md-map changes). Trigger-frequency: fires only on restatement-RA + foreign-ticket-edit events; failure-severity: authorship collapse / norm conflict (empirically fired 2026-07-24); enforceability: discipline-only.
- **Accretion defense:** +3 sentences of skill-loaded payload; decay mitigation named — retirement trigger: subsumable into a consolidated authorship-respect audit file if one materializes; the three cross-pointers make the future consolidation mechanical.
- Placement validated via `turn-memory-pre-flight` decision tree (Step 2: lifecycle-workflow → skill payload) + ADR-0007 (atlas-tier, §5.4 additive-drift check: no new audit/checklist surface, prose clarification only).

## Deltas from ticket

None substantive.

## Test Evidence

- `npm run agent-preflight -- --no-fix` on all three files — all gates passed (docs-only, no `.mjs` in scope).
- Mutual-pointer resolution verified by grep: each file names the other two.
- Directly touched app/feature surfaces: `None found` (agent-substrate prose only).
- Known-cause CI note: the `lint` check inherits dev's AiConfig Test-Mutation red-base (#15824↔#15839 collision; fix = PR #15850, Iris-approved at head) — this diff has no `.mjs`/config surface.

## Post-Merge Validation

- [ ] First post-merge restatement-RA cycle follows the documented path (reviewer wording + author-side proposal/confirm) — first live use validates the reconciliation.

Authored by Clio (Fable 5, Claude Code). Session fed0f707-b481-432f-a5d9-587cc0325942.
