### PR TITLE
fix(workstation): separate cross-zone and tear-out boundaries

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -674,19 +674,21 @@ class Workspace extends Container {
         let me = this;
 
         return DockLayoutAdapter.project(me.dockModel, {
-            applyDockZoneOperation   : me.applyDockZoneOperation.bind(me),
-            // Tear-out opt-in (§2.8): arms the window-boundary hysteresis + overdrag on every
-            // projected tabs zone; the gesture handlers below route through the tear-out machine.
-            enableDockTearOut        : true,
-            onDockCrossZoneDragCancel: data => me.dragAffordances.onDragCancel(data),
-            onDockCrossZoneDragMove  : data => me.dragAffordances.onDragMove(data),
-            onDockCrossZoneDrop      : data => me.dragAffordances.onDrop(data),
-            onDockTearOutCancel      : data => me.tearOutHandlers.onDockTearOutCancel(data),
-            onDockTearOutEntry       : data => me.tearOutHandlers.onDockTearOutEntry(data),
-            onDockTearOutExit        : data => me.tearOutHandlers.onDockTearOutExit(data),
-            onDockTearOutTerminal    : data => me.tearOutHandlers.onDockTearOutTerminal(data),
-            onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
-            resolveComponentRef      : resolveComponentRef
+            applyDockZoneOperation: me.applyDockZoneOperation.bind(me),
+            // Tear-out opt-in (§2.8): every tab zone shares the Workstation root as its physical
+            // window boundary. Exiting a source toolbar remains ordinary cross-zone motion; only
+            // leaving this app/window root enters the vessel outcome machine.
+            dockTearOutBoundaryContainerId: me.id,
+            enableDockTearOut             : true,
+            onDockCrossZoneDragCancel     : data => me.dragAffordances.onDragCancel(data),
+            onDockCrossZoneDragMove       : data => me.dragAffordances.onDragMove(data),
+            onDockCrossZoneDrop           : data => me.dragAffordances.onDrop(data),
+            onDockTearOutCancel           : data => me.tearOutHandlers.onDockTearOutCancel(data),
+            onDockTearOutEntry            : data => me.tearOutHandlers.onDockTearOutEntry(data),
+            onDockTearOutExit             : data => me.tearOutHandlers.onDockTearOutExit(data),
+            onDockTearOutTerminal         : data => me.tearOutHandlers.onDockTearOutTerminal(data),
+            onDockZoneDocumentChange      : me.onDockZoneDocumentChange.bind(me),
+            resolveComponentRef           : resolveComponentRef
                 || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
             resolveRevealComponentRef  : (componentRef, item, itemId) => me.resolvePane(itemId, item)
         })

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -319,6 +319,8 @@ class DockLayoutAdapter extends Base {
      * re-projection loop) with no error surfacing anywhere.
      * @param {Object} model
      * @param {Object} [options={}]
+     * @param {String|String[]|null} [options.dockTearOutBoundaryContainerId] Main-thread DOM
+     *     boundary whose exit starts a tear-out; omitted values retain the tab-toolbar boundary.
      * @param {Boolean} [options.enableVesselConversion=false] Arms the optional source-owned
      *     conversion policy. Consumers keep this false until their physical lifecycle is ready.
      * @param {Boolean} [options.enableStackDrag=false] Decorate the model-resolved stack root
@@ -373,6 +375,7 @@ class DockLayoutAdapter extends Base {
             // tab.Container. The HOST owns vessel acquisition + the `detachItem` commit at the
             // terminal; the projection only threads the opt-in + the closure seams. Absent = fully
             // in-window, the unchanged default.
+            dockTearOutBoundaryContainerId   : options.dockTearOutBoundaryContainerId ?? null,
             enableDockTearOut                : options.enableDockTearOut === true,
             enableVesselConversion           : options.enableVesselConversion === true,
             items                            : model.items || {},
@@ -842,7 +845,13 @@ class DockLayoutAdapter extends Base {
                 // new model state: a menu selection routes through the tab.Container's existing activeIndex.
                 plugins       : [{module: TabOverflowPlugin}],
                 sortZoneConfig: {
-                    module          : DockTabSortZone,
+                    module: DockTabSortZone,
+                    // A dock host spans multiple tab strips. Its composition can therefore name
+                    // the app/window boundary whose EXIT means tear-out; retaining the toolbar
+                    // fallback keeps consumers that omit the option byte-identical.
+                    ...(context.dockTearOutBoundaryContainerId
+                        ? {boundaryContainerId: context.dockTearOutBoundaryContainerId}
+                        : null),
                     dockGroupNodeId : nodeId === context.stackDragNodeId ? nodeId : null,
                     dockItemIds     : items,
                     dockSourceNodeId: nodeId,

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -750,16 +750,17 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
     });
 
     test.describe('tear-out projection threading — opt-in flag + the clone-safe gesture seams', () => {
-        test('enableDockTearOut arms enableProxyToPopup on every projected tab sort zone and threads the four gesture seams', () => {
+        test('enableDockTearOut arms the app-boundary popup grammar on every projected tab sort zone and threads the four gesture seams', () => {
             const captured = {cancel: [], entry: [], exit: [], terminal: []};
 
             const result = DockLayoutAdapter.project(createModel(), {
-                enableDockTearOut    : true,
-                onDockTearOutCancel  : data => captured.cancel.push(data),
-                onDockTearOutEntry   : data => captured.entry.push(data),
-                onDockTearOutExit    : data => captured.exit.push(data),
-                onDockTearOutTerminal: data => captured.terminal.push(data),
-                resolveComponentRef  : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+                dockTearOutBoundaryContainerId: 'workstation-root',
+                enableDockTearOut             : true,
+                onDockTearOutCancel           : data => captured.cancel.push(data),
+                onDockTearOutEntry            : data => captured.entry.push(data),
+                onDockTearOutExit             : data => captured.exit.push(data),
+                onDockTearOutTerminal         : data => captured.terminal.push(data),
+                resolveComponentRef           : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
             });
 
             const mainTabs = result.items[0];
@@ -767,7 +768,10 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             // The serializable flag rides the sortZoneConfig; the closures live on the tab.Container
             // listeners block — the projection's proven clone-safe closure home. A function inside
             // sortZoneConfig would not survive config cloning; this split is the load-bearing shape.
-            expect(mainTabs.headerToolbar.sortZoneConfig.enableProxyToPopup).toBe(true);
+            expect(mainTabs.headerToolbar.sortZoneConfig).toMatchObject({
+                boundaryContainerId: 'workstation-root',
+                enableProxyToPopup : true
+            });
 
             for (const [listener, bucket] of [
                 ['dockTearOutCancel', 'cancel'], ['dockTearOutEntry', 'entry'],


### PR DESCRIPTION
Resolves #15968

Restores release truth for in-window Workstation tab drags by giving every projected tab strip one shared physical tear-out boundary: the Workstation root. Crossing from a source toolbar into another dock zone now remains an ordinary cross-zone drag, while leaving the app root still enters the existing vessel outcome machine.

Evidence: L3 (canonical Google Chrome with accelerated GL, real pointer input, Neural Link worker inspection, and exact combined #15967 + #15968 heads) → L3 required (release commits `audit`, overlay geometry remains host-contained, and physical boundary tear-out remains live). Residual: none for #15968.

## Deltas from ticket

- The suspected last-36-hours window was falsified. A 155-revision bisect identified `26a3e261a0a748b1ab08c912bce565a891618533` (#15840) as first bad; its immediate parent `6a67d3202c1911242a9d730943dc8101dfb26986` is green.
- The reducer and descriptor seams were not broken. #15840 enabled tear-out on every tab strip while retaining each toolbar as its inherited boundary; a legitimate cross-zone drag therefore emitted `dockTearOutExit`, opened a second window, and terminated through `dockTearOutTerminal` before `dockCrossZoneDrop` could commit.
- The repair is host-authoritative and opt-in: `DockLayoutAdapter.project()` accepts a documented `dockTearOutBoundaryContainerId`; consumers that omit it retain the prior toolbar-boundary behavior.

## Test Evidence

- Adapter boundary threading: focused regression witness RED before implementation, then 1/1 green.
- Dashboard drag/tear-out units: `npx playwright test dashboard/DockLayoutAdapter dashboard/DockTabSortZone dashboard/DockTearOut draggable/container/SortZone -c test/playwright/playwright.config.unit.mjs --workers=1 --reporter=list` — 101/101 passed.
- Workstation release truth at `38b4032884`: canonical Chrome/Neural Link targeted journey — 1/1 passed; `audit` committed into the scale zone and no second window appeared.
- Workstation drag affordances at `38b4032884`: full pre-#15967 file — 2/2 passed.
- Workstation Five Beat at `38b4032884`: 4 passed, 3 contract-defined future witnesses skipped.
- Exact combined heads (`38b4032884` + approved #15967 head `d6cbe62aec`): canonical Chrome/accelerated-GL `WorkstationDragAffordancesNL` — GL boot gate plus all 3 journeys passed (4/4 total).
- Directly touched surfaces: `DockLayoutAdapter` — unit coverage above; Workstation dock projection/release/tear-out — canonical Neural Link journeys above.

## Post-Merge Validation

- [ ] Re-run full `WorkstationDragAffordancesNL` on `dev` after #15967 and #15968 have both landed.
- [ ] Re-run `WorkstationFiveBeatNL` on that same `dev` head.

## Evolution

The visual symptom suggested a reducer-boundary regression in the recent drag-affordance series. The bisect instead proved an older physical-boundary authority error: toolbar exit had been made synonymous with app/window exit. Moving that authority into the host composition preserves both outcomes without teaching the reducer about window topology.

Related: #15967, #15966, #15840, #15906

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session f920e636-09a9-4642-b827-110564ad8bb9.
