### PR TITLE
fix(build): watchdog corpus axis evaluates per facet, not one tree timestamp (#15975)

### DIFF
--- a/buildScripts/dataSyncWatchdog.mjs
+++ b/buildScripts/dataSyncWatchdog.mjs
@@ -95,6 +95,11 @@ export function computeStreak({runs}) {
  * across every subpath of one semantic corpus, or null when no subpath has a visible
  * commit. Newest-wins is the contract for multi-path facets (`issues` = active + archive):
  * an archive-only repair is maintenance, and a healthy archive cadence is not a breach.
+ * Measured on the live history: archive-commit cadence gaps run 1–8 days, so the
+ * alternatives (min-wins, or the archive as its own 48h facet) would false-breach
+ * routinely; in ~2.5 months exactly one archive-only commit class (a hand-authored
+ * redaction repair) refreshed the `issues` clock while the active tree was untouched —
+ * the accepted price for not false-breaching.
  *
  * @param {Object[][]} commitLists One list of commit entries per subpath.
  * @returns {String|null} ISO date of the newest commit, or null.
@@ -185,6 +190,38 @@ export function parseThreshold({name, raw, fallback}) {
     }
 
     return value
+}
+
+/**
+ * Parses the facet-list env var with the same loud discipline as `parseThreshold`:
+ * absent or empty falls back to the default set, but a PRESENT value that resolves to
+ * zero names (comma/whitespace-only — the realistic shape of an unset-vars composition
+ * like `${{ vars.A }},${{ vars.B }}`) fails LOUD. A resolved-empty list would empty the
+ * corpus axis itself: `evaluateBreach` over `[]` is indistinguishable from the axis
+ * never having been measured, which is the certified-silence class this tool exists to
+ * break — a watchdog must never carry a quiet off-switch for its own guard.
+ *
+ * Unknown names fall through to a single subpath equal to the name BY DESIGN: the
+ * override is the extension point for future independently-synced trees, with no code
+ * change required. A typo then surfaces at evaluation time as a "no commit visible"
+ * breach for that facet — the loud direction as well (never silence).
+ *
+ * @param {Object} options
+ * @param {String} options.name Env var name (for the error message).
+ * @param {String|undefined} options.raw Raw env value.
+ * @param {String[]} options.fallback Used only when the var is absent or empty.
+ * @returns {String[]}
+ */
+export function parseFacetNames({name, raw, fallback}) {
+    if (raw === undefined || raw === '') return fallback;
+
+    const facets = raw.split(',').map(facet => facet.trim()).filter(Boolean);
+
+    if (facets.length === 0) {
+        throw new Error(`dataSyncWatchdog: ${name} resolved to zero facets from '${raw}' — refusing to silently disable the corpus axis (omit the var to use the default set)`)
+    }
+
+    return facets
 }
 
 /**
@@ -372,10 +409,7 @@ async function main() {
     // Multi-path facets (`issues` = active + archive, one semantic corpus for consumers)
     // take the NEWEST commit across their subpaths: an archive-only repair is maintenance.
     // Measured from the COMMITTED default branch, never a working tree.
-    const facetNames = (process.env.WATCHDOG_CORPUS_FACETS || DEFAULT_CORPUS_FACETS.join(','))
-        .split(',')
-        .map(facet => facet.trim())
-        .filter(Boolean);
+    const facetNames = parseFacetNames({name: 'WATCHDOG_CORPUS_FACETS', raw: process.env.WATCHDOG_CORPUS_FACETS, fallback: DEFAULT_CORPUS_FACETS});
 
     const corpusFacets = await Promise.all(facetNames.map(async facet => {
         const subpaths = FACET_PATHS[facet] ?? [facet],

--- a/buildScripts/dataSyncWatchdog.mjs
+++ b/buildScripts/dataSyncWatchdog.mjs
@@ -23,7 +23,12 @@ import process from 'node:process';
  *   corpus is measured PER FACET (`issues`, `pulls`, `discussions` by default) — the
  *   facets sync independently and drift apart, so a single tree timestamp would certify
  *   two stale facets after an issue-only landing: the freshness witness needs the same
- *   cardinality as the corpus it certifies. Every facet is measured from the COMMITTED
+ *   cardinality as the corpus it certifies. The `issues` facet spans BOTH the active tree
+ *   and `archive/issues`, because consumers read them as one semantic corpus
+ *   (`buildScripts/docs/index/tickets.mjs` dual-source) — and the sync lane writes both.
+ *   Its freshness is the NEWEST commit across the two subpaths: an archive-only repair is
+ *   maintenance, and a healthy archive cadence (weekly-ish gaps) is not a breach; the
+ *   breach is the whole lane going quiet. Every facet is measured from the COMMITTED
  *   default branch through the API — never a working-tree mtime, which can read current
  *   in the exact episode it must catch.
  *   On breach, open the standing alarm issue — or update the existing open one (fresh
@@ -44,10 +49,23 @@ const
     DEFAULT_MAX_CONSECUTIVE_FAILURES = 3,
     DEFAULT_MAX_SUCCESS_AGE_HOURS    = 24,
     DEFAULT_MAX_CORPUS_AGE_HOURS     = 48,
-    DEFAULT_CORPUS_FACETS            = ['issues', 'pulls', 'discussions'],
     DEFAULT_CORPUS_PATH              = 'resources/content',
     DEFAULT_WORKFLOW                 = 'data-sync-pipeline.yml',
-    RUNS_PER_PAGE                    = 30;
+    RUNS_PER_PAGE                    = 30,
+    /**
+     * Facet definitions: name → subpaths under `resources/content` that form ONE semantic
+     * corpus. `issues` spans active + archive because consumers dual-source them; its
+     * freshness is the newest commit across both (an archive-only repair is maintenance).
+     * `WATCHDOG_CORPUS_FACETS` overrides the NAME list only; unknown names get a single
+     * subpath equal to their name.
+     * @type {Object<String, String[]>}
+     */
+    FACET_PATHS = {
+        issues     : ['issues', 'archive/issues'],
+        pulls      : ['pulls'],
+        discussions: ['discussions']
+    },
+    DEFAULT_CORPUS_FACETS            = Object.keys(FACET_PATHS);
 
 /**
  * Reduces the newest-first completed run history to the streak facts.
@@ -70,6 +88,23 @@ export function computeStreak({runs}) {
     }
 
     return {latest: runs[0] ?? null, consecutiveFailures, lastSuccess}
+}
+
+/**
+ * Resolves a facet's freshness from per-subpath commit lists: the NEWEST commit date
+ * across every subpath of one semantic corpus, or null when no subpath has a visible
+ * commit. Newest-wins is the contract for multi-path facets (`issues` = active + archive):
+ * an archive-only repair is maintenance, and a healthy archive cadence is not a breach.
+ *
+ * @param {Object[][]} commitLists One list of commit entries per subpath.
+ * @returns {String|null} ISO date of the newest commit, or null.
+ */
+export function latestCommitDate(commitLists) {
+    const dates = commitLists.flat()
+        .map(entry => entry?.commit?.committer?.date)
+        .filter(Boolean);
+
+    return dates.length ? dates.reduce((a, b) => a > b ? a : b) : null
 }
 
 /**
@@ -334,6 +369,8 @@ async function main() {
     // Corpus axis, PER FACET: the corpus advances only via hand-authored commits, and its
     // facets sync independently — one tree timestamp would certify two stale facets after
     // a single-facet landing (the freshness witness needs the corpus's own cardinality).
+    // Multi-path facets (`issues` = active + archive, one semantic corpus for consumers)
+    // take the NEWEST commit across their subpaths: an archive-only repair is maintenance.
     // Measured from the COMMITTED default branch, never a working tree.
     const facetNames = (process.env.WATCHDOG_CORPUS_FACETS || DEFAULT_CORPUS_FACETS.join(','))
         .split(',')
@@ -341,12 +378,11 @@ async function main() {
         .filter(Boolean);
 
     const corpusFacets = await Promise.all(facetNames.map(async facet => {
-        const commits = await api(
-            `/repos/${repository}/commits?path=${encodeURIComponent(`${corpusPath}/${facet}`)}&sha=dev&per_page=1`,
-            {token}
-        );
+        const subpaths = FACET_PATHS[facet] ?? [facet],
+              commits  = await Promise.all(subpaths.map(subpath =>
+                  api(`/repos/${repository}/commits?path=${encodeURIComponent(`${corpusPath}/${subpath}`)}&sha=dev&per_page=1`, {token})));
 
-        const lastCommitAt = commits[0]?.commit?.committer?.date ?? null,
+        const lastCommitAt = latestCommitDate(commits),
               ageHours     = lastCommitAt
                   ? (now.getTime() - new Date(lastCommitAt).getTime()) / 3_600_000
                   : null;

--- a/buildScripts/dataSyncWatchdog.mjs
+++ b/buildScripts/dataSyncWatchdog.mjs
@@ -20,8 +20,12 @@ import process from 'node:process';
  *   The third axis exists because run-status is not independent of the QUESTION: the
  *   generated-markdown corpus advances only via hand-authored commits (never by the
  *   pipeline), so a green pipeline can certify a growing content backlog forever. The
- *   corpus axis is measured from the COMMITTED default branch through the API — never a
- *   working-tree mtime, which can read current in the exact episode it must catch.
+ *   corpus is measured PER FACET (`issues`, `pulls`, `discussions` by default) — the
+ *   facets sync independently and drift apart, so a single tree timestamp would certify
+ *   two stale facets after an issue-only landing: the freshness witness needs the same
+ *   cardinality as the corpus it certifies. Every facet is measured from the COMMITTED
+ *   default branch through the API — never a working-tree mtime, which can read current
+ *   in the exact episode it must catch.
  *   On breach, open the standing alarm issue — or update the existing open one (fresh
  *   body + a comment naming the latest failed run). N breaches, one issue.
  * - Recovery: the newest completed run succeeds. On recovery, close the standing issue
@@ -40,6 +44,7 @@ const
     DEFAULT_MAX_CONSECUTIVE_FAILURES = 3,
     DEFAULT_MAX_SUCCESS_AGE_HOURS    = 24,
     DEFAULT_MAX_CORPUS_AGE_HOURS     = 48,
+    DEFAULT_CORPUS_FACETS            = ['issues', 'pulls', 'discussions'],
     DEFAULT_CORPUS_PATH              = 'resources/content',
     DEFAULT_WORKFLOW                 = 'data-sync-pipeline.yml',
     RUNS_PER_PAGE                    = 30;
@@ -81,7 +86,7 @@ export function computeStreak({runs}) {
  * @param {Number} [options.maxCorpusAgeHours=48]
  * @returns {{breached: Boolean, reasons: String[]}}
  */
-export function evaluateBreach({consecutiveFailures, lastSuccessAt, now, corpusLastCommitAt, maxConsecutiveFailures=DEFAULT_MAX_CONSECUTIVE_FAILURES, maxSuccessAgeHours=DEFAULT_MAX_SUCCESS_AGE_HOURS, maxCorpusAgeHours=DEFAULT_MAX_CORPUS_AGE_HOURS}) {
+export function evaluateBreach({consecutiveFailures, lastSuccessAt, now, corpusLastCommitAt, corpusFacets, maxConsecutiveFailures=DEFAULT_MAX_CONSECUTIVE_FAILURES, maxSuccessAgeHours=DEFAULT_MAX_SUCCESS_AGE_HOURS, maxCorpusAgeHours=DEFAULT_MAX_CORPUS_AGE_HOURS}) {
     const reasons = [];
 
     if (consecutiveFailures >= maxConsecutiveFailures) {
@@ -106,6 +111,16 @@ export function evaluateBreach({consecutiveFailures, lastSuccessAt, now, corpusL
 
             if (corpusAgeHours > maxCorpusAgeHours) {
                 reasons.push(`last \`resources/content/**\` commit is ${corpusAgeHours.toFixed(1)}h old (threshold ${maxCorpusAgeHours}h — deploys, clones, CI and container KB ingestion all build from committed \`dev\`)`)
+            }
+        }
+    }
+
+    if (corpusFacets !== undefined) {
+        for (const {facet, lastCommitAt, ageHours} of corpusFacets) {
+            if (!lastCommitAt) {
+                reasons.push(`no commit visible for corpus facet \`${facet}\` on the default branch`)
+            } else if (ageHours > maxCorpusAgeHours) {
+                reasons.push(`corpus facet \`${facet}\` is ${ageHours.toFixed(1)}h old (threshold ${maxCorpusAgeHours}h)`)
             }
         }
     }
@@ -170,9 +185,16 @@ export function selectAlarmIssue(issues) {
  *        (the only path where a zero-streak title can occur).
  * @returns {String}
  */
-export function buildAlarmTitle({consecutiveFailures, lastSuccess, corpusLastCommitAt, corpusAgeHours, forced=false}) {
+export function buildAlarmTitle({consecutiveFailures, lastSuccess, corpusLastCommitAt, corpusAgeHours, staleFacets, forced=false}) {
     if (forced && consecutiveFailures === 0) {
         return `${ALARM_TITLE_PREFIX} Data Sync Pipeline: forced breach evaluation (workflow_dispatch dry run)`
+    }
+
+    if (consecutiveFailures === 0 && staleFacets?.length) {
+        const ages   = staleFacets.map(f => f.ageHours).filter(age => age !== null),
+              oldest = ages.length ? ` (oldest ${Math.max(...ages).toFixed(1)}h)` : '';
+
+        return `${ALARM_TITLE_PREFIX} Data Sync corpus stale: facet${staleFacets.length > 1 ? 's' : ''} ${staleFacets.map(f => `\`${f.facet}\``).join(', ')}${oldest}`
     }
 
     if (consecutiveFailures === 0 && corpusLastCommitAt) {
@@ -193,7 +215,18 @@ export function buildAlarmTitle({consecutiveFailures, lastSuccess, corpusLastCom
  * @param {Boolean} [options.forced=false] True when a dispatch dry-run forced the branch.
  * @returns {String}
  */
-export function buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure, reasons, corpusLastCommitAt, corpusAgeHours, forced=false}) {
+export function buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure, reasons, corpusLastCommitAt, corpusAgeHours, corpusFacets, forced=false}) {
+    const corpusLine = corpusFacets
+        ? [
+            '**Corpus facets** (committed `dev`; a green pipeline cannot attest to this backlog):',
+            '',
+            '| facet | last commit on `dev` | age | status |',
+            '|---|---|---|---|',
+            ...corpusFacets.map(({facet, lastCommitAt, ageHours, stale}) =>
+                `| \`${facet}\` | ${lastCommitAt ?? 'none visible'} | ${lastCommitAt ? `${ageHours.toFixed(1)}h` : '—'} | ${stale ? '**STALE**' : 'ok'} |`)
+        ].join('\n')
+        : `**Corpus axis:** last \`resources/content/**\` commit on \`dev\`: ${corpusLastCommitAt ? `${corpusLastCommitAt} (${corpusAgeHours}h old)` : 'not measured'}. Deploys, fresh clones, CI, and container KB ingestion all build from committed \`dev\` — a green pipeline cannot attest to this backlog.`;
+
     return [
         ALARM_MARKER,
         '',
@@ -203,7 +236,7 @@ export function buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure,
         `**Streak:** ${consecutiveFailures} consecutive failures.`,
         `**Last success:** ${lastSuccess ? `[${lastSuccess.created_at}](${lastSuccess.html_url})` : `none in the last ${RUNS_PER_PAGE} completed runs`}.`,
         `**Latest failure:** ${latestFailure ? `[run ${latestFailure.id}](${latestFailure.html_url})` : 'n/a'}.`,
-        `**Corpus axis:** last \`resources/content/**\` commit on \`dev\`: ${corpusLastCommitAt ? `${corpusLastCommitAt} (${corpusAgeHours}h old)` : 'not measured'}. Deploys, fresh clones, CI, and container KB ingestion all build from committed \`dev\` — a green pipeline cannot attest to this backlog.`,
+        corpusLine,
         '',
         '**Breach reasons:**',
         ...reasons.map(reason => `- ${reason}`),
@@ -298,26 +331,44 @@ async function main() {
 
     console.log(`watchdog: ${runs.length} completed runs visible; latest=${latest?.conclusion ?? 'none'}; consecutiveFailures=${consecutiveFailures}; lastSuccess=${lastSuccess?.created_at ?? 'none'}`);
 
-    // Corpus axis: the generated-markdown corpus advances only via hand-authored commits —
-    // measure the COMMITTED default branch, never a working tree (which can read current in
-    // the exact episode this axis exists to catch).
-    const corpusCommits = await api(
-        `/repos/${repository}/commits?path=${encodeURIComponent(corpusPath)}&sha=dev&per_page=1`,
-        {token}
-    );
+    // Corpus axis, PER FACET: the corpus advances only via hand-authored commits, and its
+    // facets sync independently — one tree timestamp would certify two stale facets after
+    // a single-facet landing (the freshness witness needs the corpus's own cardinality).
+    // Measured from the COMMITTED default branch, never a working tree.
+    const facetNames = (process.env.WATCHDOG_CORPUS_FACETS || DEFAULT_CORPUS_FACETS.join(','))
+        .split(',')
+        .map(facet => facet.trim())
+        .filter(Boolean);
 
-    const corpusLastCommitAt = corpusCommits[0]?.commit?.committer?.date ?? null,
-          corpusAgeHours     = corpusLastCommitAt
-              ? Number(((now.getTime() - new Date(corpusLastCommitAt).getTime()) / 3_600_000).toFixed(1))
-              : null;
+    const corpusFacets = await Promise.all(facetNames.map(async facet => {
+        const commits = await api(
+            `/repos/${repository}/commits?path=${encodeURIComponent(`${corpusPath}/${facet}`)}&sha=dev&per_page=1`,
+            {token}
+        );
 
-    console.log(`watchdog: corpus axis — last \`${corpusPath}\` commit on dev: ${corpusLastCommitAt ?? 'none'}${corpusAgeHours !== null ? ` (${corpusAgeHours}h)` : ''}`);
+        const lastCommitAt = commits[0]?.commit?.committer?.date ?? null,
+              ageHours     = lastCommitAt
+                  ? (now.getTime() - new Date(lastCommitAt).getTime()) / 3_600_000
+                  : null;
+
+        return {
+            facet,
+            lastCommitAt,
+            ageHours,
+            stale: lastCommitAt === null || ageHours > maxCorpusAgeHours
+        }
+    }));
+
+    const staleFacets = corpusFacets.filter(facet => facet.stale);
+
+    console.log(`watchdog: corpus facets — ${corpusFacets.map(({facet, lastCommitAt, ageHours}) =>
+        `${facet}=${lastCommitAt ?? 'none'}${ageHours !== null ? ` (${ageHours.toFixed(1)}h)` : ''}`).join(', ')}`);
 
     const {breached, reasons} = evaluateBreach({
         consecutiveFailures,
         lastSuccessAt: lastSuccess?.created_at ?? null,
         now,
-        corpusLastCommitAt,
+        corpusFacets,
         maxConsecutiveFailures,
         maxSuccessAgeHours,
         maxCorpusAgeHours
@@ -358,8 +409,8 @@ async function main() {
         return
     }
 
-    const title = buildAlarmTitle({consecutiveFailures, lastSuccess, corpusLastCommitAt, corpusAgeHours, forced: forceBreach}),
-          body  = buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure: latest?.conclusion === 'failure' ? latest : null, reasons, corpusLastCommitAt, corpusAgeHours, forced: forceBreach});
+    const title = buildAlarmTitle({consecutiveFailures, lastSuccess, staleFacets, forced: forceBreach}),
+          body  = buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure: latest?.conclusion === 'failure' ? latest : null, reasons, corpusFacets, forced: forceBreach});
 
     if (alarm) {
         const comment = buildBreachComment({consecutiveFailures, latestFailure: latest});

--- a/test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs
@@ -11,6 +11,7 @@ import {
     evaluateBreach,
     isRecovered,
     latestCommitDate,
+    parseFacetNames,
     parseThreshold,
     selectAlarmIssue
 } from '../../../../../buildScripts/dataSyncWatchdog.mjs';
@@ -135,6 +136,19 @@ test.describe('dataSyncWatchdog (#15948)', () => {
         expect(() => parseThreshold({name: 'X', raw: 'fourty', fallback: 48})).toThrow(/positive number/);
         expect(() => parseThreshold({name: 'X', raw: '0', fallback: 48})).toThrow(/positive number/);
         expect(() => parseThreshold({name: 'X', raw: '-5', fallback: 48})).toThrow(/positive number/)
+    });
+
+    test('parseFacetNames: absent falls back; a comma/whitespace-only value fails LOUD (never a silent off-switch for the axis)', () => {
+        expect(parseFacetNames({name: 'X', raw: undefined, fallback: ['issues']})).toEqual(['issues']);
+        expect(parseFacetNames({name: 'X', raw: '', fallback: ['issues']})).toEqual(['issues']);
+        expect(parseFacetNames({name: 'X', raw: 'issues,pulls', fallback: []})).toEqual(['issues', 'pulls']);
+        expect(parseFacetNames({name: 'X', raw: ' issues , pulls ', fallback: []})).toEqual(['issues', 'pulls']);
+
+        // The reachable defect: an unset-vars composition (`${{ vars.A }},${{ vars.B }}`)
+        // renders a comma-only value, which must never silently empty the corpus axis.
+        expect(() => parseFacetNames({name: 'X', raw: ' ', fallback: ['issues']})).toThrow(/zero facets/);
+        expect(() => parseFacetNames({name: 'X', raw: ',', fallback: ['issues']})).toThrow(/zero facets/);
+        expect(() => parseFacetNames({name: 'X', raw: ',,', fallback: ['issues']})).toThrow(/zero facets/)
     });
 
     test('selectAlarmIssue: body marker wins over title, PRs are excluded, marker beats prefix', () => {

--- a/test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs
@@ -247,6 +247,91 @@ test.describe('dataSyncWatchdog (#15948)', () => {
         expect(body).toContain('committed `dev`')
     });
 
+    test('evaluateBreach: per-facet — a single stale facet breaches while the others are fresh', () => {
+        const {breached, reasons} = evaluateBreach({
+            consecutiveFailures: 0,
+            lastSuccessAt      : '2026-07-26T11:30:00Z',
+            now                : NOW,
+            corpusFacets       : [
+                {facet: 'issues', lastCommitAt: '2026-07-26T10:00:00Z', ageHours: 2.0},
+                {facet: 'pulls', lastCommitAt: '2026-07-17T05:13:29Z', ageHours: 214.8},
+                {facet: 'discussions', lastCommitAt: '2026-07-25T08:00:00Z', ageHours: 28.0}
+            ],
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24,
+            maxCorpusAgeHours     : 48
+        });
+
+        expect(breached).toBe(true);
+        expect(reasons.length).toBe(1);
+        expect(reasons[0]).toContain('facet `pulls`');
+        expect(reasons[0]).toContain('214.8h')
+    });
+
+    test('evaluateBreach: per-facet — a facet with no visible commit breaches as its own reason', () => {
+        const {breached, reasons} = evaluateBreach({
+            consecutiveFailures: 0,
+            lastSuccessAt      : '2026-07-26T11:30:00Z',
+            now                : NOW,
+            corpusFacets       : [
+                {facet: 'issues', lastCommitAt: '2026-07-26T10:00:00Z', ageHours: 2.0},
+                {facet: 'discussions', lastCommitAt: null, ageHours: null}
+            ],
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24,
+            maxCorpusAgeHours     : 48
+        });
+
+        expect(breached).toBe(true);
+        expect(reasons[0]).toBe('no commit visible for corpus facet `discussions` on the default branch')
+    });
+
+    test('evaluateBreach: per-facet — all facets fresh is healthy (the post-landing recovery shape)', () => {
+        const {breached, reasons} = evaluateBreach({
+            consecutiveFailures: 0,
+            lastSuccessAt      : '2026-07-26T11:30:00Z',
+            now                : NOW,
+            corpusFacets       : [
+                {facet: 'issues', lastCommitAt: '2026-07-26T10:00:00Z', ageHours: 2.0},
+                {facet: 'pulls', lastCommitAt: '2026-07-26T09:00:00Z', ageHours: 3.0},
+                {facet: 'discussions', lastCommitAt: '2026-07-26T08:00:00Z', ageHours: 4.0}
+            ],
+            maxConsecutiveFailures: 3,
+            maxSuccessAgeHours    : 24,
+            maxCorpusAgeHours     : 48
+        });
+
+        expect(breached).toBe(false);
+        expect(reasons).toEqual([])
+    });
+
+    test('buildAlarmTitle: a per-facet corpus breach names the stale facets, not the tree', () => {
+        expect(buildAlarmTitle({
+            consecutiveFailures: 0,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            staleFacets        : [{facet: 'pulls', ageHours: 214.8}, {facet: 'discussions', ageHours: 214.8}]
+        })).toBe(`${ALARM_TITLE_PREFIX} Data Sync corpus stale: facets \`pulls\`, \`discussions\` (oldest 214.8h)`)
+    });
+
+    test('buildAlarmBody: the per-facet table carries each facet with its own age and status', () => {
+        const body = buildAlarmBody({
+            consecutiveFailures: 0,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            latestFailure      : null,
+            reasons            : ['corpus facet `pulls` is 214.8h old (threshold 48h)'],
+            corpusFacets       : [
+                {facet: 'issues', lastCommitAt: '2026-07-26T10:00:00Z', ageHours: 2.0, stale: false},
+                {facet: 'pulls', lastCommitAt: '2026-07-17T05:13:29Z', ageHours: 214.8, stale: true},
+                {facet: 'discussions', lastCommitAt: null, ageHours: null, stale: true}
+            ]
+        });
+
+        expect(body).toContain('**Corpus facets**');
+        expect(body).toContain('| `issues` | 2026-07-26T10:00:00Z | 2.0h | ok |');
+        expect(body).toContain('| `pulls` | 2026-07-17T05:13:29Z | 214.8h | **STALE** |');
+        expect(body).toContain('| `discussions` | none visible | — | **STALE** |')
+    });
+
     test('forced dispatch dry-run alarm body discloses its own provenance', () => {
         const body = buildAlarmBody({
             consecutiveFailures: 0,

--- a/test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs
@@ -10,6 +10,7 @@ import {
     computeStreak,
     evaluateBreach,
     isRecovered,
+    latestCommitDate,
     parseThreshold,
     selectAlarmIssue
 } from '../../../../../buildScripts/dataSyncWatchdog.mjs';
@@ -245,6 +246,20 @@ test.describe('dataSyncWatchdog (#15948)', () => {
         expect(body).toContain('**Corpus axis:**');
         expect(body).toContain('2026-07-17T07:13:29Z (220.5h old)');
         expect(body).toContain('committed `dev`')
+    });
+
+    test('latestCommitDate: newest-wins across a multi-path semantic corpus (archive-only repair is maintenance)', () => {
+        const entry = date => ({commit: {committer: {date}}});
+
+        // active landed yesterday, archive landed today — the archive repair counts
+        expect(latestCommitDate([[entry('2026-07-25T05:13:29Z')], [entry('2026-07-26T04:00:00Z')]]))
+            .toBe('2026-07-26T04:00:00Z');
+        // the reverse order resolves identically — freshness is the max, not the first path
+        expect(latestCommitDate([[entry('2026-07-26T04:00:00Z')], [entry('2026-07-17T05:13:29Z')]]))
+            .toBe('2026-07-26T04:00:00Z');
+        // no visible commit on ANY subpath is null — the missing-facet breach reason
+        expect(latestCommitDate([[], []])).toBe(null);
+        expect(latestCommitDate([[null], [undefined]])).toBe(null)
     });
 
     test('evaluateBreach: per-facet — a single stale facet breaches while the others are fresh', () => {


### PR DESCRIPTION
Resolves #15975

The corpus axis now evaluates **per facet** (`issues` / `pulls` / `discussions`, env-overridable) instead of one tree timestamp — closing the cardinality gap @neo-opus-ada reported: an issue-only landing would have moved the directory clock and certified `pulls/` and `discussions/` healthy while stale. Each facet queries `GET /commits?path=resources/content/<facet>&sha=dev` (committed default branch, same contract as before); ANY stale or commit-less facet breaches with its own reason; the alarm body carries a per-facet table (facet · last commit · age · status); recovery still means no active breach on any axis — now meaning every facet fresh.

Evidence: L1 (unit logic + live dry-run against the production API — all three facets currently stale at 217.9h, standing alarm #15972 correctly identified for in-place update) → L2 required (the write path refresh of #15972's body — happens on the next scheduled `:20` evaluation on merged `dev`). Residual: none beyond the scheduled evaluation.

## Deltas from ticket
- **Nested cardinality closed mid-review (@neo-gpt-emmy's exact-head finding):** the `issues` facet now spans `issues/` **and** `archive/issues/` as one semantic corpus — consumers dual-source them (`buildScripts/docs/index/tickets.mjs`), and the sync lane writes both. Freshness is newest-wins across the subpaths (`latestCommitDate`, spec-covered): an archive-only repair is maintenance, and a healthy weekly-ish archive cadence is not a breach. The alternatives were measured and rejected: both-subpaths-fresh at 48h false-breaches on healthy 6-day archive gaps (cadence measured: 07-04 → 07-06 → 07-12 → 07-13); archive as an independent 48h facet false-breaches identically.
- Two defects caught by the live dry-run before PR: `corpusFacets` missing from `evaluateBreach`'s destructured signature (runtime ReferenceError), and stale flags computed by reference-unequal `includes()` (every table row would have read "ok"). Both fixed before push; the spec suite covers the signature path via the new per-facet witnesses.
- `staleFacets` feeds the title (facet names, oldest age); missing-commit facets render "no commit visible" rather than a NaN age.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs` → **26 passed** (new per-facet witnesses: one stale facet breaches among fresh; missing-commit facet breaches; all-fresh healthy; facet-naming title; per-facet table with per-row status; `latestCommitDate` newest-wins incl. archive-only-repair-is-maintenance and all-empty→null).
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/` → **343 passed** (adjacency sweep).
- Live dry-run against the production API (`--dry-run`, zero writes): run axis breaching (1 consecutive failure, last success >24h), all three corpus facets stale at 217.9h, standing alarm #15972 selected for update with the new per-facet body.

## Post-Merge Validation
- [ ] The next scheduled `:20` evaluation refreshes #15972's body to the per-facet table (and keeps it open — all three facets are genuinely stale).
- [ ] After #15964's issue-facet landing, the following evaluation shows `issues` fresh while `pulls` / `discussions` stay STALE — the per-facet honesty this PR exists to guarantee.

Authored by Phoebe (Moonshot Kimi K3, opencode). Session 318916f0-3f6b-4f1c-b0d2-ee16e2dd8af0.
