### PR TITLE
fix(ai): skip dot data entries (#15831)

### DIFF
--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -566,6 +566,9 @@ export async function symlinkDataDir({
     for (const entry of entries) {
         const name = entry.name;
 
+        // Dot-entries are OS/tool artifacts, not managed shared substrate.
+        if (name.startsWith('.')) continue;
+
         if (blocklistSet.has(name) || readAliasSet.has(name) || readAliasSourceSet.has(name)) {
             log(`symlink skip (blocklisted): ${name}`);
             result.blocklisted.push(name);

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -585,6 +585,27 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(await fs.readFile(path.join(dst, 'canary.txt'), 'utf-8')).toBe('main-memory-wal-canary\n');
         });
 
+        test('skips dot-entries while still linking ordinary canonical children', async () => {
+            const mainDataDir = path.join(fakeMainCheckout, dataDir);
+
+            await fs.ensureDir(mainDataDir);
+            await fs.writeFile(path.join(mainDataDir, '.DS_Store'), 'finder metadata');
+            await seedMainSubdirs(['sqlite']);
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                dryRun     : true,
+                log         : () => {}
+            });
+
+            expect(result.linked).toContain('sqlite');
+            expect(result.linked).not.toContain('.DS_Store');
+            expect(result.alreadyLinked).not.toContain('.DS_Store');
+            expect(await fs.pathExists(path.join(fakeWorktree, dataDir, '.DS_Store'))).toBe(false);
+            expect(await fs.pathExists(path.join(fakeWorktree, dataDir, 'sqlite'))).toBe(false);
+        });
+
         test('symlinks a top-level FILE child, not just directories', async () => {
             // .neo-ai-data can hold file children (e.g. memory-core.sqlite); they must link too.
             await fs.ensureDir(path.join(fakeMainCheckout, dataDir));


### PR DESCRIPTION
**Does this PR resolve an issue?** (Required)

Resolves #15831

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills this requirement:**

- [x] It's submitted to the `dev` branch, not the `main` branch

**Other information:**

`symlinkDataDir()` now skips dot-prefixed canonical `.neo-ai-data` entries before classification. OS and tool artifacts such as `.DS_Store` therefore cannot be linked or reported as shared substrate, while ordinary children continue through the existing path.

Evidence: L2 focused filesystem unit test under Node 24; repository CI provides the full L3 unit-suite validation.

## Deltas from ticket

None. `DATA_SUBDIRS_BLOCKLIST` remains unchanged.

## Test Evidence

- Fail-first: `linked` contained `[.DS_Store, sqlite]`.
- After fix: focused regression passed, 1/1.
- `git diff --check` passed.
- The standard full-file run is locally blocked by Chroma's lack of Windows x64 support; CI runs on the supported environment.

## Post-Merge Validation

- [ ] Confirm the repository unit suite remains green.
- [ ] Confirm reconciliation ignores `.DS_Store` while continuing to classify ordinary substrate children.

Authored by Chai (GPT-5, Codex Desktop). Session 019e60ad-dab2-7ba2-935b-caecf70d4b36.