### PR TITLE
feat(workstation): complete cross-window docking journey

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -306,6 +306,12 @@ class Workspace extends Container {
 
         me.dockModel   = DockZoneModel.clone(initialDocument);
         me.dockService = Neo.create(DockService, {});
+
+        // Cross-window hit testing reads manager.Window as its one geometry authority. Movement
+        // snapshots alone go stale after a main-window resize, so this render target publishes
+        // live extents from construction just like every admitted vessel does on connect.
+        Neo.main.addon.WindowPosition?.setConfigs({observeResize: true, windowId: me.windowId});
+
         me.tourRunner  = Neo.create(TourRunner, {
             componentId: me.id,
             dockService: me.dockService,
@@ -727,6 +733,36 @@ class Workspace extends Container {
     }
 
     /**
+     * @summary Retries an exact retained vessel retirement before admitting a successor tear-out.
+     *
+     * A strict close refusal keeps both lifecycle owners so recovery remains possible. The next
+     * boundary exit must retire that generation and clear its park owner before opening another
+     * popup; a second refusal ends the newly armed window drag instead of leaving it wedged.
+     * @param {Object} data
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async onDockTearOutExit(data) {
+        let me     = this,
+            active = me.tearOutHandlers.activeVessel;
+
+        if (active) {
+            const retired = await me.tearOutHandlers.retireActiveVessel(active);
+
+            if (!retired) {
+                data.sortZone?.endWindowDrag();
+                return false
+            }
+
+            me.vesselParkHandlers.onVesselRetired({itemId: active.itemId, retirement: true})
+        }
+
+        await me.tearOutHandlers.onDockTearOutExit(data);
+
+        return true
+    }
+
+    /**
      * Projects the committed document with instance-bound reducer/view callbacks.
      * @param {Function|null} [resolveComponentRef=null] Optional staging resolver.
      * @returns {Object}
@@ -754,7 +790,7 @@ class Workspace extends Container {
             onDockCrossZoneDrop      : data => me.dragAffordances.onDrop(data),
             onDockTearOutCancel      : data => me.tearOutHandlers.onDockTearOutCancel(data),
             onDockTearOutEntry       : data => me.tearOutHandlers.onDockTearOutEntry(data),
-            onDockTearOutExit        : data => me.tearOutHandlers.onDockTearOutExit(data),
+            onDockTearOutExit        : data => me.onDockTearOutExit(data),
             onDockTearOutTerminal    : data => me.tearOutHandlers.onDockTearOutTerminal(data),
             onDockVesselConversionIn : data => {
                 me.vesselConversionTargetWindowId = data.targetId ?? null;
@@ -774,7 +810,8 @@ class Workspace extends Container {
             resolveComponentRef           : resolveComponentRef
                 || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
             resolveRevealComponentRef        : (componentRef, item, itemId) => me.resolvePane(itemId, item),
-            resolveVesselConversionSourceRect: data => me.resolveVesselConversionSourceRect(data)
+            resolveVesselConversionSourceRect: data => me.resolveVesselConversionSourceRect(data),
+            workspaceId                      : Workspace.MAIN_WORKSPACE_ID
         })
     }
 
@@ -1994,6 +2031,7 @@ class Workspace extends Container {
                     itemId,
                     windowName
                 });
+                me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
                 me.revokeVesselOwnerGrant('tear-out', itemId);
                 me.tearOutRetirements.delete(itemId);
                 delete me.tearOutPanes[itemId];
@@ -2024,6 +2062,7 @@ class Workspace extends Container {
                     itemId,
                     windowName
                 });
+                me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
                 me.revokeVesselOwnerGrant('tear-out', itemId);
                 me.tearOutRetirements.delete(itemId);
                 return
@@ -2045,6 +2084,7 @@ class Workspace extends Container {
                     itemId,
                     windowName
                 });
+                me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
                 me.reintegrateTearOutItem(itemId);
                 break
             }

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -17,6 +17,8 @@ import StateProvider                            from '../../../src/state/Provide
 import TourRunner                               from '../../../src/ai/client/TourRunner.mjs';
 import {createDockTearOutHandlers}              from '../../../src/dashboard/DockTearOut.mjs';
 import {createDockVesselEmbodiment}             from '../../../src/dashboard/DockVesselEmbodiment.mjs';
+import {createDockWorkspaceSet}                 from '../../../src/dashboard/DockWorkspaceSet.mjs';
+import {createVesselParkHandlers}               from '../../../src/dashboard/DockVesselPark.mjs';
 import {previewToOperation}                     from '../../../src/dashboard/dockPreviewContract.mjs';
 import {workstationTourScript, initialDocument} from '../tour/denseWorkstation.mjs';
 import '../../../src/button/Base.mjs';
@@ -73,6 +75,21 @@ class Workspace extends Container {
      * @static
      */
     static FEED_INTERVAL_MS = 500
+    /**
+     * The stable semantic identity of the main workspace document inside the cross-window
+     * workspace set — a workspace is one dock-zone document owned by one container; windows are
+     * render targets, never state owners.
+     * @member {String} MAIN_WORKSPACE_ID='workstation-main'
+     * @static
+     */
+    static MAIN_WORKSPACE_ID = 'workstation-main'
+    /**
+     * The DragCoordinator sort group every workstation dock zone registers under as a
+     * cross-window drag source and target.
+     * @member {String} CROSS_WINDOW_SORT_GROUP='workstation-cross-window'
+     * @static
+     */
+    static CROSS_WINDOW_SORT_GROUP = 'workstation-cross-window'
 
     static config = {
         /**
@@ -187,6 +204,26 @@ class Workspace extends Container {
      * @protected
      */
     tearOutRetirements = new Set()
+    /**
+     * The runtime window id of the vessel an in-flight conversion is hovering over — stashed by
+     * the conversion-in seam so the park's cover geometry resolves the exact target. Never
+     * persisted workspace state: a window is a render target.
+     * @member {String|Number|null} vesselConversionTargetWindowId=null
+     * @protected
+     */
+    vesselConversionTargetWindowId = null
+    /**
+     * The in-gesture vessel lifecycle authority (park / re-show / dispose-on-commit).
+     * @member {Object|null} vesselParkHandlers=null
+     * @protected
+     */
+    vesselParkHandlers = null
+    /**
+     * The worker-owned cross-window workspace registry — `{workspaceId → document accessors}`.
+     * @member {Object|null} workspaceSet=null
+     * @protected
+     */
+    workspaceSet = null
     /**
      * Product-semantic vessel owner grants by `flow:itemId`.
      * @member {Map} vesselOwnerGrants=new Map()
@@ -331,6 +368,27 @@ class Workspace extends Container {
             closeVessel     : vessel => me.closeTearOutVessel(vessel),
             onDocumentChange: (document, operation, vessel) => me.onTearOutDocumentChange(document, operation, vessel),
             openVessel      : request => me.openTearOutVessel(request)
+        });
+
+        // The cross-window composition (docking design record §2.1/§2.3): one worker-owned
+        // workspace set resolves documents by STABLE workspace identity — windowId, screen
+        // geometry, and projection state never enter it; a window is a render target, not a
+        // state owner. Vessel workspaces register lazily on first dock-INTO (Edit 2).
+        me.workspaceSet = createDockWorkspaceSet();
+
+        me.workspaceSet.register(Workspace.MAIN_WORKSPACE_ID, {
+            getDocument: () => me.dockModel,
+            setDocument: document => me.dockModel = document
+        });
+
+        // Conversion never re-acquires a popup: close-and-reopen is a one-way door (mid-gesture
+        // acquisition consumes transient activation and reads as unsolicited), so conversion
+        // PARKS the real vessel behind its target, out-conversion re-shows the SAME generation,
+        // and only a commit disposes — every other outcome restores.
+        me.vesselParkHandlers = createVesselParkHandlers({
+            disposeVessel: vessel => me.disposeParkedTearOutVessel(vessel),
+            parkVessel   : vessel => me.parkTearOutVessel(vessel),
+            reshowVessel : vessel => me.reshowTearOutVessel(vessel)
         });
 
         // vessel lifecycle: a granted `?popout=` window adopts the live pane on connect,
@@ -678,22 +736,45 @@ class Workspace extends Container {
 
         return DockLayoutAdapter.project(me.dockModel, {
             applyDockZoneOperation: me.applyDockZoneOperation.bind(me),
+            // Cross-window participation (§2.3): every projected tab zone registers as a
+            // coordinator-visible drag source under one sort group; the workspace id rides the
+            // payload for the receiving window's `transferItem` resolution.
+            crossWindowSortGroup        : Workspace.CROSS_WINDOW_SORT_GROUP,
             // Tear-out opt-in (§2.8): every tab zone shares the Workstation root as its physical
             // window boundary. Exiting a source toolbar remains ordinary cross-zone motion; only
             // leaving this app/window root enters the vessel outcome machine.
             dockTearOutBoundaryContainerId: me.id,
             enableDockTearOut             : true,
-            onDockCrossZoneDragCancel     : data => me.dragAffordances.onDragCancel(data),
-            onDockCrossZoneDragMove       : data => me.dragAffordances.onDragMove(data),
-            onDockCrossZoneDrop           : data => me.dragAffordances.onDrop(data),
-            onDockTearOutCancel           : data => me.tearOutHandlers.onDockTearOutCancel(data),
-            onDockTearOutEntry            : data => me.tearOutHandlers.onDockTearOutEntry(data),
-            onDockTearOutExit             : data => me.tearOutHandlers.onDockTearOutExit(data),
-            onDockTearOutTerminal         : data => me.tearOutHandlers.onDockTearOutTerminal(data),
+            // Vessel conversion (the multi-window amendment): popup-over-vessel converts to a
+            // proxy over the target while the park keeps the real vessel alive — the projection
+            // threads the opt-in; this host owns every platform effect.
+            enableVesselConversion   : true,
+            onDockCrossZoneDragCancel: data => me.dragAffordances.onDragCancel(data),
+            onDockCrossZoneDragMove  : data => me.dragAffordances.onDragMove(data),
+            onDockCrossZoneDrop      : data => me.dragAffordances.onDrop(data),
+            onDockTearOutCancel      : data => me.tearOutHandlers.onDockTearOutCancel(data),
+            onDockTearOutEntry       : data => me.tearOutHandlers.onDockTearOutEntry(data),
+            onDockTearOutExit        : data => me.tearOutHandlers.onDockTearOutExit(data),
+            onDockTearOutTerminal    : data => me.tearOutHandlers.onDockTearOutTerminal(data),
+            onDockVesselConversionIn : data => {
+                me.vesselConversionTargetWindowId = data.targetId ?? null;
+
+                return me.vesselParkHandlers.onConversionIn({
+                    itemId    : data.itemId,
+                    sourceRect: data.record?.sourceRect ?? null,
+                    windowName: me.resolveTearOutVessel(data.itemId)?.windowName
+                })
+            },
+            onDockVesselConversionOut: data => me.vesselParkHandlers.onConversionOut({
+                rect: data.logicalRect ?? data.record?.sourceRect ?? null
+            }),
+            onDockVesselConversionTerminal: data => me.vesselParkHandlers.onGestureTerminal(data),
+            onDockVesselConversionRetired : data => me.vesselParkHandlers.onVesselRetired(data),
             onDockZoneDocumentChange      : me.onDockZoneDocumentChange.bind(me),
             resolveComponentRef           : resolveComponentRef
                 || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
-            resolveRevealComponentRef  : (componentRef, item, itemId) => me.resolvePane(itemId, item)
+            resolveRevealComponentRef        : (componentRef, item, itemId) => me.resolvePane(itemId, item),
+            resolveVesselConversionSourceRect: data => me.resolveVesselConversionSourceRect(data)
         })
     }
 
@@ -1467,6 +1548,160 @@ class Workspace extends Container {
         });
 
         return resolved
+    }
+
+    /**
+     * Consumes the tear-out machine's active slot, then closes its exact parked vessel — the ONE
+     * settle path for a committed conversion; a refusal retains exact retry authority.
+     * @param {Object} vessel
+     * @param {String} vessel.itemId
+     * @param {String} vessel.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async disposeParkedTearOutVessel({itemId, windowName}) {
+        return this.tearOutHandlers.retireActiveVessel({itemId, windowName})
+    }
+
+    /**
+     * Parks one converted vessel behind its conversion target — the cover geometry that keeps
+     * the REAL OS window alive while the proxy embodies over the target. Close-and-reopen is a
+     * one-way door (mid-gesture popup acquisition reads as unsolicited), so conversion parks
+     * instead: the same exact generation re-shows on out-conversion or restore. The focus /
+     * move / refocus chain is the platform-law choreography (z-order hides the parked vessel);
+     * a refocus refusal compensates back to the source rect rather than leaving a hidden window.
+     * @param {Object} vessel
+     * @param {String} vessel.itemId
+     * @param {String} vessel.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async parkTearOutVessel({itemId, windowName}) {
+        let me           = this,
+            entry        = me.resolveTearOutVessel(itemId),
+            route        = entry?.nativeRoute,
+            sourceWindow = Neo.manager?.Window?.get(entry?.windowId),
+            targetWindow = Neo.manager?.Window?.get(me.vesselConversionTargetWindowId),
+            targetRoute  = targetWindow?.nativeRoute,
+            // The cover geometry and the authority check both speak published inner-window
+            // geometry; a child omitting outerRect never rejects an authorized live vessel.
+            sourceRect   = sourceWindow?.innerRect,
+            targetRect   = targetWindow?.innerRect;
+
+        if (
+            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
+            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
+            !targetRoute?.nativeHandleKey || targetRoute.ownerWindowId !== me.windowId ||
+            targetRoute.targetWindowId !== me.vesselConversionTargetWindowId ||
+            targetRoute.capabilities?.focus !== true ||
+            entry.windowName !== windowName || !sourceRect || !targetRect ||
+            sourceRect.width > targetRect.width || sourceRect.height > targetRect.height
+        ) {
+            return false
+        }
+
+        try {
+            let focused = await Neo.Main.windowNativeFocus({
+                    nativeHandleKey: targetRoute.nativeHandleKey,
+                    targetWindowId : targetRoute.targetWindowId,
+                    windowId       : me.windowId
+                }) === true;
+
+            if (!focused) return false;
+
+            let moved = await Neo.main.addon.DragDrop.parkWindowDrag({
+                nativeHandleKey: route.nativeHandleKey,
+                targetWindowId : route.targetWindowId,
+                windowId       : me.windowId,
+                windowName,
+                x              : targetRect.x,
+                y              : targetRect.y
+            }) === true;
+
+            if (!moved) return false;
+
+            let refocused = await Neo.Main.windowNativeFocus({
+                nativeHandleKey: targetRoute.nativeHandleKey,
+                targetWindowId : targetRoute.targetWindowId,
+                windowId       : me.windowId
+            }) === true;
+
+            if (!refocused) {
+                let compensated = await Neo.main.addon.DragDrop.resumeWindowDrag({
+                    nativeHandleKey: route.nativeHandleKey,
+                    targetWindowId : route.targetWindowId,
+                    windowId       : me.windowId,
+                    windowName,
+                    x              : sourceRect.x,
+                    y              : sourceRect.y
+                }) === true;
+
+                return !compensated
+            }
+
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /**
+     * Re-shows the same exact parked generation at the logical pointer-owned origin. During a
+     * live gesture the DragDrop addon also resumes physical pointer-follow; at a native drag
+     * terminal that addon has already reset its session, so a strict refusal falls through to
+     * the same exact Main route for the final restore; semantic-name routing is never used.
+     * @param {Object} vessel
+     * @param {String} vessel.itemId
+     * @param {Object} vessel.rect
+     * @param {Boolean} [vessel.terminal=false]
+     * @param {String} vessel.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async reshowTearOutVessel({itemId, rect, terminal=false, windowName}) {
+        let me    = this,
+            entry = me.resolveTearOutVessel(itemId),
+            route = entry?.nativeRoute;
+
+        if (
+            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
+            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
+            entry.windowName !== windowName ||
+            !Number.isFinite(rect?.x) || !Number.isFinite(rect?.y)
+        ) return false;
+
+        let data = {
+            nativeHandleKey: route.nativeHandleKey,
+            targetWindowId : route.targetWindowId,
+            windowId       : me.windowId,
+            windowName,
+            x              : rect.x,
+            y              : rect.y
+        };
+
+        try {
+            return terminal
+                ? await Neo.Main.windowNativeMoveTo(data) === true
+                : await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true
+        } catch {
+            return false
+        }
+    }
+
+    /**
+     * Resolves one dragged vessel's exact live inner rect for conversion sampling — the metric
+     * speaks published inner-window geometry, and only the runtime window identity may select
+     * the manager-owned rect (the logical drag proxy is intentionally ignored).
+     * @param {Object} data
+     * @param {String|null} data.itemId
+     * @returns {Object|null}
+     * @protected
+     */
+    resolveVesselConversionSourceRect({itemId}) {
+        let windowId = this.resolveTearOutVessel(itemId)?.windowId,
+            rect     = windowId && Neo.manager?.Window?.get(windowId)?.innerRect;
+
+        return rect && {height: rect.height, width: rect.width, x: rect.x, y: rect.y}
     }
 
     /**

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -90,6 +90,24 @@ class Workspace extends Container {
      * @static
      */
     static CROSS_WINDOW_SORT_GROUP = 'workstation-cross-window'
+    /**
+     * Returns one vessel's stable semantic workspace identity. Runtime window ids never enter it.
+     * @param {String} itemId
+     * @returns {String|null}
+     * @static
+     */
+    static vesselWorkspaceId(itemId) {
+        return typeof itemId === 'string' && itemId ? `workstation-vessel:${itemId}` : null
+    }
+    /**
+     * Returns the stable landing-tabs identity for one lazily seeded vessel document.
+     * @param {String} itemId
+     * @returns {String|null}
+     * @static
+     */
+    static vesselTabsNodeId(itemId) {
+        return typeof itemId === 'string' && itemId ? `workstation-vessel-tabs:${itemId}` : null
+    }
 
     static config = {
         /**
@@ -224,6 +242,32 @@ class Workspace extends Container {
      * @protected
      */
     workspaceSet = null
+    /**
+     * Target-side adapters keyed by stable workspace identity. The main workspace registers during
+     * construction; vessel targets register only after their exact child window joins.
+     * @member {Map<String,Neo.dashboard.DockCrossWindowParticipation>} crossWindowParticipations
+     * @protected
+     */
+    crossWindowParticipations = new Map()
+    /**
+     * Readiness of the main workspace's late-bound participation. The dynamic import keeps the
+     * manager.Window singleton behind the app/harness construction boundary.
+     * @member {Promise<Neo.dashboard.DockCrossWindowParticipation|null>} crossWindowParticipationPromise
+     * @protected
+     */
+    crossWindowParticipationPromise = null
+    /**
+     * Worker-owned vessel workspace records keyed by stable workspace identity. Entries carry
+     * document ownership and render-target refs, never cached geometry.
+     * @member {Map<String,Object>} vesselWorkspaces
+     * @protected
+     */
+    vesselWorkspaces = new Map()
+    /**
+     * Most recent cross-window transfer receipt for the film/spec boundary.
+     * @member {Object|null} lastCrossWindowTransfer=null
+     */
+    lastCrossWindowTransfer = null
     /**
      * Product-semantic vessel owner grants by `flow:itemId`.
      * @member {Map} vesselOwnerGrants=new Map()
@@ -386,6 +430,12 @@ class Workspace extends Container {
             getDocument: () => me.dockModel,
             setDocument: document => me.dockModel = document
         });
+
+        me.crossWindowParticipationPromise = me.refreshCrossWindowParticipation(Workspace.MAIN_WORKSPACE_ID)
+            .catch(error => {
+                me.lastCrossWindowTransfer = {applied: false, errors: [error.message]};
+                return null
+            });
 
         // Conversion never re-acquires a popup: close-and-reopen is a one-way door (mid-gesture
         // acquisition consumes transient activation and reads as unsolicited), so conversion
@@ -816,6 +866,653 @@ class Workspace extends Container {
     }
 
     /**
+     * Creates one target-side adapter over a stable workspace identity. Geometry remains entirely
+     * manager.Window-owned; the app stores documents and render refs only.
+     * @param {Object} data
+     * @param {String|Number} data.windowId
+     * @param {String} data.workspaceId
+     * @returns {Promise<Neo.dashboard.DockCrossWindowParticipation|null>}
+     * @protected
+     */
+    async createCrossWindowParticipation({windowId, workspaceId}) {
+        let me            = this,
+            Participation = (await import('../../../src/dashboard/DockCrossWindowParticipation.mjs')).default;
+
+        if (me.isDestroyed) return null;
+
+        return Neo.create(Participation, {
+            clearPreview      : () => me.clearCrossWindowPreview(workspaceId),
+            commitLocal       : operation => me.commitLocalWorkspaceOperation(workspaceId, operation),
+            commitTransfer    : data => me.commitCrossWindowTransfer(data),
+            getDocument       : () => me.getWorkspaceDocument(workspaceId),
+            getForeignDocument: sourceWorkspaceId => me.getWorkspaceDocument(sourceWorkspaceId),
+            hitTest           : (localX, localY) => me.hitTestCrossWindowTarget(workspaceId, localX, localY),
+            previewFor        : data => me.renderCrossWindowPreview(workspaceId, data),
+            previewToOperation,
+            sortGroup         : Workspace.CROSS_WINDOW_SORT_GROUP,
+            windowId,
+            workspaceId
+        })
+    }
+
+    /**
+     * Re-registers one stable participation after its render projection. Dock tab zones and the
+     * stable workspace target share a per-window coordinator slot, so the stable target must win
+     * the final registration write after every projection.
+     * @param {String} workspaceId
+     * @returns {Promise<Neo.dashboard.DockCrossWindowParticipation|null>}
+     * @protected
+     */
+    async refreshCrossWindowParticipation(workspaceId) {
+        let me       = this,
+            isMain   = workspaceId === Workspace.MAIN_WORKSPACE_ID,
+            state    = isMain ? null : me.vesselWorkspaces.get(workspaceId),
+            windowId = isMain ? me.windowId : state?.windowId;
+
+        if (windowId == null || (!isMain && !state)) return null;
+
+        me.crossWindowParticipations.get(workspaceId)?.destroy();
+        me.crossWindowParticipations.delete(workspaceId);
+        state && (state.participation = null);
+
+        const participation = await me.createCrossWindowParticipation({windowId, workspaceId});
+
+        if (
+            !participation ||
+            me.isDestroyed ||
+            (!isMain && (
+                me.vesselWorkspaces.get(workspaceId) !== state ||
+                state.app?.mainView?.isDestroyed
+            ))
+        ) {
+            participation?.destroy();
+            return null
+        }
+
+        me.crossWindowParticipations.set(workspaceId, participation);
+        state && (state.participation = participation);
+
+        return participation
+    }
+
+    /**
+     * Registers a connected bare-pane vessel as a stable remote target. Its document accessor stays
+     * lazy: hover creates no workspace state; the first accepted drop seeds it.
+     * @param {Object} data
+     * @param {Neo.app.Base} data.app
+     * @param {String} data.itemId
+     * @param {String|Number} data.windowId
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    async registerVesselWorkspaceTarget({app, itemId, windowId}) {
+        let me          = this,
+            workspaceId = Workspace.vesselWorkspaceId(itemId),
+            current     = workspaceId && me.vesselWorkspaces.get(workspaceId);
+
+        if (!workspaceId || !app?.mainView || !me.tearOutPanes[itemId]) return null;
+        if (current?.windowId === windowId) {
+            if (current.participationPromise) {
+                await current.participationPromise
+            } else if (!current.participation && !current.committed && !current.closeRequested) {
+                current.participationPromise = me.refreshCrossWindowParticipation(workspaceId);
+                await current.participationPromise;
+                current.participationPromise = null
+            }
+
+            return me.vesselWorkspaces.get(workspaceId) === current ? current : null
+        }
+        if (current?.committed) return null;
+
+        current && me.retireVesselWorkspaceTarget(itemId);
+
+        const state = {
+            app,
+            closeRequested      : false,
+            committed           : false,
+            disconnected        : false,
+            document            : null,
+            host                : null,
+            itemId,
+            participation       : null,
+            participationPromise: null,
+            preview             : null,
+            reconciling         : false,
+            windowId,
+            workspaceId
+        };
+
+        me.vesselWorkspaces.set(workspaceId, state);
+
+        app.mainView.addCls('workstation-vessel-target');
+        state.preview = app.mainView.add({module: DockPreview});
+
+        await app.mainView.promiseUpdate();
+        state.participationPromise = me.refreshCrossWindowParticipation(workspaceId);
+        await state.participationPromise;
+        state.participationPromise = null;
+
+        return me.vesselWorkspaces.get(workspaceId) === state ? state : null
+    }
+
+    /**
+     * Retires one vessel target's registry and arbitration identities. Window destruction owns the
+     * rendered subtree; this method only destroys live refs when the render target still exists.
+     * @param {String} itemId
+     * @returns {Boolean}
+     * @protected
+     */
+    retireVesselWorkspaceTarget(itemId) {
+        let me          = this,
+            workspaceId = Workspace.vesselWorkspaceId(itemId),
+            state       = workspaceId && me.vesselWorkspaces.get(workspaceId);
+
+        if (!state) return false;
+
+        state.participation?.destroy();
+        me.crossWindowParticipations.delete(workspaceId);
+        state.committed && me.workspaceSet.unregister(workspaceId);
+
+        me.vesselWorkspaces.delete(workspaceId);
+
+        return true
+    }
+
+    /**
+     * Resolves a workspace's current document. A vessel creates an unregistered provisional
+     * landing document only when a transfer first asks for it; registration and hover remain
+     * mutation-free.
+     * @param {String} workspaceId
+     * @returns {Object|null}
+     * @protected
+     */
+    getWorkspaceDocument(workspaceId) {
+        if (workspaceId === Workspace.MAIN_WORKSPACE_ID) return this.dockModel;
+
+        let state = this.vesselWorkspaces.get(workspaceId);
+
+        return state ? state.document ??= this.createVesselWorkspaceDocument(state.itemId) : null
+    }
+
+    /**
+     * Seeds a valid empty landing document. The popup remains a bare pane until the first accepted
+     * transfer moves both the detached owner and the dragged pane into this document atomically.
+     * @param {String} itemId
+     * @returns {Object|null}
+     * @protected
+     */
+    createVesselWorkspaceDocument(itemId) {
+        let item       = this.dockModel?.items?.[itemId],
+            tabsNodeId = Workspace.vesselTabsNodeId(itemId);
+
+        if (!item || !tabsNodeId) return null;
+
+        return {
+            schema: DockZoneModel.SCHEMA,
+            root  : `workstation-vessel-root:${itemId}`,
+            items : {},
+            nodes : {
+                [`workstation-vessel-root:${itemId}`]: {type: 'edge-zone', zones: {center: tabsNodeId}},
+                [tabsNodeId]                         : {type: 'tabs', items: [], activeItemId: null}
+            }
+        }
+    }
+
+    /**
+     * D-013 hit-test: accepts only points inside the live manager.Window inner rect. No app-local
+     * window geometry or per-workspace measurement registry exists.
+     * @param {String} workspaceId
+     * @param {Number} localX
+     * @param {Number} localY
+     * @returns {Boolean}
+     * @protected
+     */
+    hitTestCrossWindowTarget(workspaceId, localX, localY) {
+        let me       = this,
+            isMain   = workspaceId === Workspace.MAIN_WORKSPACE_ID,
+            state    = isMain ? null : me.vesselWorkspaces.get(workspaceId),
+            windowId = isMain ? me.windowId : state?.windowId,
+            inner    = windowId != null ? Neo.manager?.Window?.get(windowId)?.innerRect : null;
+
+        return Boolean(
+            inner && Number.isFinite(localX) && Number.isFinite(localY) &&
+            localX >= 0 && localY >= 0 && localX <= inner.width && localY <= inner.height &&
+            (isMain || (
+                state && !state.committed && !state.closeRequested &&
+                me.tearOutPanes[state.itemId]
+            ))
+        )
+    }
+
+    /**
+     * Computes and renders one remote preview from live manager.Window dimensions. A vessel uses
+     * its stable lazy landing node; the main workspace returns a stack to its captured semantic home.
+     * @param {String} workspaceId
+     * @param {Object} data
+     * @returns {Object|null}
+     * @protected
+     */
+    renderCrossWindowPreview(workspaceId, data) {
+        let me              = this,
+            isMain          = workspaceId === Workspace.MAIN_WORKSPACE_ID,
+            state           = isMain ? null : me.vesselWorkspaces.get(workspaceId),
+            windowId        = isMain ? me.windowId : state?.windowId,
+            inner           = windowId != null ? Neo.manager?.Window?.get(windowId)?.innerRect : null,
+            draggedItem     = data?.draggedItem,
+            itemId          = draggedItem?.dockItemId,
+            groupNodeId     = draggedItem?.dockGroupNodeId ?? null,
+            sourceWorkspace = draggedItem?.dockSourceWorkspaceId,
+            sourceState     = me.vesselWorkspaces.get(sourceWorkspace),
+            storedHome      = sourceState && me.tearOutPlacements[sourceState.itemId]?.tabsNodeId,
+            targetNodeId    = isMain
+                ? (me.dockModel.nodes?.[storedHome]?.type === 'tabs'
+                    ? storedHome
+                    : Object.entries(me.dockModel.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0])
+                : Workspace.vesselTabsNodeId(state?.itemId),
+            pointer         = {x: data?.localX, y: data?.localY},
+            rect            = inner && {x: 0, y: 0, width: inner.width, height: inner.height},
+            previewPointer  = isMain || !rect
+                ? pointer
+                : {x: rect.width / 2, y: rect.height / 2},
+            renderer        = isMain ? me.dragAffordances?.preview : state?.preview,
+            preview;
+
+        if (
+            !itemId || !targetNodeId || !rect || state?.committed || state?.closeRequested ||
+            !me.hitTestCrossWindowTarget(workspaceId, pointer.x, pointer.y)
+        ) {
+            return null
+        }
+
+        preview = me.dragAffordances.producer.produce({
+            containerId : isMain ? me.getReference('dock-host')?.id : state.app?.mainView?.id,
+            groupNodeId,
+            itemId,
+            pointer     : previewPointer,
+            sourceNodeId: data?.sourceNodeId,
+            zones       : [{nodeId: targetNodeId, rect}]
+        });
+
+        if (renderer) {
+            renderer.dockPreview = preview;
+            preview && renderer.applyTargetGeometry(rect)
+        }
+
+        return preview
+    }
+
+    /**
+     * Clears one target's transient preview without touching committed workspace state.
+     * @param {String} workspaceId
+     * @protected
+     */
+    clearCrossWindowPreview(workspaceId) {
+        if (workspaceId === Workspace.MAIN_WORKSPACE_ID) {
+            this.dragAffordances?.clear()
+        } else {
+            let state   = this.vesselWorkspaces.get(workspaceId),
+                preview = state?.preview;
+
+            preview && (preview.dockPreview = null);
+            state && !state.committed && (state.document = null)
+        }
+    }
+
+    /**
+     * Applies an ordinary same-workspace operation through the matching owner.
+     * @param {String} workspaceId
+     * @param {Object} descriptor
+     * @returns {{document:Object,errors:String[]}|null}
+     * @protected
+     */
+    commitLocalWorkspaceOperation(workspaceId, descriptor) {
+        let me       = this,
+            state    = me.vesselWorkspaces.get(workspaceId),
+            document = workspaceId === Workspace.MAIN_WORKSPACE_ID || state?.committed
+                ? me.getWorkspaceDocument(workspaceId)
+                : null,
+            result   = document && DockZoneModel.applyOperation(document, descriptor);
+
+        if (!result || result.errors.length) return result;
+
+        if (workspaceId === Workspace.MAIN_WORKSPACE_ID) {
+            me.onDockZoneDocumentChange(result.document)
+        } else {
+            me.vesselWorkspaces.get(workspaceId).document = result.document
+        }
+
+        return result
+    }
+
+    /**
+     * Publishes one executor-validated document pair synchronously, then queues target-first render
+     * reconciliation. First dock-into composes the incoming pane transfer with a second pure
+     * transfer of the already-detached vessel owner, then adopts the final pair exactly once.
+     * @param {Object} data
+     * @returns {Boolean}
+     * @protected
+     */
+    commitCrossWindowTransfer(data) {
+        let me = this,
+            {
+                descriptor,
+                sourceDocument,
+                sourceWorkspaceId,
+                targetDocument,
+                targetWorkspaceId
+            } = data || {},
+            sourceState  = me.vesselWorkspaces.get(sourceWorkspaceId),
+            targetState  = me.vesselWorkspaces.get(targetWorkspaceId),
+            mainToVessel = sourceWorkspaceId === Workspace.MAIN_WORKSPACE_ID && Boolean(targetState),
+            vesselToMain = targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID && Boolean(sourceState),
+            registeredTarget = false;
+
+        if (!descriptor || (!mainToVessel && !vesselToMain)) return false;
+        if (mainToVessel && (targetState.committed || targetState.reconciling)) return false;
+        if (vesselToMain && (!sourceState.committed || !me.workspaceSet.has(sourceWorkspaceId))) return false;
+
+        if (mainToVessel && !targetState.committed) {
+            if (descriptor.operation !== 'transferItem' || me.workspaceSet.has(targetWorkspaceId)) return false;
+
+            const ownerTransfer = DockZoneModel.transferItem(sourceDocument, targetDocument, {
+                itemId: targetState.itemId,
+                sourceWorkspaceId,
+                targetWorkspaceId,
+                target: {
+                    operation : 'addTab',
+                    tabsNodeId: Workspace.vesselTabsNodeId(targetState.itemId),
+                    index     : 0
+                }
+            });
+
+            if (ownerTransfer.errors.length) {
+                targetState.document = null;
+                return false
+            }
+
+            sourceDocument = ownerTransfer.sourceDocument;
+            targetDocument = ownerTransfer.targetDocument;
+            registeredTarget = me.workspaceSet.register(targetWorkspaceId, {
+                getDocument: () => targetState.document,
+                setDocument: document => targetState.document = document
+            });
+
+            if (!registeredTarget) {
+                targetState.document = null;
+                return false
+            }
+        }
+
+        try {
+            if (!me.workspaceSet.adoptTransfer({
+                sourceDocument,
+                sourceWorkspaceId,
+                targetDocument,
+                targetWorkspaceId
+            })) {
+                registeredTarget && me.workspaceSet.unregister(targetWorkspaceId);
+                registeredTarget && (targetState.document = null);
+                return false
+            }
+        } catch (error) {
+            registeredTarget && me.workspaceSet.unregister(targetWorkspaceId);
+            registeredTarget && (targetState.document = null);
+            me.lastCrossWindowTransfer = {applied: false, errors: [error.message]};
+            return false
+        }
+
+        if (registeredTarget) {
+            targetState.committed   = true;
+            targetState.reconciling = true
+        }
+
+        const receipt = me.lastCrossWindowTransfer = {
+            applied       : true,
+            closeRequested: false,
+            descriptor    : DockZoneModel.clone(descriptor),
+            reconciled    : false,
+            sourceWorkspaceId,
+            targetWorkspaceId,
+            topologyExited: false
+        };
+
+        me.refreshPromise = (me.refreshPromise || Promise.resolve())
+            .then(() => me.timeout(0))
+            .then(async () => {
+                if (mainToVessel) {
+                    if (me.vesselWorkspaces.get(targetWorkspaceId) !== targetState) {
+                        throw new Error('vessel target retired before projection')
+                    }
+                    if (!await me.mountVesselWorkspace(targetWorkspaceId) ||
+                        me.vesselWorkspaces.get(targetWorkspaceId) !== targetState) {
+                        throw new Error('vessel target projection did not settle')
+                    }
+
+                    await me.refreshDockWorkspace({
+                        preserveItemIds: Object.keys(targetState.document?.items || {})
+                    });
+                    targetState.reconciling = false
+                } else {
+                    await me.refreshDockWorkspace();
+
+                    if (me.vesselWorkspaces.get(sourceWorkspaceId) === sourceState) {
+                        await me.retireReturnedVessel(sourceWorkspaceId)
+                    }
+                }
+
+                receipt.reconciled = true;
+                return receipt
+            })
+            .catch(error => {
+                targetState && (targetState.reconciling = false);
+                receipt.errors  = [error.message];
+                return receipt
+            });
+
+        return true
+    }
+
+    /**
+     * Replaces a bare vessel pane with its first real dock projection while reusing every cached
+     * pane instance. The existing preview overlay moves into the host; no pane is recreated.
+     * @param {String} workspaceId
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async mountVesselWorkspace(workspaceId) {
+        let me       = this,
+            state    = me.vesselWorkspaces.get(workspaceId),
+            document = state?.document,
+            mainView = state?.app?.mainView;
+
+        if (!state || !document || !mainView || mainView.isDestroyed) return false;
+        if (state.host && !state.host.isDestroyed) return false;
+
+        Object.keys(document.items || {}).forEach(itemId => {
+            let pane = me.paneCache[itemId];
+
+            pane?.parent?.remove(pane, false)
+        });
+        state.preview?.parent?.remove(state.preview, false);
+
+        state.host = mainView.add({
+            module: Container,
+            cls   : ['workstation-vessel-dock-host', 'neo-dashboard'],
+            flex  : 1,
+            items : [
+                me.projectVesselDockModel(workspaceId),
+                state.preview || {module: DockPreview}
+            ],
+            layout: {ntype: 'fit'}
+        });
+        state.preview ??= state.host.down({ntype: 'dock-preview'});
+
+        await state.host.promiseUpdate();
+        state.participation?.destroy();
+        state.participation = null;
+        me.crossWindowParticipations.delete(workspaceId);
+
+        return true
+    }
+
+    /**
+     * Projects a committed vessel document with one whole-stack drag grip and no nested tear-out.
+     * @param {String} workspaceId
+     * @returns {Object}
+     * @protected
+     */
+    projectVesselDockModel(workspaceId) {
+        let me       = this,
+            state    = me.vesselWorkspaces.get(workspaceId),
+            document = state?.document;
+
+        return DockLayoutAdapter.project(document, {
+            applyDockZoneOperation   : descriptor => me.commitLocalWorkspaceOperation(workspaceId, descriptor),
+            crossWindowSortGroup     : Workspace.CROSS_WINDOW_SORT_GROUP,
+            enableStackDrag          : true,
+            onDockCrossZoneDragCancel: () => me.clearCrossWindowPreview(Workspace.MAIN_WORKSPACE_ID),
+            onDockCrossZoneDrop      : () => me.clearCrossWindowPreview(Workspace.MAIN_WORKSPACE_ID),
+            onDockStackDragTerminal  : () => me.clearCrossWindowPreview(Workspace.MAIN_WORKSPACE_ID),
+            onDockZoneDocumentChange : nextDocument => state.document = nextDocument,
+            resolveComponentRef      : (componentRef, item, itemId) => me.resolvePane(itemId, item),
+            resolveRevealComponentRef: (componentRef, item, itemId) => me.resolvePane(itemId, item),
+            workspaceId
+        })
+    }
+
+    /**
+     * Closes an emptied vessel only after the main target projection has adopted the committed
+     * stack. Physical disconnect remains the topology-exit terminal.
+     * @param {String} workspaceId
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async retireReturnedVessel(workspaceId) {
+        let me     = this,
+            state  = me.vesselWorkspaces.get(workspaceId),
+            vessel = state && me.resolveTearOutVessel(state.itemId);
+
+        if (!state || Object.keys(state.document?.items || {}).length || !vessel) return false;
+
+        const closed = await me.closeTearOutVessel(vessel);
+
+        if (closed) {
+            state.closeRequested = true;
+            state.participation?.destroy();
+            state.participation = null;
+            me.crossWindowParticipations.delete(workspaceId);
+
+            if (
+                me.lastCrossWindowTransfer?.sourceWorkspaceId === workspaceId &&
+                me.lastCrossWindowTransfer.targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID
+            ) {
+                me.lastCrossWindowTransfer.closeRequested = true
+            }
+        }
+
+        return closed
+    }
+
+    /**
+     * Atomically recovers every pane from a committed vessel whose physical window disappeared
+     * before an authored whole-stack return. The headless document remains registered if any
+     * executor/adoption gate refuses, so the only surviving A+B truth is never discarded.
+     * @param {String} itemId
+     * @returns {Boolean}
+     * @protected
+     */
+    recoverDisconnectedVesselWorkspace(itemId) {
+        let me          = this,
+            workspaceId = Workspace.vesselWorkspaceId(itemId),
+            state       = workspaceId && me.vesselWorkspaces.get(workspaceId),
+            itemIds     = Object.keys(state?.document?.items || {});
+
+        if (!state?.committed || !me.workspaceSet.has(workspaceId)) return false;
+        if (!itemIds.length) return true;
+
+        let placement  = me.tearOutPlacements[itemId],
+            storedHome = placement && me.dockModel.nodes?.[placement.tabsNodeId]?.type === 'tabs'
+                ? placement.tabsNodeId
+                : null,
+            targetNodeId = storedHome
+                || Object.entries(me.dockModel.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],
+            nodeId       = DockZoneModel.resolveStackRoot(state.document);
+
+        if (!nodeId || !targetNodeId) {
+            me.lastCrossWindowTransfer = {
+                applied: false,
+                errors : ['disconnected vessel has no recoverable stack or main target']
+            };
+            return false
+        }
+
+        const descriptor = {
+                operation        : 'transferNode',
+                nodeId,
+                sourceWorkspaceId: workspaceId,
+                targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                target           : {targetNodeId, placement: {kind: 'tab-into'}}
+            },
+            result = DockZoneModel.transferNode(state.document, me.dockModel, descriptor);
+
+        if (result.errors.length) {
+            me.lastCrossWindowTransfer = {applied: false, errors: result.errors};
+            return false
+        }
+
+        try {
+            if (!me.workspaceSet.adoptTransfer({
+                sourceDocument   : result.sourceDocument,
+                sourceWorkspaceId: workspaceId,
+                targetDocument   : result.targetDocument,
+                targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID
+            })) {
+                me.lastCrossWindowTransfer = {
+                    applied: false,
+                    errors : ['workspace-set refused disconnected-vessel recovery']
+                };
+                return false
+            }
+        } catch (error) {
+            me.lastCrossWindowTransfer = {applied: false, errors: [error.message]};
+            return false
+        }
+
+        me.lastCrossWindowTransfer = {
+            applied              : true,
+            descriptor           : DockZoneModel.clone(descriptor),
+            recoveredOnDisconnect: true,
+            sourceWorkspaceId    : workspaceId,
+            targetWorkspaceId    : Workspace.MAIN_WORKSPACE_ID,
+            topologyExited       : true
+        };
+        me.onDockZoneDocumentChange(me.dockModel, {preserveItemIds: itemIds});
+
+        return true
+    }
+
+    /**
+     * Removes only dead render-target seams while retaining a committed headless document for
+     * retry and diagnostics after recovery refused.
+     * @param {Object} state
+     * @protected
+     */
+    demoteDisconnectedVesselWorkspace(state) {
+        if (!state) return;
+
+        state.participation?.destroy();
+        this.crossWindowParticipations.delete(state.workspaceId);
+        state.app            = null;
+        state.closeRequested = false;
+        state.disconnected   = true;
+        state.host           = null;
+        state.participation  = null;
+        state.preview        = null;
+        state.reconciling    = false;
+        state.windowId       = null
+    }
+
+    /**
      * Assigns a new trend array to a registered visible scale record and refreshes the
      * viewport pool. Coarse dock projection preserves cached pane identities, while a resized
      * viewport pool can allocate new Canvas cells whose registration settles asynchronously;
@@ -987,7 +1684,8 @@ class Workspace extends Container {
         });
         host.updateDepth = -1;
         host.update();
-        await host.promiseUpdate()
+        await host.promiseUpdate();
+        await me.refreshCrossWindowParticipation(Workspace.MAIN_WORKSPACE_ID)
     }
 
     /**
@@ -1838,6 +2536,14 @@ class Workspace extends Container {
             } else {
                 me.reparentTearOutPane(itemId, connected)
             }
+
+            me.registerVesselWorkspaceTarget({
+                app     : Neo.apps[connected.windowId],
+                itemId,
+                windowId: connected.windowId
+            }).catch(error => {
+                me.lastCrossWindowTransfer = {applied: false, errors: [error.message]}
+            })
         }
     }
 
@@ -1994,6 +2700,10 @@ class Workspace extends Container {
         } else {
             me.tearOutConnects[itemId] = connection
         }
+
+        if (me.tearOutPanes[itemId]) {
+            await me.registerVesselWorkspaceTarget({app, itemId, windowId})
+        }
     }
 
     /**
@@ -2033,6 +2743,7 @@ class Workspace extends Container {
                 });
                 me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
                 me.revokeVesselOwnerGrant('tear-out', itemId);
+                me.retireVesselWorkspaceTarget(itemId);
                 me.tearOutRetirements.delete(itemId);
                 delete me.tearOutPanes[itemId];
                 committed && me.reintegrateTearOutItem(itemId);
@@ -2064,6 +2775,7 @@ class Workspace extends Container {
                 });
                 me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
                 me.revokeVesselOwnerGrant('tear-out', itemId);
+                me.retireVesselWorkspaceTarget(itemId);
                 me.tearOutRetirements.delete(itemId);
                 return
             }
@@ -2073,7 +2785,16 @@ class Workspace extends Container {
         // has no entry in either map and needs nothing.
         for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
             if (entry.windowId === data.windowId) {
-                const windowName = entry.windowName ?? `tearout-${itemId}`;
+                const
+                    windowName     = entry.windowName ?? `tearout-${itemId}`,
+                    workspaceId    = Workspace.vesselWorkspaceId(itemId),
+                    workspaceState = me.vesselWorkspaces.get(workspaceId);
+                let workspaceSettled = true;
+
+                if (workspaceState?.committed) {
+                    workspaceSettled = Object.keys(workspaceState.document?.items || {}).length === 0
+                        || me.recoverDisconnectedVesselWorkspace(itemId)
+                }
 
                 delete me.tearOutPanes[itemId];
                 delete me.tearOutConnects[itemId];
@@ -2085,7 +2806,22 @@ class Workspace extends Container {
                     windowName
                 });
                 me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
-                me.reintegrateTearOutItem(itemId);
+
+                if (workspaceSettled) {
+                    if (
+                        workspaceState?.committed &&
+                        me.lastCrossWindowTransfer?.sourceWorkspaceId === workspaceId &&
+                        me.lastCrossWindowTransfer.targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID
+                    ) {
+                        me.lastCrossWindowTransfer.topologyExited = true
+                    }
+
+                    me.retireVesselWorkspaceTarget(itemId);
+                    me.reintegrateTearOutItem(itemId)
+                } else {
+                    me.demoteDisconnectedVesselWorkspace(workspaceState)
+                }
+
                 break
             }
         }
@@ -2996,6 +3732,9 @@ class Workspace extends Container {
             scope     : me
         });
 
+        me.crossWindowParticipations.forEach(participation => participation?.destroy());
+        me.crossWindowParticipations.clear();
+        me.vesselWorkspaces.clear();
         me.tourRunner?.destroy();
         me.dockService?.destroy();
         me.dragAffordances?.destroy();

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -269,6 +269,13 @@ class Workspace extends Container {
      */
     lastCrossWindowTransfer = null
     /**
+     * Most recent exact vessel-close attempt for bounded headed-failure diagnosis. Native handle
+     * authority is represented only by presence/match booleans; its secret key never enters this
+     * worker-visible receipt.
+     * @member {Object|null} lastTearOutClose=null
+     */
+    lastTearOutClose = null
+    /**
      * Product-semantic vessel owner grants by `flow:itemId`.
      * @member {Map} vesselOwnerGrants=new Map()
      * @protected
@@ -631,9 +638,21 @@ class Workspace extends Container {
      * @returns {String|null}
      */
     getPaneIdentity(itemId) {
-        const item = this.dockModel.items[itemId];
+        let me   = this,
+            pane = me.paneCache[itemId],
+            item = me.dockModel.items[itemId];
 
-        return item ? this.resolvePane(itemId, item).id : null
+        if (pane && !pane.isDestroyed) return pane.id;
+
+        if (!item) {
+            for (const state of me.vesselWorkspaces.values()) {
+                item = state.document?.items?.[itemId];
+
+                if (item) break
+            }
+        }
+
+        return item ? me.resolvePane(itemId, item).id : null
     }
 
     /**
@@ -843,7 +862,15 @@ class Workspace extends Container {
             onDockTearOutExit        : data => me.onDockTearOutExit(data),
             onDockTearOutTerminal    : data => me.tearOutHandlers.onDockTearOutTerminal(data),
             onDockVesselConversionIn : data => {
-                me.vesselConversionTargetWindowId = data.targetId ?? null;
+                let targetWorkspaceId = data.targetId,
+                    targetState       = me.vesselWorkspaces.get(targetWorkspaceId);
+
+                // The coordinator speaks stable claim identity. Platform effects speak runtime
+                // window identity. Resolve the former through the app-owned workspace registry;
+                // never reinterpret `workstation-vessel:<item>` as a manager.Window id.
+                me.vesselConversionTargetWindowId = targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID
+                    ? me.windowId
+                    : targetState?.windowId ?? null;
 
                 return me.vesselParkHandlers.onConversionIn({
                     itemId    : data.itemId,
@@ -1270,6 +1297,7 @@ class Workspace extends Container {
             applied       : true,
             closeRequested: false,
             descriptor    : DockZoneModel.clone(descriptor),
+            phases        : ['documents-adopted'],
             reconciled    : false,
             sourceWorkspaceId,
             targetWorkspaceId,
@@ -1287,13 +1315,16 @@ class Workspace extends Container {
                         me.vesselWorkspaces.get(targetWorkspaceId) !== targetState) {
                         throw new Error('vessel target projection did not settle')
                     }
+                    receipt.phases.push('target-projected');
 
                     await me.refreshDockWorkspace({
                         preserveItemIds: Object.keys(targetState.document?.items || {})
                     });
+                    receipt.phases.push('main-projected');
                     targetState.reconciling = false
                 } else {
                     await me.refreshDockWorkspace();
+                    receipt.phases.push('main-projected');
 
                     if (me.vesselWorkspaces.get(sourceWorkspaceId) === sourceState) {
                         await me.retireReturnedVessel(sourceWorkspaceId)
@@ -1388,11 +1419,20 @@ class Workspace extends Container {
      * @protected
      */
     async retireReturnedVessel(workspaceId) {
-        let me     = this,
-            state  = me.vesselWorkspaces.get(workspaceId),
-            vessel = state && me.resolveTearOutVessel(state.itemId);
+        let me      = this,
+            state   = me.vesselWorkspaces.get(workspaceId),
+            vessel  = state && me.resolveTearOutVessel(state.itemId),
+            receipt = me.lastCrossWindowTransfer;
 
         if (!state || Object.keys(state.document?.items || {}).length || !vessel) return false;
+
+        if (
+            receipt?.sourceWorkspaceId === workspaceId &&
+            receipt.targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID
+        ) {
+            receipt.phases ??= [];
+            receipt.phases.push('close-dispatched')
+        }
 
         const closed = await me.closeTearOutVessel(vessel);
 
@@ -1406,7 +1446,9 @@ class Workspace extends Container {
                 me.lastCrossWindowTransfer?.sourceWorkspaceId === workspaceId &&
                 me.lastCrossWindowTransfer.targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID
             ) {
-                me.lastCrossWindowTransfer.closeRequested = true
+                me.lastCrossWindowTransfer.closeRequested = true;
+                me.lastCrossWindowTransfer.phases ??= [];
+                me.lastCrossWindowTransfer.phases.push('close-acknowledged')
             }
         }
 
@@ -2197,11 +2239,25 @@ class Workspace extends Container {
             embodiedWindowId = entry?.windowId ?? admission?.windowId ?? me.tearOutEmbodiment.getWindowId(itemId),
             closed           = false;
 
+        const closeReceipt = me.lastTearOutClose = {
+            identity: {
+                admissionMatches : !Number.isFinite(admissionToken) || admissionToken === exactToken,
+                entryNameMatches : !entry || entry.windowName === windowName,
+                generationMatches: !Number.isFinite(generation) || generation === exactGeneration,
+                hasEntry         : Boolean(entry),
+                hasItemId        : Boolean(itemId),
+                windowNameMatches: windowName === expected
+            },
+            itemId: itemId ?? null,
+            stage : 'validating-identity'
+        };
+
         if (
             !itemId || windowName !== expected || (entry && entry.windowName !== windowName) ||
             (Number.isFinite(generation) && generation !== exactGeneration) ||
             (Number.isFinite(admissionToken) && admissionToken !== exactToken)
         ) {
+            closeReceipt.stage = 'identity-refused';
             return false
         }
 
@@ -2211,11 +2267,26 @@ class Workspace extends Container {
 
         const exactWindowId = entry?.windowId ?? admission?.windowId;
 
+        closeReceipt.route = {
+            closeCapable      : !nativeRoute || nativeRoute.capabilities?.close === true,
+            exactTargetMatches: !nativeRoute || !exactWindowId || nativeRoute.targetWindowId === exactWindowId,
+            exactWindowId     : exactWindowId ?? null,
+            hasHandle         : !nativeRoute || Boolean(nativeRoute.nativeHandleKey),
+            ownerMatches      : !nativeRoute || nativeRoute.ownerWindowId === me.windowId,
+            ownerWindowId     : nativeRoute?.ownerWindowId ?? null,
+            present           : Boolean(nativeRoute),
+            targetPresent     : !nativeRoute || Boolean(nativeRoute.targetWindowId),
+            targetWindowId    : nativeRoute?.targetWindowId ?? null
+        };
+
         if (nativeRoute && (
             !nativeRoute.nativeHandleKey || nativeRoute.ownerWindowId !== me.windowId ||
             !nativeRoute.targetWindowId || nativeRoute.capabilities?.close !== true ||
             (exactWindowId && nativeRoute.targetWindowId !== exactWindowId)
-        )) return false;
+        )) {
+            closeReceipt.stage = 'route-refused';
+            return false
+        }
 
         // Establish retirement before restoring any source embodiment or awaiting the platform.
         // A refused close retains the exact route + tear-out machine slot for retry, but the
@@ -2229,17 +2300,24 @@ class Workspace extends Container {
                       itemId, windowId: embodiedWindowId
                   });
 
-            if (!settled) return false
+            closeReceipt.embodiment = {settled, sourceOwns, staged: true};
+
+            if (!settled) {
+                closeReceipt.stage = 'embodiment-refused';
+                return false
+            }
         }
 
         try {
             if (nativeRoute) {
+                closeReceipt.stage = 'native-dispatched';
                 closed = await Neo.Main.windowNativeClose({
                     nativeHandleKey: nativeRoute.nativeHandleKey,
                     targetWindowId : nativeRoute.targetWindowId,
                     windowId       : me.windowId
                 }) === true
             } else {
+                closeReceipt.stage = 'semantic-dispatched';
                 // Before connect there is no exact route to correlate yet; the active tear-out
                 // slot's unguessable semantic name is the only available authority. Once a route
                 // exists, ANY invalidity above fails closed — never downgrade to same-name close.
@@ -2247,15 +2325,23 @@ class Workspace extends Container {
                 closed = true
             }
         } catch (error) {
+            closeReceipt.error = String(error?.message || error);
+            closeReceipt.stage = 'threw';
             return false
         }
 
-        if (!closed) return false;
+        closeReceipt.closed = closed;
+
+        if (!closed) {
+            closeReceipt.stage = 'platform-refused';
+            return false
+        }
 
         delete me.tearOutConnects[itemId];
         me.tearOutConnectAdmissions.delete(itemId);
         me.revokeVesselOwnerGrant('tear-out', itemId);
         me.tearOutRetirements.delete(itemId);
+        closeReceipt.stage = 'acknowledged';
 
         return true
     }
@@ -2273,6 +2359,7 @@ class Workspace extends Container {
 
         const resolved = {
             ...entry,
+            itemId,
             nativeRoute: entry.nativeRoute ?? Neo.manager?.Window?.get(entry.windowId)?.nativeRoute ?? null,
             windowName : entry.windowName ?? `tearout-${itemId}`
         };
@@ -2813,7 +2900,9 @@ class Workspace extends Container {
                         me.lastCrossWindowTransfer?.sourceWorkspaceId === workspaceId &&
                         me.lastCrossWindowTransfer.targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID
                     ) {
-                        me.lastCrossWindowTransfer.topologyExited = true
+                        me.lastCrossWindowTransfer.topologyExited = true;
+                        me.lastCrossWindowTransfer.phases ??= [];
+                        me.lastCrossWindowTransfer.phases.push('topology-exited')
                     }
 
                     me.retireVesselWorkspaceTarget(itemId);
@@ -2836,10 +2925,11 @@ class Workspace extends Container {
      * style delta.
      * @param {Number} clientX
      * @param {Number} clientY
+     * @param {String|Number} [windowId=this.windowId]
      * @returns {Neo.component.Base}
      * @protected
      */
-    createFilmCursorDot(clientX, clientY) {
+    createFilmCursorDot(clientX, clientY, windowId=this.windowId) {
         let me        = this,
             cursorDot = Neo.create({
                 className    : 'Neo.component.Base',
@@ -2847,7 +2937,7 @@ class Workspace extends Container {
                 autoInitVnode: true,
                 autoMount    : true,
                 parentId     : 'document.body',
-                windowId     : me.windowId,
+                windowId,
                 cls          : ['film-cursor'],
                 style        : {
                     backgroundColor: 'rgba(255, 90, 0, 0.92)',
@@ -2865,7 +2955,7 @@ class Workspace extends Container {
             });
 
         cursorDot.mountedPromise.then(() => {
-            console.log(`[film-cursor] dot mounted at client (${clientX}, ${clientY})`)
+            console.log(`[film-cursor] dot mounted in ${windowId} at client (${clientX}, ${clientY})`)
         });
 
         return cursorDot
@@ -3247,6 +3337,590 @@ class Workspace extends Container {
             return {applied: false, errors: [error?.message || String(error)]}
         } finally {
             restoreProxyPopupConfig();
+            cursorDot?.destroy()
+        }
+    }
+
+    /**
+     * @summary Reads the semantic, rendered, arbitration, and physical-park truth for one
+     * cross-window pointer frame.
+     *
+     * The film executors use this as their pre-release gate: mouseup is withheld until the
+     * coordinator has exactly one stable claim, its winning target is engaged, and the target's
+     * semantic preview equals the preview rendered in that window. A converting tear-out can add
+     * `parkedItemId`, which additionally requires the exact source vessel to be strictly parked.
+     * @param {Object} context
+     * @param {String|null} [context.parkedItemId=null]
+     * @param {Neo.dashboard.DockTabSortZone} context.sourceZone
+     * @param {String} context.targetWorkspaceId
+     * @returns {Object}
+     * @protected
+     */
+    readCrossWindowGestureSnapshot({parkedItemId=null, sourceZone, targetWorkspaceId}={}) {
+        let me            = this,
+            isMain        = targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID,
+            state         = isMain ? null : me.vesselWorkspaces.get(targetWorkspaceId),
+            participation = me.crossWindowParticipations.get(targetWorkspaceId),
+            target        = participation?.target,
+            coordinator   = sourceZone?.dragCoordinator,
+            arbiter       = coordinator?.pointerClaimArbiter,
+            winner        = arbiter?.resolve?.() ?? null,
+            semantic      = target?.currentPreview ?? null,
+            renderer      = isMain ? me.dragAffordances?.preview : state?.preview,
+            rendered      = renderer?.dockPreview ?? null,
+            sensor        = sourceZone?.vesselConversionSensor,
+            parkedVessel  = me.vesselParkHandlers?.parkedVessel ?? null,
+            sourceVessel  = parkedItemId && me.resolveTearOutVessel(parkedItemId),
+            snapshot      = {
+                claimCount           : arbiter?.claimCount ?? 0,
+                converted            : sensor?.converted === true && sensor?.transitioning !== true,
+                engaged              : coordinator?.activeTargetZone === target,
+                parkedItemId         : parkedVessel?.itemId ?? null,
+                preview              : semantic ? DockZoneModel.clone(semantic) : null,
+                rendered             : rendered ? DockZoneModel.clone(rendered) : null,
+                sourceVesselConnected: Boolean(
+                    sourceVessel?.windowId && Neo.manager?.Window?.get(sourceVessel.windowId)
+                ),
+                sourceVesselWindowId: sourceVessel?.windowId ?? null,
+                targetWorkspaceId,
+                winnerStableId      : winner?.stableId ?? null
+            };
+
+        snapshot.ready = snapshot.claimCount === 1
+            && snapshot.engaged
+            && snapshot.winnerStableId === targetWorkspaceId
+            && Boolean(snapshot.preview?.previewId)
+            && snapshot.rendered?.previewId === snapshot.preview.previewId
+            && (parkedItemId == null || (
+                snapshot.converted && snapshot.parkedItemId === parkedItemId &&
+                snapshot.sourceVesselConnected
+            ));
+
+        return snapshot
+    }
+
+    /**
+     * @summary Polls one exact cross-window transfer through model adoption and queued projection.
+     * @param {Object} expected
+     * @param {String} expected.sourceWorkspaceId
+     * @param {String} expected.targetWorkspaceId
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=240]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    async waitForCrossWindowTransfer(expected, {attempts=240, delay=16}={}) {
+        let me = this,
+            receipt;
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            receipt = me.lastCrossWindowTransfer;
+
+            if (
+                receipt?.applied === true && receipt.reconciled === true &&
+                receipt.sourceWorkspaceId === expected?.sourceWorkspaceId &&
+                receipt.targetWorkspaceId === expected?.targetWorkspaceId
+            ) {
+                return receipt
+            }
+
+            attempt < attempts && await me.timeout(delay)
+        }
+
+        return receipt ?? null
+    }
+
+    /**
+     * @summary Scene 3's real-pointer executor: converts a second tear-out while the gesture remains
+     * down, parks that exact OS window over a committed sibling vessel, and releases only after one
+     * semantic + rendered target claim has settled.
+     *
+     * The source stays on the ordinary tab-drag path. It first crosses the source workspace boundary
+     * to acquire its real vessel; subsequent events keep source-local coordinates outside while
+     * moving in global screen space over the target vessel. The landed conversion sensor and
+     * coordinator therefore own the park, preview, arbitration, and atomic transfer. This method
+     * drives and reports those seams; it never calls a reducer or target commit directly.
+     * @param {Object} step
+     * @param {String} step.itemId Incoming pane id.
+     * @param {String} step.sourceNodeId Main-workspace tabs node currently holding the pane.
+     * @param {String} step.targetItemId Existing detached pane whose vessel becomes the target.
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=240]
+     * @param {Number} [options.moveDelay=16]
+     * @param {Number} [options.moveSteps=4]
+     * @param {Boolean} [options.showCursor=false] Film mode: show the synthetic cursor in whichever
+     * window currently owns the visible leg of the gesture.
+     * @returns {Promise<Object>}
+     */
+    async executeCrossWindowDockStep(step, {attempts=240, moveDelay=16, moveSteps=4, showCursor=false}={}) {
+        let me                                   = this,
+            {itemId, sourceNodeId, targetItemId} = step || {},
+            targetWorkspaceId                    = Workspace.vesselWorkspaceId(targetItemId),
+            targetState                          = targetWorkspaceId && me.vesselWorkspaces.get(targetWorkspaceId),
+            sourceDocument                       = me.dockModel,
+            sourceNode                           = sourceDocument?.nodes?.[sourceNodeId],
+            button                               = null,
+            cursorDot                            = null,
+            release                              = null,
+            sortZone                             = null;
+
+        if (
+            !itemId || !targetItemId || itemId === targetItemId ||
+            sourceNode?.type !== 'tabs' || !sourceNode.items.includes(itemId)
+        ) {
+            return {applied: false, errors: ['cross-window dock step must name distinct live source and target panes']}
+        }
+        if (
+            !targetState || targetState.committed || targetState.closeRequested ||
+            !me.tearOutPanes[targetItemId]
+        ) {
+            return {applied: false, errors: ['target vessel is not an available first-dock workspace']}
+        }
+
+        let pane = me.paneCache[itemId];
+
+        if (!pane || pane.isDestroyed || !sourceDocument.items?.[itemId]) {
+            return {applied: false, errors: ['incoming pane is not live and owned by the main workspace']}
+        }
+
+        try {
+            await me.refreshPromise;
+            targetState.participationPromise && await targetState.participationPromise;
+
+            let host          = me.getReference('dock-host'),
+                tabs          = host?.down({dockNodeId: sourceNodeId}),
+                itemIndex     = sourceNode.items.indexOf(itemId),
+                WindowManager = (await import('../../../src/manager/Window.mjs')).default;
+
+            button   = tabs?.getTabAtIndex(itemIndex);
+            sortZone = tabs?.getTabBar()?.sortZone;
+
+            let [buttonRect] = button ? await button.getDomRect([button.id], button.windowId) : [],
+                sourceWindow = WindowManager.get(button?.windowId),
+                targetWindow = WindowManager.get(targetState.windowId);
+
+            if (
+                !button || !sortZone || !buttonRect || !sourceWindow?.innerRect ||
+                !targetWindow?.innerRect || !targetState.participation
+            ) {
+                return {applied: false, errors: ['cross-window dock gesture surfaces are not ready']}
+            }
+
+            let startX  = buttonRect.x + buttonRect.width / 2,
+                startY  = buttonRect.y + buttonRect.height / 2,
+                startSX = sourceWindow.innerRect.x + startX,
+                startSY = sourceWindow.innerRect.y + startY,
+                opt     = (clientX, clientY, screenX, screenY, buttons) => ({
+                    bubbles: true, button: 0, buttons, cancelable: true,
+                    clientX, clientY, screenX, screenY
+                }),
+                moveCursor = (clientX, clientY) => {
+                    if (cursorDot) {
+                        cursorDot.style = {
+                            ...cursorDot.style,
+                            left: `${clientX - 8}px`,
+                            top : `${clientY - 8}px`
+                        }
+                    }
+                };
+
+            delete me.tearOutConnects[itemId];
+            showCursor && (cursorDot = me.createFilmCursorDot(startX, startY, button.windowId));
+
+            await me.interactionService.simulateEvent({events: [{
+                targetId: button.id, type: 'mousedown', windowId: button.windowId,
+                options : opt(startX, startY, startSX, startSY, 1)
+            }, {
+                delay  : 120, targetId: button.id, type: 'mousemove', windowId: button.windowId,
+                options: opt(startX + 8, startY + 2, startSX + 8, startSY + 2, 1)
+            }, {
+                delay  : moveDelay, targetId: button.id, type: 'mousemove', windowId: button.windowId,
+                options: opt(startX + 16, startY + 24, startSX + 16, startSY + 24, 1)
+            }]});
+
+            if (!await me.waitForTearOutDragArmed(sortZone)) {
+                release = {clientX: startX, clientY: startY, screenX: startSX, screenY: startSY};
+
+                let cancellation = await me.cancelTearOutGesture(button, release, {sortZone});
+
+                return {
+                    applied: false,
+                    errors : ['cross-window source drag did not arm'],
+                    proof  : {cancellation}
+                }
+            }
+
+            let boundary = sortZone.boundaryContainerRect,
+                right    = boundary.right  ?? boundary.x + boundary.width,
+                bottom   = boundary.bottom ?? boundary.y + boundary.height,
+                outX     = Math.round(right + 120),
+                outY     = Math.round(bottom + 120);
+
+            for (let index = 1; index <= moveSteps; index++) {
+                let t       = index / moveSteps,
+                    clientX = Math.round(startX + (outX - startX) * t),
+                    clientY = Math.round(startY + (outY - startY) * t);
+
+                moveCursor(clientX, clientY);
+
+                await me.interactionService.simulateEvent({events: [{
+                    delay  : moveDelay, targetId: button.id, type: 'mousemove', windowId: button.windowId,
+                    options: opt(
+                        clientX,
+                        clientY,
+                        sourceWindow.innerRect.x + clientX,
+                        sourceWindow.innerRect.y + clientY,
+                        1
+                    )
+                }]})
+            }
+
+            if (!await me.waitForTearOutVessel(itemId, {attempts})) {
+                release = {
+                    clientX: outX,
+                    clientY: outY,
+                    screenX: sourceWindow.innerRect.x + outX,
+                    screenY: sourceWindow.innerRect.y + outY
+                };
+
+                let cancellation = await me.cancelTearOutGesture(button, release, {sortZone});
+
+                return {
+                    applied: false,
+                    errors : ['cross-window source vessel was not born while the gesture remained down'],
+                    proof  : {cancellation}
+                }
+            }
+
+            let remoteSnapshot;
+
+            if (showCursor) {
+                cursorDot?.destroy();
+                cursorDot = null
+            }
+
+            for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+                targetWindow = WindowManager.get(targetState.windowId);
+
+                if (!targetWindow?.innerRect) break;
+
+                let targetClientX = Math.round(targetWindow.innerRect.width  / 2) + attempt % 2,
+                    targetClientY = Math.round(targetWindow.innerRect.height / 2),
+                    targetScreenX = Math.round(targetWindow.innerRect.x + targetClientX),
+                    targetScreenY = Math.round(targetWindow.innerRect.y + targetClientY);
+
+                showCursor && !cursorDot &&
+                    (cursorDot = me.createFilmCursorDot(targetClientX, targetClientY, targetState.windowId));
+                moveCursor(targetClientX, targetClientY);
+
+                release = {clientX: outX, clientY: outY, screenX: targetScreenX, screenY: targetScreenY};
+
+                await me.interactionService.simulateEvent({events: [{
+                    delay  : moveDelay, targetId: button.id, type: 'mousemove', windowId: button.windowId,
+                    options: opt(outX + attempt % 2, outY, targetScreenX, targetScreenY, 1)
+                }]});
+
+                let transition = sortZone.vesselConversionSensor?.transitionPromise;
+
+                transition && await transition;
+                remoteSnapshot = me.readCrossWindowGestureSnapshot({
+                    parkedItemId: itemId,
+                    sourceZone  : sortZone,
+                    targetWorkspaceId
+                });
+
+                if (remoteSnapshot.ready) break
+            }
+
+            if (!remoteSnapshot?.ready) {
+                let cancellation = await me.cancelTearOutGesture(button, release, {sortZone});
+
+                return {
+                    applied: false,
+                    errors : ['target vessel did not reach one parked semantic + rendered claim'],
+                    proof  : {cancellation, remoteSnapshot}
+                }
+            }
+
+            me.lastCrossWindowTransfer = null;
+
+            await me.interactionService.simulateEvent({events: [{
+                targetId: button.id, type: 'mouseup', windowId: button.windowId,
+                options : opt(release.clientX, release.clientY, release.screenX, release.screenY, 0)
+            }]});
+
+            let transfer = await me.waitForCrossWindowTransfer({
+                    sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                    targetWorkspaceId
+                }, {attempts}),
+                sourceAfter = DockZoneModel.clone(me.dockModel),
+                targetAfter = DockZoneModel.clone(me.vesselWorkspaces.get(targetWorkspaceId)?.document),
+                retired     = await me.waitForTearOutVesselRetired(itemId, {attempts}),
+                targetItems = targetAfter?.nodes?.[Workspace.vesselTabsNodeId(targetItemId)]?.items || [],
+                sourceOwns  = DockZoneModel.findContainingTabsId(sourceAfter, itemId) != null
+                    || DockZoneModel.findContainingTabsId(sourceAfter, targetItemId) != null,
+                applied     = transfer?.reconciled === true && retired && !sourceOwns
+                    && targetItems.length === 2
+                    && targetItems[0] === targetItemId
+                    && targetItems[1] === itemId;
+
+            return {
+                applied,
+                errors: applied ? [] : ['cross-window dock did not settle as one A+B target adoption'],
+                proof : {
+                    remoteSnapshot,
+                    sourceDocument     : sourceAfter,
+                    sourceVesselRetired: retired,
+                    targetDocument     : targetAfter,
+                    transfer           : transfer ? DockZoneModel.clone(transfer) : null
+                }
+            }
+        } catch (error) {
+            button && await me.cancelTearOutGesture(button, release, {sortZone}).catch(() => {});
+
+            return {applied: false, errors: [error?.message || String(error)]}
+        } finally {
+            cursorDot?.destroy()
+        }
+    }
+
+    /**
+     * @summary Scene 4's real-pointer executor: drags a committed vessel's model-resolved stack
+     * grip home and waits through atomic `transferNode`, main projection, native close request, and
+     * physical topology exit.
+     *
+     * The pointer starts on the actual nested `.neo-dock-stack-handle`, so
+     * {@link Neo.dashboard.DockTabSortZone} authors the group payload. The executor never invokes
+     * `transferNode` itself; it withholds mouseup until the main target's one semantic + rendered
+     * claim settles, then observes the resulting receipt through window disconnect.
+     * @param {Object} step
+     * @param {String} step.ownerItemId The pane whose committed vessel owns the stack.
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=240]
+     * @param {Number} [options.moveDelay=16]
+     * @param {Boolean} [options.showCursor=false] Film mode: move the synthetic cursor from the
+     * committed vessel into the main window with the physical gesture.
+     * @returns {Promise<Object>}
+     */
+    async executeStackReturnStep(step, {attempts=240, moveDelay=16, showCursor=false}={}) {
+        let me            = this,
+            {ownerItemId} = step || {},
+            workspaceId   = Workspace.vesselWorkspaceId(ownerItemId),
+            state         = workspaceId && me.vesselWorkspaces.get(workspaceId),
+            button        = null,
+            cursorDot     = null,
+            handleId      = null,
+            release       = null,
+            sortZone      = null;
+
+        if (!state?.committed || !state.document || !me.workspaceSet.has(workspaceId)) {
+            return {applied: false, errors: ['stack return requires one committed vessel workspace']}
+        }
+
+        try {
+            await me.refreshPromise;
+            await me.crossWindowParticipationPromise;
+
+            let nodeId        = DockZoneModel.resolveStackRoot(state.document),
+                tabsNodeId    = Workspace.vesselTabsNodeId(ownerItemId),
+                tabsNode      = state.document.nodes?.[tabsNodeId],
+                activeItemId  = tabsNode?.activeItemId ?? tabsNode?.items?.[0],
+                activeIndex   = tabsNode?.items?.indexOf(activeItemId) ?? -1,
+                tabs          = state.host?.down({dockNodeId: tabsNodeId}),
+                WindowManager = (await import('../../../src/manager/Window.mjs')).default;
+
+            button   = tabs?.getTabAtIndex(activeIndex);
+            sortZone = tabs?.getTabBar()?.sortZone;
+            handleId = DockLayoutAdapter.stackHandleDomId(activeItemId);
+
+            let [handleRect] = button && handleId
+                    ? await button.getDomRect([handleId], button.windowId)
+                    : [],
+                sourceWindow = WindowManager.get(state.windowId),
+                targetWindow = WindowManager.get(me.windowId);
+
+            if (
+                !nodeId || !button || !sortZone || !handleRect || !sourceWindow?.innerRect ||
+                !targetWindow?.innerRect || !me.crossWindowParticipations.get(Workspace.MAIN_WORKSPACE_ID)
+            ) {
+                return {applied: false, errors: ['whole-stack gesture surfaces are not ready']}
+            }
+
+            let startX  = handleRect.x + handleRect.width / 2,
+                startY  = handleRect.y + handleRect.height / 2,
+                startSX = sourceWindow.innerRect.x + startX,
+                startSY = sourceWindow.innerRect.y + startY,
+                opt     = (clientX, clientY, screenX, screenY, buttons) => ({
+                    bubbles: true, button: 0, buttons, cancelable: true,
+                    clientX, clientY, screenX, screenY
+                }),
+                moveCursor = (clientX, clientY) => {
+                    if (cursorDot) {
+                        cursorDot.style = {
+                            ...cursorDot.style,
+                            left: `${clientX - 8}px`,
+                            top : `${clientY - 8}px`
+                        }
+                    }
+                };
+
+            showCursor && (cursorDot = me.createFilmCursorDot(startX, startY, state.windowId));
+
+            await me.interactionService.simulateEvent({events: [{
+                targetId: handleId, type: 'mousedown', windowId: button.windowId,
+                options : opt(startX, startY, startSX, startSY, 1)
+            }, {
+                delay  : 120, targetId: handleId, type: 'mousemove', windowId: button.windowId,
+                options: opt(startX + 8, startY, startSX + 8, startSY, 1)
+            }, {
+                delay  : moveDelay, targetId: handleId, type: 'mousemove', windowId: button.windowId,
+                options: opt(startX + 24, startY, startSX + 24, startSY, 1)
+            }]});
+
+            let armed = false;
+
+            for (let attempt = 0; attempt <= 120 && !me.isDestroyed; attempt++) {
+                armed = Boolean(sortZone.stackDragActive && sortZone.dragProxy && sortZone.dragCoordinator);
+
+                if (armed) break;
+
+                attempt < 120 && await me.timeout(16)
+            }
+
+            if (!armed) {
+                release = {clientX: startX, clientY: startY, screenX: startSX, screenY: startSY};
+
+                let cancellation = await me.cancelTearOutGesture(button, release, {sortZone, targetId: handleId});
+
+                return {
+                    applied: false,
+                    errors : ['whole-stack source drag did not arm from the rendered grip'],
+                    proof  : {
+                        cancellation,
+                        sourceArm: {
+                            dockGroupNodeId: sortZone.dockGroupNodeId,
+                            dragComponent  : sortZone.dragComponent?.id ?? null,
+                            dragProxyReady : Boolean(sortZone.dragProxy),
+                            stackDragActive: sortZone.stackDragActive === true,
+                            startIndex     : sortZone.startIndex
+                        }
+                    }
+                }
+            }
+
+            let remoteSnapshot;
+
+            if (showCursor) {
+                cursorDot?.destroy();
+                cursorDot = null
+            }
+
+            for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+                targetWindow = WindowManager.get(me.windowId);
+
+                if (!targetWindow?.innerRect) break;
+
+                let targetClientX = Math.round(targetWindow.innerRect.width  / 2) + attempt % 2,
+                    targetClientY = Math.round(targetWindow.innerRect.height / 2),
+                    targetScreenX = Math.round(targetWindow.innerRect.x + targetClientX),
+                    targetScreenY = Math.round(targetWindow.innerRect.y + targetClientY);
+
+                showCursor && !cursorDot &&
+                    (cursorDot = me.createFilmCursorDot(targetClientX, targetClientY, me.windowId));
+                moveCursor(targetClientX, targetClientY);
+
+                release = {
+                    clientX: startX + 32,
+                    clientY: startY,
+                    screenX: targetScreenX,
+                    screenY: targetScreenY
+                };
+
+                await me.interactionService.simulateEvent({events: [{
+                    delay  : moveDelay, targetId: handleId, type: 'mousemove', windowId: button.windowId,
+                    options: opt(
+                        release.clientX + attempt % 2,
+                        release.clientY,
+                        release.screenX,
+                        release.screenY,
+                        1
+                    )
+                }]});
+
+                remoteSnapshot = me.readCrossWindowGestureSnapshot({
+                    sourceZone       : sortZone,
+                    targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID
+                });
+
+                if (remoteSnapshot.ready) break
+            }
+
+            if (!remoteSnapshot?.ready) {
+                let cancellation = await me.cancelTearOutGesture(button, release, {sortZone, targetId: handleId});
+
+                return {
+                    applied: false,
+                    errors : ['main workspace did not reach one semantic + rendered stack-return claim'],
+                    proof  : {cancellation, remoteSnapshot}
+                }
+            }
+
+            let sourceWindowId = state.windowId,
+                sourceItemIds  = [
+                    ...(state.document.nodes?.[nodeId]?.items || Object.keys(state.document.items || {}))
+                ];
+
+            me.lastCrossWindowTransfer = null;
+
+            await me.interactionService.simulateEvent({events: [{
+                targetId: handleId, type: 'mouseup', windowId: button.windowId,
+                options : opt(release.clientX, release.clientY, release.screenX, release.screenY, 0)
+            }]});
+
+            let transfer = await me.waitForCrossWindowTransfer({
+                sourceWorkspaceId: workspaceId,
+                targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID
+            }, {attempts});
+
+            for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+                if (transfer?.topologyExited === true && !WindowManager.get(sourceWindowId)) break;
+
+                attempt < attempts && await me.timeout(16)
+            }
+
+            let mainAfter        = DockZoneModel.clone(me.dockModel),
+                targetNodeId     = remoteSnapshot.preview?.target?.nodeId,
+                returnedItems    = mainAfter.nodes?.[targetNodeId]?.items || [],
+                requiredPhases   = ['documents-adopted', 'main-projected', 'close-dispatched', 'topology-exited'],
+                phaseOrder       = (transfer?.phases || []).filter(phase => requiredPhases.includes(phase)),
+                sourceWindowGone = !WindowManager.get(sourceWindowId),
+                applied          = transfer?.descriptor?.operation === 'transferNode'
+                    && transfer.closeRequested === true
+                    && transfer.topologyExited === true
+                    && JSON.stringify(phaseOrder) === JSON.stringify(requiredPhases)
+                    && sourceWindowGone
+                    && sourceItemIds.every(itemId => returnedItems.includes(itemId));
+
+            return {
+                applied,
+                errors: applied ? [] : ['whole-stack return did not settle through model-before-close topology exit'],
+                proof : {
+                    closeReceipt: me.lastTearOutClose ? DockZoneModel.clone(me.lastTearOutClose) : null,
+                    mainDocument: mainAfter,
+                    phaseOrder,
+                    remoteSnapshot,
+                    sourceItemIds,
+                    sourceWindowGone,
+                    sourceWindowId,
+                    transfer    : transfer ? DockZoneModel.clone(transfer) : null
+                }
+            }
+        } catch (error) {
+            button && await me.cancelTearOutGesture(button, release, {sortZone, targetId: handleId}).catch(() => {});
+
+            return {applied: false, errors: [error?.message || String(error)]}
+        } finally {
             cursorDot?.destroy()
         }
     }

--- a/resources/scss/src/apps/workstation/Viewport.scss
+++ b/resources/scss/src/apps/workstation/Viewport.scss
@@ -47,6 +47,36 @@
     background: var(--workstation-ground);
 }
 
+// A committed bare-pane vessel becomes a remote dock TARGET without changing its scene-2 surface:
+// the preview is an absolute sibling and therefore contributes zero layout. Only the first
+// accepted dock-INTO swaps the pane for `.workstation-vessel-dock-host`; that host keeps the same
+// overlay contract while real tab chrome owns the two live pane instances.
+.workstation-popout-host.workstation-vessel-target {
+    position: relative;
+
+    > .neo-dock-preview {
+        inset         : 0;
+        pointer-events: none;
+        position      : absolute;
+        z-index       : 25;
+    }
+
+    > .workstation-vessel-dock-host {
+        background: var(--workstation-ground);
+        min-height: 0;
+        min-width : 0;
+        padding   : 8px;
+        position  : relative;
+
+        > .neo-dock-preview {
+            inset         : 0;
+            pointer-events: none;
+            position      : absolute;
+            z-index       : 25;
+        }
+    }
+}
+
 // Pane SKIN — everything a pane keeps when it is torn out of the workspace.
 //
 // The token bridge above made a vessel-hosted pane resolve the right colours; these rules are

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -211,12 +211,29 @@ class DockLayoutAdapter extends Base {
                 {
                     'aria-hidden': true,
                     cls          : ['neo-dock-stack-handle'],
+                    id           : this.stackHandleDomId(itemId),
                     tag          : 'span',
                     text         : '⠿',
                     title        : 'Drag whole stack'
                 }
             ]
         }
+    }
+
+    /**
+     * @summary Returns the stable DOM identity of one projected whole-stack grip.
+     *
+     * The grip is runtime projection state, not document state. Its semantic item id makes the
+     * address stable across re-projections so app-owned pointer choreography can target the real
+     * nested handle instead of bypassing {@link Neo.dashboard.DockTabSortZone#isStackHandleDrag}.
+     * @param {String} itemId Stable item identity.
+     * @returns {String|null}
+     * @static
+     */
+    static stackHandleDomId(itemId) {
+        return typeof itemId === 'string' && itemId
+            ? `neo-dock-stack-handle-${encodeURIComponent(itemId)}`
+            : null
     }
 
     /**

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -328,6 +328,27 @@ class DockTabSortZone extends TabHeaderSortZone {
     }
 
     /**
+     * @summary Prevents popup-scale boundary overlap from impersonating a source-window re-entry
+     * after a remote target already won the current pointer frame.
+     *
+     * The coordinator resolves claims before the base boundary sampler runs. Once a remote claim
+     * exists, that frame belongs to the remote window even when the future-vessel-sized proxy
+     * geometrically overlaps the source boundary. The next claim-free frame delegates unchanged,
+     * preserving ordinary void motion and the real return-to-source transition.
+     * @param {Object} data
+     * @returns {Boolean}
+     * @protected
+     */
+    checkWindowBoundary(data) {
+        let me          = this,
+            remoteClaim = me.dragCoordinator?.pointerClaimArbiter?.resolve?.() ?? null;
+
+        if (me.isWindowDragging && remoteClaim) return true;
+
+        return super.checkWindowBoundary(data)
+    }
+
+    /**
      * @summary Ends a non-terminal conversion because its target disappeared.
      *
      * Unlike {@link #resetVesselConversion}, this path emits the sensor's convert-out seam before
@@ -893,13 +914,25 @@ class DockTabSortZone extends TabHeaderSortZone {
 
     /**
      * @summary Whether this drag originated on the opt-in whole-stack grip.
+     *
+     * `main.addon.DragDrop#getEventData` preserves the native mousedown element as `target` and
+     * its original composed path as `targetPath`, but replaces `path` with the custom `drag:start`
+     * event path. That path begins at the draggable tab button, so a nested grip cannot be inferred
+     * from it in the production mouse pipeline. Keep all three scans for direct/native callers
+     * while treating the preserved target surfaces as the authoritative origin.
      * @param {Object} data drag-start payload with the main-thread DOM path
      * @returns {Boolean}
      * @protected
      */
     isStackHandleDrag(data) {
-        return !!this.dockGroupNodeId && (data?.path || []).some(node =>
-            Array.isArray(node.cls) && node.cls.includes('neo-dock-stack-handle'))
+        let hasMarker = node =>
+            Array.isArray(node?.cls) && node.cls.includes('neo-dock-stack-handle');
+
+        return !!this.dockGroupNodeId && (
+            hasMarker(data?.target) ||
+            (data?.targetPath || []).some(hasMarker) ||
+            (data?.path || []).some(hasMarker)
+        )
     }
 
     /**

--- a/src/manager/Window.mjs
+++ b/src/manager/Window.mjs
@@ -164,8 +164,9 @@ class Window extends Manager {
     }
 
     /**
+     * @summary Removes live geometry when its source window disconnects.
      * @param {Object} data
-     * @param {Number} data.appName
+     * @param {String} data.appName
      * @param {String} data.windowId
      */
     onWindowDisconnect({windowId}) {
@@ -173,6 +174,7 @@ class Window extends Manager {
     }
 
     /**
+     * @summary Updates geometry forwarded by the App Worker from a live source port.
      * Updates the geometric state of a window based on data from the Main Thread.
      * This method is called via direct delegation from the App Worker to minimize overhead.
      * @param {Object} data

--- a/src/worker/App.mjs
+++ b/src/worker/App.mjs
@@ -621,8 +621,13 @@ class App extends Base {
 
     /**
      * @param {Object} data
+     * @param {String} data.appName
+     * @param {Object} [data.sourcePort]
+     * @param {String} data.windowId
      */
     async onConnect(data) {
+        let me = this;
+
         if (this.aiClientPromise) {
             await this.aiClientPromise
         }
@@ -630,8 +635,12 @@ class App extends Base {
         // short delay to ensure app VCs are in place
         await this.timeout(10);
 
-        let {appName, windowId} = data,
+        let {appName, sourcePort, windowId} = data,
             windowData;
+
+        if (!me.isCurrentPort(sourcePort, {appName, windowId})) {
+            return
+        }
 
         try {
             windowData = await Neo.Main.getWindowData({windowId})
@@ -639,7 +648,11 @@ class App extends Base {
             console.error('onConnect: getWindowData failed', e)
         }
 
-        this.fire('connect', {appName, windowData, windowId})
+        if (!me.isCurrentPort(sourcePort, {appName, windowId})) {
+            return
+        }
+
+        me.fire('connect', {appName, windowData, windowId})
     }
 
     /**
@@ -710,9 +723,10 @@ class App extends Base {
 
     /**
      * @param {Object} msg
+     * @param {Object} [sourcePort]
      */
-    onRegisterNeoConfig(msg) {
-        super.onRegisterNeoConfig(msg);
+    onRegisterNeoConfig(msg, sourcePort) {
+        super.onRegisterNeoConfig(msg, sourcePort);
 
         if (Neo.config.useSharedWorkers) {
             import('../manager/Window.mjs')
@@ -808,8 +822,13 @@ class App extends Base {
     /**
      * @param {Object} data
      * @param {Object} data.data
+     * @param {Object} [sourcePort]
      */
-    onWindowPositionChange({data}) {
+    onWindowPositionChange({data}, sourcePort) {
+        if (!this.isCurrentPort(sourcePort, {windowId: data.windowId})) {
+            return
+        }
+
         // Only available in shared workers
         Neo.manager.Window?.onWindowPositionChange(data);
         Neo.manager.DragCoordinator?.onWindowPositionChange(data);
@@ -824,7 +843,7 @@ class App extends Base {
      */
     registerApp(appName, windowId) {
         // register the name as fast as possible
-        this.onRegisterApp({appName});
+        this.onRegisterApp({appName}, this.getPort({windowId}));
         this.sendMessage(windowId, {action: 'registerAppName', appName})
     }
 

--- a/src/worker/Base.mjs
+++ b/src/worker/Base.mjs
@@ -121,7 +121,7 @@ class Worker extends Base {
             hasMatch = true;
 
             Object.entries(opts).forEach(([key, value]) => {
-                if (value !== port[key]) {
+                if (key === 'appName' ? !this.hasPortApp(port, value) : value !== port[key]) {
                     hasMatch = false
                 }
             });
@@ -135,14 +135,50 @@ class Worker extends Base {
     }
 
     /**
+     * @summary Checks one app registration without reducing a multi-app browser window to one scalar owner.
+     * @param {Object} portEntry
+     * @param {String} appName
+     * @returns {Boolean}
+     */
+    hasPortApp(portEntry, appName) {
+        return portEntry.appNames instanceof Set
+            ? portEntry.appNames.has(appName)
+            : portEntry.appName === appName
+    }
+
+    /**
+     * @summary Verifies that an async operation still belongs to the exact connected port generation.
+     * @param {Object|null} portEntry
+     * @param {Object} [identity]
+     * @param {String} [identity.appName]
+     * @param {String} [identity.windowId]
+     * @returns {Boolean}
+     */
+    isCurrentPort(portEntry, {appName, windowId}={}) {
+        return !portEntry || (
+            this.ports.includes(portEntry)
+            && (!appName  || this.hasPortApp(portEntry, appName))
+            && (!windowId || portEntry.windowId === windowId)
+        )
+    }
+
+    /**
      * Only relevant for SharedWorkers
      * @param {Object} data
+     * @param {String} data.appName
+     * @param {Object} [data.sourcePort]
+     * @param {String} data.windowId
      */
     async onConnect(data) {
         // short delay to ensure app VCs are in place
         await this.timeout(10);
 
-        let {appName, windowId} = data;
+        let {appName, sourcePort, windowId} = data;
+
+        if (!this.isCurrentPort(sourcePort, {appName, windowId})) {
+            return
+        }
+
         this.fire('connect', {appName, windowId})
     }
 
@@ -151,19 +187,19 @@ class Worker extends Base {
      * @param {Object} e
      */
     onConnected(e) {
-        let me = this,
-            id = Neo.getId('port');
+        let me        = this,
+            id        = Neo.getId('port'),
+            portEntry = {
+                appNames: new Set(),
+                id,
+                port    : e.ports[0],
+                windowId: null
+            };
 
         me.isConnected = true;
 
-        me.ports.push({
-            appName : null,
-            id,
-            port    : e.ports[0],
-            windowId: null
-        });
-
-        me.ports[me.ports.length - 1].port.onmessage = me.onMessage.bind(me);
+        me.ports.push(portEntry);
+        portEntry.port.onmessage = event => me.onMessage(event, portEntry);
 
         // core.Base: initRemote() subscribes to this event for the SharedWorkers context
         me.fire('connected');
@@ -175,6 +211,34 @@ class Worker extends Base {
         });
 
         me.afterConnect()
+    }
+
+    /**
+     * @summary Retires one exact SharedWorker port generation and releases its message handler.
+     * @param {Object} portEntry
+     * @returns {Boolean} True when the entry was live and removed
+     */
+    removePort(portEntry) {
+        const
+            me    = this,
+            index = me.ports.indexOf(portEntry);
+
+        if (index === -1) {
+            return false
+        }
+
+        me.ports.splice(index, 1);
+        portEntry.port.onmessage = null;
+        portEntry.port.close?.();
+
+        Object.entries(me.promises).forEach(([id, promise]) => {
+            if (promise.portEntry === portEntry) {
+                delete me.promises[id];
+                promise.reject(new Error(`Worker port disconnected before reply: ${portEntry.id}`))
+            }
+        });
+
+        return true
     }
 
     /**
@@ -194,27 +258,54 @@ class Worker extends Base {
     /**
      * Only relevant for SharedWorkers
      * @param {Object} data
+     * @param {String} data.appName
+     * @param {String} data.windowId
+     * @param {Object} [sourcePort]
      */
-    onDisconnect(data) {
-        let {appName, windowId} = data;
+    onDisconnect(data, sourcePort) {
+        let me                  = this,
+            {appName, windowId} = data;
+
+        sourcePort ??= me.isSharedWorker ? me.getPort({windowId}) : null;
+
+        if (sourcePort && !me.isCurrentPort(sourcePort, {appName, windowId})) {
+            return
+        }
+
+        if (me.isSharedWorker && !sourcePort) {
+            return
+        }
+
+        if (sourcePort?.appNames instanceof Set) {
+            sourcePort.appNames.delete(appName);
+            sourcePort.appNames.size || me.removePort(sourcePort)
+        } else if (sourcePort) {
+            me.removePort(sourcePort)
+        }
+
         this.fire('disconnect', {appName, windowId})
     }
 
     /**
      * @param {Object} e
+     * @param {Object} [sourcePort] Exact SharedWorker port entry which delivered the message
      */
-    onMessage(e) {
+    onMessage(e, sourcePort) {
         let me                = this,
             {data}            = e,
             {action, replyId} = data,
             promise;
+
+        if (sourcePort && !me.ports.includes(sourcePort)) {
+            return
+        }
 
         if (!action) {
             throw new Error('Message action is missing: ' + data.id)
         }
 
         if (action !== 'reply') {
-            me['on' + Neo.capitalize(action)](data);
+            me['on' + Neo.capitalize(action)](data, sourcePort);
         } else if (promise = action === 'reply' && me.promises[replyId]) {
             if (data.reject) {
                 promise.reject(data.data)
@@ -237,18 +328,19 @@ class Worker extends Base {
      * Only relevant for SharedWorkers
      * @param {Object} msg
      * @param {String} msg.appName
+     * @param {Object} [sourcePort]
      */
-    onRegisterApp(msg) {
+    onRegisterApp(msg, sourcePort) {
         let me        = this,
             {appName} = msg,
-            port;
+            port      = sourcePort || me.ports.find(item => (
+                item.appNames instanceof Set ? item.appNames.size === 0 : !item.appName
+            ));
 
-        for (port of me.ports) {
-            if (!port.appName) {
-                port.appName = appName;
-                me.onConnect({appName, windowId: port.windowId});
-                break
-            }
+        if (port && !me.hasPortApp(port, appName)) {
+            port.appNames ??= new Set(port.appName ? [port.appName] : []);
+            port.appNames.add(appName);
+            me.onConnect({appName, sourcePort: port, windowId: port.windowId})
         }
     }
 
@@ -261,15 +353,15 @@ class Worker extends Base {
      * @param {Object} msg The incoming message object.
      * @param {Object} msg.data The initial global Neo.config data object.
      * @param {String} msg.data.windowId The unique ID of the window/tab.
+     * @param {Object} [sourcePort]
      */
-    onRegisterNeoConfig({data}) {
+    onRegisterNeoConfig({data}, sourcePort) {
         Neo.ns('Neo.config', true);
 
-        for (const port of this.ports) {
-            if (!port.windowId) {
-                port.windowId = data.windowId;
-                break
-            }
+        let port = sourcePort || this.ports.find(item => !item.windowId);
+
+        if (port) {
+            port.windowId = data.windowId
         }
 
         if (!Neo.config.windowId) {
@@ -318,7 +410,11 @@ class Worker extends Base {
                 // a window got closed and the message port no longer exist (SharedWorkers)
                 reject()
             } else {
-                me.promises[msgId] = {reject, resolve}
+                me.promises[msgId] = {
+                    portEntry: message.port ? me.getPort({id: message.port}) : null,
+                    reject,
+                    resolve
+                }
             }
         })
     }
@@ -370,7 +466,12 @@ class Worker extends Base {
                 // Last-resort only when no routing key was given at all: delivering a keyed
                 // message to an arbitrary port would misroute it into a foreign window, which
                 // loses it just as silently as dropping it.
-                port = me.ports[0]?.port
+                portObject = me.ports[0];
+
+                if (portObject) {
+                    port      = portObject.port;
+                    opts.port = portObject.id
+                }
             }
         }
 

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -20,19 +20,17 @@ import {assertPreviewZoneAlignment, readComponentRects} from '../utils/dockGeome
  *  5. «The signature»        — final topology plus the continuity readout: the same live
  *                              instances, heartbeats monotonic across every transition.
  *
- * Scene 2 is LIVE (the workstation composes the shipped tear-out machinery: `?popout=` vessel
- * shell + DockTearOut/DockVesselEmbodiment composition + the app-owned `executeTearOutStep`
- * executor), including the back-IN morph witness — one continuous drag out and home again,
- * zero mutation by guard. Beats 3-4 remain CONTRACTED (test.fixme) until the cross-window
- * docking wiring lands (conversion, remote zone previews, arbitration, stack return; the
- * mechanics are already shipped in src/dashboard). Each fixme names the worker-truth receipts
- * its activation must assert, so the contract stays reviewable and the legs turn on without
- * reshaping the suite.
+ * Scenes 2-4 are LIVE through app-owned real-pointer executors: tear-out + back-IN morph,
+ * convert-while-dragging into another vessel, deterministic remote arbitration, and whole-stack
+ * return through physical topology exit. Scene 5 remains CONTRACTED (test.fixme) until the
+ * two-take full-journey composition binds these independently executable receipts into one
+ * deterministic beat log.
  *
- * Determinism contract: the executable journey runs TWICE per spec run; the per-beat logs must
- * be identical across runs (structural facts only — no clock-coupled values), with a
- * zero-residue reload between takes. The film's recording pipeline replays exactly this drive
- * headed, so a surface fix re-runs the spec instead of re-recording a one-shot video.
+ * Scene 1 and the showcase witness already run twice per spec with structural equality. Scene 5's
+ * remaining determinism contract is the uninterrupted full journey twice, with identical
+ * clock-free beat logs and a zero-residue reload between takes. The film's recording pipeline
+ * replays the same app-owned drives headed, so a surface fix re-runs the spec instead of
+ * re-recording a one-shot video.
  *
  * Claim boundary: this spec makes NO cross-platform, default-selection, or release-portability
  * claims — its receipts are macOS-headed only, and caption copy derived from it inherits the
@@ -261,6 +259,48 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
      */
     async function readHeartbeat(app, wsId) {
         return (await app.getComponent(wsId, ['feedSequence'])).feedSequence
+    }
+
+    /**
+     * @summary Creates scene 3's committed A+B vessel through two real pointer gestures.
+     *
+     * The first gesture tears `metrics` out into the target vessel. The second tears `commits` out
+     * while still down, parks that exact popup over the first, and commits through the remote
+     * participation. The panes originate in different tabs nodes so the main workspace retains a
+     * concrete semantic home for the whole-stack return. Both popup handles come from Playwright's
+     * real window set.
+     * @param {Object} data
+     * @param {Object} data.app Neural Link app wrapper.
+     * @param {Object} data.page Playwright page.
+     * @param {String} data.wsId Workspace component id.
+     * @returns {Promise<Object>}
+     */
+    async function stageMergedVessel({app, page, wsId}) {
+        const
+            targetPopupPromise = page.waitForEvent('popup', {timeout: 90000}),
+            ownerResult        = await app.callMethod(wsId, 'executeTearOutStep', [
+                {itemId: 'metrics', sourceNodeId: 'right-top-tabs'},
+                filmPace
+            ]),
+            targetPopup        = await targetPopupPromise,
+            sourcePopupPromise = page.waitForEvent('popup', {timeout: 90000}),
+            dockResult         = await app.callMethod(wsId, 'executeCrossWindowDockStep', [
+                {itemId: 'commits', sourceNodeId: 'right-bottom-tabs', targetItemId: 'metrics'},
+                {
+                    attempts  : filmPace.birthAttempts ?? 180,
+                    moveDelay : filmPace.moveDelay ?? 16,
+                    moveSteps : filmPace.moveSteps ?? 4,
+                    showCursor: filmPace.showCursor ?? false
+                }
+            ]),
+            sourcePopup = await sourcePopupPromise;
+
+        await expect.poll(() => sourcePopup.isClosed(), {
+            message: 'the converted source vessel must retire after its remote commit',
+            timeout: 15000
+        }).toBe(true);
+
+        return {dockResult, ownerResult, sourcePopup, targetPopup}
     }
 
     /**
@@ -988,25 +1028,122 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(pageErrors).toEqual([])
     });
 
-    test.fixme('scene 3 — the second window learns to dock: convert-while-dragging + exactly one preview', async () => {
-        // Receipts this leg must assert when activated:
-        //  - a second pane converts to a vessel while its drag continues (park-not-close
-        //    lifecycle: the vessel is parked during the gesture, never destroyed mid-flight);
-        //  - dragged over the first popup, the TARGET popup's zones preview (remote previews
-        //    rendered inside the other window);
-        //  - with two overlapping candidates, EXACTLY ONE preview claims — deterministic
-        //    arbitration, asserted from the claim registry, not from pixels;
-        //  - release docks: two panes in one popup, both stores still streaming.
+    test('scene 3 — the second window learns to dock: convert-while-dragging + exactly one preview', async ({page, neuralLink}) => {
+        const {app, pageErrors, wsId} = await boot({page, neuralLink});
+        const
+            heartbeatBefore                        = await readHeartbeat(app, wsId),
+            metricsBefore                          = await app.callMethod(wsId, 'getPaneIdentity', ['metrics']),
+            commitsBefore                          = await app.callMethod(wsId, 'getPaneIdentity', ['commits']),
+            {dockResult, ownerResult, targetPopup} = await stageMergedVessel({app, page, wsId});
+
+        expect(ownerResult.errors).toEqual([]);
+        expect(ownerResult.applied, 'pane A must commit into the first real vessel').toBe(true);
+        expect(
+            dockResult.errors,
+            `cross-window dock receipt: ${JSON.stringify(dockResult.proof ?? null)}`
+        ).toEqual([]);
+        expect(dockResult.applied, 'pane B must commit into A through the remote target').toBe(true);
+
+        const snapshot = dockResult.proof.remoteSnapshot;
+
+        expect(snapshot).toMatchObject({
+            claimCount           : 1,
+            converted            : true,
+            engaged              : true,
+            parkedItemId         : 'commits',
+            sourceVesselConnected: true,
+            targetWorkspaceId    : 'workstation-vessel:metrics',
+            winnerStableId       : 'workstation-vessel:metrics'
+        });
+        expect(snapshot.sourceVesselWindowId, 'the parked physical source vessel must still exist pre-mouseup')
+            .toBeTruthy();
+        expect(snapshot.preview.previewId, 'the target must publish one semantic preview').toBeTruthy();
+        expect(snapshot.rendered.previewId, 'that same preview must paint inside the target popup')
+            .toBe(snapshot.preview.previewId);
+        expect(snapshot.preview.target.nodeId).toBe('workstation-vessel-tabs:metrics');
+
+        const targetTabs = dockResult.proof.targetDocument.nodes['workstation-vessel-tabs:metrics'];
+
+        expect(targetTabs.items, 'the first accepted drop must compose A then B').toEqual(['metrics', 'commits']);
+        expect(dockResult.proof.transfer).toMatchObject({
+            applied          : true,
+            reconciled       : true,
+            sourceWorkspaceId: 'workstation-main',
+            targetWorkspaceId: 'workstation-vessel:metrics',
+            descriptor       : {operation: 'transferItem', itemId: 'commits'}
+        });
+        expect(dockResult.proof.sourceVesselRetired, 'B must retire only after the target commit').toBe(true);
+        expect(targetPopup.isClosed(), 'the merged A+B target vessel must remain open').toBe(false);
+
+        expect(await app.callMethod(wsId, 'getPaneIdentity', ['metrics'])).toBe(metricsBefore);
+        expect(await app.callMethod(wsId, 'getPaneIdentity', ['commits'])).toBe(commitsBefore);
+        expect(await readHeartbeat(app, wsId)).toBeGreaterThan(heartbeatBefore);
+        expect(pageErrors).toEqual([])
     });
 
-    test.fixme('scene 4 — reintegration: whole stack home, commit precedes the vessel self-close', async () => {
-        // Receipts this leg must assert when activated:
-        //  - stack-handle drag home over main; main zones preview;
-        //  - the commit lands the WHOLE stack atomically (one document transaction);
-        //  - the emptied vessel closes itself AFTER the commit — and a native close resolves
-        //    provisionally: the receipt is terminal only when the runtime windowId leaves the
-        //    connected topology (dispatch success is never effect proof);
-        //  - same-instance identity + heartbeat continuity across the return.
+    test('scene 4 — reintegration: whole stack home, commit precedes the vessel self-close', async ({page, neuralLink}) => {
+        const {app, pageErrors, wsId} = await boot({page, neuralLink});
+        const
+            heartbeatBefore                        = await readHeartbeat(app, wsId),
+            metricsBefore                          = await app.callMethod(wsId, 'getPaneIdentity', ['metrics']),
+            commitsBefore                          = await app.callMethod(wsId, 'getPaneIdentity', ['commits']),
+            {dockResult, ownerResult, targetPopup} = await stageMergedVessel({app, page, wsId});
+
+        expect(ownerResult.applied).toBe(true);
+        expect(dockResult.applied).toBe(true);
+
+        const result = await app.callMethod(wsId, 'executeStackReturnStep', [
+            {ownerItemId: 'metrics'},
+            {
+                attempts  : filmPace.birthAttempts ?? 180,
+                moveDelay : filmPace.moveDelay ?? 16,
+                showCursor: filmPace.showCursor ?? false
+            }
+        ]);
+
+        expect(result.errors, JSON.stringify({
+            closeReceipt    : result.proof?.closeReceipt,
+            phaseOrder      : result.proof?.phaseOrder,
+            remoteSnapshot  : result.proof?.remoteSnapshot,
+            sourceItemIds   : result.proof?.sourceItemIds,
+            sourceWindowGone: result.proof?.sourceWindowGone,
+            transfer        : result.proof?.transfer
+        })).toEqual([]);
+        expect(result.applied, 'the grouped pointer gesture must settle through physical topology exit').toBe(true);
+        expect(result.proof.remoteSnapshot).toMatchObject({
+            claimCount       : 1,
+            engaged          : true,
+            targetWorkspaceId: 'workstation-main',
+            winnerStableId   : 'workstation-main'
+        });
+        expect(result.proof.remoteSnapshot.rendered.previewId)
+            .toBe(result.proof.remoteSnapshot.preview.previewId);
+        expect(result.proof.transfer).toMatchObject({
+            applied          : true,
+            closeRequested   : true,
+            descriptor       : {operation: 'transferNode'},
+            reconciled       : true,
+            sourceWorkspaceId: 'workstation-vessel:metrics',
+            targetWorkspaceId: 'workstation-main',
+            topologyExited   : true
+        });
+        expect(result.proof.phaseOrder).toEqual([
+            'documents-adopted',
+            'main-projected',
+            'close-dispatched',
+            'topology-exited'
+        ]);
+        expect(result.proof.sourceItemIds).toEqual(['metrics', 'commits']);
+        expect(result.proof.sourceWindowGone, 'close acknowledgement alone is not topology exit').toBe(true);
+        expect(targetPopup.isClosed(), 'the empty committed vessel closes only after main adoption').toBe(true);
+
+        const documentAfter = await readDocument(app, wsId);
+
+        expect(documentAfter.nodes['right-top-tabs'].items).toEqual(['audit', 'metrics', 'commits']);
+        expect(await app.callMethod(wsId, 'getPaneIdentity', ['metrics'])).toBe(metricsBefore);
+        expect(await app.callMethod(wsId, 'getPaneIdentity', ['commits'])).toBe(commitsBefore);
+        expect(await readHeartbeat(app, wsId)).toBeGreaterThan(heartbeatBefore);
+        expect(pageErrors).toEqual([])
     });
 
     test.fixme('scene 5 — the signature: full journey in ONE run, two-take beat-log equality', async () => {

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -20,17 +20,16 @@ import {assertPreviewZoneAlignment, readComponentRects} from '../utils/dockGeome
  *  5. «The signature»        — final topology plus the continuity readout: the same live
  *                              instances, heartbeats monotonic across every transition.
  *
- * Scenes 2-4 are LIVE through app-owned real-pointer executors: tear-out + back-IN morph,
- * convert-while-dragging into another vessel, deterministic remote arbitration, and whole-stack
- * return through physical topology exit. Scene 5 remains CONTRACTED (test.fixme) until the
- * two-take full-journey composition binds these independently executable receipts into one
- * deterministic beat log.
+ * Scenes 2-5 are LIVE through app-owned real-pointer executors: tear-out + back-IN morph,
+ * convert-while-dragging into another vessel, deterministic remote arbitration, whole-stack
+ * return through physical topology exit, and the two-take full-journey composition that binds
+ * these independently executable receipts into one deterministic beat log.
  *
- * Scene 1 and the showcase witness already run twice per spec with structural equality. Scene 5's
- * remaining determinism contract is the uninterrupted full journey twice, with identical
- * clock-free beat logs and a zero-residue reload between takes. The film's recording pipeline
- * replays the same app-owned drives headed, so a surface fix re-runs the spec instead of
- * re-recording a one-shot video.
+ * Scene 1, the showcase witness, and Scene 5 run twice per spec with structural equality. Scene 5's
+ * determinism contract is the uninterrupted full journey twice, with identical clock-free beat
+ * logs and a zero-residue reload between takes. The film's recording pipeline replays the same
+ * app-owned drives headed, so a surface fix re-runs the spec instead of re-recording a one-shot
+ * video.
  *
  * Claim boundary: this spec makes NO cross-platform, default-selection, or release-portability
  * claims — its receipts are macOS-headed only, and caption copy derived from it inherits the
@@ -189,33 +188,45 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
      * birth failure needs, logged as they happen because a failed birth can outlive the bridge
      * call that reports it).
      * @param {Object} fixtures `{page, neuralLink}`
-     * @returns {Promise<Object>} `{app, pageErrors, popupProbe, wsId}`
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.navigate=true] Set false only after this runner's own reload, so
+     * the next worker read witnesses that exact navigation instead of hiding it behind a goto.
+     * @returns {Promise<Object>} `{app, disposeObservers, pageErrors, popupProbe, wsId}`
      */
-    async function boot({page, neuralLink}) {
+    async function boot({page, neuralLink}, {navigate=true}={}) {
         const pageErrors = [],
               popupProbe = [];
         let stageReceipt;
 
-        page.on('pageerror', error => {
-            let value = String(error?.stack || error?.message || error || '');
+        const
+            onPageError = error => {
+                let value = String(error?.stack || error?.message || error || '');
 
-            value && value !== 'undefined' && pageErrors.push(value)
-        });
+                value && value !== 'undefined' && pageErrors.push(value)
+            },
+            onPopup = popup => {
+                const fact = {urlAtOpen: popup.url(), loaded: false};
+
+                popupProbe.push(fact);
+                console.log(`[vessel-probe] popup created urlAtOpen=${fact.urlAtOpen}`);
+                popup.on('pageerror', error => {
+                    let value = String(error?.stack || error?.message || error || '');
+
+                    value && value !== 'undefined' && pageErrors.push(`[popup] ${value}`)
+                });
+                popup.once('load',  () => {fact.loaded = true; fact.urlAtLoad = popup.url(); console.log(`[vessel-probe] popup loaded ${fact.urlAtLoad}`)});
+                popup.once('close', () => {fact.closed = true; console.log('[vessel-probe] popup closed')})
+            };
+
+        page.on('pageerror', onPageError);
 
         // Passive birth-layer probe: whether the platform CREATED a popup window is a different
         // fact from whether its page loaded, which is a different fact from whether the vessel
         // joined the shared heap (the executor's own gate). A birth failure needs all three —
         // logged EAGERLY, because a failed birth can outlive the bridge call that reports it.
-        page.on('popup', popup => {
-            const fact = {urlAtOpen: popup.url(), loaded: false};
+        page.on('popup', onPopup);
 
-            popupProbe.push(fact);
-            console.log(`[vessel-probe] popup created urlAtOpen=${fact.urlAtOpen}`);
-            popup.once('load',  () => {fact.loaded = true; fact.urlAtLoad = popup.url(); console.log(`[vessel-probe] popup loaded ${fact.urlAtLoad}`)});
-            popup.once('close', () => {fact.closed = true; console.log('[vessel-probe] popup closed')})
-        });
-
-        await page.goto('/apps/workstation/index.html');
+        navigate && await page.goto('/apps/workstation/index.html');
         await page.waitForSelector('.workstation-tour-play',    {timeout: 30000});
         await page.waitForSelector('.neo-tab-overflow-control', {timeout: 30000});
 
@@ -229,14 +240,26 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             stageReceipt = await pinToCaptureDisplay(page)
         }
 
-        const app        = await neuralLink.connectToApp('Workstation'),
-              workspaces = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
-              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+        const
+            app        = await neuralLink.connectToApp('Workstation'),
+            found      = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+            workspaces = Array.isArray(found) ? found : found ? [found] : [],
+            wsId       = workspaces[0]?.id;
 
+        expect(workspaces, 'the connected page must own exactly one current Workspace').toHaveLength(1);
         expect(wsId, 'the App Worker must own one Workspace').toBeTruthy();
         stageReceipt && await assertStageGeometryPublished(app, stageReceipt);
 
-        return {app, pageErrors, popupProbe, wsId}
+        return {
+            app,
+            disposeObservers() {
+                page.off('pageerror', onPageError);
+                page.off('popup', onPopup)
+            },
+            pageErrors,
+            popupProbe,
+            wsId
+        }
     }
 
     /**
@@ -621,6 +644,8 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             if (run < journeyRuns - 1) {
                 await page.reload()
             }
+
+            ctx.disposeObservers()
         }
 
         // The normal proof profile retains its two-run equality contract. Film mode records one
@@ -718,6 +743,8 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             if (run < journeyRuns - 1) {
                 await page.reload()
             }
+
+            ctx.disposeObservers()
         }
 
         if (!filmTake) {
@@ -1135,7 +1162,10 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         ]);
         expect(result.proof.sourceItemIds).toEqual(['metrics', 'commits']);
         expect(result.proof.sourceWindowGone, 'close acknowledgement alone is not topology exit').toBe(true);
-        expect(targetPopup.isClosed(), 'the empty committed vessel closes only after main adoption').toBe(true);
+        await expect.poll(() => targetPopup.isClosed(), {
+            message: 'the empty committed vessel must physically close after main adoption',
+            timeout: 15000
+        }).toBe(true);
 
         const documentAfter = await readDocument(app, wsId);
 
@@ -1146,10 +1176,262 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(pageErrors).toEqual([])
     });
 
-    test.fixme('scene 5 — the signature: full journey in ONE run, two-take beat-log equality', async () => {
-        // The capstone contract: all five beats consecutively, one headed run, real pointer,
-        // the per-beat worker-truth asserts above, two consecutive runs with identical beat
-        // logs, and the final continuity readout (feed counts monotonic end-to-end) as the
-        // closing shot the film records.
+    test('scene 5 — the signature: full journey in ONE run, two-take beat-log equality', async ({page, neuralLink}) => {
+        const
+            logs             = [],
+            openingDocuments = [],
+            pageErrorRuns    = [];
+
+        for (let run = 0; run < journeyRuns; run++) {
+            const
+                ctx              = await boot({page, neuralLink}, {navigate: run === 0}),
+                {app, wsId}      = ctx,
+                beatLog          = [],
+                opening          = await readDocument(app, wsId),
+                heartbeatAtOpen  = await readHeartbeat(app, wsId),
+                metricsBefore    = await app.callMethod(wsId, 'getPaneIdentity', ['metrics']),
+                commitsBefore    = await app.callMethod(wsId, 'getPaneIdentity', ['commits']),
+                livePopupsAtOpen = page.context().pages()
+                    .filter(candidate => candidate !== page && !candidate.isClosed());
+
+            pageErrorRuns.push(ctx.pageErrors);
+
+            expect(livePopupsAtOpen, 'each take must start without a surviving vessel').toEqual([]);
+            expect(opening.nodes['scale-tabs'].items).toEqual(['scale']);
+            expect(opening.nodes['heavy-tabs'].items).toHaveLength(12);
+            expect(opening.nodes['right-top-tabs'].items).toEqual(['metrics', 'audit']);
+            expect(opening.nodes['right-bottom-tabs'].items).toEqual(['commits']);
+            expect(opening.items.graph.autoHidden).toBe(true);
+            expect(opening.items.inspector.autoHidden).toBe(true);
+            expect(heartbeatAtOpen, 'the feed producer must be alive before the uninterrupted journey')
+                .toBeGreaterThan(0);
+            expect(metricsBefore, 'metrics must be one live pane before it crosses a window').toBeTruthy();
+            expect(commitsBefore, 'commits must be one live pane before it crosses a window').toBeTruthy();
+
+            if (openingDocuments.length) {
+                expect(opening, 'reload must restore pristine worker truth before the second take')
+                    .toEqual(openingDocuments[0])
+            } else {
+                openingDocuments.push(opening)
+            }
+
+            const roomSpec = await app.callMethod(wsId, 'runTourSpec', [{
+                schema: 'neo.tour.script.v1',
+                id    : 'five-beat-signature-room',
+                title : 'scene 5 — the room is alive',
+                scenes: [{
+                    id   : 'room-alive',
+                    title: 'resize',
+                    steps: [{
+                        type      : 'op',
+                        descriptor: {operation: 'resizeSplit', splitNodeId: 'split-main', sizes: [0.52, 0.48]},
+                        expect    : [{path: 'nodes.split-main.sizes.0', equals: 0.52}]
+                    }, {
+                        type  : 'topology-assert',
+                        expect: [{path: 'nodes.split-main.sizes.1', equals: 0.48}]
+                    }]
+                }]
+            }]);
+
+            expect(roomSpec.completed, 'the opening resize must commit through the app-owned tour runner')
+                .toBe(true);
+            expect(roomSpec.errors).toEqual([]);
+            expect(roomSpec.document.nodes['split-main'].sizes).toEqual([0.52, 0.48]);
+
+            await expect.poll(async () => (await readDocument(app, wsId)).nodes['split-main'].sizes, {
+                message  : 'the committed document must carry the opening resize',
+                timeout  : 10000,
+                intervals: [100, 250]
+            }).toEqual([0.52, 0.48]);
+
+            await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-light']);
+
+            await expect.poll(async () =>
+                (await app.getComponent(wsId, ['theme'])).theme, {
+                message: 'the uninterrupted journey must reach the light theme',
+                timeout: 10000
+            }).toBe('neo-theme-neo-light');
+
+            themeDwell && await page.waitForTimeout(themeDwell);
+
+            await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-dark']);
+
+            await expect.poll(async () =>
+                (await app.getComponent(wsId, ['theme'])).theme, {
+                message: 'the uninterrupted journey must return to the dark theme',
+                timeout: 10000
+            }).toBe('neo-theme-neo-dark');
+
+            beatLog.push({
+                beat      : 'room-alive',
+                finalTheme: 'neo-theme-neo-dark',
+                heavyCount: opening.nodes['heavy-tabs'].items.length,
+                railed    : ['graph', 'inspector'],
+                sizes     : [0.52, 0.48]
+            });
+
+            const
+                {dockResult, ownerResult, sourcePopup, targetPopup} =
+                    await stageMergedVessel({app, page, wsId});
+
+            expect(ownerResult.errors).toEqual([]);
+            expect(ownerResult.proof.born, 'the first vessel must exist before pointer-up').toBe(true);
+            expect(ownerResult.proof.survivedProbe,
+                'the first vessel must survive post-birth pointer movement').toBe(true);
+            expect(ownerResult.applied, 'metrics must commit into its real vessel').toBe(true);
+            expect(targetPopup.isClosed(), 'the first committed vessel must stay physically open').toBe(false);
+
+            beatLog.push({
+                beat            : 'tear-out',
+                bornMidGesture  : true,
+                detachCommitted : ownerResult.proof.detachCommitted,
+                ownerWorkspaceId: 'workstation-vessel:metrics',
+                sourceItems     : ownerResult.proof.documentAfter.nodes['right-top-tabs'].items
+            });
+
+            expect(
+                dockResult.errors,
+                `cross-window dock receipt: ${JSON.stringify(dockResult.proof ?? null)}`
+            ).toEqual([]);
+            expect(dockResult.applied, 'commits must join metrics through one remote target').toBe(true);
+            expect(dockResult.proof.remoteSnapshot).toMatchObject({
+                claimCount           : 1,
+                converted            : true,
+                engaged              : true,
+                parkedItemId         : 'commits',
+                sourceVesselConnected: true,
+                targetWorkspaceId    : 'workstation-vessel:metrics',
+                winnerStableId       : 'workstation-vessel:metrics'
+            });
+            expect(dockResult.proof.remoteSnapshot.rendered.previewId)
+                .toBe(dockResult.proof.remoteSnapshot.preview.previewId);
+            expect(dockResult.proof.remoteSnapshot.preview.target.nodeId)
+                .toBe('workstation-vessel-tabs:metrics');
+            expect(dockResult.proof.targetDocument.nodes['workstation-vessel-tabs:metrics'].items)
+                .toEqual(['metrics', 'commits']);
+            expect(dockResult.proof.transfer).toMatchObject({
+                applied          : true,
+                reconciled       : true,
+                sourceWorkspaceId: 'workstation-main',
+                targetWorkspaceId: 'workstation-vessel:metrics',
+                descriptor       : {operation: 'transferItem', itemId: 'commits'}
+            });
+            expect(dockResult.proof.sourceVesselRetired).toBe(true);
+            expect(sourcePopup.isClosed(), 'the converted source vessel must be physically gone').toBe(true);
+
+            beatLog.push({
+                beat             : 'vessel-dock',
+                claimCount       : 1,
+                sourceRetired    : true,
+                targetItems      : ['metrics', 'commits'],
+                targetWorkspaceId: 'workstation-vessel:metrics',
+                transfer         : 'transferItem',
+                winnerStableId   : 'workstation-vessel:metrics'
+            });
+
+            const returnResult = await app.callMethod(wsId, 'executeStackReturnStep', [
+                {ownerItemId: 'metrics'},
+                {
+                    attempts  : filmPace.birthAttempts ?? 180,
+                    moveDelay : filmPace.moveDelay ?? 16,
+                    showCursor: filmPace.showCursor ?? false
+                }
+            ]);
+
+            expect(returnResult.errors, JSON.stringify({
+                closeReceipt    : returnResult.proof?.closeReceipt,
+                phaseOrder      : returnResult.proof?.phaseOrder,
+                remoteSnapshot  : returnResult.proof?.remoteSnapshot,
+                sourceItemIds   : returnResult.proof?.sourceItemIds,
+                sourceWindowGone: returnResult.proof?.sourceWindowGone,
+                transfer        : returnResult.proof?.transfer
+            })).toEqual([]);
+            expect(returnResult.applied,
+                'the grouped pointer gesture must settle through physical topology exit').toBe(true);
+            expect(returnResult.proof.remoteSnapshot).toMatchObject({
+                claimCount       : 1,
+                engaged          : true,
+                targetWorkspaceId: 'workstation-main',
+                winnerStableId   : 'workstation-main'
+            });
+            expect(returnResult.proof.remoteSnapshot.rendered.previewId)
+                .toBe(returnResult.proof.remoteSnapshot.preview.previewId);
+            expect(returnResult.proof.transfer).toMatchObject({
+                applied          : true,
+                closeRequested   : true,
+                descriptor       : {operation: 'transferNode'},
+                reconciled       : true,
+                sourceWorkspaceId: 'workstation-vessel:metrics',
+                targetWorkspaceId: 'workstation-main',
+                topologyExited   : true
+            });
+            expect(returnResult.proof.phaseOrder).toEqual([
+                'documents-adopted',
+                'main-projected',
+                'close-dispatched',
+                'topology-exited'
+            ]);
+            expect(returnResult.proof.sourceItemIds).toEqual(['metrics', 'commits']);
+            expect(returnResult.proof.sourceWindowGone,
+                'native close acknowledgement alone is not topology exit').toBe(true);
+            await expect.poll(() => targetPopup.isClosed(), {
+                message: 'the emptied vessel must be physically gone',
+                timeout: 15000
+            }).toBe(true);
+
+            const documentAfter = await readDocument(app, wsId);
+
+            expect(documentAfter.nodes['right-top-tabs'].items).toEqual(['audit', 'metrics', 'commits']);
+
+            beatLog.push({
+                beat          : 'reintegration',
+                finalTarget   : 'right-top-tabs',
+                phaseOrder    : returnResult.proof.phaseOrder,
+                sourceItems   : returnResult.proof.sourceItemIds,
+                topologyExited: true,
+                transfer      : 'transferNode'
+            });
+
+            const
+                heartbeatAtClose  = await readHeartbeat(app, wsId),
+                metricsAfter      = await app.callMethod(wsId, 'getPaneIdentity', ['metrics']),
+                commitsAfter      = await app.callMethod(wsId, 'getPaneIdentity', ['commits']),
+                livePopupsAtClose = page.context().pages()
+                    .filter(candidate => candidate !== page && !candidate.isClosed());
+
+            expect(metricsAfter, 'metrics must remain the same live instance end-to-end')
+                .toBe(metricsBefore);
+            expect(commitsAfter, 'commits must remain the same live instance end-to-end')
+                .toBe(commitsBefore);
+            expect(heartbeatAtClose, 'the feed must advance without resetting during the journey')
+                .toBeGreaterThan(heartbeatAtOpen);
+            expect(livePopupsAtClose,
+                'physical vessel topology must be empty before the zero-residue reload').toEqual([]);
+            expect(ctx.pageErrors, 'the uninterrupted journey must be browser-error-free').toEqual([]);
+
+            beatLog.push({
+                beat                    : 'signature',
+                commitsInstancePreserved: true,
+                feedAdvanced            : true,
+                metricsInstancePreserved: true,
+                survivingVessels        : 0
+            });
+            logs.push(beatLog);
+
+            if (run < journeyRuns - 1) {
+                await page.reload()
+            }
+
+            ctx.disposeObservers()
+        }
+
+        if (!filmTake) {
+            expect(logs[1], 'two clean takes must emit the same clock-free five-beat log')
+                .toEqual(logs[0])
+        }
+
+        expect(logs.every(log => log.length === 5),
+            'each uninterrupted journey must emit exactly five semantic beats').toBe(true);
+        expect(pageErrorRuns.flat(), 'both journeys must stay browser-error-free').toEqual([])
     });
 });

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -313,7 +313,16 @@ test.describe.serial('Workstation.view.Workspace', () => {
             windowPosition.setConfigs = data => resizeCalls.push(data);
             workspace = Neo.create(Workspace, {});
 
-            const chrome = readTabChrome(workspace);
+            const
+                chrome            = readTabChrome(workspace),
+                targetWorkspaceId = Workspace.vesselWorkspaceId('alerts');
+
+            workspace.vesselWorkspaces.set(targetWorkspaceId, {windowId: 'window-alerts'});
+            chrome.get('right-top-tabs').tab.fire('dockVesselConversionIn', {
+                itemId  : 'audit',
+                record  : {sourceRect: null},
+                targetId: targetWorkspaceId
+            });
 
             expect(resizeCalls).toEqual([{
                 observeResize: true,
@@ -321,6 +330,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             }]);
             expect(workspace.workspaceSet.ids()).toEqual([Workspace.MAIN_WORKSPACE_ID]);
             expect(workspace.workspaceSet.getDocument(Workspace.MAIN_WORKSPACE_ID)).toBe(workspace.dockModel);
+            expect(workspace.vesselConversionTargetWindowId).toBe('window-alerts');
 
             chrome.forEach(({bar}, nodeId) => {
                 expect(bar.sortZoneConfig, `${nodeId} joins the one cross-window source group`).toMatchObject({
@@ -427,6 +437,25 @@ test.describe.serial('Workstation.view.Workspace', () => {
             expect(state.document).toBeNull();
             expect(preview.dockPreview).toBeNull();
             expect(destroyed).toEqual([])
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('pane identity remains readable after the catalog moves into a vessel workspace', () => {
+        const workspace = Neo.create(Workspace, {});
+
+        try {
+            const
+                alertsIdentity   = workspace.getPaneIdentity('alerts'),
+                securityIdentity = workspace.getPaneIdentity('security');
+
+            stageCommittedVessel(workspace);
+
+            expect(workspace.dockModel.items.alerts).toBeUndefined();
+            expect(workspace.dockModel.items.security).toBeUndefined();
+            expect(workspace.getPaneIdentity('alerts')).toBe(alertsIdentity);
+            expect(workspace.getPaneIdentity('security')).toBe(securityIdentity)
         } finally {
             workspace.destroy()
         }
@@ -714,11 +743,11 @@ test.describe.serial('Workstation.view.Workspace', () => {
         const
             workspace              = Neo.create(Workspace, {}),
             {state, workspaceId}   = stageCommittedVessel(workspace),
-            originalResolve        = workspace.resolveTearOutVessel,
             originalClose          = workspace.closeTearOutVessel,
             originalTearOut        = workspace.tearOutHandlers,
             originalPark           = workspace.vesselParkHandlers,
             participantRetirements = [];
+        let closedVessel;
 
         try {
             const
@@ -758,11 +787,18 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
                 topologyExited   : false
             };
-            workspace.resolveTearOutVessel = () => ({windowId: 'window-alerts'});
-            workspace.closeTearOutVessel   = async () => true;
+            workspace.closeTearOutVessel = async vessel => {
+                closedVessel = vessel;
+                return true
+            };
 
             await expect(workspace.retireReturnedVessel(workspaceId)).resolves.toBe(true);
 
+            expect(closedVessel).toMatchObject({
+                itemId    : 'alerts',
+                windowId  : 'window-alerts',
+                windowName: 'tearout-alerts'
+            });
             expect(state.closeRequested).toBe(true);
             expect(workspace.vesselWorkspaces.get(workspaceId)).toBe(state);
             expect(workspace.workspaceSet.has(workspaceId)).toBe(true);
@@ -781,10 +817,9 @@ test.describe.serial('Workstation.view.Workspace', () => {
             expect(workspace.lastCrossWindowTransfer.topologyExited).toBe(true);
             expect(participantRetirements).toEqual(['destroy'])
         } finally {
-            workspace.resolveTearOutVessel  = originalResolve;
-            workspace.closeTearOutVessel    = originalClose;
-            workspace.tearOutHandlers       = originalTearOut;
-            workspace.vesselParkHandlers    = originalPark;
+            workspace.closeTearOutVessel = originalClose;
+            workspace.tearOutHandlers    = originalTearOut;
+            workspace.vesselParkHandlers = originalPark;
             workspace.destroy()
         }
     });

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -10,6 +10,8 @@ import {test, expect}           from '@playwright/test';
 import Neo                      from '../../../../../src/Neo.mjs';
 import * as core                from '../../../../../src/core/_export.mjs';
 import DockProjectionReconciler from '../../../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockZoneModel            from '../../../../../src/dashboard/DockZoneModel.mjs';
+import {previewToOperation}     from '../../../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../../../src/manager/Instance.mjs';
 import FeedPane  from '../../../../../apps/workstation/view/FeedPane.mjs';
 import ScalePane from '../../../../../apps/workstation/view/ScalePane.mjs';
@@ -42,6 +44,79 @@ const readTabChrome = workspace => {
             tab
         }]
     }))
+};
+
+/**
+ * @summary Builds one committed bare-owner + incoming-pane vessel pair without render effects.
+ * @param {Workstation.view.Workspace} workspace
+ * @param {String} [ownerItemId='alerts']
+ * @param {String} [incomingItemId='security']
+ * @returns {Object}
+ */
+const stageCommittedVessel = (workspace, ownerItemId='alerts', incomingItemId='security') => {
+    const
+        workspaceId = Workspace.vesselWorkspaceId(ownerItemId),
+        tabsNodeId  = Workspace.vesselTabsNodeId(ownerItemId),
+        detached    = DockZoneModel.applyOperation(workspace.dockModel, {
+            operation: 'detachItem',
+            itemId   : ownerItemId
+        });
+
+    if (detached.errors.length) throw new Error(detached.errors.join('; '));
+
+    workspace.dockModel = detached.document;
+
+    const
+        provisional = workspace.createVesselWorkspaceDocument(ownerItemId),
+        incoming    = DockZoneModel.transferItem(detached.document, provisional, {
+            itemId           : incomingItemId,
+            sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+            targetWorkspaceId: workspaceId,
+            target           : {operation: 'addTab', tabsNodeId}
+        }),
+        owner       = DockZoneModel.transferItem(incoming.sourceDocument, incoming.targetDocument, {
+            itemId           : ownerItemId,
+            sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+            targetWorkspaceId: workspaceId,
+            target           : {operation: 'addTab', tabsNodeId, index: 0}
+        });
+
+    if (incoming.errors.length || owner.errors.length) {
+        throw new Error([...incoming.errors, ...owner.errors].join('; '))
+    }
+
+    const state = {
+        app                 : {mainView: {isDestroyed: false}},
+        closeRequested      : false,
+        committed           : true,
+        disconnected        : false,
+        document            : provisional,
+        host                : null,
+        itemId              : ownerItemId,
+        participation       : null,
+        participationPromise: null,
+        preview             : null,
+        reconciling         : false,
+        windowId            : `window-${ownerItemId}`,
+        workspaceId
+    };
+
+    workspace.vesselWorkspaces.set(workspaceId, state);
+    workspace.workspaceSet.register(workspaceId, {
+        getDocument: () => state.document,
+        setDocument: document => state.document = document
+    });
+
+    if (!workspace.workspaceSet.adoptTransfer({
+        sourceDocument   : owner.sourceDocument,
+        sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+        targetDocument   : owner.targetDocument,
+        targetWorkspaceId: workspaceId
+    })) {
+        throw new Error('workspace-set refused fixture transfer')
+    }
+
+    return {state, tabsNodeId, workspaceId}
 };
 
 /**
@@ -263,6 +338,552 @@ test.describe.serial('Workstation.view.Workspace', () => {
             } else {
                 delete Neo.main.addon.WindowPosition
             }
+        }
+    });
+
+    test('a connected vessel stays unregistered until an accepted drop seeds document ownership', async () => {
+        const
+            workspace   = Neo.create(Workspace, {}),
+            workspaceId = Workspace.vesselWorkspaceId('alerts'),
+            classes     = [],
+            destroyed   = [],
+            preview     = {dockPreview: null, applyTargetGeometry() {}},
+            mainView    = {
+                id           : 'workstation-vessel-view',
+                isDestroyed  : false,
+                add          : () => preview,
+                addCls       : cls => classes.push(cls),
+                promiseUpdate: async () => {}
+            };
+
+        try {
+            await workspace.crossWindowParticipationPromise;
+
+            workspace.createCrossWindowParticipation = async data => ({
+                ...data,
+                destroy: () => destroyed.push(data.workspaceId)
+            });
+            workspace.tearOutPanes.alerts = {windowId: 'window-alerts'};
+
+            const state = await workspace.registerVesselWorkspaceTarget({
+                app     : {mainView},
+                itemId  : 'alerts',
+                windowId: 'window-alerts'
+            });
+
+            expect(state).toMatchObject({
+                committed: false,
+                document : null,
+                itemId   : 'alerts',
+                windowId : 'window-alerts',
+                workspaceId
+            });
+            expect(workspaceId).toBe('workstation-vessel:alerts');
+            expect(workspaceId).not.toContain('window-alerts');
+            expect(classes).toEqual(['workstation-vessel-target']);
+            expect(workspace.workspaceSet.ids()).toEqual([Workspace.MAIN_WORKSPACE_ID]);
+            expect(workspace.crossWindowParticipations.get(workspaceId)).toBe(state.participation);
+
+            const provisional = workspace.getWorkspaceDocument(workspaceId);
+
+            expect(DockZoneModel.validate(provisional)).toEqual([]);
+            expect(provisional.items).toEqual({});
+            expect(provisional.nodes[Workspace.vesselTabsNodeId('alerts')]).toEqual({
+                activeItemId: null,
+                items       : [],
+                type        : 'tabs'
+            });
+            expect(workspace.workspaceSet.ids()).toEqual([Workspace.MAIN_WORKSPACE_ID]);
+
+            const
+                WindowManager = Neo.manager.Window,
+                originalGet   = WindowManager.get;
+
+            try {
+                WindowManager.get = () => ({innerRect: {width: 480, height: 320}});
+
+                const edgePreview = workspace.renderCrossWindowPreview(workspaceId, {
+                    draggedItem: {
+                        dockItemId           : 'security',
+                        dockSourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID
+                    },
+                    localX      : 1,
+                    localY      : 1,
+                    sourceNodeId: 'heavy-tabs'
+                });
+
+                expect(previewToOperation(edgePreview)).toEqual({
+                    operation : 'addTab',
+                    itemId    : 'security',
+                    index     : null,
+                    tabsNodeId: Workspace.vesselTabsNodeId('alerts')
+                })
+            } finally {
+                WindowManager.get = originalGet
+            }
+
+            workspace.clearCrossWindowPreview(workspaceId);
+
+            expect(state.document).toBeNull();
+            expect(preview.dockPreview).toBeNull();
+            expect(destroyed).toEqual([])
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('first dock adopts A+B once; whole-stack return projects main before a refused close', async () => {
+        const
+            workspace     = Neo.create(Workspace, {}),
+            workspaceId   = Workspace.vesselWorkspaceId('alerts'),
+            tabsNodeId    = Workspace.vesselTabsNodeId('alerts'),
+            originalAdopt = workspace.workspaceSet.adoptTransfer,
+            order         = [];
+
+        try {
+            await workspace.refreshPromise;
+
+            const detached = DockZoneModel.applyOperation(workspace.dockModel, {
+                operation: 'detachItem',
+                itemId   : 'alerts'
+            });
+
+            expect(detached.errors).toEqual([]);
+            workspace.dockModel = detached.document;
+
+            const state = {
+                app          : {mainView: {isDestroyed: false}},
+                committed    : false,
+                document     : workspace.createVesselWorkspaceDocument('alerts'),
+                host         : null,
+                itemId       : 'alerts',
+                participation: null,
+                preview      : null,
+                windowId     : 'window-alerts',
+                workspaceId
+            };
+
+            workspace.tearOutPanes.alerts = {windowId: 'window-alerts'};
+            workspace.vesselWorkspaces.set(workspaceId, state);
+            workspace.timeout = async () => {};
+            workspace.mountVesselWorkspace = async id => {
+                order.push(['project-target', id]);
+                return true
+            };
+            workspace.refreshCrossWindowParticipation = async id => order.push(['participation', id]);
+            workspace.refreshDockWorkspace = async () => {
+                order.push(['project-main']);
+                await workspace.refreshCrossWindowParticipation(Workspace.MAIN_WORKSPACE_ID)
+            };
+            workspace.retireReturnedVessel = async id => {
+                order.push(['close-refused', id]);
+                return false
+            };
+
+            const transferIncoming = () => DockZoneModel.transferItem(
+                workspace.dockModel,
+                state.document,
+                {
+                    itemId           : 'security',
+                    sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                    targetWorkspaceId: workspaceId,
+                    target           : {operation: 'addTab', tabsNodeId}
+                }
+            );
+            let incoming = transferIncoming();
+
+            expect(incoming.errors).toEqual([]);
+
+            workspace.workspaceSet.adoptTransfer = () => false;
+
+            expect(workspace.commitCrossWindowTransfer({
+                descriptor: {
+                    operation        : 'transferItem',
+                    itemId           : 'security',
+                    sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                    targetWorkspaceId: workspaceId,
+                    target           : {operation: 'addTab', tabsNodeId}
+                },
+                sourceDocument   : incoming.sourceDocument,
+                sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                targetDocument   : incoming.targetDocument,
+                targetWorkspaceId: workspaceId
+            })).toBe(false);
+            expect(workspace.workspaceSet.has(workspaceId)).toBe(false);
+            expect(state).toMatchObject({committed: false, document: null});
+            expect(workspace.dockModel).toBe(detached.document);
+            expect(order).toEqual([]);
+
+            state.document = workspace.createVesselWorkspaceDocument('alerts');
+            incoming = transferIncoming();
+            let adoptionCount = 0;
+
+            workspace.workspaceSet.adoptTransfer = data => {
+                adoptionCount++;
+                order.push(['adopt']);
+                return originalAdopt(data)
+            };
+
+            expect(workspace.commitCrossWindowTransfer({
+                descriptor: {
+                    operation        : 'transferItem',
+                    itemId           : 'security',
+                    sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                    targetWorkspaceId: workspaceId,
+                    target           : {operation: 'addTab', tabsNodeId}
+                },
+                sourceDocument   : incoming.sourceDocument,
+                sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                targetDocument   : incoming.targetDocument,
+                targetWorkspaceId: workspaceId
+            })).toBe(true);
+
+            expect(adoptionCount).toBe(1);
+            expect(order).toEqual([['adopt']]);
+            expect(state.committed).toBe(true);
+            expect(workspace.workspaceSet.has(workspaceId)).toBe(true);
+            expect(state.document.nodes[tabsNodeId].items).toEqual(['alerts', 'security']);
+            expect(workspace.dockModel.items.alerts).toBeUndefined();
+            expect(workspace.dockModel.items.security).toBeUndefined();
+            expect(state.document.items.alerts).toEqual(initialDocument.items.alerts);
+            expect(state.document.items.security).toEqual(initialDocument.items.security);
+
+            await workspace.refreshPromise;
+
+            expect(order).toEqual([
+                ['adopt'],
+                ['project-target', workspaceId],
+                ['project-main'],
+                ['participation', Workspace.MAIN_WORKSPACE_ID]
+            ]);
+            expect(workspace.lastCrossWindowTransfer).toMatchObject({
+                applied          : true,
+                reconciled       : true,
+                sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                targetWorkspaceId: workspaceId
+            });
+
+            order.length = 0;
+
+            const returnDescriptor = {
+                    operation        : 'transferNode',
+                    nodeId           : DockZoneModel.resolveStackRoot(state.document),
+                    sourceWorkspaceId: workspaceId,
+                    targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                    target           : {
+                        targetNodeId: 'heavy-tabs',
+                        placement   : {kind: 'tab-into'}
+                    }
+                },
+                returned = DockZoneModel.transferNode(
+                    state.document,
+                    workspace.dockModel,
+                    returnDescriptor
+                );
+
+            expect(returned.errors).toEqual([]);
+            expect(workspace.commitCrossWindowTransfer({
+                descriptor       : returnDescriptor,
+                sourceDocument   : returned.sourceDocument,
+                sourceWorkspaceId: workspaceId,
+                targetDocument   : returned.targetDocument,
+                targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID
+            })).toBe(true);
+            expect(adoptionCount).toBe(2);
+            expect(order).toEqual([['adopt']]);
+            expect(workspace.dockModel.items.alerts).toEqual(initialDocument.items.alerts);
+            expect(workspace.dockModel.items.security).toEqual(initialDocument.items.security);
+            expect(state.document.items).toEqual({});
+
+            await workspace.refreshPromise;
+
+            expect(order).toEqual([
+                ['adopt'],
+                ['project-main'],
+                ['participation', Workspace.MAIN_WORKSPACE_ID],
+                ['close-refused', workspaceId]
+            ]);
+            expect(state.committed).toBe(true);
+            expect(workspace.workspaceSet.has(workspaceId)).toBe(true);
+            expect(workspace.dockModel.items.alerts).toEqual(initialDocument.items.alerts);
+            expect(workspace.dockModel.items.security).toEqual(initialDocument.items.security)
+        } finally {
+            workspace.workspaceSet.adoptTransfer = originalAdopt;
+            workspace.destroy()
+        }
+    });
+
+    test('unexpected vessel death atomically recovers the whole A+B stack', () => {
+        const
+            workspace              = Neo.create(Workspace, {}),
+            {state, workspaceId}   = stageCommittedVessel(workspace),
+            originalTearOut        = workspace.tearOutHandlers,
+            originalPark           = workspace.vesselParkHandlers,
+            originalDocumentChange = workspace.onDockZoneDocumentChange,
+            projections            = [];
+
+        try {
+            workspace.tearOutPlacements.alerts = {index: 0, tabsNodeId: 'heavy-tabs'};
+            workspace.tearOutPanes.alerts = {
+                admissionToken: 7,
+                generation    : 3,
+                windowId      : 'window-alerts',
+                windowName    : 'tearout-alerts'
+            };
+            workspace.tearOutHandlers = {onVesselRetired() {}};
+            workspace.vesselParkHandlers = {onVesselRetired() {}};
+            workspace.onDockZoneDocumentChange = (document, options) => {
+                projections.push({document, options})
+            };
+
+            workspace.onWindowDisconnect({windowId: 'window-alerts'});
+
+            expect(workspace.dockModel.items.alerts).toEqual(initialDocument.items.alerts);
+            expect(workspace.dockModel.items.security).toEqual(initialDocument.items.security);
+            expect(state.document.items).toEqual({});
+            expect(workspace.vesselWorkspaces.has(workspaceId)).toBe(false);
+            expect(workspace.workspaceSet.has(workspaceId)).toBe(false);
+            expect(workspace.tearOutPanes.alerts).toBeUndefined();
+            expect(workspace.tearOutPlacements.alerts).toBeUndefined();
+            expect(workspace.lastCrossWindowTransfer).toMatchObject({
+                applied              : true,
+                recoveredOnDisconnect: true,
+                sourceWorkspaceId    : workspaceId,
+                targetWorkspaceId    : Workspace.MAIN_WORKSPACE_ID,
+                topologyExited       : true
+            });
+            expect(projections).toHaveLength(1);
+            expect(new Set(projections[0].options.preserveItemIds)).toEqual(new Set(['alerts', 'security']))
+        } finally {
+            workspace.tearOutHandlers        = originalTearOut;
+            workspace.vesselParkHandlers     = originalPark;
+            workspace.onDockZoneDocumentChange = originalDocumentChange;
+            workspace.destroy()
+        }
+    });
+
+    test('a refused disconnect recovery retains the only A+B truth as a headless workspace', () => {
+        const
+            workspace            = Neo.create(Workspace, {}),
+            {state, workspaceId} = stageCommittedVessel(workspace),
+            originalAdopt        = workspace.workspaceSet.adoptTransfer,
+            originalTearOut      = workspace.tearOutHandlers,
+            originalPark         = workspace.vesselParkHandlers;
+
+        try {
+            workspace.tearOutPlacements.alerts = {index: 0, tabsNodeId: 'heavy-tabs'};
+            workspace.tearOutPanes.alerts = {
+                admissionToken: 7,
+                generation    : 3,
+                windowId      : 'window-alerts',
+                windowName    : 'tearout-alerts'
+            };
+            workspace.tearOutHandlers = {onVesselRetired() {}};
+            workspace.vesselParkHandlers = {onVesselRetired() {}};
+            workspace.workspaceSet.adoptTransfer = () => false;
+
+            workspace.onWindowDisconnect({windowId: 'window-alerts'});
+
+            expect(workspace.dockModel.items.alerts).toBeUndefined();
+            expect(workspace.dockModel.items.security).toBeUndefined();
+            expect(state.document.items.alerts).toEqual(initialDocument.items.alerts);
+            expect(state.document.items.security).toEqual(initialDocument.items.security);
+            expect(workspace.vesselWorkspaces.get(workspaceId)).toBe(state);
+            expect(workspace.workspaceSet.has(workspaceId)).toBe(true);
+            expect(state).toMatchObject({
+                app         : null,
+                disconnected: true,
+                host        : null,
+                preview     : null,
+                windowId    : null
+            });
+            expect(workspace.tearOutPlacements.alerts).toEqual({index: 0, tabsNodeId: 'heavy-tabs'});
+            expect(workspace.lastCrossWindowTransfer).toMatchObject({
+                applied: false,
+                errors : ['workspace-set refused disconnected-vessel recovery']
+            })
+        } finally {
+            workspace.workspaceSet.adoptTransfer = originalAdopt;
+            workspace.tearOutHandlers            = originalTearOut;
+            workspace.vesselParkHandlers         = originalPark;
+            workspace.destroy()
+        }
+    });
+
+    test('close acknowledgement retains workspace truth until exact topology exit', async () => {
+        const
+            workspace              = Neo.create(Workspace, {}),
+            {state, workspaceId}   = stageCommittedVessel(workspace),
+            originalResolve        = workspace.resolveTearOutVessel,
+            originalClose          = workspace.closeTearOutVessel,
+            originalTearOut        = workspace.tearOutHandlers,
+            originalPark           = workspace.vesselParkHandlers,
+            participantRetirements = [];
+
+        try {
+            const
+                descriptor = {
+                    operation        : 'transferNode',
+                    nodeId           : DockZoneModel.resolveStackRoot(state.document),
+                    sourceWorkspaceId: workspaceId,
+                    targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                    target           : {
+                        targetNodeId: 'heavy-tabs',
+                        placement   : {kind: 'tab-into'}
+                    }
+                },
+                returned = DockZoneModel.transferNode(state.document, workspace.dockModel, descriptor);
+
+            expect(returned.errors).toEqual([]);
+            expect(workspace.workspaceSet.adoptTransfer({
+                sourceDocument   : returned.sourceDocument,
+                sourceWorkspaceId: workspaceId,
+                targetDocument   : returned.targetDocument,
+                targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID
+            })).toBe(true);
+
+            state.participation = {destroy: () => participantRetirements.push('destroy')};
+            workspace.crossWindowParticipations.set(workspaceId, state.participation);
+            workspace.tearOutPlacements.alerts = {index: 0, tabsNodeId: 'heavy-tabs'};
+            workspace.tearOutPanes.alerts = {
+                admissionToken: 7,
+                generation    : 3,
+                windowId      : 'window-alerts',
+                windowName    : 'tearout-alerts'
+            };
+            workspace.lastCrossWindowTransfer = {
+                applied          : true,
+                closeRequested   : false,
+                sourceWorkspaceId: workspaceId,
+                targetWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                topologyExited   : false
+            };
+            workspace.resolveTearOutVessel = () => ({windowId: 'window-alerts'});
+            workspace.closeTearOutVessel   = async () => true;
+
+            await expect(workspace.retireReturnedVessel(workspaceId)).resolves.toBe(true);
+
+            expect(state.closeRequested).toBe(true);
+            expect(workspace.vesselWorkspaces.get(workspaceId)).toBe(state);
+            expect(workspace.workspaceSet.has(workspaceId)).toBe(true);
+            expect(workspace.lastCrossWindowTransfer).toMatchObject({
+                closeRequested: true,
+                topologyExited: false
+            });
+            expect(participantRetirements).toEqual(['destroy']);
+
+            workspace.tearOutHandlers = {onVesselRetired() {}};
+            workspace.vesselParkHandlers = {onVesselRetired() {}};
+            workspace.onWindowDisconnect({windowId: 'window-alerts'});
+
+            expect(workspace.vesselWorkspaces.has(workspaceId)).toBe(false);
+            expect(workspace.workspaceSet.has(workspaceId)).toBe(false);
+            expect(workspace.lastCrossWindowTransfer.topologyExited).toBe(true);
+            expect(participantRetirements).toEqual(['destroy'])
+        } finally {
+            workspace.resolveTearOutVessel  = originalResolve;
+            workspace.closeTearOutVessel    = originalClose;
+            workspace.tearOutHandlers       = originalTearOut;
+            workspace.vesselParkHandlers    = originalPark;
+            workspace.destroy()
+        }
+    });
+
+    test('vessel projection retires its one-shot incoming target after paint', async () => {
+        const
+            workspace   = Neo.create(Workspace, {}),
+            workspaceId = Workspace.vesselWorkspaceId('alerts'),
+            provisional = workspace.createVesselWorkspaceDocument('alerts'),
+            moved       = DockZoneModel.transferItem(workspace.dockModel, provisional, {
+                itemId           : 'alerts',
+                sourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID,
+                targetWorkspaceId: workspaceId,
+                target           : {operation: 'addTab', tabsNodeId: Workspace.vesselTabsNodeId('alerts')}
+            }),
+            order       = [],
+            preview     = {parent: {remove: () => order.push('preview-parked')}},
+            host        = {
+                isDestroyed  : false,
+                promiseUpdate: async () => order.push('paint')
+            },
+            mainView    = {
+                isDestroyed: false,
+                add        : () => {
+                    order.push('projection-created');
+                    return host
+                }
+            },
+            participation = {destroy: () => order.push('target-retired')};
+
+        try {
+            expect(moved.errors).toEqual([]);
+
+            workspace.vesselWorkspaces.set(workspaceId, {
+                app      : {mainView},
+                committed: true,
+                document : moved.targetDocument,
+                host     : null,
+                itemId   : 'alerts',
+                participation,
+                preview,
+                windowId : 'window-alerts',
+                workspaceId
+            });
+            workspace.crossWindowParticipations.set(workspaceId, participation);
+
+            await expect(workspace.mountVesselWorkspace(workspaceId)).resolves.toBe(true);
+            expect(order).toEqual([
+                'preview-parked',
+                'projection-created',
+                'paint',
+                'target-retired'
+            ]);
+            expect(workspace.crossWindowParticipations.has(workspaceId)).toBe(false);
+            expect(workspace.vesselWorkspaces.get(workspaceId).participation).toBeNull()
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('cross-window hit-testing follows live manager.Window dimensions', async () => {
+        const
+            workspace   = Neo.create(Workspace, {}),
+            workspaceId = Workspace.vesselWorkspaceId('alerts');
+
+        try {
+            await workspace.crossWindowParticipationPromise;
+            workspace.tearOutPanes.alerts = {windowId: 'window-alerts'};
+            workspace.vesselWorkspaces.set(workspaceId, {
+                itemId  : 'alerts',
+                windowId: 'window-alerts'
+            });
+
+            const
+                WindowManager = Neo.manager.Window,
+                originalGet   = WindowManager.get;
+            let innerRect = {width: 320, height: 240};
+
+            try {
+                WindowManager.get = () => ({innerRect});
+
+                expect(workspace.hitTestCrossWindowTarget(
+                    workspaceId,
+                    300,
+                    200
+                )).toBe(true);
+
+                innerRect = {width: 240, height: 160};
+
+                expect(workspace.hitTestCrossWindowTarget(
+                    workspaceId,
+                    300,
+                    200
+                )).toBe(false)
+            } finally {
+                WindowManager.get = originalGet
+            }
+        } finally {
+            workspace.destroy()
         }
     });
 

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -226,6 +226,134 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('cross-window source projection publishes stable workspace identity and conversion ownership', () => {
+        const
+            originalWindowPosition = Neo.main.addon.WindowPosition,
+            windowPosition         = originalWindowPosition ?? Neo.ns('Neo.main.addon.WindowPosition', true),
+            originalSetConfigs     = windowPosition.setConfigs,
+            resizeCalls            = [];
+        let workspace;
+
+        try {
+            windowPosition.setConfigs = data => resizeCalls.push(data);
+            workspace = Neo.create(Workspace, {});
+
+            const chrome = readTabChrome(workspace);
+
+            expect(resizeCalls).toEqual([{
+                observeResize: true,
+                windowId     : workspace.windowId
+            }]);
+            expect(workspace.workspaceSet.ids()).toEqual([Workspace.MAIN_WORKSPACE_ID]);
+            expect(workspace.workspaceSet.getDocument(Workspace.MAIN_WORKSPACE_ID)).toBe(workspace.dockModel);
+
+            chrome.forEach(({bar}, nodeId) => {
+                expect(bar.sortZoneConfig, `${nodeId} joins the one cross-window source group`).toMatchObject({
+                    dockWorkspaceId       : Workspace.MAIN_WORKSPACE_ID,
+                    enableVesselConversion: true,
+                    sortGroup             : Workspace.CROSS_WINDOW_SORT_GROUP
+                })
+            })
+        } finally {
+            workspace?.destroy();
+            if (originalWindowPosition) {
+                originalSetConfigs
+                    ? windowPosition.setConfigs = originalSetConfigs
+                    : delete windowPosition.setConfigs
+            } else {
+                delete Neo.main.addon.WindowPosition
+            }
+        }
+    });
+
+    test('physical vessel death clears both tear-out and park lifecycle owners', () => {
+        const
+            workspace       = Neo.create(Workspace, {}),
+            originalTearOut = workspace.tearOutHandlers,
+            originalPark    = workspace.vesselParkHandlers,
+            calls           = [];
+
+        try {
+            workspace.tearOutConnects.alerts = {
+                admissionToken: 7,
+                generation    : 3,
+                windowId      : 'tear-child'
+            };
+            workspace.tearOutHandlers = {
+                onVesselRetired: data => calls.push(['tear-out', data])
+            };
+            workspace.vesselParkHandlers = {
+                onVesselRetired: data => calls.push(['park', data])
+            };
+
+            workspace.onWindowDisconnect({windowId: 'tear-child'});
+
+            expect(workspace.tearOutConnects.alerts).toBeUndefined();
+            expect(calls).toEqual([
+                ['tear-out', {
+                    admissionToken: 7,
+                    generation    : 3,
+                    itemId        : 'alerts',
+                    windowName    : 'tearout-alerts'
+                }],
+                ['park', {itemId: 'alerts', retirement: true}]
+            ])
+        } finally {
+            workspace.tearOutHandlers  = originalTearOut;
+            workspace.vesselParkHandlers = originalPark;
+            workspace.destroy()
+        }
+    });
+
+    test('a successor tear-out retries retained retirement before opening a fresh vessel', async () => {
+        const
+            workspace       = Neo.create(Workspace, {}),
+            originalTearOut = workspace.tearOutHandlers,
+            originalPark    = workspace.vesselParkHandlers,
+            active          = {itemId: 'alerts', windowName: 'tearout-alerts'},
+            calls           = [];
+        let admitRetirement = true;
+
+        workspace.tearOutHandlers = {
+            activeVessel     : active,
+            onDockTearOutExit: async data => {
+                calls.push(['exit', data]);
+                return true
+            },
+            retireActiveVessel: async data => {
+                calls.push(['retire', data]);
+                return admitRetirement
+            }
+        };
+        workspace.vesselParkHandlers = {
+            onVesselRetired: data => calls.push(['park-retired', data])
+        };
+
+        const data = {sortZone: {endWindowDrag: () => calls.push('end')}};
+
+        try {
+            await expect(workspace.onDockTearOutExit(data)).resolves.toBe(true);
+            expect(calls).toEqual([
+                ['retire', active],
+                ['park-retired', {itemId: 'alerts', retirement: true}],
+                ['exit', data]
+            ]);
+
+            calls.length    = 0;
+            admitRetirement = false;
+
+            await expect(workspace.onDockTearOutExit(data)).resolves.toBe(false);
+            expect(calls).toEqual([
+                ['retire', active],
+                'end'
+            ])
+        } finally {
+            workspace.tearOutHandlers  = originalTearOut;
+            workspace.vesselParkHandlers = originalPark;
+            workspace.destroy()
+        }
+    });
+
     test('previewLanguage maps to the dock-host modifier: initial, live swap, null reset, open values', () => {
         const workspace = Neo.create(Workspace, {previewLanguage: 'signal'});
 

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -907,6 +907,7 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
 
             expect(decorated).toBe(pane);
             expect(grip.cls).toEqual(['neo-dock-stack-handle']);
+            expect(grip.id).toBe('neo-dock-stack-handle-live');
 
             const restored = DockLayoutAdapter.decorateProjectedItem(pane, 'live', item);
 
@@ -933,6 +934,7 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             expect(header.text[1]).toMatchObject({
                 'aria-hidden': true,
                 cls          : ['neo-dock-stack-handle'],
+                id           : 'neo-dock-stack-handle-swarm',
                 tag          : 'span',
                 title        : 'Drag whole stack'
             });

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -229,7 +229,13 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
                     items     : [strategy, swarm]
                 }
             };
-            const data = {path: [{cls: ['neo-dock-stack-handle']}, {id: 'swarm-button'}]};
+            // Production DragDrop shape: the original nested mousedown survives as `target`,
+            // while the custom drag:start `path` begins at the draggable button.
+            const data = {
+                path      : [{id: 'swarm-button'}],
+                target    : {cls: ['neo-dock-stack-handle']},
+                targetPath: [{cls: ['neo-dock-stack-handle']}, {id: 'swarm-button'}]
+            };
 
             await DockTabSortZone.prototype.onDragStart.call(zone, data);
 
@@ -566,6 +572,35 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
 
             // proxy-less call (torn down mid-gesture) stays safe — the flag still resets
             DockTabSortZone.prototype.endWindowDrag.call({dragProxy: null, isWindowDragging: true})
+        })
+
+        test('a winning remote pointer claim outranks popup-scale source-boundary overlap for that frame', () => {
+            const fired = [];
+            const zone  = {
+                boundaryContainerRect: {bottom: 100, height: 100, right: 100, width: 100, x: 0, y: 0},
+                dragCoordinator      : {pointerClaimArbiter: {resolve: () => ({stableId: 'workspace-a'})}},
+                dragPlaceholder      : null,
+                fire                 : name => fired.push(name),
+                isWindowDragging     : true,
+                lastIntersectionRatio: 0,
+                lastProxyDims        : {height: 80, width: 80},
+                onWindowDragContinue : () => fired.push('continue'),
+                reattachArmed        : true,
+                reattachThreshold    : 0.6
+            };
+            const frame = {
+                proxyRect: {bottom: 80, height: 80, right: 80, width: 80, x: 0, y: 0}
+            };
+
+            expect(DockTabSortZone.prototype.checkWindowBoundary.call(zone, frame)).toBe(true);
+            expect(fired, 'the claimed remote frame cannot retire the source vessel').toEqual([]);
+
+            zone.dragCoordinator.pointerClaimArbiter.resolve = () => null;
+
+            expect(DockTabSortZone.prototype.checkWindowBoundary.call(zone, frame)).toBe(true);
+            expect(fired, 'the next claim-free source frame delegates to ordinary re-entry').toEqual([
+                'dragBoundaryEntry'
+            ])
         })
     });
 

--- a/test/playwright/unit/worker/ReplyLoss.spec.mjs
+++ b/test/playwright/unit/worker/ReplyLoss.spec.mjs
@@ -43,11 +43,17 @@ class ReplyLossWorker extends WorkerBase {
 Neo.setupClass(ReplyLossWorker);
 
 const createCapturingPort = () => {
-    const sent = [];
+    const
+        sent  = [],
+        state = {closed: false};
 
     return {
         sent,
+        state,
         port: {
+            close() {
+                state.closed = true
+            },
             postMessage(message) {
                 sent.push(message)
             }
@@ -201,4 +207,234 @@ test.describe('Worker reply loss on null port lookup (#12958)', () => {
         expect(sent[0].replyId).toBe('q-8');
         expect(sent[0].reject).toBeUndefined()
     });
+});
+
+test.describe('SharedWorker source-port lifecycle (#15906)', () => {
+    test('onConnected binds registration messages to the exact source port', () => {
+        const
+            first       = createCapturingPort(),
+            second      = createCapturingPort(),
+            worker      = createSharedWorker([]),
+            connections = [];
+
+        worker.onConnected({ports: [first.port]});
+        worker.onConnected({ports: [second.port]});
+        worker.onConnect = data => connections.push(data);
+
+        second.port.onmessage({
+            data: {
+                action: 'registerNeoConfig',
+                data  : {windowId: 'win-source'}
+            }
+        });
+        second.port.onmessage({
+            data: {
+                action : 'registerApp',
+                appName: 'SourceBoundApp'
+            }
+        });
+
+        const [firstEntry, sourceEntry] = worker.ports;
+
+        expect(firstEntry.windowId).toBeNull();
+        expect([...firstEntry.appNames]).toEqual([]);
+        expect(sourceEntry.windowId).toBe('win-source');
+        expect([...sourceEntry.appNames]).toEqual(['SourceBoundApp']);
+        expect(connections).toHaveLength(1);
+        expect(connections[0].sourcePort).toBe(sourceEntry)
+    });
+
+    test('one source port preserves every hosted app until its final disconnect', async () => {
+        const
+            captured     = createCapturingPort(),
+            worker       = createSharedWorker([]),
+            connected    = [],
+            disconnected = [];
+
+        worker.on({
+            connect   : data => connected.push(data.appName),
+            disconnect: data => disconnected.push(data.appName)
+        });
+        worker.timeout = () => Promise.resolve();
+        worker.onConnected({ports: [captured.port]});
+
+        const [portEntry] = worker.ports;
+
+        portEntry.windowId = 'win-multi-app';
+        portEntry.port.onmessage({data: {action: 'registerApp', appName: 'AppA'}});
+        portEntry.port.onmessage({data: {action: 'registerApp', appName: 'AppB'}});
+
+        await Promise.resolve();
+
+        expect([...portEntry.appNames]).toEqual(['AppA', 'AppB']);
+        expect(connected).toEqual(['AppA', 'AppB']);
+
+        worker.onDisconnect({appName: 'AppA', windowId: 'win-multi-app'}, portEntry);
+
+        expect(worker.ports).toEqual([portEntry]);
+        expect([...portEntry.appNames]).toEqual(['AppB']);
+        expect(captured.state.closed).toBe(false);
+        expect(disconnected).toEqual(['AppA']);
+
+        worker.onDisconnect({appName: 'AppB', windowId: 'win-multi-app'}, portEntry);
+
+        expect(worker.ports).toHaveLength(0);
+        expect(captured.state.closed).toBe(true);
+        expect(disconnected).toEqual(['AppA', 'AppB'])
+    });
+
+    test('disconnect retires the exact source port and drops its queued messages', () => {
+        const
+            captured  = createCapturingPort(),
+            portEntry = {
+                appNames: new Set(['DepartedApp']),
+                id      : 'port-departed',
+                port    : captured.port,
+                windowId: 'win-departed'
+            },
+            worker = createSharedWorker([portEntry]);
+
+        let queuedGeometryDispatches = 0;
+
+        portEntry.port.onmessage = () => {};
+        worker.onWindowPositionChange = () => queuedGeometryDispatches++;
+        worker.onDisconnect({
+            appName : 'DepartedApp',
+            windowId: 'win-departed'
+        }, portEntry);
+        worker.onMessage({
+            data: {
+                action: 'windowPositionChange',
+                data  : {windowId: 'win-departed'}
+            }
+        }, portEntry);
+
+        expect(worker.ports).toHaveLength(0);
+        expect(worker.getPort({windowId: 'win-departed'})).toBeNull();
+        expect(portEntry.port.onmessage).toBeNull();
+        expect(captured.state.closed).toBe(true);
+        expect(queuedGeometryDispatches).toBe(0)
+    });
+
+    test('disconnect cleanup stays bounded across unique window ids', () => {
+        const worker = createSharedWorker([]);
+
+        for (let index = 0; index < 1000; index++) {
+            const portEntry = {
+                appNames: new Set(['BoundedApp']),
+                id      : `port-${index}`,
+                port    : createCapturingPort().port,
+                windowId: `win-${index}`
+            };
+
+            worker.ports.push(portEntry);
+            worker.onDisconnect({
+                appName : 'BoundedApp',
+                windowId: portEntry.windowId
+            }, portEntry)
+        }
+
+        expect(worker.ports).toHaveLength(0)
+    });
+
+    test('a replacement with identical routing keys cannot complete an old async connect', async () => {
+        const
+            oldPort  = createCapturingPort(),
+            oldEntry = {
+                appNames: new Set(['GenerationApp']),
+                id      : 'port-generation',
+                port    : oldPort.port,
+                windowId: 'win-generation'
+            },
+            worker      = createSharedWorker([oldEntry]),
+            connections = [];
+
+        let releaseDelay;
+
+        worker.on({connect: data => connections.push(data)});
+        worker.timeout = () => new Promise(resolve => {
+            releaseDelay = resolve
+        });
+
+        const pendingConnect = worker.onConnect({
+            appName   : 'GenerationApp',
+            sourcePort: oldEntry,
+            windowId  : 'win-generation'
+        });
+
+        worker.onDisconnect({
+            appName : 'GenerationApp',
+            windowId: 'win-generation'
+        }, oldEntry);
+        worker.ports.push({
+            appNames: new Set(['GenerationApp']),
+            id      : 'port-generation',
+            port    : createCapturingPort().port,
+            windowId: 'win-generation'
+        });
+
+        releaseDelay();
+        await pendingConnect;
+
+        expect(worker.ports).toHaveLength(1);
+        expect(connections).toHaveLength(0)
+    });
+
+    test('disconnect rejects and deletes promises owned by the retired port', async () => {
+        const
+            captured  = createCapturingPort(),
+            portEntry = {
+                appNames: new Set(['PendingApp']),
+                id      : 'port-pending',
+                port    : captured.port,
+                windowId: 'win-pending'
+            },
+            worker  = createSharedWorker([portEntry]),
+            pending = worker.promiseMessage('win-pending', {action: 'pendingReply'});
+
+        const [{id}] = captured.sent;
+
+        worker.onDisconnect({
+            appName : 'PendingApp',
+            windowId: 'win-pending'
+        }, portEntry);
+
+        await expect(pending).rejects.toThrow('Worker port disconnected before reply: port-pending');
+        expect(worker.promises[id]).toBeUndefined()
+    });
+
+    test('retiring an old entry cannot reject a successor generation promise with the same routing id', async () => {
+        const
+            oldEntry = {
+                appNames: new Set(['GenerationApp']),
+                id      : 'port-generation',
+                port    : createCapturingPort().port,
+                windowId: 'win-generation'
+            },
+            successorPort = createCapturingPort(),
+            successor     = {
+                appNames: new Set(['GenerationApp']),
+                id      : 'port-generation',
+                port    : successorPort.port,
+                windowId: 'win-generation'
+            },
+            worker  = createSharedWorker([oldEntry, successor]),
+            pending = worker.promiseMessage('win-generation', {action: 'pendingReply'}),
+            [{id}]  = successorPort.sent;
+
+        worker.removePort(oldEntry);
+
+        expect(worker.promises[id]).toBeDefined();
+
+        worker.onMessage({
+            data: {
+                action : 'reply',
+                data   : 'successor-reply',
+                replyId: id
+            }
+        }, successor);
+
+        await expect(pending).resolves.toBe('successor-reply');
+        expect(worker.promises[id]).toBeUndefined()
+    })
 });


### PR DESCRIPTION
Resolves #15906

Related: #15252

The Workstation cross-window docking journey is implemented. A second popup converts while its pointer drag remains live, docks into the first vessel through one rendered/semantic claim, and returns the resulting stack to main through one grouped transfer. The full five-beat signature ran twice across a direct reload at `3a951c7da4`; exact-head lifecycle hardening at `9606e3fd32` now prevents a disconnected MessagePort generation from publishing late geometry or resurrecting a ghost window.

## Contract delivery

| Surface | Delivered behavior |
| :--- | :--- |
| Main workspace participation | Registers stable `workstation-main` cross-window target and re-establishes it after projections |
| Lazy vessel participation | Bare popup becomes a remote target without document mutation on hover |
| Atomic first dock | Incoming B seeds detached owner A at index 0 and publishes `[A,B]` through one compensated adoption |
| Remote-claim boundary | A winning remote pointer claim outranks popup-scale source overlap for that frame; claim-free motion still delegates to ordinary re-entry |
| Production grip transport | Whole-stack origin resolves through preserved native `target`/`targetPath`, with stable projected grip DOM ids |
| Render reconciliation | Vessel target projects after adoption, then main refreshes; cached pane identities survive |
| Whole-stack return | One `transferNode` returns the stack, projects main, dispatches exact native close, and becomes terminal only at disconnect |
| Disconnect recovery | Unexpected vessel death atomically recovers A+B or retains headless truth on refusal |
| Port-generation lifecycle | Registration binds to the exact source port; multi-app membership survives until the last app disconnects; retired generations reject owned promises and cannot publish queued geometry or late connect events |
| Geometry and arbitration | Uses live `manager.Window.innerRect`, semantic workspace IDs, exactly one claim, and semantic/rendered preview equality |
| Close authority | Resolver carries queried `itemId`; diagnostics expose only match booleans/ids, never native handle keys |
| Signature witness | Two uninterrupted normal-mode journeys produced the same five-entry semantic beat log across a direct reload at `3a951c7da4`; film mode uses the same app-owned executor for one presentation take |

## Deltas from ticket

- Scene 3 is executable and headed-green at exact head: `metrics` + `commits` form one live vessel through one winning target claim.
- Scene 4 is executable and headed-green at exact head: the exact stack returns to `right-top-tabs` as `['audit','metrics','commits']`; model adoption precedes native close and physical topology exit.
- Scene 5 remains executable. It was headed-green at `3a951c7da4`; the exact-head rerun at `9606e3fd32` reached the second take before Chromium terminated itself after repeated GPU-process exits.
- The second Scene-5 journey observes the direct reload already issued by the test. It does not add a second navigation.
- Reload recovery proves the full opening document, exactly one current `Workspace`, no popup residue, stable pane identities, monotonic feed state, and identical five-entry semantic logs.
- Page-error and window-observer listeners are explicitly disposed at every reload boundary.
- SharedWorker routing no longer assigns app/config registration to the first unbound port. The exact source port is the generation authority across async connect, geometry, disconnect, and pending reply cleanup.
- One browser window may host multiple apps; per-port membership preserves every app-level disconnect and closes the physical port only after the final member leaves.
- Iris's original composition commit remains attributed to `neo-kimi-iris`; Emmy's follow-up commits own lifecycle hardening, participation, and headed witnesses.

## Commits

- `2d8b56231b` — arm vessel conversion and cross-window sort-group transport (`neo-kimi-iris`)
- `c84ed4f541` — harden cross-window vessel ownership
- `ac3a1f657d` — compose vessel docking participation
- `2a1d4a9d43` — activate the real-pointer cross-window journey witnesses
- `3a951c7da4` — activate the five-beat two-journey signature witness
- `9606e3fd32` — retire disconnected SharedWorker port generations

## Test Evidence

Evidence: L4 was achieved for every #15906 close-target AC at `3a951c7da4`. Exact head `9606e3fd32` revalidates Scenes 3 and 4 at L4 plus the lifecycle surface at L3; Scene 5 is not promoted to exact-head green because the browser host aborted during its second take.

- Exact head: `9606e3fd32de6445e8b47577cbd1c53bd592f34b`.
- Focused worker + Window unit suite at exact head — **22 passed** in 4.0s.
- Staged-file and commit hooks passed whitespace, shorthand, AiConfig test mutation, JSDoc types, derived-domain, ticket-archaeology, block-alignment, and parse gates.
- Scene 3 product test passed at exact head with the accelerated-GL setup witness.
- Isolated Scene 4 invocation at exact head — **2 passed** in 14.6s, including the accelerated-GL setup witness.
- Scene 5 exact-head invocation — GL setup passed and the product reached take 2. Chromium then reported repeated `GPU process exited unexpectedly: exit_code=11`, `FATAL ... GPU process isn't usable. Goodbye.`, and exited with `SIGTRAP`. The App Worker disconnect and Neural Link call-30 timeout occurred after the browser abort.
- Historical full headed Workstation invocation at `3a951c7da4` — **9 passed** in 1.4m.
- Headed platform boundary: macOS Chromium on ANGLE Metal / Apple M5 Max, real Neural Link, and real popup connect/park/close/disconnect.
- Scene 3 proves one claim, semantic/rendered preview equality, source survival until release, `[metrics, commits]`, exact source retirement, and identity/feed continuity.
- Scene 4 proves one grouped `transferNode`, phase order `documents-adopted → main-projected → close-dispatched → topology-exited`, exact native close, physical popup disappearance, `['audit','metrics','commits']`, and identity/feed continuity.
- The historical Scene 5 green proves two complete normal-mode journeys, one direct zero-residue reload, exact opening-document equality, exactly one current workspace, identical five-entry semantic logs, and zero surviving popup pages.

## Current merge boundary

- [ ] Re-run Scene 5 at exact head after the Chromium/GPU host is stable; do not convert the downstream Neural Link timeout into an app failure.
- [ ] Obtain a fresh cross-family exact-head review; the approval on `3a951c7da4` is stale after the lifecycle commit.
- [ ] Confirm required `dev` checks, including `integration-parity`.

## Post-Merge Validation

- [ ] Run film-take mode through the same app-owned executors and preserve the macOS-headed claim boundary in the #15252 captions.

## Review routing

Review role: exact-head audit of the SharedWorker generation lifecycle plus the five-scene docking journey. Attack multi-app membership, duplicate ownership, claim arbitration, grip-origin transport, projection ordering, native-close authority, observer cleanup, exactly-one-workspace recovery, and beat-log equality. Do not treat close acknowledgement as physical exit, or a browser-process abort as an app assertion.

Cross-family review remains required. Sharp falsifiers: one port dropping its second hosted app; an old port generation resolving/rejecting a successor's promise; late geometry after disconnect; duplicate A ownership; more than one first-drop adoption; semantic/rendered preview mismatch; source popup destroyed before commit; model projection after close; a close receipt without physical topology removal; a second navigation after reload; stale listeners; or logs that encode runtime window IDs, geometry, timestamps, raw heartbeat values, or retry attempts.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session `27de6eb7-04ae-4eba-8b73-2b9f5eaf4dc3`.
