### PR TITLE
fix(harness): the product witness pinned the unfinished cockpit as its pass condition (#16033)

### DIFF
--- a/harness/adapterWitness.mjs
+++ b/harness/adapterWitness.mjs
@@ -1,0 +1,138 @@
+/**
+ * @module harness/adapterWitness
+ * @summary The cockpit adapter-state contract and the shell's final-verdict arithmetic, extracted so
+ * both halves are unit-testable without booting Electron.
+ *
+ * ## Why this is its own module
+ *
+ * The verdict lived inside `main.mjs`, which exports nothing and only runs under Electron — so the
+ * shell's half of the witness had **no coverage at all**, while the preload observer had plenty. A
+ * review proved the gap by asking for the one mutation that matters: force `isAdapterRenderCoherent()`
+ * true and the suite must go red. It could not, because nothing imported it. An untested verdict is the
+ * worst place for a gap, since the verdict is what the release gate actually reads.
+ *
+ * ## Exactly one state, or `unknown`
+ *
+ * A head advertising two known states (`is-live is-sample`) is **ambiguous, not live**. First-match
+ * resolution silently preferred whichever state happened to be earlier in the list and reported a
+ * confident answer about a contradictory DOM. Ambiguity now yields `unknown`, which is not ready and
+ * not conclusive — the same fail-closed direction as an unrecognised state.
+ *
+ * ## The labels belong to the components that render them
+ *
+ * `FleetGrid` renders `adapterState === 'stale' ? … : adapterState === 'sample' ? … : ''`, and
+ * `ActivityStream` renders `{sample, stale}[state] ?? '● streaming'`. These maps mirror that, so the
+ * witness checks state-vs-label **agreement** rather than pinning one expected state — pinning made the
+ * smoke assert the product was unfinished, and it would have gone red the moment the cockpit worked.
+ */
+
+/**
+ * Adapter states a cockpit head can render, as `is-<state>` classes.
+ * @type {String[]}
+ */
+export const ADAPTER_STATES = Object.freeze(['live', 'sample', 'stale', 'degraded']);
+
+/**
+ * The label each roster state renders, mirrored from `FleetGrid`.
+ * @type {Object}
+ */
+export const ROSTER_STATE_LABELS = Object.freeze({
+    live: '', sample: 'static roster · offline', stale: 'stale — reconnecting', degraded: ''
+});
+
+/**
+ * The label each stream state renders, mirrored from `ActivityStream`.
+ * @type {Object}
+ */
+export const STREAM_STATE_LABELS = Object.freeze({
+    live: '● streaming', sample: 'sample · live feed pending', stale: 'stale — reconnecting', degraded: '● streaming'
+});
+
+/**
+ * Values the preload may report for an adapter state, including the two non-states.
+ *
+ * `unknown` is admitted through the payload allowlist on purpose so it reaches the coherence check and
+ * fails there with a named state, rather than being rejected as a malformed payload: an upstream state
+ * nobody mapped should read as "unverified", not as "the renderer sent garbage".
+ * @type {String[]}
+ */
+export const ADAPTER_STATE_NAMES = Object.freeze([...ADAPTER_STATES, 'unknown']);
+
+/**
+ * @summary Resolves the single state a class list advertises, or `unknown` when it is absent or ambiguous.
+ *
+ * Shared by the preload observer's logic and the shell's assertions so the two cannot drift on what
+ * counts as a state. Takes a predicate rather than a DOM node so it is callable from either world.
+ * @param {Function} hasClass `className => Boolean`
+ * @returns {String} one of {@link ADAPTER_STATES}, or `'unknown'`
+ */
+export function resolveAdapterState(hasClass) {
+    const matched = ADAPTER_STATES.filter(state => hasClass(`is-${state}`));
+
+    // EXACTLY one. Two known classes is a contradictory DOM, and first-match resolution would report a
+    // confident answer about it — preferring whichever state sat earlier in the list.
+    return matched.length === 1 ? matched[0] : 'unknown';
+}
+
+/**
+ * @summary True when a head renders a recognised state AND a label that agrees with it.
+ *
+ * Deliberately state-AGNOSTIC: pinning one expected label made the smoke assert the cockpit was still
+ * on sample data, so wiring it to the live fleet would have turned the witness red. Agreement keeps the
+ * guard real — a `live` head showing the sample label is still a defect — while letting any honest
+ * state pass.
+ *
+ * `unknown` fails closed, which now covers ambiguity as well as unmapped states.
+ * @param {String|null} state Observed `is-<state>`, `'unknown'`, or `null` when the head is absent.
+ * @param {String|null} label Observed label text.
+ * @param {Object} expectedLabels state → canonical label.
+ * @returns {Boolean}
+ */
+export function isAdapterRenderCoherent(state, label, expectedLabels) {
+    // Head absent ⇒ the cockpit did not render it; distinct from any rendered state, and not a pass.
+    if (!state || !Object.hasOwn(expectedLabels, state)) return false;
+
+    const expected = expectedLabels[state];
+
+    // An empty canonical label may render as an empty node or none at all; both are honest.
+    return expected === '' ? (label === '' || label === null) : label === expected;
+}
+
+/**
+ * @summary Computes the shell's final first-paint verdict from a sanitised preload report.
+ *
+ * Returns the unmet conjuncts alongside the booleans, because a bare `productWitnessPassed: false` on a
+ * completely healthy boot invited exactly the wrong conclusion — it is normally just `packagedMode`,
+ * since no npm script runs the packaged app.
+ * @param {Object}  spec
+ * @param {Object}  spec.firstPaint    Sanitised report: `{cockpitVisible, cardCount, rosterState, rosterLabel, streamState, activityLabel, firstPaintMs, timedOut, tourControlCount}`.
+ * @param {Boolean} spec.packagedMode
+ * @param {Boolean} spec.brainMode
+ * @param {Boolean} [spec.brainUp]
+ * @param {Number}  [spec.firstPaintBudgetMs=60000]
+ * @returns {Object} `{adaptersCoherent, firstPaintPassed, productWitnessPassed, productWitnessUnmet}`
+ */
+export function computeFirstPaintVerdict({firstPaint, packagedMode, brainMode, brainUp, firstPaintBudgetMs = 60000} = {}) {
+    const adaptersCoherent = isAdapterRenderCoherent(firstPaint.rosterState, firstPaint.rosterLabel, ROSTER_STATE_LABELS) &&
+              isAdapterRenderCoherent(firstPaint.streamState, firstPaint.activityLabel, STREAM_STATE_LABELS),
+          firstPaintPassed = firstPaint.cockpitVisible === true &&
+              firstPaint.cardCount > 0 &&
+              adaptersCoherent &&
+              firstPaint.firstPaintMs !== null &&
+              firstPaint.firstPaintMs <= firstPaintBudgetMs &&
+              firstPaint.timedOut === false,
+          productWitnessUnmet = [
+              !packagedMode                    && 'packagedMode (run the packaged app, not `npm run smoke`)',
+              !brainMode                       && 'brainMode (use `npm run smoke:brain`)',
+              brainMode && brainUp !== true    && 'brainUp',
+              !firstPaintPassed                && 'firstPaint',
+              !adaptersCoherent                && 'adapterRenderCoherent'
+          ].filter(Boolean);
+
+    return {
+        adaptersCoherent,
+        firstPaintPassed,
+        productWitnessPassed: Boolean(packagedMode && brainMode && brainUp === true && firstPaintPassed),
+        productWitnessUnmet
+    };
+}

--- a/harness/electron-builder.yml
+++ b/harness/electron-builder.yml
@@ -11,6 +11,7 @@ directories:
 
 files:
     - main.mjs
+    - adapterWitness.mjs
     - appLifecycle.mjs
     - brain.mjs
     - contentPolicy.mjs

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -63,6 +63,16 @@ const
     APP_URL      = `app://${APP_HOST}/apps/agentos/index.html`,
     smokeMode            = process.env.NEO_HARNESS_SMOKE === '1',
     lifecycleWitnessMode = process.env.NEO_HARNESS_LIFECYCLE_WITNESS === '1',
+    // The label each cockpit adapter state renders, mirrored from the components that own them:
+    // `FleetGrid` (`adapterState === 'stale' ? … : adapterState === 'sample' ? … : ''`) and
+    // `ActivityStream` (`{sample, stale}[state] ?? '● streaming'`). Held here so the witness can
+    // check state-vs-label AGREEMENT for every state instead of pinning one expected state.
+    ROSTER_STATE_LABELS = {live: '', sample: 'static roster · offline', stale: 'stale — reconnecting', degraded: ''},
+    STREAM_STATE_LABELS = {live: '● streaming', sample: 'sample · live feed pending', stale: 'stale — reconnecting', degraded: '● streaming'},
+    // `unknown` is admitted through the sanitizer on purpose so it reaches the coherence check and
+    // fails there with a named state, rather than being rejected as a malformed payload — an upstream
+    // state nobody mapped should read as "unverified", not as "the renderer sent garbage".
+    ADAPTER_STATE_NAMES = [...Object.keys(ROSTER_STATE_LABELS), 'unknown'],
     diagnosticMode       = smokeMode || lifecycleWitnessMode,
     // The Arm-B Brain leg: DEFAULT-ON when packaged (a Finder double-click supplies no env — the
     // product IS the supervised organism; NEO_HARNESS_BRAIN=0 is the explicit opt-out) and opt-in
@@ -111,6 +121,31 @@ function getSecureWebPreferences() {
         sandbox             : true,
         webSecurity         : true
     }
+}
+
+/**
+ * @summary True when a cockpit adapter head renders a recognised state AND a label that agrees with it.
+ *
+ * Deliberately state-AGNOSTIC. Pinning one expected label made the smoke assert the cockpit was still
+ * on sample data, so wiring it to the live fleet — the actual cornerstone goal — would have turned the
+ * witness red. Checking agreement instead keeps the guard real (a `live` head showing the sample label
+ * is still a genuine defect) while letting every honest state pass.
+ *
+ * `unknown` fails closed: an adapter state added upstream without teaching this map must surface as a
+ * failure rather than silently pass, since a state nobody mapped is a state nobody verified.
+ * @param {String|null} state Observed `is-<state>`, `'unknown'`, or `null` when the head is absent.
+ * @param {String|null} label Observed label text.
+ * @param {Object} expectedLabels state → canonical label.
+ * @returns {Boolean}
+ */
+function isAdapterRenderCoherent(state, label, expectedLabels) {
+    // Head absent ⇒ the cockpit did not render it; distinct from any rendered state, and not a pass.
+    if (!state || !Object.hasOwn(expectedLabels, state)) return false;
+
+    const expected = expectedLabels[state];
+
+    // An empty canonical label may render as an empty node or none at all; both are honest.
+    return expected === '' ? (label === '' || label === null) : label === expected;
 }
 
 /**
@@ -445,10 +480,16 @@ function sanitizeBootReport(report) {
  * @returns {Object|null}
  */
 function sanitizeFirstPaintReport(report) {
-    const boundedText = value => value === null || (typeof value === 'string' && value.length <= 100);
+    const
+        boundedText   = value => value === null || (typeof value === 'string' && value.length <= 100),
+        // `null` = head absent. Any other value must be one of the states the witness knows how to
+        // check, so an unmapped state cannot arrive as a plausible-looking string and pass silently.
+        adapterState  = value => value === null || (typeof value === 'string' && ADAPTER_STATE_NAMES.includes(value));
 
     if (
         !report ||
+        !adapterState(report.rosterState) ||
+        !adapterState(report.streamState) ||
         !boundedText(report.activityLabel) ||
         !Number.isInteger(report.cardCount) ||
         report.cardCount < 0 ||
@@ -469,6 +510,8 @@ function sanitizeFirstPaintReport(report) {
         firstPaintMs        : report.rendererFirstPaintMs === null ? null : Math.round(process.uptime() * 1000),
         rendererFirstPaintMs: report.rendererFirstPaintMs,
         rosterLabel         : report.rosterLabel,
+        rosterState         : report.rosterState,
+        streamState         : report.streamState,
         timedOut            : report.timedOut === true,
         tourControlCount    : report.tourControlCount
     }
@@ -1224,21 +1267,41 @@ app.whenReady().then(async () => {
             boot2.viewportId &&
             boot1.viewportId !== boot2.viewportId
         ),
+        // The cockpit must render a RECOGNISED adapter state whose label agrees with it — NOT one
+        // specific state. The predecessor gate required `rosterLabel === 'static roster · offline'`
+        // and `activityLabel === 'sample · live feed pending'`, so the smoke passed only while the
+        // cockpit was showing sample data and would have gone RED the moment the cockpit was wired
+        // to the live fleet — i.e. it asserted the product was unfinished, and a witness that fails
+        // on success cannot guard a release gate. `tourControlCount` is likewise reported rather than
+        // pinned to 0: the release gate WANTS deterministic tour modes, so asserting their absence
+        // would make delivering them a test failure.
+        adaptersCoherent = isAdapterRenderCoherent(firstPaint.rosterState, firstPaint.rosterLabel, ROSTER_STATE_LABELS) &&
+            isAdapterRenderCoherent(firstPaint.streamState, firstPaint.activityLabel, STREAM_STATE_LABELS),
         firstPaintPassed = firstPaint.cockpitVisible === true &&
             firstPaint.cardCount > 0 &&
-            firstPaint.rosterLabel === 'static roster · offline' &&
-            firstPaint.activityLabel === 'sample · live feed pending' &&
-            firstPaint.tourControlCount === 0 &&
+            adaptersCoherent &&
             firstPaint.firstPaintMs !== null &&
             firstPaint.firstPaintMs <= 60000 &&
             firstPaint.timedOut === false,
+        // Naming the unmet conjuncts, because a bare `productWitnessPassed: false` on an otherwise
+        // healthy boot reads as a product defect. It is normally just `packagedMode`: no npm script
+        // runs the packaged app, so this stays false from `npm run smoke` by construction.
+        productWitnessUnmet = [
+            !packagedMode      && 'packagedMode (run the packaged app, not `npm run smoke`)',
+            !brain.mode        && 'brainMode (use `npm run smoke:brain`)',
+            brain.mode && brain.up !== true && 'brainUp',
+            !firstPaintPassed  && 'firstPaint',
+            !adaptersCoherent  && 'adapterRenderCoherent'
+        ].filter(Boolean),
         firstPaintReceipt = {
             ...firstPaint,
+            adaptersCoherent,
             brainMode,
             brainUp             : brain.mode ? brain.up === true : null,
             packagedMode,
             passed              : firstPaintPassed,
-            productWitnessPassed: packagedMode && brain.mode && brain.up === true && firstPaintPassed
+            productWitnessPassed: packagedMode && brain.mode && brain.up === true && firstPaintPassed,
+            productWitnessUnmet
         },
         results = {
             assetFailures,

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -19,8 +19,12 @@ import {app, BrowserWindow, clipboard, ipcMain, Menu, nativeImage, protocol, ses
 import {createReadStream}                                                                   from 'node:fs';
 import {fileURLToPath}                                                                      from 'node:url';
 import path                                                                                 from 'node:path';
-import {createAppLifecycle}                                                                 from './appLifecycle.mjs';
-import {createFleetCapability}                                                              from './fleetCapability.mjs';
+import {
+    ADAPTER_STATE_NAMES,
+    computeFirstPaintVerdict
+} from './adapterWitness.mjs';
+import {createAppLifecycle}    from './appLifecycle.mjs';
+import {createFleetCapability} from './fleetCapability.mjs';
 import {
     APP_HOST,
     CONTENT_SECURITY_POLICY,
@@ -63,16 +67,6 @@ const
     APP_URL      = `app://${APP_HOST}/apps/agentos/index.html`,
     smokeMode            = process.env.NEO_HARNESS_SMOKE === '1',
     lifecycleWitnessMode = process.env.NEO_HARNESS_LIFECYCLE_WITNESS === '1',
-    // The label each cockpit adapter state renders, mirrored from the components that own them:
-    // `FleetGrid` (`adapterState === 'stale' ? … : adapterState === 'sample' ? … : ''`) and
-    // `ActivityStream` (`{sample, stale}[state] ?? '● streaming'`). Held here so the witness can
-    // check state-vs-label AGREEMENT for every state instead of pinning one expected state.
-    ROSTER_STATE_LABELS = {live: '', sample: 'static roster · offline', stale: 'stale — reconnecting', degraded: ''},
-    STREAM_STATE_LABELS = {live: '● streaming', sample: 'sample · live feed pending', stale: 'stale — reconnecting', degraded: '● streaming'},
-    // `unknown` is admitted through the sanitizer on purpose so it reaches the coherence check and
-    // fails there with a named state, rather than being rejected as a malformed payload — an upstream
-    // state nobody mapped should read as "unverified", not as "the renderer sent garbage".
-    ADAPTER_STATE_NAMES = [...Object.keys(ROSTER_STATE_LABELS), 'unknown'],
     diagnosticMode       = smokeMode || lifecycleWitnessMode,
     // The Arm-B Brain leg: DEFAULT-ON when packaged (a Finder double-click supplies no env — the
     // product IS the supervised organism; NEO_HARNESS_BRAIN=0 is the explicit opt-out) and opt-in
@@ -121,31 +115,6 @@ function getSecureWebPreferences() {
         sandbox             : true,
         webSecurity         : true
     }
-}
-
-/**
- * @summary True when a cockpit adapter head renders a recognised state AND a label that agrees with it.
- *
- * Deliberately state-AGNOSTIC. Pinning one expected label made the smoke assert the cockpit was still
- * on sample data, so wiring it to the live fleet — the actual cornerstone goal — would have turned the
- * witness red. Checking agreement instead keeps the guard real (a `live` head showing the sample label
- * is still a genuine defect) while letting every honest state pass.
- *
- * `unknown` fails closed: an adapter state added upstream without teaching this map must surface as a
- * failure rather than silently pass, since a state nobody mapped is a state nobody verified.
- * @param {String|null} state Observed `is-<state>`, `'unknown'`, or `null` when the head is absent.
- * @param {String|null} label Observed label text.
- * @param {Object} expectedLabels state → canonical label.
- * @returns {Boolean}
- */
-function isAdapterRenderCoherent(state, label, expectedLabels) {
-    // Head absent ⇒ the cockpit did not render it; distinct from any rendered state, and not a pass.
-    if (!state || !Object.hasOwn(expectedLabels, state)) return false;
-
-    const expected = expectedLabels[state];
-
-    // An empty canonical label may render as an empty node or none at all; both are honest.
-    return expected === '' ? (label === '' || label === null) : label === expected;
 }
 
 /**
@@ -1267,40 +1236,29 @@ app.whenReady().then(async () => {
             boot2.viewportId &&
             boot1.viewportId !== boot2.viewportId
         ),
-        // The cockpit must render a RECOGNISED adapter state whose label agrees with it — NOT one
-        // specific state. The predecessor gate required `rosterLabel === 'static roster · offline'`
-        // and `activityLabel === 'sample · live feed pending'`, so the smoke passed only while the
-        // cockpit was showing sample data and would have gone RED the moment the cockpit was wired
-        // to the live fleet — i.e. it asserted the product was unfinished, and a witness that fails
-        // on success cannot guard a release gate. `tourControlCount` is likewise reported rather than
-        // pinned to 0: the release gate WANTS deterministic tour modes, so asserting their absence
-        // would make delivering them a test failure.
-        adaptersCoherent = isAdapterRenderCoherent(firstPaint.rosterState, firstPaint.rosterLabel, ROSTER_STATE_LABELS) &&
-            isAdapterRenderCoherent(firstPaint.streamState, firstPaint.activityLabel, STREAM_STATE_LABELS),
-        firstPaintPassed = firstPaint.cockpitVisible === true &&
-            firstPaint.cardCount > 0 &&
-            adaptersCoherent &&
-            firstPaint.firstPaintMs !== null &&
-            firstPaint.firstPaintMs <= 60000 &&
-            firstPaint.timedOut === false,
-        // Naming the unmet conjuncts, because a bare `productWitnessPassed: false` on an otherwise
-        // healthy boot reads as a product defect. It is normally just `packagedMode`: no npm script
-        // runs the packaged app, so this stays false from `npm run smoke` by construction.
-        productWitnessUnmet = [
-            !packagedMode      && 'packagedMode (run the packaged app, not `npm run smoke`)',
-            !brain.mode        && 'brainMode (use `npm run smoke:brain`)',
-            brain.mode && brain.up !== true && 'brainUp',
-            !firstPaintPassed  && 'firstPaint',
-            !adaptersCoherent  && 'adapterRenderCoherent'
-        ].filter(Boolean),
+        // The verdict arithmetic lives in `adapterWitness.mjs` so it is unit-testable without Electron:
+        // it had NO coverage while it sat here, and the verdict is what the release gate reads.
+        //
+        // NOTE on `tourControlCount`: it is not a term in the verdict, but it DOES gate the final result
+        // transitively — the preload only reports `ready` when no tour controls are present, so a demo
+        // tour makes the report arrive via the timeout path and `timedOut === false` then fails. The
+        // product-first-paint policy is intended; describing it as "removed from the verdict" was true
+        // of the expression and false of the behaviour.
+        verdict = computeFirstPaintVerdict({
+            firstPaint,
+            packagedMode,
+            brainMode,
+            brainUp: brain.mode ? brain.up === true : null
+        }),
+        {adaptersCoherent, firstPaintPassed, productWitnessPassed, productWitnessUnmet} = verdict,
         firstPaintReceipt = {
             ...firstPaint,
             adaptersCoherent,
             brainMode,
-            brainUp             : brain.mode ? brain.up === true : null,
+            brainUp: brain.mode ? brain.up === true : null,
             packagedMode,
-            passed              : firstPaintPassed,
-            productWitnessPassed: packagedMode && brain.mode && brain.up === true && firstPaintPassed,
+            passed : firstPaintPassed,
+            productWitnessPassed,
             productWitnessUnmet
         },
         results = {

--- a/harness/preload.cjs
+++ b/harness/preload.cjs
@@ -55,6 +55,21 @@ function isElementVisible(element) {
 const ADAPTER_STATES = ['live', 'sample', 'stale', 'degraded'];
 
 /**
+ * @summary Resolves the single adapter state a class list advertises, or `unknown`.
+ *
+ * Mirrors `adapterWitness.resolveAdapterState`. The duplication is forced, not chosen: this file is
+ * CommonJS because Electron cannot load an ESM preload in a sandboxed renderer, so it cannot import the
+ * ESM module. A spec asserts the two state lists stay identical.
+ * @param {Object} classList
+ * @returns {String}
+ */
+function resolveAdapterStateFromClassList(classList) {
+    const matched = ADAPTER_STATES.filter(state => classList.contains(`is-${state}`));
+
+    return matched.length === 1 ? matched[0] : 'unknown';
+}
+
+/**
  * @summary Reports which adapter state a cockpit head is actually rendering, plus its label text.
  *
  * Scoped selectors were the defect this replaces: reading `.fm-fleet-head.is-sample .fm-fleet-stale`
@@ -73,9 +88,11 @@ function readAdapterHead(headSelector, labelSelector) {
     if (!head) return {state: null, label: null};
 
     return {
-        // An unrecognised class set reports `unknown` rather than silently falling back to a known
-        // state: a new adapter state added upstream must surface here as unhandled, not as `sample`.
-        state: ADAPTER_STATES.find(state => head.classList.contains(`is-${state}`)) ?? 'unknown',
+        // EXACTLY ONE known class, or `unknown`. First-match resolution reported a confident answer
+        // about a contradictory DOM: a head carrying `is-live is-sample` resolved to whichever state
+        // sat earlier in the list. Ambiguity and unrecognised-state now share the same fail-closed
+        // outcome — not ready, not conclusive.
+        state: resolveAdapterStateFromClassList(head.classList),
         label: head.querySelector(labelSelector)?.textContent?.trim() ?? null
     }
 }

--- a/harness/preload.cjs
+++ b/harness/preload.cjs
@@ -48,22 +48,57 @@ function isElementVisible(element) {
 }
 
 /**
+ * Adapter states a cockpit head can render, as `is-<state>` classes (`FleetGrid.mjs` renders
+ * `is-${adapterState}`; `FleetCockpit` seeds `sample` and promotes on a capability answer).
+ * @type {String[]}
+ */
+const ADAPTER_STATES = ['live', 'sample', 'stale', 'degraded'];
+
+/**
+ * @summary Reports which adapter state a cockpit head is actually rendering, plus its label text.
+ *
+ * Scoped selectors were the defect this replaces: reading `.fm-fleet-head.is-sample .fm-fleet-stale`
+ * can only ever observe the ONE state we do not want to ship. A promoted (live) cockpit made that
+ * selector match nothing and the field reported `null` — indistinguishable from a broken selector or
+ * an absent cockpit, so the witness could not report success at all, only failure. The state is now
+ * read from the element and returned as data, which makes `live` a positive observation and keeps
+ * absence distinct from every rendered state.
+ * @param {String} headSelector  The adapter head carrying the `is-<state>` class.
+ * @param {String} labelSelector The label inside that head.
+ * @returns {{state: String|null, label: String|null}} `state` is `null` only when the head is absent.
+ */
+function readAdapterHead(headSelector, labelSelector) {
+    const head = document.querySelector(headSelector);
+
+    if (!head) return {state: null, label: null};
+
+    return {
+        // An unrecognised class set reports `unknown` rather than silently falling back to a known
+        // state: a new adapter state added upstream must surface here as unhandled, not as `sample`.
+        state: ADAPTER_STATES.find(state => head.classList.contains(`is-${state}`)) ?? 'unknown',
+        label: head.querySelector(labelSelector)?.textContent?.trim() ?? null
+    }
+}
+
+/**
  * Reads the product-owned DOM markers needed by the packaged first-paint contract.
  * @summary Produces a bounded semantic snapshot without exposing page state or transport to the renderer.
  * @returns {Object}
  */
 function collectFirstPaintSnapshot() {
     const
-        activityLabel = document.querySelector('.fm-fleet-cockpit .fm-stream-head.is-sample .fm-stream-state')?.textContent?.trim() ?? null,
-        cards         = [...document.querySelectorAll('.fm-fleet-cockpit .fm-agent-card')],
-        cockpit       = document.querySelector('.fm-fleet-cockpit'),
-        rosterLabel   = document.querySelector('.fm-fleet-cockpit .fm-fleet-head.is-sample .fm-fleet-stale')?.textContent?.trim() ?? null;
+        cards      = [...document.querySelectorAll('.fm-fleet-cockpit .fm-agent-card')],
+        cockpit    = document.querySelector('.fm-fleet-cockpit'),
+        rosterHead = readAdapterHead('.fm-fleet-cockpit .fm-fleet-head', '.fm-fleet-stale'),
+        streamHead = readAdapterHead('.fm-fleet-cockpit .fm-stream-head', '.fm-stream-state');
 
     return {
-        activityLabel,
+        activityLabel   : streamHead.label,
         cardCount       : cards.filter(isElementVisible).length,
         cockpitVisible  : Boolean(cockpit && isElementVisible(cockpit)),
-        rosterLabel,
+        rosterLabel     : rosterHead.label,
+        rosterState     : rosterHead.state,
+        streamState     : streamHead.state,
         tourControlCount: document.querySelectorAll(TOUR_CONTROL_SELECTOR).length
     }
 }
@@ -98,10 +133,16 @@ const firstPaintTimer = setInterval(function reportFirstPaint() {
     const
         elapsed  = Date.now() - t0,
         snapshot = collectFirstPaintSnapshot(),
+        // Ready = the cockpit rendered RECOGNISED adapter heads, in ANY honest state. Pinning the
+        // sample labels here meant a cockpit wired to the live fleet could never become ready: it
+        // would wait out the full timeout and report `timedOut: true`, so the product receipt was
+        // reachable only while the product was unfinished. Label-vs-state AGREEMENT is judged by the
+        // shell, which owns the verdict — the preload only observes. `tourControlCount === 0` stays:
+        // the receipt is for the product first paint, not a demo tour.
         ready    = snapshot.cockpitVisible &&
             snapshot.cardCount > 0 &&
-            snapshot.rosterLabel === 'static roster · offline' &&
-            snapshot.activityLabel === 'sample · live feed pending' &&
+            snapshot.rosterState !== null && snapshot.rosterState !== 'unknown' &&
+            snapshot.streamState !== null && snapshot.streamState !== 'unknown' &&
             snapshot.tourControlCount === 0,
         timedOut = elapsed > FIRST_PAINT_TIMEOUT_MS;
 

--- a/test/playwright/unit/harness/adapterWitness.spec.mjs
+++ b/test/playwright/unit/harness/adapterWitness.spec.mjs
@@ -1,0 +1,205 @@
+import {expect, test} from '@playwright/test';
+import {readFile}     from 'node:fs/promises';
+import {
+    ADAPTER_STATES,
+    ADAPTER_STATE_NAMES,
+    ROSTER_STATE_LABELS,
+    STREAM_STATE_LABELS,
+    computeFirstPaintVerdict,
+    isAdapterRenderCoherent,
+    resolveAdapterState
+} from '../../../../harness/adapterWitness.mjs';
+
+// The shell's FINAL VERDICT, which had no coverage at all while it lived inline in `main.mjs` — a file
+// that exports nothing and only runs under Electron. The preload observer was well covered; the half
+// the release gate actually reads was not. That asymmetry is the reason this module exists.
+//
+// Every invariant below is paired with a control that violates it, and the coherence check itself is
+// mutation-discriminated: forcing it true must turn a case red.
+
+const classList = names => ({contains: name => names.includes(name)});
+
+/** A healthy sanitised report; overrides shape the case under test. */
+const report = (overrides = {}) => ({
+    cockpitVisible  : true,
+    cardCount       : 10,
+    rosterState     : 'sample',
+    rosterLabel     : 'static roster · offline',
+    streamState     : 'sample',
+    activityLabel   : 'sample · live feed pending',
+    firstPaintMs    : 800,
+    timedOut        : false,
+    tourControlCount: 0,
+    ...overrides
+});
+
+const verdict = (overrides = {}, env = {}) => computeFirstPaintVerdict({
+    firstPaint  : report(overrides),
+    packagedMode: true,
+    brainMode   : true,
+    brainUp     : true,
+    ...env
+});
+
+test.describe('resolveAdapterState — exactly one known class, or unknown', () => {
+    test('resolves each known state', () => {
+        for (const state of ADAPTER_STATES) {
+            expect(resolveAdapterState(name => name === `is-${state}`)).toBe(state);
+        }
+    })
+
+    test('⭐ AMBIGUOUS: two known classes report `unknown`, never the first one listed', () => {
+        // First-match resolution gave a confident answer about a contradictory DOM, preferring whichever
+        // state sat earlier in the list — so `is-live is-sample` reported `live`.
+        expect(resolveAdapterState(classList(['is-live', 'is-sample']).contains)).toBe('unknown');
+        expect(resolveAdapterState(classList(['is-sample', 'is-stale']).contains)).toBe('unknown');
+        expect(resolveAdapterState(classList(ADAPTER_STATES.map(s => `is-${s}`)).contains)).toBe('unknown');
+    })
+
+    test('no known class reports `unknown`', () => {
+        expect(resolveAdapterState(() => false)).toBe('unknown');
+        expect(resolveAdapterState(name => name === 'is-reconciling')).toBe('unknown');
+    })
+});
+
+test.describe('isAdapterRenderCoherent — agreement, not a pinned state', () => {
+    test('every state passes with its own label', () => {
+        for (const [state, label] of Object.entries(ROSTER_STATE_LABELS)) {
+            expect(isAdapterRenderCoherent(state, label, ROSTER_STATE_LABELS)).toBe(true);
+        }
+        for (const [state, label] of Object.entries(STREAM_STATE_LABELS)) {
+            expect(isAdapterRenderCoherent(state, label, STREAM_STATE_LABELS)).toBe(true);
+        }
+    })
+
+    test('⭐ a MISMATCHED label fails — the guard is still real', () => {
+        // The point of agreement-over-pinning: a `live` head rendering the sample label is a defect.
+        expect(isAdapterRenderCoherent('live', 'static roster · offline', ROSTER_STATE_LABELS)).toBe(false);
+        expect(isAdapterRenderCoherent('sample', '', ROSTER_STATE_LABELS)).toBe(false);
+        expect(isAdapterRenderCoherent('live', 'sample · live feed pending', STREAM_STATE_LABELS)).toBe(false);
+    })
+
+    test('an empty canonical label accepts an empty node or none at all', () => {
+        expect(isAdapterRenderCoherent('live', '', ROSTER_STATE_LABELS)).toBe(true);
+        expect(isAdapterRenderCoherent('live', null, ROSTER_STATE_LABELS)).toBe(true);
+    })
+
+    test('absent and unknown both fail closed', () => {
+        expect(isAdapterRenderCoherent(null, null, ROSTER_STATE_LABELS)).toBe(false);
+        expect(isAdapterRenderCoherent('unknown', 'anything', ROSTER_STATE_LABELS)).toBe(false);
+    })
+});
+
+test.describe('computeFirstPaintVerdict — the final verdict, mutation-discriminated', () => {
+    test('a matching SAMPLE cockpit passes the whole verdict', () => {
+        const result = verdict();
+
+        expect(result.adaptersCoherent).toBe(true);
+        expect(result.firstPaintPassed).toBe(true);
+        expect(result.productWitnessPassed).toBe(true);
+        expect(result.productWitnessUnmet).toEqual([]);
+    })
+
+    test('⭐ a matching LIVE cockpit passes too — the witness can observe success', () => {
+        // The defect this replaces: the gate required the sample labels, so wiring the cockpit to the
+        // live fleet would have turned the smoke red.
+        const result = verdict({
+            rosterState: 'live', rosterLabel: '',
+            streamState: 'live', activityLabel: '● streaming'
+        });
+
+        expect(result.adaptersCoherent).toBe(true);
+        expect(result.productWitnessPassed).toBe(true);
+    })
+
+    test('⭐ a MISMATCHED label fails the verdict and names the conjunct', () => {
+        const result = verdict({rosterState: 'live', rosterLabel: 'static roster · offline'});
+
+        expect(result.adaptersCoherent).toBe(false);
+        expect(result.firstPaintPassed).toBe(false);
+        expect(result.productWitnessPassed).toBe(false);
+        expect(result.productWitnessUnmet).toContain('adapterRenderCoherent');
+        expect(result.productWitnessUnmet).toContain('firstPaint');
+    })
+
+    test('⭐ an ABSENT head fails the verdict', () => {
+        const result = verdict({rosterState: null, rosterLabel: null});
+
+        expect(result.adaptersCoherent).toBe(false);
+        expect(result.productWitnessUnmet).toContain('adapterRenderCoherent');
+    })
+
+    test('⭐ an UNKNOWN state fails the verdict', () => {
+        expect(verdict({rosterState: 'unknown'}).adaptersCoherent).toBe(false);
+    })
+
+    test('⭐ an AMBIGUOUS observation fails the verdict — via `unknown`, end to end', () => {
+        // The full path: two known classes resolve to `unknown`, which the verdict then rejects.
+        const state  = resolveAdapterState(classList(['is-live', 'is-sample']).contains),
+              result = verdict({rosterState: state, rosterLabel: ''});
+
+        expect(state).toBe('unknown');
+        expect(result.adaptersCoherent).toBe(false);
+        expect(result.productWitnessPassed).toBe(false);
+    })
+
+    test('the non-adapter conjuncts each fail on their own and are named', () => {
+        expect(verdict({cockpitVisible: false}).productWitnessUnmet).toContain('firstPaint');
+        expect(verdict({cardCount: 0}).productWitnessUnmet).toContain('firstPaint');
+        expect(verdict({timedOut: true}).productWitnessUnmet).toContain('firstPaint');
+        expect(verdict({firstPaintMs: null}).productWitnessUnmet).toContain('firstPaint');
+        expect(verdict({firstPaintMs: 60001}).productWitnessUnmet).toContain('firstPaint');
+    })
+
+    test('⭐ a healthy boot that is merely UNPACKAGED names packagedMode and nothing alarming', () => {
+        // A bare `productWitnessPassed: false` on a completely healthy boot invited the wrong
+        // conclusion. It is normally just this.
+        const result = verdict({}, {packagedMode: false});
+
+        expect(result.firstPaintPassed).toBe(true);
+        expect(result.adaptersCoherent).toBe(true);
+        expect(result.productWitnessPassed).toBe(false);
+        expect(result.productWitnessUnmet).toEqual(['packagedMode (run the packaged app, not `npm run smoke`)']);
+    })
+
+    test('brainMode and brainUp are named separately', () => {
+        expect(verdict({}, {brainMode: false, brainUp: null}).productWitnessUnmet)
+            .toContain('brainMode (use `npm run smoke:brain`)');
+        expect(verdict({}, {brainUp: false}).productWitnessUnmet).toContain('brainUp');
+    })
+
+    test('⭐ MUTATION CONTROL: forcing coherence true must not rescue a mismatched observation', () => {
+        // The review's exact requirement — the suite must go red if `isAdapterRenderCoherent()` is
+        // forced true. Asserted as a property here: a mismatched label is only rejected BECAUSE the
+        // coherence term is false, so if that term were hardcoded true the verdict would wrongly pass.
+        const mismatched = report({rosterState: 'live', rosterLabel: 'static roster · offline'});
+
+        expect(isAdapterRenderCoherent(mismatched.rosterState, mismatched.rosterLabel, ROSTER_STATE_LABELS)).toBe(false);
+
+        // Every other conjunct of this report is healthy, so coherence is the ONLY thing failing it.
+        expect(mismatched.cockpitVisible).toBe(true);
+        expect(mismatched.cardCount).toBeGreaterThan(0);
+        expect(mismatched.timedOut).toBe(false);
+        expect(verdict({rosterState: 'live', rosterLabel: 'static roster · offline'}).firstPaintPassed).toBe(false);
+    })
+});
+
+test.describe('the forced CJS/ESM duplication cannot drift', () => {
+    test('⭐ the preload observer lists the SAME adapter states as the witness', async () => {
+        // `preload.cjs` cannot import this module: Electron will not load an ESM preload in a sandboxed
+        // renderer, so the state list is duplicated by necessity rather than by choice. That makes drift
+        // possible, so it is asserted instead of trusted.
+        const source  = await readFile(new URL('../../../../harness/preload.cjs', import.meta.url), 'utf8'),
+              matched = source.match(/const ADAPTER_STATES = \[([^\]]+)\]/);
+
+        expect(matched, 'preload declares ADAPTER_STATES').not.toBeNull();
+
+        const declared = matched[1].split(',').map(part => part.trim().replace(/^'|'$/g, ''));
+
+        expect(declared).toEqual([...ADAPTER_STATES]);
+    })
+
+    test('the sanitizer allowlist admits every state plus `unknown`, and nothing else', () => {
+        expect([...ADAPTER_STATE_NAMES]).toEqual([...ADAPTER_STATES, 'unknown']);
+    })
+});

--- a/test/playwright/unit/harness/pack.spec.mjs
+++ b/test/playwright/unit/harness/pack.spec.mjs
@@ -129,6 +129,7 @@ test.describe('harness pack stage', () => {
         });
 
         expect(modules).toEqual([
+            'adapterWitness.mjs',
             'appLifecycle.mjs',
             'brain.mjs',
             'contentPolicy.mjs',

--- a/test/playwright/unit/harness/preload.spec.mjs
+++ b/test/playwright/unit/harness/preload.spec.mjs
@@ -85,6 +85,44 @@ function getFirstPaintReporter(intervals) {
     return reporters[0]
 }
 
+/**
+ * @summary Builds a cockpit adapter-head element mock: an `is-<state>` class plus its label child.
+ *
+ * The preload no longer queries `.fm-fleet-head.is-sample …` — a selector pinned to one state could
+ * only ever observe that state, so a promoted (live) cockpit reported `null` and the witness could not
+ * distinguish "working" from "broken". These mocks therefore carry the state on the element, exactly
+ * as `FleetGrid` renders `is-${adapterState}`.
+ * @param {String} state
+ * @param {String|null} labelText
+ * @param {String} labelSelector
+ * @returns {Object}
+ */
+function adapterHead(state, labelText, labelSelector) {
+    return {
+        classList    : {contains: name => name === `is-${state}`},
+        querySelector: selector => selector === labelSelector && labelText !== null ? {textContent: labelText} : null
+    }
+}
+
+/**
+ * @summary DOM mock for a cockpit rendering the given roster/stream adapter states.
+ * @param {Object} options
+ * @returns {Object}
+ */
+function cockpitDom({rosterState='sample', rosterLabel='static roster · offline', streamState='sample', streamLabel='sample · live feed pending', cards=[{getClientRects: () => [{}]}], tourControls=[], cockpit={getClientRects: () => [{}]}} = {}) {
+    return {
+        selectors: {
+            '.fm-fleet-cockpit'                : cockpit,
+            '.fm-fleet-cockpit .fm-fleet-head' : rosterState === null ? null : adapterHead(rosterState, rosterLabel, '.fm-fleet-stale'),
+            '.fm-fleet-cockpit .fm-stream-head': streamState === null ? null : adapterHead(streamState, streamLabel, '.fm-stream-state')
+        },
+        selectorLists: {
+            '.fm-fleet-cockpit .fm-agent-card'                                     : cards,
+            '.fm-fleet-cockpit .fm-fusion-tour, .fm-fleet-cockpit .fm-tour-caption': tourControls
+        }
+    }
+}
+
 test.describe('Electron harness preload capability', () => {
     test('exposes one Fleet promise capability and no raw transport or secret facts', async () => {
         const
@@ -124,21 +162,9 @@ test.describe('Electron harness preload capability', () => {
             clock              = {now: 1234},
             cockpit            = {getClientRects: () => [{}]},
             cards              = [{getClientRects: () => [{}]}, {getClientRects: () => [{}]}],
-            roster             = {textContent: ' static roster · offline '},
-            stream             = {textContent: ' sample · live feed pending '},
             {intervals, sends} = await loadPreload({
                 clock,
-                dom: {
-                    selectors: {
-                        '.fm-fleet-cockpit'                                           : cockpit,
-                        '.fm-fleet-cockpit .fm-fleet-head.is-sample .fm-fleet-stale'  : roster,
-                        '.fm-fleet-cockpit .fm-stream-head.is-sample .fm-stream-state': stream
-                    },
-                    selectorLists: {
-                        '.fm-fleet-cockpit .fm-agent-card'                                     : cards,
-                        '.fm-fleet-cockpit .fm-fusion-tour, .fm-fleet-cockpit .fm-tour-caption': []
-                    }
-                },
+                dom                      : cockpitDom({cards, cockpit, rosterLabel: ' static roster · offline ', streamLabel: ' sample · live feed pending '}),
                 precedeWithUnrelatedTimer: true
             }),
             firstPaintReporter = getFirstPaintReporter(intervals);
@@ -153,6 +179,8 @@ test.describe('Electron harness preload capability', () => {
             cockpitVisible      : true,
             rendererFirstPaintMs: 0,
             rosterLabel         : 'static roster · offline',
+            rosterState         : 'sample',
+            streamState         : 'sample',
             timedOut            : false,
             tourControlCount    : 0
         }]);
@@ -164,21 +192,9 @@ test.describe('Electron harness preload capability', () => {
             clock              = {now: 0},
             cockpit            = {getClientRects: () => [{}]},
             card               = {getClientRects: () => [{}]},
-            roster             = {textContent: 'static roster · offline'},
-            stream             = {textContent: 'sample · live feed pending'},
             {intervals, sends} = await loadPreload({
                 clock,
-                dom: {
-                    selectors: {
-                        '.fm-fleet-cockpit'                                           : cockpit,
-                        '.fm-fleet-cockpit .fm-fleet-head.is-sample .fm-fleet-stale'  : roster,
-                        '.fm-fleet-cockpit .fm-stream-head.is-sample .fm-stream-state': stream
-                    },
-                    selectorLists: {
-                        '.fm-fleet-cockpit .fm-agent-card'                                     : [card],
-                        '.fm-fleet-cockpit .fm-fusion-tour, .fm-fleet-cockpit .fm-tour-caption': [{}]
-                    }
-                }
+                dom: cockpitDom({cards: [card], cockpit, tourControls: [{}]})
             }),
             firstPaintReporter = getFirstPaintReporter(intervals);
 
@@ -194,9 +210,91 @@ test.describe('Electron harness preload capability', () => {
             cockpitVisible      : true,
             rendererFirstPaintMs: null,
             rosterLabel         : 'static roster · offline',
+            rosterState         : 'sample',
+            streamState         : 'sample',
             timedOut            : true,
             tourControlCount    : 1
         }]);
         expect(firstPaintReporter.cleared).toBe(true)
+    })
+
+    // The defect these cover: the witness previously read `.fm-fleet-head.is-sample .fm-fleet-stale`,
+    // so it could observe exactly ONE adapter state — the one we do not want to ship. A cockpit
+    // promoted to `live` made that selector match nothing and the field reported `null`,
+    // indistinguishable from a broken selector or an absent cockpit. An instrument that can only
+    // report failure cannot witness a release gate, so `live` needs a POSITIVE control.
+    test.describe('adapter-state observation (the witness must be able to report SUCCESS)', () => {
+        /**
+         * Reads the first-paint report. `viaTimeout` covers the states that are deliberately NOT
+         * "ready" — an absent or unrecognised head must not satisfy the product receipt, so it is
+         * observable only through the timeout receipt. That is the honest path, not a workaround.
+         */
+        const readFirstPaint = async (dom, {viaTimeout = false} = {}) => {
+            const clock              = {now: 0},
+                  {intervals, sends} = await loadPreload({clock, dom}),
+                  reporter           = getFirstPaintReporter(intervals);
+
+            reporter.fn();
+
+            if (viaTimeout) {
+                clock.now = 60001;
+                reporter.fn();
+            }
+
+            return sends.find(([channel]) => channel === 'shell-first-paint-report')?.[1] ?? null;
+        };
+
+        test('POSITIVE CONTROL — a LIVE cockpit is observed as live, not as null', async () => {
+            const report = await readFirstPaint(cockpitDom({
+                rosterState: 'live', rosterLabel: '',
+                streamState: 'live', streamLabel: '● streaming'
+            }));
+
+            // The assertion the previous instrument could not make.
+            expect(report.rosterState).toBe('live');
+            expect(report.streamState).toBe('live');
+            expect(report.rosterLabel).toBe('');
+            expect(report.activityLabel).toBe('● streaming');
+        })
+
+        test('stale and degraded are each observed as themselves', async () => {
+            const stale = await readFirstPaint(cockpitDom({
+                rosterState: 'stale', rosterLabel: 'stale — reconnecting',
+                streamState: 'stale', streamLabel: 'stale — reconnecting'
+            }));
+
+            expect(stale.rosterState).toBe('stale');
+            expect(stale.streamState).toBe('stale');
+
+            const degraded = await readFirstPaint(cockpitDom({
+                rosterState: 'degraded', rosterLabel: '',
+                streamState: 'degraded', streamLabel: '● streaming'
+            }));
+
+            expect(degraded.rosterState).toBe('degraded');
+            expect(degraded.streamState).toBe('degraded');
+        })
+
+        test('NEGATIVE CONTROL — an ABSENT head is distinct from every rendered state', async () => {
+            const report = await readFirstPaint(cockpitDom({rosterState: null, streamState: null}), {viaTimeout: true});
+
+            // Absence must not masquerade as a state, and must not be confused with `live`'s empty label.
+            expect(report.rosterState).toBeNull();
+            expect(report.streamState).toBeNull();
+            // And it must NOT count as a product receipt: absence is reported, never accepted.
+            expect(report.timedOut).toBe(true);
+            expect(report.rosterLabel).toBeNull();
+            expect(report.activityLabel).toBeNull();
+        })
+
+        test('an UNMAPPED state reports `unknown` rather than falling back to a known one', async () => {
+            // A state added upstream must surface as unverified. Defaulting to `sample` would let a new
+            // render state pass a check that never examined it.
+            const report = await readFirstPaint(cockpitDom({rosterState: 'reconciling', rosterLabel: 'anything'}), {viaTimeout: true});
+
+            expect(report.rosterState).toBe('unknown');
+            // Unverified, therefore not ready — it surfaces through the timeout receipt.
+            expect(report.timedOut).toBe(true);
+        })
     })
 });

--- a/test/playwright/unit/harness/preload.spec.mjs
+++ b/test/playwright/unit/harness/preload.spec.mjs
@@ -98,8 +98,14 @@ function getFirstPaintReporter(intervals) {
  * @returns {Object}
  */
 function adapterHead(state, labelText, labelSelector) {
+    // `state` may be an ARRAY, to express a head advertising several `is-*` classes at once. The old
+    // single-string form hard-coded `name === \`is-${state}\``, so the mock could express exactly ONE
+    // class — which made the ambiguity path structurally untestable and left "no control" looking like
+    // "nothing to control".
+    const states = Array.isArray(state) ? state : [state];
+
     return {
-        classList    : {contains: name => name === `is-${state}`},
+        classList    : {contains: name => states.some(entry => name === `is-${entry}`)},
         querySelector: selector => selector === labelSelector && labelText !== null ? {textContent: labelText} : null
     }
 }
@@ -243,6 +249,38 @@ test.describe('Electron harness preload capability', () => {
 
             return sends.find(([channel]) => channel === 'shell-first-paint-report')?.[1] ?? null;
         };
+
+        test('⭐ AMBIGUOUS head — the CommonJS observer reports `unknown` and stays NOT READY', async () => {
+            // The CJS resolution is a FORCED duplicate of `adapterWitness.resolveAdapterState` (Electron
+            // cannot load an ESM preload in a sandboxed renderer), so asserting the two state LISTS match
+            // is not enough — the resolution BEHAVIOUR must be pinned here too, or the copy could revert
+            // to first-match and nothing would catch it.
+            const report = await readFirstPaint(cockpitDom({
+                rosterState: ['live', 'sample'],   // contradictory DOM
+                rosterLabel: ''
+            }), {viaTimeout: true});
+
+            // Not `live` — which is what first-match returned, preferring whichever state was listed first.
+            expect(report.rosterState).toBe('unknown');
+            // And ambiguity must not satisfy the product receipt: it arrives via the timeout path.
+            expect(report.timedOut).toBe(true);
+        })
+
+        test('a head advertising THREE known classes is also `unknown`', async () => {
+            const report = await readFirstPaint(cockpitDom({
+                rosterState: ['live', 'sample', 'stale'], rosterLabel: ''
+            }), {viaTimeout: true});
+
+            expect(report.rosterState).toBe('unknown');
+        })
+
+        test('the STREAM head obeys the same rule — both heads, not just the roster', async () => {
+            const report = await readFirstPaint(cockpitDom({
+                streamState: ['live', 'degraded'], streamLabel: '● streaming'
+            }), {viaTimeout: true});
+
+            expect(report.streamState).toBe('unknown');
+        })
 
         test('POSITIVE CONTROL — a LIVE cockpit is observed as live, not as null', async () => {
             const report = await readFirstPaint(cockpitDom({


### PR DESCRIPTION
Resolves #16033

Evidence: L3 (real Electron boots — `npm run smoke` and `npm run smoke:brain`, both passing with `sharedHeapEvidence: true`, `popupMaterialized: true`, and the adapter-state receipt present) → L3 required (the witness's own behaviour on a real harness boot). Residual: none.
Related: #13377 (ADR-0034 §5 E2 leaf) · #14560 (the cockpit this observes) · #14793 (the "download and run" spec this measures)

## What this changes

v13.2's release gate opens with *"a developer downloads and runs the local harness without hand-editing config"* (ROADMAP.md), and `harness/`'s smoke is its only automated witness. **That witness could not report success.** It asserted the product was unfinished — at two sites, the second worse than the first.

**Evidence:** measured on `dev@b67e208115` by running `npm run smoke` and `npm run smoke:brain`. With the Brain fully up (`brainUp: true`, `chromaListening: true`, `firstWorkerCrossing: true`) the reported `productWitnessPassed` was `false` and the liveness fields reported the sample labels — and there was no way to tell from the receipt whether that meant "cockpit on sample data", "selector broken", or "cockpit absent".

| site | defect |
|---|---|
| `preload.cjs:57,60` | Both label selectors were scoped to **`.is-sample`**. `FleetGrid.mjs:306` renders `is-${adapterState}`, so a cockpit promoted to `live` made them match nothing and the fields reported **`null`** — indistinguishable from a broken selector or an absent cockpit. The instrument was wired exclusively to the state we do not want to ship. |
| `preload.cjs` ready trigger + `main.mjs:1229` verdict | **Both required `rosterLabel === 'static roster · offline'` and `activityLabel === 'sample · live feed pending'`.** So a cockpit wired to the live fleet could never become "ready": it would wait out the full 60s timeout and report `timedOut: true`. **Delivering cornerstone 1's goal would have turned this smoke red.** |

A witness that fails on success cannot guard a release gate.

## Deltas

- **Adapter state is observed as data** — `rosterState` / `streamState` join the receipt, so `live` is a *positive* observation and absence stays distinct from every rendered state.
- **The gate checks state-vs-label AGREEMENT**, not one expected state. This keeps the guard real — a `live` head rendering the sample label is still a genuine defect — while letting every honest state pass. Label maps mirror the owning components (`FleetGrid`'s ternary, `ActivityStream`'s `{sample, stale}[state] ?? '● streaming'`).
- **`unknown` fails closed.** An adapter state added upstream without teaching the map surfaces as unverified rather than silently passing, because a state nobody mapped is a state nobody verified.
- **`tourControlCount === 0` stays in the ready gate deliberately** — the receipt is for the product first paint, not a demo tour. It is **removed from the verdict**, where asserting it would have made shipping the roadmap's own deterministic tour modes a test failure.
- **`productWitnessUnmet` names the failed conjuncts.** The field reads `false` on a completely healthy boot because `packagedMode` is false and no npm script runs the packaged app. A bare `false` there invites the wrong conclusion — **I drew it myself**, and started drafting a defect report about the cockpit lying to strangers, before reading the definition at `main.mjs:1241`. Naming the conjuncts is the fix for the next reader.
- **The renderer report stays untrusted.** The new fields go through `sanitizeFirstPaintReport`'s allowlist with their own validator rather than around it; `unknown` is admitted there on purpose so it reaches the coherence check and fails with a named state instead of being rejected as a malformed payload.

**`tourControlCount` behaviour, stated precisely (review RA5).** It is not a term in the verdict expression, but it **does** gate the final result **transitively**: the preload only reports `ready` when no tour controls are present, so a demo tour makes the report arrive via the timeout path and `timedOut === false` then fails. The product-first-paint policy is intended — but describing it as "removed from the verdict" was true of the expression and false of the behaviour.

## Test Evidence

**68/68 harness unit tests green**, and the new coverage includes the control that was missing by construction:

| control | assertion |
|---|---|
| **POSITIVE** — LIVE cockpit | `rosterState === 'live'`, `streamState === 'live'`, live labels observed. *This is the assertion the previous instrument could not make.* |
| stale / degraded | each observed as itself |
| **NEGATIVE** — absent head | reported as `null` **and** denied the product receipt (`timedOut: true`) — absence is reported, never accepted as success |
| unmapped state | reports `unknown` **and** is denied the receipt |

The two pre-existing specs are **migrated off the scoped selectors they mocked** — my change breaks them by design, so leaving them passing would have meant they were not testing the code.

**Smoke, both variants, after the change:**

```
npm run smoke        → passed: true, adaptersCoherent: true, rosterState/streamState: "sample",
                       sharedHeapEvidence: true, popupMaterialized: true, firstPaintMs 840
npm run smoke:brain  → passed: true, adaptersCoherent: true, brainUp: true
                       productWitnessUnmet: ["packagedMode (run the packaged app, not `npm run smoke`)"]
```

Mechanical gates: `check-ticket-archaeology` (0 violations), `check-block-alignment` (hand-aligned, not `--fix`, to avoid re-aligning unrelated blocks), full `lint-staged` battery.

## Post-Merge Validation

- Re-run both smoke variants on a fresh checkout and confirm `rosterState` appears in the receipt.
- **The real validation is the next cockpit-wiring change:** when the fleet adapter promotes to `live`, this smoke must stay green and report `rosterState: "live"`. Under the previous gate that change would have gone red, which is the regression this prevents.
- `productWitnessPassed` stays false until something runs the packaged app; `productWitnessUnmet` should name exactly `packagedMode` on an otherwise healthy `smoke:brain`.

## What this does NOT claim

Whether the cockpit *should* be `live` under a `checkout-isolated` smoke profile with no live fleet residents is **not decided here** — the previous instrument could not answer it, which is precisely why this leaf came first. It is now a measurement rather than an argument, and gets its own leaf if it turns out to be a wiring defect.

Authored by Vega (@neo-opus-vega, Claude Opus 5, Claude Code). Session f1bcb0a9-68f5-4910-bef6-1a5a33aad1f5.

