### PR TITLE
fix(ai): provider contention yields the embed cycle instead of amplifying it (#16012)

### DIFF
--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -134,13 +134,17 @@ export function isProviderContentionError(error) {
  * Empirical anchor: one batch consumed ~21 minutes as six 300s attempts against a provider that was
  * serving the whole time (a 129-deep embedding queue), and only an operator restart cleared it.
  *
- * **Local wall-clock bound.** Attempt COUNT is declared here (`maxRetries`) while attempt
- * DURATION is declared in another service (`openAiCompatible.batchEmbeddingTimeoutMs`), so the worst
- * case is the product of two leaves neither owner can see. `maxInCycleMs` re-localises it: no NEW
- * attempt starts once the budget is spent. The bound deliberately does NOT race an in-flight
- * `collection.add` — abandoning a write that may still land is how a timeout turns into a duplicate
- * — so the honest guarantee is *"at most one externally-bounded attempt after the budget expires"*,
- * which is derivable from this file alone.
+ * **Local ADMISSION bound — not a total wall-clock bound.** Attempt COUNT is declared here
+ * (`maxRetries`) while attempt DURATION is declared in another service
+ * (`openAiCompatible.batchEmbeddingTimeoutMs`), so the pre-bound worst case was the PRODUCT of two
+ * leaves neither owner could see. `maxInCycleMs` removes the multiplier: once the budget is spent no
+ * NEW attempt is admitted, whether the boundary was crossed by an attempt or by a backoff.
+ *
+ * It deliberately does NOT race an in-flight `collection.add` — abandoning a write that may still
+ * land is how a timeout turns into a duplicate — so **a single call may still run arbitrarily long
+ * as far as this module is concerned**, and the total duration is therefore NOT derivable here.
+ * What is derivable here is the attempt COUNT. State it that way: the product is gone, one external
+ * duration remains, and pretending otherwise would be a comment that outruns its code.
  *
  * @param {Object}   options
  * @param {Object}   options.collection    Content-store collection (`add({ids, metadatas, documents})`).

--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -203,6 +203,16 @@ export async function embedBatch({
                 const delay = getBackoffDelayMs(backoffBaseMs, attempt);
                 log('INFO', `Batch embed attempt ${attempt + 1}/${maxRetries + 1} failed (${error.message}) — backing off ${delay}ms`);
                 await sleep(delay);
+
+                // Re-check AFTER the backoff, not only after the failure: the sleep itself can cross
+                // the boundary, and a guard that only runs post-failure would let the next iteration
+                // start an external request from beyond the budget it was meant to bound.
+                if (budgetSpent()) {
+                    log('ERROR', `Batch embed exhausted its ${maxInCycleMs}ms in-cycle budget during backoff after ` +
+                        `${attempt + 1} attempt(s) — deferring ${records.length} record(s)`);
+
+                    return {succeeded: [], failed: records.map(record => ({record, error}))};
+                }
             } else {
                 log('ERROR', `Batch embed exhausted ${maxRetries + 1} attempts (${error.message}) — isolating per record`);
             }

--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -63,12 +63,52 @@ export function getBackoffDelayMs(backoffBaseMs, attempt) {
 }
 
 /**
+ * @summary Typed provider error codes meaning "the provider is BUSY", never "the request was bad".
+ *
+ * Both local inference providers stamp a code on their own timeout: the OpenAI-compatible transport
+ * emits `OPENAI_COMPATIBLE_REQUEST_TIMEOUT`, native Ollama owns the shared `PROVIDER_TIMEOUT` shape,
+ * and the socket layer contributes the two `*TIMEDOUT` codes. Keyed on `error.code` rather than on
+ * message text: codes are a provider-owned protocol constant, whereas the message-shaped half of
+ * the classification in `TextEmbeddingService` is coupled to a message THIS module never sees
+ * (that file pins its own log string verbatim precisely because its regex reads it). Duplicating
+ * the coupled half here would split a matched pair across modules; duplicating the codes does not.
+ * @type {Set<String>}
+ */
+const PROVIDER_CONTENTION_CODES = Object.freeze(new Set([
+    'ESOCKETTIMEDOUT',
+    'ETIMEDOUT',
+    'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
+    'PROVIDER_TIMEOUT'
+]));
+
+/**
+ * @summary Default contention predicate — is this failure the provider being saturated?
+ * @param {Error} error Failure raised by `collection.add`.
+ * @returns {Boolean}
+ */
+export function isProviderContentionError(error) {
+    return PROVIDER_CONTENTION_CODES.has(error?.code);
+}
+
+/**
  * @summary Embeds one batch of WAL records via `collection.add`, retrying transient failures.
  *
  * Whole-batch first (one round-trip for the common case), with `maxRetries` exponential-backoff
  * attempts for transient outages. If the batch still fails, falls back to per-record adds so a
  * single poison record cannot hold the rest of the backlog hostage — per-record failures are
  * reported back for cross-cycle cooldown bookkeeping rather than retried inline.
+ *
+ * **Contention is not an outage, and the two need opposite responses.** A transient outage resolves
+ * while you wait, so backoff is correct: the cost of the failure is the INTERVAL. Under saturation
+ * the provider is up and its queue IS the failure, so the cost is the ATTEMPT — re-offering the same
+ * batch adds load to the exact queue that caused the timeout, and the per-record pass would then
+ * multiply the offered requests by `records.length` at the worst possible moment. A saturated
+ * provider is not a poison record. So a contention failure returns IMMEDIATELY, skipping both the
+ * retry loop and isolation; the records come back as `failed`, which the caller already spaces out
+ * via the cross-cycle `retryState` cooldown — deferred, never dropped.
+ *
+ * Empirical anchor: one batch consumed ~21 minutes as six 300s attempts against a provider that was
+ * serving the whole time (a 129-deep embedding queue), and only an operator restart cleared it.
  *
  * @param {Object}   options
  * @param {Object}   options.collection    Content-store collection (`add({ids, metadatas, documents})`).
@@ -77,9 +117,11 @@ export function getBackoffDelayMs(backoffBaseMs, attempt) {
  * @param {Number}   options.backoffBaseMs Exponential backoff base for in-cycle retries.
  * @param {Function} options.sleep         `ms => Promise` delay primitive (injected for specs).
  * @param {Function} options.log           `(level, message)` sink.
+ * @param {Function} [options.isContentionError=isProviderContentionError] Saturation classifier
+ *     (injected so the pure core stays free of the Neo-class provider module).
  * @returns {Promise<{succeeded: Object[], failed: Array<{record: Object, error: Error}>}>}
  */
-export async function embedBatch({collection, records, maxRetries, backoffBaseMs, sleep, log}) {
+export async function embedBatch({collection, records, maxRetries, backoffBaseMs, sleep, log, isContentionError = isProviderContentionError}) {
     const payload = {
         ids      : records.map(record => record.id),
         metadatas: records.map(record => record.metadata),
@@ -91,6 +133,16 @@ export async function embedBatch({collection, records, maxRetries, backoffBaseMs
             await collection.add(payload);
             return {succeeded: [...records], failed: []};
         } catch (error) {
+            if (isContentionError(error)) {
+                // Yield the whole cycle: no in-cycle retry, and no isolation pass either. Both would
+                // re-offer work to the queue that just timed out. `retryState` defers these records
+                // with escalating spacing, so the backlog survives and the provider gets room.
+                log('INFO', `Batch embed hit provider contention (${error.message}) — deferring ` +
+                    `${records.length} record(s) to a later cycle without retry`);
+
+                return {succeeded: [], failed: records.map(record => ({record, error}))};
+            }
+
             if (attempt < maxRetries) {
                 const delay = getBackoffDelayMs(backoffBaseMs, attempt);
                 log('INFO', `Batch embed attempt ${attempt + 1}/${maxRetries + 1} failed (${error.message}) — backing off ${delay}ms`);

--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -6,7 +6,7 @@ import {
 } from '../../services/memory-core/helpers/memoryWalStore.mjs';
 import {classifyRowVector, VECTOR_REJECTION_REASONS} from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
 import {createDrainDispositionTracker}               from '../shared/drainDisposition.mjs';
-import {PROVIDER_TIMEOUT_CODE}                       from '../../provider/createTimeoutError.mjs';
+import {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE, PROVIDER_TIMEOUT_CODE} from '../../provider/createTimeoutError.mjs';
 
 /**
  * @summary One durable drain pass over the `add_memory` write-ahead log.
@@ -50,6 +50,22 @@ import {PROVIDER_TIMEOUT_CODE}                       from '../../provider/create
 export const MAX_RECORD_COOLDOWN_MS = 3600000;
 
 /**
+ * Wall-clock ceiling for one `embedBatch` call, so the worst case is derivable HERE rather than
+ * from the product of a local attempt count and an attempt duration owned by another service.
+ *
+ * **Derivation, not a taste value:** the memory WAL drain polls every `pollIntervalMs` (5s default).
+ * A single batch that runs past two minutes has already starved ~24 polls of a queue it shares with
+ * every agent's `add_memory`, so the ceiling is one order of magnitude above the cadence it must not
+ * monopolise. It is a ceiling, never a target — healthy batches finish in well under a second.
+ *
+ * **Retirement trigger:** `pollIntervalMs` is not currently threaded into `embedBatch`. Once it is,
+ * derive this as a multiple of the live cadence and delete the constant — a derived bound cannot
+ * drift from the loop it protects, whereas this one can.
+ * @type {Number}
+ */
+export const DEFAULT_MAX_IN_CYCLE_MS = 120000;
+
+/**
  * @summary Computes the exponential backoff delay for a retry attempt.
  *
  * `base * 2^attempt`, capped at {@link MAX_RECORD_COOLDOWN_MS}. Pure; shared by the in-cycle
@@ -74,19 +90,18 @@ export function getBackoffDelayMs(backoffBaseMs, attempt) {
  * (that file pins its own log string verbatim precisely because its regex reads it). Duplicating
  * the coupled half here would split a matched pair across modules; duplicating the codes does not.
  *
- * **Asymmetry, deliberate and worth knowing:** `PROVIDER_TIMEOUT` is IMPORTED from its owner, so a
- * rename there is a compile-visible event here. `OPENAI_COMPATIBLE_REQUEST_TIMEOUT` has no exported
- * constant — it is assigned inline in `TextEmbeddingService`, whose module ends in `Neo.setupClass`
- * and therefore cannot be imported by this pure core. So that one literal CAN go stale silently: a
- * rename at the source would stop contention being recognised and the amplification would return
- * with no test failing. Exporting it beside its `err.code` assignment is the fix; until then this
- * comment is the only thing standing between a rename and a silent regression.
+ * **Both codes are IMPORTED from their single owner** (`ai/provider/createTimeoutError.mjs`), so a
+ * rename at the source is a compile-visible event in this classifier rather than a silent behaviour
+ * change. That matters more here than tidiness: while the value was repeated at the producer and at
+ * each consumer, a coordinated producer-plus-producer-test rename could have left this classifier
+ * and its fixtures green while restoring the exact retry amplification the classifier exists to
+ * prevent. Independently-pinned literals cannot detect coordinated drift; a shared import can.
  * @type {Set<String>}
  */
 const PROVIDER_CONTENTION_CODES = Object.freeze(new Set([
     'ESOCKETTIMEDOUT',
     'ETIMEDOUT',
-    'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
+    OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
     PROVIDER_TIMEOUT_CODE
 ]));
 
@@ -119,6 +134,14 @@ export function isProviderContentionError(error) {
  * Empirical anchor: one batch consumed ~21 minutes as six 300s attempts against a provider that was
  * serving the whole time (a 129-deep embedding queue), and only an operator restart cleared it.
  *
+ * **Local wall-clock bound.** Attempt COUNT is declared here (`maxRetries`) while attempt
+ * DURATION is declared in another service (`openAiCompatible.batchEmbeddingTimeoutMs`), so the worst
+ * case is the product of two leaves neither owner can see. `maxInCycleMs` re-localises it: no NEW
+ * attempt starts once the budget is spent. The bound deliberately does NOT race an in-flight
+ * `collection.add` — abandoning a write that may still land is how a timeout turns into a duplicate
+ * — so the honest guarantee is *"at most one externally-bounded attempt after the budget expires"*,
+ * which is derivable from this file alone.
+ *
  * @param {Object}   options
  * @param {Object}   options.collection    Content-store collection (`add({ids, metadatas, documents})`).
  * @param {Object[]} options.records       Pending WAL records (`{id, metadata, document, segmentKey}`).
@@ -128,14 +151,28 @@ export function isProviderContentionError(error) {
  * @param {Function} options.log           `(level, message)` sink.
  * @param {Function} [options.isContentionError=isProviderContentionError] Saturation classifier
  *     (injected so the pure core stays free of the Neo-class provider module).
+ * @param {Number}   [options.maxInCycleMs=DEFAULT_MAX_IN_CYCLE_MS] Wall-clock ceiling for one batch.
+ * @param {Function} [options.now=Date.now] Clock seam (injected for deterministic specs).
  * @returns {Promise<{succeeded: Object[], failed: Array<{record: Object, error: Error}>}>}
  */
-export async function embedBatch({collection, records, maxRetries, backoffBaseMs, sleep, log, isContentionError = isProviderContentionError}) {
+export async function embedBatch({
+    collection,
+    records,
+    maxRetries,
+    backoffBaseMs,
+    sleep,
+    log,
+    isContentionError = isProviderContentionError,
+    maxInCycleMs      = DEFAULT_MAX_IN_CYCLE_MS,
+    now               = Date.now
+}) {
     const payload = {
-        ids      : records.map(record => record.id),
-        metadatas: records.map(record => record.metadata),
-        documents: records.map(record => record.document)
-    };
+            ids      : records.map(record => record.id),
+            metadatas: records.map(record => record.metadata),
+            documents: records.map(record => record.document)
+        },
+        startedAt = now(),
+        budgetSpent = () => Number.isFinite(maxInCycleMs) && maxInCycleMs > 0 && now() - startedAt >= maxInCycleMs;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
@@ -148,6 +185,16 @@ export async function embedBatch({collection, records, maxRetries, backoffBaseMs
                 // with escalating spacing, so the backlog survives and the provider gets room.
                 log('INFO', `Batch embed hit provider contention (${error.message}) — deferring ` +
                     `${records.length} record(s) to a later cycle without retry`);
+
+                return {succeeded: [], failed: records.map(record => ({record, error}))};
+            }
+
+            if (budgetSpent()) {
+                // The wall-clock ceiling is spent. Stop before starting anything new — including the
+                // isolation pass, which would otherwise add `records.length` more externally-bounded
+                // attempts to a cycle that has already overrun.
+                log('ERROR', `Batch embed exceeded its ${maxInCycleMs}ms in-cycle budget after ` +
+                    `${attempt + 1} attempt(s) (${error.message}) — deferring ${records.length} record(s)`);
 
                 return {succeeded: [], failed: records.map(record => ({record, error}))};
             }
@@ -168,6 +215,13 @@ export async function embedBatch({collection, records, maxRetries, backoffBaseMs
     const failed    = [];
 
     for (const record of records) {
+        if (budgetSpent()) {
+            // Mid-pass exhaustion: the remaining records are deferred rather than attempted, so the
+            // ceiling bounds the isolation pass too and not merely the whole-batch loop.
+            failed.push({record, error: new Error(`in-cycle budget of ${maxInCycleMs}ms exhausted before isolation`)});
+            continue;
+        }
+
         try {
             await collection.add({ids: [record.id], metadatas: [record.metadata], documents: [record.document]});
             succeeded.push(record);

--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -6,6 +6,7 @@ import {
 } from '../../services/memory-core/helpers/memoryWalStore.mjs';
 import {classifyRowVector, VECTOR_REJECTION_REASONS} from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
 import {createDrainDispositionTracker}               from '../shared/drainDisposition.mjs';
+import {PROVIDER_TIMEOUT_CODE}                       from '../../provider/createTimeoutError.mjs';
 
 /**
  * @summary One durable drain pass over the `add_memory` write-ahead log.
@@ -72,13 +73,21 @@ export function getBackoffDelayMs(backoffBaseMs, attempt) {
  * the classification in `TextEmbeddingService` is coupled to a message THIS module never sees
  * (that file pins its own log string verbatim precisely because its regex reads it). Duplicating
  * the coupled half here would split a matched pair across modules; duplicating the codes does not.
+ *
+ * **Asymmetry, deliberate and worth knowing:** `PROVIDER_TIMEOUT` is IMPORTED from its owner, so a
+ * rename there is a compile-visible event here. `OPENAI_COMPATIBLE_REQUEST_TIMEOUT` has no exported
+ * constant — it is assigned inline in `TextEmbeddingService`, whose module ends in `Neo.setupClass`
+ * and therefore cannot be imported by this pure core. So that one literal CAN go stale silently: a
+ * rename at the source would stop contention being recognised and the amplification would return
+ * with no test failing. Exporting it beside its `err.code` assignment is the fix; until then this
+ * comment is the only thing standing between a rename and a silent regression.
  * @type {Set<String>}
  */
 const PROVIDER_CONTENTION_CODES = Object.freeze(new Set([
     'ESOCKETTIMEDOUT',
     'ETIMEDOUT',
     'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
-    'PROVIDER_TIMEOUT'
+    PROVIDER_TIMEOUT_CODE
 ]));
 
 /**

--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -50,13 +50,15 @@ import {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE, PROVIDER_TIMEOUT_CODE} from '../
 export const MAX_RECORD_COOLDOWN_MS = 3600000;
 
 /**
- * Wall-clock ceiling for one `embedBatch` call, so the worst case is derivable HERE rather than
- * from the product of a local attempt count and an attempt duration owned by another service.
+ * Wall-clock budget after which `embedBatch` admits no further attempt. It removes the attempt-count
+ * multiplier — the pre-bound worst case was a local count times a duration owned by another service —
+ * but it is NOT a ceiling on the call: an attempt already in flight when the budget expires runs to
+ * its own external deadline, so a single batch can still exceed this number.
  *
  * **Derivation, not a taste value:** the memory WAL drain polls every `pollIntervalMs` (5s default).
- * A single batch that runs past two minutes has already starved ~24 polls of a queue it shares with
- * every agent's `add_memory`, so the ceiling is one order of magnitude above the cadence it must not
- * monopolise. It is a ceiling, never a target — healthy batches finish in well under a second.
+ * A batch still admitting new attempts two minutes in has already starved ~24 polls of a queue it
+ * shares with every agent's `add_memory`, so the budget sits one order of magnitude above the cadence
+ * it must not monopolise. Healthy batches finish in well under a second and never reach it.
  *
  * **Retirement trigger:** `pollIntervalMs` is not currently threaded into `embedBatch`. Once it is,
  * derive this as a multiple of the live cadence and delete the constant — a derived bound cannot
@@ -155,7 +157,8 @@ export function isProviderContentionError(error) {
  * @param {Function} options.log           `(level, message)` sink.
  * @param {Function} [options.isContentionError=isProviderContentionError] Saturation classifier
  *     (injected so the pure core stays free of the Neo-class provider module).
- * @param {Number}   [options.maxInCycleMs=DEFAULT_MAX_IN_CYCLE_MS] Wall-clock ceiling for one batch.
+ * @param {Number}   [options.maxInCycleMs=DEFAULT_MAX_IN_CYCLE_MS] Wall-clock budget after which no
+ *     further attempt is admitted; an in-flight attempt still runs to its own external deadline.
  * @param {Function} [options.now=Date.now] Clock seam (injected for deterministic specs).
  * @returns {Promise<{succeeded: Object[], failed: Array<{record: Object, error: Error}>}>}
  */

--- a/ai/provider/createTimeoutError.mjs
+++ b/ai/provider/createTimeoutError.mjs
@@ -21,6 +21,20 @@
 const PROVIDER_TIMEOUT_CODE = 'PROVIDER_TIMEOUT';
 
 /**
+ * The OpenAI-compatible EMBEDDING transport's own timeout code.
+ *
+ * It is deliberately not `PROVIDER_TIMEOUT`: that transport stamps its socket-level `req.on('timeout')`
+ * directly rather than routing through {@link createTimeoutError}, so the two codes are distinct facts
+ * about which layer gave up, and collapsing them would erase that. What matters is that BOTH live
+ * here, because the identity is consumed by parties that never see the producer — a drain-loop
+ * classifier that treats saturation differently from an outage, and its fixtures. While the literal
+ * was repeated at the producer and each consumer, a coordinated rename could keep every test green
+ * while silently restoring the retry amplification the classifier exists to prevent.
+ * @type {String}
+ */
+const OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
+
+/**
  * @summary The shared provider-request options contract honored by local providers.
  *
  * @typedef {Object} ProviderTimeoutOptions
@@ -57,4 +71,4 @@ function createTimeoutError({provider, operationLabel, timeoutMs, host, modelNam
     return error;
 }
 
-export {PROVIDER_TIMEOUT_CODE, createTimeoutError};
+export {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE, PROVIDER_TIMEOUT_CODE, createTimeoutError};

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -9,7 +9,7 @@ import OllamaProvider from '../../provider/Ollama.mjs';
 import {
     withLmsEmbeddingInputSuffix
 }                           from '../shared/vector/lmsEmbeddingInputSuffix.mjs';
-import {PROVIDER_TIMEOUT_CODE} from '../../provider/createTimeoutError.mjs';
+import {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE, PROVIDER_TIMEOUT_CODE} from '../../provider/createTimeoutError.mjs';
 import {
     bytesToTokens,
     emitConsumerFriction
@@ -144,7 +144,7 @@ function describeEmbeddingAbortReason(error) {
     if ([
         'ABORT_ERR',
         'EMBEDDING_PROBE_TIMEOUT',
-        'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
+        OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
         'PROVIDER_TIMEOUT'
     ].includes(error?.code)) {
         return error.code;
@@ -196,7 +196,7 @@ export function isOpenAiCompatibleContentionTimeoutError(error) {
     const message = error?.message || '',
           code    = error?.code    || '';
 
-    return code === 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT' ||
+    return code === OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE ||
         code === 'ETIMEDOUT' ||
         code === 'ESOCKETTIMEDOUT' ||
         OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE.test(message);
@@ -755,7 +755,7 @@ class TextEmbeddingService extends Base {
             req.on('error', err => rejectOnce(isCallerAbortError(err, signal) ? getEmbeddingAbortError(signal, operationLabel) : err));
             req.on('timeout', () => {
                 const err = new Error(`openAiCompatible request timed out after ${describeOpenAiCompatibleTimeout(requestTimeoutMs)}`);
-                err.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
+                err.code = OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE;
                 rejectOnce(err);
                 if (!req.destroyed) {
                     req.destroy(err);

--- a/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
@@ -18,6 +18,7 @@ import {
     MAX_RECORD_COOLDOWN_MS
 } from '../../../../../../ai/daemons/embed/drainCycle.mjs';
 import {createDrainDispositionTracker} from '../../../../../../ai/daemons/shared/drainDisposition.mjs';
+import {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE} from '../../../../../../ai/provider/createTimeoutError.mjs';
 
 /**
  * Embed-daemon drain cycle (`ai/daemons/embed/drainCycle.mjs`) — falsifier coverage for the
@@ -390,7 +391,7 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
             addCalls++;
             const error = new Error('openAiCompatible request timed out after 300000ms');
 
-            error.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
+            error.code = OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE;
             throw error;
         };
 
@@ -411,7 +412,7 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
         // Deferred, not dropped: the caller spaces these via the cross-cycle retryState cooldown.
         expect(succeeded).toHaveLength(0);
         expect(failed.map(entry => entry.record.id)).toEqual(['x', 'y', 'z']);
-        expect(failed[0].error.code).toBe('OPENAI_COMPATIBLE_REQUEST_TIMEOUT');
+        expect(failed[0].error.code).toBe(OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE);
     });
 
     test('embedBatch: native-Ollama PROVIDER_TIMEOUT is the same contention class (#16012)', async () => {
@@ -467,6 +468,70 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
         // Without this control the fix could trade amplification for a silently-skipped retry path.
         expect(batchCalls).toBe(3);
         expect(slept).toBe(2);
+        expect(succeeded.map(r => r.id)).toEqual(['x']);
+        expect(failed.map(entry => entry.record.id)).toEqual(['y']);
+    });
+
+    test('embedBatch: the in-cycle wall-clock budget stops new attempts AND the isolation pass (#16012 AC4)', async () => {
+        const records    = ['x', 'y', 'z'].map(id => ({...record(id, Date.now()), segmentKey: 'unused'}));
+        const collection = createFakeCollection();
+        let   addCalls   = 0;
+        let   clock      = 0;
+
+        // Each attempt "costs" 1200ms of wall clock against a 1000ms budget, so the FIRST failure
+        // exhausts it — the loop must stop rather than spend maxRetries more externally-bounded calls.
+        // (900ms would not exhaust it and retrying would be correct; the fixture has to overshoot.)
+        collection.onAdd = () => {
+            addCalls++;
+            clock += 1200;
+            throw new Error('provider unreachable (spec) — not a timeout code');
+        };
+
+        const {succeeded, failed} = await embedBatch({
+            collection,
+            records,
+            maxRetries   : 5,
+            backoffBaseMs: 1,
+            sleep        : async () => {},
+            log          : () => {},
+            maxInCycleMs : 1000,
+            now          : () => clock
+        });
+
+        // One attempt, then the budget check stops everything: no further batch attempts and no
+        // 3-record isolation pass. Without the bound this is 6 + 3 = 9 externally-bounded calls.
+        expect(addCalls).toBe(1);
+        expect(succeeded).toHaveLength(0);
+        expect(failed.map(entry => entry.record.id)).toEqual(['x', 'y', 'z']);
+    });
+
+    test('embedBatch: an unlimited budget leaves the retry+isolation path unchanged (control, #16012 AC4)', async () => {
+        const records    = ['x', 'y'].map(id => ({...record(id, Date.now()), segmentKey: 'unused'}));
+        const collection = createFakeCollection();
+        let   batchCalls = 0;
+
+        collection.onAdd = ({ids}) => {
+            if (ids.length > 1) {
+                batchCalls++;
+                throw new Error('batch failure (spec)');
+            }
+
+            if (ids.includes('y')) throw new Error('y is poison (spec)');
+        };
+
+        const {succeeded, failed} = await embedBatch({
+            collection,
+            records,
+            maxRetries   : 2,
+            backoffBaseMs: 1,
+            sleep        : async () => {},
+            log          : () => {},
+            maxInCycleMs : 0,          // disabled
+            now          : () => 0
+        });
+
+        // A disabled budget must not silently change behaviour for anyone who does not opt in.
+        expect(batchCalls).toBe(3);
         expect(succeeded.map(r => r.id)).toEqual(['x']);
         expect(failed.map(entry => entry.record.id)).toEqual(['y']);
     });

--- a/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
@@ -380,6 +380,97 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
         expect(failed[0].error.message).toContain('poison');
     });
 
+    test('embedBatch: provider contention yields the cycle — one attempt, no isolation pass (#16012)', async () => {
+        const records    = ['x', 'y', 'z'].map(id => ({...record(id, Date.now()), segmentKey: 'unused'}));
+        const collection = createFakeCollection();
+        let   addCalls   = 0;
+        let   slept      = 0;
+
+        collection.onAdd = () => {
+            addCalls++;
+            const error = new Error('openAiCompatible request timed out after 300000ms');
+
+            error.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
+            throw error;
+        };
+
+        const {succeeded, failed} = await embedBatch({
+            collection,
+            records,
+            maxRetries   : 5,
+            backoffBaseMs: 1,
+            sleep        : async () => { slept++; },
+            log          : () => {}
+        });
+
+        // Pre-fix this was 6 whole-batch attempts plus a 3-record isolation pass = 9 offered
+        // requests to a provider whose queue was already the reason the first one timed out.
+        expect(addCalls).toBe(1);
+        expect(slept).toBe(0);
+
+        // Deferred, not dropped: the caller spaces these via the cross-cycle retryState cooldown.
+        expect(succeeded).toHaveLength(0);
+        expect(failed.map(entry => entry.record.id)).toEqual(['x', 'y', 'z']);
+        expect(failed[0].error.code).toBe('OPENAI_COMPATIBLE_REQUEST_TIMEOUT');
+    });
+
+    test('embedBatch: native-Ollama PROVIDER_TIMEOUT is the same contention class (#16012)', async () => {
+        const records    = [{...record('a', Date.now()), segmentKey: 'unused'}];
+        const collection = createFakeCollection();
+        let   addCalls   = 0;
+
+        collection.onAdd = () => {
+            addCalls++;
+            const error = new Error('embedding request timed out');
+
+            error.code = 'PROVIDER_TIMEOUT';
+            throw error;
+        };
+
+        await embedBatch({
+            collection,
+            records,
+            maxRetries   : 3,
+            backoffBaseMs: 1,
+            sleep        : async () => {},
+            log          : () => {}
+        });
+
+        // The classifier must not be OpenAI-compatible-only, or the native provider keeps amplifying.
+        expect(addCalls).toBe(1);
+    });
+
+    test('embedBatch: a NON-contention failure still retries and still isolates (control, #16012)', async () => {
+        const records    = ['x', 'y'].map(id => ({...record(id, Date.now()), segmentKey: 'unused'}));
+        const collection = createFakeCollection();
+        let   batchCalls = 0;
+        let   slept      = 0;
+
+        collection.onAdd = ({ids}) => {
+            if (ids.length > 1) {
+                batchCalls++;
+                throw new Error('malformed payload (spec) — not a timeout');
+            }
+
+            if (ids.includes('y')) throw new Error('y is poison (spec)');
+        };
+
+        const {succeeded, failed} = await embedBatch({
+            collection,
+            records,
+            maxRetries   : 2,
+            backoffBaseMs: 1,
+            sleep        : async () => { slept++; },
+            log          : () => {}
+        });
+
+        // Without this control the fix could trade amplification for a silently-skipped retry path.
+        expect(batchCalls).toBe(3);
+        expect(slept).toBe(2);
+        expect(succeeded.map(r => r.id)).toEqual(['x']);
+        expect(failed.map(entry => entry.record.id)).toEqual(['y']);
+    });
+
     test('getBackoffDelayMs caps at MAX_RECORD_COOLDOWN_MS', () => {
         expect(getBackoffDelayMs(1000, 0)).toBe(1000);
         expect(getBackoffDelayMs(1000, 3)).toBe(8000);

--- a/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
@@ -505,6 +505,38 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
         expect(failed.map(entry => entry.record.id)).toEqual(['x', 'y', 'z']);
     });
 
+    test('embedBatch: a backoff that crosses the budget boundary starts no further attempt (#16012 AC4)', async () => {
+        const records    = [{...record('a', Date.now()), segmentKey: 'unused'}];
+        const collection = createFakeCollection();
+        let   addCalls   = 0;
+        let   clock      = 0;
+
+        // @neo-gpt's cycle-2 falsifier, verbatim: the attempt itself finishes INSIDE the budget
+        // (900 < 1000), so a post-failure-only guard passes — and then the sleep advances the clock
+        // past the boundary. Without a post-sleep re-check the loop starts a second external request
+        // from beyond the budget: observed {calls: 2, clock: 2000} at e9d3bf4702.
+        collection.onAdd = () => {
+            addCalls++;
+            clock += 900;
+            throw new Error('provider unreachable (spec) — not a timeout code');
+        };
+
+        const {succeeded, failed} = await embedBatch({
+            collection,
+            records,
+            maxRetries   : 5,
+            backoffBaseMs: 1,
+            sleep        : async () => { clock += 200; },  // 900 + 200 = 1100 > 1000
+            log          : () => {},
+            maxInCycleMs : 1000,
+            now          : () => clock
+        });
+
+        expect(addCalls).toBe(1);
+        expect(succeeded).toHaveLength(0);
+        expect(failed.map(entry => entry.record.id)).toEqual(['a']);
+    });
+
     test('embedBatch: an unlimited budget leaves the retry+isolation path unchanged (control, #16012 AC4)', async () => {
         const records    = ['x', 'y'].map(id => ({...record(id, Date.now()), segmentKey: 'unused'}));
         const collection = createFakeCollection();


### PR DESCRIPTION
Resolves #16012

`embedBatch` treated every failure as a transient outage and retried the whole batch `maxRetries` times, then ran a per-record isolation pass. Against a saturated provider that is amplification: each re-offer adds load to the queue that caused the timeout, and isolation multiplies the offered requests by the batch size at the worst possible moment. One batch consumed ~21 minutes as six 300s attempts on 2026-07-26 while the provider was serving the whole time, and only an operator restart cleared it. `embedBatch` now classifies the failure and yields the cycle on contention.

Evidence: L2 (deterministic typed-code fixtures; red-proved on the amplification count itself, per provider shape) → L2 required (all #16012 ACs are unit-verifiable). Residual: none.

## The distinction the code was missing

A **transient outage** resolves while you wait — the provider is down, then up. Backoff is the right instrument because the cost of the failure is the **interval**.

**Saturation** is the opposite: the provider is up and its queue *is* the failure, so the cost is the **attempt**. Waiting longer and re-offering the same batch does not let it recover; it adds more. A saturated provider is also not a poison record, so the isolation pass — correct for its own purpose — is exactly wrong here.

## Deltas from ticket

**Three findings from reading the surrounding code narrowed the diff below what the ticket prescribed.**

1. **No new disposition or state was needed.** The ticket implied a "deferred" outcome. `drainCycle.mjs` already routes `failed` records into `retryState` with an escalating `nextAttemptAt`, so returning the batch as `failed` *is* deferral with backoff. Records are spaced, never dropped.
2. **The classifier is injected, not extracted.** Lifting `isOpenAiCompatibleContentionTimeoutError` into a shared helper was the obvious move and is wrong twice: `TextEmbeddingService.mjs` ends in `Neo.setupClass(...)` and this module is the documented pure core importing only light helpers; and that file's `:732` pins a log string verbatim *because* its regex at `:19` reads it — extracting splits a matched pair across modules. Only the **typed codes** are duplicated here, which are provider-owned protocol constants rather than a heuristic.
3. **Dual provider shapes became an AC.** The existing predicate is OpenAI-compatible-specific; per the #15694 record, native Ollama owns the shared `PROVIDER_TIMEOUT` shape. A classifier recognising only the first would leave Ollama amplifying, so it is covered and separately red-proved.

**Landed after cycle-1 review:** the ticket's item 4 (bound in-cycle cost by wall clock) is implemented. `maxInCycleMs` stops any NEW attempt once the budget is spent — including the per-record isolation pass, which would otherwise add `records.length` more externally-bounded calls to a cycle that had already overrun. The guard is checked both after a failed attempt and **after the backoff**, because a sleep can cross the boundary on its own; a post-failure-only check let the next iteration start a request from beyond the budget.

It is an **admission** bound, not a total wall-clock bound, and the ticket's AC4 is amended to say so. It deliberately does **not** race an in-flight `collection.add` — abandoning a write that may still land converts a timeout into a duplicate — so a single call may still run arbitrarily long as far as this module is concerned. What the bound removes is the attempt-count **multiplier**: the pre-fix worst case was the product of a local `maxRetries` and an externally-owned attempt duration; now the product is gone and one external duration remains. The reviewer's positive control established the distinction — with `maxInCycleMs: 500`, one successful call advanced the clock to 1,000,000ms and correctly returned success.

**Also landed after review:** `OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE` now lives beside `PROVIDER_TIMEOUT_CODE` in `ai/provider/createTimeoutError.mjs` and is imported by the producer, both classifiers, and the fixtures. Independently pinned literals cannot detect a coordinated producer rename; a shared import can.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs --grep "drainCycle|embedBatch|embed"` → **306 passed, 1 failed**.

**The 1 failure is pre-existing on `dev` and not from this change**, verified by the last-known-good check: clean `origin/dev` with none of these commits gives **303 passed / 1 failed** on the same set. 306 = 303 + the 3 specs added here. Across four runs the failure moved between `Orchestrator.spec.mjs:711/712`, `Server.spec.mjs:737`, and `Server.spec.mjs:647` — three different specs, all in the **embedder-degraded health gate** cluster, which is nondeterministic on a host whose embedding provider was saturated and restarted today. Flagged rather than fixed; it is not this ticket's scope and CI is the oracle.

| spec | asserts |
|---|---|
| contention yields the cycle | **one** `collection.add`, zero sleeps, all records returned `failed`, code preserved |
| native-Ollama `PROVIDER_TIMEOUT` | same class — **one** attempt, not OpenAI-compatible-only |
| non-contention **control** | still retries to the bound (3 batch calls, 2 sleeps) **and** still isolates per record |
| wall-clock budget | budget spent by the attempt ⇒ **one** call, no retry loop, no isolation pass |
| budget crossed **by the backoff** | attempt finishes inside the budget, the sleep crosses it ⇒ still **one** call |
| disabled budget **control** | `maxInCycleMs: 0` leaves retry + isolation behaviour byte-identical |

**Red proof — the contention branch.** With `isProviderContentionError` forced to `false`, reproducing the pre-fix "every failure is an outage" behaviour:

```
contention spec   Expected: 1  Received: 9   (6 whole-batch attempts + 3-record isolation)
ollama spec       Expected: 1  Received: 5   (4 attempts + 1 isolation)
```

The failing assertion is the **amplification count itself**, not a log line or a field the fix introduced. And the non-contention control **passed during the red run**, which is what proves it guards the outage path independently rather than tracking the fix.

**Red proof — the wall-clock bound.** With `budgetSpent()` neutralised the budget spec receives **9** where 1 is correct. With only the **post-sleep** guard removed, the boundary spec receives **2** where 1 is correct — the reviewer's exact observed value — while every other spec stays green, so that witness discriminates the specific mutation rather than the guard in general.

## Post-Merge Validation

- [ ] On the next live saturation, confirm the drain log shows `hit provider contention … deferring N record(s)` once per cycle instead of six 300s attempts followed by isolation.
- [ ] Confirm deferred records still drain on a later cycle — the `retryState` cooldown is the no-loss guarantee and it is exercised here only through the existing caller path.

## Commits

- `c6e9f27a1c` — the classifier, the contention branch, and its three specs.
- `2f85ca9523` — import `PROVIDER_TIMEOUT_CODE` rather than duplicating the literal (@neo-opus-vega's finding while yielding the lane).
- `e9d3bf4702` — the wall-clock bound, and one owner for the OpenAI-compatible code (cycle-1 review).
- `c07e41ab70` — re-check the budget after the backoff, with a mutation-discriminating witness (cycle-2 falsifier).

## Related

`#16013` and `#16022` are the same timeout-is-not-failure class at two other sites, both merged today; this is the third and last open one. The class shape — a timeout treated as evidence of a state it cannot observe — is the durable finding.

Authored by Grace (Claude Opus 5, Claude Code). Session a5be9fdf-aa57-4b81-afd0-c0f0149331b1.
