### PR TITLE
docs(ai): the declaration-form docs describe the shipped shape again (#15929)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -10,8 +10,8 @@ const neoRootDir = path.resolve(__dirname, '../');
 // Fallback to neoRootDir if cwd is root (e.g., container/daemon edge cases)
 const projectRoot = process.cwd() === '/' ? neoRootDir : process.cwd();
 // The single plane-member anchor: every durable data-plane default below derives from this
-// const (env-free twin resolution — the leaf machinery owns all env binding), so no member
-// re-derives its own root and no member resolves against ambient cwd.
+// const. `resolvePlaneDataRoot` reads no env of its own — the leaf machinery owns all env
+// binding — so no member re-derives its own root and no member resolves against ambient cwd.
 const planeDataRootDefault  = resolvePlaneDataRoot({rootDir: neoRootDir});
 const chromaUnitTestDataDir = path.join(os.tmpdir(), 'neo-chroma-unit-test');
 
@@ -53,10 +53,11 @@ class ConfigBase extends ConfigProvider {
             projectRoot: leaf(projectRoot),
             /**
              * The declared plane-identity subtree — the first-class object the data-root
-             * placement election decides placement FOR. Declaration source is the pure-defaults
-             * twin `ai/planeConfig.mjs` (ticket-ref-ok: ADR 0019 §5.5 names that module shape):
-             * the leaf imports the twin's frozen literals + env names, so leaf↔twin drift is
-             * impossible by construction.
+             * placement election decides placement FOR. The literals below are declared FROM
+             * `ai/planeConfig.mjs`, a shared-constant module these leaves import: it holds the
+             * canonical id, the env-free data-root derivation, and the id parser the leaf binds
+             * as its own `parse` hook. It carries no resolver of its own and reads no env, so
+             * there is no second resolution path for these leaves to drift against.
              * Three concepts, never conflated: `id` is opaque identity (no path/checkout content);
              * `dataRoot` is the resolved evidence every plane-member leaf derives from;
              * `NEO_AI_CANONICAL_ROOT` (provisioning-time, `bootstrapWorktree.mjs`) names a
@@ -68,9 +69,10 @@ class ConfigBase extends ConfigProvider {
                  * Stable opaque plane identity. Overlays, cloud deployments, and ephemeral
                  * isolation planes (Option F overlays) override via env; equality of `planeId`
                  * is the ONLY sanctioned "same plane?" predicate — never path comparison.
-                 * The env layer routes through the twin's `parsePlaneIdEnv`, so a path-shaped
-                 * override fails loud at boot — the opacity invariant holds on RESOLVED values,
-                 * not only on the frozen default the load guard covers.
+                 * The env layer routes through `parsePlaneIdEnv`, carried on this leaf's own
+                 * `parse` hook, so a path-shaped override fails loud at boot — the opacity
+                 * invariant holds on RESOLVED values, not only on the frozen default the load
+                 * guard covers.
                  * @type {string}
                  */
                 id: leaf(CANONICAL_PLANE_ID, 'NEO_PLANE_ID', 'string', {parse: parsePlaneIdEnv}),
@@ -90,7 +92,7 @@ class ConfigBase extends ConfigProvider {
              * The turn-end hooks are thread-entrypoints: they bootstrap `Neo` + `core/_export` and
              * read these leaves at the use site, so these stay plain declarative leaves with no
              * companion defaults module. Measured: bootstrap plus resolve is ~50ms against the hook's
-             * 10s budget, so no twin indirection is warranted.
+             * 10s budget, so the extra indirection would buy nothing.
              * @member {Object} data.stopHook
              */
             stopHook: {

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -53,11 +53,14 @@ class ConfigBase extends ConfigProvider {
             projectRoot: leaf(projectRoot),
             /**
              * The declared plane-identity subtree — the first-class object the data-root
-             * placement election decides placement FOR. The literals below are declared FROM
-             * `ai/planeConfig.mjs`, a shared-constant module these leaves import: it holds the
-             * canonical id, the env-free data-root derivation, and the id parser the leaf binds
-             * as its own `parse` hook. It carries no resolver of its own and reads no env, so
-             * there is no second resolution path for these leaves to drift against.
+             * placement election decides placement FOR. These leaves declare FROM
+             * `ai/planeConfig.mjs`, which must never grow an env read or a resolver of its own:
+             * env binding belongs to the leaf, alone. A second resolution path beside the leaf
+             * is precisely what the retired shape was — two resolvers for one value, free to
+             * disagree — and it was removed, not shrunk: the exported defaults map and env-name
+             * map are both gone, and the one surviving constant crosses the boundary only
+             * because the boot coherence assertion must compare against the same literal this
+             * leaf declares. Growing that surface back re-creates the drift channel.
              * Three concepts, never conflated: `id` is opaque identity (no path/checkout content);
              * `dataRoot` is the resolved evidence every plane-member leaf derives from;
              * `NEO_AI_CANONICAL_ROOT` (provisioning-time, `bootstrapWorktree.mjs`) names a

--- a/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
+++ b/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
@@ -96,7 +96,7 @@ aiConfig.engines.chroma.database = `graph-service-test-${process.pid}-${Date.now
 ## 5. Sanctioned patterns (the fix, in one place)
 
 1. **Read at the use site:** `const dir = AiConfig.engines.chroma.dataDir;` — no export (B1), no once-used alias (B2), no `?.` (B3), no threading into other consumers (B5).
-2. **Leaves are declarative:** `leaf(default, env, type)`. No inline env-ternaries (A4), no `hasEnvValue` (A5).
+2. **Leaves are declarative:** `leaf(default, env, type, metadata)`. No inline env-ternaries (A4), no `hasEnvValue` (A5). A custom env parser rides **`metadata.parse`** — the only sanctioned way to declare one, and it overrides the type-derived parser. **A hand-written descriptor object (`name: {default, env, parse}`) is non-canonical**, and the cost is not stylistic: the config-path collector counts a descriptor as a leaf only when `default` + `env` + `type` are all present, so a hand-written one reads as a **namespace** — and the module-scope capture rule *passes* namespace captures while *failing* leaf captures, so the misread silently widens what B5 permits. (2026-07-25, `#15914` — `metadata.parse` was added precisely to remove the reason the descriptor form existed; it converted the four live instances.)
 3. **Formulas only for genuine computed values** — reactive on real deps. Never to re-derive a leaf (A6/A7) or for a plain path-join (A9); a path-under-root is a derivation, not a formula.
 4. **Tests isolate by construction** (`UNIT_TEST_MODE` → the config resolves the test DB). Never mutate the shared singleton (B4).
 5. **The C1×B5 sanctioned shape** (V-B-A'd against `dev` — most "daemon C1" sites are actually A1):


### PR DESCRIPTION
Resolves #15929

Two merged PRs changed how `ai/` config declarations are written, and neither swept the documentation describing them. **Both gaps are mine** — I authored the ADR §10.1 rewrite that retired the twin sanction, and I claimed this ADR clause in my own review of `#15914` rather than routing my documentation debt through the author's branch.

## What was wrong

**`ai/configBase.mjs` narrated a deleted architecture.** Five JSDoc lines still described the plane twin that `#15896` removed. The worst was line 57, and its problem was sharper than a stale reference: it cited **ADR-0019 §5.5** as the authority for the twin module shape. That section still resolves — but its own parenthetical now reads *"retires … the pure-defaults-twin shape it sanctioned"*. The comment cited, as its authority, the exact passage that abolished it.

Line 71 compounded the same sentence from a second direction: `#15914` converted that declaration from a raw descriptor object to `leaf(CANONICAL_PLANE_ID, 'NEO_PLANE_ID', 'string', {parse: parsePlaneIdEnv})`. So one sentence was wrong about the twin **and** about the shape, from two PRs neither of which touched it.

**ADR §5 item 2 documented a signature that can no longer express a sanctioned case.** It read `leaf(default, env, type)`. `#15914` added the fourth parameter, and that was the *enabler* rather than a cosmetic: before `metadata.parse` existed, a leaf needing a custom env parser had to be written as a raw descriptor object literal — and the config-path collector counts a descriptor as a leaf only when `default` + `env` + `type` are all present, so a hand-written one reads as a **namespace**.

That is not a stylistic misread. The module-scope capture rule **passes** namespace captures and **fails** leaf captures, so classifying a real leaf as a namespace silently widens what B5 permits. Nothing recorded that the descriptor form was non-canonical, so a future author reading §5 item 2, needing a custom parser, would reach for exactly the shape `#15914` removed.

## The fix

Replaced the twin narration with the shipped shape rather than deleting it — `ai/planeConfig.mjs` is a shared-constant module the leaves declare **from**, carrying no resolver of its own and reading no env, so there is no second resolution path to drift against.

**The ADR reference is dropped, not repointed.** The tempting minimal edit is to update the section number; it would re-rot on the next reshape, which is what `check-ticket-archaeology` exists to prevent. The behavior is fully statable without any ADR citation, so the `ticket-ref-ok` marker goes with it.

## Evidence

Evidence: L2 achieved (documentation-only change, verified non-moving against the config lint) → L2 required (no runtime surface). Residual: none.

```
$ grep -c "twin" ai/configBase.mjs
0

$ grep -c "ticket-ref-ok\|ADR 0019\|§5.5" ai/configBase.mjs
0

$ node ./ai/scripts/lint/lint-config-template-ssot.mjs
[lint-config-template-ssot] OK - 0 inline-env leaf default(s), 4 AiConfig implementation SSOT
hit(s), 4 module-scope AiConfig capture(s), 0 test config-authority violation(s), all
baselined or target-zero.
```

The lint run is the load-bearing one: a documentation-only change must leave the parity surface exactly where it was, and this proves it did.

ADR §5 item 2, after:

> **Leaves are declarative:** `leaf(default, env, type, metadata)`. … A custom env parser rides **`metadata.parse`** — the only sanctioned way to declare one, and it overrides the type-derived parser. **A hand-written descriptor object (`name: {default, env, parse}`) is non-canonical** …

## Test Evidence

No tests added or changed — this ships no behavior. The existing coverage for the surfaces it *describes* already landed with `#15914` (`ConfigProvider.spec.mjs` pins both the `metadata.parse` override and the env-free-leaf-stays-null case), and re-asserting it here would duplicate green CI rather than establish anything new.

The falsifier that matters for a docs change is the one above: the config lint proves the declared surface did not move.

## Deltas from ticket

**One, and it narrows the ticket's own framing.** In my `#15914` review I said this clause belonged in ADR **§3** (the antipattern catalog). Wrong home, and I corrected it while filing: §3 catalogues what not to do, but the actual gap was that the **sanctioned-patterns** list documented a signature that could no longer express a sanctioned case. §5 item 2 is where an author looks for the declaration form, so that is where the correction has to live. The ticket carries the corrected placement; this notes it because peers read the review, not just the ticket.

## Post-Merge Validation

None. No runtime surface, no deferred verification, no residual ACs — the config lint is reachable from this exact head and is green.

Out of scope by explicit decision, recorded so the absence is a judgment rather than an oversight: **no mechanical guard against raw descriptor objects.** This ticket documents; enforcement would need its own red proof and is a larger change. The related `isDescriptor` sensitivity (a descriptor missing `type` classifying as a namespace) is pre-existing, has zero live instances after `#15914`, and belongs with that guard.

Authored by Grace (Claude Opus 5, Claude Code). Session 26e73986-66fa-4d28-9b02-6053541a5671.
