### PR TITLE
docs(adr): B4's status cites the live gate, not a closed ticket and a stale count (#15843)

### DIFF
--- a/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
+++ b/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
@@ -59,7 +59,7 @@ A reviewer checks a config-touching diff against this list; the lint (sub #2) me
 | B1 | exporting config values/subtrees (`export const X = AiConfig.Y`) | `[live: TaskDefinitions.mjs]` | consumers import `AiConfig` and read at use site |
 | B2 | `const X = AiConfig.Y` pointers | review-only | read inline — alias only if used 3+ times in one scope |
 | B3 | defensive `?.` on `AiConfig` reads | `[live-on-dev]` | the SSOT guarantees the tree; let it fail loud |
-| **B4 ⭐** | **SAFETY-CRITICAL — runtime writes to `AiConfig`** (see §4) | `[live: ~21 test files; #12435]` | tests isolate by construction (`UNIT_TEST_MODE`); NEVER mutate the shared singleton |
+| **B4 ⭐** | **SAFETY-CRITICAL — runtime writes to `AiConfig`** (see §4) | `[live-on-dev: check-aiconfig-test-mutation]` — the gate is the live count; it scans `test/**` only, so `ai/**` is unenforced | tests isolate by construction (`UNIT_TEST_MODE`); NEVER mutate the shared singleton |
 | B5 | passing `AiConfig` values into other consumers' configs (`Orchestrator → buildTaskDefinitions({chromaPort, …})`, 14 threaded args) | `[live: daemons]` | the consumer imports `AiConfig` and reads it (see §5 for the C1×B5 resolution) |
 
 ### Group C — boundary / duplication

--- a/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
+++ b/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
@@ -59,7 +59,7 @@ A reviewer checks a config-touching diff against this list; the lint (sub #2) me
 | B1 | exporting config values/subtrees (`export const X = AiConfig.Y`) | `[live: TaskDefinitions.mjs]` | consumers import `AiConfig` and read at use site |
 | B2 | `const X = AiConfig.Y` pointers | review-only | read inline — alias only if used 3+ times in one scope |
 | B3 | defensive `?.` on `AiConfig` reads | `[live-on-dev]` | the SSOT guarantees the tree; let it fail loud |
-| **B4 ⭐** | **SAFETY-CRITICAL — runtime writes to `AiConfig`** (see §4) | `[live-on-dev: check-aiconfig-test-mutation]` — the gate is the live count; it scans `test/**` only, so `ai/**` is unenforced | tests isolate by construction (`UNIT_TEST_MODE`); NEVER mutate the shared singleton |
+| **B4 ⭐** | **SAFETY-CRITICAL — runtime writes to `AiConfig`** (see §4) | `[live-on-dev: check-aiconfig-test-mutation]` — the gate is the enforcement anchor; it scans `test/**` only, so `ai/**` is unenforced (§4) | tests isolate by construction (`UNIT_TEST_MODE`); NEVER mutate the shared singleton |
 | B5 | passing `AiConfig` values into other consumers' configs (`Orchestrator → buildTaskDefinitions({chromaPort, …})`, 14 threaded args) | `[live: daemons]` | the consumer imports `AiConfig` and reads it (see §5 for the C1×B5 resolution) |
 
 ### Group C — boundary / duplication
@@ -84,7 +84,12 @@ aiConfig.engines.chroma.database = `graph-service-test-${process.pid}-${Date.now
 ```
 — is **how test data bleeds into live DBs.** The proxy set-trap routes that assignment to `setData` on the *owning provider* (the shared singleton), so failed cleanup, a shared process, or test-ordering means the next consumer (or a non-mutating path) reads the test DB — or a live read lands on test state. This is the **#12335 orphan-incident mechanism** (~1,281 orphans `purgeTestCollections` reclaims), already fixed at great cost by `chromaTestIsolation` (isolate **by construction** under `UNIT_TEST_MODE`) — and **bypassed** in #12420 by hand-rolled config-mutation. The lesson did not stick because nothing mechanical enforced it.
 
-**Rule:** a test NEVER mutates the shared `AiConfig`; isolation is by construction. **Lint (sub #2, fail-build):** flag any `aiConfig.<path> = …` runtime assignment, especially in tests — one check prevents the whole orphan-bleeding class. (V-B-A: ~21 test files currently do this; ticket #12435.)
+**Rule:** a test NEVER mutates the shared `AiConfig`; isolation is by construction. **Lint (sub #2, fail-build):** flag any `aiConfig.<path> = …` runtime assignment, especially in tests — one check prevents the whole orphan-bleeding class.
+
+**Live status — `check-aiconfig-test-mutation` is the enforcement anchor.** Run it for the current disposition rather than trusting any number written here; two distinct figures it reports must not be conflated:
+
+- **Enforcement reach** — the files the gate actually scans. It walks `test/` only (`find test -type f -name '*.mjs'`, filtered to `test/`), so **`ai/**` is outside the scan set by construction** and no rule-tightening inside the checker reaches it.
+- **Legacy census** — `ALLOWLIST.size`, a point-in-time count of pre-existing exempted files, shrinking as they are repaired. It measures remaining debt, not enforcement strength, and a green gate says nothing about the unscanned region.
 
 ## 5. Sanctioned patterns (the fix, in one place)
 


### PR DESCRIPTION
ADR-0019's **B4 row — the safety-critical one** — cited a closed ticket and a count that had drifted by five.

**Net: 1 file, both B4 status sites.**

Evidence: L1 achieved (both claims falsified by direct query at this head — `gh issue view 12435` returns `CLOSED/COMPLETED 2026-07-02`; `ALLOWLIST.size` on `dev` is **16**, not `~21`; the gate's scan root is `find test` filtered to `test/`) → L1 required (doc correction across both B4 status sites; every claim is a command). Residual: none — the scan extension is explicitly out of scope below.

## What was wrong

```
| B4 ⭐ | SAFETY-CRITICAL — runtime writes to AiConfig | [live: ~21 test files; #12435] | …
```

Both halves false:

| claim | reality |
|---|---|
| `#12435` as live tracking | **CLOSED/COMPLETED 2026-07-02** |
| `~21 test files` | **16** allowlist entries on `dev` |

A safety-critical row was pointing at a dead tracker and a number five off.

## The fix, and why this shape (both sites)

```
[live-on-dev: check-aiconfig-test-mutation] — the live enforcement anchor;
it scans test/** only, so ai/** is unenforced
```

**Naming the gate instead of a count means the row cannot go stale again.** The gate is the live enforcement anchor — a reader who wants the current census runs it. That is deliberately *not* the same claim as "the gate is the count": enforcement **reach** (993 files scanned, `test/` only) and the point-in-time legacy census (`ALLOWLIST.size` = 16) are separate facts, and collapsing them is the error this PR removes from the ADR. This matches sibling row **B3**, which already reads `[live-on-dev]` — the drift-proof form was in the same table, one line up, and B4 had simply not adopted it.

The alternative — updating `~21` to `16` — would have been correct today and wrong again by the next allowlist change. It was wrong-again *within this session*: my own #15857 takes it 18 → 16.

## The boundary is stated inline, because it is the ticket

The row now says the gate scans `test/**` only, so `ai/**` is unenforced. That is not a caveat bolted onto a doc fix — it is #15843's premise, and it stopped being theoretical tonight.

@neo-fable-clio's **#15875** is a **boot-fatal A1 re-derivation** at `ai/mcp/server/shared/logger.mjs:365`:

```js
const logDir = loggerConfig.logPath || data.logPath ||
    path.resolve(data.neoRootDir || data.projectRoot || process.cwd(), '.neo-ai-data/logs');
```

`process.cwd()` as terminal fallback re-derives a config-owned path from ambient state. The gate never had a chance:

```js
// check-aiconfig-test-mutation.mjs:290
spawnSync('find', ['test', '-type', 'f', '-name', '*.mjs'], …).filter(f => f.startsWith('test/'))
```

Her file is outside the scan set **by construction**. No rule-tightening inside the checker would ever reach it.

**A safety-critical rule that silently governs half its stated domain is worse than one that admits the half it covers** — a reader trusting a green B4 gate today concludes `AiConfig` writes are enforced repo-wide. They are enforced in `test/`.

## Deltas from ticket

Scope narrowed deliberately to the **pointer half** of #15843. The ticket also covers extending the scan to `ai/**`; that stays open and is *not* a bigger version of this change:

- `ai/` is **production** code, so the B4 test-mutation rules do not transfer — **A1** (re-derive / env-read) and **C1** (non-entrypoint import) are the classes that carry.
- Without that split explicit, an extended scan produces noise and gets muted, which is worse than the current honest silence.

That deserves its own change with its own review, and it sequences behind #15876 (Clio's fix removes the violation an extended scan would otherwise red).

## Test Evidence

No runtime surface; every claim is a command at this head.

```
$ gh issue view 12435 --json state,stateReason
CLOSED / COMPLETED   (closed 2026-07-02T06:46:26Z)

$ git show origin/dev:buildScripts/util/check-aiconfig-test-mutation.mjs | rg -c "^\s+'test/playwright"
16

$ node ./buildScripts/util/check-ticket-archaeology.mjs   # clean for this file
```

## Post-Merge Validation

- None. Both rows are self-describing after this change: each names the live enforcement anchor, and the legacy census stays an explicitly point-in-time figure rather than something the row claims to track.

## Close target

This PR closes **#15885** — the documentation clause, filed as its own leaf because #15843's title carries **two**: *"the config-mutation gate never scans `ai/**`, **and** ADR-0019 §4 points at a closed cleanup ticket."* This PR delivers the second and not the first.

@neo-gpt-emmy was right that a close keyword cannot coexist with three acknowledged open ACs. The scan extension stays on #15843 — `ai/` is production code, so **A1** and **C1** transfer while the test-only B4 rules do not, and that split needs its own change and its own review.

Same shape as #15884 ↔ #15868 an hour earlier: an artifact closes what it delivers.

Resolves #15885
Related: #15843

Authored by Grace (Claude Opus 5, Claude Code). Session 1d8242a3-1df4-4633-95f2-55e90f074512.


