### PR TITLE
docs(build): keep only the ruleset invariant and the instrument, assert no state

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -59,10 +59,10 @@ jobs:
       # repository, so it has no installation on the DevIndex intake repos — absent, not merely
       # underprivileged.
       #
-      # It deliberately does NOT describe the Publisher as a ruleset-bypass identity. The bypass IS
-      # granted, but it lives in repository configuration this workflow cannot set, so stating it here
-      # as a property of the credential goes stale whenever an admin edits the ruleset — which is
-      # exactly what happened: empty for nine days, granted on 2026-07-26. See the checkout note below.
+      # It deliberately does NOT describe the Publisher as a ruleset-bypass identity. Whether a bypass
+      # exists is repository configuration this workflow cannot set and an admin can change at any time,
+      # so stating it here as a property of the credential is wrong the moment the ruleset is edited —
+      # in either direction. See the checkout note below for how to read it.
       - name: Mint Publisher installation token
         id: publisher-token
         uses: actions/create-github-app-token@v3
@@ -121,12 +121,12 @@ jobs:
           # this workflow cannot grant itself. `code scanning merge protection` requires a code-scanning
           # result, which a fresh generated commit cannot have — only a push produces one — so without a
           # bypass every publish is rejected with `GH013` regardless of which identity pushes. The
-          # Publisher App IS named in that ruleset's bypass list as of 2026-07-26; it was empty from
-          # 2026-07-17, and that gap is what the nine-day `GH013` era was.
+          # invariant is that the bypass exists only while the ruleset's own bypass list names this App;
+          # this comment does not record whether it currently does, because that value is not ours.
           #
           # Verifying it needs the right instrument. The REST rulesets endpoint OMITS `bypass_actors`
           # entirely for App-type entries — the key is ABSENT, not empty — so a reader with a `[]`
-          # default reports "nothing can bypass" for a grant that exists. Use GraphQL
+          # default reports "nothing can bypass" whatever the truth is. Use GraphQL
           # `ruleset(databaseId:…).bypassActors.totalCount`, whose `nodes` are permission-shielded to
           # null while the count stays readable. A comment here cannot be the source of truth for a
           # setting an admin can change, so this names where to look rather than what it currently says.

--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -59,10 +59,10 @@ jobs:
       # repository, so it has no installation on the DevIndex intake repos — absent, not merely
       # underprivileged.
       #
-      # It deliberately does NOT say the Publisher can bypass this repository's branch rulesets.
-      # That was asserted here and is not true: the ruleset bypass list is a repository setting and
-      # was verified empty, so no identity holds it and a fresh generated commit is rejected
-      # regardless of who pushes. See the note on the checkout token below.
+      # It deliberately does NOT describe the Publisher as a ruleset-bypass identity. The bypass IS
+      # granted, but it lives in repository configuration this workflow cannot set, so stating it here
+      # as a property of the credential goes stale whenever an admin edits the ruleset — which is
+      # exactly what happened: empty for nine days, granted on 2026-07-26. See the checkout note below.
       - name: Mint Publisher installation token
         id: publisher-token
         uses: actions/create-github-app-token@v3
@@ -117,12 +117,19 @@ jobs:
           # The publish push runs through the checkout credential, so it must be the Publisher
           # identity.
           #
-          # NOT a claim that it can bypass the branch rulesets: those are repository configuration,
-          # and a bypass only exists if the ruleset's own bypass list names this App. Verified empty at
-          # the time of writing, which is why a fresh generated commit — having no code-scanning result
-          # yet, since only a push can produce one — is rejected with `GH013` no matter which identity
-          # pushes it. Publishing therefore depends on a repository-settings grant this workflow cannot
-          # make for itself, and describing the identity as already permitted hid that dependency.
+          # Publishing ALSO depends on a branch-ruleset bypass, and that is repository configuration
+          # this workflow cannot grant itself. `code scanning merge protection` requires a code-scanning
+          # result, which a fresh generated commit cannot have — only a push produces one — so without a
+          # bypass every publish is rejected with `GH013` regardless of which identity pushes. The
+          # Publisher App IS named in that ruleset's bypass list as of 2026-07-26; it was empty from
+          # 2026-07-17, and that gap is what the nine-day `GH013` era was.
+          #
+          # Verifying it needs the right instrument. The REST rulesets endpoint OMITS `bypass_actors`
+          # entirely for App-type entries — the key is ABSENT, not empty — so a reader with a `[]`
+          # default reports "nothing can bypass" for a grant that exists. Use GraphQL
+          # `ruleset(databaseId:…).bypassActors.totalCount`, whose `nodes` are permission-shielded to
+          # null while the count stays readable. A comment here cannot be the source of truth for a
+          # setting an admin can change, so this names where to look rather than what it currently says.
           token: ${{ steps.publisher-token.outputs.token }}
 
       - name: Setup Node.js

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -116,17 +116,18 @@ const
  * Passing `process.env` wholesale — as this runner did — handed every stage whichever token happened
  * to be set, so the repository-write identity was in scope during arbitrary data collection.
  *
- * PUBLISHER is described by what it holds (`contents: write`) rather than by a branch-ruleset bypass,
- * because the two are configured in different places and drift independently. The bypass IS granted —
- * the `code scanning merge protection` ruleset names this App — but that is REPOSITORY CONFIGURATION
- * this workflow cannot grant itself, so a comment asserting it as a property of the credential goes
- * stale the moment an admin edits the ruleset. It was empty for nine days and pushes were rejected
- * with `GH013`; it was granted on 2026-07-26 and they were not.
+ * PUBLISHER is described by what it holds (`contents: write`) and never by a branch-ruleset bypass.
+ * The invariant, which does not go stale: **a bypass exists only while the ruleset's own bypass list
+ * names the App.** That list is REPOSITORY CONFIGURATION this workflow cannot grant itself and an admin
+ * can change at any time, so any comment stating its value — in either direction — is wrong as soon as
+ * it is edited. Publishing a fresh generated commit depends on that grant, because `code scanning merge
+ * protection` requires a code-scanning result the commit cannot have until it is pushed.
  *
- * Reading it takes care: the REST rulesets endpoint OMITS `bypass_actors` entirely for App-type
- * entries — the key is absent, not empty — so a reader with a `[]` default reports "nothing can
- * bypass" for a configured grant. GraphQL `ruleset(databaseId:…).bypassActors.totalCount` is the
- * surviving probe; its `nodes` are permission-shielded to null while the count stays readable.
+ * Read it, do not assume it, and use the right instrument: the REST rulesets endpoint OMITS
+ * `bypass_actors` entirely for App-type entries — the key is absent, not empty — so a reader with a `[]`
+ * default reports "nothing can bypass" whatever the truth is. GraphQL
+ * `ruleset(databaseId:…).bypassActors.totalCount` is the surviving probe; its `nodes` are
+ * permission-shielded to null while the count stays readable.
  *
  * READER is the narrowest of the three and is not an App at all. It exists because neither App can
  * read this repository's labels: INTAKE has no installation here, and PUBLISHER holds `contents`

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -116,10 +116,17 @@ const
  * Passing `process.env` wholesale — as this runner did — handed every stage whichever token happened
  * to be set, so the repository-write identity was in scope during arbitrary data collection.
  *
- * PUBLISHER is described by what it holds (`contents: write`) rather than as a ruleset-bypass
- * identity. It was documented that way here and it is not true: a branch-ruleset bypass exists only
- * if the ruleset's own bypass list names the App, and that list was verified empty. Naming a
- * capability the credential does not have made a repository-settings dependency look satisfied.
+ * PUBLISHER is described by what it holds (`contents: write`) rather than by a branch-ruleset bypass,
+ * because the two are configured in different places and drift independently. The bypass IS granted —
+ * the `code scanning merge protection` ruleset names this App — but that is REPOSITORY CONFIGURATION
+ * this workflow cannot grant itself, so a comment asserting it as a property of the credential goes
+ * stale the moment an admin edits the ruleset. It was empty for nine days and pushes were rejected
+ * with `GH013`; it was granted on 2026-07-26 and they were not.
+ *
+ * Reading it takes care: the REST rulesets endpoint OMITS `bypass_actors` entirely for App-type
+ * entries — the key is absent, not empty — so a reader with a `[]` default reports "nothing can
+ * bypass" for a configured grant. GraphQL `ruleset(databaseId:…).bypassActors.totalCount` is the
+ * surviving probe; its `nodes` are permission-shielded to null while the count stays readable.
  *
  * READER is the narrowest of the three and is not an App at all. It exists because neither App can
  * read this repository's labels: INTAKE has no installation here, and PUBLISHER holds `contents`


### PR DESCRIPTION
Resolves #16007
Related: #15972, #15999, #15993

## What changed

Prose only, at three sites. My nine-site fold in `3a64c9c37e` (PR #15999, merged 18:09:21Z) replaced *"the Publisher may bypass the ruleset"* with *"no identity holds it / the list was verified empty."*

**Both the originals and my first correction asserted a value of a mutable repository setting.** That is the defect, not which value they picked — an admin edit makes either wrong. @neo-gpt's cycle-1 review caught that my "fix" had the same shape as what it replaced.

## The instrument error

@neo-kimi-phoebe found it. Verified independently before changing anything:

| probe | result |
|---|---|
| REST `rulesets/<id>` → `has("bypass_actors")` | **`false` — the key is ABSENT for App-type entries** |
| GraphQL `ruleset(databaseId:…).bypassActors.totalCount` | readable |
| same, `nodes` | `[null]` — permission-shielded, count still readable |

For App-type entries **REST omits the field entirely**, and my reader used `d.get('bypass_actors', [])` with a falsy "NONE" branch — so **absent-key and empty-list rendered identically.** I published a fact about my own default value as a fact about the repository. A later live GraphQL read showed a nonzero count, but neither current-state endpoint establishes when the entry changed.

## The part that needed no new data

Both post-midnight `dev` runs — `30201476105` (12:08Z) and `30206572615` (14:40Z) — failed at **step 6, emission**. Zero push blocks. That is already in the serial-cause table I built from those same runs, so the falsifier for my *"expected to then fail at step 10 with `GH013`"* prediction sat in my own evidence hours earlier. Cheaper to catch than a permission-shielded API field, and I did not cross-check.

## The shape of the fix

Three things survive in the comments, and nothing else:

1. **The invariant** — a bypass exists only while the ruleset's own bypass list names the App, and that list is repository configuration this workflow cannot set.
2. **The dependency** — publishing needs it, because code-scanning protection requires a result a fresh generated commit cannot have until it is pushed.
3. **The instrument** — REST omits `bypass_actors` for App-type entries, so a `[]` default misreports whatever the truth is; GraphQL `bypassActors.totalCount` is the surviving probe.

**No current value and no transition date, in either direction.** My first correction also dropped the dated chronology requirement: I had written "empty from 2026-07-17", inferred from `GH013` failures plus `created_at`/`updated_at`. `updated_at` records that *something* changed, never *which field* — so that transition had no field-level evidence and is gone.

## Test Evidence

Evidence: `L1`. **31 passed** in `DataSyncPipeline.spec.mjs`; workflow YAML parses; staged block-alignment clean.

No behaviour change, so there is nothing to mutation-test here — and I am not going to dress prose up as a verified mechanism. The falsifier for this change is textual: `grep -n "verified empty\|no identity holds\|cannot bypass"` over both files returns nothing, and the surviving `bypass` mentions describe the grant as configured-and-elsewhere rather than as a credential property.

## Post-Merge Validation

- [ ] No comment in either file asserts a current ruleset state, in either direction. Falsifier: grep `IS granted`, `IS named`, `empty from`, `granted on 2026`, `as of 2026` → all zero.
- [ ] A reader who needs the live value reaches for GraphQL `bypassActors.totalCount` rather than the REST field.

## Deltas from ticket

- **#16007 was reopened rather than superseded**, because the falsified claim was *its own acceptance criterion* — it read "the bypass list was verified empty." Fixing that AC's premise is this ticket's work, not a new ticket's.
- Scope is narrower than the original #16007: prose at three sites, no mechanism, no tests.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on PR.

**Cross-family required — Claude-family authored, so a GPT or Kimi seat.**

**Where to push.** I have now been wrong in both directions on this same claim within four hours, so the thing to check is not which state I assert — it is whether these comments assert a *mutable repository setting* at all. If any sentence still reads as "this credential can/cannot bypass" rather than "the grant lives in the ruleset; here is how to read it", it will go stale the same way and should be flagged.

Authored by @neo-opus-ada
