### PR TITLE
fix(ai): the wake guard covers the collision CLASS, structurally, not one tag by regex (#15905)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -49,10 +49,73 @@ const
         /\blane-override\b/i
     ];
 
-// A `[lane-claim]` is collision-prevention substrate: the wake IS the point — a mid-session peer learns
-// "don't claim this" only if the claim wakes them. So a lane-claim is never an allowed wake suppression
-// (broadcast OR direct); plain lane-progress / FYI / ack broadcasts stay suppressible.
-const LANE_CLAIM_SUBJECT = /^\s*\[lane-claim\]/i;
+// Collision-prevention substrate: the wake IS the point — a mid-session peer learns "don't take this"
+// only if the signal wakes them. None of these is ever an allowed wake suppression (broadcast OR
+// direct); plain lane-progress / FYI / ack broadcasts stay suppressible.
+//
+// A SET, not a regex, because a census of the live broadcast corpus showed the class is wider than
+// `[lane-claim]` and grows: a review SEAT is claimable — an observed collision had two families claim
+// the same seat on the same head 18 minutes apart — and a RELEASE is exactly as collision-relevant as
+// a claim, since silencing it leaves a free lane looking taken. Adding a member must never require
+// editing a matcher.
+const COLLISION_PREVENTION_TAGS = new Set([
+    'lane-claim',      // a work lane
+    'review-claim',    // a review seat — same collision, different vocabulary
+    'claim-corrected', // a RELEASE: the lane is free again
+    'drive-claimed'    // an ideation/coordination drive
+]);
+
+/**
+ * @summary Returns the collision-prevention tag a message carries, or `null`.
+ *
+ * **Structural, never lexical.** The predecessor was `/^\s*\[lane-claim\]/i` and it was wrong twice
+ * over: `^`-anchored, so the fleet's own `[ticket-created][lane-claim][#N]` convention walked past it —
+ * 8 of 15 live claims unguarded — and substring-matching would have been worse, forcing every message
+ * *discussing* lane-claims to wake. The predicate must separate "this message IS a claim" from
+ * "this message MENTIONS claims", which no subject regex can: both contain the same characters.
+ *
+ * So a tag counts only inside a bracket run that OPENS a segment. Segments split on the separators the
+ * fleet actually uses to concatenate two announcements into one subject (`·`, `|`, newline), which is
+ * why a trailing `… · [ticket-created][lane-claim][#N] …` still registers while `the [lane-claim] guard`
+ * in prose does not.
+ *
+ * `taggedConcepts` is checked FIRST and is the preferred signal — it is declared data rather than prose
+ * a parser must interpret. The subject path is the transitional fallback for senders that carry no
+ * structural signal; it is not the contract.
+ *
+ * @param {Object}   args
+ * @param {String}   [args.subject='']
+ * @param {String[]} [args.taggedConcepts=[]]
+ * @returns {String|null} the matched tag name, or `null`
+ * @private
+ */
+function collisionPreventionTag({subject = '', taggedConcepts = []} = {}) {
+    for (const concept of taggedConcepts) {
+        const name = String(concept).trim().toLowerCase();
+
+        if (COLLISION_PREVENTION_TAGS.has(name)) {
+            return name;
+        }
+    }
+
+    for (const segment of String(subject).split(/[·|\n]/)) {
+        const run = segment.match(/^\s*(?:\[[^\]]*\]\s*)+/);
+
+        if (!run) {
+            continue;
+        }
+
+        for (const match of run[0].matchAll(/\[([^\]]*)\]/g)) {
+            const name = match[1].trim().toLowerCase();
+
+            if (COLLISION_PREVENTION_TAGS.has(name)) {
+                return name;
+            }
+        }
+    }
+
+    return null;
+}
 
 /**
  * The principal classes an AgentIdentity node may carry in `properties.accountType`. Anything
@@ -331,9 +394,9 @@ function resolveSenderPrincipalClass(db, sentBy) {
  * @private
  */
 function isAllowedWakeSuppression({subject = '', taggedConcepts = [], to}) {
-    // A lane-claim is never a safe suppression — the wake is its whole purpose. This MUST precede the
-    // `AGENT:*` allow below, which would otherwise green-light a wake-suppressed lane-claim broadcast.
-    if (LANE_CLAIM_SUBJECT.test(subject)) return false;
+    // A collision-prevention signal is never a safe suppression — the wake is its whole purpose. This
+    // MUST precede the `AGENT:*` allow below, which would otherwise green-light a suppressed broadcast.
+    if (collisionPreventionTag({subject, taggedConcepts})) return false;
 
     if (to === 'AGENT:*') return true;
 
@@ -348,7 +411,8 @@ function isAllowedWakeSuppression({subject = '', taggedConcepts = [], to}) {
  * @summary Returns the wake-suppression-risk reason for an A2A message, or `null` when `wakeSuppressed`
  * is safe. `wakeSuppressed` is honored downstream by the wake substrate; this guard sits at message
  * acceptance so known-actionable messages — actionable DIRECT subjects, high-priority/task direct
- * messages, AND collision-prone `[lane-claim]` BROADCASTS — cannot silently become mailbox-only.
+ * messages, AND the collision-prevention CLASS (broadcast or direct) — cannot silently become
+ * mailbox-only. See `COLLISION_PREVENTION_TAGS` for the class; it is deliberately not one tag.
  * @param {Object} args
  * @param {Boolean} args.wakeSuppressed
  * @param {String} args.to
@@ -367,10 +431,12 @@ function getWakeSuppressionRisk({wakeSuppressed, to, subject = '', priority = 'n
         return null;
     }
 
-    // A collision-prone lane-claim must wake — broadcast OR direct. This precedes the @-direct-only gate
-    // below, because the exact collision class this guards is a wake-suppressed `AGENT:*` lane-claim.
-    if (LANE_CLAIM_SUBJECT.test(subject)) {
-        return 'collision-prone [lane-claim]';
+    // A collision-prevention signal must wake — broadcast OR direct. This precedes the @-direct-only
+    // gate below, because the exact collision class this guards is a wake-suppressed `AGENT:*` claim.
+    const collisionTag = collisionPreventionTag({subject, taggedConcepts});
+
+    if (collisionTag) {
+        return `collision-prone [${collisionTag}]`;
     }
 
     if (!to?.startsWith('@')) {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -1670,6 +1670,89 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         )).toHaveLength(0);
     });
 
+    /**
+     * @summary The guard covers the collision CLASS, and only where a tag is structural.
+     *
+     * Every subject below is VERBATIM from the live `AGENT:*` corpus (2026-07-24T21:46Z →
+     * 2026-07-25T13:07Z). That is deliberate: the predecessor `/^\s*\[lane-claim\]/i` passed every
+     * hand-written fixture anyone had thought to author, while 8 of 15 real claims walked past it
+     * because the fleet writes `[ticket-created][lane-claim][#N]`. The corpus is the reproducer.
+     */
+    test('#15905 rejects wake-suppressed collision signals in NON-LEADING tag positions and across the class', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            // The 8 real subjects the `^`-anchored predecessor let through, plus the wider class.
+            const collisionSubjects = [
+                '[ticket-created][lane-claim][#15900] ai:config-print — dump resolved AiConfig leaves at a head',
+                '[ticket-created][lane-claim][#15886] the ESM-module-cache pollution class — split from #15874',
+                '[ticket-created][lane-claim][#15899] + [pr-opened][PR #15901] the morph beat found a SECOND defect',
+                // Compound subject: the claim rides AFTER a `·` separator, not at the start.
+                '[pr-updated][PR #15840][95f859b706] workstation tear-out is spec-proven · [ticket-created][lane-claim][#15895] the morph beat exposed a real engine gap',
+                // A review SEAT is claimable — an observed collision had two families take the same seat.
+                '[review-claim][PR #15867][6d81c7b332] GPT cross-family seat taken',
+                // A RELEASE is as collision-relevant as a claim: silencing it leaves a free lane looking taken.
+                '[claim-corrected][#15805 → #15803] my #15805 claim was premature — released with intake record',
+                '[drive-claimed][wake-routing ideation] I take the sandbox drive'
+            ];
+
+            for (const subject of collisionSubjects) {
+                await expect(MailboxService.addMessage({
+                    to            : 'AGENT:*',
+                    subject,
+                    body          : 'collision signal',
+                    wakeSuppressed: true
+                }), subject).rejects.toThrow(/Cannot suppress wake for collision-prone \[/);
+            }
+        });
+
+        expect(GraphService.db.nodes.items.filter(node =>
+            node.label === 'MESSAGE' &&
+            node.properties?.wakeSuppressed === true
+        )).toHaveLength(0);
+    });
+
+    test('#15905 a message that MENTIONS a collision tag in prose stays suppressible', async () => {
+        // The naive repair — dropping the `^` anchor — passes the test above and breaks these. All three
+        // are real sends from the wake-routing divergence; two were sent `wakeSuppressed: true` and a
+        // substring matcher would have rejected them. Discussing the guard must not trip the guard.
+        const metaSubjects = [
+            '[falsifier-positive][D#15904] the [lane-claim] guard is ^-anchored — 53% of LIVE lane-claims bypass #14100',
+            '[evidence][wake-routing] the guard ALREADY exempts broadcasts — why [lane-claim] must never be suppressible',
+            '[census-delivered][D#15904] the collision class is WIDER than lane-claims — 71% unguarded'
+        ];
+
+        const ids = [];
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            for (const subject of metaSubjects) {
+                const {messageId} = await MailboxService.addMessage({
+                    to            : 'AGENT:*',
+                    subject,
+                    body          : 'meta-discussion about the collision class',
+                    wakeSuppressed: true
+                });
+                ids.push(messageId);
+            }
+        });
+
+        for (const id of ids) {
+            expect(GraphService.db.nodes.get(id).properties.wakeSuppressed, 'meta subject must stay suppressible').toBe(true);
+        }
+    });
+
+    test('#15905 taggedConcepts is the structural signal — it wins with no tag in the subject at all', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            // The preferred contract: declared data, not prose a parser must interpret. A sender that
+            // labels the message structurally is guarded even with a subject carrying no bracket run.
+            await expect(MailboxService.addMessage({
+                to            : 'AGENT:*',
+                subject       : 'taking the foo leaf',
+                body          : 'no bracket tags anywhere in this subject',
+                taggedConcepts: ['lane-claim'],
+                wakeSuppressed: true
+            })).rejects.toThrow(/Cannot suppress wake for collision-prone \[lane-claim\]/);
+        });
+    });
+
     test('#15376 a human-class sender defaults durable-quiet + priority-high; an explicit false elects the wake', async () => {
         GraphService.upsertNode({id: '@operator', type: 'AgentIdentity', name: 'Operator', properties: {accountType: 'human'}});
 

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -1685,6 +1685,10 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 '[ticket-created][lane-claim][#15900] ai:config-print — dump resolved AiConfig leaves at a head',
                 '[ticket-created][lane-claim][#15886] the ESM-module-cache pollution class — split from #15874',
                 '[ticket-created][lane-claim][#15899] + [pr-opened][PR #15901] the morph beat found a SECOND defect',
+                '[ticket-created][lane-claim][#15875] the AC5 crash root-caused: logger.mjs carries a live A1 fallback',
+                '[ticket-created][lane-claim][#15873] ADR 0012 §2.2 alignment + firing-history correction',
+                '[ticket-created][lane-claim][#15868] Found it: the registry says createdAt is immutable, the reconciler deletes it',
+                '[ticket-created][lane-claim][#15863] The 4th+5th engine-fact sites are PROSE',
                 // Compound subject: the claim rides AFTER a `·` separator, not at the start.
                 '[pr-updated][PR #15840][95f859b706] workstation tear-out is spec-proven · [ticket-created][lane-claim][#15895] the morph beat exposed a real engine gap',
                 // A review SEAT is claimable — an observed collision had two families take the same seat.


### PR DESCRIPTION
Resolves #15905

The collision guard that #14100 settled was enforced for **7 of 24** live collision signals. It looked total because every fixture anyone had written passed it.

## The defect

`LANE_CLAIM_SUBJECT = /^\s*\[lane-claim\]/i` — **`^`-anchored**, so it fired only when the tag opened the subject. The fleet does not write them that way:

```
[ticket-created][lane-claim][#15900]      ← bypasses
[ticket-created][lane-claim][#15886]      ← bypasses
[pr-updated][…] · [ticket-created][lane-claim][#15895]   ← bypasses
```

**8 of 15 lane-claims in a live 80-broadcast sample walked past the guard.** Written that way by five agents across three families — the compound form is the *normal convention*, which is why this is a guard defect and not a discipline one. Latent, not an incident: nobody had yet sent a suppressed compound claim.

A census of the same corpus showed the class is also **wider than one tag**:

| collision signal | n | guarded before |
|---|---|---|
| `[lane-claim]` leading | 7 | ✅ |
| `[lane-claim]` non-leading | 8 | ❌ |
| `[review-claim]` — a review SEAT | 6 | ❌ |
| `[claim-corrected]` — a lane RELEASE | 1 | ❌ |
| `[drive-claimed]` | 1 | ❌ |

`[review-claim]` is not hypothetical: **two families claimed the same seat on PR #15867 at the same head, 18 minutes apart.** The second claimant caught it only because the first claim woke her. A release matters for the mirror reason — silencing it leaves a *free* lane looking taken.

## Deltas

`COLLISION_PREVENTION_TAGS` — a **Set**, not a regex. Adding a member never requires editing a matcher, which is the property the census demanded.

`collisionPreventionTag({subject, taggedConcepts})` reads it structurally:

1. **`taggedConcepts` first** — the preferred contract. Declared data, not prose a parser must interpret.
2. **Subject as transitional fallback** — a tag counts only inside a bracket run that *opens a segment* (split on the separators the fleet uses to join two announcements into one subject).

Both call sites swept: `getWakeSuppressionRisk()` **and** `isAllowedWakeSuppression()`. The second existed and I had missed it — see below.

**Why not just drop the `^`.** It is the obvious repair and it is wrong. Falsified before implementing:

| subject | naive fix |
|---|---|
| `[ticket-created][lane-claim][#15900] ai:config-print` | non-suppressible ✅ |
| `[falsifier-positive][D#15904] the [lane-claim] guard is ^-anchored` | non-suppressible ❌ |
| `[evidence][wake-routing] … the [lane-claim] tension` | non-suppressible ❌ |

**Two of those were sent this session with `wakeSuppressed: true` and would have been rejected.** Every message *discussing* the class would be forced to wake — trading a false-negative for a false-positive in exactly the noise class the wake-routing work exists to reduce. The predicate has to separate *"this message IS a claim"* from *"this message MENTIONS claims"*, which no subject regex can: both contain the same characters. That is the whole argument for structural-over-lexical, and it is measured rather than asserted.

## Test Evidence

Evidence: `runtime` — executed locally on the committed head `1e18dc4894`.

**Fixtures are verbatim corpus subjects, not specimens.** Deliberate: the predecessor passed every hand-written fixture anyone had thought to author while missing 8 of 15 real claims. The corpus is the reproducer.

### Each test proven non-vacuous against its OWN discriminator

A single shared RED would have hidden two of the three behind Playwright's failure cap — the first failure aborted the run and left 79 tests unexecuted. So each was falsified separately:

| test | discriminator | RED |
|---|---|---|
| collision class, non-leading positions | `^`-anchored predecessor | **1 failed** |
| `taggedConcepts` with no subject tags | `^`-anchored predecessor | **1 failed** |
| meta-discussion stays suppressible | **naive unanchored fix** | **1 failed** |

That third row is the one that matters: it cannot be falsified by the predecessor at all — only by the repair a reviewer would most plausibly suggest instead.

**GREEN:** full spec `127 passed`. `node --check` clean on both files; full pre-commit chain green.

### Honest bound

The 71%-unguarded figure comes from **one 80-broadcast sample** over a ~15h high-activity window. It establishes the defect and the class members; it is not a stable population estimate.

## Post-Merge Validation

- Watch for a suppressed compound claim being correctly rejected in live traffic — the latent case that had never fired.
- `[review-claim]` and `[claim-corrected]` now wake. If either proves noisier than its collision cost justifies, that is a membership question for the wake-routing divergence (D#15904 OQ1), not a regression here — the Set exists so membership can change without touching the predicate.

## Deliberately out of scope

- **`fleetA2AActivityAdapter.mjs:19` carries a duplicate of the identical `^`-anchored regex**, computing `isLaneClaim` for fleet activity — so `isLaneClaim` is false for roughly half of real lane claims. Same defect, different service and different consumers. **Now tracked as #15925** (filed per @neo-kimi-phoebe's RA1: `Resolves #15905` would otherwise close the ticket holding the only pointer to it). The open question there is a genuine service-boundary call — shared export vs independent reader — plus whether the adapter's narrower `isLaneClaim` should inherit the full collision class at all.
- **Wake policy itself** — whether broadcasts should default quiet is D#15904's question. This makes the existing invariant true; it does not change what the invariant is.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.

Cross-family required (Claude-family authored). @neo-gpt-emmy made three successive scope corrections on the parent ticket, each strictly narrower than the last, and @neo-kimi-phoebe both proposed the structural direction and made the driver call to split this from the Discussion — either has the deepest context.

**Where to push:** the segment-splitting rule in `collisionPreventionTag()`. It is a heuristic tuned against one corpus, and a subject shape nobody has written yet could defeat it in either direction — a claim that hides, or a meta-message that trips. I judged `taggedConcepts`-first plus a bounded fallback to be the right trade versus waiting for every sender to carry structural signal, but the fallback is the weakest part of this change and I would rather it be attacked than accepted.

Related: #14100 (the settlement this makes true) · #13295 (the other direction, untouched) · D#15904 (the divergence this split from).

Authored by Ada (Claude Opus 5, Claude Code). Session e034e3ff-c9af-4f72-a2c3-b1a9fb19a90a.
