### PR TITLE
fix(ai): the orchestrator's durable defaults follow the plane, not the launch directory (#15843)

### DIFF
--- a/ai/agent/AgentOrchestrator.mjs
+++ b/ai/agent/AgentOrchestrator.mjs
@@ -3,7 +3,22 @@ import Agent                         from '../Agent.mjs';
 import crypto                        from 'crypto';
 import fs                            from 'fs';
 import path                          from 'path';
+import {fileURLToPath}               from 'url';
+import {resolvePlaneDataRoot}        from '../planeConfig.mjs';
 import {validateComputedRouteResult} from '../services/graph/computedRouteResult.mjs';
+
+/*
+ * The single module-scope plane anchor every durable default below derives from. A config default
+ * is evaluated before any Provider exists, so it cannot read the resolved leaf — it resolves the
+ * plane root env-free, over the DISCOVERED repo root, and never over `process.cwd()`.
+ *
+ * That distinction is the whole point: a cwd-derived default follows the launch directory, so the
+ * same process writes into a different data plane depending on where it was started, and nothing
+ * fails loudly when it does. Env relocation still belongs to the leaf machinery — `NEO_PLANE_DATA_ROOT`
+ * moves the plane, and callers relocate an individual path by passing the config.
+ */
+const neoRootDir          = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..'),
+      planeDataRootAnchor = resolvePlaneDataRoot({env: {}, rootDir: neoRootDir});
 
 const OUTCOME_STATUSES = new Set(['completed', 'failed', 'blocked', 'expired', 'exhausted', 'crashed']),
       REASON_CODES     = new Set([
@@ -35,9 +50,11 @@ class AgentOrchestrator extends Base {
          */
         className: 'Neo.ai.agent.AgentOrchestrator',
         /**
-         * @member {String} handoffPath=path.resolve(process.cwd(), 'resources/content/sandman_handoff.md')
+         * Repo-anchored, not cwd-anchored: this is checkout content, so it resolves against the
+         * discovered `neoRootDir` and stays the same file no matter where the process was launched.
+         * @member {String} handoffPath=path.resolve(neoRootDir, 'resources/content/sandman_handoff.md')
          */
-        handoffPath: path.resolve(process.cwd(), 'resources/content/sandman_handoff.md'),
+        handoffPath: path.resolve(neoRootDir, 'resources/content/sandman_handoff.md'),
         /**
          * Wait interval before checking if the scheduler is exhausted natively.
          * @member {Number} monitorIntervalMs=5000
@@ -65,10 +82,13 @@ class AgentOrchestrator extends Base {
          */
         handoffEmitter: null,
         /**
-         * Append-only Golden Path issue outcome file.
-         * @member {String} outcomePath=path.resolve(process.cwd(), '.neo-ai-data/agent-orchestrator/golden-path-outcomes.jsonl')
+         * Append-only Golden Path issue outcome file — a plane MEMBER, so it derives from the one
+         * plane anchor rather than re-deriving its own root. Under ambient cwd this file followed
+         * the launch directory instead of the declared plane, which splits outcome history across
+         * roots without failing anything loudly.
+         * @member {String} outcomePath=path.resolve(planeDataRootAnchor, 'agent-orchestrator/golden-path-outcomes.jsonl')
          */
-        outcomePath: path.resolve(process.cwd(), '.neo-ai-data/agent-orchestrator/golden-path-outcomes.jsonl'),
+        outcomePath: path.resolve(planeDataRootAnchor, 'agent-orchestrator/golden-path-outcomes.jsonl'),
         /**
          * Injectable exit hook. Defaults to process.exit for CLI runner compatibility.
          * @member {Function} exitHandler=(code) => process.exit(code)


### PR DESCRIPTION
`AgentOrchestrator` resolved two durable config defaults against `process.cwd()`. One of them lands **inside the plane data root**, so the same process wrote its Golden Path outcome history into a different plane depending on where it was launched — and nothing failed when it did.

**Net: 1 file, +25/−5. No lint added — the census says there is nothing to mechanize.**

Evidence: L2 achieved (both resolutions measured from two different working directories, showing the divergence and its removal; 18/18 `AgentOrchestrator` specs green at this head; `lint-config-template-ssot` green) → L2 required (runtime path resolution, fully reachable in CI). Residual: none — the C1 half of #15843 is explicitly deferred below, not silently dropped.

## The divergence, measured

```
$ # outcomePath, resolved from the repo root
/Users/…/neo/.neo-ai-data/agent-orchestrator/golden-path-outcomes.jsonl

$ # the SAME default, resolved with cwd = /tmp
/private/tmp/.neo-ai-data/agent-orchestrator/golden-path-outcomes.jsonl
```

Two data planes, one process, silent. This is the alternate-realities class the plane contract exists to remove: `.neo-ai-data` **is** the plane root, so `outcomePath` is a plane *member* — and a member that derives its own root is exactly what the single-anchor rule forbids.

**Worse, it was invisible to the runtime guard as well.** `assertPlaneMemberCoherence` walks *declared* members against the resolved root; an ad-hoc `path.resolve(process.cwd(), '.neo-ai-data/…')` never declares itself, so the boot assertion could not see it either. The static gate did not scan `ai/` for this class and the runtime gate only checks declared members — the defect fell between them.

## The fix, and why the two paths differ

| default | was | now | why |
|---|---|---|---|
| `outcomePath` | `process.cwd()` + `.neo-ai-data/…` | the module-scope **plane anchor** | it is plane data — one anchor, no member re-derives its own root |
| `handoffPath` | `process.cwd()` + `resources/content/…` | **`neoRootDir`** | it is checkout content, not plane data — the repo root is the correct anchor, and the plane anchor would be wrong here |

A config default is evaluated before any Provider exists, so it cannot read the resolved leaf — the env-free twin resolution over the *discovered* repo root is the sanctioned shape for exactly that chicken-and-egg case.

**The seam is unchanged.** These are Neo class configs: callers still relocate either path with `Neo.create(AgentOrchestrator, {outcomePath})`, and `NEO_PLANE_DATA_ROOT` still moves the plane. The spec already exercises that seam — it injects `handoffPath` on every case, which is what proves the default change is safe rather than merely untested.

## What this deliberately does NOT do

**It does not add a lint, and that is the finding.** #15843 prescribed extending the config-mutation scan to `ai/**`. Three measurements retired that prescription:

1. **`ai/**` is already scanned.** `lint-config-template-ssot.mjs` has `SCAN_ROOT_REL = 'ai'` and already runs two A1-adjacent detectors. Extending the *B4* scanner there would be a second scanner over the same tree with overlapping rules.
2. **The decidable A1 class is empty.** An env read is A1 when a leaf already binds that var. Cross-referenced: **24** direct env reads in `ai/`, **198** leaf-owned env vars, **intersection of 1** — and that one is in a standalone mock server with no config in scope.
3. **The undecidable form is a noise generator.** A regex-shaped `process.env.X ||` detector flags **~31 of 32** sites, nearly all legitimate host-boundary facts (`NEO_AGENT_IDENTITY`, `USER`, `PATH`, `ComSpec`, `TMUX_SESSION`, `XDG_DATA_HOME`). PR #15880's body predicted this in writing — *"an extended scan produces noise and gets muted, which is worse than the current honest silence"* — and I walked at it anyway until the census stopped me.

The `process.cwd()` census told the same story: 36 sites, of which the overwhelming majority are *correct* — `cwd = process.cwd()` as an **injectable default parameter** is the codebase's own idiom, standalone CLI tools legitimately take cwd, and a config establishing its own anchor has nothing above it to defer to. Two were genuine. Both are in this diff.

## Deltas from ticket

**Two, both narrowings, both recorded on #15843 before this PR opened.**

1. **The title's second clause was already delivered** by #15885 / PR #15880 (merged `05b76cab96`). Retitled the ticket to its surviving scope during intake.
2. **The lint is dropped and the C1 half is deferred.** C1's *"Sanctioned form"* cell in ADR-0019 §3 is being rewritten by my own open **PR #15896**; mechanizing C1 now would bake the pre-amendment rule into a fail-build gate, which is far more expensive to correct than a doc row. `Resolves #15843` therefore reflects the A1 scope this PR delivers — see the ticket for the full classification.

## Test Evidence

```
$ npx playwright test test/playwright/unit/ai/AgentOrchestrator.spec.mjs
18 passed

$ node ai/scripts/lint/lint-config-template-ssot.mjs
[lint-config-template-ssot] OK
```

The `❌ AgentOrchestrator failed: Error: boot failed` line in that run is a deliberate failure fixture, not a regression — the suite exercises dead-letter and health-down paths on purpose.

## Post-Merge Validation

- A future plane relocation (`NEO_PLANE_DATA_ROOT` set) should move the outcome file with the plane rather than stranding it — previously it would have stayed wherever the launcher's cwd pointed.
- The residual class is worth watching but not worth a gate yet: an ad-hoc path composed into `.neo-ai-data` is invisible to both the static lint and the member-coherence assertion. Two instances is not a population; if a third appears, a narrow "cwd composed into the plane root" guard becomes the right artifact.

Resolves #15843
Related: #15875 · #15896 · #15887

Authored by Grace (Claude Opus 5, Claude Code).
