### PR TITLE
fix(build): scope the watchdog run axis to the guarded branch

### DIFF
--- a/buildScripts/dataSyncWatchdog.mjs
+++ b/buildScripts/dataSyncWatchdog.mjs
@@ -51,6 +51,13 @@ const
     DEFAULT_MAX_CORPUS_AGE_HOURS     = 48,
     DEFAULT_CORPUS_PATH              = 'resources/content',
     DEFAULT_WORKFLOW                 = 'data-sync-pipeline.yml',
+    /**
+     * The branch every axis measures. ONE declaration feeds both the run-history query and the
+     * corpus commit queries, because the two axes must certify the same branch: a run axis scoped
+     * differently from the corpus axis would report health for a branch nobody deploys.
+     * @type {String}
+     */
+    DEFAULT_BRANCH                   = 'dev',
     RUNS_PER_PAGE                    = 30,
     /**
      * Facet definitions: name → subpaths under `resources/content` that form ONE semantic
@@ -225,6 +232,53 @@ export function parseFacetNames({name, raw, fallback}) {
 }
 
 /**
+ * Parses the measured-branch env var with the same loud discipline as `parseThreshold` and
+ * `parseFacetNames`: absent or empty falls back, but a PRESENT value that resolves to nothing
+ * (whitespace-only) fails LOUD. A silently-empty override would drop the `branch=` filter and
+ * widen the run axis back to EVERY branch — the exact defect this parameter exists to close,
+ * where one feature-branch success truncates the default branch's failure streak and the alarm
+ * goes quiet while the branch it guards is still red.
+ *
+ * @param {Object} options
+ * @param {String} options.name Env var name (for the error message).
+ * @param {String|undefined} options.raw Raw env value.
+ * @param {String} options.fallback Used only when the var is absent or empty.
+ * @returns {String}
+ */
+export function parseBranchName({name, raw, fallback}) {
+    if (raw === undefined || raw === '') return fallback;
+
+    const branch = raw.trim();
+
+    if (branch === '') {
+        throw new Error(`dataSyncWatchdog: ${name} resolved to an empty branch from '${raw}' — refusing to widen the run axis to every branch (omit the var to measure '${fallback}')`)
+    }
+
+    return branch
+}
+
+/**
+ * Builds the run-history query. Extracted so the branch scope is assertable: the defect this
+ * closes was an unscoped query, and an inline template literal leaves that invariant with no
+ * witness. `branch` is REQUIRED — there is deliberately no default here, because a default
+ * would let a caller reintroduce the unscoped form by omission.
+ *
+ * @param {Object} options
+ * @param {String} options.repository `owner/name`.
+ * @param {String} options.workflow Workflow file name.
+ * @param {String} options.branch Branch to measure.
+ * @param {Number} [options.perPage=RUNS_PER_PAGE]
+ * @returns {String} API path including the `branch` filter.
+ */
+export function buildRunsQuery({repository, workflow, branch, perPage = RUNS_PER_PAGE}) {
+    if (typeof branch !== 'string' || branch.trim() === '') {
+        throw new Error('dataSyncWatchdog.buildRunsQuery: branch is required — an unscoped run query mixes feature-branch runs into the guarded branch\'s streak')
+    }
+
+    return `/repos/${repository}/actions/workflows/${workflow}/runs?branch=${encodeURIComponent(branch)}&per_page=${perPage}`
+}
+
+/**
  * @param {Object} options
  * @param {String|null} options.latestConclusion Conclusion of the newest completed run.
  * @param {Boolean} options.breached Whether ANY axis is breaching (a green run axis never
@@ -287,7 +341,7 @@ export function buildAlarmTitle({consecutiveFailures, lastSuccess, corpusLastCom
  * @param {Boolean} [options.forced=false] True when a dispatch dry-run forced the branch.
  * @returns {String}
  */
-export function buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure, reasons, corpusLastCommitAt, corpusAgeHours, corpusFacets, forced=false}) {
+export function buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure, reasons, corpusLastCommitAt, corpusAgeHours, corpusFacets, branch, forced=false}) {
     const corpusLine = corpusFacets
         ? [
             '**Corpus facets** (committed `dev`; a green pipeline cannot attest to this backlog):',
@@ -305,7 +359,7 @@ export function buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure,
         '**Standing alarm — one per breach episode.** This issue is maintained by `dataSyncWatchdog.mjs`:',
         'the body is refreshed on every breach evaluation and the issue closes automatically on recovery.',
         '',
-        `**Streak:** ${consecutiveFailures} consecutive failures.`,
+        `**Streak:** ${consecutiveFailures} consecutive failures${branch ? ` on \`${branch}\`` : ''}.`,
         `**Last success:** ${lastSuccess ? `[${lastSuccess.created_at}](${lastSuccess.html_url})` : `none in the last ${RUNS_PER_PAGE} completed runs`}.`,
         `**Latest failure:** ${latestFailure ? `[run ${latestFailure.id}](${latestFailure.html_url})` : 'n/a'}.`,
         corpusLine,
@@ -376,6 +430,7 @@ async function main() {
         token                  = process.env.GITHUB_TOKEN,
         repository             = process.env.GITHUB_REPOSITORY || 'neomjs/neo',
         workflow               = process.env.WATCHDOG_WORKFLOW || DEFAULT_WORKFLOW,
+        branch                 = parseBranchName({name: 'WATCHDOG_BRANCH', raw: process.env.WATCHDOG_BRANCH, fallback: DEFAULT_BRANCH}),
         corpusPath             = process.env.WATCHDOG_CORPUS_PATH || DEFAULT_CORPUS_PATH,
         maxConsecutiveFailures = parseThreshold({name: 'WATCHDOG_MAX_CONSECUTIVE_FAILURES', raw: process.env.WATCHDOG_MAX_CONSECUTIVE_FAILURES, fallback: DEFAULT_MAX_CONSECUTIVE_FAILURES}),
         maxSuccessAgeHours     = parseThreshold({name: 'WATCHDOG_MAX_SUCCESS_AGE_HOURS', raw: process.env.WATCHDOG_MAX_SUCCESS_AGE_HOURS, fallback: DEFAULT_MAX_SUCCESS_AGE_HOURS}),
@@ -390,7 +445,11 @@ async function main() {
     }
 
     const runsResponse = await api(
-        `/repos/${repository}/actions/workflows/${workflow}/runs?per_page=${RUNS_PER_PAGE}`,
+        // Branch-SCOPED deliberately. Unscoped, this list mixes feature-branch runs with the
+        // branch being guarded, and computeStreak breaks on the first success it meets — so one
+        // passing branch run truncates the real streak and can hand `lastSuccess` a run from a
+        // branch nobody deploys. The corpus axis has always pinned the branch; this axis must too.
+        buildRunsQuery({repository, workflow, branch}),
         {token}
     );
 
@@ -414,7 +473,7 @@ async function main() {
     const corpusFacets = await Promise.all(facetNames.map(async facet => {
         const subpaths = FACET_PATHS[facet] ?? [facet],
               commits  = await Promise.all(subpaths.map(subpath =>
-                  api(`/repos/${repository}/commits?path=${encodeURIComponent(`${corpusPath}/${subpath}`)}&sha=dev&per_page=1`, {token})));
+                  api(`/repos/${repository}/commits?path=${encodeURIComponent(`${corpusPath}/${subpath}`)}&sha=${encodeURIComponent(branch)}&per_page=1`, {token})));
 
         const lastCommitAt = latestCommitDate(commits),
               ageHours     = lastCommitAt
@@ -480,7 +539,7 @@ async function main() {
     }
 
     const title = buildAlarmTitle({consecutiveFailures, lastSuccess, staleFacets, forced: forceBreach}),
-          body  = buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure: latest?.conclusion === 'failure' ? latest : null, reasons, corpusFacets, forced: forceBreach});
+          body  = buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure: latest?.conclusion === 'failure' ? latest : null, reasons, corpusFacets, branch, forced: forceBreach});
 
     if (alarm) {
         const comment = buildBreachComment({consecutiveFailures, latestFailure: latest});

--- a/buildScripts/dataSyncWatchdog.mjs
+++ b/buildScripts/dataSyncWatchdog.mjs
@@ -341,17 +341,17 @@ export function buildAlarmTitle({consecutiveFailures, lastSuccess, corpusLastCom
  * @param {Boolean} [options.forced=false] True when a dispatch dry-run forced the branch.
  * @returns {String}
  */
-export function buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure, reasons, corpusLastCommitAt, corpusAgeHours, corpusFacets, branch, forced=false}) {
+export function buildAlarmBody({consecutiveFailures, lastSuccess, latestFailure, reasons, corpusLastCommitAt, corpusAgeHours, corpusFacets, branch=DEFAULT_BRANCH, forced=false}) {
     const corpusLine = corpusFacets
         ? [
-            '**Corpus facets** (committed `dev`; a green pipeline cannot attest to this backlog):',
+            `**Corpus facets** (committed \`${branch}\`; a green pipeline cannot attest to this backlog):`,
             '',
-            '| facet | last commit on `dev` | age | status |',
+            `| facet | last commit on \`${branch}\` | age | status |`,
             '|---|---|---|---|',
             ...corpusFacets.map(({facet, lastCommitAt, ageHours, stale}) =>
                 `| \`${facet}\` | ${lastCommitAt ?? 'none visible'} | ${lastCommitAt ? `${ageHours.toFixed(1)}h` : '—'} | ${stale ? '**STALE**' : 'ok'} |`)
         ].join('\n')
-        : `**Corpus axis:** last \`resources/content/**\` commit on \`dev\`: ${corpusLastCommitAt ? `${corpusLastCommitAt} (${corpusAgeHours}h old)` : 'not measured'}. Deploys, fresh clones, CI, and container KB ingestion all build from committed \`dev\` — a green pipeline cannot attest to this backlog.`;
+        : `**Corpus axis:** last \`resources/content/**\` commit on \`${branch}\`: ${corpusLastCommitAt ? `${corpusLastCommitAt} (${corpusAgeHours}h old)` : 'not measured'}. Deploys, fresh clones, CI, and container KB ingestion all build from committed \`${branch}\` — a green pipeline cannot attest to this backlog.`;
 
     return [
         ALARM_MARKER,

--- a/test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs
@@ -203,6 +203,36 @@ test.describe('dataSyncWatchdog (#15948)', () => {
         expect(scoped.lastSuccess).toBe(null)
     });
 
+    test('every branch label in the alarm body follows WATCHDOG_BRANCH, never a literal (#15994)', () => {
+        const body = buildAlarmBody({
+            consecutiveFailures: 4,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            latestFailure      : null,
+            reasons            : ['corpus facet `pulls` is 214.8h old (threshold 48h)'],
+            corpusFacets       : [{facet: 'pulls', lastCommitAt: '2026-07-17T05:13:29Z', ageHours: 214.8, stale: true}],
+            branch             : 'release/13.2'
+        });
+
+        // Streak line, corpus header AND the table column all name the measured branch. A literal
+        // `dev` in any of them is a false statement the moment the branch is overridden.
+        expect(body).toContain('consecutive failures on `release/13.2`');
+        expect(body).toContain('**Corpus facets** (committed `release/13.2`');
+        expect(body).toContain('| facet | last commit on `release/13.2` | age | status |');
+        expect(body).not.toContain('`dev`');
+
+        // Omitted branch still renders the default truthfully rather than "undefined".
+        const defaulted = buildAlarmBody({
+            consecutiveFailures: 1,
+            lastSuccess        : run('success', '2026-07-26T00:17:01Z'),
+            latestFailure      : null,
+            reasons            : ['x'],
+            corpusFacets       : [{facet: 'pulls', lastCommitAt: '2026-07-17T05:13:29Z', ageHours: 214.8, stale: true}]
+        });
+
+        expect(defaulted).toContain('committed `dev`');
+        expect(defaulted).not.toContain('undefined')
+    });
+
     test('selectAlarmIssue: body marker wins over title, PRs are excluded, marker beats prefix', () => {
         const marked   = {number: 10, title: 'renamed alarm', body: `x ${ALARM_MARKER} y`},
               prefixed = {number: 11, title: `${ALARM_TITLE_PREFIX} legacy`, body: 'no marker'},

--- a/test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs
@@ -10,7 +10,9 @@ import {
     computeStreak,
     evaluateBreach,
     isRecovered,
+    buildRunsQuery,
     latestCommitDate,
+    parseBranchName,
     parseFacetNames,
     parseThreshold,
     selectAlarmIssue
@@ -149,6 +151,56 @@ test.describe('dataSyncWatchdog (#15948)', () => {
         expect(() => parseFacetNames({name: 'X', raw: ' ', fallback: ['issues']})).toThrow(/zero facets/);
         expect(() => parseFacetNames({name: 'X', raw: ',', fallback: ['issues']})).toThrow(/zero facets/);
         expect(() => parseFacetNames({name: 'X', raw: ',,', fallback: ['issues']})).toThrow(/zero facets/)
+    });
+
+    test('buildRunsQuery is branch-SCOPED, and refuses to build an unscoped query (#15994)', () => {
+        const q = buildRunsQuery({repository: 'neomjs/neo', workflow: 'data-sync-pipeline.yml', branch: 'dev'});
+
+        expect(q).toContain('branch=dev');
+        expect(q).toContain('/repos/neomjs/neo/actions/workflows/data-sync-pipeline.yml/runs?');
+
+        // The defect this closes: an unscoped query. There is deliberately no branch default,
+        // so omission cannot silently reintroduce the all-branches form.
+        expect(() => buildRunsQuery({repository: 'neomjs/neo', workflow: 'w.yml'})).toThrow(/branch is required/);
+        expect(() => buildRunsQuery({repository: 'neomjs/neo', workflow: 'w.yml', branch: '   '})).toThrow(/branch is required/);
+
+        // A branch needing encoding stays a single query parameter.
+        expect(buildRunsQuery({repository: 'r/n', workflow: 'w.yml', branch: 'feature/a b'}))
+            .toContain('branch=feature%2Fa%20b');
+    });
+
+    test('parseBranchName falls back when absent, fails LOUD on whitespace-only (#15994)', () => {
+        expect(parseBranchName({name: 'X', raw: undefined, fallback: 'dev'})).toBe('dev');
+        expect(parseBranchName({name: 'X', raw: '', fallback: 'dev'})).toBe('dev');
+        expect(parseBranchName({name: 'X', raw: ' main ', fallback: 'dev'})).toBe('main');
+
+        // A silently-empty override would drop the filter and widen the axis back to EVERY branch.
+        expect(() => parseBranchName({name: 'X', raw: '   ', fallback: 'dev'})).toThrow(/empty branch/);
+    });
+
+    test('computeStreak truncates on ANY success — which is why the query must be branch-scoped (#15994)', () => {
+        // The exact live shape on 2026-07-26: four dev failures, then a FEATURE-BRANCH success
+        // sitting among them. Unscoped, computeStreak stops there and reports 4 while dev was
+        // ~98 deep, and hands lastSuccess a run from a branch nobody deploys.
+        const mixed = [
+            {conclusion: 'failure', head_branch: 'dev',                             created_at: '2026-07-26T12:08:22Z'},
+            {conclusion: 'failure', head_branch: 'dev',                             created_at: '2026-07-26T10:06:00Z'},
+            {conclusion: 'failure', head_branch: 'dev',                             created_at: '2026-07-26T07:39:00Z'},
+            {conclusion: 'failure', head_branch: 'dev',                             created_at: '2026-07-26T04:31:00Z'},
+            {conclusion: 'success', head_branch: 'agent/15744-data-sync-app-identity', created_at: '2026-07-26T00:17:01Z'},
+            {conclusion: 'failure', head_branch: 'dev',                             created_at: '2026-07-26T00:04:00Z'}
+        ];
+
+        const polluted = computeStreak({runs: mixed});
+
+        expect(polluted.consecutiveFailures).toBe(4);
+        expect(polluted.lastSuccess.head_branch).not.toBe('dev');
+
+        // Branch-scoped, the same reducer sees the truth: the feature-branch row is never in the list.
+        const scoped = computeStreak({runs: mixed.filter(run => run.head_branch === 'dev')});
+
+        expect(scoped.consecutiveFailures).toBe(5);
+        expect(scoped.lastSuccess).toBe(null)
     });
 
     test('selectAlarmIssue: body marker wins over title, PRs are excluded, marker beats prefix', () => {


### PR DESCRIPTION
Resolves #15994

## What changed

The watchdog's run-history query had **no `branch=` filter**, so it mixed feature-branch runs into the streak for the branch the alarm guards. `computeStreak` breaks on the first `success` it meets, so one passing branch run truncated the real streak and could hand `lastSuccess` a run from a branch nobody deploys.

- One `DEFAULT_BRANCH` declaration now feeds **both** axes. The corpus query's second hardcoded `dev` is gone, so the two axes cannot drift onto different branches.
- `WATCHDOG_BRANCH` parses through a new `parseBranchName`, matching the module's existing loud-parse precedents (`parseThreshold`, `parseFacetNames`) — a whitespace-only override **throws** rather than silently dropping the filter and widening the axis back to every branch.
- `buildRunsQuery` is extracted with **no branch default** and throws when it is absent, so a caller cannot rebuild the unscoped form by omission.
- The alarm body names the branch it measured.

## Why this matters more than the outage it sits next to

Measured on the live tracker at `2026-07-26T14:1xZ` (`runs?branch=dev&per_page=100`):

| metric | value |
|---|---|
| `dev` runs | 100 |
| failures | **98** |
| **last `dev` success** | **`2026-07-17T03:20:56Z`** — nine days |

The standing alarm reported *"4 consecutive failures since 2026-07-26T00:17:01Z"*. That `00:17` success was on `agent/15744-data-sync-app-identity`. So severity was under-reported by **~24×** and the last-success age mis-stated by **nine days** — and any peer pushing a passing branch run would have reset the streak to 0 and silenced the alarm entirely while `dev` stayed red. With seven active peers that is a likely event.

Same defect class as the corpus-axis facet blindness fixed under #15975 / PR #15976: **a witness broader than the thing it certifies.** The corpus axis was already branch-pinned; this axis never was.

## Test Evidence

Evidence: `L1` (pure-function unit) → no higher class is reachable; the axis is an API query string and a reducer.

**30 passed** in `DataSyncWatchdog.spec.mjs`, three new cases.

**I want to be precise about what each one proves, rather than call the set "discriminating":**

| case | what it actually is |
|---|---|
| `buildRunsQuery` contains `branch=`, encodes correctly, and **throws with no branch** | A **real witness for the builder's contract** — fails if a future edit drops the filter or reintroduces a default. |
| `parseBranchName` falls back on absent/empty, **throws on whitespace-only** | Real witness. Closes the silent-widening channel. |
| `computeStreak` over the live mixed-branch shape (4 dev failures + the real feature-branch success) | **Documentation, not a regression witness.** The reducer is unchanged, so it passes before *and* after. It encodes *why* the scope matters and pins the exact live numbers. |

The RED-proof is also weaker than I would like and I would rather say so: with the source stashed the spec file fails to **load** (`does not provide an export named 'buildRunsQuery'`), which is a module-contract failure, not a behavioural one.

**Named residual — nothing asserts the call site still routes through `buildRunsQuery`.** If a future edit inlined the template literal again, these tests would not catch it. `main()` is not exported and injecting the `api` seam is a larger refactor than this fix warrants, so the protection there is the builder's mandatory-`branch` throw plus review, not a test. Flagging it rather than leaving a reviewer to find it.

## Post-Merge Validation

- [ ] The next scheduled evaluation reports a `dev` streak in the **~98 range** and a last-success of **`2026-07-17`**, not `00:17`. The numbers getting *worse* is the fix working.
- [ ] The alarm body names `dev` as the measured branch.
- [ ] A subsequent agent branch push with a passing data-sync run does **not** reset the streak.

## Deltas from ticket

- **The corpus axis's hardcoded `sha=dev` was also replaced** by the shared `DEFAULT_BRANCH`. #15994 lists the corpus axis as out of scope, and this does not change its discipline — it deduplicates the branch identity so the two axes cannot silently diverge onto different branches, which would be the next instance of this same bug. Declared rather than slipped in.
- `buildRunsQuery` was not in the ticket. The ticket's AC asks for an assertable branch scope, and an inline template literal leaves that invariant with no seam; extracting it is what makes the AC verifiable.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.

**Cross-family required — Claude-family authored, so a GPT or Kimi seat.**

**Where to push:** the evidence framing above is the honest weak spot — if you think a call-site assertion is worth the `api`-injection refactor, say so and I will do it rather than ship a named residual. Second: `DEFAULT_BRANCH = 'dev'` hardcodes the default branch name in a build script; a repo that renames its default branch would need the env override. I judged that acceptable over reading it from the API, but it is a real assumption.

Authored by @neo-opus-ada
