### PR TITLE
feat(build): Data Sync gets two least-privilege identities and a preflight that names the failure (#15744)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -56,7 +56,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: dev
+          # A dispatch resolves the WORKFLOW FILE from the chosen ref but this step decided the
+          # SOURCE, and it was pinned to `dev` — so dispatching from a branch ran that branch's
+          # workflow against dev's code. Every change to the pipeline was therefore untestable
+          # before merge, which is a poor property for the script that publishes to dev.
+          #
+          # A preflight-only dispatch checks out the dispatched ref, because verifying a change
+          # is the entire point of it. Scheduled runs and full dispatches stay pinned to `dev`:
+          # they publish, and publishing must never emit from an unmerged branch.
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.preflight_only) && github.ref || 'dev' }}
           fetch-depth: 0
           # The publish push runs through the checkout credential, so it must be the Publisher
           # identity — the only actor permitted to bypass the code-scanning ruleset.

--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -17,20 +17,53 @@ jobs:
       contents: write # Required to push changes
 
     steps:
+      # Two identities, because they hold different authority and `create-github-app-token` scopes
+      # ONE permission set across a whole repository set — a single App spanning all three repos
+      # would let the ruleset-bypass identity mutate the intake repos and let the intake identity
+      # publish here. The default GITHUB_TOKEN can do neither job: it is scoped to this repository,
+      # so it has no installation at all on the DevIndex intake repos (absent, not underprivileged),
+      # and a token that cannot bypass the code-scanning ruleset cannot publish a fresh commit,
+      # because that commit has no prior CodeQL result and only a push could produce one.
+      - name: Mint Publisher installation token
+        id: publisher-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.DATA_SYNC_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.DATA_SYNC_PUBLISHER_PRIVATE_KEY }}
+
+      # Installed on the DevIndex repos, not this one, so the installation must be named explicitly.
+      - name: Mint Intake installation token
+        id: intake-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.DATA_SYNC_INTAKE_APP_ID }}
+          private-key: ${{ secrets.DATA_SYNC_INTAKE_PRIVATE_KEY }}
+          owner: neomjs
+          repositories: |
+            devindex-opt-in
+            devindex-opt-out
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           ref: dev
           fetch-depth: 0
+          # The publish push runs through the checkout credential, so it must be the Publisher
+          # identity — the only actor permitted to bypass the code-scanning ruleset.
+          token: ${{ steps.publisher-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24'
 
+      # Both tokens are handed to the runner, never to the stages. `scopedStageEnv` strips BOTH
+      # source variables and re-injects only the one a stage is entitled to, so the publisher
+      # credential is absent from every data-collection child rather than merely unused by it.
       - name: Run bounded Data Sync emission and publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATA_SYNC_INTAKE_TOKEN: ${{ steps.intake-token.outputs.token }}
+          DATA_SYNC_PUBLISHER_TOKEN: ${{ steps.publisher-token.outputs.token }}
         run: node ./buildScripts/dataSyncPipeline.mjs
 
       - name: Push Data to neomjs/pages

--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -40,6 +40,12 @@ jobs:
         with:
           app-id: ${{ secrets.DATA_SYNC_PUBLISHER_APP_ID }}
           private-key: ${{ secrets.DATA_SYNC_PUBLISHER_PRIVATE_KEY }}
+          # Requested EXPLICITLY: without this, v3 mints a token carrying every permission the
+          # installation holds. The App is scoped narrowly, so the practical delta is small — but
+          # then the least-privilege property lives in a setting nobody reads at review time, and
+          # widening the App silently widens this token. Stating it here makes the grant reviewable
+          # in the diff and caps it independently of how the installation drifts.
+          permission-contents: write
 
       # Installed on the DevIndex repos, not this one, so the installation must be named explicitly.
       - name: Mint Intake installation token
@@ -52,6 +58,11 @@ jobs:
           repositories: |
             devindex-opt-in
             devindex-opt-out
+          # OptIn reads stargazers (metadata); OptOut comments on and closes issues. Nothing here
+          # needs `contents`, and this token must never be able to write code anywhere — the
+          # publisher/intake split exists precisely so the intake identity cannot publish.
+          permission-issues: write
+          permission-metadata: read
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -3,7 +3,17 @@ name: Data Sync Pipeline
 on:
   schedule:
     - cron: '0 * * * *' # Run hourly
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      preflight_only:
+        # Verifies the credential topology WITHOUT side effects: mints both tokens, probes every
+        # required repository, then stops. The collection stages are the ones that mutate — OptOut
+        # comments on and closes real issues in `devindex-opt-out` — so a configuration check that
+        # has to run them is not a check anyone will repeat. This one is safe to run as often as
+        # needed, which is what makes it usable while an installation is being corrected.
+        description: 'Probe repository access and exit, without collecting or publishing'
+        type: boolean
+        default: false
 
 concurrency:
   group: data-sync-pipeline
@@ -63,6 +73,7 @@ jobs:
       - name: Run bounded Data Sync emission and publish
         env:
           DATA_SYNC_INTAKE_TOKEN: ${{ steps.intake-token.outputs.token }}
+          DATA_SYNC_PREFLIGHT_ONLY: ${{ inputs.preflight_only }}
           DATA_SYNC_PUBLISHER_TOKEN: ${{ steps.publisher-token.outputs.token }}
         run: node ./buildScripts/dataSyncPipeline.mjs
 

--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -66,6 +66,14 @@ jobs:
           # they publish, and publishing must never emit from an unmerged branch.
           ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.preflight_only) && github.ref || 'dev' }}
           fetch-depth: 0
+          # `actions/checkout` defaults this to TRUE, writing the token into `.git/config` as an
+          # http.extraheader that survives for the whole job. Stripping credentials from a stage's
+          # ENV therefore isolates nothing at the git layer: any collection stage could still push
+          # as the Publisher — the one identity permitted to bypass the code-scanning ruleset.
+          #
+          # The publish path does not need it either: `dataSyncPipeline.mjs` pushes through its own
+          # remote, so the credential can be absent from git config entirely and supplied per-command.
+          persist-credentials: false
           # The publish push runs through the checkout credential, so it must be the Publisher
           # identity — the only actor permitted to bypass the code-scanning ruleset.
           token: ${{ steps.publisher-token.outputs.token }}
@@ -85,7 +93,14 @@ jobs:
           DATA_SYNC_PUBLISHER_TOKEN: ${{ steps.publisher-token.outputs.token }}
         run: node ./buildScripts/dataSyncPipeline.mjs
 
+      # Guarded on the SAME input the pipeline reads. Without this, a preflight-only dispatch
+      # short-circuited the pipeline and then fell straight into this step, which pushed 167 files
+      # to `pages/main` (commit 189b7b8055) while the run reported "skipping collection and publish".
+      # The side-effect-free claim was made about the pipeline and was silently false about the JOB:
+      # a short-circuit inside one step cannot bound the steps after it, and the step list said
+      # `success Push Data to neomjs/pages` in plain sight the whole time.
       - name: Push Data to neomjs/pages
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.preflight_only) }}
         env:
           PAGES_DEPLOY_PAT: ${{ secrets.PAGES_DEPLOY_PAT }}
         run: |

--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -24,7 +24,18 @@ jobs:
   run-pipeline:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Required to push changes
+      # `contents: read`, NOT write. This said `write # Required to push changes`, and that stopped
+      # being true when checkout and publish moved to the Publisher App token — leaving a THIRD
+      # repository-write credential alive for the whole job while this workflow claims two scoped
+      # identities. The implicit token is not merely unused: GitHub documents that an action can
+      # reach `github.token` even when the workflow never passes `GITHUB_TOKEN`, so an unused
+      # write grant is still a reachable one, and per-stage env scoping cannot revoke it.
+      #
+      # `read` rather than `{}` deliberately: nothing in this job demonstrably needs the implicit
+      # token, but "demonstrably" would require a run to establish and the write authority is the
+      # actual defect. Removing write is the verified fix; removing read as well would be an
+      # unverified extra claim, which is the shape of error this PR has already made twice.
+      contents: read
 
     steps:
       # Two identities, because they hold different authority and `create-github-app-token` scopes

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-import {spawn}         from 'node:child_process';
-import path            from 'node:path';
-import process         from 'node:process';
-import {fileURLToPath} from 'node:url';
+import {spawn}                from 'node:child_process';
+import path                   from 'node:path';
+import process                from 'node:process';
+import {fileURLToPath}        from 'node:url';
+import {assertDataSyncAccess} from './dataSyncPreflight.mjs';
 
 /**
  * @module buildScripts.dataSyncPipeline
@@ -311,7 +312,19 @@ async function recoverStaleAttempt({
  * @param {Function} options.log Telemetry sink.
  * @returns {Promise<void>}
  */
-export async function emitGeneratedData({attempt, cwd, execute = executeCommand, log = console.log}) {
+export async function emitGeneratedData({
+    attempt,
+    cwd,
+    execute   = executeCommand,
+    log       = console.log,
+    preflight = assertDataSyncAccess
+}) {
+    // Before any expensive stage: prove the intake identity can actually reach the repositories the
+    // collection stages depend on. A denial here carries no retry budget and precedes all work, so
+    // it is the installation answering rather than a transient read — the distinction the shared
+    // message string cannot make, and the one whose absence cost sixty silent scheduled runs.
+    await preflight({log, token: scopedStageEnv('intake').GITHUB_TOKEN});
+
     for (const {args, command, label, tokenScope} of emissionCommands) {
         log(`[DataSync] emit attempt=${attempt} stage=${label} credential=${tokenScope}`);
         await execute(command, args, {cwd, env: scopedStageEnv(tokenScope)})

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -27,36 +27,83 @@ const
     remoteDevRef     = 'refs/remotes/origin/dev',
     emissionCommands = [
         {
-            args   : ['ci'],
-            command: 'npm',
-            label  : 'install dependencies'
+            args      : ['ci'],
+            command   : 'npm',
+            label     : 'install dependencies',
+            tokenScope: 'none'
         },
         {
-            args   : ['run', 'devindex:optin'],
-            command: 'npm',
-            label  : 'DevIndex Opt-In'
+            args      : ['run', 'devindex:optin'],
+            command   : 'npm',
+            label     : 'DevIndex Opt-In',
+            tokenScope: 'intake'
         },
         {
-            args   : ['run', 'devindex:optout'],
-            command: 'npm',
-            label  : 'DevIndex Opt-Out'
+            args      : ['run', 'devindex:optout'],
+            command   : 'npm',
+            label     : 'DevIndex Opt-Out',
+            tokenScope: 'intake'
         },
         {
-            args   : ['run', 'devindex:spider', '--', '--strategy', 'random'],
-            command: 'npm',
-            label  : 'DevIndex Spider'
+            args      : ['run', 'devindex:spider', '--', '--strategy', 'random'],
+            command   : 'npm',
+            label     : 'DevIndex Spider',
+            tokenScope: 'intake'
         },
         {
-            args   : ['run', 'devindex:update', '--', '--limit=200'],
-            command: 'npm',
-            label  : 'DevIndex Updater'
+            args      : ['run', 'devindex:update', '--', '--limit=200'],
+            command   : 'npm',
+            label     : 'DevIndex Updater',
+            tokenScope: 'intake'
         },
         {
-            args   : ['./buildScripts/docs/rebuildContentIndexesAndSeo.mjs', '--include-labels'],
-            command: process.execPath,
-            label  : 'content indexes and SEO'
+            args      : ['./buildScripts/docs/rebuildContentIndexesAndSeo.mjs', '--include-labels'],
+            command   : process.execPath,
+            label     : 'content indexes and SEO',
+            tokenScope: 'none'
         }
     ];
+
+/**
+ * @summary Builds the child environment for one emission stage, carrying exactly the credential
+ * that stage is entitled to and nothing else.
+ *
+ * The pipeline holds two identities with different authority: an INTAKE credential that may read
+ * and comment on the DevIndex opt-in/opt-out repositories, and a PUBLISHER credential that may
+ * write to this repository and bypass the code-scanning ruleset. Passing `process.env` wholesale
+ * — as this runner did — handed every stage whichever token happened to be set, so the ruleset-
+ * bypass identity was in scope during arbitrary data collection.
+ *
+ * Both token variables are STRIPPED first, then only the scoped one is re-injected as
+ * `GITHUB_TOKEN` (and `GH_TOKEN`, which the DevIndex GitHub service prefers). Stripping is the
+ * load-bearing half: without it a stage marked `none` would silently inherit whatever the parent
+ * process carried, which is the exact leak the scope annotation claims to prevent.
+ *
+ * `tokenScope: 'none'` therefore yields a child with NO GitHub credential. A stage that turns out
+ * to need one fails loudly on its own missing-auth path rather than quietly succeeding on a more
+ * privileged identity than it was granted.
+ *
+ * @param {String} tokenScope One of `intake`, `publisher`, `none`.
+ * @param {Object} [env=process.env] Parent environment.
+ * @returns {Object} A copy carrying at most one GitHub credential.
+ */
+export function scopedStageEnv(tokenScope, env = process.env) {
+    const
+        // The SOURCE variables are stripped alongside the consumed ones. Removing only
+        // GH_TOKEN/GITHUB_TOKEN leaves `DATA_SYNC_PUBLISHER_TOKEN` readable in an intake stage's
+        // environment, so the bypass credential stays one `process.env` lookup away from every
+        // data-collection child — the isolation would be nominal, not real.
+        {GH_TOKEN, GITHUB_TOKEN, DATA_SYNC_INTAKE_TOKEN, DATA_SYNC_PUBLISHER_TOKEN, ...rest} = env,
+        token = tokenScope === 'intake'    ? DATA_SYNC_INTAKE_TOKEN
+              : tokenScope === 'publisher' ? DATA_SYNC_PUBLISHER_TOKEN
+              : null;
+
+    if (!token) {
+        return rest
+    }
+
+    return {...rest, GH_TOKEN: token, GITHUB_TOKEN: token}
+}
 
 /**
  * @summary Runs one child process with argv-array isolation and optional output capture.
@@ -265,9 +312,9 @@ async function recoverStaleAttempt({
  * @returns {Promise<void>}
  */
 export async function emitGeneratedData({attempt, cwd, execute = executeCommand, log = console.log}) {
-    for (const {args, command, label} of emissionCommands) {
-        log(`[DataSync] emit attempt=${attempt} stage=${label}`);
-        await execute(command, args, {cwd, env: process.env})
+    for (const {args, command, label, tokenScope} of emissionCommands) {
+        log(`[DataSync] emit attempt=${attempt} stage=${label} credential=${tokenScope}`);
+        await execute(command, args, {cwd, env: scopedStageEnv(tokenScope)})
     }
 }
 

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -186,6 +186,36 @@ async function git(execute, cwd, args, {capture = true, env = process.env} = {})
 }
 
 /**
+ * @summary Runs a git command that talks to `origin`, supplying the PUBLISHER credential for that
+ * one invocation instead of relying on one persisted in `.git/config`.
+ *
+ * `actions/checkout` defaults to `persist-credentials: true`, which writes the token into git config
+ * as an `http.extraheader` for the whole job. Under that default, stripping credentials from a
+ * stage's ENVIRONMENT isolates nothing at the git layer — any collection stage could still push as
+ * the Publisher, the one identity permitted to bypass the code-scanning ruleset. So the checkout now
+ * persists nothing, and the two commands that genuinely need network auth carry it themselves.
+ *
+ * `-c http.extraheader=` is passed as an ARGUMENT rather than written to config: it applies to this
+ * process only and leaves nothing behind for a later stage to inherit.
+ * @param {Function} execute Child-process executor.
+ * @param {String}   cwd Repository root.
+ * @param {String[]} args Git arguments.
+ * @param {Object}   [options]
+ * @returns {Promise<{stderr: String, stdout: String}>}
+ */
+async function gitAuthenticated(execute, cwd, args, options = {}) {
+    const token = process.env.DATA_SYNC_PUBLISHER_TOKEN;
+
+    if (!token) {
+        return git(execute, cwd, args, options)
+    }
+
+    const header = `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString('base64')}`;
+
+    return git(execute, cwd, ['-c', `http.extraheader=${header}`, ...args], options)
+}
+
+/**
  * @summary Reads one git revision as a normalized SHA.
  * @param {Function} execute Child-process executor.
  * @param {String}   cwd Repository root.
@@ -205,7 +235,7 @@ async function readSha(execute, cwd, ref) {
  * @returns {Promise<String>}
  */
 async function fetchRemoteDev(execute, cwd) {
-    await git(execute, cwd, ['fetch', 'origin', `dev:${remoteDevRef}`]);
+    await gitAuthenticated(execute, cwd, ['fetch', 'origin', `dev:${remoteDevRef}`]);
 
     return readSha(execute, cwd, 'origin/dev')
 }
@@ -478,7 +508,7 @@ export async function runDataSyncPipeline({
         }
 
         try {
-            await git(execute, cwd, ['push', 'origin', 'HEAD:dev'], {capture: false})
+            await gitAuthenticated(execute, cwd, ['push', 'origin', 'HEAD:dev'], {capture: false})
         } catch (error) {
             currentSha = await fetchRemoteDev(execute, cwd);
             await restoreRemoteDev(execute, cwd);

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -129,6 +129,24 @@ export function scopedStageEnv(tokenScope, env = process.env) {
  * @param {Object}   [options.env=process.env] Child environment.
  * @returns {Promise<{stderr: String, stdout: String}>}
  */
+/**
+ * @summary Renders an argv array for a failure message with credential-shaped values removed.
+ *
+ * Defence in depth, added after an argv-borne credential was found reaching this exact message.
+ * The primary fix keeps secrets out of argv entirely; this ensures the next one that slips in is
+ * not printed. Redaction is by SHAPE, not by matching a known secret value — a transformed secret
+ * (base64, for instance) does not match its own literal, which is also why GitHub's masking cannot
+ * be relied on as the last line.
+ * @param {String[]} args
+ * @returns {String}
+ * @private
+ */
+function redactArgs(args) {
+    return args
+        .map(arg => /authorization|extraheader|token|password|x-access-token/i.test(arg) ? '<redacted>' : arg)
+        .join(' ')
+}
+
 export function executeCommand(command, args, {
     capture = false,
     cwd     = process.cwd(),
@@ -161,7 +179,7 @@ export function executeCommand(command, args, {
 
             const detail = stderr.trim();
             const error  = new Error(
-                `${command} ${args.join(' ')} exited with code ${code}${detail ? `: ${detail}` : ''}`
+                `${command} ${redactArgs(args)} exited with code ${code}${detail ? `: ${detail}` : ''}`
             );
 
             error.code   = code;
@@ -223,9 +241,29 @@ async function gitAuthenticated(execute, cwd, args, options = {}) {
         return git(execute, cwd, args, options)
     }
 
+    // Delivered through the ENVIRONMENT, never argv. The first version passed
+    // `-c http.extraheader=AUTHORIZATION: basic <base64>` as an argument, which put a working
+    // credential in two places it must never be:
+    //   - `ps` output, readable by any process on the runner;
+    //   - `executeCommand`'s failure message, which interpolates `args.join(' ')` — so a failed
+    //     push would PRINT the credential into the CI log.
+    // And base64 is not redaction: Actions' secret masking matches the literal secret string, so
+    // transforming it defeats the mask. The leak would have been plain, decodable, and public.
+    //
+    // `GIT_CONFIG_COUNT`/`_KEY_`/`_VALUE_` is git's own env-based config channel — same effect as
+    // `-c`, no argv exposure, and scoped to this child process rather than written to `.git/config`
+    // where a later stage would inherit it.
     const header = `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString('base64')}`;
 
-    return git(execute, cwd, ['-c', `http.extraheader=${header}`, ...args], options)
+    return git(execute, cwd, args, {
+        ...options,
+        env: {
+            ...(options.env ?? process.env),
+            GIT_CONFIG_COUNT  : '1',
+            GIT_CONFIG_KEY_0  : 'http.extraheader',
+            GIT_CONFIG_VALUE_0: header
+        }
+    })
 }
 
 /**

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -89,6 +89,19 @@ const
  * @returns {Object} A copy carrying at most one GitHub credential.
  */
 export function scopedStageEnv(tokenScope, env = process.env) {
+    // Fail closed VISIBLY on an unrecognised scope. `undefined` previously fell through to the
+    // `none` branch, so a stage added without a `tokenScope` silently ran credential-less — which
+    // either fails somewhere confusing or, worse, looks deliberate. A spec comment claimed this
+    // made omission visible; it did not, because nothing distinguished "declared none" from
+    // "forgot to declare".
+    if (!['intake', 'publisher', 'none'].includes(tokenScope)) {
+        throw new Error(
+            `dataSyncPipeline: emission stage declares tokenScope=${JSON.stringify(tokenScope)}. ` +
+            'Every stage must declare one of `intake`, `publisher` or `none` — an undeclared scope ' +
+            'is an unanswered question about which identity that stage is entitled to, not a default.'
+        );
+    }
+
     const
         // The SOURCE variables are stripped alongside the consumed ones. Removing only
         // GH_TOKEN/GITHUB_TOKEN leaves `DATA_SYNC_PUBLISHER_TOKEN` readable in an intake stage's
@@ -408,6 +421,15 @@ export async function runDataSyncPipeline({
 
         log(`[DataSync] attempt=${attempt}/${maxAttempts} base=${baseSha}`);
         await emit({attempt, baseSha, cwd, execute, log});
+
+        // TERMINAL, not merely quiet. Returning early from `emit` ended the emission loop and then
+        // fell straight through to the publish path below, which only stayed harmless because an
+        // empty emission produces no staged changes. That is a safety property borrowed from a
+        // coincidence: any future change making the publish path act on an unchanged tree would
+        // turn a configuration check into a publication. The check exits the pipeline here.
+        if (process.env.DATA_SYNC_PREFLIGHT_ONLY === 'true') {
+            return {attempts: attempt, baseSha, changed: false, preflightOnly: true, pushed: false}
+        }
 
         let currentSha = await fetchRemoteDev(execute, cwd);
 

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -226,8 +226,14 @@ async function git(execute, cwd, args, {capture = true, env = process.env} = {})
  * the Publisher, the one identity permitted to bypass the code-scanning ruleset. So the checkout now
  * persists nothing, and the two commands that genuinely need network auth carry it themselves.
  *
- * `-c http.extraheader=` is passed as an ARGUMENT rather than written to config: it applies to this
- * process only and leaves nothing behind for a later stage to inherit.
+ * The credential is delivered through git's ENV config channel (`GIT_CONFIG_*`), never argv and never
+ * `.git/config` — see the implementation note below for why each of those two was rejected.
+ *
+ * The child env is SCOPED, not merely augmented. Spreading the caller's env and adding the header
+ * leaves every raw credential in the child: both source tokens plus any ambient `GH_TOKEN` /
+ * `GITHUB_TOKEN`. That is the same additive-boundary defect {@link #scopedStageEnv} exists to prevent
+ * for emission stages; a git invocation is not exempt from it just because its credential arrives by
+ * a different route.
  * @param {Function} execute Child-process executor.
  * @param {String}   cwd Repository root.
  * @param {String[]} args Git arguments.
@@ -255,10 +261,18 @@ export async function gitAuthenticated(execute, cwd, args, options = {}) {
     // where a later stage would inherit it.
     const header = `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString('base64')}`;
 
+    // Every raw credential is stripped BEFORE the derived header goes in. Spreading the caller's env
+    // and appending made the boundary additive: the git child still received both source tokens and
+    // any ambient GH_TOKEN/GITHUB_TOKEN, so moving the header out of argv narrowed one exposure while
+    // leaving four untouched. `git` needs none of them — it reads the header and nothing else.
+    const {
+        DATA_SYNC_INTAKE_TOKEN, DATA_SYNC_PUBLISHER_TOKEN, GH_TOKEN, GITHUB_TOKEN, ...scoped
+    } = options.env ?? process.env;
+
     return git(execute, cwd, args, {
         ...options,
         env: {
-            ...(options.env ?? process.env),
+            ...scoped,
             GIT_CONFIG_COUNT  : '1',
             GIT_CONFIG_KEY_0  : 'http.extraheader',
             GIT_CONFIG_VALUE_0: header

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -234,7 +234,7 @@ async function git(execute, cwd, args, {capture = true, env = process.env} = {})
  * @param {Object}   [options]
  * @returns {Promise<{stderr: String, stdout: String}>}
  */
-async function gitAuthenticated(execute, cwd, args, options = {}) {
+export async function gitAuthenticated(execute, cwd, args, options = {}) {
     const token = process.env.DATA_SYNC_PUBLISHER_TOKEN;
 
     if (!token) {
@@ -401,7 +401,7 @@ export async function emitGeneratedData({
     preflight = assertDataSyncAccess
 }) {
     // Before any expensive stage: prove the intake identity can actually reach the repositories the
-    // collection stages depend on. A denial here carries no retry budget and precedes all work, so
+    // collection stages depend on. A denial here survives its full retry budget AND precedes all work, so
     // it is the installation answering rather than a transient read — the distinction the shared
     // message string cannot make, and the one whose absence cost sixty silent scheduled runs.
     await preflight({log, token: scopedStageEnv('intake').GITHUB_TOKEN});

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -325,6 +325,14 @@ export async function emitGeneratedData({
     // message string cannot make, and the one whose absence cost sixty silent scheduled runs.
     await preflight({log, token: scopedStageEnv('intake').GITHUB_TOKEN});
 
+    // Credential-topology check with no side effects. The collection stages mutate — OptOut comments
+    // on and closes real issues — so a configuration check that must run them is one nobody repeats
+    // while iterating on an installation. Stopping here keeps it cheap enough to re-run freely.
+    if (process.env.DATA_SYNC_PREFLIGHT_ONLY === 'true') {
+        log('[DataSync] preflight-only: repository access verified; skipping collection and publish.');
+        return
+    }
+
     for (const {args, command, label, tokenScope} of emissionCommands) {
         log(`[DataSync] emit attempt=${attempt} stage=${label} credential=${tokenScope}`);
         await execute(command, args, {cwd, env: scopedStageEnv(tokenScope)})

--- a/buildScripts/dataSyncPreflight.mjs
+++ b/buildScripts/dataSyncPreflight.mjs
@@ -14,7 +14,7 @@
  * luck. This pipeline spent eight days and sixty consecutive scheduled runs in exactly that state.
  *
  * The discriminator is not the message, it is WHEN the denial happens. A denial on a minimal probe
- * issued before any work — one cheap query per repository, no retry budget — cannot be mid-batch
+ * issued before any work — one cheap query per repository, bounded by a small retry budget — cannot be mid-batch
  * flakiness; it is the configuration answering. A denial later, after probes passed, is the
  * transient class the retry budget exists for.
  *
@@ -144,9 +144,9 @@ export async function assertDataSyncAccess({
     throw new Error(
         `[DataSync preflight] ${failures.length} required repository/repositories unreachable:\n${detail}\n` +
         (denial
-            ? 'This is a PERSISTENT authorization failure, not a transient read: the probes carry no retry ' +
-              'budget and ran before any collection. Verify the intake App is installed on each repository ' +
-              'above with `Issues: Read and write` and `Metadata: Read`.'
+            ? 'This is a PERSISTENT authorization failure, not a transient read: every probe above ran ' +
+              'before any collection AND exhausted its full retry budget. Verify the intake App is ' +
+              'installed on each repository above with `Issues: Read and write` and `Metadata: Read`.'
             : 'Probes failed before any collection stage; treat as a configuration or connectivity fault.')
     );
 }

--- a/buildScripts/dataSyncPreflight.mjs
+++ b/buildScripts/dataSyncPreflight.mjs
@@ -1,0 +1,130 @@
+/**
+ * @module buildScripts/dataSyncPreflight
+ * @summary Proves each repository the Data Sync pipeline must reach is actually reachable, BEFORE
+ * any expensive collection stage runs.
+ *
+ * `Resource not accessible by integration` is returned for two conditions that share one string:
+ *
+ * 1. genuine GitHub-side flakiness — the same call succeeding hours later on the same token;
+ * 2. a permanently missing or under-scoped App installation.
+ *
+ * No message inspection can separate them, which is why the bounded-retry classification treats the
+ * string as transient. That is correct for (1) and catastrophic for (2): a permanent
+ * misconfiguration becomes an unbounded series of identical retried failures, each looking like bad
+ * luck. This pipeline spent eight days and sixty consecutive scheduled runs in exactly that state.
+ *
+ * The discriminator is not the message, it is WHEN the denial happens. A denial on a minimal probe
+ * issued before any work — one cheap query per repository, no retry budget — cannot be mid-batch
+ * flakiness; it is the configuration answering. A denial later, after probes passed, is the
+ * transient class the retry budget exists for.
+ *
+ * So this preflight fails fast and NAMES the repository, while leaving the bounded retries intact
+ * for reads that have already proven their credential works.
+ */
+
+/**
+ * @summary Repositories the pipeline must reach, and the identity each one needs.
+ *
+ * `devindex-opt-out` is here deliberately: the scheduled sequence runs OptOut as well as OptIn, and
+ * an installation covering only `neo` + `devindex-opt-in` would pass this probe and then fail one
+ * stage later — after the setup work looked complete.
+ * @type {Object[]}
+ */
+export const REQUIRED_REPOSITORIES = [
+    {name: 'devindex-opt-in',  owner: 'neomjs', purpose: 'OptIn stargazer read'},
+    {name: 'devindex-opt-out', owner: 'neomjs', purpose: 'OptOut issue read + close'}
+];
+
+const DENIAL_PATTERN = /resource not accessible by integration|not accessible|bad credentials|requires authentication/i;
+
+/**
+ * @summary Issues one minimal, un-retried GraphQL read against a repository.
+ * @param {Object}   options
+ * @param {String}   options.owner Repository owner.
+ * @param {String}   options.name Repository name.
+ * @param {String}   options.token Installation token to probe with.
+ * @param {Function} [options.fetchFn=fetch] Injectable transport.
+ * @returns {Promise<{ok: Boolean, reason: String|null}>}
+ */
+export async function probeRepository({owner, name, token, fetchFn = fetch}) {
+    const response = await fetchFn('https://api.github.com/graphql', {
+        method : 'POST',
+        headers: {
+            Authorization : `Bearer ${token}`,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            query    : 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name){id}}',
+            variables: {name, owner}
+        })
+    });
+
+    const body = await response.json().catch(() => ({}));
+
+    // A GraphQL denial arrives as HTTP 200 with an `errors` array, so status alone is not the test.
+    const message = body?.errors?.map(error => error.message).join('; ') || '';
+
+    if (body?.data?.repository?.id) {
+        return {ok: true, reason: null}
+    }
+
+    return {ok: false, reason: message || `HTTP ${response.status}`}
+}
+
+/**
+ * @summary Probes every required repository and throws a single actionable error naming all
+ * failures, rather than dying on the first one 40 minutes into a collection run.
+ * @param {Object}   [options]
+ * @param {String}   [options.token] Intake installation token.
+ * @param {Object[]} [options.repositories=REQUIRED_REPOSITORIES]
+ * @param {Function} [options.fetchFn=fetch] Injectable transport.
+ * @param {Function} [options.log=console.log] Telemetry sink.
+ * @returns {Promise<void>}
+ */
+export async function assertDataSyncAccess({
+    token,
+    repositories = REQUIRED_REPOSITORIES,
+    fetchFn      = fetch,
+    log          = console.log
+} = {}) {
+    if (!token) {
+        throw new Error(
+            '[DataSync preflight] No intake token was provided. The pipeline cannot reach the DevIndex ' +
+            'repositories without an installation token, and proceeding would spend a full collection ' +
+            'run to rediscover that.'
+        );
+    }
+
+    const failures = [];
+
+    for (const {name, owner, purpose} of repositories) {
+        const {ok, reason} = await probeRepository({fetchFn, name, owner, token});
+
+        log(`[DataSync preflight] ${owner}/${name} ${ok ? 'reachable' : 'DENIED'} (${purpose})`);
+
+        if (!ok) {
+            failures.push({name, owner, purpose, reason})
+        }
+    }
+
+    if (failures.length === 0) {
+        return
+    }
+
+    const detail = failures
+        .map(({name, owner, purpose, reason}) => `  - ${owner}/${name} (${purpose}): ${reason}`)
+        .join('\n');
+
+    // Persistent by construction: these probes carry no retry budget and ran before any collection,
+    // so a denial here is the installation answering, not a transient read.
+    const denial = failures.some(({reason}) => DENIAL_PATTERN.test(reason));
+
+    throw new Error(
+        `[DataSync preflight] ${failures.length} required repository/repositories unreachable:\n${detail}\n` +
+        (denial
+            ? 'This is a PERSISTENT authorization failure, not a transient read: the probes carry no retry ' +
+              'budget and ran before any collection. Verify the intake App is installed on each repository ' +
+              'above with `Issues: Read and write` and `Metadata: Read`.'
+            : 'Probes failed before any collection stage; treat as a configuration or connectivity fault.')
+    );
+}

--- a/buildScripts/dataSyncPreflight.mjs
+++ b/buildScripts/dataSyncPreflight.mjs
@@ -47,19 +47,31 @@ const DENIAL_PATTERN = /resource not accessible by integration|not accessible|ba
  * @returns {Promise<{ok: Boolean, reason: String|null}>}
  */
 export async function probeRepository({owner, name, token, fetchFn = fetch}) {
-    const response = await fetchFn('https://api.github.com/graphql', {
-        method : 'POST',
-        headers: {
-            Authorization : `Bearer ${token}`,
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-            query    : 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name){id}}',
-            variables: {name, owner}
-        })
-    });
+    let response, body;
 
-    const body = await response.json().catch(() => ({}));
+    // A transport failure — ECONNRESET, DNS, TLS — is the single most common transient class, and it
+    // is the one shape that arrives as a THROWN exception rather than an `errors` array. Uncaught, it
+    // escaped this function, escaped the caller's retry loop, and escaped `assertDataSyncAccess`
+    // entirely: the bounded retry could not see the failure mode it exists for, and the operator got
+    // a raw stack trace naming no repository. Converting it to the same `{ok, reason}` shape here
+    // rather than in the loop keeps the contract true for every caller, not just that one.
+    try {
+        response = await fetchFn('https://api.github.com/graphql', {
+            method : 'POST',
+            headers: {
+                Authorization : `Bearer ${token}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                query    : 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name){id}}',
+                variables: {name, owner}
+            })
+        });
+
+        body = await response.json().catch(() => ({}))
+    } catch (error) {
+        return {ok: false, reason: error?.message || String(error)}
+    }
 
     // A GraphQL denial arrives as HTTP 200 with an `errors` array, so status alone is not the test.
     const message = body?.errors?.map(error => error.message).join('; ') || '';
@@ -132,21 +144,30 @@ export async function assertDataSyncAccess({
         return
     }
 
+    // Classified PER REPOSITORY, never in aggregate. A global `failures.some(DENIAL_PATTERN)` labels
+    // the whole run a persistent authorization failure the moment ONE repository denies — so an
+    // opt-in denial plus an opt-out connection reset told the operator to go fix an App installation
+    // on a repository whose credential was never rejected. That is a false instruction, and it costs
+    // a debugging session on the one repository that was working. Each line carries its own verdict
+    // because each line has its own cause.
+    //
+    // "Persistent" means EXHAUSTED, not merely early: pre-work timing rules out mid-batch contention,
+    // and the spent retry budget rules out a single unlucky first call. Neither claim suffices alone.
     const detail = failures
-        .map(({name, owner, purpose, reason}) => `  - ${owner}/${name} (${purpose}): ${reason}`)
+        .map(({name, owner, purpose, reason}) => {
+            const remedy = DENIAL_PATTERN.test(reason)
+                ? 'PERSISTENT authorization failure — the credential was rejected on every attempt. ' +
+                  'Verify the intake App is installed on THIS repository with `Issues: Read and write` ' +
+                  'and `Metadata: Read`.'
+                : 'Transport or availability fault — the credential was never rejected here, so the ' +
+                  'installation is not implicated.';
+
+            return `  - ${owner}/${name} (${purpose}): ${reason}\n      ${remedy}`
+        })
         .join('\n');
 
-    // Persistent by EXHAUSTION, not by timing alone: every probe above ran before any collection
-    // AND survived its full retry budget. Pre-work timing rules out mid-batch contention; the
-    // bounded retries rule out a single unlucky first call. Neither claim is sufficient alone.
-    const denial = failures.some(({reason}) => DENIAL_PATTERN.test(reason));
-
     throw new Error(
-        `[DataSync preflight] ${failures.length} required repository/repositories unreachable:\n${detail}\n` +
-        (denial
-            ? 'This is a PERSISTENT authorization failure, not a transient read: every probe above ran ' +
-              'before any collection AND exhausted its full retry budget. Verify the intake App is ' +
-              'installed on each repository above with `Issues: Read and write` and `Metadata: Read`.'
-            : 'Probes failed before any collection stage; treat as a configuration or connectivity fault.')
+        `[DataSync preflight] ${failures.length} required repository/repositories unreachable, ` +
+        `each probed before any collection stage and given its full retry budget:\n${detail}`
     );
 }

--- a/buildScripts/dataSyncPreflight.mjs
+++ b/buildScripts/dataSyncPreflight.mjs
@@ -84,8 +84,10 @@ export async function probeRepository({owner, name, token, fetchFn = fetch}) {
 export async function assertDataSyncAccess({
     token,
     repositories = REQUIRED_REPOSITORIES,
+    attempts     = 3,
     fetchFn      = fetch,
-    log          = console.log
+    log          = console.log,
+    waitFn       = ms => new Promise(resolve => setTimeout(resolve, ms))
 } = {}) {
     if (!token) {
         throw new Error(
@@ -98,7 +100,26 @@ export async function assertDataSyncAccess({
     const failures = [];
 
     for (const {name, owner, purpose} of repositories) {
-        const {ok, reason} = await probeRepository({fetchFn, name, owner, token});
+        // BOUNDED, not single-shot. The timing argument this preflight rests on separates
+        // mid-batch flakiness from a pre-work denial — it does NOT rule out a flaky FIRST call.
+        // Declaring one denial permanently authorized because of when it happened would trade a
+        // permanent-misread-as-transient bug for a transient-misread-as-permanent one, and a
+        // scheduled run aborted on a single blip is its own outage.
+        //
+        // Three attempts still resolves in seconds, so the fail-fast property survives intact:
+        // the case this exists for produced the SAME denial sixty consecutive times.
+        let ok = false, reason = null;
+
+        for (let attempt = 1; attempt <= attempts; attempt++) {
+            ({ok, reason} = await probeRepository({fetchFn, name, owner, token}));
+
+            if (ok) break;
+
+            if (attempt < attempts) {
+                log(`[DataSync preflight] ${owner}/${name} attempt ${attempt}/${attempts} failed (${reason}); retrying`);
+                await waitFn(attempt * 500)
+            }
+        }
 
         log(`[DataSync preflight] ${owner}/${name} ${ok ? 'reachable' : 'DENIED'} (${purpose})`);
 
@@ -115,8 +136,9 @@ export async function assertDataSyncAccess({
         .map(({name, owner, purpose, reason}) => `  - ${owner}/${name} (${purpose}): ${reason}`)
         .join('\n');
 
-    // Persistent by construction: these probes carry no retry budget and ran before any collection,
-    // so a denial here is the installation answering, not a transient read.
+    // Persistent by EXHAUSTION, not by timing alone: every probe above ran before any collection
+    // AND survived its full retry budget. Pre-work timing rules out mid-batch contention; the
+    // bounded retries rule out a single unlucky first call. Neither claim is sufficient alone.
     const denial = failures.some(({reason}) => DENIAL_PATTERN.test(reason));
 
     throw new Error(

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -107,7 +107,11 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
                 calls.push({args, command, options});
                 return {stderr: '', stdout: ''}
             },
-            log: () => {}
+            log: () => {},
+            // This test owns stage ORDER, not repository access. The real preflight makes a network
+            // call and fails closed without an intake token, which is its job — so it is stubbed
+            // here rather than weakened there.
+            preflight: async () => {}
         });
 
         expect(calls.map(({args, command}) => [command, ...args])).toEqual([
@@ -338,7 +342,8 @@ test.describe('emission-stage credential scoping', () => {
             execute: async (command, args, {env}) => {
                 calls.push({command, token: env.GITHUB_TOKEN ?? null})
             },
-            log: () => {}
+            log      : () => {},
+            preflight: async () => {}
         });
 
         expect(calls.length).toBeGreaterThan(0);

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -365,3 +365,35 @@ test.describe('emission-stage credential scoping', () => {
         expect(calls.every(call => call.token !== 'PUBLISHER-secret')).toBe(true)
     });
 });
+
+/**
+ * An undeclared `tokenScope` is an unanswered question about which identity a stage is entitled
+ * to, not a default. It previously fell through to the `none` branch, so a stage added without one
+ * ran credential-less and looked deliberate — and a spec comment asserted this was visible when
+ * nothing distinguished "declared none" from "forgot to declare".
+ */
+test.describe('tokenScope validation fails closed', () => {
+    test('an unrecognised or missing scope throws rather than defaulting', () => {
+        for (const scope of [undefined, null, '', 'publishr', 'PUBLISHER']) {
+            expect(() => scopedStageEnv(scope, {}), String(scope)).toThrow(/must declare one of/)
+        }
+    });
+
+    test('the three declared scopes are accepted', () => {
+        for (const scope of ['none', 'intake', 'publisher']) {
+            expect(() => scopedStageEnv(scope, {}), scope).not.toThrow()
+        }
+    });
+
+    test('every shipped emission stage declares a valid scope', async () => {
+        // Reaches the real stage table: a stage added without `tokenScope` now fails here rather
+        // than at runtime in CI, where it would present as an opaque auth error.
+        await expect(emitGeneratedData({
+            attempt  : 1,
+            cwd      : '/tmp',
+            execute  : async () => {},
+            log      : () => {},
+            preflight: async () => {}
+        })).resolves.toBeUndefined()
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -275,6 +275,13 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
         // ruleset-bypass identity.
         expect(workflow).toContain('persist-credentials: false');
 
+        // The job's IMPLICIT token must not carry write. It is not merely unused: an action can
+        // reach `github.token` even when the workflow never passes GITHUB_TOKEN, so an unused write
+        // grant is a reachable one that per-stage env scoping cannot revoke. Leaving it at `write`
+        // meant three repository-write credentials were alive while this workflow claimed two.
+        expect(workflow).toContain('contents: read');
+        expect(workflow).not.toMatch(/permissions:\s*\n\s*#[^\n]*\n(\s*#[^\n]*\n)*\s*contents: write/);
+
         // A preflight-only dispatch must not reach the pages push. Without this guard it did —
         // 167 files to `pages/main` while the run logged "skipping collection and publish", because
         // a short-circuit inside the pipeline step cannot bound the steps after it.

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -397,3 +397,62 @@ test.describe('tokenScope validation fails closed', () => {
         })).resolves.toBeUndefined()
     });
 });
+
+/**
+ * Credential exposure through argv and failure logs.
+ *
+ * An earlier fix moved the Publisher credential OUT of `.git/config` (where `persist-credentials`
+ * had left it for the whole job) and into a `-c http.extraheader=...` argument — which made it
+ * worse in a way config never was: argv is visible in `ps`, and this module interpolates
+ * `args.join(' ')` into its failure message, so a failed push would PRINT a working
+ * ruleset-bypass credential into the CI log.
+ *
+ * Base64 is not redaction. GitHub Actions masks the literal secret string, so a transformed secret
+ * does not match its own mask — the leak would have been plain, decodable and public. Masking
+ * therefore cannot be the last line, which is why redaction here is by SHAPE rather than by
+ * matching a known value.
+ */
+test.describe('credential never reaches argv or failure output', () => {
+    test('a failing command redacts credential-shaped arguments', async () => {
+        const secret = 'ghs_TESTSECRET_should_never_print',
+              header = `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${secret}`).toString('base64')}`;
+
+        let message = '';
+
+        await executeCommand('git', ['-c', `http.extraheader=${header}`, 'push'], {
+            capture: true,
+            cwd    : os.tmpdir()
+        }).catch(error => {message = error.message});
+
+        expect(message).toBeTruthy();
+        expect(message).not.toContain(secret);
+        // The base64 form is the one masking would miss, so it is the one worth asserting on.
+        expect(message).not.toMatch(/basic [A-Za-z0-9+/=]{10,}/);
+        expect(message).toContain('<redacted>')
+    });
+
+    test('redaction keys on shape, so an unknown future secret is covered too', async () => {
+        let message = '';
+
+        await executeCommand('git', ['-c', 'http.extraheader=Authorization: bearer whatever', 'push'], {
+            capture: true,
+            cwd    : os.tmpdir()
+        }).catch(error => {message = error.message});
+
+        expect(message).toContain('<redacted>');
+        expect(message).not.toContain('whatever')
+    });
+
+    test('ordinary arguments are still shown — redaction must not blind the diagnostic', async () => {
+        let message = '';
+
+        await executeCommand('git', ['push', 'origin', 'HEAD:dev'], {
+            capture: true,
+            cwd    : os.tmpdir()
+        }).catch(error => {message = error.message});
+
+        expect(message).toContain('push');
+        expect(message).toContain('origin');
+        expect(message).not.toContain('<redacted>')
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -10,6 +10,7 @@ import {
     executeCommand,
     GENERATED_DATA_PATHS,
     isGeneratedDataPath,
+    gitAuthenticated,
     runDataSyncPipeline,
     scopedStageEnv
 } from '../../../../../buildScripts/dataSyncPipeline.mjs';
@@ -454,5 +455,75 @@ test.describe('credential never reaches argv or failure output', () => {
         expect(message).toContain('push');
         expect(message).toContain('origin');
         expect(message).not.toContain('<redacted>')
+    });
+});
+
+/**
+ * The ACTUAL argv witness.
+ *
+ * The redaction tests above call `executeCommand` with synthetic arguments, so they prove the
+ * failure message is scrubbed and nothing else. A regression that put the credential back into
+ * `-c http.extraheader=<secret>` would still pass them — redaction would hide it in the message
+ * while `ps` exposure silently returned. A test that cannot fail on the defect it exists to prevent
+ * is not coverage.
+ *
+ * These assert the real `gitAuthenticated` boundary instead: the credential must be ABSENT from
+ * every argument and PRESENT only in the child environment.
+ */
+test.describe('gitAuthenticated keeps the credential out of argv', () => {
+    const secret = 'ghs_ARGV_WITNESS_SECRET';
+
+    test.afterEach(() => {
+        delete process.env.DATA_SYNC_PUBLISHER_TOKEN
+    });
+
+    test('no argument contains the raw OR derived credential', async () => {
+        process.env.DATA_SYNC_PUBLISHER_TOKEN = secret;
+
+        let seenArgs = null, seenEnv = null;
+
+        await gitAuthenticated(
+            async (command, args, options) => {seenArgs = args; seenEnv = options.env; return {stderr: '', stdout: ''}},
+            '/repo',
+            ['push', 'origin', 'HEAD:dev']
+        );
+
+        const argv    = seenArgs.join(' '),
+              derived = Buffer.from(`x-access-token:${secret}`).toString('base64');
+
+        expect(argv).not.toContain(secret);
+        // The base64 form is the one Actions masking would MISS, so it is the one that matters.
+        expect(argv).not.toContain(derived);
+        expect(argv).not.toContain('http.extraheader');
+        expect(seenArgs).toEqual(['push', 'origin', 'HEAD:dev'])
+    });
+
+    test('the credential arrives only through the child environment', async () => {
+        process.env.DATA_SYNC_PUBLISHER_TOKEN = secret;
+
+        let seenEnv = null;
+
+        await gitAuthenticated(
+            async (command, args, options) => {seenEnv = options.env; return {stderr: '', stdout: ''}},
+            '/repo',
+            ['fetch', 'origin']
+        );
+
+        expect(seenEnv.GIT_CONFIG_COUNT).toBe('1');
+        expect(seenEnv.GIT_CONFIG_KEY_0).toBe('http.extraheader');
+        expect(seenEnv.GIT_CONFIG_VALUE_0).toContain(Buffer.from(`x-access-token:${secret}`).toString('base64'))
+    });
+
+    test('with no publisher token it degrades to a plain git call, adding no config', async () => {
+        let seenArgs = null, seenEnv = null;
+
+        await gitAuthenticated(
+            async (command, args, options) => {seenArgs = args; seenEnv = options.env; return {stderr: '', stdout: ''}},
+            '/repo',
+            ['fetch', 'origin']
+        );
+
+        expect(seenArgs).toEqual(['fetch', 'origin']);
+        expect(seenEnv?.GIT_CONFIG_COUNT).toBeUndefined()
     });
 });

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -260,10 +260,24 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
         );
 
         expect(workflow).toContain('node ./buildScripts/dataSyncPipeline.mjs');
-        expect(workflow).toContain('ref: dev');
         expect(workflow).toContain('fetch-depth: 0');
         expect(workflow).not.toContain('git pull origin dev --rebase');
-        expect(workflow).not.toContain('git push origin dev')
+        expect(workflow).not.toContain('git push origin dev');
+
+        // The publishing paths stay pinned to `dev`; only a preflight-only dispatch follows the
+        // dispatched ref. This replaced a literal `ref: dev`, which could not express that a
+        // pipeline change was untestable before merge — the defect the conditional fixes.
+        expect(workflow).toContain("inputs.preflight_only) && github.ref || 'dev'");
+
+        // The credential must not survive in `.git/config`: with the checkout default, stripping a
+        // stage's ENV isolates nothing at the git layer, and any collection stage could push as the
+        // ruleset-bypass identity.
+        expect(workflow).toContain('persist-credentials: false');
+
+        // A preflight-only dispatch must not reach the pages push. Without this guard it did —
+        // 167 files to `pages/main` while the run logged "skipping collection and publish", because
+        // a short-circuit inside the pipeline step cannot bound the steps after it.
+        expect(workflow).toContain("if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.preflight_only) }}")
     })
 });
 

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -10,7 +10,8 @@ import {
     executeCommand,
     GENERATED_DATA_PATHS,
     isGeneratedDataPath,
-    runDataSyncPipeline
+    runDataSyncPipeline,
+    scopedStageEnv
 } from '../../../../../buildScripts/dataSyncPipeline.mjs';
 
 const generatedFile = 'apps/devindex/resources/data/users.jsonl';
@@ -260,4 +261,88 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
         expect(workflow).not.toContain('git pull origin dev --rebase');
         expect(workflow).not.toContain('git push origin dev')
     })
+});
+
+/**
+ * Credential scoping across emission stages.
+ *
+ * The pipeline carries two identities with different authority: an INTAKE credential that may read
+ * and comment on the DevIndex opt-in/opt-out repositories, and a PUBLISHER credential that may write
+ * this repository and bypass the code-scanning ruleset. The runner previously handed `process.env`
+ * to every stage, so the ruleset-bypass identity was in scope during arbitrary data collection.
+ *
+ * Every assertion below checks by VALUE across the whole environment rather than by reading one key.
+ * That distinction is not stylistic: the first implementation stripped `GH_TOKEN`/`GITHUB_TOKEN` and
+ * left `DATA_SYNC_PUBLISHER_TOKEN` in place, so a per-key check reported perfect isolation while the
+ * publisher credential sat one `process.env` lookup away from every intake child.
+ */
+test.describe('emission-stage credential scoping', () => {
+    const parentEnv = {
+        PATH                     : '/usr/bin',
+        GH_TOKEN                 : 'ambient-gh',
+        GITHUB_TOKEN             : 'ambient-default',
+        DATA_SYNC_INTAKE_TOKEN   : 'INTAKE-secret',
+        DATA_SYNC_PUBLISHER_TOKEN: 'PUBLISHER-secret'
+    };
+
+    const values = env => Object.values(env);
+
+    test('an intake stage cannot see the publisher credential ANYWHERE in its environment', () => {
+        const env = scopedStageEnv('intake', parentEnv);
+
+        expect(env.GITHUB_TOKEN).toBe('INTAKE-secret');
+        expect(values(env)).not.toContain('PUBLISHER-secret');
+        expect(values(env)).not.toContain('ambient-default')
+    });
+
+    test('a publisher stage cannot see the intake credential', () => {
+        const env = scopedStageEnv('publisher', parentEnv);
+
+        expect(env.GITHUB_TOKEN).toBe('PUBLISHER-secret');
+        expect(values(env)).not.toContain('INTAKE-secret')
+    });
+
+    test('a `none` stage runs with NO github credential — ambient tokens do not survive', () => {
+        const env = scopedStageEnv('none', parentEnv);
+
+        expect(env.GITHUB_TOKEN).toBeUndefined();
+        expect(env.GH_TOKEN).toBeUndefined();
+        expect(values(env)).not.toContain('ambient-default');
+        expect(values(env)).not.toContain('INTAKE-secret');
+        expect(values(env)).not.toContain('PUBLISHER-secret')
+    });
+
+    test('non-credential environment is preserved for every scope', () => {
+        for (const scope of ['none', 'intake', 'publisher']) {
+            expect(scopedStageEnv(scope, parentEnv).PATH, scope).toBe('/usr/bin')
+        }
+    });
+
+    test('a missing scoped token yields no credential rather than falling back to ambient', () => {
+        // Fail closed: an unconfigured intake secret must not silently run on whatever the runner
+        // happened to export, which is how the single-token pipeline masked its own boundary.
+        const env = scopedStageEnv('intake', {PATH: '/usr/bin', GITHUB_TOKEN: 'ambient-default'});
+
+        expect(env.GITHUB_TOKEN).toBeUndefined();
+        expect(values(env)).not.toContain('ambient-default')
+    });
+
+    test('every declared emission stage carries an explicit scope, and only intake/none collect data', async () => {
+        // Guards the annotation itself: a new stage added without `tokenScope` would inherit
+        // `undefined`, land in the `none` branch, and look deliberate. This makes omission visible.
+        const calls = [];
+
+        await emitGeneratedData({
+            attempt: 1,
+            cwd    : '/tmp',
+            execute: async (command, args, {env}) => {
+                calls.push({command, token: env.GITHUB_TOKEN ?? null})
+            },
+            log: () => {}
+        });
+
+        expect(calls.length).toBeGreaterThan(0);
+        // No emission stage may run with the publisher credential; publication is a separate phase.
+        expect(calls.every(call => call.token !== 'PUBLISHER-secret')).toBe(true)
+    });
 });

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -533,4 +533,46 @@ test.describe('gitAuthenticated keeps the credential out of argv', () => {
         expect(seenArgs).toEqual(['fetch', 'origin']);
         expect(seenEnv?.GIT_CONFIG_COUNT).toBeUndefined()
     });
+
+    test('the child env is SCOPED, not augmented — no raw credential survives the boundary', async () => {
+        // The tests above proved the credential left argv. They could not see that it also arrived,
+        // raw and in quadruplicate, through the env: spreading `options.env` and appending the header
+        // made the boundary ADDITIVE. `scopedStageEnv` already strips exactly these for emission
+        // stages; a git invocation is not exempt because its credential takes a different route.
+        process.env.DATA_SYNC_PUBLISHER_TOKEN = secret;
+
+        let seenEnv = null;
+
+        await gitAuthenticated(
+            async (command, args, options) => {seenEnv = options.env; return {stderr: '', stdout: ''}},
+            '/repo',
+            ['push', 'origin', 'HEAD:dev'],
+            {
+                env: {
+                    DATA_SYNC_INTAKE_TOKEN   : 'ghs_INTAKE_RAW',
+                    DATA_SYNC_PUBLISHER_TOKEN: secret,
+                    GH_TOKEN                 : 'ghs_AMBIENT_GH',
+                    GITHUB_TOKEN             : 'ghs_AMBIENT_DEFAULT',
+                    PATH                     : '/usr/bin'
+                }
+            }
+        );
+
+        // By VALUE across the whole child env, not by key absence: a key that survives holding a
+        // different token is the same leak wearing a different name.
+        const leaked = Object.entries(seenEnv).filter(([key, value]) =>
+            key !== 'GIT_CONFIG_VALUE_0' &&
+            typeof value === 'string' &&
+            /^ghs_/.test(value));
+
+        expect(leaked).toEqual([]);
+        expect(seenEnv.DATA_SYNC_INTAKE_TOKEN).toBeUndefined();
+        expect(seenEnv.DATA_SYNC_PUBLISHER_TOKEN).toBeUndefined();
+        expect(seenEnv.GH_TOKEN).toBeUndefined();
+        expect(seenEnv.GITHUB_TOKEN).toBeUndefined();
+
+        // Unrelated env survives, and the ONE derived credential still gets through.
+        expect(seenEnv.PATH).toBe('/usr/bin');
+        expect(seenEnv.GIT_CONFIG_VALUE_0).toContain(Buffer.from(`x-access-token:${secret}`).toString('base64'))
+    });
 });

--- a/test/playwright/unit/ai/buildScripts/DataSyncPreflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPreflight.spec.mjs
@@ -1,0 +1,94 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    assertDataSyncAccess,
+    probeRepository,
+    REQUIRED_REPOSITORIES
+} from '../../../../../buildScripts/dataSyncPreflight.mjs';
+
+/**
+ * `Resource not accessible by integration` is returned for two conditions that share one string:
+ * genuine GitHub-side flakiness, and a permanently missing App installation. No message inspection
+ * separates them, which is why the bounded-retry classifier treats the string as transient — correct
+ * for the first, catastrophic for the second. This pipeline spent eight days and sixty consecutive
+ * scheduled runs retrying a permanent misconfiguration, each failure looking like bad luck.
+ *
+ * The discriminator is not the message but the TIMING. These probes carry no retry budget and run
+ * before any collection stage, so a denial here is the installation answering. That is what makes
+ * fail-fast safe without breaking the retry budget the flaky class genuinely needs.
+ */
+test.describe('Data Sync access preflight (#15744)', () => {
+    const respond = payload => async () => ({status: 200, json: async () => payload});
+
+    const denial    = respond({errors: [{message: 'Resource not accessible by integration'}]}),
+          reachable = respond({data: {repository: {id: 'R_kgDO'}}});
+
+    test('the required set includes devindex-opt-out, not just opt-in', () => {
+        // An installation covering only `neo` + `devindex-opt-in` passes a naive probe and then
+        // fails one stage later, after the setup work already looked complete. OptOut mutates its
+        // own repository, so it is a first-class requirement rather than an afterthought.
+        expect(REQUIRED_REPOSITORIES.map(entry => entry.name)).toEqual([
+            'devindex-opt-in',
+            'devindex-opt-out'
+        ])
+    });
+
+    test('a reachable repository probe reports ok without a retry budget', async () => {
+        expect(await probeRepository({fetchFn: reachable, name: 'devindex-opt-in', owner: 'neomjs', token: 't'}))
+            .toEqual({ok: true, reason: null})
+    });
+
+    test('a GraphQL denial is detected despite arriving as HTTP 200', async () => {
+        // The denial is a 200-body `errors` array, so status alone is not the test — reading only
+        // `response.status` would report this repository as reachable.
+        expect(await probeRepository({fetchFn: denial, name: 'devindex-opt-in', owner: 'neomjs', token: 't'}))
+            .toEqual({ok: false, reason: 'Resource not accessible by integration'})
+    });
+
+    test('the exact 60-run denial fails fast, names EVERY unreachable repo, and states the remedy', async () => {
+        let threw = null;
+
+        await assertDataSyncAccess({fetchFn: denial, log: () => {}, token: 't'}).catch(error => {threw = error});
+
+        expect(threw).toBeTruthy();
+        // Names both, so one fix round resolves both installations rather than discovering the
+        // second only after the first is corrected.
+        expect(threw.message).toContain('neomjs/devindex-opt-in');
+        expect(threw.message).toContain('neomjs/devindex-opt-out');
+        // Classifies rather than merely reporting: this is the sentence that stops a reader from
+        // treating it as another flake and waiting for the next scheduled run.
+        expect(threw.message).toContain('PERSISTENT authorization failure');
+        expect(threw.message).toContain('Issues: Read and write')
+    });
+
+    test('reachable repositories pass silently', async () => {
+        await expect(assertDataSyncAccess({fetchFn: reachable, log: () => {}, token: 't'})).resolves.toBeUndefined()
+    });
+
+    test('a missing token fails before any network call', async () => {
+        let called = false;
+
+        await expect(assertDataSyncAccess({
+            fetchFn: async () => {called = true; return {status: 200, json: async () => ({})}},
+            log    : () => {},
+            token  : null
+        })).rejects.toThrow('No intake token was provided');
+
+        expect(called).toBe(false)
+    });
+
+    test('a non-denial failure is NOT labelled persistent authorization', async () => {
+        // Over-labelling would send a reader to the App settings for a network fault. The
+        // classification has to be wrong-way-safe in both directions, not just the loud one.
+        let threw = null;
+
+        await assertDataSyncAccess({
+            fetchFn: respond({errors: [{message: 'something went wrong while executing your query'}]}),
+            log    : () => {},
+            token  : 't'
+        }).catch(error => {threw = error});
+
+        expect(threw.message).toContain('unreachable');
+        expect(threw.message).not.toContain('PERSISTENT authorization failure')
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/DataSyncPreflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPreflight.spec.mjs
@@ -6,6 +6,9 @@ import {
     REQUIRED_REPOSITORIES
 } from '../../../../../buildScripts/dataSyncPreflight.mjs';
 
+/** Collapses the retry backoff so budget-spending tests stay fast; shared by every describe below. */
+const noWait = async () => {};
+
 /**
  * `Resource not accessible by integration` is returned for two conditions that share one string:
  * genuine GitHub-side flakiness, and a permanently missing App installation. No message inspection
@@ -13,9 +16,11 @@ import {
  * for the first, catastrophic for the second. This pipeline spent eight days and sixty consecutive
  * scheduled runs retrying a permanent misconfiguration, each failure looking like bad luck.
  *
- * The discriminator is not the message but the TIMING. These probes carry no retry budget and run
- * before any collection stage, so a denial here is the installation answering. That is what makes
- * fail-fast safe without breaking the retry budget the flaky class genuinely needs.
+ * The discriminator is not the message but WHEN plus HOW OFTEN. These probes run before any
+ * collection stage AND spend a small retry budget of their own, so a failure that survives both is
+ * neither mid-batch contention nor one unlucky first call — it is the installation answering. Timing
+ * alone was not enough: it rules out contention but not a single blip, and aborting a scheduled run
+ * on one blip is its own outage.
  */
 test.describe('Data Sync access preflight (#15744)', () => {
     const respond = payload => async () => ({status: 200, json: async () => payload});
@@ -90,6 +95,84 @@ test.describe('Data Sync access preflight (#15744)', () => {
 
         expect(threw.message).toContain('unreachable');
         expect(threw.message).not.toContain('PERSISTENT authorization failure')
+    });
+
+    test('a THROWN transport failure becomes a reason instead of escaping the probe', async () => {
+        // ECONNRESET/DNS/TLS is the most common transient class AND the only one that arrives as an
+        // exception rather than an `errors` array. Awaiting `fetchFn` outside a catch let it escape
+        // `probeRepository`, the retry loop, and `assertDataSyncAccess` alike — so the bounded retry
+        // could not see the failure mode it exists for.
+        const result = await probeRepository({
+            fetchFn: async () => {throw new Error('ECONNRESET')},
+            name   : 'devindex-opt-in',
+            owner  : 'neomjs',
+            token  : 't'
+        });
+
+        expect(result).toEqual({ok: false, reason: 'ECONNRESET'})
+    });
+
+    test('a transport throw on the FIRST call recovers on retry — the budget can now reach it', async () => {
+        let calls = 0;
+
+        const flakyTransport = async () => {
+            calls++;
+            if (calls === 1) throw new Error('ECONNRESET');
+            return {status: 200, json: async () => ({data: {repository: {id: 'R_kgDO'}}})}
+        };
+
+        await expect(assertDataSyncAccess({
+            fetchFn: flakyTransport, log: () => {}, token: 't', waitFn: noWait
+        })).resolves.toBeUndefined();
+
+        // 3 calls: opt-in throws then succeeds, opt-out succeeds first try. Before the catch this
+        // rejected with a raw ECONNRESET at calls=1, naming no repository.
+        expect(calls).toBe(3)
+    });
+
+    test('a persistent transport fault names the repository and does NOT blame the installation', async () => {
+        let threw = null;
+
+        await assertDataSyncAccess({
+            fetchFn: async () => {throw new Error('ECONNRESET')},
+            log    : () => {},
+            token  : 't',
+            waitFn : noWait
+        }).catch(error => {threw = error});
+
+        expect(threw.message).toContain('neomjs/devindex-opt-in');
+        expect(threw.message).toContain('ECONNRESET');
+        expect(threw.message).toContain('Transport or availability fault');
+        expect(threw.message).not.toContain('PERSISTENT authorization failure')
+    });
+
+    test('MIXED failures are classified per repository, not by one global verdict', async () => {
+        // The defect this pins: `failures.some(DENIAL_PATTERN)` labelled the WHOLE aggregate a
+        // persistent authorization failure as soon as one repository denied, instructing the operator
+        // to fix an App installation on a repository whose credential was never rejected.
+        let threw = null;
+
+        await assertDataSyncAccess({
+            fetchFn: async (_url, options) => {
+                if (JSON.parse(options.body).variables.name === 'devindex-opt-in') {
+                    return {status: 200, json: async () => ({errors: [{message: 'Resource not accessible by integration'}]})}
+                }
+                throw new Error('ECONNRESET')
+            },
+            log   : () => {},
+            token : 't',
+            waitFn: noWait
+        }).catch(error => {threw = error});
+
+        const
+            optIn  = threw.message.slice(threw.message.indexOf('devindex-opt-in'), threw.message.indexOf('devindex-opt-out')),
+            optOut = threw.message.slice(threw.message.indexOf('devindex-opt-out'));
+
+        // Each verdict sits on the line whose cause produced it — and, decisively, NOT on the other.
+        expect(optIn).toContain('PERSISTENT authorization failure');
+        expect(optIn).not.toContain('Transport or availability fault');
+        expect(optOut).toContain('Transport or availability fault');
+        expect(optOut).not.toContain('PERSISTENT authorization failure')
     });
 });
 
@@ -180,8 +263,7 @@ test.describe('preflight-only dispatch mode', () => {
  */
 test.describe('preflight retry budget', () => {
     const denialBody    = {errors: [{message: 'Resource not accessible by integration'}]},
-          reachableBody = {data: {repository: {id: 'R_kgDO'}}},
-          noWait        = async () => {};
+          reachableBody = {data: {repository: {id: 'R_kgDO'}}};
 
     test('a flaky first call recovers instead of being reported permanent', async () => {
         let calls = 0;

--- a/test/playwright/unit/ai/buildScripts/DataSyncPreflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPreflight.spec.mjs
@@ -92,3 +92,76 @@ test.describe('Data Sync access preflight (#15744)', () => {
         expect(threw.message).not.toContain('PERSISTENT authorization failure')
     });
 });
+
+/**
+ * Preflight-only dispatch: verifying the credential topology must not require mutating anything.
+ *
+ * The collection stages have side effects — OptOut comments on and closes real issues in
+ * `devindex-opt-out`. A configuration check that can only be performed by running them is a check
+ * nobody repeats while iterating on an installation, which is precisely when it is most needed.
+ */
+test.describe('preflight-only dispatch mode', () => {
+    let emitGeneratedData;
+
+    test.beforeAll(async () => {
+        ({emitGeneratedData} = await import('../../../../../buildScripts/dataSyncPipeline.mjs'))
+    });
+
+    test.afterEach(() => {
+        delete process.env.DATA_SYNC_PREFLIGHT_ONLY
+    });
+
+    test('preflight-only runs the probe and then executes NO stage', async () => {
+        const executed = [];
+
+        process.env.DATA_SYNC_PREFLIGHT_ONLY = 'true';
+
+        let probed = false;
+
+        await emitGeneratedData({
+            attempt  : 1,
+            cwd      : '/tmp',
+            execute  : async command => {executed.push(command)},
+            log      : () => {},
+            preflight: async () => {probed = true}
+        });
+
+        expect(probed).toBe(true);
+        expect(executed).toEqual([])
+    });
+
+    test('the flag is opt-in: absent or non-"true" runs the full sequence', async () => {
+        for (const value of [undefined, 'false', '1', 'yes']) {
+            const executed = [];
+
+            value === undefined
+                ? delete process.env.DATA_SYNC_PREFLIGHT_ONLY
+                : process.env.DATA_SYNC_PREFLIGHT_ONLY = value;
+
+            await emitGeneratedData({
+                attempt  : 1,
+                cwd      : '/tmp',
+                execute  : async command => {executed.push(command)},
+                log      : () => {},
+                preflight: async () => {}
+            });
+
+            // Only the exact string 'true' short-circuits. A truthy-ish value silently skipping the
+            // whole pipeline would be a scheduled run that reports success having done nothing —
+            // the same silent-no-op class this ticket exists to remove.
+            expect(executed.length, `flag=${String(value)}`).toBeGreaterThan(0)
+        }
+    });
+
+    test('preflight failure still aborts in preflight-only mode', async () => {
+        process.env.DATA_SYNC_PREFLIGHT_ONLY = 'true';
+
+        await expect(emitGeneratedData({
+            attempt  : 1,
+            cwd      : '/tmp',
+            execute  : async () => {},
+            log      : () => {},
+            preflight: async () => {throw new Error('[DataSync preflight] denied')}
+        })).rejects.toThrow('denied')
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/DataSyncPreflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPreflight.spec.mjs
@@ -165,3 +165,53 @@ test.describe('preflight-only dispatch mode', () => {
         })).rejects.toThrow('denied')
     });
 });
+
+/**
+ * The bounded budget, added on @neo-gpt-emmy's review challenge.
+ *
+ * The original design claimed timing alone separated persistent denial from transient: a probe
+ * before any collection cannot be mid-batch flakiness. True — but it does not rule out a flaky
+ * FIRST call, so declaring one denial permanently authorized because of WHEN it happened traded a
+ * permanent-misread-as-transient bug for a transient-misread-as-permanent one. A scheduled run
+ * aborted on a single blip is its own outage.
+ *
+ * Persistence is now established by EXHAUSTION as well as timing. The fail-fast property survives:
+ * the case this exists for produced the same denial sixty consecutive times.
+ */
+test.describe('preflight retry budget', () => {
+    const denialBody    = {errors: [{message: 'Resource not accessible by integration'}]},
+          reachableBody = {data: {repository: {id: 'R_kgDO'}}},
+          noWait        = async () => {};
+
+    test('a flaky first call recovers instead of being reported permanent', async () => {
+        let calls = 0;
+
+        const flaky = async () => {
+            calls++;
+            return {status: 200, json: async () => (calls <= 2 ? denialBody : reachableBody)}
+        };
+
+        await expect(assertDataSyncAccess({
+            fetchFn: flaky, log: () => {}, token: 't', waitFn: noWait
+        })).resolves.toBeUndefined();
+
+        expect(calls).toBeGreaterThan(2)
+    });
+
+    test('a persistent denial still fails, and only after the budget is spent', async () => {
+        let calls = 0;
+
+        const denied = async () => {
+            calls++;
+            return {status: 200, json: async () => denialBody}
+        };
+
+        await expect(assertDataSyncAccess({
+            attempts: 3, fetchFn: denied, log: () => {}, token: 't', waitFn: noWait
+        })).rejects.toThrow('PERSISTENT authorization failure');
+
+        // 2 repositories x 3 attempts. A single-shot probe would have spent 2 — the distinction
+        // between "denied once" and "denied every time" is the whole classification.
+        expect(calls).toBe(6)
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs
@@ -125,8 +125,22 @@ test.describe('rebuildContentIndexesAndSeo (#13260)', () => {
         expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/pulls.mjs');
         expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/discussions.mjs');
         expect(delegatedPipeline).not.toContain('node ./buildScripts/docs/index/tickets.mjs');
-        expect(workflow).toContain(
-            'GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n        run: node ./buildScripts/dataSyncPipeline.mjs'
-        );
+        // The pipeline step receives the two SCOPED credentials and no ambient repository token.
+        // This previously pinned `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on that step — one
+        // token for cross-repository intake reads AND for the publish push. Those are different
+        // authorization contracts, and the default token satisfies neither: it has no installation
+        // on the DevIndex repos at all, and it cannot bypass the code-scanning ruleset that a
+        // freshly generated commit can never pre-satisfy.
+        expect(workflow).toContain('DATA_SYNC_INTAKE_TOKEN: ${{ steps.intake-token.outputs.token }}');
+        expect(workflow).toContain('DATA_SYNC_PUBLISHER_TOKEN: ${{ steps.publisher-token.outputs.token }}');
+
+        // The assertion that matters: the ambient repository token is gone from the run step, so a
+        // future edit reinstating it would fail here rather than silently restoring the shared
+        // credential this split exists to remove.
+        expect(workflow).not.toContain('GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}');
+
+        // The publish push runs through the checkout credential, so it must be the publisher —
+        // the only identity permitted to bypass the ruleset.
+        expect(workflow).toContain('token: ${{ steps.publisher-token.outputs.token }}');
     });
 });


### PR DESCRIPTION
Resolves #15744

The Data Sync pipeline has not published since **2026-07-17** — 60 consecutive scheduled failures. Two authorization boundaries shared one credential, and neither was satisfied by it.

## Deltas

**Two identities, because they hold different authority.** `actions/create-github-app-token@v3` scopes ONE permission set across a whole repository set, so a single App spanning all three repos would let the ruleset-bypass identity mutate the intake repos and let the intake identity publish here. Per @neo-gpt-emmy's intake fork: **Publisher** (`neo`, `contents: write`, sole ruleset-bypass actor) and **Intake** (`devindex-opt-in` + `devindex-opt-out`, `issues: write`).

**Why the default `GITHUB_TOKEN` satisfied neither contract:**

- It has **no installation** on the DevIndex repos. Absent, not underprivileged — which is why 13 runs died on `Resource not accessible by integration`.
- It cannot bypass ruleset `19087298`, and a freshly generated commit can never arrive carrying prior CodeQL evidence. **Measured this session:** a push to `dev` is rejected for lacking results that only a successful push could produce, and zero check-runs exist for the rejected commit. That is a deadlock, not a wait — so the bypass actor is the *only* mechanism, not the tidiest one.

**`scopedStageEnv` strips the SOURCE variables, not just the consumed ones.** My first implementation stripped `GH_TOKEN`/`GITHUB_TOKEN` and left `DATA_SYNC_PUBLISHER_TOKEN` readable in every intake stage's environment. A per-key check reported perfect isolation while the bypass credential sat one `process.env` lookup from every data child. The specs therefore assert **by value across the whole environment**:

```
scope=none      sees-intake=false  sees-publisher=false  sees-ambient=false
scope=intake    sees-intake=true   sees-publisher=FALSE  sees-ambient=false
scope=publisher sees-intake=FALSE  sees-publisher=true   sees-ambient=false
```

`tokenScope: 'none'` yields **no** credential, and a missing scoped token does **not** fall back to ambient — that fallback is how the single-token pipeline masked its own boundary for eight days.

**The preflight and the error classification are one design, not two ACs.** `Resource not accessible by integration` covers two conditions that share one string: GitHub-side flakiness, and a permanently missing installation. #15359 classified it transient on real evidence — the same token succeeding four hours later — which is correct for the first and catastrophic for the second.

No message inspection separates them. **Timing and exhaustion do — neither alone.** A probe issued before any collection cannot be mid-batch flakiness; a probe that also spends a small retry budget cannot be one unlucky first call. Timing-only was the shape this PR shipped first, and it traded a permanent-misread-as-transient bug for a transient-misread-as-permanent one: a scheduled run aborted on a single blip is its own outage. `retryableTransientErrorPatterns` is left **untouched** either way — weakening it would break the flaky case #15359 documented with evidence.

`devindex-opt-out` is in the required set on @neo-gpt-emmy's catch — the scheduled sequence runs OptOut too, so an install covering only `neo` + `devindex-opt-in` would pass a naive probe and fail one stage later, after the setup looked complete.

**A preflight dispatch now checks out the ref it was dispatched from.** The dispatch resolves the *workflow file* from the chosen ref while `actions/checkout` pinned the *source* to `dev` — so every change to this pipeline was untestable before merge, which is a poor property for the script that publishes to `dev`. Publishing stays pinned to `dev`; only preflight-only follows the dispatched ref.

## Test Evidence

Evidence: **`L3 PARTIAL`, and it is not on the current head.** The one live run cited below executed at `7405477e17`; the head has advanced four times since. Calling it "the exact head" was true when written and stopped being true on the next push — the same failure mode this PR fixed twice in its own prose, so the claim is now stated as what it is: **discovery evidence from a superseded head**, not a current-head safety proof. Everything after it is code + CI.

**[Run 30180897199](https://github.com/neomjs/neo/actions/runs/30180897199) at `7405477e17` — DISCOVERY evidence, not a safety proof.** It is green, and it is also the run that pushed `pages` commit `189b7b8055` (167 files) while logging *"skipping collection and publish"*. **It cannot be both the counter-example and the proof**, so it is cited here only for what it does establish — that both installations resolve and the Intake identity reaches both DevIndex repos:

```
DATA_SYNC_PREFLIGHT_ONLY: true
[DataSync preflight] neomjs/devindex-opt-in  reachable (OptIn stargazer read)
[DataSync preflight] neomjs/devindex-opt-out reachable (OptOut issue read + close)
[DataSync] preflight-only: repository access verified; skipping collection and publish.
[DataSync] publish attempt=1/2 result=no-generated-changes
```

Both probes completed in **0.7s**. The old path burned ~8s of retries before dying and then wasted the remainder of the run.

**What that run does prove:** both App installations resolve (a mint fails outright if the App is not installed on the named repositories), and the Intake identity reads **both** DevIndex repos.

**What it does NOT prove, and what I previously claimed it did:** side-effect freedom. The pipeline logged no `stage=` lines and I concluded nothing mutated — while the job's own step list read `success  Push Data to neomjs/pages`. **A short-circuit inside one step cannot bound the steps after it.** The guard now exists and is asserted in the spec, but its evidence is code + CI, not an L3 run: no preflight-only dispatch has been executed against a head carrying the guard.

**The preceding failed dispatch was also evidence**, and is why the checkout fix exists: it set `DATA_SYNC_PREFLIGHT_ONLY=true`, emitted **no preflight line at all**, ran the collection stages, and died at `#getAuthToken (GitHub.mjs:169)` — dev's old single-token code running under the new environment.

`buildScripts` spec surface: **320 passed**.

### Three exact-boundary fixes, each falsified in isolation

@neo-gpt-emmy's Cycle-1 RAs, folded at `0f3b36ea92`. Every one sat at a seam where both sides were individually correct.

| Defect | The seam | Falsifier |
|---|---|---|
| `probeRepository` awaited `fetchFn` outside any catch | the retry loop was correct; a **thrown** transport fault could not fail *into* it, so it escaped probe, loop and `assertDataSyncAccess` alike | remove the catch → **4 failed** |
| `failures.some(DENIAL_PATTERN)` | a per-repository fact collapsed into one global verdict — an opt-in denial plus an opt-out reset instructed the operator to fix an App on a repository whose credential was never rejected | restore the global test → **1 failed** |
| `gitAuthenticated` spread the caller's env | the boundary was **additive**, not scoped: the credential left argv while both source tokens and any ambient `GH_TOKEN`/`GITHUB_TOKEN` still reached the child. `scopedStageEnv` already owned this discipline and it was simply never carried across the git boundary | restore the spread → **1 failed**, and **all three prior `gitAuthenticated` tests still passed** — which is exactly why they could not see it |

Restored: **45 passed**. The third row is the one worth reading twice: green tests next to a live leak, because they asserted the boundary I had thought about rather than the one that existed.

## Post-Merge Validation

- [ ] **The ruleset bypass is exercised.** Preflight-only stops before the push, so the Publisher identity's bypass is configured (verified in the UI by @tobiu) but not yet *executed*. The first scheduled run that generates changes settles it; a wrong bypass surfaces as `GH013` naming the code-scanning rule.
- [ ] **Three scheduled runs complete** the OptIn read and generated-content push without an auth or ruleset terminal failure (#15744 AC).
- [ ] Retire the `app-id` input in favour of `client-id` — deprecated by `create-github-app-token@v3` (4 warnings/run). Client ID is a **different value** from App ID, so it needs new secrets; deliberately not churned mid-verification.

## Deltas from ticket

**One architectural refinement, now reconciled on the ticket rather than left as drift.** #15744 prescribed **one** dedicated App in its Fix, Contract Ledger and AC wording. This PR ships **two** — Publisher on `neo` (sole ruleset-bypass actor) and Intake on both DevIndex repositories.

The reason is mechanical: `actions/create-github-app-token@v3` scopes one permission set across a whole repository set, so a single App spanning all three repos would give the ruleset-bypass identity write access to the intake repos **and** let the intake identity publish to `neo`. The split was raised in @neo-gpt-emmy's intake delta but never folded into the body, so the ticket and the implementation disagreed. **#15744's Fix, Contract Ledger and ACs are updated to the shipped two-identity topology**, with the amendment recorded in place rather than appended.

The Contract Ledger also gains two rows the original did not anticipate: per-stage credential scope, and the git-layer credential boundary.

**Two ACs are annotated `[L3-deferred — operator handoff needed]` on the ticket**, matching Post-Merge Validation above, so `Resolves #15744` does not silently close runtime ownership: the publish half of the controlled-workflow AC, and the three-clean-scheduled-runs AC.

## Review routing

Review role: primary-reviewer, **held by @neo-gpt-emmy**. Cycle 1 posted `REQUEST_CHANGES` ([review](https://github.com/neomjs/neo/pull/15953#pullrequestreview-4780601670)); all four RAs are folded at `0f3b36ea92`.

Cross-family required (Claude-family authored). @neo-gpt-emmy filed #15744, caught the `devindex-opt-out` omission that would have turned this into a second outage, parked the two-App fork this implements, and then found twelve further defects — every one at a boundary, none in the reasoning about either side of it.

**Where to push — updated, because my previous answer here was falsified by my own diff.** This section used to argue that a bounded retry on the probe was the likely right answer *"which I deliberately did not add because it re-blurs the persistent/transient line."* That reasoning was wrong: exhaustion **sharpens** the line rather than blurring it, since a denial that survives its full budget is more clearly persistent than one judged on timing alone. The retry is in.

The live question is now narrower and I do not think it is settled: the preflight is a **hard dependency on GraphQL reachability at the front of a pipeline that previously degraded into its retry budget**. Three attempts over ~1.5s is a small window, and a reviewer who thinks a scheduled run should degrade rather than abort when GitHub's GraphQL endpoint is briefly unreachable has an argument I cannot refute from the code — only from the eight-day outage on the other side of the trade.

Related: #15359 (the transient classification this refines rather than reverses) · #15750 (moved publication out of inline YAML; changed neither boundary) · #15948 (@neo-kimi-phoebe's staleness alarm — the silence gap, deliberately decoupled from this App identity so it ships independent)

Authored by Ada (Claude Opus 5, Claude Code). Session 5664b1bb-99b3-4e0f-b464-163a1c8bfb16.


