### PR TITLE
test(workstation): honor film profile for canvas pixels (#16000)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -8,10 +8,10 @@ import {workstationTourScript} from '../../../../apps/workstation/tour/denseWork
  * and owns what only the App Worker + DOM + Canvas Worker composition can prove: one Provider,
  * two stable Store<Model> identities, an exact 100k renderer-rich grid, a sustained capped
  * feed, one owner-exact overflow surface, two real rails, frame-sampled midpoint continuity,
- * Canvas-worker pixel change, DevIndex-sized chart geometry, honest progress paints, both
- * themes, host-relative edge bands, visible real splitters, user-driven semantic resize,
- * pane-owned chrome, replacement-chrome motion containment, sequential clip-safe fixed staging,
- * and identity preservation.
+ * Canvas-worker value change (plus pixel change under the film profile), DevIndex-sized chart
+ * geometry, honest progress paints, both themes, host-relative edge bands, visible real splitters,
+ * user-driven semantic resize, pane-owned chrome, replacement-chrome motion containment,
+ * sequential clip-safe fixed staging, and identity preservation.
  *
  * Run: NEO_E2E_PORT=8124 npx playwright test workstation/WorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -36,7 +36,16 @@ const initialTabNodeIds = [
     'right-top-tabs', 'right-bottom-tabs', 'bottom-tabs'
 ];
 
-const asArray = value => Array.isArray(value) ? value : value ? [value] : [];
+const asArray  = value => Array.isArray(value) ? value : value ? [value] : [],
+      filmTake = Boolean(process.env.NEO_FILM_TAKE);
+
+/**
+ * @summary Captures the exact Canvas pixels when the film profile presents frames on glass.
+ *
+ * @param {import('@playwright/test').Locator} canvas
+ * @returns {Promise<String>} Base64-encoded PNG for the current Canvas pixels.
+ */
+const readCanvasPixels = async canvas => (await canvas.screenshot()).toString('base64');
 
 /**
  * @param {Object} app Neural Link fixture app handle.
@@ -1148,18 +1157,24 @@ test.describe('Workstation — dense living-data composition', () => {
 
         await page.waitForTimeout(150);
 
+        // The benchmark profile deliberately includes --disable-frame-rate-limit: its worker truth
+        // stays live, but the capture-profile contract exposes no presented frame to screenshots.
+        // Film mode drops that flag and therefore adds the independent on-glass pixel receipt.
         const targetCanvas = page.locator(`[id="${pulseTarget.id}"]`),
-              beforePixels = (await targetCanvas.screenshot()).toString('base64'),
+              beforePixels = filmTake ? await readCanvasPixels(targetCanvas) : null,
               beforeValues = pulseTarget.properties.values,
               pulseReceipt = await app.callMethod(workspaceId, 'pulseScaleSparkline', [pulseTarget.id]);
 
         expect(pulseReceipt.componentId).toBe(pulseTarget.id);
         expect(pulseReceipt.recordId).toBeTruthy();
-        await expect.poll(async () => (await targetCanvas.screenshot()).toString('base64'), {
-            message  : 'the exact scale canvas changes after its worker receives new data',
-            timeout  : 10000,
-            intervals: [100, 250]
-        }).not.toBe(beforePixels);
+
+        if (filmTake) {
+            await expect.poll(() => readCanvasPixels(targetCanvas), {
+                message  : 'the exact scale Canvas changes after its worker receives new data',
+                timeout  : 10000,
+                intervals: [100, 250]
+            }).not.toBe(beforePixels)
+        }
 
         const pulseTargetAfter = (await readScaleSparklines(app, page))
             .find(entry => entry.id === pulseTarget.id);


### PR DESCRIPTION
Resolves #16000

`WorkstationNL` now consumes the browser contract its surrounding film pipeline already declares: every run keeps the exact Sparkline component, record, and worker-value mutation receipts, while only `NEO_FILM_TAKE=1` asks Chromium for the independent exact-canvas pixel delta. The default benchmark profile therefore no longer waits for a compositor frame that `--disable-frame-rate-limit` intentionally suppresses, and the film profile retains the stronger on-glass proof.

Evidence: L3 (live Chromium runs exercised both launch profiles through the Canvas gate) → L3 required (profile-specific worker and pixel receipts). No residuals.

Related: #15252, #15912, #15906

## Deltas from ticket

The original `boundingBox()` plus page-level clipped-screenshot prescription was falsified: page screenshots and CDP screencasts share the same missing presented-frame dependency, while placeholder `toDataURL()` remains static under the benchmark profile. The ticket was corrected in place before handoff. The final diff is narrower than that prescription and changes one test file; no launch-profile, production, or app code changed.

## Test Evidence

- Default benchmark profile: `NEO_E2E_PORT=8124 npx playwright test workstation/WorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1` → GL probe passed; the former Canvas screenshot gate cleared; the journey reached the later, separately owned `preview:audit:scale-tabs:edge-bottom` indicator assertion. Result: 1 passed / 1 failed at the later cross-zone receipt.
- Film profile: `NEO_E2E_PORT=8124 NEO_FILM_TAKE=1 npx playwright test workstation/WorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1` → GL probe passed; exact-canvas before/after screenshots and worker-value assertions cleared; the same later cross-zone receipt remained. Result: 1 passed / 1 failed at the later assertion.
- Touched surface: `test/playwright/e2e/workstation/WorkstationNL.spec.mjs` → both declared launch modes exercised in real Chromium.
- `npm run agent-preflight -- test/playwright/e2e/workstation/WorkstationNL.spec.mjs` → passed; only unrelated stale-overlay warnings reported.

## Post-Merge Validation

- [ ] Re-run both profiles after the separately owned cross-zone indicator correction lands and confirm the complete journey has no unexpected failures.
- [ ] Confirm the next `#15252` film take continues to exercise the exact-canvas pixel receipt under `NEO_FILM_TAKE=1`.

## Evolution

Live falsification changed the implementation shape three times before handoff: clipped page capture still starved; CDP emitted no default-profile frame; and placeholder serialization stayed static while worker truth changed. Re-reading the merged capture-profile authority exposed the actual invariant: the benchmark path proves worker state, while the film path is the only valid on-glass pixel witness.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019f9e1e-2ef1-72c3-a04d-6bc67a531a8b.
