### PR TITLE
The B4 allowlist was licensing the de-scoping act, not the isolation — burn it down 16 → 4

### DIFF
--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -70,24 +70,32 @@ export const DB_PATH_MUTATION = new RegExp(
 );
 
 /*
- * Files that already mutate Class-A DB paths, grandfathered while the cleanup migrates them to
- * by-construction isolation. The ratchet bites only NEW offenders; this set shrinks as the cleanup
- * lands. Paths are repo-relative POSIX.
+ * Files whose Class-A mutation is load-bearing — NOT a grandfathering queue. Every entry whose write
+ * duplicated isolation the harness already provides by construction has been removed; what survives
+ * is here because by-construction isolation provably cannot serve it, and each entry states why. A new entry needs that same justification, not a migration promise: an unexplained
+ * entry is a silent licence, and the gate stops counting a file the moment it is listed.
+ *
+ * Both survivors restore what they write, which is what keeps the blast radius inside the spec.
+ * Paths are repo-relative POSIX.
  */
 export const ALLOWLIST = new Set([
+    /*
+     * The three logger siblings repoint `data.logPath` at a per-process temp dir. The harness DOES
+     * worker-scope these (`configTemplateResolver` sets NEO_{MEMORY,KB,NL}_LOG_PATH per worker), but
+     * worker-scoped is not spec-scoped: every spec sharing a worker appends to the same daily file,
+     * and these suites assert on the FIRST LINE of that file. Reading the resolved path instead would
+     * make the assertion depend on whichever spec logged first — so the only removal available here
+     * weakens an assertion, which the burndown does not do.
+     */
     'test/playwright/unit/ai/mcp/server/knowledge-base/logger.spec.mjs',
     'test/playwright/unit/ai/mcp/server/memory-core/logger.spec.mjs',
     'test/playwright/unit/ai/mcp/server/neural-link/logger.spec.mjs',
+    /*
+     * Flips `useUnitTestDatabase` / `useTestHarness` to false in order to assert that the destructive-
+     * operation guard fires when they ARE false. The off state is the subject under test, so it cannot
+     * be supplied by construction: the harness exists to hold those selectors on.
+     */
     'test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs',
-    'test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs',
-    'test/playwright/unit/ai/services/graph/LazyEdgeDrainer.spec.mjs',
-    'test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs',
-    'test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs',
-    'test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs',
-    'test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs',
-    'test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs',
-    'test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs',
-    'test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs',
 ]);
 
 /**

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -81,15 +81,12 @@ export const ALLOWLIST = new Set([
     'test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs',
     'test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs',
     'test/playwright/unit/ai/services/graph/LazyEdgeDrainer.spec.mjs',
-    'test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs',
     'test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs',
     'test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs',
     'test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs',
     'test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs',
     'test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs',
-    'test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs',
     'test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs',
-    'test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs',
     'test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs',
 ]);
 

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -1,5 +1,10 @@
 import {test, expect}                                  from '@playwright/test';
+import {existsSync}                                    from 'node:fs';
+import path                                            from 'node:path';
+import {fileURLToPath}                                 from 'node:url';
 import {findDbPathMutations, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
 
 /**
  * Self-test for the Class-A DB-path AiConfig test-mutation guard: the mechanical enforcement of the
@@ -129,9 +134,25 @@ test.describe('check-aiconfig-test-mutation guard', () => {
         expect(findDbPathMutations(`aiConfig.storagePaths.graph = p; // ${ESCAPE_MARKER}: legacy shim, migrates in #12435`)).toEqual([])
     });
 
-    test('the grandfather allowlist is populated (the ratchet bites only new offenders)', () => {
+    test('every allowlist entry names a file that still exists (a stale entry is a silent licence)', () => {
+        /*
+         * This deliberately does NOT pin a member path. The predecessor did — it named one specific
+         * grandfathered spec — so the burndown that retired that entry turned the guard's own self-test
+         * red for the one reason that is not a defect: the burndown working. A pinned member is the
+         * same point-in-time figure the B4 row itself stopped carrying, and it re-breaks on every
+         * future burndown step.
+         *
+         * What the checker's own header asserts is the contract worth testing: this is a
+         * justified-exception set, and "the gate stops counting a file the moment it is listed". So an
+         * entry that outlives its file is a silent exemption on a path nothing can reach again — the
+         * exact residue a burndown leaves if it deletes the file and forgets the entry.
+         *
+         * Sunset: when the set reaches empty, the exemption branch in the checker has no consumer left
+         * — retire the mechanism and this test together rather than relaxing the bound below.
+         */
         expect(ALLOWLIST.size).toBeGreaterThan(0);
-        expect(ALLOWLIST.has('test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs')).toBe(true)
+
+        expect([...ALLOWLIST].filter(entry => !existsSync(path.join(repoRoot, entry)))).toEqual([])
     });
 
     /*

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -84,9 +84,9 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, { recursive: true });
         }
-        const testDbName = `memory-core-goldenpath-test-${process.pid}-${Date.now()}.sqlite`;
-        const testDbPath = path.join(tmpDir, testDbName);
-        aiConfig.storagePaths.graph = testDbPath;
+        // Isolation is by construction: `storagePaths.graph` is a formula resolving `graphTest`
+        // (`:memory:`) under `UNIT_TEST_MODE`, and a `:memory:` store is process-local — stronger
+        // than the shared tmp file this suite used to repoint it at.
 
         // Read the resolved per-worker test handoff path (a computed formula under UNIT_TEST_MODE);
         // the writer targets the same resolved path, so the read-backs match. Mutating
@@ -165,8 +165,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     });
 
     test.afterAll(async () => {
-        const testDbPath = aiConfig.storagePaths.graph;
-        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
+        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, null, fs, 'clear');
     });
 
     test('derives repo-enrichment identity projections from identityRoots', () => {

--- a/test/playwright/unit/ai/services/graph/LazyEdgeDrainer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/LazyEdgeDrainer.spec.mjs
@@ -31,9 +31,7 @@ test.describe('Neo.ai.daemons.services.LazyEdgeDrainer', () => {
     let logger;
     let originalLinkNodesAsync;
 
-    const testDbName = `memory-core-lazy-edge-drainer-test-${process.pid}-${Date.now()}.sqlite`;
-    const queueName  = `test-lazy-edges-${process.pid}-${Date.now()}.jsonl`;
-    let testDbPath;
+    const queueName = `test-lazy-edges-${process.pid}-${Date.now()}.jsonl`;
     let queuePath;
 
     test.beforeAll(async () => {
@@ -43,22 +41,17 @@ test.describe('Neo.ai.daemons.services.LazyEdgeDrainer', () => {
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, {recursive: true});
         }
-        testDbPath = path.join(tmpDir, testDbName);
-        queuePath  = path.join(tmpDir, queueName);
+        queuePath = path.join(tmpDir, queueName);
 
-        aiConfig.storagePaths.graph   = testDbPath;
+        // Isolation is by construction: `storagePaths.graph` is a formula resolving `graphTest`
+        // (`:memory:`) under `UNIT_TEST_MODE`, and a `:memory:` store is process-local — stronger
+        // than the shared tmp file this suite used to repoint it at.
         aiConfig.autoIngestFileSystem = false;
 
         LazyEdgeDrainer        = (await import('../../../../../../ai/services/graph/LazyEdgeDrainer.mjs')).default;
         GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         logger                 = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
-
-        if (fs.existsSync(testDbPath)) {
-            try { fs.unlinkSync(testDbPath); } catch (e) {}
-            if (fs.existsSync(`${testDbPath}-wal`)) try { fs.unlinkSync(`${testDbPath}-wal`); } catch (e) {}
-            if (fs.existsSync(`${testDbPath}-shm`)) try { fs.unlinkSync(`${testDbPath}-shm`); } catch (e) {}
-        }
 
         if (!SystemLifecycleService._initPromise) {
             await SystemLifecycleService.initAsync();
@@ -86,7 +79,7 @@ test.describe('Neo.ai.daemons.services.LazyEdgeDrainer', () => {
     });
 
     test.afterAll(async () => {
-        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
+        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, null, fs, 'clear');
     });
 
     test('drainQueue on non-existent queue file is a no-op', async () => {

--- a/test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs
@@ -28,8 +28,6 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
     let logger;
     let SystemLifecycleService;
 
-    const testDbName = `memory-core-concept-ingestor-test-${process.pid}-${Date.now()}.sqlite`;
-    let testDbPath;
     let tmpConceptsDir;
     let restoreAiConfig;
 
@@ -43,11 +41,11 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, {recursive: true});
         }
-        testDbPath = path.join(tmpDir, testDbName);
+        restoreAiConfig = snapshotAiConfig(aiConfig, ['handoffFilePath']);
 
-        restoreAiConfig = snapshotAiConfig(aiConfig, ['storagePaths.graph', 'handoffFilePath']);
-
-        aiConfig.storagePaths.graph = testDbPath;
+        // Isolation is by construction: `storagePaths.graph` is a formula resolving `graphTest`
+        // (`:memory:`) under `UNIT_TEST_MODE`, and a `:memory:` store is process-local — stronger
+        // than the shared tmp file this suite used to repoint it at.
         aiConfig.handoffFilePath    = path.join(tmpDir, 'mock_sandman_handoff_concept_ingestor.md');
 
         GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
@@ -55,14 +53,6 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
         ConceptService         = (await import('../../../../../../ai/services/ConceptService.mjs')).default;
         logger                 = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
-
-        if (fs.existsSync(testDbPath)) {
-            try {
-                fs.unlinkSync(testDbPath);
-                if (fs.existsSync(`${testDbPath}-wal`)) fs.unlinkSync(`${testDbPath}-wal`);
-                if (fs.existsSync(`${testDbPath}-shm`)) fs.unlinkSync(`${testDbPath}-shm`);
-            } catch (e) {}
-        }
 
         if (!SystemLifecycleService._initPromise) {
             await SystemLifecycleService.initAsync();
@@ -124,7 +114,7 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
     });
 
     test.afterAll(async () => {
-        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
+        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, null, fs, 'clear');
     });
 
     /**

--- a/test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs
@@ -33,8 +33,6 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
     let logger;
     let SystemLifecycleService;
 
-    const testDbName = `memory-core-memory-session-ingestor-test-${process.pid}-${Date.now()}.sqlite`;
-    let testDbPath;
     let restoreAiConfig;
 
     let originalWarn;
@@ -75,25 +73,17 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, {recursive: true});
         }
-        testDbPath = path.join(tmpDir, testDbName);
+        restoreAiConfig = snapshotAiConfig(aiConfig, ['handoffFilePath']);
 
-        restoreAiConfig = snapshotAiConfig(aiConfig, ['storagePaths.graph', 'handoffFilePath']);
-
-        aiConfig.storagePaths.graph = testDbPath;
+        // Isolation is by construction: `storagePaths.graph` is a formula resolving `graphTest`
+        // (`:memory:`) under `UNIT_TEST_MODE`, and a `:memory:` store is process-local — stronger
+        // than the shared tmp file this suite used to repoint it at.
         aiConfig.handoffFilePath    = path.join(tmpDir, 'mock_sandman_handoff_memory_session_ingestor.md');
 
         GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         MemorySessionIngestor  = (await import('../../../../../../ai/services/ingestion/MemorySessionIngestor.mjs')).default;
         logger                 = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
-
-        if (fs.existsSync(testDbPath)) {
-            try {
-                fs.unlinkSync(testDbPath);
-                if (fs.existsSync(`${testDbPath}-wal`)) fs.unlinkSync(`${testDbPath}-wal`);
-                if (fs.existsSync(`${testDbPath}-shm`)) fs.unlinkSync(`${testDbPath}-shm`);
-            } catch (e) {}
-        }
 
         if (!SystemLifecycleService._initPromise) {
             await SystemLifecycleService.initAsync();
@@ -145,7 +135,7 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
     });
 
     test.afterAll(async () => {
-        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
+        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, null, fs, 'clear');
     });
 
     test('should return stats object with the documented shape', async () => {

--- a/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
@@ -43,9 +43,10 @@ test.describe('CoalescingEngineService', () => {
 
     test.beforeAll(async () => {
         const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        if (!aiConfig.collections) aiConfig.collections = {};
-        aiConfig.collections.memory = `test-memory-${process.pid}-${Date.now()}`;
-        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+        // Isolation is by construction: `collections.*` already resolve to per-process randomized
+        // `test-*` names under `UNIT_TEST_MODE`, and Chroma isolates one level higher still, at the
+        // database (`databaseTest`). Repointing the shared singleton duplicated that with a coarser
+        // generator and left the names pointing here for the rest of the worker's life.
 
         CoalescingEngineService = (await import('../../../../../../ai/services/memory-core/CoalescingEngineService.mjs')).default;
         WebhookDeliveryService  = (await import('../../../../../../ai/services/memory-core/WebhookDeliveryService.mjs')).default;

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs
@@ -32,10 +32,10 @@ test.describe('Memory_DatabaseService — backupPath routing (#10129 Phase 2 pre
 
     test.beforeAll(async () => {
         aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        if (!aiConfig.collections) aiConfig.collections = {};
-        memoryCollectionName       = `test-memory-${process.pid}-${Date.now()}`;
-        aiConfig.collections.memory = memoryCollectionName;
-        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+        // Isolation is by construction: `collections.*` already resolve to per-process randomized
+        // `test-*` names under `UNIT_TEST_MODE`, and Chroma isolates one level higher still, at the
+        // database (`databaseTest`). Repointing the shared singleton duplicated that with a coarser
+        // generator and left the names pointing here for the rest of the worker's life.
 
         SDK                    = await import('../../../../../../ai/services.mjs');
         Memory_DatabaseService = SDK.Memory_DatabaseService;

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs
@@ -87,9 +87,10 @@ test.describe('Memory_DatabaseService — Chroma preserve-live parity for #impor
 
     test.beforeAll(async () => {
         const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        if (!aiConfig.collections) aiConfig.collections = {};
-        aiConfig.collections.memory  = `test-memory-${process.pid}-${Date.now()}`;
-        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
+        // Isolation is by construction: `collections.*` already resolve to per-process randomized
+        // `test-*` names under `UNIT_TEST_MODE`, and Chroma isolates one level higher still, at the
+        // database (`databaseTest`). Repointing the shared singleton duplicated that with a coarser
+        // generator and left the names pointing here for the rest of the worker's life.
 
         // The atomic vector-write invariant validates each imported row's embedding length against the
         // resolved aiConfig.vectorDimension. Build fixtures AT that dimension (READ it, never mutate — the

--- a/test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs
@@ -25,33 +25,27 @@ test.describe('Neo.ai.services.memory-core.FileSystemIngestor', () => {
     let GraphService;
     let SystemLifecycleService;
     let FileSystemIngestor;
-    const testDbName = `memory-core-fs-test-${process.pid}-${Date.now()}.sqlite`;
-    let testDbPath;
     let mockFsRoot;
-    let originalDbPath;
 
     test.beforeAll(async () => {
-        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        originalDbPath = aiConfig.storagePaths.graph;
-
+        // Isolation is by CONSTRUCTION, not by mutation. Under `UNIT_TEST_MODE`, `storagePaths.graph`
+        // is a formula resolving `graphTest` (`:memory:`) and `collections.*` resolve to generated
+        // test names — both declared in `configBase.mjs`. This suite previously repointed all three
+        // on the shared config singleton, so the writes bought nothing the harness had not already
+        // provided; and only the graph path was ever handed back, leaving the two collection names
+        // pointing at this suite's values for the remaining life of the worker.
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, { recursive: true });
         }
-        testDbPath = path.join(tmpDir, testDbName);
         mockFsRoot = path.join(tmpDir, `fs-ingest-mock-${process.pid}-${Date.now()}`);
-
-        aiConfig.storagePaths.graph = testDbPath;
-        if (!aiConfig.collections) aiConfig.collections = {};
-        aiConfig.collections.memory = `test-memory-${Date.now()}`;
-        aiConfig.collections.session = `test-session-${Date.now()}`;
 
         GraphService       = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         FileSystemIngestor = (await import('../../../../../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
 
         const { TestLifecycleHelper } = await import('./util.mjs');
-        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
+        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, null, fs, 'clear');
 
         if (!SystemLifecycleService._initPromise) { await SystemLifecycleService.initAsync(); } else { await SystemLifecycleService.ready(); }
 
@@ -103,10 +97,9 @@ test.describe('Neo.ai.services.memory-core.FileSystemIngestor', () => {
         const { cleanupChromaManager, TestLifecycleHelper } = await import('./util.mjs');
         await cleanupChromaManager();
 
-        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        aiConfig.storagePaths.graph = originalDbPath;
-
-        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
+        // No config to hand back — nothing was mutated. The `'clear'` strategy never reads the path
+        // argument: it clears the in-memory stores and calls `storage.clear()`.
+        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, null, fs, 'clear');
 
         fs.removeSync(mockFsRoot);
     });

--- a/test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs
@@ -22,26 +22,15 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
 test.describe('Neo.ai.services.memory-core.PermissionService', () => {
     test.describe.configure({ mode: 'serial' });
     let PermissionService, GraphService, LifecycleService, originalAutoSave;
-    let dbPath, originalDbPath, hadGraphDb = false;
+    let hadGraphDb = false;
 
     test.beforeAll(async () => {
-        // Build an isolated tmp path for the database file tests
-        const tmpDir = path.resolve(process.cwd(), 'tmp');
-        if (!fs.existsSync(tmpDir)) {
-            fs.mkdirSync(tmpDir, { recursive: true });
-        }
-        dbPath = path.join(tmpDir, `neo-permission-test-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
-
-        // Force temp file DB config instead of :memory: to prevent initialization race wipes
-        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        originalDbPath = aiConfig.storagePaths.graph;
-        aiConfig.storagePaths.graph = dbPath;
-
-        // Mock Chroma collections to prevent production data wipes
-        if (!aiConfig.collections) aiConfig.collections = {};
-        aiConfig.collections.memory = `test-memory-${process.pid}-${Date.now()}`;
-        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
-
+        // Isolation is by construction. `storagePaths.graph` resolves `graphTest` (`:memory:`) and
+        // `collections.*` resolve to per-process randomized `test-*` names, both under `UNIT_TEST_MODE`.
+        // The removed writes carried two stale rationales: a temp file was said to beat `:memory:`
+        // against "initialization race wipes" (the suite is green on `:memory:` across repeated runs),
+        // and the collection names were said to prevent production wipes — Chroma isolates at the
+        // database level (`databaseTest`) before any collection name is resolved.
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         PermissionService = (await import('../../../../../../ai/services/memory-core/PermissionService.mjs')).default;
         LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
@@ -78,10 +67,7 @@ test.describe('Neo.ai.services.memory-core.PermissionService', () => {
             GraphService.db.autoSave = originalAutoSave;
         }
 
-        await TestLifecycleHelper.cleanupGraphService(GraphService, LifecycleService, dbPath, fs, 'clear');
-
-        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        aiConfig.storagePaths.graph = originalDbPath;
+        await TestLifecycleHelper.cleanupGraphService(GraphService, LifecycleService, null, fs, 'clear');
 
         if (hadGraphDb) {
             await GraphService.initAsync();

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -29,22 +29,10 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
 test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     test.describe.configure({mode: 'serial'});
     let WakeSubscriptionService, GraphService, LifecycleService, CoalescingEngineService, callTool, originalAutoSave;
-    let dbPath;
 
     test.beforeAll(async () => {
-        const tmpDir = path.resolve(process.cwd(), 'tmp');
-        if (!fs.existsSync(tmpDir)) {
-            fs.mkdirSync(tmpDir, {recursive: true});
-        }
-        dbPath = path.join(tmpDir, `neo-wake-subscription-test-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
-
-        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-        aiConfig.storagePaths.graph = dbPath;
-
-        if (!aiConfig.collections) aiConfig.collections = {};
-        aiConfig.collections.memory = `test-memory-${process.pid}-${Date.now()}`;
-        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
-
+        // Isolation is by construction: `storagePaths.graph` resolves `graphTest` (`:memory:`) and
+        // `collections.*` resolve to per-process randomized `test-*` names under `UNIT_TEST_MODE`.
         GraphService            = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         WakeSubscriptionService = (await import('../../../../../../ai/services/memory-core/WakeSubscriptionService.mjs')).default;
         CoalescingEngineService = (await import('../../../../../../ai/services/memory-core/CoalescingEngineService.mjs')).default;
@@ -55,7 +43,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         globalThis.GraphMaintenanceService = GraphMaintenanceService;
 
         const { TestLifecycleHelper } = await import('./util.mjs');
-        await TestLifecycleHelper.cleanupGraphService(GraphService, LifecycleService, dbPath, fs, 'clear');
+        await TestLifecycleHelper.cleanupGraphService(GraphService, LifecycleService, null, fs, 'clear');
 
         if (!LifecycleService._initPromise) { await LifecycleService.initAsync(); } else { await LifecycleService.ready(); }
 
@@ -67,7 +55,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         const { cleanupChromaManager, TestLifecycleHelper } = await import('./util.mjs');
         await cleanupChromaManager();
         GraphService.db.autoSave = originalAutoSave;
-        await TestLifecycleHelper.cleanupGraphService(GraphService, LifecycleService, dbPath, fs, 'clear');
+        await TestLifecycleHelper.cleanupGraphService(GraphService, LifecycleService, null, fs, 'clear');
     });
 
     test.beforeEach(async () => {


### PR DESCRIPTION
The B4 allowlist was read as a queue of specs awaiting isolation the harness could not yet give them. It is the opposite: the harness already gives it, and the listed writes are what throw it away.

**Net: `ALLOWLIST` 16 → 4. 32 violation lines → 10, all four survivors justified inline.**

Evidence: L2 achieved (the gate is green at every step with the reduced allowlist — 993 scanned, 0 violations — plus all 10 touched specs green together at 239 passed, and a two-run-each before/after comparison of `unit/ai/services` at `workers:1`) → L2 required (test-only change, no runtime surface; the removal is self-proving because a stale licence cannot be detected any other way). Residual: the three logger siblings and `DestructiveOperationGuard` keep their writes, argued below rather than deferred.

## The measurement this rests on

Resolved at this head, `UNIT_TEST_MODE=true`:

```
storagePaths.graph  = ":memory:"
collections.memory  = "test-memory-1784938330825-mr1zhh"
collections.session = "test-session-1784938330826-10tkb"
```

`storagePaths.graph` resolves the `graphTest` leaf through the `useTestDatabase` formula. A `:memory:` SQLite store is **process-local** — it cannot be shared between Playwright workers at any worker count. `collections.*` already resolve to per-process randomized names, and Chroma isolates one level higher still, at the database (`databaseTest`).

So a spec writing `storagePaths.graph = <path in tmp/>` moves its store **off** a process-local DB and **onto a file every worker sees**. Under `workers:4` the write is not weaker isolation than the default — it is the de-scoping act itself. That inverts how an allowlist entry reads: not a licence for missing isolation, but the thing that removed it.

## What came out

| Class | Specs | Writes | Why removable |
|---|---|---|---|
| `storagePaths.graph = <file>` | `PermissionService` · `WakeSubscriptionService` · `ConceptIngestor` · `MemorySessionIngestor` · `LazyEdgeDrainer` · `GoldenPathSynthesizer` | 7 | Replaces `:memory:` with a shared file |
| `collections.* = test-…` | `CoalescingEngineService` · `DatabaseService.importMergeChroma` · `DatabaseService.backupPath` | 8 | Duplicates the resolved default with a coarser generator |
| `FileSystemIngestor` (first commit) | 1 spec | 3 | Both of the above, and only the graph path was ever handed back |
| Stale licences | `SemanticGraphExtractor` · `SessionService.ResumeValidation` | 0 | Entries outlived the writes that earned them |

The dead `tmp/*.sqlite` plumbing goes with them — path construction, `unlink`/`-wal`/`-shm` teardown, and the `testDbPath` argument passed to `cleanupGraphService(…, 'clear')`, a strategy that never reads it.

**One rationale was tested rather than assumed stale.** `PermissionService` said: *force temp file DB config instead of `:memory:` to prevent initialization race wipes*. Removed and run three consecutive times — 92 passed each. Stale.

## What stays, and why it is not deferral

Four entries survive, each now carrying its reason in the file:

- **The three logger siblings** assert on the **first line** of a daily-rotated log file. `configTemplateResolver` does worker-scope the log paths, but worker-scoped is not spec-scoped: siblings in one worker append to the same file. Reading the resolved path would make the assertion depend on whichever spec logged first — the only available removal weakens an assertion, and this change does not do that.
- **`DestructiveOperationGuard`** flips `useUnitTestDatabase` / `useTestHarness` to `false` to assert the guard fires when they are false. The off state **is** the subject under test, so it cannot come from a harness whose job is holding those selectors on.

Both restore what they write, which is what keeps the blast radius inside the spec. The header comment no longer promises a migration: an entry now requires a justification, because a listed file is one the gate stops counting — which is exactly how the two stale licences stayed invisible.

## The ledger side, which the first push got wrong

The one red check on this branch was the burndown working. The guard's own self-test pinned a **specific member path** — `DatabaseService.backupPath.spec.mjs` — and this change retires that entry, so the assertion went red for the only reason that is not a defect.

Fixing the pin by repointing it at a survivor would have reproduced the defect one step later: a pinned member is the same point-in-time figure the B4 row itself stopped carrying, and it re-breaks on **every** future burndown step. So the self-test now asserts the invariant the checker's header actually states — a justified-exception set in which *the gate stops counting a file the moment it is listed*:

```js
expect([...ALLOWLIST].filter(entry => !existsSync(path.join(repoRoot, entry)))).toEqual([])
```

An entry that outlives its file is a silent exemption on a path nothing can reach again — precisely the residue a burndown leaves if it deletes the file and forgets the entry. That is a real class this suite did not cover before, and it is stable across 16 → 4 → 0. The sunset condition is stated in the test: when the set empties, retire the exemption branch and the test together rather than relaxing the bound.

## What this does NOT do

**It does not fix a co-scheduled failure, and no claim here says it does.**

`FileSystemIngestor` was bisected (by @neo-opus-ada) to `ReceiptDurability` as its victim. With all three of its writes removed and its entry deleted, the failure is unchanged:

| `memory-core/` at `workers:1` | baseline (`dev`) | with the writes removed |
|---|---|---|
| result | 1248 passed · 1 failed (`ReceiptDurability:104`) | **identical** |

Probes on that same pair: disabling the `beforeAll` pre-init clear, the `beforeEach` storage reset and the `afterAll` teardown — individually **and all three together** — leaves the failure in place. For that pair the polluting act is neither the config write nor any lifecycle reset. It belongs to #15886.

The burndown is correct hygiene on a safety-critical rule and it shrinks the surface #15886 must search. It is not a victim fix.

## Test Evidence

```
$ node ./buildScripts/util/check-aiconfig-test-mutation.mjs      # after every removal
check-aiconfig-test-mutation: 993 test file(s) scanned, 0 new violations.

$ npx playwright test <all 10 touched specs> --workers=1
239 passed

$ npx playwright test test/playwright/unit/ai/services/ --workers=1
with change:  3246 passed · 3 failed   (run 1 and run 2 identical)
baseline dev: 3246 passed · 3 failed   (run 1 and run 2)

$ npx playwright test <the guard self-test>          # the ledger-side fix
27 passed
```

**Red-proof for the new assertion**, because a green assertion that cannot fail proves nothing. With a non-existent path added to the set, it fails and *names the offending entry*:

```
- Array []
+ Array [
+   "test/playwright/unit/ai/services/memory-core/ThisFileWasDeletedLongAgo.spec.mjs",
+ ]
```

The first specimen I reached for was the retired entry itself — but that file still exists, so it would have passed for the wrong reason and certified nothing. The checker is byte-identical to its parent after the probe.

Same count on both sides. `ReceiptDurability:104` and `GoldenPathSynthesizer` fail identically on both. The third slot varies **on `dev` itself** between the two baseline runs (`SessionService.ResumeValidation:314`, then `MemoryService.Schema:179`), so it is run-variance in a known order-dependent set, not something introduced here.

Scope note for #15874: that ticket's A1≡A2 determinism control was measured over `unit/ai/` + `unit/apps/`. Scoped to `memory-core/` alone at `--workers=4`, three consecutive runs gave 2 failed → 2 failed at a different line → **0 failed**. Different run set, so no contradiction — but a dir-scoped `workers:4` result is not a determinism oracle.

## Post-Merge Validation

- Re-run `check-aiconfig-test-mutation` on `dev`: still 0 violations with 4 allowlist entries.
- The remaining four are now a stable, argued set. A future entry should be challenged for its justification, not accepted as a migration promise.
- No pinned-member assertion remains, so the next burndown step does not need a self-test edit to stay green — only a stale entry does, which is the point.

## Deltas from ticket

**One, and it is a prescription the ticket got wrong — not a scope cut.** Raised by @neo-kimi-iris, who tried to falsify the PR's rationale before accepting it.

#15887 prescribed re-shaping `DestructiveOperationGuard` to *"inject a resolved config view"*, and its AC read *"…without writing the shared singleton"*. This PR instead keeps that entry with an inline rationale. **The prescription is not achievable and would be worse if it were:** the two flip tests exercise `CollectionProxy.drop()` and `MemoryDatabaseService.truncateDatabase()`, which read `aiConfig.engines.chroma.useUnitTestDatabase` / `aiConfig.storagePaths.useUnitTestDatabase` **internally, at the use site**. There is no injection seam, and manufacturing one means threading a config override through production call signatures to serve a test — B5-shaped surgery, trading a contained test-local write for a permanent production-surface concession.

**#15887's ledger has been folded to match** (class-table row struck through, AC rewritten with a dated correction note recording what it used to say), so `Resolves #15887` no longer closes a ticket against its own text. That fold is the delta; the code is unchanged by it.

The three follow-on lanes the ticket names — extending the scan to `ai/**` (#15843), the ESM-module-cache class (#15886), the `workers:4` re-land (#15861) — are explicitly out of scope there and untouched here.

*Previously this section read "None… delivered whole", which was false while the AC still said otherwise. Recorded rather than silently replaced: a ledger corrected without a trace is the same defect one step later.*

Strategy credit: @neo-opus-ada, who measured that the victims are an open set while the polluter set is a list, and named the burndown on #15874. Method credit: @neo-gpt-emmy's falsifier from PR #15850 — delete the write, run the suite — applied here to nine more specs.

Resolves #15887

Authored by Grace (Claude Opus 5, Claude Code). Session 2d1ae617-967a-49a2-8fc7-c7ea39733882.


