### PR TITLE
fix: shield mailbox read carriers from ambient graph decay (#15973)

### DIFF
--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -75,6 +75,9 @@ function isValidGraphNodeId(id) {
 export const PROTECTED_EDGE_TYPES = Object.freeze([
     'ADVANCED_BY',   // business layer: goal→work advancement is history, never scent; zombie-priority is handled by explicit retirement reweight (ai/graph/businessSchema.mjs), not decay
     'ATTRIBUTED_TO', // direction layer: motion→direction attribution is measurement substrate — a velocity number built on decaying edges rots invisibly; fact-class per the direction contract (ai/graph/directionSchema.mjs)
+    'DELIVERED_TO',  // mailbox layer: per-recipient broadcast read/archive carrier — readAt/archivedAt live ON this edge (ai/services/memory-core/MailboxService.mjs markRead/archive); pruning it resurfaces read messages as unread
+    'SENT_TO',       // mailbox layer: recipiency authorization — markRead/archive resolve "is this mine?" by walking it; deletion erases who a message was for, which never becomes less true with age
+    'SENT_BY',       // mailbox layer: sender provenance — record, not scent; the decay floor sits below the prune threshold, so an unprotected carrier is a countdown, not an equilibrium
     'IMPLEMENTS',
     'EXTENDS',
     'SYSTEM_TENET',

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -296,9 +296,10 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         // cannot pass by disabling decay itself.
         GraphService.linkNodes('MailScentSource', 'MailScentTarget', 'RELATES_TO', 0.05);
 
-        // Assertions read the PERSISTED authority, never the RAM cache: the bulk-SQL decay
-        // path bypasses the Store mutation layer, so the cache retains pre-decay state by
-        // construction (see the syncCache note inside decayGlobalTopology).
+        // Storage read-back, not cache read-back: a durability assertion must be answered by
+        // the durable store on principle. (decayGlobalTopology does call syncCache(), so the
+        // cache is not known-stale here — which is precisely why cache agreement would prove
+        // nothing on its own.)
         const edgeRow = GraphService.db.storage.db.prepare(`
             SELECT data
             FROM Edges

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -274,6 +274,60 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(edgeRow.get('ScentSource', 'ScentTarget', 'RELATES_TO')).toBeUndefined();
     });
 
+    test('decayGlobalTopology preserves mailbox read/authorization carriers — read state is record, not scent (#15973)', async () => {
+        await GraphService.upsertNode({id: 'MESSAGE:decay-proof', type: 'MESSAGE'});
+        await GraphService.upsertNode({id: '@decay-recipient',    type: 'AGENT_IDENTITY'});
+        await GraphService.upsertNode({id: '@decay-sender',       type: 'AGENT_IDENTITY'});
+        await GraphService.upsertNode({id: 'MailScentSource',     type: 'TEST_NODE'});
+        await GraphService.upsertNode({id: 'MailScentTarget',     type: 'TEST_NODE'});
+
+        // Seed every mailbox carrier at a weight ALREADY below the prune threshold — the exact
+        // state the countdown produces. Read/archive state ride ON the per-recipient broadcast
+        // edge (MailboxService markRead / archiveMessage), so survival must mean "with
+        // properties intact", not merely "row exists".
+        GraphService.linkNodes('MESSAGE:decay-proof', '@decay-recipient', 'DELIVERED_TO', 0.05, {
+            archivedAt: '2026-07-02T00:00:00.000Z',
+            readAt    : '2026-07-01T00:00:00.000Z'
+        });
+        GraphService.linkNodes('MESSAGE:decay-proof', '@decay-recipient', 'SENT_TO', 0.05);
+        GraphService.linkNodes('MESSAGE:decay-proof', '@decay-sender',    'SENT_BY', 0.05);
+
+        // Control: an unprotected edge at the same weight must still be pruned, so this spec
+        // cannot pass by disabling decay itself.
+        GraphService.linkNodes('MailScentSource', 'MailScentTarget', 'RELATES_TO', 0.05);
+
+        // Assertions read the PERSISTED authority, never the RAM cache: the bulk-SQL decay
+        // path bypasses the Store mutation layer, so the cache retains pre-decay state by
+        // construction (see the syncCache note inside decayGlobalTopology).
+        const edgeRow = GraphService.db.storage.db.prepare(`
+            SELECT data
+            FROM Edges
+            WHERE source = ?
+              AND target = ?
+              AND type = ?
+        `);
+
+        // Self-validating seed: prove the read state landed in storage BEFORE decay runs,
+        // so a green survival assertion cannot be a seeding artifact.
+        const seededProps = JSON.parse(edgeRow.get('MESSAGE:decay-proof', '@decay-recipient', 'DELIVERED_TO').data).properties;
+        expect(seededProps.readAt).toBe('2026-07-01T00:00:00.000Z');
+
+        GraphService.decayGlobalTopology(0.5, 0.2, true);
+
+        const deliveredRow = edgeRow.get('MESSAGE:decay-proof', '@decay-recipient', 'DELIVERED_TO');
+        expect(deliveredRow).toBeTruthy();
+
+        const deliveredProps = JSON.parse(deliveredRow.data).properties;
+        expect(deliveredProps.readAt).toBe('2026-07-01T00:00:00.000Z');
+        expect(deliveredProps.archivedAt).toBe('2026-07-02T00:00:00.000Z');
+        expect(deliveredProps.weight).toBe(0.05);
+
+        expect(edgeRow.get('MESSAGE:decay-proof', '@decay-recipient', 'SENT_TO')).toBeTruthy();
+        expect(edgeRow.get('MESSAGE:decay-proof', '@decay-sender',    'SENT_BY')).toBeTruthy();
+
+        expect(edgeRow.get('MailScentSource', 'MailScentTarget', 'RELATES_TO')).toBeUndefined();
+    });
+
     test('getNodeRecord returns the properties blob that getNode strips (#11637)', async () => {
         test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
         await GraphService.upsertNode({


### PR DESCRIPTION
Resolves #15973

Adds the three mailbox carriers — `DELIVERED_TO`, `SENT_TO`, `SENT_BY` — to `PROTECTED_EDGE_TYPES`, each with the per-entry rationale comment the shield's existing entries carry. Mailbox structure is record, not scent: `readAt`/`archivedAt` ride ON the per-recipient `DELIVERED_TO` edge, recipiency authorization walks `SENT_TO`, and sender provenance is `SENT_BY` — none of these become less true with age, and the decay floor (`0.1`) sits below the prune threshold (`0.2`), so an unprotected carrier is a countdown, not an equilibrium. The fix is the shield's own precedent shape (the third reactive addition, after `RESOLVES` in #12644, `ADVANCED_BY` in #14446, `ATTRIBUTED_TO` in #14567) and deliberately does not touch the decay algorithm, the threshold, the factor, or #15920's designed archive-only decay — protecting the carriers from deletion is what makes a safe archive-based decay possible at all.

Evidence: L3 (red-proved spec executing the real decay SQL against real SQLite storage — the exact consumed boundary; RED `1 failed / 44 passed` pre-fix → GREEN `158 passed` post-fix) → L3 required (AC2–AC4 name precisely this witness shape). Residual: none — AC5 (the #15920 AC4 durability-window amendment) is discharged via a comment on #15920, linked from this PR's thread.

## Deltas from ticket

1. **Countdown arithmetic corrected (credit @neo-gpt-emmy's intake-correction):** the ticket computed "~10 cycles from weight 1.0" using factor `0.85`; the shipped default is `decayFactor: leaf(0.98, 'NEO_GRAPH_DECAY_FACTOR')` (`ai/mcp/server/memory-core/configBase.mjs:658`), giving `ln(0.2)/ln(0.98) ≈ 80` cycles ≈ 80 days for a fresh weight-1.0 edge. The countdown thesis and Emmy's two-cycle slice measurement (564 of 2,844 read-bearing rows) are unchanged — that population is already near the threshold; only the fresh-edge horizon moves. The shipped shield rationale comments are deliberately factor-agnostic.
2. **Self-validating seed assertion (spec hardening beyond the AC text):** the spec asserts `readAt` is present in storage BEFORE decay runs, so a green survival assertion cannot be a seeding artifact.
3. **Cache-staleness rationale inverted → corrected (credit @neo-opus-grace's authority-delta split):** the ticket's original AC4 rationale claimed the RAM cache "retains pre-decay state by construction"; `decayGlobalTopology` in fact calls `syncCache()` unconditionally (`GraphService.mjs:692`), so stale RAM is the counterfactual that call prevents, not shipped behavior. The requirement is unchanged — the spec still reads the durable store — but on principle (a durability assertion must be answered by the durable authority), not because the cache is known to lie. Ticket body corrected at source by Grace; the spec comment carries the corrected rationale.

## Test Evidence

- RED (pre-fix shield — AC2's required failing witness): `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs --workers=1` → `1 failed` (the new #15973 spec; the `DELIVERED_TO` survival assertion fails because the unprotected row is pruned) / `44 passed` (zero collateral).
- GREEN (post-fix — all four suites that import the changed module): GraphService.spec.mjs + GoldenPathSynthesizer.spec.mjs + ConceptIngestor.spec.mjs + manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs → `158 passed (7.6s)`.
- Memory-core graph decay surface: `test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs` (extended) — survival asserted with `readAt`/`archivedAt`/`weight` intact, read back from the durable store (the authority a durability assertion is about; `decayGlobalTopology` syncs the cache, so cache agreement would prove nothing on its own), plus an unprotected `RELATES_TO` control that must still be pruned so the spec cannot pass by disabling decay. Post-rebase re-verification: `45 passed`.

## Post-Merge Validation

- [ ] After the next live decay cycle on the canonical plane (24h algorithmic lock), re-run the #15973 population measurement: protected mailbox rows must survive with read-state intact while ambient pruning of unprotected types continues.

## Commits

- 89abe5f54c — shield entries + red-proved spec
- e8417e8253 — spec rationale corrected per Grace's authority-delta split (cache-staleness inversion retracted; storage read-back justified on principle)

Authored by Vega (Claude Fable 5, Claude Code). Session 7ffa4544-0acf-47ac-82ba-7c4139967eba.
