### PR TITLE
fix(dashboard): preserve stable projection frames (#15927)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -563,6 +563,8 @@ class Workspace extends Container {
      * Defers the instance-preserving re-projection after a successful reducer commit.
      * @param {Object} document
      * @param {Object} [options={}]
+     * @param {Boolean} [options.geometryOnly] Explicit stable-topology projection admission.
+     * @param {String} [options.operation] Committed reducer operation.
      * @param {String[]} [options.preserveItemIds] Owner-held panes the reconciler must park.
      */
     onDockZoneDocumentChange(document, options={}) {
@@ -770,11 +772,13 @@ class Workspace extends Container {
      * transaction shared with other docking workspaces. Workstation supplies its cached-pane resolver,
      * header text, FLIP motion, retained-indicator suppression, and the heavy Overflow menu witness.
      * @param {Object} [options={}]
+     * @param {Boolean} [options.geometryOnly=false] Explicit stable-topology projection admission.
+     * @param {String|null} [options.operation=null] Committed reducer operation.
      * @param {String[]} [options.preserveItemIds=[]] Owner-held panes the reconciler must park
      *     instead of destroy (a terminal-first tear-out vessel owns its pane before it connects).
      * @returns {Promise<void>}
      */
-    async refreshDockWorkspace({preserveItemIds=[]}={}) {
+    async refreshDockWorkspace({geometryOnly=false, operation=null, preserveItemIds=[]}={}) {
         const
             me           = this,
             host         = me.getReference('dock-host'),
@@ -782,6 +786,8 @@ class Workspace extends Container {
             placeholders = new Map();
 
         if (!host) return;
+
+        geometryOnly = geometryOnly || operation === 'resizeSplit';
 
         // Every re-projection retires the active gesture session — a stale geometry promise
         // must never survive a topology change (the controller's generation guards depend on it).
@@ -806,6 +812,7 @@ class Workspace extends Container {
         let animationSuppressedBars = [];
 
         const {nextShell} = await DockProjectionReconciler.reconcileProjection({
+            geometryOnly,
             host,
             nextConfig,
             placeholders,
@@ -991,7 +998,7 @@ class Workspace extends Container {
             });
 
         me.dockModel = DockZoneModel.clone(initialDocument);
-        await me.refreshDockWorkspace();
+        await me.refreshDockWorkspace({geometryOnly: true});
 
         try {
             const result = await runner.start();
@@ -1138,7 +1145,7 @@ class Workspace extends Container {
         me.dockModel       = DockZoneModel.clone(initialDocument);
         await me.setPipProgress(0);
 
-        await me.refreshDockWorkspace();
+        await me.refreshDockWorkspace({geometryOnly: true});
 
         const
             feedStore      = me.getStateProvider().getStore('feed'),

--- a/src/dashboard/DockProjectionReconciler.mjs
+++ b/src/dashboard/DockProjectionReconciler.mjs
@@ -2,6 +2,8 @@ import Component from '../component/Base.mjs';
 import Base      from '../core/Base.mjs';
 import NeoArray  from '../util/Array.mjs';
 
+const projectionNodeTypes = new Set(['edge-zone', 'split', 'tabs']);
+
 /**
  * @summary Preserves live tab-chrome identity across dock-layout projections.
  *
@@ -52,6 +54,138 @@ class DockProjectionReconciler extends Base {
         visit(root);
 
         return tabs
+    }
+
+    /**
+     * @summary Collects the dock-node topology below one projected shell.
+     *
+     * Pane descendants stop the traversal at tabs nodes: application content may itself contain
+     * `dockNodeId` metadata, but only the projected shell's structural nodes belong to this
+     * reconciliation boundary. Synthetic affordances and wrappers stay traversal-transparent.
+     * Duplicate or incomplete structural identities fail closed because they cannot prove a
+     * one-to-one live projection.
+     * @param {Neo.component.Base|Object|null} root
+     * @returns {Map<String, Object>|null}
+     * @static
+     */
+    static collectProjectionTopology(root) {
+        const nodes = new Map();
+        let   valid = true;
+
+        const visit = (node, parentNodeId=null) => {
+            if (!valid || !node || node.isDestroyed) return;
+
+            let ownerNodeId = parentNodeId;
+
+            const structural = projectionNodeTypes.has(node.dockNodeType);
+
+            if (structural) {
+                if (!node.dockNodeId || nodes.has(node.dockNodeId)
+                    || parentNodeId && !nodes.has(parentNodeId)) {
+                    valid = false;
+                    return
+                }
+
+                ownerNodeId = node.dockNodeId;
+                nodes.set(ownerNodeId, {
+                    childNodeIds: [],
+                    node,
+                    parentNodeId,
+                    type        : node.dockNodeType
+                });
+
+                if (parentNodeId) {
+                    nodes.get(parentNodeId)?.childNodeIds.push(ownerNodeId)
+                }
+
+                if (node.dockNodeType === 'tabs') return
+            }
+
+            node.items?.forEach(child => visit(child, ownerNodeId))
+        };
+
+        visit(root);
+
+        return valid ? nodes : null
+    }
+
+    /**
+     * @summary Reconciles a geometry-only projection without moving live dock chrome.
+     *
+     * The fast path is deliberately strict: dock-node ancestry/order, split orientation, tab item
+     * order, and active selection must all be unchanged. Only then may projected child `flex`
+     * values be applied to the retained shell in place. Any structural or ownership delta defers
+     * to the staged descendant → ancestor transaction in {@link #reconcileProjection}.
+     * @param {Neo.component.Base} oldShell
+     * @param {Object} nextConfig
+     * @param {Map<String,Neo.component.Base>} placeholders
+     * @returns {{currentTabs:Map,nextShell:Neo.component.Base,plans:Map}|null}
+     * @static
+     */
+    static reconcileStableTopology(oldShell, nextConfig, placeholders) {
+        const
+            currentNodes = this.collectProjectionTopology(oldShell),
+            nextNodes    = this.collectProjectionTopology(nextConfig);
+
+        if (!currentNodes || !nextNodes || !currentNodes.size || currentNodes.size !== nextNodes.size) return null;
+
+        for (const [nodeId, current] of currentNodes) {
+            const
+                next                 = nextNodes.get(nodeId),
+                currentLayoutNtype   = String(current.node.layout?.ntype || '').replace(/^layout-/, ''),
+                projectedLayoutNtype = String(next?.node.layout?.ntype || '').replace(/^layout-/, '');
+
+            if (!next
+                || current.type !== next.type
+                || current.parentNodeId !== next.parentNodeId
+                || current.type === 'split' && currentLayoutNtype !== projectedLayoutNtype
+                || current.childNodeIds.join('\0') !== next.childNodeIds.join('\0')) {
+                return null
+            }
+
+            if (current.type === 'tabs') {
+                const
+                    currentItems = current.node.getTabBar()?.sortZoneConfig?.dockItemIds || [],
+                    nextItems    = next.node.headerToolbar?.sortZoneConfig?.dockItemIds || [];
+
+                if (current.node.activeIndex !== next.node.activeIndex
+                    || currentItems.join('\0') !== nextItems.join('\0')) {
+                    return null
+                }
+            }
+        }
+
+        const
+            currentTabs = this.collectProjectedTabs(oldShell),
+            plans       = new Map();
+
+        nextNodes.forEach((next, nodeId) => {
+            const current = currentNodes.get(nodeId).node;
+
+            if (Object.hasOwn(next.node, 'flex')) {
+                current.setSilent({
+                    flex        : next.node.flex,
+                    wrapperStyle: {...current.wrapperStyle, flex: next.node.flex ?? null}
+                })
+            }
+
+            if (next.type === 'tabs') {
+                plans.set(nodeId, {
+                    activeIndex : next.node.activeIndex,
+                    config      : next.node,
+                    desiredItems: [...(next.node.headerToolbar?.sortZoneConfig?.dockItemIds || [])],
+                    placeholder : null,
+                    tab         : current
+                })
+            }
+        });
+
+        placeholders.forEach(placeholder => {
+            !placeholder.parent && !placeholder.isDestroyed && placeholder.destroy()
+        });
+        placeholders.clear();
+
+        return {currentTabs, nextShell: oldShell, plans}
     }
 
     /**
@@ -121,6 +255,7 @@ class DockProjectionReconciler extends Base {
      * outside this method. `onProjectionStaged` can decorate retained chrome before the first commit.
      * @param {Object} options
      * @param {Neo.container.Base} options.host Dock host containing the current shell.
+     * @param {Boolean} [options.geometryOnly=false] Explicitly admits strict in-place geometry reconciliation.
      * @param {*} options.nextConfig Fresh {@link Neo.dashboard.DockLayoutAdapter} projection.
      * @param {Map<String,Neo.component.Base>} options.placeholders Item placeholders created by the caller.
      * @param {Iterable<String>} [options.preserveItemIds=[]] Owner-held panes which are absent
@@ -133,6 +268,7 @@ class DockProjectionReconciler extends Base {
      * @static
      */
     static async reconcileProjection({
+        geometryOnly=false,
         host,
         nextConfig,
         placeholders,
@@ -146,6 +282,28 @@ class DockProjectionReconciler extends Base {
 
         if (!oldShell) {
             throw new Error(`Dock projection could not find a current shell at index ${shellIndex}`)
+        }
+
+        const stableProjection = geometryOnly
+            ? this.reconcileStableTopology(oldShell, nextConfig, placeholders)
+            : null;
+
+        if (stableProjection) {
+            host.updateDepth = -1;
+            host.update();
+            await host.promiseUpdate();
+
+            const overflowPlugins = [...new Set([...stableProjection.plans.values()]
+                .map(plan => plan.tab?.getTabBar()?.getPlugin('tab-overflow'))
+                .filter(Boolean))];
+
+            await Promise.all(overflowPlugins.map(plugin => plugin.project(true)));
+
+            if (waitForOverflowProjection) {
+                await Promise.all(overflowPlugins.map(plugin => waitForOverflowProjection(plugin)))
+            }
+
+            return {...stableProjection, overflowPlugins}
         }
 
         const

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -188,7 +188,192 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         return (await app.getComponent(wsId, ['feedSequence'])).feedSequence
     }
 
-    test('scene 1 — the room is alive: two runs, identical beat logs, heartbeat never resets', async ({page, neuralLink}) => {
+    /**
+     * @summary Captures and measures every compositor frame presented while one workspace action runs.
+     *
+     * CDP screencast events are the browser's consecutive presented-frame stream, not sampled
+     * screenshots. Chromium does not promise an initial event for an unchanged page, so a tiny
+     * compositor animation outside the measured dock crop supplies a continuous presentation clock.
+     * The detached-canvas measurement crops the real dock-host rectangle and computes grayscale
+     * Shannon entropy in-page, avoiding a recorder/cut dependency and any optional image decoder
+     * package. A body-clear frame collapses the dense workspace's entropy while the outer shell
+     * remains painted.
+     * @param {Object} page Playwright page.
+     * @param {Function} action Awaited workspace mutation.
+     * @returns {Promise<Object>} Action result plus frame-count and entropy receipt.
+     */
+    async function captureWorkspaceContinuity(page, action) {
+        const
+            viewport = page.viewportSize(),
+            box      = await page.locator('.workstation-dock-host').boundingBox(),
+            session  = await page.context().newCDPSession(page),
+            frames   = [],
+            acks     = [];
+        let resolveFirstFrame;
+
+        expect(box, 'the dock host must expose a measurable compositor region').toBeTruthy();
+        expect(viewport, 'the page must expose a fixed film viewport').toBeTruthy();
+
+        const firstFrame = new Promise(resolve => {
+            resolveFirstFrame = resolve
+        });
+
+        session.on('Page.screencastFrame', frame => {
+            frames.push(frame.data);
+            resolveFirstFrame?.();
+            resolveFirstFrame = null;
+            acks.push(session.send('Page.screencastFrameAck', {sessionId: frame.sessionId})
+                .catch(error => error))
+        });
+
+        let baseline, frameTimer, result;
+
+        try {
+            await session.send('Page.enable');
+            await session.send('Page.startScreencast', {
+                everyNthFrame: 1,
+                format       : 'jpeg',
+                maxHeight    : 500,
+                maxWidth     : 800,
+                quality      : 70
+            });
+            await page.evaluate(() => {
+                const marker = document.createElement('div');
+
+                marker.id = 'workstation-compositor-frame-clock';
+                Object.assign(marker.style, {
+                    background   : '#fff',
+                    height       : '2px',
+                    left         : '0',
+                    pointerEvents: 'none',
+                    position     : 'fixed',
+                    top          : '0',
+                    width        : '2px',
+                    zIndex       : '2147483647'
+                });
+                document.body.append(marker);
+
+                let light = true;
+
+                const tick = () => {
+                    if (!marker.isConnected) return;
+
+                    light = !light;
+                    marker.style.background = light ? '#fff' : '#000';
+                    requestAnimationFrame(tick)
+                };
+
+                requestAnimationFrame(tick)
+            });
+            await Promise.race([
+                firstFrame,
+                new Promise((_, reject) => {
+                    frameTimer = setTimeout(() => reject(
+                        new Error('CDP screencast emitted no compositor frame within 5 seconds')
+                    ), 5000)
+                })
+            ]);
+            clearTimeout(frameTimer);
+
+            baseline = frames.at(-1);
+            frames.length = 0;
+
+            result = await action();
+
+            await page.evaluate(() => new Promise(resolve =>
+                requestAnimationFrame(() => requestAnimationFrame(resolve))
+            ))
+        } finally {
+            clearTimeout(frameTimer);
+            await session.send('Page.stopScreencast').catch(() => {});
+            await Promise.allSettled(acks);
+            await session.detach().catch(() => {});
+            await page.evaluate(() => {
+                document.getElementById('workstation-compositor-frame-clock')?.remove()
+            }).catch(() => {})
+        }
+
+        const
+            actionFrames = frames,
+            entropies    = await page.evaluate(async ({baseline, box, frames, viewport}) => {
+                const measure = async source => {
+                    const image = new Image();
+
+                    image.src = `data:image/jpeg;base64,${source}`;
+                    await image.decode();
+
+                    const
+                        scaleX = image.naturalWidth  / viewport.width,
+                        scaleY = image.naturalHeight / viewport.height,
+                        sx     = Math.max(0, Math.floor(box.x * scaleX)),
+                        sy     = Math.max(0, Math.floor(box.y * scaleY)),
+                        sw     = Math.min(image.naturalWidth - sx,  Math.ceil(box.width  * scaleX)),
+                        sh     = Math.min(image.naturalHeight - sy, Math.ceil(box.height * scaleY)),
+                        canvas = document.createElement('canvas'),
+                        width  = 160,
+                        height = Math.max(1, Math.round(width * sh / sw)),
+                        counts = new Uint32Array(256);
+
+                    canvas.width  = width;
+                    canvas.height = height;
+
+                    const context = canvas.getContext('2d', {willReadFrequently: true});
+
+                    context.drawImage(image, sx, sy, sw, sh, 0, 0, width, height);
+
+                    const pixels = context.getImageData(0, 0, width, height).data;
+
+                    for (let index = 0; index < pixels.length; index += 4) {
+                        counts[Math.round(
+                            pixels[index] * 0.2126
+                            + pixels[index + 1] * 0.7152
+                            + pixels[index + 2] * 0.0722
+                        )]++
+                    }
+
+                    let entropy = 0;
+
+                    counts.forEach(count => {
+                        if (!count) return;
+
+                        const probability = count / (width * height);
+
+                        entropy -= probability * Math.log2(probability)
+                    });
+
+                    return entropy
+                };
+
+                const values = [];
+
+                for (const frame of [baseline, ...frames]) {
+                    values.push(await measure(frame))
+                }
+
+                return values
+            }, {
+                baseline,
+                box,
+                frames: actionFrames,
+                viewport
+            });
+
+        const
+            baselineEntropy = entropies.shift(),
+            minEntropy      = Math.min(...entropies),
+            minFrameIndex   = entropies.indexOf(minEntropy);
+
+        return {
+            baselineEntropy,
+            frameCount: actionFrames.length,
+            frames    : actionFrames,
+            minEntropy,
+            minFrameIndex,
+            result
+        }
+    }
+
+    test('scene 1 — the room is alive: two runs, identical beat logs, heartbeat never resets', async ({page, neuralLink}, testInfo) => {
         const logs       = [],
               pageErrors = [];
 
@@ -223,23 +408,51 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             // commit lives on the adapter's documentChange path, and `runTourSpec` is the
             // workspace's own spec-mode front door: fresh document, reducer op, runner-owned
             // deterministic log — the same contract the film's recording pipeline replays. ──
-            const spec = await app.callMethod(wsId, 'runTourSpec', [{
-                schema: 'neo.tour.script.v1',
-                id    : 'five-beat-scene1',
-                title : 'scene 1 — the room answers',
-                scenes: [{
-                    id   : 's1',
-                    title: 'resize',
-                    steps: [{
-                        type      : 'op',
-                        descriptor: {operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.52, 0.48]},
-                        expect    : [{path: 'nodes.split-main.sizes.0', equals: 0.52}]
-                    }, {
-                        type  : 'topology-assert',
-                        expect: [{path: 'nodes.split-main.sizes.1', equals: 0.48}]
+            const runSpec = () =>
+                app.callMethod(wsId, 'runTourSpec', [{
+                    schema: 'neo.tour.script.v1',
+                    id    : 'five-beat-scene1',
+                    title : 'scene 1 — the room answers',
+                    scenes: [{
+                        id   : 's1',
+                        title: 'resize',
+                        steps: [{
+                            type      : 'op',
+                            descriptor: {operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.52, 0.48]},
+                            expect    : [{path: 'nodes.split-main.sizes.0', equals: 0.52}]
+                        }, {
+                            type  : 'topology-assert',
+                            expect: [{path: 'nodes.split-main.sizes.1', equals: 0.48}]
+                        }]
                     }]
-                }]
-            }]);
+                }]),
+                continuity = filmTake ? await captureWorkspaceContinuity(page, runSpec) : null,
+                spec       = continuity ? continuity.result : await runSpec();
+
+            if (continuity) {
+                console.log('[rendered-continuity]', JSON.stringify({
+                    baselineEntropy: continuity.baselineEntropy,
+                    frameCount     : continuity.frameCount,
+                    minEntropy     : continuity.minEntropy,
+                    minFrameIndex  : continuity.minFrameIndex,
+                    run            : run + 1
+                }));
+
+                expect(continuity.frameCount,
+                    'the resize/reset boundary must expose consecutive compositor frames').toBeGreaterThan(2);
+
+                const entropyFloor = continuity.baselineEntropy * 0.65;
+
+                if (continuity.minEntropy < entropyFloor) {
+                    await testInfo.attach(`scene-1-run-${run + 1}-minimum-entropy-frame`, {
+                        body       : Buffer.from(continuity.frames[continuity.minFrameIndex], 'base64'),
+                        contentType: 'image/jpeg'
+                    })
+                }
+
+                expect(continuity.minEntropy,
+                    'no presented frame may clear the dense workspace body').toBeGreaterThanOrEqual(entropyFloor)
+            }
 
             expect(spec.completed, 'the spec-mode replay must complete cleanly').toBe(true);
             expect(spec.errors).toEqual([]);

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -29,6 +29,80 @@ const createRootTabsModel = () => ({
     }
 });
 
+const createSplitModel = () => ({
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'root-split',
+    items : {
+        alpha: {componentRef: 'alpha', kind: 'panel', title: 'Alpha'},
+        beta : {componentRef: 'beta',  kind: 'panel', title: 'Beta'}
+    },
+    nodes: {
+        'alpha-tabs': {activeItemId: 'alpha', items: ['alpha'], type: 'tabs'},
+        'beta-tabs' : {activeItemId: 'beta', items: ['beta'], type: 'tabs'},
+        'root-split': {
+            children   : ['alpha-tabs', 'beta-tabs'],
+            orientation: 'horizontal',
+            sizes      : [0.6, 0.4],
+            type       : 'split'
+        }
+    }
+});
+
+const createThreeChildSplitModel = () => {
+    const model = createSplitModel();
+
+    model.items.gamma = {componentRef: 'gamma', kind: 'panel', title: 'Gamma'};
+    model.nodes['gamma-tabs'] = {activeItemId: 'gamma', items: ['gamma'], type: 'tabs'};
+    model.nodes['root-split'].children.push('gamma-tabs');
+    model.nodes['root-split'].sizes = [0.4, 0.35, 0.25];
+
+    return model
+};
+
+const reconcileModel = async (model, mutate, {geometryOnly=false}={}) => {
+    const
+        panes = Object.fromEntries(Object.entries(model.items)
+            .map(([itemId, item]) => [itemId, Neo.create(Component, {header: {text: item.title}})])),
+        host = Neo.create(Container, {
+            items: [DockLayoutAdapter.project(model, {
+                resolveComponentRef: (_componentRef, _item, itemId) => panes[itemId]
+            })]
+        }),
+        oldShell     = host.items[0],
+        nextModel    = structuredClone(model),
+        placeholders = new Map();
+
+    mutate(nextModel);
+
+    const nextConfig = DockLayoutAdapter.project(nextModel, {
+        resolveComponentRef(_componentRef, item, itemId) {
+            const placeholder = Neo.create(Component, {
+                header: {text: item.title},
+                hidden: true
+            });
+
+            placeholders.set(itemId, placeholder);
+
+            return placeholder
+        }
+    });
+
+    let stagedCount = 0;
+
+    const result = await DockProjectionReconciler.reconcileProjection({
+        geometryOnly,
+        host,
+        nextConfig,
+        placeholders,
+        resolveItem: itemId => panes[itemId],
+        onProjectionStaged() {
+            stagedCount++
+        }
+    });
+
+    return {host, nextModel, oldShell, result, stagedCount}
+};
+
 test.describe('Neo.dashboard.DockProjectionReconciler', () => {
     test('keys retained tab chrome and reserves only its projected destination', () => {
         const
@@ -217,6 +291,124 @@ test.describe('Neo.dashboard.DockProjectionReconciler', () => {
         } finally {
             host.destroy()
         }
+    });
+
+    test('updates stable split geometry in place without moving retained tab chrome', async () => {
+        const
+            model = createSplitModel(),
+            panes = {
+                alpha: Neo.create(Component, {header: {text: 'Alpha'}}),
+                beta : Neo.create(Component, {header: {text: 'Beta'}})
+            },
+            host = Neo.create(Container, {
+                items: [DockLayoutAdapter.project(model, {
+                    resolveComponentRef: (_componentRef, _item, itemId) => panes[itemId]
+                })]
+            }),
+            oldShell     = host.items[0],
+            currentTabs  = DockProjectionReconciler.collectProjectedTabs(oldShell),
+            alphaTab     = currentTabs.get('alpha-tabs'),
+            betaTab      = currentTabs.get('beta-tabs'),
+            nextModel    = structuredClone(model),
+            placeholders = new Map();
+
+        nextModel.nodes['root-split'].sizes = [0.52, 0.48];
+
+        try {
+            const nextConfig = DockLayoutAdapter.project(nextModel, {
+                resolveComponentRef(_componentRef, item, itemId) {
+                    const placeholder = Neo.create(Component, {
+                        header: {text: item.title},
+                        hidden: true
+                    });
+
+                    placeholders.set(itemId, placeholder);
+
+                    return placeholder
+                }
+            });
+
+            const result = await DockProjectionReconciler.reconcileProjection({
+                geometryOnly: true,
+                host,
+                nextConfig,
+                placeholders,
+                resolveItem : itemId => panes[itemId]
+            });
+
+            expect(result.nextShell).toBe(oldShell);
+            expect(host.items).toEqual([oldShell]);
+            expect(DockProjectionReconciler.collectProjectedTabs(oldShell))
+                .toEqual(currentTabs);
+            expect(currentTabs.get('alpha-tabs')).toBe(alphaTab);
+            expect(currentTabs.get('beta-tabs')).toBe(betaTab);
+            expect(alphaTab.flex).toBe(0.52);
+            expect(betaTab.flex).toBe(0.48);
+            expect(alphaTab.wrapperStyle.flex).toBe(0.52);
+            expect(betaTab.wrapperStyle.flex).toBe(0.48);
+            expect(placeholders.size).toBe(0)
+        } finally {
+            host.destroy()
+        }
+    });
+
+    test('keeps same-topology non-geometry refreshes on the staged transaction by default', async () => {
+        const receipt = await reconcileModel(createSplitModel(), nextModel => {
+            nextModel.items.alpha.title = 'Renamed'
+        });
+
+        try {
+            expect(receipt.stagedCount).toBe(1);
+            expect(receipt.result.nextShell).not.toBe(receipt.oldShell)
+        } finally {
+            receipt.host.destroy()
+        }
+    });
+
+    test('falls back when a geometry-only projection changes split orientation', async () => {
+        const receipt = await reconcileModel(createSplitModel(), nextModel => {
+            nextModel.nodes['root-split'].orientation = 'vertical'
+        }, {geometryOnly: true});
+
+        try {
+            expect(receipt.stagedCount).toBe(1);
+            expect(receipt.result.nextShell).not.toBe(receipt.oldShell);
+            expect(String(receipt.result.nextShell.layout.ntype).replace(/^layout-/, '')).toBe('vbox')
+        } finally {
+            receipt.host.destroy()
+        }
+    });
+
+    test('falls back when a geometry-only projection reorders three split children', async () => {
+        const receipt = await reconcileModel(createThreeChildSplitModel(), nextModel => {
+            nextModel.nodes['root-split'].children = ['gamma-tabs', 'alpha-tabs', 'beta-tabs']
+        }, {geometryOnly: true});
+
+        try {
+            const childNodeIds = receipt.result.nextShell.items
+                .filter(item => item.dockNodeType !== 'splitter')
+                .map(item => item.dockNodeId);
+
+            expect(receipt.stagedCount).toBe(1);
+            expect(receipt.result.nextShell).not.toBe(receipt.oldShell);
+            expect(childNodeIds).toEqual(['gamma-tabs', 'alpha-tabs', 'beta-tabs'])
+        } finally {
+            receipt.host.destroy()
+        }
+    });
+
+    test('fails closed on duplicate structural projection identities', () => {
+        expect(DockProjectionReconciler.collectProjectionTopology({
+            dockNodeId  : 'root-split',
+            dockNodeType: 'split',
+            items       : [{
+                dockNodeId  : 'duplicate-tabs',
+                dockNodeType: 'tabs'
+            }, {
+                dockNodeId  : 'duplicate-tabs',
+                dockNodeType: 'tabs'
+            }]
+        })).toBeNull()
     });
 
     test('retires a pane and button that are absent from every projected tab exactly once', async () => {


### PR DESCRIPTION
Resolves #15927

The Workstation now keeps its existing dock projection on glass when a reset or `resizeSplit` changes geometry without changing topology. A strict opt-in reconciler updates split flex in place; any structural ambiguity still falls back to the existing staged ownership transaction. The film profile also gains a consecutive presented-frame witness, so worker truth can no longer hide a one-frame body clear.

Evidence: L3 (exact-head local headed Chromium on accelerated ANGLE/Metal, native CDP presented-frame cadence with `everyNthFrame: 1`) → L3 required (all rendered-continuity and live Workstation ACs). No residuals.

Related: #15252 · #15947

## Causal boundary

The two-run isolation matrix on pre-fix `origin/dev` at `645bf1e75d` separated the visual operations before implementation:

| cell | consecutive frames | minimum normalized B entropy | verdict |
|---|---:|---:|---|
| idle control | 141 | 0.4822 | clean |
| light-theme entry | 78 | 0.4821 | clean |
| dark-theme return | 135 | 0.4239 | clean; expected palette shift |
| spec reset only | 265 | 0.0833 at frame 216 | body clear; frames 215 and 217 remain dense |
| spec reset + `resizeSplit` | 290 | 0.0819 at frame 175 | same body-clear class |

That convicts the dock projection transaction, not the theme, recorder, cut, or native display capture. The exact renderer trace showed a stable-topology refresh mounting a hidden replacement shell and then moving six retained tab containers during the visibility swap. Chromium could present the old shell after its dense children moved but before the replacement became visible.

The repair keeps the general transaction intact and adds one deliberately narrow path:

- `geometryOnly` is explicit; Workstation admits it for `resizeSplit` and its reset-to-known-document boundary.
- `DockProjectionReconciler` verifies node count, type, parent, ordered children, split orientation, ordered tab items, and active tab index before touching the live tree.
- Missing, incomplete, or duplicate structural IDs fail closed to the existing staged transaction.
- A proven-stable topology updates only split/wrapper flex and retains the same component and DOM identities.
- Structural/content operations continue through the visibility-staged ownership transfer unchanged.

After the repair, isolated reset and resize cells each retained dense-body entropy across 142 and 140 consecutive frames respectively; the historical body-clear class was approximately `0.65` raw entropy while both repaired minima were `3.778`.

## Deltas from ticket

- The ticket left the boundary open between projection, theme repaint, and browser compositing. The isolation matrix narrows it to stable-topology dock reprojection, with the browser compositor exposing the otherwise short ownership gap.
- The durable witness reads Chromium's consecutive `Page.screencastFrame` stream directly instead of decoding a post-produced video. It crops the real `.workstation-dock-host`, computes grayscale Shannon entropy for every action frame, and attaches the minimum frame only on failure.
- The screencast witness is film-only (`NEO_FILM_TAKE=1`). Ordinary E2E retains the existing worker-truth assertions without capture overhead.
- A 2×2 `requestAnimationFrame` paint clock sits outside the measured dock crop so unchanged pages still emit compositor frames; it cannot inflate measured workspace entropy.

## Test Evidence

- `DockProjectionReconciler`: focused unit suite — **11 passed**. Coverage includes stable identity, default staged behavior, orientation mismatch, three-child reorder, duplicate IDs, and strict fallback.
- Workstation ordinary profile:
  `NEO_E2E_PORT=8142 npx playwright test workstation/WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --grep 'scene 1 — the room is alive'`
  — **2 passed**.
- Workstation headless film profile at rebased head `39bd463077`: the same focused command with `NEO_FILM_TAKE=1` — **2 passed**; scene repetitions emitted 78 and 80 action frames, and each minimum entropy equaled its dense baseline (`4.950770` and `4.950777`).
- Exact headed film profile at rebased review head `39bd463077`:
  `NEO_E2E_PORT=8138 NEO_FILM_TAKE=1 npx playwright test workstation/WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed`
  — **4 passed, 3 intentionally skipped**; GL probe observed accelerated ANGLE/Metal on Apple M5 Max.

| headed scene-1 run | action frames | baseline entropy | minimum entropy | ratio |
|---|---:|---:|---:|---:|
| 1 | 80 | 5.016509 | 5.014715 | 99.96% |
| 2 | 80 | 4.946903 | 4.946903 | 100.00% |

Both minima are far above the 65% body-clear rejection floor. The scene also retains identical two-run beat logs, committed `[0.52, 0.48]` split sizes, final dark theme, monotonic heartbeat, and `pageErrors === []`.

- `npm run agent-preflight -- --no-fix` — pass.
- `npx lint-staged --no-stash` — whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, and AiConfig mutation guards all pass.
- `git diff --cached --check` — pass before commit.

## Post-Merge Validation

- [ ] Hosted CI remains green on the exact PR head.
- [ ] The next film-v1 raw-capture census contains no full-workspace body-clear frame matching this ticket's shell-painted signature; unrelated local canvas/sparkline candidates stay in their own classification lane.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019f98df-25e8-7472-bf05-7a7a453e42a1.
