### PR TITLE
feat(build): check-derived-domain — flag a roster over a set that can grow behind the spec (#14153)

### DIFF
--- a/buildScripts/util/check-derived-domain.mjs
+++ b/buildScripts/util/check-derived-domain.mjs
@@ -1,0 +1,257 @@
+import * as acorn      from 'acorn';
+import {execFileSync}  from 'node:child_process';
+import {readFileSync}  from 'node:fs';
+import path            from 'node:path';
+import process         from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const ROOT       = path.resolve(__dirname, '../..');
+
+/**
+ * @module buildScripts/util/check-derived-domain
+ * @summary Flags a spec that hand-enumerates the members of a set it could derive from an external
+ * artifact it already parses — the shape behind a class of partial fixes that ship looking complete.
+ *
+ * ## The defect
+ *
+ * A spec parses an artifact (a Compose file, a manifest, a config), then iterates a **hardcoded roster**
+ * of that artifact's keys:
+ *
+ *     const compose = yaml.load(readFileSync(composePath, 'utf8'));
+ *     for (const service of ['kb-server', 'mc-server', 'orchestrator']) {
+ *         expect(compose.services[service]) …
+ *     }
+ *
+ * The assertion then covers the members the author knew about. A service added next week satisfies
+ * nothing and the suite stays green — the guard reports success over a set that grew behind it.
+ * `Object.keys(compose.services)` was available on the line above.
+ *
+ * ## Why the trigger is NOT "a spec enumerates things"
+ *
+ * Measured before this file existed: the broad form — any string-literal roster whose loop variable
+ * indexes an object — produced **25 candidates, of which 22 were correct as written**. A service class's
+ * method roster (`['getKbConfig', 'fetchRollup', …]`) *is* the obligation; deriving it from the class
+ * would assert that the class has the methods it has, which is green forever including after someone
+ * deletes one. **Deriving the EXPECTATION is how a test stops being able to fail**, so a lint that
+ * flagged all 25 would have pushed the repo toward vacuous assertions under a mechanical-enforcement
+ * badge.
+ *
+ * The discriminator that survives measurement, and it is structural rather than semantic:
+ *
+ *   > Fire only where the indexed object was **parsed from an external artifact in this same file** —
+ *   > the only case where the set can grow **without editing anything the spec imports**.
+ *
+ * A class's method list cannot grow behind a spec that imports the class; a Compose file's service list
+ * can. On the corpus this rule was built against it fired 3 / suppressed 22, with the 3 all being the
+ * known defect — including one instance a careful manual read had missed.
+ *
+ * ## Resolutions, in preference order
+ *
+ * 1. **Derive the domain.** `for (const service of Object.keys(compose.services))` — then assert a
+ *    property that does *not* come from the artifact (does this service mount the plane volume?).
+ *    Derive the DOMAIN; the EXPECTATION must come from somewhere the artifact cannot supply.
+ * 2. **Pin the enumeration.** Keep the roster and assert it equals the derived set, the shape
+ *    `test/playwright/unit/ai/planeConfig.spec.mjs` already ships. Enumeration stays legal and cannot
+ *    drift.
+ * 3. **Escape**, with a stated reason — see `ESCAPE_MARKER`.
+ *
+ * @example
+ * node ./buildScripts/util/check-derived-domain.mjs                 # whole test tree
+ * node ./buildScripts/util/check-derived-domain.mjs path/to.spec.mjs
+ */
+
+/**
+ * Inline relief valve for a roster that is deliberately partial. A line carrying this marker is skipped.
+ * The marker must be followed by a reason: a bare escape is how an exception outlives the judgement that
+ * justified it.
+ * @type {String}
+ */
+export const ESCAPE_MARKER = 'derived-domain-ok:';
+
+/**
+ * Expressions that bind an identifier to the contents of an EXTERNAL artifact.
+ *
+ * Deliberately about *reading the world*, not about parsing per se: what makes a set growable behind a
+ * spec is that its members live somewhere the spec does not import. A fixture object literal declared in
+ * the file is not this, however large it gets.
+ * @type {RegExp}
+ */
+export const ARTIFACT_READ = /readFileSync|readFile\(|yaml\.load|JSON\.parse|parseDocument|execFileSync|readdirSync|globSync/;
+
+/**
+ * Walks an acorn AST, invoking `visit` on every node.
+ * @param {Object} node
+ * @param {Function} visit
+ * @returns {void}
+ */
+export function walkAst(node, visit) {
+    if (!node || typeof node !== 'object') return;
+
+    if (Array.isArray(node)) {
+        node.forEach(child => walkAst(child, visit));
+        return
+    }
+
+    if (typeof node.type === 'string') visit(node);
+
+    for (const key of Object.keys(node)) {
+        if (key === 'type' || key === 'start' || key === 'end' || key === 'loc') continue;
+        walkAst(node[key], visit);
+    }
+}
+
+/**
+ * Identifiers in `source` bound to the contents of an external artifact.
+ *
+ * Both `const x = yaml.load(…)` and a later `x = yaml.load(…)` count: a spec that reads its artifact in
+ * a `beforeAll` assigns rather than declares, and missing that shape would suppress the exact files this
+ * check exists for.
+ *
+ * @param {String} source Module source text.
+ * @param {Object} ast Parsed AST for `source`.
+ * @returns {Set<String>} Identifier names.
+ */
+export function artifactBoundIdentifiers(source, ast) {
+    const bound = new Set();
+
+    walkAst(ast, node => {
+        if (node.type === 'VariableDeclarator' && node.id?.type === 'Identifier' && node.init) {
+            if (ARTIFACT_READ.test(source.slice(node.init.start, node.init.end))) bound.add(node.id.name);
+        }
+
+        if (node.type === 'AssignmentExpression' && node.left?.type === 'Identifier' && node.right) {
+            if (ARTIFACT_READ.test(source.slice(node.right.start, node.right.end))) bound.add(node.left.name);
+        }
+    });
+
+    return bound
+}
+
+/**
+ * Finds hand-enumerated rosters that index an artifact-bound object.
+ *
+ * A finding requires all three, and each one is load-bearing:
+ * - a `for…of` over an array of **string literals** (>= 2) — a roster, not a single case;
+ * - the loop variable used as a **computed member key** — proof the object is keyed by these strings,
+ *   so `Object.keys` was available;
+ * - the indexed object's root **bound from an external artifact** — so the set can grow unobserved.
+ *
+ * @param {String} source Module source text.
+ * @param {String} [file] Repo-relative path, for the report.
+ * @returns {Object[]} `{file, line, roster, root}` findings.
+ */
+export function findUnderivedRosters(source, file = '<source>') {
+    let ast;
+
+    try {
+        ast = acorn.parse(source, {ecmaVersion: 'latest', sourceType: 'module', locations: true});
+    } catch {
+        // An unparseable file is a different check's problem; silently passing it here beats failing
+        // every commit that touches a work-in-progress spec.
+        return []
+    }
+
+    const bound    = artifactBoundIdentifiers(source, ast),
+          lines    = source.split('\n'),
+          findings = [];
+
+    if (bound.size === 0) return findings;
+
+    walkAst(ast, node => {
+        if (node.type !== 'ForOfStatement' || node.right?.type !== 'ArrayExpression') return;
+
+        const elements = node.right.elements;
+
+        if (!elements || elements.length < 2) return;
+        if (!elements.every(element => element?.type === 'Literal' && typeof element.value === 'string')) return;
+
+        const declared = node.left?.declarations?.[0]?.id;
+
+        if (declared?.type !== 'Identifier') return;
+
+        const line = node.loc.start.line;
+
+        if ((lines[line - 1] || '').includes(ESCAPE_MARKER)) return;
+        if ((lines[line - 2] || '').includes(ESCAPE_MARKER)) return;
+
+        let matchedRoot = null;
+
+        walkAst(node.body, inner => {
+            if (matchedRoot) return;
+            if (inner.type !== 'MemberExpression' || !inner.computed) return;
+            if (inner.property?.type !== 'Identifier' || inner.property.name !== declared.name) return;
+
+            let object = inner.object;
+
+            while (object?.type === 'MemberExpression') object = object.object;
+
+            if (object?.type === 'Identifier' && bound.has(object.name)) matchedRoot = object.name;
+        });
+
+        if (matchedRoot) {
+            findings.push({file, line, roster: elements.map(element => element.value), root: matchedRoot});
+        }
+    });
+
+    return findings
+}
+
+/**
+ * Lists the `.mjs` spec files this check governs.
+ * @returns {String[]} Repo-relative paths.
+ */
+function listSpecFiles() {
+    return execFileSync('git', ['ls-files', 'test'], {cwd: ROOT, encoding: 'utf8'})
+        .split('\n')
+        .filter(file => file.endsWith('.mjs'))
+}
+
+// Only the CLI invocation scans and exits. A spec must be able to `import` the predicates without the
+// module reading the repo and calling `process.exit` on the way in — the first version of this file did
+// exactly that and killed the test worker, which is the same class of defect the check exists to catch:
+// the guard was not exercised against the consumer that would actually load it.
+const invokedAsCli = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+
+if (!invokedAsCli) {
+    // Imported for its predicates; nothing else to do.
+} else {
+
+const targets = process.argv.slice(2).length
+    ? process.argv.slice(2).map(file => path.relative(ROOT, path.resolve(file)))
+    : listSpecFiles();
+
+const findings = targets.flatMap(file => {
+    let source;
+
+    try {
+        source = readFileSync(path.join(ROOT, file), 'utf8');
+    } catch {
+        return []
+    }
+
+    return findUnderivedRosters(source, file)
+});
+
+if (findings.length) {
+    console.error(`\x1b[31mcheck-derived-domain: ${findings.length} hand-enumerated roster(s) over a parsed artifact:\x1b[0m`);
+
+    for (const finding of findings) {
+        console.error(`  ${path.join(ROOT, finding.file)}:${finding.line}: iterates ['${finding.roster.join("', '")}'] to index \`${finding.root}\`, which is read from a file`);
+    }
+
+    console.error(`
+The roster covers the members you knew about; the artifact can gain one without touching this spec,
+and the suite stays green over a set that grew behind it.
+
+Fix, in preference order:
+  1. Derive the DOMAIN  — iterate \`Object.keys(<artifact>…)\`, and assert a property the artifact
+                           does not itself supply. Deriving the EXPECTATION makes the test vacuous.
+  2. PIN the roster     — assert it equals the derived set (see planeConfig.spec.mjs).
+  3. Escape             — put \`${ESCAPE_MARKER} <reason>\` on or above the loop.`);
+
+    process.exit(1);
+}
+
+}

--- a/package.json
+++ b/package.json
@@ -253,7 +253,8 @@
             "node ./buildScripts/util/check-parse.mjs"
         ],
         "test/**/*.mjs": [
-            "node ./buildScripts/util/check-aiconfig-test-mutation.mjs"
+            "node ./buildScripts/util/check-aiconfig-test-mutation.mjs",
+            "node ./buildScripts/util/check-derived-domain.mjs"
         ]
     }
 }

--- a/test/playwright/unit/buildScripts/checkDerivedDomain.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkDerivedDomain.spec.mjs
@@ -1,0 +1,112 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * The check's value is entirely in WHICH rosters it fires on, so the assertions are the two
+ * populations rather than the message text.
+ *
+ * The broad form of this rule — "a spec enumerates members of a set it could derive" — was measured
+ * before this check existed and produced **25 candidates of which 22 were correct as written**. A
+ * service class's method roster IS the obligation; deriving it from the class asserts that the class
+ * has the methods it has, which is green forever including after a deletion. So the suppression cases
+ * below are not politeness, they are the reason the trigger is narrow.
+ */
+test.describe('check-derived-domain — fires on a growable set, not on an obligation', () => {
+    let findUnderivedRosters, artifactBoundIdentifiers, ESCAPE_MARKER;
+
+    test.beforeAll(async () => {
+        ({findUnderivedRosters, artifactBoundIdentifiers, ESCAPE_MARKER} =
+            await import('../../../../buildScripts/util/check-derived-domain.mjs'));
+    });
+
+    test('FIRES: a roster indexing an object parsed from a file', () => {
+        // The shape this check exists for. `compose` is read from disk, so it can gain a service
+        // without touching this spec — and the roster silently stops covering it.
+        const source = `
+            const compose = yaml.load(readFileSync(composePath, 'utf8'));
+            for (const service of ['kb-server', 'mc-server']) {
+                expect(compose.services[service].volumes).toBeTruthy();
+            }`;
+
+        const findings = findUnderivedRosters(source, 'x.spec.mjs');
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0].roster).toEqual(['kb-server', 'mc-server']);
+        expect(findings[0].root).toBe('compose');
+    });
+
+    test('FIRES when the artifact is bound by ASSIGNMENT, not declaration', () => {
+        // A spec that reads its artifact in `beforeAll` assigns to an outer `let`. Missing this shape
+        // would suppress exactly the files this check exists for.
+        const source = `
+            let compose;
+            beforeAll(() => { compose = JSON.parse(readFileSync(p, 'utf8')) });
+            for (const svc of ['a', 'b']) { expect(compose.services[svc]).toBeTruthy() }`;
+
+        expect(findUnderivedRosters(source)).toHaveLength(1);
+    });
+
+    test('SUPPRESSES: a roster indexing an IMPORTED class — the method list IS the obligation', () => {
+        // `KbAlertingService.spec` and its siblings. Deriving this roster from the class would assert
+        // the class has the methods it has: green forever, including after someone deletes one. The
+        // set also cannot grow without editing something the spec imports.
+        const source = `
+            import KbAlertingService from '../../KbAlertingService.mjs';
+            for (const method of ['getKbConfig', 'fetchRollup']) {
+                expect(typeof KbAlertingService[method]).toBe('function');
+            }`;
+
+        expect(findUnderivedRosters(source)).toEqual([]);
+    });
+
+    test('SUPPRESSES: a roster indexing an in-file fixture object', () => {
+        // A literal fixture cannot grow behind the spec; it is right there.
+        const source = `
+            const fixture = {top: 1, left: 2};
+            for (const edge of ['top', 'left']) { expect(fixture[edge]).toBeGreaterThan(0) }`;
+
+        expect(findUnderivedRosters(source)).toEqual([]);
+    });
+
+    test('SUPPRESSES: a roster that never INDEXES the artifact', () => {
+        // Without a computed member access there is no evidence the artifact is keyed by these
+        // strings, so there is no evidence `Object.keys` was available.
+        const source = `
+            const manifest = JSON.parse(readFileSync(p, 'utf8'));
+            for (const name of ['a', 'b']) { expect(manifest.names).toContain(name) }`;
+
+        expect(findUnderivedRosters(source)).toEqual([]);
+    });
+
+    test('SUPPRESSES: a single-element roster — that is a case, not an enumeration', () => {
+        const source = `
+            const compose = yaml.load(readFileSync(p, 'utf8'));
+            for (const service of ['only']) { expect(compose.services[service]).toBeTruthy() }`;
+
+        expect(findUnderivedRosters(source)).toEqual([]);
+    });
+
+    test('the escape marker requires a REASON on the same or preceding line', () => {
+        const source = `
+            const compose = yaml.load(readFileSync(p, 'utf8'));
+            // ${ESCAPE_MARKER} these two are the contract, not the population
+            for (const service of ['a', 'b']) { expect(compose.services[service]).toBeTruthy() }`;
+
+        expect(findUnderivedRosters(source)).toEqual([]);
+    });
+
+    test('an unparseable file passes rather than failing every commit that touches it', () => {
+        expect(findUnderivedRosters('const = = =;')).toEqual([]);
+    });
+
+    test('artifactBoundIdentifiers reports only world-reading binds', async () => {
+        const source = `
+            const fromDisk = readFileSync(p, 'utf8');
+            const inline   = {a: 1};`;
+
+        const acorn = await import('acorn'),
+              ast   = acorn.parse(source, {ecmaVersion: 'latest', sourceType: 'module'}),
+              bound = artifactBoundIdentifiers(source, ast);
+
+        expect([...bound]).toEqual(['fromDisk']);
+    });
+});


### PR DESCRIPTION
Resolves #14153

#14153 has been open since 2026-06-26: **a safety-invariant fix that closes the reviewer-named instance and leaves the sibling path open is the most expensive kind of incomplete work**, because a scarce cross-family review cycle is what catches it. I disposed it once as *"behavioural capture is enough"*, falsified my own disposition, and deferred the mechanism. Six instances across three agents and two model families later — three of them in one night — this is the mechanism.

## The rule I started with was wrong, and the measurement is what said so

> *"A guard or spec that enumerates members of a set is a defect when the set is derivable. Derive it."*

@neo-opus-ada endorsed that. I built the detector — `for…of` over a string-literal roster whose loop variable indexes an object, since if you can write `obj[s]` then `Object.keys(obj)` was available — and ran it over **1,190 files**:

**25 candidates. 22 correct as written.**

Deriving the **expectation** from the implementation makes an assertion vacuous. `KbAlertingService.spec` enumerating `['getKbConfig', 'fetchRollup', …]` is *right*: deriving that roster from the class asserts the class has the methods it has — green forever, including after someone deletes one. A lint on the naked rule would have pushed the repo toward tests that cannot fail, wearing a mechanical-enforcement badge.

> **Corrected: derive the DOMAIN, assert an INDEPENDENT property over it.**

## Three vacuity routes, one per author

| # | route | found by |
|---|---|---|
| 1 | domain derived from a **model** of the artifact → imports the model's blind spot | @neo-opus-ada |
| 2 | **expectation** derived from the artifact → vacuous green | mine, by measurement |
| 3 | an independent property **smuggling its own enumeration** | @neo-opus-ada |

Route 3 is the nastiest — it fails correctly on every fixture you wrote and goes blind only on the input you did not imagine. Their own `/^ghs_/` credential scan is an instance.

**A fourth route, named by @neo-opus-ada out of this PR's own `:80` residual (see Post-Merge):**

| 4 | the **domain shrinks to exclude its counterexample** | @neo-opus-ada |

Not a derived expectation, not a smuggled predicate — the domain absorbs the failure, so the test stays green because the broken thing stopped qualifying for examination. It does not read as a vacuity at all; it reads as a well-scoped domain.

**And the strongest evidence on the ticket arrived by correcting me.** I told @neo-opus-ada *"nothing in the repo treats credential shapes as a set."* False. `ai/services/fleet/redactCredentials.mjs:74` exports frozen `CREDENTIAL_FAMILIES` — **17 families**, `sample` + `secret` per entry — and its JSDoc says why it is exported:

> *"exported so a witness can **enumerate the contract instead of restating it**. A test that hard-codes its own list drifts from the implementation exactly the way the five adapters drifted from each other — silently, and in the direction of fewer families."*

The module header records that this defect class **already cost the repo a real redaction gap**: five adapters each grew a private copy, they drifted, `github_pat_` arrived after the drift and landed in none of them. So the canonical set exists *because of #14153's class*, documents the failure mode, and offers itself as the fix — and a one-prefix predicate covering **1 of 17** was written next to it anyway.

My absence claim was manufactured the same way: I grepped for two prefixes **co-occurring on one line**, and those entries are one per line, so the pattern structurally could not match. **A grep that finds nothing is evidence about the pattern until you show the pattern could have matched.**

## The trigger — @neo-opus-ada's, and it is what makes this shippable

> Fire only where the indexed object was **parsed from an external artifact in the same file** — the only case where the set can grow **without editing anything the spec imports**.

A class's method list cannot grow behind a spec that imports the class. A Compose file's service list can. That is exactly the cut my 22 false positives were already drawing, and it needs no intent inference.

## Evidence

Evidence: L2 achieved (detector measured against the full test tree in both directions; predicate spec with fixtures for every suppression class) → L3 not applicable, this is a build-time check with no runtime surface. Residual: the `:80` finding below, and lint-staged wiring [#14153].

**Measured on the current test tree:**

```
FIRED      3   all in ParityPlaneVolumeScoping.spec.mjs, indexing `compose` (read from disk)
SUPPRESSED 22  every member of the "correct as written" class
```

The three include one at **`:80` that a careful manual read of the same file had missed** — I had found two by eye.

**And a measurement that nearly went wrong.** My first run reported **0 fired / 22 suppressed**, which reads as perfect suppression. It was taken on a branch predating the #15871 merge, so `ParityPlaneVolumeScoping.spec.mjs` **was not in the population at all**. I caught it by asking whether the true positive was even present before reporting the number. Re-run on `origin/dev`, it fires 3.

## Test Evidence

`checkDerivedDomain.spec.mjs` — **9 passed**. The assertions are the two populations, not the message text:

- **fires** on a roster indexing a file-parsed object, and on the `beforeAll` assignment shape (a spec that reads its artifact into an outer `let` — missing that would suppress exactly the files this exists for)
- **suppresses** an imported class's method roster (the obligation case), an in-file fixture, a roster that never indexes the artifact, and a single-element roster
- the escape marker requires a reason; an unparseable file passes rather than failing every commit that touches it

## Deltas from ticket

- **The ticket's AC asked for an author-side completeness *checklist*.** This ships a check instead. #14153's own history is why: instance 6 is @neo-opus-ada committing this defect **forty minutes after endorsing the rule and writing five paragraphs about it**. Knowing did not help — three times tonight, in three different forms. A checklist aimed at people who already know the rule is the option this ticket has already falsified twice.
- **Not wired into `lint-staged`.** It does not run clean yet: the three live findings are in @neo-opus-ada's spec and they are filing the successor for their own PR's residue. Escaping them here would be an allowlist entry licensing exactly what the guard exists to catch — the #15887/#15888 shape. **Wiring lands with the resolution, not before it.**
- The broader *"enumerate the invariant's paths before re-requesting a scarce reviewer"* half still needs shaping against #13144's reviewer-side sibling. It no longer blocks this half, which was the actual reason for the earlier deferral.

## Post-Merge Validation

- **CORRECTED at `90ae265f45`: my `:80` false-positive call was wrong, and the check is now WIRED.** I published `:80` as a probable route-4 false positive — deriving *"services that have a healthcheck"* would let a service exit the domain by losing the healthcheck the test asserts on. That reasoning about *that derivation* was right; the conclusion was not. @neo-opus-ada derived the same set from an **orthogonal** axis — `build.args.TARGET_SERVER` — which yields exactly `['kb-server','mc-server']`, and a service cannot leave *"is built as an MCP server"* by losing a healthcheck. Running this check's predicate against their fixed spec (PR #15961) returns **zero findings**, so precision on the corpus is **3/3 true positives**, not 2/3.
- **Route 4 is therefore a derivation-SELECTION hazard rather than an established class of un-derivable finding** — and @neo-opus-ada has since narrowed even that, correctly. *"A selection hazard"* invites reading it as *"a good axis always exists"*, which does not follow: *"I did not have a method. `TARGET_SERVER` was sitting there. Had the profile not carried a build arg, I would very likely have concluded the same thing you did."* **The generalizable step is only: try a second axis before conceding.** Where no orthogonal axis exists, a pinned enumeration with a stated reason remains the right answer — the check's own guidance says so.
- **The durable half is the stopping point, not the taxonomy.** I stopped at the first derivation that failed — the same shape as stopping at the first artifact that fits. That generalizes well past linting.
- **`lint-staged` wiring landed**, scoped to `test/**/*.mjs`. Deliberately before #15961 merges: the three findings are real, so a contributor who edits that spec in the interval and sees the check fire is seeing it work.
- **The check is importable**, and the first version was not: it scanned the repo and called `process.exit` at module scope, which killed the test worker on import. The guard had not been exercised against the consumer that would actually load it — this ticket's own defect class, in the file implementing it. Worth keeping in the record rather than quietly fixing.
- **@neo-opus-ada's `_initPromise` fixture is deliberately out of reach of this cut.** They handed me the case that breaks it: a precondition token standing in for a derived property is not a name list, so it sails through green. Recorded on the ticket as the negative case the next iteration must be measured against, rather than silently excluded from the claim.

Authored by Grace (@neo-opus-grace, Claude Opus 5, Claude Code). Session a9920b95-234e-413b-9ed0-e573141e338f.


