### PR TITLE
fix(ai): make direct mailbox receipts durability-aware

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1256,6 +1256,31 @@ async function persistReceiptEdge(edge) {
 }
 
 /**
+ * Durably persists a receipt mutation already applied to a direct-DM `MESSAGE` node, and reports
+ * whether the durable write actually ran.
+ *
+ * Direct messages intentionally carry read/archive state on their shared node rather than a
+ * per-recipient `DELIVERED_TO` edge. This writes that existing carrier directly because
+ * `GraphService.upsertNode` gates storage on `autoSave` and returns no durability signal;
+ * receipt mutations are user-originated writes, never load echoes that `autoSave` may suppress.
+ *
+ * @param {Object} node `MESSAGE` node carrying the already-applied receipt property.
+ * @returns {Promise<Boolean>} `true` when the durable write ran; `false` when there was no storage.
+ */
+async function persistReceiptNode(node) {
+    const db = GraphService.db;
+
+    if (!db?.storage) {
+        return false;
+    }
+
+    await db.storage.addNodes([node]);
+    db.acknowledgeLocalMutations?.();
+
+    return true;
+}
+
+/**
  * Builds the receipt a mailbox lifecycle tool returns, degrading it honestly when the durable
  * write did not run.
  *
@@ -1307,6 +1332,22 @@ async function setDeliveryEdgeReadAt(edge, readAt) {
 }
 
 /**
+ * Sets the read timestamp on a direct-DM `MESSAGE` node and reports whether that mutation reached
+ * durable storage.
+ *
+ * @param {Object} node Direct-DM `MESSAGE` node.
+ * @param {String} readAt ISO timestamp.
+ * @returns {Promise<Boolean>} `true` when the read state was persisted durably.
+ */
+async function setMessageNodeReadAt(node, readAt) {
+    // MESSAGE records expose a reference-stable properties object. Preserve that object so
+    // existing consumers holding it observe the same mutation, matching the established DM path.
+    getRecordProperties(node).readAt = readAt;
+
+    return persistReceiptNode(node);
+}
+
+/**
  * Sets the archive timestamp on a per-recipient DELIVERED_TO edge for broadcast
  * messages. Mirrors `setDeliveryEdgeReadAt` exactly — both delegate to
  * `persistReceiptEdge`, so broadcast archive state participates in the same durability
@@ -1325,6 +1366,20 @@ async function setDeliveryEdgeArchivedAt(edge, archivedAt) {
     });
 
     return persistReceiptEdge(edge);
+}
+
+/**
+ * Sets the archive timestamp on a direct-DM `MESSAGE` node and reports whether that mutation
+ * reached durable storage.
+ *
+ * @param {Object} node Direct-DM `MESSAGE` node.
+ * @param {String} archivedAt ISO timestamp.
+ * @returns {Promise<Boolean>} `true` when the archive state was persisted durably.
+ */
+async function setMessageNodeArchivedAt(node, archivedAt) {
+    getRecordProperties(node).archivedAt = archivedAt;
+
+    return persistReceiptNode(node);
 }
 
 function linkOptionalMailboxEdge(source, target, type, weight, properties) {
@@ -2343,7 +2398,8 @@ class MailboxService extends Base {
      * never fails the batch, so a bulk drain cannot abort on one stale entry.
      * @param {Object} args
      * @param {String|String[]} args.messageId The ID of the message to mark read, or an array of IDs
-     * @returns {Promise<Object>} Single form: `{messageId, readAt, status}`; array form: `{results: [...]}`.
+     * @returns {Promise<Object>} Single form: `{messageId, readAt, status}` (plus
+     *   `{durable: false, warning}` when storage is absent); array form: `{results: [...]}`.
      */
     async markRead({ messageId }) {
         if (Array.isArray(messageId)) {
@@ -2452,11 +2508,11 @@ class MailboxService extends Base {
             throw new Error(`Unauthorized: you are not the recipient of message ${messageId}`);
         }
 
-        // Trigger an upsert to save to file backing store and notify listeners
-        messageNode.properties.readAt = new Date().toISOString();
-        GraphService.upsertNode(messageNode);
+        const readAt = new Date().toISOString();
 
-        return { messageId, readAt: messageNode.properties.readAt, status: 'read' };
+        const durable = await setMessageNodeReadAt(messageNode, readAt);
+
+        return receiptWithDurability({ messageId, readAt, status: 'read' }, durable, 'mark_read');
     }
 
     /**
@@ -2478,7 +2534,8 @@ class MailboxService extends Base {
      *
      * @param {Object} args
      * @param {String} args.messageId The ID of the message to archive.
-     * @returns {Promise<Object>} `{messageId, archivedAt, status: 'archived'}`.
+     * @returns {Promise<Object>} `{messageId, archivedAt, status: 'archived'}` (plus
+     *   `{durable: false, warning}` when storage is absent).
      */
     async archiveMessage({ messageId }) {
         const boundIdentity = RequestContextService.getAgentIdentityNodeId();
@@ -2532,11 +2589,11 @@ class MailboxService extends Base {
             throw new Error(`Unauthorized: you are not the recipient of message ${messageId}`);
         }
 
-        // Direct DM path: stamp on the MESSAGE node + upsert (same shape as markRead's direct-DM branch).
-        messageNode.properties.archivedAt = new Date().toISOString();
-        GraphService.upsertNode(messageNode);
+        const archivedAt = new Date().toISOString();
 
-        return { messageId, archivedAt: messageNode.properties.archivedAt, status: 'archived' };
+        const durable = await setMessageNodeArchivedAt(messageNode, archivedAt);
+
+        return receiptWithDurability({ messageId, archivedAt, status: 'archived' }, durable, 'archive_message');
     }
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.ReceiptDurability.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.ReceiptDurability.spec.mjs
@@ -22,18 +22,17 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
 /**
  * A read receipt must not out-claim its durable write.
  *
- * `mark_read` / `archive_message` mutate the in-memory `DELIVERED_TO` edge unconditionally, then
- * persisted only when `db.autoSave` was set — while the tool returned `status: 'read'` either way.
- * An acknowledged write that was never persisted is a false receipt: the mark survives until the
- * process restarts and then silently reverts to unread.
+ * `mark_read` / `archive_message` carry broadcast state on the per-recipient `DELIVERED_TO` edge
+ * and direct-DM state on the shared `MESSAGE` node. Both mutations happen in memory first; their
+ * receipts may claim unqualified success only after the matching carrier reached storage.
  *
  * These specs assert durability **against storage**, not against a spy: after the call they read
- * the edge back through `storage.loadNodeVicinitySync` (bypassing the in-memory cache the mutation
- * always updates), which is the only way to tell "persisted" from "looked persisted".
+ * the matching node or edge back through `storage.loadNodeVicinitySync` (bypassing the in-memory
+ * cache the mutation always updates), the only way to tell "persisted" from "looked persisted".
  */
 test.describe.configure({mode: 'serial'});
 
-test.describe('MailboxService — receipt durability cannot outrun the durable write (#15821)', () => {
+test.describe('MailboxService — receipt durability cannot outrun the durable write (#15821, #15957)', () => {
     let MailboxService, GraphService, LifecycleService;
     let originalAutoSave;
 
@@ -84,8 +83,16 @@ test.describe('MailboxService — receipt durability cannot outrun the durable w
         }) || null;
     };
 
-    const propertiesOf = edge => {
-        const raw = edge?.properties ?? edge?.data?.properties;
+    /** Reads the direct-DM MESSAGE node back FROM STORAGE, never from the in-memory cache. */
+    const readMessageFromStorage = messageId => {
+        const vicinity = GraphService.db.storage.loadNodeVicinitySync([messageId]),
+              nodes    = vicinity?.nodes || [];
+
+        return nodes.find(node => (node.id ?? node?.data?.id) === messageId) || null;
+    };
+
+    const propertiesOf = record => {
+        const raw = record?.properties ?? record?.data?.properties;
 
         return typeof raw === 'string' ? JSON.parse(raw) : (raw || {});
     };
@@ -94,6 +101,14 @@ test.describe('MailboxService — receipt durability cannot outrun the durable w
     const sendBroadcast = async subject => {
         const sent = await RequestContextService.run({agentIdentityNodeId: SENDER}, () =>
             MailboxService.addMessage({to: 'AGENT:*', subject, body: 'receipt durability fixture'}));
+
+        return sent.messageId;
+    };
+
+    /** Sends a direct message whose read/archive state rides the shared MESSAGE node. */
+    const sendDirect = async subject => {
+        const sent = await RequestContextService.run({agentIdentityNodeId: SENDER}, () =>
+            MailboxService.addMessage({to: RECIPIENT, subject, body: 'direct receipt durability fixture'}));
 
         return sent.messageId;
     };
@@ -184,6 +199,70 @@ test.describe('MailboxService — receipt durability cannot outrun the durable w
 
             expect(receipt.durable).toBe(false);
             expect(receipt.warning).toMatch(/archive_message/);
+        } finally {
+            GraphService.db.storage = realStorage;
+        }
+    });
+
+    test('direct-DM mark_read persists with autoSave OFF and keeps the legacy receipt shape', async () => {
+        const messageId = await sendDirect('durability: direct mark autoSave off');
+
+        GraphService.db.autoSave = false;
+
+        try {
+            const receipt = await asRecipient(() => MailboxService.markRead({messageId}));
+
+            expect(Object.keys(receipt).sort()).toEqual(['messageId', 'readAt', 'status']);
+            expect(propertiesOf(readMessageFromStorage(messageId)).readAt).toBe(receipt.readAt);
+        } finally {
+            GraphService.db.autoSave = originalAutoSave;
+        }
+    });
+
+    test('direct-DM mark_read degrades honestly with no storage', async () => {
+        const messageId   = await sendDirect('durability: direct mark no storage');
+        const realStorage = GraphService.db.storage;
+
+        try {
+            GraphService.db.storage = null;
+
+            const receipt = await asRecipient(() => MailboxService.markRead({messageId}));
+
+            expect(receipt.status).toBe('read');
+            expect(receipt.durable).toBe(false);
+            expect(receipt.warning).toMatch(/mark_read.*NOT persisted/);
+        } finally {
+            GraphService.db.storage = realStorage;
+        }
+    });
+
+    test('direct-DM archive_message persists with autoSave OFF and keeps the legacy receipt shape', async () => {
+        const messageId = await sendDirect('durability: direct archive autoSave off');
+
+        GraphService.db.autoSave = false;
+
+        try {
+            const receipt = await asRecipient(() => MailboxService.archiveMessage({messageId}));
+
+            expect(Object.keys(receipt).sort()).toEqual(['archivedAt', 'messageId', 'status']);
+            expect(propertiesOf(readMessageFromStorage(messageId)).archivedAt).toBe(receipt.archivedAt);
+        } finally {
+            GraphService.db.autoSave = originalAutoSave;
+        }
+    });
+
+    test('direct-DM archive_message degrades honestly with no storage', async () => {
+        const messageId   = await sendDirect('durability: direct archive no storage');
+        const realStorage = GraphService.db.storage;
+
+        try {
+            GraphService.db.storage = null;
+
+            const receipt = await asRecipient(() => MailboxService.archiveMessage({messageId}));
+
+            expect(receipt.status).toBe('archived');
+            expect(receipt.durable).toBe(false);
+            expect(receipt.warning).toMatch(/archive_message.*NOT persisted/);
         } finally {
             GraphService.db.storage = realStorage;
         }


### PR DESCRIPTION
Resolves #15957

Direct-message `mark_read` and `archive_message` now consult the same durability contract as their broadcast siblings. The MESSAGE node remains the direct-DM carrier; its mutation is committed through a mailbox-local boolean-returning helper, and the existing `receiptWithDurability` wrapper preserves the legacy success shape while exposing `durable: false` only when storage is absent.

Evidence: L2 (real SQLite storage reads through the isolated unit harness, bypassing the in-memory graph cache) → L2 required (both lifecycle methods and both mailbox carrier classes). Residual: this restores receipt truth; it does not claim to diagnose #15825's separate read-state resurfacing mechanism.

## Deltas from ticket

- The ticket's recommended low-blast shape survives: `GraphService.upsertNode` and its shared return contract are unchanged.
- The implementation uses one MESSAGE-node persistence helper plus read/archive-specific setters, mirroring the existing DELIVERED_TO-edge helpers without unifying the two intentionally different carriers.
- MESSAGE record properties remain reference-stable and mutate in place before the direct storage commit, preserving the established direct-DM observation semantics.
- No AiConfig state is mutated. The predecessor's `UNIT_TEST_MODE`-resolved in-memory SQLite harness remains the isolation authority under ADR-0019.

## Test Evidence

- Baseline focused suite before new witnesses: 7/7 passed.
- RED, direct `mark_read` with `autoSave:false`: the receipt returned a new timestamp while a direct SQLite read still held `readAt:null`.
- RED, direct `mark_read` with no storage: the receipt returned `durable:undefined` instead of the existing honest-degradation contract.
- GREEN, focused `MailboxService.ReceiptDurability.spec.mjs`: 11/11 passed, covering direct read/archive persistence, no-storage degradation, legacy key shapes, and the unchanged broadcast controls.
- GREEN, full `MailboxService.spec.mjs`: 130/130 passed.
- GREEN, `npm run agent-preflight -- --no-fix`; the only output beyond the passing gates was the pre-existing non-blocking Tier-1 stale-overlay warning.
- GREEN, full pre-commit hook stack: whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, and AiConfig test-mutation checks.

## Post-Merge Validation

- [ ] Re-run the focused receipt-durability suite on merged `dev`.
- [ ] Confirm a normal-storage direct `mark_read` and `archive_message` still return only the legacy success keys.
- [ ] Keep #15825's resurfacing investigation independent; do not treat this contract repair as evidence for its unresolved loss mechanism.

## Evolution

#15824 made broadcast receipts honest but selected only the `DELIVERED_TO` branch of a two-carrier lifecycle. This patch derives the repair from the operation's contract instead of its first observed carrier: every receipt now consults whether its own state holder reached storage, while the carrier split documented by #15936 remains intact.

Related: #15821, #15824, #15825, #15936

Authored by Emmy (GPT-5.6 Sol Ultra, Codex).
