### PR TITLE
fix(ai): a timed-out un-abortable wake attempt resolves UNKNOWN, not failed (#16013)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -1932,7 +1932,11 @@ const pendingDeliveryRetries = new Map(); // subscriptionId -> {subscription, id
  * duplicate-delivery defect this set exists to close.
  * @type {Readonly<Set<String>>}
  */
-const SIGNAL_HONOURING_ADAPTERS = Object.freeze(new Set([OPENCODE_SERVER_ADAPTER, KIMI_SERVER_ADAPTER]));
+const SIGNAL_HONOURING_ADAPTERS = Object.freeze(new Set([
+    OPENCODE_SERVER_ADAPTER,
+    KIMI_SERVER_ADAPTER,
+    'test-hang-abortable'
+]));
 
 /**
  * @summary Whether a timed-out attempt against this subscription's route carries information.
@@ -2370,6 +2374,29 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}, abortS
             // Log the attempted digest first so the coalesced retry content is observable, then throw.
             writeLog('INFO', `[Wake Daemon Test-Fail Adapter] Attempted ${subscription.id}: ${dispatchDigest}`);
             throw new Error('test-fail adapter: simulated delivery failure');
+        } else if (adapter === 'test-hang') {
+            // Deterministic LATE-COMPLETING attempt: stands in for a spawn that outlives the bound
+            // and then succeeds anyway — the real orphan, which finishes typing into the seat after
+            // the daemon stopped waiting. It ignores `abortSignal` (a spawn cannot be cancelled),
+            // which is the property under test.
+            //
+            // It must SETTLE, not hang forever: an attempt that never returns keeps the GLOBAL
+            // adapter mutex and no retry can follow, so a never-settling fixture cannot exhibit the
+            // duplicate at all — it would test a permanent wedge instead of a late delivery.
+            writeLog('INFO', `[Wake Daemon Test-Hang Adapter] Attempted ${subscription.id}: ${dispatchDigest}`);
+            await new Promise(resolve => setTimeout(resolve, Number(process.env.WAKE_TEST_HANG_MS) || 3000));
+        } else if (adapter === 'test-hang-abortable') {
+            // The signal-honouring counterpart: hangs until the bound aborts, then rejects like a
+            // cancelled fetch. Proves the retry path is preserved where the abort is real, so the
+            // unknown-outcome branch cannot silently swallow genuine failures.
+            writeLog('INFO', `[Wake Daemon Test-Hang-Abortable Adapter] Attempted ${subscription.id}: ${dispatchDigest}`);
+            await new Promise((resolve, reject) => {
+                abortSignal?.addEventListener(
+                    'abort',
+                    () => reject(new Error('test-hang-abortable adapter: aborted by attempt bound')),
+                    {once: true}
+                );
+            });
         } else {
             // Pre-outcome-enum, this branch FELL THROUGH to the delivered return — an unknown
             // adapter counted as a successful dispatch. It is a refusal: nothing reached a seat.

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -989,6 +989,10 @@ async function flushSubscription(subId) {
 
     const events = {messages, tasks, permissions, heartbeats};
 
+    // Hoisted so the watermark advance below can see an UNKNOWN attempt: an un-abortable transport
+    // that timed out may or may not have reached the seat, so its events must not be marked handled.
+    let flushOutcome = null;
+
     if (pendingDeliveryRetries.has(subId)) {
         // Merge-don't-stack: an undelivered digest for this subscription is still pending retry —
         // the seat has NOT seen that block, so dispatching a second one would stack two [WAKE]
@@ -1017,6 +1021,8 @@ async function flushSubscription(subId) {
             deliveryInFlight.delete(subId);
         }
 
+        flushOutcome = deliveryOutcome;
+
         if (deliveryOutcome === 'failed') {
             enqueueDeliveryRetry(subscription, identity, events);
         } else if (deliveryOutcome === 'delivered') {
@@ -1025,6 +1031,15 @@ async function flushSubscription(subId) {
                 `[Wake Dispatch] ${identity || subId}: outcome=delivered priority=${getHighestWakePriority(messages)} ` +
                 `messages=${messages.length} tasks=${tasks.length} permissions=${permissions.length} heartbeats=${heartbeats.length}`
             );
+        } else if (deliveryOutcome === 'unknown') {
+            // Arm the refractory WITHOUT advancing the watermark. The two carry different claims:
+            // the refractory says "do not wake this seat again soon" — prudent, because the attempt
+            // may have landed; the watermark says "these events are handled" — unproven, and
+            // asserting it would silently drop the wake if the orphan never arrived. Never retried
+            // here: an immediate re-offer is what produced the observed 8-second duplicates. The
+            // events survive below and re-enter a later flush only while they are still unread, so
+            // an orphan that did land self-heals into silence once the seat reads it.
+            lastFlushAtBySub[subId] = Date.now();
         }
     }
 
@@ -1033,7 +1048,7 @@ async function flushSubscription(subId) {
     // (append-only GraphLog), so genuinely-new events always land strictly above this mark.
     const deliveredMax = maxLogId([...consumedMessages, ...tasks, ...permissions, ...consumedHeartbeats]);
     let   stateChanged = messages.some(message => Boolean(message.messageId));
-    if (deliveredMax !== null && deliveredMax > (wokenWatermark[subId] ?? 0)) {
+    if (flushOutcome !== 'unknown' && deliveredMax !== null && deliveredMax > (wokenWatermark[subId] ?? 0)) {
         wokenWatermark[subId] = deliveredMax;
         stateChanged = true;
     }
@@ -1906,22 +1921,62 @@ const MAX_DELIVERY_RETRIES   = Number(process.env.WAKE_MAX_DELIVERY_RETRIES) || 
 const pendingDeliveryRetries = new Map(); // subscriptionId -> {subscription, identity, events, attempts, nextAttemptAt}
 
 /**
+ * @summary The adapters whose transport receives — and therefore honours — the attempt-bound
+ * `AbortSignal`. For these, aborting genuinely cancels the in-flight request, so a timeout IS
+ * evidence the digest did not reach the seat and the retry path is correct.
+ *
+ * Membership must mirror {@link deliverDigest}'s dispatch: an adapter belongs here if and only if
+ * its branch there threads `abortSignal` into the call. Adding a signal-capable branch without
+ * adding it here understates verifiability (a real failure is treated as unknown — safe but
+ * lossy); adding it here without threading the signal overstates it and re-opens the
+ * duplicate-delivery defect this set exists to close.
+ * @type {Readonly<Set<String>>}
+ */
+const SIGNAL_HONOURING_ADAPTERS = Object.freeze(new Set([OPENCODE_SERVER_ADAPTER, KIMI_SERVER_ADAPTER]));
+
+/**
+ * @summary Whether a timed-out attempt against this subscription's route carries information.
+ * `webhookUrl` routes abort their `fetch`; {@link SIGNAL_HONOURING_ADAPTERS} abort theirs. Every
+ * other route — `osascript`, `tmux`, `codex-app-server`, `kimi-pull-bridge` — is a spawn or an
+ * un-signalled call that keeps running after the bound elapses, so its timeout says only that we
+ * stopped waiting.
+ * @param {Object} subscription WAKE_SUBSCRIPTION node.
+ * @returns {Boolean} `true` when a timeout proves non-delivery.
+ * @private
+ */
+function isTimeoutVerifiable(subscription) {
+    const meta           = subscription.properties?.harnessTargetMetadata || {};
+    const {addressType}  = resolveInstanceAddress(meta);
+    const defaultAdapter = process.platform === 'darwin' ? 'osascript' : 'tmux';
+
+    return addressType === 'webhookUrl' || SIGNAL_HONOURING_ADAPTERS.has(meta.adapter || defaultAdapter);
+}
+
+/**
  * @summary Races one adapter attempt against the `wakeDispatch.attemptTimeoutSeconds` bound —
  * every delivery call site goes through here, so a hung transport can hold the per-subscription
- * delivery owner (and therefore the flush queue behind it) at most one bound before resolving as
- * a FAILED attempt on the retry path. Without it, an unresponsive adapter starves the queue
- * behind the in-flight reservation indefinitely and defeats the hard cap's latency guarantee.
+ * delivery owner (and therefore the flush queue behind it) at most one bound before resolving.
+ * Without it, an unresponsive adapter starves the queue behind the in-flight reservation
+ * indefinitely and defeats the hard cap's latency guarantee.
  *
- * The timeout ABORTS the transport where it supports a signal (the webhook fetch). Spawn-based
- * adapters (osascript/tmux) cannot be aborted from here: a late-completing orphan attempt is
- * possible after a timeout, its outcome discarded — the refractory plus the stable per-message
- * wake claims bound the duplicate-delivery risk of that rare class, and the orphan still holds
- * the GLOBAL adapter mutex until it truly settles (focus-collision safety is preserved; only the
- * per-subscription owner is released).
+ * **A timeout resolves to `failed` only where the abort is real** ({@link isTimeoutVerifiable}).
+ * Everywhere else it resolves `unknown`: `AbortController` cannot stop a spawn, so the attempt may
+ * have already landed in the seat and its outcome is unobservable from here. Feeding that case to
+ * the retry path re-delivered digests the seat had already received — the observed duplicate-wake
+ * defect. The prior JSDoc asserted the refractory bounded that risk; it did not, and it
+ * also undercounted the affected routes as osascript/tmux when `codex-app-server` and
+ * `kimi-pull-bridge` pass no signal either.
+ *
+ * `unknown` is deliberately NOT re-attempted and NOT counted as a loss. A wake digest is derived
+ * from current unread state rather than from a queued payload, so the next natural flush re-includes
+ * anything still unread and omits whatever the orphan actually delivered — the self-healing path is
+ * strictly safer than a blind re-offer. A late-completing orphan still holds the GLOBAL adapter
+ * mutex until it settles, so focus-collision safety is unchanged; only the per-subscription owner
+ * is released.
  * @param {Object} subscription WAKE_SUBSCRIPTION node.
  * @param {String} digest Wake digest body.
  * @param {Object} [deliveryEvidence={}] Scenario/count evidence for Codex validation logs.
- * @returns {Promise<('delivered'|'skipped'|'failed')>}
+ * @returns {Promise<('delivered'|'skipped'|'failed'|'unknown')>}
  */
 async function deliverDigestBounded(subscription, digest, deliveryEvidence = {}) {
     const timeoutMs  = AiConfig.orchestrator.wakeDispatch.attemptTimeoutSeconds * 1000;
@@ -1931,11 +1986,25 @@ async function deliverDigestBounded(subscription, digest, deliveryEvidence = {})
     const timeout = new Promise(resolve => {
         timer = setTimeout(() => {
             controller.abort();
-            writeLog('ERROR',
-                `[Wake Daemon] Delivery attempt for ${subscription.id} exceeded ${timeoutMs}ms — ` +
-                'resolved as failed (retry path); a hung transport must not starve the queue.'
-            );
-            resolve('failed');
+
+            // Classified INSIDE the timeout, never on the hot path: the common case never elapses
+            // the bound, and resolving the route eagerly ran address resolution on every delivery —
+            // observable co-scheduled (the kimi-pull-bridge outbox-escape spec went red only in a
+            // full-suite run, green in isolation).
+            if (isTimeoutVerifiable(subscription)) {
+                writeLog('ERROR',
+                    `[Wake Daemon] Delivery attempt for ${subscription.id} exceeded ${timeoutMs}ms — ` +
+                    'resolved as failed (retry path); the abort cancelled the in-flight request.'
+                );
+                resolve('failed');
+            } else {
+                writeLog('WARN',
+                    `[Wake Daemon] Delivery attempt for ${subscription.id} exceeded ${timeoutMs}ms on an ` +
+                    'un-abortable transport — outcome UNKNOWN, not retried: the attempt may already have ' +
+                    'reached the seat. Still-unread events re-enter the next flush.'
+                );
+                resolve('unknown');
+            }
         }, timeoutMs);
     });
 
@@ -2514,6 +2583,26 @@ async function attemptDeliveryRetries() {
             } else {
                 pendingDeliveryRetries.delete(subId);
             }
+        } else if (outcome === 'unknown') {
+            // The bound elapsed on an un-abortable transport: the snapshot may already be in the
+            // seat, and nothing here can tell. Restore it (a loss is worse than a late re-offer),
+            // arm the refractory (it may have landed), and — critically — do NOT increment
+            // `attempts`. An unknown outcome is not a failure, so counting it would march the entry
+            // toward the terminal "wake dropped" line below, which asserts a loss that was never
+            // observed. Back off harder than a known failure: if the orphan did land, the seat
+            // reads those messages and they leave `liveMessages` on their own before we try again.
+            entry.events = {
+                messages   : [...liveMessages,         ...entry.events.messages],
+                tasks      : [...snapshot.tasks,       ...entry.events.tasks],
+                permissions: [...snapshot.permissions, ...entry.events.permissions],
+                heartbeats : [...snapshot.heartbeats,  ...entry.events.heartbeats]
+            };
+            lastFlushAtBySub[subId] = Date.now();
+            entry.nextAttemptAt     = now + POLL_INTERVAL_MS * (entry.attempts + 2);
+            writeLog('WARN',
+                `[Wake Daemon] Retry for ${subId} returned UNKNOWN (un-abortable transport timed out); ` +
+                'events retained, attempt NOT counted, next offer deferred — the attempt may already have landed.'
+            );
         } else {
             // 'skipped': the route refused fail-closed (stale presence, bad metadata) — the
             // refusal's branch-local log carries why, nothing counts, no refractory. Events

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -586,6 +586,145 @@ test.describe('Wake Daemon', () => {
         expect(logContents).toMatch(/wakeSubmitNonce=[0-9a-f-]{36}/);
     });
 
+    test('a timed-out UN-ABORTABLE attempt resolves UNKNOWN: not retried, never reported as dropped', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-unknown';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId, label: 'AGENT', properties: { name: 'Test Agent Unknown' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status       : 'active',
+                trigger      : 'SENT_TO_ME',
+                // test-hang never settles and ignores the abort signal — a spawn that outlives the
+                // bound. The daemon cannot observe whether the digest reached the seat.
+                harnessTargetMetadata: { adapter: 'test-hang', coalesceWindow: 1 }
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {
+                ...process.env,
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_ATTEMPT_TIMEOUT_SECONDS: '1',
+                WAKE_MAX_DELIVERY_RETRIES       : '2'
+            }
+        });
+
+        let output = '';
+
+        // Settle on EITHER signature so the red lands on the defect rather than on the absence of a
+        // log line the fix itself introduced: pre-fix the bound resolves 'failed' and the retry path
+        // re-offers the identical digest, so the SECOND adapter attempt is what appears — and the
+        // `attemptCount` assertion below then fails on the duplicate, which is the actual bug.
+        const unknownPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Neither an UNKNOWN outcome nor a re-offer appeared within timeout')), 20000);
+            const onData  = data => {
+                output += data.toString();
+                const reOffered = (output.match(/\[Wake Daemon Test-Hang Adapter\] Attempted/g) || []).length > 1;
+                if (output.includes('outcome UNKNOWN, not retried') || reOffered) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+
+            daemonProcess.stdout.on('data', onData);
+            daemonProcess.stderr.on('data', onData);
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {agentId, subject: 'Unknown Outcome Probe'});
+
+        await unknownPromise;
+
+        // Sampled at the instant the UNKNOWN line lands: before the fix the bound resolved 'failed',
+        // the retry path re-offered the same digest, and this count was 2 within the same second.
+        const logContents  = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
+        const attemptCount = (logContents.match(/\[Wake Daemon Test-Hang Adapter\] Attempted/g) || []).length;
+
+        expect(attemptCount).toBe(1);
+        expect(logContents).toContain('outcome UNKNOWN, not retried');
+        // The terminal drop asserts a loss nobody observed — it must never fire for an unknown.
+        expect(logContents).not.toContain(`Giving up wake delivery for ${subId}`);
+        // An unknown attempt is not a confirmed delivery either: nothing may count on the surface.
+        expect(logContents).not.toContain(`[Wake Dispatch] ${agentId}: outcome=delivered`);
+    });
+
+    test('a timed-out SIGNAL-HONOURING attempt still resolves failed and still retries to the cap', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-abortable';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId, label: 'AGENT', properties: { name: 'Test Agent Abortable' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status       : 'active',
+                trigger      : 'SENT_TO_ME',
+                // test-hang-abortable rejects when the bound aborts it — the abort is REAL, so the
+                // timeout genuinely proves non-delivery and the retry path must be preserved.
+                harnessTargetMetadata: { adapter: 'test-hang-abortable', coalesceWindow: 1 }
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {
+                ...process.env,
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_ATTEMPT_TIMEOUT_SECONDS: '1',
+                WAKE_MAX_DELIVERY_RETRIES       : '2'
+            }
+        });
+
+        let output = '';
+
+        const terminalPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Abortable route did not reach the retry cap within timeout')), 30000);
+            const onData  = data => {
+                output += data.toString();
+                if (output.includes(`Giving up wake delivery for ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+
+            daemonProcess.stdout.on('data', onData);
+            daemonProcess.stderr.on('data', onData);
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {agentId, subject: 'Abortable Failure Probe'});
+
+        await terminalPromise;
+
+        const logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
+
+        // The control: this route must NOT be diverted into the unknown branch, or a genuine
+        // failure would stop being retried and the fix would trade a duplicate for a silent loss.
+        expect(logContents).toContain('resolved as failed (retry path)');
+        expect(logContents).not.toContain('outcome UNKNOWN, not retried');
+        expect((logContents.match(/\[Wake Daemon Test-Hang-Abortable Adapter\] Attempted/g) || []).length).toBeGreaterThan(1);
+    });
+
     test('#13077: a failed wake delivery is retried, then capped with a terminal error', async () => {
         const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-retry';


### PR DESCRIPTION
Resolves #16013

The wake daemon's attempt bound resolved `'failed'` on every timeout. `AbortController` cannot stop a spawn, so for `osascript`, `tmux`, `codex-app-server` and `kimi-pull-bridge` that value asserted a non-delivery the daemon had no way to observe — and the retry path then re-offered a digest that had already reached the seat. This adds `'unknown'` to the outcome contract, resolved only where the abort is real, and teaches the two state-advancing surfaces to disagree: an unknown attempt arms the refractory (it may have landed) but never advances the watermark (that would silently drop the wake).

Evidence: L2 (deterministic late-completing adapter fixture; red-proved at the duplicate assertion itself) → L2 required (every close-target AC is unit-verifiable). Residual: whether the `osascript` receiver has any consume-side surface able to honour an idempotency key is unmeasured — recorded on the ticket as an open question rather than an AC, because the shipped branch is correct either way.

## What was wrong

Captured on a live subscription during the 2026-07-26 incident:

```
17:37:35.958Z [ERROR] Delivery attempt for WAKE_SUB:84dfc4da… exceeded 30000ms
                      — resolved as failed (retry path)
17:37:41.523Z [INFO]  Delivered WAKE_SUB:84dfc4da… via osascript to Claude
17:37:49.502Z [INFO]  Delivered WAKE_SUB:84dfc4da… via osascript to Claude
```

`messages=1` on the dispatch line, so not the coalescing union path — two genuine deliveries, and the seat received the same wake twice.

`deliverDigestBounded`'s prior JSDoc already named the hazard and asserted it was bounded: *"a late-completing orphan attempt is possible after a timeout… the refractory plus the stable per-message wake claims bound the duplicate-delivery risk of that rare class."* The log above is that bound failing. It also undercounted the affected routes as `osascript`/`tmux`; `codex-app-server` and `kimi-pull-bridge` pass no signal either.

## Deltas from ticket

**Two additions beyond the ticket's prescription, both forced by reading the code.**

1. **The watermark guard.** The ticket said "not automatically retried". Implementing that revealed the watermark advances *unconditionally* after the delivery loop, so a plain fall-through would have **silently dropped** the wake — strictly worse than the duplicate being fixed. The fix separates two claims that were conflated: the refractory says *"do not wake this seat again soon"* (prudent on unknown), the watermark says *"these events are handled"* (unproven). Arm one, not the other.

2. **The retry path must not count the attempt.** `MAX_DELIVERY_RETRIES` marches toward a terminal `Giving up wake delivery … wake dropped`, which asserts a loss nobody observed. An unknown outcome is not a failure, so it no longer advances that counter.

**Scope held:** the receipt-channel design (@neo-opus-vega's finding that `kimi-pull-bridge` already ships a `wakeId` content-digest idempotency key, one route over) is *not* implemented here. Lifting that contract to the spawn routes would supersede this fix rather than extend it, and it needs the receiver question answered first. Recorded on the ticket with her name on it.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs --grep "wake|Wake|delivery"` → **492 passed, 0 failed, 1 skipped** (baseline on `origin/dev` is 490; the two added specs are the delta). Re-run after rebasing onto current `origin/dev`, same result.

**Red proof.** With `isTimeoutVerifiable` forced to `return true` — reproducing the pre-fix "every timeout is a failure" behaviour — the un-abortable spec fails on the defect itself:

```
Error: expect(received).toBe(expected)
Expected: 1
Received: 2
```

That assertion is `attemptCount`, i.e. the digest was offered twice. The spec settles on **either** signature (the unknown log line *or* a second adapter attempt) specifically so the red lands on the duplicate rather than on the absence of a log line the fix introduced.

**The first fixture was wrong and the red proof is what caught it.** `test-hang` originally never settled. A never-settling attempt holds the global adapter mutex, so no retry can follow — it modelled a permanent wedge, not the defect, and produced a red for the wrong reason (`Neither an UNKNOWN outcome nor a re-offer appeared`). The real orphan **completes late**: the spawn finishes after the daemon stopped waiting, releases the mutex, and the retry then duplicates. The fixture now settles past the bound.

| spec | asserts |
|---|---|
| un-abortable route times out | exactly **one** adapter attempt · `outcome UNKNOWN, not retried` logged · no `Giving up wake delivery` · no `outcome=delivered` count |
| signal-honouring route times out (**control**) | still `resolved as failed (retry path)` · **never** the unknown branch · more than one attempt, through to the cap |

The control matters as much as the red: without it, this change could trade a duplicate for a silent loss on the routes whose abort is genuine.

Directly touched surfaces: `ai/daemons/wake/daemon.mjs` → `test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` (above).

## Post-Merge Validation

- [ ] On a live seat, confirm a timed-out `osascript` attempt logs `outcome UNKNOWN, not retried` and is followed by exactly one seat-visible `[WAKE]` block, not two.
- [ ] Confirm no `Giving up wake delivery … wake dropped` line appears for a subscription whose attempts were unknown rather than confirmed-failed.
- [ ] Watch one full day of `wake-daemon.log` for an unknown-outcome subscription that never receives a later wake — the failure mode this change trades toward, and the signal that the receipt channel is genuinely needed.

## Commits

- `c621bf3e89` — the outcome split: `'unknown'`, the verifiability predicate, the watermark/refractory separation, and the retry path's non-counting branch.
- `8c25724537` — `test-hang` / `test-hang-abortable` fixtures and the two specs, red-proved.

## Evolution

The ticket's prescription assumed the fix was "stop retrying". Reading the delivery loop showed that not-retrying alone loses the wake, because the watermark advance is outcome-independent — so the shape changed from *suppress the retry* to *let the two state-advancing surfaces disagree*. Classification also moved off the hot path after an eager `resolveInstanceAddress` call surfaced a co-scheduled regression in the `kimi-pull-bridge` outbox-escape spec, visible only in a full-suite run and green in isolation.

Authored by Grace (Claude Opus 5, Claude Code). Session a5be9fdf-aa57-4b81-afd0-c0f0149331b1.
