### PR TITLE
fix(draggable): window-drag re-entry normalizes by the smaller rect, keeping reattachThreshold reachable (#15895)

### DIFF
--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -289,7 +289,19 @@ class SortZone extends DragZone {
                 intersection      = Rectangle.getIntersection(proxyRect, boundaryRect),
                 proxyArea         = proxyRect.width * proxyRect.height,
                 intersectionArea  = intersection ? intersection.width * intersection.height : 0,
-                intersectionRatio = proxyArea > 0 ? intersectionArea / proxyArea : 0,
+                // During window-drag the move payload's proxy embodies the FUTURE VESSEL
+                // (popupWidth × popupHeight, src/main/addon/DragDrop.mjs), which can dwarf a
+                // strip-scale boundary; a proxy-area denominator then caps the ratio at
+                // boundaryArea/proxyArea and reattachThreshold becomes unreachable. Normalizing
+                // by the smaller rect keeps same-scale gestures byte-identical (min === proxy
+                // area) while re-entry reads "the returning proxy substantially covers the
+                // boundary". The exit test below stays proxy-normalized.
+                boundaryArea      = boundaryRect.width * boundaryRect.height,
+                minArea           = Math.min(proxyArea, boundaryArea),
+                coverageRatio     = minArea > 0 ? intersectionArea / minArea : 0,
+                intersectionRatio = me.isWindowDragging
+                    ? coverageRatio
+                    : (proxyArea > 0 ? intersectionArea / proxyArea : 0),
                 isMovingIn        = intersectionRatio > me.lastIntersectionRatio,
                 isMovingOut       = intersectionRatio < me.lastIntersectionRatio;
 
@@ -301,7 +313,10 @@ class SortZone extends DragZone {
                     // Re-entry must be earned: the ratio has to sit below reattachThreshold before a
                     // return counts. A slow exit (crossing at ~detachThreshold) starts UNarmed; a
                     // single-move fling that already landed below reattachThreshold is pre-armed.
-                    me.reattachArmed = intersectionRatio < me.reattachThreshold;
+                    // From the next sample on this branch reads the min-area coverage scale, so the
+                    // arming test and the direction baseline both seed in that scale here.
+                    me.reattachArmed         = coverageRatio < me.reattachThreshold;
+                    me.lastIntersectionRatio = coverageRatio;
 
                     me.fire('dragBoundaryExit', {
                         draggedItem: me.dragComponent,

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -182,6 +182,85 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
         expect(sortZone.isWindowDragging).toBe(true);
     });
 
+    test('re-entry stays reachable when the window-drag proxy dwarfs the boundary', async () => {
+        const mockOwner = {
+            id   : 'mockOwner2',
+            items: [{
+                id          : 'item2',
+                vdom        : {cls: ['neo-draggable']},
+                wrapperStyle: {}
+            }],
+            vdom           : {},
+            addDomListeners: () => {},
+            getDomRect     : () => Promise.resolve([{x:0, y:0, width:100, height:40}]),
+            on             : () => {}
+        };
+
+        sortZone = Neo.create(DashboardSortZone, {
+            owner             : mockOwner,
+            detachThreshold   : 0.8,
+            reattachThreshold : 0.6,
+            enableProxyToPopup: true
+        });
+
+        // Strip-scale boundary: during window-drag the move payload's proxy embodies the future
+        // vessel and is LARGER than the boundary, so a proxy-area denominator would cap the
+        // ratio at boundaryArea/proxyArea (~0.2 here) and 0.6 could never be reached. The
+        // re-entry test therefore normalizes by the smaller rect: full boundary cover = 1.
+        sortZone.boundaryContainerRect = new Rectangle(0, 0, 314, 49);
+        sortZone.dragProxy = { id: 'proxy2', destroy: () => {} };
+        sortZone.dragPlaceholder = { id: 'placeholder2', wrapperStyle: {}, destroy: () => {} };
+
+        sortZone.lastIntersectionRatio = 1;
+        sortZone.isWindowDragging = false;
+
+        const simulateMove = async (x, y, width, height) => {
+            const proxyRect = new Rectangle(x, y, width, height);
+            await sortZone.onDragMove({
+                clientX: x,
+                clientY: y,
+                proxyRect,
+                screenX: x,
+                screenY: y,
+                path   : []
+            });
+        };
+
+        sortZone.itemRects = [{left:0, top:0, width:100, height:40}];
+        sortZone.indexMap = {0: 0};
+        sortZone.currentIndex = 0;
+        sortZone.isScrolling = false;
+
+        sortZone.fire = (event) => {
+            if (event === 'dragBoundaryExit') sortZone.isWindowDragging = true;
+            if (event === 'dragBoundaryEntry') sortZone.isWindowDragging = false;
+        };
+
+        // In-window phase drives an item-scale DOM proxy: leaving the strip fires the exit
+        // (proxy-normalized, unchanged semantics) and pre-arms re-entry in coverage scale.
+        await simulateMove(300, 60, 100, 40);
+        expect(sortZone.isWindowDragging).toBe(true);
+        expect(sortZone.reattachArmed).toBe(true);
+        expect(sortZone.lastIntersectionRatio).toBe(0);
+
+        // Window-drag phase: the payload proxy is now vessel-sized (320×240 > the boundary).
+        // Far outside — coverage 0, still window-dragging.
+        await simulateMove(400, 200, 320, 240);
+        expect(sortZone.lastIntersectionRatio).toBe(0);
+        expect(sortZone.isWindowDragging).toBe(true);
+
+        // Partial return: the vessel covers ~54% of the strip — rising, but below the threshold.
+        await simulateMove(100, 10, 320, 240);
+        expect(sortZone.lastIntersectionRatio).toBeCloseTo(0.5424, 3);
+        expect(sortZone.isWindowDragging).toBe(true);
+
+        // Full strip cover: min-area coverage reads 1 and re-entry fires. Under a proxy-area
+        // denominator this sample would read 15386/76800 ≈ 0.2 and re-entry would be unreachable.
+        await simulateMove(0, 0, 320, 240);
+        expect(sortZone.lastIntersectionRatio).toBe(1);
+        expect(sortZone.isWindowDragging).toBe(false);
+    });
+
     test('does not move a remote drag visitor into the target when it leaves (#8162)', async () => {
         const appliedDeltas = [];
 


### PR DESCRIPTION
Resolves #15895

The window-drag re-entry test in `Neo.draggable.container.SortZone#checkWindowBoundary` now normalizes the boundary intersection by `min(proxyArea, boundaryArea)` instead of always by the proxy area. During window-drag the move payload's proxy embodies the future vessel (`popupWidth × popupHeight`, minted by the DragDrop main addon), which can dwarf a strip-scale boundary — the proxy-area denominator capped the achievable ratio at `boundaryArea/proxyArea` (measured `0.2003` on the workstation stage, hit exactly at full strip cover) against `reattachThreshold: 0.6`, making `dockTearOutEntry` unreachable from every real pointer position. With min-area coverage, full boundary cover reads `1.0`; same-scale gestures are byte-identical (`min === proxyArea`). The exit test stays proxy-normalized, and the exit→window-drag mode flip seeds both the re-entry arming test and the direction baseline in coverage scale, so the Schmitt-trigger hysteresis carries over without a cross-scale direction glitch.

Evidence: L2 achieved (unit RED→GREEN on the exact regression geometry; existing directional-logic suite green unmodified) → L3 required for the journey claim (real-pointer morph witness is e2e-not-in-CI). Residual: workstation morph-leg activation [#15252 / PR #15840].

## Deltas from ticket

None substantive — the fix shape (min-area normalization scoped to the `isWindowDragging` branch, exit untouched) is exactly the ticket's prescription. One precision beyond the ticket text: the mode-flip sample also re-seeds `lastIntersectionRatio` in coverage scale, killing the one cross-scale direction comparison the ticket's analysis flagged as guarded-but-ugly.

## Test Evidence

- `npx playwright test draggable/dashboard/SortZone -c test/playwright/playwright.config.unit.mjs --workers=1` → **10 passed** (9 existing directional-logic tests unmodified + the new vessel-scale re-entry test).
- RED receipt: the new test against the stashed pre-fix math → **1 failed** (`lastIntersectionRatio` capped at `0.2003`, re-entry never fires) — the regression witness is load-bearing.
- Directly touched surfaces: draggable core → this suite; dock tear-out consumers → `test/playwright/unit/dashboard/DockTearOut.spec.mjs` + `DockTabSortZone.spec.mjs` (existing, untouched, green in CI); workstation journey → `test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs` morph leg (post-merge witness, currently `test.fixme` naming this mechanism).

## Post-Merge Validation

- [ ] Activate the workstation morph leg (`scene 2 (morph)` fixme in `WorkstationFiveBeatNL.spec.mjs`, PR #15840 branch) and confirm green: vessel born mid-gesture, retired on walk-back, committed document byte-identical.
- [ ] DemoB tear-out manual smoke: drag a tab out past the boundary and back in — the vessel should now retire mid-gesture (re-entry was unreachable there too).

## Production context

Found and receipted while wiring the workstation five-beat film capstone (#15252): the film's cold-open beat — one continuous drag out past the edge and BACK IN, the popup morphing into an in-app proxy mid-gesture — is exactly the re-entry this fix makes reachable.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b8c9e338-27b3-4385-99ac-dce459733940.
