### PR TITLE
fix(neural-link): require injected bridge log path (#16008)

### DIFF
--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -76,18 +76,18 @@ export const getBridgePayloadByteLength = payload => {
  * @summary Resolves the detached Bridge process stdout/stderr log file.
  * @param {Object} [options={}]
  * @param {String} [options.logPath=aiConfig.logPath]
- * @param {String} [options.neoRootDir=aiConfig.neoRootDir]
- * @param {String} [options.cwd=process.cwd()]
  * @returns {String}
  */
 export const getBridgeStdioLogPath = ({
-    logPath   = aiConfig.logPath,
-    neoRootDir = aiConfig.neoRootDir,
-    cwd       = process.cwd()
+    logPath = aiConfig.logPath
 } = {}) => {
-    const logDir = logPath || path.resolve(neoRootDir || cwd, '.neo-ai-data/logs');
+    if (typeof logPath !== 'string' || logPath.trim() === '') {
+        throw new Error(
+            'Missing aiConfig.logPath: Neural Link Bridge stdio requires an injected log directory'
+        )
+    }
 
-    return path.join(logDir, 'neural-link-bridge-stdio.log')
+    return path.join(logPath, 'neural-link-bridge-stdio.log')
 };
 
 /**
@@ -734,14 +734,13 @@ class ConnectionService extends Base {
      * Spawns the Bridge process.
      * @param {Object} [options={}]
      * @param {String} [options.logPath=aiConfig.logPath] Directory for spawned Bridge stdout/stderr.
-     * @param {String} [options.neoRootDir=aiConfig.neoRootDir] Repo root fallback for log path resolution.
      * @param {Number} [options.startupDelayMs=2000] Delay before resolving after spawning.
      * @returns {Promise<void>}
      */
-    async spawnBridge({logPath = aiConfig.logPath, neoRootDir = aiConfig.neoRootDir, startupDelayMs = 2000} = {}) {
+    async spawnBridge({logPath = aiConfig.logPath, startupDelayMs = 2000} = {}) {
         return new Promise(resolve => {
             const args    = ['run', 'ai:server-neural-link'];
-            const file    = getBridgeStdioLogPath({logPath, neoRootDir});
+            const file    = getBridgeStdioLogPath({logPath});
             const logFile = this.openBridgeLogFile(file);
             const port    = aiConfig.port;
 

--- a/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
@@ -20,7 +20,7 @@ import * as core                 from '../../../../../../src/core/_export.mjs';
 import {STALE_BRIDGE_ERROR_CODE} from '../../../../../../ai/mcp/server/neural-link/BridgeProtocol.mjs';
 
 /**
- * @summary Unit coverage for the Neural Link ConnectionService freshness gate.
+ * @summary Unit coverage for Neural Link connection freshness and Bridge process boundaries.
  *
  * These tests deliberately stub `connectToBridge` / `spawnBridge` rather than opening a WebSocket:
  * importing the singleton is safe because `unitTestMode` suppresses auto-connect, and the branch logic
@@ -71,27 +71,55 @@ test.describe('Neo.ai.services.neural-link.ConnectionService — bridge freshnes
         expect(url).toBe('ws://127.0.0.1:19081/?role=agent&id=agent-test&token=token+with+spaces');
     });
 
-    test('resolves Bridge stdio logs under the configured Neural Link log directory (#13899)', () => {
+    test('resolves Bridge stdio logs only under the injected Neural Link log directory', () => {
         const logDir = path.resolve(os.tmpdir(), `nl-bridge-stdio-path-${process.pid}`);
 
         expect(getBridgeStdioLogPath({logPath: logDir}))
             .toBe(path.join(logDir, 'neural-link-bridge-stdio.log'));
-        expect(getBridgeStdioLogPath({logPath: '', neoRootDir: '/repo'}))
-            .toBe(path.join('/repo', '.neo-ai-data/logs/neural-link-bridge-stdio.log'));
+        expect(() => getBridgeStdioLogPath({
+            cwd       : '/repo',
+            logPath   : '',
+            neoRootDir: '/repo'
+        })).toThrow(/aiConfig\.logPath/);
+        expect(() => getBridgeStdioLogPath({logPath: '  '})).toThrow(/aiConfig\.logPath/);
     });
 
-    test('creates the configured Bridge stdio log directory before opening the file (#13899)', () => {
-        const logDir  = path.join(os.tmpdir(), `nl-bridge-stdio-open-${process.pid}-${Date.now()}`);
-        const logPath = getBridgeStdioLogPath({logPath: logDir});
-        const fd      = ConnectionService.openBridgeLogFile(logPath);
+    test('fails before opening or spawning when the injected log directory is absent', async () => {
+        let opened = false, spawned = false;
+
+        ConnectionService.openBridgeLogFile = () => {
+            opened = true;
+        };
+        ConnectionService.spawnBridgeProcess = () => {
+            spawned = true;
+        };
+
+        await expect(ConnectionService.spawnBridge({
+            logPath       : '',
+            neoRootDir    : '/real-seat',
+            startupDelayMs: 0
+        })).rejects.toThrow(/aiConfig\.logPath/);
+
+        expect(opened).toBe(false);
+        expect(spawned).toBe(false);
+    });
+
+    test('writes Bridge stdio only inside an injected overlay path on a real-dir seat', () => {
+        const
+            seatRoot         = fs.mkdtempSync(path.join(os.tmpdir(), 'nl-bridge-real-seat-')),
+            canonicalLogPath = path.join(seatRoot, '.neo-ai-data', 'logs'),
+            overlayLogDir    = path.join(seatRoot, '.neo-ai-data-overlay', 'logs'),
+            overlayLogPath   = getBridgeStdioLogPath({logPath: overlayLogDir}),
+            fd               = ConnectionService.openBridgeLogFile(overlayLogPath);
 
         fs.closeSync(fd);
 
         try {
-            expect(fs.existsSync(logDir)).toBe(true);
-            expect(fs.existsSync(logPath)).toBe(true);
+            expect(fs.existsSync(overlayLogDir)).toBe(true);
+            expect(fs.existsSync(overlayLogPath)).toBe(true);
+            expect(fs.existsSync(canonicalLogPath)).toBe(false);
         } finally {
-            fs.rmSync(logDir, {recursive: true, force: true});
+            fs.rmSync(seatRoot, {recursive: true, force: true});
         }
     });
 


### PR DESCRIPTION
Resolves #16008

`ConnectionService` now treats the injected Neural Link `logPath` as its only Bridge-stdio authority. Missing, empty, or whitespace-only values fail before any file open or child spawn; a configured overlay directory continues to resolve the same `neural-link-bridge-stdio.log` file. The `neoRootDir` / `cwd` reconstruction of canonical `.neo-ai-data/logs` is gone.

Evidence: L2 (isolated real-directory filesystem and pre-side-effect unit proof) → L2 required (the complete close-target contract). No residuals.

Related: #15931, #15984, #15875, #13899

## Deltas from ticket

None. The diff matches #16008's narrow Contract Ledger: one injected-only helper boundary, the corresponding `spawnBridge()` option cleanup, and focused negative/overlay tests. It deliberately does not close parent #15931, change the #15984 plane-member/compose contract, or touch `TenantRepoSyncService`.

## Test Evidence

- `npx playwright test test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs -c test/playwright/playwright.config.unit.mjs --project=unit-brain --workers=1` → 13 passed.
- Missing/blank `logPath` proof → helper rejects; `openBridgeLogFile()` and `spawnBridgeProcess()` spies remain false.
- Real-directory overlay proof → the injected overlay log file exists while the sibling canonical `.neo-ai-data/logs` directory remains absent.
- `npm run ai:lint-config-template-ssot` → passed: zero inline-env leaf defaults and zero test config-authority violations.
- `npm run agent-preflight -- --no-fix ai/services/neural-link/ConnectionService.mjs test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs` → passed; only unrelated stale-overlay warnings reported.
- `git diff --check` → passed.

## Post-Merge Validation

None deferred. Every close-target AC is covered by the focused unit/filesystem proof; #15984 separately owns the relocated parity-stack boot witness.

## Evolution

The intake census found that #15931's “every remaining derivation” umbrella is broader than this two-file correction: older Fleet/concept runtime roots also require independent disposition. Rather than use a green Neural Link patch to overclaim that umbrella, this work created the narrow #16008 close target and released #15931 for its remaining census. The resulting PR is smaller and its closure semantics are stronger.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019f9e1e-2ef1-72c3-a04d-6bc67a531a8b.
