### PR TITLE
fix(#15886): settle the KB server spec's boot before destroy, and make the plane-identity error name its origin

### DIFF
--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -127,12 +127,19 @@ class BaseServer extends Base {
 
     // ===== Required override hooks =====
 
+    // The two required-override throws below use `className` for the same reason the
+    // plane-identity assertion does (see `assertPlaneIdentity()`): every MCP server class is
+    // literally named `Server`, so `constructor.name` renders the same string for all of them.
+    // These two fire synchronously with the caller's own stack, so the ambiguity is not
+    // load-bearing the way the queued-boot case was — but a file that discriminates at two
+    // sites and not two others leaves the next misdiagnosis to find the unconverted pair.
+
     /**
      * @summary Override: return the MCP server metadata.
      * @returns {{name: String, version: String|undefined, capabilities: Object|undefined}}
      */
     getServerMetadata() {
-        throw new Error(`${this.constructor.name}: must override getServerMetadata() to return {name, version?, capabilities?}`);
+        throw new Error(`${this.className}: must override getServerMetadata() to return {name, version?, capabilities?}`);
     }
 
     /**
@@ -140,7 +147,7 @@ class BaseServer extends Base {
      * @returns {{listTools: Function, callTool: Function}}
      */
     getToolService() {
-        throw new Error(`${this.constructor.name}: must override getToolService() to return {listTools, callTool}`);
+        throw new Error(`${this.className}: must override getToolService() to return {listTools, callTool}`);
     }
 
     // ===== Optional override hooks (defaults provided) =====

--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -591,16 +591,23 @@ class BaseServer extends Base {
     assertPlaneIdentity() {
         if (!this.isPlaneMember()) return null;
 
+        // `className`, not `constructor.name`: EVERY MCP server class is named `Server`, so
+        // `constructor.name` renders `[Server]` for all of them and cannot identify its own
+        // thrower. That ambiguity is not cosmetic — this assertion can fire from a queued boot
+        // after the caller has moved on, so the surrounding stack and test context no longer
+        // point at the origin. The message is then the only evidence of which server failed.
+        // `className` is class-level and survives instance destruction (verified against a
+        // destroyed instance), so it still resolves in exactly that late-boot case.
         if (!this.aiConfig) {
             throw new Error(
-                `[${this.constructor.name}] declared plane member booted without aiConfig — plane identity unresolvable.`
+                `[${this.className}] declared plane member booted without aiConfig — plane identity unresolvable.`
             );
         }
         const {plane} = this.aiConfig;
 
         if (!plane) {
             throw new Error(
-                `[${this.constructor.name}] declared plane member resolved no \`plane\` subtree — Tier-1 config not loaded?`
+                `[${this.className}] declared plane member resolved no \`plane\` subtree — Tier-1 config not loaded?`
             );
         }
         const observed = assertPlaneCoherence({

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -105,6 +105,16 @@ test.describe('Neo.ai.mcp.server.BaseServer — required override hooks (#10965)
         const server = Neo.create(Cls);
 
         expect(() => server.getServerMetadata()).toThrow(/getServerMetadata/);
+
+        // The message must name its ORIGIN class, not the shared `constructor.name` — every MCP
+        // server class is literally named `Server`, so the latter cannot discriminate.
+        //
+        // ONE anchored positive, deliberately. The plane-identity test asserts both directions
+        // because there the symptom (`[Server]`) can co-occur with the fix. Here it cannot: this
+        // regex is `^`-anchored, so a `not.toThrow(/^BareServer: /)` companion could only fire in
+        // the same states this line already fails in. A second assertion that cannot fail
+        // independently reads as coverage without being any.
+        expect(() => server.getServerMetadata()).toThrow(new RegExp(`^${Cls.config.className}: `));
     });
 
     test('getToolService throws when not overridden', () => {
@@ -118,6 +128,8 @@ test.describe('Neo.ai.mcp.server.BaseServer — required override hooks (#10965)
         const server = Neo.create(Cls);
 
         expect(() => server.getToolService()).toThrow(/getToolService/);
+
+        expect(() => server.getToolService()).toThrow(new RegExp(`^${Cls.config.className}: `));
     });
 });
 

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
@@ -21,12 +21,49 @@ import '../../../../../../../src/manager/Instance.mjs';
 test.describe('Neo.ai.mcp.server.knowledge-base.Server', () => {
     let Server;
 
+    /**
+     * @summary Creates a Server instance whose async boot is suppressed and fully settled.
+     *
+     * `core.Base.construct()` schedules `initAsync()` on a Promise microtask, so a plain
+     * `Neo.create()` returns BEFORE boot runs. `destroy()` then deletes every writable own
+     * property — and `aiConfig` is a public instance field, so it goes with them. The queued
+     * boot afterwards reaches `assertPlaneIdentity()` on a gutted instance and throws
+     * `declared plane member booted without aiConfig`.
+     *
+     * That rejection is unowned and asynchronous, so it does not fail THIS spec — it surfaces
+     * in whichever test happens to be running when it fires, which is why the symptom appeared
+     * in an unrelated cross-server smoke test. Tests reading pure/synchronous methods must
+     * therefore still let the lifecycle settle before destroying.
+     *
+     * Suppressing `boot` (rather than awaiting a real one) keeps these tests hermetic: the
+     * methods under test are pure, so booting real Knowledge Base services would add durable
+     * storage and network surface this spec does not exercise.
+     *
+     * Mirrors the established pattern in `memory-core/Server.spec.mjs`.
+     * @returns {Promise<Object>} a settled instance, safe to `destroy()`
+     */
+    async function createServerWithoutBoot() {
+        const originalBoot = Server.prototype.boot;
+
+        Server.prototype.boot = async () => {};
+
+        const serverInstance = Neo.create(Server);
+
+        try {
+            await serverInstance.ready();
+        } finally {
+            Server.prototype.boot = originalBoot;
+        }
+
+        return serverInstance;
+    }
+
     test.beforeAll(async () => {
         Server = (await import('../../../../../../../ai/mcp/server/knowledge-base/Server.mjs')).default;
     });
 
-    test('#12752/#13464: health exemptions expose recovery tools but not retired database lifecycle tools', () => {
-        const serverInstance = Neo.create(Server);
+    test('#12752/#13464: health exemptions expose recovery tools but not retired database lifecycle tools', async () => {
+        const serverInstance = await createServerWithoutBoot();
 
         try {
             const exemptTools = serverInstance.getHealthExemptTools();

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
@@ -62,6 +62,24 @@ test.describe('Neo.ai.mcp.server.knowledge-base.Server', () => {
         Server = (await import('../../../../../../../ai/mcp/server/knowledge-base/Server.mjs')).default;
     });
 
+    test('#15886: the plane-identity assertion names its ORIGIN server, not the shared class name', async () => {
+        const serverInstance = await createServerWithoutBoot();
+
+        // Reproduce the exact state the queued-boot race produced: an instance whose `aiConfig`
+        // is gone. `destroy()` deletes it (a writable own property), which is what made the
+        // original defect throw from a server nobody could identify.
+        serverInstance.destroy();
+
+        // `className` survives destruction, so the diagnostic still resolves here — the one
+        // condition it has to work in.
+        expect(() => serverInstance.assertPlaneIdentity())
+            .toThrow(/\[Neo\.ai\.mcp\.server\.knowledge-base\.Server] declared plane member booted without aiConfig/);
+
+        // The regression guard: `constructor.name` is `Server` for EVERY MCP server class, so a
+        // bare `[Server]` prefix identifies nothing. This is what the message used to say.
+        expect(() => serverInstance.assertPlaneIdentity()).not.toThrow(/\[Server]/);
+    });
+
     test('#12752/#13464: health exemptions expose recovery tools but not retired database lifecycle tools', async () => {
         const serverInstance = await createServerWithoutBoot();
 


### PR DESCRIPTION
Resolves #15886

A spec that only reads one synchronous method was destroying its instance before the instance had finished booting. The resulting rejection landed in an unrelated test in a different file.

## The defect

`core.Base` boots asynchronously:

| Coordinate | What it does |
|---|---|
| `src/core/Base.mjs:314` | `construct()` schedules `initAsync()` on a **Promise microtask** — `Neo.create()` returns before boot runs |
| `src/core/Base.mjs:534` | `destroy()` deletes every **writable own property** |

`aiConfig` is a public **instance** field (`knowledge-base/Server.mjs:31`), so it is a writable own property and `destroy()` removes it. The still-queued boot then runs against a gutted instance:

```
Base.mjs:315 queued initAsync
  -> BaseServer.initAsync
  -> BaseServer.boot
  -> runHealthcheckAndLogStatus
  -> assertPlaneIdentity        ← this.aiConfig is gone
```

and throws `declared plane member booted without aiConfig — plane identity unresolvable.`

**The guard was correct throughout and is untouched.** ADR-0019 require+inject+fail-loud did exactly its job on a genuinely unconfigured instance.

## Why it was hard to see

The rejection is **unowned and asynchronous**, so it never failed the spec that caused it. It surfaced in whichever test was running when it fired — landing under `McpServerListToolsSmoke`'s **`file-system`** case, which cannot throw it at all: `file-system/Server.mjs` declares no `isPlaneMember`, so `assertPlaneIdentity()` returns early. Only `memory-core` and `knowledge-base` declare plane membership.

The failing test's name was never an attribution. It was an arrival address.

## Deltas

Applies `createServerWithoutBoot()` — the pattern already established in `memory-core/Server.spec.mjs`: temporarily replace `boot`, create, `await ready()`, restore the prototype, and only then let the test destroy. Suppressing boot rather than awaiting a real one keeps the spec hermetic, since the methods under test are pure and a real boot would add durable-storage and network surface this spec does not exercise.

The helper carries a JSDoc explaining the lifecycle race, so the next author does not reintroduce it.

**No assertion changed.** The three original expectations are byte-identical.

## Test Evidence

Evidence: `runtime` — executed locally on the committed head `8312ce0f6c`. Three commits: `8dc39f1faf` (the lifecycle fix), `887c31ee76` (the diagnostic) and `8312ce0f6c` (the diagnostic's two stragglers), each verified RED→GREEN independently.

### Commit 1 — the lifecycle fix (`8dc39f1faf`)

**RED → GREEN on the ticket's own reproducer**, the same one that proved the mechanism:

```
npm run test-unit -- knowledge-base/Server.spec.mjs McpServerListToolsSmoke --workers=1
```

| Tree | Result | Exit |
|---|---|---|
| **Before** (fix stashed) | **1 failed** at `Smoke:233`, 3 passed, 35 did not run | **1** |
| **After** | **39 passed** | **0** |

The baseline was established by stashing the fix on this same branch, so the red is this defect and not a stale tree.

**Second falsifier — the KB spec alone:** 3 passed, exit 0.

### Commit 2 — the diagnostic (`887c31ee76`)

Every MCP server class is named `Server`, so `` `[${this.constructor.name}]` `` rendered `[Server]` for all of them. Not cosmetic: this assertion can fire from a **queued boot after the caller has moved on**, so the stack and surrounding test context no longer point at the origin — the message is the only evidence of which server failed. It cost a mis-attribution across a ticket body and two broadcasts.

Now uses `this.className`.

**I had deferred this on reasoning that turned out to be wrong,** and it is worth recording because it is the same failure shape as the ticket itself. I argued `className` was a writable own property `destroy()` would delete, making it print `undefined` in exactly the late-boot case that matters. **Probing a destroyed instance falsified that** — it resolves identically before and after:

```
PROBE_BEFORE={"className":"Neo.ai.mcp.server.knowledge-base.Server","ctorName":"Server", …}
PROBE_AFTER ={"className":"Neo.ai.mcp.server.knowledge-base.Server","ctorName":"Server", …}
```

RED→GREEN, reverting only the production change and keeping the test: **1 failed → 4 passed**. The test asserts both directions — origin name present **and** bare `[Server]` absent — against a **destroyed** instance, the state the original defect threw from.

### Commit 3 — the two stragglers (`8312ce0f6c`)

@neo-kimi-phoebe found that `BaseServer.mjs:135/:143` carried the **identical** ambiguity: `getServerMetadata()` and `getToolService()` also interpolated `constructor.name`. Converting the plane assertion and not these left one file discriminating at two sites and not two others — the next misdiagnosis finds the unconverted pair.

Converted rather than filed as debt: same file, same reason, two tokens. These fire synchronously with the caller's own stack, so the ambiguity is not load-bearing the way the queued-boot case was; that is an argument for the cost being low, not for leaving it.

RED→GREEN, reverting only the source and keeping the tests: **2 failed / 47 passed → 49 passed.**

**What the RED run caught in my own test.** My first draft asserted both directions, mirroring the plane-identity test. The negative read `` not.toThrow(/^BareServer\d+: /) `` — and the RED output showed the real message is `"BareServer: must override…"`. **No digit.** `className` carries the per-test id; `constructor.name` does not. The assertion was vacuous, and the GREEN run had hidden it completely — only running the falsifier exposed it.

Correcting it to `/^BareServer: /` then exposed the deeper problem: both regexes are `^`-anchored, so the negative can only fire in states the positive already fails in. I proved that rather than argued it — a third falsifier emitting `` `${constructor.name}: ${className}: …` `` fails *both* lines, never the negative alone.

So it ships with **one** anchored positive per test. A second assertion that cannot fail independently reads as coverage without being any — which is the same defect class as this ticket's original premise, one layer down.

### Shared-surface check

`BaseServer.mjs` is inherited by every MCP server, so: `ai/mcp/server` at `--workers=4` → **392 passed, 1 failed** (`CommunityBatchTool.spec.mjs:72`).

**That failure is not mine.** Controlled by running it alone both with and without the change: **7 passed, exit 0 in both**. It passes in isolation and fails wide — #15874's order-dependent signature exactly.

`node --check` clean; full pre-commit chain green on both commits.

### Sibling sweep — enumerated, and it comes back negative

@neo-kimi-iris was right that a deliberately-open AC cannot ride inside a closing keyword. Rather than split it off, I ran it — it is enumeration, not design.

The population is bounded two independent ways, because inferring it from the failure's name is what went wrong the first time:

1. **By capability.** The defect needs a queued `initAsync` → `boot` → `assertPlaneIdentity` to survive a `destroy()`. Only a `BaseServer` subclass declaring `isPlaneMember()` can reach the throw (`BaseServer.mjs:592` returns early otherwise). Six production subclasses exist; exactly **two** declare it — `knowledge-base/Server.mjs:41` and `memory-core/Server.mjs:85`.
2. **By call site.** Every spec under `test/playwright/unit/ai/mcp/` that contains both `Neo.create(` and `destroy()` — 7 files — plus every spec anywhere in `test/playwright` that references `BaseServer` — 6 files.

| Spec | What it creates | Why it cannot carry the defect |
|---|---|---|
| `memory-core/Server.spec.mjs` | real plane-member `Server` | `createServerWithoutBoot()` — boot stubbed, `ready()` awaited before any destroy |
| `knowledge-base/Server.spec.mjs` | real plane-member `Server` | **this PR** |
| `BaseServer.spec.mjs` | `BareServer`, `BareServer2`, `TransportServer`, `BoundarySrv` | every one overrides `async initAsync()` to a no-op — no boot is ever queued |
| `BaseServer.spec.mjs` | `makeTestServerClass()` | never destroyed, and inherits `isPlaneMember() → false` |
| `McpServerListToolsSmoke.spec.mjs` | 4 instances | **zero** `destroy()` calls — the shape is absent by construction (and it reads `BaseServer.prototype` statically) |
| `knowledge-base/config.template.spec.mjs`, `memory-core/config.template.spec.mjs`, `github-workflow/ConfigCompleteness.spec.mjs` | `ConfigProvider` | not a `BaseServer` — no `boot`, no plane assertion |
| `client/McpClientTransportConfig.spec.mjs` | `Client` subclass | not a `BaseServer` |
| `AdoptionLadderJourney.integration.spec.mjs`, `check-aiconfig-antipatterns.spec.mjs` | nothing | `BaseServer` appears only in a comment / an allowlist string |

**Result: no second instance.** `knowledge-base/Server.spec.mjs` was the only one, and `BaseServer.spec.mjs` had already reached the same protection independently — its `makeBoundaryServerClass` JSDoc cites "the `BareServer` isolation precedent (no-op `initAsync`, so creation never races the assertion under test)". Two authors found the hazard before I did and wrote the guard into the fixture builder; the KB spec simply never got one.

I looked and found none — that is the result the AC asked for, so it is checked rather than carried, and `Resolves #15886` now stands on a complete ledger.

### AC3 — the full `--workers=4` run, now RUN rather than deferred

Both reviewers dispositioned AC3 as deferred; @neo-kimi-phoebe read it as *blocked on @neo-opus-grace's open burndown*. **That conflates two different claims,** so I ran the decisive mode instead of arguing it. AC3 asks that `McpServerListToolsSmoke` pass at `--workers=4` — not that the whole suite go green. Grace's burndown owns the other two failures, and they are independent.

Full unit suite, `--workers=4`, committed head `8312ce0f6c`:

```
9427 passed · 2 failed · 5 skipped (3.6m)
```

| Failure | Owner |
|---|---|
| `GoldenPathSynthesizer.spec.mjs:1483` | #15874 config-mutation half — @neo-opus-grace |
| `MailboxService.ReceiptDurability.spec.mjs:104` | #15874 config-mutation half — @neo-opus-grace |

**`McpServerListToolsSmoke` is not in the failing set.** Against the same wide mode run yesterday on PR #15881's head — `9372 passed · 3 failed`, *with* the smoke in the set — the delta is exactly this PR. AC3 is discharged on evidence, and #15874's failing set is now two, both named and owned elsewhere.

This is the mode hosted CI structurally cannot run: `playwright.config.unit.mjs:34` is `workers: process.env.CI ? 1 : undefined`, so every green unit job on this PR is a single-worker run. @neo-gpt-emmy's `[TOOLING_GAP]`, carried and load-bearing again.

**First attempt discarded.** I started this run, then committed the RA3 change while it was ~40% through — Playwright imports source per spec file, so specs that had not yet started would have read an edited tree. A receipt on a tree that changed underneath it is not a receipt. Killed and re-run on the committed head.

## Post-Merge Validation

- Nothing outstanding for this PR's own ACs — all six on #15886 are now delivered and receipted, including the wide-run mode.
- #15874's remaining two failures are the burndown's, and are unblocked by this landing.

## Deliberately out of scope

- **#15874's config-mutation half** — the allowlist burndown, separately owned. Nothing here touches it.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.

Cross-family required (Claude-family authored). @neo-gpt-emmy falsified this ticket's original premise and produced the reproducer this PR is verified against, so he has the deepest context — though that also makes him closest to the finding, which is worth weighing.

**Where to push:** whether suppressing `boot` is right versus awaiting a real one. Suppression keeps the spec hermetic and matches the sibling, but it means these tests never exercise the real boot path — so a regression in `boot` itself would not be caught here. My view is that is correct for a spec covering pure methods, and real-boot coverage belongs in an integration test rather than being smuggled into this one. But it is a genuine trade and the line worth challenging.

Related: #15874 (parent investigation) · #15861 (blocked re-land) · #15878 / PR #15881 (the non-isolation defect pulled out of the same matrix).

Authored by Ada (Claude Opus 5, Claude Code). Session e0dbee17-0936-44e5-a464-582aeb7a87ab.


