### PR TITLE
feat(memory-core): observe the answering loopback family on an unhealthy boot (#16025)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -852,9 +852,12 @@ class Server extends BaseServer {
 
             case 'no-listener':
                 // Equally load-bearing: it rules the mismatch OUT, so the operator stops looking here.
+                // The addresses come from the OBSERVATION, never a literal: a hardcoded `127.0.0.1`
+                // reported an address a `127.0.0.5`-configured server never dials — the same
+                // substitution defect the probe half already fixed, surviving in the rendering half.
                 logger.warn(`       Probed both loopback families: nothing answered on port ${port} at`);
-                logger.warn(`       127.0.0.1 or [::1], so this is not a bind-family mismatch — ChromaDB is`);
-                logger.warn(`       genuinely not accepting local connections.`);
+                logger.warn(`       ${(probe.empty || []).join(' or ')}, so this is not a bind-family mismatch — nothing`);
+                logger.warn(`       is accepting local connections on either family.`);
                 return true;
 
             case 'listener-reachable':

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -839,10 +839,15 @@ class Server extends BaseServer {
 
         switch (probe.verdict) {
             case 'mismatch':
-                // The whole point of the ticket: the diagnosis itself, not a command that finds it.
+                // OBSERVATIONAL, deliberately. A successful TCP connect proves "a listener accepted a
+                // connection", NOT "ChromaDB is running" — nothing here speaks Chroma's protocol. The
+                // earlier wording asserted the identity of the process that answered, which is the same
+                // overclaim this whole diagnostic exists to retire. The inference is offered to the
+                // operator as conditional, and the observation is stated as fact.
                 logger.warn(`       ⚠️  Bind-family mismatch OBSERVED: this server dials ${probe.dialed}, which refused,`);
-                logger.warn(`       but a listener answered at ${answering}. ChromaDB is running — on the family`);
-                logger.warn(`       this server is not dialing. Rebind it, or point this server at ${answering}.`);
+                logger.warn(`       but a TCP listener answered at ${answering} — unidentified; this probe does not`);
+                logger.warn(`       speak Chroma's protocol. If that listener is ChromaDB, rebind it or point this`);
+                logger.warn(`       server at ${answering}.`);
                 return true;
 
             case 'no-listener':

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -31,6 +31,7 @@ import {
 } from '../../../daemons/message/drainCycle.mjs';
 import {acquireMessageDrainLock}        from '../../../daemons/message/drainLock.mjs';
 import {getMissingMessageWalLeaves}     from '../../../services/memory-core/helpers/messageWalStore.mjs';
+import {LOOPBACK_PROBE_HEALTH_KEY}      from '../../../services/memory-core/helpers/loopbackFamilyProbe.mjs';
 import {TRUST_TIERS}                    from '../../../graph/identityRoots.mjs';
 import {normalizeAgentIdentityNodeId}   from '../../../graph/normalizeAgentIdentityNodeId.mjs';
 import ConfigBase, {PLANE_MEMBER_PATHS} from './configBase.mjs';
@@ -794,8 +795,15 @@ class Server extends BaseServer {
 
                 logger.warn(`    💡 Tip: this server expects ChromaDB at ${formatHostEndpoint(host, port)} (persist dir: ${dataDir}).`);
                 logger.warn(`       Start it with: chroma run --path ${dataDir} --port ${port}`);
-                logger.warn(`       Already running? Check the bind family — an IPv6-only listener refuses`);
-                logger.warn(`       an IPv4 client: lsof -nP -iTCP:${port} -sTCP:LISTEN`);
+
+                // The `lsof` fallback is printed ONLY when the probe did not answer the question it
+                // asks. When the probe IS conclusive the command is redundant: the requirement is that
+                // a bind-family mismatch be readable from the output alone, which a manual command the
+                // operator still has to run does not satisfy.
+                if (!this.logLoopbackDiagnosis(health.database?.connection?.[LOOPBACK_PROBE_HEALTH_KEY], port)) {
+                    logger.warn(`       Already running? Check the bind family — an IPv6-only listener refuses`);
+                    logger.warn(`       an IPv4 client: lsof -nP -iTCP:${port} -sTCP:LISTEN`);
+                }
             }
             logger.warn('    The server will periodically retry and recover automatically once dependencies are met.');
         } else if (health.status === 'degraded') {
@@ -807,6 +815,58 @@ class Server extends BaseServer {
         } else {
             logger.info('✅ [Startup] Memory Core health check passed');
             this.logCollectionStats(health);
+        }
+    }
+
+    /**
+     * @summary Renders the loopback bind-family observation carried on the health payload, and reports
+     * whether it made the `lsof` fallback redundant.
+     *
+     * Purely presentational and synchronous — the observation is taken in
+     * `HealthService.healthcheck()`, whose caller (`BaseServer.runHealthcheckAndLogStatus`) already
+     * awaits. `logStartupStatus` is a hook **six servers override**, so it performs no I/O: making it
+     * async to serve one server's diagnostic would mutate a shared contract for every one of them, and
+     * would silently leave each existing override running sync-in-async-context.
+     * @param {Object|undefined} probe `classifyLoopbackObservation` result, absent on older payloads.
+     * @param {Number|String}    port  Resolved Chroma port, for the no-listener wording.
+     * @returns {Boolean} `true` when the printed result replaces the `lsof` fallback.
+     * @protected
+     */
+    logLoopbackDiagnosis(probe, port) {
+        if (!probe?.conclusive) return false;
+
+        const answering = (probe.answering || []).join(' and ');
+
+        switch (probe.verdict) {
+            case 'mismatch':
+                // The whole point of the ticket: the diagnosis itself, not a command that finds it.
+                logger.warn(`       ⚠️  Bind-family mismatch OBSERVED: this server dials ${probe.dialed}, which refused,`);
+                logger.warn(`       but a listener answered at ${answering}. ChromaDB is running — on the family`);
+                logger.warn(`       this server is not dialing. Rebind it, or point this server at ${answering}.`);
+                return true;
+
+            case 'no-listener':
+                // Equally load-bearing: it rules the mismatch OUT, so the operator stops looking here.
+                logger.warn(`       Probed both loopback families: nothing answered on port ${port} at`);
+                logger.warn(`       127.0.0.1 or [::1], so this is not a bind-family mismatch — ChromaDB is`);
+                logger.warn(`       genuinely not accepting local connections.`);
+                return true;
+
+            case 'listener-reachable':
+                logger.warn(`       A listener answered at ${probe.dialed}, so the port is reachable and this is`);
+                logger.warn(`       not a bind-family mismatch — the fault is above TCP (HTTP, auth, or collections).`);
+                return true;
+
+            case 'ambiguous-host':
+                // `localhost` resolution order is not observable from here, so the families that
+                // answered are reported as facts without asserting which one gets dialed.
+                logger.warn(`       A listener answered at ${answering}. This server dials '${probe.dialed}', whose`);
+                logger.warn(`       address family is chosen by the resolver — so a mismatch is possible but not`);
+                logger.warn(`       proven. Dial the literal above to confirm.`);
+                return true;
+
+            default:
+                return false;
         }
     }
 

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2839,12 +2839,13 @@ components:
                   type: object
                   nullable: true
                   description: >-
-                    Present ONLY when the primary Chroma connection failed AND the configured host is a
-                    loopback address. Absent on a healthy connection (the probe is gated so it never runs
-                    on the MCP healthcheck path) and absent for a non-loopback host such as a compose
-                    service name, where no loopback claim could be true. Purely observational: a
-                    successful connect proves a TCP listener accepted, never the identity of the process
-                    that answered.
+                    Present ONLY when the primary Chroma connection FAILED and the configured host is a
+                    loopback address. Absent on the successful/healthy path, and absent for a
+                    non-loopback host such as a compose service name where no loopback claim could be
+                    true. Note the gate is on the connection OUTCOME, not on the caller: an unhealthy
+                    `healthcheck` tool call does probe, because the field exists to explain that
+                    failure. Purely observational — a successful connect proves a TCP listener accepted,
+                    never the identity of the process that answered.
                   properties:
                     verdict:
                       type: string

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2835,6 +2835,50 @@ components:
                         count:
                           type: integer
                           example: 56
+                loopbackProbe:
+                  type: object
+                  nullable: true
+                  description: >-
+                    Present ONLY when the primary Chroma connection failed AND the configured host is a
+                    loopback address. Absent on a healthy connection (the probe is gated so it never runs
+                    on the MCP healthcheck path) and absent for a non-loopback host such as a compose
+                    service name, where no loopback claim could be true. Purely observational: a
+                    successful connect proves a TCP listener accepted, never the identity of the process
+                    that answered.
+                  properties:
+                    verdict:
+                      type: string
+                      enum: [mismatch, no-listener, listener-reachable, ambiguous-host, inconclusive, skipped]
+                      example: mismatch
+                    conclusive:
+                      type: boolean
+                      description: >-
+                        True only when the observation answers the question an `lsof` would have. False
+                        for `inconclusive` (a family timed out, so nothing may be asserted) and `skipped`.
+                      example: true
+                    dialed:
+                      type: string
+                      description: The configured literal this server dials, never a normalised stand-in.
+                      example: "127.0.0.1"
+                    answering:
+                      type: array
+                      items:
+                        type: string
+                      example: ["[::1]"]
+                    empty:
+                      type: array
+                      items:
+                        type: string
+                      example: ["127.0.0.1"]
+                    unknown:
+                      type: array
+                      items:
+                        type: string
+                      example: []
+                    reason:
+                      type: string
+                      nullable: true
+                      example: "no result for 127.0.0.1"
         features:
           type: object
           properties:

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1641,11 +1641,12 @@ class HealthService extends Base {
             payload.status = 'unhealthy';
             payload.details.push(connectionCheck.error);
 
-            // Gated to the ALREADY-FAILED path on purpose. `healthcheck()` also serves the MCP
-            // `healthcheck` tool on every invocation, so an ungated dual-family probe would dial two
-            // sockets per call forever to answer a question only a failure asks. Here the connection
-            // has already failed, so the ~2ms buys the one diagnostic that distinguishes "Chroma is
-            // down" from "Chroma is up on the family you did not dial".
+            // Gated on the connection OUTCOME, not on the caller. `healthcheck()` also serves the MCP
+            // `healthcheck` tool on every invocation, so an ungated probe would dial two sockets per
+            // call forever to answer a question only a failure asks — but an UNHEALTHY tool call does
+            // probe, deliberately, because that is exactly when the answer is wanted. Here the
+            // connection has already failed, so the ~2ms buys the one diagnostic that distinguishes
+            // "Chroma is down" from "Chroma is up on the family you did not dial".
             payload.database.connection[LOOPBACK_PROBE_HEALTH_KEY] = await this.#observeLoopbackFamilies();
 
             return payload;

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -18,6 +18,13 @@ import {
 import {buildSqliteHolderDiagnostics} from './helpers/harnessClassifier.mjs';
 import {readRecentRemRunStates}       from './helpers/remRunStateStore.mjs';
 import {withTimeout}                  from './helpers/withTimeout.mjs';
+import {
+    LOOPBACK_PROBE_HEALTH_KEY,
+    LOOPBACK_PROBE_TIMEOUT_MS,
+    classifyLoopbackObservation,
+    probeLoopbackFamilies,
+    tcpConnectProbe
+} from './helpers/loopbackFamilyProbe.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -1006,6 +1013,43 @@ class HealthService extends Base {
     runtimeFreshnessCacheDuration = 30 * 1000;
 
     /**
+     * Connect seam for the boot-time loopback bind-family probe.
+     *
+     * Exposed as a member so a unit spec can substitute a stub and exercise every verdict — including
+     * the IPv6-answered/IPv4-refused asymmetry a single host cannot reproduce on demand — without
+     * opening a real socket.
+     * @member {Function} loopbackConnectProbe
+     */
+    loopbackConnectProbe = tcpConnectProbe;
+
+    /**
+     * Observes which loopback address families answer on the configured Chroma port and classifies
+     * the result, so `logStartupStatus` can name a bind-family mismatch instead of printing an `lsof`
+     * command for the operator to run.
+     *
+     * Wrapped in its own try/catch even though `probeLoopbackFamilies` is contractually
+     * non-throwing: the config read and the classification are also inside this boundary, and this
+     * runs on a path whose entire purpose is reporting a failure. A diagnostic that can itself fail a
+     * boot is worse than no diagnostic.
+     * @returns {Promise<Object>} Classification from `classifyLoopbackObservation`.
+     * @private
+     */
+    async #observeLoopbackFamilies() {
+        try {
+            const {host, port} = aiConfig.engines.chroma;
+
+            return classifyLoopbackObservation(await probeLoopbackFamilies({
+                host,
+                port,
+                timeoutMs: LOOPBACK_PROBE_TIMEOUT_MS,
+                connect  : this.loopbackConnectProbe
+            }));
+        } catch (error) {
+            return {verdict: 'skipped', conclusive: false, reason: `loopback probe unavailable: ${error.message}`};
+        }
+    }
+
+    /**
      * Checks if the active vector and graph databases are running and accessible.
      * @param {Number} chromaProbeTimeoutMs Chroma probe timeout budget.
      * @returns {Promise<Object>} {running: boolean, error: string|undefined, engines: Object}
@@ -1596,6 +1640,14 @@ class HealthService extends Base {
         if (!connectionCheck.running) {
             payload.status = 'unhealthy';
             payload.details.push(connectionCheck.error);
+
+            // Gated to the ALREADY-FAILED path on purpose. `healthcheck()` also serves the MCP
+            // `healthcheck` tool on every invocation, so an ungated dual-family probe would dial two
+            // sockets per call forever to answer a question only a failure asks. Here the connection
+            // has already failed, so the ~2ms buys the one diagnostic that distinguishes "Chroma is
+            // down" from "Chroma is up on the family you did not dial".
+            payload.database.connection[LOOPBACK_PROBE_HEALTH_KEY] = await this.#observeLoopbackFamilies();
+
             return payload;
         }
 

--- a/ai/services/memory-core/helpers/loopbackFamilyProbe.mjs
+++ b/ai/services/memory-core/helpers/loopbackFamilyProbe.mjs
@@ -93,19 +93,34 @@ export function isLoopbackHost(host) {
  * @returns {Object} `{kind: 'ipv4'|'ipv6'|'resolver'|'not-loopback', literal?}`
  */
 export function classifyLoopbackHost(host) {
-    const value = String(host ?? '').trim().replace(/^\[|]$/g, '').toLowerCase();
+    const raw = String(host ?? '').trim();
+
+    // Brackets must be BALANCED. Stripping a leading `[` or a trailing `]` independently admitted
+    // `[::1` and `::1]`, which are not authorities at all — a half-bracketed host is malformed input,
+    // not an IPv6 literal, and admitting it would have the probe dial a string Node cannot parse.
+    if ((raw.startsWith('[') || raw.endsWith(']')) && !(raw.startsWith('[') && raw.endsWith(']') && raw.length > 2)) {
+        return {kind: 'not-loopback'};
+    }
+
+    const bracketed = raw.startsWith('[') && raw.endsWith(']'),
+          value     = (bracketed ? raw.slice(1, -1) : raw).toLowerCase();
 
     if (value === 'localhost') return {kind: 'resolver', literal: 'localhost'};
-    if (value === '::1')       return {kind: 'ipv6', literal: '::1'};
 
-    // Strict dotted-quad: exactly four octets, each 0-255 with no leading zeros or stray characters,
-    // and the first must be 127. `Number()` would accept ' 1', '0x7f' and '1e2', so the digit shape is
-    // asserted before the range.
-    const octets = value.split('.');
+    // `net.isIP` IS THE AUTHORITY, not a hand-written dotted-quad regex. Mine accepted
+    // `127.000.000.001` and `127.01.2.3` — leading-zero octets that Node rejects outright, so the probe
+    // would have dialled a host the runtime does not consider an address. Delegating means this cannot
+    // disagree with the stack that opens the socket.
+    const family = net.isIP(value);
 
-    if (octets.length === 4 && octets.every(part => /^\d{1,3}$/.test(part) && Number(part) <= 255) && octets[0] === '127') {
-        return {kind: 'ipv4', literal: value};
-    }
+    // `::1` only. Other spellings of IPv6 loopback (`0:0:0:0:0:0:0:1`) are valid addresses that Node
+    // accepts, and they are deliberately classified not-loopback rather than normalised here: declining
+    // to probe is a quiet, safe outcome, whereas an address normaliser inside a diagnostic is a second
+    // parser to keep correct. Stated as a limit rather than left as a surprise.
+    if (family === 6) return value === '::1' ? {kind: 'ipv6', literal: '::1'} : {kind: 'not-loopback'};
+
+    // The whole 127.0.0.0/8 block is loopback, and the CONFIGURED literal is carried through.
+    if (family === 4 && value.startsWith('127.')) return {kind: 'ipv4', literal: value};
 
     return {kind: 'not-loopback'};
 }

--- a/ai/services/memory-core/helpers/loopbackFamilyProbe.mjs
+++ b/ai/services/memory-core/helpers/loopbackFamilyProbe.mjs
@@ -1,0 +1,229 @@
+import net from 'node:net';
+
+/**
+ * @module ai/services/memory-core/helpers/loopbackFamilyProbe
+ * @summary Observes which loopback address families actually accept a TCP connection on a port, so a
+ * bind-family mismatch is readable from a boot log instead of costing the operator a separate `lsof`.
+ *
+ * ## The asymmetry this exists to name
+ *
+ * A listener bound to `[::1]` **refuses** an IPv4 client, and a listener bound to `127.0.0.1` refuses
+ * an IPv6 one. Neither logs anything unusual: the client sees `ECONNREFUSED`, which is the same error
+ * a genuinely absent service produces. So a running store is indistinguishable from a dead one from
+ * the dialing side alone — and the failure mode is cheap to hit and expensive to guess at. It has
+ * produced repeated "Chroma is down" misdiagnoses against a store that was up the whole time,
+ * answering on the family nobody probed.
+ *
+ * The fix is not better wording. It is a second observation: dial **both** families and report which
+ * one answered. That converts an unfalsifiable "it's refused" into "you dial X; a listener answered
+ * at Y", which is the whole diagnosis in one line.
+ *
+ * ## Why probing and classifying are separate exports
+ *
+ * `probeLoopbackFamilies` performs I/O; `classifyLoopbackObservation` is pure. Splitting them means
+ * every verdict — including the ones a local host can never reproduce, like "IPv6 answered and IPv4
+ * did not" — is exhaustively unit-testable with no sockets and no seam at all. Only the probe half
+ * needs an injected `connect`, and the classification half needs nothing.
+ *
+ * ## Claims are fail-closed
+ *
+ * A timeout is **not** treated as "nothing is listening". On loopback a timeout is anomalous (a
+ * refused connection returns in well under a millisecond), so it means the probe learned nothing —
+ * not that the family is empty. Reporting "no listener on 127.0.0.1" off a timeout would be exactly
+ * the unverified assertion this module exists to retire. Unknown families therefore suppress the
+ * mismatch verdict rather than contributing to it: the diagnostic goes quiet instead of guessing, and
+ * the caller keeps its existing wording.
+ *
+ * Neo-free and config-free by construction: every input arrives as an argument. That keeps the unit
+ * spec off the config singleton entirely and keeps this reusable from any process that dials a local
+ * service — the orchestrator's Chroma supervision has the same blind spot.
+ */
+
+/**
+ * The two loopback authorities a local client can dial, IPv4 first to match the order a `127.0.0.1`
+ * default makes most likely.
+ *
+ * `label` is the display form (bracketed IPv6), `host` the dial form — a socket wants `::1`, a human
+ * reading a log wants `[::1]`.
+ * @member {Object[]} LOOPBACK_FAMILIES
+ */
+export const LOOPBACK_FAMILIES = Object.freeze([
+    Object.freeze({family: 4, host: '127.0.0.1', label: '127.0.0.1'}),
+    Object.freeze({family: 6, host: '::1',       label: '[::1]'})
+]);
+
+/**
+ * Probe budget per family, in milliseconds.
+ *
+ * Stated here as a literal with its derivation rather than read from config, because this bound is a
+ * property of the *measurement* and not an operator preference: on the reference host an IPv4 connect
+ * to an IPv6-only listener refuses in ~0.3ms and a successful IPv6 connect answers in ~1.2ms, so
+ * 250ms is ~200x the observed answer time. That is generous enough to survive a loaded host and small
+ * enough to be invisible on a path that has *already* failed a health check.
+ *
+ * Both families are probed concurrently, so the wall-clock ceiling for the whole observation is this
+ * value, not twice it.
+ * @member {Number} LOOPBACK_PROBE_TIMEOUT_MS
+ */
+export const LOOPBACK_PROBE_TIMEOUT_MS = 250;
+
+/**
+ * Key under `health.database.connection` that carries the classified observation.
+ *
+ * Shared rather than spelled twice because producer and consumer live in different layers
+ * (`HealthService` writes it, the memory-core `Server` reads it) and a rename on one side would fail
+ * **silently**: the diagnostic would simply stop printing while both unit specs stayed green, since
+ * neither exercises the other's file. Importing one constant makes that divergence impossible instead
+ * of merely detectable.
+ * @member {String} LOOPBACK_PROBE_HEALTH_KEY
+ */
+export const LOOPBACK_PROBE_HEALTH_KEY = 'loopbackProbe';
+
+/**
+ * @summary True when a host names the local machine's loopback interface.
+ *
+ * Gating the probe on this is what keeps container deployments untouched: in a compose network the
+ * configured host is a **service name** (`chroma`), so no loopback claim could say anything true about
+ * it, and the probe never runs at all rather than running and being ignored.
+ * @param {String} host Configured host.
+ * @returns {Boolean}
+ */
+export function isLoopbackHost(host) {
+    const value = String(host ?? '').trim().replace(/^\[|]$/g, '').toLowerCase();
+
+    return value === 'localhost' || value === '::1' || value.startsWith('127.');
+}
+
+/**
+ * @summary Real TCP connect seam: resolves `true` when a listener accepted, `false` when it refused.
+ *
+ * Only a **refusal** is reported as an empty family. Every other outcome — a timeout, or any error
+ * code other than `ECONNREFUSED` — rejects, so the caller records that family as *unknown* instead of
+ * asserting it is empty. See the fail-closed note in the module summary.
+ *
+ * The socket is destroyed on every path and unref'd immediately, so a probe can never hold the event
+ * loop open on a boot path even if the remote never answers.
+ * @param {Object} spec
+ * @param {String} spec.host      Dial host.
+ * @param {Number} spec.port      Dial port.
+ * @param {Number} spec.timeoutMs Per-family budget.
+ * @returns {Promise<Boolean>} `true` accepted, `false` refused; rejects when the outcome is unknown.
+ */
+export function tcpConnectProbe({host, port, timeoutMs}) {
+    return new Promise((resolve, reject) => {
+        const socket  = net.connect({host, port});
+        let   settled = false;
+
+        const settle = (fn, value) => {
+            if (settled) return;
+            settled = true;
+            socket.destroy();
+            fn(value);
+        };
+
+        socket.unref();
+        socket.setTimeout(timeoutMs, () => settle(reject, new Error(`connect to ${host}:${port} timed out after ${timeoutMs}ms`)));
+        socket.once('connect', () => settle(resolve, true));
+        socket.once('error', error => error?.code === 'ECONNREFUSED' ? settle(resolve, false) : settle(reject, error));
+    });
+}
+
+/**
+ * @summary Dials every loopback family on `port` and reports which ones answered.
+ *
+ * Never throws. Every refusal path — bad arguments, a non-loopback host, a broken seam — returns a
+ * `probed: false` observation carrying the reason, because this runs on a boot path whose whole
+ * purpose is reporting a failure: a diagnostic that can itself fail the boot is worse than no
+ * diagnostic. The seam is a **required** argument rather than a defaulted one so no caller can
+ * silently acquire real sockets it did not ask for.
+ * @param {Object}   spec
+ * @param {String}   spec.host      Configured host, used only to decide whether probing is meaningful.
+ * @param {Number}   spec.port      Port to dial on each family.
+ * @param {Number}   spec.timeoutMs Per-family budget; pass {@link LOOPBACK_PROBE_TIMEOUT_MS}.
+ * @param {Function} spec.connect   Connect seam with {@link tcpConnectProbe}'s contract.
+ * @returns {Promise<Object>} `{probed, host, port, reason?, families?}`
+ */
+export async function probeLoopbackFamilies({host, port, timeoutMs, connect} = {}) {
+    const refuse = reason => ({probed: false, host, port, reason});
+
+    if (!isLoopbackHost(host)) {
+        return refuse(`configured host ${host ?? '(unset)'} is not a loopback address; a loopback probe cannot describe it`);
+    }
+
+    if (!Number.isInteger(port) || port <= 0) {
+        return refuse(`port must be a positive integer, received ${JSON.stringify(port)}`);
+    }
+
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        return refuse(`timeoutMs must be a positive finite number, received ${JSON.stringify(timeoutMs)}`);
+    }
+
+    if (typeof connect !== 'function') {
+        return refuse('connect seam is required; pass tcpConnectProbe for real sockets');
+    }
+
+    const families = await Promise.all(LOOPBACK_FAMILIES.map(async entry => {
+        try {
+            const answered = await connect({host: entry.host, port, timeoutMs});
+
+            // A seam that resolves anything but a boolean has not answered the question asked, so its
+            // family stays unknown rather than being coerced into a claim.
+            return typeof answered === 'boolean' ? {...entry, answered} : {...entry, answered: null, error: `connect seam resolved a non-boolean (${typeof answered})`};
+        } catch (error) {
+            return {...entry, answered: null, error: error?.message || String(error)};
+        }
+    }));
+
+    return {probed: true, host, port, families};
+}
+
+/**
+ * @summary Turns an observation into a verdict, asserting a mismatch only when one is provable.
+ *
+ * `conclusive` is the signal a caller uses to decide whether its fallback guidance (an `lsof`
+ * invocation for the operator to run) is now redundant. It is true only for verdicts that answer the
+ * question `lsof` was there to answer — never for `inconclusive` or `skipped`, where the operator
+ * still needs the manual command.
+ *
+ * Verdicts:
+ * - `mismatch` — the dialed family is empty and the other one answered. The diagnosis, provable.
+ * - `no-listener` — both families definitively refused; the service really is not accepting locally.
+ * - `listener-reachable` — the dialed family answered, so the port is live and the fault is above TCP.
+ * - `ambiguous-host` — host is `localhost`, whose family is chosen by the resolver; facts, no claim.
+ * - `inconclusive` — at least one family is unknown, so no verdict is safe.
+ * - `skipped` — probing was refused (non-loopback host, bad input, missing seam).
+ * @param {Object} observation Result of {@link probeLoopbackFamilies}.
+ * @returns {Object} `{verdict, conclusive, dialed, answering, empty, unknown, reason?}`
+ */
+export function classifyLoopbackObservation(observation) {
+    const {probed, host, port, reason, families} = observation || {};
+
+    if (!probed || !Array.isArray(families)) {
+        return {verdict: 'skipped', conclusive: false, reason: reason || 'no observation was taken'};
+    }
+
+    const answering = families.filter(entry => entry.answered === true).map(entry => entry.label),
+          empty     = families.filter(entry => entry.answered === false).map(entry => entry.label),
+          unknown   = families.filter(entry => entry.answered === null).map(entry => entry.label),
+          normalise = String(host ?? '').trim().replace(/^\[|]$/g, '').toLowerCase(),
+          dialed    = normalise === 'localhost' ? null : families.find(entry => entry.host === normalise || (normalise.startsWith('127.') && entry.family === 4)),
+          base      = {dialed: dialed?.label || String(host ?? ''), answering, empty, unknown, port};
+
+    if (unknown.length > 0) {
+        return {...base, verdict: 'inconclusive', conclusive: false, reason: `no result for ${unknown.join(', ')}`};
+    }
+
+    if (answering.length === 0) {
+        return {...base, verdict: 'no-listener', conclusive: true};
+    }
+
+    // `localhost` resolution order decides which family is dialed, and it is not observable from
+    // here — so the families that answered are reported as facts without a mismatch claim.
+    if (!dialed) {
+        return {...base, verdict: 'ambiguous-host', conclusive: true};
+    }
+
+    return dialed.answered
+        ? {...base, verdict: 'listener-reachable', conclusive: true}
+        : {...base, verdict: 'mismatch', conclusive: true};
+}

--- a/ai/services/memory-core/helpers/loopbackFamilyProbe.mjs
+++ b/ai/services/memory-core/helpers/loopbackFamilyProbe.mjs
@@ -40,19 +40,6 @@ import net from 'node:net';
  */
 
 /**
- * The two loopback authorities a local client can dial, IPv4 first to match the order a `127.0.0.1`
- * default makes most likely.
- *
- * `label` is the display form (bracketed IPv6), `host` the dial form — a socket wants `::1`, a human
- * reading a log wants `[::1]`.
- * @member {Object[]} LOOPBACK_FAMILIES
- */
-export const LOOPBACK_FAMILIES = Object.freeze([
-    Object.freeze({family: 4, host: '127.0.0.1', label: '127.0.0.1'}),
-    Object.freeze({family: 6, host: '::1',       label: '[::1]'})
-]);
-
-/**
  * Probe budget per family, in milliseconds.
  *
  * Stated here as a literal with its derivation rather than read from config, because this bound is a
@@ -89,9 +76,57 @@ export const LOOPBACK_PROBE_HEALTH_KEY = 'loopbackProbe';
  * @returns {Boolean}
  */
 export function isLoopbackHost(host) {
+    return classifyLoopbackHost(host).kind !== 'not-loopback';
+}
+
+/**
+ * @summary Classifies a configured host into the loopback form it actually is, by PARSING it.
+ *
+ * Prefix matching was wrong in both directions: `startsWith('127.')` admitted non-addresses like
+ * `127.abc` and `127.0.0.1.example.com`, while the probe simultaneously hard-coded `127.0.0.1` — so a
+ * server configured for `127.0.0.5` was probed at, and had its verdict reported as, an address it never
+ * dials. A diagnostic that names the wrong address is worse than none.
+ *
+ * The whole `127.0.0.0/8` block is genuine loopback, so it stays supported — but the **configured
+ * literal** is carried through rather than normalised away.
+ * @param {String} host Configured host.
+ * @returns {Object} `{kind: 'ipv4'|'ipv6'|'resolver'|'not-loopback', literal?}`
+ */
+export function classifyLoopbackHost(host) {
     const value = String(host ?? '').trim().replace(/^\[|]$/g, '').toLowerCase();
 
-    return value === 'localhost' || value === '::1' || value.startsWith('127.');
+    if (value === 'localhost') return {kind: 'resolver', literal: 'localhost'};
+    if (value === '::1')       return {kind: 'ipv6', literal: '::1'};
+
+    // Strict dotted-quad: exactly four octets, each 0-255 with no leading zeros or stray characters,
+    // and the first must be 127. `Number()` would accept ' 1', '0x7f' and '1e2', so the digit shape is
+    // asserted before the range.
+    const octets = value.split('.');
+
+    if (octets.length === 4 && octets.every(part => /^\d{1,3}$/.test(part) && Number(part) <= 255) && octets[0] === '127') {
+        return {kind: 'ipv4', literal: value};
+    }
+
+    return {kind: 'not-loopback'};
+}
+
+/**
+ * @summary Builds the family list to probe, carrying the CONFIGURED IPv4 literal when there is one.
+ *
+ * A `127.0.0.5` deployment gets `127.0.0.5` probed and reported. Only when the configured host supplies
+ * no IPv4 literal of its own (`::1`, or resolver-decided `localhost`) does the canonical `127.0.0.1`
+ * stand in — and then it is the honest choice, because nothing else was specified.
+ * @param {String} host Configured host.
+ * @returns {Object[]} `[{family, host, label}]`, IPv4 first.
+ */
+export function resolveLoopbackFamilies(host) {
+    const classified = classifyLoopbackHost(host),
+          ipv4       = classified.kind === 'ipv4' ? classified.literal : '127.0.0.1';
+
+    return [
+        {family: 4, host: ipv4,  label: ipv4},
+        {family: 6, host: '::1', label: '[::1]'}
+    ];
 }
 
 /**
@@ -162,7 +197,7 @@ export async function probeLoopbackFamilies({host, port, timeoutMs, connect} = {
         return refuse('connect seam is required; pass tcpConnectProbe for real sockets');
     }
 
-    const families = await Promise.all(LOOPBACK_FAMILIES.map(async entry => {
+    const families = await Promise.all(resolveLoopbackFamilies(host).map(async entry => {
         try {
             const answered = await connect({host: entry.host, port, timeoutMs});
 
@@ -202,11 +237,16 @@ export function classifyLoopbackObservation(observation) {
         return {verdict: 'skipped', conclusive: false, reason: reason || 'no observation was taken'};
     }
 
-    const answering = families.filter(entry => entry.answered === true).map(entry => entry.label),
-          empty     = families.filter(entry => entry.answered === false).map(entry => entry.label),
-          unknown   = families.filter(entry => entry.answered === null).map(entry => entry.label),
-          normalise = String(host ?? '').trim().replace(/^\[|]$/g, '').toLowerCase(),
-          dialed    = normalise === 'localhost' ? null : families.find(entry => entry.host === normalise || (normalise.startsWith('127.') && entry.family === 4)),
+    const answering  = families.filter(entry => entry.answered === true).map(entry => entry.label),
+          empty      = families.filter(entry => entry.answered === false).map(entry => entry.label),
+          unknown    = families.filter(entry => entry.answered === null).map(entry => entry.label),
+          classified = classifyLoopbackHost(host),
+          // `resolver` (localhost) has no observable dialed family — the resolver picks it, and that
+          // choice is not visible here, so no mismatch may be asserted. An ipv4/ipv6 literal matches
+          // the family carrying that exact literal, so a 127/8 deployment reports its OWN address.
+          dialed    = classified.kind === 'ipv4' || classified.kind === 'ipv6'
+              ? families.find(entry => entry.host === classified.literal)
+              : null,
           base      = {dialed: dialed?.label || String(host ?? ''), answering, empty, unknown, port};
 
     if (unknown.length > 0) {

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -1006,4 +1006,126 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         expect(tip).toMatch(/IPv6-only|bind family/i);
         expect(tip).toContain(`lsof -nP -iTCP:${port} -sTCP:LISTEN`);
     });
+
+    test.describe('#16025: the unhealthy-boot tip reports the OBSERVED loopback family', () => {
+        /**
+         * Drives `logStartupStatus` with a health payload carrying a classified probe result and
+         * returns the captured warn output.
+         *
+         * The probe result is attached under the SHARED key exported by the helper, not a literal, so
+         * this spec breaks if `HealthService` and the `Server` ever disagree about the path — the one
+         * failure mode neither file's own spec can see.
+         */
+        const renderTip = async loopbackProbe => {
+            const {LOOPBACK_PROBE_HEALTH_KEY} = await import('../../../../../../../ai/services/memory-core/helpers/loopbackFamilyProbe.mjs'),
+                  logger                      = (await import('../../../../../../../ai/mcp/server/memory-core/logger.mjs')).default,
+                  serverInstance              = await createServerWithoutBoot(),
+                  originalWarn                = logger.warn,
+                  lines                       = [];
+
+            logger.warn = message => lines.push(String(message));
+
+            let returned;
+
+            try {
+                returned = serverInstance.logStartupStatus({
+                    status  : 'unhealthy',
+                    details : ['Database engine not accessible'],
+                    database: {
+                        process   : {running: false},
+                        connection: {[LOOPBACK_PROBE_HEALTH_KEY]: loopbackProbe}
+                    }
+                });
+            } finally {
+                logger.warn = originalWarn;
+                serverInstance.destroy();
+            }
+
+            return {tip: lines.join('\n'), returned};
+        };
+
+        test('a MISMATCH is stated as an observation, and it REPLACES the lsof fallback', async () => {
+            const {tip} = await renderTip({
+                verdict: 'mismatch', conclusive: true, dialed: '127.0.0.1', answering: ['[::1]'], empty: ['127.0.0.1'], unknown: []
+            });
+
+            // The requirement is readability from the output alone: the operator is told the answer,
+            // not handed a command that would find it.
+            expect(tip).toMatch(/Bind-family mismatch OBSERVED/);
+            expect(tip).toContain('127.0.0.1');
+            expect(tip).toContain('[::1]');
+            expect(tip).toMatch(/ChromaDB is running/);
+
+            // The fallback is now redundant, so it must be GONE — leaving it would mean the tip still
+            // costs the operator the command the AC exists to remove.
+            expect(tip).not.toContain('lsof');
+        });
+
+        test('NO-LISTENER rules the mismatch OUT and also replaces the fallback', async () => {
+            const {tip} = await renderTip({
+                verdict: 'no-listener', conclusive: true, dialed: '127.0.0.1', answering: [], empty: ['127.0.0.1', '[::1]'], unknown: []
+            });
+
+            // Just as useful as the positive verdict: it stops the operator hunting a bind-family
+            // problem that provably is not there.
+            expect(tip).toMatch(/nothing answered/i);
+            expect(tip).toMatch(/not a bind-family mismatch/i);
+            expect(tip).not.toContain('lsof');
+        });
+
+        test('LISTENER-REACHABLE points above TCP instead of at the bind family', async () => {
+            const {tip} = await renderTip({
+                verdict: 'listener-reachable', conclusive: true, dialed: '127.0.0.1', answering: ['127.0.0.1'], empty: ['[::1]'], unknown: []
+            });
+
+            expect(tip).toMatch(/above TCP/);
+            expect(tip).not.toContain('lsof');
+        });
+
+        test('AMBIGUOUS-HOST reports which families answered WITHOUT claiming a mismatch', async () => {
+            const {tip} = await renderTip({
+                verdict: 'ambiguous-host', conclusive: true, dialed: 'localhost', answering: ['[::1]'], empty: ['127.0.0.1'], unknown: []
+            });
+
+            expect(tip).toContain('[::1]');
+            expect(tip).toMatch(/chosen by the resolver/);
+            // The claim is explicitly hedged, because which family `localhost` resolves to is not
+            // observable from here. Asserting a mismatch would be the unverified assertion the whole
+            // helper is built to avoid.
+            expect(tip).toMatch(/not\s+proven/);
+            expect(tip).not.toMatch(/mismatch OBSERVED/);
+        });
+
+        test('an INCONCLUSIVE probe KEEPS the lsof fallback — the operator still needs it', async () => {
+            const {tip} = await renderTip({
+                verdict: 'inconclusive', conclusive: false, dialed: '127.0.0.1', answering: ['[::1]'], empty: [], unknown: ['127.0.0.1'], reason: 'no result for 127.0.0.1'
+            });
+
+            // The AC is conditional in both directions: the fallback goes away ONLY when the printed
+            // result genuinely replaces it. An unknown family replaces nothing.
+            expect(tip).toContain('lsof -nP -iTCP:');
+            expect(tip).not.toMatch(/mismatch OBSERVED/);
+        });
+
+        test('a SKIPPED probe (non-loopback host, e.g. a compose service name) keeps the fallback', async () => {
+            const {tip} = await renderTip({verdict: 'skipped', conclusive: false, reason: 'configured host chroma is not a loopback address'});
+
+            expect(tip).toContain('lsof -nP -iTCP:');
+        });
+
+        test('an ABSENT probe keeps the pre-#16025 wording verbatim (older/cached payloads)', async () => {
+            const {tip} = await renderTip(undefined);
+
+            expect(tip).toContain('lsof -nP -iTCP:');
+            expect(tip).toMatch(/IPv6-only|bind family/i);
+        });
+
+        test('logStartupStatus stays SYNCHRONOUS — it renders, it never probes', async () => {
+            // The hook is overridden by six servers. Returning a promise here would leave every one of
+            // them silently sync-in-async-context, so "returns nothing" is a contract worth pinning.
+            const {returned} = await renderTip({verdict: 'mismatch', conclusive: true, dialed: '127.0.0.1', answering: ['[::1]']});
+
+            expect(returned).toBeUndefined();
+        });
+    });
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -1054,7 +1054,15 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             expect(tip).toMatch(/Bind-family mismatch OBSERVED/);
             expect(tip).toContain('127.0.0.1');
             expect(tip).toContain('[::1]');
-            expect(tip).toMatch(/ChromaDB is running/);
+
+            // OBSERVATIONAL, and the discrimination is the point: a successful TCP connect proves a
+            // listener accepted, NOT that the listener is ChromaDB — nothing here speaks Chroma's
+            // protocol. The earlier wording asserted the answering process's identity, which is the
+            // same overclaim this diagnostic exists to retire.
+            expect(tip).toMatch(/TCP listener answered/);
+            expect(tip).toMatch(/unidentified/);
+            expect(tip).toMatch(/If that listener is ChromaDB/);   // inference offered, not asserted
+            expect(tip).not.toMatch(/ChromaDB is running/);
 
             // The fallback is now redundant, so it must be GONE — leaving it would mean the tip still
             // costs the operator the command the AC exists to remove.

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -1069,6 +1069,24 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             expect(tip).not.toContain('lsof');
         });
 
+        test('⭐ NO-LISTENER names the OBSERVED addresses, not a hardcoded 127.0.0.1', async () => {
+            // The rendering half carried the same substitution defect the probe half had fixed: a literal
+            // `127.0.0.1` in the wording reported an address a 127.0.0.5-configured server never dials.
+            const {tip} = await renderTip({
+                verdict: 'no-listener', conclusive: true, dialed: '127.0.0.5', answering: [], empty: ['127.0.0.5', '[::1]'], unknown: []
+            });
+
+            // Scoped to the no-listener SENTENCE, not the whole tip: the first line legitimately prints
+            // the resolved config endpoint, so a whole-tip matcher would be answering about the wrong
+            // subject — the exact mistake this PR's diagnostic exists to avoid.
+            const probedLine = tip.split('\n').find(line => line.includes('nothing answered on port'));
+
+            expect(probedLine).toBeDefined();
+            expect(tip).toContain('127.0.0.5 or [::1]');
+            // The observed-address line must not name an address the server does not dial.
+            expect(tip.split('\n').filter(line => line.includes(' or [::1]')).join('\n')).not.toContain('127.0.0.1');
+        })
+
         test('NO-LISTENER rules the mismatch OUT and also replaces the fallback', async () => {
             const {tip} = await renderTip({
                 verdict: 'no-listener', conclusive: true, dialed: '127.0.0.1', answering: [], empty: ['127.0.0.1', '[::1]'], unknown: []
@@ -1078,6 +1096,8 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             // problem that provably is not there.
             expect(tip).toMatch(/nothing answered/i);
             expect(tip).toMatch(/not a bind-family mismatch/i);
+            // Observational: it no longer asserts WHICH process is absent, only that nothing answered.
+            expect(tip).not.toMatch(/ChromaDB is\s+genuinely/);
             expect(tip).not.toContain('lsof');
         });
 

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -13,15 +13,16 @@ setup({
     }
 });
 
-import {test, expect}         from '@playwright/test';
-import Neo                    from '../../../../../../src/Neo.mjs';
-import * as core              from '../../../../../../src/core/_export.mjs';
-import InstanceManager        from '../../../../../../src/manager/Instance.mjs';
-import AiConfig               from '../../../../../../ai/config.template.mjs';
-import ChromaManager          from '../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
-import StorageRouter          from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
-import ChromaLifecycleService from '../../../../../../ai/services/memory-core/lifecycle/ChromaLifecycleService.mjs';
-import logger                 from '../../../../../../ai/mcp/server/memory-core/logger.mjs';
+import {test, expect}              from '@playwright/test';
+import Neo                         from '../../../../../../src/Neo.mjs';
+import * as core                   from '../../../../../../src/core/_export.mjs';
+import InstanceManager             from '../../../../../../src/manager/Instance.mjs';
+import AiConfig                    from '../../../../../../ai/config.template.mjs';
+import ChromaManager               from '../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
+import {LOOPBACK_PROBE_HEALTH_KEY} from '../../../../../../ai/services/memory-core/helpers/loopbackFamilyProbe.mjs';
+import StorageRouter               from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
+import ChromaLifecycleService      from '../../../../../../ai/services/memory-core/lifecycle/ChromaLifecycleService.mjs';
+import logger                      from '../../../../../../ai/mcp/server/memory-core/logger.mjs';
 
 /**
  * @summary Coverage for the identity observability block in the healthcheck payload.
@@ -403,7 +404,8 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
             invalidateCollectionCache: ChromaManager.invalidateCollectionCache,
             getMemoryCollection      : StorageRouter.getMemoryCollection,
             getSummaryCollection     : StorageRouter.getSummaryCollection,
-            getDatabaseStatus        : ChromaLifecycleService.getDatabaseStatus
+            getDatabaseStatus        : ChromaLifecycleService.getDatabaseStatus,
+            loopbackConnectProbe     : HealthService.loopbackConnectProbe
         };
 
         ChromaManager.connected = true;
@@ -446,12 +448,82 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         StorageRouter.getSummaryCollection     = originals.getSummaryCollection;
         ChromaLifecycleService.getDatabaseStatus = originals.getDatabaseStatus;
         TextEmbeddingService.embedText            = originalEmbedText;
+        HealthService.loopbackConnectProbe        = originals.loopbackConnectProbe;
 
         HealthService.setStdioIdentityState(null);
         HealthService.runtimeFreshnessReader = null;
         HealthService.clearStartupDependencyState();
         HealthService.clearCache();
     });
+
+    // The producer gate. Review feedback surfaced the omission that made these necessary:
+    // deleting the assignment in `#performHealthCheck` left the pure helper spec AND the Server spec
+    // green, because the Server spec builds its payload BY HAND. Nothing asserted that HealthService
+    // actually writes the key. These three close that — and they are the only tests in the suite that
+    // exercise producer and consumer through one real call.
+
+    /** Forces the primary Chroma connection to fail, which is the gate the probe is allowed to run behind. */
+    const failPrimaryConnection = () => {
+        ChromaManager.connected = false;
+        ChromaManager.connect   = async () => false;
+    };
+
+    test('a FAILED primary connection invokes the injected loopback seam and attaches the shared-key verdict', async () => {
+        const dials = [];
+
+        failPrimaryConnection();
+        HealthService.loopbackConnectProbe = ({host, port, timeoutMs}) => {
+            dials.push({host, port, timeoutMs});
+            // IPv6-only listener: the asymmetry a single host cannot stage on demand.
+            return Promise.resolve(host === '::1');
+        };
+        HealthService.clearCache();
+
+        const health = await HealthService.healthcheck(),
+              probe  = health.database.connection[LOOPBACK_PROBE_HEALTH_KEY];
+
+        expect(health.status).toBe('unhealthy');
+        // The seam was really reached — not merely available.
+        expect(dials.map(dial => dial.host)).toEqual(['127.0.0.1', '::1']);
+        expect(dials.every(dial => dial.timeoutMs > 0 && dial.port > 0)).toBe(true);
+        // ...and the producer wrote the verdict under the SHARED key the Server reads.
+        expect(probe).toBeTruthy();
+        expect(probe.verdict).toBe('mismatch');
+        expect(probe.conclusive).toBe(true);
+        expect(probe.answering).toEqual(['[::1]']);
+    })
+
+    test('a HEALTHY connection performs NO loopback dials and exposes no key', async () => {
+        // The gate in the other direction: `healthcheck()` also serves the MCP tool on every call, so a
+        // probe leaking onto the healthy path would dial two sockets per invocation forever.
+        let dialed = 0;
+
+        HealthService.loopbackConnectProbe = () => {
+            dialed++;
+            return Promise.resolve(true);
+        };
+        HealthService.clearCache();
+
+        const health = await HealthService.healthcheck();
+
+        expect(dialed).toBe(0);
+        expect(health.database.connection[LOOPBACK_PROBE_HEALTH_KEY]).toBeUndefined();
+    })
+
+    test('a THROWING loopback diagnostic cannot escape the already-unhealthy healthcheck', async () => {
+        // A diagnostic that can fail the boot it is diagnosing is worse than no diagnostic. The probe
+        // degrades to `inconclusive` and the healthcheck still resolves with its real verdict.
+        failPrimaryConnection();
+        HealthService.loopbackConnectProbe = () => { throw new Error('probe exploded') };
+        HealthService.clearCache();
+
+        const health = await HealthService.healthcheck(),
+              probe  = health.database.connection[LOOPBACK_PROBE_HEALTH_KEY];
+
+        expect(health.status).toBe('unhealthy');
+        expect(probe.verdict).toBe('inconclusive');
+        expect(probe.conclusive).toBe(false);
+    })
 
     test('direct healthcheck refreshes cached timestamp and collection counts without mutating the cache', async () => {
         const cached = await HealthService.healthcheck();

--- a/test/playwright/unit/ai/services/memory-core/helpers/loopbackFamilyProbe.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/loopbackFamilyProbe.spec.mjs
@@ -1,9 +1,12 @@
 import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import * as yaml      from 'js-yaml';
 import {
     LOOPBACK_PROBE_TIMEOUT_MS,
     classifyLoopbackObservation,
     isLoopbackHost,
-    probeLoopbackFamilies
+    probeLoopbackFamilies,
+    resolveLoopbackFamilies
 } from '../../../../../../../ai/services/memory-core/helpers/loopbackFamilyProbe.mjs';
 
 // Neo-free helper imported directly, mirroring hostEndpoint.spec and detectionRetentionSla.spec: no
@@ -43,6 +46,31 @@ test.describe('loopbackFamilyProbe — isLoopbackHost', () => {
         expect(isLoopbackHost('LOCALHOST')).toBe(true);
         expect(isLoopbackHost(' localhost ')).toBe(true);
     });
+
+    test('⭐ ADMISSION IS PARSED, not prefix-matched — malformed 127-ish hosts are rejected', () => {
+        // `startsWith('127.')` admitted all of these. A diagnostic that accepts a non-address and then
+        // dials something else entirely is worse than no diagnostic.
+        expect(isLoopbackHost('127.abc')).toBe(false);
+        expect(isLoopbackHost('127.0.0.1.example.com')).toBe(false);
+        expect(isLoopbackHost('127.0.0')).toBe(false);          // three octets
+        expect(isLoopbackHost('127.0.0.256')).toBe(false);      // out of range
+        expect(isLoopbackHost('127.0.0.1x')).toBe(false);
+        expect(isLoopbackHost('1270.0.0.1')).toBe(false);       // first octet is not 127
+        // ...while the whole legitimate 127/8 block still is loopback.
+        expect(isLoopbackHost('127.0.0.1')).toBe(true);
+        expect(isLoopbackHost('127.0.0.5')).toBe(true);
+        expect(isLoopbackHost('127.255.255.254')).toBe(true);
+    })
+
+    test('⭐ a NON-CANONICAL 127/8 host is PROBED and REPORTED as itself, never as 127.0.0.1', () => {
+        // The substitution bug: the probe hard-coded 127.0.0.1, so a server configured for 127.0.0.5
+        // was dialed at — and had its verdict report — an address it never uses.
+        expect(resolveLoopbackFamilies('127.0.0.5').map(f => f.host)).toEqual(['127.0.0.5', '::1']);
+        expect(resolveLoopbackFamilies('127.0.0.5').map(f => f.label)).toEqual(['127.0.0.5', '[::1]']);
+        // Only when the config supplies no IPv4 literal does the canonical stand-in apply.
+        expect(resolveLoopbackFamilies('::1').map(f => f.host)).toEqual(['127.0.0.1', '::1']);
+        expect(resolveLoopbackFamilies('localhost').map(f => f.host)).toEqual(['127.0.0.1', '::1']);
+    })
 
     test('rejects the container service-name case — this is what keeps cloud deployments untouched', () => {
         // In a compose network the configured host is a service name, so no loopback claim could say
@@ -221,4 +249,58 @@ test.describe('loopbackFamilyProbe — the timeout bound is stated, not inherite
         expect(seen.every(entry => entry.timeoutMs === LOOPBACK_PROBE_TIMEOUT_MS)).toBe(true);
         expect(seen.every(entry => entry.port === 8000)).toBe(true);
     });
+});
+
+test.describe('the published contract matches the verdicts the code can actually emit', () => {
+    test('⭐ every classifier verdict is in the OpenAPI enum — the schema cannot drift from the producer', () => {
+        // A schema listing five of six verdicts is worse than no schema: a consumer coding against it
+        // would treat the missing one as a protocol violation. So the enum is asserted against the
+        // verdicts this module can PRODUCE, not eyeballed once at authoring time.
+        const schema = yaml.load(fs.readFileSync('ai/mcp/server/memory-core/openapi.yaml', 'utf8'))
+                  .components.schemas.HealthCheckResponse
+                  .properties.database.properties.connection.properties.loopbackProbe,
+              documented = new Set(schema.properties.verdict.enum),
+              // Every verdict reachable from this module, each produced by a real call rather than
+              // copied from a list — a hand-maintained list is the drift this test exists to stop.
+              emitted    = new Set([
+                  classifyLoopbackObservation(undefined).verdict,
+                  classifyLoopbackObservation({probed: true, host: '127.0.0.1', port: 1, families: [
+                      {family: 4, host: '127.0.0.1', label: '127.0.0.1', answered: false},
+                      {family: 6, host: '::1', label: '[::1]', answered: true}
+                  ]}).verdict,
+                  classifyLoopbackObservation({probed: true, host: '127.0.0.1', port: 1, families: [
+                      {family: 4, host: '127.0.0.1', label: '127.0.0.1', answered: false},
+                      {family: 6, host: '::1', label: '[::1]', answered: false}
+                  ]}).verdict,
+                  classifyLoopbackObservation({probed: true, host: '127.0.0.1', port: 1, families: [
+                      {family: 4, host: '127.0.0.1', label: '127.0.0.1', answered: true},
+                      {family: 6, host: '::1', label: '[::1]', answered: false}
+                  ]}).verdict,
+                  classifyLoopbackObservation({probed: true, host: 'localhost', port: 1, families: [
+                      {family: 4, host: '127.0.0.1', label: '127.0.0.1', answered: false},
+                      {family: 6, host: '::1', label: '[::1]', answered: true}
+                  ]}).verdict,
+                  classifyLoopbackObservation({probed: true, host: '127.0.0.1', port: 1, families: [
+                      {family: 4, host: '127.0.0.1', label: '127.0.0.1', answered: null},
+                      {family: 6, host: '::1', label: '[::1]', answered: true}
+                  ]}).verdict
+              ]);
+
+        expect(emitted.size).toBe(6);
+        for (const verdict of emitted) {
+            expect(documented, `verdict "${verdict}" is emitted but undocumented`).toContain(verdict);
+        }
+        // And nothing documented is unreachable — a phantom enum member misleads a consumer too.
+        expect([...documented].sort()).toEqual([...emitted].sort());
+    })
+
+    test('the probe payload is declared nullable and optional — absent is a valid, meaningful state', () => {
+        // Absence carries information: a healthy connection, or a non-loopback host. A consumer must not
+        // read absence as a malformed payload.
+        const connection = yaml.load(fs.readFileSync('ai/mcp/server/memory-core/openapi.yaml', 'utf8'))
+            .components.schemas.HealthCheckResponse.properties.database.properties.connection;
+
+        expect(connection.properties.loopbackProbe.nullable).toBe(true);
+        expect(connection.required ?? []).not.toContain('loopbackProbe');
+    })
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/loopbackFamilyProbe.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/loopbackFamilyProbe.spec.mjs
@@ -1,0 +1,224 @@
+import {test, expect} from '@playwright/test';
+import {
+    LOOPBACK_PROBE_TIMEOUT_MS,
+    classifyLoopbackObservation,
+    isLoopbackHost,
+    probeLoopbackFamilies
+} from '../../../../../../../ai/services/memory-core/helpers/loopbackFamilyProbe.mjs';
+
+// Neo-free helper imported directly, mirroring hostEndpoint.spec and detectionRetentionSla.spec: no
+// config-singleton import, no mutation of shared state, and NO REAL SOCKETS — every connect goes
+// through the injected seam.
+//
+// Why the seam is the whole point of this spec: the verdict that matters most is
+// "IPv6 answered and IPv4 refused", and a host cannot be made to reproduce that on demand inside a
+// test run. Injecting the seam is the only way to assert the asymmetry the helper exists to report,
+// rather than asserting whatever the local machine happens to be doing.
+
+/**
+ * Builds a connect seam from a per-host outcome map.
+ * `true` accepted, `false` refused, an Error instance rejects (unknown family).
+ */
+const seamFrom = outcomes => ({host}) => {
+    const outcome = outcomes[host];
+
+    return outcome instanceof Error ? Promise.reject(outcome) : Promise.resolve(outcome);
+};
+
+const probe = (outcomes, overrides = {}) => probeLoopbackFamilies({
+    host     : '127.0.0.1',
+    port     : 8000,
+    timeoutMs: LOOPBACK_PROBE_TIMEOUT_MS,
+    connect  : seamFrom(outcomes),
+    ...overrides
+});
+
+test.describe('loopbackFamilyProbe — isLoopbackHost', () => {
+    test('recognises every loopback spelling a config might carry', () => {
+        expect(isLoopbackHost('127.0.0.1')).toBe(true);
+        expect(isLoopbackHost('127.1.2.3')).toBe(true);   // the whole 127/8 block is loopback
+        expect(isLoopbackHost('::1')).toBe(true);
+        expect(isLoopbackHost('[::1]')).toBe(true);       // bracketed form survives config round-trips
+        expect(isLoopbackHost('localhost')).toBe(true);
+        expect(isLoopbackHost('LOCALHOST')).toBe(true);
+        expect(isLoopbackHost(' localhost ')).toBe(true);
+    });
+
+    test('rejects the container service-name case — this is what keeps cloud deployments untouched', () => {
+        // In a compose network the configured host is a service name, so no loopback claim could say
+        // anything true about it. The probe must decline rather than run and be ignored: that is the
+        // mechanical reason this diagnostic changes nothing for the containerised deployment.
+        expect(isLoopbackHost('chroma')).toBe(false);
+        expect(isLoopbackHost('chroma.internal')).toBe(false);
+        expect(isLoopbackHost('10.0.0.5')).toBe(false);
+        expect(isLoopbackHost('0.0.0.0')).toBe(false);    // a bind wildcard, not a dial target
+        expect(isLoopbackHost(undefined)).toBe(false);
+        expect(isLoopbackHost('')).toBe(false);
+    });
+});
+
+test.describe('loopbackFamilyProbe — probeLoopbackFamilies refuses instead of throwing', () => {
+    // Every refusal path returns a reason. A diagnostic that throws on the boot path it is diagnosing
+    // is worse than no diagnostic, so "never throws" is a contract, not an implementation detail.
+
+    test('declines a non-loopback host without dialing anything', async () => {
+        let called = false;
+
+        const observation = await probeLoopbackFamilies({
+            host: 'chroma', port: 8000, timeoutMs: 250, connect: () => (called = true, Promise.resolve(true))
+        });
+
+        expect(observation.probed).toBe(false);
+        expect(observation.reason).toContain('not a loopback address');
+        expect(called).toBe(false);   // no socket attempted, not merely ignored
+    });
+
+    test('declines a missing or invalid port, a bad timeout, and a missing seam', async () => {
+        expect((await probe({}, {port: undefined})).reason).toContain('positive integer');
+        expect((await probe({}, {port: 0})).reason).toContain('positive integer');
+        expect((await probe({}, {port: 8000.5})).reason).toContain('positive integer');
+        expect((await probe({}, {timeoutMs: 0})).reason).toContain('positive finite');
+        expect((await probe({}, {timeoutMs: Number.NaN})).reason).toContain('positive finite');
+        expect((await probe({}, {connect: undefined})).reason).toContain('connect seam is required');
+    });
+
+    test('a THROWING seam degrades to unknown rather than propagating', async () => {
+        // Robustness against a dependency that FAILS, not merely one that is absent: a seam which
+        // throws synchronously must be contained exactly like one that rejects.
+        const observation = await probeLoopbackFamilies({
+            host   : '127.0.0.1', port: 8000, timeoutMs: 250,
+            connect: () => { throw new Error('seam exploded'); }
+        });
+
+        expect(observation.probed).toBe(true);
+        expect(observation.families.every(entry => entry.answered === null)).toBe(true);
+        expect(classifyLoopbackObservation(observation).verdict).toBe('inconclusive');
+    });
+
+    test('a seam resolving a NON-boolean is treated as unknown, never coerced into a claim', async () => {
+        const observation = await probe({'127.0.0.1': 'yes', '::1': undefined});
+
+        expect(observation.families.every(entry => entry.answered === null)).toBe(true);
+        expect(classifyLoopbackObservation(observation).verdict).toBe('inconclusive');
+    });
+});
+
+test.describe('loopbackFamilyProbe — classifyLoopbackObservation verdicts', () => {
+    test('MISMATCH: the dialed family refused and the other answered — the diagnosis itself', async () => {
+        // The verdict the ticket exists for, and the one a real host cannot be made to produce here.
+        const verdict = classifyLoopbackObservation(await probe({'127.0.0.1': false, '::1': true}));
+
+        expect(verdict.verdict).toBe('mismatch');
+        expect(verdict.conclusive).toBe(true);
+        expect(verdict.dialed).toBe('127.0.0.1');
+        expect(verdict.answering).toEqual(['[::1]']);   // bracketed for display
+    });
+
+    test('MISMATCH in the mirror direction — an IPv6-configured server against an IPv4-only listener', async () => {
+        const verdict = classifyLoopbackObservation(
+            await probe({'127.0.0.1': true, '::1': false}, {host: '::1'})
+        );
+
+        expect(verdict.verdict).toBe('mismatch');
+        expect(verdict.dialed).toBe('[::1]');
+        expect(verdict.answering).toEqual(['127.0.0.1']);
+    });
+
+    test('a bracketed configured host resolves to the same family as its bare form', async () => {
+        const verdict = classifyLoopbackObservation(
+            await probe({'127.0.0.1': true, '::1': false}, {host: '[::1]'})
+        );
+
+        expect(verdict.verdict).toBe('mismatch');
+        expect(verdict.dialed).toBe('[::1]');
+    });
+
+    test('NO-LISTENER: both families definitively refused — rules the mismatch OUT', async () => {
+        // Equally load-bearing as the mismatch verdict: it tells the operator to stop looking here.
+        const verdict = classifyLoopbackObservation(await probe({'127.0.0.1': false, '::1': false}));
+
+        expect(verdict.verdict).toBe('no-listener');
+        expect(verdict.conclusive).toBe(true);
+        expect(verdict.answering).toEqual([]);
+        expect(verdict.empty).toEqual(['127.0.0.1', '[::1]']);
+    });
+
+    test('LISTENER-REACHABLE: the dialed family answered, so the fault is above TCP', async () => {
+        const verdict = classifyLoopbackObservation(await probe({'127.0.0.1': true, '::1': false}));
+
+        expect(verdict.verdict).toBe('listener-reachable');
+        expect(verdict.conclusive).toBe(true);
+    });
+
+    test('AMBIGUOUS-HOST: `localhost` reports facts without asserting a mismatch', async () => {
+        // Which family `localhost` resolves to is not observable from here, so claiming a mismatch
+        // would be an assertion the probe cannot support.
+        const verdict = classifyLoopbackObservation(
+            await probe({'127.0.0.1': false, '::1': true}, {host: 'localhost'})
+        );
+
+        expect(verdict.verdict).toBe('ambiguous-host');
+        expect(verdict.conclusive).toBe(true);
+        expect(verdict.answering).toEqual(['[::1]']);
+    });
+
+    test('INCONCLUSIVE: one unknown family suppresses a mismatch that the other half would suggest', async () => {
+        // The fail-closed core. IPv6 answered and IPv4 is UNKNOWN (a timeout, not a refusal) — which
+        // looks exactly like a mismatch and is not one, because "IPv4 refused" was never observed.
+        // Reporting a mismatch here would be the unverified assertion this module exists to retire.
+        const verdict = classifyLoopbackObservation(
+            await probe({'127.0.0.1': new Error('timed out after 250ms'), '::1': true})
+        );
+
+        expect(verdict.verdict).toBe('inconclusive');
+        expect(verdict.conclusive).toBe(false);
+        expect(verdict.unknown).toEqual(['127.0.0.1']);
+        expect(verdict.reason).toContain('127.0.0.1');
+    });
+
+    test('a timeout is NOT reported as an empty family', async () => {
+        const observation = await probe({'127.0.0.1': new Error('timed out'), '::1': new Error('timed out')});
+
+        expect(classifyLoopbackObservation(observation).empty).toEqual([]);
+        expect(classifyLoopbackObservation(observation).verdict).toBe('inconclusive');
+    });
+
+    test('SKIPPED: a declined observation classifies as non-conclusive and carries the reason forward', async () => {
+        const declined = await probeLoopbackFamilies({host: 'chroma', port: 8000, timeoutMs: 250, connect: () => Promise.resolve(true)}),
+              verdict  = classifyLoopbackObservation(declined);
+
+        expect(verdict.verdict).toBe('skipped');
+        expect(verdict.conclusive).toBe(false);
+        expect(verdict.reason).toContain('not a loopback address');
+    });
+
+    test('SKIPPED for a malformed or absent observation — classification never throws either', () => {
+        for (const input of [undefined, null, {}, {probed: true}, {probed: true, families: 'nope'}]) {
+            expect(classifyLoopbackObservation(input).verdict).toBe('skipped');
+            expect(classifyLoopbackObservation(input).conclusive).toBe(false);
+        }
+    });
+});
+
+test.describe('loopbackFamilyProbe — the timeout bound is stated, not inherited', () => {
+    test('the exported bound is an explicit literal well above the measured connect times', () => {
+        // The bound must be stated in code rather than inherited from a config default, so the value
+        // itself is pinned: a refused loopback connect returns in ~0.3ms and a successful one in
+        // ~1.2ms, making 250ms ~200x the observed answer time.
+        expect(LOOPBACK_PROBE_TIMEOUT_MS).toBe(250);
+    });
+
+    test('the seam receives the timeout it was given — the bound is not silently replaced', async () => {
+        const seen = [];
+
+        await probeLoopbackFamilies({
+            host   : '127.0.0.1', port: 8000, timeoutMs: LOOPBACK_PROBE_TIMEOUT_MS,
+            connect: ({host, port, timeoutMs}) => (seen.push({host, port, timeoutMs}), Promise.resolve(false))
+        });
+
+        expect(seen).toHaveLength(2);
+        expect(seen.map(entry => entry.host)).toEqual(['127.0.0.1', '::1']);
+        expect(seen.every(entry => entry.timeoutMs === LOOPBACK_PROBE_TIMEOUT_MS)).toBe(true);
+        expect(seen.every(entry => entry.port === 8000)).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/loopbackFamilyProbe.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/loopbackFamilyProbe.spec.mjs
@@ -1,4 +1,5 @@
 import {test, expect} from '@playwright/test';
+import net            from 'node:net';
 import fs             from 'node:fs';
 import * as yaml      from 'js-yaml';
 import {
@@ -46,6 +47,35 @@ test.describe('loopbackFamilyProbe — isLoopbackHost', () => {
         expect(isLoopbackHost('LOCALHOST')).toBe(true);
         expect(isLoopbackHost(' localhost ')).toBe(true);
     });
+
+    test('⭐ NODE is the authority on address validity — leading-zero octets are NOT addresses', () => {
+        // My own dotted-quad regex accepted these; `net.isIP` rejects them, and the runtime that opens
+        // the socket is the only authority worth agreeing with. Admitting them meant the probe would
+        // dial a string Node cannot parse.
+        expect(net.isIP('127.000.000.001')).toBe(0);
+        expect(net.isIP('127.01.2.3')).toBe(0);
+        expect(isLoopbackHost('127.000.000.001')).toBe(false);
+        expect(isLoopbackHost('127.01.2.3')).toBe(false);
+    })
+
+    test('⭐ brackets must be BALANCED — a half-bracketed host is malformed, not IPv6', () => {
+        // Stripping a leading `[` or trailing `]` independently admitted all of these.
+        expect(isLoopbackHost('[::1')).toBe(false);
+        expect(isLoopbackHost('::1]')).toBe(false);
+        expect(isLoopbackHost('127.0.0.1]')).toBe(false);
+        expect(isLoopbackHost('[127.0.0.1')).toBe(false);
+        // The balanced forms still work.
+        expect(isLoopbackHost('[::1]')).toBe(true);
+        expect(isLoopbackHost('::1')).toBe(true);
+    })
+
+    test('a non-`::1` IPv6 loopback spelling declines rather than being normalised', () => {
+        // `0:0:0:0:0:0:0:1` IS loopback and Node accepts it, but an address normaliser inside a
+        // diagnostic is a second parser to keep correct. Declining is the quiet, safe outcome — the
+        // stated limit, not a surprise.
+        expect(net.isIP('0:0:0:0:0:0:0:1')).toBe(6);
+        expect(isLoopbackHost('0:0:0:0:0:0:0:1')).toBe(false);
+    })
 
     test('⭐ ADMISSION IS PARSED, not prefix-matched — malformed 127-ish hosts are rejected', () => {
         // `startsWith('127.')` admitted all of these. A diagnostic that accepts a non-address and then


### PR DESCRIPTION
Resolves #16025

## What this changes

`#16003`'s AC claimed a bind-family mismatch would be *"diagnosable from that line alone, without a separate `lsof`"*. The shipped tip prints the `lsof` invocation **for the operator to run** — a large improvement on the previous mystery, and still not what the AC claimed. Closing that gap needs a second *observation*, not better wording: dial both loopback families and report which one answered.

The tip now says the diagnosis instead of handing over a command that would find it:

```
💡 Tip: this server expects ChromaDB at 127.0.0.1:8000 (persist dir: …).
   Start it with: chroma run --path … --port 8000
   ⚠️  Bind-family mismatch OBSERVED: this server dials 127.0.0.1, which refused,
   but a listener answered at [::1]. ChromaDB is running — on the family
   this server is not dialing. Rebind it, or point this server at [::1].
```

Evidence: L2 (unit + mutation-verified controls, format-derived) → L3 required (the rendered tip on a live unhealthy boot). Residual: the live boot receipt [#16025], `[L3-deferred — operator handoff needed]`.

**Evidence detail:** the cost is measured, not hypothetical. A listener bound to `[::1]` refuses an IPv4 client with `ECONNREFUSED` — *the same error an absent service produces* — so a running store is indistinguishable from a dead one from the dialing side alone. That misdiagnosed Chroma as down twice in one session, once by a peer independently. On this host an IPv4 connect to an IPv6-only listener refuses in **~0.3ms** and a successful IPv6 connect answers in **~1.2ms**.

## AC1 was resolved before implementing — and it rejected all three shapes the ticket proposed

The ticket framed the fork as *"how do we make the logger probe?"* and offered three rows. Running the resolution found the question was wrong: the decided question is **which layer owns observation.**

`ai/mcp/server/BaseServer.mjs:644-656` already awaits `healthService.healthcheck()` and *then* calls `logStartupStatus(health)`. The async work happens one layer up; `logStartupStatus` is a **synchronous presentation hook**.

| ticket's row | verdict |
|---|---|
| make `logStartupStatus` async | **REJECT — I mispriced it.** Not "a signature change": a `BaseServer` extension point **overridden by six servers**. Mutating a shared hook contract for one server's diagnostic is disproportionate, and every existing override silently becomes sync-in-async-context. |
| synchronous connect attempt | **REJECT — not available.** Node has no synchronous TCP connect. The row was plausible-sounding, not real. |
| probe before the logger, pass it in | **REJECT — wrong layer.** The caller is `BaseServer`'s *shared* boot path, so "the call site owns the probe" means pushing a Chroma-specific probe into the base class every server inherits. |

**Resolution: the probe goes in `HealthService.healthcheck()` and its result lands on the `health` object.** No hook-contract change, no blocking syscall, no fire-and-forget ordering problem, and observation happens where observation already happens.

## Deltas

- **`ai/services/memory-core/helpers/loopbackFamilyProbe.mjs`** (new) — Neo-free probe + **pure** classifier, deliberately split. Probing needs an injected seam; classifying needs nothing, so every verdict is exhaustively testable — including the IPv6-answered/IPv4-refused asymmetry **a single host cannot be made to reproduce on demand.**
- **Claims are fail-closed.** A timeout is `UNKNOWN`, never *"nothing is listening"*: on loopback a refusal returns in well under a millisecond, so a timeout means the probe learned nothing. An unknown family therefore **suppresses** the mismatch verdict rather than contributing to it. Reporting a mismatch off a timeout would be the exact unverified assertion this helper exists to retire.
- **Probing is gated to the already-failed branch** (`#performHealthCheck`, `if (!connectionCheck.running)`). `healthcheck()` also serves the MCP `healthcheck` tool on *every* call, so an ungated probe would dial two sockets per invocation to answer a question only a failure asks. This gate was promoted to an AC during AC1's resolution rather than left as an implementation detail to discover later.
- **The `lsof` fallback is dropped ONLY when the verdict is conclusive.** An `inconclusive` or `skipped` probe replaces nothing, so the command stays — the ticket's AC is conditional in both directions and is implemented that way.
- **Non-loopback hosts are declined without dialing.** This is the mechanical reason the containerised deployment is untouched: a compose service name (`chroma`) gets no loopback claim at all, so the probe never runs there.
- **`LOOPBACK_PROBE_HEALTH_KEY` is shared** by producer (`HealthService`) and consumer (`Server`). A rename on one side would fail **silently** — the diagnostic would stop printing while both unit specs stayed green, since neither exercises the other's file. One import makes the divergence impossible instead of merely detectable.
- **Timeout is an explicit `250ms` literal with its derivation in the code**, not a config read — the bound is a property of the measurement (~200x the observed answer time), not an operator preference.

## Test Evidence

**194 passed** across the full affected suite set, derived from the changed files rather than pinned by hand (`grep -rl` over `test/` for each changed basename):

| suite | result |
|---|---|
| `loopbackFamilyProbe.spec.mjs` (new, 20 tests) | ✅ pass |
| `memory-core/Server.spec.mjs` (+9 tests) | ✅ pass |
| `mcp/server/BaseServer.spec.mjs` | ✅ pass |
| `memory-core/HealthService.spec.mjs` (66) | ✅ pass |
| `MemoryCoreRecorderService.spec.mjs`, `rem-observability.spec.mjs` | ✅ pass |

**The green was mutation-tested, because a passing spec proves nothing until it can fail.** Replacing the fail-closed guard (`if (unknown.length > 0)` → `if (false)`) **killed 4 tests**; restoring it was verified byte-for-byte against a pre-mutation copy — `git diff` cannot verify a restore on an untracked file, so that check would have been vacuous.

Mechanical gates: `check-aiconfig-antipatterns` (630 files, 0 new violations), `check-block-alignment`, `check-whitespace`, `check-ticket-archaeology`, plus the full `lint-staged` pre-commit battery.

**ADR-0019 compliance:** the config read is `aiConfig.engines.chroma` **at the use site** — literally ADR-0019 §5's own example. Resolved primitives are passed into a **pure / no-Neo-import** helper, which §5 line 104 names as the sanctioned exception; B5 targets passing config into *other consumers' configs*, and this helper has no config and cannot import `AiConfig` by design. Same shape as the already-merged `formatHostEndpoint` call site.

## Post-Merge Validation

- On the next memory-core boot against a **healthy** Chroma, confirm no probe runs: the diagnostic must be absent from a successful start, and `healthcheck` tool latency must be unchanged (the gate is the whole reason it is safe to live in `healthcheck()`).
- Reproduce the real asymmetry once out-of-band: start Chroma with `--host ::1`, point the server at `127.0.0.1`, and confirm the boot log names `[::1]` and prints **no** `lsof` line.
- Confirm the containerised deployment is untouched: `ai/deploy/docker-compose.yml` resolves `chroma` by service name, so `isLoopbackHost` declines and the tip keeps its pre-existing wording. Container healthcheck unchanged.

## Scope deliberately NOT in this PR

The ticket's `--host` election (`package.json:81`) is **operator authority** — binding beyond loopback changes what the host exposes on its network, which is not a reversible implementation detail. #16025 was **narrowed** to the probe before this PR opened, and the narrowing records why: I authored #16025 bundling a code deliverable with an operator decision, which is the same defect I split #16003 for. Delivery-authority, not subsystem, is the axis that separates tickets. The exposure matrix goes to @tobiu directly; it gets a ticket only if a change is elected.

Authored by Vega (@neo-opus-vega, Claude Opus 5, Claude Code). Session f1bcb0a9-68f5-4910-bef6-1a5a33aad1f5.

