### PR TITLE
test(workstation): systematic dock geometry rect assertions in whitebox e2e (#15965)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -441,7 +441,10 @@ class Workspace extends Container {
             flex  : 'none',
             layout: {ntype: 'hbox', align: 'center'},
             ntype : 'toolbar',
-            items : [{
+            // The boot containment chain asserts tourbar→statusbar→dock-host adjacency
+            // via component-id rects — the bar needs a stable reference to be one of them.
+            reference: 'tour-bar',
+            items    : [{
                 cls      : ['workstation-tour-play'],
                 handler  : () => me.startTour(),
                 iconCls  : 'fa fa-play',

--- a/test/playwright/e2e/utils/dockGeometry.mjs
+++ b/test/playwright/e2e/utils/dockGeometry.mjs
@@ -1,0 +1,215 @@
+import {expect} from '@playwright/test';
+
+/**
+ * @summary Shared DOM-rect assertions for dock containers and drag affordances.
+ *
+ * Why this module exists: the drop-overlay geometry contract (overlays are dock-host-local)
+ * shipped a viewport-rooted realization through a fully green suite — the
+ * `tab-into` preview rendered −98px from its zone and the top edge chip painted inside the
+ * tourbar — because no assertion ever read a rect. The flicker census cannot see a static
+ * offset, so the only detector that fired was a human eye. These families make the geometry
+ * contract mechanical.
+ *
+ * Discipline (binding):
+ * - **Component ids, not class selectors.** Rects come from the Neural Link fixture's
+ *   `getDomRect(componentIds)` — component identity survives restyling; classes do not.
+ *   Transient painted nodes that are not components (the preview affordance vnode child)
+ *   are read by the caller and passed in as pre-measured rects.
+ * - **Containment and parity, never coordinate-space unification.** Explicit `screenX/Y`
+ *   axes are intentionally mixed in Neo drag surfaces (one dock demo pairs source client
+ *   coords with target-window screen coords — proven by a 21-call-site census of the drag
+ *   surfaces). These families assert "inside" and "equal within tolerance", never
+ *   "same coordinate space".
+ * - **Mid-gesture is the assertion point.** The displacement was only visible while a drag
+ *   was parked; end-state reads miss it (whitebox-e2e protocol §5.1).
+ *
+ * @see test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+ * @see test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+ */
+
+/**
+ * Reads DOM rects for component ids through the Neural Link bridge.
+ * @param {Object} app the connected neuralLink app wrapper
+ * @param {String[]} ids component ids
+ * @returns {Promise<Object>} map of id → rect {x, y, top, left, right, bottom, width, height}
+ */
+export async function readComponentRects(app, ids) {
+    const rects = await app.getDomRect(ids);
+
+    // The bridge returns either a bare array aligned to `ids` or an {id: rect} map; normalize.
+    if (Array.isArray(rects)) {
+        return Object.fromEntries(ids.map((id, index) => [id, rects[index]]))
+    }
+
+    return rects
+}
+
+/**
+ * Strict rect-in-rect check with a small anti-rounding tolerance.
+ * @param {Object} inner
+ * @param {Object} outer
+ * @param {Number} [tolerance=1]
+ * @returns {Boolean}
+ */
+export function withinRect(inner, outer, tolerance = 1) {
+    return inner.left   >= outer.left   - tolerance
+        && inner.top    >= outer.top    - tolerance
+        && inner.right  <= outer.right  + tolerance
+        && inner.bottom <= outer.bottom + tolerance
+}
+
+/**
+ * Rect intersection test (zero-area rects never intersect).
+ * @param {Object} first
+ * @param {Object} second
+ * @returns {Boolean}
+ */
+export function intersectsRect(first, second) {
+    return first.left < second.right
+        && first.right > second.left
+        && first.top < second.bottom
+        && first.bottom > second.top
+}
+
+/**
+ * Family 1 — the boot containment chain: the app's chrome bands tile the window without gaps
+ * or overlaps, and the dock host owns everything below them. This is the chain the overlay
+ * displacement broke: when the indicator layer rooted at the viewport instead of the host,
+ * the header bands were the first surface it bled into.
+ *
+ * Asserts: tourBar.bottom = statusBar.top, statusBar.bottom = dockHost.top (adjacency, ±1px),
+ * and the dock host reaches the window's bottom edge.
+ *
+ * @param {Object} app the connected neuralLink app wrapper
+ * @param {Object} ids {tourBarId, statusBarId, dockHostId} component ids (the tour bar needs
+ *   `reference: 'tour-bar'` on the workspace — added with this family)
+ * @param {Object} [options] {viewportHeight} expected window inner height; omit to skip the
+ *   bottom-edge leg (e.g. when the host's own bottom chrome is intentional)
+ */
+export async function assertBootContainmentChain(app, {tourBarId, statusBarId, dockHostId}, {viewportHeight} = {}) {
+    const rects  = await readComponentRects(app, [tourBarId, statusBarId, dockHostId]),
+          tour   = rects[tourBarId],
+          status = rects[statusBarId],
+          host   = rects[dockHostId];
+
+    expect(tour?.height,   'tour bar must render with height').toBeGreaterThan(0);
+    expect(status?.height, 'status bar must render with height').toBeGreaterThan(0);
+    expect(host?.height,   'dock host must render with height').toBeGreaterThan(0);
+
+    expect(Math.abs(tour.bottom - status.top),
+        'tour bar and status bar must tile without gap or overlap').toBeLessThanOrEqual(1);
+    expect(Math.abs(status.bottom - host.top),
+        'status bar and dock host must tile without gap or overlap').toBeLessThanOrEqual(1);
+
+    if (viewportHeight !== undefined) {
+        expect(Math.abs(host.bottom - viewportHeight),
+            'the dock host owns everything below the chrome bands').toBeLessThanOrEqual(1)
+    }
+
+    return rects
+}
+
+/**
+ * Family 2 — affordance containment: every painted indicator child and the painted preview
+ * region stays inside the dock host. The 2026-07-26 regression's signature was the top edge
+ * chip escaping into the tourbar; containment makes that shape impossible to re-ship silently.
+ *
+ * @param {Object} app the connected neuralLink app wrapper
+ * @param {Object} geometry {dockHostId, indicatorIds, previewRect} — dockHost + indicator
+ *   component ids (the seeded cross/chip children carry `candidateKey`), and the caller-read
+ *   rect of the transient preview affordance node
+ * @param {Number} [tolerance=1]
+ */
+export async function assertAffordanceContainment(app, {dockHostId, indicatorIds, previewRect}, tolerance = 1) {
+    const rects = await readComponentRects(app, [dockHostId, ...indicatorIds]),
+          host  = rects[dockHostId];
+
+    for (const id of indicatorIds) {
+        const rect = rects[id];
+
+        if (!rect || rect.width === 0 || rect.height === 0) continue; // hidden (off) children have no paint
+
+        expect(withinRect(rect, host, tolerance),
+            `indicator ${id} must paint inside the dock host`).toBe(true)
+    }
+
+    if (previewRect) {
+        expect(withinRect(previewRect, host, tolerance),
+            'the painted preview region must stay inside the dock host').toBe(true)
+    }
+
+    return rects
+}
+
+/**
+ * Family 3 — preview/zone alignment: the painted preview equals its target zone rect within
+ * tolerance for `tab-into`, or forms a band at the named zone edge for edge previews. The
+ * band height must not exceed `edgeBandMax` (the skin's 24px default at authoring time) and
+ * must hug the zone's own edge — never float free and never extend past it.
+ *
+ * @param {Object} app the connected neuralLink app wrapper
+ * @param {Object} geometry {zoneId, previewRect, kind: 'tab-into' | 'edge-top' | 'edge-right' | 'edge-bottom' | 'edge-left', edgeBandMax?}
+ * @param {Number} [tolerance=2]
+ */
+export async function assertPreviewZoneAlignment(app, {zoneId, previewRect, kind, edgeBandMax = 24}, tolerance = 2) {
+    const rects = await readComponentRects(app, [zoneId]),
+          zone  = rects[zoneId];
+
+    expect(zone?.width, 'the target zone must be measurable').toBeGreaterThan(0);
+
+    if (kind === 'tab-into') {
+        for (const key of ['left', 'top', 'width', 'height']) {
+            expect(Math.abs(previewRect[key] - zone[key]),
+                `tab-into preview ${key} must equal the zone rect`).toBeLessThanOrEqual(tolerance)
+        }
+    } else {
+        const edge = kind.replace('edge-', '');
+
+        expect(withinRect(previewRect, zone, tolerance),
+            'an edge preview never extends past its zone').toBe(true);
+
+        if (edge === 'top' || edge === 'bottom') {
+            expect(previewRect.height, 'edge band height stays within the skin budget')
+                .toBeLessThanOrEqual(edgeBandMax + tolerance);
+
+            const anchor = edge === 'top' ? 'top' : 'bottom';
+            expect(Math.abs(previewRect[anchor] - zone[anchor]),
+                `the ${edge} band hugs the zone's ${edge} edge`).toBeLessThanOrEqual(tolerance)
+        } else {
+            expect(previewRect.width, 'edge band width stays within the skin budget')
+                .toBeLessThanOrEqual(edgeBandMax + tolerance);
+
+            const anchor = edge;
+            expect(Math.abs(previewRect[anchor] - zone[anchor]),
+                `the ${edge} band hugs the zone's ${edge} edge`).toBeLessThanOrEqual(tolerance)
+        }
+    }
+
+    return rects
+}
+
+/**
+ * Family 4 — chip/header exclusion: no painted indicator rect may intersect the tour bar.
+ * The operator-visible half of the 2026-07-26 displacement (top chip at y=10..36 inside the
+ * tourbar) is named directly here. Containment (family 2) implies this, but the exclusion is
+ * asserted against the header explicitly so a boot-chain regression fails with the header in
+ * the message, not a coordinate.
+ *
+ * @param {Object} app the connected neuralLink app wrapper
+ * @param {Object} geometry {tourBarId, indicatorIds}
+ */
+export async function assertChipHeaderExclusion(app, {tourBarId, indicatorIds}) {
+    const rects = await readComponentRects(app, [tourBarId, ...indicatorIds]),
+          tour  = rects[tourBarId];
+
+    for (const id of indicatorIds) {
+        const rect = rects[id];
+
+        if (!rect || rect.width === 0 || rect.height === 0) continue;
+
+        expect(intersectsRect(rect, tour),
+            `indicator ${id} must never overlap the tour bar`).toBe(false)
+    }
+
+    return rects
+}

--- a/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
@@ -1,4 +1,5 @@
-import {test, expect} from '../../fixtures.mjs';
+import {test, expect}                                                                       from '../../fixtures.mjs';
+import {assertAffordanceContainment, assertBootContainmentChain, assertChipHeaderExclusion} from '../utils/dockGeometry.mjs';
 
 /**
  * Whitebox-e2e: the FLAGSHIP's drag-affordance journey — the durable real-pointer proof
@@ -184,6 +185,52 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
         expect(Math.abs(geometry.previewAffordance.top - geometry.targetZone.top)).toBeLessThanOrEqual(1);
         expect(Math.abs(geometry.previewAffordance.width - geometry.targetZone.width)).toBeLessThanOrEqual(1);
         expect(Math.abs(geometry.previewAffordance.height - geometry.targetZone.height)).toBeLessThanOrEqual(1);
+
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(120);
+        await page.mouse.up();
+        await page.waitForTimeout(300)
+    });
+
+    /**
+     * The systematic rect layer's flagship home — the boot containment chain and the
+     * per-child affordance families, read through component ids (restyle-proof), complementing
+     * the fix-critical class-selector witness above rather than replacing it.
+     */
+    test('the flagship chrome tiles the window, and every affordance child stays contained by component-id truth', async ({page, neuralLink}) => {
+        const {app, scaleBox} = await bootFlagship(page, neuralLink);
+
+        const readId = result => result?.properties?.id ?? result?.id ?? (Array.isArray(result) ? readId(result[0]) : null);
+
+        const [tourBar, statusBar, dockHost] = await Promise.all([
+                app.queryComponent({reference: 'tour-bar'},   ['id']),
+                app.queryComponent({reference: 'status-bar'}, ['id']),
+                app.queryComponent({reference: 'dock-host'},  ['id'])
+            ]),
+            ids = {dockHostId: readId(dockHost), statusBarId: readId(statusBar), tourBarId: readId(tourBar)};
+
+        expect(ids.tourBarId,   'the tour bar must expose a component id (reference: tour-bar)').toBeTruthy();
+        expect(ids.statusBarId, 'the status bar must expose a component id').toBeTruthy();
+        expect(ids.dockHostId,  'the dock host must expose a component id').toBeTruthy();
+
+        // Family 1 — the boot containment chain: chrome bands tile without gaps, host owns the rest
+        await assertBootContainmentChain(app, ids, {viewportHeight: await page.evaluate(() => globalThis.innerHeight)});
+
+        // Families 2 + 4 — mid-gesture: every seeded affordance child contained, none over the header
+        const center = {x: scaleBox.x + scaleBox.width / 2, y: scaleBox.y + scaleBox.height / 2};
+
+        await parkAuditDrag(page, center);
+
+        const candidateKeys = ['cross-center', 'cross-top', 'cross-right', 'cross-bottom', 'cross-left',
+                'chip-top', 'chip-right', 'chip-bottom', 'chip-left'],
+            children = await Promise.all(candidateKeys.map(candidateKey =>
+                app.queryComponent({candidateKey}, ['id']))),
+            indicatorIds = children.map(readId).filter(Boolean);
+
+        expect(indicatorIds.length, 'the nine seeded affordance children must resolve').toBe(9);
+
+        await assertAffordanceContainment(app, {dockHostId: ids.dockHostId, indicatorIds});
+        await assertChipHeaderExclusion(app, {tourBarId: ids.tourBarId, indicatorIds});
 
         await page.keyboard.press('Escape');
         await page.waitForTimeout(120);

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1,4 +1,5 @@
-import {test, expect} from '../../fixtures.mjs';
+import {test, expect}                                   from '../../fixtures.mjs';
+import {assertPreviewZoneAlignment, readComponentRects} from '../utils/dockGeometry.mjs';
 
 /**
  * @summary The five-beat multi-window journey witness for the flagship workstation — the
@@ -672,6 +673,96 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(cancelLogs[1], 'two cancel drives produce identical semantic dwell logs').toEqual(cancelLogs[0]);
         expect(commitLogs[1], 'two commit drives produce identical semantic dwell logs').toEqual(commitLogs[0]);
         expect(pageErrorRuns.flat(), 'both live gesture-time error streams stay empty').toEqual([])
+    });
+
+    /**
+     * The showcase beat's dwell previews must ALIGN with their target zones — the
+     * systematic rect layer's second consumer. Dwell detection rides the preview contract
+     * object (worker truth); the painted rect is read by component DOM id (never class
+     * selectors); the gesture ends in cancel, so the document is untouched.
+     */
+    test('showcase dwell previews align with their zones — component-id rect truth', async ({page, neuralLink}) => {
+        const
+            rectPace    = {birthAttempts: 240, curve: 0.18, dwellDelay: 900, moveDelay: 33, moveSteps: 24, showCursor: false},
+            {app, wsId} = await boot({page, neuralLink}),
+            readId      = result => result?.properties?.id ?? result?.id ?? (Array.isArray(result) ? readId(result[0]) : null),
+            zoneIds     = {};
+
+        for (const nodeId of ['scale-tabs', 'right-bottom-tabs']) {
+            zoneIds[nodeId] = readId(await app.queryComponent({dockNodeId: nodeId}, ['id']));
+
+            expect(zoneIds[nodeId], `zone ${nodeId} must resolve a component id`).toBeTruthy()
+        }
+
+        const dockHostId = readId(await app.queryComponent({reference: 'dock-host'}, ['id'])),
+              previewId  = readId(await app.queryComponent({reference: 'dock-preview'}, ['id']));
+
+        expect(dockHostId, 'the dock host must resolve').toBeTruthy();
+        expect(previewId,  'the dock preview overlay must resolve').toBeTruthy();
+
+        const readPaintedPreview = async () => {
+            const [state, host] = await Promise.all([
+                    app.getComponent(previewId, ['dockPreview']),
+                    readComponentRects(app, [dockHostId]).then(rects => rects[dockHostId])
+                ]),
+                dockPreview = state?.properties?.dockPreview ?? state?.dockPreview;
+
+            if (!dockPreview?.target?.nodeId) return null;
+
+            const style = await page.evaluate(id => {
+                const el = document.getElementById(id)?.firstElementChild;
+
+                return el?.style && {height: el.style.height, left: el.style.left, top: el.style.top, width: el.style.width}
+            }, previewId);
+
+            if (!style || !Number.parseFloat(style.width)) return null;
+
+            const num  = value => Number.parseFloat(value) || 0,
+                  left = host.left + num(style.left),
+                  top  = host.top  + num(style.top);
+
+            return {
+                dockPreview,
+                rect: {
+                    bottom: top + num(style.height),
+                    height: num(style.height),
+                    left,
+                    right : left + num(style.width),
+                    top,
+                    width : num(style.width)
+                }
+            }
+        };
+
+        const stepPromise = app.callMethod(wsId, 'executeCrossZoneShowcaseStep', [{
+            dwells: [
+                {placementKind: 'edge-bottom', targetNodeId: 'scale-tabs'},
+                {placementKind: 'tab-into',    targetNodeId: 'right-bottom-tabs'}
+            ],
+            itemId      : 'audit',
+            sourceNodeId: 'right-top-tabs',
+            terminal    : 'cancel'
+        }, rectPace]);
+
+        // Dwell 1 — the edge band must hug the scale zone's bottom edge inside its budget
+        await expect.poll(readPaintedPreview, {intervals: [50, 100, 200], timeout: 15000})
+            .toMatchObject({dockPreview: {placement: {kind: 'edge-bottom'}, target: {nodeId: 'scale-tabs'}}});
+
+        const dwell1 = await readPaintedPreview();
+
+        await assertPreviewZoneAlignment(app, {kind: 'edge-bottom', previewRect: dwell1.rect, zoneId: zoneIds['scale-tabs']});
+
+        // Dwell 2 — the tab-into preview must equal the right-bottom zone rect
+        await expect.poll(readPaintedPreview, {intervals: [50, 100, 200], timeout: 15000})
+            .toMatchObject({dockPreview: {placement: {kind: 'tab-into'}, target: {nodeId: 'right-bottom-tabs'}}});
+
+        const dwell2 = await readPaintedPreview();
+
+        await assertPreviewZoneAlignment(app, {kind: 'tab-into', previewRect: dwell2.rect, zoneId: zoneIds['right-bottom-tabs']});
+
+        const result = await stepPromise;
+
+        expect(result.cancelled, 'the gesture ends as a clean cancel — zero document mutation').toBe(true)
     });
 
     // ── beats 3-4: contracted legs — activate as the cross-window docking wiring lands ──


### PR DESCRIPTION
Resolves #15965

The systematic dock-geometry rect layer: a shared assertion helper (`test/playwright/e2e/utils/dockGeometry.mjs`) with four families — boot containment chain (tourbar→statusbar→dockHost tiling + host-to-viewport-bottom), affordance containment (every painted indicator child inside the host), preview-zone alignment (`tab-into` ≈ zone rect ±2px; edge band ≤24px hugging its zone edge), chip-header exclusion (no indicator rect intersects the tourbar) — consumed by two specs. All rect reads are component-id based (`getDomRect` via the Neural Link fixture; `queryComponent` by `reference` / `candidateKey` / `dockNodeId`), never class selectors; containment and parity only, never coordinate-space unification (the #15971 census folded into the ticket design).

Evidence: L3 (real Chrome drag gestures + Neural Link worker truth + browser-painted rect assertions, headless) → L3 required (all observable-geometry ACs). Residual: none.

## Deltas from ticket
- The RED→GREEN receipt was re-anchored: the ticket wrote it against `61a8d34e6d`; with #15967 merged, the RED was reproduced at `f33eb328c2` (pre-#15967 dev) — the family-2 containment assertion fails there with `indicator neo-component-22 must paint inside the dock host`, and the same test is green at this PR's head.
- The tour-bar reference the ticket named was added (`apps/workstation/view/Workspace.mjs`) — the only app-side change.
- #15971's guidance folded as designed: the browser→manager parity seam is consumed through the FiveBeat boot (not duplicated); no explicit `screenX/Y` normalization anywhere.

## Test Evidence
- Workstation drag-affordance surface: full `WorkstationDragAffordancesNL` **5/5** at head (including the new "flagship chrome tiles the window…" journey); the same journey RED at `f33eb328c2` (pre-#15967) with the containment failure named above.
- Workstation five-beat surface: full `WorkstationFiveBeatNL` **6/6** at head (including the new "showcase dwell previews align with their zones…" journey — dwell detection via the preview contract object, painted style read by component DOM id, cancel terminal, zero document mutation).

## Post-Merge Validation
- [ ] None — the guard is the merged suite itself.

Authored by @neo-kimi-iris (Kimi K3, Kimi Code CLI)
