### PR TITLE
test: film-take launch profile — frames on glass, births gated, probe drift closed (#15912)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1262,7 +1262,13 @@ class Workspace extends Container {
         admissionToken = Number.isFinite(admissionToken) ? admissionToken : ownerGrant.generation;
         ownerGrant.admissionToken = admissionToken;
 
+        // Diagnostic trail for the birth gate: absence has three distinct layers (admission
+        // refused / platform refused the window / window granted but never connected), and the
+        // failure diag must name which one this gesture died in.
+        me.lastVesselOpen = {itemId, stage: 'invoked'};
+
         if (me.tearOutRetirements.has(itemId)) {
+            me.lastVesselOpen.stage = 'blocked-by-retirement';
             me.revokeVesselOwnerGrant('tear-out', itemId);
             return null
         }
@@ -1285,6 +1291,8 @@ class Workspace extends Container {
                 windowName
             });
 
+            me.lastVesselOpen.stage = opened === false ? 'windowOpen-false' : 'granted';
+
             if (opened === false) {
                 me.revokeVesselOwnerGrant('tear-out', itemId);
                 return null
@@ -1300,6 +1308,8 @@ class Workspace extends Container {
                 windowName
             }
         } catch (error) {
+            me.lastVesselOpen.stage = 'threw';
+            me.lastVesselOpen.error = String(error?.message || error);
             me.revokeVesselOwnerGrant('tear-out', itemId);
             return null
         }
@@ -1875,6 +1885,17 @@ class Workspace extends Container {
                 return {applied: false, errors: ['tear-out drag did not arm'], proof: {armed: false, cancellation, documentBefore}}
             }
 
+            // Pre-birth entry sentinels: a curved outward path can transiently re-cover the strip
+            // AFTER the exit fired, retiring the newborn vessel before it ever connects — the
+            // birth-failure diag must carry whether that happened, or the death reads as absence.
+            let preBirthBoundaryEntries = 0,
+                preBirthEntries         = 0,
+                preBirthBoundaryProbe   = () => {preBirthBoundaryEntries++},
+                preBirthEntryProbe      = () => {preBirthEntries++};
+
+            sortZone.on('dragBoundaryEntry', preBirthBoundaryProbe);
+            tabs.on('dockTearOutEntry', preBirthEntryProbe);
+
             // The tear-out exit fires when the proxy LEAVES `boundaryContainerRect`. Target past
             // its bottom-right corner, fully outside, so intersectionRatio collapses below the
             // reattach threshold.
@@ -1910,8 +1931,11 @@ class Workspace extends Container {
             // Gate on the vessel's ACTUAL birth: a `?popout=` window connecting through onWindowConnect.
             let born = await me.waitForTearOutVessel(itemId, {attempts: birthAttempts});
 
+            sortZone.un('dragBoundaryEntry', preBirthBoundaryProbe);
+            tabs.un('dockTearOutEntry', preBirthEntryProbe);
+
             if (!born) {
-                let diag         = `exitFired=${Boolean(sortZone.isWindowDragging)} lastRatio=${sortZone.lastIntersectionRatio} boundary=${JSON.stringify(b)} out=(${outX},${outY}) itemRects=${sortZone.itemRects?.length ?? 'null'}`,
+                let diag         = `exitFired=${Boolean(sortZone.isWindowDragging)} vesselOpen=${JSON.stringify(me.lastVesselOpen ?? null)} preBirthBoundaryEntries=${preBirthBoundaryEntries} preBirthEntries=${preBirthEntries} lastRatio=${sortZone.lastIntersectionRatio} boundary=${JSON.stringify(b)} out=(${outX},${outY}) itemRects=${sortZone.itemRects?.length ?? 'null'}`,
                     cancellation = await me.cancelTearOutGesture(button, release);
 
                 return {

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1785,6 +1785,9 @@ class Workspace extends Container {
      * @param {String} step.itemId The dock item to tear out.
      * @param {String} step.sourceNodeId The tabs node currently holding it.
      * @param {Object} [options={}]
+     * @param {Number} [options.birthAttempts=180] Vessel-birth poll attempts (16ms each) — film
+     *     pacing widens this: vsync-limited boot can push the popup's shared-heap join past the
+     *     default three-second gate.
      * @param {Boolean} [options.cancel=false] Escape while detached — the zero-mutation witness.
      * @param {Number} [options.curve=0] Perpendicular path bow as a fraction of path length.
      * @param {Number} [options.moveDelay=16] Milliseconds between pointer samples.
@@ -1793,7 +1796,7 @@ class Workspace extends Container {
      * @param {Boolean} [options.reenter=false] Walk back inside instead of releasing — the morph witness.
      * @returns {Promise<Object>}
      */
-    async executeTearOutStep(step, {cancel=false, curve=0, moveDelay=16, moveSteps=4, postBirthMoves=2, reenter=false}={}) {
+    async executeTearOutStep(step, {birthAttempts=180, cancel=false, curve=0, moveDelay=16, moveSteps=4, postBirthMoves=2, reenter=false}={}) {
         let me                     = this,
             {itemId, sourceNodeId} = step || {},
             document               = me.dockModel,
@@ -1905,7 +1908,7 @@ class Workspace extends Container {
             }
 
             // Gate on the vessel's ACTUAL birth: a `?popout=` window connecting through onWindowConnect.
-            let born = await me.waitForTearOutVessel(itemId);
+            let born = await me.waitForTearOutVessel(itemId, {attempts: birthAttempts});
 
             if (!born) {
                 let diag         = `exitFired=${Boolean(sortZone.isWindowDragging)} lastRatio=${sortZone.lastIntersectionRatio} boundary=${JSON.stringify(b)} out=(${outX},${outY}) itemRects=${sortZone.itemRects?.length ?? 'null'}`,

--- a/test/playwright/e2e/gl.setup.mjs
+++ b/test/playwright/e2e/gl.setup.mjs
@@ -1,6 +1,6 @@
-import {test as setup, expect} from '@playwright/test';
-import {claimsGpuAcceleration} from './utils/gpuIntent.mjs';
-import {readGlState}           from './utils/glState.mjs';
+import {test as setup, expect}                   from '@playwright/test';
+import {activeLaunchArgs, claimsGpuAcceleration} from './utils/gpuIntent.mjs';
+import {readGlState}                             from './utils/glState.mjs';
 
 /**
  * @summary Boot gate: the E2E suite refuses to run silently on a GPU it only *claims* to have.
@@ -26,7 +26,7 @@ import {readGlState}           from './utils/glState.mjs';
  */
 setup('E2E boot: GPU-intent flags resolve to real GL', async ({page}) => {
     const
-        demandsGl = claimsGpuAcceleration(),
+        demandsGl = claimsGpuAcceleration(activeLaunchArgs()),
         gl        = await readGlState(page),
         detail    = `state=${gl.state} renderer=${gl.renderer ?? 'n/a'} vendor=${gl.vendor ?? 'n/a'} generic=${gl.generic ?? 'n/a'} reason=${gl.reason ?? 'none'}`;
 

--- a/test/playwright/e2e/utils/gpuIntent.mjs
+++ b/test/playwright/e2e/utils/gpuIntent.mjs
@@ -69,6 +69,31 @@ export const BASE_LAUNCH_ARGS = [
 export const E2E_LAUNCH_ARGS = [...GPU_INTENT_ARGS, ...BASE_LAUNCH_ARGS];
 
 /**
+ * @summary The film-take launch profile: capture needs frames ON GLASS.
+ *
+ * `--disable-frame-rate-limit` suppresses headed compositing entirely on retina hosts —
+ * `page.screenshot` starves for the full test timeout and every screen-capture grain records
+ * black while worker-truth stays green — so a filmable run must drop it. The GPU-intent flags
+ * are benchmark claims a film take does not make. The backgrounding-disable trio STAYS: a
+ * newborn tear-out vessel is an occluded window whose renderer must keep running long enough
+ * to join the shared heap, or vessels are never born.
+ * @type {String[]}
+ */
+export const FILM_LAUNCH_ARGS = BASE_LAUNCH_ARGS.filter(arg => arg !== '--disable-frame-rate-limit');
+
+/**
+ * @summary The launch list the CURRENT run mode actually uses.
+ *
+ * Single selection point for config projects AND the boot probe: the probe must demand GL
+ * proportional to the args the suite really launches with — reading intent from one list while
+ * launching another is the drift class this module exists to prevent.
+ * @returns {String[]}
+ */
+export function activeLaunchArgs() {
+    return process.env.NEO_FILM_TAKE ? FILM_LAUNCH_ARGS : E2E_LAUNCH_ARGS
+}
+
+/**
  * @summary Whether a given argument list claims hardware acceleration.
  * @param {String[]} [args=E2E_LAUNCH_ARGS]
  * @returns {Boolean}

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -48,29 +48,16 @@ import {test, expect} from '../../fixtures.mjs';
 // witness is not a take.
 // birthAttempts ceiling: gesture time + the birth gate must stay UNDER the Neural Link
 // rpcTimeout (10s) or a failed birth times the bridge call out and replaces the executor's
-// layered diag with a bare "Request timed out" — the knob would destroy its own receipts.
-// 240 × 16ms ≈ 3.8s of gate + ~1s of film-paced gesture keeps the whole call inside the
-// window; NEO_FILM_BIRTH_ATTEMPTS overrides for bisect cells.
+// layered diag with a bare "Request timed out" — the widened gate would destroy its own
+// receipts. 240 × 16ms ≈ 3.8s of gate + ~1s of film-paced gesture keeps the whole call
+// inside the window; birth is absence-not-slowness when it fails, so a longer gate buys
+// nothing but a worse error.
 const
     filmTake = Boolean(process.env.NEO_FILM_TAKE),
-    // NEO_FILM_PACE_OFF: bisect knob — film launch args with SPEC-DEFAULT gesture
-    // pacing, isolating "the launch profile" from "the film gesture shape" as birth factors.
-    filmPace = filmTake && !process.env.NEO_FILM_PACE_OFF ? {
-        birthAttempts: Number(process.env.NEO_FILM_BIRTH_ATTEMPTS) || 240,
-        // NEO_FILM_CURVE: bisect knob — curve-only override inside otherwise-full film
-        // pacing; a bowed outward path can transiently re-cover the strip post-exit.
-        curve    : process.env.NEO_FILM_CURVE !== undefined ? Number(process.env.NEO_FILM_CURVE) : 0.18,
-        moveDelay: 33,
-        // NEO_FILM_STEPS: bisect knob — post-exit sample count is the suspected
-        // false-reattach trigger dimension.
-        moveSteps    : Number(process.env.NEO_FILM_STEPS) || 24
-    } : {};
+    filmPace = filmTake ? {birthAttempts: 240, curve: 0.18, moveDelay: 33, moveSteps: 24} : {};
 
 // `video` must live at file level (a describe-scoped use() would force a new worker).
-// NEO_FILM_NOVIDEO: bisect knob — the per-page recorder attaches a screencast to
-// every page INCLUDING the newborn vessel; whether that attach interacts with first-navigation
-// commit under real-vsync compositing is a matrix dimension.
-test.use({video: filmTake && !process.env.NEO_FILM_NOVIDEO ? 'on' : 'off'});
+test.use({video: filmTake ? 'on' : 'off'});
 
 test.describe('Workstation — the five-beat multi-window journey', () => {
     test.setTimeout(180000);
@@ -82,9 +69,12 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
     });
 
     /**
-     * Boots the workstation, connects the Neural Link bridge, and wires error capture.
+     * Boots the workstation, connects the Neural Link bridge, and wires error capture plus the
+     * eager popup-layer probe (window created / page loaded / window closed — the three facts a
+     * birth failure needs, logged as they happen because a failed birth can outlive the bridge
+     * call that reports it).
      * @param {Object} fixtures `{page, neuralLink}`
-     * @returns {Promise<Object>} `{app, pageErrors, wsId}`
+     * @returns {Promise<Object>} `{app, pageErrors, popupProbe, wsId}`
      */
     async function boot({page, neuralLink}) {
         const pageErrors = [],
@@ -105,13 +95,6 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
             popupProbe.push(fact);
             console.log(`[vessel-probe] popup created urlAtOpen=${fact.urlAtOpen}`);
-            // Bisect knob: a newborn vessel window that is fully occluded on glass may
-            // never receive a BeginFrame under real-vsync compositing — fronting it at birth is
-            // the occlusion-commit discriminator (and the film wants the vessel on camera anyway).
-            process.env.NEO_FILM_FRONT_VESSEL && popup.bringToFront().then(
-                () => console.log('[vessel-probe] popup fronted'),
-                () => {}
-            );
             popup.once('load',  () => {fact.loaded = true; fact.urlAtLoad = popup.url(); console.log(`[vessel-probe] popup loaded ${fact.urlAtLoad}`)});
             popup.once('close', () => {fact.closed = true; console.log('[vessel-probe] popup closed')})
         });
@@ -125,13 +108,6 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         // deterministic — never AppleScript (two same-bundle Chrome processes make script
         // addressing flip-flop between instances).
         filmTake && await page.bringToFront();
-
-        // Bisect knobs (vessel-birth matrix): NEO_FILM_BOOT_SHOT forces one compositor
-        // frame-request post-boot (the round-2 green differed from the red runs by exactly this);
-        // NEO_FILM_BOOT_WAIT=<ms> is its time-only control — together they discriminate
-        // "first-frame kick" from "settle time" as the birth enabler.
-        process.env.NEO_FILM_BOOT_SHOT && await page.screenshot();
-        process.env.NEO_FILM_BOOT_WAIT && await page.waitForTimeout(Number(process.env.NEO_FILM_BOOT_WAIT));
 
         const app        = await neuralLink.connectToApp('Workstation'),
               workspaces = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -46,12 +46,31 @@ import {test, expect} from '../../fixtures.mjs';
 // switch from spec pacing to the production record's D-010 film pacing (slightly-quick, curved,
 // ~30fps pointer sampling). The spec's assertions stay identical: a take that cannot pass the
 // witness is not a take.
+// birthAttempts ceiling: gesture time + the birth gate must stay UNDER the Neural Link
+// rpcTimeout (10s) or a failed birth times the bridge call out and replaces the executor's
+// layered diag with a bare "Request timed out" — the knob would destroy its own receipts.
+// 240 × 16ms ≈ 3.8s of gate + ~1s of film-paced gesture keeps the whole call inside the
+// window; NEO_FILM_BIRTH_ATTEMPTS overrides for bisect cells.
 const
     filmTake = Boolean(process.env.NEO_FILM_TAKE),
-    filmPace = filmTake ? {birthAttempts: 600, curve: 0.18, moveDelay: 33, moveSteps: 24} : {};
+    // NEO_FILM_PACE_OFF: bisect knob — film launch args with SPEC-DEFAULT gesture
+    // pacing, isolating "the launch profile" from "the film gesture shape" as birth factors.
+    filmPace = filmTake && !process.env.NEO_FILM_PACE_OFF ? {
+        birthAttempts: Number(process.env.NEO_FILM_BIRTH_ATTEMPTS) || 240,
+        // NEO_FILM_CURVE: bisect knob — curve-only override inside otherwise-full film
+        // pacing; a bowed outward path can transiently re-cover the strip post-exit.
+        curve    : process.env.NEO_FILM_CURVE !== undefined ? Number(process.env.NEO_FILM_CURVE) : 0.18,
+        moveDelay: 33,
+        // NEO_FILM_STEPS: bisect knob — post-exit sample count is the suspected
+        // false-reattach trigger dimension.
+        moveSteps    : Number(process.env.NEO_FILM_STEPS) || 24
+    } : {};
 
 // `video` must live at file level (a describe-scoped use() would force a new worker).
-test.use({video: filmTake ? 'on' : 'off'});
+// NEO_FILM_NOVIDEO: bisect knob — the per-page recorder attaches a screencast to
+// every page INCLUDING the newborn vessel; whether that attach interacts with first-navigation
+// commit under real-vsync compositing is a matrix dimension.
+test.use({video: filmTake && !process.env.NEO_FILM_NOVIDEO ? 'on' : 'off'});
 
 test.describe('Workstation — the five-beat multi-window journey', () => {
     test.setTimeout(180000);
@@ -68,12 +87,33 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
      * @returns {Promise<Object>} `{app, pageErrors, wsId}`
      */
     async function boot({page, neuralLink}) {
-        const pageErrors = [];
+        const pageErrors = [],
+              popupProbe = [];
 
         page.on('pageerror', error => {
             let value = String(error?.stack || error?.message || error || '');
 
             value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        // Passive birth-layer probe: whether the platform CREATED a popup window is a different
+        // fact from whether its page loaded, which is a different fact from whether the vessel
+        // joined the shared heap (the executor's own gate). A birth failure needs all three —
+        // logged EAGERLY, because a failed birth can outlive the bridge call that reports it.
+        page.on('popup', popup => {
+            const fact = {urlAtOpen: popup.url(), loaded: false};
+
+            popupProbe.push(fact);
+            console.log(`[vessel-probe] popup created urlAtOpen=${fact.urlAtOpen}`);
+            // Bisect knob: a newborn vessel window that is fully occluded on glass may
+            // never receive a BeginFrame under real-vsync compositing — fronting it at birth is
+            // the occlusion-commit discriminator (and the film wants the vessel on camera anyway).
+            process.env.NEO_FILM_FRONT_VESSEL && popup.bringToFront().then(
+                () => console.log('[vessel-probe] popup fronted'),
+                () => {}
+            );
+            popup.once('load',  () => {fact.loaded = true; fact.urlAtLoad = popup.url(); console.log(`[vessel-probe] popup loaded ${fact.urlAtLoad}`)});
+            popup.once('close', () => {fact.closed = true; console.log('[vessel-probe] popup closed')})
         });
 
         await page.goto('/apps/workstation/index.html');
@@ -86,13 +126,20 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         // addressing flip-flop between instances).
         filmTake && await page.bringToFront();
 
+        // Bisect knobs (vessel-birth matrix): NEO_FILM_BOOT_SHOT forces one compositor
+        // frame-request post-boot (the round-2 green differed from the red runs by exactly this);
+        // NEO_FILM_BOOT_WAIT=<ms> is its time-only control — together they discriminate
+        // "first-frame kick" from "settle time" as the birth enabler.
+        process.env.NEO_FILM_BOOT_SHOT && await page.screenshot();
+        process.env.NEO_FILM_BOOT_WAIT && await page.waitForTimeout(Number(process.env.NEO_FILM_BOOT_WAIT));
+
         const app        = await neuralLink.connectToApp('Workstation'),
               workspaces = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
               wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
 
         expect(wsId, 'the App Worker must own one Workspace').toBeTruthy();
 
-        return {app, pageErrors, wsId}
+        return {app, pageErrors, popupProbe, wsId}
     }
 
     /**
@@ -228,7 +275,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
     // ── beats 3-4: contracted legs — activate as the cross-window docking wiring lands ──
 
     test('scene 2 — the tear-out: a real pointer drag births a vessel MID-GESTURE', async ({page, neuralLink}) => {
-        const {app, pageErrors, wsId} = await boot({page, neuralLink});
+        const {app, pageErrors, popupProbe, wsId} = await boot({page, neuralLink});
 
         const
             heartbeatBefore = await readHeartbeat(app, wsId),
@@ -243,6 +290,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             filmPace
         ]);
 
+        console.log('[vessel-probe][commit-leg]', JSON.stringify(popupProbe));
         expect(result.errors).toEqual([]);
         expect(result.proof.born,  'the vessel must be born MID-GESTURE (before pointer-up)').toBe(true);
         expect(result.proof.survivedProbe, 'post-birth outward moves must not reap the vessel').toBe(true);
@@ -277,7 +325,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
     // entry fires on placeholder-less zones (the layout restore is gated on its own marker) — one
     // continuous drag out past the edge and home again, zero mutation by guard.
     test('scene 2 (morph) — out past the edge and BACK IN: the vessel retires mid-drag, zero mutation', async ({page, neuralLink}) => {
-        const {app, pageErrors, wsId} = await boot({page, neuralLink});
+        const {app, pageErrors, popupProbe, wsId} = await boot({page, neuralLink});
 
         const
             heartbeatBefore = await readHeartbeat(app, wsId),
@@ -291,6 +339,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             {reenter: true, ...filmPace}
         ]);
 
+        console.log('[vessel-probe][morph-leg]', JSON.stringify(popupProbe));
         expect(result.errors).toEqual([]);
         expect(result.proof.born, 'the vessel must be born mid-gesture').toBe(true);
         expect(result.reentered, 'the vessel must retire on re-entry while the pointer is down').toBe(true);

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -48,7 +48,7 @@ import {test, expect} from '../../fixtures.mjs';
 // witness is not a take.
 const
     filmTake = Boolean(process.env.NEO_FILM_TAKE),
-    filmPace = filmTake ? {curve: 0.18, moveDelay: 33, moveSteps: 24} : {};
+    filmPace = filmTake ? {birthAttempts: 600, curve: 0.18, moveDelay: 33, moveSteps: 24} : {};
 
 // `video` must live at file level (a describe-scoped use() would force a new worker).
 test.use({video: filmTake ? 'on' : 'off'});

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -12,7 +12,11 @@ import {BASE_LAUNCH_ARGS}      from './e2e/utils/gpuIntent.mjs';
 // backgrounding-disable trio STAYS: a newborn tear-out vessel is an occluded window whose
 // renderer must keep running long enough to join the shared heap, or vessels are never
 // born. Bisect receipt table: the film-profile ticket this block cites.
-const FILM_LAUNCH_ARGS = BASE_LAUNCH_ARGS.filter(arg => arg !== '--disable-frame-rate-limit');
+// NEO_FILM_KEEP_GPU: bisect knob — the film profile changed TWO things at once
+// (dropped the frame-rate-limit flag AND the four GPU-intent flags); this isolates the
+// second half: E2E args minus ONLY the frame-limiter.
+const FILM_LAUNCH_ARGS = (process.env.NEO_FILM_KEEP_GPU ? E2E_LAUNCH_ARGS : BASE_LAUNCH_ARGS)
+    .filter(arg => arg !== '--disable-frame-rate-limit');
 
 // Per-process by default: this suite renders ITS OWN checkout (reuseExistingServer:false below), so a
 // fixed default would silently adopt a foreign dev-server squatting on 8080 — that server serves the
@@ -62,7 +66,11 @@ export default defineConfig({
         name        : 'chromium',
         dependencies: ['gl-probe'],
         use         : {
-            channel      : 'chrome', // Use local Google Chrome instead of Playwright's Chromium binary
+            // Use local Google Chrome instead of Playwright's Chromium binary.
+            // NEO_FILM_CHROMIUM: bisect knob — the bundled Chromium carries a DIFFERENT
+            // macOS bundle id, so per-bundle desktop state (Space assignment, the AllSpaces Dock
+            // binding) does not apply: it isolates bundle-environmental effects on vessel birth.
+            ...(process.env.NEO_FILM_CHROMIUM ? {} : {channel: 'chrome'}),
             // Declared once in e2e/utils/gpuIntent.mjs so the boot probe reads the same list this
             // launches with. A second copy here would drift, and drift between two statements of one
             // fact is how a dead GL flag stayed invisible for five months.

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -3,6 +3,16 @@ import './configTemplateResolver.mjs';
 import {defineConfig, devices} from '@playwright/test';
 import {resolveFreePortSync}   from './resolveFreePort.mjs';
 import {E2E_LAUNCH_ARGS}       from './e2e/utils/gpuIntent.mjs';
+import {BASE_LAUNCH_ARGS}      from './e2e/utils/gpuIntent.mjs';
+
+// Film-take launch profile: capture needs frames ON GLASS. `--disable-frame-rate-limit`
+// suppresses headed compositing entirely on retina hosts (page.screenshot starves for the
+// full test timeout; every screen-capture grain records black while worker-truth stays
+// green), and the GPU-intent args are benchmark claims a film take does not make. The
+// backgrounding-disable trio STAYS: a newborn tear-out vessel is an occluded window whose
+// renderer must keep running long enough to join the shared heap, or vessels are never
+// born. Bisect receipt table: the film-profile ticket this block cites.
+const FILM_LAUNCH_ARGS = BASE_LAUNCH_ARGS.filter(arg => arg !== '--disable-frame-rate-limit');
 
 // Per-process by default: this suite renders ITS OWN checkout (reuseExistingServer:false below), so a
 // fixed default would silently adopt a foreign dev-server squatting on 8080 — that server serves the
@@ -56,7 +66,7 @@ export default defineConfig({
             // Declared once in e2e/utils/gpuIntent.mjs so the boot probe reads the same list this
             // launches with. A second copy here would drift, and drift between two statements of one
             // fact is how a dead GL flag stayed invisible for five months.
-            launchOptions: {args: E2E_LAUNCH_ARGS}
+            launchOptions: {args: process.env.NEO_FILM_TAKE ? FILM_LAUNCH_ARGS : E2E_LAUNCH_ARGS}
         }
     }]
 });

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -2,21 +2,7 @@ import './configTemplateResolver.mjs';
 
 import {defineConfig, devices} from '@playwright/test';
 import {resolveFreePortSync}   from './resolveFreePort.mjs';
-import {E2E_LAUNCH_ARGS}       from './e2e/utils/gpuIntent.mjs';
-import {BASE_LAUNCH_ARGS}      from './e2e/utils/gpuIntent.mjs';
-
-// Film-take launch profile: capture needs frames ON GLASS. `--disable-frame-rate-limit`
-// suppresses headed compositing entirely on retina hosts (page.screenshot starves for the
-// full test timeout; every screen-capture grain records black while worker-truth stays
-// green), and the GPU-intent args are benchmark claims a film take does not make. The
-// backgrounding-disable trio STAYS: a newborn tear-out vessel is an occluded window whose
-// renderer must keep running long enough to join the shared heap, or vessels are never
-// born. Bisect receipt table: the film-profile ticket this block cites.
-// NEO_FILM_KEEP_GPU: bisect knob — the film profile changed TWO things at once
-// (dropped the frame-rate-limit flag AND the four GPU-intent flags); this isolates the
-// second half: E2E args minus ONLY the frame-limiter.
-const FILM_LAUNCH_ARGS = (process.env.NEO_FILM_KEEP_GPU ? E2E_LAUNCH_ARGS : BASE_LAUNCH_ARGS)
-    .filter(arg => arg !== '--disable-frame-rate-limit');
+import {activeLaunchArgs}      from './e2e/utils/gpuIntent.mjs';
 
 // Per-process by default: this suite renders ITS OWN checkout (reuseExistingServer:false below), so a
 // fixed default would silently adopt a foreign dev-server squatting on 8080 — that server serves the
@@ -61,20 +47,17 @@ export default defineConfig({
         // with the SAME args as the suite — probing a different browser would prove nothing.
         name     : 'gl-probe',
         testMatch: /gl\.setup\.mjs$/,
-        use      : {channel: 'chrome', launchOptions: {args: E2E_LAUNCH_ARGS}}
+        use      : {channel: 'chrome', launchOptions: {args: activeLaunchArgs()}}
     }, {
         name        : 'chromium',
         dependencies: ['gl-probe'],
         use         : {
-            // Use local Google Chrome instead of Playwright's Chromium binary.
-            // NEO_FILM_CHROMIUM: bisect knob — the bundled Chromium carries a DIFFERENT
-            // macOS bundle id, so per-bundle desktop state (Space assignment, the AllSpaces Dock
-            // binding) does not apply: it isolates bundle-environmental effects on vessel birth.
-            ...(process.env.NEO_FILM_CHROMIUM ? {} : {channel: 'chrome'}),
+            channel      : 'chrome', // Use local Google Chrome instead of Playwright's Chromium binary
             // Declared once in e2e/utils/gpuIntent.mjs so the boot probe reads the same list this
             // launches with. A second copy here would drift, and drift between two statements of one
-            // fact is how a dead GL flag stayed invisible for five months.
-            launchOptions: {args: process.env.NEO_FILM_TAKE ? FILM_LAUNCH_ARGS : E2E_LAUNCH_ARGS}
+            // fact is how a dead GL flag stayed invisible for five months. The mode selection
+            // (film vs benchmark) lives in the same module for the same reason.
+            launchOptions: {args: activeLaunchArgs()}
         }
     }]
 });


### PR DESCRIPTION
Resolves #15912

The film-take launch profile ships as a first-class mode of the E2E config: `NEO_FILM_TAKE=1` launches `FILM_LAUNCH_ARGS` — `BASE_LAUNCH_ARGS` minus `--disable-frame-rate-limit`, no GPU-intent args — declared in `gpuIntent.mjs` beside the E2E list with an `activeLaunchArgs()` selector that BOTH config projects and the `gl.setup` boot probe consume, so the probe demands GL proportional to the args the suite actually launches with (the drift class the module's own header warns about, closed rather than reproduced). On this host the frame-limiter flag suppresses headed compositing entirely: under E2E args `page.screenshot` starves for the full test timeout and every capture grain records black while worker-truth stays green; under the film profile the workstation paints on glass (receipts on the ticket + take-14 footage). The five-beat spec gains the film-pace block (`birthAttempts: 240` — capped so gesture + birth gate stay UNDER the Neural Link 10s `rpcTimeout`, because a failed birth that outlives the bridge call replaces its own layered diag with a bare "Request timed out"), an eager popup-layer probe (window created / page loaded / window closed, logged as they happen), and the executor diag now carries the vessel-open outcome trail (`invoked | blocked-by-retirement | windowOpen-false | granted | threw`) plus pre-birth entry sentinels — the instrumentation that produced the 14-cell bisect matrix (ticket, issuecomment-5079085748) and pinned `#15915`.

Evidence: L3 achieved (headed film-profile runs on the target host: scene-2 both legs green ×2 at this exact head post-`#15915`-rebase, plus the default-path 4/4 control at the refactor — logs `fivebeat-take14-preflight1/2.log`, `fivebeat-15912-refactor-defaultpath.log`; take-14 shot real footage under this profile same-hour) → L3 required (AC1 is a headed-host AC). Residual: none.

## Deltas from ticket

The bisect knobs the WIP carried (`NEO_FILM_BOOT_SHOT`/`BOOT_WAIT`/`FRONT_VESSEL`/`NOVIDEO`/`KEEP_GPU`/`CHROMIUM`/`PACE_OFF`/`CURVE`/`STEPS`/`BIRTH_ATTEMPTS`) are RETIRED in the final commit — every hypothesis they discriminated is falsified-and-documented on the ticket's matrix, and dead knobs in a witness spec are drift surface. The permanent diagnostics (probe + outcome trail + sentinels) stay: they turned "vessel not born" from a mystery into a named layer in one red run. The birth-gate clamp (600→240) is a delta from the WIP's own widening — the 10s rpc ceiling makes the wide gate self-defeating, and birth failure is absence-not-slowness, so the long gate bought nothing but a worse error.

## Test Evidence

- Film profile, both scene-2 legs, headed, full film pacing, knobs off, at this head: `NEO_E2E_PORT=8124 NEO_FILM_TAKE=1 npx playwright test workstation/WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed --grep "scene 2"` → **3 passed** ×2 consecutive runs.
- Default path (no `NEO_FILM_TAKE`), same command minus env/grep → **4 passed** (gl-probe demands + gets hardware GL under E2E args; scene 1 + both legs green) — the refactor changes nothing for benchmarks.
- Touched surface coverage: `apps/workstation` → `WorkstationFiveBeatNL` (this spec); `gpuIntent.mjs`/`gl.setup.mjs` → the gl-probe project exercises both on every e2e run.
- Live proof of purpose: take-14 recorded real workstation footage under this profile (4/4 green during the take) and the v0 draft cut was delivered to the operator from it.

## Post-Merge Validation

- [ ] Full five-beat suite green at the merged head, default path (CI e2e lane runs headless E2E args — unchanged behavior expected).
- [ ] Next film session: `NEO_FILM_TAKE=1` capture runs ride the merged profile with zero branch-local state.

## Commits (if multi-commit)

- `528917e96e` — film launch profile + film-wide birth gate (WIP, paint proven)
- `79a0d349c8` — birth-layer diagnostics + bisect knobs (the matrix instrumentation)
- `771cd71e04` — film profile promoted to the gpuIntent single declaration, probe drift closed, knobs retired

Authored by Mnemosyne (Fable 5, Claude Code). Session 8e3ca9dd-427d-4c93-9054-edd660fda27b.
