### PR TITLE
fix(ai): ensure the frontier hub from the boot manifest before linking GUIDES

### DIFF
--- a/ai/graph/bootSeedManifest.mjs
+++ b/ai/graph/bootSeedManifest.mjs
@@ -70,6 +70,36 @@ export function createGraphBootSeedManifest({identities = IDENTITIES} = {}) {
 }
 
 /**
+ * @summary Returns a detached clone of one fixed boot-seed node spec by id.
+ *
+ * Exists so a runtime consumer that must guarantee a boot-seed node is present can
+ * reuse THIS module's declaration instead of hand-writing a second copy. A hand-written
+ * copy is not merely duplication: it drifts (description text, `semanticVectorId`), and
+ * because the module header makes this manifest the completeness predicate for
+ * fresh-target recovery, a divergent copy makes that predicate fail closed.
+ *
+ * Fixed specs only — identity roots are not addressable here, because they are supplied
+ * per-call to {@link createGraphBootSeedManifest} and are not a fixed part of the manifest.
+ *
+ * @param {String} id Fixed boot-seed node id, e.g. `'frontier'`.
+ * @returns {Object} Detached spec clone, suitable for `GraphService.upsertGlobalNode()`.
+ * @throws {Error} When `id` names no fixed boot-seed node — an unknown id is a contract
+ * breach by the caller, never a silent miss that would reintroduce a hand-written spec.
+ */
+export function getGraphBootSeedNodeSpec(id) {
+    const spec = FIXED_NODE_SPECS.find(candidate => candidate.id === id);
+
+    if (!spec) {
+        throw new Error(
+            `getGraphBootSeedNodeSpec: "${id}" is not a fixed boot-seed node. ` +
+            `Known ids: ${FIXED_NODE_SPECS.map(candidate => candidate.id).join(', ')}.`
+        )
+    }
+
+    return cloneJsonValue(spec)
+}
+
+/**
  * @summary Projects one boot node input spec into its exact persisted graph
  * record shape.
  *

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -1409,6 +1409,14 @@ class GoldenPathSynthesizer extends Base {
                       scored: entry
                   }));
 
+            // The GUIDES edges below all originate at the shared `frontier` hub. linkNodes
+            // culls an edge whose endpoint is missing and reports no error, so an absent hub
+            // drops every reinforcement write in silence — inbound structural support reads
+            // zero while this method still reports success. Ensure once, from the boot manifest,
+            // before the loop; the edges stay tenant-scoped because Golden Path reinforcement
+            // is per-tenant learning.
+            GraphService.ensureGlobalBootSeedNode('frontier');
+
             renderedRows.forEach(row => {
                 GraphService.linkNodes('frontier', row.id, 'GUIDES', row.scored?.score ?? row.score ?? 0);
 

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -810,15 +810,13 @@ class SemanticGraphExtractor extends Base {
     async commitTriVectorPayload(payload, session) {
         const artifact = payload.session_artifact;
 
-        if (!GraphService.db.nodes.has('frontier')) {
-            GraphService.upsertNode({
-                id              : 'frontier',
-                type            : 'SYSTEM_ANCHOR',
-                name            : 'Active Context Frontier',
-                description     : 'The actively tracked development front for the current project scope.',
-                semanticVectorId: null
-            });
-        }
+        // Was a hand-written `frontier` spec upserted through plain upsertNode, which carried
+        // two defects: the local description had drifted from the boot manifest, making the
+        // persisted graph non-manifest-equal so the fresh-target recovery predicate fails
+        // closed; and plain upsertNode stamps the caller's identity, leaving the restored hub
+        // tenant-scoped where the manifest requires global — the per-tenant invisibility that
+        // GraphService#upsertGlobalNode's own docs warn about for shared sentinels.
+        GraphService.ensureGlobalBootSeedNode('frontier');
 
         const VALID_TYPES = ['SESSION', 'MEMORY', 'ARTIFACT_PLAN', 'ARTIFACT_TASK', 'ISSUE', 'STRATEGY', 'SYSTEM_ANCHOR', 'CONCEPT', 'CLASS', 'METHOD', 'FILE', 'GUIDE', 'BLOG', 'TEST'];
 

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -6,6 +6,7 @@ import CoreDatabase                  from '../../../ai/graph/Database.mjs';
 import SQLite                        from '../../../ai/graph/storage/SQLite.mjs';
 import { IDENTITIES }                from '../../../ai/graph/identityRoots.mjs';
 import {createGraphBootSeedManifest} from '../../../ai/graph/bootSeedManifest.mjs';
+import {getGraphBootSeedNodeSpec}    from '../../../ai/graph/bootSeedManifest.mjs';
 import { normalizeUserId }           from '../../mcp/server/shared/services/RequestContextService.mjs';
 import fsExtra                       from 'fs-extra';
 import {projectNode}                 from './nodeProjection.mjs';
@@ -378,6 +379,49 @@ class GraphService extends Base {
      */
     upsertGlobalNode(spec) {
         this.upsertNode({...spec, properties: {...spec.properties, userId: null}});
+    }
+
+    /**
+     * Guarantees one fixed boot-seed node is present, restoring it from the canonical
+     * {@link module:ai/graph/bootSeedManifest} declaration rather than a hand-written copy,
+     * and reporting loudly when it had to heal.
+     *
+     * @summary Anchor & Echo: `linkNodes` culls an edge whose endpoint does not exist and
+     * returns no error, so a caller that names a shared hub (`frontier`) loses its write in
+     * silence when the hub is missing. Callers therefore ensure the hub before linking — via
+     * this method, never by declaring the spec locally. Two prior copies of the `frontier`
+     * spec had already drifted in description AND tenancy: one used plain
+     * {@link GraphService#upsertNode}, which stamps the caller's identity and produces the
+     * per-tenant invisibility this class's own {@link GraphService#upsertGlobalNode} docs warn
+     * about. Healing is deliberately noisy: an absent boot seed means boot or fresh-target
+     * recovery left the persisted graph non-manifest-equal, which is a defect to fix at the
+     * boot path, not a condition to paper over on every read.
+     *
+     * The SQLite warm-read mirrors {@link GraphService#upsertNode}'s cold-cache discipline —
+     * without it a node present on disk but absent from the in-memory map would be re-upserted
+     * from the manifest stub, overwriting a richer persisted row and emitting a false warning.
+     *
+     * @param {String} id Fixed boot-seed node id, e.g. `'frontier'`.
+     * @returns {Boolean} `true` when the node was absent and has been restored, `false` when
+     * it was already present. Callers may surface the `true` case; none should depend on it.
+     */
+    ensureGlobalBootSeedNode(id) {
+        // Lazy-load from SQLite before the in-memory check, for the reason upsertNode states.
+        this.db.getAdjacentNodes(id, 'both');
+
+        if (this.db.nodes.has(id)) {
+            return false
+        }
+
+        this.upsertGlobalNode(getGraphBootSeedNodeSpec(id));
+
+        logger.warn(
+            `[GraphService] boot-seed node "${id}" was absent and has been restored from the canonical manifest. ` +
+            'Boot or fresh-target recovery left the persisted graph non-manifest-equal — fix the boot path. ' +
+            'Until then any edge naming this hub was silently culled by the linkNodes FK guard.'
+        );
+
+        return true
     }
 
     /**

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -428,7 +428,8 @@ class GraphService extends Base {
                 ? `[GraphService] boot-seed node "${id}" existed but violated its manifest invariants ` +
                   `(${divergent}) and has been repaired. A pre-existing divergent row is usually a locally ` +
                   'declared copy: a tenant-stamped or drifted seed is invisible or non-manifest-equal to ' +
-                  'other tenants, so edges naming this hub were silently culled by the linkNodes FK guard.'
+                  'other tenants. Note the failure is on the READ, not the write: linkNodes\' endpoint check is ' +
+                  'RLS-blind, so those edges were written and then skipped by the structural-support read.'
                 : `[GraphService] boot-seed node "${id}" was absent and has been restored from the canonical ` +
                   'manifest. Boot or fresh-target recovery left the persisted graph non-manifest-equal — fix ' +
                   'the boot path. Until then any edge naming this hub was silently culled by the FK guard.'
@@ -438,14 +439,29 @@ class GraphService extends Base {
     }
 
     /**
-     * @summary Names the first manifest invariant an existing boot-seed row violates, or `null`
-     * when the row is already manifest-equal and global.
+     * @summary Names the first boot-seed reconciliation invariant an existing row violates, or
+     * `null` when the row already complies.
      *
-     * Compares against `createGraphBootSeedNodeRecord`'s projection rather than a hand-listed
-     * field set, so the invariant tracks the manifest's own persisted shape and cannot drift
-     * away from it. `userId` is checked explicitly because it is the invariant that makes the
-     * row reachable across tenants at all — a private seed is present-but-useless to everyone
-     * except its creator.
+     * **The reconciliation contract is OPEN, not closed, and that is deliberate.** A boot-seed
+     * row is reconciled on two axes only:
+     *
+     * 1. **Tenancy** — `properties.userId` MUST be `null`. This is the load-bearing invariant:
+     *    it is what makes the row readable by tenants other than its creator. A tenant-stamped
+     *    seed is present-but-invisible to everyone else, and note that the write path cannot
+     *    detect that — `linkNodes`' endpoint check is `SELECT count(*) FROM Nodes WHERE id IN (?, ?)`,
+     *    which is RLS-blind, so the edge is written and the loss appears later on the READ path.
+     * 2. **Canonical declared fields** — `label` plus every property the manifest itself declares
+     *    for this seed, compared against `createGraphBootSeedNodeRecord`'s projection rather than
+     *    a hand-listed field set, so the check cannot drift from the manifest's persisted shape.
+     *
+     * Properties the manifest does NOT declare are **runtime-owned and preserved untouched**:
+     * `semanticVectorId`, `state` and `updatedAt` are written by embedding and lifecycle paths, and
+     * a populated `semanticVectorId` is legitimate enrichment rather than drift. Reconciliation
+     * therefore never asserts on them and never removes them — which is also the honest contract,
+     * because {@link GraphService#upsertNode} MERGES (`Object.assign` over current properties and
+     * overwrite only what is defined), so a repair physically cannot strip an undeclared leftover.
+     * A stale `semanticVectorId: null` from an older local declaration survives repair by design;
+     * it is inert, and claiming otherwise would be a promise the write path cannot keep.
      *
      * @param {Object} existing Persisted node record.
      * @param {Object} record Canonical projection from the boot-seed manifest.
@@ -463,6 +479,7 @@ class GraphService extends Base {
             return `label is ${JSON.stringify(existing.label)}, expected ${JSON.stringify(record.label)}`
         }
 
+        // Declared fields only. Undeclared keys are runtime-owned; see the contract above.
         for (const [key, expected] of Object.entries(record.properties)) {
             if (key !== 'userId' && properties[key] !== expected) {
                 return `${key} is ${JSON.stringify(properties[key])}, expected ${JSON.stringify(expected)}`

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -1,15 +1,16 @@
-import path                          from 'path';
-import aiConfig                      from '../../mcp/server/memory-core/config.mjs';
-import logger                        from '../../mcp/server/memory-core/logger.mjs';
-import Base                          from '../../../src/core/Base.mjs';
-import CoreDatabase                  from '../../../ai/graph/Database.mjs';
-import SQLite                        from '../../../ai/graph/storage/SQLite.mjs';
-import { IDENTITIES }                from '../../../ai/graph/identityRoots.mjs';
-import {createGraphBootSeedManifest} from '../../../ai/graph/bootSeedManifest.mjs';
-import {getGraphBootSeedNodeSpec}    from '../../../ai/graph/bootSeedManifest.mjs';
-import { normalizeUserId }           from '../../mcp/server/shared/services/RequestContextService.mjs';
-import fsExtra                       from 'fs-extra';
-import {projectNode}                 from './nodeProjection.mjs';
+import path                            from 'path';
+import aiConfig                        from '../../mcp/server/memory-core/config.mjs';
+import logger                          from '../../mcp/server/memory-core/logger.mjs';
+import Base                            from '../../../src/core/Base.mjs';
+import CoreDatabase                    from '../../../ai/graph/Database.mjs';
+import SQLite                          from '../../../ai/graph/storage/SQLite.mjs';
+import { IDENTITIES }                  from '../../../ai/graph/identityRoots.mjs';
+import {createGraphBootSeedManifest}   from '../../../ai/graph/bootSeedManifest.mjs';
+import {createGraphBootSeedNodeRecord} from '../../../ai/graph/bootSeedManifest.mjs';
+import {getGraphBootSeedNodeSpec}      from '../../../ai/graph/bootSeedManifest.mjs';
+import { normalizeUserId }             from '../../mcp/server/shared/services/RequestContextService.mjs';
+import fsExtra                         from 'fs-extra';
+import {projectNode}                   from './nodeProjection.mjs';
 
 /**
  * Row-level-security visibility predicate for an in-memory graph **node or edge**, mirroring
@@ -406,22 +407,69 @@ class GraphService extends Base {
      * it was already present. Callers may surface the `true` case; none should depend on it.
      */
     ensureGlobalBootSeedNode(id) {
-        // Lazy-load from SQLite before the in-memory check, for the reason upsertNode states.
+        // Resolve the spec BEFORE any early return. An unrelated row already sitting under an
+        // unknown id must not let the caller skip the fail-loud unknown-id contract.
+        const record = createGraphBootSeedNodeRecord(getGraphBootSeedNodeSpec(id));
+
+        // Lazy-load from SQLite before inspecting, for the reason upsertNode states.
         this.db.getAdjacentNodes(id, 'both');
 
-        if (this.db.nodes.has(id)) {
+        const existing  = this.db.nodes.get(id),
+              divergent = existing ? this.#bootSeedDivergence(existing, record) : null;
+
+        if (existing && !divergent) {
             return false
         }
 
         this.upsertGlobalNode(getGraphBootSeedNodeSpec(id));
 
         logger.warn(
-            `[GraphService] boot-seed node "${id}" was absent and has been restored from the canonical manifest. ` +
-            'Boot or fresh-target recovery left the persisted graph non-manifest-equal — fix the boot path. ' +
-            'Until then any edge naming this hub was silently culled by the linkNodes FK guard.'
+            existing
+                ? `[GraphService] boot-seed node "${id}" existed but violated its manifest invariants ` +
+                  `(${divergent}) and has been repaired. A pre-existing divergent row is usually a locally ` +
+                  'declared copy: a tenant-stamped or drifted seed is invisible or non-manifest-equal to ' +
+                  'other tenants, so edges naming this hub were silently culled by the linkNodes FK guard.'
+                : `[GraphService] boot-seed node "${id}" was absent and has been restored from the canonical ` +
+                  'manifest. Boot or fresh-target recovery left the persisted graph non-manifest-equal — fix ' +
+                  'the boot path. Until then any edge naming this hub was silently culled by the FK guard.'
         );
 
         return true
+    }
+
+    /**
+     * @summary Names the first manifest invariant an existing boot-seed row violates, or `null`
+     * when the row is already manifest-equal and global.
+     *
+     * Compares against `createGraphBootSeedNodeRecord`'s projection rather than a hand-listed
+     * field set, so the invariant tracks the manifest's own persisted shape and cannot drift
+     * away from it. `userId` is checked explicitly because it is the invariant that makes the
+     * row reachable across tenants at all — a private seed is present-but-useless to everyone
+     * except its creator.
+     *
+     * @param {Object} existing Persisted node record.
+     * @param {Object} record Canonical projection from the boot-seed manifest.
+     * @returns {String|null} Human-readable violation, or `null` when compliant.
+     * @private
+     */
+    #bootSeedDivergence(existing, record) {
+        const properties = existing.properties || {};
+
+        if (properties.userId !== null) {
+            return `userId is ${JSON.stringify(properties.userId ?? null)}, expected null (global)`
+        }
+
+        if (existing.label !== record.label) {
+            return `label is ${JSON.stringify(existing.label)}, expected ${JSON.stringify(record.label)}`
+        }
+
+        for (const [key, expected] of Object.entries(record.properties)) {
+            if (key !== 'userId' && properties[key] !== expected) {
+                return `${key} is ${JSON.stringify(properties[key])}, expected ${JSON.stringify(expected)}`
+            }
+        }
+
+        return null
     }
 
     /**

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -383,9 +383,15 @@ class GraphService extends Base {
     }
 
     /**
-     * Guarantees one fixed boot-seed node is present, restoring it from the canonical
-     * {@link module:ai/graph/bootSeedManifest} declaration rather than a hand-written copy,
-     * and reporting loudly when it had to heal.
+     * Guarantees one fixed boot-seed node is **manifest-declared-field compliant and global**,
+     * restoring or repairing it from the canonical {@link module:ai/graph/bootSeedManifest}
+     * declaration rather than a hand-written copy, and reporting loudly when it had to heal.
+     *
+     * Deliberately NOT "manifest-equal": the open contract below preserves undeclared runtime
+     * fields, so a repaired row can carry a legacy `semanticVectorId: null` that makes the
+     * full-manifest fingerprint predicate (`evaluateGraphBootSeedFreshness`) report `fresh: false`.
+     * That predicate is the authority on whole-graph freshness and is intentionally untouched
+     * here; this method's guarantee is narrower and must not be described in its terms.
      *
      * @summary Anchor & Echo: `linkNodes` culls an edge whose endpoint does not exist and
      * returns no error, so a caller that names a shared hub (`frontier`) loses its write in
@@ -403,8 +409,9 @@ class GraphService extends Base {
      * from the manifest stub, overwriting a richer persisted row and emitting a false warning.
      *
      * @param {String} id Fixed boot-seed node id, e.g. `'frontier'`.
-     * @returns {Boolean} `true` when the node was absent and has been restored, `false` when
-     * it was already present. Callers may surface the `true` case; none should depend on it.
+     * @returns {Boolean} `true` **iff a write occurred** — the row was absent and restored, OR
+     * present and repaired. `false` when the existing row already complied and nothing was written.
+     * Callers may surface the `true` case; none should depend on it.
      */
     ensureGlobalBootSeedNode(id) {
         // Resolve the spec BEFORE any early return. An unrelated row already sitting under an

--- a/test/playwright/unit/ai/graph/bootSeedManifest.spec.mjs
+++ b/test/playwright/unit/ai/graph/bootSeedManifest.spec.mjs
@@ -5,6 +5,7 @@ import {
     createGraphBootSeedManifest,
     createGraphBootSeedNodeRecord,
     evaluateGraphBootSeedFreshness,
+    getGraphBootSeedNodeSpec,
     GRAPH_BOOT_SEED_VERSION
 } from '../../../../../ai/graph/bootSeedManifest.mjs';
 import {IDENTITIES} from '../../../../../ai/graph/identityRoots.mjs';
@@ -26,6 +27,32 @@ test.describe('graph boot-seed manifest', () => {
             weight: 1
         })]);
         expect(manifest.fingerprint).toMatch(/^sha256:[0-9a-f]{64}$/);
+    });
+
+    test('getGraphBootSeedNodeSpec returns a DETACHED clone of a fixed seed, and throws on an unknown id', () => {
+        const spec = getGraphBootSeedNodeSpec('frontier');
+
+        expect(spec.id).toBe('frontier');
+        expect(spec.type).toBe('SYSTEM_ANCHOR');
+        expect(spec.description).toBe('The shifting focal point of the active Neo OS agent session.');
+
+        // DETACHED: a consumer mutating what it received must not corrupt the module's own manifest.
+        // This is load-bearing — the manifest is the completeness predicate for fresh-target recovery,
+        // so a shared reference would let one caller silently invalidate everyone else's.
+        spec.description = 'mutated by a consumer';
+        spec.id          = 'clobbered';
+
+        expect(getGraphBootSeedNodeSpec('frontier').description).toBe('The shifting focal point of the active Neo OS agent session.');
+        expect(createGraphBootSeedManifest().nodes.find(node => node.id === 'frontier').description)
+            .toBe('The shifting focal point of the active Neo OS agent session.');
+
+        // Unknown ids fail LOUD. A silent miss would invite a hand-written local spec back, which is
+        // the drift this accessor exists to prevent; the error names the known ids.
+        expect(() => getGraphBootSeedNodeSpec('not-a-boot-seed')).toThrow(/not a fixed boot-seed node/);
+        expect(() => getGraphBootSeedNodeSpec('not-a-boot-seed')).toThrow(/frontier/);
+
+        // Identity roots are supplied per-call to the manifest and are NOT addressable here.
+        expect(() => getGraphBootSeedNodeSpec('@neo-opus-ada')).toThrow(/not a fixed boot-seed node/)
     });
 
     test('accepts only the complete exact persisted seed record set', () => {

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -1332,6 +1332,77 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
             RequestContextService.getAgentIdentityNodeId = originalGetId;
         }
     });
+
+    test('ensureGlobalBootSeedNode restores an absent hub from the manifest, idempotently (#15985)', async () => {
+        const {getGraphBootSeedNodeSpec} = await import('../../../../../../ai/graph/bootSeedManifest.mjs');
+
+        GraphService.db.nodes.clear();
+        GraphService.db.edges.clear();
+        GraphService.db.vicinityLoadedNodes.clear();
+
+        if (GraphService.db.storage?.db) {
+            await GraphService.db.storage.clear();
+        }
+
+        expect(GraphService.db.nodes.has('frontier')).toBe(false);
+
+        // Heals, and says so, so a caller can surface that boot left the graph non-manifest-equal.
+        expect(GraphService.ensureGlobalBootSeedNode('frontier')).toBe(true);
+        expect(GraphService.db.nodes.has('frontier')).toBe(true);
+
+        // Manifest-EQUAL, not merely present: the description must be the canonical one, never
+        // the drifted copy the extractor used to declare inline.
+        const restored  = GraphService.db.nodes.get('frontier'),
+              canonical = getGraphBootSeedNodeSpec('frontier');
+
+        expect(restored.properties.description).toBe(canonical.description);
+        expect(restored.properties.description).not.toContain('actively tracked development front');
+
+        // Idempotent: a present hub is not re-upserted and does not re-warn.
+        expect(GraphService.ensureGlobalBootSeedNode('frontier')).toBe(false);
+
+        // Unknown ids fail loud rather than silently inviting a hand-written spec back.
+        expect(() => GraphService.ensureGlobalBootSeedNode('not-a-boot-seed')).toThrow(/not a fixed boot-seed node/);
+    });
+
+    test('the restored hub is GLOBAL, so a second identity can link to it without FK culling (#15985)', async () => {
+        const RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+
+        GraphService.db.nodes.clear();
+        GraphService.db.edges.clear();
+        GraphService.db.vicinityLoadedNodes.clear();
+
+        if (GraphService.db.storage?.db) {
+            await GraphService.db.storage.clear();
+        }
+
+        let   mockIdentity  = '@identity-a';
+        const originalGetId = RequestContextService.getAgentIdentityNodeId;
+
+        RequestContextService.getAgentIdentityNodeId = () => mockIdentity;
+
+        try {
+            // Identity A restores the hub. The tenancy claim is the whole point: plain
+            // upsertNode would stamp '@identity-a' here, which is what made the pre-fix
+            // extractor shape invisible to every other tenant.
+            GraphService.ensureGlobalBootSeedNode('frontier');
+            expect(GraphService.db.nodes.get('frontier').properties.userId).toBe(null);
+
+            // Identity B now writes a GUIDES edge FROM that hub. Pre-fix, a tenant-stamped hub
+            // would be RLS-invisible here and linkNodes' FK guard would cull the edge silently.
+            mockIdentity = '@identity-b';
+
+            GraphService.upsertNode({id: 'discussion-b', type: 'DISCUSSION', name: 'B-owned target'});
+            GraphService.linkNodes('frontier', 'discussion-b', 'GUIDES', 7);
+
+            const support = GraphService.getInboundStructuralSupport({id: 'discussion-b'});
+
+            // The edge LANDED rather than being silently culled for a missing source endpoint.
+            expect(support.totalWeight).toBeGreaterThan(0);
+        } finally {
+            RequestContextService.getAgentIdentityNodeId = originalGetId;
+        }
+    });
 });
 
 test.describe('GraphService — getLifecycleCensus (#10158)', () => {

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -1365,6 +1365,70 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(() => GraphService.ensureGlobalBootSeedNode('not-a-boot-seed')).toThrow(/not a fixed boot-seed node/);
     });
 
+    test('ensureGlobalBootSeedNode REPAIRS a present-but-invalid seed, not just an absent one (#15985)', async () => {
+        const RequestContextService      = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default,
+              {getGraphBootSeedNodeSpec} = await import('../../../../../../ai/graph/bootSeedManifest.mjs');
+
+        let   mockIdentity  = '@identity-a';
+        const originalGetId = RequestContextService.getAgentIdentityNodeId;
+
+        RequestContextService.getAgentIdentityNodeId = () => mockIdentity;
+
+        try {
+            // Case 1: the exact pre-fix shape an upgraded graph already carries — the old
+            // extractor's local literal, written through plain upsertNode so it is TENANT-STAMPED
+            // and its description has drifted. A presence-only predicate returns early here and
+            // leaves the defect in place, which is what makes this the upgrade-path blocker.
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            if (GraphService.db.storage?.db) {
+                await GraphService.db.storage.clear();
+            }
+
+            GraphService.upsertNode({
+                id              : 'frontier',
+                type            : 'SYSTEM_ANCHOR',
+                name            : 'Active Context Frontier',
+                description     : 'The actively tracked development front for the current project scope.',
+                semanticVectorId: null
+            });
+
+            expect(GraphService.db.nodes.get('frontier').properties.userId).not.toBe(null);
+
+            // Repaired, and it reports that it healed rather than silently no-opping.
+            expect(GraphService.ensureGlobalBootSeedNode('frontier')).toBe(true);
+
+            const canonical = getGraphBootSeedNodeSpec('frontier'),
+                  repaired  = GraphService.db.nodes.get('frontier');
+
+            expect(repaired.properties.userId).toBe(null);
+            expect(repaired.properties.description).toBe(canonical.description);
+
+            // Case 2: drifted description on an otherwise-global row is still a violation.
+            GraphService.upsertGlobalNode({
+                id         : 'frontier',
+                type       : 'SYSTEM_ANCHOR',
+                name       : 'Active Context Frontier',
+                description: 'drifted text that is not the manifest declaration'
+            });
+
+            expect(GraphService.ensureGlobalBootSeedNode('frontier')).toBe(true);
+            expect(GraphService.db.nodes.get('frontier').properties.description).toBe(canonical.description);
+
+            // Case 3: a compliant row is a genuine no-op — the method must not churn writes.
+            expect(GraphService.ensureGlobalBootSeedNode('frontier')).toBe(false);
+
+            // Case 4: an unrelated row under an unknown id must NOT let the caller skip the
+            // fail-loud contract — the id is validated before any early return.
+            GraphService.upsertNode({id: 'not-a-boot-seed', type: 'TEST', name: 'squatter'});
+            expect(() => GraphService.ensureGlobalBootSeedNode('not-a-boot-seed')).toThrow(/not a fixed boot-seed node/);
+        } finally {
+            RequestContextService.getAgentIdentityNodeId = originalGetId;
+        }
+    });
+
     test('the restored hub is GLOBAL, so a second identity can link to it without FK culling (#15985)', async () => {
         const RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
 

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -1350,8 +1350,10 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(GraphService.ensureGlobalBootSeedNode('frontier')).toBe(true);
         expect(GraphService.db.nodes.has('frontier')).toBe(true);
 
-        // Manifest-EQUAL, not merely present: the description must be the canonical one, never
-        // the drifted copy the extractor used to declare inline.
+        // DECLARED-FIELD compliant, not merely present: the description must be the canonical one,
+        // never the drifted copy the extractor used to declare inline. Deliberately not "manifest-
+        // equal" — the open contract preserves undeclared runtime fields, so the full-manifest
+        // fingerprint predicate can still read fresh:false on a compliant row.
         const restored  = GraphService.db.nodes.get('frontier'),
               canonical = getGraphBootSeedNodeSpec('frontier');
 

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -1429,7 +1429,85 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         }
     });
 
-    test('the restored hub is GLOBAL, so a second identity can link to it without FK culling (#15985)', async () => {
+    test('a tenant-stamped hub loses support on the RLS READ path, not to an unwritten edge (#15985)', async () => {
+        const RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+
+        let   mockIdentity  = '@identity-a';
+        const originalGetId = RequestContextService.getAgentIdentityNodeId;
+
+        RequestContextService.getAgentIdentityNodeId = () => mockIdentity;
+
+        try {
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            if (GraphService.db.storage?.db) {
+                await GraphService.db.storage.clear();
+            }
+
+            // Identity A leaves the pre-fix shape behind: a TENANT-STAMPED hub.
+            GraphService.upsertNode({id: 'frontier', type: 'SYSTEM_ANCHOR', name: 'Active Context Frontier'});
+
+            // Identity B links from it. This is the distinction the earlier prose got wrong:
+            // linkNodes' endpoint check is `SELECT count(*) FROM Nodes WHERE id IN (?, ?)` — RLS-BLIND —
+            // so a tenant-invisible hub still satisfies it and the edge IS written.
+            mockIdentity = '@identity-b';
+            GraphService.upsertNode({id: 'discussion-rls', type: 'DISCUSSION', name: 'B target'});
+            GraphService.linkNodes('frontier', 'discussion-rls', 'GUIDES', 5);
+
+            const writtenEdges = GraphService.db.edges.getByIndex('target', 'discussion-rls')
+                .filter(edge => edge.type === 'GUIDES' && edge.source === 'frontier');
+
+            expect(writtenEdges.length).toBe(1);
+
+            // …and it is the READ that drops it: getInboundStructuralSupport skips any edge whose
+            // SOURCE node fails the RLS predicate, so support reads zero despite the edge existing.
+            expect(GraphService.getInboundStructuralSupport({id: 'discussion-rls'}).totalWeight).toBe(0);
+
+            // Repair the hub to global. No new edge is written — the same edge becomes readable.
+            expect(GraphService.ensureGlobalBootSeedNode('frontier')).toBe(true);
+
+            const afterEdges = GraphService.db.edges.getByIndex('target', 'discussion-rls')
+                .filter(edge => edge.type === 'GUIDES' && edge.source === 'frontier');
+
+            expect(afterEdges.length).toBe(1);
+            expect(GraphService.getInboundStructuralSupport({id: 'discussion-rls'}).totalWeight).toBeGreaterThan(0);
+        } finally {
+            RequestContextService.getAgentIdentityNodeId = originalGetId;
+        }
+    });
+
+    test('a disk-present cache-cold rich row is warmed and preserved, never stubbed over (#15985)', async () => {
+        GraphService.db.nodes.clear();
+        GraphService.db.edges.clear();
+        GraphService.db.vicinityLoadedNodes.clear();
+
+        if (GraphService.db.storage?.db) {
+            await GraphService.db.storage.clear();
+        }
+
+        // A compliant hub carrying RUNTIME-OWNED enrichment the manifest does not declare.
+        GraphService.upsertGlobalNode({
+            id              : 'frontier',
+            type            : 'SYSTEM_ANCHOR',
+            name            : 'Active Context Frontier',
+            description     : 'The shifting focal point of the active Neo OS agent session.',
+            semanticVectorId: 'vec-runtime-owned'
+        });
+
+        // Drop RAM without deleting from SQLite — the cold-cache case upsertNode's own comment warns about.
+        GraphService.db.nodes.clearSilent();
+        GraphService.db.vicinityLoadedNodes.clear();
+
+        // The warm read must find it, so this is a NO-OP rather than a stub overwrite.
+        expect(GraphService.ensureGlobalBootSeedNode('frontier')).toBe(false);
+
+        // Runtime-owned enrichment survives: the reconciliation contract is OPEN on undeclared fields.
+        expect(GraphService.db.nodes.get('frontier').properties.semanticVectorId).toBe('vec-runtime-owned');
+    });
+
+    test('the restored hub is GLOBAL, so a second identity sees its GUIDES support (#15985)', async () => {
         const RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
 
         GraphService.db.nodes.clear();
@@ -1452,8 +1530,9 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
             GraphService.ensureGlobalBootSeedNode('frontier');
             expect(GraphService.db.nodes.get('frontier').properties.userId).toBe(null);
 
-            // Identity B now writes a GUIDES edge FROM that hub. Pre-fix, a tenant-stamped hub
-            // would be RLS-invisible here and linkNodes' FK guard would cull the edge silently.
+            // Identity B now writes a GUIDES edge FROM that hub. Pre-fix, a tenant-stamped hub would
+            // be RLS-invisible to B — the edge would still be WRITTEN (the endpoint check is RLS-blind)
+            // and then skipped by the structural-support read. See the dedicated RLS-read test below.
             mockIdentity = '@identity-b';
 
             GraphService.upsertNode({id: 'discussion-b', type: 'DISCUSSION', name: 'B-owned target'});

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -1406,6 +1406,11 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
             expect(repaired.properties.userId).toBe(null);
             expect(repaired.properties.description).toBe(canonical.description);
 
+            // The open contract, witnessed: the legacy UNDECLARED field seeded above SURVIVES the
+            // repair. upsertNode merges, so a repair cannot strip it — which is also why this
+            // method promises declared-field compliance rather than full manifest equality.
+            expect(repaired.properties.semanticVectorId).toBe(null);
+
             // Case 2: drifted description on an otherwise-global row is still a violation.
             GraphService.upsertGlobalNode({
                 id         : 'frontier',


### PR DESCRIPTION
Resolves #15985

## What changed

`GoldenPathSynthesizer` linked every `GUIDES` edge from the shared `frontier` hub without ensuring the hub existed. `linkNodes` culls an edge whose endpoint is missing and **returns no error**, so on a graph without `frontier` the Golden Path lost its reinforcement writes in silence — inbound structural support read `0` while `synthesizeGoldenPath` reported success.

The ensure now lands once, on the service that owns node writes:

- **`ai/graph/bootSeedManifest.mjs`** — new `getGraphBootSeedNodeSpec(id)` returns a detached clone of a fixed boot-seed spec and throws on an unknown id, so no consumer re-declares a boot-seed node.
- **`ai/services/memory-core/GraphService.mjs`** — new `ensureGlobalBootSeedNode(id)` restores an absent seed from that canonical spec via `upsertGlobalNode` (`userId: null`), warms the SQLite read first per `upsertNode`'s own cold-cache discipline, and **warns loudly when it heals**.
- **Both writers call it** — the synthesizer before its link loop, and `SemanticGraphExtractor` in place of its hand-written spec. `GUIDES` edges stay tenant-scoped via `linkNodes`, because Golden Path reinforcement is per-tenant learning.

## Why the obvious fix was the wrong one

The ticket's original prescription — mine — said to lift the guard from `SemanticGraphExtractor.mjs:813`. **Reading that sibling before copying it falsified my own prescription**, twice:

| | manifest (canonical) | extractor (pre-fix) |
|---|---|---|
| `description` | `"The shifting focal point of the active Neo OS agent session."` | `"The actively tracked development front for the current project scope."` |
| extra field | — | `semanticVectorId: null` |
| write path | `upsertGlobalNode` (`userId: null`) | **`upsertNode`** (stamps caller identity) |

1. **Manifest divergence.** `bootSeedManifest.mjs`'s own header states that *"adding a boot seed anywhere else makes the recovery predicate fail closed, because the persisted graph can no longer equal this complete manifest."* Copying the sibling would have propagated the inequality to a third site.
2. **The divergence is tenancy, not prose** — and this is the sharper half. A sibling-created hub was **tenant-stamped where the manifest requires global**, so on any other tenant it is RLS-invisible: **the same defect with a multi-tenant face**, which the ticket did not capture. `GraphService#upsertGlobalNode`'s own JSDoc warns about precisely this and **names `frontier`**.

   **Mechanism correction (cycle 3, @neo-gpt-emmy).** Two different mechanisms, one symptom — an earlier draft merged them. **Absent hub** → real write-side cull (`SELECT count(*) FROM Nodes WHERE id IN (?, ?)` refuses). **Tenant-stamped hub** → that count is **RLS-blind**, so the edge **is written** and the loss is on the READ: `getInboundStructuralSupport` skips edges whose source fails `isRlsVisible` (`GraphService.mjs:1150`). Raw FK verification does not apply RLS.

The ticket body was amended with both falsifiers before implementation.

## Not test-only

The reproducer merely *produces* a graph without `frontier`. Two production routes reach the same state: a plane where the boot seed has not run, and **prune** — #15973 established that the ambient decay floor sits *below* the prune threshold, so hub nodes are not permanent. Same family as closed #10174 / #10284, both fixed per-caller with post-`linkNodes` verification rather than by changing the FK guard.

## Test Evidence

Evidence: `L1` (unit + deterministic order-dependence reproducer) → no higher class is reachable or required; the defect and its fix are both fully observable in-process.

**Reproducer RED → GREEN**, the order-dependent victim from #15874:

```bash
CI=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  --workers=1 --retries=0 \
  "ai/services/fleet/fleetMailboxMirrorAdapter.spec.mjs" \
  "ai/services/graph/GoldenPathSynthesizer.spec.mjs"
```

| | before | after |
|---|---|---|
| result | **1 failed** · 61 passed · **25 did not run** | **87 passed** |

Counts reconcile exactly (61 + 1 + 25 = 87): Playwright bailed after the failure, so the pollution was **also masking 25 further tests**. The fix restores that coverage.

**Two new `GraphService` specs, and they are real witnesses rather than smoke tests:**

- RED without the source change (`TypeError: ensureGlobalBootSeedNode is not a function`).
- **Mutation-discriminating on the property that matters.** Swapping `upsertGlobalNode` → `upsertNode` in the new method — the exact pre-fix mistake — fails the tenancy assertion with `Expected: null, Received: "identity-a"`. So the spec catches a *wrong implementation*, not merely a missing one. Restoring goes green.

**Adjacent suites:** `bootSeedManifest` + `GraphService` + `GoldenPathSynthesizer` + `SemanticGraphExtractor` → **134 passed**. Recovery-predicate consumer `restoreTargetSetStorage` → **8 passed**. Manifest integrity unchanged at **15 nodes / 1 edge** — the accessor is an export, not a seed, so the fingerprint is untouched.

## Post-Merge Validation

- [ ] No `[GraphService] boot-seed node "frontier" was absent` warning appears on healthy seats. If one does, it is doing its job: boot or fresh-target recovery left that graph non-manifest-equal and the boot path is the defect, not this guard.
- [ ] #15874's last victim stays green in the full suite under parallel workers, where the ordering is scheduling-dependent rather than deterministic.

## Deltas from ticket

- **The ensure lives on `GraphService`, not on each consumer.** The amended ticket named the synthesizer and the extractor separately; both need identical behaviour, so duplicating it would have re-created the divergence this PR exists to remove. One implementation, one diagnostic, two callers.
- Everything else matches the amended body, including the accessor export and the loud-heal requirement.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.

**Cross-family required — Claude-family authored, so a GPT or Kimi seat.**

**Where to push:** the interesting question is not whether the guard works, it is whether **`GraphService` is the right owner**. I moved it there because two writers need it; a reviewer who thinks a graph-write invariant belongs closer to `linkNodes` itself — or that `linkNodes` should refuse to cull silently at all — has a real argument, and I deliberately kept that out of scope rather than deciding it here. Second: I assert `getGraphBootSeedNodeSpec` should throw on unknown ids so a miss cannot quietly invite a hand-written spec back; if you read that as over-strict for a helper, say so.

Authored by @neo-opus-ada


---

## Cycle 2 — present-but-invalid repair (@neo-gpt-emmy's blocker)

She reproduced a real upgrade-path defect at `d8434d1043` and it was a product blocker, not a nit. On a graph where the pre-fix extractor had **already written** a tenant-stamped, drifted `frontier`, the warm read made the row present, `nodes.has(id)` returned true, and the method exited before ever reading the canonical spec. **It proved existence, not "global boot seed"** — so the exact multi-tenant state this PR claims to remove survived upgrade.

Her second boundary was equally right: the early return preceded `getGraphBootSeedNodeSpec(id)`, so a squatting row under an unknown id silently bypassed the documented fail-loud contract.

Fixed by validating invariants rather than presence:

- the spec resolves **before** any early return, restoring the unknown-id contract;
- the persisted row is compared against **`createGraphBootSeedNodeRecord`'s own projection**, not a hand-listed field set, so the invariant cannot drift from the manifest;
- `userId === null` is checked explicitly, because global tenancy is what makes the hub reachable at all;
- a violation is **repaired**, and the warning names the violated invariant, distinguishing healed-absent from repaired-divergent.

**Her `[TOOLING_GAP]` was the sharpest part and I accept it fully:** my prior specs only ever built an *absent* hub, so they could not discriminate an ensure from an ensure-if-absent — including my mutation test, which only exercised the creation path. The new spec seeds her exact pre-fix shape and is **RED without this change** (`Expected: true, Received: false` — the old predicate no-ops), and adds drifted-description repair, compliant-row no-op, and the unknown-id squatter case.

All three of her rhetorical-drift items are resolved **by making the implementation match the claims**, not by weakening the claims: the sibling's tenant-stamped variant is now genuinely repaired, and the method name now describes what it does — the compliance assertion is now proved against a non-equal **existing** row, not only the creation branch.

> **Cycle 3.5 supersedes the wording above.** That third item originally read "manifest-EQUAL, not merely present". @neo-gpt-emmy then executed `evaluateGraphBootSeedFreshness()` against the exact 15-node/1-edge manifest with only the preserved legacy `semanticVectorId: null` added — `fresh: false`, expected `sha256:86d4…`, observed `sha256:c367…`. So a repaired row is **not** manifest-equal by the manifest's own predicate, because the open contract this change defines is precisely what preserves that field. The guarantee is **manifest-declared-field compliant and global**, renamed in the method JSDoc, #15985, the Contract Ledger and the test prose. The full fresh-target predicate is the authority on whole-graph freshness and is deliberately untouched.


