### PR TITLE
refactor(skills): shorten post-review-pickup to its intent — 20396 → 7852 bytes (#15891)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -1,322 +1,164 @@
 # Post-Review Pickup Workflow
 
-This payload is the Atlas entry for post-review-cycle pickup discipline. Keep
-the surrounding PR lifecycle documents as maps: they identify when this skill
-fires, but the operational matrices live here so the high-level workflow files
-do not accumulate edge-case payload.
+Atlas entry for lifecycle-boundary pickup. The surrounding PR lifecycle documents
+stay maps; the operational specifics live here.
 
-## 1. Trigger
+## 1. The whole intent
 
-Use this skill immediately after ANY lifecycle event that closes a discrete unit
-of work and creates a state-transition boundary. The skill scope expanded from
-"PR review cycle only" to "any lifecycle-event boundary" via #11455 / Discussion
-#11423 Option B.1-prime — single skill, broader trigger surface, kept to
-avoid skill-sprawl (no new `state-transition` skill per #11424 Description-Router
-hardening).
+After you finish a unit of work — a review posted, a PR opened or updated, an
+implementation chunk done, a ticket filed, a blocked state exited — **pick up
+another lane.**
 
-Canonical trigger events (use this skill after any of these):
+1. **Never claim there is nothing to do.** There are 200+ open tickets, a mailbox
+   that generates lanes on its own once peers are online (help requests, review
+   requests), and two skills that mint effectively unbounded new work
+   (`ideation-sandbox`, `tech-debt-radar`).
+2. **Prefer a lane adjacent to your current context.** This is a cost lever, not
+   a focus preference: your context is already loaded, and ~90% of a session's
+   token cost is re-reading it. A distant lane forces a cold rebuild, and the
+   same work costs ~2.3× more late in a session than early. Adjacency is the
+   cheapest lane you will ever pick.
+3. **Among several strong candidates, do not optimize the choice.** Ordering them
+   costs more than picking the wrong one.
 
-- **Reviewer post-handoff**: posted a substantive PR review, chained a formal
-  GitHub review state when required, and sent the A2A commentId handoff.
-- **Author post-handoff**: posted a review-response comment with fixup commits
-  and sent the author-side A2A commentId handoff.
-- **Post-implementation completion**: finished a discrete implementation chunk
-  (a feature slice, a bug fix, a refactor) before opening the PR — that
-  completion IS a lifecycle event; do not silently idle between implementation
-  and PR-open.
-- **Post-PR-open/update**: just opened a PR, pushed a fixup, or otherwise
-  surfaced a discrete PR-lifecycle artifact. The PR is now in cross-family
-  review-cycle ownership; pick up the next independent lane.
-- **Post-ticket-create**: just filed a ticket (via `create_issue`). The ticket
-  is on the team board for priorization; pick up the next assigned/claim-eligible
-  lane (or execute on the ticket if it's the lane you'll claim).
-- **Post-blocked-state-resolution**: just exited a `blocked-task-state` (the
-  blocker resolved, the dependency landed, the missing input arrived). The
-  exit IS the lifecycle event; pick up the next forward-motion lane rather
-  than re-evaluating the no-longer-blocked task as if fresh.
-- **Pre-review intake (fresh-session/watchdog wake)**: fresh session, session
-  recovery, or watchdog wake presents a PR review / re-review request while the
-  agent has no active author or implementation lane — see §1.5 Pre-Review Intake
-  Gate (#11610 / #11609).
+Everything below is the operational detail that makes those three concrete. The
+stance behind them — that a done / blocked / merge-pending lane is never a stop —
+is already in the always-loaded L3 firewall and is deliberately not restated here.
 
-The goal is to prevent silent idle at ANY of these boundaries AND to prevent
-pre-review reviewer-only cycles. The handled artifact is now owned by the next
-actor in that cycle (or the team board for ticket creation); unrelated ready
-lanes can proceed in parallel.
+**Scope boundary:** this skill covers the EXIT from a blocked state. It is not a
+tool for discovering or declaring a new one. If an active lane exposes a defect,
+file or route the bug, then continue picking the next lane.
 
-If a watchdog or night-shift wake is paired with an operator-suppressed
-`AGENT:*` broadcast channel, treat that as a coordination-shape constraint, not
-as lack of work. Use the operator-authorized reachable peer DM as the lane
-coordination substitute and continue the lane-discovery protocol below.
-
-**Scope boundary**: this skill covers the EXIT from a previously blocked state
-(forward-motion resumption). It must not be used to search for or declare a new
-blocked state during lane discovery. If an active lane exposes a defect or
-dependency, capture it with the governing bug/follow-up signal, then continue
-the next-lane cycle.
-
-## 1.5 Pre-Review Intake Gate
+## 2. Sibling payloads (read on trigger only)
 
 <!-- trigger: fresh-session/watchdog review intake with no active author lane → read ./pre-review-intake-lane-gate.md before loading /pr-review -->
+- [`./pre-review-intake-lane-gate.md`](./pre-review-intake-lane-gate.md) — when
+  role payloads must be read before lane choice, and when review-first is
+  legitimate.
 
-Primary codification of the pre-review intake lane-discovery gate:
-[`./pre-review-intake-lane-gate.md`](./pre-review-intake-lane-gate.md).
-It defines when role payloads must be read before lane choice, how to survey
-positive-ROI author lanes, and when a review-first rationale is legitimate.
-This is a trigger-ordering guard, not a quota or blame mechanism.
+<!-- trigger: watchdog/night-shift wake, operator driver command, or lane-driver handoff → read learn/agentos/wake-substrate/NightShiftLeasedDriver.md -->
+- `learn/agentos/wake-substrate/NightShiftLeasedDriver.md` — TTL, renewal, and
+  direct-driver routing for autonomous windows. A lane-ownership contract, not a
+  review-pickup variant.
 
-## 1.6 Night-Shift Leased Driver Gate
+<!-- trigger: lane-discovery moment → read ./author-concentration-detector.md -->
+- [`./author-concentration-detector.md`](./author-concentration-detector.md) —
+  authorship concentration is **telemetry, not policy**: no band, no scoreboard,
+  no throttle. When it fires, route to making cold peers live; never slow a
+  productive author.
 
-<!-- trigger: watchdog/night-shift wake, direct operator driver command, lane-driver handoff, or repeated no-progress cycles -> read learn/agentos/wake-substrate/NightShiftLeasedDriver.md before declaring no-delta or any turn-terminal -->
+## 3. Drain the lifecycle queue before opening a new lane
 
-Night-shift driver handling is a lane-ownership contract, not a generic
-review-pickup variant. The linked wake-substrate document defines the TTL,
-renewal, direct-driver routing, and no-idle obligations for autonomous windows.
+Order matters — it is what keeps peers unblocked:
 
-## 1.7 Three-Heartbeat Critical Failure Threshold
+1. own PR with `REQUEST_CHANGES` or an owed author-response;
+2. a designated peer review / re-review request, unless (1) is active;
+3. routing a reviewer to your own green PR;
+4. only then a new lane.
 
-A delivered heartbeat or watchdog pulse is ignored when the recipient ends the
-turn without progress evidence: lane claim, implementation/review/PR update,
-targeted blocker route, verified handoff, ticket triage/retraction,
-ideation/epic-resolution artifact, or an explicit recovery escalation. A
-freshly verified blocker with a named next probe counts as progress evidence;
-repeating an unchanged pause, halt, or no-delta reason does not.
+Awareness wakes are live-state hints, not work. If the artifact is already
+handled, merged, owned, or routed, acknowledge or mark it read rather than
+duplicating. When reviewer scarcity is the bottleneck, prefer review and
+coordination lanes over adding another PR to the queue.
 
-An ignored heartbeat is already a failure on the first occurrence. The threshold
-does not permit two passive misses; it marks the third consecutive miss as a
-critical recovery event.
+## 4. Author-side: the RC-response is one atomic step
 
-Three consecutive ignored pulses in the same active goal/session are a critical
-failure, not a legitimate terminal. On the third pulse, the agent MUST stop
-repeating no-delta/paused/halt prose, name the missed lane or goal, choose one
-concrete recovery action, and emit a `[critical-failure]` A2A signal with the
-evidence chain. Repeating the same unchanged no-delta reason does not reset
-the counter.
+Fixup commits alone do NOT discharge it (#14735):
 
-This threshold governs recipient behavior after a heartbeat is delivered. It is
-separate from upstream wake-decision skips (`active AND idle AND ready`), safety
-gates, or disabled wake substrate paths.
+1. an author-response comment ON the PR — each RA addressed or contested, exact
+   head hash;
+2. an A2A re-review request to the reviewer, **waking-required** (RC-class must
+   wake);
+3. only then is the lane free to move.
 
-## 2. Reviewer Pickup Matrix
+## 5. PR-state freshness gate
 
-After completing the reviewer-side handoff, the reviewer MUST choose one of
-these next states before ending the turn:
+Any report, A2A message, or lane declaration that names a PR's review or merge
+status MUST first read live state:
 
-| Review verdict just posted | Next pickup target |
-|---|---|
-| `Approve` or `Approve+Follow-Up` | Treat the PR as at the human merge gate per `AGENTS.md §0`; then pick up the next assigned ticket, next implementation lane, follow-up ticket creation, or another review request. If the verdict named non-blocking follow-ups and the reviewer owns them, file or claim that follow-up before any terminal. |
-| `Request Changes` | The author owns the response cycle. Do not wait on that PR unless the author immediately pings back with a blocker. Pick up a different lane: another PR review, an assigned ticket, or a follow-up ticket surfaced by the review. |
-| `Drop+Supersede` | If the reviewer owns the superseding work, enter that ticket-create / ticket-intake / PR lane immediately. If another agent owns it, send the handoff and pick up the next unrelated lane. |
+```bash
+gh pr view <N> --json state,mergedAt,baseRefName,reviewRequests
+```
 
-After the matrix action, emit the explicit `lane-state:` form from §2.5. A
-human-gated PR is lane-local state, not a turn terminal: broaden the survey
-through backlog, tech-debt, and ideation surfaces until a next lane is selected.
-Do not search for a blocker to justify stopping; if the active lane exposes a
-real system defect, file or route the bug ticket, then continue lane selection.
+Wakes are hints, not cache. A non-empty `reviewRequests` is **not** merge-ready
+even at `reviewDecision=APPROVED` — name the outstanding reviewer(s) as the
+remaining gate. For stacked PRs, name base readiness too; a stale base is
+routable, not a terminal. Relay the review body's verdict, not the flattened
+enum. `ai/scripts/lifecycle/validateMergeReady.mjs` encodes this contract.
 
-**PR-State Freshness Gate:** any `lane-state:`, A2A broadcast, or report that names a PR's
-review/merge status MUST first run live `gh pr view <N> --json state,mergedAt,baseRefName`;
-wakes are hints, not cache. For stacked PRs, also name base readiness; a dirty/stale
-base is routable, not `human-gate` / `verified-empty`. Relay the review body's §9 verdict,
-not the flattened enum. Also fetch `reviewRequests`: a non-empty list is not strict-merge-ready
-even at `reviewDecision=APPROVED` — name the reviewer(s) as the remaining gate until each is
-disposed. `validateMergeReady` (ai/scripts/lifecycle) encodes this contract.
+## 6. Before claiming a lane
 
-## 2.5. Mandatory Lane-State Emission at Every Lifecycle Boundary
+- targeted review requests **where you are the assigned reviewer** — verify with
+  `gh pr view <N> --json reviewRequests`; do not claim a review you were not
+  assigned;
+- assigned issues and your own PR follow-ups;
+- recent `[lane-claim]` / `[lane-override]` A2A for collision state;
+- open unassigned lanes, excluding `-label:not-code-ready -label:epic`;
+- scan **comments and prior-PR closure**, not just the body — a not-ready state
+  usually hides there. Mark it `not-code-ready` rather than re-surveying it.
 
-Per #11455 AC, every lifecycle boundary (reviewer post, author response,
-post-implementation, PR open/update, ticket create, blocked-state exit) emits
-the human-readable prose form:
+## 7. Deferring a known lane
+
+**A defer needs a named falsifier; a second defer of the same lane needs a
+decision.**
+
+- Legitimate defer: name the artifact to re-read, the check to run, the peer
+  signal awaited, or the external unblock condition. "Do it fresh next turn" or
+  "await steer" name nothing.
+- Deferring the same positive-ROI lane twice while busy elsewhere is drift.
+  Resolve it: execute, hand off to a named peer with the collision state, or
+  downgrade it with evidence that it is no longer positive-ROI.
+
+Surface the decision where lifecycle decisions already surface. Never build
+dedicated telemetry substrate for it.
+
+## 8. Emitting lane-state
+
+Emit the human-readable prose line — peers and the operator read it, and it costs
+one line:
 
 ```text
 lane-state: next-lane (picking up ticket #NNNN)
 lane-state: next-lane (claiming #NNNN as primary reviewer)
-lane-state: next-lane (filing follow-up ticket for friction surfaced in #NNNN)
-lane-state: next-lane (PR #NNNN at human merge gate; picking up unrelated ticket #MMMM)
-lane-state: next-lane (filed/routed blocker bug #NNNN; picking up unrelated ticket #MMMM)
+lane-state: next-lane (PR #NNNN at human merge gate; picking up unrelated #MMMM)
 ```
 
 **The fenced machine block is emitted ONLY when `stopHook.laneContinuation` is
-enabled** (#15877). Its sole consumer is `parseLaneState()` inside the turn-end
-hooks; with the leaf off — the shipped default — nothing reads it, so emitting it
-is pure waste in every turn's output budget. Do not emit it by habit, and do not
-treat its absence as a missing deliverable. When the leaf IS enabled, the block
-is required and takes this shape:
+enabled.** Its sole consumer is `parseLaneState()` in the turn-end hooks; with
+the leaf off — the shipped default — nothing reads it, so emitting it is pure
+waste. Do not emit it by habit; do not treat its absence as a missing
+deliverable. When the leaf IS on it is required, and prose alone does not satisfy
+it:
 
 ```lane-state
 {"laneContinuation":"next-lane","namedGates":[{"ref":"PR #NNNN","checkedAt":"YYYY-MM-DDTHH:mm:ssZ"}]}
 ```
 
-The prose form stays unconditional: it is coordination substrate peers and the
-operator actually read, and it costs one line. Only `next-lane` is normal here.
-"Holding", "standby", "nothing actionable", "idle", bare `paused`,
-`verified-empty`, `human-gate`, and blocker-as-exit-ramp are not turn terminals
-(§5) — that stays true of the prose form regardless of the leaf, because it is a
-discipline about what you may CALL a terminal, not about what the hook parses.
-When the machine block IS in play, `parseLaneState()` reads only the fenced
-block, so prose alone does not satisfy it: no gate → `namedGates: []`; merge
-claim → `"mergeClaim":true,"field":"mergedAt"`.
+Before an implementation `[lane-claim]`: `preBriefSession({ticket})` (plus a
+`query_raw_memories` failure-mode sweep if un-graphed) → a one-line brief.
 
-## 2.6. Deferring a Known Lane
+## 9. Broadcast-suppressed coordination
 
-**A defer needs a named falsifier; a second defer of the same lane needs a
-decision.** That is the whole discipline.
+Operator suppression of `AGENT:*` broadcast is a coordination-shape constraint,
+not a lack of work. Avoid the suppressed channel exactly as instructed, use the
+authorized peer DM as the lane-claim substitute, and name the fallback in the A2A
+body so future readers know why the canonical path was not used. If no safe
+channel exists, route that as the blocker and take a lane that does not depend on
+it.
 
-- Legitimate defer: name the artifact to re-read, the check to run, the peer
-  signal awaited, or the external unblock condition. Politeness, "do it fresh
-  next turn", or "await steer" name nothing and are not evidence.
-- Deferring the same known positive-ROI lane a second time while busy elsewhere
-  is drift. Resolve it: execute, hand off to a named peer with the collision
-  state, or downgrade it with the evidence that it is no longer positive-ROI.
+## 10. Integration points
 
-Surface the decision where lifecycle decisions already surface (an A2A note or
-graph node). Never build dedicated telemetry substrate for it.
+- `pr-review-guide.md §11` — reviewer-side map pointer into this skill.
+- `pull-request-workflow.md §6.3` — author-side map pointer.
+- `review-response-protocol.md §14` — author-side commentId handoff SSOT.
+- `pr-review-guide.md §10` — reviewer-side commentId handoff SSOT.
 
-*Compressed 2026-07-25 from a 3.1KB ledger/lease specification — typed event
-keys, a deferral counter, threshold-immutability rules, and a four-verb lease
-response taxonomy — that was authored for a weaker model generation and was
-never mechanized (it self-described as "telemetry-routes-not-gates" and deferred
-its own implementation). The discipline above is what the specification was
-protecting; the choreography around it was cost without a consumer. Full prior
-text is in git history and its source Discussion.*
-
-## 2.7. Pre-Implementation Brief Gate
-
-Before an implementation `[lane-claim]`: `preBriefSession({ticket})` (+ `query_raw_memories` failure-mode if un-graphed) → a one-line brief. Mandatory; skip trivial-familiarity. Detail: #9961.
-
-## 3. Author Pickup Matrix
-
-The author-side RC-response is **one atomic step, not three optional** (#14735);
-fixup commits alone do NOT discharge it:
-
-1. author-response comment ON the PR — each RA addressed/contested, exact head hash;
-2. A2A re-review request to the reviewer, **waking-required** (RC-class MUST wake, wake-policy #14576);
-3. only then lane-state moves off `own-pr-changes`.
-
-Then choose one of these next states before ending the turn:
-
-| Author state after response | Next pickup target |
-|---|---|
-| RC-response discharged (all three above) | Start the next assigned ticket, draft the next ready PR, file the follow-up ticket discovered during the response, or review a separate PR if that is the current lane. |
-| Current PR still blocks all local work | Blocks only that lane; survey lifecycle/backlog/tech-debt/ideation until a next lane is selected (§5). "No independent lane assigned" + unqueried backlog is NOT a terminal. |
-| Reviewer feedback produced a superseding direction | Enter the superseding ticket / PR creation lane if the author owns it; otherwise hand off the supersede target and pick up the next unrelated lane. |
-
-## 4. Author-Concentration Detector (Telemetry)
-
-<!-- trigger: lane-discovery moment (post-review, post-completion, fresh-boot, peer-role-exit) → read ./author-concentration-detector.md for the telemetry signal (NOT a band/scoreboard/throttle) -->
-
-Authorship balance is **telemetry, not policy** (FAIR-band-as-policy retired per Epic #12440 → #12443). The author-concentration detector is defined in [`./author-concentration-detector.md`](./author-concentration-detector.md): a merged-window concentration signal (open-pipeline as amber) read at lane-discovery, with **no band, no scoreboard, no throttle, and no PR-body declaration**. Flat-peer-team self-selection is preserved; when concentration fires it is a liveness/capability signal (route to making cold peers live — the sibling legs #12444 / #12445 / #12446), never a reason to slow the productive author.
-
-## 5. The Cycle Is the Operating Model; Turn-Terminals Are Externally-Falsifiable
-
-Lineage: #10970 established lifecycle pickup; #11165 tightened the backlog
-self-survey; #11221 closed stated-intent-without-execution; #11669 adds the
-broadcast-suppressed fallback below; #12632 (Discussion #12630) deleted the
-holding vocabulary and made the cycle the operating model.
-
-**Operating model — the cycle.** At every turn boundary, drain the actionable
-lifecycle queue before opening a new lane: (1) own PR `REQUEST_CHANGES` or
-required author-response; (2) designated peer review/re-review, unless (1) is
-active; (3) own green PR review routing; (4) only then next lane. Awareness
-wakes are live-state hints, not work by themselves; if the artifact is already
-handled/merged/owned/routed, acknowledge or mark read instead of duplicating
-work. If reviewer scarcity is the bottleneck, prefer coordination, review, or
-cleanup lanes over opening another implementation PR into the same queue.
-
-The own-open-PR cap governs which next step to choose, not whether lifecycle
-work happens. This is liveness, not throughput: no contribution counter, per-wake
-ledger, or N-PR quota.
-
-**Turn-boundary rule:** lifecycle clearance is not a terminal. The default
-outcome is `lane-state: next-lane (...)`: survey live lifecycle work, then the
-repository backlog, tech-debt-radar, and ideation surfaces until a positive-ROI
-lane is selected. `blocked-task-state` is not a lane-discovery result: if an
-active lane uncovers an external blocker, create or route the bug/follow-up that
-captures it, then pick another lane. Operator-requested pause is an external
-falsifier; context exhaustion routes to `session-sunset` only after a concrete
-cap warning, recurring factual degradation, repeated re-reads, stable-artifact
-drift, or measured substrate-error increase. Otherwise continue the cycle.
-
-### Gated Own Lanes Are Not Turn Terminals
-
-Own PRs/lanes blocked on human merge, reviewer response, CI, or operator
-`CHANGES_REQUESTED` exclude only those lanes — not proof there is no work; the
-default next move is an independent backlog lane, review request, or co-design
-surface after collision checks. Minimum survey shape before filing/routing a
-blocker bug from the active lane:
-
-- targeted review / re-review requests **where you are the assigned github
-  reviewer** (verify: `gh pr view <N> --json reviewRequests`) — do not claim a PR
-  review you were not assigned to; clean assigned requests need
-  review/decline/handoff/blocker before new work;
-- assigned issues and currently self-authored PR follow-ups;
-- recent `[lanes-available]`, `[lane-claim]`, and `[lane-override]` A2A signals
-  for collision state;
-- open unassigned current-epic / substrate lanes — exclude `not-code-ready`
-  and `epic` parents (`-label:not-code-ready -label:epic`);
-- broader non-conflicting backlog if the current-epic surface is empty.
-
-Before claiming, scan **comments + prior-PR closure**, not just the body — a
-not-ready state often hides there; mark it `not-code-ready` (see `ticket-intake`),
-don't re-survey it.
-
-If any positive-ROI candidate survives that survey, emit `lane-state: next-lane
-(...)` and start the intake/claim path. If none survives, broaden to
-tech-debt-radar / ideation / general backlog and create the missing lane. A
-human-gated own PR plus an unqueried broader backlog is the stale-yield/idle-out
-failure mode that Epic #12440 rejects.
-
-### Broadcast-Suppressed Coordination Fallback
-
-`AGENT:*` broadcast is the canonical lane-visibility path, but temporary
-operator suppression of broadcast is not by itself a turn-terminal. If the
-operator suppresses broadcast to protect an unstable peer harness, the agent MUST:
-
-1. Avoid the suppressed peer / channel exactly as instructed.
-2. Use the operator-authorized reachable peer DM as the lane-claim /
-   lane-coordination substitute.
-3. Name the fallback in the A2A body so future readers understand why the
-   canonical broadcast path was not used.
-4. Continue the broad backlog / tech-debt / ideation survey before filing or
-   routing any blocker bug.
-
-If no safe coordination channel exists, file or route that as the blocker bug
-and continue with a lane that does not depend on the broken channel. Coordination
-failure is a defect signal, not permission to idle.
-
-Lead-role and peer-role agents are explicitly expected to **self-select from the backlog and announce the lane pickup** rather than treating absence-of-operator-direction or absence-of-broadcast as legitimate halt. Per AGENTS.md §15.6: *"Proactively select high-value tickets from the backlog AND begin the lane in the same turn."*
-
-### Substrate-evolution-flywheel reality
-
-Operator-named substrate-work-supply for lead/peer agents: v13 Project board + repository backlog (300+ items each); opening PRs surfaces friction → new tickets; `tech-debt-radar` / `industry-friction-radar` surface debt + external-precedent friction as new tickets on each re-invocation (long loop). **The probability of zero positive-ROI work available is "as close to zero as it gets" per operator-framing.** Defaulting to any turn-terminal at a non-externally-falsifiable trigger is deference-slip.
-
-Do not broadcast generic "idle" state. If an active lane exposes a blocker,
-file or route the bug with a targeted A2A shape, then continue with another
-lane.
-
-## 6. Integration Points
-
-- `pr-review-guide.md §11` is the reviewer-side map pointer into this skill.
-- `pull-request-workflow.md §6.3` is the author-side map pointer into this
-  skill.
-- `review-response-protocol.md §14` remains the author-side commentId handoff
-  source of truth.
-- `pr-review-guide.md §10` remains the reviewer-side commentId handoff source
-  of truth.
-
-This is the public successor anchor for the `feedback_peer_not_assistant_mode`
-lineage: act as a peer progressing lifecycle phases, not as an assistant waiting
-for the next prompt. Ticket #10970 is the instance-codification.
-
-## 7. Anti-Patterns
+## 11. Anti-patterns
 
 | Anti-pattern | Why it harms |
 |---|---|
-| Declaring `verified-empty` / `human-gate` as a turn terminal | Codifies idle despite the backlog + tech-debt + ideation flywheel; reverses AGENTS.md §15.6 self-select discipline |
-| Treating operator-suppressed `AGENT:*` broadcast as work-stop | Confuses coordination visibility with implementation authority; use the authorized direct-DM fallback or declare a real blocker. |
-| Watchdog wake -> ack -> nothing to do without broad lane search | Burns wake cycles while positive-ROI backlog lanes exist; repeat wakes must re-check A2A + live repo state + broad backlog and, for night-shift/driver contexts, apply the leased-driver contract before any no-delta response. |
-| Three delivered heartbeats -> repeated unchanged pause/halt/no-delta | Crosses the critical-failure threshold; the third pulse must route recovery and emit `[critical-failure]`, not another passive state. |
-| Ending the turn after `Approved` without checking the next lane | Leaves the swarm idle at the human merge gate even when unrelated work is ready. |
-| Waiting for author response after `Request Changes` | Serializes work that can proceed in parallel. |
-| Broadcasting generic idle/capacity status | Creates coordination noise without assigning ownership or naming the blocker. |
-| Duplicating this matrix into PR lifecycle maps | Violates the Map vs Atlas split and increases routine context load. |
+| Naming a PR's merge state from a wake payload instead of live `gh pr view` | Wakes are stale by construction; this is how false merge-ready claims reach the operator |
+| Claiming a review you were not assigned | Collides with the assigned reviewer and distorts cross-family seat accounting |
+| Fixup commits without the author-response comment + waking A2A | Leaves the reviewer unaware; the RC cycle silently stalls |
+| Treating operator-suppressed broadcast as work-stop | Confuses coordination visibility with implementation authority |
+| Duplicating this content into the PR lifecycle maps | Violates the Map vs Atlas split and raises routine context load |

--- a/.agents/skills/post-review-pickup/references/pre-review-intake-lane-gate.md
+++ b/.agents/skills/post-review-pickup/references/pre-review-intake-lane-gate.md
@@ -58,8 +58,8 @@ review-first rationale: <why review precedes author-lane pickup>
 Do not stop merely because no operator assigned a lane. Per `§no_hold_state`,
 a gated, blocked, or absent current lane excludes only that lane; it does not
 create a turn terminal. If the author/review surface is empty, continue through
-the backlog self-survey in `post-review-pickup-workflow.md §5` and choose the
-next named lane.
+the claim survey in `post-review-pickup-workflow.md §6` and choose the next
+named lane.
 
 ## Anti-Patterns
 

--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -7,6 +7,7 @@
     "payloadBudget": 80000,
     "perFilePayloadBudget": 25000,
     "oversizedWorkflowMaps": [
+      ".agents/skills/post-review-pickup/references/post-review-pickup-workflow.md",
       ".agents/skills/pr-review/references/pr-review-guide.md",
       ".agents/skills/pull-request/references/pull-request-workflow.md"
     ],


### PR DESCRIPTION
## Summary

`post-review-pickup-workflow.md` goes from **20,396 → 7,852 bytes (−61%)**, and the skill is added to the recursive Map/Atlas decay guard so the reduction cannot silently re-inflate.

The payload existed to prevent one failure mode: an agent finishing a PR and claiming *"there is nothing left to do"* — absurd against 200+ open tickets, a mailbox that generates lanes on its own once peers are online, and two skills (`ideation-sandbox`, `tech-debt-radar`) that mint effectively unbounded work.

That intent is four facts. The file was 20KB.

## Evidence

Evidence: three of the four intent facts were **already turn-loaded** in the always-present L3 firewall block — *"A lane done / blocked / merge-pending / peer-waiting is never a stop — jump to a different high-value area; high-value work is infinite, we never run out."* The payload was paying a second time for a stance that already costs nothing.

The fourth fact — **prefer a lane adjacent to your current context** — was absent, and it is the one that matters most economically. Measured this session (401 assistant messages, 1.79h):

| component | share of session cost |
|---|---|
| cache-read of context | **89.7%** |
| cache write | 6.8% |
| output tokens | 3.4% |

| | tokens/message |
|---|---|
| first 25 messages | 19,871 |
| last 25 messages | 44,894 (**2.26×**) |

So lane adjacency is not a focus preference — it is the cheapest lane you will ever pick, and the payload never said so. It does now.

Model-generation context: this content was authored when the swarm ran Gemini 3 Pro, Opus 4.6 and GPT 5.5. The seats are now GPT 5.6 Sol, Opus 5, Fable 5 and Kimi K3. Choreography that scaffolded a weaker model's lane selection is drain.

## Dispositions (ADR 0007 3-Axis Slot Rule)

Per-section, so the reduction is reviewable as judgment rather than as a byte total:

| Section | Bytes | Disposition | Rationale |
|---|---|---|---|
| Three-Heartbeat threshold | 1,232 | `retire` | A counter for ignored pulses — no-hold apparatus whose consumer PR #15890 switched off |
| Reviewer Pickup Matrix | 2,007 | `retire` | Three rows all resolving to "the artifact is someone else's now, take another lane" |
| Author Pickup Matrix rows | ~700 | `retire` | Same collapse |
| Substrate-evolution-flywheel | 666 | `retire` | Restates "the backlog is never empty" at length; now one clause in §1 |
| My own compression-provenance note | ~400 | `retire` | Justified in its PR; does not belong in the payload forever |
| Trigger | 2,894 → ~600 | `compress` | The seven-event enumeration is a list a current-generation model does not need; the scope boundary survives |
| The Cycle | 1,792 → ~500 | `compress` | **The lifecycle-first priority order survives verbatim in substance**; lineage citations and liveness-not-throughput prose do not |
| Gated Own Lanes | 1,523 → ~450 | `compress` | Survey commands kept, "not a terminal" framing dropped (turn-loaded) |
| Broadcast-Suppressed | 1,166 → ~300 | `compress` | Operational content kept, restatement dropped |
| Anti-Patterns | 1,428 → ~400 | `compress` | Kept only rows carrying non-obvious content |
| PR-state freshness gate | — | `keep` | Prevents false merge-ready claims reaching the operator |
| RC-response atomicity | — | `keep` | Prevents silently stalled review cycles |
| Claim survey commands | — | `keep` | Prevents claiming another reviewer's seat |
| Sibling trigger pointers, integration points | — | `keep` | Progressive Disclosure routing |

The keep/retire line is **does it change the verdict, or only the format?** Verdict-changing content earns its slot at any model tier. `pr-review` was explicitly excluded from this lane on the same test — its payload flips approve vs request-changes and surfaces findings that would otherwise be missed.

## Decay guard

Added to `defaults.oversizedWorkflowMaps`, which was a hand-maintained **two-entry** allowlist (`pr-review-guide.md`, `pull-request-workflow.md`) — not a measured threshold. This file had therefore never been under recursive Map/Atlas pressure, only the global `maxPositiveDeltaBytes: 250` net-growth budget, which is a one-way ratchet: it blocks accretion and never forces reduction. Without this entry the reduction silently re-inflates.

This is the decay-mitigation the `§self_evolving_systems` Substrate Accretion Defense requires.

## Test Evidence

- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → **OK** (structure + growth budget).
- All four outbound pointers verified to resolve: `pre-review-intake-lane-gate.md`, `author-concentration-detector.md`, `learn/agentos/wake-substrate/NightShiftLeasedDriver.md`, `ai/scripts/lifecycle/validateMergeReady.mjs`.
- Inbound reference swept: `pre-review-intake-lane-gate.md` cited `§5` (backlog self-survey), which renumbered to `§6` (claim survey). **Both sides of the cross-reference moved together** — a stale section pointer would have survived as a silent contradiction.
- `skills.manifest.json` diff verified surgical: **1 insertion**. An earlier revision of this branch reformatted all 448 lines (2-space → 4-space via a JSON round-trip); that was reverted and replaced with a targeted edit before review.

## Post-Merge Validation

Nothing to run. The payload is read on skill invocation, so the next `/post-review-pickup` picks it up.

- Sanity check: the next lifecycle boundary should still produce a `lane-state: next-lane (...)` prose line and should NOT emit the fenced machine block (`stopHook.laneContinuation` defaults off since #15890).
- Regression signal to watch: if a peer starts declaring `verified-empty` or `human-gate` as a terminal, that is this reduction cutting too deep — the L3 firewall is supposed to carry that stance, and this PR's premise is that it does.

## Deltas

- **vs the ticket:** #15891's AC set is met as written — ≤8,000 bytes (7,852), negative net delta, no `[skill-growth-justified:]` escape, per-section dispositions recorded, manifest entry added, `SKILL.md` router untouched.
- One AC is **not** in this PR: *"the parent epic #13652's premise shift is recorded on the epic."* #13652's thesis is *"mechanical enforcement replaces prompt-machinery"* — keep the hook, absorb the prose into its directive. #15890 inverted half of that by defaulting the hook's continuation OFF. Both positions agree the prose shrinks; they disagree on what replaces it. That is an epic-body edit, not a skill edit, and it belongs in its own commit so the epic's history reads cleanly. Flagging it explicitly rather than silently deferring.

Resolves #15891

Authored by Grace (@neo-opus-grace, Opus 5)
