### PR TITLE
fix(draggable): re-entry fires on placeholder-less zones — layout restore gated on its own marker (#15899)

### DIFF
--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -336,29 +336,36 @@ class SortZone extends DragZone {
                 }
 
                 if (me.reattachArmed && isMovingIn && intersectionRatio > me.reattachThreshold) {
-                    // Restore layout
-                    me.dragPlaceholder.wrapperStyle = {
-                        ...me.dragPlaceholder.wrapperStyle,
-                        visibility: 'visible'
-                    };
+                    // The layout restore is the wrapperStyle-managed zone family's concern, and
+                    // the placeholder is its marker. Projection-owned zones (dock tab strips)
+                    // never captured an in-window layout — for them the restore is semantically
+                    // a no-op, and the EVENT below is the whole re-entry contract. An unguarded
+                    // dereference here dies inside the DOM-event dispatch, so the fire is never
+                    // reached and the gesture is stuck in window-drag with no visible error.
+                    if (me.dragPlaceholder) {
+                        me.dragPlaceholder.wrapperStyle = {
+                            ...me.dragPlaceholder.wrapperStyle,
+                            visibility: 'visible'
+                        };
 
-                    // Re-applying the current state:
-                    me.itemRects.forEach((rect, index) => {
-                        let mappedIndex = me.indexMap[index];
-                        if (mappedIndex !== -1) {
-                            let item = me.owner.items[mappedIndex];
+                        // Re-applying the current state:
+                        me.itemRects.forEach((rect, index) => {
+                            let mappedIndex = me.indexMap[index];
+                            if (mappedIndex !== -1) {
+                                let item = me.owner.items[mappedIndex];
 
-                            if (item !== me.dragPlaceholder && item !== me.dragComponent) {
-                                item.wrapperStyle = {
-                                    ...item.wrapperStyle,
-                                    height: `${rect.height}px`,
-                                    left  : `${rect.left}px`,
-                                    top   : `${rect.top}px`,
-                                    width : `${rect.width}px`
+                                if (item && item !== me.dragPlaceholder && item !== me.dragComponent) {
+                                    item.wrapperStyle = {
+                                        ...item.wrapperStyle,
+                                        height: `${rect.height}px`,
+                                        left  : `${rect.left}px`,
+                                        top   : `${rect.top}px`,
+                                        width : `${rect.width}px`
+                                    }
                                 }
                             }
-                        }
-                    });
+                        })
+                    }
 
                     me.fire('dragBoundaryEntry', {
                         draggedItem: me.dragComponent,

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -261,6 +261,80 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
         expect(sortZone.isWindowDragging).toBe(false);
     });
 
+    test('re-entry fires on placeholder-less zones instead of dying in the layout restore', async () => {
+        const mockOwner = {
+            id   : 'mockOwner3',
+            items: [{
+                id          : 'item3',
+                vdom        : {cls: ['neo-draggable']},
+                wrapperStyle: {}
+            }],
+            vdom           : {},
+            addDomListeners: () => {},
+            getDomRect     : () => Promise.resolve([{x:0, y:0, width:100, height:40}]),
+            on             : () => {}
+        };
+
+        sortZone = Neo.create(DashboardSortZone, {
+            owner             : mockOwner,
+            detachThreshold   : 0.8,
+            reattachThreshold : 0.6,
+            enableProxyToPopup: true
+        });
+
+        sortZone.boundaryContainerRect = new Rectangle(0, 0, 314, 49);
+        sortZone.dragProxy = { id: 'proxy3', destroy: () => {} };
+        // Projection-owned zones (dock tab strips) never create a drag placeholder: their
+        // in-window layout is owned by the committed model projection, so there is nothing to
+        // restore on re-entry — the EVENT is the whole contract. The restore block must not
+        // dereference the absent placeholder ahead of the fire.
+        sortZone.dragPlaceholder = null;
+
+        sortZone.lastIntersectionRatio = 1;
+        sortZone.isWindowDragging = false;
+
+        const simulateMove = async (x, y, width, height) => {
+            const proxyRect = new Rectangle(x, y, width, height);
+            await sortZone.onDragMove({
+                clientX: x,
+                clientY: y,
+                proxyRect,
+                screenX: x,
+                screenY: y,
+                path   : []
+            });
+        };
+
+        sortZone.itemRects = [{left:0, top:0, width:100, height:40}];
+        sortZone.indexMap = {0: 0};
+        sortZone.currentIndex = 0;
+        sortZone.isScrolling = false;
+
+        let entryFired = 0;
+
+        sortZone.fire = (event) => {
+            if (event === 'dragBoundaryExit') sortZone.isWindowDragging = true;
+            if (event === 'dragBoundaryEntry') {
+                entryFired++;
+                sortZone.isWindowDragging = false
+            }
+        };
+
+        // Exit past the strip (item-scale in-window proxy), pre-armed in coverage scale.
+        await simulateMove(300, 60, 100, 40);
+        expect(sortZone.isWindowDragging).toBe(true);
+        expect(sortZone.reattachArmed).toBe(true);
+
+        // Window-drag walk-back to full strip cover with the vessel-sized proxy: the crossing
+        // sample must FIRE the entry — with an unguarded placeholder dereference it throws
+        // before the fire and this await rejects.
+        await simulateMove(400, 200, 320, 240);
+        await simulateMove(0, 0, 320, 240);
+
+        expect(entryFired).toBe(1);
+        expect(sortZone.isWindowDragging).toBe(false);
+    });
+
     test('does not move a remote drag visitor into the target when it leaves (#8162)', async () => {
         const appliedDeltas = [];
 


### PR DESCRIPTION
Resolves #15899

The window-drag re-entry block in `Neo.draggable.container.SortZone#checkWindowBoundary` restored the in-window layout BEFORE firing `dragBoundaryEntry`, and that restore dereferences `dragPlaceholder` unconditionally. Dock tab strips are placeholder-less by design (their geometry is owned by the committed model projection — `DockTabSortZone`'s own contract), so the crossing sample threw a `TypeError` inside the DOM-event dispatch: the fire was never reached, `endWindowDrag` never ran, and the gesture stayed stuck in window-drag with no visible error. The restore steps are now gated on the placeholder's presence (the wrapperStyle-managed-zone marker), the item loop additionally skips `undefined` entries, and the fire is unconditional — the event is the universal part of the re-entry contract; the restore is one zone family's implementation detail.

Found by the exact post-merge smoke PR #15897 named: with min-area coverage the ratio now crosses (`0.7898 > 0.6`, armed, rising, live-measured) — and three-hop event probes showed `boundaryEntrySeen=false` while `lastIntersectionRatio` updated on the crossing sample, pinning the death between the condition and the fire. This defect was masked BEHIND #15895: an unreachable threshold meant the throwing block never executed before today.

Evidence: L2 achieved (unit RED→GREEN on the placeholder-less geometry; existing suite green unmodified) → L3 required for the journey claim (real-pointer morph witness is e2e-not-in-CI). Residual: workstation morph-leg activation [#15252 / PR #15840].

## Deltas from ticket

None substantive — the fix is the ticket's prescription (gate the restore on `dragPlaceholder`, guard `item`, fire unconditionally).

## Test Evidence

- `npx playwright test draggable/dashboard/SortZone -c test/playwright/playwright.config.unit.mjs --workers=1` → **11 passed** (10 existing unmodified + the new placeholder-less re-entry test).
- RED receipt: the new test against the stashed unguarded block → **1 failed** (the `simulateMove` await rejects with the `TypeError`; the fire never happens).
- Directly touched surfaces: draggable core → this suite; dock tear-out consumers → `test/playwright/unit/dashboard/DockTearOut.spec.mjs` + `DockTabSortZone.spec.mjs` (existing, untouched); workstation journey → the morph leg in `test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs` (post-merge witness; currently `test.fixme` naming this exact mechanism, with three-hop probe diagnostics shipped in the executor).

## Post-Merge Validation

- [ ] Activate the workstation morph leg (PR #15840 branch) and confirm green end-to-end: vessel born mid-gesture, retired on walk-back via `dockTearOutEntry`, committed document byte-identical — this same smoke also empirically settles the cross-scale-seam challenge recorded in PR #15897's review.
- [ ] DemoB tear-out manual smoke: drag a tab out and back in — first-ever working re-entry on a dock strip.

## Production context

Second engine defect surfaced by the film's cold-open morph beat on #15252 (one continuous drag out past the edge and home again). The first (#15895) made the ratio reachable; this one lets the event actually fire.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b8c9e338-27b3-4385-99ac-dce459733940.
