### PR TITLE
docs(agentos): A2A.md states where read-state lives, not just the delivery topology (#15936)

### DIFF
--- a/learn/agentos/A2A.md
+++ b/learn/agentos/A2A.md
@@ -65,6 +65,26 @@ edges such as `SENT_BY`, `SENT_TO`, and, for broadcasts, per-recipient
 threads, and concepts. `list_messages` reads that graph back with permission
 checks, read/archive filtering, and live pull-request echoes where available.
 
+Read and archive state therefore live in **two different places, by message
+kind**, and this is the fact most consumers get wrong. A broadcast needs
+per-recipient isolation — one seat reading it must not mark it read for everyone
+— so its `readAt` and `archivedAt` ride that seat's own `DELIVERED_TO` edge. A
+direct message has exactly one recipient and no delivery cohort to isolate, so
+its state rides the shared `MESSAGE` node instead.
+
+The consequence is what makes this worth knowing: **anything that reads one
+carrier is silently wrong about the other half of the traffic, and wrong in the
+quiet direction.** A probe that asks "does the `DELIVERED_TO` row carry a
+`readAt`?" finds no row at all for a direct message and reads that absence as
+"never persisted" rather than "wrong carrier" — a false negative, not an error.
+A counter over `DELIVERED_TO` under-reports directed traffic to zero rather than
+failing. Two independent consumers hit exactly these two failures within one hour
+on 2026-07-25 (`#15825`'s probe, `#15935`'s first delivery series), which is why
+the failure mode is stated here and not just the topology: knowing that
+`DELIVERED_TO` exists only for broadcasts does not tell you where the other half
+of the state lives, and the natural inference — that read-state rides the
+delivery edge — is correct for broadcasts and wrong for direct messages.
+
 Wake routing hangs off that durable write. `WakeSubscriptionService` evaluates
 graph deltas for subscriptions such as `SENT_TO_ME`, `TASK_STATE_CHANGED`,
 `PERMISSION_GRANTED`, and `HEARTBEAT_PULSE`. The wake layer may push through MCP


### PR DESCRIPTION
Resolves #15936

`learn/agentos/A2A.md` documented the delivery **topology** correctly and was silent on where read/archive **state** lives. That silence cost two consumers an hour apart on 2026-07-25, in opposite directions.

## What was already right — and why the ticket is narrower than it first looked

My first framing was going to be *"document the `DELIVERED_TO` asymmetry."* Checking before filing killed it: `A2A.md:63` already says it, verbatim — *"and, **for broadcasts**, per-recipient `DELIVERED_TO` edges."* Correct, consumer-facing, in the paragraph a consumer actually reads. **@neo-opus-ada and I had both simply not read it.**

Filing at the layer where the pain was felt would have shipped a PR adding a sentence already present, leaving the real gap open.

## The real gap

```
$ git show origin/dev:learn/agentos/A2A.md | grep -c "readAt|read-state|archivedAt"
0
$ rg -l "MESSAGE.readAt|shared read-state" learn/
(no matches)
```

Knowing `DELIVERED_TO` is broadcast-only does **not** tell you where a direct message's read-state lives. The natural inference from the documented topology — *read-state rides the delivery edge* — is correct for broadcasts and wrong for DMs.

| message kind | read/archive carrier | why |
|---|---|---|
| broadcast (`to: 'AGENT:*'`) | that recipient's `DELIVERED_TO` edge | needs per-recipient isolation |
| direct (`to: '@seat'`) | the shared `MESSAGE` node | one recipient, no cohort to isolate |

## Why the failure mode is stated, not just the split

Because the split alone would have stopped neither of us. Both consumers knew the topology; both inferred the carrier from it. What was needed was the consequence:

- **#15825** (mine) — the probe asks *"does the `DELIVERED_TO` storage row carry the `readAt`?"* and treats a missing row as *"never persisted → a write-skip route remains."* For a DM there is no row **by design**, so it reports a route that does not exist while the actual carrier goes uninspected. Corrected on the ticket before @neo-fable-clio spent a reproduction on it.
- **PR #15935** (@neo-opus-ada) — a JSDoc claimed *"per-recipient delivery counts."* A failing test disagreed: two sends, one delivery. Narrowed the claim and made the boundary an assertion.

Both failed **quietly**: a false negative and an under-count, not an error. That is the sentence the doc was missing.

## Evidence

Evidence: L2 achieved (documentation-only; the claims are verified against the implementation and against live storage) → L2 required. Residual: none.

Implementation anchors behind each claim:

- `MailboxService._projectMessageWalRecord` creates `DELIVERED_TO` only under `if (to === 'AGENT:*')`, stamped `deliveryKind: 'broadcast'`.
- The listing path matches `SENT_TO` with `deliveryEdge = null` — a DM has no per-recipient delivery edge to carry state.

Live storage on one seat, which is what made the split visible rather than inferred:

```
DELIVERED_TO → @neo-opus-grace   918 rows   15 readAt   903 unread
SENT_TO      → @neo-opus-grace   322 rows    0 readAt   322 unread
MESSAGE nodes (all)             6795 rows  2209 readAt
903 + 322 = 1225   vs a reported unreadCount of 1259 (rest arrived mid-measurement)
```

The `0 of 322` is the design, not a defect — and is exactly the number that gets misread as one without this paragraph.

## Test Evidence

No tests. This is prose describing shipped behavior; the behavior itself is covered by `MailboxService.ReceiptDurability.spec.mjs` and the mailbox suite, and re-asserting it here would duplicate green CI rather than establish anything.

The falsifier that fits a documentation change is the grep, and it is in the AC list: `readAt` occurrences in `A2A.md` go `0 → 2`, `archivedAt` `0 → 1`.

## Deltas from ticket

None. The ticket was authored after the check that reshaped it, so its scope and this diff agree.

## Post-Merge Validation

None — no runtime surface.

Out of scope by explicit decision: **a mechanical guard** (a lint flagging `DELIVERED_TO` reads without a kind branch). Plausible successor, needs its own red proof, and documentation is the cheap first move for a fact that has bitten twice rather than twenty times. Recorded so the absence is a judgment rather than an oversight.

Authored by Grace (Claude Opus 5, Claude Code). Session 26e73986-66fa-4d28-9b02-6053541a5671.
