### PR TITLE
fix: separate Workstation film presentation profile

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -53,8 +53,10 @@ import {test, expect} from '../../fixtures.mjs';
 // inside the window; birth is absence-not-slowness when it fails, so a longer gate buys
 // nothing but a worse error.
 const
-    filmTake = Boolean(process.env.NEO_FILM_TAKE),
-    filmPace = filmTake
+    filmTake    = Boolean(process.env.NEO_FILM_TAKE),
+    journeyRuns = filmTake ? 1 : 2,
+    themeDwell  = filmTake ? 3200 : 0,
+    filmPace    = filmTake
         ? {birthAttempts: 240, curve: 0.18, dwellDelay: 700, moveDelay: 33, moveSteps: 24, showCursor: true}
         : {};
 
@@ -445,11 +447,11 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         }
     }
 
-    test('scene 1 — the room is alive: two runs, identical beat logs, heartbeat never resets', async ({page, neuralLink}, testInfo) => {
+    test('scene 1 — the room is alive: resize and theme preserve continuity', async ({page, neuralLink}, testInfo) => {
         const logs       = [],
               pageErrors = [];
 
-        for (let run = 0; run < 2; run++) {
+        for (let run = 0; run < journeyRuns; run++) {
             const ctx     = await boot({page, neuralLink}),
                   {app}   = ctx,
                   {wsId}  = ctx,
@@ -547,6 +549,10 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
                 timeout: 10000
             }).toBe('neo-theme-neo-light');
 
+            // The poll above is the correctness gate. This fixed wait is presentation pacing only:
+            // B-03's light-theme beat must remain readable for at least three seconds on film.
+            themeDwell && await page.waitForTimeout(themeDwell);
+
             await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-dark']);
 
             await expect.poll(async () =>
@@ -571,13 +577,17 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             logs.push(beatLog);
 
             // zero-residue between takes: a fresh boot must reproduce the identical beat log
-            if (run === 0) {
+            if (run < journeyRuns - 1) {
                 await page.reload()
             }
         }
 
-        // the determinism AC: two scripted runs replay the identical structural beat log
-        expect(logs[1], 'two runs must replay the identical beat log').toEqual(logs[0]);
+        // The normal proof profile retains its two-run equality contract. Film mode records one
+        // presentation pass and therefore never puts the determinism reload seam on camera.
+        if (!filmTake) {
+            expect(logs[1], 'two runs must replay the identical beat log').toEqual(logs[0])
+        }
+
         expect(pageErrors, 'the journey must be error-free').toEqual([])
     });
 
@@ -598,7 +608,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
                 }]
             };
 
-        for (let run = 0; run < 2; run++) {
+        for (let run = 0; run < journeyRuns; run++) {
             const
                 ctx            = await boot({page, neuralLink}),
                 {app, wsId}    = ctx,
@@ -664,14 +674,17 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             cancelLogs.push(cancelled.beatLog);
             commitLogs.push(committed.beatLog);
 
-            if (run === 0) {
+            if (run < journeyRuns - 1) {
                 await page.reload()
             }
         }
 
-        expect(cancelLogs[1], 'two cancel drives produce identical semantic dwell logs').toEqual(cancelLogs[0]);
-        expect(commitLogs[1], 'two commit drives produce identical semantic dwell logs').toEqual(commitLogs[0]);
-        expect(pageErrorRuns.flat(), 'both live gesture-time error streams stay empty').toEqual([])
+        if (!filmTake) {
+            expect(cancelLogs[1], 'two cancel drives produce identical semantic dwell logs').toEqual(cancelLogs[0]);
+            expect(commitLogs[1], 'two commit drives produce identical semantic dwell logs').toEqual(commitLogs[0])
+        }
+
+        expect(pageErrorRuns.flat(), 'all live gesture-time error streams stay empty').toEqual([])
     });
 
     // ── beats 3-4: contracted legs — activate as the cross-window docking wiring lands ──


### PR DESCRIPTION
Resolves #15978
Related: #15252

Separates the Workstation's correctness proof from its recording profile: the default path retains two-run reload/equality evidence, while `NEO_FILM_TAKE=1` records one presentation pass and holds the already-proven light state long enough to read on camera.

Evidence: L3 (headed Chromium + Neural Link worker-truth assertions + every-frame decode) → L3 required (all #15978 close-target ACs). Residual: none.

## Deltas from ticket

The ticket set a floor of 3,000ms. A first implementation used that exact value, but the complete page-video census measured only 2.92s of light frames because cross-thread paint followed the worker-state poll. The final value is 3,200ms and yields one continuous 3.08s light interval. No scope was added.

## Test Evidence

- Collection: `npx playwright test workstation/WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --list` — 8 tests collected.
- Default proof profile: `NEO_E2E_PORT=8139 npx playwright test workstation/WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed --grep "scene 1|showcase beat"` — accelerated GL + both targeted tests, **3 passed** in 21.4s.
- Film profile: `NEO_E2E_PORT=8139 NEO_FILM_TAKE=1 NEO_FILM_DISPLAY_BOUNDS='1750,52,1282,880' npx playwright test workstation/WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed --grep "scene 1|showcase beat"` — accelerated GL + both targeted tests, **3 passed** in 49.3s.
- Geometry: both film boots observed browser and `manager.Window` inner rect `1750,52,1280,800`; parity delta 0.
- Full frame census: 538/538 retained frames decoded; scene 1 has one 77-frame light interval (`t=2.24–5.32s` = 3.08s); both streams have 0 post-ready blank/black frames.
- Diagnostic hashes: scene 1 `062da9a4d9eb8b4d520f15a8cef4257f4cb9499efad70d6e5763a693ace4d893`; showcase `05b51549d8d6a44787d7c253bc31e270b3e8d69f6256c7e62c12ad1f26193bd4`.
- Staged repository gates: whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, and AiConfig test-mutation checks all pass.
- Directly touched surface — `WorkstationFiveBeatNL.spec.mjs`: default and film-profile headed journeys above.

## Post-Merge Validation

- [ ] First merged-`dev` native film take confirms the readable theme beat under native display capture (tracked by #15252; not a #15978 merge blocker).
- [ ] Preserve the operator hands-off lease, privacy-clean frame-zero, and whole-retained-media gates before admitting any take.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session a202c0c8-420d-4cd4-ba8a-f90df4c764ef.
