### PR TITLE
fix(ai): sync facets persist independently instead of all-or-nothing

### DIFF
--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -117,119 +117,180 @@ class SyncService extends Base {
      * git delivery step so a failed rebase can reset the checkout, re-emit the generated files,
      * and retry without leaving the repository mid-rebase.
      *
-     * 1.  Loads the persistent metadata from the last sync via `MetadataManager`.
-     * 2.  Fetches and caches GitHub release data via `ReleaseNotesSyncer`.
-     * 3.  Reconciles closed issue locations (archives stale issues) via `IssueSyncer`.
-     * 4.  **Pushes** any local issue changes to GitHub via `IssueSyncer`.
-     * 5.  **Pulls** the latest issue changes from GitHub via `IssueSyncer`.
-     * 6.  Syncs release notes into local Markdown files via `ReleaseNotesSyncer`.
-     * 7.  Syncs discussions into local Markdown files via `DiscussionSyncer`.
-     * 8.  Syncs pull requests into local Markdown files via `PullRequestSyncer`.
-     * 9.  Carries `metadata.discussions` + `metadata.pulls` onto `newMetadata` so the
-     *     per-syncer cache populations survive `MetadataManager.save`.
-     * 10. Caches releases in `newMetadata` for next run.
-     * 11. Saves the updated, pruned metadata to disk via `MetadataManager`.
-     * 12. Rebuilds Portal content indexes and SEO artifacts from the emitted content.
-     * @returns {Promise<object>} Statistics for the emitted generated content.
+     * **The facets are ISOLATED and persist independently.** Each runs through `#runFacet`, which saves
+     * metadata the moment that facet completes and rolls back only that facet's own slices when it does
+     * not. So a corpus too large for one pass converges across runs instead of failing whole, and one
+     * facet's failure neither discards the facets before it nor skips the facets after it.
+     *
+     * 1. Loads the persistent metadata via `MetadataManager` — one accumulator every facet mutates.
+     * 2. Facet `releases`: fetches release data and caches it for the next run (`ReleaseNotesSyncer`).
+     * 3. Facet `issues`: reconciles closed issue locations, **pushes** local changes, then **pulls**
+     *    remote changes, merging the returned metadata into the accumulator (`IssueSyncer`).
+     * 4. Facet `releaseNotes`: syncs release notes into local Markdown (`ReleaseNotesSyncer`).
+     * 5. Facet `discussions`: syncs discussions into local Markdown (`DiscussionSyncer`).
+     * 6. Facet `pulls`: reconciles closed pull locations, syncs pulls, repairs duplicates, realigns
+     *    `_index.json`, and takes the integrity verdict that decides whether the facet advances at all
+     *    (`PullRequestSyncer`).
+     * 7. Rebuilds Portal content indexes and SEO artifacts from whatever advanced.
+     * 8. Throws one aggregate verdict naming every facet that did not advance — partial progress must
+     *    never report as a clean run.
+     * @returns {Promise<object>} Statistics for the emitted generated content, plus `facetOutcomes`.
      */
     async emitGeneratedContentAndDerive() {
-        const metadata = await MetadataManager.load();
+        const
+            metadata = await MetadataManager.load(),
+            outcomes = [],
+            facet    = (name, owns, run) => this.#runFacet({metadata, name, outcomes, owns, run});
+
+        // Normalized ONCE, here, instead of coerced with `|| {}` at the save site. `load()` supplies all
+        // four on both its paths, but a hand-written metadata file or a stub may not — and then every
+        // facet downstream has to defend against `undefined`, which is how the empty-object guarantee
+        // gets lost: one site forgets the coercion and a consumer reads `undefined` where the contract
+        // promises `{}`. One normalization makes the accumulator's shape an invariant rather than a
+        // habit, and it is also what lets `MetadataManager.save` read `metadata.issues` unguarded.
+        metadata.discussions ??= {};
+        metadata.issues      ??= {};
+        metadata.pulls       ??= {};
+        metadata.releases    ??= {};
 
         // 1. Fetch releases first, as they are needed for issue archiving
-        await ReleaseNotesSyncer.fetchAndCacheReleases(metadata);
+        await facet('releases', ['releases', 'releasesLastFetched'], async () => {
+            await ReleaseNotesSyncer.fetchAndCacheReleases(metadata);
 
-        // 2. Reconcile closed issue locations - archive stale closed issues before pull
-        const reconcileStats = await IssueSyncer.reconcileClosedIssueLocations(metadata);
+            // Cached HERE rather than at the end of the chain. These two assignments used to live after
+            // every facet had run, so any later throw discarded a fetch that had already succeeded and
+            // the next run paid for it again.
+            metadata.releases            = ReleaseNotesSyncer.releases;
+            metadata.releasesLastFetched = new Date().toISOString()
+        });
 
-        // 2b. Reconcile closed PULL locations — the sibling reconcile that was missing. The
-        //     delta-only pull sync skips PRs untouched since the last cutoff, so old merged PRs marooned
-        //     in active pulls/ are never re-bucketed; this per-sync reconcile (mirroring the issue one)
-        //     archives them and keeps pulls archived going forward.
-        const pullReconcileStats = await PullRequestSyncer.reconcileClosedPullRequestLocations(metadata);
+        // 2 + 3 + 4. Reconcile closed issue locations (archiving stale closed issues BEFORE the pull),
+        //     push local changes, then pull remote changes. One facet, because the ordering between them
+        //     is load-bearing: splitting them would let a run persist a pull whose reconcile never ran.
+        let reconcileStats = null,
+            pushStats      = null,
+            pullStats      = null;
 
-        // 3. Push local changes
-        const pushStats = await IssueSyncer.pushToGitHub(metadata);
+        await facet('issues', ['issues', 'pushFailures', 'lastSync'], async () => {
+            reconcileStats = await IssueSyncer.reconcileClosedIssueLocations(metadata);
+            pushStats      = await IssueSyncer.pushToGitHub(metadata);
 
-        // 4. Pull remote changes
-        const { newMetadata, stats: pullStats } = await IssueSyncer.pullFromGitHub(metadata);
+            const {newMetadata, stats} = await IssueSyncer.pullFromGitHub(metadata);
+
+            pullStats = stats;
+
+            // MERGED into the accumulator rather than replacing it. `pullFromGitHub` returns a fresh
+            // object carrying only `{issues, pushFailures, lastSync}`, and the old chain saved THAT
+            // object at the very end — so discussion and pull populations had to be hand-copied back
+            // onto it or they were silently dropped. Merging makes the carry-over structural: a syncer
+            // that populates a new slice cannot lose it to a save that does not know the slice exists.
+            Object.assign(metadata, newMetadata);
+
+            // Self-heal push failures: a previously failed issue that pulled successfully is not failing.
+            if (metadata.pushFailures?.length > 0) {
+                metadata.pushFailures = metadata.pushFailures.filter(failedId => !metadata.issues[failedId])
+            }
+        });
 
         // 5. Sync release notes
-        const releaseStats = await ReleaseNotesSyncer.syncNotes(metadata);
+        const releaseStats = await facet('releaseNotes', ['releases'], () => ReleaseNotesSyncer.syncNotes(metadata));
 
         // 6. Sync discussions
-        const discussionStats = await DiscussionSyncer.syncDiscussions(metadata);
+        const discussionStats = await facet('discussions', ['discussions'], () => DiscussionSyncer.syncDiscussions(metadata));
 
-        // 7. Sync pull requests
-        const pullStats2 = await PullRequestSyncer.syncPullRequests(metadata);
+        // 7. The pull facet: reconcile, sync, repair, project, and the integrity verdict that decides
+        //    whether any of it counts. All one facet because 7c's abort must revert THIS facet and only
+        //    this facet — the whole point of the verdict is that a pull corpus measured broken does not
+        //    advance, and the whole point of the isolation is that it no longer takes the other facets
+        //    down with it.
+        let pullReconcileStats = null,
+            pullDuplicateStats = null,
+            pullIndexStats     = null,
+            pullIntegrity      = null;
 
-        // 7a. Restore any pull request owning more than one artifact from canonical GitHub state.
-        //     A divergent pair cannot be resolved locally — both files are real renderings and
-        //     nothing on disk says which is current — so neither is trusted and the artifact is
-        //     re-derived from the source of truth. Runs BEFORE the index realign so the restored
-        //     placement is what gets indexed, and is a no-op on a corpus with no duplicates.
-        const pullDuplicateStats = await PullRequestSyncer.repairDuplicateArtifacts(metadata);
+        const pullStats2 = await facet('pulls', ['pulls'], async () => {
+            // 7-a. Reconcile closed PULL locations — the sibling reconcile that was missing. The
+            //      delta-only pull sync skips PRs untouched since the last cutoff, so old merged PRs
+            //      marooned in active pulls/ are never re-bucketed; this per-sync reconcile (mirroring
+            //      the issue one) archives them and keeps pulls archived going forward. It ran before
+            //      the ISSUE push/pull previously; it belongs with the pull corpus it reconciles, and
+            //      what its own rationale requires is only that it precede `syncPullRequests`.
+            pullReconcileStats = await PullRequestSyncer.reconcileClosedPullRequestLocations(metadata);
 
-        // 7b. Realign `_index.json` with the pull corpus now that placement is final for this run.
-        //     Preventing new drift does not remove old drift: entries that went stale when a move
-        //     did not carry its upsert name files that are ALREADY archived, so the relocate pass
-        //     never revisits them and the delta sync never fetches them — no existing mechanism
-        //     could ever have healed them. The index is a projection of the corpus, so this
-        //     recomputes it from disk. Idempotent and silent on a healthy corpus (it upserts only
-        //     entries that disagree), so the generated-content diff stays empty when nothing drifted.
-        const pullIndexStats = await PullRequestSyncer.reconcilePullRequestIndex();
+            const stats = await PullRequestSyncer.syncPullRequests(metadata);
 
-        // 7c. One terminal integrity verdict, CONSUMED. Every pass above reports its own outcome and
-        //     degrades softly on its own terms, which is exactly how a corpus reaches the commit with
-        //     each step reporting success and the whole known-broken: a repair that fails logs and
-        //     returns, an unrepaired duplicate stays unindexed, and nothing downstream asks. So the
-        //     verdict is taken AFTER placement, restoration and projection are final, and it aborts —
-        //     before the metadata save, before the derive, before the auto-push. Committing a corpus
-        //     we have already measured as broken is worse than failing the run: the run can be
-        //     retried, but a generated commit is what every consumer then reads as truth.
-        const pullIntegrity = await PullRequestSyncer.verifyCorpusIntegrity();
+            // 7-b. Restore any pull request owning more than one artifact from canonical GitHub state.
+            //      A divergent pair cannot be resolved locally — both files are real renderings and
+            //      nothing on disk says which is current — so neither is trusted and the artifact is
+            //      re-derived from the source of truth. Runs BEFORE the index realign so the restored
+            //      placement is what gets indexed, and is a no-op on a corpus with no duplicates.
+            pullDuplicateStats = await PullRequestSyncer.repairDuplicateArtifacts(metadata);
 
-        if (pullDuplicateStats.failed.length > 0 || !pullIntegrity.ok) {
-            logger.error(formatIntegrityReport(pullIntegrity));
+            // 7-c. Realign `_index.json` with the pull corpus now that placement is final for this run.
+            //      Preventing new drift does not remove old drift: entries that went stale when a move
+            //      did not carry its upsert name files that are ALREADY archived, so the relocate pass
+            //      never revisits them and the delta sync never fetches them — no existing mechanism
+            //      could ever have healed them. The index is a projection of the corpus, so this
+            //      recomputes it from disk. Idempotent and silent on a healthy corpus (it upserts only
+            //      entries that disagree), so the generated-content diff stays empty when nothing drifted.
+            pullIndexStats = await PullRequestSyncer.reconcilePullRequestIndex();
 
+            // 7-d. One terminal integrity verdict, CONSUMED. Every pass above reports its own outcome and
+            //      degrades softly on its own terms, which is exactly how a corpus reaches the commit with
+            //      each step reporting success and the whole known-broken: a repair that fails logs and
+            //      returns, an unrepaired duplicate stays unindexed, and nothing downstream asks. So the
+            //      verdict is taken AFTER placement, restoration and projection are final, and it aborts —
+            //      before this facet's metadata save, before the derive, before the auto-push. Committing
+            //      a corpus we have already measured as broken is worse than failing the run: the run can
+            //      be retried, but a generated commit is what every consumer then reads as truth.
+            //
+            //      What ISOLATION changed and did not change: the abort no longer discards the issue,
+            //      release and discussion facets that already succeeded. It still prevents this facet
+            //      from advancing, so the next run re-fetches exactly these pulls. The `_index.json`
+            //      realign above has already touched disk by this point and is not rolled back — that is
+            //      acceptable only because it is idempotent by construction (its own note above), and it
+            //      is the reason the verdict must stay inside this facet rather than becoming advisory.
+            pullIntegrity = await PullRequestSyncer.verifyCorpusIntegrity();
+
+            if (pullDuplicateStats.failed.length > 0 || !pullIntegrity.ok) {
+                logger.error(formatIntegrityReport(pullIntegrity));
+
+                throw new Error(
+                    'Pull corpus integrity is not clean after repair — refusing to commit generated content. ' +
+                    `stale=${pullIntegrity.staleIndexEntries.length} ` +
+                    `inconsistent=${pullIntegrity.inconsistentIndexEntries.length} ` +
+                    `duplicateIndexRows=${pullIntegrity.duplicateIndexEntryIds.length} ` +
+                    `unindexed=${pullIntegrity.unindexedIds.length} ` +
+                    `divergentDuplicates=${pullIntegrity.divergentDuplicateIds.length} ` +
+                    `failedRepairs=${pullDuplicateStats.failed.length}`
+                );
+            }
+
+            return stats
+        });
+
+        // 8. Derive the portal projection from whatever DID advance. The indexes are a projection of the
+        //    corpus on disk, so a partially-advanced corpus derives a correspondingly partial projection
+        //    rather than a wrong one — and running it before the verdict below means a facet failure does
+        //    not also strand the facets that succeeded without their indexes.
+        await this.rebuildContentIndexesAndSeo();
+
+        const failedFacets = outcomes.filter(outcome => !outcome.advanced);
+
+        // 9. One aggregate verdict, AFTER every facet has had its turn.
+        //
+        //    Partial progress is the point — a corpus too large for one pass must converge across runs
+        //    rather than failing whole — but a partial run must never REPORT as a clean one. Exiting 0
+        //    here would trade total loss for silent loss: the corpus would look synced while a facet sat
+        //    stale, and no consumer could tell. So the progress is partial and the verdict is not.
+        if (failedFacets.length > 0) {
             throw new Error(
-                'Pull corpus integrity is not clean after repair — refusing to commit generated content. ' +
-                `stale=${pullIntegrity.staleIndexEntries.length} ` +
-                `inconsistent=${pullIntegrity.inconsistentIndexEntries.length} ` +
-                `duplicateIndexRows=${pullIntegrity.duplicateIndexEntryIds.length} ` +
-                `unindexed=${pullIntegrity.unindexedIds.length} ` +
-                `divergentDuplicates=${pullIntegrity.divergentDuplicateIds.length} ` +
-                `failedRepairs=${pullDuplicateStats.failed.length}`
+                `[SyncService] ${failedFacets.length} of ${outcomes.length} sync facets did not advance: ` +
+                failedFacets.map(({name, reason}) => `${name} (${reason})`).join('; ') + '. ' +
+                'Facets that advanced were persisted as they completed; the failed facets kept their ' +
+                'previous high-water marks, so the next run retries exactly those and nothing else.'
             );
         }
-
-        // 8. Self-heal push failures: If a previously failed issue was successfully pulled, remove it from the failure list
-        if (newMetadata.pushFailures?.length > 0) {
-            newMetadata.pushFailures = newMetadata.pushFailures.filter(failedId => !newMetadata.issues[failedId]);
-        }
-
-        // 9. Carry over per-syncer metadata mutations.
-        //
-        // `newMetadata` is a fresh object constructed by `IssueSyncer.pullFromGitHub` carrying
-        // only `{issues, pushFailures, lastSync}`. `DiscussionSyncer.syncDiscussions(metadata)`
-        // and `PullRequestSyncer.syncPullRequests(metadata)` mutate the OLD `metadata` argument
-        // (their `metadata.discussions` / `metadata.pulls` populations). Without explicit
-        // carry-over, those mutations are dropped at `save(newMetadata)` and the on-disk diff
-        // cache stays empty after every sync.
-        //
-        // This prevents a fresh metadata object from dropping discussion and PR cache populations
-        // created by their dedicated syncers, which would otherwise leave the on-disk diff cache
-        // empty after every sync.
-        newMetadata.discussions = metadata.discussions || {};
-        newMetadata.pulls       = metadata.pulls       || {};
-
-        // 10. Cache releases in metadata for next run.
-        newMetadata.releases            = ReleaseNotesSyncer.releases;
-        newMetadata.releasesLastFetched = new Date().toISOString();
-
-        // 11. Save metadata.
-        await MetadataManager.save(newMetadata);
-
-        await this.rebuildContentIndexesAndSeo();
 
         return {
             reconcileStats,
@@ -241,8 +302,60 @@ class SyncService extends Base {
             pullStats2,
             pullDuplicateStats,
             pullIndexStats,
-            pullIntegrity
+            pullIntegrity,
+            facetOutcomes: outcomes
         };
+    }
+
+    /**
+     * @summary Runs one sync facet in isolation — persisting its progress the moment it completes, and
+     * rolling back only ITS OWN metadata slices when it fails.
+     *
+     * The chain this replaces was a bare sequential `await` list with a single `MetadataManager.save`
+     * at the very end. One facet throwing therefore discarded every facet that had already succeeded
+     * AND skipped every facet after it: a deterministic failure in discussions meant pull requests were
+     * never fetched at all and the run wrote nothing, so consecutive runs made no progress rather than
+     * partial progress. With a deterministic trigger that is not "slowly falling behind" — it is a
+     * corpus frozen indefinitely while every individual facet's own code works correctly.
+     *
+     * Rollback is per-SLICE, not whole-object, because facets mutate the shared accumulator in place.
+     * Without restoring its slices, a facet that failed its integrity verdict would still have its
+     * partial mutations persisted by the NEXT facet's save — which would make "this facet advanced" and
+     * "this facet did not" inseparable claims, and publish exactly the broken corpus the verdict exists
+     * to withhold.
+     *
+     * @param {Object}   args
+     * @param {Object}   args.metadata The shared accumulator, mutated in place by the facet.
+     * @param {String}   args.name Facet name, used in the log line and the aggregate failure.
+     * @param {Object[]} args.outcomes Accumulator for per-facet results.
+     * @param {String[]} args.owns The metadata keys this facet may advance; restored verbatim on failure.
+     * @param {Function} args.run The facet body.
+     * @returns {Promise<*>} The facet's return value, or `null` when it did not advance.
+     * @private
+     */
+    async #runFacet({metadata, name, outcomes, owns, run}) {
+        // A Map rather than an object literal so an ABSENT key snapshots as absent instead of being
+        // fabricated into `null` — `MetadataManager.save` reads `metadata.issues` unguarded, and a
+        // restore that invented a value would be a different bug than the one being prevented.
+        const snapshot = new Map(owns.map(key => [key, structuredClone(metadata[key])]));
+
+        try {
+            const value = await run();
+
+            await MetadataManager.save(metadata);
+            outcomes.push({advanced: true, name});
+
+            return value
+        } catch (error) {
+            owns.forEach(key => {
+                metadata[key] = snapshot.get(key)
+            });
+
+            outcomes.push({advanced: false, name, reason: error.message});
+            logger.error(`[SyncService] facet "${name}" did not advance; its previous state is kept: ${error.message}`);
+
+            return null
+        }
     }
 
     /**

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -119,11 +119,20 @@ class SyncService extends Base {
      *
      * **The facets are ISOLATED and persist independently.** Each runs through `#runFacet`, which saves
      * metadata the moment that facet completes and rolls back only that facet's own slices when it does
-     * not. So a corpus too large for one pass converges across runs instead of failing whole, and one
-     * facet's failure neither discards the facets before it nor skips the facets after it.
+     * not. So one facet's failure neither discards the facets before it nor skips the facets after it.
+     *
+     * Scope note: that is BETWEEN-facet independence only. Within-facet page-level resume — a single
+     * facet too large for one pass converging across runs — is deliberately not implemented here.
+     *
+     * **Isolation is sound only over the dependency graph.** Release history is a PREREQUISITE, not an
+     * independent facet: `sortedReleases` is the bucketing reference every closed-artifact planner reads,
+     * and an absent reference does not fail — it silently places closed artifacts in the active bucket.
+     * The dependent facets are therefore gated, because catching a prerequisite failure and continuing is
+     * how a caught error gets mistaken for an independent one.
      *
      * 1. Loads the persistent metadata via `MetadataManager` — one accumulator every facet mutates.
-     * 2. Facet `releases`: fetches release data and caches it for the next run (`ReleaseNotesSyncer`).
+     * 2. Prerequisite `releases`: fetches release data and caches it (`ReleaseNotesSyncer`). Dependent
+     *    facets run only if this advanced or a non-empty cached bucketing reference survived.
      * 3. Facet `issues`: reconciles closed issue locations, **pushes** local changes, then **pulls**
      *    remote changes, merging the returned metadata into the accumulator (`IssueSyncer`).
      * 4. Facet `releaseNotes`: syncs release notes into local Markdown (`ReleaseNotesSyncer`).
@@ -140,7 +149,15 @@ class SyncService extends Base {
         const
             metadata = await MetadataManager.load(),
             outcomes = [],
-            facet    = (name, owns, run) => this.#runFacet({metadata, name, outcomes, owns, run});
+            facet    = (name, owns, run) => this.#runFacet({metadata, name, outcomes, owns, run}),
+            advanced = name => outcomes.some(outcome => outcome.name === name && outcome.advanced),
+            // A facet that never RAN is still a facet that did not advance, and it has to appear in the
+            // aggregate verdict — otherwise skipping a dependent silently shrinks the denominator and a
+            // run that did four of six things reports as clean.
+            skip     = (name, reason) => {
+                outcomes.push({advanced: false, name, reason});
+                logger.error(`[SyncService] facet "${name}" was SKIPPED: ${reason}`)
+            };
 
         // Normalized ONCE, here, instead of coerced with `|| {}` at the save site. `load()` supplies all
         // four on both its paths, but a hand-written metadata file or a stub may not — and then every
@@ -153,7 +170,19 @@ class SyncService extends Base {
         metadata.pulls       ??= {};
         metadata.releases    ??= {};
 
-        // 1. Fetch releases first, as they are needed for issue archiving
+        // 1. Release history is a PREREQUISITE, not an independent facet.
+        //
+        //    `ReleaseNotesSyncer.sortedReleases` is the bucketing reference for closed issues, pulls and
+        //    discussions — its own JSDoc says so. Every one of those planners resolves `closedAt` against
+        //    it, and an ABSENT reference does not fail: it resolves to "no release version applies", which
+        //    places closed artifacts in the ACTIVE bucket. So a failed release fetch does not merely skip
+        //    release notes, it silently mis-buckets the entire corpus — and per-facet persistence would
+        //    then write that placement to disk and to metadata.
+        //
+        //    The old sequential chain was accidentally safe here: a release throw aborted everything
+        //    downstream. Isolating the facets REMOVED that implicit guard, which is the trap in treating a
+        //    caught failure as an independent one. Caught and independent are different properties, and
+        //    isolation is only sound over the dependency graph.
         await facet('releases', ['releases', 'releasesLastFetched'], async () => {
             await ReleaseNotesSyncer.fetchAndCacheReleases(metadata);
 
@@ -164,6 +193,23 @@ class SyncService extends Base {
             metadata.releasesLastFetched = new Date().toISOString()
         });
 
+        // Satisfiable two ways, because a fetch failure is not the same as an absent reference:
+        // the facet advanced, OR a non-empty reference survived from the cached fast-path that runs
+        // before the network call. An EMPTY array after a SUCCESSFUL fetch is legitimate — a repo with no
+        // releases genuinely has nothing to bucket into — which is why this checks the failure case
+        // against the reference rather than against emptiness alone.
+        const bucketingReady = advanced('releases') ||
+            (Array.isArray(ReleaseNotesSyncer.sortedReleases) && ReleaseNotesSyncer.sortedReleases.length > 0);
+
+        // Every facet below places closed artifacts by release, so none of them may run — or persist as
+        // advanced — without the reference. Skipping is the safe direction: a facet that did not run leaves
+        // its previous high-water mark intact and retries next run, whereas one that ran without the
+        // reference writes wrong placements that look like progress.
+        const dependentFacet = (name, owns, run) => bucketingReady
+            ? facet(name, owns, run)
+            : Promise.resolve(skip(name, 'release history unavailable and no cached bucketing reference — ' +
+                'closed artifacts would be placed in the active bucket'));
+
         // 2 + 3 + 4. Reconcile closed issue locations (archiving stale closed issues BEFORE the pull),
         //     push local changes, then pull remote changes. One facet, because the ordering between them
         //     is load-bearing: splitting them would let a run persist a pull whose reconcile never ran.
@@ -171,7 +217,7 @@ class SyncService extends Base {
             pushStats      = null,
             pullStats      = null;
 
-        await facet('issues', ['issues', 'pushFailures', 'lastSync'], async () => {
+        await dependentFacet('issues', ['issues', 'pushFailures', 'lastSync'], async () => {
             reconcileStats = await IssueSyncer.reconcileClosedIssueLocations(metadata);
             pushStats      = await IssueSyncer.pushToGitHub(metadata);
 
@@ -193,10 +239,10 @@ class SyncService extends Base {
         });
 
         // 5. Sync release notes
-        const releaseStats = await facet('releaseNotes', ['releases'], () => ReleaseNotesSyncer.syncNotes(metadata));
+        const releaseStats = await dependentFacet('releaseNotes', ['releases'], () => ReleaseNotesSyncer.syncNotes(metadata));
 
         // 6. Sync discussions
-        const discussionStats = await facet('discussions', ['discussions'], () => DiscussionSyncer.syncDiscussions(metadata));
+        const discussionStats = await dependentFacet('discussions', ['discussions'], () => DiscussionSyncer.syncDiscussions(metadata));
 
         // 7. The pull facet: reconcile, sync, repair, project, and the integrity verdict that decides
         //    whether any of it counts. All one facet because 7c's abort must revert THIS facet and only
@@ -208,7 +254,7 @@ class SyncService extends Base {
             pullIndexStats     = null,
             pullIntegrity      = null;
 
-        const pullStats2 = await facet('pulls', ['pulls'], async () => {
+        const pullStats2 = await dependentFacet('pulls', ['pulls'], async () => {
             // 7-a. Reconcile closed PULL locations — the sibling reconcile that was missing. The
             //      delta-only pull sync skips PRs untouched since the last cutoff, so old merged PRs
             //      marooned in active pulls/ are never re-bucketed; this per-sync reconcile (mirroring

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -582,4 +582,110 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         expect(savedMetadata.discussions).toEqual({});
         expect(savedMetadata.pulls).toEqual({});
     });
+
+    /**
+     * Facet isolation. The chain was a bare sequential `await` list with one save at the end, so one
+     * facet throwing discarded every facet that had already succeeded AND skipped every facet after it.
+     * With a deterministic trigger that is not "slowly falling behind" — it is a corpus frozen while
+     * each facet's own code works correctly, and it is why two content facets were starved by one fault.
+     */
+    test('a failing facet does not skip the facets AFTER it', async () => {
+        let pullSyncCalled = 0;
+
+        DiscussionSyncer.syncDiscussions = async () => { throw new Error('discussion page cost ceiling') };
+        PullRequestSyncer.syncPullRequests = async () => { pullSyncCalled++; return {count: 0} };
+
+        await expect(SyncService.runFullSync()).rejects.toThrow(/did not advance/);
+
+        // The whole point: pull requests are fetched even though discussions threw first. Before
+        // isolation this was 0, and that single fact is why `pulls/` went stale from a discussions bug.
+        expect(pullSyncCalled).toBe(1);
+    });
+
+    test('a failing facet advances NOTHING while the facets that succeeded are persisted', async () => {
+        const saved = [];
+
+        MetadataManager.load = async () => ({
+            issues     : {},
+            releases   : {},
+            discussions: {1: {number: 1, path: 'd-1.md', contentHash: 'PRE-EXISTING'}},
+            pulls      : {}
+        });
+        MetadataManager.save = async md => saved.push(structuredClone(md));
+
+        // The facet mutates the shared accumulator and THEN throws — the ordering that makes per-slice
+        // rollback load-bearing. Without it, this half-write is persisted by the next facet's save.
+        DiscussionSyncer.syncDiscussions = async md => {
+            md.discussions[2] = {number: 2, path: 'd-2.md', contentHash: 'HALF-WRITTEN'};
+            throw new Error('failed after mutating')
+        };
+
+        await expect(SyncService.runFullSync()).rejects.toThrow(/did not advance/);
+
+        expect(saved.length).toBeGreaterThan(0);
+
+        // No save anywhere may carry the failed facet's partial mutation, and the pre-existing entry
+        // must survive: the failed facet keeps its previous high-water mark rather than losing it.
+        saved.forEach((md, index) => {
+            expect(Object.keys(md.discussions), `save #${index}`).toEqual(['1']);
+            expect(md.discussions[1].contentHash, `save #${index}`).toBe('PRE-EXISTING')
+        });
+    });
+
+    test('the aggregate verdict NAMES every facet that did not advance', async () => {
+        // Partial progress is the point, but a partial run must never report as a clean one — exiting 0
+        // would trade total loss for silent loss, where the corpus looks synced while a facet sits stale.
+        DiscussionSyncer.syncDiscussions = async () => { throw new Error('cost ceiling') };
+        ReleaseNotesSyncer.syncNotes = async () => { throw new Error('release notes boom') };
+
+        const error = await SyncService.runFullSync().then(() => null, e => e);
+
+        expect(error).toBeTruthy();
+        expect(error.message).toMatch(/discussions/);
+        expect(error.message).toMatch(/releaseNotes/);
+        expect(error.message).toMatch(/cost ceiling/);
+        expect(error.message).toMatch(/2 of \d+ sync facets/);
+    });
+
+    test('an integrity abort withholds the PULL facet only — sibling facets still advance', async () => {
+        // The narrowed guarantee. A pull corpus measured broken must not advance, and that must no
+        // longer take the discussion facet down with it.
+        const saved = [];
+
+        MetadataManager.save = async md => saved.push(structuredClone(md));
+
+        DiscussionSyncer.syncDiscussions = async md => {
+            md.discussions[7] = {number: 7, path: 'd-7.md', contentHash: 'ADVANCED'};
+            return {count: 1}
+        };
+        PullRequestSyncer.syncPullRequests = async md => {
+            md.pulls[9] = {state: 'MERGED', path: 'p-9.md', contentHash: 'SHOULD-NOT-PERSIST'};
+            return {count: 1}
+        };
+        PullRequestSyncer.verifyCorpusIntegrity = async () => ({
+            ok                      : false,
+            staleIndexEntries       : [{id: 9}],
+            inconsistentIndexEntries: [],
+            duplicateIndexEntryIds  : [],
+            unindexedIds            : [],
+            identicalDuplicateIds   : [],
+            divergentDuplicateIds   : []
+        });
+
+        const error = await SyncService.runFullSync().then(() => null, e => e),
+              last  = saved.at(-1);
+
+        expect(error).toBeTruthy();
+        expect(last.discussions[7]?.contentHash).toBe('ADVANCED');
+        expect(last.pulls).toEqual({});
+
+        // The rollback assertions above hold even under a whole-run abort, so on their own they witness
+        // ROLLBACK rather than ISOLATION. This is the part that separates the two: the failure must be
+        // reported through the per-facet accounting, naming `pulls` as the ONLY facet withheld. A
+        // re-throwing chain surfaces the bare integrity message with no accounting and fails here.
+        expect(error.message).toMatch(/1 of \d+ sync facets did not advance/);
+        expect(error.message).toMatch(/pulls \(/);
+        expect(error.message).not.toMatch(/discussions \(/);
+        expect(error.message).toMatch(/integrity is not clean/);
+    });
 });

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -37,6 +37,10 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
     let originalPull;
     let originalFetchReleases;
     let originalSyncNotes;
+    // Captured because the prerequisite witnesses MUTATE it, and it lives on a singleton — an
+    // unrestored `sortedReleases` leaks into every later test in this serial file and into any other
+    // spec sharing the worker.
+    let originalSortedReleases;
     let originalSyncDiscussions;
     let originalSyncPullRequests;
     let originalReconcileClosedPulls;
@@ -83,6 +87,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         originalPull = IssueSyncer.pullFromGitHub;
         originalFetchReleases = ReleaseNotesSyncer.fetchAndCacheReleases;
         originalSyncNotes = ReleaseNotesSyncer.syncNotes;
+        originalSortedReleases = ReleaseNotesSyncer.sortedReleases;
         originalSyncDiscussions = DiscussionSyncer.syncDiscussions;
         originalSyncPullRequests = PullRequestSyncer.syncPullRequests;
         originalReconcileClosedPulls = PullRequestSyncer.reconcileClosedPullRequestLocations;
@@ -132,6 +137,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         IssueSyncer.pullFromGitHub = originalPull;
         ReleaseNotesSyncer.fetchAndCacheReleases = originalFetchReleases;
         ReleaseNotesSyncer.syncNotes = originalSyncNotes;
+        ReleaseNotesSyncer.sortedReleases = originalSortedReleases;
         DiscussionSyncer.syncDiscussions = originalSyncDiscussions;
         PullRequestSyncer.syncPullRequests = originalSyncPullRequests;
         PullRequestSyncer.reconcileClosedPullRequestLocations = originalReconcileClosedPulls;
@@ -645,6 +651,59 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         expect(error.message).toMatch(/releaseNotes/);
         expect(error.message).toMatch(/cost ceiling/);
         expect(error.message).toMatch(/2 of \d+ sync facets/);
+    });
+
+    test('a failed release PREREQUISITE skips the dependent facets instead of mis-bucketing (#16010)', async () => {
+        // Release history is not an independent facet. `ReleaseNotesSyncer.sortedReleases` is the bucketing
+        // reference every closed-artifact planner reads, and an ABSENT reference does not throw — it
+        // resolves to "no release version applies", which places closed artifacts in the ACTIVE bucket. So
+        // catching a release failure and continuing does not isolate one facet; it silently mis-buckets the
+        // corpus, and per-facet persistence then writes that placement to disk.
+        //
+        // The old sequential chain was accidentally safe here: a release throw aborted everything after it.
+        // Isolation REMOVED that implicit guard, which is the trap this asserts against — caught and
+        // independent are different properties.
+        const ran = [];
+
+        ReleaseNotesSyncer.fetchAndCacheReleases = async () => { throw new Error('releases endpoint down') };
+        ReleaseNotesSyncer.sortedReleases        = null;
+
+        IssueSyncer.pullFromGitHub         = async md => { ran.push('issues');      return {newMetadata: md, stats: {pulled: {count: 0, created: 0, updated: 0, moved: 0}, dropped: {count: 0}}} };
+        ReleaseNotesSyncer.syncNotes       = async () => { ran.push('releaseNotes'); return {count: 0} };
+        DiscussionSyncer.syncDiscussions   = async () => { ran.push('discussions');  return {count: 0} };
+        PullRequestSyncer.syncPullRequests = async () => { ran.push('pulls');        return {count: 0} };
+
+        const error = await SyncService.runFullSync().then(() => null, e => e);
+
+        // NONE of the dependents may execute without the bucketing reference.
+        expect(ran).toEqual([]);
+
+        // And they must be REPORTED, not silently dropped — otherwise skipping shrinks the denominator
+        // and a run that did one of six things could read as clean.
+        expect(error).toBeTruthy();
+        expect(error.message).toMatch(/5 of \d+ sync facets did not advance/);
+        for (const name of ['releases', 'issues', 'releaseNotes', 'discussions', 'pulls']) {
+            expect(error.message, `${name} must appear in the verdict`).toMatch(new RegExp(name));
+        }
+    });
+
+    test('a CACHED bucketing reference lets the dependents run even when the fetch fails (#16010)', async () => {
+        // The prerequisite is satisfiable two ways, because a fetch failure is not the same as an absent
+        // reference: `fetchAndCacheReleases` populates `sortedReleases` from a cached fast-path BEFORE its
+        // network call. If that survived, placement is still resolvable and gating the dependents would be
+        // a false negative that strands the corpus on a transient outage.
+        const ran = [];
+
+        ReleaseNotesSyncer.fetchAndCacheReleases = async () => { throw new Error('releases endpoint down') };
+        ReleaseNotesSyncer.sortedReleases        = [{tagName: 'v13.0.0', publishedAt: '2026-05-10T00:00:00Z'}];
+
+        DiscussionSyncer.syncDiscussions   = async () => { ran.push('discussions'); return {count: 0} };
+        PullRequestSyncer.syncPullRequests = async () => { ran.push('pulls');       return {count: 0} };
+
+        await expect(SyncService.runFullSync()).rejects.toThrow(/did not advance/);
+
+        expect(ran).toContain('discussions');
+        expect(ran).toContain('pulls');
     });
 
     test('an integrity abort withholds the PULL facet only — sibling facets still advance', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -149,14 +149,28 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         IssueIngestor.ingestPullRequestFeedback = originalIngestPullRequestFeedback;
     });
 
-    test('an unclean pull-corpus verdict ABORTS before metadata save, derive, and auto-push', async () => {
+    test('an unclean pull-corpus verdict NEVER reaches the auto-push, and the pull facet does not advance', async () => {
         // Every pass reports its own outcome and degrades softly on its own terms, which is exactly
         // how a corpus reaches the commit with each step reporting success and the whole known-broken.
         // The verdict is only worth taking if something consumes it: a generated commit is what every
         // consumer then reads as truth, and unlike a failed run it cannot be retried away.
-        const order = [];
+        //
+        // This test previously asserted `order === []` — that NOTHING ran, including the metadata save
+        // and the derive. That was the whole-run abort, and it is deliberately narrowed: a failure in one
+        // facet must no longer discard the facets that already succeeded, or a deterministic failure
+        // anywhere freezes the entire corpus indefinitely.
+        //
+        // So the assertion moves to the property that actually protects consumers, and it is STRONGER
+        // for being explicit: **no auto-push**, and **the pull slice does not advance**. A generated
+        // commit still requires every facet clean, because the aggregate verdict throws before delivery.
+        const
+            order      = [],
+            savedPulls = [];
 
-        MetadataManager.save = async () => { order.push('metadata-save') };
+        MetadataManager.save = async metadata => {
+            order.push('metadata-save');
+            savedPulls.push(structuredClone(metadata.pulls ?? null))
+        };
         SyncService.rebuildContentIndexesAndSeo = async () => { order.push('derive') };
         RepositoryService.getViewerPermission = async () => { order.push('permission-check'); return {permission: 'READ'} };
 
@@ -172,22 +186,31 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
 
         await expect(SyncService.runFullSync()).rejects.toThrow(/integrity is not clean/);
 
-        // None of the three ran: the corpus is never committed in a state we already measured as broken.
-        expect(order).toEqual([]);
+        // THE invariant: delivery is never reached, so a corpus measured broken is never committed.
+        expect(order).not.toContain('permission-check');
+
+        // The pull facet is the one that failed, so it contributed no save of its own. Any save that did
+        // happen came from an earlier facet — which is the point — and none of them may carry pull
+        // mutations made after the last good state.
+        expect(savedPulls.every(pulls => !pulls || !Object.keys(pulls).length)).toBe(true);
     });
 
     test('a FAILED duplicate repair aborts too, even when the verdict is otherwise clean', async () => {
         // The repair reports its failures rather than throwing, so a soft-failed restoration would
         // otherwise sail past a verdict that cannot see it.
+        //
+        // Narrowed with its sibling above: the abort is now facet-local, so the assertion is that
+        // DELIVERY is never reached, not that no facet before it persisted.
         const order = [];
 
         MetadataManager.save = async () => { order.push('metadata-save') };
+        RepositoryService.getViewerPermission = async () => { order.push('permission-check'); return {permission: 'READ'} };
         PullRequestSyncer.repairDuplicateArtifacts = async () => ({
             repaired: [], removed: 0, failed: [{id: 10124, reason: 'network down'}]
         });
 
         await expect(SyncService.runFullSync()).rejects.toThrow(/integrity is not clean/);
-        expect(order).toEqual([]);
+        expect(order).not.toContain('permission-check');
     });
 
     test('a clean verdict lets the run proceed — the gate can PASS', async () => {
@@ -220,7 +243,22 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         const result = await SyncService.runFullSync();
 
         expect(result.success).toBe(true);
-        expect(order).toEqual(['metadata-save', 'derive', 'permission-check']);
+
+        // The claim under test is an ORDERING — persist, then derive, then check push permission — and it
+        // is asserted as one here rather than as an exact three-element sequence. The save count is no
+        // longer one: each facet persists as it completes, so a corpus too large for a single pass
+        // converges across runs instead of failing whole. Pinning the count would make this test fail on
+        // every future facet while saying nothing about the order it exists to protect.
+        const
+            lastSave    = order.lastIndexOf('metadata-save'),
+            firstDerive = order.indexOf('derive'),
+            pushCheck   = order.indexOf('permission-check');
+
+        expect(lastSave).toBeGreaterThanOrEqual(0);
+        expect(lastSave).toBeLessThan(firstDerive);
+        expect(firstDerive).toBeLessThan(pushCheck);
+        expect(order.filter(step => step === 'derive')).toHaveLength(1);
+        expect(order.filter(step => step === 'permission-check')).toHaveLength(1);
     });
 
     test('runFullSync rejects before auto-push and Stage 2 when the post-sync derive fails (#13260)', async () => {
@@ -315,7 +353,10 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         expect(result.success).toBe(true);
         expect(result.statistics.pulled.count).toBe(2);
         expect(pullRuns).toBe(2);
-        expect(saves).toBe(2);
+        // NOT pinned to the pass count: each facet persists as it completes, so a pass makes several
+        // saves. `derives` is the pass counter, so `saves > derives` asserts per-facet persistence is in
+        // force without hardcoding how many facets exist.
+        expect(saves).toBeGreaterThan(derives);
         expect(derives).toBe(2);
         expect(stage2Calls).toEqual({
             issueStates        : 1,
@@ -387,7 +428,10 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         expect(result.success).toBe(true);
         expect(result.statistics.pulled.count).toBe(2);
         expect(pullRuns).toBe(2);
-        expect(saves).toBe(2);
+        // NOT pinned to the pass count: each facet persists as it completes, so a pass makes several
+        // saves. `derives` is the pass counter, so `saves > derives` asserts per-facet persistence is in
+        // force without hardcoding how many facets exist.
+        expect(saves).toBeGreaterThan(derives);
         expect(derives).toBe(2);
         expect(stage2Calls).toEqual({
             issueStates        : 1,


### PR DESCRIPTION
Resolves #16010
Related: #16002, #16001, #15972, #15993, #16007

## What changed

`SyncService.emitGeneratedContentAndDerive` was a bare sequential `await` chain with one `MetadataManager.save` at the very end. One facet throwing did **both** of these at once:

- **discarded every facet that had already succeeded** — releases, issue reconcile, issue push and pull all completed and were thrown away unwritten;
- **skipped every facet after it** — a discussions failure meant `PullRequestSyncer.syncPullRequests` was **never called**.

So `pulls/` and `discussions/` being stale was **one** fault, not two. And with a deterministic trigger it was not "slowly falling behind" — it was a corpus frozen indefinitely while every facet's own code worked correctly.

Each facet now runs through a private `#runFacet` that persists metadata the moment that facet completes and rolls back **only that facet's own slices** when it does not.

## Why rollback is per-slice

Facets mutate a shared accumulator in place. Without restoring its slices, a facet that throws *after* mutating — exactly what the pull-integrity verdict does — would still have its partial work persisted by the **next** facet's save. That would make "this facet advanced" and "this facet did not" inseparable claims, and publish the broken corpus the verdict exists to withhold.

`pullFromGitHub`'s fresh metadata object is **merged** into the accumulator rather than replacing it, which **deleted** the hand-maintained carry-over that existed only because the save happened once at the end.

## The integrity verdict is preserved, not removed

Its own comment argues the case well — *"committing a corpus we have already measured as broken is worse than failing the run"* — and that survives. A pull corpus measured broken still does not advance, and **delivery is still never reached**, because the aggregate verdict throws before the auto-push. A generated commit therefore still requires **every** facet clean. What changed is only that the abort no longer takes the other facets down with it.

## Test Evidence

Evidence: `L1` (unit). **557 passed** across `ai/services/github-workflow`; `check-block-alignment` silent.

**Four new witnesses, each verified RED per-test** against a `#runFacet` that re-throws, which reproduces the pre-fix chain exactly:

| witness | under mutation |
|---|---|
| a failing facet does not skip the facets AFTER it | **1 failed** |
| a failing facet advances NOTHING while succeeded facets persist | **1 failed** |
| the aggregate verdict names every facet that did not advance | **1 failed** |
| an integrity abort withholds the PULL facet only | **1 failed** |

**Two method notes, because both changed a conclusion.**

The fourth witness needed strengthening. As first written it asserted rollback state that holds under a whole-run abort too — so it witnessed *rollback* rather than *isolation*, and passed under the mutation. It now asserts the per-facet accounting in the aggregate message (names `pulls`, not `discussions`) and fails without it.

And my first mutation run reported **1 failed of 4** with the other three "passing". They had been **skipped** — `test.describe.configure({mode: 'serial'})` halts the remainder after a failure, so suite-level mutation evidence was *inconclusive*, not negative. Re-running per witness with `-g` produced the table above.

**Three pre-existing tests changed, each checked for regression-vs-pinning rather than edited to green:**

- ×2 pinned the whole-run abort (`order === []`) — deliberate narrowing; rewritten to assert the invariant that survives (no auto-push, failed facet advances nothing), which is stronger than the old incidental absence.
- ×2 pinned `saves === 2` on the retry path — a count artifact; `derives`, `pullRuns` and `stage2Calls` were all unchanged, which is what proved it non-behavioural.
- ×1 was **a real contract I broke** — the empty-object metadata guarantee, lost when I removed the `|| {}` coercion. Fixed in the **source**, not the test: one normalization of the accumulator after load, which also makes `save` reading `metadata.issues` unguarded safe by construction.

## Post-Merge Validation

- [ ] A local `syncGithubWorkflow` advances at least one currently-starved facet (`pulls/`) **while #16001 is still unfixed** — proving isolation independently of the symptom.
- [ ] A partial run exits non-zero and names the facets that did not advance.
- [ ] **NOT claimed:** a green pipeline, `#15972` closing, or within-facet resume. `#16002` stays open for the page-level half.

## Deltas from ticket

- **Facet grouping.** The pull reconcile moved from before the issue push/pull to the start of the pull facet. Its own rationale requires only that it precede `syncPullRequests`, which it still does; grouping it with the corpus it reconciles is what makes the facet's rollback coherent.
- **Releases caching moved into its own facet** from the end of the chain, so a later throw no longer discards a fetch that already succeeded.
- Everything else matches.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.

**Cross-family required — Claude-family authored, so a GPT or Kimi seat.**

**Where to push.** The pull facet's `_index.json` realign touches disk *before* the integrity verdict runs, and a metadata rollback does not undo that. I argue it is acceptable because the realign is idempotent by its own documented design, and that this is precisely why the verdict must stay **inside** the facet rather than becoming advisory — but a reviewer who thinks disk effects need their own rollback has a real argument.

Second: I grouped reconcile+push+pull into one `issues` facet on the grounds that their ordering is load-bearing. If you think the push and the pull should be separately resumable, that is a coarser-grained choice than necessary and worth saying.

Authored by @neo-opus-ada
