### PR TITLE
feat(workstation): choreograph cross-zone showcase (#15933)

### DIFF
--- a/apps/workstation/tour/denseWorkstation.mjs
+++ b/apps/workstation/tour/denseWorkstation.mjs
@@ -3,9 +3,10 @@
  *
  * Twenty live items prove workstation density rather than catalog density. The dominant
  * scale grid and the live feed remain mounted as the screenplay resizes a real split,
- * opens the real overflow menu, scrolls the 100k grid, promotes a heavy tab through the
- * shipped `splitNode` descriptor, returns it through `addTab`, and flips both themes.
- * Surface cues are visual actions; the three document operations remain deterministic.
+ * opens the real overflow menu, scrolls the 100k grid, drives one tab across two live
+ * dropzone placements, promotes a heavy tab through the shipped `splitNode` descriptor,
+ * returns it through `addTab`, and flips both themes. Surface cues are visual actions;
+ * every document-tier operation remains deterministic.
  */
 
 /**
@@ -51,8 +52,9 @@ export const initialDocument = Object.freeze({
 });
 
 /**
- * The three-beat dense-workstation story. `promote` is prose only: the executable
- * vocabulary is the shipped `splitNode` + `addTab` pair.
+ * The four-scene dense-workstation story. `promote` is prose only: the executable
+ * vocabulary is the shipped `splitNode` + `addTab` pair; cross-zone choreography is
+ * a real-input surface cue over the same preview-operation pipeline.
  * @type {Object}
  */
 export const workstationTourScript = Object.freeze({
@@ -94,6 +96,34 @@ export const workstationTourScript = Object.freeze({
             ms     : 1400,
             cue    : {type: 'scroll', index: 50000},
             caption: 'the 100k grid crosses its midpoint without a blank frame'
+        }]
+    }, {
+        id     : 's-cross-zone',
+        title  : 'Dropzone choreography — every target answers the pointer',
+        caption: 'One live tab crosses two foreign zones; an edge split and a center merge answer with distinct previews before release.',
+        steps  : [{
+            type: 'pause',
+            ms  : 1600,
+            cue : {
+                type        : 'cross-zone-showcase',
+                itemId      : 'audit',
+                sourceNodeId: 'right-top-tabs',
+                terminal    : 'commit',
+                dwells      : [{
+                    targetNodeId : 'scale-tabs',
+                    placementKind: 'edge-bottom'
+                }, {
+                    targetNodeId : 'right-bottom-tabs',
+                    placementKind: 'tab-into'
+                }],
+                options: {
+                    dwellDelay: 700,
+                    moveDelay : 24,
+                    moveSteps : 18,
+                    showCursor: true
+                }
+            },
+            caption: 'Audit crosses the matrix split preview, then joins Commits through the live center target'
         }]
     }, {
         id     : 's2',

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -17,6 +17,7 @@ import StateProvider                            from '../../../src/state/Provide
 import TourRunner                               from '../../../src/ai/client/TourRunner.mjs';
 import {createDockTearOutHandlers}              from '../../../src/dashboard/DockTearOut.mjs';
 import {createDockVesselEmbodiment}             from '../../../src/dashboard/DockVesselEmbodiment.mjs';
+import {previewToOperation}                     from '../../../src/dashboard/dockPreviewContract.mjs';
 import {workstationTourScript, initialDocument} from '../tour/denseWorkstation.mjs';
 import '../../../src/button/Base.mjs';
 import '../../../src/tab/Container.mjs';
@@ -491,6 +492,8 @@ class Workspace extends Container {
             case 'canvas-update':
                 await this.refreshPromise;
                 return this.pulseScaleSparkline()
+            case 'cross-zone-showcase':
+                return this.executeCrossZoneShowcaseStep(cue, cue.options)
             case 'theme':
                 return this.setWorkspaceTheme(cue.theme)
             default:
@@ -1809,6 +1812,430 @@ class Workspace extends Container {
     }
 
     /**
+     * @summary Creates the film-only cursor that rides one gesture executor's own coordinates.
+     *
+     * CDP-dispatched pointer events move no OS cursor, so an unassisted take reads as
+     * UI-moving-itself. The create shape carries the required `className`, floating-component
+     * mount pair, stable `document.body` parent, and owning `windowId` for every subsequent
+     * style delta.
+     * @param {Number} clientX
+     * @param {Number} clientY
+     * @returns {Neo.component.Base}
+     * @protected
+     */
+    createFilmCursorDot(clientX, clientY) {
+        let me        = this,
+            cursorDot = Neo.create({
+                className    : 'Neo.component.Base',
+                appName      : me.appName,
+                autoInitVnode: true,
+                autoMount    : true,
+                parentId     : 'document.body',
+                windowId     : me.windowId,
+                cls          : ['film-cursor'],
+                style        : {
+                    backgroundColor: 'rgba(255, 90, 0, 0.92)',
+                    borderRadius   : '50%',
+                    boxShadow      : '0 0 10px rgba(255, 90, 0, 0.95), 0 0 3px rgba(255, 255, 255, 0.85)',
+                    display        : 'block',
+                    height         : '16px',
+                    left           : `${clientX - 8}px`,
+                    pointerEvents  : 'none',
+                    position       : 'fixed',
+                    top            : `${clientY - 8}px`,
+                    width          : '16px',
+                    zIndex         : 99999
+                }
+            });
+
+        cursorDot.mountedPromise.then(() => {
+            console.log(`[film-cursor] dot mounted at client (${clientX}, ${clientY})`)
+        });
+
+        return cursorDot
+    }
+
+    /**
+     * @summary Drives the in-window showcase beat through real simulated pointer input.
+     *
+     * One live tab crosses at least two foreign zones and two placement kinds. Each dwell first
+     * seeds the target zone's indicator menu, then aims at the indicator component's OWN computed
+     * geometry; the receipt comes from `DockDragAffordances`' live `activeCandidate.preview`, never
+     * a parallel DOM or pointer inference. Commit compares the resulting document with the exact
+     * preview operation applied to the pre-gesture document. Cancel proves byte-identical document
+     * truth and fully retired overlay/session state.
+     * @param {Object} step
+     * @param {Object[]} step.dwells Ordered `{targetNodeId, placementKind}` dwell requests.
+     * @param {String} step.itemId The live dock item to drag.
+     * @param {String} step.sourceNodeId The tabs node currently holding it.
+     * @param {'commit'|'cancel'} [step.terminal='commit']
+     * @param {Object} [options={}]
+     * @param {Number} [options.dwellDelay=120] Milliseconds each accepted preview stays visible.
+     * @param {Number} [options.moveDelay=16] Milliseconds between pointer samples.
+     * @param {Number} [options.moveSteps=12] Samples per path leg.
+     * @param {Number} [options.safetyMargin=48] Required inset from every window edge.
+     * @param {Boolean} [options.showCursor=false] Film mode: show the shared synthetic cursor.
+     * @returns {Promise<Object>}
+     */
+    async executeCrossZoneShowcaseStep(step, {dwellDelay=120, moveDelay=16, moveSteps=12, safetyMargin=48, showCursor=false}={}) {
+        let me = this,
+            {dwells=[], itemId, sourceNodeId, terminal='commit'} = step || {},
+            document                                 = me.dockModel,
+            sourceNode                               = document?.nodes?.[sourceNodeId],
+            button                                   = null,
+            cursorDot                                = null,
+            lastPoint                                = null,
+            proxyPopupEnabled                        = null,
+            restoreProxyPopupConfig                  = () => {
+                if (!sortZone || sortZone.isDestroyed || proxyPopupEnabled === null) {
+                    return {after: null, before: proxyPopupEnabled, restored: false}
+                }
+
+                sortZone.enableProxyToPopup = proxyPopupEnabled;
+
+                return {
+                    after   : sortZone.enableProxyToPopup,
+                    before  : proxyPopupEnabled,
+                    restored: sortZone.enableProxyToPopup === proxyPopupEnabled
+                }
+            },
+            sortZone                                 = null,
+            tabs                                     = null,
+            windowRect                               = null;
+
+        if (!itemId || sourceNode?.type !== 'tabs' || !sourceNode.items.includes(itemId)) {
+            return {applied: false, errors: ['cross-zone showcase must name a live item held by its source tabs node']}
+        }
+
+        if (!Array.isArray(dwells) || dwells.length < 2
+            || new Set(dwells.map(dwell => dwell?.targetNodeId)).size < 2
+            || new Set(dwells.map(dwell => dwell?.placementKind)).size < 2
+            || dwells.some(dwell => !dwell?.targetNodeId || !dwell?.placementKind || dwell.targetNodeId === sourceNodeId)) {
+            return {applied: false, errors: ['cross-zone showcase requires two distinct foreign zones and two distinct placement kinds']}
+        }
+
+        if (!['commit', 'cancel'].includes(terminal)) {
+            return {applied: false, errors: [`unsupported cross-zone terminal '${terminal}'`]}
+        }
+
+        try {
+            await me.refreshPromise;
+
+            let host          = me.getReference('dock-host'),
+                itemIndex     = sourceNode.items.indexOf(itemId),
+                WindowManager = (await import('../../../src/manager/Window.mjs')).default;
+
+            tabs     = host?.down({dockNodeId: sourceNodeId});
+            sortZone = tabs?.getTabBar()?.sortZone;
+            button   = tabs?.getTabAtIndex(itemIndex);
+
+            let window       = WindowManager.get(button?.windowId),
+                [buttonRect] = button ? await button.getDomRect([button.id], button.windowId) : [];
+
+            if (!button || !sortZone || !buttonRect || !window?.innerRect) {
+                return {applied: false, errors: ['cross-zone gesture surfaces are not ready']}
+            }
+
+            windowRect        = window.innerRect;
+            proxyPopupEnabled = sortZone.enableProxyToPopup;
+            // Tear-out hysteresis is measured against the SOURCE TOOLBAR, not the browser edge:
+            // an ordinary cross-zone path necessarily leaves that strip. Disarm only the popup
+            // conversion branch for this gesture; `finally` restores the live config on every
+            // terminal. The window inset below remains a visual-stage safety rule.
+            sortZone.enableProxyToPopup = false;
+
+            let documentBefore = DockZoneModel.clone(document),
+                startX         = buttonRect.x + buttonRect.width / 2,
+                startY         = buttonRect.y + buttonRect.height / 2,
+                directionX     = startX > window.innerRect.width  / 2 ? -1 : 1,
+                directionY     = startY > window.innerRect.height / 2 ? -1 : 1,
+                opt            = (clientX, clientY, buttons) => ({
+                    bubbles   : true,
+                    button    : 0,
+                    buttons,
+                    cancelable: true,
+                    clientX,
+                    clientY,
+                    screenX   : window.innerRect.x + clientX,
+                    screenY   : window.innerRect.y + clientY
+                }),
+                safe           = ({x, y}) => Number.isFinite(x) && Number.isFinite(y)
+                    && x >= safetyMargin && y >= safetyMargin
+                    && x <= window.innerRect.width  - safetyMargin
+                    && y <= window.innerRect.height - safetyMargin,
+                releaseAt      = point => ({
+                    clientX: point?.x ?? startX,
+                    clientY: point?.y ?? startY,
+                    screenX: window.innerRect.x + (point?.x ?? startX),
+                    screenY: window.innerRect.y + (point?.y ?? startY)
+                }),
+                waitUntil      = async (predicate, attempts=120) => {
+                    for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+                        if (predicate()) return true;
+
+                        attempt < attempts && await me.timeout(16)
+                    }
+
+                    return Boolean(predicate())
+                },
+                moveTo         = (x, y) => {
+                    if (cursorDot) {
+                        cursorDot.style = {...cursorDot.style, left: `${x - 8}px`, top: `${y - 8}px`}
+                    }
+
+                    return me.interactionService.simulateEvent({events: [{
+                        delay  : moveDelay,
+                        // Once the sort starts, its render can replace the source button DOM identity.
+                        // Native drag sensors are document-global after arming, so keep the synthetic
+                        // stream on the same stable owner instead of addressing a stale source node.
+                        targetId: 'document.body',
+                        type    : 'mousemove',
+                        windowId: button.windowId,
+                        options : opt(x, y, 1)
+                    }]})
+                },
+                walkTo         = async point => {
+                    if (!safe(point)) {
+                        throw new Error(`cross-zone path point violates the ${safetyMargin}px window-edge margin`)
+                    }
+
+                    let from     = lastPoint,
+                        distance = from ? Math.hypot(point.x - from.x, point.y - from.y) : 0,
+                        steps    = distance < 1 ? 1 : Math.max(2, Math.floor(moveSteps));
+
+                    for (let index = 1; index <= steps; index++) {
+                        let ratio = index / steps;
+
+                        await moveTo(
+                            Math.round(from.x + (point.x - from.x) * ratio),
+                            Math.round(from.y + (point.y - from.y) * ratio)
+                        )
+                    }
+
+                    lastPoint = point
+                },
+                overlaysRetired = () => !me.dragAffordances.dragGeometry
+                    && !me.dragAffordances.indicators?.candidateSet
+                    && !me.dragAffordances.indicators?.activeCandidate
+                    && !me.dragAffordances.preview?.dockPreview;
+
+            if (!safe({x: startX, y: startY})) {
+                return {applied: false, errors: [`source tab violates the ${safetyMargin}px window-edge margin`]}
+            }
+
+            let armOne = {x: startX + directionX * 8,  y: startY + directionY * 2},
+                armTwo = {x: startX + directionX * 16, y: startY + directionY * 24};
+
+            if (![armOne, armTwo].every(safe)) {
+                return {applied: false, errors: [`drag-arming path violates the ${safetyMargin}px window-edge margin`]}
+            }
+
+            await me.interactionService.simulateEvent({events: [{
+                targetId: button.id,
+                type    : 'mousedown',
+                windowId: button.windowId,
+                options : opt(startX, startY, 1)
+            }, {
+                delay   : 120,
+                targetId: button.id,
+                type    : 'mousemove',
+                windowId: button.windowId,
+                options : opt(armOne.x, armOne.y, 1)
+            }]});
+
+            lastPoint = armOne;
+
+            if (!await me.waitForTearOutDragArmed(sortZone)) {
+                let cancellation = await me.cancelTearOutGesture(
+                    button,
+                    releaseAt(lastPoint),
+                    {sortZone, targetId: 'document.body'}
+                );
+
+                return {applied: false, errors: ['cross-zone drag did not arm'], proof: {cancellation}}
+            }
+
+            // The first threshold-crossing move can replace the source tab DOM. Only after the
+            // sensor reports its document-global ownership do we advance on the stable carrier.
+            await moveTo(armTwo.x, armTwo.y);
+            lastPoint = armTwo;
+
+            showCursor && (cursorDot = me.createFilmCursorDot(lastPoint.x, lastPoint.y));
+
+            let geometry = await me.dragAffordances.ensureGeometry();
+
+            if (!geometry) {
+                throw new Error('cross-zone geometry did not become measurable')
+            }
+
+            let beats        = [],
+                finalPreview = null;
+
+            for (let [index, dwell] of dwells.entries()) {
+                let zone = geometry.zones.find(entry => entry.nodeId === dwell.targetNodeId);
+
+                if (!zone) {
+                    throw new Error(`cross-zone target '${dwell.targetNodeId}' is not measurable`)
+                }
+
+                let seedPoint = {
+                    x: Math.round(zone.rect.x + zone.rect.width  / 2),
+                    y: Math.round(zone.rect.y + zone.rect.height / 2)
+                };
+
+                await walkTo(seedPoint);
+
+                let candidateSetReady = await waitUntil(() =>
+                    me.dragAffordances.indicators?.candidateSet?.zone?.nodeId === dwell.targetNodeId);
+
+                if (!candidateSetReady) {
+                    throw new Error(
+                        `indicator set did not settle on '${dwell.targetNodeId}' — ` +
+                        `current=${me.dragAffordances.indicators?.candidateSet?.zone?.nodeId ?? 'null'} ` +
+                        `seed=(${seedPoint.x},${seedPoint.y}) zones=${geometry.zones.map(entry => entry.nodeId).join(',')} ` +
+                        `dragProxy=${Boolean(sortZone.dragProxy)} startIndex=${sortZone.startIndex} currentIndex=${sortZone.currentIndex}`
+                    )
+                }
+
+                let indicators = me.dragAffordances.indicators,
+                    candidate  = indicators.candidateSet.cross
+                        .find(entry => entry.preview?.placement?.kind === dwell.placementKind),
+                    indicator  = candidate && indicators.items
+                        .find(item => item.candidateKey === `cross-${candidate.position}`),
+                    hostRect   = indicators.hostRect,
+                    left       = Number.parseFloat(indicator?.style?.left),
+                    top        = Number.parseFloat(indicator?.style?.top),
+                    width      = Number.parseFloat(indicator?.style?.width),
+                    height     = Number.parseFloat(indicator?.style?.height);
+
+                if (!candidate || !hostRect || [left, top, width, height].some(value => !Number.isFinite(value))) {
+                    throw new Error(`indicator geometry is unavailable for '${dwell.placementKind}'`)
+                }
+
+                let indicatorPoint = {
+                    x: Math.round(hostRect.x + left + width  / 2),
+                    y: Math.round(hostRect.y + top  + height / 2)
+                };
+
+                await walkTo(indicatorPoint);
+
+                let candidateActive = await waitUntil(() =>
+                    indicators.activeCandidate?.preview?.previewId === candidate.preview.previewId);
+
+                if (!candidateActive) {
+                    throw new Error(`indicator '${candidate.preview.previewId}' never became active`)
+                }
+
+                dwellDelay > 0 && await me.timeout(dwellDelay);
+
+                let preview = indicators.activeCandidate.preview;
+
+                finalPreview = JSON.parse(JSON.stringify(preview));
+                beats.push({
+                    dwell        : index + 1,
+                    placementKind: preview.placement.kind,
+                    previewId    : preview.previewId,
+                    targetNodeId : preview.target.nodeId
+                })
+            }
+
+            if (terminal === 'cancel') {
+                let cancellation = await me.cancelTearOutGesture(
+                        button,
+                        releaseAt(lastPoint),
+                        {sortZone, targetId: 'document.body'}
+                    ),
+                    retired      = await waitUntil(overlaysRetired),
+                    documentAfter = DockZoneModel.clone(me.dockModel),
+                    unchanged     = JSON.stringify(documentAfter) === JSON.stringify(documentBefore),
+                    popupConfig   = restoreProxyPopupConfig();
+
+                return {
+                    applied  : false,
+                    beatLog  : beats,
+                    cancelled: true,
+                    errors   : cancellation.settled && retired && unchanged
+                        ? []
+                        : ['cross-zone cancel left drag, document, or overlay residue'],
+                    proof : {
+                        cancellation,
+                        documentAfter,
+                        documentBefore,
+                        documentsUnchanged: unchanged,
+                        overlaysRetired   : retired,
+                        popupConfig
+                    }
+                }
+            }
+
+            let descriptor     = previewToOperation(finalPreview),
+                expectedResult = descriptor && DockZoneModel.applyOperation(
+                    DockZoneModel.clone(documentBefore),
+                    descriptor
+                );
+
+            if (!descriptor || !expectedResult || expectedResult.errors?.length || !expectedResult.document) {
+                throw new Error('final active preview did not resolve to one valid document operation')
+            }
+
+            let expectedDocument   = DockZoneModel.clone(expectedResult.document),
+                expectedSerialized = JSON.stringify(expectedDocument);
+
+            await me.interactionService.simulateEvent({events: [{
+                targetId: 'document.body',
+                type    : 'mouseup',
+                windowId: button.windowId,
+                options : opt(lastPoint.x, lastPoint.y, 0)
+            }]});
+
+            let settled = await waitUntil(() => JSON.stringify(me.dockModel) === expectedSerialized);
+
+            settled && await me.refreshPromise;
+
+            let documentAfter          = DockZoneModel.clone(me.dockModel),
+                documentMatchesPreview = JSON.stringify(documentAfter) === expectedSerialized,
+                retired                = await waitUntil(overlaysRetired),
+                popupConfig            = restoreProxyPopupConfig(),
+                applied                = settled && documentMatchesPreview && retired && popupConfig.restored;
+
+            return {
+                applied,
+                beatLog: beats,
+                errors : applied ? [] : ['cross-zone commit did not equal the previewed operation or retire its overlays'],
+                proof  : {
+                    descriptor,
+                    documentAfter,
+                    documentBefore,
+                    documentMatchesPreview,
+                    expectedDocument,
+                    finalPreview,
+                    overlaysRetired: retired,
+                    popupConfig
+                }
+            }
+        } catch (error) {
+            let clientX = lastPoint?.x ?? 0,
+                clientY = lastPoint?.y ?? 0;
+
+            button && await me.cancelTearOutGesture(
+                button,
+                {
+                    clientX,
+                    clientY,
+                    screenX: (windowRect?.x ?? 0) + clientX,
+                    screenY: (windowRect?.y ?? 0) + clientY
+                },
+                {sortZone, targetId: 'document.body'}
+            ).catch(() => {});
+
+            return {applied: false, errors: [error?.message || String(error)]}
+        } finally {
+            restoreProxyPopupConfig();
+            cursorDot?.destroy()
+        }
+    }
+
+    /**
      * @summary The app-owned tear-out journey executor — scene 2's real-pointer drive.
      *
      * Arms a tab drag, flings the proxy past the window boundary so
@@ -1929,48 +2356,8 @@ class Workspace extends Container {
                 return {applied: false, errors: ['tear-out drag did not arm'], proof: {armed: false, cancellation, documentBefore}}
             }
 
-            // Film mode only: the visible synthetic cursor. CDP-dispatched pointer events move no
-            // OS cursor, so an unassisted take reads as UI-moving-itself. The dot rides the SAME
-            // coordinates the executor logs (single source of truth — it never re-derives a
-            // position), stays pointer-events:none, and never enters the dock document (worker
-            // truth is blind to it by construction: it is a presentation layer for the camera).
-            // The create shape carries four keys, each earned by a real failure in this lane:
-            // `className` (a bare `ntype` object config makes Neo.create return null), the
-            // autoInitVnode+autoMount pair (the floating-component idiom — parentId alone
-            // registers, it never renders), `parentId: 'document.body'` (the DragZone
-            // proxyParentId precedent — no re-rendering ancestor can strand the node), and
-            // `windowId` (null-windowId vdom deltas misroute in a multi-window app: the mount
-            // render lands, every subsequent style delta is lost).
             if (showCursor) {
-                cursorDot = Neo.create({
-                    className    : 'Neo.component.Base',
-                    appName      : me.appName,
-                    autoInitVnode: true,
-                    autoMount    : true,
-                    parentId     : 'document.body',
-                    windowId     : me.windowId,
-                    cls          : ['film-cursor'],
-                    style        : {
-                        backgroundColor: 'rgba(255, 90, 0, 0.92)',
-                        borderRadius   : '50%',
-                        boxShadow      : '0 0 10px rgba(255, 90, 0, 0.95), 0 0 3px rgba(255, 255, 255, 0.85)',
-                        display        : 'block',
-                        height         : '16px',
-                        left           : `${startX - 8}px`,
-                        pointerEvents  : 'none',
-                        position       : 'fixed',
-                        top            : `${startY - 8}px`,
-                        width          : '16px',
-                        zIndex         : 99999
-                    }
-                });
-
-                // The text receipt beside the frame receipt: assertions stay byte-identical
-                // (AC4), so observability is the only guard against a silent camera-truth
-                // regression (a green suite cannot see the dot).
-                cursorDot.mountedPromise.then(() => {
-                    console.log(`[film-cursor] dot mounted at client (${startX}, ${startY})`)
-                })
+                cursorDot = me.createFilmCursorDot(startX, startY)
             }
 
             // Pre-birth entry sentinels: a curved outward path can transiently re-cover the strip
@@ -2267,29 +2654,48 @@ class Workspace extends Container {
      * consumes) followed by a settling mouseup.
      * @param {Neo.component.Base} button The dragged tab button.
      * @param {Object} release `{clientX, clientY, screenX, screenY}` the release point.
+     * @param {Object} [options={}]
+     * @param {Neo.draggable.container.SortZone|null} [options.sortZone=null] Zone whose idle facts gate settlement.
+     * @param {String} [options.targetId=button.id] Stable DOM owner for both terminal events.
      * @returns {Promise<Object>}
      * @protected
      */
-    async cancelTearOutGesture(button, release) {
+    async cancelTearOutGesture(button, release, {sortZone=null, targetId=button?.id}={}) {
         let me = this;
 
-        if (!button) return {escapeDispatched: false, releaseDispatched: false, settled: false};
+        if (!button || !targetId) return {escapeDispatched: false, releaseDispatched: false, settled: false};
 
         let {clientX=0, clientY=0, screenX=0, screenY=0} = release || {},
             escapeDispatched = await me.interactionService.dispatch({
-                id      : button.id,
+                id      : targetId,
                 type    : 'keydown',
                 windowId: button.windowId,
                 options : {bubbles: true, cancelable: true, code: 'Escape', key: 'Escape'}
             }),
             releaseDispatched = await me.interactionService.dispatch({
-                id      : button.id,
+                id      : targetId,
                 type    : 'mouseup',
                 windowId: button.windowId,
                 options : {bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY, screenX, screenY}
             });
 
-        return {escapeDispatched, releaseDispatched, settled: true}
+        if (!sortZone) {
+            return {escapeDispatched, releaseDispatched, settled: true}
+        }
+
+        for (let attempt = 0; attempt <= 60 && !me.isDestroyed; attempt++) {
+            let settled = sortZone.owner?.cls?.includes?.('neo-is-dragging') !== true
+                && sortZone.dragEndActive !== true
+                && sortZone.data == null
+                && !sortZone.dragPlaceholder
+                && !sortZone.dragProxy;
+
+            if (settled) return {escapeDispatched, releaseDispatched, settled: true};
+
+            attempt < 60 && await me.timeout(16)
+        }
+
+        return {escapeDispatched, releaseDispatched, settled: false}
     }
 
     /**

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -54,7 +54,9 @@ import {test, expect} from '../../fixtures.mjs';
 // nothing but a worse error.
 const
     filmTake = Boolean(process.env.NEO_FILM_TAKE),
-    filmPace = filmTake ? {birthAttempts: 240, curve: 0.18, moveDelay: 33, moveSteps: 24, showCursor: true} : {};
+    filmPace = filmTake
+        ? {birthAttempts: 240, curve: 0.18, dwellDelay: 700, moveDelay: 33, moveSteps: 24, showCursor: true}
+        : {};
 
 /**
  * Film mode only: pins the main window to a deterministic stage via CDP `Browser.setWindowBounds` —
@@ -507,6 +509,99 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         // the determinism AC: two scripted runs replay the identical structural beat log
         expect(logs[1], 'two runs must replay the identical beat log').toEqual(logs[0]);
         expect(pageErrors, 'the journey must be error-free').toEqual([])
+    });
+
+    test('showcase beat — one drag crosses two live dropzones; cancel and commit stay deterministic', async ({page, neuralLink}) => {
+        const
+            cancelLogs    = [],
+            commitLogs    = [],
+            pageErrorRuns = [],
+            gesture       = {
+                itemId      : 'audit',
+                sourceNodeId: 'right-top-tabs',
+                dwells      : [{
+                    targetNodeId : 'scale-tabs',
+                    placementKind: 'edge-bottom'
+                }, {
+                    targetNodeId : 'right-bottom-tabs',
+                    placementKind: 'tab-into'
+                }]
+            };
+
+        for (let run = 0; run < 2; run++) {
+            const
+                ctx            = await boot({page, neuralLink}),
+                {app, wsId}    = ctx,
+                documentBefore = await readDocument(app, wsId),
+                heartbeatStart = await readHeartbeat(app, wsId),
+                paneId         = await app.callMethod(wsId, 'getPaneIdentity', ['audit']);
+
+            pageErrorRuns.push(ctx.pageErrors);
+
+            const cancelled = await app.callMethod(wsId, 'executeCrossZoneShowcaseStep', [{
+                ...gesture,
+                terminal: 'cancel'
+            }, filmPace]);
+
+            expect(cancelled.errors).toEqual([]);
+            expect(cancelled.cancelled, 'Escape settles the in-window gesture as cancel').toBe(true);
+            expect(cancelled.proof.documentsUnchanged, 'cancel commits no document mutation').toBe(true);
+            expect(cancelled.proof.overlaysRetired, 'cancel retires geometry, menu, selection, and preview').toBe(true);
+            expect(cancelled.proof.popupConfig.restored,
+                'cancel restores the exact popup-conversion setting before resolving').toBe(true);
+            expect(cancelled.proof.popupConfig.after).toBe(cancelled.proof.popupConfig.before);
+            expect(await readDocument(app, wsId), 'fresh worker truth remains byte-identical after cancel')
+                .toEqual(documentBefore);
+
+            const committed = await app.callMethod(wsId, 'executeCrossZoneShowcaseStep', [{
+                ...gesture,
+                terminal: 'commit'
+            }, filmPace]);
+
+            expect(committed.errors).toEqual([]);
+            expect(committed.applied, 'release commits the exact active preview').toBe(true);
+            expect(committed.proof.documentMatchesPreview,
+                'the committed document equals previewToOperation(preview) applied to pre-gesture truth').toBe(true);
+            expect(committed.proof.overlaysRetired, 'commit retires geometry, menu, selection, and preview').toBe(true);
+            expect(committed.proof.popupConfig.restored,
+                'commit restores the exact popup-conversion setting before resolving').toBe(true);
+            expect(committed.proof.popupConfig.after).toBe(committed.proof.popupConfig.before);
+            expect(committed.proof.descriptor).toEqual({
+                operation : 'addTab',
+                itemId    : 'audit',
+                tabsNodeId: 'right-bottom-tabs',
+                index     : null
+            });
+
+            const documentAfter = await readDocument(app, wsId);
+
+            expect(documentAfter, 'independent App Worker truth equals the executor expected document')
+                .toEqual(committed.proof.expectedDocument);
+            expect(documentAfter.nodes['right-top-tabs'].items,
+                'the source stays alive with its sibling').toEqual(['metrics']);
+            expect(documentAfter.nodes['right-bottom-tabs'].items,
+                'the final center target owns the dragged item').toEqual(['commits', 'audit']);
+            expect(committed.beatLog.map(({placementKind, targetNodeId}) => ({placementKind, targetNodeId})))
+                .toEqual([
+                    {placementKind: 'edge-bottom', targetNodeId: 'scale-tabs'},
+                    {placementKind: 'tab-into',    targetNodeId: 'right-bottom-tabs'}
+                ]);
+            expect(await app.callMethod(wsId, 'getPaneIdentity', ['audit']),
+                'the same pane instance crosses the workspace').toBe(paneId);
+            expect(await readHeartbeat(app, wsId), 'living content advances through both gestures')
+                .toBeGreaterThan(heartbeatStart);
+
+            cancelLogs.push(cancelled.beatLog);
+            commitLogs.push(committed.beatLog);
+
+            if (run === 0) {
+                await page.reload()
+            }
+        }
+
+        expect(cancelLogs[1], 'two cancel drives produce identical semantic dwell logs').toEqual(cancelLogs[0]);
+        expect(commitLogs[1], 'two commit drives produce identical semantic dwell logs').toEqual(commitLogs[0]);
+        expect(pageErrorRuns.flat(), 'both live gesture-time error streams stay empty').toEqual([])
     });
 
     // ── beats 3-4: contracted legs — activate as the cross-window docking wiring lands ──

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -1490,11 +1490,38 @@ test.describe('Workstation — dense living-data composition', () => {
             .toBe(true);
         expect(tourReceipt.errors).toEqual([]);
         expect(tourReceipt.cueReceipts.map(entry => entry.cue.type))
-            .toEqual(['overflow', 'scroll', 'canvas-update', 'theme', 'theme']);
+            .toEqual([
+                'overflow',
+                'scroll',
+                'cross-zone-showcase',
+                'canvas-update',
+                'theme',
+                'theme'
+            ]);
         expect(tourReceipt.cueReceipts.find(entry => entry.cue.type === 'overflow').receipt)
             .toMatchObject({activatedItemId: 'security'});
         expect(tourReceipt.cueReceipts.find(entry => entry.cue.type === 'overflow').receipt.menuItemCount)
             .toBeGreaterThan(0);
+        const crossZoneReceipt = tourReceipt.cueReceipts
+            .find(entry => entry.cue.type === 'cross-zone-showcase').receipt;
+
+        expect(crossZoneReceipt.errors).toEqual([]);
+        expect(crossZoneReceipt.applied, 'the visible tour commits the final live candidate').toBe(true);
+        expect(crossZoneReceipt.beatLog.map(({placementKind, targetNodeId}) => ({placementKind, targetNodeId})))
+            .toEqual([
+                {placementKind: 'edge-bottom', targetNodeId: 'scale-tabs'},
+                {placementKind: 'tab-into',    targetNodeId: 'right-bottom-tabs'}
+            ]);
+        expect(crossZoneReceipt.proof.descriptor).toEqual({
+            operation : 'addTab',
+            itemId    : 'audit',
+            tabsNodeId: 'right-bottom-tabs',
+            index     : null
+        });
+        expect(crossZoneReceipt.proof.documentMatchesPreview,
+            'the visible drop equals the captured preview operation').toBe(true);
+        expect(crossZoneReceipt.proof.overlaysRetired,
+            'the drop leaves no indicator, preview, or geometry residue').toBe(true);
         expect(tourReceipt.cueReceipts.find(entry => entry.cue.type === 'canvas-update').receipt.componentId)
             .toBeTruthy();
         expect(tourReceipt.cueReceipts.filter(entry => entry.cue.type === 'theme').map(entry => entry.receipt))
@@ -1515,6 +1542,8 @@ test.describe('Workstation — dense living-data composition', () => {
             'alerts', 'activity', 'topology', 'runtime', 'traces', 'logs',
             'console', 'builds', 'deploys', 'memory', 'files', 'security'
         ]);
+        expect(tourReceipt.document.nodes['right-top-tabs'].items).toEqual(['metrics']);
+        expect(tourReceipt.document.nodes['right-bottom-tabs'].items).toEqual(['commits', 'audit']);
         expect(tourReceipt.document.nodes['split-main'].sizes, 'the visible tour demonstrates resizeSplit')
             .toEqual([0.52, 0.48]);
 
@@ -1609,10 +1638,26 @@ test.describe('Workstation — dense living-data composition', () => {
             intervals: [50, 100]
         }).toBe(true);
 
-        const postTourChrome = await readTabChromeIdentity(app, workspaceId);
+        const
+            postTourChrome         = await readTabChromeIdentity(app, workspaceId),
+            expectedPostTourChrome = {
+                ...beforeChrome,
+                'right-top-tabs': {
+                    ...beforeChrome['right-top-tabs'],
+                    buttons: {metrics: beforeChrome['right-top-tabs'].buttons.metrics}
+                },
+                'right-bottom-tabs': {
+                    ...beforeChrome['right-bottom-tabs'],
+                    buttons: {
+                        ...beforeChrome['right-bottom-tabs'].buttons,
+                        audit: beforeChrome['right-top-tabs'].buttons.audit
+                    }
+                }
+            };
 
-        expect(postTourChrome, 'split + return preserves the complete opening tab-chrome identity matrix')
-            .toEqual(beforeChrome);
+        expect(postTourChrome,
+            'cross-zone + split/return preserve every chrome identity while Audit changes owner')
+            .toEqual(expectedPostTourChrome);
 
         const indicatorSetup = await page.evaluate(receipt => {
             const
@@ -1676,7 +1721,7 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(afterIdentity, 'workspace, heavy pane, data panes, Provider, and stores survive all transformations')
             .toEqual(beforeIdentity);
         expect(afterChrome, 'ordinary active-tab input also preserves every tab-chrome component identity')
-            .toEqual(beforeChrome);
+            .toEqual(postTourChrome);
         expect(scaleSparklinesAfter.length, 'the viewport-bounded scale component pool remains live')
             .toBeGreaterThan(0);
         expect(stableScaleComponentIds.every(id => scaleSparklinesAfter.some(entry => entry.id === id)),

--- a/test/playwright/unit/apps/workstation/tour/denseWorkstation.spec.mjs
+++ b/test/playwright/unit/apps/workstation/tour/denseWorkstation.spec.mjs
@@ -74,9 +74,25 @@ test.describe.serial('apps/workstation/tour/denseWorkstation', () => {
         expect(Object.entries(initialDocument.items)
             .filter(([, item]) => item.autoHidden === true)
             .map(([itemId]) => itemId)).toEqual(['graph', 'inspector']);
-        expect(cues).toEqual(['overflow', 'scroll', 'canvas-update', 'theme', 'theme']);
+        expect(cues).toEqual([
+            'overflow',
+            'scroll',
+            'cross-zone-showcase',
+            'canvas-update',
+            'theme',
+            'theme'
+        ]);
         expect(workstationTourScript.scenes.flatMap(scene => scene.steps)
             .find(step => step.cue?.type === 'overflow').cue.itemId).toBe('security');
+        expect(workstationTourScript.scenes.flatMap(scene => scene.steps)
+            .find(step => step.cue?.type === 'cross-zone-showcase').cue.dwells)
+            .toEqual([{
+                targetNodeId : 'scale-tabs',
+                placementKind: 'edge-bottom'
+            }, {
+                targetNodeId : 'right-bottom-tabs',
+                placementKind: 'tab-into'
+            }]);
         expect(operations).toEqual(['resizeSplit', 'splitNode', 'addTab']);
         operations.forEach(operation => expect(DockZoneModel.operations).toContain(operation));
         expect(operations).not.toContain('promote')


### PR DESCRIPTION
Resolves #15933

The Workstation tour now shows the in-window docking grammar the v0 film missed: one live Audit tab crosses two foreign dock zones, dwells on an edge-split preview and then a center-merge preview, and commits the exact final candidate. The executor uses real synthetic mouse input, the shipped `DockDragAffordances` session as its only preview truth, and the same script/pace contract for tests and film takes.

Evidence: L3 (exact-head local Chromium on accelerated ANGLE/Metal through the Neural Link app boundary) → L3 required for the executor's cancel/commit, document, overlay, identity, heartbeat, and two-run determinism ACs. One residual remains explicit: the older all-in-one visible-tour test is `NOT_YET_MEASURED` for this cue because it times out at its pre-tour Canvas screenshot before playback begins.

Related: #15252 · #15906 · #15923 · #15924

## Causal boundary

The ticket's original premise said a window-edge inset would prevent the gesture from becoming a tear-out. Live source and headed input falsified that boundary:

- `SortZone#checkWindowBoundary` measures the proxy against the source tab toolbar, not the browser window.
- A legitimate cross-zone path must leave that toolbar, so the executor disables only `enableProxyToPopup` for its gesture and restores the exact captured value before either successful terminal resolves and again in `finally`.
- Arming the sort can replace the source tab button's DOM identity. The threshold-crossing move stays on the live button; after the zone proves document-global sensor ownership, every move and terminal uses `document.body`.
- Each dwell seeds a real target zone, then aims at the rendered indicator component. The semantic receipt is copied from `activeCandidate.preview`; `previewToOperation()` supplies the commit descriptor.

The choreography therefore consumes the shipped docking grammar without changing `DockDragAffordances`, `DockPreview`, `DockDropIndicators`, `DockLayoutAdapter`, or the dock reducer.

## Deltas from ticket

- Corrected the window-margin isolation premise in the issue body before implementation. The 48px inset remains a visual-stage guard only.
- Added `Workspace#executeCrossZoneShowcaseStep()` and routed the `cross-zone-showcase` cue through `executeCue()`.
- Extended `cancelTearOutGesture()` with an optional stable target and bounded SortZone-idle witness; existing callers retain their prior behavior.
- Extracted the already-shipped film cursor construction so both tear-out and cross-zone executors share the same presentation-only component.
- Added the fourth screenplay scene: `audit` crosses `scale-tabs` / `edge-bottom`, then `right-bottom-tabs` / `tab-into`, and commits the center merge.
- Added exact popup-config before/after receipts and retained the live page-error arrays through both gesture terminals after an independent diff audit found those evidence gaps.

## Test Evidence

- Exact PR head `66cf26559fd320facb44245e7e3e440fa1a2ddbe`, rebased conflict-free onto `dev` head `786666fe72`.
- Tour schema/reducer unit:
  `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/apps/workstation/tour/denseWorkstation.spec.mjs`
  — **2 passed**.
- Complete multi-window journey:
  `NEO_E2E_PORT=8152 npx playwright test workstation/WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1`
  — **5 passed, 3 intentionally skipped**. This includes two fresh cross-zone boots with cancel + commit per boot, exact `addTab` descriptor/document equality, overlay retirement, exact popup-config restoration, pane identity, monotonic heartbeat, live page-error capture, and identical semantic dwell logs. Existing tear-out and out/back-in morph legs also remain green.
- Visible all-in-one tour:
  `NEO_E2E_PORT=8153 npx playwright test workstation/WorkstationNL -c test/playwright/playwright.config.e2e.mjs --grep 'the real tour keeps density' --workers=1`
  — **NOT_YET_MEASURED for #15933**. It repeats the pre-existing 150s timeout at `targetCanvas.screenshot()` line 1152, before tour playback begins (the #15933 assertions start after line 1490). Trace and error context were emitted under `test/playwright/test-results/e2e/artifacts/workstation-WorkstationNL--3543f-s-rails-and-identities-live-chromium/`.
- Five changed `.mjs` files pass syntax checks and `git diff --check`.
- Staged `npm run agent-preflight` — **pass**, 5 files scanned, 0 ticket-archaeology violations; only the unrelated known local AiConfig overlay warning remains.
- Commit hooks — whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, block alignment, and parse — **all pass**.

## Post-Merge Validation

- [ ] Hosted CI remains green on the exact PR head.
- [ ] Re-run the all-in-one visible-tour witness after its pre-tour Canvas screenshot stability blocker is resolved; then promote that row from `NOT_YET_MEASURED`.
- [ ] The next film-v1 take visibly holds both distinct preview dwells and the final center merge before the cut is accepted.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019f98df-25e8-7472-bf05-7a7a453e42a1.
