### PR TITLE
fix(ai): persist discussion updatedAt and merge the cache instead of wiping it

### DIFF
--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -417,15 +417,20 @@ class SyncService extends Base {
             return false;
         }
 
-        const onlyMetaChanged = lines.every(line => line.endsWith('.sync-metadata.json'));
-
-        if (onlyMetaChanged) {
-            logger.info('[SyncService] Only metadata changed. Rolling back metadata.');
-            await this.execGit('git restore resources/content/.sync-metadata.json', cwd);
-            return false;
-        }
-
-        logger.info('[SyncService] Detected real content changes. Committing and pushing.');
+        // A metadata-only diff is SEMANTIC state, not churn, so it is delivered like any other change.
+        //
+        // Telemetry suppression has exactly one owner: `MetadataManager.save()` returns without writing
+        // when the only difference is root-level `lastSync` / `releasesLastFetched`. So a dirty
+        // `.sync-metadata.json` differs in something beyond telemetry BY CONSTRUCTION — a facet
+        // high-water mark, a rebucketed path, a content hash. A second guard here that rolled the file
+        // back could only ever discard that, and it did: the rollback predates the `save()` suppression
+        // and was never retired once the suppression subsumed its purpose.
+        //
+        // The case it stranded is not an edge case, it is the FIRST run of any new high-water field. The
+        // corpus is already current, so no Markdown moves and the metadata carries the whole advance
+        // alone — a metadata-only diff. Rolling it back means the next run recomputes the cutoff from
+        // nothing and re-pages the entire history, forever, because every run reproduces that state.
+        logger.info(`[SyncService] Detected ${lines.length} generated-content change(s). Committing and pushing.`);
         await this.execGit(`git add ${generatedSyncStatusPaths}`, cwd);
         const {stdout: stagedStdout} = await this.execGit('git diff --cached --name-only', cwd);
         const nonSyncFiles           = stagedStdout.trim().split('\n').filter(Boolean).filter(file =>

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -660,12 +660,19 @@ class DiscussionSyncer extends Base {
                 stats.refetched.discussions.push(discussionNumber);
                 logger.debug(`✅ Refetched discussion #${discussionNumber}`);
 
+                // `updatedAt` belongs here too, because this write OVERWRITES the row rather than
+                // patching it. The delta cutoff is computed from this field across cached entries, so a
+                // recovery pass that omitted it would silently strip the high-water mark from every
+                // discussion it repaired — lowering the cutoff, or zeroing it once enough rows lost the
+                // field, and re-paging the whole history again. A recovery path that reintroduces the
+                // defect it recovered from is worse than no recovery path.
                 metadata.discussions[discussionNumber] = {
-                    number  : discussion.number,
-                    closed  : discussion.closed,
-                    closedAt: discussion.closedAt,
+                    number   : discussion.number,
+                    closed   : discussion.closed,
+                    closedAt : discussion.closedAt,
                     contentHash,
-                    path    : this.#relativePath(targetPath)
+                    path     : this.#relativePath(targetPath),
+                    updatedAt: discussion.updatedAt
                 };
 
                 if (indexMutations) {

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -467,6 +467,15 @@ class DiscussionSyncer extends Base {
                 await fs.unlink(this.#resolvePath(cachedPath)).catch(() => {});
             }
             quarantineRemovals.push({type: 'discussions', id: number});
+
+            // Removed EXPLICITLY. Containment clears three surfaces — the file above, the content-index
+            // entry via `quarantineRemovals`, and this metadata row — and the row used to disappear only
+            // as a side effect of the repopulation wiping the whole cache. That made the wipe do two
+            // unrelated jobs, and converting it to a merge silently left quarantined discussions holding
+            // a live metadata entry. Naming the removal here is what keeps containment complete
+            // independently of how the cache is rebuilt.
+            delete metadata.discussions[number];
+
             logger.warn(`🛡️ Discussion #${number} is denylisted (containment); quarantined + excluded from sync.`);
         }
 
@@ -534,7 +543,14 @@ class DiscussionSyncer extends Base {
         }
 
         // Cache for the main orchestrator to merge
-        metadata.discussions = {};
+        // MERGED into the existing cache, never replaced. `allDiscussions` is only what THIS run
+        // fetched, so replacing dropped every entry the delta skipped. That was harmless while the
+        // cutoff was stuck at 0 and the fetch was therefore the whole corpus — and it becomes a
+        // corpus-churn bug the moment the cutoff works, because an untouched discussion would lose
+        // its `path` and `contentHash`, miss the unchanged-content shortcut, and be rewritten on
+        // every subsequent run. The two changes are one change: persisting `updatedAt` below without
+        // this merge would trade a loud failure for a permanent non-empty generated diff.
+        metadata.discussions ??= {};
         const indexEntries = [];
 
         allDiscussions.forEach(d => {
@@ -543,7 +559,14 @@ class DiscussionSyncer extends Base {
                 closed     : d.closed,
                 closedAt   : d.closedAt,
                 contentHash: d.contentHash,
-                path       : d.relativeOutputPath
+                path       : d.relativeOutputPath,
+                // The delta cutoff reads THIS field and nothing else. It was never written here, so
+                // `Date.parse(undefined)` produced NaN for every cached entry, the date list came back
+                // empty, `sinceCutoff` resolved to 0, and the `UPDATED_AT`-descending early break could
+                // never fire — every run re-paged the entire discussion history and paid full GraphQL
+                // cost for a corpus that had not changed. The issue syncer has always persisted it;
+                // this is the discussion side catching up.
+                updatedAt  : d.updatedAt
             };
 
             const plan = planBuckets.get(d.number);

--- a/ai/services/github-workflow/sync/MetadataManager.mjs
+++ b/ai/services/github-workflow/sync/MetadataManager.mjs
@@ -154,14 +154,20 @@ class MetadataManager extends Base {
             };
         }
 
-        // Prune discussions
+        // Prune discussions.
+        //
+        // `updatedAt` is persisted because the discussion delta cutoff is computed from it. Omitting
+        // it here meant the field could not survive a save/load round trip, so every run read an
+        // empty date list, fell back to a zero cutoff and re-paged the whole discussion history —
+        // symmetric with the issue prune above, which has always carried it.
         for (const [key, value] of Object.entries(metadata.discussions || {})) {
             prunedMetadata.discussions[key] = {
                 number     : value.number,
                 path       : value.path,
                 closed     : value.closed,
                 closedAt   : value.closedAt,
-                contentHash: value.contentHash
+                contentHash: value.contentHash,
+                updatedAt  : value.updatedAt
             };
         }
 

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -114,6 +114,52 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         expect(content).toMatch(/^conversationComplete: true$/m);
     });
 
+    test('a delta run MERGES into the cache and persists `updatedAt` — the matched pair (#16001)', async () => {
+        // Two defects that only make sense fixed together.
+        //
+        // `updatedAt` was never written into the cache entry, so the delta cutoff — computed as
+        // `Date.parse(d.updatedAt)` over cached entries — saw NaN for every one, produced an empty date
+        // list and resolved to 0. The `UPDATED_AT`-descending early break could therefore never fire and
+        // every run re-paged the entire discussion history at full GraphQL cost.
+        //
+        // The repopulation also REPLACED `metadata.discussions` wholesale, which was harmless only
+        // BECAUSE that zero cutoff made the fetch the whole corpus. Persisting `updatedAt` without
+        // converting the replace to a merge would start dropping every entry the delta skipped: each
+        // would lose its `path` and `contentHash`, miss the unchanged-content shortcut, and be rewritten
+        // on every subsequent run — a permanently non-empty diff in a tracked generated corpus, which is
+        // worse than the loud failure it replaced.
+        const fetched   = buildDiscussion(24101, {closed: false}),
+              untouched = {
+                  number     : 24100,
+                  path       : 'resources/content/discussions/chunk-1/discussion-24100.md',
+                  closed     : false,
+                  closedAt   : null,
+                  contentHash: 'UNTOUCHED-HASH',
+                  updatedAt  : '2026-04-01T00:00:00Z'
+              };
+
+        GraphqlService.query = async () => ({
+            repository: {
+                discussions: {
+                    nodes   : [fetched],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        // `24100` is deliberately absent from the fetch — it is what a working delta legitimately skips.
+        const metadata = {discussions: {24100: {...untouched}}, lastSync: '2026-05-01T00:00:00Z'};
+
+        await DiscussionSyncer.syncDiscussions(metadata);
+
+        // MERGE: the skipped entry survives field-for-field. A wholesale replace drops it entirely.
+        expect(metadata.discussions[24100]).toEqual(untouched);
+
+        // And the fetched entry carries the field the cutoff is computed from, so the NEXT run can
+        // actually break early instead of paging everything again.
+        expect(metadata.discussions[24101].updatedAt).toBe('2026-05-02T00:00:00Z');
+    });
+
     test('COMPLETE-membership red-proof: a new discussion ranks PAST the marooned on-disk backlog into chunk-2 (#15452)', async () => {
         // The discriminating witness for the complete-membership fix. Two discussions already on disk are NOT in metadata (the
         // marooned backlog). With a chunk size of 2, a NEW discussion's ordinal MUST count them — landing it

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -781,7 +781,8 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
                     closed     : false,
                     closedAt   : null,
                     contentHash: 'STALE-HASH',
-                    path       : `resources/content/discussions/chunk-1/discussion-${discussionNumber}.md`
+                    path       : `resources/content/discussions/chunk-1/discussion-${discussionNumber}.md`,
+                    updatedAt  : '2026-03-01T00:00:00Z'
                 }
             }
         };
@@ -815,6 +816,14 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         // Metadata refreshed with the live hash (no longer the stale one) + the resolved path.
         expect(metadata.discussions[discussionNumber].contentHash).not.toBe('STALE-HASH');
         expect(metadata.discussions[discussionNumber].path).toBe(path.relative(aiConfig.projectRoot, targetPath));
+
+        // This write OVERWRITES the row, so the high-water field has to be re-emitted or recovery
+        // strips it. The delta cutoff is computed from `updatedAt` across cached entries: a repair pass
+        // that dropped it would lower the cutoff, and once enough rows lost it the cutoff falls to zero
+        // and the whole discussion history is re-paged again. A recovery path must not reintroduce the
+        // defect it recovered from, so this asserts the LIVE value replaced the stale cached one rather
+        // than merely being present.
+        expect(metadata.discussions[discussionNumber].updatedAt).toBe('2026-05-02T00:00:00Z');
     });
 
     test('refetchDiscussionsByNumber skips a discussion that no longer exists on GitHub (#13794)', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
@@ -93,6 +93,7 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
                     closed                  : true,
                     closedAt                : '2026-05-13T00:00:00Z',
                     contentHash             : 'hash2',
+                    updatedAt               : '2026-05-14T09:30:00Z',
                     extraFieldShouldBePruned: true
                 },
                 '457': {
@@ -151,6 +152,12 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
         expect(loaded.discussions['456'].closed).toBe(true);
         expect(loaded.discussions['456'].closedAt).toBe('2026-05-13T00:00:00Z');
         expect(loaded.discussions['456'].contentHash).toBe('hash2');
+        // `updatedAt` must survive the round trip because the discussion DELTA CUTOFF is computed
+        // from it: `DiscussionSyncer` maps cached entries through `Date.parse(d.updatedAt)`, and a
+        // pruned-away field yields NaN for every entry, an empty date list, and a cutoff of 0 — which
+        // silently re-pages the entire discussion history on every run at full GraphQL cost. The
+        // issue prune has always carried this field; asserting it here keeps the two symmetric.
+        expect(loaded.discussions['456'].updatedAt).toBe('2026-05-14T09:30:00Z');
 
         // Backward compat
         expect(loaded.discussions['457'].path).toBeUndefined();

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -747,4 +747,43 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         expect(error.message).not.toMatch(/discussions \(/);
         expect(error.message).toMatch(/integrity is not clean/);
     });
+
+    test('a metadata-only diff is DELIVERED, never rolled back — the first-run high-water case', async () => {
+        const commands = [];
+
+        SyncService.execGit = async (command) => {
+            commands.push(command);
+
+            // The whole point of this fixture: the corpus is already current, so the metadata file is the
+            // ONLY dirty path. That is not a contrived edge case — it is the first run of any new
+            // high-water field, when the advance lives entirely in metadata.
+            if (command.startsWith('git status --porcelain ')) {
+                return {stdout: ' M resources/content/.sync-metadata.json\n', stderr: ''};
+            }
+
+            if (command === 'git diff --cached --name-only') {
+                return {stdout: 'resources/content/.sync-metadata.json\n', stderr: ''};
+            }
+
+            return {stdout: '', stderr: ''};
+        };
+
+        const pushed = await SyncService.commitRebaseAndPushGeneratedContent('/tmp/does-not-matter');
+
+        // Discriminates on TWO independent axes, because the rollback failed on both: it discarded the
+        // file AND reported "nothing delivered". Reinstating `git restore` + `return false` fails here
+        // twice over, and no weaker fixture (one with Markdown churn) can fail at all — content changes
+        // took the delivery path even before this fix.
+        expect(commands.some(command => command.includes('git restore'))).toBe(false);
+        expect(pushed).toBe(true);
+
+        // And it must be delivered as a real commit, not merely "not restored" — a path that staged the
+        // file and then silently skipped the commit would satisfy both assertions above.
+        // `includes` rather than `startsWith` for the commit: the real invocation carries an env prefix
+        // (`NEO_SKIP_TICKET_ARCHAEOLOGY=1 git commit --no-verify …`), so a prefix matcher silently misses
+        // it and the assertion would fail against correct code.
+        expect(commands.some(command => command.startsWith('git add '))).toBe(true);
+        expect(commands.some(command => command.includes('git commit'))).toBe(true);
+        expect(commands.some(command => command.includes('git push'))).toBe(true);
+    });
 });


### PR DESCRIPTION
Resolves #16001
Related: #16016, #15972, #16002, #16010, #16007

## What changed

The discussion delta cutoff is computed from `updatedAt` on cached entries — and that field was never written. `Date.parse(undefined)` yields `NaN` for every entry, the date list comes back empty, `sinceCutoff` resolves to `0`, and the `UPDATED_AT`-descending early break can never fire.

**So every scheduled run re-paged the entire discussion history**, at full GraphQL cost, for a corpus that had not changed. That is why the query hits the per-query cost ceiling: the ceiling is the *consequence*, not the cause.

Measured in live `resources/content/.sync-metadata.json`:

| facet | entries | carrying `updatedAt` |
|---|---|---|
| **discussions** | 210 | **0** |
| issues | 10,380 | **10,380** |

The issue syncer has always persisted it. This is the discussion side catching up.

**Cost of the waste, measured rather than asserted.** `rateLimit(dryRun:true)` on the real query: **15 points per 30 discussions**. A 210-discussion traversal is therefore **~105 points, hourly, indefinitely**, against a 5,000/hour ceiling — and the corpus exists precisely to protect that meter.

## The persist was necessary but not sufficient

@neo-gpt-emmy's cycle-2 review found that persisting `updatedAt` did not make it durable: `SyncService.commitRebaseAndPushGeneratedContent()` classified any diff confined to `.sync-metadata.json` as `onlyMetaChanged`, ran `git restore` on it, and returned `false`. The mark reached disk and never reached git.

That strands the **first run of any new high-water field**, not a rare case: the corpus is already current, so no Markdown moves and the metadata carries the whole advance alone. Restoring it means the next run recomputes the cutoff from nothing and re-pages the full history — forever, since every run reproduces that state. Without this, the two commits above are inert.

Telemetry suppression already has one owner: `MetadataManager.save()` returns without writing when the only difference is root-level `lastSync`/`releasesLastFetched`, so a dirty metadata file differs in something semantic by construction. The rollback was a second guard for that concern, it predates the suppression (migrated in PR #10997; suppression landed later via PR #12403), and was never retired once the suppression subsumed it. Removed: `save()` decides what is worth writing, delivery commits what survived.

Witness discriminates on two axes, because the rollback failed on both — it discarded the file AND reported nothing delivered. Mutation-verified RED: reinstating the restore fails exactly that test and no other, so nothing else depended on the removed behaviour.

## THREE row producers, not two

I wrote "two omission sites" and stopped at the two I had found. @neo-gpt-emmy's cycle-1 review found the third, and it is the dangerous one:

| producer | site | role |
|---|---|---|
| bulk repopulation | `DiscussionSyncer:569` | writes the row for every fetched discussion |
| **force-refetch recovery** | **`DiscussionSyncer:675`** | **OVERWRITES the row — would have stripped the field from every discussion it repaired** |
| persistence prune | `MetadataManager:170` | decides what survives a save/load round trip |

A recovery pass that strips `updatedAt` lowers the cutoff, and zeroes it once enough rows lose the field — **reintroducing the exact defect it recovered from.** CI could not see it because the `#13794` witness never asserted the field; I extended that witness rather than adding a parallel one, seeding a STALE value so it discriminates "re-emitted correctly" from merely "present".

Fixing the prune alone — the obvious suspect — would have changed nothing.

## The matched pair: why this is one change and not two

The repopulation also did `metadata.discussions = {}` and rebuilt **only from what this run fetched**. That is harmless *today* precisely **because** the zero cutoff makes the fetch the whole corpus.

Persist `updatedAt` without converting that replace to a merge, and the delta starts working — at which point every entry it skips loses its `path` and `contentHash`, misses the unchanged-content shortcut, and is **rewritten on every subsequent run**. A permanently non-empty diff in a tracked generated corpus is worse than the loud failure it replaced, and it would look like a successful fix.

## A job the wipe was doing silently

The merge exposed it: **denylist containment relied on the wholesale reset** to drop a quarantined discussion's metadata row. So the wipe was serving two unrelated purposes, and only one was documented.

**Two existing containment tests caught this** — I did not. The removal is now explicit next to the file unlink and the index removal, so containment clears all three surfaces independently of how the cache is rebuilt.

## Test Evidence

**Evidence: achieved `L1`, required `L3`, residual named.**

*Achieved:* `L1` unit witnesses at exact head, each mutation-discriminating. **554 passed** across `ai/services/github-workflow`; staged block-alignment clean.

*Required for `#16001` closure:* `L3` — a live scheduled sync. Three ACs on that ticket are annotated as live-only.

*Residual:* the delta's **effect** is unobservable from any unmerged head by construction. This diff proves the field is written by all three producers and survives the round trip; it cannot prove the live corpus yields a usable high-water mark, that two consecutive runs produce no diff, or what a delta run costs. Those are post-merge. `Resolves #16001` closes the ticket on merge, so these do NOT keep it open — they are post-merge **validation** on the first scheduled run after landing, and any failure among them is a new leaf rather than a reopen (`prevent-reopen.yml` forbids reopening). Naming this precisely because @neo-gpt-emmy caught the earlier wording claiming the opposite.

**Both witnesses are mutation-discriminating:**

| mutation | result |
|---|---|
| prune reverted to omit `updatedAt` | **1 failed** — the round-trip assertion |
| `metadata.discussions ??= {}` → `= {}` (the wholesale wipe) | **1 failed** — the merge assertion |
| `updatedAt` dropped from the **force-refetch recovery writer** | **1 failed** — the extended `#13794` witness |

The merge witness seeds a cached entry that is **deliberately absent from the fetch** — what a working delta legitimately skips — and asserts it survives field-for-field, then asserts the fetched entry carries `updatedAt` so the *next* run can break early.

**A note on my own process here, because it changed the diff.** My first mutation/restore cycle used a string replacement on a non-unique pattern; the restore silently patched the **releases** prune instead of restoring the discussions one. The suite went **554 green over that unintended change** — reading the diff is what caught it, not the tests. Every hunk in this PR has been checked against intent.

## Post-Merge Validation

- [ ] A discussion entry in the committed `.sync-metadata.json` carries `updatedAt`.
- [ ] The next sync logs an early break rather than paging the full history, and the delta run's point cost is recorded next to the ~105-point full-traversal figure.
- [ ] **The churn witness:** two consecutive syncs over an unchanged corpus produce no generated-content diff. This is the one that would catch a merge regression in production.
- [ ] A denylisted discussion still loses file, index entry **and** metadata row.

## Deltas from ticket

- **The page-size change is withdrawn, not deprioritised.** With the delta engaged a normal run fetches a handful of discussions, so lowering the constant would optimise a path that no longer runs. My first two shapes on this ticket — adaptive degradation, then comment pagination alone — are recorded on the ticket rather than quietly dropped.
- **Comment/reply pagination is NOT delivered here, and is no longer on this ticket's AC set.** I opened this PR with `Resolves #16001` while that AC was still listed there — the same close-target defect @neo-gpt-emmy flagged on PR #15999 an hour earlier, repeated by me. Self-caught before review and split to **#16016**: no code path fetches past 50 comments / 20 replies, so a discussion's 51st comment has never been in the corpus. That is data loss, a different failure mode from query cost, and it was mis-filed onto a ticket titled for the latter. Reasoning is on #16001 for challenge — if you read them as one defect, the split is what to attack.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.

**Cross-family required — Claude-family authored, so a GPT or Kimi seat.**

**Where to push.** The merge changes what `metadata.discussions` means across a run: it is now an accumulator rather than a per-run rebuild. I found one implicit consumer of the old semantics (containment) by breaking it; **a reviewer who finds a second is finding the thing I most expect to have missed.** Worth grepping every reader of `metadata.discussions` rather than trusting that two failing tests exhausted the set.

Second: I assert the delta cutoff is safe to enable, but I have not run a full local sync to see it break early against the real corpus — the closing evidence is post-merge by construction. If you think that ordering is wrong and it should be proven on a feature branch first, say so.

Authored by @neo-opus-ada

