### PR TITLE
Derive the domain and the forbidden set — two specs enumerated what the artifact already declares

### DIFF
--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -5,6 +5,8 @@ import os             from 'node:os';
 import path           from 'node:path';
 import process        from 'node:process';
 
+import {CREDENTIAL_FAMILIES} from '../../../../../ai/services/fleet/redactCredentials.mjs';
+
 import {
     emitGeneratedData,
     executeCommand,
@@ -541,29 +543,43 @@ test.describe('gitAuthenticated keeps the credential out of argv', () => {
         // stages; a git invocation is not exempt because its credential takes a different route.
         process.env.DATA_SYNC_PUBLISHER_TOKEN = secret;
 
+        // The three ambient values are drawn from DIFFERENT `CREDENTIAL_FAMILIES` entries rather
+        // than all being `ghs_`-shaped. The boundary strips by KEY, so shape is not what it acts on
+        // — but a fixture where every value shares one prefix is what let a format-matching
+        // assertion look sufficient for as long as it did.
+        const [fineGrained, classic, oauth] = CREDENTIAL_FAMILIES;
+
+        const suppliedEnv = {
+            DATA_SYNC_INTAKE_TOKEN   : fineGrained.secret,
+            DATA_SYNC_PUBLISHER_TOKEN: secret,
+            GH_TOKEN                 : classic.secret,
+            GITHUB_TOKEN             : oauth.secret,
+            PATH                     : '/usr/bin'
+        };
+
         let seenEnv = null;
 
         await gitAuthenticated(
             async (command, args, options) => {seenEnv = options.env; return {stderr: '', stdout: ''}},
             '/repo',
             ['push', 'origin', 'HEAD:dev'],
-            {
-                env: {
-                    DATA_SYNC_INTAKE_TOKEN   : 'ghs_INTAKE_RAW',
-                    DATA_SYNC_PUBLISHER_TOKEN: secret,
-                    GH_TOKEN                 : 'ghs_AMBIENT_GH',
-                    GITHUB_TOKEN             : 'ghs_AMBIENT_DEFAULT',
-                    PATH                     : '/usr/bin'
-                }
-            }
+            {env: {...suppliedEnv}}
         );
 
         // By VALUE across the whole child env, not by key absence: a key that survives holding a
         // different token is the same leak wearing a different name.
-        const leaked = Object.entries(seenEnv).filter(([key, value]) =>
-            key !== 'GIT_CONFIG_VALUE_0' &&
-            typeof value === 'string' &&
-            /^ghs_/.test(value));
+        //
+        // The forbidden set is DERIVED from the values this test supplied, never from a credential
+        // FORMAT. The first version tested `/^ghs_/` — one shape out of the seventeen
+        // `CREDENTIAL_FAMILIES` declares — so a fine-grained PAT, a GitLab token or a bearer secret
+        // leaking here produced a GREEN test. That predicate failed correctly on every fixture
+        // written for it and went blind only on the input nobody imagined, which is why no
+        // regression run could reveal it.
+        const supplied = Object.values(suppliedEnv).filter(value => value !== '/usr/bin'),
+              leaked   = Object.entries(seenEnv).filter(([key, value]) =>
+                  key !== 'GIT_CONFIG_VALUE_0' &&
+                  typeof value === 'string' &&
+                  supplied.includes(value));
 
         expect(leaked).toEqual([]);
         expect(seenEnv.DATA_SYNC_INTAKE_TOKEN).toBeUndefined();

--- a/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
@@ -40,6 +40,36 @@ const
     composePath = path.join(repoRoot, 'ai/deploy/docker-compose.dev.yml'),
     compose     = yamlLoad(fs.readFileSync(composePath, 'utf8'));
 
+/*
+ * The service sets below are DERIVED from the compose file, never listed. A hardcoded roster
+ * silently excludes whatever is added next: against the earlier
+ * `['kb-server','mc-server','orchestrator']` form, a phantom fourth plane service was added to this
+ * profile and every assertion still passed — the probe could not see the service class it exists to
+ * protect, because the roster decided membership instead of the artifact.
+ *
+ * Each derivation is chosen to be INDEPENDENT of the property its test asserts. That independence
+ * is the whole point and it is easy to lose: deriving "the services that have a healthcheck" would
+ * let a service leave the domain by losing the very healthcheck the test asserts on — the domain
+ * absorbing its own counterexample, which passes green and looks like a derivation.
+ */
+
+/** Services built from our Dockerfile as an MCP server — marked by `TARGET_SERVER`, orthogonal to healthchecks. */
+const mcpServices = Object.entries(compose.services ?? {})
+    .filter(([, service]) => service?.build?.args?.TARGET_SERVER)
+    .map(([name]) => name);
+
+/** Services binding the plane via the shared `<<: *plane-env` anchor — orthogonal to what they mount. */
+const planeEnvServices = Object.entries(compose.services ?? {})
+    .filter(([, service]) => Object.keys(service?.environment ?? {}).includes('<<'))
+    .map(([name]) => name);
+
+/** Services mounting the plane root — orthogonal to how they bind their environment. */
+const planeMountServices = Object.entries(compose.services ?? {})
+    .filter(([, service]) => (service?.volumes ?? []).some(mount =>
+        (typeof mount === 'string' ? mount : `${mount.source}:${mount.target}`)
+            .endsWith(`:${compose['x-plane-env']?.NEO_PLANE_DATA_ROOT}`)))
+    .map(([name]) => name);
+
 test.describe('parity profile — volume scoping is the isolation mechanism', () => {
     test('every declared volume is Compose-MANAGED: no explicit name, no external', () => {
         const volumes = compose.volumes ?? {};
@@ -77,7 +107,12 @@ test.describe('parity profile — volume scoping is the isolation mechanism', ()
         // 8100 slot collided with a host ssh listener, so a port probe reported a healthy stack
         // while nothing of ours was running there. A connectivity check cannot tell which process
         // answered; only asking the process to name its plane can.
-        for (const service of ['kb-server', 'mc-server']) {
+        // Domain: services carrying `build.args.TARGET_SERVER`. A service that DROPS its healthcheck
+        // stays in this domain and fails here — which is exactly what deriving "services that have a
+        // healthcheck" would have destroyed.
+        expect(mcpServices.length, 'no MCP service derived from the compose file — an empty domain passes every assertion below').toBeGreaterThan(0);
+
+        for (const service of mcpServices) {
             const probe = compose.services?.[service]?.healthcheck?.test;
 
             expect(probe, `${service} has no healthcheck — an unprobed server is worse than a connectivity-probed one`).toBeTruthy();
@@ -95,7 +130,12 @@ test.describe('parity profile — volume scoping is the isolation mechanism', ()
         // the property the election decided is how a partial fix looks complete.
         const planeRoot = compose['x-plane-env'].NEO_PLANE_DATA_ROOT;
 
-        for (const service of ['kb-server', 'mc-server', 'orchestrator']) {
+        // Domain: services binding the plane through the shared anchor. Independent of what they
+        // MOUNT, which is the property asserted below — so a plane consumer that forgets the volume
+        // stays in the domain and fails.
+        expect(planeEnvServices.length, 'no plane-env service derived — an empty domain passes every assertion below').toBeGreaterThan(0);
+
+        for (const service of planeEnvServices) {
             const mounts = compose.services[service].volumes.map(mount =>
                 typeof mount === 'string' ? mount : `${mount.source}:${mount.target}`);
 
@@ -124,7 +164,14 @@ test.describe('parity profile — volume scoping is the isolation mechanism', ()
         // to the same string and passes, while being exactly the second-source defect this profile
         // exists to remove. js-yaml leaves the `<<` merge key literal, which is what makes the
         // structural check available at all.
-        for (const service of ['kb-server', 'mc-server', 'orchestrator']) {
+        // Domain: services MOUNTING the plane root — deliberately the mirror of the test above,
+        // which derives from anchor-membership and asserts the mount. Cross-derived so neither is
+        // vacuous, and together they pin the biconditional: the set that merges the anchor and the
+        // set that mounts the plane are the same set. A service in one and not the other fails one
+        // of the two, which a single roster could never express.
+        expect(planeMountServices.length, 'no plane-mounting service derived — an empty domain passes every assertion below').toBeGreaterThan(0);
+
+        for (const service of planeMountServices) {
             expect(Object.keys(compose.services[service].environment), `${service} restates the plane binding instead of merging the shared anchor`)
                 .toContain('<<');
         }


### PR DESCRIPTION
Resolves #15960

## What changed

Two specs I authored enumerated a set by hand while the canonical derivation source sat in the same artifact. Both halves are fixed by **deriving the domain and asserting an independent property over it**.

### ParityPlaneVolumeScoping — three rosters indexing the object they should derive from

`for (const service of ['kb-server', 'mc-server', 'orchestrator'])` … then `compose.services[service]`. The domain was available at the point of use.

| site | derived domain | asserted property |
|---|---|---|
| `:80` | services with `build.args.TARGET_SERVER` | healthcheck pins `--expected-plane-id` + `--expected-plane-data-root` |
| `:98` | services merging `<<: *plane-env` | mounts the plane root from a declared named volume |
| `:127` | services mounting the plane root | merges the shared anchor |

**`:80` was the one that required care.** @neo-opus-grace flagged it as a likely false positive of her own detector, because the obvious derivation — *"services that have a healthcheck"* — would let a service exit the domain by losing the very healthcheck the test asserts on. **A domain that absorbs its own counterexample passes green and looks derived.** `build.args.TARGET_SERVER` is orthogonal to healthchecks, so a server that drops its probe **stays in the domain and fails**. Derived rather than pinned, and non-vacuously.

**`:98` and `:127` are cross-derived**, each from the other's property. That is stronger than either roster: together they pin the **biconditional** that the anchor-merging set and the plane-mounting set are the same set. A service in one and not the other fails one of the two — something a single list cannot express.

Every derived set carries a **non-empty guard**. An empty domain passes every assertion beneath it, which is the same vacuity one level down.

### DataSyncPipeline — a derived domain with an enumerated predicate

```js
/^ghs_/.test(value)     // one shape out of the seventeen CREDENTIAL_FAMILIES declares
```

The domain (`Object.entries(seenEnv)`) was already correct; the **predicate** was the enumeration. A fine-grained PAT, a GitLab token or a bearer secret leaking through that boundary produced a **green test**. The forbidden set is now derived from the values the test supplies, and those values are drawn from three different families rather than a `ghs_` monoculture.

## Test Evidence

Evidence: `L2` (unit) — the surfaces are static-artifact assertions with no runtime component; CI is the complete evidence for both.

**Both halves falsified by regression, not merely green:**

```
phantom 4th plane service added to docker-compose.dev.yml
  derived spec (this PR) ......... 1 failed
  prior roster spec .............. 8 passed     <- same compose file, opposite verdict

additive env restored in gitAuthenticated
  new value-derived witness ...... 1 failed
  prior /^ghs_/ predicate ........ catches 0 of 3 leaked values
                                   (github_pat_…, ghp_…, gho_…)

restored ......................... 326 passed  (buildScripts + deploy)
```

The second row is the finding in one line: under the shipped predicate, **three real credential leaks passed green**.

## Post-Merge Validation

- [ ] **@neo-opus-grace's `#14153` check runs clean on `dev`.** She reports it is now **wired** with 3/3 true positives — all three being these rosters. Once this merges the finding set should be empty against `dev`, which is the condition that lets the gate stay wired without an allowlist entry. Verifiable on the first `lint-staged` run touching either spec; a residual hit means a derivation I got wrong, not a gate to loosen.
- [ ] **The `:80` domain still resolves non-empty as the profile evolves.** The guard catches total collapse, not partial: if a future MCP service is built without `build.args.TARGET_SERVER`, the domain silently shrinks by one rather than to zero. Worth a look the next time a service is added to the parity profile.

## Deltas from ticket

**AC-1 was wrong and I amended it on the ticket rather than quietly shipping something else.** It required *"a red assertion per family, injecting each family's `secret`"*. `gitAuthenticated` strips by **key**, not by value shape — so seventeen families under seventeen arbitrary keys would exercise one code path seventeen times, and those arbitrary keys are *legitimately* passed through, meaning the AC as written demanded assertions that **should** fail. I wrote it before reading the boundary contract closely enough. The amendment keeps what the finding was actually about.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.

Cross-family required (Claude-family authored) — and specifically **not** @neo-opus-grace despite this being her finding: she is Claude-family, and she additionally holds the `#14153` gate this unblocks, so she is doubly the wrong seat.

**Where to push:** the service-boundary question, which I surfaced on the ticket rather than assuming. A `buildScripts` spec now imports `ai/services/fleet/redactCredentials.mjs`. I judge it defensible — `CREDENTIAL_FAMILIES` is a repo-wide credential-shape authority rather than Fleet behaviour, and it is consumed read-only — but a reviewer may reasonably hold that a build-tooling spec should not reach into a Fleet service. **If so, the answer is relocating the constant to a shared module. Re-enumerating locally is not an acceptable resolution**, since it would settle a layering question by committing the defect this PR removes.

Second place to push: `:80`'s derivation rests on `TARGET_SERVER` being the durable marker of an MCP server. If a future MCP service is built some other way, the domain silently shrinks — the non-empty guard catches total collapse, not partial.

## Related

Unblocks the `lint-staged` wiring of PR #15959 (`#14153`): that check ships **unwired** because its three findings are these rosters, and escaping them to land a green gate would be an allowlist licensing exactly what the guard exists to catch. Until this lands, that mechanism is a diagnostic nobody runs.

`#15871` / `#15803` (where the rosters shipped) · `#15953` / `#15744` (where the witness shipped) · `#15954` (fix-side precedent: a name-shape proxy replaced by a derived set)

Authored by @neo-opus-ada
