### PR TITLE
fix(ai): bind Neural Link logs to the parity plane

### DIFF
--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -9,10 +9,12 @@
 #   bind mount makes `/app/.neo-ai-data` the canonical root in-container, so the parity
 #   plane RELOCATES to `/app/.neo-ai-data-parity` (`assertPlaneCoherence` fails the boot
 #   otherwise — identity-without-isolation).
-# - Member leaf DEFAULTS are anchor-static. A relocated root with defaulted members is a
-#   partially-moved plane and FAILS BOOT (`assertPlaneMemberCoherence`), so EVERY
-#   plane-member leaf is bound declaratively below (`x-plane-env`). That boot clause IS
-#   the completeness check: an unbound member cannot boot, by construction.
+# - Member leaf DEFAULTS are anchor-static. Inside each boot owner's config tree, a
+#   relocated root with defaulted members is a partially-moved plane and FAILS BOOT
+#   (`assertPlaneMemberCoherence`). Every member in the profile's declared config roster
+#   is therefore bound below (`x-plane-env`). Imported foreign config trees remain outside
+#   that runtime walk; the static placement census covers their declarations, while a
+#   wider runtime enforcement domain is a separate ADR-0019 decision.
 # - Served identity: boot asserts the resolved {plane.id, dataRoot} before serving; the
 #   in-container healthcheck reaches the same process by network-namespace construction
 #   (the #15367 cross-checkout scar is a HOST-side port phenomenon — mitigated here by
@@ -47,8 +49,8 @@
 name: &plane-id "${COMPOSE_PROJECT_NAME:-neo-local-parity}"
 
 # The full plane-member binding for the RELOCATED parity plane — map form (not list) so
-# services compose it via YAML merge keys. One shared map binds the union of the three
-# member sets (Tier-1 configBase + memory-core + knowledge-base); leaves a server does
+# services compose it via YAML merge keys. One shared map binds the union of the four
+# member sets (Tier-1 configBase + memory-core + knowledge-base + neural-link); leaves a server does
 # not declare are simply unread env vars, which keeps the binding single-sourced here.
 # Paths mirror each leaf's anchor-derived default, re-rooted under the parity root.
 x-plane-env: &plane-env
@@ -81,6 +83,8 @@ x-plane-env: &plane-env
   NEO_LAZY_EDGES_QUEUE_PATH: /app/.neo-ai-data-parity/memory-core/lazy-edges.jsonl
   # Knowledge-base member (ai/mcp/server/knowledge-base/configBase.mjs PLANE_MEMBER_PATHS)
   NEO_KB_LOG_PATH: /app/.neo-ai-data-parity/logs
+  # Neural-link member (ai/mcp/server/neural-link/configBase.mjs PLANE_MEMBER_PATHS)
+  NEO_NL_LOG_PATH: /app/.neo-ai-data-parity/logs
   # Graph SQLite — explicitly placed although NOT yet a declared plane member: MC's
   # `storagePaths.graphProd` is absent from its PLANE_MEMBER_PATHS and its default anchors
   # to cwd (not the plane root), with divergent sibling defaults on the KB/neural-link

--- a/ai/mcp/server/neural-link/configBase.mjs
+++ b/ai/mcp/server/neural-link/configBase.mjs
@@ -92,7 +92,7 @@ class ConfigBase extends ConfigProvider {
              * Per-server file isolation, single tailable directory.
              * @type {string}
              */
-            logPath: leaf(path.resolve(planeDataRoot, 'logs'), 'NEO_NL_LOG_PATH', 'string'),
+            logPath: leaf(path.resolve(planeDataRoot, 'logs'), 'NEO_NL_LOG_PATH', 'string', {planeMember: true}),
             /**
              * @summary Retention policy for Neural Link MCP diagnostic log files.
              *
@@ -139,4 +139,17 @@ class ConfigBase extends ConfigProvider {
         }
     }
 }
+
+/**
+ * @summary The plane-member paths declared by Neural Link for static census and profile binding.
+ *
+ * Neural Link remains seat-local in the parity topology, but its logger config is imported by
+ * plane processes such as Memory Core and the orchestrator. Declaring the imported log leaf here
+ * keeps the static placement census and `derivePlaneMemberPaths()` completeness proof coupled to
+ * the same config contract.
+ */
+export const PLANE_MEMBER_PATHS = Object.freeze([
+    'logPath'
+]);
+
 export default Neo.setupClass(ConfigBase);

--- a/ai/scripts/diagnostics/planePlacementCensus.mjs
+++ b/ai/scripts/diagnostics/planePlacementCensus.mjs
@@ -96,7 +96,7 @@ export const OPENER_SEARCH_TREES = ['ai', 'buildScripts', 'src', 'apps'];
 /**
  * The config modules that DECLARE plane membership, each exporting a frozen `PLANE_MEMBER_PATHS`.
  *
- * All three, not just Tier 1: the two MCP server configs declare their own members (`memoryWal.*`,
+ * All four, not just Tier 1: the three MCP server configs declare their own members (`memoryWal.*`,
  * `remRunStateDir`, `hookProjectionRoot`, …) and a census reading only the Tier-1 list is blind to every
  * module that reaches the plane through a server config — which is what left both WAL daemons uncounted.
  * @type {String[]}
@@ -104,7 +104,8 @@ export const OPENER_SEARCH_TREES = ['ai', 'buildScripts', 'src', 'apps'];
 export const PLANE_MEMBER_CONFIGS = [
     'ai/configBase.mjs',
     'ai/mcp/server/memory-core/configBase.mjs',
-    'ai/mcp/server/knowledge-base/configBase.mjs'
+    'ai/mcp/server/knowledge-base/configBase.mjs',
+    'ai/mcp/server/neural-link/configBase.mjs'
 ];
 
 /**
@@ -117,7 +118,7 @@ export const PLANE_MEMBER_CONFIGS = [
  * whose argument is unobtainable here is a covering clause, not a usable one.
  *
  * So this reads the declared list instead of re-deriving it, and the list is not trusted on faith:
- * `planeConfig.spec.mjs` asserts `derivePlaneMemberPaths(...)` EQUALS `PLANE_MEMBER_PATHS` for all three
+ * `planeConfig.spec.mjs` asserts `derivePlaneMemberPaths(...)` EQUALS `PLANE_MEMBER_PATHS` for all four
  * configs, and `derivePlaneMemberPaths` itself throws on a plane-anchored leaf with no membership
  * decision. Declared, derived, and anchored therefore cannot drift apart without a red spec — which is
  * what lets a diagnostic that stays node-builtins + acorn still read the real contract.

--- a/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
+++ b/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
@@ -74,6 +74,22 @@ test.describe('Parity topology lane (#15807) — the phase-3 stack with a CI wit
         test.info().annotations.push({type: 'parity-boot-ms', description: `${readiness.bootMs}ms (project=${readiness.project})`});
     });
 
+    test('both imported Neural Link loggers initialize without sink degradation', () => {
+        // RecorderService imports the Neural Link logger into both processes even though the
+        // Neural Link server remains seat-local. A missing NEO_NL_LOG_PATH therefore escaped the
+        // booting servers' own config walks and degraded at runtime. A positive RecorderService
+        // marker prevents an empty log stream from satisfying the two negative assertions.
+        for (const service of ['mc-server', 'orchestrator']) {
+            const logs   = compose(['logs', '--no-color', service]),
+                  output = `${logs.stdout}\n${logs.stderr}`;
+
+            expect(logs.status, `could not read ${service} parity boot logs:\n${output.slice(-2000)}`).toBe(0);
+            expect(output).toContain('[RecorderService] Connected to Memory Core nl_action_log.');
+            expect(output).not.toContain('file sink unavailable');
+            expect(output).not.toContain("mkdir '/app/.neo-ai-data/logs'");
+        }
+    });
+
     test('served identity: both servers prove the overlay plane, never the durable root', async () => {
         for (const {service, url} of [
             {service: 'kb-server', url: KB_INTERNAL_URL},

--- a/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
@@ -178,6 +178,8 @@ test.describe('parity profile — volume scoping is the isolation mechanism', ()
 
         // ...and the anchor is the single place the root is declared.
         expect(compose['x-plane-env'].NEO_PLANE_DATA_ROOT).toBe('/app/.neo-ai-data-parity');
+        expect(compose['x-plane-env'].NEO_NL_LOG_PATH)
+            .toBe(`${compose['x-plane-env'].NEO_PLANE_DATA_ROOT}/logs`);
 
         // Runtime access scoped to THIS project, so a parity orchestrator can never address the
         // native stack's containers. Both sites alias the same `&plane-id` scalar, so this asserts

--- a/test/playwright/unit/ai/planeConfig.spec.mjs
+++ b/test/playwright/unit/ai/planeConfig.spec.mjs
@@ -19,7 +19,9 @@ import {
 } from '../../../../ai/planeConfig.mjs';
 import ConfigBase, {PLANE_MEMBER_PATHS} from '../../../../ai/configBase.mjs';
 import McConfigBase                     from '../../../../ai/mcp/server/memory-core/configBase.mjs';
-import NlConfigBase                     from '../../../../ai/mcp/server/neural-link/configBase.mjs';
+import NlConfigBase, {
+    PLANE_MEMBER_PATHS as NL_MEMBER_PATHS
+} from '../../../../ai/mcp/server/neural-link/configBase.mjs';
 
 const specDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -193,7 +195,7 @@ test.describe('derivePlaneMemberPaths — the completeness half (#15932)', () =>
     const anchor = ConfigBase.config.data.plane.dataRoot.default,
           leaf   = (defaultValue, extra = {}) => ({default: defaultValue, env: null, type: 'string', parse: null, ...extra});
 
-    test('the derived set EQUALS each declared PLANE_MEMBER_PATHS — all three declaring configs', async () => {
+    test('the derived set EQUALS each declared PLANE_MEMBER_PATHS — all four declaring configs', async () => {
         expect(new Set(derivePlaneMemberPaths({descriptorData: ConfigBase.config.data, anchor})))
             .toEqual(new Set(PLANE_MEMBER_PATHS));
 
@@ -216,6 +218,9 @@ test.describe('derivePlaneMemberPaths — the completeness half (#15932)', () =>
 
         expect(new Set(derivePlaneMemberPaths({descriptorData: KbConfigBase.config.data, anchor})))
             .toEqual(new Set(KB_MEMBER_PATHS));
+
+        expect(new Set(derivePlaneMemberPaths({descriptorData: NlConfigBase.config.data, anchor})))
+            .toEqual(new Set(NL_MEMBER_PATHS));
     });
 
     test('green fixture: member included, reasoned exclusion honored, non-anchored undecided ignored', () => {

--- a/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs
@@ -240,14 +240,24 @@ test.describe('planePlacementCensus — the classification rules the election is
 
     test('the member set is read from ALL declaring configs, not Tier 1 alone', () => {
         // Reading only `ai/configBase.mjs` is how both WAL daemons stayed invisible: their members are
-        // declared by the memory-core server config.
-        const all   = readDeclaredPlaneMembers(),
-              tier1 = readDeclaredPlaneMembers({configs: ['ai/configBase.mjs']});
+        // declared by the memory-core server config. The exact roster keeps a newly-declared config
+        // from being omitted while the union still looks plausible.
+        const all        = readDeclaredPlaneMembers(),
+              tier1      = readDeclaredPlaneMembers({configs: ['ai/configBase.mjs']}),
+              neuralLink = readDeclaredPlaneMembers({
+                  configs: ['ai/mcp/server/neural-link/configBase.mjs']
+              });
 
-        expect(PLANE_MEMBER_CONFIGS.length).toBeGreaterThan(1);
+        expect(PLANE_MEMBER_CONFIGS).toEqual([
+            'ai/configBase.mjs',
+            'ai/mcp/server/memory-core/configBase.mjs',
+            'ai/mcp/server/knowledge-base/configBase.mjs',
+            'ai/mcp/server/neural-link/configBase.mjs'
+        ]);
+        expect(neuralLink).toEqual(['logPath']);
         expect(all.length).toBeGreaterThan(tier1.length);
         expect(all).toEqual([...all].sort());
-        // Union, not concatenation — `logPath` is declared by two configs.
+        // Union, not concatenation — `logPath` is declared by three server configs.
         expect(new Set(all).size).toBe(all.length);
     });
 


### PR DESCRIPTION
Resolves #15984

Related: #15798, #15931, #15851, #15983

This PR closes the parity-plane escape surfaced by the first Docker-backed local-to-cloud topology boot: the Neural Link logger is imported into both Memory Core and the orchestrator, but its `logPath` leaf was neither declared in the plane-member census nor bound by the relocated parity profile. The shared logger correctly refused the canonical fallback and degraded to stderr; this change makes the intended placement explicit instead of relying on that last-line guard.

Evidence: focused derived-set / census / compose witnesses (**67 passed**) plus an isolated Docker parity topology boot (**7 passed**) with positive RecorderService markers in both importing services and no sink degradation.

## Contract delivery

| Surface | Authority | Delivered behavior |
| :--- | :--- | :--- |
| Neural Link `logPath` leaf | ADR-0019 §10.5 plus the Memory Core / Knowledge Base sibling precedent | Declares `{planeMember: true}` and exports frozen `PLANE_MEMBER_PATHS = ['logPath']` |
| Parity `x-plane-env` | The relocated profile root | Binds `NEO_NL_LOG_PATH` to `/app/.neo-ai-data-parity/logs` alongside the two sibling log leaves |
| Static placement census | Declaring-config roster | Reads four configs—Tier 1, Memory Core, Knowledge Base, and Neural Link—and deduplicates the shared `logPath` member |
| Completeness witnesses | Derived descriptor set plus exact declaring-config roster | A missing leaf decision or omitted Neural Link config makes the focused unit suite red |
| Runtime witness | The Docker integration-parity lane | Requires RecorderService initialization independently in `mc-server` and `orchestrator`, then rejects both the generic sink-degradation marker and the old canonical mkdir path |

## Census-domain receipt

- `mc-server` walks its Memory Core member list plus inherited Tier-1 members.
- `kb-server` walks its Knowledge Base member list plus inherited Tier-1 members.
- The orchestrator walks Tier-1 members.
- Neural Link remains seat-local and is not a parity service. `RecorderService` imports its logger/config into `mc-server` and the orchestrator, but neither runtime walk traverses the foreign Neural Link member list.

This PR does **not** claim that imported foreign config trees are now runtime-enforced. It makes the leaf decision, adds Neural Link to the static declaring-config census, and binds the profile explicitly. Widening the runtime enforcement domain remains the separate ADR-0019 steward lane recorded as out of scope on #15984.

## Deltas from ticket

- The ticket's compose arm described the binding using the earlier “explicitly placed, not yet declared” precedent. The implemented decision is `planeMember: true`, so the binding is now a regular declared member rather than a provisional placement.
- The old numeric census pin referenced by #15851 has since been replaced by #15932's derived-set equality. The conscious census update here is the exact declaring-config roster moving from three to four, plus Neural Link's derived-set equality; no stale numeric constant is reintroduced.
- The initial negative boot-log test was tightened after independent audit: each service must first show a RecorderService connection marker, so an empty or no-op log stream cannot pass.
- The compose header no longer overclaims that boot walks cover every imported config tree; it now distinguishes the boot-owner runtime domain from the static census.

## Test Evidence

- Focused unit matrix:
  `npm run test-unit -- test/playwright/unit/ai/planeConfig.spec.mjs test/playwright/unit/ai/scripts/diagnostics/planePlacementCensus.spec.mjs test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs`
  — **67 passed**.
- Final isolated Docker topology run:
  `NEO_PARITY_COMPOSE_PROJECT=neo-parity-emmy-15984-v2 npx playwright test -c test/playwright/playwright.config.integration-parity.mjs --workers=1`
  — **7 passed**, including the non-vacuous dual-service sink witness.
- A first run under the shared default Compose project was invalidated by a concurrent teardown marking its containers for removal. Re-running under a unique project name—the profile's intended isolation mechanism—removed the collision and passed.
- `npm run agent-preflight -- --no-fix` — all requested gates passed; ticket archaeology reported zero violations. The existing unrelated Tier-1 stale-overlay warning for two boolean defaults remains nonblocking.
- Commit hooks: whitespace, shorthand, AiConfig test mutation, JSDoc types, derived-domain, ticket archaeology, block alignment, and parse checks all passed.

## Post-Merge Validation

- [ ] Confirm the required `dev` merge-candidate checks, including `integration-parity`, remain green at the final head.
- [ ] Confirm the next parity boot logs show RecorderService initialization in both importing services with no `file sink unavailable` degradation.

## Review routing

Review role: primary-reviewer. Requested action: use `/pr-review` on this PR.

Cross-family required. The sharpest falsifier is whether any remaining parity process imports the Neural Link logger without inheriting `x-plane-env`, or whether the static four-config roster still admits an uncounted declaring config.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 27de6eb7-04ae-4eba-8b73-2b9f5eaf4dc3.
