### PR TITLE
test(ci): mandatory parity topology lane with fail-closed docker gate (#15807)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,20 +165,19 @@ jobs:
             // Whitelist (#15807): the parity lane is the single-reality witness for the
             // phase-3 stack — it boots ai/deploy/docker-compose.dev.yml (+ the parity-ci
             // overlay) on an overlay planeId and asserts topology + the mock-embedding
-            // contract, FAILING CLOSED when docker is absent (never best-effort). The
-            // filter covers: the deploy surface (compose files, Dockerfile, mocks), the
-            // plane subtree (planeConfig + the config bases declaring PLANE_MEMBER_PATHS),
-            // the MCP server/transport seams, the orchestrator boot walk, the
-            // served-identity probe, and the parity suite itself. Keep this COMPLETE —
-            // a missed path silently skips the witness (false-negative). Non-parity PRs
-            // are unaffected: the suite only runs for these paths.
+            // contract, FAILING CLOSED when docker is absent (never best-effort).
+            //
+            // Completeness source, made explicit per review: the lane boots MC, KB, and
+            // the orchestrator — a runtime whose import closure spans ai/services/**,
+            // ai/mcp/**, ai/daemons/**, and the config chain. Deriving that closure
+            // per-PR would be a second, hand-maintained dependency graph (the exact
+            // drift class this lane exists to kill), and at a measured 2m02s cold the
+            // lane is cheap enough to run on the CONSERVATIVE ROOT instead: all of ai/.
+            // Any ai/ change can affect the booted stack; none may skip the witness.
+            // The suite itself, its config, dep manifests, and this workflow round out
+            // the set. Non-ai paths (src/, learn/, resources/) never trigger it.
             const isParityRelevantPath = file =>
-              file.startsWith('ai/deploy/') ||
-              file === 'ai/planeConfig.mjs' ||
-              file === 'ai/configBase.mjs' ||
-              file.startsWith('ai/mcp/server/') ||
-              file.startsWith('ai/daemons/orchestrator/') ||
-              file === 'ai/scripts/diagnostics/mcpHealthcheck.mjs' ||
+              file.startsWith('ai/') ||
               file.startsWith('test/playwright/integration-parity/') ||
               file === 'test/playwright/playwright.config.integration-parity.mjs' ||
               file === 'package.json' ||

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,22 +167,19 @@ jobs:
             // overlay) on an overlay planeId and asserts topology + the mock-embedding
             // contract, FAILING CLOSED when docker is absent (never best-effort).
             //
-            // Completeness source, made explicit per review: the lane boots MC, KB, and
-            // the orchestrator — a runtime whose import closure spans ai/services/**,
-            // ai/mcp/**, ai/daemons/**, and the config chain. Deriving that closure
-            // per-PR would be a second, hand-maintained dependency graph (the exact
-            // drift class this lane exists to kill), and at a measured 2m02s cold the
-            // lane is cheap enough to run on the CONSERVATIVE ROOT instead: all of ai/.
-            // Any ai/ change can affect the booted stack; none may skip the witness.
-            // The suite itself, its config, dep manifests, and this workflow round out
-            // the set. Non-ai paths (src/, learn/, resources/) never trigger it.
+            // Boundary, not a new list: the booted stack's runtime closure is the SAME
+            // one the integration suite already treats as bootable — src/ (the engine
+            // hemisphere the servers extend), ai/ (services, config chain, daemons,
+            // deploy), the integration fixtures + harness. Parity relevance therefore
+            // INHERITS isIntegrationRelevantPath and adds only the lane's own files.
+            // One boundary, one owner: a future runtime import the integration
+            // whitelist learns about is inherited here automatically; an invented
+            // subset would drift the moment the stack crosses it (it already crosses
+            // into src/state/Provider, src/core/Base, and the shared mcpClient fixture).
             const isParityRelevantPath = file =>
-              file.startsWith('ai/') ||
+              isIntegrationRelevantPath(file) ||
               file.startsWith('test/playwright/integration-parity/') ||
-              file === 'test/playwright/playwright.config.integration-parity.mjs' ||
-              file === 'package.json' ||
-              file === 'package-lock.json' ||
-              file === '.github/workflows/test.yml';
+              file === 'test/playwright/playwright.config.integration-parity.mjs';
 
             const runIntegration = normalizedFiles.some(isIntegrationRelevantPath);
             const runUnit        = normalizedFiles.some(file => !isDocsOnlyPath(file) || requiresUnitForContent(file));

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       run_integration: ${{ steps.scope.outputs.run_integration }}
       run_unit: ${{ steps.scope.outputs.run_unit }}
       run_components: ${{ steps.scope.outputs.run_components }}
+      run_parity: ${{ steps.scope.outputs.run_parity }}
       skip_reason: ${{ steps.scope.outputs.skip_reason }}
 
     steps:
@@ -87,6 +88,7 @@ jobs:
               core.setOutput('run_integration', 'false');
               core.setOutput('run_unit', 'false');
               core.setOutput('run_components', 'false');
+              core.setOutput('run_parity', 'false');
               core.setOutput('skip_reason', reason);
               await core.summary
                 .addHeading('Stale workflow attempt')
@@ -107,6 +109,7 @@ jobs:
               core.setOutput('run_integration', 'true');
               core.setOutput('run_unit', 'true');
               core.setOutput('run_components', 'true');
+              core.setOutput('run_parity', 'true');
               core.setOutput('skip_reason', 'changed files unavailable');
               return;
             }
@@ -159,18 +162,44 @@ jobs:
               file === 'package-lock.json' ||
               file === '.github/workflows/test.yml';
 
+            // Whitelist (#15807): the parity lane is the single-reality witness for the
+            // phase-3 stack — it boots ai/deploy/docker-compose.dev.yml (+ the parity-ci
+            // overlay) on an overlay planeId and asserts topology + the mock-embedding
+            // contract, FAILING CLOSED when docker is absent (never best-effort). The
+            // filter covers: the deploy surface (compose files, Dockerfile, mocks), the
+            // plane subtree (planeConfig + the config bases declaring PLANE_MEMBER_PATHS),
+            // the MCP server/transport seams, the orchestrator boot walk, the
+            // served-identity probe, and the parity suite itself. Keep this COMPLETE —
+            // a missed path silently skips the witness (false-negative). Non-parity PRs
+            // are unaffected: the suite only runs for these paths.
+            const isParityRelevantPath = file =>
+              file.startsWith('ai/deploy/') ||
+              file === 'ai/planeConfig.mjs' ||
+              file === 'ai/configBase.mjs' ||
+              file.startsWith('ai/mcp/server/') ||
+              file.startsWith('ai/daemons/orchestrator/') ||
+              file === 'ai/scripts/diagnostics/mcpHealthcheck.mjs' ||
+              file.startsWith('test/playwright/integration-parity/') ||
+              file === 'test/playwright/playwright.config.integration-parity.mjs' ||
+              file === 'package.json' ||
+              file === 'package-lock.json' ||
+              file === '.github/workflows/test.yml';
+
             const runIntegration = normalizedFiles.some(isIntegrationRelevantPath);
             const runUnit        = normalizedFiles.some(file => !isDocsOnlyPath(file) || requiresUnitForContent(file));
             const runComponents  = normalizedFiles.some(isComponentsRelevantPath);
+            const runParity      = normalizedFiles.some(isParityRelevantPath);
 
             core.info(`Changed files: ${normalizedFiles.join(', ')}`);
             core.info(`run_integration=${runIntegration}`);
             core.info(`run_unit=${runUnit}`);
             core.info(`run_components=${runComponents}`);
+            core.info(`run_parity=${runParity}`);
 
             core.setOutput('run_integration', String(runIntegration));
             core.setOutput('run_unit', String(runUnit));
             core.setOutput('run_components', String(runComponents));
+            core.setOutput('run_parity', String(runParity));
             core.setOutput(
               'skip_reason',
               'change does not touch relevant paths for this suite (docs/content/config or unrelated test suite)'
@@ -194,6 +223,8 @@ jobs:
         include:
           - suite: integration-unified
             run: ${{ needs.changes.outputs.run_integration }}
+          - suite: integration-parity
+            run: ${{ needs.changes.outputs.run_parity }}
           - suite: unit
             run: ${{ needs.changes.outputs.run_unit }}
           - suite: components

--- a/ai/deploy/docker-compose.parity-ci.yml
+++ b/ai/deploy/docker-compose.parity-ci.yml
@@ -1,0 +1,63 @@
+# CI overlay for the parity stack (#15807) — merged OVER docker-compose.dev.yml:
+#
+#   docker compose \
+#     -f ai/deploy/docker-compose.dev.yml \
+#     -f ai/deploy/docker-compose.parity-ci.yml
+#
+# Adds the deterministic mock OpenAI-compatible endpoint (the same mock the
+# integration-unified stack wires via docker-compose.test.yml) and points both MCP
+# servers at it, so the parity lane exercises TOPOLOGY with zero real-model calls
+# and no external network dependency (the #15807 scope: shape, never behavior).
+#
+# The dev file stays a dev artifact: local seats bring their own provider story
+# (real Ollama, real keys). Mock wiring is a CI concern and lives only here.
+#
+# Merge mechanics (Compose spec): `environment` merges by key, `depends_on` merges
+# by service name, `networks` resolve across files — the overlay ADDS, never
+# restates. Plane identity stays single-sourced at the dev file's &plane-id anchor;
+# this file never touches it.
+services:
+  # #10917 pattern, parity edition: CI has no local Ollama/OpenAI-compatible daemon.
+  # A tiny deterministic OpenAI-compatible endpoint inside the compose network keeps
+  # the embedding path real HTTP end-to-end while making every vector deterministic
+  # (sha256-derived) — semantic recall is exercised without a model host.
+  embedding-server:
+    image: node:24-alpine
+    working_dir: /app
+    command: ["node", "ai/deploy/mock-openai-embedding-server.mjs"]
+    environment:
+      - NEO_TEST_EMBEDDING_DIMENSIONS=4096
+      - NEO_TEST_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
+    volumes:
+      - ../..:/app:ro
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:11434/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - neo-parity-network
+
+  kb-server:
+    environment:
+      NEO_MODEL_PROVIDER: openAiCompatible
+      NEO_EMBEDDING_PROVIDER: openAiCompatible
+      NEO_OPENAI_COMPATIBLE_HOST: http://embedding-server:11434
+      NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: text-embedding-qwen3-embedding-8b
+      # Placeholder credential for the mock endpoint only — never a real key, never
+      # resolves outside the compose network.
+      NEO_OPENAI_COMPATIBLE_API_KEY: neo-parity-ci-key
+    depends_on:
+      embedding-server:
+        condition: service_healthy
+
+  mc-server:
+    environment:
+      NEO_MODEL_PROVIDER: openAiCompatible
+      NEO_EMBEDDING_PROVIDER: openAiCompatible
+      NEO_OPENAI_COMPATIBLE_HOST: http://embedding-server:11434
+      NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: text-embedding-qwen3-embedding-8b
+      NEO_OPENAI_COMPATIBLE_API_KEY: neo-parity-ci-key
+    depends_on:
+      embedding-server:
+        condition: service_healthy

--- a/ai/deploy/docker-compose.parity-ci.yml
+++ b/ai/deploy/docker-compose.parity-ci.yml
@@ -80,8 +80,13 @@ networks:
   neo-parity-network:
     # The no-egress contract, enforced at the network layer rather than asserted as
     # prose: containers on an internal network cannot route to external destinations
-    # at all. Published ports (host-side probes) are ingress and keep working; the
-    # mock endpoint, Chroma, and the servers all resolve in-network. The dev file
-    # keeps its egress-capable bridge for local seats — isolation is a CI concern,
-    # same as the mock wiring.
+    # at all. MEASURED trade: an internal network silently drops the dev file's
+    # published port bindings (`docker port` returns empty; host curl connects to
+    # nothing) — so the lane's probes run IN-CONTAINER via `docker compose exec`,
+    # never through a host port. That also retires the wrong-process-on-a-host-port
+    # class (the profile's 8100 ssh-collision lesson) in CI by construction: no host
+    # port exists for a foreign process to squat on. The mock endpoint, Chroma, and
+    # the servers resolve by compose DNS inside the network. The dev file keeps its
+    # egress-capable bridge + working published ports for local seats — isolation is
+    # a CI concern, same as the mock wiring.
     internal: true

--- a/ai/deploy/docker-compose.parity-ci.yml
+++ b/ai/deploy/docker-compose.parity-ci.yml
@@ -61,3 +61,27 @@ services:
     depends_on:
       embedding-server:
         condition: service_healthy
+
+  orchestrator:
+    environment:
+      # Same mock binding as the MCP servers — the orchestrator's SessionService
+      # initializes a generation model at boot, and the CI contract is NO real-model
+      # calls anywhere in the profile, not only on the servers the specs call.
+      NEO_MODEL_PROVIDER: openAiCompatible
+      NEO_EMBEDDING_PROVIDER: openAiCompatible
+      NEO_OPENAI_COMPATIBLE_HOST: http://embedding-server:11434
+      NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: text-embedding-qwen3-embedding-8b
+      NEO_OPENAI_COMPATIBLE_API_KEY: neo-parity-ci-key
+    depends_on:
+      embedding-server:
+        condition: service_healthy
+
+networks:
+  neo-parity-network:
+    # The no-egress contract, enforced at the network layer rather than asserted as
+    # prose: containers on an internal network cannot route to external destinations
+    # at all. Published ports (host-side probes) are ingress and keep working; the
+    # mock endpoint, Chroma, and the servers all resolve in-network. The dev file
+    # keeps its egress-capable bridge for local seats — isolation is a CI concern,
+    # same as the mock wiring.
+    internal: true

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
         "test-components"                      : "playwright test -c test/playwright/playwright.config.component.mjs",
         "test-e2e"                             : "playwright test -c test/playwright/playwright.config.e2e.mjs",
         "test-integration-unified"             : "playwright test -c test/playwright/playwright.config.integration.mjs",
+        "test-integration-parity"              : "playwright test -c test/playwright/playwright.config.integration-parity.mjs",
         "test-unit"                            : "playwright test -c test/playwright/playwright.config.unit.mjs",
         "watch-themes"                         : "node ./buildScripts/helpers/watchThemes.mjs"
     },

--- a/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
+++ b/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
@@ -1,0 +1,124 @@
+import {test, expect} from '@playwright/test';
+
+import {runHealthcheck}                                      from '../../../ai/scripts/diagnostics/mcpHealthcheck.mjs';
+import {callHealthcheck, callJsonTool, createIdentityClient} from '../integration/fixtures/mcpClient.mjs';
+
+const KB_URL              = process.env.NEO_PARITY_KB_URL || 'http://127.0.0.1:3100';
+const MC_URL              = process.env.NEO_PARITY_MC_URL || 'http://127.0.0.1:3101';
+const PLANE_ID            = process.env.NEO_PARITY_COMPOSE_PROJECT || 'neo-parity-ci';
+const PLANE_DATA_ROOT     = '/app/.neo-ai-data-parity';
+const CANONICAL_DATA_ROOT = '/app/.neo-ai-data';
+const DEFAULT_READY_URL   = process.env.NEO_PARITY_READY_URL || 'http://127.0.0.1:13095/ready';
+
+/**
+ * @summary Reads the parity fixture readiness endpoint.
+ * @returns {Promise<Object>} The readiness payload (topology snapshot + wall-clock receipt).
+ */
+async function getReadiness() {
+    const response = await fetch(DEFAULT_READY_URL);
+
+    return response.json();
+}
+
+test.describe('Parity topology lane (#15807) — the phase-3 stack with a CI witness', () => {
+    test('the complete plane boots: chroma + both MCP servers healthy, the orchestrator running', async () => {
+        const readiness = await getReadiness();
+
+        // Fail-closed by construction: a docker-less runner never reaches this spec (the
+        // webServer stays 503 until the job times out RED). This assertion is the belt to
+        // that suspenders — it guards a locally-pointed NEO_PARITY_READY_URL.
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        const byName = Object.fromEntries((readiness.services || []).map(s => [s.Service, s]));
+
+        expect(byName['chroma']?.Health).toBe('healthy');
+        expect(byName['kb-server']?.Health).toBe('healthy');
+        expect(byName['mc-server']?.Health).toBe('healthy');
+        // The plane's writer has no healthcheck of its own — a failed F-invariant boot walk
+        // surfaces as an exited container, never as a green check.
+        expect(byName['orchestrator']?.State, 'orchestrator is not running — a failed plane boot walk exits the container').toBe('running');
+
+        // AC4 wall-clock receipt: the readiness payload carries the measured boot time.
+        expect(readiness.bootMs, 'readiness payload must carry the boot wall-clock receipt').toBeGreaterThan(0);
+        test.info().annotations.push({type: 'parity-boot-ms', description: `${readiness.bootMs}ms (project=${readiness.project})`});
+    });
+
+    test('served identity: both servers prove the overlay plane, never the durable root', async () => {
+        const [kb, mc] = await Promise.all([
+            runHealthcheck({url: KB_URL, clientName: 'neo-parity-ci-spec-kb', expectedPlaneId: PLANE_ID, expectedPlaneDataRoot: PLANE_DATA_ROOT}),
+            runHealthcheck({url: MC_URL, clientName: 'neo-parity-ci-spec-mc', expectedPlaneId: PLANE_ID, expectedPlaneDataRoot: PLANE_DATA_ROOT})
+        ]);
+
+        for (const served of [kb, mc]) {
+            expect(served.plane.id).toBe(PLANE_ID);
+            expect(served.plane.dataRoot).toBe(PLANE_DATA_ROOT);
+            // The isolation arm, stated positively: whatever the overlay serves, it is
+            // never the canonical durable root (the F-invariant's whole point — identity
+            // without isolation is the failure class the parity epic kills).
+            expect(served.plane.dataRoot).not.toBe(CANONICAL_DATA_ROOT);
+        }
+    });
+
+    test('fail-closed: foreign plane expectations are rejected at the wire', async () => {
+        // The durable-root fail-closed invariant, exercised at the served-identity boundary:
+        // the booted process refuses to masquerade as a different plane — a responder that
+        // cannot prove the expected identity is a failed check, never a pass.
+        await expect(runHealthcheck({
+            url            : MC_URL,
+            clientName     : 'neo-parity-ci-spec-foreign-id',
+            expectedPlaneId: 'neo-canonical-durable-plane'
+        })).rejects.toThrow(/Served plane id/);
+
+        await expect(runHealthcheck({
+            url                  : MC_URL,
+            clientName           : 'neo-parity-ci-spec-foreign-root',
+            expectedPlaneId      : PLANE_ID,
+            expectedPlaneDataRoot: CANONICAL_DATA_ROOT
+        })).rejects.toThrow(/dataRoot/);
+    });
+
+    test('mock-embedding contract: deterministic provider, semantic recall end to end', async () => {
+        const [kbHealth, mcHealth] = await Promise.all([
+            callHealthcheck(KB_URL, {clientName: 'neo-parity-ci-spec-kb-health'}),
+            callHealthcheck(MC_URL, {clientName: 'neo-parity-ci-spec-mc-health'})
+        ]);
+
+        // The mock wiring, asserted at the served config surface: the active embedding
+        // provider is the OpenAI-compatible mock (compose-internal, no real model host,
+        // no external network) — never a real-provider fallback.
+        expect(mcHealth.providers.embedding.active).toBe('openAiCompatible');
+        expect(mcHealth.providers.embedding.error).toBeUndefined();
+        expect(kbHealth.features.embedding).toBe(true);
+
+        // The end-to-end arm: a memory written through the MCP boundary is embedded by the
+        // mock, drained by the in-process WAL loop, and retrievable by semantic recall —
+        // the whole embedding path exercised, not just a config value.
+        const token  = `parity-ci-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+        const client = await createIdentityClient({baseUrl: MC_URL, clientName: 'neo-parity-ci-spec-memory', identity: 'neo-parity-ci-spec'});
+
+        try {
+            await callJsonTool(client, 'add_memory', {
+                prompt  : `Parity CI probe prompt ${token}`,
+                thought : `Parity CI probe thought ${token}`,
+                response: `Parity CI probe response ${token}`
+            });
+
+            let   found    = false;
+            const deadline = Date.now() + 30000;
+
+            while (!found && Date.now() < deadline) {
+                const result = await callJsonTool(client, 'query_raw_memories', {query: token, nResults: 5});
+
+                found = JSON.stringify(result).includes(token);
+
+                if (!found) {
+                    await new Promise(resolve => setTimeout(resolve, 2000));
+                }
+            }
+
+            expect(found, `semantic recall never surfaced the probe memory (token=${token}) — the embedding path (mock provider, WAL drain, chroma write) is broken`).toBe(true);
+        } finally {
+            await client.close();
+        }
+    });
+});

--- a/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
+++ b/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
@@ -1,14 +1,45 @@
-import {test, expect} from '@playwright/test';
+import {test, expect}  from '@playwright/test';
+import {spawnSync}     from 'node:child_process';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
 
-import {runHealthcheck}                                      from '../../../ai/scripts/diagnostics/mcpHealthcheck.mjs';
-import {callHealthcheck, callJsonTool, createIdentityClient} from '../integration/fixtures/mcpClient.mjs';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../..');
 
-const KB_URL              = process.env.NEO_PARITY_KB_URL || 'http://127.0.0.1:3100';
-const MC_URL              = process.env.NEO_PARITY_MC_URL || 'http://127.0.0.1:3101';
+const KB_INTERNAL_URL     = 'http://127.0.0.1:3000';
+const MC_INTERNAL_URL     = 'http://127.0.0.1:3001';
 const PLANE_ID            = process.env.NEO_PARITY_COMPOSE_PROJECT || 'neo-parity-ci';
 const PLANE_DATA_ROOT     = '/app/.neo-ai-data-parity';
 const CANONICAL_DATA_ROOT = '/app/.neo-ai-data';
 const DEFAULT_READY_URL   = process.env.NEO_PARITY_READY_URL || 'http://127.0.0.1:13095/ready';
+
+/**
+ * @summary Runs a docker compose invocation against the same project + file set the
+ * lane's fixture booted, returning the spawnSync result for assertion.
+ * @param {String[]} args Compose arguments after the project/file flags.
+ * @returns {Object} The spawnSync result ({status, stdout, stderr, error}).
+ */
+function compose(args) {
+    return spawnSync('docker', [
+        'compose', '-p', PLANE_ID,
+        '-f', 'ai/deploy/docker-compose.dev.yml',
+        '-f', 'ai/deploy/docker-compose.parity-ci.yml',
+        ...args
+    ], {cwd: repoRoot, encoding: 'utf8', timeout: 150000});
+}
+
+/**
+ * @summary Executes a node probe inside a running service container. The CI overlay's
+ * internal network publishes no host ports, so network-dependent assertions run where
+ * the network is: inside it.
+ * @param {String} service Compose service name.
+ * @param {String[]} nodeArgs Arguments after `node`.
+ * @returns {Object} The spawnSync result.
+ */
+function execProbe(service, nodeArgs) {
+    return compose(['exec', '-T', service, 'node', ...nodeArgs]);
+}
 
 /**
  * @summary Reads the parity fixture readiness endpoint.
@@ -44,12 +75,22 @@ test.describe('Parity topology lane (#15807) — the phase-3 stack with a CI wit
     });
 
     test('served identity: both servers prove the overlay plane, never the durable root', async () => {
-        const [kb, mc] = await Promise.all([
-            runHealthcheck({url: KB_URL, clientName: 'neo-parity-ci-spec-kb', expectedPlaneId: PLANE_ID, expectedPlaneDataRoot: PLANE_DATA_ROOT}),
-            runHealthcheck({url: MC_URL, clientName: 'neo-parity-ci-spec-mc', expectedPlaneId: PLANE_ID, expectedPlaneDataRoot: PLANE_DATA_ROOT})
-        ]);
+        for (const {service, url} of [
+            {service: 'kb-server', url: KB_INTERNAL_URL},
+            {service: 'mc-server', url: MC_INTERNAL_URL}
+        ]) {
+            const probe = execProbe(service, [
+                'ai/scripts/diagnostics/mcpHealthcheck.mjs',
+                '--url', url,
+                '--client-name', `neo-parity-ci-spec-${service}`,
+                '--expected-plane-id', PLANE_ID,
+                '--expected-plane-data-root', PLANE_DATA_ROOT
+            ]);
 
-        for (const served of [kb, mc]) {
+            expect(probe.status, `served-identity probe failed for ${service}: ${(probe.stderr || '').slice(-400)}`).toBe(0);
+
+            const served = JSON.parse(probe.stdout.trim().split('\n').pop());
+
             expect(served.plane.id).toBe(PLANE_ID);
             expect(served.plane.dataRoot).toBe(PLANE_DATA_ROOT);
             // The isolation arm, stated positively: whatever the overlay serves, it is
@@ -59,66 +100,102 @@ test.describe('Parity topology lane (#15807) — the phase-3 stack with a CI wit
         }
     });
 
-    test('fail-closed: foreign plane expectations are rejected at the wire', async () => {
-        // The durable-root fail-closed invariant, exercised at the served-identity boundary:
-        // the booted process refuses to masquerade as a different plane — a responder that
-        // cannot prove the expected identity is a failed check, never a pass.
-        await expect(runHealthcheck({
-            url            : MC_URL,
-            clientName     : 'neo-parity-ci-spec-foreign-id',
-            expectedPlaneId: 'neo-canonical-durable-plane'
-        })).rejects.toThrow(/Served plane id/);
+    test('served-identity probe: foreign plane expectations are rejected at the wire', async () => {
+        // The CLIENT-side contract: the probe refuses a responder that cannot prove the
+        // expected identity — the wrong-process arm (the profile's 8100 ssh-collision
+        // lesson). This complements, and does not replace, the server-side boot refusal
+        // asserted two tests below: a probe that never rejects would rubber-stamp a
+        // foreign process even when the boot walk did its job.
+        const foreignId = execProbe('mc-server', [
+            'ai/scripts/diagnostics/mcpHealthcheck.mjs',
+            '--url', MC_INTERNAL_URL,
+            '--client-name', 'neo-parity-ci-spec-foreign-id',
+            '--expected-plane-id', 'neo-canonical-durable-plane'
+        ]);
 
-        await expect(runHealthcheck({
-            url                  : MC_URL,
-            clientName           : 'neo-parity-ci-spec-foreign-root',
-            expectedPlaneId      : PLANE_ID,
-            expectedPlaneDataRoot: CANONICAL_DATA_ROOT
-        })).rejects.toThrow(/dataRoot/);
+        expect(foreignId.status).not.toBe(0);
+        expect(`${foreignId.stdout}\n${foreignId.stderr}`).toMatch(/Served plane id/);
+
+        const foreignRoot = execProbe('mc-server', [
+            'ai/scripts/diagnostics/mcpHealthcheck.mjs',
+            '--url', MC_INTERNAL_URL,
+            '--client-name', 'neo-parity-ci-spec-foreign-root',
+            '--expected-plane-id', PLANE_ID,
+            '--expected-plane-data-root', CANONICAL_DATA_ROOT
+        ]);
+
+        expect(foreignRoot.status).not.toBe(0);
+        expect(`${foreignRoot.stdout}\n${foreignRoot.stderr}`).toMatch(/dataRoot/);
+    });
+
+    test('the durable-root invariant: an overlay that resolves the canonical root is REFUSED at boot', async () => {
+        // The SERVER-side arm (the F-invariant itself): force a non-canonical plane id
+        // (the project-derived NEO_PLANE_ID still holds) onto the canonical data root
+        // and prove the process refuses to serve — `assertPlaneCoherence` fires at the
+        // boot walk, the container exits, and the failure names the collision. A fast
+        // exit is the witness; a hanging server would mean the invariant did not fire.
+        const bad = compose(['run', '--rm', '--no-deps',
+            '-e', `NEO_PLANE_DATA_ROOT=${CANONICAL_DATA_ROOT}`,
+            'kb-server'
+        ]);
+
+        const output = `${bad.stdout}\n${bad.stderr}`;
+
+        expect(bad.error?.code, `boot refusal must be fast — a timeout means the server kept running:\n${output.slice(-2000)}`).not.toBe('ETIMEDOUT');
+        expect(output).toMatch(/resolves the durable root/);
+    });
+
+    test('no egress: external destinations are unreachable from inside the parity network', async () => {
+        // The no-external-network contract, falsified at the network layer: the CI
+        // overlay marks the parity network internal, so an outbound fetch from inside
+        // a running service container cannot resolve/route anywhere. EGRESS-OPEN in
+        // the output would mean the isolation mechanism failed — the mock contract
+        // would no longer be the only model path.
+        const probe = compose(['exec', '-T', 'kb-server', 'node', '-e',
+            `fetch('https://api.github.com', {signal: AbortSignal.timeout(8000)})` +
+            `.then(r => console.log('EGRESS-OPEN', r.status))` +
+            `.catch(() => console.log('EGRESS-BLOCKED'))`
+        ]);
+
+        const output = `${probe.stdout}\n${probe.stderr}`;
+
+        expect(output).toContain('EGRESS-BLOCKED');
+        expect(output).not.toContain('EGRESS-OPEN');
     });
 
     test('mock-embedding contract: deterministic provider, semantic recall end to end', async () => {
-        const [kbHealth, mcHealth] = await Promise.all([
-            callHealthcheck(KB_URL, {clientName: 'neo-parity-ci-spec-kb-health'}),
-            callHealthcheck(MC_URL, {clientName: 'neo-parity-ci-spec-mc-health'})
-        ]);
-
         // The mock wiring, asserted at the served config surface: the active embedding
         // provider is the OpenAI-compatible mock (compose-internal, no real model host,
         // no external network) — never a real-provider fallback.
-        expect(mcHealth.providers.embedding.active).toBe('openAiCompatible');
-        expect(mcHealth.providers.embedding.error).toBeUndefined();
+        const mcProviders = execProbe('mc-server', [
+            'test/playwright/integration-parity/fixtures/parityProbe.mjs', 'providers', MC_INTERNAL_URL
+        ]);
+
+        expect(mcProviders.status, (mcProviders.stderr || '').slice(-400)).toBe(0);
+
+        const mcHealth = JSON.parse(mcProviders.stdout.trim().split('\n').pop());
+
+        expect(mcHealth.embedding.active).toBe('openAiCompatible');
+        expect(mcHealth.embedding.error).toBeUndefined();
+
+        const kbProviders = execProbe('kb-server', [
+            'test/playwright/integration-parity/fixtures/parityProbe.mjs', 'providers', KB_INTERNAL_URL
+        ]);
+
+        expect(kbProviders.status, (kbProviders.stderr || '').slice(-400)).toBe(0);
+
+        const kbHealth = JSON.parse(kbProviders.stdout.trim().split('\n').pop());
+
         expect(kbHealth.features.embedding).toBe(true);
 
         // The end-to-end arm: a memory written through the MCP boundary is embedded by the
         // mock, drained by the in-process WAL loop, and retrievable by semantic recall —
         // the whole embedding path exercised, not just a config value.
-        const token  = `parity-ci-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-        const client = await createIdentityClient({baseUrl: MC_URL, clientName: 'neo-parity-ci-spec-memory', identity: 'neo-parity-ci-spec'});
+        const recall = execProbe('mc-server', [
+            'test/playwright/integration-parity/fixtures/parityProbe.mjs', 'recall', MC_INTERNAL_URL
+        ]);
 
-        try {
-            await callJsonTool(client, 'add_memory', {
-                prompt  : `Parity CI probe prompt ${token}`,
-                thought : `Parity CI probe thought ${token}`,
-                response: `Parity CI probe response ${token}`
-            });
-
-            let   found    = false;
-            const deadline = Date.now() + 30000;
-
-            while (!found && Date.now() < deadline) {
-                const result = await callJsonTool(client, 'query_raw_memories', {query: token, nResults: 5});
-
-                found = JSON.stringify(result).includes(token);
-
-                if (!found) {
-                    await new Promise(resolve => setTimeout(resolve, 2000));
-                }
-            }
-
-            expect(found, `semantic recall never surfaced the probe memory (token=${token}) — the embedding path (mock provider, WAL drain, chroma write) is broken`).toBe(true);
-        } finally {
-            await client.close();
-        }
+        expect(recall.status, (recall.stderr || '').slice(-600)).toBe(0);
+        expect(recall.stdout).toContain('RECALL-OK');
     });
 });

--- a/test/playwright/integration-parity/fixtures/parityComposeWebServer.mjs
+++ b/test/playwright/integration-parity/fixtures/parityComposeWebServer.mjs
@@ -1,0 +1,287 @@
+import {spawn, spawnSync} from 'node:child_process';
+import http               from 'node:http';
+import path               from 'node:path';
+import {fileURLToPath}    from 'node:url';
+
+import {runHealthcheck}   from '../../../../ai/scripts/diagnostics/mcpHealthcheck.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../..');
+
+// The parity lane boots the phase-3 stack (docker-compose.dev.yml) plus the CI overlay
+// (docker-compose.parity-ci.yml): the dev file carries the plane, the overlay wires the
+// deterministic mock embedding contract. Order matters — later files merge over earlier ones.
+const composeFiles = [
+    path.join(repoRoot, 'ai/deploy/docker-compose.dev.yml'),
+    path.join(repoRoot, 'ai/deploy/docker-compose.parity-ci.yml')
+];
+
+// The compose project IS the overlay plane id (the dev file's &plane-id anchor resolves
+// from COMPOSE_PROJECT_NAME's same-scope sibling). A CI run boots an isolated plane:
+// distinct identity, own project-scoped volumes, never the durable root.
+const projectName = process.env.NEO_PARITY_COMPOSE_PROJECT || 'neo-parity-ci';
+const readyPort   = Number(process.env.NEO_PARITY_READY_PORT || 13095);
+
+const PLANE_DATA_ROOT = '/app/.neo-ai-data-parity';
+const KB_URL          = process.env.NEO_PARITY_KB_URL || 'http://127.0.0.1:3100';
+const MC_URL          = process.env.NEO_PARITY_MC_URL || 'http://127.0.0.1:3101';
+
+const state = {
+    dockerAvailable: null,
+    servicesReady  : false,
+    composeStarted : false,
+    bootStartedAt  : null,
+    readyAt        : null,
+    bootMs         : null,
+    project        : projectName,
+    services       : [],
+    reason         : 'Docker compose startup has not completed yet.'
+};
+
+let composeProcess;
+let shuttingDown = false;
+
+function dockerCompose(args, options = {}) {
+    const composeArgs = ['compose', '-p', projectName];
+
+    for (const file of composeFiles) {
+        composeArgs.push('-f', file);
+    }
+
+    return spawnSync('docker', [...composeArgs, ...args], {
+        cwd     : repoRoot,
+        encoding: 'utf8',
+        ...options
+    });
+}
+
+/**
+ * @summary Writes captured Docker CLI output to stderr when it is non-empty.
+ * @param {String} label  Human-readable command label.
+ * @param {Object} result The spawnSync result from a Docker command.
+ * @returns {void}
+ */
+function writeProcessOutput(label, result) {
+    const output = [
+        result.stdout?.trim(),
+        result.stderr?.trim()
+    ].filter(Boolean).join('\n');
+
+    if (output) {
+        console.error(`[parityComposeWebServer] ${label}\n${output}`);
+    }
+}
+
+/**
+ * @summary Emits Docker Compose process and log diagnostics for failed startup.
+ * @param {String} reason The failure reason that triggered diagnostics.
+ * @returns {void}
+ */
+function writeComposeDiagnostics(reason) {
+    console.error(`[parityComposeWebServer] ${reason}`);
+
+    writeProcessOutput('docker compose ps -a', dockerCompose(['ps', '-a']));
+    writeProcessOutput('docker compose logs --tail 200', dockerCompose(['logs', '--no-color', '--tail', '200']));
+}
+
+function isDockerAvailable() {
+    const version = spawnSync('docker', ['compose', 'version'], {encoding: 'utf8'});
+
+    if (version.status !== 0) {
+        state.reason = version.error?.message || version.stderr || 'Docker compose is not available.';
+        return false;
+    }
+
+    const info = spawnSync('docker', ['info'], {encoding: 'utf8'});
+
+    if (info.status !== 0) {
+        state.reason = info.error?.message || info.stderr || 'Docker daemon is not reachable.';
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @summary Reads the compose service table as structured objects.
+ *
+ * `docker compose ps --format json` emits NDJSON (one object per service) on current
+ * Compose; older 2.x shapes emitted a single array. Accept both — the parse is the
+ * compatibility shim, never the assertion.
+ * @returns {Object[]} Service rows ({Service, State, Health, ...}).
+ */
+function readComposeServices() {
+    const result = dockerCompose(['ps', '--format', 'json']);
+
+    if (result.status !== 0 || !result.stdout?.trim()) {
+        return [];
+    }
+
+    const raw = result.stdout.trim();
+
+    try {
+        const parsed = JSON.parse(raw);
+
+        return Array.isArray(parsed) ? parsed : [parsed];
+    } catch {
+        return raw.split('\n').map(line => {
+            try {
+                return JSON.parse(line);
+            } catch {
+                return null;
+            }
+        }).filter(Boolean);
+    }
+}
+
+/**
+ * @summary Served-identity gate: asks BOTH MCP servers to name their plane through the
+ * published host ports.
+ *
+ * The in-container healthchecks already assert identity network-namespace-locally; this
+ * host-side re-probe is the end-to-end arm. The 8100 ssh collision (the parity profile's
+ * own field evidence) proved a listening host port can belong to a foreign process —
+ * container-local green is not host-side green. Ports are a property of the host;
+ * identity is a property of the process.
+ * @returns {Promise<void>} Resolves only when both servers prove the expected plane.
+ */
+async function assertServedIdentity() {
+    await Promise.all([
+        runHealthcheck({
+            url                  : KB_URL,
+            clientName           : 'neo-parity-ci-readiness-kb',
+            expectedPlaneId      : projectName,
+            expectedPlaneDataRoot: PLANE_DATA_ROOT
+        }),
+        runHealthcheck({
+            url                  : MC_URL,
+            clientName           : 'neo-parity-ci-readiness-mc',
+            expectedPlaneId      : projectName,
+            expectedPlaneDataRoot: PLANE_DATA_ROOT
+        })
+    ]);
+}
+
+async function waitForServices() {
+    const deadline = Date.now() + Number(process.env.NEO_PARITY_STACK_TIMEOUT_MS || 480000);
+
+    while (!shuttingDown && Date.now() < deadline) {
+        try {
+            const services = readComposeServices();
+
+            state.services = services;
+
+            const healthy = name => services.find(s => s.Service === name)?.Health === 'healthy';
+            const running = name => services.find(s => s.Service === name)?.State  === 'running';
+
+            // Topology gate: the complete plane — vector store + both MCP servers healthy,
+            // and the orchestrator (the plane's writer) running. A failed F-invariant boot
+            // walk surfaces here as an exited container, never as a green check.
+            if (healthy('chroma') && healthy('kb-server') && healthy('mc-server') && running('orchestrator')) {
+                await assertServedIdentity();
+
+                state.servicesReady = true;
+                state.readyAt       = new Date().toISOString();
+                state.bootMs        = Date.parse(state.readyAt) - Date.parse(state.bootStartedAt);
+                state.reason        = 'Parity stack is ready: complete plane healthy, served identity verified host-side.';
+
+                console.log(`[parityComposeWebServer] ready in ${state.bootMs}ms (project=${projectName})`);
+                return;
+            }
+
+            state.reason = `Waiting for parity stack readiness: ${services.map(s => `${s.Service}=${s.State}/${s.Health || 'no-healthcheck'}`).join(', ') || 'no services yet'}`;
+        } catch (error) {
+            state.reason = error.message;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+
+    state.reason = `Timed out waiting for the parity stack. Last state: ${state.reason}`;
+    writeComposeDiagnostics(state.reason);
+}
+
+function cleanup() {
+    if (shuttingDown) return;
+
+    shuttingDown = true;
+
+    if (composeProcess && !composeProcess.killed) {
+        composeProcess.kill('SIGTERM');
+    }
+
+    // --volumes: the CI plane is ephemeral — project-scoped named volumes die with the
+    // run, so no run can inherit another run's plane state (or its WAL, or its graph).
+    dockerCompose(['down', '--remove-orphans', '--volumes'], {stdio: 'ignore'});
+}
+
+const server = http.createServer((req, res) => {
+    if (req.url !== '/ready') {
+        res.writeHead(404, {'content-type': 'application/json'});
+        res.end(JSON.stringify({error: 'Not found'}));
+        return;
+    }
+
+    // Docker availability is a PROVISIONING requirement for this lane, never a skip
+    // condition. The integration-unified fixture reports ready when docker is missing
+    // (`dockerAvailable === false || servicesReady`) — that best-effort bypass is
+    // deliberately NOT replicated here. With no docker this endpoint stays 503 until
+    // the runner times the job out RED: a parity claim without a witness is precisely
+    // the failure class this lane exists to kill.
+    const ready = state.servicesReady;
+
+    res.writeHead(ready ? 200 : 503, {'content-type': 'application/json'});
+    res.end(JSON.stringify(state));
+});
+
+server.listen(readyPort, '127.0.0.1', async () => {
+    state.dockerAvailable = isDockerAvailable();
+
+    if (!state.dockerAvailable) {
+        state.reason = `Docker is a provisioning REQUIREMENT for the parity lane and is unavailable: ${state.reason} ` +
+            'Failing closed — the suite must not green-skip on a missing daemon.';
+        console.error(`[parityComposeWebServer] ${state.reason}`);
+        return;
+    }
+
+    state.bootStartedAt = new Date().toISOString();
+
+    dockerCompose(['down', '--remove-orphans', '--volumes'], {stdio: 'ignore'});
+
+    composeProcess = spawn('docker', [
+        'compose',
+        '-p', projectName,
+        ...composeFiles.flatMap(file => ['-f', file]),
+        'up',
+        '--build',
+        '--remove-orphans'
+    ], {
+        cwd  : repoRoot,
+        stdio: 'inherit'
+    });
+
+    state.composeStarted = true;
+
+    composeProcess.once('exit', code => {
+        if (!shuttingDown) {
+            state.servicesReady = false;
+            state.reason        = `docker compose exited before shutdown with code ${code}.`;
+            writeComposeDiagnostics(state.reason);
+        }
+    });
+
+    await waitForServices();
+});
+
+process.once('SIGINT', () => {
+    cleanup();
+    process.exit(0);
+});
+
+process.once('SIGTERM', () => {
+    cleanup();
+    process.exit(0);
+});
+
+process.once('exit', cleanup);

--- a/test/playwright/integration-parity/fixtures/parityComposeWebServer.mjs
+++ b/test/playwright/integration-parity/fixtures/parityComposeWebServer.mjs
@@ -3,15 +3,14 @@ import http               from 'node:http';
 import path               from 'node:path';
 import {fileURLToPath}    from 'node:url';
 
-import {runHealthcheck}   from '../../../../ai/scripts/diagnostics/mcpHealthcheck.mjs';
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const repoRoot   = path.resolve(__dirname, '../../../..');
 
 // The parity lane boots the phase-3 stack (docker-compose.dev.yml) plus the CI overlay
 // (docker-compose.parity-ci.yml): the dev file carries the plane, the overlay wires the
-// deterministic mock embedding contract. Order matters — later files merge over earlier ones.
+// deterministic mock embedding contract and marks the network internal. Order matters —
+// later files merge over earlier ones.
 const composeFiles = [
     path.join(repoRoot, 'ai/deploy/docker-compose.dev.yml'),
     path.join(repoRoot, 'ai/deploy/docker-compose.parity-ci.yml')
@@ -24,8 +23,15 @@ const projectName = process.env.NEO_PARITY_COMPOSE_PROJECT || 'neo-parity-ci';
 const readyPort   = Number(process.env.NEO_PARITY_READY_PORT || 13095);
 
 const PLANE_DATA_ROOT = '/app/.neo-ai-data-parity';
-const KB_URL          = process.env.NEO_PARITY_KB_URL || 'http://127.0.0.1:3100';
-const MC_URL          = process.env.NEO_PARITY_MC_URL || 'http://127.0.0.1:3101';
+
+// In-container probe targets. The overlay's internal network publishes NO host ports,
+// so there is no host-side endpoint to probe — the identity check rides the network
+// namespace itself (service loopback), where the wrong-process-on-a-host-port class is
+// inexpressible by construction.
+const PROBES = [
+    {service: 'kb-server', url: 'http://127.0.0.1:3000'},
+    {service: 'mc-server', url: 'http://127.0.0.1:3001'}
+];
 
 const state = {
     dockerAvailable: null,
@@ -136,31 +142,32 @@ function readComposeServices() {
 }
 
 /**
- * @summary Served-identity gate: asks BOTH MCP servers to name their plane through the
- * published host ports.
+ * @summary Served-identity gate: asks BOTH MCP servers to name their plane, executed
+ * INSIDE the network by a fresh probe process per service.
  *
- * The in-container healthchecks already assert identity network-namespace-locally; this
- * host-side re-probe is the end-to-end arm. The 8100 ssh collision (the parity profile's
- * own field evidence) proved a listening host port can belong to a foreign process —
- * container-local green is not host-side green. Ports are a property of the host;
- * identity is a property of the process.
+ * The CI overlay's internal network has no host-published ports, so the probe cannot
+ * ride the host — and need not: the container-local arm is the honest one here. A
+ * host-port probe exists to catch a foreign process squatting a published port (the
+ * profile's 8100 ssh-collision lesson), and with no published ports that class is
+ * inexpressible. What remains worth asserting independently — rather than trusting
+ * each container's own healthcheck process — is the same contract from a second
+ * process: `mcpHealthcheck.mjs` with the expected plane id + root, exec'd fresh.
  * @returns {Promise<void>} Resolves only when both servers prove the expected plane.
  */
 async function assertServedIdentity() {
-    await Promise.all([
-        runHealthcheck({
-            url                  : KB_URL,
-            clientName           : 'neo-parity-ci-readiness-kb',
-            expectedPlaneId      : projectName,
-            expectedPlaneDataRoot: PLANE_DATA_ROOT
-        }),
-        runHealthcheck({
-            url                  : MC_URL,
-            clientName           : 'neo-parity-ci-readiness-mc',
-            expectedPlaneId      : projectName,
-            expectedPlaneDataRoot: PLANE_DATA_ROOT
-        })
-    ]);
+    for (const {service, url} of PROBES) {
+        const result = dockerCompose(['exec', '-T', service,
+            'node', 'ai/scripts/diagnostics/mcpHealthcheck.mjs',
+            '--url', url,
+            '--client-name', `neo-parity-ci-readiness-${service}`,
+            '--expected-plane-id', projectName,
+            '--expected-plane-data-root', PLANE_DATA_ROOT
+        ]);
+
+        if (result.status !== 0) {
+            throw new Error(`served-identity probe failed for ${service}: ${(result.stderr || result.stdout || '').trim().slice(-400)}`);
+        }
+    }
 }
 
 async function waitForServices() {

--- a/test/playwright/integration-parity/fixtures/parityComposeWebServer.mjs
+++ b/test/playwright/integration-parity/fixtures/parityComposeWebServer.mjs
@@ -191,7 +191,7 @@ async function waitForServices() {
                 state.servicesReady = true;
                 state.readyAt       = new Date().toISOString();
                 state.bootMs        = Date.parse(state.readyAt) - Date.parse(state.bootStartedAt);
-                state.reason        = 'Parity stack is ready: complete plane healthy, served identity verified host-side.';
+                state.reason        = 'Parity stack is ready: complete plane healthy, served identity verified by in-container probe.';
 
                 console.log(`[parityComposeWebServer] ready in ${state.bootMs}ms (project=${projectName})`);
                 return;

--- a/test/playwright/integration-parity/fixtures/parityProbe.mjs
+++ b/test/playwright/integration-parity/fixtures/parityProbe.mjs
@@ -1,0 +1,59 @@
+import {callHealthcheck, callJsonTool, createIdentityClient} from '../../integration/fixtures/mcpClient.mjs';
+
+/**
+ * @summary In-container probe for the parity lane's network-dependent assertions.
+ *
+ * The CI overlay marks the parity network `internal`, so no host-published ports exist
+ * to probe from the runner — by construction, which is also what makes the
+ * wrong-process-on-a-host-port class (the profile's 8100 ssh-collision lesson)
+ * inexpressible in CI. The specs therefore exec THIS script inside a service container
+ * and assert on its output: provider/mock inspection (`providers`) and the end-to-end
+ * embedding round trip (`recall`). It runs against loopback or compose DNS from inside
+ * the network, never against a host port.
+ *
+ * Usage: `node test/playwright/integration-parity/fixtures/parityProbe.mjs <providers|recall> <baseUrl>`
+ */
+
+const [action, baseUrl] = process.argv.slice(2);
+
+if (action === 'providers') {
+    const health = await callHealthcheck(baseUrl, {clientName: 'neo-parity-ci-probe'});
+
+    console.log(JSON.stringify({embedding: health.providers?.embedding, features: health.features}));
+} else if (action === 'recall') {
+    const token  = `parity-ci-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const client = await createIdentityClient({baseUrl, clientName: 'neo-parity-ci-spec-memory', identity: 'neo-parity-ci-spec'});
+
+    try {
+        await callJsonTool(client, 'add_memory', {
+            prompt  : `Parity CI probe prompt ${token}`,
+            thought : `Parity CI probe thought ${token}`,
+            response: `Parity CI probe response ${token}`
+        });
+
+        let   found    = false;
+        const deadline = Date.now() + 30000;
+
+        while (!found && Date.now() < deadline) {
+            const result = await callJsonTool(client, 'query_raw_memories', {query: token, nResults: 5});
+
+            found = JSON.stringify(result).includes(token);
+
+            if (!found) {
+                await new Promise(resolve => setTimeout(resolve, 2000));
+            }
+        }
+
+        if (!found) {
+            console.error(`RECALL-FAILED: semantic recall never surfaced the probe memory (token=${token}) — the embedding path (mock provider, WAL drain, chroma write) is broken`);
+            process.exit(1);
+        }
+
+        console.log('RECALL-OK');
+    } finally {
+        await client.close();
+    }
+} else {
+    console.error(`parityProbe: unknown action "${action}" — expected providers|recall`);
+    process.exit(2);
+}

--- a/test/playwright/playwright.config.integration-parity.mjs
+++ b/test/playwright/playwright.config.integration-parity.mjs
@@ -1,0 +1,54 @@
+import './configTemplateResolver.mjs';
+
+import {defineConfig}        from '@playwright/test';
+import {resolveFreePortSync} from './resolveFreePort.mjs';
+
+// Per-process ready-port, same idiom as the integration-unified config: a fixed default +
+// reuseExistingServer:false wedges concurrent runs on the shared multi-agent machine
+// (see resolveFreePort.mjs). The parityComposeWebServer fixture reads the same env var,
+// so the derived value is passed down via the webServer env.
+const readyPort = resolveFreePortSync(process.env.NEO_PARITY_READY_PORT);
+
+// Write the derived values back into the runner env (the unit config's writeback idiom):
+// test WORKERS inherit this process's env, and the parity specs resolve their readiness
+// endpoint from it.
+process.env.NEO_PARITY_READY_PORT = String(readyPort);
+process.env.NEO_PARITY_READY_URL  = process.env.NEO_PARITY_READY_URL || `http://127.0.0.1:${readyPort}/ready`;
+
+export default defineConfig({
+    testDir      : './integration-parity',
+    outputDir    : './test-results/integration-parity/artifacts',
+    fullyParallel: false,
+    workers      : 1,
+    timeout      : 120000,
+
+    reporter: [
+        ['list'],
+        ['json', {outputFile: 'test-results/integration-parity/results.json'}]
+    ],
+
+    use: {
+        trace: 'on-first-retry'
+    },
+
+    webServer: {
+        command: 'node ./integration-parity/fixtures/parityComposeWebServer.mjs',
+        url    : `http://127.0.0.1:${readyPort}/ready`,
+        // Cold budget: the first run builds the parity images (in-container npm ci +
+        // better-sqlite3 native rebuild) and then waits out the 90s healthcheck
+        // start_periods. The timeout is an upper bound, not a target — the wall-clock
+        // receipt lives in the readiness payload (bootMs).
+        timeout            : 600000,
+        reuseExistingServer: false,
+        stdout             : 'pipe',
+        stderr             : 'pipe',
+        env                : {
+            ...process.env,
+            NEO_PARITY_READY_PORT: String(readyPort)
+        },
+        gracefulShutdown   : {
+            signal : 'SIGTERM',
+            timeout: 30000
+        }
+    }
+});

--- a/test/playwright/unit/ai/buildScripts/util/WorkflowConcurrency.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/WorkflowConcurrency.spec.mjs
@@ -141,13 +141,13 @@ test.describe('GitHub workflow concurrency (#15593)', () => {
             run_components : 'true',
             run_integration: 'true',
             run_unit       : 'true',
-            run_parity     : 'false'
+            run_parity     : 'true'
         });
         expect(Object.fromEntries(push.outputs)).toMatchObject({
             run_components : 'true',
             run_integration: 'true',
             run_unit       : 'true',
-            run_parity     : 'false'
+            run_parity     : 'true'
         });
     });
 
@@ -181,14 +181,20 @@ test.describe('GitHub workflow concurrency (#15593)', () => {
 
         // The lane boots MC, KB, and the orchestrator. A change to any direct runtime
         // dependency of those processes must trip the witness — a filter that admits
-        // `ai/deploy/**` but skips the services the stack actually runs would be a
-        // completeness claim the dependency graph falsifies.
+        // `ai/` but skips the engine hemisphere the servers extend (src/core/Base,
+        // src/state/Provider) or the shared integration fixture would be a completeness
+        // claim the dependency graph falsifies. The lane inherits the integration
+        // suite's boundary, so these all admit it.
         const runtimeDependencies = [
             'ai/services/memory-core/MemoryService.mjs',
             'ai/services/knowledge-base/HealthService.mjs',
             'ai/config.mjs',
             'ai/ConfigProvider.mjs',
-            'ai/planeConfig.mjs'
+            'ai/planeConfig.mjs',
+            'src/Neo.mjs',
+            'src/core/Base.mjs',
+            'src/state/Provider.mjs',
+            'test/playwright/integration/fixtures/mcpClient.mjs'
         ];
 
         for (const file of runtimeDependencies) {

--- a/test/playwright/unit/ai/buildScripts/util/WorkflowConcurrency.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/WorkflowConcurrency.spec.mjs
@@ -118,6 +118,7 @@ test.describe('GitHub workflow concurrency (#15593)', () => {
             run_integration: 'false',
             run_unit       : 'false',
             run_components : 'false',
+            run_parity     : 'false',
             skip_reason    : 'stale workflow head stale-head; live PR head is current-head'
         });
         expect(runtime.summary.join(' ')).toContain('Stale workflow attempt');
@@ -139,12 +140,38 @@ test.describe('GitHub workflow concurrency (#15593)', () => {
         expect(Object.fromEntries(current.outputs)).toMatchObject({
             run_components : 'true',
             run_integration: 'true',
-            run_unit       : 'true'
+            run_unit       : 'true',
+            run_parity     : 'false'
         });
         expect(Object.fromEntries(push.outputs)).toMatchObject({
             run_components : 'true',
             run_integration: 'true',
-            run_unit       : 'true'
+            run_unit       : 'true',
+            run_parity     : 'false'
+        });
+    });
+
+    test('the Tests classifier routes the parity surface to its lane (and only for those paths)', async () => {
+        const workflow = readWorkflow('test.yml'),
+              script   = workflow.jobs.changes.steps.find(step => step.id === 'scope').with.script,
+              parity   = createRuntime({ eventHead: 'current-head', files: ['ai/deploy/docker-compose.dev.yml'] }),
+              docsOnly = createRuntime({ eventHead: 'current-head', files: ['learn/guides/README.md'] });
+
+        await executeScript(script, parity);
+        await executeScript(script, docsOnly);
+
+        // The parity lane runs BESIDE the suites its surface already trips (`ai/` also
+        // admits integration; non-docs admits unit) — it is an additional witness, never
+        // a replacement.
+        expect(Object.fromEntries(parity.outputs)).toMatchObject({
+            run_integration: 'true',
+            run_unit       : 'true',
+            run_parity     : 'true'
+        });
+
+        // Non-parity PRs stay unaffected: no witness, no runner spent.
+        expect(Object.fromEntries(docsOnly.outputs)).toMatchObject({
+            run_parity: 'false'
         });
     });
 

--- a/test/playwright/unit/ai/buildScripts/util/WorkflowConcurrency.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/WorkflowConcurrency.spec.mjs
@@ -175,6 +175,33 @@ test.describe('GitHub workflow concurrency (#15593)', () => {
         });
     });
 
+    test('the Tests classifier cannot skip the lane for the booted stack\'s runtime dependencies', async () => {
+        const workflow = readWorkflow('test.yml'),
+              script   = workflow.jobs.changes.steps.find(step => step.id === 'scope').with.script;
+
+        // The lane boots MC, KB, and the orchestrator. A change to any direct runtime
+        // dependency of those processes must trip the witness — a filter that admits
+        // `ai/deploy/**` but skips the services the stack actually runs would be a
+        // completeness claim the dependency graph falsifies.
+        const runtimeDependencies = [
+            'ai/services/memory-core/MemoryService.mjs',
+            'ai/services/knowledge-base/HealthService.mjs',
+            'ai/config.mjs',
+            'ai/ConfigProvider.mjs',
+            'ai/planeConfig.mjs'
+        ];
+
+        for (const file of runtimeDependencies) {
+            const runtime = createRuntime({ eventHead: 'current-head', files: [file] });
+
+            await executeScript(script, runtime);
+
+            expect(Object.fromEntries(runtime.outputs), `${file} must trip the parity lane — the booted stack imports it`).toMatchObject({
+                run_parity: 'true'
+            });
+        }
+    });
+
     test('failed-job reruns recheck the live head before every expensive step', async () => {
         const workflow   = readWorkflow('test.yml'),
               steps      = workflow.jobs.test.steps,


### PR DESCRIPTION
Resolves #15807

The parity stack gets its CI witness: a new `integration-parity` suite boots the phase-3 dev-compose profile (plus a CI overlay wiring the deterministic mock-embedding endpoint and marking the network `internal`) on an overlay `planeId` derived from the compose project. The lane asserts the complete plane (chroma + both MCP servers healthy, orchestrator running), verifies served identity from inside the network, exercises the **actual durable-root boot refusal** (`assertPlaneCoherence` fires on a forced canonical-root overlay), proves **external egress unreachable**, and validates the embedding path end-to-end through the mock. The classifier **inherits the integration suite's relevance boundary** (`src/**`, `ai/**`, the shared integration fixtures/harness — the booted stack's actual cross-hemisphere closure) plus the lane's own files, and the fixture **fails closed when docker is absent**.

Evidence: L3 (live, non-destructive, exact-head: cold CI boot receipt `85417ms` / 4-spec green at `96099e8f29`; cycle-2 local colima run 6/6 with the boot-refusal and no-egress arms observed firing; classifier witnesses green) — the AC1 branch-protection half is **operator-side and open**: live ruleset verified to carry no required-status rule for this check. It is named in Post-Merge Validation and tracked on the close-target comment; this PR must not merge until the human flip lands or the close line is downgraded to `Related:`.

## Deltas from ticket

- **Measured correction:** the ticket's "21 docker-native integration specs" is stale — 19 at current dev. Substance holds.
- **Mock wiring + egress isolation land in a NEW CI overlay** (`ai/deploy/docker-compose.parity-ci.yml`) merged over the dev compose; the dev file stays a dev artifact (local seats keep egress + their own provider story).
- **Fail-closed at two layers:** readiness never reports ready without docker (webServer timeout → RED), and readiness requires an independent served-identity probe.
- **Internal-network trade, discovered empirically in review cycle 2:** `internal: true` silently drops published port bindings (`docker port` empty, host curl dead) — so all network-dependent probes moved **in-container** (fresh `mcpHealthcheck.mjs` exec + a new `parityProbe.mjs`), which also makes the host-port wrong-process class (the 8100 ssh lesson) inexpressible in CI by construction.
- **Classifier boundary inherited, not invented:** parity relevance = the integration suite's own `isIntegrationRelevantPath` (`src/**`, `ai/**`, shared fixtures/harness, dep manifests, the workflow) plus the lane's own files. One completeness boundary, one owner — a future runtime import the integration whitelist learns about is inherited automatically; an invented subset would drift the moment the stack crosses it (it already crosses into `src/state/Provider`, `src/core/Base`, and the shared `mcpClient` fixture — cycle-3 review caught exactly that).
- **Observation handed to the epic steward (not fixed here):** the neural-link `logPath` census escape behind the boot-log `file sink unavailable` degradation — filed as #15984, linked under #15798.

## Contract Ledger

| Target Surface | Source of Authority | Proposed Behavior | Fallback / Edge Case | Docs | Evidence |
|---|---|---|---|---|---|
| `run_parity` classifier output | #15807 AC1/AC5 | `true` iff any changed file matches the inherited integration boundary (`src/**`, `ai/**`, shared integration fixtures/harness, dep manifests, the workflow) or the parity lane's own files — one boundary, one owner | Stale-head / unavailable-files paths set all four outputs explicitly | Workflow comment | `WorkflowConcurrency.spec.mjs` routing + runtime-dependency witnesses |
| `integration-parity` status check | #15807 AC1 | Runs when admitted; SUCCESS only after the booted stack proves the overlay plane | Docker absent → webServer never readies → job RED; never a skip | Workflow comment | 3× green runs; first-run unit witness caught the contract change |
| `docker-compose.parity-ci.yml` overlay | #15807 AC3 | Merges over the dev file: mock service + provider bindings on kb/mc/orchestrator; `neo-parity-network: internal: true` | Merge-by-key only; never restates plane identity | Overlay header | `docker compose config` render receipts; no-egress spec |
| Overlay plane identity | #15799 / #15803 | `COMPOSE_PROJECT_NAME` resolves via the dev `&plane-id` anchor as `NEO_PLANE_ID`; volumes project-scoped; teardown `down --volumes` | Non-canonical id resolving the durable root → boot refused | Compose + fixture comments | Boot-refusal spec arm (observed firing) |
| Served-identity probe | #15803 AC | Both servers prove `{id, dataRoot}` via fresh in-container `mcpHealthcheck.mjs` exec; readiness + spec both assert | Absent/foreign plane block → non-zero exit; never connectivity-only | Fixture + spec comments | Served-identity ± spec arms |
| Mock / no-egress contract | #15807 AC3 | Every model-capable service (kb, mc, **orchestrator**) bound to the in-network mock; external destinations unreachable | Real-provider fallback fails the provider assertion; egress attempt → `EGRESS-BLOCKED` | Overlay + spec comments | providers/recall probe output; egress spec arm |
| `test-integration-parity` npm script | repo convention | Runs only `playwright.config.integration-parity.mjs` | Never the default playwright invocation | `package.json` | CI step logs |

## Test Evidence

- **Cycle-2 local (colima, head `cd320f7a23`): 6/6 green** — complete-plane boot, served identity ±, foreign-plane wire rejection, **durable-root boot refusal** (log shows `planeConfig.assertPlaneCoherence: plane "neo-parity-ci" resolves the durable root`), **no egress** (`EGRESS-BLOCKED`), mock-embedding e2e (`RECALL-OK`; provider host visibly `embedding-server:11434`). Readiness 19.6s warm.
- **Cycle-1 CI cold (head `c79f344996`, run 30200851162): `integration-parity` SUCCESS — 4/4, boot `85417ms`, job 2m02s** end-to-end. Budget context: ~5× cheaper than the 9.5m unit suite.
- Classifier witness: `WorkflowConcurrency.spec.mjs` 10/10 — stale-head exact-output pin, parity routing, and nine runtime-dependency paths (`ai/services/**`, `ai/config.mjs`, `ai/ConfigProvider.mjs`, `ai/planeConfig.mjs`, `src/Neo.mjs`, `src/core/Base.mjs`, `src/state/Provider.mjs`, the shared `mcpClient` fixture) each proven unable to skip the lane; docs-only proven to skip it.
- Merge render + workflow compile checks as before (v1 body); the internal-network render additionally verified live (`docker network inspect … Internal=true`; `docker port` empty → probes moved in-container).
- Directly touched app/feature surface: none (CI/test-infra only). Adjacent static guard `ParityPlaneVolumeScoping.spec.mjs` unaffected (dev file untouched).

## Post-Merge Validation

- [ ] **Operator (repo-admin), the AC1 human half — requested in-session:** add `integration-parity` to the required status checks for `dev` (live ruleset currently carries deletion / non-fast-forward / Copilot review / CodeQL only — verified). If the flip cannot land before merge, the close line downgrades to `Related: #15807` first.
- [ ] The cycle-2 CI run at `cd320f7a23` re-proves the lane with the new arms cold (boot-refusal + no-egress ran local-verified only so far).
- [ ] The next `src/**` or `ai/**` PR shows the lane running under the inherited integration boundary; the next docs-only PR shows it skipping.
- [ ] D#15958's graduated baseline (#15990) owns credential wiring into this lane (explicit auth mode + admission on the parity profile) — named in its AC set via the convergence record; the lane's undeclared-mode fail-boot witness arm follows that contract (#15807 follow-up offer stands).

## Evolution

Cycle-1 → cycle-2 (Emmy's RC): path filter widened from the ticket's named subset to a conservative `ai/` root after the reviewer falsifier showed the booted stack's runtime dependencies skipping the lane; the false-expectation "fail-closed" test renamed to its actual claim (served-identity probe) and joined by the real boot-refusal arm; the no-egress contract moved from prose to the network layer (`internal: true`), which dropped host port publishing and moved every network-dependent probe in-container; orchestrator bound to the mock; evidence declaration corrected L4→L3; Contract Ledger backfilled (also proposed onto #15807 by comment). Cycle-2 → cycle-3 (Emmy's carried RA-1): the `ai/` root itself falsified as not the runtime boundary (the stack crosses into `src/` and the shared integration fixture) — the classifier now inherits `isIntegrationRelevantPath` rather than inventing any root of its own, with four cross-boundary witnesses added and the stale prose folded.

Authored by Phoebe (Moonshot Kimi K3, opencode). Session 8e137ae8-b978-4f2e-9d36-168e430b51bb.
