### PR TITLE
fix(ai): the plane census reads the config contract, not a Path/Dir name shape (#15842)

### DIFF
--- a/ai/scripts/diagnostics/planePlacementCensus.mjs
+++ b/ai/scripts/diagnostics/planePlacementCensus.mjs
@@ -222,7 +222,13 @@ export function buildPlanePathSource(memberPaths) {
         throw new Error('planePlacementCensus.buildPlanePathSource: refusing to build a matcher from an empty member set — it would silently report a plausible, much smaller census.');
     }
 
-    const declared = memberPaths.map(member => member.replace(/\./g, '\\.')).join('|');
+    // Escape EVERY regex metacharacter, not just the dot separator. `$` is legal in a JS identifier, so a
+    // leaf named `$foo` is a real declaration — and left unescaped it becomes an end-anchor, producing a
+    // matcher that silently stops matching the very member it was built from. A silent false negative is
+    // precisely the class this census exists to remove, so it must not be reintroduced by its own builder.
+    // A metacharacter that instead makes the pattern invalid throws in the RegExp constructor, which is the
+    // acceptable half of this failure; the silent half is not.
+    const declared = memberPaths.map(member => member.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
 
     return new RegExp(`storagePaths\\.|\\b[A-Za-z0-9_$]*[Cc]onfig\\.(?:${declared})\\b|\\.neo-ai-data|NEO_AI_DATA|aiDataRoot`)
 }

--- a/ai/scripts/diagnostics/planePlacementCensus.mjs
+++ b/ai/scripts/diagnostics/planePlacementCensus.mjs
@@ -26,6 +26,11 @@ import * as acorn      from 'acorn';
  * acorn's `onComment` ranges — this is not a nicety: a naive line match counted doc-comment *mentions*
  * of plane paths as code paths and inflated the count by roughly 20% (61 → 52 at first measurement).
  *
+ * "Resolves a plane path" is defined by the **config contract**, not by this file: the member set is read
+ * from the declaring configs' `PLANE_MEMBER_PATHS` (`readDeclaredPlaneMembers`). The census holds no
+ * opinion about what a plane member *is* — only about which modules reference one. Its predecessor did
+ * hold one, a `*Path`/`*Dir` name shape, and it was wrong in both directions at once.
+ *
  * The split that actually prices the branch is **host-side runners** (scripts, daemons, buildScripts —
  * invoked directly on the host) versus **in-server modules** (services and MCP servers, loaded inside a
  * server process). On macOS a named volume is VM-interior and host-invisible, so a host-side runner needs
@@ -89,24 +94,148 @@ export const PLANE_DIR_NAME = '.neo-ai-data';
 export const OPENER_SEARCH_TREES = ['ai', 'buildScripts', 'src', 'apps'];
 
 /**
- * Matches an expression that resolves a plane path.
+ * The config modules that DECLARE plane membership, each exporting a frozen `PLANE_MEMBER_PATHS`.
  *
- * Three shapes, because the plane is reached three ways and an earlier version saw only the first:
- *   1. `storagePaths.<leaf>` — the DB-path subtree.
- *   2. A `*Path` / `*Dir` leaf read off the config singleton (`AiConfig.backupPath`, `aiConfig.logPath`,
- *      `…wakeDaemonHeartbeatAlivePath`, `…hierarchyPath`, …). `configBase.mjs` declares a whole family of
- *      these and matching only `storagePaths` silently dropped every module that reached the plane through
- *      another one — the miss @neo-gpt-emmy found on `SwarmHeartbeatService`.
- *   3. A literal `.neo-ai-data` / `NEO_AI_DATA` / `aiDataRoot` reference.
+ * All three, not just Tier 1: the two MCP server configs declare their own members (`memoryWal.*`,
+ * `remRunStateDir`, `hookProjectionRoot`, …) and a census reading only the Tier-1 list is blind to every
+ * module that reaches the plane through a server config — which is what left both WAL daemons uncounted.
+ * @type {String[]}
+ */
+export const PLANE_MEMBER_CONFIGS = [
+    'ai/configBase.mjs',
+    'ai/mcp/server/memory-core/configBase.mjs',
+    'ai/mcp/server/knowledge-base/configBase.mjs'
+];
+
+/**
+ * Reads the declared plane-member paths out of the config modules, by STATIC PARSE — never by import.
  *
- * This is a SHAPE proxy for the config contract, not the contract itself: it recognises the *form* of a
- * config plane-path read without importing the singleton into a diagnostic. A leaf whose name does not end
- * in `Path`/`Dir` would still be missed — the durable fix is to reconcile against the config module's
- * declared plane-member set rather than a name shape, and this JSDoc states that limit rather than
- * implying completeness.
+ * The import is not merely heavy, it does not work: every config module ends in `Neo.setupClass(...)`, so
+ * `import('ai/configBase.mjs')` outside a Neo entrypoint throws `Neo is not defined`. A named import does
+ * not help — the module body still evaluates. `derivePlaneMemberPaths` (`ai/planeConfig.mjs`) is pure and
+ * Neo-free, but its INPUT is `ConfigBase.config.data`, which only exists after that boot; a pure function
+ * whose argument is unobtainable here is a covering clause, not a usable one.
+ *
+ * So this reads the declared list instead of re-deriving it, and the list is not trusted on faith:
+ * `planeConfig.spec.mjs` asserts `derivePlaneMemberPaths(...)` EQUALS `PLANE_MEMBER_PATHS` for all three
+ * configs, and `derivePlaneMemberPaths` itself throws on a plane-anchored leaf with no membership
+ * decision. Declared, derived, and anchored therefore cannot drift apart without a red spec — which is
+ * what lets a diagnostic that stays node-builtins + acorn still read the real contract.
+ *
+ * FAILS LOUD by design. A missing export or a non-literal array yields no members, and a census whose
+ * member set silently empties would report a plausible, much smaller total — the failure mode a
+ * measurement instrument must never have.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.projectRoot=PROJECT_ROOT] Repo root.
+ * @param {String[]} [options.configs=PLANE_MEMBER_CONFIGS] Declaring config modules, repo-relative.
+ * @returns {String[]} Sorted union of every declared member path (dotted, relative to each config's data).
+ */
+export function readDeclaredPlaneMembers({projectRoot = PROJECT_ROOT, configs = PLANE_MEMBER_CONFIGS} = {}) {
+    const members = new Set();
+
+    for (const file of configs) {
+        const source = fs.readFileSync(path.join(projectRoot, file), 'utf8'),
+              ast    = acorn.parse(source, {ecmaVersion: 'latest', sourceType: 'module'});
+
+        let found = false;
+
+        for (const node of ast.body) {
+            if (node.type !== 'ExportNamedDeclaration' || node.declaration?.type !== 'VariableDeclaration') {
+                continue
+            }
+
+            for (const declarator of node.declaration.declarations) {
+                if (declarator.id.name !== 'PLANE_MEMBER_PATHS') {
+                    continue
+                }
+
+                // `Object.freeze([...])` — unwrap to the array literal it froze.
+                const init = declarator.init?.type === 'CallExpression' ? declarator.init.arguments[0] : declarator.init;
+
+                if (init?.type !== 'ArrayExpression') {
+                    throw new Error(`planePlacementCensus: ${file} exports PLANE_MEMBER_PATHS as a non-literal — the census reads it statically and cannot evaluate it.`);
+                }
+
+                for (const element of init.elements) {
+                    if (element?.type !== 'Literal' || typeof element.value !== 'string') {
+                        throw new Error(`planePlacementCensus: ${file} has a non-string-literal PLANE_MEMBER_PATHS entry — a member the census cannot read is a member it would silently drop.`);
+                    }
+
+                    members.add(element.value);
+                }
+
+                found = true;
+            }
+        }
+
+        if (!found) {
+            throw new Error(`planePlacementCensus: ${file} exports no PLANE_MEMBER_PATHS — the census reconciles against the declared contract and must not fall back to guessing.`);
+        }
+    }
+
+    return [...members].sort()
+}
+
+/**
+ * Builds the plane-path matcher from a declared member set.
+ *
+ * Three shapes, because the plane is reached three ways:
+ *   1. `storagePaths.<leaf>` — the memory-core DB-path subtree. Kept as a literal branch on purpose: its
+ *      `graphProd` leaf declares `planeMember: false` whose own reason states the decision is OPEN rather
+ *      than settled, so it is absent from the derived set while the graph SQLite is still, factually, the
+ *      plane's core artifact under the plane root. Dropping it would un-count ~10 graph consumers on the
+ *      strength of a placeholder. Retirement trigger: when that membership is decided, this branch either
+ *      becomes redundant (member) or is deleted with the leaf (non-member) — read the leaf's
+ *      `planeMemberReason` for the ticket that owns it.
+ *      ticket-ref-ok: none cited — the reason string on the leaf is the live pointer, so this branch's
+ *      sunset condition cannot rot when that ticket closes or is renamed.
+ *   2. A DECLARED member path read through a config object — `AiConfig.fleet.instanceRoot`,
+ *      `memoryCoreConfig.memoryWal.daemonDataDir`, `loggerConfig.logPath`. The leaf set comes from the
+ *      contract; only the *carrier* is matched by shape, and it is any identifier ending `Config`/`config`
+ *      rather than `AiConfig` alone — the WAL daemons and the shared logger read theirs under other names.
+ *   3. A literal `.neo-ai-data` / `NEO_AI_DATA` / `aiDataRoot` reference — a module resolving the plane
+ *      ROOT directly rather than through a leaf, which is a different signal and stays.
+ *
+ * **What replaced what, and why it moved the numbers in BOTH directions.** The previous branch 2 was
+ * `\b[Aa]iConfig\.[A-Za-z]*(?:Path|Dir)\b` — a name-shape proxy. It was wrong twice over, and only the
+ * first was anticipated:
+ * - **False negatives.** `[A-Za-z]*` cannot cross a dot and the name had to end `Path`/`Dir`, so declared
+ *   members like `fleet.instanceRoot`, `memoryWal.daemonDataDir`, `orchestrator.dataDir` and
+ *   `hookProjectionRoot` were invisible. Six modules opened the plane uncounted — four of them daemons,
+ *   including BOTH WAL daemons, in the host-side bucket the election is priced on.
+ * - **False positives, the larger error.** The shape also matched leaves that merely END in `Path`/`Dir`
+ *   and resolve into the REPO, not the plane: `neoRootDir` (the repo root), `hierarchyPath`
+ *   (`docs/output/class-hierarchy.json`), `handoffFilePath` (`resources/content/…`). Fourteen modules —
+ *   eleven of them knowledge-base sources reading `aiConfig.neoRootDir` — were counted as plane openers
+ *   while touching nothing a volume decision affects.
+ *
+ * The over-count direction the module documents elsewhere (co-occurrence, not data flow) is unchanged and
+ * still deliberate; this removes a class of match that was not over-counting but simply measuring the
+ * wrong tree.
+ *
+ * @param {String[]} memberPaths Declared member paths, dotted.
+ * @returns {RegExp}
+ */
+export function buildPlanePathSource(memberPaths) {
+    if (!Array.isArray(memberPaths) || memberPaths.length === 0) {
+        throw new Error('planePlacementCensus.buildPlanePathSource: refusing to build a matcher from an empty member set — it would silently report a plausible, much smaller census.');
+    }
+
+    const declared = memberPaths.map(member => member.replace(/\./g, '\\.')).join('|');
+
+    return new RegExp(`storagePaths\\.|\\b[A-Za-z0-9_$]*[Cc]onfig\\.(?:${declared})\\b|\\.neo-ai-data|NEO_AI_DATA|aiDataRoot`)
+}
+
+/**
+ * Matches an expression that resolves a plane path, reconciled against the declared config contract.
+ *
+ * Built at module scope so the census reads the contract as it stands in the checkout being measured: add a
+ * plane member to any of the three configs and it is counted with no census edit, remove one and it stops
+ * being counted. See `buildPlanePathSource` for the three branches and what the name-shape proxy got wrong.
  * @type {RegExp}
  */
-export const PLANE_PATH_SOURCE = /storagePaths\.|\b[Aa]iConfig\.[A-Za-z]*(?:Path|Dir)\b|\.neo-ai-data|NEO_AI_DATA|aiDataRoot/;
+export const PLANE_PATH_SOURCE = buildPlanePathSource(readDeclaredPlaneMembers());
 
 /**
  * Matches a filesystem operation. Deliberately broad: the axis is "does this module open the plane",

--- a/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
@@ -33,6 +33,7 @@ test.describe('planePlacementCensus — the classification rules the election is
     let stripComments, auditSeatContainment, censusPlaneOpeners, PLANE_DIR_NAME;
     let attributeWalSegment, normalizeSeatIdentity, resolveLatestWalSegment, WAL_DIR_NAME;
     let listCensusFiles, PLANE_PATH_SOURCE, CENSUS_SELF_PATH;
+    let readDeclaredPlaneMembers, buildPlanePathSource, PLANE_MEMBER_CONFIGS;
     let workRoot;
 
     test.beforeAll(async () => {
@@ -47,7 +48,10 @@ test.describe('planePlacementCensus — the classification rules the election is
             PLANE_PATH_SOURCE,
             CENSUS_SELF_PATH,
             PLANE_DIR_NAME,
-            WAL_DIR_NAME
+            WAL_DIR_NAME,
+            readDeclaredPlaneMembers,
+            buildPlanePathSource,
+            PLANE_MEMBER_CONFIGS
         } = await import('../../../../../../ai/scripts/diagnostics/planePlacementCensus.mjs'));
 
         workRoot = path.resolve(process.cwd(), 'tmp', `plane-census-${process.pid}-${Date.now()}`);
@@ -140,18 +144,113 @@ test.describe('planePlacementCensus — the classification rules the election is
         expect(listCensusFiles()).not.toContain(CENSUS_SELF_PATH);
     });
 
-    test('PLANE_PATH_SOURCE recognises the whole *Path/*Dir config-leaf family, not just storagePaths', () => {
-        // The miss @neo-gpt-emmy found: SwarmHeartbeatService reads AiConfig.wakeDaemonHeartbeatAlivePath, a
-        // plane leaf that is not `storagePaths`, and was silently dropped.
-        expect(PLANE_PATH_SOURCE.test('AiConfig.wakeDaemonHeartbeatAlivePath')).toBe(true);
-        expect(PLANE_PATH_SOURCE.test('aiConfig.backupPath')).toBe(true);
-        expect(PLANE_PATH_SOURCE.test('AiConfig.hierarchyPath')).toBe(true);
-        expect(PLANE_PATH_SOURCE.test('aiConfig.socketDir')).toBe(true);
-        // Still matches the original shapes.
+    // ───────── the matcher reconciles against the declared contract, not a name shape ─────────
+
+    test('EVERY declared plane member matches when read through a config carrier', () => {
+        // The invariant, asserted over the whole live set rather than a pinned example: a member that
+        // stops matching is a module the census stops counting, and the election is priced on that count.
+        const members = readDeclaredPlaneMembers();
+
+        expect(members.length).toBeGreaterThan(0);
+
+        for (const member of members) {
+            expect(PLANE_PATH_SOURCE.test(`AiConfig.${member}`), `declared member "${member}" must match`).toBe(true);
+        }
+    });
+
+    test('the declared set CONTAINS members no Path/Dir name shape could reach — the false negatives', () => {
+        // Why the proxy had to go, proven from the contract instead of from an example that can be edited
+        // away: members exist whose name does not end Path/Dir, or that sit behind a dotted trail the old
+        // `[A-Za-z]*` could not cross. `fleet.instanceRoot` and `memoryWal.daemonDataDir` are both.
+        const members   = readDeclaredPlaneMembers(),
+              nameShape = /^[A-Za-z]*(?:Path|Dir)$/;
+
+        expect(members.some(member => !nameShape.test(member))).toBe(true);
+
+        // And the proxy itself, reconstructed, misses them — so this is the old behaviour, not a guess.
+        const proxy = /\b[Aa]iConfig\.[A-Za-z]*(?:Path|Dir)\b/;
+
+        expect(members.some(member => !proxy.test(`AiConfig.${member}`))).toBe(true);
+    });
+
+    test('a *Path/*Dir leaf that is NOT a declared member is not a plane reference — the false positives', () => {
+        // The larger half of the defect, and the one the ticket did not predict: `neoRootDir` is the REPO
+        // root and `hierarchyPath` is `docs/output/class-hierarchy.json`. Both merely END in Dir/Path, and
+        // the shape proxy counted every module reading them — eleven knowledge-base sources among them —
+        // as plane openers, pricing a volume decision on files a volume decision does not touch.
+        const members = readDeclaredPlaneMembers();
+
+        // Guarded, so a future membership change reports WHY this flipped instead of just going red.
+        expect(members).not.toContain('neoRootDir');
+        expect(members).not.toContain('hierarchyPath');
+
+        expect(PLANE_PATH_SOURCE.test('aiConfig.neoRootDir')).toBe(false);
+        expect(PLANE_PATH_SOURCE.test('AiConfig.hierarchyPath')).toBe(false);
+        expect(PLANE_PATH_SOURCE.test('AiConfig.vectorDimension')).toBe(false);
+    });
+
+    test('the carrier is any *Config identifier, not AiConfig alone', () => {
+        // Both WAL daemons read `memoryCoreConfig.*` and the shared logger reads `loggerConfig.logPath`.
+        // Requiring the AiConfig spelling left all three uncounted while they opened the plane.
+        const source = buildPlanePathSource(['memoryWal.daemonDataDir', 'logPath']);
+
+        expect(source.test('memoryCoreConfig.memoryWal.daemonDataDir')).toBe(true);
+        expect(source.test('loggerConfig.logPath')).toBe(true);
+        expect(source.test('this.aiConfig.logPath')).toBe(true);
+        // The carrier still has to BE a config — a same-named property on anything else is not a plane read.
+        expect(source.test('options.logPath')).toBe(false);
+        expect(source.test('this.logPath')).toBe(false);
+    });
+
+    test('reconciliation is BIDIRECTIONAL — a member removed from the contract stops being counted', () => {
+        // The half a purely additive fix would miss: the matcher is BUILT from the set, so shrinking the
+        // set shrinks the matcher. Asserted on a fixture, because asserting it on the live contract would
+        // require removing a real member to prove it.
+        const before = buildPlanePathSource(['alpha.one', 'beta.two']),
+              after  = buildPlanePathSource(['alpha.one']);
+
+        expect(before.test('AiConfig.beta.two')).toBe(true);
+        expect(after.test('AiConfig.beta.two')).toBe(false);
+        expect(after.test('AiConfig.alpha.one')).toBe(true);
+    });
+
+    test('the root-reference and storagePaths branches survive — they are a different signal', () => {
+        // `.neo-ai-data` detects a module resolving the plane ROOT directly rather than through a leaf.
+        // `storagePaths.` stays literal because `graphProd` declares planeMember:false with a reason that
+        // says the decision is still OPEN, while the graph SQLite is the plane's core artifact — dropping
+        // it would un-count ~10 graph consumers on the strength of a placeholder.
         expect(PLANE_PATH_SOURCE.test('config.storagePaths.graph')).toBe(true);
         expect(PLANE_PATH_SOURCE.test("'.neo-ai-data/sqlite'")).toBe(true);
-        // A non-path config read is NOT a plane reference.
-        expect(PLANE_PATH_SOURCE.test('AiConfig.vectorDimension')).toBe(false);
+        expect(PLANE_PATH_SOURCE.test('NEO_AI_DATA')).toBe(true);
+        expect(PLANE_PATH_SOURCE.test('aiDataRoot')).toBe(true);
+    });
+
+    test('the member set is read from ALL declaring configs, not Tier 1 alone', () => {
+        // Reading only `ai/configBase.mjs` is how both WAL daemons stayed invisible: their members are
+        // declared by the memory-core server config.
+        const all   = readDeclaredPlaneMembers(),
+              tier1 = readDeclaredPlaneMembers({configs: ['ai/configBase.mjs']});
+
+        expect(PLANE_MEMBER_CONFIGS.length).toBeGreaterThan(1);
+        expect(all.length).toBeGreaterThan(tier1.length);
+        expect(all).toEqual([...all].sort());
+        // Union, not concatenation — `logPath` is declared by two configs.
+        expect(new Set(all).size).toBe(all.length);
+    });
+
+    test('a config that stops declaring its members FAILS LOUD rather than shrinking the census', () => {
+        // The failure mode a measurement instrument must not have: an empty member set still produces a
+        // perfectly plausible, much smaller total that no reviewer would question.
+        const bare = path.join(workRoot, 'bare-config');
+
+        fs.mkdirSync(path.join(bare, 'ai'), {recursive: true});
+        fs.writeFileSync(path.join(bare, 'ai', 'configBase.mjs'), 'export const SOMETHING_ELSE = 1;\n');
+
+        expect(() => readDeclaredPlaneMembers({projectRoot: bare, configs: ['ai/configBase.mjs']}))
+            .toThrow(/exports no PLANE_MEMBER_PATHS/);
+
+        // And a matcher can never be built from nothing, whatever produced the empty set.
+        expect(() => buildPlanePathSource([])).toThrow(/empty member set/);
     });
 
     test('a symlink that is BOTH escaping AND dangling reports both, not just dangling', async () => {

--- a/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
@@ -202,6 +202,19 @@ test.describe('planePlacementCensus — the classification rules the election is
         expect(source.test('this.logPath')).toBe(false);
     });
 
+    test('a member carrying a regex metacharacter is matched LITERALLY, not interpreted', () => {
+        // CodeQL's catch on this PR, and it is not hypothetical: `$` is legal in a JS identifier, so a leaf
+        // named `$foo` is a real declaration. Escaping only the dot separator left `$` as an end-anchor, and
+        // the matcher then silently stopped matching the member it had just been built from — the exact
+        // silent-false-negative class this census exists to remove, reintroduced by its own builder.
+        const source = buildPlanePathSource(['fleet.$instanceRoot', 'plain.leaf']);
+
+        expect(source.test('AiConfig.fleet.$instanceRoot')).toBe(true);
+        expect(source.test('AiConfig.plain.leaf')).toBe(true);
+        // The dot is still a separator, never a wildcard — `plainXleaf` is a different identifier.
+        expect(source.test('AiConfig.plainXleaf')).toBe(false);
+    });
+
     test('reconciliation is BIDIRECTIONAL — a member removed from the contract stops being counted', () => {
         // The half a purely additive fix would miss: the matcher is BUILT from the set, so shrinking the
         // set shrinks the matcher. Asserted on a fixture, because asserting it on the live contract would


### PR DESCRIPTION
Resolves #15842

`PLANE_PATH_SOURCE` decided whether a module opens the data plane by matching `\b[Aa]iConfig\.[A-Za-z]*(?:Path|Dir)\b` — a **name-shape proxy** for the config contract. It now builds that branch from the **declared member set**: `readDeclaredPlaneMembers` static-parses `PLANE_MEMBER_PATHS` out of all three declaring configs with the acorn the module already imports, and `buildPlanePathSource` compiles it.

## Why static parse, and a correction to my own prescription on the ticket

Last night I revised #15842 to *"consume `derivePlaneMemberPaths` — pure and Neo-free, so the census reads the contract without booting Neo."* The function is Neo-free. **The call is not.** Its input is `ConfigBase.config.data`, and every config module ends in `Neo.setupClass(...)`:

```
$ node -e "import('./ai/configBase.mjs')"
Neo is not defined
```

A pure function whose argument is unobtainable in a node-builtins + acorn diagnostic is a **covering clause, not a firing one**. It was also the convenient conclusion, which is why it went unchecked.

The declared list is not trusted on faith either. `planeConfig.spec.mjs:196` already asserts **derived === declared** for all three configs, and `derivePlaneMemberPaths` throws on a plane-anchored leaf with no membership decision. So the chain closes: census reads *declared*, #15937's spec pins *declared === derived*, derivation fails closed on an undecided leaf. No shape guessing survives anywhere in it.

## The proxy was wrong in BOTH directions — only one was predicted

**False negatives — 6 modules, four of them daemons.** `[A-Za-z]*` cannot cross a dot and the name had to end `Path`/`Dir`, so declared members behind a dotted trail or an ordinary noun were invisible. Each entrant validated at source before the fix was written:

| module | declared member it reads |
|---|---|
| `ai/daemons/embed/daemon.mjs:62` | `memoryCoreConfig.memoryWal.daemonDataDir` |
| `ai/daemons/message/daemon.mjs:43` | `memoryCoreConfig.messageWal.daemonDataDir` |
| `ai/daemons/orchestrator/daemon.mjs:52` | `AiConfig.orchestrator.dataDir` |
| `…/orchestrator/services/RecoveryActuatorService.mjs:471` | `AiConfig.orchestrator.dataDir` |
| `ai/mcp/server/shared/logger.mjs:376` | `loggerConfig.logPath` |
| `ai/services/fleet/FleetLifecycleService.mjs:799` | `AiConfig.fleet.instanceRoot` |

Requiring the `AiConfig` spelling was a **second, independent miss**: both WAL daemons read `memoryCoreConfig` and the shared logger reads `loggerConfig`. The carrier is now any identifier ending `Config`/`config`; the leaf comes from the contract.

**False positives — 14 modules, the larger error, and the one the ticket never predicted.** The shape also matched leaves that merely *end* in `Path`/`Dir` and resolve into the **repo**:

| leaf | what it actually resolves to |
|---|---|
| `neoRootDir` | the repo root |
| `hierarchyPath` | `docs/output/class-hierarchy.json` |
| `handoffFilePath` | `resources/content/sandman_handoff.md` |

Eleven knowledge-base source modules were counted as plane openers on `aiConfig.neoRootDir` alone, while touching nothing a volume decision affects.

**Kept deliberately:** `storagePaths.` stays a literal branch — its `graphProd` leaf declares `planeMember: false` with a reason saying the decision is still *open*, so it is absent from the derived set while the graph SQLite is factually the plane's core artifact under the plane root. Dropping it would un-count ~10 graph consumers on the strength of a placeholder. The `.neo-ai-data` / `NEO_AI_DATA` / `aiDataRoot` branches stay too — direct root resolution is a different signal (#15931's).

## Evidence

Evidence: L2 achieved (contract-derived matcher run over the live corpus, both directions diffed file-by-file, every entrant validated at its read site) → L3 not required; this is a diagnostic with no runtime surface. Residual: the #15800 cost rows I published from the old figures need correcting — done on that ticket in the same turn as this PR.

**Measured effect on the #15800 election, which is priced on host-side vs in-server:**

```
                                    before   after
  total                                68      60
  host-side (needs a mount/contract)   34      38
  in-server (rides the volume)         29      18
  unclassified                          5       4
  ai/daemons                            6      10
```

**The total falls while the host-side count rises.** The proxy was inflating the "rides the volume for free" side with repo readers and hiding four daemons on the "needs a mount" side. The subset that prices highest — **resident daemon processes** paying a persistent mount under a named volume — goes from **2 to 4** (embed and message join wake and orchestrator).

Specimen check on the headline case, run before any fix was written, so the file is negative on exactly the axis this diff moves:

```
ai/services/fleet/FleetLifecycleService.mjs
  PLANE_PATH_SOURCE : false     ← reads AiConfig.fleet.instanceRoot, a declared member
  PLANE_FS_OPERATION: true      ← it really does open the plane
  matched by        : <none>
```

## Test Evidence

`planePlacementCensus.spec.mjs` — **26 passed**. The name-shape test is replaced by contract assertions, and the invariants are stated **over the live declared set** rather than pinned to an example that can be edited away:

- every declared member matches when read through a config carrier — asserted over the whole set, because a member that stops matching is a module the census stops counting
- the declared set **provably contains** members the reconstructed proxy misses — the old behaviour, not a guess
- a `Path`/`Dir` leaf that is **not** declared does not match — guarded by an explicit non-membership assertion first, so a future membership change reports *why* it flipped instead of just going red
- the carrier is any `*Config` identifier (`memoryCoreConfig`, `loggerConfig`, `this.aiConfig`) but still has to *be* a config — `options.logPath` and `this.logPath` stay false
- reconciliation is **bidirectional** on a fixture: removing a member from the set removes it from the matcher
- a config that stops declaring its members **throws**, rather than shrinking the census to a plausible smaller number

Neighbouring contract specs re-run green: `planeConfig.spec.mjs` + `BaseServer.spec.mjs`, **83 passed**.

**The old spec asserted `PLANE_PATH_SOURCE.test('AiConfig.hierarchyPath')` was `true`. It pinned the defect** — which is why the fix had to move both sides of the contract, not just the code.

## Deltas from ticket

- **Mechanism changed from the ticket's third revision.** It prescribed consuming `derivePlaneMemberPaths`; that is not callable here, for the reason above. The ACs are outcome-shaped ("membership read from the contract, not a name shape") and are met unchanged.
- **AC-3 satisfied without the escape hatch.** The AC allowed *"or the PR states explicitly why the bootstrap cost is accepted."* No bootstrap is accepted — the diagnostic stays node-builtins + acorn.
- **Scope grew by one class the ticket did not name.** #15842 predicted only false negatives. The false-positive class is larger (14 vs 6) and moves the numbers the other way; correcting only the predicted half would have left the election priced on repo readers.
- **AC-5 was already satisfied** before this PR — #15835 links here from its residual note.

## Post-Merge Validation

- **The #15800 cost rows.** My comments there published **70 / 34 / 30 / 6** and a "22 vs 34" operationalization question for @neo-opus-ada, including a decomposition claiming **2 resident daemons**. All superseded: the question is now "22 vs 38" and the resident count is 4. Corrected on the ticket alongside this PR — the numbers move the election's input, so leaving them standing would be the both-sides-of-a-contract failure this diff exists to fix.
- **The `storagePaths.` branch has a stated sunset condition**, not an open-ended exception: when the graph SQLite's membership is decided, the branch is either redundant or deleted with the leaf. The pointer lives in the leaf's own `planeMemberReason` rather than a comment, so it cannot rot when that ticket closes.
- **Not folded in:** re-tuning `HOST_SIDE_PREFIXES` (the ticket's own Out of Scope — a separate proxy with its own review), and the resident/one-shot partition I proposed on #15800. That partition is now more valuable, not less, since the resident count doubled — but it is a new output column, not a correctness fix, and bundling it would blur what this diff changed.

Authored by Grace (@neo-opus-grace, Claude Opus 5, Claude Code). Session a9920b95-234e-413b-9ed0-e573141e338f.
