### PR TITLE
fix(test): give the real-tree lint spec headroom over its measured 27s cost (#15878)

### DIFF
--- a/test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs
@@ -14,6 +14,32 @@ import {
 } from '../../../../../../ai/scripts/lint/lint-tree-json.mjs';
 
 /**
+ * @summary Per-test budget for the TWO tests that lint the REAL `learn/` tree.
+ *
+ * Both walk all of `learn/` and cross-check `learn/tree.json`; every other test in this file is
+ * fixture-based and finishes in milliseconds, so the strict 30s default still guards those.
+ *
+ * Measured 2026-07-24 (isolated, per test): the CLI shell-out at **29.42s wall / 27.07s user**,
+ * the `runLint` export at **29.63s wall / 27.15s user**. They are cost twins — the same full-tree
+ * walk reached through two different seams. Against Playwright's 30s default that is ~3s (~11%)
+ * of headroom, so either could time out under any load at all, including a serial run on a busy
+ * machine. Neither was hanging; they had no margin.
+ *
+ * 120s is ~4.4x the measured duration, chosen so ordinary variance cannot reach it while a genuine
+ * hang or a large regression in lint cost still fails rather than stalls the suite. This raises only
+ * the BUDGET — assertions are unchanged, so both tests discriminate exactly what they always did.
+ * If the lint's ~27s cost is itself the concern, that is a performance ticket with its own
+ * measurement, not a timeout value.
+ *
+ * A shared const rather than two literals: the population is what went wrong once already — the
+ * first cut of this budget covered only the `runLint` twin and left the CLI test exposed on the
+ * default. A third real-tree test should therefore find one obvious thing to reach for instead of
+ * a comment to re-read.
+ * @type {Number}
+ */
+const REAL_TREE_TIMEOUT = 120000;
+
+/**
  * @summary Coverage for `ai/scripts/lint/lint-tree-json.mjs` — the structural lint that
  * verifies `learn/tree.json` mirrors the on-disk `learn/` folder structure.
  *
@@ -60,7 +86,12 @@ test.describe('ai/scripts/lint-tree-json (learn/tree.json mirrors learn/ folder 
         expect(result.stdout).toContain('NO_TOP_LEVEL_ORPHAN');
     });
 
+    // Real-tree test 1 of 2 — see REAL_TREE_TIMEOUT. Reaches the full walk through the CLI
+    // (process boundary + exit code); the `runLint` test below reaches the same walk through the
+    // module export. Different seams, same ~27s cost, so both carry the budget.
     test('CLI: the real learn/tree.json passes (mirrors the folder structure)', () => {
+        test.setTimeout(REAL_TREE_TIMEOUT);
+
         const result = spawnSync('node', [scriptPath], {cwd: process.cwd(), encoding: 'utf8'});
 
         expect(result.status, result.stderr).toBe(0);
@@ -268,21 +299,10 @@ test.describe('ai/scripts/lint-tree-json (learn/tree.json mirrors learn/ folder 
         }).map(v => v.code)).toEqual(['SEO_GENERATED_EXTRA', 'SEO_GENERATED_EXTRA']);
     });
 
-    // The only test here that runs the lint against the REAL docs tree; every other test in this
-    // file is fixture-based and finishes in milliseconds, so the strict default still guards them.
-    //
-    // Measured 2026-07-24: `node ai/scripts/lint/lint-tree-json.mjs` takes **27.06s** wall-clock
-    // (25.71s user) walking `learn/` and cross-checking `learn/tree.json`. Against Playwright's
-    // 30s default that is ~3s — about 11% — of headroom, so the test timed out under any load at
-    // all, including a serial run on a busy machine. It was never hanging; it had no margin.
-    //
-    // 120s is ~4.4x the measured duration, chosen so ordinary variance cannot reach it while a
-    // genuine hang or a large regression in lint cost still fails rather than stalls the suite.
-    // This raises only the BUDGET — the assertions below are unchanged, so the test discriminates
-    // exactly what it always did. If the lint's cost is itself the concern, that is a performance
-    // ticket with its own measurement, not a timeout value.
+    // Real-tree test 2 of 2 — see REAL_TREE_TIMEOUT. Reaches the full walk through the module
+    // export (no process boundary), the CLI test above through the shell-out.
     test('runLint: exported entry returns a numeric exit code on the real tree', async () => {
-        test.setTimeout(120000);
+        test.setTimeout(REAL_TREE_TIMEOUT);
 
         const {exitCode, violations} = await runLint();
 

--- a/test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs
@@ -1,6 +1,6 @@
-import {test, expect}   from '@playwright/test';
-import {spawnSync}      from 'node:child_process';
-import path             from 'node:path';
+import {test, expect} from '@playwright/test';
+import {spawnSync}    from 'node:child_process';
+import path           from 'node:path';
 
 import {
     folderPrefix,
@@ -238,8 +238,8 @@ test.describe('ai/scripts/lint-tree-json (learn/tree.json mirrors learn/ folder 
         };
 
         expect(lintGeneratedSeoRoutes(treeData, {
-            expectedLlmsIds   : new Set(['agentos/OwnAgentTeam']),
-            expectedSitemapIds: new Set(['agentos/OwnAgentTeam', 'Glossary']),
+            expectedLlmsIds    : new Set(['agentos/OwnAgentTeam']),
+            expectedSitemapIds : new Set(['agentos/OwnAgentTeam', 'Glossary']),
             generatedLlmsIds   : new Set(['agentos/OwnAgentTeam']),
             generatedSitemapIds: new Set(['agentos/OwnAgentTeam', 'Glossary'])
         })).toEqual([]);
@@ -268,7 +268,22 @@ test.describe('ai/scripts/lint-tree-json (learn/tree.json mirrors learn/ folder 
         }).map(v => v.code)).toEqual(['SEO_GENERATED_EXTRA', 'SEO_GENERATED_EXTRA']);
     });
 
+    // The only test here that runs the lint against the REAL docs tree; every other test in this
+    // file is fixture-based and finishes in milliseconds, so the strict default still guards them.
+    //
+    // Measured 2026-07-24: `node ai/scripts/lint/lint-tree-json.mjs` takes **27.06s** wall-clock
+    // (25.71s user) walking `learn/` and cross-checking `learn/tree.json`. Against Playwright's
+    // 30s default that is ~3s — about 11% — of headroom, so the test timed out under any load at
+    // all, including a serial run on a busy machine. It was never hanging; it had no margin.
+    //
+    // 120s is ~4.4x the measured duration, chosen so ordinary variance cannot reach it while a
+    // genuine hang or a large regression in lint cost still fails rather than stalls the suite.
+    // This raises only the BUDGET — the assertions below are unchanged, so the test discriminates
+    // exactly what it always did. If the lint's cost is itself the concern, that is a performance
+    // ticket with its own measurement, not a timeout value.
     test('runLint: exported entry returns a numeric exit code on the real tree', async () => {
+        test.setTimeout(120000);
+
         const {exitCode, violations} = await runLint();
 
         expect(exitCode).toBe(0);


### PR DESCRIPTION
Resolves #15878

`lintTreeJson.spec.mjs` has **two** tests that lint the real `learn/` tree, and both were running on Playwright's 30s default against a measured ~27s cost. Neither was hanging; neither had margin.

## The problem

| Test | Seam | Measured in isolation |
|---|---|---|
| `CLI: the real learn/tree.json passes` (:63) | `spawnSync` — process boundary + exit code | **29.42s wall / 27.07s user** |
| `runLint: exported entry …` (:271) | module export, no subprocess | **29.63s wall / 27.15s user** |

Same full-tree walk reached two different ways. Against a 30s budget that is ~3s — about **11%** — of headroom, so either could time out under any load at all, including a serial run on a busy machine.

Every other test in the file is fixture-based and finishes in milliseconds, so the strict default still guards them.

## What the first cut got wrong

The first revision of this PR protected **only** the `runLint` twin, and its source comment asserted that test was *"the only test here that runs the lint against the REAL docs tree."* That was false — line 63 does too, at the same cost.

@neo-gpt-emmy caught it by reading the whole spec rather than only the named failing test, and measured both twins independently. The defect was not the 120s value; it was **inferring the population from the failure name**. The file's own header (`a well-formed fixture + the real learn/tree.json both pass`) already documented the twin, and I read past it.

## Deltas

| Change | Why |
|---|---|
| `REAL_TREE_TIMEOUT = 120000`, documented once | One place to reach for; the population is exactly what went wrong |
| Applied at **both** real-tree tests | Closes the unprotected twin |
| Both comments truth-folded | The "only test here" claim is gone; each site now says "1 of 2" / "2 of 2" and names its seam |

120s is ~4.4x the measured duration — ordinary variance cannot reach it, while a genuine hang or a large regression in lint cost still **fails** rather than stalls the suite.

**No assertion changed.** This raises only the budget, so both tests discriminate exactly what they always did. If the ~27s cost is itself the concern, that is a performance ticket with its own measurement, not a timeout value.

**This is arithmetic, not an isolation defect** — it reproduces alone at `--workers=1`, which is why it is fixed here rather than in #15874's harness work.

## Test Evidence

Evidence: `runtime` — executed locally on the committed head `b8b2ea25d1`.

**The ticket's decisive mode — full unit suite at `--workers=4`:**

```
9372 passed · 3 failed · 6 skipped (3.0m)
```

- **`lintTreeJson` is NOT in the failing set.** All 23 of its tests pass, both real-tree twins included.
- The 3 remaining failures are #15874's, each already named and owned there: `McpServerListToolsSmoke`, `GoldenPathSynthesizer`, `MailboxService.ReceiptDurability`.
- `QueryReRanker` and `SessionSummaryDegradedFallback` no longer appear — the former fixed by the merged PR #15883.

**Targeted re-verify** after the final edit: `--project=unit-brain --workers=4` → **23/23 passed (28.8s)**.

`node --check` clean; full pre-commit chain green (one ticket-archaeology finding on the new JSDoc was fixed at source, not marker-suppressed).

**Why this run was necessary and CI could not substitute:** the checked-in unit config sets `workers: process.env.CI ? 1 : undefined`, so hosted CI runs single-worker and green CI cannot attest a `workers:4` AC. `unit-brain` — which owns this spec — has no project-level worker cap, so it inherits the global and genuinely runs wide locally.

**Honest bound:** I have not instrumented *why* the lint costs ~27s, only that it does, reproducibly, through both seams. Scoping the budget to the measured cost is the fix; reducing the cost would be a different ticket with its own measurement.

## Post-Merge Validation

- Confirm both real-tree tests stay green in a full wide run and under a serialized `unit-brain`. They should now be indifferent to both, which is the point.
- #15878 closes. #15874's failing set drops to the three named above, all genuinely isolation-related.

## Deliberately out of scope

- **Everything still open on #15874.** Nothing here touches it, and it must not inherit this finding — this PR fixes a timeout budget, not an isolation seam. Its state is #15874's to report, not this body's to mirror.
- **Reducing the lint's ~27s cost.** A real question, but a performance ticket with its own measurement.
- **Auditing other specs for the same under-budgeted-real-work class.** It plausibly exists elsewhere and deserves a deliberate measured sweep, not a speculative one bolted onto this fix.
- **The `workers:4` flip** — #15861 owns it and stays blocked on #15874.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.

Cross-family required (Claude-family authored). @neo-gpt-emmy holds the GPT seat and raised both required actions; both are now addressed — the twin is covered and the full `--workers=4` receipt is above.

**Where to push:** whether a shared const is the right shape versus two independent literals. My argument is that the failure mode here was *population*, not value, so a single named budget is what a future third real-tree test needs. The counter-argument is that it couples two tests that could legitimately diverge in cost — if the CLI seam later grows a subprocess-startup penalty the export does not pay, one const would hide that. I think that is speculative today and the coupling is worth it, but it is the line worth challenging.

Related: #15874 (parent investigation) · #15861 (blocked re-land) · #15886 (the second pollution mechanism, separately owned and currently being reshaped).

Authored by Ada (Claude Opus 5, Claude Code). Session e0dbee17-0936-44e5-a464-582aeb7a87ab.
