### PR TITLE
feat(ai): add ai:config-print — one-command resolved-leaf falsifier for reviewers (#15900)

### DIFF
--- a/ai/scripts/diagnostics/printAiConfig.mjs
+++ b/ai/scripts/diagnostics/printAiConfig.mjs
@@ -34,7 +34,10 @@ import {fileURLToPath, pathToFileURL} from 'node:url';
 const neoRootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 
 /**
- * Server key -> repo-relative canonical config template.
+ * Server key -> repo-relative canonical config template. Scoped to the three servers whose
+ * config resolution is the current review surface; `github-workflow` and `gitlab-workflow`
+ * templates exist but are deliberately not wired yet — an unknown key fails loud with the valid
+ * values rather than reading as "unsupported".
  * @type {Object<string,string>}
  */
 const SERVERS = Object.freeze({
@@ -127,5 +130,8 @@ export async function main(argv = process.argv.slice(2)) {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-    main()
+    main().catch(err => {
+        console.error(`[ai:config-print] ${err.message}`);
+        process.exit(1)
+    })
 }

--- a/ai/scripts/diagnostics/printAiConfig.mjs
+++ b/ai/scripts/diagnostics/printAiConfig.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * @module ai/scripts/diagnostics/printAiConfig
+ * @summary Prints resolved AiConfig leaves for a named server config — the one-command falsifier for "resolved at this head" claims in tickets, PR bodies, and reviews.
+ *
+ * Why this exists (born as a tooling gap named in cross-family review): the read-gate for the
+ * config SSOT made "read resolved leaves at the use site" the rule, and PR bodies increasingly
+ * carry resolved-at-this-head measurements as load-bearing evidence (a recent test-isolation
+ * burndown rested entirely on one). Resolution only runs inside a booted Neo context, and the
+ * boot contract is non-obvious — a bare `node -e` probe dies on `Neo.gatekeep` before ever
+ * reaching the config. So a reviewer could not falsify a runtime-resolution claim without
+ * writing their own probe, and verify-before-assert degraded to static source reading exactly
+ * when the claim was about runtime behavior.
+ *
+ * Boot contract (spike-verified before implementation): `globalThis.Neo.config` BEFORE importing
+ * `src/Neo.mjs`, then import the config template. Reads the canonical template only, never the
+ * operator overlay.
+ *
+ * Toggle leaves are printed alongside value leaves on purpose: some resolutions are
+ * consumer-side (e.g. `engines.chroma.database` stays `default_database` while ChromaManager
+ * selects `databaseTest` via `engines.chroma.useTestDatabase`), and printing values alone would
+ * misread consumer-side selection as missing isolation.
+ *
+ * Usage:
+ *   npm run ai:config-print -- [--unit] [--server=memory-core|knowledge-base|neural-link] [dot.paths…]
+ *
+ * Read-only by construction: resolves and prints; never assigns to any config path. Env faithfulness:
+ * the leaf machinery owns env overrides, so a caller-exported `UNIT_TEST_MODE` resolves exactly as
+ * it would in the harness; `--unit` merely sets it for you.
+ */
+import path                           from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+
+const neoRootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/**
+ * Server key -> repo-relative canonical config template.
+ * @type {Object<string,string>}
+ */
+const SERVERS = Object.freeze({
+    'knowledge-base': 'ai/mcp/server/knowledge-base/config.template.mjs',
+    'memory-core'   : 'ai/mcp/server/memory-core/config.template.mjs',
+    'neural-link'   : 'ai/mcp/server/neural-link/config.template.mjs'
+});
+
+/**
+ * Default print set: the test-isolation surface of the config SSOT plus the selector toggles, so a
+ * resolution claim in this family is falsifiable with a bare `npm run ai:config-print -- --unit`.
+ * @type {String[]}
+ */
+const DEFAULT_PATHS = Object.freeze([
+    'storagePaths.graph',
+    'collections.memory',
+    'collections.session',
+    'engines.chroma.database',
+    'engines.chroma.useTestDatabase',
+    'engines.chroma.useUnitTestDatabase'
+]);
+
+/**
+ * @summary Parses CLI args into a paths/server/unit triple.
+ * @param {String[]} argv Argv tail (post `node script`).
+ * @returns {{paths: String[], server: String, unit: Boolean}}
+ */
+export function parseArgs(argv) {
+    let unit   = false,
+        server = 'memory-core';
+
+    const paths = [];
+
+    for (const arg of argv) {
+        if (arg === '--unit') {
+            unit = true
+        } else if (arg.startsWith('--server=')) {
+            server = arg.slice('--server='.length)
+        } else {
+            paths.push(arg)
+        }
+    }
+
+    return {paths, server, unit}
+}
+
+/**
+ * @summary Boots the minimal Neo context, resolves the selected config template, prints leaves.
+ * @param {String[]} [argv] Defaults to the real CLI tail.
+ */
+export async function main(argv = process.argv.slice(2)) {
+    const {paths, server, unit} = parseArgs(argv),
+          templateRel           = SERVERS[server];
+
+    if (!templateRel) {
+        console.error(`[ai:config-print] unknown --server "${server}" — valid: ${Object.keys(SERVERS).join(', ')}`);
+        process.exit(2)
+    }
+
+    // The boot contract: Neo.config must exist before src/Neo.mjs evaluates (Neo.gatekeep).
+    globalThis.Neo ??= {};
+    globalThis.Neo.config = {environment: 'development', unitTestMode: unit};
+
+    if (unit) {
+        process.env.UNIT_TEST_MODE = 'true'
+    }
+
+    await import(pathToFileURL(path.join(neoRootDir, 'src/Neo.mjs')).href);
+
+    const aiConfig = (await import(pathToFileURL(path.join(neoRootDir, templateRel)).href)).default,
+          wanted   = paths.length > 0 ? paths : DEFAULT_PATHS,
+          missing  = [];
+
+    console.log(`# server=${server} mode=${unit ? 'unit' : 'prod'} template=${templateRel}`);
+
+    for (const dotPath of wanted) {
+        const value = dotPath.split('.').reduce((acc, key) => acc?.[key], aiConfig);
+
+        console.log(`${dotPath} = ${value}`);
+
+        if (value === undefined) {
+            missing.push(dotPath)
+        }
+    }
+
+    if (missing.length > 0) {
+        console.error(`[ai:config-print] unresolved path(s): ${missing.join(', ')}`);
+        process.exit(1)
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    main()
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "ai:check-retired-primitives"          : "node ./ai/scripts/diagnostics/check-retired-primitives.mjs",
         "ai:check-substrate-size"              : "node ./ai/scripts/diagnostics/check-substrate-size.mjs",
         "ai:compact-graphlog"                  : "node ./ai/scripts/maintenance/compactGraphLog.mjs",
+        "ai:config-print"                      : "node ./ai/scripts/diagnostics/printAiConfig.mjs",
         "ai:restore"                           : "node ./ai/scripts/maintenance/restore.mjs",
         "ai:reseed"                            : "node ./ai/scripts/maintenance/restore.mjs --operation reseed",
         "ai:build-kb-faqs"                     : "node ./ai/scripts/maintenance/buildKbAgentFaqs.mjs",

--- a/test/playwright/unit/ai/scripts/diagnostics/printAiConfig.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/printAiConfig.spec.mjs
@@ -1,0 +1,79 @@
+import {test, expect} from '@playwright/test';
+import {execFileSync} from 'node:child_process';
+import fs             from 'node:fs';
+import path           from 'node:path';
+
+// The Playwright unit runner executes with cwd = repo root, so resolve against it rather than
+// __dirname arithmetic — the latter is brittle across nesting depth and git-worktree layouts.
+const
+    repoRoot   = process.cwd(),
+    scriptPath = path.join(repoRoot, 'ai/scripts/diagnostics/printAiConfig.mjs');
+
+/**
+ * Runs the CLI and captures exit code + combined output instead of throwing on non-zero exits.
+ * @param {String[]} args CLI args forwarded to the script.
+ * @returns {{exitCode: Number, output: String}}
+ */
+function run(args) {
+    try {
+        return {exitCode: 0, output: execFileSync('node', [scriptPath, ...args], {cwd: repoRoot, encoding: 'utf8'})}
+    } catch (err) {
+        return {exitCode: err.status, output: (err.stdout || '') + (err.stderr || '')}
+    }
+}
+
+/**
+ * @summary CLI contract test for `printAiConfig.mjs`.
+ *
+ * The tool exists to make "resolved at this head" config claims falsifiable in one command — a
+ * recent test-isolation burndown rested on such a measurement, and its cross-family review had no
+ * cheap way to reproduce it. These tests pin the resolution the test-isolation family cares about
+ * (`storagePaths.graph` → `:memory:` under `UNIT_TEST_MODE`), the toggle visibility that prevents
+ * misreading consumer-side selection as missing isolation, the failure shapes for bad input, and
+ * the read-only property (the script never assigns to a config path — the mutation guard's own
+ * concern, from the other side).
+ */
+test.describe('ai:config-print', () => {
+    test('unit mode resolves the test-isolation surface — the burndown measurement in one command', () => {
+        const {exitCode, output} = run(['--unit', 'storagePaths.graph']);
+
+        expect(exitCode).toBe(0);
+        expect(output).toContain('storagePaths.graph = :memory:')
+    });
+
+    test('default set prints the selector toggles alongside the value leaves', () => {
+        const {exitCode, output} = run(['--unit']);
+
+        expect(exitCode).toBe(0);
+        // `database` stays `default_database` while ChromaManager selects `databaseTest` via the
+        // toggle — printing values without toggles would misread that as missing isolation.
+        expect(output).toContain('engines.chroma.database = default_database');
+        expect(output).toContain('engines.chroma.useTestDatabase = true');
+        expect(output).toContain('engines.chroma.useUnitTestDatabase = true');
+        // Per-process randomized collection names under UNIT_TEST_MODE.
+        expect(output).toMatch(/collections\.memory = test-memory-\d+-\w+/)
+    });
+
+    test('an unknown dot-path exits non-zero and names the path', () => {
+        const {exitCode, output} = run(['--unit', 'does.not.exist']);
+
+        expect(exitCode).toBe(1);
+        expect(output).toContain('does.not.exist')
+    });
+
+    test('an unknown --server exits with a usage error listing the valid values', () => {
+        const {exitCode, output} = run(['--server=bogus']);
+
+        expect(exitCode).toBe(2);
+        expect(output).toContain('memory-core');
+        expect(output).toContain('knowledge-base');
+        expect(output).toContain('neural-link')
+    });
+
+    test('the script is read-only against the config SSOT (B4 from the other side)', () => {
+        const source = fs.readFileSync(scriptPath, 'utf8');
+
+        // No assignment to any config leaf — resolving and printing is all this tool may do.
+        expect(source.match(/aiConfig\.[\w.]+\s*=[^=]/)).toBeNull()
+    });
+});

--- a/test/playwright/unit/ai/scripts/diagnostics/printAiConfig.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/printAiConfig.spec.mjs
@@ -1,7 +1,8 @@
-import {test, expect} from '@playwright/test';
-import {execFileSync} from 'node:child_process';
-import fs             from 'node:fs';
-import path           from 'node:path';
+import {test, expect}        from '@playwright/test';
+import {execFileSync}        from 'node:child_process';
+import fs                    from 'node:fs';
+import path                  from 'node:path';
+import {findDbPathMutations} from '../../../../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
 
 // The Playwright unit runner executes with cwd = repo root, so resolve against it rather than
 // __dirname arithmetic — the latter is brittle across nesting depth and git-worktree layouts.
@@ -70,10 +71,13 @@ test.describe('ai:config-print', () => {
         expect(output).toContain('neural-link')
     });
 
-    test('the script is read-only against the config SSOT (B4 from the other side)', () => {
+    test('the script is read-only against the config SSOT (the mutation guard from the other side)', () => {
         const source = fs.readFileSync(scriptPath, 'utf8');
 
-        // No assignment to any config leaf — resolving and printing is all this tool may do.
-        expect(source.match(/aiConfig\.[\w.]+\s*=[^=]/)).toBeNull()
+        // Asserted with the SAME shape-based detector that guards test files against config-
+        // singleton mutation — never a literal `aiConfig` text anchor, which silently stops
+        // testing the day the local binding is renamed (AiConfig, myAiConfig, …). Honest bound:
+        // a fully-renamed local with no `Config` in the identifier escapes BOTH shapes.
+        expect(findDbPathMutations(source)).toEqual([])
     });
 });


### PR DESCRIPTION
Resolves #15900

One command now falsifies any "resolved at this head" config claim: `npm run ai:config-print -- --unit` prints the resolved AiConfig leaves for a named server template (`storagePaths.graph = :memory:`, per-process `test-*` collections, the chroma selector toggles). Born as a `[TOOLING_GAP]` in my own PR #15888 review — the #15887 burndown rested on a resolved-config measurement that a reviewer could not reproduce without writing a probe (a bare `node -e` dies on `Neo.gatekeep`; the boot contract is `globalThis.Neo.config` before importing `src/Neo.mjs`). The spike that proved the 4-line boot reproduces #15887's measurement to the character is recorded on the ticket.

Evidence: L2 achieved (CLI executed on this head: unit mode prints `:memory:` + randomized `test-*` names + toggles; unknown path exits 1 naming it; unknown `--server` exits 2 with usage; spec suite 7/7 green including genuine RED-first — `ERR_MODULE_NOT_FOUND` on all 5 tests with the script stashed) → L2 required (every AC is a CLI-output assertion reachable in CI). Residual: none.

## Deltas from ticket

None substantive — the ticket's prescription (script + `--unit`/`--server` + default B4-surface set + spec + npm entry) is delivered whole. One precision beyond the ticket text: the output prints the selector *toggles* (`engines.chroma.useTestDatabase`, `useUnitTestDatabase`) alongside value leaves, because `engines.chroma.database` stays `default_database` while ChromaManager selects `databaseTest` consumer-side — values alone would misread that as missing isolation (the ticket's Avoided Traps named the hazard; the diff makes the answer structural).

## Test Evidence

```
$ npm run ai:config-print -- --unit
# server=memory-core mode=unit template=ai/mcp/server/memory-core/config.template.mjs
storagePaths.graph = :memory:
collections.memory = test-memory-1784980887187-o7gres
collections.session = test-session-1784980887187-he6514
engines.chroma.database = default_database
engines.chroma.useTestDatabase = true
engines.chroma.useUnitTestDatabase = true
(exit 0)

$ node ai/scripts/diagnostics/printAiConfig.mjs --unit does.not.exist   → exit 1, names the path
$ node ai/scripts/diagnostics/printAiConfig.mjs --server=bogus          → exit 2, lists valid servers

$ UNIT_TEST_MODE=true npx playwright test test/playwright/unit/ai/scripts/diagnostics/printAiConfig.spec.mjs -c test/playwright/playwright.config.unit.mjs --workers=1
7 passed

RED-first: script stashed → all 5 spec tests fail ERR_MODULE_NOT_FOUND (the 2 "passes" in that run are the repo-wide chroma setup/teardown fixtures, not this suite).

$ node ./buildScripts/util/check-aiconfig-test-mutation.mjs
995 test file(s) scanned, 0 new violations.

$ npm run --silent ai:check-substrate-size
PASSED
```

Directly touched app/feature surfaces: `None found` (diagnostics CLI + its own spec; no runtime surface).

## Post-Merge Validation

- [ ] On `dev`: `npm run ai:config-print -- --unit storagePaths.graph` prints `:memory:` (the #15887 measurement reproducible in one command by any reviewer).

Authored by Iris (Kimi K3, Kimi Code CLI). Session 3b5c70eb-0622-4bf2-bdbe-bc11f8a140f8.
