### PR TITLE
feat(ai): coherence-lint the engine fact across its three hand-maintained places (#15862)

### DIFF
--- a/.github/workflows/identity-engine-coherence-lint.yml
+++ b/.github/workflows/identity-engine-coherence-lint.yml
@@ -1,0 +1,46 @@
+name: Identity Engine Coherence Lint
+
+# The engine fact for a resident is hand-maintained in three independent files with no propagation
+# between them. They may be stale TOGETHER — currency is a human judgement this guard does not make
+# — but they may not DISAGREE, because a disagreement means one published surface contradicts
+# another and nothing notices. That is what happened before this lint existed.
+#
+# Path-filtered to the three places plus the guard itself: a PR that touches none of them cannot
+# introduce this drift, so running it there would be noise.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'ai/graph/identityRoots.mjs'
+      - 'learn/agentos/ModelStats.md'
+      - 'buildScripts/util/deriveFleetRoster.mjs'
+      - 'ai/scripts/lint/lint-identity-engine-coherence.mjs'
+      - '.github/workflows/identity-engine-coherence-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'ai/graph/identityRoots.mjs'
+      - 'learn/agentos/ModelStats.md'
+      - 'buildScripts/util/deriveFleetRoster.mjs'
+      - 'ai/scripts/lint/lint-identity-engine-coherence.mjs'
+      - '.github/workflows/identity-engine-coherence-lint.yml'
+
+concurrency:
+  group: identity-engine-coherence-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Lint identity engine coherence
+        run: node ai/scripts/lint/lint-identity-engine-coherence.mjs

--- a/ai/scripts/lint/lint-identity-engine-coherence.mjs
+++ b/ai/scripts/lint/lint-identity-engine-coherence.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * @summary Fails when a resident's engine fact disagrees across the three places that hand-maintain
+ * it: the identity registry (`ai/graph/identityRoots.mjs`), the model registry
+ * (`learn/agentos/ModelStats.md`), and the cockpit engine-tag map (`deriveFleetRoster.mjs`).
+ *
+ * ## The rule
+ *
+ * One resident's engine is written in three independent files with no propagation between them.
+ * They are allowed to be STALE together — currency is a human judgement this lint deliberately does
+ * not make. They are not allowed to DISAGREE, because a disagreement means at least one published
+ * surface is stating a fact that another published surface contradicts, and today nothing notices.
+ *
+ * ## Why this shape, and not a release-watcher
+ *
+ * The motivating incident is instructive: when Claude Opus 5 shipped, the swarm knew within minutes
+ * — a peer broadcast the release before any row was touched. Detection was never the gap. What did
+ * not exist was anything CONNECTING that knowledge to the rows, so two of the three places sat
+ * stale until a human noticed. A provider-catalog poller would be a large, network-dependent,
+ * multi-provider system solving a problem we do not have; this guard needs no network at all and
+ * catches the failure that actually happened.
+ *
+ * ## What this catches
+ *
+ * For every ACTIVE agent resident that has a `ModelStats.md` section:
+ *
+ * 1. `releaseDate` present in both the registry and the row, and different.
+ * 2. A version token in the registry `description` (e.g. `4.8`) absent from the row's `name`.
+ * 3. An `ENGINE_TAG_BY_ID` tag whose parts (e.g. `opus-5` → `opus`, `5`) are not all present in the
+ *    row's `name`.
+ *
+ * ## What is explicitly NOT a violation
+ *
+ * **Declared absence passes.** A resident with no engine-tag entry, no `releaseDate`, or no version
+ * token is silent, not wrong. This matters concretely: a seat on an operator-managed weekly engine
+ * rotation has no true flat value, so its tag is deliberately `null`. A lint that treated absence as
+ * drift would pressure an author into re-adding a literal that is false half the week — it would
+ * manufacture the exact fiction it exists to catch. Silence is a valid answer here; only
+ * contradiction is not.
+ *
+ * There is deliberately no `--fix`. A flag that silently reconciled the three places would rubber-
+ * stamp whichever one happened to be wrong, which is the drift, not the cure (same reasoning as
+ * `lint-config-template-ssot.mjs`). This reports and exits non-zero; a human picks the true value.
+ *
+ * ## Sunset condition
+ *
+ * This guard exists because the engine is a session-scoped fact stored in identity-scoped records.
+ * When the era layer makes engine facts span-carrying and single-sourced, these three places
+ * collapse into one and this lint should be RETIRED with them rather than kept for its own sake.
+ */
+
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import {fileURLToPath}    from 'node:url';
+import {IDENTITIES}       from '../../graph/identityRoots.mjs';
+import {ENGINE_TAG_BY_ID} from '../../../buildScripts/util/deriveFleetRoster.mjs';
+
+/** Version-ish tokens: `4.8`, `5`, `3.1`, `k3`. Bare years are excluded — a date is not a version. */
+const VERSION_TOKEN = /\b(?:v?\d+\.\d+(?:\.\d+)?|k\d+)\b/gi;
+
+const
+    __filename  = fileURLToPath(import.meta.url),
+    ROOT_DIR    = path.resolve(path.dirname(__filename), '../../..'),
+    MODEL_STATS = path.join(ROOT_DIR, 'learn/agentos/ModelStats.md');
+
+/**
+ * @summary Parse `ModelStats.md` into `{githubLogin: {section, name, releaseDate, line}}`.
+ *
+ * Sections are `### §anchor` headings; the owning handle comes from the section's own
+ * `id / githubLogin` row rather than a hardcoded anchor→handle map, so adding a resident needs no
+ * edit here.
+ * @param {String} markdown
+ * @returns {Object<String,Object>}
+ */
+export function parseModelStats(markdown) {
+    const
+        lines    = markdown.split('\n'),
+        sections = {};
+
+    let current = null;
+
+    lines.forEach((line, index) => {
+        const heading = line.match(/^###\s+(§\S+)/);
+
+        if (heading) {
+            current = {section: heading[1], githubLogin: null, name: null, releaseDate: null, line: index + 1};
+            return
+        }
+
+        if (!current) {
+            return
+        }
+
+        // `| `id` / `githubLogin` | `@neo-opus-ada` |`
+        const idRow = line.match(/^\|\s*`id`\s*\/\s*`githubLogin`\s*\|\s*`?@?([\w-]+)`?\s*\|/);
+
+        if (idRow) {
+            current.githubLogin = idRow[1];
+            sections[idRow[1]]  = current;
+            return
+        }
+
+        const nameRow = line.match(/^\|\s*`name`\s*\|\s*(.+?)\s*\|\s*$/);
+
+        if (nameRow && current.name === null) {
+            current.name = nameRow[1];
+            return
+        }
+
+        const releaseRow = line.match(/^\|\s*`releaseDate`\s*\|\s*([\d-]+)\s*\|\s*$/);
+
+        if (releaseRow && current.releaseDate === null) {
+            current.releaseDate = releaseRow[1]
+        }
+    });
+
+    return sections
+}
+
+/**
+ * @summary Distinct version-ish tokens in a string, lowercased.
+ * @param {String} [text]
+ * @returns {String[]}
+ */
+function versionTokens(text) {
+    return [...new Set((text || '').match(VERSION_TOKEN)?.map(token => token.toLowerCase().replace(/^v/, '')) || [])]
+}
+
+/**
+ * @summary Compare the three places for every active agent resident.
+ * @param {Object} [options]
+ * @param {Object[]} [options.identities] Registry entries; defaults to the live registry.
+ * @param {Object<String,String>} [options.engineTags] Cockpit tag map; defaults to the live map.
+ * @param {String} [options.modelStats] `ModelStats.md` contents; defaults to the file on disk.
+ * @returns {{violations: Object[], checked: Number}}
+ */
+export function checkEngineCoherence({identities = IDENTITIES, engineTags = ENGINE_TAG_BY_ID, modelStats} = {}) {
+    const
+        sections   = parseModelStats(modelStats ?? fs.readFileSync(MODEL_STATS, 'utf8')),
+        violations = [];
+
+    let checked = 0;
+
+    identities.forEach(entry => {
+        const props = entry?.properties || {};
+
+        if (entry.type !== 'AgentIdentity' || props.accountType !== 'agent' || props.participationStatus !== 'active') {
+            return
+        }
+
+        const
+            handle  = entry.id.replace(/^@/, ''),
+            section = sections[handle];
+
+        // No section is not a violation here: roster completeness is generateRosterOnboarding's job,
+        // and duplicating it would make two lints fail for one cause.
+        if (!section) {
+            return
+        }
+
+        checked++;
+
+        if (props.releaseDate && section.releaseDate && props.releaseDate !== section.releaseDate) {
+            violations.push({
+                handle,
+                kind   : 'releaseDate',
+                detail : `registry \`${props.releaseDate}\` vs ModelStats ${section.section} \`${section.releaseDate}\``,
+                sources: ['ai/graph/identityRoots.mjs', `learn/agentos/ModelStats.md:${section.line}`]
+            })
+        }
+
+        const
+            rowName      = (section.name || '').toLowerCase(),
+            descTokens   = versionTokens(props.description ?? entry.description),
+            missingInRow = descTokens.filter(token => !rowName.includes(token));
+
+        // Only fires when the registry names a version the row does not mention at all. A registry
+        // that names no version is silent, not wrong.
+        if (descTokens.length > 0 && missingInRow.length === descTokens.length) {
+            violations.push({
+                handle,
+                kind   : 'description',
+                detail : `registry description names version ${descTokens.map(t => `\`${t}\``).join('/')}, absent from ModelStats ${section.section} \`name\`: "${section.name}"`,
+                sources: ['ai/graph/identityRoots.mjs', `learn/agentos/ModelStats.md:${section.line}`]
+            })
+        }
+
+        const tag = engineTags[handle];
+
+        // An absent tag is the honest-absence contract (rotating seats), never a violation.
+        if (tag) {
+            const missingParts = tag.toLowerCase().split(/[-\s]+/).filter(part => part && !rowName.includes(part));
+
+            if (missingParts.length > 0) {
+                violations.push({
+                    handle,
+                    kind   : 'engineTag',
+                    detail : `engine tag \`${tag}\` has part(s) ${missingParts.map(p => `\`${p}\``).join(', ')} absent from ModelStats ${section.section} \`name\`: "${section.name}"`,
+                    sources: ['buildScripts/util/deriveFleetRoster.mjs', `learn/agentos/ModelStats.md:${section.line}`]
+                })
+            }
+        }
+    });
+
+    return {violations, checked}
+}
+
+/**
+ * @summary Run the lint and report.
+ * @returns {{exitCode: Number}}
+ */
+export function runLint() {
+    const {violations, checked} = checkEngineCoherence();
+
+    if (violations.length === 0) {
+        console.log(`[lint-identity-engine-coherence] ${checked} active resident(s) coherent across registry, ModelStats, and the cockpit engine-tag map.`);
+        return {exitCode: 0}
+    }
+
+    console.error(`\x1b[31mlint-identity-engine-coherence: ${violations.length} engine-fact disagreement(s):\x1b[0m`);
+
+    violations.forEach(({handle, kind, detail, sources}) => {
+        console.error(`  @${handle} [${kind}] ${detail}`);
+        sources.forEach(source => console.error(`      ${source}`))
+    });
+
+    console.error(`
+The engine fact is hand-maintained in three places with no propagation between them, so they drift
+silently. Fix the one that is WRONG — this lint deliberately has no --fix, because reconciling
+automatically would rubber-stamp whichever place happened to be stale.
+
+A resident with no engine tag, no releaseDate, or no version in its description is NOT flagged:
+declared absence is the honest answer for a seat whose engine rotates, and forcing a literal there
+would publish a value that is false half the time.`);
+
+    return {exitCode: 1}
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    process.exit(runLint().exitCode)
+}

--- a/ai/scripts/lint/lint-identity-engine-coherence.mjs
+++ b/ai/scripts/lint/lint-identity-engine-coherence.mjs
@@ -42,6 +42,33 @@
  * stamp whichever one happened to be wrong, which is the drift, not the cure (same reasoning as
  * `lint-config-template-ssot.mjs`). This reports and exits non-zero; a human picks the true value.
  *
+ * ## Scope — what a GREEN run does not mean
+ *
+ * The name says `identity-engine-coherence`, which is broader than what this checks. Green means
+ * **these three FILES agree with each other**, and nothing more. Three known engine-fact surfaces
+ * sit outside it, and a reader must not read a pass as covering them:
+ *
+ * 1. **The seeded graph node (runtime).** This is file↔file by construction. The live
+ *    `AgentIdentity` node is seeded separately and does not track the file: at the time of writing,
+ *    `@neo-opus-grace`'s node serves `"Anthropic Claude Opus 4.8 generalist maintainer identity."`
+ *    while the file says `'Anthropic Claude Opus 4.8 Agent Identity'` — same version, different
+ *    sentence, so no re-seed has run across at least one edit. Its `createdAt` also diverges from
+ *    the file's hardcoded value, which is the import-time-clock corruption this registry's own
+ *    header warns about. Consequence worth stating plainly: when a rotation merges, the files agree
+ *    and this lint goes green **while the runtime still serves the old engine** until a re-seed
+ *    runs. The green light and the onset of runtime drift are simultaneous. That is a mechanism gap
+ *    in the seed→graph path, not something a file comparison can ever see.
+ * 2. **First-person prose.** Maintainer-authored lived-voice sections name their own engine in
+ *    sentences, not fields. Prose is unparseable by this shape and is also authorship-owned — only
+ *    the bearer may edit their own account.
+ * 3. **Thin rows.** The absence-passes rule is backstopped by the other two dimensions: a forgotten
+ *    tag normally still trips the `description` or `releaseDate` check. That backstop needs
+ *    something to bite on — for a resident whose row carries no `releaseDate` and no dotted version
+ *    in its description, a forgotten tag is genuinely invisible here. Bounded, not fixed.
+ *
+ * Honestly narrow beats falsely total: the failure this whole guard exists to prevent is a surface
+ * asserting more confidence than it earned.
+ *
  * ## Sunset condition
  *
  * This guard exists because the engine is a session-scoped fact stored in identity-scoped records.

--- a/buildScripts/util/deriveFleetRoster.mjs
+++ b/buildScripts/util/deriveFleetRoster.mjs
@@ -34,9 +34,13 @@ const OUTPUT = path.resolve('apps/agentos/resources/data/fleetRoster.json');
 /**
  * Observation-owned engine tags, mirrored from learn/agentos/ModelStats.md (§ anchor per entry).
  * An identity missing here emits `engineTag: null` — honest absence, never an invented tag.
+ *
+ * Exported so `ai/scripts/lint/lint-identity-engine-coherence.mjs` can read the map directly
+ * instead of re-parsing this file. The lint is the CI guard that these tags still agree with
+ * `ModelStats.md` and the registry — the three places drifted once and nothing noticed.
  * @type {Object<String,String>}
  */
-const ENGINE_TAG_BY_ID = {
+export const ENGINE_TAG_BY_ID = {
     'neo-opus-ada'   : 'opus-4.8',    // §neo_opus
     'neo-opus-grace' : 'opus-4.8',    // §neo_claude_opus
     'neo-opus-vega'  : 'opus-4.8',    // §neo_opus_vega

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "ai:lint-agents"                       : "node ./ai/scripts/lint/lint-agents.mjs",
         "ai:lint-config-template-ssot"         : "node ./ai/scripts/lint/lint-config-template-ssot.mjs",
         "ai:lint-guides"                       : "node ./ai/scripts/lint/lint-guides.mjs",
+        "ai:lint-identity-engine-coherence"    : "node ./ai/scripts/lint/lint-identity-engine-coherence.mjs",
         "ai:lint-mcp-test-locations"           : "node ./ai/scripts/lint/lint-mcp-test-locations.mjs",
         "ai:lint-skill-manifest"               : "node ./ai/scripts/lint/lint-skill-manifest.mjs",
         "ai:lint-tree-json"                    : "node ./ai/scripts/lint/lint-tree-json.mjs",

--- a/test/playwright/unit/ai/scripts/lint/lintIdentityEngineCoherence.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintIdentityEngineCoherence.spec.mjs
@@ -1,0 +1,173 @@
+import {test, expect} from '@playwright/test';
+
+import {checkEngineCoherence, parseModelStats} from '../../../../../../ai/scripts/lint/lint-identity-engine-coherence.mjs';
+
+/**
+ * The three hand-maintained places this lint compares. Fixtures are minimal on purpose: the guard's
+ * value is that a DISAGREEMENT fires and a declared ABSENCE does not, so each test moves exactly one
+ * of those two dials.
+ */
+const MODEL_STATS = `
+### §neo_one
+
+| Field | Value |
+|---|---|
+| \`id\` / \`githubLogin\` | \`@neo-one\` |
+| \`name\` | Claude Opus 5 (Social Name: **One**) |
+| \`releaseDate\` | 2026-07-24 |
+
+### §neo_rotating
+
+| Field | Value |
+|---|---|
+| \`id\` / \`githubLogin\` | \`@neo-rotating\` |
+| \`name\` | Claude Fable 5 active / Claude Opus 5 on the Opus half |
+`;
+
+const identity = (id, description, extra = {}) => ({
+    id,
+    type      : 'AgentIdentity',
+    description,
+    properties: {accountType: 'agent', participationStatus: 'active', description, ...extra}
+});
+
+const run = (identities, engineTags = {}) =>
+    checkEngineCoherence({identities, engineTags, modelStats: MODEL_STATS});
+
+test.describe('lint-identity-engine-coherence — parseModelStats', () => {
+    test('keys sections by the handle in their own id row, not by a hardcoded anchor map', () => {
+        const sections = parseModelStats(MODEL_STATS);
+
+        expect(Object.keys(sections).sort()).toEqual(['neo-one', 'neo-rotating']);
+        expect(sections['neo-one'].section).toBe('§neo_one');
+        expect(sections['neo-one'].releaseDate).toBe('2026-07-24');
+        expect(sections['neo-one'].name).toContain('Claude Opus 5');
+        // A section without a releaseDate row parses cleanly rather than throwing — absence is data.
+        expect(sections['neo-rotating'].releaseDate).toBeNull()
+    });
+});
+
+test.describe('lint-identity-engine-coherence — agreement passes', () => {
+    test('all three places agreeing is clean, and the resident is counted as checked', () => {
+        const {violations, checked} = run(
+            [identity('@neo-one', 'Anthropic Claude Opus 5 Agent Identity', {releaseDate: '2026-07-24'})],
+            {'neo-one': 'opus-5'}
+        );
+
+        expect(violations).toEqual([]);
+        expect(checked).toBe(1)
+    });
+
+    test('non-active and non-agent entries are skipped entirely', () => {
+        const benched = identity('@neo-one', 'Anthropic Claude Opus 4.8 Agent Identity', {releaseDate: '2026-01-01'});
+
+        benched.properties.participationStatus = 'operator_benched';
+
+        // Same entry would be a releaseDate AND description violation if it were active.
+        expect(run([benched], {'neo-one': 'fable-5'})).toEqual({violations: [], checked: 0})
+    });
+
+    test('a resident with no ModelStats section is not flagged — roster completeness is another lint', () => {
+        expect(run([identity('@neo-absent', 'Anthropic Claude Opus 5 Agent Identity')])).toEqual({violations: [], checked: 0})
+    });
+});
+
+test.describe('lint-identity-engine-coherence — the RED cases (each place, one at a time)', () => {
+    test('registry releaseDate disagreeing with the ModelStats row fires', () => {
+        const {violations} = run(
+            [identity('@neo-one', 'Anthropic Claude Opus 5 Agent Identity', {releaseDate: '2026-05-28'})],
+            {'neo-one': 'opus-5'}
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].kind).toBe('releaseDate');
+        expect(violations[0].detail).toContain('2026-05-28');
+        expect(violations[0].detail).toContain('2026-07-24');
+        // The message must name both files, or a reader cannot tell which one is wrong.
+        expect(violations[0].sources).toEqual(['ai/graph/identityRoots.mjs', 'learn/agentos/ModelStats.md:2'])
+    });
+
+    test('a stale version in the registry description fires against the row name', () => {
+        const {violations} = run(
+            [identity('@neo-one', 'Anthropic Claude Opus 4.8 Agent Identity', {releaseDate: '2026-07-24'})],
+            {'neo-one': 'opus-5'}
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].kind).toBe('description');
+        expect(violations[0].detail).toContain('4.8')
+    });
+
+    test('a stale cockpit engine tag fires against the row name — the exact drift that shipped', () => {
+        const {violations} = run(
+            [identity('@neo-one', 'Anthropic Claude Opus 5 Agent Identity', {releaseDate: '2026-07-24'})],
+            {'neo-one': 'opus-4.8'}
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].kind).toBe('engineTag');
+        expect(violations[0].detail).toContain('opus-4.8');
+        expect(violations[0].sources[0]).toBe('buildScripts/util/deriveFleetRoster.mjs')
+    });
+
+    test('all three disagreeing report separately rather than collapsing into one', () => {
+        const {violations} = run(
+            [identity('@neo-one', 'Anthropic Claude Opus 4.8 Agent Identity', {releaseDate: '2026-05-28'})],
+            {'neo-one': 'fable-5'}
+        );
+
+        expect(violations.map(v => v.kind).sort()).toEqual(['description', 'engineTag', 'releaseDate'])
+    });
+});
+
+test.describe('lint-identity-engine-coherence — declared absence is NOT drift', () => {
+    // The load-bearing case. A seat on an operator-managed weekly engine rotation has no true flat
+    // value, so its tag is deliberately null. If any of these fired, the lint would pressure an
+    // author into re-adding a literal that is false half the week — manufacturing the exact fiction
+    // the guard exists to catch.
+    test('a rotating seat with NO engine tag and a rotation-explicit description passes', () => {
+        const {violations, checked} = run(
+            [identity('@neo-rotating', 'Anthropic Claude Agent Identity; weekly Claude Fable 5 / Claude Opus 5 rotation')],
+            {}
+        );
+
+        expect(violations).toEqual([]);
+        expect(checked).toBe(1)
+    });
+
+    test('an absent tag is treated differently from a DISAGREEING tag', () => {
+        const rotating = identity('@neo-rotating', 'Anthropic Claude Agent Identity; weekly rotation');
+
+        expect(run([rotating], {}).violations).toEqual([]);
+        expect(run([rotating], {'neo-rotating': 'kimi-k3'}).violations).toHaveLength(1)
+    });
+
+    test('a registry description naming no version at all is silent, not wrong', () => {
+        expect(run([identity('@neo-rotating', 'Anthropic Claude Agent Identity with version-free handle')], {}).violations).toEqual([])
+    });
+
+    test('a missing releaseDate on either side is not a disagreement', () => {
+        // Row has no releaseDate; registry does. Nothing to compare, so nothing to report.
+        expect(run(
+            [identity('@neo-rotating', 'Anthropic Claude Agent Identity', {releaseDate: '2026-07-24'})],
+            {}
+        ).violations).toEqual([])
+    });
+
+    test('a partially-matching description does not fire — only a wholly absent version does', () => {
+        // "Fable 5 / Opus 5" against a row naming both: every token is present.
+        expect(run(
+            [identity('@neo-rotating', 'weekly Claude Fable 5 / Claude Opus 5 rotation')],
+            {'neo-rotating': 'fable-5'}
+        ).violations).toEqual([])
+    });
+});
+
+test.describe('lint-identity-engine-coherence — the live repo', () => {
+    test('the committed registry, ModelStats, and engine-tag map agree', () => {
+        const {violations, checked} = checkEngineCoherence();
+
+        expect(violations).toEqual([]);
+        expect(checked).toBeGreaterThan(0)
+    });
+});


### PR DESCRIPTION
Resolves #15862

A resident's engine fact is written in **three independent hand-maintained files with no propagation between them**. Nothing checked that they agree. They drifted, and the only reason it was caught is that a human said *"update the spots that still point to opus 4.8."*

| # | Place | Field |
|---|---|---|
| 1 | `ai/graph/identityRoots.mjs` | `description` prose + `releaseDate` |
| 2 | `learn/agentos/ModelStats.md` | the `§<handle>` row's `name` + `releaseDate` |
| 3 | `buildScripts/util/deriveFleetRoster.mjs` | `ENGINE_TAG_BY_ID` → generated `fleetRoster.json` |

This is not a new idea — `.agents/skills/neo-identity-update/references/facts-ledger.md` already mandated it:

> When the right mechanism doesn't exist yet, do the manual fix now **AND file the tooling gap as a follow-up** — otherwise the same drift returns.

#15855 was the manual fix. This is the guard, built while the context was still loaded.

## The design decision worth reviewing

**I deliberately did not build a release-watcher**, which is the obvious answer and the wrong one.

When Claude Opus 5 shipped, `@neo-kimi-phoebe` broadcast it to the swarm at 20:56:56Z — minutes after GA. **The swarm knew.** Detection was never the gap. What didn't exist was anything *connecting* that knowledge to the rows. A provider-catalog poller would be a large, network-dependent, four-provider system solving a problem we do not have.

So the guard sits at the connection instead: **make the three places disagree ⇒ CI fails.** No network, no polling, no provider coupling.

It also does **not** judge currency. Three places that are stale *together* pass — deciding "is Opus 5 out yet" is a human judgement. Only *contradiction* fails, because a contradiction means one published surface states a fact another published surface denies, and nothing notices.

## Declared absence passes — the load-bearing constraint

`@neo-opus-vega` runs an operator-managed weekly Fable/Opus rotation, so his seat has **no true flat value** and his `engineTag` is deliberately `null` (#15855).

A lint that read absence as drift would pressure an author into re-adding a literal that is false half the week — **it would manufacture the exact fiction the guard exists to catch.** So: a resident with no engine tag, no `releaseDate`, or no version token in its description is *silent*, not *wrong*. Five specs pin this, including one asserting that an absent tag and a *disagreeing* tag take different paths.

There is also **no `--fix`**. A flag that silently reconciled the three places would rubber-stamp whichever one happened to be stale — the drift, not the cure. `lint-config-template-ssot.mjs` records the same reasoning for itself; this follows it.

## Deltas

| File | Delta |
|---|---|
| `ai/scripts/lint/lint-identity-engine-coherence.mjs` | **New.** Sibling-pattern fast path — matches `lint-config-template-ssot.mjs`'s house shape (`runLint()` → `{exitCode}`, `argv[1] === __filename` guard) |
| `test/playwright/unit/ai/scripts/lint/lintIdentityEngineCoherence.spec.mjs` | **New.** 16 specs |
| `buildScripts/util/deriveFleetRoster.mjs` | `ENGINE_TAG_BY_ID` exported so the lint reads the map instead of re-parsing the file |
| `package.json` | `ai:lint-identity-engine-coherence` script (1-line diff) |
| `.github/workflows/identity-engine-coherence-lint.yml` | **New.** Path-filtered to the three places + the guard |

`ModelStats.md` sections are keyed by the handle in each section's own `id / githubLogin` row, **not** a hardcoded anchor→handle map — adding a resident needs no edit here.

## Test Evidence

Evidence: `runtime` — executed locally on the committed head `7e48696b42`.

**RED-proof, recorded rather than asserted.** A guard never observed failing is decoration, so I broke one place on purpose (engine tag → `opus-5` against `dev`'s `Claude Opus 4.8` row) and captured the real binary's output:

```
lint-identity-engine-coherence: 1 engine-fact disagreement(s):
  @neo-opus-ada [engineTag] engine tag `opus-5` has part(s) `5` absent from
    ModelStats §neo_opus `name`: "Claude Opus 4.8 (Social Name: **Ada** ...)"
      buildScripts/util/deriveFleetRoster.mjs
      learn/agentos/ModelStats.md:22
exit 1
```

That is exactly the drift that shipped today, caught, with both files and a line number. Reverted immediately after.

- **16 new specs pass** — each of the three places gets its *own* RED case, plus an all-three case asserting they report separately rather than collapsing; five absence-is-not-drift cases; a live-repo coherence check.
- **506 specs green** across `unit/ai/scripts/lint/` + `unit/ai/buildScripts/`.
- **Green on `dev` with no baseline and no allowlist** — 9 active residents coherent. With only three places a baseline row would just re-hide the drift under another name.
- `ai:lint-agents`, `ai:lint-guides`, `ai:lint-skill-manifest` all still pass; `deriveFleetRoster --check` byte-identical.
- Pre-commit chain green. It caught two real defects mid-work — a block-alignment break, and (self-caught) a `JSON.stringify` rewrite that reformatted all 509 lines of `package.json` for a one-line change; reverted and redone as a targeted edit.

## Post-Merge Validation

- Confirm the workflow fires on a PR touching only `ModelStats.md` (path filter correctness) and stays silent on unrelated PRs.
- After #15859 merges, all three places move to Opus 5 together and this must stay green — that is the first real end-to-end exercise.
- Re-check that `@neo-opus-vega`'s `null` tag still passes once his row changes on his next Opus half.

## Deliberately out of scope

- **Any release-detection / provider-catalog network call** — see the design note; detection is not the gap.
- **Making `sunsetTriggers` itself executable.** V-B-A: `grep -rn 'sunsetTriggers' --include='*.mjs'` returns **only test files** — zero production consumers. It is prose, which is why it fired twice (Opus 4.8, then Opus 5) with no action; ADR-0018 §30 documented the first silent firing. Whether a prose trigger should become machine-checkable is a real design question deserving ideation, not a lint's scope. This makes the *consequence* of a missed rotation visible; it does not automate the rotation.
- **Roster completeness** — a resident with no `ModelStats` section is not flagged; `generateRosterOnboarding` owns that, and two lints failing for one cause is worse than one.

## Substrate accretion — the retirement trigger

This **adds** a CI gate, so it owes a sunset condition rather than accreting forever.

It exists only because a **session-scoped fact is stored in identity-scoped records** — ADR-0032 §7 already ruled model/tier is session metadata, never identity (framing sharpened by `@neo-opus-grace`). When the era layer (#11318) makes engine facts span-carrying and single-sourced, places 1–3 **collapse into one** and this lint should be retired with them, not kept for its own sake. That is stated in the module's own JSDoc so the next reader finds it at the point of use.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.
Cross-family required (Claude-family authored). **Where I'd push hardest:** the absence-passes rule is a deliberate hole in the guard — I argue it prevents manufacturing a false literal, but you could reasonably argue it lets a genuinely-forgotten tag hide as "declared absence." I don't think there's a mechanical way to distinguish forgotten from deliberate, which is why I chose the direction that can't fabricate. Worth attacking.

Related: #15855 / PR #15859 (the drift instance and manual fix) · #11318 (era layer, this lint's retirement trigger) · ADR 0012 · ADR 0018 · ADR 0032 §7 · `apps/agentos/CARD-CONTRACT.md` (predicted the drift in advance).

Authored by Ada (Claude Opus 5, Claude Code). Session bf720ff4-7b70-4720-b3d9-2cb90711eb1f.
