### PR TITLE
fix(ai): one structural reader for collision tags — the fleet activity copy stops undercounting claims (#15925)

### DIFF
--- a/ai/services/fleet/fleetA2AActivityAdapter.mjs
+++ b/ai/services/fleet/fleetA2AActivityAdapter.mjs
@@ -2,7 +2,8 @@ import {
     createFleetCockpitEvent,
     FLEET_COCKPIT_SOURCES
 } from '../../../src/ai/fleet/fleetCockpitStatus.mjs'
-import {redactCredentials} from './redactCredentials.mjs'
+import {collisionPreventionTag} from '../shared/a2aCollisionTags.mjs'
+import {redactCredentials}      from './redactCredentials.mjs'
 
 /**
  * @module ai/services/fleet/fleetA2AActivityAdapter
@@ -12,11 +13,14 @@ import {redactCredentials} from './redactCredentials.mjs'
  * singleton directly, so callers keep ownership of identity binding and read permissions. It never
  * copies full message bodies into the cockpit DTO; the operator surface gets sender, recipient class,
  * subject/status metadata, related ticket ids, timestamps, and a source label only.
+ *
+ * Lane-claim detection rides the shared structural reader (`a2aCollisionTags`) — the same definition
+ * the wake guard uses, so the two surfaces can never drift again. The adapter's question stays NARROW:
+ * only `lane-claim` sets the flag; the wider collision class (`review-claim`, `claim-corrected`,
+ * `drive-claimed`) is the guard's business, not the activity projection's.
  */
 
 export const DEFAULT_FLEET_A2A_ACTIVITY_EVENT_LIMIT = 50
-
-const LANE_CLAIM_SUBJECT = /^\s*\[lane-claim\]/i
 
 /**
  * @summary Read recent A2A mailbox summaries through a Memory Core-owned read path and map them into
@@ -188,7 +192,7 @@ function normalizeA2AMessage(message, capturedAt) {
         taskState          : message.task?.state || null,
         wakeSuppressed     : Boolean(message.wakeSuppressed),
         occurredAt         : toIsoString(message.sentAt || message.createdAt, capturedAt),
-        isLaneClaim        : LANE_CLAIM_SUBJECT.test(subject || '')
+        isLaneClaim        : collisionPreventionTag({subject, taggedConcepts: message.taggedConcepts}) === 'lane-claim'
     }
 }
 

--- a/ai/services/fleet/fleetA2AActivityAdapter.mjs
+++ b/ai/services/fleet/fleetA2AActivityAdapter.mjs
@@ -192,7 +192,10 @@ function normalizeA2AMessage(message, capturedAt) {
         taskState          : message.task?.state || null,
         wakeSuppressed     : Boolean(message.wakeSuppressed),
         occurredAt         : toIsoString(message.sentAt || message.createdAt, capturedAt),
-        isLaneClaim        : collisionPreventionTag({subject, taggedConcepts: message.taggedConcepts}) === 'lane-claim'
+        // Classify the RAW subject: the display form above is whitespace-collapsed and truncated,
+        // and the reader's grammar is segments and length — normalizing the evidence first can
+        // erase a claim that opens a later line or lands past the display boundary.
+        isLaneClaim        : collisionPreventionTag({subject: message.subject, taggedConcepts: message.taggedConcepts}) === 'lane-claim'
     }
 }
 

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -6,6 +6,7 @@ import {canonicalizeTaggedConceptIds}           from '../graph/conceptSpineCanon
 import GraphService                             from './GraphService.mjs';
 import PermissionService                        from './PermissionService.mjs';
 import WakeSubscriptionService                  from './WakeSubscriptionService.mjs';
+import {collisionPreventionTag}                 from '../shared/a2aCollisionTags.mjs';
 import {
     TASK_ASSIGNMENT_AUTHORITY,
     TASK_STATES,
@@ -51,71 +52,9 @@ const
 
 // Collision-prevention substrate: the wake IS the point — a mid-session peer learns "don't take this"
 // only if the signal wakes them. None of these is ever an allowed wake suppression (broadcast OR
-// direct); plain lane-progress / FYI / ack broadcasts stay suppressible.
-//
-// A SET, not a regex, because a census of the live broadcast corpus showed the class is wider than
-// `[lane-claim]` and grows: a review SEAT is claimable — an observed collision had two families claim
-// the same seat on the same head 18 minutes apart — and a RELEASE is exactly as collision-relevant as
-// a claim, since silencing it leaves a free lane looking taken. Adding a member must never require
-// editing a matcher.
-const COLLISION_PREVENTION_TAGS = new Set([
-    'lane-claim',      // a work lane
-    'review-claim',    // a review seat — same collision, different vocabulary
-    'claim-corrected', // a RELEASE: the lane is free again
-    'drive-claimed'    // an ideation/coordination drive
-]);
-
-/**
- * @summary Returns the collision-prevention tag a message carries, or `null`.
- *
- * **Structural, never lexical.** The predecessor was `/^\s*\[lane-claim\]/i` and it was wrong twice
- * over: `^`-anchored, so the fleet's own `[ticket-created][lane-claim][#N]` convention walked past it —
- * 8 of 15 live claims unguarded — and substring-matching would have been worse, forcing every message
- * *discussing* lane-claims to wake. The predicate must separate "this message IS a claim" from
- * "this message MENTIONS claims", which no subject regex can: both contain the same characters.
- *
- * So a tag counts only inside a bracket run that OPENS a segment. Segments split on the separators the
- * fleet actually uses to concatenate two announcements into one subject (`·`, `|`, newline), which is
- * why a trailing `… · [ticket-created][lane-claim][#N] …` still registers while `the [lane-claim] guard`
- * in prose does not.
- *
- * `taggedConcepts` is checked FIRST and is the preferred signal — it is declared data rather than prose
- * a parser must interpret. The subject path is the transitional fallback for senders that carry no
- * structural signal; it is not the contract.
- *
- * @param {Object}   args
- * @param {String}   [args.subject='']
- * @param {String[]} [args.taggedConcepts=[]]
- * @returns {String|null} the matched tag name, or `null`
- * @private
- */
-function collisionPreventionTag({subject = '', taggedConcepts = []} = {}) {
-    for (const concept of taggedConcepts) {
-        const name = String(concept).trim().toLowerCase();
-
-        if (COLLISION_PREVENTION_TAGS.has(name)) {
-            return name;
-        }
-    }
-
-    for (const segment of String(subject).split(/[·|\n]/)) {
-        const run = segment.match(/^\s*(?:\[[^\]]*\]\s*)+/);
-
-        if (!run) {
-            continue;
-        }
-
-        for (const match of run[0].matchAll(/\[([^\]]*)\]/g)) {
-            const name = match[1].trim().toLowerCase();
-
-            if (COLLISION_PREVENTION_TAGS.has(name)) {
-                return name;
-            }
-        }
-    }
-
-    return null;
-}
+// direct); plain lane-progress / FYI / ack broadcasts stay suppressible. The tag vocabulary and the
+// structural reader live in `ai/services/shared/a2aCollisionTags.mjs` — one definition for every
+// consumer (this guard fires on ANY class member; narrower surfaces compare the returned tag name).
 
 /**
  * The principal classes an AgentIdentity node may carry in `properties.accountType`. Anything
@@ -412,7 +351,7 @@ function isAllowedWakeSuppression({subject = '', taggedConcepts = [], to}) {
  * is safe. `wakeSuppressed` is honored downstream by the wake substrate; this guard sits at message
  * acceptance so known-actionable messages — actionable DIRECT subjects, high-priority/task direct
  * messages, AND the collision-prevention CLASS (broadcast or direct) — cannot silently become
- * mailbox-only. See `COLLISION_PREVENTION_TAGS` for the class; it is deliberately not one tag.
+ * mailbox-only. See `ai/services/shared/a2aCollisionTags.mjs` for the class; it is deliberately not one tag.
  * @param {Object} args
  * @param {Boolean} args.wakeSuppressed
  * @param {String} args.to

--- a/ai/services/shared/a2aCollisionTags.mjs
+++ b/ai/services/shared/a2aCollisionTags.mjs
@@ -1,0 +1,80 @@
+/**
+ * @module ai/services/shared/a2aCollisionTags
+ * @summary The single structural reader for A2A collision-prevention tags — one definition, shared
+ * by every consumer that must separate "this message IS a claim" from "this message MENTIONS claims".
+ *
+ * A SET, not a regex, because a census of the live broadcast corpus showed the class is wider than
+ * `[lane-claim]` and grows: a review SEAT is claimable — an observed collision had two families claim
+ * the same seat on the same head 18 minutes apart — and a RELEASE is exactly as collision-relevant as
+ * a claim, since silencing it leaves a free lane looking taken. Adding a member must never require
+ * editing a matcher.
+ *
+ * Centralized here (the `storeWriteGuard` precedent) because the class definition had already been
+ * copy-pasted into two services, and a fix in one place left the other wrong: the wake guard was
+ * repaired while a fleet-activity copy of the old anchored regex kept undercounting live claims.
+ * A tag that lives in two places drifts.
+ */
+
+/**
+ * The collision-prevention tag vocabulary. Membership is owned here and only here; consumers decide
+ * per-surface how WIDE their own question is (the wake guard fires on any member; fleet activity
+ * counts only `lane-claim`) by comparing against the returned tag name.
+ * @type {Set<String>}
+ */
+export const COLLISION_PREVENTION_TAGS = new Set([
+    'lane-claim',      // a work lane
+    'review-claim',    // a review seat — same collision, different vocabulary
+    'claim-corrected', // a RELEASE: the lane is free again
+    'drive-claimed'    // an ideation/coordination drive
+]);
+
+/**
+ * @summary Returns the collision-prevention tag a message carries, or `null`.
+ *
+ * **Structural, never lexical.** The predecessor was `/^\s*\[lane-claim\]/i` and it was wrong twice
+ * over: `^`-anchored, so the fleet's own `[ticket-created][lane-claim][#N]` convention walked past it —
+ * 8 of 15 live claims unguarded — and substring-matching would have been worse, forcing every message
+ * *discussing* lane-claims to wake. The predicate must separate "this message IS a claim" from
+ * "this message MENTIONS claims", which no subject regex can: both contain the same characters.
+ *
+ * So a tag counts only inside a bracket run that OPENS a segment. Segments split on the separators the
+ * fleet actually uses to concatenate two announcements into one subject (`·`, `|`, newline), which is
+ * why a trailing `… · [ticket-created][lane-claim][#N] …` still registers while `the [lane-claim] guard`
+ * in prose does not.
+ *
+ * `taggedConcepts` is checked FIRST and is the preferred signal — it is declared data rather than prose
+ * a parser must interpret. The subject path is the transitional fallback for senders that carry no
+ * structural signal; it is not the contract.
+ *
+ * @param {Object}   args
+ * @param {String}   [args.subject='']
+ * @param {String[]} [args.taggedConcepts=[]]
+ * @returns {String|null} the matched tag name, or `null`
+ */
+export function collisionPreventionTag({subject = '', taggedConcepts = []} = {}) {
+    for (const concept of taggedConcepts) {
+        const name = String(concept).trim().toLowerCase();
+
+        if (COLLISION_PREVENTION_TAGS.has(name)) {
+            return name;
+        }
+    }
+
+    for (const segment of String(subject).split(/[·|\n]/)) {
+        const run = segment.match(/^\s*(?:\[[^\]]*\]\s*)+/);
+
+        if (!run) {
+            continue;
+        }
+
+        for (const match of run[0].matchAll(/\[([^\]]*)\]/g)) {
+            const name = match[1].trim().toLowerCase();
+
+            if (COLLISION_PREVENTION_TAGS.has(name)) {
+                return name;
+            }
+        }
+    }
+
+    return null;
+}

--- a/ai/services/shared/a2aCollisionTags.mjs
+++ b/ai/services/shared/a2aCollisionTags.mjs
@@ -16,12 +16,14 @@
  */
 
 /**
- * The collision-prevention tag vocabulary. Membership is owned here and only here; consumers decide
- * per-surface how WIDE their own question is (the wake guard fires on any member; fleet activity
- * counts only `lane-claim`) by comparing against the returned tag name.
+ * The collision-prevention tag vocabulary. PRIVATE to this module — the consumed contract is the
+ * reader below, never the Set: an exported mutable Set lets any importer rewrite every consumer's
+ * classifier at once (`.delete()` is a silent global veto). Consumers decide per-surface how WIDE
+ * their own question is (the wake guard fires on any member; fleet activity counts only
+ * `lane-claim`) by comparing against the returned tag name.
  * @type {Set<String>}
  */
-export const COLLISION_PREVENTION_TAGS = new Set([
+const COLLISION_PREVENTION_TAGS = new Set([
     'lane-claim',      // a work lane
     'review-claim',    // a review seat — same collision, different vocabulary
     'claim-corrected', // a RELEASE: the lane is free again

--- a/test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs
@@ -27,18 +27,18 @@ import {FLEET_COCKPIT_SOURCES} from '../../../../../../src/ai/fleet/fleetCockpit
 test.describe('fleetA2AActivityAdapter - Memory Core A2A activity mapping', () => {
     test('maps mailbox summaries without exposing bodies or exact recipient ids', () => {
         const [event] = createA2AMessageActivityEvents([{
-            messageId     : 'MESSAGE:123',
-            subject       : '[review-request] PR #14703 token=secret',
-            body          : 'full body ghp_secret must not reach the cockpit',
-            bodyText      : 'full body ghp_secret must not reach the cockpit',
-            from          : '@neo-opus-ada',
-            to            : '@neo-gpt',
-            priority      : 'normal',
-            sentAt        : '2026-07-04T06:00:00Z',
-            relatedTickets: ['#14572', '#14703'],
+            messageId          : 'MESSAGE:123',
+            subject            : '[review-request] PR #14703 token=secret',
+            body               : 'full body ghp_secret must not reach the cockpit',
+            bodyText           : 'full body ghp_secret must not reach the cockpit',
+            from               : '@neo-opus-ada',
+            to                 : '@neo-gpt',
+            priority           : 'normal',
+            sentAt             : '2026-07-04T06:00:00Z',
+            relatedTickets     : ['#14572', '#14703'],
             relatedPullRequests: [{number: 14703}],
-            task          : {state: 'Submitted', input: 'secret=hidden'},
-            wakeSuppressed: true
+            task               : {state: 'Submitted', input: 'secret=hidden'},
+            wakeSuppressed     : true
         }])
 
         expect(event).toMatchObject({
@@ -48,15 +48,15 @@ test.describe('fleetA2AActivityAdapter - Memory Core A2A activity mapping', () =
             confidence: 'observed',
             occurredAt: '2026-07-04T06:00:00.000Z',
             payload   : {
-                kind              : 'a2a-message',
-                messageId         : 'MESSAGE:123',
-                from              : 'neo-opus-ada',
-                recipientClass    : 'agent',
-                relatedTickets    : [14572, 14703],
+                kind               : 'a2a-message',
+                messageId          : 'MESSAGE:123',
+                from               : 'neo-opus-ada',
+                recipientClass     : 'agent',
+                relatedTickets     : [14572, 14703],
                 relatedPullRequests: [14703],
-                status            : 'unread',
-                taskState         : 'Submitted',
-                wakeSuppressed    : true
+                status             : 'unread',
+                taskState          : 'Submitted',
+                wakeSuppressed     : true
             }
         })
 
@@ -140,6 +140,38 @@ test.describe('fleetA2AActivityAdapter - Memory Core A2A activity mapping', () =
         }
     })
 
+    test('classifies the RAW subject — a claim opening a later line still counts (representation boundary)', () => {
+        // The display subject is whitespace-collapsed; the reader's grammar is segments, so a
+        // claim that opens a later LINE must be judged before normalization, not after.
+        const [event] = createA2AMessageActivityEvents([{
+            messageId: 'MESSAGE:newline',
+            subject  : '[merge-eligible][PR #15926] film lane 3 approved at head\n[lane-claim][#15925] the fleet activity regex copy',
+            from     : '@neo-fable',
+            to       : 'AGENT:*',
+            sentAt   : '2026-07-25T19:00:00Z'
+        }])
+
+        expect(event.type).toBe('lane-claim');
+        expect(event.payload.kind).toBe('a2a-lane-claim')
+    });
+
+    test('classifies the RAW subject — a claim past the 180-char display boundary still counts (representation boundary)', () => {
+        // The display subject truncates at 180; a trailing claim segment lives beyond it.
+        const filler  = 'x'.repeat(200),
+              [event] = createA2AMessageActivityEvents([{
+                  messageId: 'MESSAGE:truncated',
+                  subject  : `[merged][PR #15926] ${filler} · [lane-claim][#15925] the fleet activity regex copy`,
+                  from     : '@neo-opus-grace',
+                  to       : 'AGENT:*',
+                  sentAt   : '2026-07-25T19:30:00Z'
+              }]);
+
+        expect(event.type).toBe('lane-claim');
+        expect(event.payload.kind).toBe('a2a-lane-claim');
+        // …and the payload keeps the SAFE display form: collapsed, redacted, truncated.
+        expect(event.payload.subject.length).toBeLessThanOrEqual(180)
+    })
+
     test('sorts newest first, applies timestamp bounds, and limits events', () => {
         const snapshot = createFleetA2AActivitySnapshot({
             capturedAt: '2026-07-04T06:10:00Z',
@@ -180,9 +212,9 @@ test.describe('fleetA2AActivityAdapter - Memory Core A2A activity mapping', () =
         const seenArgs = []
 
         const snapshot = await readFleetA2AActivitySnapshot({
-            capturedAt : '2026-07-04T06:12:00Z',
-            limit      : 2,
-            listArgs   : {box: 'inbox', status: 'unread', includeArchived: false},
+            capturedAt  : '2026-07-04T06:12:00Z',
+            limit       : 2,
+            listArgs    : {box: 'inbox', status: 'unread', includeArchived: false},
             listMessages: async(args) => {
                 seenArgs.push(args)
 
@@ -213,7 +245,7 @@ test.describe('fleetA2AActivityAdapter - Memory Core A2A activity mapping', () =
             capturedAt: '2026-07-04T06:12:00Z'
         })
         const failed = await readFleetA2AActivitySnapshot({
-            capturedAt : '2026-07-04T06:12:00Z',
+            capturedAt  : '2026-07-04T06:12:00Z',
             listMessages: async() => {
                 throw new Error('Memory Core token=secret unavailable')
             }

--- a/test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs
@@ -90,6 +90,56 @@ test.describe('fleetA2AActivityAdapter - Memory Core A2A activity mapping', () =
         })
     })
 
+    test('counts lane-claims in NON-leading tag position — the real-corpus bypass class (#15925)', () => {
+        // The fleet writes compound claims — `[ticket-created][lane-claim][#N] …` — and the
+        // ^-anchored regex read all eight of these as plain activity. Fixtures: three verbatim
+        // from the wake-guard census reproducer, five live sends from the 2026-07-25 mailbox.
+        const bypassSubjects = [
+            '[ticket-created][lane-claim][#15900] ai:config-print',
+            '[ticket-created][lane-claim][#15886] the ESM-module-cache pollution class',
+            '[ticket-created][lane-claim][#15875] the AC5 crash root-caused',
+            '[ticket-created][lane-claim][#15923] vessel theme propagation — claimed 16:48Z; also: the ticket was still ASSIGNED to @neo-fable, third field/message divergence today',
+            '[ticket-created][lane-claim][#15915] the film found engine defect #3 — false re-entry across the proxy-identity swap stillbirths tear-out vessels; 14-cell matrix pinned it, mine to fix',
+            '[ticket-created][lane-claim][#15905] the wake guard\'s lane-claim predicate — filed on Phoebe\'s split-nod, mine to fix. And the OBVIOUS fix is falsified in the body',
+            '[ticket-created][lane-claim][#15932] PLANE_MEMBER_PATHS is guarded by a pinned count, not the config tree — #15872 is its first confirmed instance',
+            '[ticket-created][lane-claim][#15923] operator glitch-review of film v0 → the vessel renders its pane UNSTYLED (popout shell drops the theme) — first defect only visible now that frames exist'
+        ]
+
+        for (const [index, subject] of bypassSubjects.entries()) {
+            const [event] = createA2AMessageActivityEvents([{
+                messageId: `MESSAGE:bypass-${index}`,
+                subject,
+                from     : '@neo-opus-grace',
+                to       : 'AGENT:*',
+                sentAt   : '2026-07-25T16:00:00Z'
+            }])
+
+            expect(event.type, `non-leading claim must count: ${subject}`).toBe('lane-claim');
+            expect(event.payload.kind).toBe('a2a-lane-claim')
+        }
+    })
+
+    test('does NOT count a subject that merely MENTIONS [lane-claim] in prose (#15925)', () => {
+        // The unanchored-substring trap the class was built against: discussing claims ≠ claiming.
+        const mentionSubjects = [
+            '[falsifier-positive][D#15904] the [lane-claim] guard is ^-anchored — 53% of LIVE lane-claims bypass #14100 today',
+            '[ticket-created ×2][#15933 + #15934] lane 4 claimed + the secondary-display engine defect promoted'
+        ]
+
+        for (const subject of mentionSubjects) {
+            const [event] = createA2AMessageActivityEvents([{
+                messageId: 'MESSAGE:mention',
+                subject,
+                from     : '@neo-opus-ada',
+                to       : 'AGENT:*',
+                sentAt   : '2026-07-25T17:00:00Z'
+            }])
+
+            expect(event.type, `prose mention must NOT count: ${subject}`).toBe('a2a-activity');
+            expect(event.payload.kind).toBe('a2a-message')
+        }
+    })
+
     test('sorts newest first, applies timestamp bounds, and limits events', () => {
         const snapshot = createFleetA2AActivitySnapshot({
             capturedAt: '2026-07-04T06:10:00Z',

--- a/test/playwright/unit/ai/services/shared/a2aCollisionTags.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/a2aCollisionTags.spec.mjs
@@ -1,0 +1,50 @@
+import {test, expect} from '@playwright/test'
+import {
+    COLLISION_PREVENTION_TAGS,
+    collisionPreventionTag
+} from '../../../../../../ai/services/shared/a2aCollisionTags.mjs'
+
+/**
+ * @summary Contract suite for the shared collision-tag reader — the structural rules both consumers
+ * (the wake guard, fleet activity) depend on: declared concepts beat prose, a tag counts only inside
+ * a segment-opening bracket run, and the class vocabulary lives in exactly one Set.
+ */
+test.describe('a2aCollisionTags — the structural reader', () => {
+    test('taggedConcepts wins over prose and needs no subject at all', () => {
+        expect(collisionPreventionTag({subject: 'anything at all', taggedConcepts: ['lane-claim']}))
+            .toBe('lane-claim');
+        expect(collisionPreventionTag({subject: '', taggedConcepts: ['  Review-Claim  ']}))
+            .toBe('review-claim');
+        expect(collisionPreventionTag({subject: 'the [lane-claim] guard in prose', taggedConcepts: ['unrelated']}))
+            .toBeNull()
+    });
+
+    test('a tag counts inside a segment-opening bracket run, leading or not', () => {
+        expect(collisionPreventionTag({subject: '[lane-claim][#15919] T1 wake-side'}))
+            .toBe('lane-claim');
+        expect(collisionPreventionTag({subject: '[ticket-created][lane-claim][#15900] ai:config-print'}))
+            .toBe('lane-claim');
+        expect(collisionPreventionTag({subject: '[merged][PR #15926] film lane 3 landed · [lane-claim][#15925] regex copy'}))
+            .toBe('lane-claim')
+    });
+
+    test('prose mentions never count — the IS-vs-MENTIONS boundary', () => {
+        expect(collisionPreventionTag({subject: '[falsifier-positive][D#15904] the [lane-claim] guard is ^-anchored'}))
+            .toBeNull();
+        expect(collisionPreventionTag({subject: 'a subject discussing [lane-claim] mid-sentence'}))
+            .toBeNull();
+        expect(collisionPreventionTag({subject: '[ticket-created ×2][#15933 + #15934] lane 4 claimed'}))
+            .toBeNull()
+    });
+
+    test('the class vocabulary is the owned Set, all four members reachable', () => {
+        expect(COLLISION_PREVENTION_TAGS.size).toBe(4);
+
+        for (const tag of COLLISION_PREVENTION_TAGS) {
+            expect(collisionPreventionTag({subject: `[${tag}][#1] x`})).toBe(tag)
+        }
+
+        expect(collisionPreventionTag({subject: '[not-a-tag][#1] x'})).toBeNull();
+        expect(collisionPreventionTag({})).toBeNull()
+    });
+});

--- a/test/playwright/unit/ai/services/shared/a2aCollisionTags.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/a2aCollisionTags.spec.mjs
@@ -1,13 +1,10 @@
-import {test, expect} from '@playwright/test'
-import {
-    COLLISION_PREVENTION_TAGS,
-    collisionPreventionTag
-} from '../../../../../../ai/services/shared/a2aCollisionTags.mjs'
+import {test, expect}           from '@playwright/test'
+import {collisionPreventionTag} from '../../../../../../ai/services/shared/a2aCollisionTags.mjs'
 
 /**
  * @summary Contract suite for the shared collision-tag reader — the structural rules both consumers
  * (the wake guard, fleet activity) depend on: declared concepts beat prose, a tag counts only inside
- * a segment-opening bracket run, and the class vocabulary lives in exactly one Set.
+ * a segment-opening bracket run, and the vocabulary is exercised ONLY through the reader.
  */
 test.describe('a2aCollisionTags — the structural reader', () => {
     test('taggedConcepts wins over prose and needs no subject at all', () => {
@@ -37,10 +34,10 @@ test.describe('a2aCollisionTags — the structural reader', () => {
             .toBeNull()
     });
 
-    test('the class vocabulary is the owned Set, all four members reachable', () => {
-        expect(COLLISION_PREVENTION_TAGS.size).toBe(4);
-
-        for (const tag of COLLISION_PREVENTION_TAGS) {
+    test('the vocabulary is reachable only through the reader — all four canonical names', () => {
+        // The Set itself is private by contract (a mutable export lets any importer veto the
+        // class globally); the four canonical names pin today's vocabulary via the public API.
+        for (const tag of ['lane-claim', 'review-claim', 'claim-corrected', 'drive-claimed']) {
             expect(collisionPreventionTag({subject: `[${tag}][#1] x`})).toBe(tag)
         }
 


### PR DESCRIPTION
Resolves #15925

Fleet activity's lane-claim classification was the second copy of the `^`-anchored regex the wake guard retired in #15918 — 8 of 15 real claims read as plain activity. This PR removes the copy at the class level: **one structural reader, one home, both consumers.**

Evidence: L2 achieved (CI-reachable unit specs incl. the 8 real-corpus bypass fixtures + the structural-reader contract spec; guard suites 135/135 prove the extraction is behavior-preserving) → L2 required (the ACs are classification semantics, fully covered by unit specs). Residual: none.

## Deltas from ticket

**One, on the shape.** The ticket recommends a shared export from `MailboxService`; this PR extracts to `ai/services/shared/a2aCollisionTags.mjs` instead. Deciding fact the ticket predates: the adapter's module doc forbids importing the service singleton, so the recommended import would fix a duplication by violating the consumer's decoupling contract. The AC's substance — exactly one definition of the class — is fully honored.

**One, on fixture provenance.** The AC asks for "the 8 bypassing census subjects, verbatim"; the verbatim 8 do not exist in the record (#15905 carries 3 in its reproducer). The fixture set is those 3 verbatim + 5 live sends from the 2026-07-25 mailbox, disclosed rather than reconstructed silently.

## The shape decision (the ticket's own deliverable)

Three shapes weighed, one new fact deciding:

- **Shared export from `MailboxService`** (the ticket's recommendation) — rejected on evidence the ticket predates: the adapter's own module doc forbids importing the service singleton ("consumes `listMessages()` output *instead of importing the singleton directly*, so callers keep ownership of identity binding"). A service-to-service import would violate the adapter's decoupling contract to fix a duplication.
- **Independent reader in the adapter** — rejected with the ticket: the duplication is the defect.
- **Shared leaf module** (chosen): `ai/services/shared/a2aCollisionTags.mjs`, the `storeWriteGuard` precedent (one classifier, one home, no drifting copies). `MailboxService` deletes its local definition and imports it; the adapter imports it too. Exactly one definition of the class remains repo-wide — grep-verified.

**The semantic-width question, resolved deliberately:** the wake guard fires on the full collision class (`lane-claim`, `review-claim`, `claim-corrected`, `drive-claimed`); the adapter's question stays narrow — `isLaneClaim` is `collisionPreventionTag(...) === 'lane-claim'`, so the activity projection inherits the structural reader without inheriting the wider vocabulary. The class membership stays owned in one `Set`, per the ticket's out-of-scope note (#15919 may grow it).

**Sibling swept and rejected:** `fleetPrLaneActivityAdapter.mjs:25` carries a deliberately *broader* activity heuristic (`claiming`, `lane-state: next-lane`) over a different source — a different contract with its own pinned behavior, not a copy of the guard regex. Untouched.

## Test Evidence

```
RED (against the ^-anchored constant): the 8 non-leading fixtures fail —
  "non-leading claim must count: [ticket-created][lane-claim][#15900] ai:config-print"
  (1 failed / 8 passed)

GREEN (this head):
$ UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
    test/playwright/unit/ai/services/shared/a2aCollisionTags.spec.mjs \
    test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs
13 passed — 4 structural-reader contracts (taggedConcepts-first, segment-opening runs,
  IS-vs-MENTIONS boundary, owned Set) + the 8 bypass fixtures + 2 prose-mention negatives
  + all 7 pre-existing adapter tests

Guard behavior unchanged (extraction is behavior-preserving):
  MailboxService.spec + ReceiptDurability.spec → 135 passed

AC's consumer sweep: zero remaining `\[lane-claim\]` regex definitions repo-wide (the two
  seat-config generator hits are prose strings, not matchers).
```

Fixtures per the AC: three verbatim from #15905's census reproducer, five live sends from the 2026-07-25 mailbox. The mention-negative controls prove the unanchored-substring trap stays closed (a subject *discussing* `[lane-claim]` never counts).

Directly touched surfaces: `ai/services/shared/a2aCollisionTags.mjs` (new) · `ai/services/memory-core/MailboxService.mjs` (local def → import) · `ai/services/fleet/fleetA2AActivityAdapter.mjs` (regex → shared reader, narrow semantics) · one new spec + adapter spec additions.

## Post-Merge Validation

- The fleet activity feed counts today's compound `[ticket-created][lane-claim][#N]` claims as lane claims (observable on the next cockpit refresh — live-forward per the ticket's no-backfill scoping).
- The next collision-class member (if #15919 grows the vocabulary) lands in exactly one file, and this PR's structural contract spec fails if a second definition reappears beside it.

Authored by Iris (Kimi K3, Kimi Code CLI). Session a76464c2-c4b7-48b4-a2cc-30ae42ab3dd0.

