### PR TITLE
fix: re-entry arming re-earned across the proxy-identity swap (#15915)

### DIFF
--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -214,6 +214,18 @@ class SortZone extends DragZone {
      * @protected
      */
     reattachArmed = false
+    /**
+     * `{width, height}` of the proxy rect from the previous window-drag sample. The move stream
+     * swaps proxy IDENTITY mid-gesture — the in-window DOM proxy until the vessel grant lands,
+     * the future vessel's dimensions afterwards (see {@link Neo.main.addon.DragDrop#onDragMove}) —
+     * and an intersection ratio compared across that discontinuity manufactures "moving in" plus
+     * a threshold cross in a single sample: a false re-entry that retires a vessel which may not
+     * have connected yet. A dims change is therefore a geometry RESEED, not a movement:
+     * {@link #reattachArmed} must be re-earned in the new scale before any entry can fire.
+     * @member {Object|null} lastProxyDims=null
+     * @protected
+     */
+    lastProxyDims = null
 
     /**
      * Appends one event to the active drag trace. Events carry where the drag logic
@@ -317,6 +329,7 @@ class SortZone extends DragZone {
                     // arming test and the direction baseline both seed in that scale here.
                     me.reattachArmed         = coverageRatio < me.reattachThreshold;
                     me.lastIntersectionRatio = coverageRatio;
+                    me.lastProxyDims         = {height: proxyRect.height, width: proxyRect.width};
 
                     me.fire('dragBoundaryExit', {
                         draggedItem: me.dragComponent,
@@ -326,6 +339,21 @@ class SortZone extends DragZone {
                     return true // Stop further processing in onDragMove
                 }
             } else if (me.isWindowDragging) {
+                // A proxy-dims change mid-window-drag is the move stream swapping proxy IDENTITY
+                // (in-window DOM proxy → granted vessel dimensions): the ratio delta against the
+                // previous sample is a geometry artifact, not movement, and evaluating entry on it
+                // retires a vessel that may not have connected yet. Reseed, re-earn the arming in
+                // the new scale, and resume entry evaluation from the next sample. A null record
+                // (window-drag entered without a boundary exit, e.g. a mid-drag conversion) seeds
+                // silently.
+                if (!me.lastProxyDims) {
+                    me.lastProxyDims = {height: proxyRect.height, width: proxyRect.width}
+                } else if (me.lastProxyDims.width !== proxyRect.width || me.lastProxyDims.height !== proxyRect.height) {
+                    me.lastProxyDims = {height: proxyRect.height, width: proxyRect.width};
+                    me.reattachArmed = intersectionRatio < me.reattachThreshold;
+                    return true
+                }
+
                 // The exit fires just UNDER detachThreshold — inside the reattach zone — so the raw
                 // direction test alone would let one post-exit positive-delta sample (pointer jitter,
                 // exit-choreography geometry side effects) fire a false re-entry that closes the
@@ -414,6 +442,7 @@ class SortZone extends DragZone {
         me.currentIndex     = me.startIndex;
         me.isOverDragging   = false;
         me.isWindowDragging = false;
+        me.lastProxyDims    = null;
         me.reattachArmed    = false;
 
         me.fire('dragCancel', data);

--- a/test/playwright/unit/draggable/container/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/container/SortZone.spec.mjs
@@ -385,3 +385,99 @@ test.describe('checkWindowBoundary — the re-entry Schmitt trigger (the false-r
         expect(fired).toEqual(['dragBoundaryExit', 'dragBoundaryEntry'])
     })
 });
+
+test.describe('checkWindowBoundary — arming across the proxy-identity swap (the vessel stillbirth)', () => {
+    // The move stream swaps proxy IDENTITY mid-window-drag: the in-window DOM proxy until the
+    // vessel grant lands, the future vessel's dimensions afterwards. Arming earned in the small
+    // proxy's scale must NOT discharge in the vessel's scale — the ratio jump at the swap sample
+    // is a geometry artifact, not movement. Same 1000×1000 boundary; smallAt(f) is the 100×100
+    // pre-grant proxy, vesselAt(f) the 320×240 post-grant proxy — each placed so
+    // intersectionArea/proxyArea === f.
+    const BOUNDARY = {x: 0, y: 0, width: 1000, height: 1000, left: 0, top: 0, right: 1000, bottom: 1000};
+
+    const smallAt = f => {
+        const x = 1000 - 100 * f;
+        return {x, y: 450, width: 100, height: 100, left: x, top: 450, right: x + 100, bottom: 550}
+    };
+
+    const vesselAt = f => {
+        const x = 1000 - 320 * f;
+        return {x, y: 300, width: 320, height: 240, left: x, top: 300, right: x + 320, bottom: 540}
+    };
+
+    const zoneFor = () => {
+        const fired = [], continued = [];
+
+        const zone = {
+            boundaryContainerRect: BOUNDARY,
+            detachThreshold      : 0.8,
+            dragComponent        : {id: 'dragged'},
+            dragPlaceholder      : {wrapperStyle: {}},
+            indexMap             : [],
+            isWindowDragging     : false,
+            itemRects            : [],
+            lastIntersectionRatio: 1,
+            owner                : {items: []},
+            reattachArmed        : false,
+            reattachThreshold    : 0.6,
+            fire                 : name => fired.push(name),
+            onWindowDragContinue : () => continued.push(1)
+        };
+
+        const move = rect => SortZone.prototype.checkWindowBoundary.call(zone, {proxyRect: rect});
+
+        return {continued, fired, move, zone}
+    };
+
+    test('the stillbirth sequence: arming earned pre-swap must NOT discharge on the swap sample', () => {
+        const {continued, fired, move, zone} = zoneFor();
+
+        zone.lastIntersectionRatio = 0.85;
+
+        move(smallAt(0.79));                            // exit — window-drag begins, dims seeded
+        move(smallAt(0.5));                             // demonstrably left — arms in the SMALL scale
+        expect(zone.reattachArmed).toBe(true);
+
+        move(vesselAt(0.95));                           // the grant lands: vessel dims, ratio jumps
+        expect(fired, 'the swap sample must not fire an entry — the vessel has not connected yet')
+            .toEqual(['dragBoundaryExit']);
+        expect(zone.reattachArmed, 'arming is re-earned in the NEW scale').toBe(false);
+        expect(zone.lastProxyDims).toEqual({height: 240, width: 320});
+
+        move(vesselAt(0.9));                            // still high in the new scale, disarmed
+        expect(fired, 'no entry until re-entry is earned post-swap').toEqual(['dragBoundaryExit'])
+    });
+
+    test('genuine post-swap return still re-enters exactly once', () => {
+        const {fired, move, zone} = zoneFor();
+
+        zone.lastIntersectionRatio = 0.85;
+
+        move(smallAt(0.79));
+        move(smallAt(0.5));                             // armed in the small scale
+        move(vesselAt(0.95));                           // swap — reseed + disarm
+        move(vesselAt(0.4));                            // leaves below reattachThreshold — re-earns
+        expect(zone.reattachArmed).toBe(true);
+
+        move(vesselAt(0.65));                           // rising back across the threshold
+        expect(fired).toEqual(['dragBoundaryExit', 'dragBoundaryEntry'])
+    });
+
+    test('a swap landing already below reattachThreshold re-arms immediately and skips the continue hook', () => {
+        const {continued, fired, move, zone} = zoneFor();
+
+        zone.lastIntersectionRatio = 0.85;
+
+        move(smallAt(0.79));
+        move(smallAt(0.3));                             // armed, one continue sample
+        expect(continued.length).toBe(1);
+
+        move(vesselAt(0.2));                            // swap sample far outside — reseed, stays armed
+        expect(zone.reattachArmed).toBe(true);
+        expect(continued.length, 'the swap sample is a reseed, not a movement — no continue call').toBe(1);
+        expect(fired).toEqual(['dragBoundaryExit']);
+
+        move(vesselAt(0.65));                           // genuine return in the vessel scale
+        expect(fired).toEqual(['dragBoundaryExit', 'dragBoundaryEntry'])
+    })
+});


### PR DESCRIPTION
Resolves #15915

The window-boundary re-entry Schmitt trigger now survives the mid-gesture proxy-identity swap: when the move stream's proxy dims change while `isWindowDragging` (the in-window DOM proxy being replaced by the granted vessel's dimensions, `Neo.main.addon.DragDrop#onDragMove`), `checkWindowBoundary` treats that sample as a geometry RESEED — it re-earns `reattachArmed` in the new scale and skips entry evaluation for that one sample — instead of comparing ratios across the discontinuity, where arming earned in the small-proxy scale discharged in the vessel scale and a single sample manufactured `isMovingIn` + a threshold cross. That false `dragBoundaryEntry` retired tear-out vessels before they connected (worker-truth read "never born"); the 14-cell bisect matrix that pinned it — and exonerated launch args, GPU flags, video recorder, occlusion, bundle id, position, and curvature — is on #15912 (issuecomment-5079085748). A null dims record (window-drag entered without a boundary exit, e.g. mid-drag conversion) seeds silently with no behavior change; same-scale gestures never trigger the reseed and are byte-identical.

Evidence: L3 achieved (unit RED→GREEN at the decision-chain grain + 514 adjacent unit tests + the previously 9/9-red film-grain cell green ×2, headed on the target host) → L3 required (AC3 is a headed-host AC). Residual: none.

## Deltas from ticket

None substantive. AC4 (`preBirthEntries` reads 0 in green runs) is satisfied by construction rather than by a printed counter: the executor diag only prints on birth failure, and a green run under the film profile is only reachable when no pre-birth entry fired — the sentinel stays in the failure diag as the regression tripwire.

## Test Evidence

- RED (fix stashed): `npx playwright test draggable/container/SortZone -c test/playwright/playwright.config.unit.mjs --workers=1` → **3 failed / 12 passed** — exactly the three new swap-discipline tests fail on the unfixed prototype.
- GREEN (fix restored): same command → **15 passed**.
- Adjacent consumers: `npx playwright test unit/dashboard unit/draggable -c test/playwright/playwright.config.unit.mjs --workers=4` → **514 passed / 0 failed** (dock tab strips, tear-out terminals, vessel conversion/embodiment/park, cross-window participation).
- Film-grain (the defect's native habitat): `WorkstationFiveBeatNL` scene-2 BOTH legs (commit + morph), film profile + full film pacing (curve 0.18 / delay 33 / steps 24), headed, on a local merge of this branch into the `#15912` film branch → **3 passed** twice consecutively (E1/E2). The identical configuration was red 9/9 across the bisect matrix pre-fix, with the pre-birth entry sentinel firing on every instrumented red.
- Touched surface coverage: `src/draggable/container/SortZone.mjs` → `test/playwright/unit/draggable/container/SortZone.spec.mjs` (this PR extends it; both Schmitt-trigger describe blocks green).

## Post-Merge Validation

- [ ] Five-beat suite green at the merged head under the default path (`NEO_E2E_PORT=8124 npx playwright test workstation/WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1`).
- [ ] `#15912` film branch rebases onto the merged head and the film-profile scene-2 cells stay green with all bisect knobs off (take-14 preflight).

## Commits (if multi-commit)

Single commit: `77aeb7e39b` — fix + member JSDoc + three swap-discipline unit tests.

Authored by Mnemosyne (Fable 5, Claude Code). Session 8e3ca9dd-427d-4c93-9054-edd660fda27b.
