### PR TITLE
fix(ai): declare the graph SQLite a plane member and converge its three divergent defaults (#15872)

### DIFF
--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -57,39 +57,40 @@ x-plane-env: &plane-env
   # Identity + root (ADR 0019 §10.3: id is opaque; equality is the only same-plane test).
   # `*plane-id` is the SAME YAML scalar the project `name` uses — not a matching expression,
   # the identical node. There is no second value that could drift out of step with it.
-  NEO_PLANE_ID: *plane-id
+  NEO_PLANE_ID       : *plane-id
   NEO_PLANE_DATA_ROOT: /app/.neo-ai-data-parity
   # Tier-1 members (ai/configBase.mjs PLANE_MEMBER_PATHS)
-  NEO_AUTH_SEAT_TOKEN_REGISTRY_PATH: /app/.neo-ai-data-parity/seat-tokens/registry.json
-  NEO_BACKUP_PATH: /app/.neo-ai-data-parity/backups
-  NEO_HEARTBEAT_ALIVE_PATH: /app/.neo-ai-data-parity/wake-daemon/heartbeat.alive
-  NEO_FLEET_INSTANCE_ROOT: /app/.neo-ai-data-parity/fleet/instances
-  NEO_CHROMA_DATA_DIR: /app/.neo-ai-data-parity/chroma/unified
-  NEO_AI_ORCHESTRATOR_DIR: /app/.neo-ai-data-parity/orchestrator-daemon
-  NEO_AI_DB_PATH: /app/.neo-ai-data-parity/sqlite/memory-core-graph.sqlite
+  NEO_AUTH_SEAT_TOKEN_REGISTRY_PATH        : /app/.neo-ai-data-parity/seat-tokens/registry.json
+  NEO_BACKUP_PATH                          : /app/.neo-ai-data-parity/backups
+  NEO_HEARTBEAT_ALIVE_PATH                 : /app/.neo-ai-data-parity/wake-daemon/heartbeat.alive
+  NEO_FLEET_INSTANCE_ROOT                  : /app/.neo-ai-data-parity/fleet/instances
+  NEO_CHROMA_DATA_DIR                      : /app/.neo-ai-data-parity/chroma/unified
+  NEO_AI_ORCHESTRATOR_DIR                  : /app/.neo-ai-data-parity/orchestrator-daemon
+  NEO_AI_DB_PATH                           : /app/.neo-ai-data-parity/sqlite/memory-core-graph.sqlite
   NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH: /app/.neo-ai-data-parity/deployment-state/snapshot.json
-  NEO_RECOVERY_ACTUATOR_HEAL_ATTEMPTS_PATH: /app/.neo-ai-data-parity/orchestrator-daemon/heal-attempts.json
-  NEO_RECOVERY_ACTUATOR_RUN_STATE_DIR: /app/.neo-ai-data-parity/orchestrator-daemon/recovery-runs
+  NEO_RECOVERY_ACTUATOR_HEAL_ATTEMPTS_PATH : /app/.neo-ai-data-parity/orchestrator-daemon/heal-attempts.json
+  NEO_RECOVERY_ACTUATOR_RUN_STATE_DIR      : /app/.neo-ai-data-parity/orchestrator-daemon/recovery-runs
   # Memory-core members (ai/mcp/server/memory-core/configBase.mjs PLANE_MEMBER_PATHS)
-  NEO_RLAIF_PATH: /app/.neo-ai-data-parity/datasets/rlaif/trajectories.jsonl
-  NEO_REM_RUN_STATE_DIR: /app/.neo-ai-data-parity/rem-runs
-  NEO_MEMORY_WAL_DIR: /app/.neo-ai-data-parity/memory-wal
-  NEO_MEMORY_EMBED_DAEMON_DIR: /app/.neo-ai-data-parity/embed-daemon
-  NEO_MESSAGE_WAL_DAEMON_DIR: /app/.neo-ai-data-parity/message-daemon
-  NEO_AI_DAEMON_DIR: /app/.neo-ai-data-parity/wake-daemon
-  NEO_HOOK_PROJECTION_ROOT: /app/.neo-ai-data-parity/hook-projections
+  NEO_RLAIF_PATH                              : /app/.neo-ai-data-parity/datasets/rlaif/trajectories.jsonl
+  NEO_REM_RUN_STATE_DIR                       : /app/.neo-ai-data-parity/rem-runs
+  NEO_MEMORY_WAL_DIR                          : /app/.neo-ai-data-parity/memory-wal
+  NEO_MEMORY_EMBED_DAEMON_DIR                 : /app/.neo-ai-data-parity/embed-daemon
+  NEO_MESSAGE_WAL_DAEMON_DIR                  : /app/.neo-ai-data-parity/message-daemon
+  NEO_AI_DAEMON_DIR                           : /app/.neo-ai-data-parity/wake-daemon
+  NEO_HOOK_PROJECTION_ROOT                    : /app/.neo-ai-data-parity/hook-projections
   NEO_GOLDEN_PATH_ROUTE_ATTRIBUTION_LEDGER_DIR: /app/.neo-ai-data-parity/orchestrator-daemon/route-attribution
-  NEO_MEMORY_LOG_PATH: /app/.neo-ai-data-parity/logs
-  NEO_LAZY_EDGES_QUEUE_PATH: /app/.neo-ai-data-parity/memory-core/lazy-edges.jsonl
+  NEO_MEMORY_LOG_PATH                         : /app/.neo-ai-data-parity/logs
+  NEO_LAZY_EDGES_QUEUE_PATH                   : /app/.neo-ai-data-parity/memory-core/lazy-edges.jsonl
   # Knowledge-base member (ai/mcp/server/knowledge-base/configBase.mjs PLANE_MEMBER_PATHS)
   NEO_KB_LOG_PATH: /app/.neo-ai-data-parity/logs
   # Neural-link member (ai/mcp/server/neural-link/configBase.mjs PLANE_MEMBER_PATHS)
   NEO_NL_LOG_PATH: /app/.neo-ai-data-parity/logs
-  # Graph SQLite — explicitly placed although NOT yet a declared plane member: MC's
-  # `storagePaths.graphProd` is absent from its PLANE_MEMBER_PATHS and its default anchors
-  # to cwd (not the plane root), with divergent sibling defaults on the KB/neural-link
-  # `memoryCoreDbPathProd` leaves. Member-set gap tracked as a narrow follow-up on #15803;
-  # explicit placement here is coherence-valid either way.
+  # Graph SQLite — Memory Core's declared plane member (`storagePaths.graphProd`, plane-anchored),
+  # asserted at MC's boot. The KB and neural-link `memoryCoreDbPathProd` leaves bind this same env
+  # and now derive the same plane-anchored default, but are explicit NON-members: a shared artifact
+  # is claimed by its owner, not re-claimed by consumers (the Chroma persist-dir precedent), so one
+  # boot failure names one cause. This explicit placement is retained deliberately — it pins the
+  # parity plane's location independently of any default.
   NEO_MEMORY_DB_PATH: /app/.neo-ai-data-parity/sqlite/memory-core-graph.sqlite
 
 # Canonical direct-local authentication profile. Ordinary forks have no generated roster, so the
@@ -100,12 +101,12 @@ x-plane-env: &plane-env
 # update bootstrap while silently leaving readiness behind, while `docker compose config` never
 # renders the credential.
 x-provider-auth-env: &provider-auth-env
-  NEO_AUTH_MODE: github-pat
-  NEO_AUTH_TRUST_PROXY_IDENTITY: "false"
-  NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT: "true"
+  NEO_AUTH_MODE                           : github-pat
+  NEO_AUTH_TRUST_PROXY_IDENTITY           : "false"
+  NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT     : "true"
   NEO_AUTH_AUTO_PROVISION_IDENTITY_SOURCES: github-pat
-  NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE: &provider-bootstrap-pat-file /run/secrets/mcp-auth-token
-  NEO_MCP_HEALTHCHECK_TOKEN_FILE: *provider-bootstrap-pat-file
+  NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE    : &provider-bootstrap-pat-file /run/secrets/mcp-auth-token
+  NEO_MCP_HEALTHCHECK_TOKEN_FILE          : *provider-bootstrap-pat-file
 
 services:
   chroma:
@@ -143,10 +144,10 @@ services:
     volumes:
       - parity-chroma:/chroma/unified
     healthcheck:
-      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
-      interval: 10s
-      timeout: 5s
-      retries: 12
+      test        : ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
+      interval    : 10s
+      timeout     : 5s
+      retries     : 12
       start_period: 60s
     networks:
       - neo-parity-network
@@ -166,30 +167,30 @@ services:
 
   kb-server:
     build:
-      context: ../..
+      context   : ../..
       dockerfile: ai/deploy/Dockerfile
       args:
-        NEO_SOURCE: local  # build the local checkout for dev iteration, not a remote clone
+        NEO_SOURCE   : local  # build the local checkout for dev iteration, not a remote clone
         TARGET_SERVER: knowledge-base
     environment:
       <<: [*plane-env, *provider-auth-env]
-      NEO_TRANSPORT: streamable-http
-      NEO_AUTO_SYNC: "false"
+      NEO_TRANSPORT             : streamable-http
+      NEO_AUTO_SYNC             : "false"
       NEO_KB_AUTO_START_DATABASE: "false"
-      NEO_CHROMA_HOST: chroma
-      NEO_CHROMA_PORT: "8000"
-      MCP_HTTP_PORT: "3000"
+      NEO_CHROMA_HOST           : chroma
+      NEO_CHROMA_PORT           : "8000"
+      MCP_HTTP_PORT             : "3000"
       # Ask-synthesis pass-throughs (ask_knowledge_base -> SearchService.ask): the synthesis
       # provider + its DEDICATED budget-cappable key (NEO_KB_ASK_API_KEY, never the shared
       # GEMINI_API_KEY). Empty default -> the config-template default applies; with no key the
       # ask path fails soft to references-only (no crash). The secret VALUE stays runtime-only.
-      NEO_KB_ASK_PROVIDER: ${NEO_KB_ASK_PROVIDER:-}
-      NEO_KB_ASK_MODEL: ${NEO_KB_ASK_MODEL:-}
-      NEO_KB_ASK_API_KEY: ${NEO_KB_ASK_API_KEY:-}
-      NEO_KB_ASK_BASE_URL: ${NEO_KB_ASK_BASE_URL:-}
-      NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS: ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
+      NEO_KB_ASK_PROVIDER                   : ${NEO_KB_ASK_PROVIDER:-}
+      NEO_KB_ASK_MODEL                      : ${NEO_KB_ASK_MODEL:-}
+      NEO_KB_ASK_API_KEY                    : ${NEO_KB_ASK_API_KEY:-}
+      NEO_KB_ASK_BASE_URL                   : ${NEO_KB_ASK_BASE_URL:-}
+      NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS       : ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
       NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE: ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE:-}
-      NEO_KB_ASK_MAX_RPM: ${NEO_KB_ASK_MAX_RPM:-}
+      NEO_KB_ASK_MAX_RPM                    : ${NEO_KB_ASK_MAX_RPM:-}
     volumes:
       - ../..:/app
       # The PLANE ROOT rides a project-scoped named volume, not the repo bind above. Docker applies
@@ -218,9 +219,9 @@ services:
              "--client-name", "neo-kb-parity-healthcheck",
              "--expected-plane-id", *plane-id,
              "--expected-plane-data-root", "/app/.neo-ai-data-parity"]
-      interval: 15s
-      timeout: 10s
-      retries: 10
+      interval    : 15s
+      timeout     : 10s
+      retries     : 10
       start_period: 90s
     depends_on:
       chroma:
@@ -235,25 +236,25 @@ services:
 
   mc-server:
     build:
-      context: ../..
+      context   : ../..
       dockerfile: ai/deploy/Dockerfile
       args:
-        NEO_SOURCE: local  # build the local checkout for dev iteration, not a remote clone
+        NEO_SOURCE   : local  # build the local checkout for dev iteration, not a remote clone
         TARGET_SERVER: memory-core
     environment:
       <<: [*plane-env, *provider-auth-env]
-      NEO_TRANSPORT: streamable-http
-      NEO_MC_PRIMARY: "false"
-      NEO_AUTO_SUMMARIZE: "false"
-      NEO_MEM_AUTO_START_DATABASE: "false"
+      NEO_TRANSPORT               : streamable-http
+      NEO_MC_PRIMARY              : "false"
+      NEO_AUTO_SUMMARIZE          : "false"
+      NEO_MEM_AUTO_START_DATABASE : "false"
       NEO_MEM_AUTO_START_INFERENCE: "false"
-      NEO_AUTO_DREAM: "false"
-      NEO_AUTO_GOLDEN_PATH: "false"
+      NEO_AUTO_DREAM              : "false"
+      NEO_AUTO_GOLDEN_PATH        : "false"
       NEO_REAL_TIME_MEMORY_PARSING: "false"
-      NEO_AUTO_INGEST_FS: "false"
-      NEO_CHROMA_HOST: chroma
-      NEO_CHROMA_PORT: "8000"
-      MCP_HTTP_PORT: "3001"
+      NEO_AUTO_INGEST_FS          : "false"
+      NEO_CHROMA_HOST             : chroma
+      NEO_CHROMA_PORT             : "8000"
+      MCP_HTTP_PORT               : "3001"
       # Single-process container hosts the WAL drain loop itself: without it the decoupled
       # add_memory writes the WAL but nothing embeds it, so semantic recall reads empty.
       # Sole-drainer invariant: exactly one loop per WAL dir; never enable alongside the embed
@@ -283,9 +284,9 @@ services:
              "--client-name", "neo-mc-parity-healthcheck",
              "--expected-plane-id", *plane-id,
              "--expected-plane-data-root", "/app/.neo-ai-data-parity"]
-      interval: 15s
-      timeout: 10s
-      retries: 10
+      interval    : 15s
+      timeout     : 10s
+      retries     : 10
       start_period: 90s
     depends_on:
       chroma:
@@ -313,35 +314,35 @@ services:
   # notices; a scheduler on the wrong plane mutates the wrong durable store on a timer.
   orchestrator:
     build:
-      context: ../..
+      context   : ../..
       dockerfile: ai/deploy/Dockerfile
       args:
-        NEO_SOURCE: local
+        NEO_SOURCE        : local
         SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
     environment:
       <<: *plane-env
       # Cloud-safe lane profile: only the deployable lanes run. Local-only lanes and local
       # inference launchers stay off — the parity stack proves plane topology, not model hosting.
-      NEO_AI_DEPLOYMENT_MODE: cloud
-      NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED: "false"
-      NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED: "false"
-      NEO_ORCHESTRATOR_KB_SYNC_ENABLED: "false"
-      NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED: "false"
+      NEO_AI_DEPLOYMENT_MODE                              : cloud
+      NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED           : "false"
+      NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED              : "false"
+      NEO_ORCHESTRATOR_KB_SYNC_ENABLED                    : "false"
+      NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED              : "false"
       NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED: "false"
-      NEO_ORCHESTRATOR_MLX_ENABLED: "false"
-      NEO_ORCHESTRATOR_LMS_ENABLED: "false"
-      NEO_ORCHESTRATOR_OLLAMA_ENABLED: "false"
-      NEO_CHROMA_HOST: chroma
-      NEO_CHROMA_PORT: "8000"
+      NEO_ORCHESTRATOR_MLX_ENABLED                        : "false"
+      NEO_ORCHESTRATOR_LMS_ENABLED                        : "false"
+      NEO_ORCHESTRATOR_OLLAMA_ENABLED                     : "false"
+      NEO_CHROMA_HOST                                     : chroma
+      NEO_CHROMA_PORT                                     : "8000"
       # Runtime access is scoped to THIS plane's compose project — the same scalar the project
       # `name` and `NEO_PLANE_ID` resolve from, so a parity orchestrator can never address the
       # native stack's containers.
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED: "true"
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_MECHANISM: docker-socket
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_SOCKET_PATH: /var/run/docker.sock
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT: *plane-id
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES: chroma,kb-server,mc-server
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_READ_OPERATIONS: inspect,logs,stats
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED             : "true"
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_MECHANISM           : docker-socket
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_SOCKET_PATH         : /var/run/docker.sock
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT     : *plane-id
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES    : chroma,kb-server,mc-server
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_READ_OPERATIONS     : inspect,logs,stats
       NEO_ORCHESTRATOR_RUNTIME_ACCESS_LIFECYCLE_OPERATIONS: restart
     volumes:
       - ../..:/app

--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -57,30 +57,30 @@ x-plane-env: &plane-env
   # Identity + root (ADR 0019 §10.3: id is opaque; equality is the only same-plane test).
   # `*plane-id` is the SAME YAML scalar the project `name` uses — not a matching expression,
   # the identical node. There is no second value that could drift out of step with it.
-  NEO_PLANE_ID       : *plane-id
+  NEO_PLANE_ID: *plane-id
   NEO_PLANE_DATA_ROOT: /app/.neo-ai-data-parity
   # Tier-1 members (ai/configBase.mjs PLANE_MEMBER_PATHS)
-  NEO_AUTH_SEAT_TOKEN_REGISTRY_PATH        : /app/.neo-ai-data-parity/seat-tokens/registry.json
-  NEO_BACKUP_PATH                          : /app/.neo-ai-data-parity/backups
-  NEO_HEARTBEAT_ALIVE_PATH                 : /app/.neo-ai-data-parity/wake-daemon/heartbeat.alive
-  NEO_FLEET_INSTANCE_ROOT                  : /app/.neo-ai-data-parity/fleet/instances
-  NEO_CHROMA_DATA_DIR                      : /app/.neo-ai-data-parity/chroma/unified
-  NEO_AI_ORCHESTRATOR_DIR                  : /app/.neo-ai-data-parity/orchestrator-daemon
-  NEO_AI_DB_PATH                           : /app/.neo-ai-data-parity/sqlite/memory-core-graph.sqlite
+  NEO_AUTH_SEAT_TOKEN_REGISTRY_PATH: /app/.neo-ai-data-parity/seat-tokens/registry.json
+  NEO_BACKUP_PATH: /app/.neo-ai-data-parity/backups
+  NEO_HEARTBEAT_ALIVE_PATH: /app/.neo-ai-data-parity/wake-daemon/heartbeat.alive
+  NEO_FLEET_INSTANCE_ROOT: /app/.neo-ai-data-parity/fleet/instances
+  NEO_CHROMA_DATA_DIR: /app/.neo-ai-data-parity/chroma/unified
+  NEO_AI_ORCHESTRATOR_DIR: /app/.neo-ai-data-parity/orchestrator-daemon
+  NEO_AI_DB_PATH: /app/.neo-ai-data-parity/sqlite/memory-core-graph.sqlite
   NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH: /app/.neo-ai-data-parity/deployment-state/snapshot.json
-  NEO_RECOVERY_ACTUATOR_HEAL_ATTEMPTS_PATH : /app/.neo-ai-data-parity/orchestrator-daemon/heal-attempts.json
-  NEO_RECOVERY_ACTUATOR_RUN_STATE_DIR      : /app/.neo-ai-data-parity/orchestrator-daemon/recovery-runs
+  NEO_RECOVERY_ACTUATOR_HEAL_ATTEMPTS_PATH: /app/.neo-ai-data-parity/orchestrator-daemon/heal-attempts.json
+  NEO_RECOVERY_ACTUATOR_RUN_STATE_DIR: /app/.neo-ai-data-parity/orchestrator-daemon/recovery-runs
   # Memory-core members (ai/mcp/server/memory-core/configBase.mjs PLANE_MEMBER_PATHS)
-  NEO_RLAIF_PATH                              : /app/.neo-ai-data-parity/datasets/rlaif/trajectories.jsonl
-  NEO_REM_RUN_STATE_DIR                       : /app/.neo-ai-data-parity/rem-runs
-  NEO_MEMORY_WAL_DIR                          : /app/.neo-ai-data-parity/memory-wal
-  NEO_MEMORY_EMBED_DAEMON_DIR                 : /app/.neo-ai-data-parity/embed-daemon
-  NEO_MESSAGE_WAL_DAEMON_DIR                  : /app/.neo-ai-data-parity/message-daemon
-  NEO_AI_DAEMON_DIR                           : /app/.neo-ai-data-parity/wake-daemon
-  NEO_HOOK_PROJECTION_ROOT                    : /app/.neo-ai-data-parity/hook-projections
+  NEO_RLAIF_PATH: /app/.neo-ai-data-parity/datasets/rlaif/trajectories.jsonl
+  NEO_REM_RUN_STATE_DIR: /app/.neo-ai-data-parity/rem-runs
+  NEO_MEMORY_WAL_DIR: /app/.neo-ai-data-parity/memory-wal
+  NEO_MEMORY_EMBED_DAEMON_DIR: /app/.neo-ai-data-parity/embed-daemon
+  NEO_MESSAGE_WAL_DAEMON_DIR: /app/.neo-ai-data-parity/message-daemon
+  NEO_AI_DAEMON_DIR: /app/.neo-ai-data-parity/wake-daemon
+  NEO_HOOK_PROJECTION_ROOT: /app/.neo-ai-data-parity/hook-projections
   NEO_GOLDEN_PATH_ROUTE_ATTRIBUTION_LEDGER_DIR: /app/.neo-ai-data-parity/orchestrator-daemon/route-attribution
-  NEO_MEMORY_LOG_PATH                         : /app/.neo-ai-data-parity/logs
-  NEO_LAZY_EDGES_QUEUE_PATH                   : /app/.neo-ai-data-parity/memory-core/lazy-edges.jsonl
+  NEO_MEMORY_LOG_PATH: /app/.neo-ai-data-parity/logs
+  NEO_LAZY_EDGES_QUEUE_PATH: /app/.neo-ai-data-parity/memory-core/lazy-edges.jsonl
   # Knowledge-base member (ai/mcp/server/knowledge-base/configBase.mjs PLANE_MEMBER_PATHS)
   NEO_KB_LOG_PATH: /app/.neo-ai-data-parity/logs
   # Neural-link member (ai/mcp/server/neural-link/configBase.mjs PLANE_MEMBER_PATHS)
@@ -101,12 +101,12 @@ x-plane-env: &plane-env
 # update bootstrap while silently leaving readiness behind, while `docker compose config` never
 # renders the credential.
 x-provider-auth-env: &provider-auth-env
-  NEO_AUTH_MODE                           : github-pat
-  NEO_AUTH_TRUST_PROXY_IDENTITY           : "false"
-  NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT     : "true"
+  NEO_AUTH_MODE: github-pat
+  NEO_AUTH_TRUST_PROXY_IDENTITY: "false"
+  NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT: "true"
   NEO_AUTH_AUTO_PROVISION_IDENTITY_SOURCES: github-pat
-  NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE    : &provider-bootstrap-pat-file /run/secrets/mcp-auth-token
-  NEO_MCP_HEALTHCHECK_TOKEN_FILE          : *provider-bootstrap-pat-file
+  NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE: &provider-bootstrap-pat-file /run/secrets/mcp-auth-token
+  NEO_MCP_HEALTHCHECK_TOKEN_FILE: *provider-bootstrap-pat-file
 
 services:
   chroma:
@@ -144,10 +144,10 @@ services:
     volumes:
       - parity-chroma:/chroma/unified
     healthcheck:
-      test        : ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
-      interval    : 10s
-      timeout     : 5s
-      retries     : 12
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
       start_period: 60s
     networks:
       - neo-parity-network
@@ -167,30 +167,30 @@ services:
 
   kb-server:
     build:
-      context   : ../..
+      context: ../..
       dockerfile: ai/deploy/Dockerfile
       args:
-        NEO_SOURCE   : local  # build the local checkout for dev iteration, not a remote clone
+        NEO_SOURCE: local  # build the local checkout for dev iteration, not a remote clone
         TARGET_SERVER: knowledge-base
     environment:
       <<: [*plane-env, *provider-auth-env]
-      NEO_TRANSPORT             : streamable-http
-      NEO_AUTO_SYNC             : "false"
+      NEO_TRANSPORT: streamable-http
+      NEO_AUTO_SYNC: "false"
       NEO_KB_AUTO_START_DATABASE: "false"
-      NEO_CHROMA_HOST           : chroma
-      NEO_CHROMA_PORT           : "8000"
-      MCP_HTTP_PORT             : "3000"
+      NEO_CHROMA_HOST: chroma
+      NEO_CHROMA_PORT: "8000"
+      MCP_HTTP_PORT: "3000"
       # Ask-synthesis pass-throughs (ask_knowledge_base -> SearchService.ask): the synthesis
       # provider + its DEDICATED budget-cappable key (NEO_KB_ASK_API_KEY, never the shared
       # GEMINI_API_KEY). Empty default -> the config-template default applies; with no key the
       # ask path fails soft to references-only (no crash). The secret VALUE stays runtime-only.
-      NEO_KB_ASK_PROVIDER                   : ${NEO_KB_ASK_PROVIDER:-}
-      NEO_KB_ASK_MODEL                      : ${NEO_KB_ASK_MODEL:-}
-      NEO_KB_ASK_API_KEY                    : ${NEO_KB_ASK_API_KEY:-}
-      NEO_KB_ASK_BASE_URL                   : ${NEO_KB_ASK_BASE_URL:-}
-      NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS       : ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
+      NEO_KB_ASK_PROVIDER: ${NEO_KB_ASK_PROVIDER:-}
+      NEO_KB_ASK_MODEL: ${NEO_KB_ASK_MODEL:-}
+      NEO_KB_ASK_API_KEY: ${NEO_KB_ASK_API_KEY:-}
+      NEO_KB_ASK_BASE_URL: ${NEO_KB_ASK_BASE_URL:-}
+      NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS: ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
       NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE: ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE:-}
-      NEO_KB_ASK_MAX_RPM                    : ${NEO_KB_ASK_MAX_RPM:-}
+      NEO_KB_ASK_MAX_RPM: ${NEO_KB_ASK_MAX_RPM:-}
     volumes:
       - ../..:/app
       # The PLANE ROOT rides a project-scoped named volume, not the repo bind above. Docker applies
@@ -219,9 +219,9 @@ services:
              "--client-name", "neo-kb-parity-healthcheck",
              "--expected-plane-id", *plane-id,
              "--expected-plane-data-root", "/app/.neo-ai-data-parity"]
-      interval    : 15s
-      timeout     : 10s
-      retries     : 10
+      interval: 15s
+      timeout: 10s
+      retries: 10
       start_period: 90s
     depends_on:
       chroma:
@@ -236,25 +236,25 @@ services:
 
   mc-server:
     build:
-      context   : ../..
+      context: ../..
       dockerfile: ai/deploy/Dockerfile
       args:
-        NEO_SOURCE   : local  # build the local checkout for dev iteration, not a remote clone
+        NEO_SOURCE: local  # build the local checkout for dev iteration, not a remote clone
         TARGET_SERVER: memory-core
     environment:
       <<: [*plane-env, *provider-auth-env]
-      NEO_TRANSPORT               : streamable-http
-      NEO_MC_PRIMARY              : "false"
-      NEO_AUTO_SUMMARIZE          : "false"
-      NEO_MEM_AUTO_START_DATABASE : "false"
+      NEO_TRANSPORT: streamable-http
+      NEO_MC_PRIMARY: "false"
+      NEO_AUTO_SUMMARIZE: "false"
+      NEO_MEM_AUTO_START_DATABASE: "false"
       NEO_MEM_AUTO_START_INFERENCE: "false"
-      NEO_AUTO_DREAM              : "false"
-      NEO_AUTO_GOLDEN_PATH        : "false"
+      NEO_AUTO_DREAM: "false"
+      NEO_AUTO_GOLDEN_PATH: "false"
       NEO_REAL_TIME_MEMORY_PARSING: "false"
-      NEO_AUTO_INGEST_FS          : "false"
-      NEO_CHROMA_HOST             : chroma
-      NEO_CHROMA_PORT             : "8000"
-      MCP_HTTP_PORT               : "3001"
+      NEO_AUTO_INGEST_FS: "false"
+      NEO_CHROMA_HOST: chroma
+      NEO_CHROMA_PORT: "8000"
+      MCP_HTTP_PORT: "3001"
       # Single-process container hosts the WAL drain loop itself: without it the decoupled
       # add_memory writes the WAL but nothing embeds it, so semantic recall reads empty.
       # Sole-drainer invariant: exactly one loop per WAL dir; never enable alongside the embed
@@ -284,9 +284,9 @@ services:
              "--client-name", "neo-mc-parity-healthcheck",
              "--expected-plane-id", *plane-id,
              "--expected-plane-data-root", "/app/.neo-ai-data-parity"]
-      interval    : 15s
-      timeout     : 10s
-      retries     : 10
+      interval: 15s
+      timeout: 10s
+      retries: 10
       start_period: 90s
     depends_on:
       chroma:
@@ -314,35 +314,35 @@ services:
   # notices; a scheduler on the wrong plane mutates the wrong durable store on a timer.
   orchestrator:
     build:
-      context   : ../..
+      context: ../..
       dockerfile: ai/deploy/Dockerfile
       args:
-        NEO_SOURCE        : local
+        NEO_SOURCE: local
         SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
     environment:
       <<: *plane-env
       # Cloud-safe lane profile: only the deployable lanes run. Local-only lanes and local
       # inference launchers stay off — the parity stack proves plane topology, not model hosting.
-      NEO_AI_DEPLOYMENT_MODE                              : cloud
-      NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED           : "false"
-      NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED              : "false"
-      NEO_ORCHESTRATOR_KB_SYNC_ENABLED                    : "false"
-      NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED              : "false"
+      NEO_AI_DEPLOYMENT_MODE: cloud
+      NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED: "false"
+      NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED: "false"
+      NEO_ORCHESTRATOR_KB_SYNC_ENABLED: "false"
+      NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED: "false"
       NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED: "false"
-      NEO_ORCHESTRATOR_MLX_ENABLED                        : "false"
-      NEO_ORCHESTRATOR_LMS_ENABLED                        : "false"
-      NEO_ORCHESTRATOR_OLLAMA_ENABLED                     : "false"
-      NEO_CHROMA_HOST                                     : chroma
-      NEO_CHROMA_PORT                                     : "8000"
+      NEO_ORCHESTRATOR_MLX_ENABLED: "false"
+      NEO_ORCHESTRATOR_LMS_ENABLED: "false"
+      NEO_ORCHESTRATOR_OLLAMA_ENABLED: "false"
+      NEO_CHROMA_HOST: chroma
+      NEO_CHROMA_PORT: "8000"
       # Runtime access is scoped to THIS plane's compose project — the same scalar the project
       # `name` and `NEO_PLANE_ID` resolve from, so a parity orchestrator can never address the
       # native stack's containers.
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED             : "true"
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_MECHANISM           : docker-socket
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_SOCKET_PATH         : /var/run/docker.sock
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT     : *plane-id
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES    : chroma,kb-server,mc-server
-      NEO_ORCHESTRATOR_RUNTIME_ACCESS_READ_OPERATIONS     : inspect,logs,stats
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED: "true"
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_MECHANISM: docker-socket
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_SOCKET_PATH: /var/run/docker.sock
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT: *plane-id
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES: chroma,kb-server,mc-server
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_READ_OPERATIONS: inspect,logs,stats
       NEO_ORCHESTRATOR_RUNTIME_ACCESS_LIFECYCLE_OPERATIONS: restart
     volumes:
       - ../..:/app

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -122,7 +122,14 @@ class ConfigBase extends ConfigProvider {
              * land beside `nl_action_log` without coupling either MCP server's schema.
              * @type {string}
              */
-            memoryCoreDbPathProd: leaf(path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'), 'NEO_MEMORY_DB_PATH', 'string'),
+            // Plane-anchored, sharing Memory Core's relative path: same env, SAME artifact. `KBRecorderService` /
+            // `RecorderService` write telemetry tables into it, while the readers (`GapInferenceEngine`,
+            // `DreamService`) resolve MC's `storagePaths.graph`. The previous homedir default therefore split
+            // writers from readers on any seat with the env unset — the recorders wrote to a file the
+            // consumers never open, and gap inference silently produced no edges. Converging the default is
+            // the repair.
+            memoryCoreDbPathProd: leaf(path.resolve(planeDataRoot, 'sqlite/memory-core-graph.sqlite'), 'NEO_MEMORY_DB_PATH', 'string',
+                {planeMember: false, planeMemberReason: 'consumer of the Memory Core graph SQLite, not its owner: MC declares `storagePaths.graphProd` and asserts it at its own boot. Mirrors the Chroma persist-dir precedent in this file — a shared artifact is claimed by its owner and not re-claimed by consumers, so one boot failure names one cause instead of three.'}),
             /**
              * @summary Per-process test destination for shared KB/NL telemetry.
              * @type {string}

--- a/ai/mcp/server/memory-core/configBase.mjs
+++ b/ai/mcp/server/memory-core/configBase.mjs
@@ -6,8 +6,7 @@ import {resolvePlaneDataRoot} from '../../../planeConfig.mjs';
 import {
     MEMORY_CORE_GRAPH_DB_ENV,
     TURN_PRESENCE_DEFAULTS,
-    TURN_PRESENCE_ENV,
-    resolveMemoryCoreGraphPath
+    TURN_PRESENCE_ENV
 } from './helpers/TurnPresenceConfig.mjs';
 
 function parseMemorySharingPolicy(envVarName, {env = process.env} = {}) {
@@ -199,7 +198,7 @@ class ConfigBase extends ConfigProvider {
                  * Production graph SQLite path. Declarative leaf; env override via `NEO_MEMORY_DB_PATH`.
                  * @type {string}
                  */
-                graphProd      : leaf(resolveMemoryCoreGraphPath({env: {}, rootDir: cwd}), MEMORY_CORE_GRAPH_DB_ENV, 'string', {planeMember: false, planeMemberReason: 'open membership decision — the graph SQLite is the plane core artifact with a plane-anchored default yet no declared membership; tracked by #15872 (membership + anchor alignment + the KB/NL memoryCoreDbPathProd sibling divergence). Explicit non-member until that ticket rules.'}),
+                graphProd      : leaf(path.resolve(planeDataRoot, 'sqlite/memory-core-graph.sqlite'), MEMORY_CORE_GRAPH_DB_ENV, 'string', {planeMember: true}),
                 /**
                  * Unit-test graph path: in-memory SQLite (ephemeral, per-process). Declarative leaf.
                  * @type {string}
@@ -886,6 +885,10 @@ class ConfigBase extends ConfigProvider {
 export const PLANE_MEMBER_PATHS = Object.freeze([
     'datasets.rlaif.trajectories',
     'remRunStateDir',
+    // The plane's core durable artifact. Its default was previously cwd-anchored while every other member
+    // derived from the plane anchor, so a different-cwd process (daemon, host CLI) resolved a path outside
+    // the plane its siblings agreed on — and boot member-coherence never covered it.
+    'storagePaths.graphProd',
     'memoryWal.dirProd',
     'memoryWal.daemonDataDir',
     'messageWal.daemonDataDir',

--- a/ai/mcp/server/neural-link/configBase.mjs
+++ b/ai/mcp/server/neural-link/configBase.mjs
@@ -61,7 +61,14 @@ class ConfigBase extends ConfigProvider {
              * Path to the memory core SQLite database for action logging.
              * @type {string}
              */
-            memoryCoreDbPathProd: leaf(path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'), 'NEO_MEMORY_DB_PATH', 'string'),
+            // Plane-anchored, sharing Memory Core's relative path: same env, SAME artifact. `KBRecorderService` /
+            // `RecorderService` write telemetry tables into it, while the readers (`GapInferenceEngine`,
+            // `DreamService`) resolve MC's `storagePaths.graph`. The previous homedir default therefore split
+            // writers from readers on any seat with the env unset — the recorders wrote to a file the
+            // consumers never open, and gap inference silently produced no edges. Converging the default is
+            // the repair.
+            memoryCoreDbPathProd: leaf(path.resolve(planeDataRoot, 'sqlite/memory-core-graph.sqlite'), 'NEO_MEMORY_DB_PATH', 'string',
+                {planeMember: false, planeMemberReason: 'consumer of the Memory Core graph SQLite, not its owner: MC declares `storagePaths.graphProd` and asserts it at its own boot. Mirrors the Chroma persist-dir precedent in the Knowledge Base config — a shared artifact is claimed by its owner and not re-claimed by consumers, so one boot failure names one cause instead of three.'}),
             /**
              * @summary Per-process test destination shared with Knowledge Base telemetry.
              * @type {string}

--- a/test/playwright/unit/ai/planeConfig.spec.mjs
+++ b/test/playwright/unit/ai/planeConfig.spec.mjs
@@ -481,6 +481,19 @@ test.describe('⭐ one env ⇒ one resolved default across every declaring confi
     };
 
     test('every leaf binding NEO_MEMORY_DB_PATH resolves the SAME absolute default', async () => {
+        // The KB config base re-wraps the registered Tier-1 singleton at module scope, so the template must be
+        // fully evaluated FIRST — the same registration shape the derivation witnesses earlier in this file
+        // use, and whose comment explains exactly this. An earlier version imported KB directly and passed
+        // only because a prior test here had already registered Tier-1: order-dependent green. @neo-gpt caught
+        // it from a clean export, where it threw `Cannot create proxy with a non-object as target` at
+        // ConfigProvider:529.
+        const templateModule = await import('../../../../ai/config.template.mjs');
+
+        if (!Neo.ai?.Config) {
+            Neo.ai        = Neo.ai || {};
+            Neo.ai.Config = templateModule.default;
+        }
+
         const kb    = await import('../../../../ai/mcp/server/knowledge-base/configBase.mjs'),
               nl    = await import('../../../../ai/mcp/server/neural-link/configBase.mjs'),
               bound = [['memory-core', McConfigBase], ['knowledge-base', kb.default], ['neural-link', nl.default]]

--- a/test/playwright/unit/ai/planeConfig.spec.mjs
+++ b/test/playwright/unit/ai/planeConfig.spec.mjs
@@ -445,3 +445,92 @@ test.describe('healthcheck contract — the observed plane is a DECLARED schema 
         });
     }
 });
+
+// One env must resolve to ONE default across every config base that binds it. The graph SQLite was the
+// counterexample, and the shape of the bug is the reason this guard is general rather than a pin:
+//
+//   MC anchored `sqlite/memory-core-graph.sqlite` under the plane root; KB and Neural Link anchored
+//   `memory-core.sqlite` under the HOME directory. Every container sets the env, so the divergence was
+//   fully masked in deployment and bit only where nothing sets it — host CLI, daemons, local seats.
+//
+// There it did real damage: `KBRecorderService` / the NL `RecorderService` write telemetry tables into
+// their leaf's path, while the READERS (`GapInferenceEngine`, `DreamService`) resolve Memory Core's
+// `storagePaths.graph`. So the recorders wrote to a file the consumers never open, and
+// `GapInferenceEngine`'s `sqlite_master` probe degraded silently — gap inference produced no
+// NL_ACTION_SEQUENCE edges and nothing reported a fault.
+test.describe('⭐ one env ⇒ one resolved default across every declaring config base', () => {
+    const graphEnv = 'NEO_MEMORY_DB_PATH';
+
+    /** Collects `{dotted, default}` for every leaf in a descriptor tree bound to `envName`. */
+    const leavesBoundTo = (descriptorData, envName, prefix = '') => {
+        const found = [];
+
+        for (const [key, value] of Object.entries(descriptorData ?? {})) {
+            if (!value || typeof value !== 'object') continue;
+
+            const dotted = prefix ? `${prefix}.${key}` : key;
+
+            if (Object.hasOwn(value, 'default') && Object.hasOwn(value, 'env')) {
+                if (value.env === envName) found.push({dotted, default: value.default});
+            } else {
+                found.push(...leavesBoundTo(value, envName, dotted));
+            }
+        }
+
+        return found;
+    };
+
+    test('every leaf binding NEO_MEMORY_DB_PATH resolves the SAME absolute default', async () => {
+        const kb    = await import('../../../../ai/mcp/server/knowledge-base/configBase.mjs'),
+              nl    = await import('../../../../ai/mcp/server/neural-link/configBase.mjs'),
+              bound = [['memory-core', McConfigBase], ['knowledge-base', kb.default], ['neural-link', nl.default]]
+                  .flatMap(([base, ctor]) => leavesBoundTo(ctor.config.data, graphEnv).map(e => ({...e, base})));
+
+        // Guards its own denominator: a rename that dropped these bindings must fail here rather than
+        // pass vacuously over an empty set.
+        expect(bound.length).toBeGreaterThanOrEqual(3);
+
+        const distinct = new Set(bound.map(entry => entry.default));
+
+        expect(distinct.size,
+            `divergent defaults for ${graphEnv}: ` +
+            bound.map(entry => `${entry.base}/${entry.dotted}=${entry.default}`).join(' | ')
+        ).toBe(1);
+
+        const [resolved] = [...distinct];
+
+        expect(path.isAbsolute(resolved)).toBe(true);
+        expect(resolved.startsWith(ConfigBase.config.data.plane.dataRoot.default)).toBe(true);
+        // The retired filename must not come back, and neither must the homedir anchor.
+        expect(resolved).not.toContain('memory-core.sqlite');
+        expect(resolved.startsWith(os.homedir() + path.sep + '.neo-ai-data' + path.sep)).toBe(false);
+    })
+
+    test('⭐ RED control: the WALKER detects divergence across synthetic descriptor trees', () => {
+        // NOT a tautology over two hardcoded strings — that version exercised none of the walker and could
+        // not fail. The part that can actually be wrong is `leavesBoundTo`: it must find env-bound leaves at
+        // arbitrary depth and miss none. Mutation-verified: removing its recursion turns this red.
+        const envName = 'NEO_SYNTHETIC_SHARED_ENV',
+              leafOf  = defaultValue => ({default: defaultValue, env: envName, type: 'string', parse: null}),
+              // Different depths, each beside a decoy bound to another env — the shape that defeats a
+              // shallow or first-match walk.
+              baseA   = {storagePaths: {graphProd: leafOf('/plane/sqlite/memory-core-graph.sqlite')},
+                         decoy       : {default: 'x', env: 'NEO_OTHER_ENV', type: 'string', parse: null}},
+              baseB   = {memoryCoreDbPathProd: leafOf(path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'))};
+
+        const found = [...leavesBoundTo(baseA, envName), ...leavesBoundTo(baseB, envName)];
+
+        expect(found.map(entry => entry.dotted).sort()).toEqual(['memoryCoreDbPathProd', 'storagePaths.graphProd']);
+        expect(new Set(found.map(entry => entry.default)).size).toBe(2);
+
+        // GREEN counterpart: converge them and the same walker+comparison reports one default. Without it
+        // the control proves only that it can say "different", never that it can say "same".
+        const converged = [
+            ...leavesBoundTo({storagePaths: {graphProd: leafOf('/plane/sqlite/memory-core-graph.sqlite')}}, envName),
+            ...leavesBoundTo({memoryCoreDbPathProd: leafOf('/plane/sqlite/memory-core-graph.sqlite')}, envName)
+        ];
+
+        expect(converged).toHaveLength(2);
+        expect(new Set(converged.map(entry => entry.default)).size).toBe(1);
+    })
+});


### PR DESCRIPTION
Resolves #15872

Declares the graph SQLite a plane member and re-anchors its default to the plane root.

**Evidence:** L2 (pure config + unit assertions, 129 green) → L2 required (the close-target ACs in scope are config-shape and membership-completeness, both statically verifiable). Residual: none in scope — the KB/NL defaults now converge on the Memory Core plane leaf; legacy rows remain retained and any recovery is an optional enhancement.

## RE-EXPANDED — and the reason is that I retracted my own reason for narrowing

I narrowed this PR on the claim that converging the KB/neural-link defaults would strand 4,694 rows and *"silently reset the Dream pipeline's telemetry history — a functional regression."* **That claim was wrong in direction, and I retracted it here** ([comment](https://github.com/neomjs/neo/pull/16042#issuecomment-5088670155)). @neo-gpt then retracted his narrowing direction and preferred re-expansion.

**What is actually true:** readers and writers already resolve *different leaves*.

| Side | Leaf resolved | Evidence |
|---|---|---|
| Readers — `GapInferenceEngine`, `DreamService` | **Memory Core's** `storagePaths.graph` | `GapInferenceEngine.mjs:424` → `GraphService.db?.storage?.db`; `GraphService.mjs:135` → `aiConfig.storagePaths.graph` |
| Writers — `KBRecorderService`, NL `RecorderService` | **KB/NL's own** `memoryCoreDbPathProd` | `KBRecorderService.mjs:59`, `RecorderService.mjs:85` |

So on env-unset seats the recorders have been writing into a file the consumers never open. `GapInferenceEngine:431` probes `sqlite_master` for `nl_action_log` and **degrades silently** when absent — which is why nobody noticed: gap inference has been producing no `NL_ACTION_SEQUENCE -> VALIDATES` edges there, quietly.

**Converging the default is therefore the repair, not the risk.** The observed rows were never consumed by the readers, so recovering them is an optional follow-up rather than a merge gate. Containers are unaffected — every profile sets the env, so all three already agree there.

I traced the writers, found `CREATE TABLE IF NOT EXISTS`, and asserted the consequence for readers without checking which leaf the readers resolve. One side of a contract mistaken for the contract — the same mechanism, this time making me *more* alarmed rather than less.

## What this PR does

`storagePaths.graphProd` was the one plane-anchored leaf sitting outside boot member-coherence:

- **Membership** — now `planeMember: true` and declared in Memory Core's `PLANE_MEMBER_PATHS`, so `assertPlaneMemberCoherence` covers the plane's core durable artifact at boot. It previously carried an explicit `planeMember: false` with a reason naming this ticket, so it was an openly-recorded open decision rather than drift — this PR rules it.
- **Anchor** — the default derived from `resolveMemoryCoreGraphPath({env: {}, rootDir: cwd})`, **cwd-anchored**, while every other member derives from `planeDataRoot`. A different-cwd process (daemon, host CLI) therefore resolved a path outside the plane its siblings agreed on. Now `path.resolve(planeDataRoot, 'sqlite/memory-core-graph.sqlite')`.

## Required actions from the review, and how each is closed

**RA1 — ADR-0019 placement.** Closed via the **second option the RA itself offers** — *"inline the leaf defaults and let the equality regression guard them."* All three leaf defaults are inlined. No second exported config literal, **no addition to `ai/planeConfig.mjs`** (it keeps its accepted one-exported-constant-plus-pure-functions shape), and `resolveMemoryCoreGraphPath`'s env path is **not** extended. Its now-unused import is dropped from `memory-core/configBase.mjs`; the function itself is untouched and keeps its one non-config caller (`helpers/TurnPresenceHookWriter.mjs:254`). The stale §10.2/twin rationale is gone with the code that leaned on it.

**RA2 — Neural Link runtime-boot claim.** Closed by following **existing precedent** instead of my earlier invention. KB and neural-link now declare `planeMember: false` with a reason: *a shared artifact is claimed by its owner and not re-claimed by consumers* — exactly the rule KB's own config already states for the Chroma persist dir (*"Tier-1-owned … and asserted by the Tier-1 member list, not re-claimed here"*).

That is strictly better than declaring them members, and it dissolves the problem the RA identified rather than patching prose around it:
- **no membership claim NL's `Server` cannot honour** — it overrides neither `isPlaneMember()` nor `getPlaneMembers()`, so any member declaration would have been static-only, which is exactly the conflation the review named;
- **no census pin moves**, so the `planePlacementCensus` roster literal is untouched;
- **one boot failure names one cause** instead of three servers asserting the same path.

This also answers the one design question I flagged as genuinely uncertain when I first requested review — and it answers it toward the precedent already in the file rather than toward my own reasoning.

**RA3 — live old-path telemetry.** Dispositioned as **aligned, with rationale** — the branch #15872's AC3 explicitly permits (*"leaves aligned, retired, or env-split with rationale"*). Alignment makes writers and readers agree for the first time on env-unset seats. No file is deleted or relocated, so the existing rows remain on disk and readable; recovering them into the canonical DB is a genuine enhancement and is listed under Post-Merge Validation rather than gating this merge.

**RA4 — stale echoes.** The compose comment now states the real shape: MC owns and asserts the member; KB/NL bind the same env with the same plane-anchored default as explicit non-members. **No census literal is bumped** — §10.5 as amended asserts set-equality, so the membership spec covers MC's new entry without a pin, and the KB/NL rosters are unchanged because they claim nothing.

## Deltas

- `storagePaths.graphProd`: `planeMember: false` + reason → `planeMember: true`; default cwd-anchored → plane-anchored with the relative path inlined.
- KB and Neural Link memoryCoreDbPathProd defaults now resolve the same plane-root leaf while remaining explicit non-members of the Memory Core-owned shared artifact.
- The one-env/one-default regression exercises all three resolved config bases and is isolated from test-worker registration order.
- `PLANE_MEMBER_PATHS` gains `storagePaths.graphProd`.
- `resolveMemoryCoreGraphPath` import removed from `memory-core/configBase.mjs`. The function itself is untouched and retains its one non-config caller, `helpers/TurnPresenceHookWriter.mjs:254`.

## Test Evidence

```
129 passed   # planeConfig + planePlacementCensus + config.template + configBase + BaseServer
```

The **set-equality spec is the membership proof** — it fails if a declared list and the derived set disagree in either direction, so the new entry is mechanically verified rather than eyeballed. The new one-env/one-default regression exercises the resolved Memory Core, Knowledge Base, and Neural Link leaves. Its direct Knowledge Base import carries the existing Tier-1 registration precondition, so the invariant passes independently rather than borrowing worker order.

**Compat, measured rather than asserted:**
```
old default: /…/neo/.neo-ai-data/sqlite/memory-core-graph.sqlite
new default: /…/neo/.neo-ai-data/sqlite/memory-core-graph.sqlite
identical at checkout root: true
```
In-checkout processes are byte-for-byte unaffected. **Different-cwd processes shift** — that is the intended correction, since they previously resolved outside the plane. No data moves: nothing deletes or relocates an existing file, and a seat whose resolved path changes finds the plane-anchored location that its sibling members already used.

**Disclosed rather than left to be found:** a 221-spec combined local run shows 2 pre-existing ordering failures (`CommonityBatchTool`, `McpServerToolLimits` — `engines.chroma.{host,port}` resolving empty in that combination). Verified as **not mine** by running the identical set on clean `dev` with the same result. Each passes alone; reported to the team, not fixed here.

## Post-Merge Validation

1. Confirm a different-cwd daemon resolves the plane-anchored path — the shift is intended, and the receipt is worth having.
2. If the retained legacy KB/NL telemetry has independent value, evaluate a bounded recovery into the canonical DB. This is optional enhancement work because the readers never consumed the old leaf.

Authored by Vega (@neo-opus-vega, Claude Opus 5, Claude Code). Session f1bcb0a9-68f5-4910-bef6-1a5a33aad1f5.

🌿
