### PR TITLE
fix: the chroma startup tip names the resolved target and the bind family (#16003)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -775,8 +775,17 @@ class Server extends BaseServer {
             health.details.forEach(detail => logger.warn(`    ${detail}`));
 
             if (!health.database?.process?.running) {
-                logger.warn('    💡 Tip: Start ChromaDB manually, for example:');
-                logger.warn(`       chroma run --path ${process.env.CHROMA_DATA_PATH || './data/chroma'} --port ${process.env.CHROMA_PORT || '8000'}`);
+                // Print the RESOLVED target this server actually dials, never invented env fallbacks:
+                // a tip that guesses can send an operator to the wrong path while the real endpoint is
+                // one line away. The bind-family hint is not decoration — a listener bound to `[::1]`
+                // only refuses an IPv4 client (and vice versa), which presents as a dead service to
+                // every `127.0.0.1` probe while `localhost` answers fine.
+                const {dataDir, host, port} = aiConfig.engines.chroma;
+
+                logger.warn(`    💡 Tip: this server expects ChromaDB at ${host}:${port} (persist dir: ${dataDir}).`);
+                logger.warn(`       Start it with: chroma run --path ${dataDir} --port ${port}`);
+                logger.warn(`       Already running? Check the bind family — an IPv6-only listener refuses`);
+                logger.warn(`       an IPv4 client: lsof -nP -iTCP:${port} -sTCP:LISTEN`);
             }
             logger.warn('    The server will periodically retry and recover automatically once dependencies are met.');
         } else if (health.status === 'degraded') {

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -5,6 +5,7 @@ import AuthMiddleware        from '../shared/services/AuthMiddleware.mjs';
 import RequestContextService from '../shared/services/RequestContextService.mjs';
 import StdioIdentityResolver from '../shared/services/StdioIdentityResolver.mjs';
 import BootEnvelopeResolver  from '../shared/services/BootEnvelopeResolver.mjs';
+import {formatHostEndpoint}  from '../shared/helpers/hostEndpoint.mjs';
 import {
     buildSqliteHolderDiagnostics,
     formatHarnessGroups
@@ -777,12 +778,21 @@ class Server extends BaseServer {
             if (!health.database?.process?.running) {
                 // Print the RESOLVED target this server actually dials, never invented env fallbacks:
                 // a tip that guesses can send an operator to the wrong path while the real endpoint is
-                // one line away. The bind-family hint is not decoration — a listener bound to `[::1]`
-                // only refuses an IPv4 client (and vice versa), which presents as a dead service to
-                // every `127.0.0.1` probe while `localhost` answers fine.
+                // one line away.
+                //
+                // The bind-family line is an INDEPENDENT diagnostic, not an explanation of any
+                // particular outage: a listener bound to `[::1]` refuses an IPv4 client (and vice
+                // versa), so the service looks dead to every `127.0.0.1` probe while `localhost`
+                // answers fine. That asymmetry is cheap to hit and expensive to guess at — but it
+                // fails FAST (a refused connection, ~1ms), so it explains a "service is down" misread,
+                // never a hang or a timeout.
+                //
+                // `formatHostEndpoint` is required rather than a `${host}:${port}` template because an
+                // IPv6 host is exactly what this branch tends to be printing, and the naive form
+                // renders `::1:8000` — not a valid authority.
                 const {dataDir, host, port} = aiConfig.engines.chroma;
 
-                logger.warn(`    💡 Tip: this server expects ChromaDB at ${host}:${port} (persist dir: ${dataDir}).`);
+                logger.warn(`    💡 Tip: this server expects ChromaDB at ${formatHostEndpoint(host, port)} (persist dir: ${dataDir}).`);
                 logger.warn(`       Start it with: chroma run --path ${dataDir} --port ${port}`);
                 logger.warn(`       Already running? Check the bind family — an IPv6-only listener refuses`);
                 logger.warn(`       an IPv4 client: lsof -nP -iTCP:${port} -sTCP:LISTEN`);

--- a/ai/mcp/server/shared/helpers/hostEndpoint.mjs
+++ b/ai/mcp/server/shared/helpers/hostEndpoint.mjs
@@ -1,0 +1,48 @@
+/**
+ * @module ai/mcp/server/shared/helpers/hostEndpoint
+ * @summary Renders a configured host + port as an endpoint string an operator can paste, bracketing
+ * bare IPv6 literals so the result stays a valid authority.
+ *
+ * A naive `${host}:${port}` template is correct for DNS names and IPv4 but produces a **malformed**
+ * endpoint for an IPv6 literal: `::1` + `8000` yields `::1:8000`, which `new URL('http://::1:8000')`
+ * rejects outright. That is the exact host family a diagnostic tip is most likely to be printing,
+ * because an IPv6-only listener is precisely the condition an operator is trying to understand — so
+ * the one case where the guidance matters most is the case the naive template breaks.
+ *
+ * The bracketing rule mirrors the one already applied by the orchestrator's Chroma health-URL
+ * builder. That builder produces a fetchable URL; this produces a human-readable authority for log
+ * output, so they are related but not interchangeable. Folding both onto one primitive is worthwhile
+ * and deliberately left alone here — it would mean editing a live supervision path to land a logging
+ * fix.
+ *
+ * Detection is structural rather than a regex on the value: **more than one colon** means the host
+ * cannot be a DNS name or IPv4 address, so it is an IPv6 literal. An already-bracketed host is
+ * passed through untouched, so the function is idempotent and safe to apply to config that may
+ * already carry brackets.
+ */
+
+/**
+ * @summary Formats a host and port into a paste-ready endpoint, bracketing bare IPv6 literals.
+ *
+ * Pure — no config reads, no I/O — so callers supply already-resolved values and tests can assert
+ * the rendering of a host the local config never selects.
+ * @param {String|Number} host Resolved host (DNS name, IPv4, bare IPv6, or bracketed IPv6).
+ * @param {String|Number} port Resolved port.
+ * @returns {String} `host:port`, with `[...]` around a bare IPv6 host.
+ * @example
+ *     formatHostEndpoint('localhost', 8000)  // 'localhost:8000'
+ *     formatHostEndpoint('127.0.0.1', 8000)  // '127.0.0.1:8000'
+ *     formatHostEndpoint('::1', 8000)        // '[::1]:8000'   (not the malformed '::1:8000')
+ *     formatHostEndpoint('[::1]', 8000)      // '[::1]:8000'   (idempotent)
+ */
+export function formatHostEndpoint(host, port) {
+    const rawHost = String(host ?? '').trim();
+
+    if (rawHost.startsWith('[') || rawHost.split(':').length - 1 <= 1) {
+        return `${rawHost}:${port}`;
+    }
+
+    return `[${rawHost}]:${port}`;
+}
+
+export default formatHostEndpoint;

--- a/ai/mcp/server/shared/helpers/hostEndpoint.mjs
+++ b/ai/mcp/server/shared/helpers/hostEndpoint.mjs
@@ -1,7 +1,8 @@
 /**
  * @module ai/mcp/server/shared/helpers/hostEndpoint
  * @summary Renders a configured host + port as an endpoint string an operator can paste, bracketing
- * bare IPv6 literals so the result stays a valid authority.
+ * bare IPv6 literals so the result stays a valid authority for DNS, IPv4, and unscoped IPv6 hosts
+ * (zone-scoped addresses are bracketed for display only — see the scope limit below).
  *
  * A naive `${host}:${port}` template is correct for DNS names and IPv4 but produces a **malformed**
  * endpoint for an IPv6 literal: `::1` + `8000` yields `::1:8000`, which `new URL('http://::1:8000')`
@@ -19,6 +20,15 @@
  * cannot be a DNS name or IPv4 address, so it is an IPv6 literal. An already-bracketed host is
  * passed through untouched, so the function is idempotent and safe to apply to config that may
  * already carry brackets.
+ *
+ * ## Scope, stated as a limit rather than left implied
+ *
+ * The output is a valid URL authority for **DNS names, IPv4, and unscoped IPv6 literals**. It is
+ * deliberately NOT one for a **zone-scoped** address: `fe80::1%eth0` cannot appear in a URL
+ * authority at all, and Node rejects both the raw and the percent-encoded form, so bracketing cannot
+ * rescue it. Such a host is still bracketed — that is the conventional display form and keeps the log
+ * line readable — but the result is for human eyes, not for `new URL`. Teaching this helper to encode
+ * zone IDs would put an address parser inside a logging path, which is the wrong home for it.
  */
 
 /**

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -977,7 +977,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         logger.warn = message => lines.push(String(message));
 
         try {
-            // The exact shape the outage produced: server up, chroma process not owned/running.
+            // The branch the tip guards: server up, chroma process not owned/running.
             serverInstance.logStartupStatus({
                 status  : 'unhealthy',
                 details : ['Embedding write canary failed'],
@@ -999,8 +999,10 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         // The invented fallbacks the predecessor printed — a path this plane never uses.
         expect(tip).not.toContain('./data/chroma');
 
-        // The bind-family hint is the diagnosis a 127.0.0.1-vs-[::1] outage needs; without it the
-        // tip is silent on the one failure mode where the service is up and the client still fails.
+        // The bind-family hint covers the one failure mode where the service is UP and the client
+        // still cannot reach it: a `[::1]`-only listener refuses an IPv4 client. It is an independent
+        // diagnostic for a "service looks down" misread — a refused connection returns in ~1ms, so it
+        // never explains a hang or a timeout, and it is not the mechanism behind any slow-boot outage.
         expect(tip).toMatch(/IPv6-only|bind family/i);
         expect(tip).toContain(`lsof -nP -iTCP:${port} -sTCP:LISTEN`);
     });

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -965,4 +965,43 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             serverInstance.destroy();
         }
     });
+
+    test('the unhealthy-boot tip names the RESOLVED chroma target, never invented fallbacks (#16003)', async () => {
+        const aiConfig              = (await import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default,
+              logger                = (await import('../../../../../../../ai/mcp/server/memory-core/logger.mjs')).default,
+              {dataDir, host, port} = aiConfig.engines.chroma,
+              serverInstance        = await createServerWithoutBoot(),
+              originalWarn          = logger.warn,
+              lines                 = [];
+
+        logger.warn = message => lines.push(String(message));
+
+        try {
+            // The exact shape the outage produced: server up, chroma process not owned/running.
+            serverInstance.logStartupStatus({
+                status  : 'unhealthy',
+                details : ['Embedding write canary failed'],
+                database: {process: {running: false}}
+            });
+        } finally {
+            logger.warn = originalWarn;
+            serverInstance.destroy();
+        }
+
+        const tip = lines.join('\n');
+
+        // Resolved truth, not guesses: the operator is told where THIS server dials.
+        expect(tip).toContain(`${host}:${port}`);
+        expect(tip).toContain(dataDir);
+        expect(tip).toContain(`--path ${dataDir}`);
+        expect(tip).toContain(`--port ${port}`);
+
+        // The invented fallbacks the predecessor printed — a path this plane never uses.
+        expect(tip).not.toContain('./data/chroma');
+
+        // The bind-family hint is the diagnosis a 127.0.0.1-vs-[::1] outage needs; without it the
+        // tip is silent on the one failure mode where the service is up and the client still fails.
+        expect(tip).toMatch(/IPv6-only|bind family/i);
+        expect(tip).toContain(`lsof -nP -iTCP:${port} -sTCP:LISTEN`);
+    });
 });

--- a/test/playwright/unit/ai/mcp/server/shared/helpers/hostEndpoint.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/helpers/hostEndpoint.spec.mjs
@@ -12,8 +12,18 @@ import {formatHostEndpoint} from '../../../../../../../../ai/mcp/server/shared/h
 test.describe('formatHostEndpoint', () => {
     test('brackets a bare IPv6 literal — the naive template produces a malformed authority', () => {
         expect(formatHostEndpoint('::1', 8000)).toBe('[::1]:8000');
-        expect(formatHostEndpoint('fe80::1%eth0', 8000)).toBe('[fe80::1%eth0]:8000');
         expect(formatHostEndpoint('2001:db8::dead:beef', 443)).toBe('[2001:db8::dead:beef]:443');
+    });
+
+    test('a ZONE-SCOPED address is bracketed for display but is NOT a valid URL authority', () => {
+        // Pinning the documented limit rather than asserting support this helper does not provide.
+        // A zone ID cannot appear in a URL authority: Node rejects both the raw and percent-encoded
+        // forms, so bracketing cannot rescue it and a zone-ID parser does not belong in a logging
+        // helper. Bracketing is still the right DISPLAY form, so the output stays readable — the
+        // claim is narrowed, the behaviour is unchanged.
+        expect(formatHostEndpoint('fe80::1%eth0', 8000)).toBe('[fe80::1%eth0]:8000');
+        expect(() => new URL('http://[fe80::1%eth0]:8000')).toThrow();
+        expect(() => new URL('http://[fe80::1%25eth0]:8000')).toThrow();
     });
 
     test('the bracketed form is a parseable URL authority and the bare form is NOT', () => {

--- a/test/playwright/unit/ai/mcp/server/shared/helpers/hostEndpoint.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/helpers/hostEndpoint.spec.mjs
@@ -1,0 +1,48 @@
+import {test, expect}       from '@playwright/test';
+import {formatHostEndpoint} from '../../../../../../../../ai/mcp/server/shared/helpers/hostEndpoint.mjs';
+
+// Pure formatter (no config / I/O) — imported directly, mirrors detectionRetentionSla.spec.
+//
+// Why this spec exists as a SEPARATE witness from the Server tip test: the tip test reads the same
+// resolved config the implementation reads, so it can only ever assert "whatever host resolved, the
+// tip printed it" — it cannot fail on a rendering bug, and unit mode never selects an IPv6 host
+// anyway. Asserting the IPv6 rendering needs a host the local config never chooses, supplied
+// explicitly and with no mutation of the shared config singleton.
+
+test.describe('formatHostEndpoint', () => {
+    test('brackets a bare IPv6 literal — the naive template produces a malformed authority', () => {
+        expect(formatHostEndpoint('::1', 8000)).toBe('[::1]:8000');
+        expect(formatHostEndpoint('fe80::1%eth0', 8000)).toBe('[fe80::1%eth0]:8000');
+        expect(formatHostEndpoint('2001:db8::dead:beef', 443)).toBe('[2001:db8::dead:beef]:443');
+    });
+
+    test('the bracketed form is a parseable URL authority and the bare form is NOT', () => {
+        // The whole reason bracketing is required rather than cosmetic. This assertion is the
+        // discriminator: it fails if the formatter ever regresses to `${host}:${port}`.
+        expect(() => new URL(`http://${formatHostEndpoint('::1', 8000)}`)).not.toThrow();
+        expect(() => new URL('http://::1:8000')).toThrow();
+    });
+
+    test('leaves DNS names and IPv4 untouched — no stray brackets in the common case', () => {
+        expect(formatHostEndpoint('localhost', 8000)).toBe('localhost:8000');
+        expect(formatHostEndpoint('127.0.0.1', 8000)).toBe('127.0.0.1:8000');
+        expect(formatHostEndpoint('chroma', 8000)).toBe('chroma:8000');
+        expect(formatHostEndpoint('my.host.example', 5432)).toBe('my.host.example:5432');
+    });
+
+    test('is idempotent on an already-bracketed host — config may carry brackets', () => {
+        expect(formatHostEndpoint('[::1]', 8000)).toBe('[::1]:8000');
+        expect(formatHostEndpoint('[2001:db8::1]', 443)).toBe('[2001:db8::1]:443');
+    });
+
+    test('accepts a numeric or string port identically', () => {
+        expect(formatHostEndpoint('::1', 8000)).toBe(formatHostEndpoint('::1', '8000'));
+        expect(formatHostEndpoint('localhost', 8000)).toBe(formatHostEndpoint('localhost', '8000'));
+    });
+
+    test('tolerates padded / empty host without inventing an authority', () => {
+        expect(formatHostEndpoint('  ::1  ', 8000)).toBe('[::1]:8000');
+        expect(formatHostEndpoint('', 8000)).toBe(':8000');
+        expect(formatHostEndpoint(undefined, 8000)).toBe(':8000');
+    });
+});


### PR DESCRIPTION
Resolves #16003

Today's MC outage was unblocked by @neo-opus-grace (`NEO_CHROMA_HOST=::1` boots in 2s). **Her IPv6-as-the-30-second-mechanism attribution was subsequently retracted, and this PR no longer relies on it** — an unreachable Chroma refuses in ~0.3ms, measured, nowhere near a handshake timeout. What survives independently is narrower and still worth fixing: **the guidance an operator reads at the moment of failure invented its own values and said nothing about the bind family** — the tip could send someone to `./data/chroma` (a path this plane never uses) while the real endpoint sat one line away, and it was silent on the one failure mode where the service is UP and the client still cannot reach it. That asymmetry explains a *"service looks down"* misread, never a hang; the supervisor mechanism behind the actual instability is #16022.

The tip now prints the resolved target this server actually dials (`engines.chroma.{host,port,dataDir}`), the launch command with those same values, and the bind-family check that turns a `127.0.0.1`-vs-`[::1]` mismatch from a mystery into one `lsof` line.

Evidence: L2 (unit-level: the real `logStartupStatus` invoked with the unhealthy shape, logger captured, resolved config asserted; plus a **pure-formatter witness whose assertion is the discriminator itself** — the bracketed authority parses, the bare form throws — red-proved against the naive template) → L2 required (the close-target ACs are a log-content contract; no runtime surface beyond the emitted lines). **Residuals: two, both moved out of scope rather than left implied** — probe-based bind-family diagnosis and the `package.json` `--host` election now live on #16025, and #16003 is narrowed accordingly. The earlier `Residual: none` was wrong: it sat beside a Post-Merge section that itself deferred the launch decision.

## Deltas from ticket

0. **Review cycle (@neo-gpt-emmy, `REQUEST_CHANGES` at `2dbcd6ee4d`) — three RAs, all verified before acting, all addressed at `14aaba33d9`.** RA-1 was two defects: the tip rendered `${host}:${port}`, which yields the malformed `::1:8000` for an IPv6 literal (her falsifier reproduces — `new URL` throws), fixed by extracting `formatHostEndpoint`; and the witness derived its expectation from the **same resolved singleton the implementation reads**, so it could not fail on a rendering bug and unit mode never selected an IPv6 host anyway — replaced with an explicit-host formatter spec. RA-2: two test comments credited the retracted IPv6 attribution; restated as an independent diagnostic with the ~1ms fast-fail stated so it cannot be re-read as a hang. RA-3: only 2 of #16003's 5 ACs were delivered — ticket narrowed, #16025 filed for the rest.

1. **No `--host` is recommended, deliberately.** The obvious "fix" is to suggest `--host ${host}`, but `host` resolves to `localhost` — which is exactly what produces the IPv6-only bind on this machine, so the tip would teach the defect it exists to prevent. The launch line stays `--path`/`--port`; choosing the bind value is the operator decision the ticket carries as a matrix, and `package.json:81` is untouched until that lands.
2. **The bind-family hint is asserted, not just written.** `expect(tip).toMatch(/IPv6-only|bind family/i)` plus the exact `lsof` invocation — because the wording is the diagnostic payload here, and a tip that loses it silently regresses to today's failure.

## Test Evidence

- RED (pre-fix `Server.mjs`, spec in tree): `npx playwright test … Server.spec.mjs -g "16003"` → **1 failed** on the first resolved-target assertion (`expect(tip).toContain('${host}:${port}')` — the old line printed neither), proving the spec discriminates rather than passing on any tip.
- GREEN (fix applied, whole file): `npx playwright test … Server.spec.mjs` → **23 passed (4.9s)**, including the pre-existing boot-order and identity specs.
- Directly touched app/feature surface: none — Brain server startup logging. Adjacent coverage: the same spec's `boot()` ordering test still passes, so the new branch does not perturb the boot sequence.

## Post-Merge Validation

- [ ] Next time a seat boots against a stopped or wrong-family Chroma, the warning names the plane's real host/port/path and the `lsof` check resolves it without a peer investigation.
- [ ] `package.json:81`'s `--host` value lands separately once the exposure decision in #16025 is made; this PR intentionally leaves that half open.

## Commits

- 2dbcd6ee4d — resolved-target tip + bind-family hint, with the red-proved spec.

Authored by Vega (Claude Opus 5, Claude Code). Session 7ffa4544-0acf-47ac-82ba-7c4139967eba.




