### PR TITLE
fix(workstation): contain dock overlays within host (#15966)

### DIFF
--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -232,7 +232,17 @@
     --dock-edge-band-right-inline-size: clamp(13.75rem, 25cqi, 20rem);
     --dock-edge-band-bottom-block-size: clamp(8.75rem, 28cqb, 12.5rem);
 
-    padding: 12px;
+    padding : 12px;
+    position: relative;
+
+    // Persistent drag affordances share this host's local geometry. The preview sits below the
+    // indicator menu and stays pointer-transparent so the sort-zone drag remains the sole owner.
+    > .neo-dock-preview {
+        inset         : 0;
+        pointer-events: none;
+        position      : absolute;
+        z-index       : 25;
+    }
 }
 
 // The generic overflow button is a floating direct-body child. Scope its cockpit skin to

--- a/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
@@ -93,6 +93,104 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
         await page.waitForTimeout(300)
     }
 
+    /**
+     * Reads the browser's painted overlay geometry while Neural Link owns interaction truth.
+     * @summary Captures the fix-critical containing-block and rect contract without creating a shared helper.
+     * @param {Object} page
+     * @returns {Promise<Object>}
+     */
+    async function readParkedOverlayGeometry(page) {
+        return page.evaluate(() => {
+            const
+                dockHost       = document.querySelector('.workstation-dock-host'),
+                indicatorLayer = document.querySelector('.neo-dashboard-dock-drop-indicators'),
+                previewLayer   = document.querySelector('.neo-dock-preview'),
+                targetZone     = [...document.querySelectorAll('.neo-dashboard-dock-tabs')]
+                    .find(element => element.querySelector('.neo-grid-container')),
+                readRect       = element => {
+                    const rect = element?.getBoundingClientRect();
+
+                    return rect && {
+                        bottom: rect.bottom,
+                        height: rect.height,
+                        left  : rect.left,
+                        right : rect.right,
+                        top   : rect.top,
+                        width : rect.width
+                    }
+                };
+
+            return {
+                dockHost               : readRect(dockHost),
+                dockHostId             : dockHost.id,
+                hostPosition           : getComputedStyle(dockHost).position,
+                indicatorLayer         : readRect(indicatorLayer),
+                indicatorOffsetParentId: indicatorLayer.offsetParent?.id,
+                indicatorZIndex        : Number.parseInt(getComputedStyle(indicatorLayer).zIndex, 10),
+                previewAffordance      : readRect(document.querySelector('.neo-dock-preview-affordance')),
+                previewLayer           : readRect(previewLayer),
+                previewOffsetParentId  : previewLayer.offsetParent?.id,
+                previewPointerEvents   : getComputedStyle(previewLayer).pointerEvents,
+                previewZIndex          : Number.parseInt(getComputedStyle(previewLayer).zIndex, 10),
+                targetZone             : readRect(targetZone),
+                topChip                : readRect(document.querySelector(
+                    '.neo-dashboard-dock-drop-chip-top:not(.neo-dashboard-dock-drop-indicator-off)'
+                )),
+                tourbar          : readRect(document.querySelector('.workstation-tourbar')),
+                visibleIndicators: [...document.querySelectorAll(
+                    '.neo-dashboard-dock-drop-indicator:not(.neo-dashboard-dock-drop-indicator-off),'
+                    + '.neo-dashboard-dock-drop-chip:not(.neo-dashboard-dock-drop-indicator-off)'
+                )].map(readRect)
+            }
+        })
+    }
+
+    test('the parked affordances stay inside the dock positioning host', async ({page, neuralLink}) => {
+        const {app, scaleBox} = await bootFlagship(page, neuralLink);
+        const center          = {x: scaleBox.x + scaleBox.width / 2, y: scaleBox.y + scaleBox.height / 2};
+
+        await parkAuditDrag(page, center);
+
+        const
+            indicators = await app.findInstances({className: 'Neo.dashboard.DockDropIndicators'}, ['id']),
+            indId      = (Array.isArray(indicators) ? indicators[0] : indicators)?.id,
+            indState   = await app.getComponent(indId, ['candidateSet', 'mounted']),
+            geometry   = await readParkedOverlayGeometry(page),
+            within     = (inner, outer) => inner.left >= outer.left - 1
+                && inner.top >= outer.top - 1
+                && inner.right <= outer.right + 1
+                && inner.bottom <= outer.bottom + 1,
+            intersects = (first, second) => first.left < second.right
+                && first.right > second.left
+                && first.top < second.bottom
+                && first.bottom > second.top;
+
+        expect(indState?.candidateSet, 'worker truth built the candidate set before geometry truth').toBeTruthy();
+        expect(geometry.hostPosition, 'the dock host establishes the overlay containing block').toBe('relative');
+        expect(geometry.indicatorOffsetParentId).toBe(geometry.dockHostId);
+        expect(geometry.previewOffsetParentId).toBe(geometry.dockHostId);
+        expect(geometry.indicatorLayer).toEqual(geometry.dockHost);
+        expect(geometry.previewLayer).toEqual(geometry.dockHost);
+        expect(geometry.previewPointerEvents).toBe('none');
+        expect(geometry.previewZIndex).toBeLessThan(geometry.indicatorZIndex);
+        expect(geometry.visibleIndicators.length).toBeGreaterThan(0);
+        expect(geometry.visibleIndicators.every(rect => within(rect, geometry.dockHost)),
+            'every painted indicator stays inside the dock host').toBe(true);
+        expect(within(geometry.previewAffordance, geometry.dockHost),
+            'the painted preview stays inside the dock host').toBe(true);
+        expect(intersects(geometry.topChip, geometry.tourbar),
+            'the top edge chip never overlaps the app header').toBe(false);
+        expect(Math.abs(geometry.previewAffordance.left - geometry.targetZone.left)).toBeLessThanOrEqual(1);
+        expect(Math.abs(geometry.previewAffordance.top - geometry.targetZone.top)).toBeLessThanOrEqual(1);
+        expect(Math.abs(geometry.previewAffordance.width - geometry.targetZone.width)).toBeLessThanOrEqual(1);
+        expect(Math.abs(geometry.previewAffordance.height - geometry.targetZone.height)).toBeLessThanOrEqual(1);
+
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(120);
+        await page.mouse.up();
+        await page.waitForTimeout(300)
+    });
+
     test('a real drag lights the menu + preview, and the release commits release truth', async ({page, neuralLink}) => {
         const {app, scaleBox, wsId} = await bootFlagship(page, neuralLink);
         const center                = {x: scaleBox.x + scaleBox.width / 2, y: scaleBox.y + scaleBox.height / 2};


### PR DESCRIPTION
Resolves #15966

Workstation now makes its dock host the containing block for both persistent drag-affordance overlays. The preview fills that host below the indicator menu without owning pointer input, so host-local geometry no longer renders from viewport `top: 0`. A focused cancellation-only Neural Link journey pins the containing block, layer bounds, painted-affordance containment, app-header exclusion, and preview-to-target alignment.

Related: #15965

Evidence: L3 (real Chrome pointer gesture + Neural Link worker truth + browser-painted rect assertions) → L3 required (all observable geometry ACs). No residuals.

## Deltas from ticket

The geometry assertions live in a dedicated cancellation-only journey inside the existing Workstation drag-affordance spec. This preserves the ticket's real pointer and Neural Link seams while isolating geometry truth from the separate current-`dev` release-outcome regression in the older commit journey.

## Test Evidence

- Workstation dock overlays: focused `WorkstationDragAffordancesNL` geometry journey — RED before the CSS repair (`position: static`), GREEN after; 1/1 passed in local Chrome.
- Workstation drag-affordance file: 2/3 passed. The new geometry journey and existing live design-language journey pass. The older release-commit journey repeats a pre-existing current-`dev` failure before and after this patch: candidate/preview truth is active, but `audit` is absent from the scale node after release.
- Source and workflow gates: `npm run agent-preflight -- resources/scss/src/apps/workstation/Workspace.scss test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs` — passed; only the non-blocking stale-overlay warning was reported.
- Whitespace validation: `git diff --check` — passed.

## Post-Merge Validation

- [ ] Confirm the deployed `dev` Workstation keeps both overlay layers host-local during a real drag.
- [ ] Let #15965 consume the repaired host contract in its systematic dock-geometry matrix.

## Evolution

The first whole-file validation exposed that current `dev` opens a second window during the cross-zone Audit drag and no longer commits `tab-into`, despite active candidate and preview truth. Because the same failure reproduces before the CSS change, this PR keeps its geometry proof cancellation-only and leaves cross-window outcome diagnosis outside #15966.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 72c0c2a3-c9f0-4298-a5e4-7a9eda5ac341.
