### PR TITLE
fix(workstation): republish film-stage geometry after CDP moves

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -61,22 +61,23 @@ const
 /**
  * Film mode only: pins the main window to a deterministic stage via CDP `Browser.setWindowBounds` —
  * the instance-addressed placement verb (never AppleScript: two same-bundle Chrome processes make
- * script addressing flip-flop, which is why the boot already fronts via CDP).
+ * script addressing flip-flop, which is why the boot already fronts via CDP). CDP moves the native
+ * window outside Neo's event path, so the adapter republishes only the browser-observed geometry
+ * through the product's existing WindowPosition authority after the landing settles.
  *
  * The stage rule, two paths with different guarantees:
  * - DEFAULT = the window's natural landing position with the size pinned. Natural landing is
  *   HOST- AND CURSOR-CONDITIONAL, not enforced: identical across runs on the author's host
  *   ({22,22} ×4), but cascade drift has been observed (75 vs 74 across one run's two boots) and
- *   the OS can seat the window on a secondary display (a roulette landing at x=1750 = the BenQ,
- *   where the morph leg currently dies — the secondary-display finding filed from this lane).
+ *   the OS can seat the window on either display.
  * - `NEO_FILM_DISPLAY_BOUNDS="left,top,width,height"` = the ENFORCED determinism path, and the
- *   take-night rule: set it explicitly to a primary-display target. Receipted green for
- *   same-display moves: 122,122,1282,880 pinned identically across two boots of the film suite.
- *   A cross-display target stays out of scope until the engine finding is answered.
- * Every landing is logged through `Browser.getWindowBounds`, never silent; a malformed override is
- * warned about and ignored — the log is the AC1 receipt, so it must name what actually ran.
+ *   take-night rule: set it explicitly to the intended capture display. After either a same- or
+ *   cross-display CDP move, the adapter observes the browser's landed geometry and republishes it
+ *   through WindowPosition before any journey gesture runs.
+ * Every landing logs the CDP bounds, browser observation, and App-Worker manager parity; a malformed
+ * override is warned about and ignored — the receipt must name what actually ran.
  * @param {Object} page Playwright page.
- * @returns {Promise<Object>} the verified window bounds
+ * @returns {Promise<Object>} the verified native bounds plus observed Neo-window identity and geometry
  */
 async function pinToCaptureDisplay(page) {
     const session    = await page.context().newCDPSession(page),
@@ -96,10 +97,77 @@ async function pinToCaptureDisplay(page) {
         console.log(`[film-stage] NEO_FILM_DISPLAY_BOUNDS invalid, ignoring: "${raw}"`)
     }
 
+    let observed;
+
+    await expect.poll(async () => {
+        observed = await page.evaluate(() => ({
+            height: globalThis.innerHeight,
+            width : globalThis.innerWidth,
+            x     : globalThis.screenX,
+            y     : globalThis.screenY
+        }));
+
+        return Math.max(Math.abs(observed.x - bounds.left), Math.abs(observed.y - bounds.top))
+    }, {
+        message  : 'the film-stage adapter must observe the requested native-window landing',
+        timeout  : 5000,
+        intervals: [25, 50, 100]
+    }).toBeLessThanOrEqual(80);
+
+    await expect.poll(() => page.evaluate(() =>
+        Boolean(globalThis.Neo?.main?.addon?.WindowPosition?.publishGeometry)
+    ), {
+        message  : 'the workstation must install its ordinary window-geometry publisher',
+        timeout  : 5000,
+        intervals: [25, 50, 100]
+    }).toBe(true);
+
+    const neoWindowId = await page.evaluate(() => {
+        globalThis.Neo.main.addon.WindowPosition.publishGeometry();
+
+        return globalThis.Neo.worker.Manager.windowId
+    });
+
     console.log(`[film-stage] window pinned via Browser.setWindowBounds: ${JSON.stringify(bounds)}` +
+        `; observed geometry republished: ${JSON.stringify(observed)}` +
         (valid ? ' (explicit NEO_FILM_DISPLAY_BOUNDS target)' : ' (natural landing, size pinned)'));
 
-    return bounds
+    return {bounds, neoWindowId, observed}
+}
+
+/**
+ * @summary Proves the CDP adapter's observed geometry reached the ordinary App-Worker window map.
+ * @param {Object} app Neural Link app wrapper.
+ * @param {Object} stageReceipt Result from {@link pinToCaptureDisplay}.
+ * @returns {Promise<Object>} browser-observed and App-Worker-managed geometry
+ */
+async function assertStageGeometryPublished(app, stageReceipt) {
+    const managers = await app.findInstances({className: 'Neo.manager.Window'}, ['id']),
+          manager  = (Array.isArray(managers) ? managers[0] : managers);
+
+    expect(manager?.id, 'the App Worker must expose its singleton window manager').toBeTruthy();
+
+    let receipt;
+
+    await expect.poll(async () => {
+        const state    = await app.callMethod(manager.id, 'toJSON'),
+              managed  = state.windows.find(item => item.id === stageReceipt.neoWindowId)?.innerRect,
+              observed = stageReceipt.observed,
+              delta    = managed && ['x', 'y', 'width', 'height']
+                  .map(key => Math.abs(managed[key] - observed[key]));
+
+        receipt = {managed, observed};
+
+        return delta ? Math.max(...delta) : Infinity
+    }, {
+        message  : 'the App Worker must consume the browser-observed film-stage geometry',
+        timeout  : 5000,
+        intervals: [25, 50, 100]
+    }).toBeLessThanOrEqual(2);
+
+    console.log(`[film-stage] manager.Window parity: ${JSON.stringify(receipt)}`);
+
+    return receipt
 }
 
 // `video` must live at file level (a describe-scoped use() would force a new worker).
@@ -125,6 +193,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
     async function boot({page, neuralLink}) {
         const pageErrors = [],
               popupProbe = [];
+        let stageReceipt;
 
         page.on('pageerror', error => {
             let value = String(error?.stack || error?.message || error || '');
@@ -156,7 +225,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         // display, so two takes land in the same frame rather than whichever display the OS chose.
         if (filmTake) {
             await page.bringToFront();
-            await pinToCaptureDisplay(page);
+            stageReceipt = await pinToCaptureDisplay(page)
         }
 
         const app        = await neuralLink.connectToApp('Workstation'),
@@ -164,6 +233,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
               wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
 
         expect(wsId, 'the App Worker must own one Workspace').toBeTruthy();
+        stageReceipt && await assertStageGeometryPublished(app, stageReceipt);
 
         return {app, pageErrors, popupProbe, wsId}
     }


### PR DESCRIPTION
Resolves #15934

The Workstation film adapter now republishes browser-observed native-window geometry after a CDP stage move and proves the App-Worker window manager consumed it before any drag gesture begins. This restores cross-display re-entry without changing SortZone, EventSimulator, DragDrop, or production window-movement behavior.

Evidence: the explicit secondary-display morph cell failed at the lane base with `lastRatio=0`; the same cell passed after the existing `WindowPosition.publishGeometry()` authority closed the stale-origin split. The browser observation and `manager.Window.innerRect` matched with zero delta on both displays.

## Deltas from ticket

- The reported cross-display failure is confirmed, but the ticket's SortZone-specific premise is superseded by the measured rect provenance.
- Workstation gesture screen coordinates came from a stale App-Worker manager rect after `Browser.setWindowBounds`; DragDrop then subtracted the live main-window origin, shifting the proxy by the display delta.
- CDP moves bypass the product's native movement/resize event path. The fix belongs in the film adapter, which now follows the same geometry-publication seam already used by sibling headed adapters.
- A 21-call-site mouse-event census confirms that a blanket EventSimulator normalization would be wrong: Demo B intentionally combines source-document `clientX/Y` with target-window `screenX/Y`.
- The ticket's proposed SortZone unit witness is replaced by a fix-critical browser-to-manager parity assertion plus exact headed RED→GREEN proof.
- The broader claim about ordinary user-driven window moves remains unproven and is not repeated here; the product's normal movement path already publishes through `WindowPosition`.

## Test Evidence

- RED at `f33eb328c2`, `NEO_FILM_DISPLAY_BOUNDS='1750,22,1280,800'`: morph failed with `boundaryEntrySeen=false`, `entrySeen=false`, `isWindowDragging=true`, `reattachArmed=true`, `lastRatio=0`.
- GREEN, unchanged cross-display causal cell: 2/2 passed (GL setup + morph).
- GREEN, explicit secondary-display full film suite: 5 passed, 3 skipped.
- GREEN, default-placement full suite: 5 passed, 3 skipped.
- GREEN, browser observation ↔ App-Worker manager parity: max delta 0 at `{x:1750,y:22,width:1280,height:800}` and `{x:22,y:22,width:1280,height:800}`.
- GREEN, `npm run agent-preflight -- --no-fix` and `git diff --check`.
- GREEN, full pre-commit hook stack: whitespace, shorthand, AiConfig test-mutation, JSDoc types, ticket archaeology, block alignment, and parse.

## Post-Merge Validation

- [ ] Re-run the explicit secondary-display morph cell on merged `dev`.
- [ ] Confirm each film boot logs CDP bounds, browser-observed geometry, and App-Worker manager parity before the first gesture.
- [ ] Let #15965 consume the parity seam for systematic dock-overlay rect assertions without normalizing explicit `screenX/Y`.

## Evolution

The failure initially looked like a drop-position/SortZone coordinate bug. Rect-provenance tracing instead exposed a boundary between browser automation and the product's movement authority: CDP can move the native window without emitting the events that keep worker geometry current. The adapter now makes that boundary explicit and self-verifying, while preserving intentional cross-window coordinate contracts.

Root-cause correction: https://github.com/neomjs/neo/issues/15934#issuecomment-5082244351

Related: #15965

Authored by Emmy (GPT-5.6 Sol Ultra, Codex).
