### PR TITLE
feat(ai): wake-envelope restore coverage + plugin load-time armament log (#15684)

### DIFF
--- a/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
+++ b/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
@@ -10,7 +10,13 @@
  *
  * What it does: on every operator-seat `session.created` event, atomically writes the seat's
  * wake envelope to `$XDG_DATA_HOME/opencode/wake-envelope.json` (fallback
- * `~/.local/share/opencode/wake-envelope.json`), mode 0600:
+ * `~/.local/share/opencode/wake-envelope.json`), mode 0600. A desktop restart with a
+ * RESTORED session never fires `session.created`, so the first qualifying `session.updated`
+ * of a restored top-level session re-binds the envelope through the same write+probe
+ * discipline (the restore gap this writer exists to close; identity always comes from an
+ * owner event's exact id, never from a listing heuristic). A load-time log line records
+ * that the plugin armed at all — after a restart, that line is what distinguishes
+ * "plugin never loaded" from "loaded but no qualifying event yet".
  *
  * ```json
  * {
@@ -51,9 +57,11 @@
  *   `written-probe-failed`. The envelope stays written either way, but an unverified
  *   envelope is a degraded result, never a silent success.
  *
- * NOTE: the envelope is written on `session.created`; a session already open when the
- * plugin is first planted re-writes it at the next session start (or immediately on
- * restart of the seat).
+ * NOTE: the envelope is written on `session.created` and re-bound on the first qualifying
+ * `session.updated` of a restored session; a session already open when the plugin is first
+ * planted re-writes it at the next session start (or immediately on restart of the seat).
+ * Within one plugin lifetime the server's port cannot change, so a once-written-or-adopted
+ * session id is the whole freshness check the frequent `session.updated` events need.
  *
  * @summary OpenCode plugin that writes the wake-daemon seat envelope on operator-seat session.created.
  * @see ai/daemons/wake/daemon.mjs deliverViaOpencodeServer (the consuming route)
@@ -146,10 +154,10 @@ export const NeoWakeEnvelope = async (ctx) => {
      *
      * @param {Object} options
      * @param {Number} options.port The resolved server port written into the envelope.
-     * @param {String} options.sessionId The exact session id from the `session.created` event.
-     * @returns {Promise<void>} Resolves when the route verifies; throws (with the cause) otherwise.
+     * @param {String} options.sessionId The exact session id from the qualifying session event.
+     * @returns {Promise<Object>} Resolves with the server's own session payload; throws (with the cause) otherwise.
      */
-    const probeEnvelopeRoute = async ({port, sessionId}) => {
+    const getSession = async ({port, sessionId}) => {
         const username = process.env.OPENCODE_SERVER_USERNAME;
         const password = process.env.OPENCODE_SERVER_PASSWORD;
 
@@ -185,38 +193,134 @@ export const NeoWakeEnvelope = async (ctx) => {
         if (session?.id !== sessionId) {
             throw new Error(`probe id mismatch: asked ${sessionId}, got ${session?.id}`);
         }
+
+        return session;
     };
+
+    const probeEnvelopeRoute = async (options) => {
+        await getSession(options);
+    };
+
+    /**
+     * Reads the on-disk envelope for the adoption check. A missing or malformed file is
+     * not an error — it simply means there is nothing to adopt.
+     *
+     * @returns {Promise<Object|null>} The parsed envelope, or null.
+     */
+    const readEnvelope = async () => {
+        try {
+            return JSON.parse(await fs.readFile(envelopePath, 'utf8'));
+        } catch (_) {
+            return null;
+        }
+    };
+
+    // The (sessionId, port) pair this plugin instance already wrote or adopted. Within one
+    // plugin lifetime the server's port cannot change, so a sessionId hit alone is proof the
+    // envelope is current — this keeps the high-frequency `session.updated` path fetch-free
+    // and lsof-free in the common case.
+    let lastTarget = null;
+
+    // Sessions already identified as child/subagent sessions. A busy subagent fires
+    // `session.updated` constantly; without this set each one would cost an authoritative
+    // parentage fetch.
+    const ignoredSessions = new Set();
+
+    // Decisive load-time instrument: after a desktop restart, this line in the seat log is
+    // what distinguishes "plugin never loaded" from "loaded but no qualifying event yet" —
+    // observability before trust (a quiet channel fails silently; instrument first).
+    await log('info', `neo-wake-envelope plugin loaded (pid ${process.pid}, directory ${directory ?? 'unknown'}) — restore coverage armed`);
 
     return {
         event: async ({ event }) => {
-            if (event?.type !== 'session.created') {
+            const type = event?.type;
+
+            if (type !== 'session.created' && type !== 'session.updated') {
                 return;
             }
 
-            const info      = event.properties?.info ?? {};
-            const sessionId = info.id;
-            const parentId  = info.parentID ?? info.parent_id ?? null;
+            const info      = event.properties?.info ?? event.properties ?? {};
+            const sessionId = info.id ?? info.sessionID ?? null;
 
-            // Child/subagent sessions never retarget the operator seat's wake route.
-            if (!sessionId || parentId) {
+            // Written or adopted this boot — within one plugin lifetime the port cannot
+            // change, so this is the whole freshness check frequent `session.updated`
+            // events need. Known child sessions are filtered without a fetch.
+            if (!sessionId || lastTarget?.sessionId === sessionId || ignoredSessions.has(sessionId)) {
                 return;
             }
 
+            if (type === 'session.created') {
+                // Child/subagent sessions never retarget the operator seat's wake route.
+                const parentId = info.parentID ?? info.parent_id ?? null;
+
+                if (parentId) {
+                    ignoredSessions.add(sessionId);
+                    return;
+                }
+
+                try {
+                    const port = await resolvePort();
+
+                    await writeEnvelope(sessionId, port);
+
+                    try {
+                        await probeEnvelopeRoute({port, sessionId});
+                        await log('info', `wake envelope written-probed for session ${sessionId} (port ${port})`);
+                    } catch (probeErr) {
+                        // Degraded, loud, never fatal: the envelope stays written — an unverified
+                        // envelope is still better than none, but it must not report success.
+                        await log('error', `written-probe-failed for session ${sessionId} (port ${port}): ${probeErr.message}`);
+                    }
+
+                    lastTarget = {sessionId, port};
+                } catch (err) {
+                    await log('error', `envelope write failed: ${err.message}`);
+                }
+
+                return;
+            }
+
+            // `session.updated` — the restore path. A restored session never fires
+            // `session.created`, so its first qualifying update is the owner event that
+            // re-binds the envelope after a desktop restart. Identity comes from the
+            // event's exact id, never from a listing heuristic — a listing cannot
+            // distinguish which of two live top-level sessions is the operator's.
             try {
                 const port = await resolvePort();
+
+                // Adopt an already-current envelope (e.g. a plugin reload within one
+                // server life) instead of rewriting it.
+                const existing = await readEnvelope();
+
+                if (existing?.sessionId === sessionId && existing?.port === port) {
+                    lastTarget = {sessionId, port};
+                    await log('debug', `envelope already targets session ${sessionId} (port ${port}) — adopted`);
+                    return;
+                }
+
+                // The updated event does not reliably carry parentage; the server's own
+                // session resource is the authoritative source for the child filter.
+                const session = await getSession({port, sessionId});
+
+                if (session?.parentID ?? session?.parent_id) {
+                    ignoredSessions.add(sessionId);
+                    await log('debug', `session.updated for child session ${sessionId} ignored — child sessions never retarget`);
+                    return;
+                }
 
                 await writeEnvelope(sessionId, port);
 
                 try {
                     await probeEnvelopeRoute({port, sessionId});
-                    await log('info', `wake envelope written-probed for session ${sessionId} (port ${port})`);
+                    await log('info', `wake envelope written-probed for restored session ${sessionId} (port ${port})`);
                 } catch (probeErr) {
-                    // Degraded, loud, never fatal: the envelope stays written — an unverified
-                    // envelope is still better than none, but it must not report success.
-                    await log('error', `written-probe-failed for session ${sessionId} (port ${port}): ${probeErr.message}`);
+                    // Same degraded-loud discipline as the created path.
+                    await log('error', `written-probe-failed for restored session ${sessionId} (port ${port}): ${probeErr.message}`);
                 }
+
+                lastTarget = {sessionId, port};
             } catch (err) {
-                await log('error', `envelope write failed: ${err.message}`);
+                await log('error', `restore-target failed for session ${sessionId}: ${err.message}`);
             }
         }
     };

--- a/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
+++ b/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
@@ -58,12 +58,14 @@
  *   envelope is a degraded result, never a silent success.
  *
  * NOTE: the envelope is written on `session.created` and re-bound on the first qualifying
- * `session.updated` of a restored session; a session already open when the plugin is first
- * planted re-writes it at the next session start (or immediately on restart of the seat).
- * Within one plugin lifetime the server's port cannot change, so a once-written-or-adopted
- * session id is the whole freshness check the frequent `session.updated` events need.
+ * `session.updated` of a restored session. A session already open when the plugin is first
+ * planted re-writes it at the next session start; after a desktop restart with a restored
+ * session, the write lands on that session's first qualifying update event (restores do
+ * not fire `session.created`). Within one plugin lifetime the server's port cannot change,
+ * so a once-written session id is the whole freshness check the frequent `session.updated`
+ * events need.
  *
- * @summary OpenCode plugin that writes the wake-daemon seat envelope on operator-seat session.created.
+ * @summary OpenCode plugin that writes the wake-daemon seat envelope on operator-seat session.created and re-binds it on a restored session's first qualifying session.updated, with a load-time armament log.
  * @see ai/daemons/wake/daemon.mjs deliverViaOpencodeServer (the consuming route)
  */
 export const NeoWakeEnvelope = async (ctx) => {
@@ -201,24 +203,13 @@ export const NeoWakeEnvelope = async (ctx) => {
         await getSession(options);
     };
 
-    /**
-     * Reads the on-disk envelope for the adoption check. A missing or malformed file is
-     * not an error — it simply means there is nothing to adopt.
-     *
-     * @returns {Promise<Object|null>} The parsed envelope, or null.
-     */
-    const readEnvelope = async () => {
-        try {
-            return JSON.parse(await fs.readFile(envelopePath, 'utf8'));
-        } catch (_) {
-            return null;
-        }
-    };
-
-    // The (sessionId, port) pair this plugin instance already wrote or adopted. Within one
+    // The (sessionId, port) pair this plugin instance already wrote this boot. Within one
     // plugin lifetime the server's port cannot change, so a sessionId hit alone is proof the
     // envelope is current — this keeps the high-frequency `session.updated` path fetch-free
-    // and lsof-free in the common case.
+    // and lsof-free in the common case. Note there is deliberately NO on-disk adoption
+    // shortcut: two matching cached fields are not route authority (stale credentials,
+    // project, directory, or file mode could ride along), so a first-seen session always
+    // pays the full validate-write-probe sequence exactly once.
     let lastTarget = null;
 
     // Sessions already identified as child/subagent sessions. A busy subagent fires
@@ -288,18 +279,10 @@ export const NeoWakeEnvelope = async (ctx) => {
             try {
                 const port = await resolvePort();
 
-                // Adopt an already-current envelope (e.g. a plugin reload within one
-                // server life) instead of rewriting it.
-                const existing = await readEnvelope();
-
-                if (existing?.sessionId === sessionId && existing?.port === port) {
-                    lastTarget = {sessionId, port};
-                    await log('debug', `envelope already targets session ${sessionId} (port ${port}) — adopted`);
-                    return;
-                }
-
                 // The updated event does not reliably carry parentage; the server's own
                 // session resource is the authoritative source for the child filter.
+                // On-disk envelope state is never consulted: matching cached coordinates
+                // are not authority over credentials, project, directory, or file mode.
                 const session = await getSession({port, sessionId});
 
                 if (session?.parentID ?? session?.parent_id) {

--- a/test/playwright/unit/ai/services/fleet/opencodeWakeEnvelopePlugin.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/opencodeWakeEnvelopePlugin.spec.mjs
@@ -11,8 +11,9 @@ import { NeoWakeEnvelope } from '../../../../../../ai/services/fleet/opencodeWak
  * probe outcomes (`written-probed` only on an end-to-end route check of the envelope's own
  * coordinates; `written-probe-failed` loud with the envelope still written), the load-time
  * armament log line (the loaded-vs-silent instrument), and the `session.updated` restore
- * path (re-bind after a restart with a restored session; on-disk adoption; closure dedup;
- * authoritative parentage from the server's own session resource).
+ * path (re-bind after a restart with a restored session; NO on-disk adoption — cached
+ * coordinates are never route authority; closure dedup; authoritative parentage from the
+ * server's own session resource).
  */
 test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
     let tmpRoot, savedEnv, logs, fetchCalls, realFetch;
@@ -342,7 +343,7 @@ test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
         expect(logs.find(entry => entry.message?.startsWith('wake envelope written-probed for restored session ses_restored_write'))).toBeTruthy();
     });
 
-    test('session.updated adopts an already-current on-disk envelope — no rewrite, no fetch', async () => {
+    test('a matching on-disk envelope with ROTATED credentials is rewritten and probed — cached coordinates are not authority', async () => {
         process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
 
         const envelopePath = path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json');
@@ -350,7 +351,63 @@ test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
         fs.writeJsonSync(envelopePath, {
             hostname : '127.0.0.1',
             port     : 41012,
-            sessionId: 'ses_already_bound',
+            sessionId: 'ses_rotated',
+            projectId: 'proj-STALE',
+            directory: '/tmp/STALE',
+            username : 'opencode',
+            password : 'STALE-SECRET',
+            updatedAt: '2026-07-25T00:00:00.000Z'
+        }, {spaces: 2});
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41012] }));
+        await fireSessionUpdated(hooks, { id: 'ses_rotated' });
+
+        const envelope = fs.readJsonSync(envelopePath);
+        // every stale field is refreshed from the current environment, not trusted from disk
+        expect(envelope.password).toBe('test-secret');
+        expect(envelope.projectId).toBe('proj-test');
+        expect(envelope.directory).toBe('/tmp/proj-test');
+        expect(envelope.updatedAt).not.toBe('2026-07-25T00:00:00.000Z');
+        // authoritative parentage fetch + post-write probe — zero-fetch adoption does not exist
+        expect(fetchCalls.map(call => call.url)).toEqual([
+            'http://127.0.0.1:41012/session/ses_rotated',
+            'http://127.0.0.1:41012/session/ses_rotated'
+        ]);
+    });
+
+    test('a matching on-disk envelope with permissive mode is repaired to 0600', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        const envelopePath = path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json');
+        fs.ensureDirSync(path.dirname(envelopePath));
+        fs.writeJsonSync(envelopePath, {
+            hostname : '127.0.0.1',
+            port     : 41013,
+            sessionId: 'ses_permissive',
+            projectId: 'proj-test',
+            directory: '/tmp/proj-test',
+            username : 'opencode',
+            password : 'test-secret',
+            updatedAt: '2026-07-25T00:00:00.000Z'
+        }, {spaces: 2});
+        fs.chmodSync(envelopePath, 0o644);
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41013] }));
+        await fireSessionUpdated(hooks, { id: 'ses_permissive' });
+
+        expect(fs.statSync(envelopePath).mode & 0o777).toBe(0o600);
+        expect(fetchCalls.length).toBe(2);
+    });
+
+    test('a pre-existing child-target envelope is never adopted — authoritative parentage filters first', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        const envelopePath = path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json');
+        fs.ensureDirSync(path.dirname(envelopePath));
+        fs.writeJsonSync(envelopePath, {
+            hostname : '127.0.0.1',
+            port     : 41014,
+            sessionId: 'ses_child_target',
             projectId: 'proj-test',
             directory: '/tmp/proj-test',
             username : 'opencode',
@@ -358,13 +415,25 @@ test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
             updatedAt: '2026-07-25T00:00:00.000Z'
         }, {spaces: 2});
 
-        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41012] }));
-        await fireSessionUpdated(hooks, { id: 'ses_already_bound' });
+        globalThis.fetch = async (input) => {
+            const url = String(input);
+            fetchCalls.push({url});
 
-        // adopted, not rewritten: the file keeps its original updatedAt, and no probe fires
+            return new Response(JSON.stringify({id: url.split('/').pop(), parentID: 'ses_operator'}), {
+                status : 200,
+                headers: {'Content-Type': 'application/json'}
+            });
+        };
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41014] }));
+        await fireSessionUpdated(hooks, { id: 'ses_child_target' });
+        await fireSessionUpdated(hooks, { id: 'ses_child_target' });
+
+        // the poisoned envelope is neither trusted (adopted) nor refreshed (written):
+        // the child filter fires before any write path, and its result is cached
         expect(fs.readJsonSync(envelopePath).updatedAt).toBe('2026-07-25T00:00:00.000Z');
-        expect(fetchCalls.length).toBe(0);
-        expect(logs.find(entry => entry.message?.includes('adopted') && entry.message?.includes('ses_already_bound'))).toBeTruthy();
+        expect(fetchCalls.length).toBe(1);
+        expect(logs.find(entry => entry.message?.includes('adopted'))).toBeFalsy();
     });
 
     test('repeated session.updated events for the same session cost one write total (closure dedup)', async () => {

--- a/test/playwright/unit/ai/services/fleet/opencodeWakeEnvelopePlugin.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/opencodeWakeEnvelopePlugin.spec.mjs
@@ -7,9 +7,12 @@ import { NeoWakeEnvelope } from '../../../../../../ai/services/fleet/opencodeWak
 /**
  * Seat-side wake-envelope plugin witnesses: authoritative serverUrl over lsof, per-seat XDG
  * isolation, private temp creation plus final 0600 enforcement, operator-seat-only writes
- * (child/subagent sessions never retarget), credential passthrough, and the mandatory post-write
+ * (child/subagent sessions never retarget), credential passthrough, the mandatory post-write
  * probe outcomes (`written-probed` only on an end-to-end route check of the envelope's own
- * coordinates; `written-probe-failed` loud with the envelope still written).
+ * coordinates; `written-probe-failed` loud with the envelope still written), the load-time
+ * armament log line (the loaded-vs-silent instrument), and the `session.updated` restore
+ * path (re-bind after a restart with a restored session; on-disk adoption; closure dedup;
+ * authoritative parentage from the server's own session resource).
  */
 test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
     let tmpRoot, savedEnv, logs, fetchCalls, realFetch;
@@ -28,6 +31,10 @@ test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
 
     const fireSessionCreated = async (hooks, info) => {
         await hooks.event({ event: { type: 'session.created', properties: { info } } });
+    };
+
+    const fireSessionUpdated = async (hooks, info) => {
+        await hooks.event({ event: { type: 'session.updated', properties: { info } } });
     };
 
     test.beforeEach(() => {
@@ -302,5 +309,146 @@ test.describe('opencodeWakeEnvelopePlugin (#15394)', () => {
         expect(failed.level).toBe('error');
         expect(failed.message).toContain('timed out after 50ms');
         expect(fs.readJsonSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json')).sessionId).toBe('ses_probe_hung');
+    });
+
+    test('a load-time log line records the plugin armed — the loaded-vs-silent instrument', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        await NeoWakeEnvelope(mockCtx({}));
+
+        const loaded = logs.find(entry => entry.message?.startsWith('neo-wake-envelope plugin loaded'));
+        expect(loaded).toBeTruthy();
+        expect(loaded.level).toBe('info');
+        expect(loaded.message).toContain('restore coverage armed');
+        // no envelope work at load — armament is observability, not a write path
+        expect(fs.existsSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json'))).toBe(false);
+    });
+
+    test('a restored session (session.updated) writes and probes when the envelope is missing', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41011] }));
+        await fireSessionUpdated(hooks, { id: 'ses_restored_write' });
+
+        const envelope = fs.readJsonSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json'));
+        expect(envelope.sessionId).toBe('ses_restored_write');
+        expect(envelope.port).toBe(41011);
+
+        // authoritative parentage fetch + post-write probe, both against the exact id
+        expect(fetchCalls.map(call => call.url)).toEqual([
+            'http://127.0.0.1:41011/session/ses_restored_write',
+            'http://127.0.0.1:41011/session/ses_restored_write'
+        ]);
+        expect(logs.find(entry => entry.message?.startsWith('wake envelope written-probed for restored session ses_restored_write'))).toBeTruthy();
+    });
+
+    test('session.updated adopts an already-current on-disk envelope — no rewrite, no fetch', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        const envelopePath = path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json');
+        fs.ensureDirSync(path.dirname(envelopePath));
+        fs.writeJsonSync(envelopePath, {
+            hostname : '127.0.0.1',
+            port     : 41012,
+            sessionId: 'ses_already_bound',
+            projectId: 'proj-test',
+            directory: '/tmp/proj-test',
+            username : 'opencode',
+            password : 'test-secret',
+            updatedAt: '2026-07-25T00:00:00.000Z'
+        }, {spaces: 2});
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41012] }));
+        await fireSessionUpdated(hooks, { id: 'ses_already_bound' });
+
+        // adopted, not rewritten: the file keeps its original updatedAt, and no probe fires
+        expect(fs.readJsonSync(envelopePath).updatedAt).toBe('2026-07-25T00:00:00.000Z');
+        expect(fetchCalls.length).toBe(0);
+        expect(logs.find(entry => entry.message?.includes('adopted') && entry.message?.includes('ses_already_bound'))).toBeTruthy();
+    });
+
+    test('repeated session.updated events for the same session cost one write total (closure dedup)', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41013] }));
+        await fireSessionUpdated(hooks, { id: 'ses_dedup' });
+        await fireSessionUpdated(hooks, { id: 'ses_dedup' });
+        await fireSessionUpdated(hooks, { id: 'ses_dedup' });
+
+        // first update: parentage fetch + probe; the rest are closure hits with zero cost
+        expect(fetchCalls.length).toBe(2);
+        expect(fs.readJsonSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json')).sessionId).toBe('ses_dedup');
+    });
+
+    test('session.created followed by session.updated for the same session does not rewrite', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41014] }));
+        await fireSessionCreated(hooks, { id: 'ses_fresh' });
+        await fireSessionUpdated(hooks, { id: 'ses_fresh' });
+
+        // created path probed once; the trailing update is a closure no-op
+        expect(fetchCalls.length).toBe(1);
+        expect(logs.filter(entry => entry.message?.startsWith('wake envelope written-probed')).length).toBe(1);
+    });
+
+    test('a child session.updated never retargets — parentage from the authoritative server payload, cached thereafter', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        globalThis.fetch = async (input) => {
+            const url = String(input);
+            fetchCalls.push({url});
+
+            return new Response(JSON.stringify({id: url.split('/').pop(), parentID: 'ses_operator'}), {
+                status : 200,
+                headers: {'Content-Type': 'application/json'}
+            });
+        };
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41015] }));
+        await fireSessionUpdated(hooks, { id: 'ses_subagent' });
+        await fireSessionUpdated(hooks, { id: 'ses_subagent' });
+
+        expect(fs.existsSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json'))).toBe(false);
+        // one authoritative parentage fetch; the second update is filtered from the cache
+        expect(fetchCalls.length).toBe(1);
+        expect(logs.find(entry => entry.message?.includes('child session ses_subagent ignored'))).toBeTruthy();
+    });
+
+    test('a session.updated the server does not know (404) fails loud and writes nothing', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        globalThis.fetch = async (input) => {
+            fetchCalls.push({url: String(input)});
+            return new Response('not found', {status: 404});
+        };
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41016] }));
+        await fireSessionUpdated(hooks, { id: 'ses_ghost' });
+
+        expect(fs.existsSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json'))).toBe(false);
+        const failed = logs.find(entry => entry.message?.startsWith('restore-target failed for session ses_ghost'));
+        expect(failed).toBeTruthy();
+        expect(failed.level).toBe('error');
+        expect(failed.message).toContain('404');
+    });
+
+    test('an operator switch to a different top-level session retargets the envelope', async () => {
+        process.env.XDG_DATA_HOME = path.join(tmpRoot, 'seatA');
+
+        const hooks = await NeoWakeEnvelope(mockCtx({ lsofPorts: [41017] }));
+        await fireSessionUpdated(hooks, { id: 'ses_morning' });
+        await fireSessionUpdated(hooks, { id: 'ses_evening' });
+
+        const envelope = fs.readJsonSync(path.join(tmpRoot, 'seatA', 'opencode', 'wake-envelope.json'));
+        expect(envelope.sessionId).toBe('ses_evening');
+
+        // each switch costs its own parentage fetch + probe against its exact id
+        expect(fetchCalls.map(call => call.url)).toEqual([
+            'http://127.0.0.1:41017/session/ses_morning',
+            'http://127.0.0.1:41017/session/ses_morning',
+            'http://127.0.0.1:41017/session/ses_evening',
+            'http://127.0.0.1:41017/session/ses_evening'
+        ]);
     });
 });


### PR DESCRIPTION
Resolves #15684

Ships the wake-envelope restore-gap coverage + load-time observability for the OpenCode seat plugin: after a desktop restart with a RESTORED session (which never fires `session.created`), the first qualifying `session.updated` now re-binds the envelope through the same write+probe discipline, and a load-time log line records that the plugin armed at all — the instrument that distinguishes "plugin never loaded" from "loaded but silent" at the next restart. Tonight's forensics on the seat proved the desktop log sink works (a direct `/log` probe landed) while the planted plugin's write path never ran; whether the file loads at all is exactly what the new armament line settles.

Evidence: L1 (unit/logic — plugin event paths mocked end-to-end) → L3 required (live desktop restart + restored-session delivery; sandbox-unreachable host effect). Residual: the operator-owned restart verification AC on #15684 — the armament line plus a restore-path envelope write are the two observations that close it.

## Deltas from ticket
- Init-time armament log line (observability-first: a quiet channel fails silently; the sink probe made the plugin's silence meaningful, and this line makes the next restart decisive).
- `session.updated` restore path: exact-id identity from the owner event (never a listing heuristic — a listing cannot tell which of two live top-level sessions is the operator's); authoritative parentage from the server's own session resource for the child filter (the updated event does not reliably carry parentage); **no on-disk adoption** — cached envelope coordinates are never route authority, so a first-seen session always pays the full validate-write-probe sequence once (stale credentials/project/directory or a permissive `0644` mode are refreshed/repaired, never trusted).
- Cost guards for the high-frequency event: closure dedup (one write per session per plugin lifetime; within one boot the port cannot change) + a child-session cache so a busy subagent's updates never repeat the parentage fetch.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/opencodeWakeEnvelopePlugin.spec.mjs` → 25 passed (13 existing + 10 new witnesses: armament log; restored write+probe; rotated-credential rewrite; permissive-mode 0600 repair; child-target never adopted; closure dedup; created-then-updated no-op; authoritative child filter cached; 404 ghost fails loud; operator-switch retarget).
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/` → 401 passed (full adjacency sweep).
- Desktop runtime surface (plugin loading + real `session.updated` delivery in the Electron app): None found — not CI-reachable; covered by the Post-Merge Validation restart observations.

## Post-Merge Validation
- [ ] Seat re-plants the plugin from merged `dev` into `~/.config/opencode/plugins/` (checksum-verified).
- [ ] After the next desktop restart: `opencode.log` carries the `neo-wake-envelope plugin loaded … restore coverage armed` line.
- [ ] With a restored session active: the first `session.updated` re-binds the envelope (`written-probed for restored session …`) — closing the last manual-heal class on the wake route.

Authored by Phoebe (Moonshot Kimi K3, opencode). Session 318916f0-3f6b-4f1c-b0d2-ee16e2dd8af0.
