### PR TITLE
fix(workstation): the vessel styles the pane it hosts — token bridge moves to the viewport (#15923)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1067,10 +1067,14 @@ class Workspace extends Container {
      * later flip across documents, so an open vessel stayed on the theme it was born with while
      * the workspace beside it changed.
      *
-     * Fanning across `Neo.apps` is the same seam the tear-out already resolves vessels through
-     * (`resolveTarget: windowId => Neo.apps[windowId]?.mainView`), and the viewport is where the
-     * app's token bridge lives — so a vessel restyles from its own theme class rather than
-     * inheriting a stale one from its boot-time body.
+     * Fanning reaches the viewport because that is where this app's token bridge lives, so a vessel
+     * restyles from its own theme class rather than inheriting a stale one from its boot-time body.
+     *
+     * `Neo.appsByName[appName]` rather than `Neo.apps`: the worker-global registry is keyed by
+     * window and can carry more than one app name (`controller/Application.mjs` indexes both), so
+     * iterating it would let a Workstation toggle retheme an unrelated co-hosted app. The
+     * name-keyed registry is the same set restricted to this app's own render targets — one window
+     * today, one per open vessel tomorrow.
      * @param {String} theme
      * @returns {String}
      */
@@ -1080,7 +1084,7 @@ class Workspace extends Container {
         me.theme = theme;
         me.syncThemeToggle(theme);
 
-        Object.values(Neo.apps || {}).forEach(app => {
+        (Neo.appsByName?.[me.appName] || []).forEach(app => {
             const view = app?.mainView;
 
             view && view !== me && view.theme !== theme && (view.theme = theme)

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1058,12 +1058,34 @@ class Workspace extends Container {
     }
 
     /**
+     * Applies the theme to every render target of this app, not only to the workspace.
+     *
+     * A theme in Neo is a CSS class an ancestor carries, and `afterSetTheme` writes it onto the
+     * component it was set on — so setting it here reaches this window's subtree and nothing else.
+     * A tear-out vessel is a SECOND document driven by the same App Worker, whose only theme
+     * carrier is the class the Stylesheet addon puts on its `body` at boot. Nothing propagates a
+     * later flip across documents, so an open vessel stayed on the theme it was born with while
+     * the workspace beside it changed.
+     *
+     * Fanning across `Neo.apps` is the same seam the tear-out already resolves vessels through
+     * (`resolveTarget: windowId => Neo.apps[windowId]?.mainView`), and the viewport is where the
+     * app's token bridge lives — so a vessel restyles from its own theme class rather than
+     * inheriting a stale one from its boot-time body.
      * @param {String} theme
      * @returns {String}
      */
     setWorkspaceTheme(theme) {
-        this.theme = theme;
-        this.syncThemeToggle(theme);
+        const me = this;
+
+        me.theme = theme;
+        me.syncThemeToggle(theme);
+
+        Object.values(Neo.apps || {}).forEach(app => {
+            const view = app?.mainView;
+
+            view && view !== me && view.theme !== theme && (view.theme = theme)
+        });
+
         return theme
     }
 

--- a/resources/scss/src/apps/workstation/Viewport.scss
+++ b/resources/scss/src/apps/workstation/Viewport.scss
@@ -1,3 +1,48 @@
+// The token bridge lives at the VIEWPORT, not the workspace.
+//
+// Workstation owns its palette (`--workstation-*`, defined globally per skin under
+// `:root .neo-theme-*`), but generic grid/tab primitives read Neo's own token names. The block
+// below is the bridge between the two, and its scope decides who gets styled: every boot mode
+// carries `.workstation-viewport`, while only the default mode mounts `.workstation-workspace`.
+//
+// The `?popout=` vessel is a viewport WITHOUT a workspace — it hosts a torn-out live pane bare
+// (Workstation.view.Viewport#onConstructed). While the bridge sat on `.workstation-workspace`,
+// that vessel inherited the palette but not the mapping, so every grid/tab token fell back to its
+// stock Neo default: cell backgrounds resolved to the ground colour, the pane dissolved into its
+// own backdrop, and the result read as unstyled text on a default background even though the
+// theme class and every component stylesheet were present. Bridging at the viewport keeps the
+// layering honest — global palette → viewport bridge → component consumption — and the vessel
+// inherits it without pretending to be a workspace.
+.workstation-viewport {
+    // Workstation is a standalone instrument, so generic grid/tab primitives inherit its own
+    // palette in both skins instead of leaking their default blue/purple values.
+    --grid-container-border-color              : var(--workstation-line);
+    --grid-container-cell-background-color     : var(--workstation-panel);
+    --grid-container-cell-background-color-even: var(--workstation-panel-2);
+    --grid-container-color                     : var(--workstation-ink-dim);
+    --grid-container-header-cell-border-bottom : 1px solid var(--workstation-line);
+    --grid-cell-background-color-hover          : color-mix(in srgb, var(--workstation-signal) 10%, var(--workstation-panel));
+    --grid-cell-progress-active-color           : var(--workstation-signal);
+    --grid-cell-progress-track-color            : var(--workstation-line);
+    --grid-header-button-background-color       : var(--workstation-panel-2);
+    --grid-header-button-background-color-hover : color-mix(in srgb, var(--workstation-signal) 12%, var(--workstation-panel-2));
+    --grid-header-button-color                  : var(--workstation-ink);
+    --grid-header-button-color-hover            : var(--workstation-ink);
+    --grid-header-button-glyph-color            : var(--workstation-ink-dim);
+    --grid-header-button-glyph-color-hover      : var(--workstation-signal);
+    // Header buttons use row-reverse to keep their sort glyph after the label. `flex-end`
+    // therefore means physical left/start alignment for the complete label + glyph group.
+    --grid-header-button-justify-content        : flex-end;
+    --grid-header-button-padding                : 0 10px;
+    --tab-button-background-color               : transparent;
+    --tab-button-background-color-active        : color-mix(in srgb, var(--workstation-signal) 12%, transparent);
+    --tab-button-background-color-hover         : color-mix(in srgb, var(--workstation-signal) 8%, transparent);
+    --tab-button-glyph-color                    : var(--workstation-ink-dim);
+    --tab-button-text-color                     : var(--workstation-ink-dim);
+    --tab-indicator-background-color-active     : var(--workstation-signal);
+    --tab-strip-background-color                : var(--workstation-panel-2);
+}
+
 .workstation-viewport.neo-viewport {
     background: var(--workstation-ground);
 }

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -3,34 +3,10 @@
 // reduced-motion collapse owned by Neo.dashboard.Container.
 
 .workstation-workspace {
-    // Workstation is a standalone instrument, so generic grid/tab primitives inherit its own
-    // palette in both skins instead of leaking their default blue/purple values.
-    --grid-container-border-color              : var(--workstation-line);
-    --grid-container-cell-background-color     : var(--workstation-panel);
-    --grid-container-cell-background-color-even: var(--workstation-panel-2);
-    --grid-container-color                     : var(--workstation-ink-dim);
-    --grid-container-header-cell-border-bottom : 1px solid var(--workstation-line);
-    --grid-cell-background-color-hover          : color-mix(in srgb, var(--workstation-signal) 10%, var(--workstation-panel));
-    --grid-cell-progress-active-color           : var(--workstation-signal);
-    --grid-cell-progress-track-color            : var(--workstation-line);
-    --grid-header-button-background-color       : var(--workstation-panel-2);
-    --grid-header-button-background-color-hover : color-mix(in srgb, var(--workstation-signal) 12%, var(--workstation-panel-2));
-    --grid-header-button-color                  : var(--workstation-ink);
-    --grid-header-button-color-hover            : var(--workstation-ink);
-    --grid-header-button-glyph-color            : var(--workstation-ink-dim);
-    --grid-header-button-glyph-color-hover      : var(--workstation-signal);
-    // Header buttons use row-reverse to keep their sort glyph after the label. `flex-end`
-    // therefore means physical left/start alignment for the complete label + glyph group.
-    --grid-header-button-justify-content        : flex-end;
-    --grid-header-button-padding                : 0 10px;
-    --tab-button-background-color               : transparent;
-    --tab-button-background-color-active        : color-mix(in srgb, var(--workstation-signal) 12%, transparent);
-    --tab-button-background-color-hover         : color-mix(in srgb, var(--workstation-signal) 8%, transparent);
-    --tab-button-glyph-color                    : var(--workstation-ink-dim);
-    --tab-button-text-color                     : var(--workstation-ink-dim);
-    --tab-indicator-background-color-active     : var(--workstation-signal);
-    --tab-strip-background-color                : var(--workstation-panel-2);
-
+    // The grid/tab token bridge sits on `.workstation-viewport`, one level up: the `?popout=`
+    // vessel is a viewport WITHOUT a workspace, so a bridge scoped here never reached the pane it
+    // tears out. What remains below is workspace-only presentation the vessel must not inherit —
+    // the gradient backdrop belongs to the dense composition, not to a bare pane host.
     background:
         radial-gradient(circle at 22% 8%, color-mix(in srgb, var(--workstation-signal) 8%, transparent), transparent 32%),
         var(--workstation-ground);

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -292,6 +292,33 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
         expect(paneIdAfter).toBe(paneIdBefore);
 
+        // …and the vessel must STYLE the pane it hosts, not merely own it. Every assertion above
+        // stayed green while the tear-out rendered as bare text on the ground colour, because the
+        // grid/tab token bridge was scoped to `.workstation-workspace` — a class this window
+        // deliberately never mounts. Note what this does NOT assert: the theme class was
+        // present throughout that bug, so a class check on the vessel document would have passed
+        // the whole time. Read the RESOLVED token instead, and compare it to the palette rather
+        // than to a hex literal, so a future palette edit moves both sides together.
+        const vesselTokens = await popup.evaluate(() => {
+            const viewport = document.querySelector('.workstation-viewport'),
+                  styles   = viewport && getComputedStyle(viewport);
+
+            return {
+                isVessel: !!document.querySelector('.workstation-popout-host'),
+                cellBg  : styles?.getPropertyValue('--grid-container-cell-background-color').trim(),
+                stripBg : styles?.getPropertyValue('--tab-strip-background-color').trim(),
+                panel   : styles?.getPropertyValue('--workstation-panel').trim(),
+                panel2  : styles?.getPropertyValue('--workstation-panel-2').trim()
+            }
+        });
+
+        expect(vesselTokens.isVessel, 'the committed popup must be the pop-out vessel host').toBe(true);
+        expect(vesselTokens.panel, 'the vessel must inherit the Workstation palette').toBeTruthy();
+        expect(vesselTokens.cellBg, 'the vessel must bridge grid tokens onto the Workstation palette')
+            .toBe(vesselTokens.panel);
+        expect(vesselTokens.stripBg, 'the vessel must bridge tab tokens onto the Workstation palette')
+            .toBe(vesselTokens.panel2);
+
         // The heartbeat moved FORWARD — nothing reloaded, nothing recreated.
         expect(await readHeartbeat(app, wsId)).toBeGreaterThan(heartbeatBefore);
         expect(pageErrors).toEqual([])

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -329,9 +329,12 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
         await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-light']);
 
-        const flipped = await popup.evaluate(async () => {
-            await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
-
+        // Poll the OBSERVABLE transition rather than sleeping a frame count. The flip crosses a
+        // worker→two-main-threads boundary and commits through a vdom update the popup does not
+        // publish an event for, so any fixed wait encodes a guess about someone else's scheduler:
+        // two rAFs sampled BEFORE the commit and failed deterministically at this exact head.
+        // Polling states the actual contract — the vessel restyles, eventually and observably.
+        const readVesselTokens = () => popup.evaluate(() => {
             const viewport = document.querySelector('.workstation-viewport'),
                   styles   = viewport && getComputedStyle(viewport);
 
@@ -341,8 +344,15 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             }
         });
 
-        expect(flipped.cellBg, 'the open vessel must restyle when the workspace theme flips')
-            .not.toBe(themeBefore);
+        await expect.poll(async () => (await readVesselTokens()).cellBg, {
+            message: 'the open vessel must restyle when the workspace theme flips',
+            timeout: 15000
+        }).not.toBe(themeBefore);
+
+        const flipped = await readVesselTokens();
+
+        // Changing is not enough: it must land on the NEW palette. A vessel that merely moved off
+        // its birth value — to a stock Neo default, say — would satisfy the assertion above.
         expect(flipped.cellBg, 'and it must land on the NEW palette, not merely change')
             .toBe(flipped.panel);
 

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -319,6 +319,35 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(vesselTokens.stripBg, 'the vessel must bridge tab tokens onto the Workstation palette')
             .toBe(vesselTokens.panel2);
 
+        // …and the skin must keep reaching it AFTER it is open. A theme is a class an ancestor
+        // carries, written by `afterSetTheme` onto the component it was set on — so a workspace-
+        // local flip reaches this window and no other, and the vessel's own `body` still carries
+        // whatever the Stylesheet addon put there at boot. Carrier-presence at birth proves
+        // initial styling only; an open vessel stranding on its birth theme is invisible to every
+        // assertion above. Flip, then read the same tokens back through the popup.
+        const themeBefore = vesselTokens.cellBg;
+
+        await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-light']);
+
+        const flipped = await popup.evaluate(async () => {
+            await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+            const viewport = document.querySelector('.workstation-viewport'),
+                  styles   = viewport && getComputedStyle(viewport);
+
+            return {
+                cellBg: styles?.getPropertyValue('--grid-container-cell-background-color').trim(),
+                panel : styles?.getPropertyValue('--workstation-panel').trim()
+            }
+        });
+
+        expect(flipped.cellBg, 'the open vessel must restyle when the workspace theme flips')
+            .not.toBe(themeBefore);
+        expect(flipped.cellBg, 'and it must land on the NEW palette, not merely change')
+            .toBe(flipped.panel);
+
+        await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-dark']);
+
         // The heartbeat moved FORWARD — nothing reloaded, nothing recreated.
         expect(await readHeartbeat(app, wsId)).toBeGreaterThan(heartbeatBefore);
         expect(pageErrors).toEqual([])


### PR DESCRIPTION
Resolves #15923

The tear-out vessel rendered its live pane unstyled. **Two defects, and cycle 1 only found the first.**

1. **The reported symptom is a design-token *bridge scope* defect** — none of the ticket's three candidates describe it, and the theme carrier was present throughout.
2. **A real theme-propagation defect exists**, found by @neo-gpt-emmy after cycle 1: an already-open vessel does not restyle when the workspace theme flips.

> **Cycle-1 correction.** This body previously asserted *"It is not a theme-propagation defect — the theme propagates correctly."* **That was false and I had not tested it.** My evidence covered initial token resolution in a freshly-booted vessel; I generalised it to propagation without ever running a flip. Emmy ran the transition and it failed. AC2 was likewise shipped as a headed-film residual when it is observable in the existing two-window harness — unfinished work classified as a sandbox ceiling. Both are fixed in this cycle rather than re-argued.

## Root cause

The Workstation token layer is two blocks at two scopes:

```scss
:root .neo-theme-neo-dark {          /* GLOBAL — reaches every window, vessel included */
    --workstation-panel: #141a23;
}

.workstation-workspace {             /* ← the vessel has no such ancestor */
    --grid-container-cell-background-color: var(--workstation-panel);
    --tab-strip-background-color          : var(--workstation-panel-2);
    …~25 more
}
```

The second block is the **bridge**: it maps the app palette onto the component token names `grid.Container` / `tab.Container` actually read. `Workstation.view.Viewport#onConstructed` adds the pop-out host cls and returns **without mounting `Workspace`** — by design; the vessel is a bare pane host.

So the vessel inherited the palette but not the mapping. Every grid/tab token fell back to its stock Neo default, cell backgrounds resolved to the **ground colour**, and the pane dissolved into its own backdrop. That is the footage exactly: bare text on a default background, while the theme class and every component stylesheet were present the entire time.

## Why the three candidates were wrong

Falsified in a live two-window run against `dev`, not by reading:

| candidate | verdict | evidence |
|---|---|---|
| 1 — vessel never applies a theme class | **false** | vessel body carries `neo-theme-neo-dark`; background `rgb(14,15,13)`. `Stylesheet.addGlobalCss()` runs per main thread. |
| 2 — per-window stylesheet set incomplete | **false** | 67 sheets incl. `grid/Container`, `tab/Container`. Re-tested with the vessel joining as the **second** window — the case a per-`windowId` `cssMap` would most plausibly break — still 67. |
| 3 — mounted without the wrapper its SCSS scopes under | **closest, wrong layer** | `DockVesselEmbodiment` has zero theme references. The missing wrapper is a *token-bridge* scope, not a theme wrapper. |

## The fix

Bridge at `.workstation-viewport`. Both boot modes carry that class, the workspace inherits it by containment (verified live: `viewport.contains(workspace) === true`), and the vessel gets it without pretending to be a workspace. `Workspace.scss` keeps only workspace-only presentation the vessel must **not** inherit — the gradient backdrop belongs to the dense composition, not a bare pane host.

Adding `workstation-workspace` to the pop-out host would also work, and is wrong: it conflates "is a workspace" with "provides tokens", and the vessel deliberately is not one.

## Evidence

Evidence: L2 achieved (computed-token measurement in both boot modes + regression control + an in-suite observable-transition witness for the cross-window flip) → L3 required for AC1 only (headed visual parity under the film profile). Residual: AC1 [#15923].

> **Cycle-2 correction.** This line previously read *"L3 required for ACs 1–2 … Residual: AC1, AC2"* while the Post-Merge section below already recorded AC2 as delivered — the body contradicted itself, and @neo-gpt-emmy caught it. AC2 is delivered and witnessed in-suite; AC1 (pixel parity) is the only residual.

Measured on the vessel viewport, **no workspace present**:

| token | before | after | resolves to |
|---|---|---|---|
| `--grid-container-cell-background-color` | `#0E0F0D` (ground — invisible) | `#141a23` | `--workstation-panel` |
| `--grid-container-border-color` | `#1D2E62` (stock Neo blue) | `#262f3d` | `--workstation-line` |
| `--tab-strip-background-color` | `transparent` | `#1a212c` | `--workstation-panel-2` |

Regression control — default workspace mode, same run: `#141a23` / `#262f3d` / `#1a212c`, unchanged, and the real `.neo-grid-container` element paints `rgb(20,26,35)`.

## Test Evidence

`scene 2` gains a vessel-styling tripwire at the point object-permanence proves the same instance crossed the boundary.

It asserts the **resolved token against the palette** — not a class, not a hex literal:

- **Not a class.** AC4 proposed a cheap DOM/class check. That check was green throughout this entire bug, because the theme class was never the thing missing. A tripwire that passes on the defect it exists to catch is not a tripwire.
- **Not a literal.** `cellBg === panel` moves with the palette, so a future skin edit cannot break the assertion without breaking the contract it encodes.

## Deltas from ticket

**One, and it corrects the ticket's own AC4.** The ticket specified a class check as the regression tripwire; this ships a computed-style assertion instead, for the reason above. The ticket's root-cause section is otherwise accurate — its three candidates were deliberately unfalsified, and working through them in order is what surfaced the two-layer token split.

## Post-Merge Validation

- **AC2 is no longer deferred — it is delivered.** Cycle 1 shipped it as a headed residual with the reasoning *"should follow for free."* That reasoning was the defect: the palette is keyed on the per-window **body** class, and a flip never touches another window's body. `setWorkspaceTheme` now fans across `Neo.apps`, and scene 2 carries the transition witness. The close-target annotation is lifted.
- **AC1** (headed visual parity with the in-window card) remains the only residual: pixel parity needs a film-profile run this branch cannot produce. It stays for the film lane, annotated `[L3-deferred — operator handoff needed]` on #15923.
- AC3 (root cause + falsifying probes for the rejected candidates) and AC4 (scene-2 tripwire, sharpened to computed-style) are green.

**What cycle 1 got wrong about its own ceiling, recorded because it is the reusable part:** "needs headed verification" was asserted for a property that a two-window computed-token probe measures directly. A declared ceiling is a claim like any other and deserves the same falsification as a finding — otherwise it becomes a place to put work that is merely unfinished.

Authored by Grace (Claude Opus 5, Claude Code). Session a9920b95-234e-413b-9ed0-e573141e338f.


