### PR TITLE
Enforce the detect-vs-retention SLA in CI: the guard had zero callers (#16021)

### DIFF
--- a/.github/workflows/detection-retention-sla.yml
+++ b/.github/workflows/detection-retention-sla.yml
@@ -1,0 +1,66 @@
+name: Detection-Retention SLA
+
+# The backup-reliability invariant: the data-integrity detect cadence must beat the backup-retention
+# window with margin, so a corruption is caught while a good backup still exists to recover from.
+#
+# This guard is expected to be GREEN. Its value is prospective — it fires on the three config edits
+# that silently make recovery impossible without touching any recovery code: shortening retention,
+# lengthening the detect interval, or disabling the detect lane. The paths below are therefore the
+# guard's real trigger surface (the config leaves + the guard's own modules), not a broad glob.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'ai/configBase.mjs'
+      - 'ai/scripts/maintenance/checkDetectionRetentionSla.mjs'
+      - 'ai/scripts/maintenance/detectionRetentionSla.mjs'
+      - 'ai/scripts/maintenance/detectionRetentionSlaInputs.mjs'
+      - '.github/workflows/detection-retention-sla.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'ai/configBase.mjs'
+      - 'ai/scripts/maintenance/checkDetectionRetentionSla.mjs'
+      - 'ai/scripts/maintenance/detectionRetentionSla.mjs'
+      - 'ai/scripts/maintenance/detectionRetentionSlaInputs.mjs'
+      - '.github/workflows/detection-retention-sla.yml'
+
+concurrency:
+  group: detection-retention-sla-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  sla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      # The guard reads the config SSOT, which resolves through ConfigProvider — node_modules must be
+      # present. --ignore-scripts skips the heavy postinstall (KB pull / server-config setup) the guard
+      # does not need.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Detect cadence must beat backup retention
+        run: node ./ai/scripts/maintenance/checkDetectionRetentionSla.mjs
+
+      # A guard that only ever passes is indistinguishable from a guard that cannot fail. This step
+      # forces a breach through the same env-override path an operator would use, and inverts the exit
+      # code: the job fails if the guard did NOT reject a detect cadence of 20d against a 15d ceiling.
+      - name: Positive control — the guard must reject a breaching cadence
+        env:
+          NEO_ORCHESTRATOR_DATA_INTEGRITY_SWEEP_INTERVAL_MS: '1728000000'
+        run: |
+          if node ./ai/scripts/maintenance/checkDetectionRetentionSla.mjs; then
+            echo "::error::Positive control FAILED — the guard passed a 20d detect cadence against a 15d ceiling, so it cannot detect a real breach."
+            exit 1
+          fi
+          echo "Positive control OK — the guard rejected the injected breach."

--- a/ai/scripts/maintenance/checkDetectionRetentionSla.mjs
+++ b/ai/scripts/maintenance/checkDetectionRetentionSla.mjs
@@ -18,6 +18,15 @@
  * Being an entrypoint is what licenses the `Neo` / `AiConfig` imports below; the two pure halves stay
  * importable by tests without pulling the config tree in.
  *
+ * ## Why the CANONICAL template, not the operator overlay
+ *
+ * This reads `ai/config.template.mjs` rather than `ai/config.mjs`. The overlay is **gitignored and
+ * generated**, so it does not exist in a fresh checkout — a guard importing it fails before reaching
+ * its own logic, which is a red build that says nothing about the invariant. It is also the wrong
+ * source on purpose: this gate asserts the invariant the **repository declares**, not a value some
+ * machine happens to override locally. Env bindings still apply, because they are declared on the
+ * leaves themselves, so an operator can still reproduce a breach verdict from the shell.
+ *
  * ## Why this guard is expected to be GREEN, and why that is not a reason to skip it
  *
  * On shipped config the verdict passes with a wide margin (hourly detect against a 30-day window
@@ -36,7 +45,7 @@
 
 import {pathToFileURL} from 'url';
 import Neo             from '../../../src/Neo.mjs';
-import AiConfig        from '../../config.mjs';
+import AiConfig        from '../../config.template.mjs';
 
 import {evaluateDetectionRetentionSla}   from './detectionRetentionSla.mjs';
 import {resolveDetectionRetentionInputs} from './detectionRetentionSlaInputs.mjs';

--- a/ai/scripts/maintenance/checkDetectionRetentionSla.mjs
+++ b/ai/scripts/maintenance/checkDetectionRetentionSla.mjs
@@ -1,0 +1,113 @@
+/**
+ * @module ai/scripts/maintenance/checkDetectionRetentionSla
+ * @summary CI guard entrypoint for the backup-reliability invariant: the data-integrity detect cadence
+ * must beat the backup-retention window with margin, so a corruption is caught while a good backup
+ * still exists to recover from.
+ *
+ * ```
+ * detectCadenceMs  <=  backupRetentionMs / safetyFactor
+ * ```
+ *
+ * This is the thread-entrypoint half of a three-part split, and the split is what keeps each part
+ * honest:
+ *
+ * 1. `detectionRetentionSla.mjs` — the SLA arithmetic, pure, config-shape-free.
+ * 2. `detectionRetentionSlaInputs.mjs` — config-shape adaptation, pure, Neo-free.
+ * 3. **this file** — the only part that reads the config SSOT, and the only part that exits a process.
+ *
+ * Being an entrypoint is what licenses the `Neo` / `AiConfig` imports below; the two pure halves stay
+ * importable by tests without pulling the config tree in.
+ *
+ * ## Why this guard is expected to be GREEN, and why that is not a reason to skip it
+ *
+ * On shipped config the verdict passes with a wide margin (hourly detect against a 30-day window
+ * leaves ~15 days of headroom). The value is entirely **prospective**: it fires when someone shortens
+ * retention, lengthens the detect interval, or disables the detect lane — the three edits that
+ * silently make recovery impossible without touching a line of recovery code. A guard measured only
+ * against config that already satisfies it proves nothing about config not yet written, which is why
+ * its unit coverage carries a positive control rather than relying on this run staying green.
+ *
+ * ## Exit contract
+ *
+ * `0` — the invariant holds. Anything else is a breach, including an input the guard could not
+ * resolve: an unresolvable window is reported as a failure, never assumed benign. The output names
+ * the required ceiling so the message carries the remedy rather than only the symptom.
+ */
+
+import {pathToFileURL} from 'url';
+import Neo             from '../../../src/Neo.mjs';
+import AiConfig        from '../../config.mjs';
+
+import {evaluateDetectionRetentionSla}   from './detectionRetentionSla.mjs';
+import {resolveDetectionRetentionInputs} from './detectionRetentionSlaInputs.mjs';
+
+/**
+ * Milliseconds per day — for rendering durations the verdict reports in ms.
+ * @type {Number}
+ */
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * @summary Renders a millisecond duration as days, for human-readable guard output.
+ * @param {Number} ms Duration in milliseconds.
+ * @returns {String}
+ */
+function asDays(ms) {
+    return `${(ms / MS_PER_DAY).toFixed(2)}d`;
+}
+
+/**
+ * @summary Evaluates the detect-vs-retention SLA against live config and reports a process verdict.
+ *
+ * Reads both leaves at the use site (the config SSOT owns their resolution; this file never
+ * re-derives or caches them), hands them to the pure resolver, and only then applies the SLA
+ * arithmetic. A resolution failure short-circuits before the arithmetic so the operator reads *which
+ * input* is missing rather than a verdict computed from a value nobody configured.
+ * @returns {Number} Process exit code — `0` when the invariant holds, `1` on any breach.
+ */
+function main() {
+    const inputs = resolveDetectionRetentionInputs({
+        dataIntegritySweepCheckMs: AiConfig.orchestrator.intervals.dataIntegritySweepCheckMs,
+        retention                : AiConfig.maintenance.backup.retention
+    });
+
+    if (!inputs.ok) {
+        console.error('check-detection-retention-sla: BREACH — inputs unresolvable');
+        console.error(`  ${inputs.reason}`);
+        console.error('  A recoverability window the guard cannot read is treated as a breach, not a pass.');
+
+        return 1;
+    }
+
+    const verdict = evaluateDetectionRetentionSla({
+        backupRetentionMs: inputs.backupRetentionMs,
+        detectCadenceMs  : inputs.detectCadenceMs
+    });
+
+    if (!verdict.withinSla) {
+        console.error('check-detection-retention-sla: BREACH — detection cannot beat backup retention');
+        console.error(`  detect cadence      : ${asDays(inputs.detectCadenceMs)}`);
+        console.error(`  retention window    : ${asDays(inputs.backupRetentionMs)}`);
+        console.error(`  required max detect : ${asDays(verdict.requiredMaxDetectMs)}`);
+        console.error(`  reason              : ${verdict.reason}`);
+        console.error('  A corruption would age past the last good backup before anyone noticed.');
+
+        return 1;
+    }
+
+    console.log('check-detection-retention-sla: OK');
+    console.log(`  detect cadence ${asDays(inputs.detectCadenceMs)} <= ceiling ` +
+                `${asDays(verdict.requiredMaxDetectMs)} (retention ${asDays(inputs.backupRetentionMs)}), ` +
+                `margin ${asDays(verdict.marginMs)}`);
+
+    return 0;
+}
+
+// Exit only when run as a CLI. Without this guard the module could not be imported at all — the
+// import itself would terminate the importing process, which would make the entrypoint untestable
+// and any future reuse impossible.
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+    process.exit(main());
+}
+
+export {asDays, main};

--- a/ai/scripts/maintenance/detectionRetentionSla.mjs
+++ b/ai/scripts/maintenance/detectionRetentionSla.mjs
@@ -17,8 +17,10 @@
  * last good backup is pruned. `safetyFactor` defaults to 2 (detect within half the window).
  *
  * This module is the **verdict-half** (pure, no I/O) — it computes the SLA verdict from
- * explicit inputs. The **wiring-half** (reading the detect-signal's live cadence config +
- * the live backup-retention config and failing CI on a breach) is the gated next slice.
+ * explicit inputs. The wiring now exists alongside it: `detectionRetentionSlaInputs.mjs` adapts the
+ * live config shapes into these two durations, and `checkDetectionRetentionSla.mjs` reads the config
+ * SSOT and fails CI on a breach. Keep this module free of config shape and of process exits — that
+ * separation is why its verdict stays unit-testable against explicit inputs.
  */
 
 /**

--- a/ai/scripts/maintenance/detectionRetentionSlaInputs.mjs
+++ b/ai/scripts/maintenance/detectionRetentionSlaInputs.mjs
@@ -1,0 +1,133 @@
+/**
+ * @module ai/scripts/maintenance/detectionRetentionSlaInputs
+ * @summary Pure input-resolution half for the backup-reliability detect-vs-retention SLA: adapts the
+ * live config shapes into the two durations `evaluateDetectionRetentionSla` consumes.
+ *
+ * `detectionRetentionSla.mjs` owns the SLA *math* and takes `{detectCadenceMs, backupRetentionMs}`.
+ * Neither duration exists in that form in config: the detect cadence is an interval leaf, and the
+ * retention window lives inside an object leaf as a **day count**. This module owns that adaptation
+ * so the math stays free of config shape and the entrypoint stays free of validation logic.
+ *
+ * **Why this is a separate module and not part of the verdict-half:** config-shape adaptation and SLA
+ * arithmetic decay for different reasons — a retention leaf can be restructured without the invariant
+ * changing, and vice versa. Keeping them apart also keeps this half Neo-free, so its unit tests never
+ * import `AiConfig` — config reads belong to the thread-entrypoint that runs the guard, not to the
+ * pure half a test imports directly.
+ *
+ * ## Every unresolvable input is a BREACH, never a pass
+ *
+ * This is the module's load-bearing decision. `cleanOldBackups` defaults a missing `maxDays` to `30`
+ * — correct there, because *pruning* must keep working when config is partial. Reproducing that
+ * default here would be actively harmful: the guard would invent the very window it exists to verify
+ * and report a pass it cannot justify. A guard that fabricates its input is worse than an absent
+ * guard, because an absent guard leaves the question open while a fabricating one closes it green.
+ *
+ * A **disabled** detect lane gets its own branch for a different reason. `dataIntegritySweep.mjs`
+ * treats a cadence of `<= 0` as "lane disabled", and the verdict-half already refuses a non-positive
+ * cadence — it *throws* (see `detectionRetentionSla.spec.mjs`, which pins `0` among the rejected
+ * inputs), so passing it through cannot produce a false pass. The problem is the failure *mode*: a
+ * deliberately disabled lane is a legitimate operational state, and surfacing it as a thrown
+ * type-error reads as a bug in the guard rather than as the policy breach it is. Resolving it to an
+ * explicit breach reason turns a stack trace into an actionable sentence, and keeps the throw path
+ * meaning what it should — a shape the guard never expected.
+ */
+
+/**
+ * Milliseconds per day — the unit the retention leaf's `maxDays` is expressed in.
+ * @type {Number}
+ */
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * @summary Answers whether a value is a usable positive duration/count.
+ *
+ * Rejects `NaN`, `Infinity`, non-numbers, and non-positive values in one predicate, so callers never
+ * branch on `typeof` and a numeric-looking string can never reach the arithmetic.
+ * @param {*} value Candidate value.
+ * @returns {Boolean}
+ */
+function isPositiveFinite(value) {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * @summary Resolves the live config shapes into the two durations the SLA verdict-half consumes.
+ *
+ * Takes the values a caller has already read from the config SSOT (the caller reads at its own use
+ * site; this module never imports `AiConfig`) and returns either both durations or a single breach
+ * reason naming which input failed and why.
+ *
+ * Resolution order is deliberate: the detect cadence is checked first because a disabled detect lane
+ * is a breach regardless of how generous retention is.
+ * @param {Object} options
+ * @param {Number} options.dataIntegritySweepCheckMs Live detect-sweep cadence in ms
+ *     (`AiConfig.orchestrator.intervals.dataIntegritySweepCheckMs`). `<= 0` means the lane is
+ *     disabled, which resolves to a breach rather than to a zero cadence.
+ * @param {Object} options.retention Live backup retention policy
+ *     (`AiConfig.maintenance.backup.retention`), whose `maxDays` expresses the window in days.
+ * @returns {{ok: Boolean, detectCadenceMs: Number|undefined, backupRetentionMs: Number|undefined, reason: String|undefined}}
+ *     `ok: true` carries both durations; `ok: false` carries a `reason` suitable for a failing
+ *     guard's output. Never partially resolved.
+ */
+export function resolveDetectionRetentionInputs({dataIntegritySweepCheckMs, retention} = {}) {
+    if (typeof dataIntegritySweepCheckMs !== 'number' || !Number.isFinite(dataIntegritySweepCheckMs)) {
+        return {
+            ok    : false,
+            reason: `detect cadence is unresolvable (${JSON.stringify(dataIntegritySweepCheckMs)}); ` +
+                    'worst-case detect latency is unknown, so the SLA cannot be certified'
+        };
+    }
+
+    if (dataIntegritySweepCheckMs <= 0) {
+        return {
+            ok    : false,
+            reason: `the data-integrity detect lane is DISABLED (cadence ${dataIntegritySweepCheckMs} <= 0); ` +
+                    'worst-case detect latency is unbounded, so no retention window can satisfy the SLA'
+        };
+    }
+
+    if (!retention || typeof retention !== 'object') {
+        return {
+            ok    : false,
+            reason: `backup retention policy is unresolvable (${JSON.stringify(retention)}); ` +
+                    'the recoverability window is unknown, so the SLA cannot be certified'
+        };
+    }
+
+    if (!isPositiveFinite(retention.maxDays)) {
+        return {
+            ok    : false,
+            reason: `backup retention \`maxDays\` is unresolvable (${JSON.stringify(retention.maxDays)}); ` +
+                    'refusing to assume a default window — a guard that invents its own input ' +
+                    'reports a pass it cannot justify'
+        };
+    }
+
+    return {
+        ok               : true,
+        detectCadenceMs  : dataIntegritySweepCheckMs,
+        backupRetentionMs: retention.maxDays * MS_PER_DAY
+    };
+}
+
+/**
+ * @summary Explains why `keepMinimum` is deliberately excluded from the resolved window.
+ *
+ * Exported as documentation-in-code rather than prose-only because the omission looks like an
+ * oversight at a glance and a future reader is likely to "fix" it.
+ *
+ * `retention.keepMinimum` floors pruning at the N newest bundles regardless of age, so it can only
+ * ever **extend** real recoverability, never shorten it. Excluding it therefore makes the resolved
+ * window a **lower bound**, which biases the verdict toward declaring a breach — the correct
+ * direction for a safety guard to be wrong in. Including it (e.g. `max(maxDays, ageOfNthNewest)`)
+ * would be more precise and strictly less safe, and it would make the guard's verdict depend on
+ * whether backup runs are currently healthy: a stalled backup schedule is exactly when `keepMinimum`
+ * preserves an old bundle past `maxDays`, so a guard counting on it would be trusting the failure
+ * mode to save it.
+ * @type {String}
+ */
+export const KEEP_MINIMUM_EXCLUSION_RATIONALE =
+    '`keepMinimum` can only extend recoverability, so excluding it makes the window a lower bound ' +
+    '(bias toward breach) rather than an over-estimate (bias toward a false pass).';
+
+export {MS_PER_DAY};

--- a/test/playwright/unit/ai/scripts/maintenance/detectionRetentionSlaInputs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/detectionRetentionSlaInputs.spec.mjs
@@ -1,0 +1,134 @@
+import {test, expect}                    from '@playwright/test';
+import {evaluateDetectionRetentionSla}   from '../../../../../../ai/scripts/maintenance/detectionRetentionSla.mjs';
+import {resolveDetectionRetentionInputs} from '../../../../../../ai/scripts/maintenance/detectionRetentionSlaInputs.mjs';
+
+// Pure input resolution (no I/O / clock / config) — imported directly, mirrors detectionRetentionSla.spec.
+// Backup-reliability wiring-half: adapts the live config shapes (an interval leaf in ms + a retention
+// object carrying `maxDays`) into the two durations the verdict-half consumes.
+//
+// The invariant every rejection case defends: an unresolvable input must be a BREACH, never a pass.
+// `cleanOldBackups` defaults a missing `maxDays` to 30 because pruning must keep working on partial
+// config; reproducing that default here would make the guard invent the window it exists to verify.
+
+const DAY = 86400000;
+
+test.describe('resolveDetectionRetentionInputs (#14030 AC3 wiring-half)', () => {
+    test('resolves the live shapes — maxDays becomes a duration, cadence passes through', () => {
+        const r = resolveDetectionRetentionInputs({
+            dataIntegritySweepCheckMs: 3600000,
+            retention                : {keepMinimum: 3, maxDays: 30}
+        });
+
+        expect(r.ok).toBe(true);
+        expect(r.detectCadenceMs).toBe(3600000);
+        expect(r.backupRetentionMs).toBe(30 * DAY);
+        expect(r.reason).toBe(undefined);
+    });
+
+    test('the resolved pair feeds the verdict-half and reproduces the live verdict', () => {
+        // The wiring's whole purpose: these are today's shipped leaf values
+        // (`dataIntegritySweepCheckMs` = 1h, `retention.maxDays` = 30), so the guard must be GREEN
+        // on current config — a red guard on an unchanged repo would be a broken guard, not a finding.
+        const r = resolveDetectionRetentionInputs({
+                dataIntegritySweepCheckMs: 3600000,
+                retention                : {keepMinimum: 3, maxDays: 30}
+            }),
+            verdict = evaluateDetectionRetentionSla({
+                backupRetentionMs: r.backupRetentionMs,
+                detectCadenceMs  : r.detectCadenceMs
+            });
+
+        expect(verdict.withinSla).toBe(true);
+        expect(verdict.requiredMaxDetectMs).toBe(15 * DAY);
+    });
+
+    test('POSITIVE CONTROL — an injected breach must actually fire', () => {
+        // A guard that only ever passes is indistinguishable from a guard that cannot fail.
+        // Retention shrunk to 10d → ceiling 5d; detect every 6d → the pair must breach.
+        const r = resolveDetectionRetentionInputs({
+                dataIntegritySweepCheckMs: 6 * DAY,
+                retention                : {keepMinimum: 3, maxDays: 10}
+            }),
+            verdict = evaluateDetectionRetentionSla({
+                backupRetentionMs: r.backupRetentionMs,
+                detectCadenceMs  : r.detectCadenceMs
+            });
+
+        expect(r.ok).toBe(true);
+        expect(verdict.withinSla).toBe(false);
+        expect(verdict.marginMs).toBeLessThan(0);
+    });
+
+    test('a DISABLED detect lane is a breach with an actionable reason, not a throw', () => {
+        // `dataIntegritySweep.mjs` treats `<= 0` as "lane disabled". The verdict-half would throw on
+        // it; a deliberately disabled lane deserves a sentence naming the policy problem instead.
+        for (const disabled of [0, -1, -60000]) {
+            const r = resolveDetectionRetentionInputs({
+                dataIntegritySweepCheckMs: disabled,
+                retention                : {keepMinimum: 3, maxDays: 30}
+            });
+
+            expect(r.ok).toBe(false);
+            expect(r.reason).toContain('DISABLED');
+            expect(r.reason).toContain('unbounded');
+            expect(r.backupRetentionMs).toBe(undefined);
+        }
+    });
+
+    test('rejects a non-numeric / non-finite detect cadence — no silent pass', () => {
+        for (const bad of [undefined, null, NaN, Infinity, '3600000', {}]) {
+            const r = resolveDetectionRetentionInputs({
+                dataIntegritySweepCheckMs: bad,
+                retention                : {keepMinimum: 3, maxDays: 30}
+            });
+
+            expect(r.ok).toBe(false);
+            expect(r.reason).toContain('detect cadence is unresolvable');
+        }
+    });
+
+    test('rejects a missing / non-object retention policy — no silent pass', () => {
+        for (const bad of [undefined, null, 30, 'thirty']) {
+            const r = resolveDetectionRetentionInputs({
+                dataIntegritySweepCheckMs: 3600000,
+                retention                : bad
+            });
+
+            expect(r.ok).toBe(false);
+            expect(r.reason).toContain('retention policy is unresolvable');
+        }
+    });
+
+    test('NEVER defaults a missing maxDays to 30 — the guard must not invent its own window', () => {
+        // The regression this pins: copying `cleanOldBackups`' `{maxDays = 30}` default into the guard
+        // would make it certify a window nobody configured.
+        for (const bad of [undefined, null, 0, -5, NaN, Infinity, '30', {}]) {
+            const r = resolveDetectionRetentionInputs({
+                dataIntegritySweepCheckMs: 3600000,
+                retention                : {keepMinimum: 3, maxDays: bad}
+            });
+
+            expect(r.ok).toBe(false);
+            expect(r.reason).toContain('`maxDays` is unresolvable');
+            expect(r.backupRetentionMs).toBe(undefined);
+        }
+    });
+
+    test('a disabled lane outranks an unresolvable retention policy', () => {
+        // Resolution order matters for the message the operator reads: a disabled detect lane is a
+        // breach no retention window can rescue, so it must be reported first.
+        const r = resolveDetectionRetentionInputs({dataIntegritySweepCheckMs: 0, retention: undefined});
+
+        expect(r.ok).toBe(false);
+        expect(r.reason).toContain('DISABLED');
+    });
+
+    test('never resolves partially — ok:false carries no durations', () => {
+        const r = resolveDetectionRetentionInputs({});
+
+        expect(r.ok).toBe(false);
+        expect(r.detectCadenceMs).toBe(undefined);
+        expect(r.backupRetentionMs).toBe(undefined);
+        expect(typeof r.reason).toBe('string');
+    });
+});


### PR DESCRIPTION
Resolves #16021

The guard that answers *"is our corruption-detect cadence fast enough that a good backup still exists when we notice?"* existed with **zero callers**. `ai/scripts/maintenance/detectionRetentionSla.mjs` describes this month's Chroma incident in its own summary — *"the last uncorrupted backup is pruned before anyone knows recovery is needed"* — and nothing ever invoked it.

Evidence: L2 (unit-level: pure halves spec-covered; the entrypoint exercised against live config and against two injected breaches through the real env-override path) → L2 required (the deliverable is a CI gate over config values; no runtime surface beyond the guard's own exit code). Residual: none.

## How the half went missing

The parent AC reads *"documented **and guarded**"*. Documented shipped; nothing guarded. The actuator fell between two closures that each pointed at the other — the sub deferred the CI-guard **up** to its parent, and the parent's closure verified that AC by citing the sub **down**. Neither closure was wrong on its own terms: verification-by-sub-citation cannot see a half deferred upward, because the sub's title and export look like the whole deliverable and only its Out-of-Scope reveals otherwise.

## Shape: three parts, and the split is what keeps each honest

| part | concern | purity |
|---|---|---|
| `detectionRetentionSla.mjs` (pre-existing) | the SLA arithmetic | pure, config-shape-free |
| `detectionRetentionSlaInputs.mjs` (new) | config-shape adaptation | pure, **Neo-free** — its tests never import `AiConfig` |
| `checkDetectionRetentionSla.mjs` (new) | reads the config SSOT, exits a process | the only entrypoint |

Neither duration the arithmetic consumes exists in that form in config: the detect cadence is an interval leaf in ms, and the retention window lives inside an object leaf as a **day count**. Being a thread-entrypoint is what licenses the `Neo`/`AiConfig` imports in part 3; parts 1–2 stay importable by tests without pulling the config tree in.

## Two design decisions worth a reviewer's challenge

**1. Every unresolvable input is a BREACH, never a pass.** `cleanOldBackups` defaults a missing `maxDays` to `30` — correct there, because *pruning* must keep working on partial config. Reproducing that default in the guard would make it invent the very window it exists to verify and report a pass it cannot justify. A guard that fabricates its input is worse than an absent guard: an absent one leaves the question open, a fabricating one closes it green.

**2. `keepMinimum` is deliberately excluded from the window.** It floors pruning at the N newest bundles regardless of age, so it can only ever **extend** real recoverability. Excluding it makes the resolved window a **lower bound**, biasing the verdict toward declaring a breach — the correct direction for a safety guard to be wrong in. `max(maxDays, ageOfNthNewest)` would be more precise and strictly less safe, and it would make the verdict depend on backup runs currently being healthy: a stalled schedule is exactly when `keepMinimum` preserves an old bundle past `maxDays`, so a guard counting on it would be trusting the failure mode to save it.

## Deltas from ticket

1. **The ticket's count-vs-duration prescription was falsified before any code was written.** The body claimed the retention leaf "appears to be a rotation count" and prescribed a `count × cadence` derivation. `backup.mjs:493-496` destructures `{keepMinimum = 3, maxDays = 30}` — the leaf is an **object** carrying both, so the window is `maxDays × 86_400_000` and no derivation is needed. Recorded on the ticket at the time rather than silently corrected.
2. **The disabled-lane branch earns its place for diagnosability, not correctness.** The module JSDoc first claimed a `0` cadence would satisfy `0 <= window/safetyFactor` and falsely pass. The verdict-half's own spec pins `0` among its **throw** cases, so a false pass was never possible. The real reason: `<= 0` is a legitimate "lane disabled" state, and a type-error stack trace reads as a bug in the guard rather than the policy breach it is.
3. **Two decay-prone refs removed from durable comments** rather than escaped with `ticket-ref-ok:` — `check-ticket-archaeology` is right that refs in JSDoc rot when the item closes, and the behaviour statements read better without them.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=1 \
  test/playwright/unit/ai/scripts/maintenance/
  → 425 passed (12.8s)
```

The whole `ai/scripts/maintenance/` directory rather than only the two touched specs, so every importer in that folder is covered.

**The entrypoint, proven to bite — not just to run:**

```
$ node ai/scripts/maintenance/checkDetectionRetentionSla.mjs
check-detection-retention-sla: OK
  detect cadence 0.04d <= ceiling 15.00d (retention 30.00d), margin 14.96d     → exit 0

$ NEO_ORCHESTRATOR_DATA_INTEGRITY_SWEEP_INTERVAL_MS=1728000000 node …
check-detection-retention-sla: BREACH — detection cannot beat backup retention  → exit 1

$ NEO_ORCHESTRATOR_DATA_INTEGRITY_SWEEP_INTERVAL_MS=0 node …
check-detection-retention-sla: BREACH — inputs unresolvable
  the data-integrity detect lane is DISABLED …                                  → exit 1
```

This guard is **expected to be green** on shipped config, which is precisely why the workflow carries a positive-control step that inverts the exit code: the job fails if the guard does *not* reject an injected 20d cadence against a 15d ceiling. A guard that only ever passes is indistinguishable from one that cannot fail.

## Post-Merge Validation

- The `Detection-Retention SLA` workflow appears on the next PR touching `ai/configBase.mjs` or the guard's own modules, and both steps pass.
- A deliberate breach PR (shorten `retention.maxDays` to `10`) turns the workflow red at the first step — the check that this gate is wired to real config rather than to its own fixtures.

## Out of scope

The Chroma `supervisor-health-recycle` defect (#16017 / #16022, @neo-gpt) and WAL coverage for `neo-agent-sessions` — this is the guard that reports when the recoverability window is at risk, not the incident that exposed it.

Authored by Vega (@neo-opus-vega, Claude Opus 5, Claude Code). Session 8850c622-2d8b-4a0c-8b31-764c592db822.
