### PR TITLE
test(ai): scope QueryReRanker's assertions to its own fixture (#15882)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
@@ -600,18 +600,35 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
             metadatas: [{sessionId: ancientSessionId, timestamp: ancientTimestamp, type: 'agent-interaction'}]
         });
 
-        // Query with 30-day window — should NOT include the ancient memory
+        // Both queries are scoped to THIS fixture's sessionId. The collection is run-scoped and
+        // every Brain spec writes to it, so an unscoped read makes the assertion depend on the
+        // collection's total size rather than on the filter under test. That broke twice, in
+        // opposite directions:
+        //
+        //   - the unscoped `toContain` FALSE-FAILED once the collection outgrew a returned page
+        //     (the fixture's own row fell outside it);
+        //   - the unscoped `not.toContain` could FALSE-PASS for the same reason — a truncated page
+        //     is *less* likely to contain the row, so the assertion would stay green even if the
+        //     $gt filter were completely broken. That one never failed, which is worse: it was
+        //     unfalsifiable rather than wrong.
+        //
+        // Scoping by sessionId makes both size-independent and turns the negative assertion into a
+        // real one: with the filter working the scoped 30-day window returns NOTHING, and if the
+        // filter regressed it would return this row.
         const thirtyDaysAgo = Date.now() - (30 * 24 * 60 * 60 * 1000);
         const recentResults = await collection.get({
-            where  : {timestamp: {'$gt': thirtyDaysAgo}},
+            where  : {$and: [{sessionId: ancientSessionId}, {timestamp: {'$gt': thirtyDaysAgo}}]},
             include: ['metadatas']
         });
 
-        const recentSessionIds = recentResults.metadatas.map(m => m.sessionId);
-        expect(recentSessionIds).not.toContain(ancientSessionId);
+        expect(recentResults.metadatas.map(m => m.sessionId)).not.toContain(ancientSessionId);
+        // Explicit: the scoped window is EMPTY. Distinguishes "correctly filtered out" from
+        // "the page happened not to include it", which the unscoped form could not.
+        expect(recentResults.metadatas).toHaveLength(0);
 
-        // Query with ALL time — should include it
+        // Query with ALL time, same scope — should include it
         const allResults = await collection.get({
+            where  : {sessionId: ancientSessionId},
             include: ['metadatas']
         });
 


### PR DESCRIPTION
Resolves #15882

`#15874`'s `QueryReRanker` failure, traced and fixed. The interesting part is that the assertion which **never failed** was the worse defect.

**Framing note:** an earlier revision of this body called this "cohort 2" and contrasted it with a "cohort 1" of opposite polarity. **That framing has since been retired on `#15874`** — bisecting showed every failure there passes in isolation, so the split did not survive. This fix is unaffected: the defect below is a query-shape bug that is wrong at any worker count, which is why it stands independently of whatever `#15874` concludes.

## The problem

`QueryReRanker.spec.mjs` asserts over the **run-scoped Chroma collection every Brain spec writes to**, without scoping either query to its own fixture. Both assertions therefore depend on the total size of a collection the test does not control — and that breaks in **two opposite directions**:

| Assertion | Failure mode | Ever observed? |
|---|---|---|
| `toContain` (fully unscoped) | **FALSE FAIL** — once the collection outgrows a returned page, the fixture's own row falls outside it | **Yes** — the `#15874` failure that led here |
| `not.toContain` (time-scoped only) | **FALSE PASS** — a truncated page is *less* likely to contain the row, so it stays green **even if the `$gt` filter is completely broken** | **Never** |

**The one that never went red is the serious one.** It could not go red: under truncation it is unfalsifiable. A test asserting *"the filter excluded my row"* that would pass equally if the filter did nothing is not testing the filter — it is decoration with a green tick.

Fixing only the observed failure would have left that in place, which is why this PR touches both.

### Why serializing surfaced it

With `unit-brain` at `workers: 1`, all Brain specs run sequentially in one worker, so everything written earlier has accumulated by the time this test runs. Wide, the same specs spread across four processes and this one can execute against a smaller collection. **Less concurrency means more accumulated state at this point, not less** — the reason reducing parallelism *broke* it.

## Deltas

| Change | Why |
|---|---|
| Negative query → `where: {$and: [{sessionId}, {timestamp: {$gt: …}}]}` | Size-independent, and scoped to this fixture |
| **New:** assert the scoped window is **empty** | Converts an unfalsifiable check into a real one — with the filter working it returns nothing; if it regressed, this row comes back |
| Positive query → `where: {sessionId}` | The fixture's row is retrievable at any collection size |
| Comment recording both failure modes | So the next reader knows why the scoping is load-bearing and does not "simplify" it away |

**No assertion weakened — the test proves strictly more than before.** It gained a falsifiable negative case it did not previously have.

**This is a query-shape bug, not an isolation bug.** It is wrong at any worker count; parallelism only changed how quickly the collection grew past the threshold. That is why it is fixed here at the spec level rather than in `#15874`'s harness work.

## Test Evidence

Evidence: `runtime` — executed locally on the committed head `20c00c77f1`.

- **16 passed, exit 0** at `--workers=1` — the exact config that exposed the failure in `#15874`'s run B.
- `node --check` clean; `check-block-alignment` clean; full pre-commit chain green.
- Trace provenance: the three-config matrix (A1/A2/B) is recorded on `#15874`; A1 ≡ A2 is the control establishing these are deterministic rather than flake. (The polarity analysis that matrix originally carried has since been retired — see the framing note above.)

**Honest bound:** I have not instrumented the exact page limit Chroma applies, so I cannot state the precise row count at which the unscoped read starts truncating. That is not needed for this fix — scoping removes the dependency on the limit entirely, whatever it is — but it means "the collection outgrew a returned page" is the mechanism I am confident of, not a number I have measured.

## Post-Merge Validation

- Confirm `QueryReRanker` passes in a full wide run **and** with `unit-brain` serialized. It should now be indifferent to both, which is the point.
- `#15874`'s `QueryReRanker` entry closes. **What remains open there is deliberately not enumerated here** — see `#15874` for its current state. This body previously carried such a list twice and it went stale both times, because a snapshot of a moving neighbour rots without anything touching the snapshot.

## Deliberately out of scope

- **Everything still open on `#15874`.** Nothing here touches it, and it must not inherit this finding — this PR fixes a query shape, not an isolation seam. Its state is `#15874`'s to report, not this body's to mirror.
- **Auditing every other unscoped Chroma read in the suite.** This class plausibly exists elsewhere and deserves a deliberate sweep; a speculative one bolted onto this fix would be scope creep, and I would rather it be its own measured pass.
- **The `workers:4` flip** — `#15861` owns it and stays blocked on `#15874`.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.
Cross-family required (Claude-family authored). **Where to push:** the added `toHaveLength(0)`. I argue it is what makes the negative case falsifiable, but you could reasonably ask whether asserting emptiness over-constrains — if a future fixture legitimately puts another row in this session's scope, it fails. My view is that scoping is per-test by construction so that cannot happen accidentally, but it is the line worth challenging.

Related: #15874 (parent investigation) · #15861 (blocked re-land) · #15878 / PR #15881 (the other non-isolation defect pulled out of the same matrix).

Authored by Ada (Claude Opus 5, Claude Code). Session bf720ff4-7b70-4720-b3d9-2cb90711eb1f.


