### PR TITLE
fix(ai): require sustained Chroma health failure (#16022)

### DIFF
--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -875,6 +875,17 @@ export class ProcessSupervisorService extends Base {
         // never reaches the down-only liveness path.
         if (state.running) {
             if (typeof task?.healthProbe === 'function') {
+                const startupGraceMs = Number(task.healthStartupGraceMs);
+
+                if (
+                    state.lastRunAt > 0
+                    && Number.isFinite(startupGraceMs)
+                    && startupGraceMs > 0
+                    && now - state.lastRunAt < startupGraceMs
+                ) {
+                    return;
+                }
+
                 this.gateRecycleOnHealthProbe(taskName, task, now, cooldownMs);
             }
             return;
@@ -912,9 +923,9 @@ export class ProcessSupervisorService extends Base {
      * Mirrors {@link gateRestartOnLivenessProbe}'s confirmed-at + in-flight de-dup (at most one
      * probe per cooldown, no overlap), but acts on the RUNNING-child surface: a healthy result is
      * silent; an unhealthy result `killTask`s the child (recycle → respawn next poll). The task owns
-     * the actual "is it serving" check via `healthProbe()` and may implement its own hysteresis
-     * (the Ollama stuck-runner path does; Chroma's heartbeat probe intentionally does not); this
-     * method only schedules the probe and acts on the boolean.
+     * the actual "is it serving" check via `healthProbe()` and may implement its own hysteresis;
+     * this method only schedules the probe and acts on the boolean. A task-level startup grace is
+     * enforced by `superviseTask` before this method is reached.
      *
      * A THROWN probe is treated as healthy (no recycle): unlike the liveness path, the child is
      * already running, so a probe fault must never kill a working process.

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -16,8 +16,10 @@ const __dirname  = path.dirname(__filename);
  */
 export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
 
-const DEFAULT_CHROMA_HEALTH_ENDPOINT   = '/api/v2/heartbeat';
-const DEFAULT_CHROMA_HEALTH_TIMEOUT_MS = 1000;
+const DEFAULT_CHROMA_HEALTH_ENDPOINT          = '/api/v2/heartbeat';
+const DEFAULT_CHROMA_HEALTH_FAILURE_THRESHOLD = 3;
+const DEFAULT_CHROMA_HEALTH_STARTUP_GRACE_MS  = 60000;
+const DEFAULT_CHROMA_HEALTH_TIMEOUT_MS        = 5000;
 
 /**
  * @summary Probes whether a local TCP port is accepting connections.
@@ -106,7 +108,7 @@ export function buildChromaHealthUrl({
  * @param {Object} options
  * @param {String} [options.host='localhost'] Configured Chroma host.
  * @param {String|Number} options.port Configured Chroma port.
- * @param {Number} [options.timeoutMs=1000] Request timeout in milliseconds.
+ * @param {Number} [options.timeoutMs=5000] Request timeout in milliseconds.
  * @param {String} [options.endpoint='/api/v2/heartbeat'] Chroma health endpoint.
  * @param {Function} [options.fetchFn=globalThis.fetch] Fetch implementation seam.
  * @returns {Promise<Boolean>}
@@ -141,6 +143,48 @@ export async function probeChromaHttpHealth({
     } finally {
         clearTimeout(timeoutId);
     }
+}
+
+/**
+ * @summary Classifies a Chroma heartbeat result with a consecutive-failure budget.
+ *
+ * One failed heartbeat is advisory: a busy or freshly-started Chroma can exceed one
+ * probe window while remaining recoverable. Only the configured sustained-failure
+ * threshold authorizes the supervisor to recycle the process.
+ *
+ * @param {Object} options
+ * @param {Boolean} options.healthy Latest heartbeat result.
+ * @param {Number} [options.consecutiveFailures=0] Failures immediately preceding this result.
+ * @param {Number} [options.threshold=3] Consecutive failures required for an unhealthy verdict.
+ * @returns {{alive: Boolean, consecutiveFailures: Number, sustainedFailure: Boolean}}
+ */
+export function classifyChromaHealth({
+    healthy,
+    consecutiveFailures = 0,
+    threshold           = DEFAULT_CHROMA_HEALTH_FAILURE_THRESHOLD
+} = {}) {
+    if (healthy) {
+        return {
+            alive              : true,
+            consecutiveFailures: 0,
+            sustainedFailure   : false
+        };
+    }
+
+    const normalizedFailures = Number.isFinite(Number(consecutiveFailures))
+              ? Math.max(0, Math.floor(Number(consecutiveFailures)))
+              : 0,
+          normalizedThreshold = Number.isFinite(Number(threshold))
+              ? Math.max(1, Math.floor(Number(threshold)))
+              : DEFAULT_CHROMA_HEALTH_FAILURE_THRESHOLD,
+          nextFailures        = normalizedFailures + 1,
+          sustainedFailure    = nextFailures >= normalizedThreshold;
+
+    return {
+        alive              : !sustainedFailure,
+        consecutiveFailures: sustainedFailure ? 0 : nextFailures,
+        sustainedFailure
+    };
 }
 
 /**
@@ -232,7 +276,9 @@ export function buildOllamaServeEnv({host, keepAlive, contextLength, requirePara
  * @param {String|Number} [options.chromaPort] Chroma daemon port — used for the `--port` arg and as the chroma task's `singletonPort` (the port the orchestrator reaps duplicate listeners on).
  * @param {String} [options.chromaDataDir] Chroma persist dir for the `--path` arg — the configured builder passes the resolved `engines.chroma.dataDir` leaf so env-shifted profiles (`UNIT_TEST_MODE` isolation) move the DATA with the port; the literal default keeps direct callers launch-resilient.
  * @param {String} [options.chromaHost='localhost'] Chroma daemon host for HTTP service-health probes.
- * @param {Number} [options.chromaHealthProbeTimeoutMs=1000] Chroma HTTP health probe timeout.
+ * @param {Number} [options.chromaHealthProbeTimeoutMs=5000] Chroma HTTP health probe timeout.
+ * @param {Number} [options.chromaHealthFailureThreshold=3] Consecutive failed probes required before recycle.
+ * @param {Number} [options.chromaHealthStartupGraceMs=60000] Delay before probing a newly-started Chroma.
  * @param {Function} [options.chromaHealthFetchFn] Optional fetch implementation seam for tests.
  * @param {String|Number} [options.devServerPort] Local webpack dev-server port — used for the `--port` arg, singleton detection, and TCP liveness probe.
  * @param {Number} [options.devServerLivenessTimeoutMs] TCP liveness probe timeout.
@@ -246,15 +292,18 @@ export function buildTaskDefinitions({
     chromaDataDir = '.neo-ai-data/chroma/unified',
     chromaHost    = 'localhost',
     chromaPort,
-    chromaHealthProbeTimeoutMs = DEFAULT_CHROMA_HEALTH_TIMEOUT_MS,
+    chromaHealthProbeTimeoutMs    = DEFAULT_CHROMA_HEALTH_TIMEOUT_MS,
+    chromaHealthFailureThreshold  = DEFAULT_CHROMA_HEALTH_FAILURE_THRESHOLD,
+    chromaHealthStartupGraceMs    = DEFAULT_CHROMA_HEALTH_STARTUP_GRACE_MS,
     chromaHealthFetchFn,
     devServerPort,
     devServerLivenessTimeoutMs,
     neuralLinkBridgePort,
     neuralLinkBridgeLivenessTimeoutMs
 } = {}) {
-    const hasDevServerPort        = devServerPort !== undefined && devServerPort !== null;
-    const hasNeuralLinkBridgePort = neuralLinkBridgePort !== undefined && neuralLinkBridgePort !== null;
+    const hasDevServerPort                = devServerPort !== undefined && devServerPort !== null;
+    const hasNeuralLinkBridgePort         = neuralLinkBridgePort !== undefined && neuralLinkBridgePort !== null;
+    let   consecutiveChromaHealthFailures = 0;
 
     const tasks = {
         chroma: {
@@ -265,16 +314,28 @@ export function buildTaskDefinitions({
             // env-shifted profile MUST move the data with the port, or a test-port launch serves the
             // production persist dir (empirically observed: a second server on the live store). The
             // parameter default keeps direct callers launch-resilient against a stale config.mjs.
-            args           : ['run', '--path', chromaDataDir, '--port', String(chromaPort)],
-            pidFileName    : 'chroma.pid',
-            expectedCommand: 'chroma',
-            singletonPort  : chromaPort,
-            healthProbe    : () => probeChromaHttpHealth({
-                host     : chromaHost,
-                port     : chromaPort,
-                timeoutMs: chromaHealthProbeTimeoutMs,
-                fetchFn  : chromaHealthFetchFn
-            })
+            args                : ['run', '--path', chromaDataDir, '--port', String(chromaPort)],
+            pidFileName         : 'chroma.pid',
+            expectedCommand     : 'chroma',
+            singletonPort       : chromaPort,
+            healthStartupGraceMs: chromaHealthStartupGraceMs,
+            healthProbe         : async () => {
+                const healthy = await probeChromaHttpHealth({
+                    host     : chromaHost,
+                    port     : chromaPort,
+                    timeoutMs: chromaHealthProbeTimeoutMs,
+                    fetchFn  : chromaHealthFetchFn
+                });
+                const verdict = classifyChromaHealth({
+                    healthy,
+                    consecutiveFailures: consecutiveChromaHealthFailures,
+                    threshold          : chromaHealthFailureThreshold
+                });
+
+                consecutiveChromaHealthFailures = verdict.consecutiveFailures;
+
+                return verdict.alive;
+            }
         },
         // `bridgeDaemon` lane id is a frozen lane-taxonomy / continuousTasks wire constant —
         // kept verbatim on the wake-daemon rename so the orchestrator keeps scheduling the lane.

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -11,7 +11,8 @@ import {
 } from '../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
 import {
     buildChromaHealthUrl,
-    buildTaskDefinitions
+    buildTaskDefinitions,
+    classifyChromaHealth
 } from '../../../../../../ai/daemons/orchestrator/taskDefinitions.mjs';
 import TaskStateService, { createInitialTaskState } from '../../../../../../ai/daemons/orchestrator/services/TaskStateService.mjs';
 import os                                           from 'os';
@@ -764,6 +765,63 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             .toBe('http://[::1]:8000/api/v2/healthcheck');
         expect(buildChromaHealthUrl({host: 'localhost:9999', port: 8000}))
             .toBe('http://localhost:8000/api/v2/heartbeat');
+    });
+
+    test('classifies Chroma unhealthy only after sustained failures (#16017)', () => {
+        expect(classifyChromaHealth({
+            healthy            : false,
+            consecutiveFailures: 0,
+            threshold          : 3
+        })).toEqual({
+            alive              : true,
+            consecutiveFailures: 1,
+            sustainedFailure   : false
+        });
+        expect(classifyChromaHealth({
+            healthy            : false,
+            consecutiveFailures: 2,
+            threshold          : 3
+        })).toEqual({
+            alive              : false,
+            consecutiveFailures: 0,
+            sustainedFailure   : true
+        });
+        expect(classifyChromaHealth({
+            healthy            : true,
+            consecutiveFailures: 2,
+            threshold          : 3
+        })).toEqual({
+            alive              : true,
+            consecutiveFailures: 0,
+            sustainedFailure   : false
+        });
+    });
+
+    test('Chroma health probing survives transient faults and resets on success (#16017)', async () => {
+        const outcomes        = ['timeout', 'timeout', 'healthy', 'timeout', 'timeout', 'timeout'];
+        const taskDefinitions = buildTaskDefinitions({
+            scriptDir          : '/repo/ai/scripts',
+            nodeBin            : '/node',
+            chromaHost         : 'localhost',
+            chromaPort         : 8000,
+            chromaHealthFetchFn: async () => {
+                const outcome = outcomes.shift();
+
+                if (outcome === 'timeout') {
+                    throw new Error('probe timed out');
+                }
+
+                return {ok: true};
+            }
+        });
+
+        expect(taskDefinitions.chroma.healthStartupGraceMs).toBe(60000);
+        await expect(taskDefinitions.chroma.healthProbe()).resolves.toBe(true);
+        await expect(taskDefinitions.chroma.healthProbe()).resolves.toBe(true);
+        await expect(taskDefinitions.chroma.healthProbe()).resolves.toBe(true);
+        await expect(taskDefinitions.chroma.healthProbe()).resolves.toBe(true);
+        await expect(taskDefinitions.chroma.healthProbe()).resolves.toBe(true);
+        await expect(taskDefinitions.chroma.healthProbe()).resolves.toBe(false);
     });
 
     test('defines the local dev-server task without browser auto-open (#13482)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -1035,6 +1035,44 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         expect(started).toEqual([{taskName: 'chroma', reason: 'supervisor-restart'}]);
     });
 
+    test('superviseTask does not probe a running task during its startup grace (#16017)', async () => {
+        const {service} = createTestService();
+        const killed    = [];
+        let   probes    = 0;
+
+        service.taskStateService.getTaskState = () => ({
+            running  : true,
+            pid      : 4242,
+            lastRunAt: 1_000_000
+        });
+        service.taskDefinitions = {
+            chroma: {
+                label               : 'chroma daemon',
+                healthStartupGraceMs: 60000,
+                healthProbe         : async () => {
+                    probes++;
+                    return false;
+                }
+            }
+        };
+        service.killTask = (taskName, reason) => killed.push({reason, taskName});
+
+        service.superviseTask('chroma', 1_030_000, 15000);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(probes).toBe(0);
+        expect(killed).toEqual([]);
+
+        service.superviseTask('chroma', 1_061_000, 15000);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(probes).toBe(1);
+        expect(killed).toEqual([{
+            reason  : 'supervisor-health-recycle',
+            taskName: 'chroma'
+        }]);
+    });
+
     test('superviseTask leaves a RUNNING task healthy per its healthProbe (no recycle)', async () => {
         const {service} = createTestService();
         const killed    = [];


### PR DESCRIPTION
Resolves #16022

Related: #16017
Related: #16021

The local Chroma supervisor now treats an isolated failed heartbeat as advisory instead of immediate SIGKILL authority. A newly spawned process receives a 60-second startup grace, heartbeat timeout matches the 5-second Compose baseline, and only three consecutive failures authorize `supervisor-health-recycle`; any successful heartbeat clears the failure streak. The existing process-alive/service-dead recovery contract remains intact.

Evidence: L2 (pure classifier, task-definition, startup-grace, sustained-failure, reset, cloud-mode, and configured-daemon contract tests) → L2 required (all #16022 ACs are locally unit-verifiable). No residuals.

## Deltas from ticket

None substantive relative to #16022. The leaf records the empirically corrected implementation shape. The earlier #16017 prescription suggested routing timeout/abort into the supervisor's thrown-probe guard; this PR instead retains the raw boolean seam and makes one failure non-destructive, preserving eventual recycle after sustained service death.

## Test Evidence

- `taskDefinitions.mjs`: classifier + default startup-grace + transient-reset coverage in `Orchestrator.spec.mjs`.
- `ProcessSupervisorService.mjs`: before/after-grace scheduling and sustained recycle coverage in `ProcessSupervisorService.spec.mjs`.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs` — 162 passed at exact head after rebasing onto `origin/dev`.
- Pre-commit source gates passed: whitespace, shorthand, AiConfig test mutation, JSDoc types, derived-domain, ticket archaeology, block alignment, and parse.
- `git diff --check` — clean.

## Post-Merge Validation

- [ ] Restart the local Orchestrator during a saturated embedding batch and confirm Chroma survives the startup window with no `supervisor-health-recycle` event. Record the live-host receipt on #16017.
- [ ] Keep #16017 open for old-vs-new recovery, WAL/durability, and post-loop measurement.
- [ ] Keep #16021 independent as the detection-retention SLA guard.

## Commit

- `f14cdde912` — `fix(ai): require sustained Chroma health failure (#16017)`

## Evolution

The controlled production probe falsified IPv6 binding as this kill mechanism. Lifetime analysis then falsified startup-only causation: long-running instances also died after one transient false result. The final repair therefore combines startup grace with sustained-failure classification instead of choosing either protection alone.

Authored by Euclid (GPT-5, Codex Desktop). Session 29c665bb-349d-4eed-83e5-9e6e8fb213af.
