### PR TITLE
fix(ai): use the tenant mirror-root config leaf (#16014)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1279,39 +1279,25 @@ class TenantRepoSyncService extends Base {
      * the prior direct `aiConfig.tenantRepos` read so the documented bootstrap / graph tiers are
      * actually honored on the pull path.
      *
-     * Then materializes per-repo `mirrorRoot` via a defensive fallback chain when the per-repo
-     * override is absent:
-     *
-     *   1. `tier1MirrorRoot` (test seam — full short-circuit)
-     *   2. `orchestratorConfig.tenantRepoMirrorRoot` (canonical path; Tier-1 env-bound default)
-     *   3. `env.NEO_TENANT_REPO_MIRROR_ROOT` (defensive — covers stale-overlay deployments
-     *      where the operator's gitignored `ai/config.mjs` predates the new
-     *      `tenantRepoMirrorRoot` key + envBindings entry, so the Tier-1 lookup misses)
-     *   4. `'/app/.neo-ai-data'` (hardcoded final fallback)
-     *
-     * The (3) layer is the "stale gitignored overlay copied into deploy image" defense:
-     * `ai/deploy/Dockerfile` does `COPY . .` before `initServerConfigs.mjs` runs in
-     * warn-only mode, so an older operator overlay survives into the container with no
-     * `tenantRepoMirrorRoot` key — but the env var is still injected via compose, so
-     * a direct `process.env` read keeps the resolver behavior correct regardless.
-     *
-     * Test seams: `ingestionService` injects a stub KB service (bypasses the live singleton
-     * lookup); `tier1MirrorRoot` short-circuits the mirrorRoot chain; `orchestratorConfig`
-     * stubs the AiConfig.orchestrator section; `env` stubs `process.env`.
+     * Then materializes an absent per-repo `mirrorRoot` from the resolved
+     * `AiConfig.orchestrator.tenantRepoMirrorRoot` leaf. That leaf owns both the cloud default
+     * and its env binding; this consumer must not re-resolve either one. `tier1MirrorRoot`
+     * remains an explicit test seam and full short-circuit.
      *
      * @param {Object} [options]
      * @param {String} [options.tier1MirrorRoot] Pre-resolved Tier-1 mirrorRoot default (test seam).
-     * @param {Object} [options.orchestratorConfig=AiConfig.orchestrator] Stub for the AiConfig.orchestrator section (test seam).
-     * @param {Object} [options.env=process.env] Stub for the env-var lookup (test seam).
      * @param {Object} [options.ingestionService] Stub KB ingestion service (test seam); defaults to the live singleton.
      * @returns {Promise<{tenantRepos: Array<Object>, configDiagnostics: Object}>} Effective repos with
      *     the Knowledge Base resolver's bounded config diagnostics preserved unchanged.
+     * @throws {TypeError} When the resolved Tier-1 mirror root is not a non-empty string.
      */
-    async resolveTenantReposConfig({tier1MirrorRoot, orchestratorConfig = AiConfig.orchestrator, env = process.env, ingestionService} = {}) {
-        const tier1Default = tier1MirrorRoot
-            ?? orchestratorConfig?.tenantRepoMirrorRoot
-            ?? env.NEO_TENANT_REPO_MIRROR_ROOT
-            ?? '/app/.neo-ai-data';
+    async resolveTenantReposConfig({tier1MirrorRoot, ingestionService} = {}) {
+        const tier1Default = tier1MirrorRoot ?? AiConfig.orchestrator.tenantRepoMirrorRoot;
+
+        if (typeof tier1Default !== 'string' || tier1Default.trim() === '') {
+            throw new TypeError('AiConfig.orchestrator.tenantRepoMirrorRoot must resolve to a non-empty string.');
+        }
+
         const kbService  = ingestionService || await this.resolveIngestionService();
         const normalized = await kbService.listConfiguredTenantRepos();
 

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -106,13 +106,6 @@ export const AI_CONFIG_IMPLEMENTATION_BASELINE = Object.freeze([
         text  : 'primaryDevSyncRootsConfig: AiConfig.orchestrator.devSyncRoots,',
         ticket: '#13939',
         reason: 'Existing entrypoint injection boundary; cleanup belongs to the #12456 fan-out.'
-    },
-    {
-        file  : 'ai/daemons/orchestrator/services/TenantRepoSyncService.mjs',
-        kind  : 'config-parameter-default',
-        text  : 'async resolveTenantReposConfig({tier1MirrorRoot, orchestratorConfig = AiConfig.orchestrator, env = process.env, ingestionService} = {}) {',
-        ticket: '#13939',
-        reason: 'Existing test seam; cleanup belongs to the #12456 fan-out.'
     }
 ]);
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -2578,7 +2578,7 @@ test.describe('TenantRepoSyncService.resolveIngestionService — export-drift gu
     });
 });
 
-test.describe('TenantRepoSyncService.resolveTenantReposConfig — Tier-1 mirrorRoot fallback (#12036 Bug C)', () => {
+test.describe('TenantRepoSyncService.resolveTenantReposConfig — Provider mirrorRoot SSOT (#16014)', () => {
     /*
      * Materialization of per-repo `mirrorRoot` from the Tier-1
      * `aiConfig.orchestrator.tenantRepoMirrorRoot` default when the per-repo
@@ -2661,7 +2661,7 @@ test.describe('TenantRepoSyncService.resolveTenantReposConfig — Tier-1 mirrorR
         expect(mirrorPath).not.toContain('tenant-repos/tenant-repos');
     });
 
-    test('stale-overlay defense: missing orchestratorConfig.tenantRepoMirrorRoot falls back to env var (#12036 cycle-2 RA1)', async () => {
+    test('an absent explicit seam reads the resolved Tier-1 Provider leaf', async () => {
         const ingestionStub = {
             listConfiguredTenantRepos: async () => ({tenantRepos: [
                 {tenantId: 't1', repoSlug: 'org/r', cloneUrl: 'https://github.com/o/r.git', credentialRef: 'env:T'}
@@ -2669,28 +2669,29 @@ test.describe('TenantRepoSyncService.resolveTenantReposConfig — Tier-1 mirrorR
         };
 
         const result = await TenantRepoSyncService.resolveTenantReposConfig({
-            ingestionService  : ingestionStub,
-            orchestratorConfig: {},  // simulate stale operator overlay (no tenantRepoMirrorRoot key)
-            env               : {NEO_TENANT_REPO_MIRROR_ROOT: '/env-bound/root'}
-        });
-
-        expect(result.tenantRepos[0].mirrorRoot).toBe('/env-bound/root');
-    });
-
-    test('stale-overlay defense: missing orchestratorConfig AND no env var → hardcoded /app/.neo-ai-data (#12036 cycle-2 RA1)', async () => {
-        const ingestionStub = {
-            listConfiguredTenantRepos: async () => ({tenantRepos: [
-                {tenantId: 't1', repoSlug: 'org/r', cloneUrl: 'https://github.com/o/r.git', credentialRef: 'env:T'}
-            ]})
-        };
-
-        const result = await TenantRepoSyncService.resolveTenantReposConfig({
-            ingestionService  : ingestionStub,
-            orchestratorConfig: {},
-            env               : {}
+            ingestionService: ingestionStub
         });
 
         expect(result.tenantRepos[0].mirrorRoot).toBe('/app/.neo-ai-data');
+    });
+
+    test('blank explicit roots fail before config enumeration', async () => {
+        let   enumerationCount = 0;
+        const ingestionStub    = {
+            listConfiguredTenantRepos: async () => {
+                enumerationCount++;
+                return {tenantRepos: []};
+            }
+        };
+
+        for (const tier1MirrorRoot of ['', '   ']) {
+            await expect(TenantRepoSyncService.resolveTenantReposConfig({
+                ingestionService: ingestionStub,
+                tier1MirrorRoot
+            })).rejects.toThrow('AiConfig.orchestrator.tenantRepoMirrorRoot must resolve to a non-empty string.');
+        }
+
+        expect(enumerationCount).toBe(0);
     });
 });
 


### PR DESCRIPTION
Resolves #16014

Tenant repo sync now consumes the resolved `AiConfig.orchestrator.tenantRepoMirrorRoot` leaf instead of maintaining a second env/default resolver. Missing per-repo roots still materialize at the service boundary, explicit per-repo roots still win unchanged, and an invalid selected root now fails before config enumeration or ingestion side effects.

Related: #15931
Related: #16008

Evidence: L2 (71 focused service contract tests plus exact-head source and lint sweeps) → L2 required (all close-target ACs). No residuals.

## Deltas from ticket

None substantive. The implementation follows the ticket contract:

- preserves the explicit `tier1MirrorRoot` test seam;
- otherwise reads the live Provider leaf at the use site;
- rejects missing, empty, or whitespace-only roots before calling `listConfiguredTenantRepos()`;
- removes the `orchestratorConfig`, `env`, direct-env, hardcoded-default, and optional-access paths;
- removes the exact `AI_CONFIG_IMPLEMENTATION_BASELINE` exception;
- retains explicit per-repo overrides and the parent-of-`tenant-repos` path contract.

## Contract Ledger

| Surface | Authority | Delivered behavior | Evidence |
|---|---|---|---|
| `resolveTenantReposConfig()` | ADR 0019 and #16014 | Explicit seam or resolved Provider leaf; invalid roots fail before enumeration | Focused positive, override, path, and negative-side-effect tests |
| `AiConfig.orchestrator.tenantRepoMirrorRoot` | `ai/configBase.mjs` | Sole owner of the cloud default and `NEO_TENANT_REPO_MIRROR_ROOT` binding for this consumer path | Exact-head `rg` sweep and config-template SSOT lint |
| `tenantRepos[].mirrorRoot` | Existing tenant-repo access contract | Explicit values remain unchanged; absent values inherit the selected Tier-1 root | Existing override and no-double-segment witnesses |
| Config-implementation lint baseline | ADR 0019 enforcement | The obsolete service exception is removed | `npm run ai:lint-config-template-ssot` reports zero test authority violations |

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — 71/71 passed on exact head `b98d2c9c14`.
- `npm run ai:lint-config-template-ssot` — passed; zero inline-env defaults and zero test config-authority violations.
- `npm run agent-preflight -- --no-fix <three changed files>` — passed; only unrelated legacy-overlay warnings.
- `node --check` on the service and spec plus `git diff --check origin/dev...HEAD` — passed.
- Broader pre-rebase `npm run test-unit` observation — 9,578 passed, 20 failed, 5 skipped, 48 did not run. Every #16014 case passed; the failures were outside this diff. The first wake-process failure was classified as sandbox `ps` denial and passed 3/3 when rerun with host process visibility. The exact-head focused suite was rerun after rebasing onto current `dev`.
- Directly touched service surface: `test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — 71/71 passed.
- Directly touched lint surface: `npm run ai:lint-config-template-ssot` — passed.

## Post-Merge Validation

- [ ] Observe the next Data Sync Pipeline run on `dev` for regression telemetry; this is not a close-target residual.

## Decision Record impact

Aligned with ADR 0019. This removes a historical consumer-side resolver after delta overlays made the stale full-copy fallback obsolete; it does not change the cloud-pinned placement decision.

## Avoided traps

- The cloud-pinned leaf is not re-anchored to `plane.dataRoot`.
- Deprecated full-copy overlays do not retain authority by forcing every consumer to become a second resolver.
- The umbrella #15931 stays open; the sibling Neural Link consumer landed separately in PR `#16009`.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019f9e1e-2ef1-72c3-a04d-6bc67a531a8b.
