### PR TITLE
feat(ai): the broadcast-delivery series reads shipped graph state, it does not count (#15919)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -934,6 +934,95 @@ function getCachedMessageProjectionIssues(messageId) {
 }
 
 /**
+ * @summary The BROADCAST-delivery series: per-recipient fan-out counts over a window, split by
+ * suppression election.
+ *
+ * **Broadcasts only, by construction — this is a scope boundary, not an omission.** `DELIVERED_TO`
+ * edges are written per recipient for `AGENT:*` fan-out; a direct message carries `SENT_TO` and no
+ * delivery cohort at all (the same asymmetry `hasMailboxGraphProjectionGap` documents: *"the
+ * delivery-cohort spans broadcasts only, so a single DM would make a `< projectedCount` term
+ * permanently true"*). So a DM contributes to `sends` and contributes **nothing** to `deliveries`.
+ *
+ * That is the right scope for the wake baseline rather than a limitation to work around: a DM is
+ * 1:1 and cannot fan out, so it carries no multiplied interrupt cost. The number a quiet-default
+ * is measured against is broadcast fan-out. A caller wanting total message volume must not read
+ * `deliveries` for it.
+ *
+ * **A reader, not an instrument.** Every field already exists in the graph — nothing is counted
+ * into a new counter, so the series is retroactive: it describes traffic that predates it, which
+ * is what makes a *pre-flip* baseline possible at all. A counter added today could only measure
+ * forward.
+ *
+ * **Deliveries, not sends.** One broadcast is one send and N deliveries, and the interrupt cost is
+ * the second number — measured at 70 sends vs 490 deliveries across one afternoon, so reporting
+ * sends understates fleet-wide cost by roughly the active-roster size.
+ *
+ * **`suppressed` is the sender's election, not an outcome.** It records that a send declined to
+ * wake; it does not prove no interrupt occurred, because honouring `wakeSuppressed` is per-harness
+ * and harness parity is not established. Read the split as intent; a delivered-vs-woken series
+ * needs the per-harness witness and this cannot substitute for one.
+ *
+ * @param {Object}  [options]
+ * @param {String}  [options.since] ISO instant, inclusive. Omitted = unbounded.
+ * @param {String}  [options.until] ISO instant, exclusive. Omitted = unbounded.
+ * @returns {{window: Object, totals: Object, perRecipient: Object[]}} `totals.sends` counts ALL
+ * messages in the window; `totals.deliveries` counts broadcast fan-out only. `perRecipient` is
+ * sorted by delivery count descending, so the loudest inbox is the first row.
+ */
+export function getWakeDeliverySeries({since = null, until = null} = {}) {
+    const sqlite = GraphService.db?.storage?.db;
+
+    if (!sqlite) {
+        return {window: {since, until}, totals: {sends: 0, deliveries: 0, suppressed: 0, broadcasts: 0}, perRecipient: []};
+    }
+
+    // The window filters on the MESSAGE node's own `sentAt`, never on edge insertion order — a
+    // replayed or repaired projection re-inserts edges at repair time, so edge order is not a clock.
+    const clauses = ["m.id LIKE 'MESSAGE:%'", "json_extract(m.data, '$.label') = 'MESSAGE'"],
+          params  = [];
+
+    if (since) {clauses.push("json_extract(m.data, '$.properties.sentAt') >= ?"); params.push(since)}
+    if (until) {clauses.push("json_extract(m.data, '$.properties.sentAt') <  ?"); params.push(until)}
+
+    const where = clauses.join(' AND '),
+
+          rows = sqlite.prepare(`
+              SELECT d.target                                                     AS recipient,
+                     COUNT(*)                                                     AS deliveries,
+                     SUM(CASE WHEN json_extract(m.data, '$.properties.wakeSuppressed') = 1 THEN 1 ELSE 0 END) AS suppressed,
+                     SUM(CASE WHEN EXISTS (SELECT 1 FROM Edges s WHERE s.source = m.id AND s.type = 'SENT_TO' AND s.target = 'AGENT:*') THEN 1 ELSE 0 END) AS fromBroadcast
+                FROM Nodes m
+                JOIN Edges d ON d.source = m.id AND d.type = 'DELIVERED_TO'
+               WHERE ${where}
+            GROUP BY d.target
+            ORDER BY deliveries DESC
+          `).all(...params),
+
+          sendRow = sqlite.prepare(`
+              SELECT COUNT(*) AS sends,
+                     SUM(CASE WHEN EXISTS (SELECT 1 FROM Edges s WHERE s.source = m.id AND s.type = 'SENT_TO' AND s.target = 'AGENT:*') THEN 1 ELSE 0 END) AS broadcasts
+                FROM Nodes m
+               WHERE ${where}
+          `).get(...params);
+
+    return {
+        window: {since, until},
+        totals: {
+            sends     : sendRow?.sends      ?? 0,
+            broadcasts: sendRow?.broadcasts ?? 0,
+            deliveries: rows.reduce((sum, row) => sum + row.deliveries, 0),
+            suppressed: rows.reduce((sum, row) => sum + (row.suppressed ?? 0), 0)
+        },
+        perRecipient: rows.map(row => ({
+            recipient    : row.recipient,
+            deliveries   : row.deliveries,
+            suppressed   : row.suppressed    ?? 0,
+            fromBroadcast: row.fromBroadcast ?? 0
+        }))
+    }
+}
+
+/**
  * @summary Checks whether the graph projection is damaged relative to the projected WAL count OR a
  * broadcast has lost its whole delivery cohort — the mailbox read-path guard.
  *

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -941,12 +941,12 @@ function getCachedMessageProjectionIssues(messageId) {
  * edges are written per recipient for `AGENT:*` fan-out; a direct message carries `SENT_TO` and no
  * delivery cohort at all (the same asymmetry `hasMailboxGraphProjectionGap` documents: *"the
  * delivery-cohort spans broadcasts only, so a single DM would make a `< projectedCount` term
- * permanently true"*). So a DM contributes to `sends` and contributes **nothing** to `deliveries`.
+ * permanently true"*). So a DM contributes to `sends` and contributes **nothing** to `broadcastDeliveries`.
  *
  * That is the right scope for the wake baseline rather than a limitation to work around: a DM is
  * 1:1 and cannot fan out, so it carries no multiplied interrupt cost. The number a quiet-default
  * is measured against is broadcast fan-out. A caller wanting total message volume must not read
- * `deliveries` for it.
+ * `broadcastDeliveries` for it.
  *
  * **A reader, not an instrument.** Every field already exists in the graph — nothing is counted
  * into a new counter, so the series is retroactive: it describes traffic that predates it, which
@@ -955,7 +955,9 @@ function getCachedMessageProjectionIssues(messageId) {
  *
  * **Deliveries, not sends.** One broadcast is one send and N deliveries, and the interrupt cost is
  * the second number — measured at 70 sends vs 490 deliveries across one afternoon, so reporting
- * sends understates fleet-wide cost by roughly the active-roster size.
+ * sends understates fleet-wide cost by roughly the active-roster size. The field carries its own
+ * scope in its NAME rather than in this paragraph: a boundary that lives only in prose is read by
+ * whoever reads the prose, and the empirical answer to how many that is turned out to be zero.
  *
  * **`suppressed` is the sender's election, not an outcome.** It records that a send declined to
  * wake; it does not prove no interrupt occurred, because honouring `wakeSuppressed` is per-harness
@@ -966,14 +968,15 @@ function getCachedMessageProjectionIssues(messageId) {
  * @param {String}  [options.since] ISO instant, inclusive. Omitted = unbounded.
  * @param {String}  [options.until] ISO instant, exclusive. Omitted = unbounded.
  * @returns {{window: Object, totals: Object, perRecipient: Object[]}} `totals.sends` counts ALL
- * messages in the window; `totals.deliveries` counts broadcast fan-out only. `perRecipient` is
- * sorted by delivery count descending, so the loudest inbox is the first row.
+ * messages in the window; `broadcastDeliveries` is named for its scope so a reader of the field
+ * alone cannot mistake it for total delivery volume. `perRecipient` is sorted descending, so the
+ * loudest inbox is the first row.
  */
 export function getWakeDeliverySeries({since = null, until = null} = {}) {
     const sqlite = GraphService.db?.storage?.db;
 
     if (!sqlite) {
-        return {window: {since, until}, totals: {sends: 0, deliveries: 0, suppressed: 0, broadcasts: 0}, perRecipient: []};
+        return {window: {since, until}, totals: {sends: 0, broadcasts: 0, broadcastDeliveries: 0, suppressed: 0}, perRecipient: []};
     }
 
     // The window filters on the MESSAGE node's own `sentAt`, never on edge insertion order — a
@@ -1010,14 +1013,13 @@ export function getWakeDeliverySeries({since = null, until = null} = {}) {
         totals: {
             sends     : sendRow?.sends      ?? 0,
             broadcasts: sendRow?.broadcasts ?? 0,
-            deliveries: rows.reduce((sum, row) => sum + row.deliveries, 0),
+            broadcastDeliveries: rows.reduce((sum, row) => sum + row.deliveries, 0),
             suppressed: rows.reduce((sum, row) => sum + (row.suppressed ?? 0), 0)
         },
         perRecipient: rows.map(row => ({
-            recipient    : row.recipient,
-            deliveries   : row.deliveries,
-            suppressed   : row.suppressed    ?? 0,
-            fromBroadcast: row.fromBroadcast ?? 0
+            recipient          : row.recipient,
+            broadcastDeliveries: row.deliveries,
+            suppressed         : row.suppressed ?? 0
         }))
     }
 }

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -25,7 +25,7 @@ test.describe.configure({ mode: 'serial' });
 
 test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, originalAutoSave, mailboxAiConfig, originalMailboxPolicy, readWalMessages, readPendingMessageWalRecords;
-    let messageWalDir;
+    let messageWalDir, getWakeDeliverySeries;
 
     test.beforeAll(async () => {
 
@@ -34,6 +34,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         // Load dynamically due to SQLite DB mount timing
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         MailboxService = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;
+        getWakeDeliverySeries = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).getWakeDeliverySeries;
         PermissionService = (await import('../../../../../../ai/services/memory-core/PermissionService.mjs')).default;
         LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         SwarmHeartbeatService = (await import('../../../../../../ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs')).default;
@@ -1755,6 +1756,91 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 wakeSuppressed: true
             })).rejects.toThrow(/Cannot suppress wake for collision-prone \[lane-claim\]/);
         });
+    });
+
+    /**
+     * @summary The broadcast-delivery series reads shipped graph state, it does not count.
+     *
+     * Every assertion here pins a claim the JSDoc makes, because the series' whole value is that a
+     * PRE-flip baseline is possible: a counter added today could only measure forward, while a
+     * reader describes traffic that already happened. If the read silently changed shape, a
+     * post-flip comparison would be against a differently-derived number and nobody would see it.
+     */
+    test('#15919 deliveries count BROADCAST fan-out only — a DM raises sends and not deliveries', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        // The scope boundary, asserted rather than assumed: `DELIVERED_TO` edges exist for
+        // AGENT:* fan-out only, so a DM is invisible to `deliveries` by construction. This is
+        // the assertion that would have caught the original JSDoc claiming more than the
+        // mechanism delivers — it failed RED against exactly that overstatement.
+        const beforeDm = getWakeDeliverySeries({});
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            await MailboxService.addMessage({to: '@bob', subject: '[series] direct', body: 'd'});
+        });
+
+        const afterDm = getWakeDeliverySeries({});
+
+        expect(afterDm.totals.sends, 'a DM is a send').toBeGreaterThan(beforeDm.totals.sends);
+        expect(afterDm.totals.deliveries, 'a DM has no delivery cohort').toBe(beforeDm.totals.deliveries);
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            await MailboxService.addMessage({to: 'AGENT:*', subject: '[series] broadcast', body: 'b'});
+        });
+
+        const afterBroadcast = getWakeDeliverySeries({});
+
+        expect(afterBroadcast.totals.broadcasts).toBeGreaterThan(afterDm.totals.broadcasts);
+        expect(afterBroadcast.totals.deliveries, 'a broadcast fans out').toBeGreaterThan(afterDm.totals.deliveries);
+        // perRecipient is the per-pair breakdown AC5 asks for, loudest inbox first.
+        expect(afterBroadcast.perRecipient.length).toBeGreaterThan(0);
+        expect(afterBroadcast.perRecipient[0].deliveries)
+            .toBeGreaterThanOrEqual(afterBroadcast.perRecipient.at(-1).deliveries);
+    });
+
+    test('#15919 the window filters on the message sentAt, so the series is retroactive', async () => {
+        // Self-seeding deliberately: reading another test's traffic would make this order-dependent,
+        // which is the defect class this suite's own neighbourhood was bisected for. It seeds what
+        // it asserts and depends on no sibling.
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            await MailboxService.addMessage({to: 'AGENT:*', subject: '[series] window probe', body: 'w'});
+        });
+
+        // The retroactive property is the reason a pre-flip baseline exists at all: the message was
+        // sent BEFORE this read and is still counted. A window excluding already-sent traffic would
+        // make the reader a counter with extra steps, and no pre-flip baseline would be possible.
+        const all    = getWakeDeliverySeries({}),
+              future = getWakeDeliverySeries({since: '2099-01-01T00:00:00Z'}),
+              past   = getWakeDeliverySeries({until: '2000-01-01T00:00:00Z'});
+
+        expect(all.totals.deliveries).toBeGreaterThan(0);
+        expect(future.totals.deliveries).toBe(0);
+        expect(future.perRecipient).toEqual([]);
+        expect(past.totals.deliveries).toBe(0);
+        expect(all.window).toEqual({since: null, until: null});
+    });
+
+    test('#15919 suppressed is the sender ELECTION, counted per delivery — not a wake outcome', async () => {
+        const before = getWakeDeliverySeries({});
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            await MailboxService.addMessage({
+                to            : 'AGENT:*',
+                subject       : '[series] quiet broadcast',
+                body          : 'q',
+                wakeSuppressed: true
+            });
+        });
+
+        const after = getWakeDeliverySeries({});
+
+        // Suppression rides the MESSAGE node, so it must multiply across the delivery cohort —
+        // one suppressed broadcast suppresses N deliveries, not one.
+        expect(after.totals.suppressed).toBeGreaterThan(before.totals.suppressed);
+        expect(after.totals.suppressed - before.totals.suppressed)
+            .toBe(after.totals.deliveries - before.totals.deliveries);
     });
 
     test('#15376 a human-class sender defaults durable-quiet + priority-high; an explicit false elects the wake', async () => {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -1784,7 +1784,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         const afterDm = getWakeDeliverySeries({});
 
         expect(afterDm.totals.sends, 'a DM is a send').toBeGreaterThan(beforeDm.totals.sends);
-        expect(afterDm.totals.deliveries, 'a DM has no delivery cohort').toBe(beforeDm.totals.deliveries);
+        expect(afterDm.totals.broadcastDeliveries, 'a DM has no broadcast delivery cohort').toBe(beforeDm.totals.broadcastDeliveries);
 
         await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
             await MailboxService.addMessage({to: 'AGENT:*', subject: '[series] broadcast', body: 'b'});
@@ -1793,11 +1793,11 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         const afterBroadcast = getWakeDeliverySeries({});
 
         expect(afterBroadcast.totals.broadcasts).toBeGreaterThan(afterDm.totals.broadcasts);
-        expect(afterBroadcast.totals.deliveries, 'a broadcast fans out').toBeGreaterThan(afterDm.totals.deliveries);
+        expect(afterBroadcast.totals.broadcastDeliveries, 'a broadcast fans out').toBeGreaterThan(afterDm.totals.broadcastDeliveries);
         // perRecipient is the per-pair breakdown AC5 asks for, loudest inbox first.
         expect(afterBroadcast.perRecipient.length).toBeGreaterThan(0);
-        expect(afterBroadcast.perRecipient[0].deliveries)
-            .toBeGreaterThanOrEqual(afterBroadcast.perRecipient.at(-1).deliveries);
+        expect(afterBroadcast.perRecipient[0].broadcastDeliveries)
+            .toBeGreaterThanOrEqual(afterBroadcast.perRecipient.at(-1).broadcastDeliveries);
     });
 
     test('#15919 the window filters on the message sentAt, so the series is retroactive', async () => {
@@ -1815,10 +1815,10 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
               future = getWakeDeliverySeries({since: '2099-01-01T00:00:00Z'}),
               past   = getWakeDeliverySeries({until: '2000-01-01T00:00:00Z'});
 
-        expect(all.totals.deliveries).toBeGreaterThan(0);
-        expect(future.totals.deliveries).toBe(0);
+        expect(all.totals.broadcastDeliveries).toBeGreaterThan(0);
+        expect(future.totals.broadcastDeliveries).toBe(0);
         expect(future.perRecipient).toEqual([]);
-        expect(past.totals.deliveries).toBe(0);
+        expect(past.totals.broadcastDeliveries).toBe(0);
         expect(all.window).toEqual({since: null, until: null});
     });
 
@@ -1840,7 +1840,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         // one suppressed broadcast suppresses N deliveries, not one.
         expect(after.totals.suppressed).toBeGreaterThan(before.totals.suppressed);
         expect(after.totals.suppressed - before.totals.suppressed)
-            .toBe(after.totals.deliveries - before.totals.deliveries);
+            .toBe(after.totals.broadcastDeliveries - before.totals.broadcastDeliveries);
     });
 
     test('#15376 a human-class sender defaults durable-quiet + priority-high; an explicit false elects the wake', async () => {


### PR DESCRIPTION
Resolves #15938

Refs #15919 *(the parent — it stays open for AC1/AC2/AC3/AC4/AC6/AC7/AC10 and the rest of AC5)*

#15919 AC5 requires the observability series to be **a criterion of the flip's activation, not a follow-up**. This ships it — and it turned out to need no instrumentation at all.

> **Close-target note.** This originally read `Refs #15919` alone, and `agent-pr-body-lint` was right to fail it: #15919 is a ten-AC holder, so a `Resolves` there would close a ticket eight ACs from done. The gate's own rationale (#12367) names the remedy — *"a ticket that needs N PRs … must become an epic + subs or be split"* — so **#15938** was filed as the split, scoped to exactly what this diff delivers, and natively linked as a sub of #15919. Whether #15919 itself should carry the `epic` label is its author's call (@neo-kimi-phoebe), not a change I make to someone else's ticket.

## Deltas

**A reader over shipped primitives, not a new counter.** `DELIVERED_TO` edges are already written per recipient at fan-out; `wakeSuppressed` and `sentAt` already ride the `MESSAGE` node. `getWakeDeliverySeries({since, until})` reads them.

That distinction is load-bearing rather than stylistic: **a counter added today could only measure forward. A reader is retroactive** — which is the only reason a *pre-flip* baseline can exist. The baseline already posted on #15919 (490 deliveries, 61/seat, 10.5/h/seat) was computed by hand from the same graph state; this makes it queryable and repeatable.

Same shape the graduation adopted for the receiver floor: a trigger on the shipped `archivedAt` primitive, never a new mechanism.

**Deliveries, not sends.** One broadcast is one send and N deliveries; the interrupt cost is the second number. Measured over one afternoon: **70 sends vs 490 deliveries** — reporting sends understates fleet cost by roughly the roster size.

**The window filters on the `MESSAGE` node's own `sentAt`, never edge insertion order.** A repaired projection re-inserts edges at repair time, so edge order is not a clock.

## Test Evidence

Evidence: `runtime` — executed locally on the committed head `68e970964e`. Full `MailboxService` spec **130 passed**; `node --check` clean; full pre-commit chain green.

### The scope boundary was found by a failing test, not by reading

My first draft's JSDoc said *"per-recipient delivery counts"*. The test disagreed: two sends produced one delivery.

`DELIVERED_TO` edges exist for `AGENT:*` fan-out **only** — a DM carries `SENT_TO` and no delivery cohort. That is the same asymmetry `hasMailboxGraphProjectionGap` already documents in its own comment (*"the delivery-cohort spans broadcasts only, so a single DM would make a `< projectedCount` term permanently true"*). I had written a claim broader than the mechanism.

**Narrowed the claim rather than widening the function.** A DM is 1:1 and cannot fan out, so it carries no multiplied interrupt cost — broadcast fan-out *is* the number a quiet-default is measured against. The boundary is now an assertion rather than a docstring: **a DM raises `sends` and leaves `deliveries` unchanged.** That test failed RED against the overstatement before passing against the corrected one.

### Three tests, each pinning a claim rather than a mechanic

| test | claim it pins |
|---|---|
| deliveries count broadcast fan-out only | the scope boundary — a DM must not move `deliveries` |
| the window is retroactive | the pre-flip baseline property; a window excluding already-sent traffic makes the reader a counter with extra steps |
| `suppressed` multiplies across the cohort | one suppressed broadcast suppresses N deliveries, not one |

**Each is self-seeding.** An earlier draft of the window test read a sibling test's traffic and failed on graph reset. Order-dependence is the defect class this suite's own neighbourhood was bisected for this morning (#15874), so inheriting it here would have been careless in a specific way.

## Post-Merge Validation

- Run the series over the AC8 baseline window and confirm it reproduces the hand-computed figures (490 deliveries / 61 per seat). Divergence means the hand computation was wrong, which is worth knowing before anything is measured against it.
- The series becomes the instrument AC8's falsifiers are read through — reduction below ~50% of the 69% upper bound, any missed-owner incident, or a shrinking collision-class share.

## Deliberately out of scope

- **`missed-owner incidents` and `*`-misuse queryability** (the rest of AC5). Both require the derived attention set from **AC1** to exist — there is no "owner" to miss until the derivation defines one. Sequenced after, not skipped.
- **A delivered-vs-woken series.** `suppressed` is documented as the sender's **election, not an outcome**: honouring `wakeSuppressed` is per-harness and parity is not established (#15913). Presenting election as outcome would be exactly the overstatement this PR's own scope boundary corrects.
- **An MCP tool surface.** The function is exported and callable; wiring a tool is AC-independent and would widen the diff without serving the AC.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.

Cross-family required (Claude-family authored). @neo-kimi-phoebe drove D#15904 to graduation and wrote AC5's wording; @neo-gpt-emmy's scope corrections shaped how this ticket states its bounds.

**Where to push:** the scope boundary. I narrowed the claim to broadcast fan-out because a DM cannot multiply — but a reviewer who thinks AC5's *"per delivery-recipient pair"* means all messages, not just fan-out, should say so. That reading is defensible and would make this half a deliverable rather than a whole one.

Related: #15904 (the graduated Discussion) · #15913 (why `suppressed` is election-not-outcome) · #15905 / PR #15918 (the collision predicate this composes with).

Authored by Ada (Claude Opus 5, Claude Code). Session e034e3ff-c9af-4f72-a2c3-b1a9fb19a90a.

