### PR TITLE
feat(auth): complete Streamable HTTP ownership (#15992)

### DIFF
--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -238,6 +238,34 @@ services:
     ports:
       - "13002:3002"
 
+  # Exact documented strip -> authenticate -> inject reference ingress. The test stack overrides
+  # only coordinates; route semantics come directly from ai/mcp/deploy/proxy/Caddyfile.
+  reference-ingress:
+    image: caddy:2-alpine
+    environment:
+      - NEO_MCP_PROXY_SITE=:8080
+      - NEO_MCP_PROXY_AUTH_UPSTREAM=oidc-server:4000
+      - NEO_MCP_PROXY_KB_UPSTREAM=kb-server:3000
+      - NEO_MCP_PROXY_MC_UPSTREAM=mc-server:3001
+    volumes:
+      - ../mcp/deploy/proxy/Caddyfile:/etc/caddy/Caddyfile:ro
+    depends_on:
+      kb-server:
+        condition: service_started
+      mc-server:
+        condition: service_started
+      oidc-server:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 8080"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - neo-mcp-test-network
+    ports:
+      - "13004:8080"
+
 networks:
   neo-mcp-test-network:
     driver: bridge

--- a/ai/deploy/mock-oidc-server.mjs
+++ b/ai/deploy/mock-oidc-server.mjs
@@ -1,7 +1,7 @@
 import http from 'node:http';
 
-const host = process.env.NEO_TEST_OIDC_HOST || '0.0.0.0';
-const port = Number(process.env.NEO_TEST_OIDC_PORT || 4000);
+const host           = process.env.NEO_TEST_OIDC_HOST || '0.0.0.0';
+const port           = Number(process.env.NEO_TEST_OIDC_PORT || 4000);
 const validAudiences = [
     'http://127.0.0.1:13002',
     'http://127.0.0.1:13003',
@@ -56,6 +56,31 @@ const server = http.createServer(async (request, response) => {
             introspection_endpoint: `http://${reqHost}/introspect`
         });
         return;
+    }
+
+    if (request.url === '/oauth2/auth') {
+        const
+            authenticatedUser = request.headers['x-test-authenticated-user'],
+            authMode          = request.headers['x-test-auth-mode'];
+
+        // Integration-only control: a successful auth decision with no user claim lets the
+        // reference-ingress test prove that caller-supplied identity headers were stripped.
+        if (authMode === 'allow-without-identity') {
+            response.writeHead(200);
+            response.end();
+            return
+        }
+
+        if (typeof authenticatedUser === 'string' && /^[A-Za-z0-9._-]+$/.test(authenticatedUser)) {
+            response.writeHead(200, {
+                'x-auth-request-preferred-username': authenticatedUser
+            });
+            response.end();
+            return
+        }
+
+        sendJson(response, 401, {error: 'Authentication required'});
+        return
     }
 
     if (request.method === 'POST' && request.url === '/introspect') {

--- a/ai/mcp/deploy/proxy/Caddyfile
+++ b/ai/mcp/deploy/proxy/Caddyfile
@@ -9,40 +9,42 @@
 # allowing your authentication layer (e.g., oauth2-proxy) to inject it.
 # ------------------------------------------------------------------------------
 
-mcp.example.com {
-    # [Out of scope: TLS termination certificates]
-    # tls /path/to/cert.pem /path/to/key.pem
+# Defaults preserve the documented standalone example. Deployment and integration profiles may
+# override the site/auth/upstream coordinates without forking this security-sensitive route.
+{$NEO_MCP_PROXY_SITE:mcp.example.com} {
+	# [Out of scope: TLS termination certificates]
+	# tls /path/to/cert.pem /path/to/key.pem
 
-    route {
-        # 1. SECURITY: Header manipulation block
-        # Strip any client-provided identity headers first!
-        request_header -X-Preferred-Username
-        request_header -X-Auth-Request-Preferred-Username
+	route {
+		# 1. SECURITY: Header manipulation block
+		# Strip any client-provided identity headers first!
+		request_header -X-Preferred-Username
+		request_header -X-Auth-Request-Preferred-Username
 
-        # 2. OAuth2 Proxy forward auth integration
-        forward_auth 127.0.0.1:4180 {
-            uri /oauth2/auth
-            copy_headers X-Auth-Request-Preferred-Username
-        }
+		# 2. OAuth2 Proxy forward auth integration
+		forward_auth {$NEO_MCP_PROXY_AUTH_UPSTREAM:127.0.0.1:4180} {
+			uri /oauth2/auth
+			copy_headers X-Auth-Request-Preferred-Username
+		}
 
-        # 3. Pathname Routing: Knowledge Base Server
-        handle_path /kb/* {
-            reverse_proxy 127.0.0.1:3000 {
-                # Inject trusted header from the forward_auth step
-                header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}
-                header_up -X-Auth-Request-Preferred-Username
-                # SSE streaming is natively supported by Caddy without specific buffering toggles
-            }
-        }
+		# 3. Pathname Routing: Knowledge Base Server
+		handle_path /kb/* {
+			reverse_proxy {$NEO_MCP_PROXY_KB_UPSTREAM:127.0.0.1:3000} {
+				# Inject trusted header from the forward_auth step
+				header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}
+				header_up -X-Auth-Request-Preferred-Username
+				# SSE streaming is natively supported by Caddy without specific buffering toggles
+			}
+		}
 
-        # 4. Pathname Routing: Memory Core Server
-        handle_path /mc/* {
-            reverse_proxy 127.0.0.1:3001 {
-                # Inject trusted header from the forward_auth step
-                header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}
-                header_up -X-Auth-Request-Preferred-Username
-                # SSE streaming natively supported
-            }
-        }
-    }
+		# 4. Pathname Routing: Memory Core Server
+		handle_path /mc/* {
+			reverse_proxy {$NEO_MCP_PROXY_MC_UPSTREAM:127.0.0.1:3001} {
+				# Inject trusted header from the forward_auth step
+				header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}
+				header_up -X-Auth-Request-Preferred-Username
+				# SSE streaming natively supported
+			}
+		}
+	}
 }

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -51,6 +51,42 @@ class AuthService extends Base {
     }
 
     /**
+     * @summary Installs authentication guards that must execute before transport CORS.
+     *
+     * Transport calls this phase for every Streamable HTTP boot without interpreting the
+     * configured strategy. Custom middleware owns its complete ingress contract and therefore
+     * suppresses built-in guards. The local-bearer strategy is the sole built-in with a
+     * pre-CORS concern: its listener must be literal IPv4 loopback, and any present Origin
+     * header must be rejected before CORS, bearer verification, or MCP session creation.
+     * @param {Object} options
+     * @param {Object} options.app Express application instance
+     * @param {Object} options.aiConfig Server configuration object
+     * @returns {void}
+     */
+    setupPreCors({app, aiConfig}) {
+        if (typeof aiConfig.authMiddleware === 'function' || aiConfig.auth.mode !== 'local-bearer') {
+            return
+        }
+
+        if (aiConfig.mcpListenHost !== '127.0.0.1') {
+            throw new Error("Local-bearer mode requires mcpListenHost to be the literal IPv4 loopback address '127.0.0.1'")
+        }
+
+        app.use((req, res, next) => {
+            if (Object.hasOwn(req.headers, 'origin')) {
+                res.status(403).json({
+                    jsonrpc: '2.0',
+                    error  : {code: -32000, message: 'Origin header is not allowed in local-bearer mode'},
+                    id     : null
+                });
+                return
+            }
+
+            next()
+        })
+    }
+
+    /**
      * @summary Sets up the configured authorization strategy for an Express application.
      * @param {Object} options
      * @param {Object} options.app The Express application instance
@@ -70,19 +106,18 @@ class AuthService extends Base {
 
         this.#validateFirstProviderSubjectPolicy(aiConfig);
 
-        // Custom-auth compatibility branch — classify custom auth before the default OIDC mode
-        // can dereference an absent endpoint, while Transport retains the one custom middleware
-        // mount until full ingress ownership migrates.
+        // Custom middleware owns the complete authentication boundary and takes precedence over
+        // every built-in state. Mount it exactly once here; Transport never interprets the leaf.
         if (hasCustomAuth) {
-            logger.info('[AuthService] Custom authorization middleware selected (compatibility branch)');
+            app.use(aiConfig.authMiddleware);
+            logger.info('[AuthService] Custom authorization middleware selected');
             return
         }
 
-        // Trusted-proxy compatibility branch — proxy identity remains resolved in Transport
-        // until the full ingress/trust boundary migrates. Reaching this state is still an
-        // explicit auth installer choice, not gateless HTTP.
+        // Proxy-only is the explicit no-OIDC compatibility state. The middleware owns header
+        // extraction, rejection, and req.auth creation before Transport can dispatch a session.
         if (isProxyOnlyCompat) {
-            logger.info('[AuthService] Trusted-proxy authorization selected (compatibility branch)');
+            this.setupProxyIdentity({app, logger});
             return
         }
 
@@ -255,15 +290,97 @@ class AuthService extends Base {
             resourceName,
         }));
 
+        // In the explicit OIDC+proxy state, bearer PRESENCE is terminal. The proxy middleware
+        // only runs its identity path when Authorization is absent; malformed or invalid
+        // credentials continue into the SDK bearer challenge and can never downgrade.
+        if (auth.trustProxyIdentity) {
+            this.setupProxyIdentity({app, logger}, {fallbackOnly: true})
+        }
+
         const authMiddleware = requireBearerAuth({
             verifier           : tokenVerifier,
             requiredScopes     : [],
             resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(mcpServerUrl),
         });
 
-        app.use(authMiddleware);
+        app.use(auth.trustProxyIdentity
+            ? this.wrapOidcBearerMiddleware(authMiddleware)
+            : authMiddleware
+        );
 
         logger.info(`[AuthService] Authorization enabled (Issuer: ${oauthUrls.issuer})`);
+    }
+
+    /**
+     * @summary Installs trusted-proxy identity authentication.
+     *
+     * Proxy-only mode always requires a trusted identity header. OIDC composition passes
+     * `fallbackOnly=true`: any present Authorization header bypasses proxy interpretation and is
+     * left exclusively to the SDK bearer middleware, while true absence may bind the proxy
+     * subject. This service trusts the header only after the deployment's documented
+     * strip/authenticate/inject ingress boundary.
+     * @param {Object} options
+     * @param {Object} options.app Express application instance
+     * @param {Object} options.logger Logger instance
+     * @param {Object} [policy]
+     * @param {Boolean} [policy.fallbackOnly=false] Defer every present Authorization header
+     * @returns {void}
+     */
+    setupProxyIdentity({app, logger}, {fallbackOnly=false}={}) {
+        app.use(this.createProxyIdentityMiddleware({logger, fallbackOnly}));
+        logger.info(`[AuthService] Trusted-proxy authorization enabled (${fallbackOnly ? 'OIDC fallback' : 'proxy-only'})`)
+    }
+
+    /**
+     * @summary Builds the trusted-proxy identity middleware.
+     * @param {Object} options
+     * @param {Object} options.logger Logger instance
+     * @param {Boolean} [options.fallbackOnly=false] Defer every present Authorization header
+     * @returns {Function} Express middleware
+     */
+    createProxyIdentityMiddleware({logger, fallbackOnly=false}) {
+        return (req, res, next) => {
+            if (fallbackOnly && Object.hasOwn(req.headers, 'authorization')) {
+                next();
+                return
+            }
+
+            const proxyUserId = req.headers['x-preferred-username'] || req.headers['x-auth-request-preferred-username'];
+
+            if (!proxyUserId) {
+                logger.warn('Unauthorized: trustProxyIdentity is enabled but X-PREFERRED-USERNAME header is missing');
+                res.status(401).json({error: 'Unauthorized: Missing proxy identity header'});
+                return
+            }
+
+            req.auth = {
+                userId  : proxyUserId,
+                username: proxyUserId,
+                source  : 'proxy-header'
+            };
+
+            next()
+        }
+    }
+
+    /**
+     * @summary Wraps OIDC bearer authentication with the trusted-proxy absence fallback.
+     *
+     * The preceding proxy middleware can create req.auth only when Authorization is absent. A
+     * proxy-bound request skips the SDK challenge; every request with Authorization still runs
+     * the unmodified bearer middleware, preserving terminal invalid/malformed-token behavior.
+     * @param {Function} authMiddleware SDK bearer middleware
+     * @returns {Function} Express middleware
+     */
+    wrapOidcBearerMiddleware(authMiddleware) {
+        return (req, res, next) => {
+            if (!Object.hasOwn(req.headers, 'authorization') && req.auth?.source === 'proxy-header') {
+                next();
+                return
+            }
+
+            return authMiddleware(req, res, next)
+        }
     }
 
     /**

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -12,8 +12,8 @@ import RequestContextService from './RequestContextService.mjs';
  * - **Session Management:** Handles the lifecycle of stateful MCP sessions via `Mcp-Session-Id`.
  * - **Transport Abstraction:** Decouples the Express app and CORS configuration from the
  *   individual server logic (e.g. Knowledge Base, Memory Core).
- * - **Auth Integration:** Automatically wires up the configured OIDC, GitLab-PAT, or
- *   possession-only local-bearer strategy.
+ * - **Authenticated Context Consumption:** Delegates authentication installation to AuthService,
+ *   then consumes the resulting `req.auth` without interpreting authentication configuration.
  * - **CORS Enforcement:** Ensures cross-origin compatibility for modern browser-based AI agents.
  * - **Request-Context Propagation:** Each `/mcp` request is wrapped in
  *   `RequestContextService.run({userId, username, sessionId}, ...)` before dispatching to the MCP
@@ -43,32 +43,6 @@ class TransportService extends Base {
          * @protected
          */
         singleton: true
-    }
-
-    /**
-     * Resolves the base authentication context, handling proxy identity injection.
-     * @param {Object} req The Express request
-     * @param {Object} aiConfig The server configuration
-     * @returns {Object} Result object containing `auth` or `error` with `status`.
-     */
-    resolveAuthContext(req, aiConfig) {
-        let baseAuth = req.auth;
-
-        if (!baseAuth && aiConfig.auth.trustProxyIdentity) {
-            const proxyUserId = req.headers['x-preferred-username'] || req.headers['x-auth-request-preferred-username'];
-            if (proxyUserId) {
-                baseAuth = {
-                    userId  : proxyUserId,
-                    username: proxyUserId,
-                    source  : 'proxy-header'
-                };
-            } else {
-                req.app?.locals?.logger?.warn('Unauthorized: trustProxyIdentity is enabled but X-PREFERRED-USERNAME header is missing');
-                return { error: 'Unauthorized: Missing proxy identity header', status: 401 };
-            }
-        }
-
-        return { auth: baseAuth };
     }
 
     /**
@@ -131,11 +105,6 @@ class TransportService extends Base {
      */
     async setup(options) {
         const { server, aiConfig, logger, resourceName } = options;
-        const isLocalBearer                              = aiConfig.auth.mode === 'local-bearer';
-
-        if (isLocalBearer && aiConfig.mcpListenHost !== '127.0.0.1') {
-            throw new Error("Local-bearer mode requires mcpListenHost to be the literal IPv4 loopback address '127.0.0.1'")
-        }
 
         const { createMcpExpressApp }           = await import('@modelcontextprotocol/sdk/server/express.js');
         const { StreamableHTTPServerTransport } = await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
@@ -149,23 +118,11 @@ class TransportService extends Base {
 
         this.app = app;
 
-        // Browser-originated requests are outside the trusted-loopback contract. Presence is the
-        // discriminator: even an empty Origin header is rejected before wildcard CORS, auth, or
-        // MCP dispatch; non-browser clients legitimately omit Origin.
-        if (isLocalBearer) {
-            app.use((req, res, next) => {
-                if (Object.hasOwn(req.headers, 'origin')) {
-                    res.status(403).json({
-                        jsonrpc: '2.0',
-                        error  : {code: -32000, message: 'Origin header is not allowed in local-bearer mode'},
-                        id     : null
-                    });
-                    return
-                }
-
-                next()
-            })
-        }
+        // AuthService alone interprets authentication state. Its universal pre-CORS phase
+        // installs any strategy guard whose order is security-significant; Transport merely
+        // supplies the Express boundary.
+        const { default: AuthService } = await import('./AuthService.mjs');
+        AuthService.setupPreCors({app, aiConfig});
 
         app.use(cors.default({
             origin        : '*',
@@ -188,7 +145,6 @@ class TransportService extends Base {
 
         // AuthService owns the legal Streamable-HTTP state machine. Transport delegates every
         // boot instead of maintaining a built-in subset that drifts whenever a mode is added.
-        const { default: AuthService } = await import('./AuthService.mjs');
         await AuthService.setup({
             app,
             aiConfig,
@@ -196,13 +152,6 @@ class TransportService extends Base {
             logger,
             resourceName
         });
-
-        // Custom-auth compatibility branch: the mount stays here during ingress ownership
-        // migration. AuthService classifies this state and deliberately mounts nothing, so there
-        // is exactly one middleware installation rather than a double-auth chain.
-        if (typeof aiConfig.authMiddleware === 'function') {
-            app.use(aiConfig.authMiddleware);
-        }
 
         app.all('/mcp', async (req, res) => {
             const sessionId = req.headers['mcp-session-id'];
@@ -256,15 +205,10 @@ class TransportService extends Base {
             //   shape was resolved, making it available to downstream RequestContextService readers.
             //
             // `req.auth` is populated by whichever bearer installer AuthService selected.
-            // Custom middleware may provide its own shape, while proxy-only compatibility is
-            // resolved above from the trusted header. A truly unconfigured HTTP boot never
-            // reaches this request path: AuthService rejects it before the listener opens.
-            const authResult = this.resolveAuthContext(req, aiConfig);
-            if (authResult.error) {
-                res.status(authResult.status).json({ error: authResult.error });
-                return;
-            }
-            let baseAuth = authResult.auth;
+            // Custom, proxy, and built-in strategies all bind the same consumed req.auth shape.
+            // A truly unconfigured HTTP boot never reaches this path: AuthService rejects it
+            // before the listener opens.
+            const baseAuth = req.auth;
 
             let requestContext;
 

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -126,7 +126,9 @@ Shared deployments need to know **which agent originated each request** so memor
 
 2. **Proxy identity injection (for deployments fronted by an identity-aware proxy)** — when an `oauth2-proxy`-style reverse proxy already terminates OIDC and injects `X-PREFERRED-USERNAME` (or the oauth2-proxy-specific `X-Auth-Request-Preferred-Username`) into the upstream request, the MC server can read that header instead of running its own OIDC verification. Gated by `auth.trustProxyIdentity`. Source provenance: `source: 'proxy-header'`.
 
-The two paths are NOT mutually exclusive — `req.auth` (OIDC) takes precedence over the proxy header by design. The proxy path only fires when `req.auth` is absent (OIDC unconfigured or token missing) AND `trustProxyIdentity` is explicitly enabled. **If `trustProxyIdentity` is enabled and no valid proxy identity header is found, the request is actively rejected with a `401 Unauthorized` error.** This strict "Verify-Before-Assert" gate prevents requests from silently falling through to an unauthenticated single-tenant context in a shared deployment. The local proof for this runtime gate is `test/playwright/integration/AuthRejection.integration.spec.mjs`, which connects without an identity header and expects the rejection before verifying an identity-bearing client can still call `healthcheck`.
+The two paths are NOT mutually exclusive. `AuthService` owns their non-downgrading composition: any present `Authorization` header is terminal and runs only through OIDC, so valid bearer identity wins while malformed or invalid bearer credentials challenge with no proxy fallback. Only true bearer absence may reach proxy identity when `trustProxyIdentity` is explicitly enabled. **If no valid proxy identity header is then found, the request is actively rejected with `401 Unauthorized` before MCP transport/session creation.** This prevents unauthenticated fallthrough in a shared deployment.
+
+The consumed proof is `test/playwright/integration/AuthRejection.integration.spec.mjs`. It mounts the exact reference Caddy configuration, verifies that a caller-supplied identity is stripped and cannot create an MC or KB session, then verifies that the identity injected by the authenticated proxy boundary can create both sessions. Focused real-HTTP unit coverage additionally exercises all four OIDC+proxy precedence cells.
 
 ### Configuration: Canonical `publicUrl` (PR #10802)
 
@@ -180,7 +182,7 @@ Every authenticated request carries a `source` tag through `Server.mjs#buildRequ
 |---|---|---|
 | OIDC introspection | `'oidc'` | MC's `AuthService.verifyAccessToken` |
 | Proxy header injection | `'proxy-header'` | The fronting proxy's deployment configuration |
-| Single-tenant fallthrough (no auth) | (empty) | None — local dev only |
+| Unconfigured HTTP authentication | no request context (boot fails) | AuthService fail-closed installer census |
 
 The source tag is graph-ingested into agent-identity memory writes; an audit query against memories can verify the proportion of `'oidc'` vs `'proxy-header'` writes against operator expectations.
 

--- a/test/playwright/integration/AuthRejection.integration.spec.mjs
+++ b/test/playwright/integration/AuthRejection.integration.spec.mjs
@@ -5,7 +5,35 @@ import {
     getReadiness
 } from './fixtures/mcpClient.mjs';
 
-const MC_URL = process.env.NEO_INTEGRATION_MC_URL || 'http://127.0.0.1:13001';
+const MC_URL                = process.env.NEO_INTEGRATION_MC_URL || 'http://127.0.0.1:13001';
+const REFERENCE_INGRESS_URL = process.env.NEO_INTEGRATION_REFERENCE_INGRESS_URL || 'http://127.0.0.1:13004';
+
+/**
+ * @summary Sends a real MCP initialize request through the documented Caddy reference ingress.
+ * @param {String} pathName Ingress path (`/mc/mcp` or `/kb/mcp`)
+ * @param {Object} headers Test-control and caller-supplied headers
+ * @returns {Promise<Response>} HTTP response from the upstream MCP server or auth boundary
+ */
+function initializeThroughReferenceIngress(pathName, headers) {
+    return fetch(`${REFERENCE_INGRESS_URL}${pathName}`, {
+        method : 'POST',
+        headers: {
+            Accept        : 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            ...headers
+        },
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            id     : 1,
+            method : 'initialize',
+            params : {
+                protocolVersion: '2024-11-05',
+                capabilities   : {},
+                clientInfo     : {name: 'reference-ingress-test', version: '1.0.0'}
+            }
+        })
+    })
+}
 
 test.describe('Dockerized MC proxy identity rejection integration (#10895)', () => {
     test('MC rejects missing proxy identity and accepts an identity-bearing client', async () => {
@@ -47,6 +75,32 @@ test.describe('Dockerized MC proxy identity rejection integration (#10895)', () 
             expect(health.status).toBe('healthy');
         } finally {
             await client.close();
+        }
+    });
+
+    test('#15992: reference ingress strips caller identity and injects only authenticated identity', async () => {
+        const readiness = await getReadiness();
+
+        test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
+
+        expect(readiness.servicesReady, readiness.reason).toBe(true);
+
+        for (const pathName of ['/mc/mcp', '/kb/mcp']) {
+            const spoofed = await initializeThroughReferenceIngress(pathName, {
+                'X-Preferred-Username': 'caller-spoof',
+                'X-Test-Auth-Mode'    : 'allow-without-identity'
+            });
+
+            expect(spoofed.status).toBe(401);
+            expect(spoofed.headers.get('mcp-session-id')).toBeNull();
+
+            const authenticated = await initializeThroughReferenceIngress(pathName, {
+                'X-Preferred-Username'     : 'caller-spoof',
+                'X-Test-Authenticated-User': 'trusted-proxy-user'
+            });
+
+            expect(authenticated.status).toBe(200);
+            expect(authenticated.headers.get('mcp-session-id')).toBeTruthy()
         }
     });
 });

--- a/test/playwright/integration/fixtures/composeWebServer.mjs
+++ b/test/playwright/integration/fixtures/composeWebServer.mjs
@@ -1,8 +1,8 @@
 import {spawn, spawnSync} from 'node:child_process';
-import http              from 'node:http';
-import net               from 'node:net';
-import path              from 'node:path';
-import {fileURLToPath}   from 'node:url';
+import http               from 'node:http';
+import net                from 'node:net';
+import path               from 'node:path';
+import {fileURLToPath}    from 'node:url';
 
 const __filename  = fileURLToPath(import.meta.url);
 const __dirname   = path.dirname(__filename);
@@ -98,21 +98,22 @@ async function waitForServices() {
 
     while (!shuttingDown && Date.now() < deadline) {
         try {
-            const [chroma, kbPort, mcPort, mcOidcPort, kbOidcPort] = await Promise.all([
+            const [chroma, kbPort, mcPort, mcOidcPort, kbOidcPort, referenceIngressPort] = await Promise.all([
                 fetch('http://127.0.0.1:18080/api/v2/heartbeat').then(r => r.ok).catch(() => false),
                 portOpen(13000),
                 portOpen(13001),
                 portOpen(13002),
-                portOpen(13003)
+                portOpen(13003),
+                portOpen(13004)
             ]);
 
-            if (chroma && kbPort && mcPort && mcOidcPort && kbOidcPort) {
+            if (chroma && kbPort && mcPort && mcOidcPort && kbOidcPort && referenceIngressPort) {
                 state.servicesReady = true;
                 state.reason        = 'Dockerized MCP integration stack is ready.';
                 return;
             }
 
-            state.reason = `Waiting for stack readiness: chroma=${chroma}, kb=${kbPort}, mc=${mcPort}, mcOidc=${mcOidcPort}, kbOidc=${kbOidcPort}`;
+            state.reason = `Waiting for stack readiness: chroma=${chroma}, kb=${kbPort}, mc=${mcPort}, mcOidc=${mcOidcPort}, kbOidc=${kbOidcPort}, referenceIngress=${referenceIngressPort}`;
         } catch (error) {
             state.reason = error.message;
         }

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
@@ -113,4 +113,133 @@ test.describe('Neo.ai.mcp.server.knowledge-base.Server', () => {
             serverInstance.destroy()
         }
     });
+
+    test('#15992: the same GitHub identity is admitted or excluded before KB dispatch', async () => {
+        const
+            admittedUser                               = 'github-kb-profile-15992',
+            serverInstance                             = await createServerWithoutBoot(),
+            [{default: TransportService}, {McpServer}] = await Promise.all([
+                import('../../../../../../../ai/mcp/server/shared/services/TransportService.mjs'),
+                import('@modelcontextprotocol/sdk/server/mcp.js')
+            ]),
+            originalFetch = globalThis.fetch,
+            contextCalls  = [];
+
+        TransportService.app        = null;
+        TransportService.httpServer = null;
+        TransportService.transports = new Map();
+        TransportService.mcpServers = new Map();
+
+        globalThis.fetch = async (url, options={}) => {
+            if (!String(url).startsWith('https://api.github.test/')) {
+                return originalFetch(url, options)
+            }
+
+            return {
+                ok     : true,
+                headers: {get: () => ''},
+                json   : async () => ({
+                    id   : 15992,
+                    login: admittedUser,
+                    name : admittedUser
+                })
+            }
+        };
+
+        const profileConfig = allowedUsers => ({
+            mcpHttpHost  : '127.0.0.1',
+            mcpListenHost: '127.0.0.1',
+            mcpHttpPort  : 0,
+            auth         : {
+                mode                        : 'github-pat',
+                host                        : null,
+                issuerUrl                   : null,
+                trustProxyIdentity          : false,
+                githubApiBaseUrl            : 'https://api.github.test',
+                patCacheTtlSeconds          : 300,
+                patValidationTimeoutMs      : 5000,
+                allowedUsers,
+                allowedClientIds            : [],
+                pinFirstProviderSubject     : false,
+                providerBootstrapPat        : '',
+                providerBootstrapPatFile    : '',
+                autoProvisionIdentitySources: []
+            }
+        });
+
+        const sendInitialize = () => originalFetch(
+            `http://127.0.0.1:${TransportService.httpServer.address().port}/mcp`,
+            {
+                method : 'POST',
+                headers: {
+                    Accept        : 'application/json, text/event-stream',
+                    Authorization : 'Bearer same-provider-identity',
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id     : 1,
+                    method : 'initialize',
+                    params : {
+                        protocolVersion: '2024-11-05',
+                        capabilities   : {},
+                        clientInfo     : {name: 'github-kb-profile-15992', version: '1.0.0'}
+                    }
+                })
+            }
+        );
+
+        const closeTransport = async () => {
+            if (TransportService.httpServer?.listening) {
+                await new Promise((resolve, reject) => {
+                    TransportService.httpServer.close(error => error ? reject(error) : resolve())
+                })
+            }
+
+            TransportService.app        = null;
+            TransportService.httpServer = null;
+            TransportService.transports.clear();
+            TransportService.mcpServers.clear()
+        };
+
+        const startProfile = allowedUsers => TransportService.setup({
+            server: {
+                createMcpServer: () => new McpServer({
+                    name   : 'github-kb-profile-admission-15992',
+                    version: '1.0.0'
+                }),
+                buildRequestContext: async reqAuth => {
+                    contextCalls.push(reqAuth.userId);
+                    return serverInstance.buildRequestContext(reqAuth)
+                },
+                onSessionClosed: () => {}
+            },
+            aiConfig    : profileConfig(allowedUsers),
+            logger      : {info: () => {}, warn: () => {}, error: () => {}},
+            resourceName: 'GithubKbProfileAdmission15992'
+        });
+
+        try {
+            await startProfile([admittedUser]);
+
+            const admitted = await sendInitialize();
+
+            expect(admitted.status).toBe(200);
+            expect(admitted.headers.get('mcp-session-id')).toBeTruthy();
+            expect(contextCalls).toEqual([admittedUser]);
+
+            await closeTransport();
+            await startProfile(['another-profile-member']);
+
+            const denied = await sendInitialize();
+
+            expect(denied.status).toBe(401);
+            expect(denied.headers.get('mcp-session-id')).toBeNull();
+            expect(contextCalls).toEqual([admittedUser])
+        } finally {
+            globalThis.fetch = originalFetch;
+            await closeTransport();
+            serverInstance.destroy()
+        }
+    });
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -287,12 +287,11 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         }
     });
 
-    test('#15990: GitHub-PAT admission precedes AgentIdentity auto-provisioning', async () => {
+    test('#15992: the same GitHub identity is admitted or excluded by profile before provisioning', async () => {
         await GraphService.initAsync();
 
         const
-            admittedUser                               = 'github-pinned-15990',
-            deniedUser                                 = 'github-outsider-15990',
+            admittedUser                               = 'github-profile-15992',
             serverInstance                             = await createServerWithoutBoot(),
             [{default: TransportService}, {McpServer}] = await Promise.all([
                 import('../../../../../../../ai/mcp/server/shared/services/TransportService.mjs'),
@@ -317,22 +316,18 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
                 return originalFetch(url, options)
             }
 
-            const
-                token = options.headers.Authorization.replace(/^Bearer /, ''),
-                login = token === 'github-outsider-pat' ? deniedUser : admittedUser;
-
             return {
                 ok     : true,
                 headers: {get: () => ''},
                 json   : async () => ({
-                    id  : login === admittedUser ? 15990 : 15991,
-                    login,
-                    name: login
+                    id   : 15992,
+                    login: admittedUser,
+                    name : admittedUser
                 })
             }
         };
 
-        const aiConfig = {
+        const profileConfig = allowedUsers => ({
             mcpHttpHost  : '127.0.0.1',
             mcpListenHost: '127.0.0.1',
             mcpHttpPort  : 0,
@@ -344,22 +339,22 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
                 githubApiBaseUrl            : 'https://api.github.test',
                 patCacheTtlSeconds          : 300,
                 patValidationTimeoutMs      : 5000,
-                allowedUsers                : [],
+                allowedUsers,
                 allowedClientIds            : [],
-                pinFirstProviderSubject     : true,
-                providerBootstrapPat        : 'github-bootstrap-pat',
+                pinFirstProviderSubject     : false,
+                providerBootstrapPat        : '',
                 providerBootstrapPatFile    : '',
                 autoProvisionIdentitySources: ['github-pat']
             }
-        };
+        });
 
-        const sendInitialize = token => originalFetch(
+        const sendInitialize = () => originalFetch(
             `http://127.0.0.1:${TransportService.httpServer.address().port}/mcp`,
             {
                 method : 'POST',
                 headers: {
                     Accept        : 'application/json, text/event-stream',
-                    Authorization : `Bearer ${token}`,
+                    Authorization : 'Bearer same-provider-identity',
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({
@@ -375,25 +370,40 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             }
         );
 
-        try {
-            await TransportService.setup({
-                server: {
-                    createMcpServer: () => new McpServer({
-                        name   : 'github-provisioning-15990',
-                        version: '1.0.0'
-                    }),
-                    buildRequestContext: async reqAuth => {
-                        contextCalls.push(reqAuth.userId);
-                        return serverInstance.buildRequestContext(reqAuth)
-                    },
-                    onSessionClosed: () => {}
-                },
-                aiConfig,
-                logger      : {info: () => {}, warn: () => {}, error: () => {}},
-                resourceName: 'GithubProvisioning15990'
-            });
+        const closeTransport = async () => {
+            if (TransportService.httpServer?.listening) {
+                await new Promise((resolve, reject) => {
+                    TransportService.httpServer.close(error => error ? reject(error) : resolve())
+                })
+            }
 
-            const admitted = await sendInitialize('github-same-subject-pat');
+            TransportService.app        = null;
+            TransportService.httpServer = null;
+            TransportService.transports.clear();
+            TransportService.mcpServers.clear()
+        };
+
+        const startProfile = allowedUsers => TransportService.setup({
+            server: {
+                createMcpServer: () => new McpServer({
+                    name   : 'github-profile-admission-15992',
+                    version: '1.0.0'
+                }),
+                buildRequestContext: async reqAuth => {
+                    contextCalls.push(reqAuth.userId);
+                    return serverInstance.buildRequestContext(reqAuth)
+                },
+                onSessionClosed: () => {}
+            },
+            aiConfig    : profileConfig(allowedUsers),
+            logger      : {info: () => {}, warn: () => {}, error: () => {}},
+            resourceName: 'GithubProfileAdmission15992'
+        });
+
+        try {
+            await startProfile([admittedUser]);
+
+            const admitted = await sendInitialize();
 
             expect(admitted.status).toBe(200);
             expect(admitted.headers.get('mcp-session-id')).toBeTruthy();
@@ -412,25 +422,17 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             expect(admittedNode.properties.description)
                 .toBe('Auto-provisioned Agent OS identity for an authenticated Memory Core principal.');
 
-            const denied = await sendInitialize('github-outsider-pat');
+            await closeTransport();
+            await startProfile(['another-profile-member']);
+
+            const denied = await sendInitialize();
 
             expect(denied.status).toBe(401);
             expect(denied.headers.get('mcp-session-id')).toBeNull();
             expect(contextCalls).toEqual([admittedUser]);
-            expect(rawGraphNode(`@${deniedUser}`)).toBeNull();
         } finally {
             globalThis.fetch = originalFetch;
-
-            if (TransportService.httpServer?.listening) {
-                await new Promise((resolve, reject) => {
-                    TransportService.httpServer.close(error => error ? reject(error) : resolve())
-                })
-            }
-
-            TransportService.app        = null;
-            TransportService.httpServer = null;
-            TransportService.transports.clear();
-            TransportService.mcpServers.clear();
+            await closeTransport();
             serverInstance.destroy()
         }
     });

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -899,7 +899,7 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitHub-PAT midd
  * every built-in strategy, configured OIDC, and the truly-unconfigured/unknown failures.
  */
 test.describe('Neo.ai.mcp.server.shared.services.AuthService — setup state discrimination', () => {
-    let AuthService;
+    let AuthService, ConfigBase;
 
     const logger = {info: () => {}, warn: () => {}, error: () => {}};
 
@@ -931,53 +931,224 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — setup state dis
         }
     }
 
+    function collectConfiguredAuthModes() {
+        const
+            descriptor = ConfigBase.config.data.auth,
+            modes      = new Set([descriptor.mode.default]);
+
+        const visit = value => {
+            if (!value || typeof value !== 'object') {
+                return
+            }
+
+            for (const requirement of value.requiredFor || []) {
+                for (const mode of requirement.modes || []) {
+                    modes.add(mode)
+                }
+            }
+
+            for (const nested of Object.values(value)) {
+                visit(nested)
+            }
+        };
+
+        visit(descriptor);
+
+        return [...modes]
+    }
+
+    function setupMethodForMode(mode) {
+        return `setup${mode.split('-').map(part => part[0].toUpperCase() + part.slice(1)).join('')}`
+    }
+
     test.beforeAll(async () => {
-        AuthService = (await import('../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default
+        AuthService = (await import('../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default;
+        ConfigBase  = (await import('../../../../../../../ai/configBase.mjs')).default
     });
 
-    test('custom middleware is classified before default OIDC and is not mounted twice', async () => {
+    test('pre-CORS phase suppresses built-in local guards when custom middleware owns auth', () => {
+        const options = createOptions({
+            auth          : {mode: 'local-bearer'},
+            authMiddleware: () => {}
+        });
+
+        options.aiConfig.mcpListenHost = '0.0.0.0';
+
+        expect(() => AuthService.setupPreCors(options)).not.toThrow();
+        expect(options.app.middlewares).toEqual([])
+    });
+
+    test('pre-CORS local guard owns bind validation and present-Origin rejection', () => {
+        const options = createOptions({auth: {mode: 'local-bearer'}});
+
+        options.aiConfig.mcpListenHost = '127.0.0.1';
+        AuthService.setupPreCors(options);
+
+        expect(options.app.middlewares).toHaveLength(1);
+
+        const
+            req = {headers: {origin: ''}},
+            res = {
+                statusCode: 200,
+                body      : null,
+                status(statusCode) {
+                    this.statusCode = statusCode;
+                    return this
+                },
+                json(body) {
+                    this.body = body
+                }
+            };
+
+        let nextCalled = false;
+
+        options.app.middlewares[0](req, res, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(false);
+        expect(res.statusCode).toBe(403);
+        expect(res.body.error.message).toContain('Origin header is not allowed')
+    });
+
+    test('custom middleware takes precedence and is mounted exactly once by AuthService', async () => {
         const customMiddleware = () => {};
         const options          = createOptions({authMiddleware: customMiddleware});
 
         await expect(AuthService.setup(options)).resolves.toBeUndefined();
 
-        // Compatibility seam: Transport still owns the one custom mount during migration.
-        expect(options.app.middlewares).toEqual([])
+        expect(options.app.middlewares).toEqual([customMiddleware])
     });
 
-    test('proxy-only compatibility does not dereference the absent default-OIDC endpoint', async () => {
+    test('proxy-only installs its owner middleware without dereferencing default OIDC', async () => {
         const options = createOptions({auth: {trustProxyIdentity: true}});
 
         await expect(AuthService.setup(options)).resolves.toBeUndefined();
 
-        // Compatibility seam: Transport still resolves the trusted-proxy header during migration.
-        expect(options.app.middlewares).toEqual([])
+        expect(options.app.middlewares).toHaveLength(1);
+
+        const
+            req = {
+                headers: {'x-preferred-username': 'proxy-user'}
+            },
+            res = {
+                status() {
+                    throw new Error('proxy identity should not reject')
+                }
+            };
+
+        let nextCalled = false;
+
+        options.app.middlewares[0](req, res, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(true);
+        expect(req.auth).toEqual({
+            userId  : 'proxy-user',
+            username: 'proxy-user',
+            source  : 'proxy-header'
+        })
     });
 
-    test('dispatches every non-OIDC built-in without a Transport-owned legal-mode list', async () => {
+    test('proxy-only rejects a missing identity before transport dispatch', async () => {
+        const options = createOptions({auth: {trustProxyIdentity: true}});
+
+        await AuthService.setup(options);
+
         const
-            methodByMode = {
-                'gitlab-pat'  : 'setupGitlabPat',
-                'github-pat'  : 'setupGithubPat',
-                'local-bearer': 'setupLocalBearer',
-                'seat-token'  : 'setupSeatToken'
-            },
-            originals    = Object.fromEntries(Object.values(methodByMode).map(method => [method, AuthService[method]])),
-            calls        = [];
+            req = {headers: {}},
+            res = {
+                statusCode: 200,
+                body      : null,
+                status(statusCode) {
+                    this.statusCode = statusCode;
+                    return this
+                },
+                json(body) {
+                    this.body = body
+                }
+            };
+
+        let nextCalled = false;
+
+        options.app.middlewares[0](req, res, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(false);
+        expect(res.statusCode).toBe(401);
+        expect(res.body).toEqual({error: 'Unauthorized: Missing proxy identity header'});
+        expect(req.auth).toBeUndefined()
+    });
+
+    test('OIDC proxy fallback defers every present Authorization header', () => {
+        const middleware = AuthService.createProxyIdentityMiddleware({
+            logger,
+            fallbackOnly: true
+        });
+
+        for (const authorization of ['Bearer valid', 'Bearer malformed', 'Basic credentials', '']) {
+            const req = {
+                headers: {
+                    authorization,
+                    'x-preferred-username': 'must-not-downgrade'
+                }
+            };
+
+            let nextCalled = false;
+
+            middleware(req, {}, () => { nextCalled = true; });
+
+            expect(nextCalled).toBe(true);
+            expect(req.auth).toBeUndefined()
+        }
+    });
+
+    test('OIDC proxy fallback binds the canonical header only when Authorization is absent', () => {
+        const middleware = AuthService.createProxyIdentityMiddleware({
+            logger,
+            fallbackOnly: true
+        });
+        const req = {
+            headers: {
+                'x-preferred-username'             : 'canonical-user',
+                'x-auth-request-preferred-username': 'secondary-user'
+            }
+        };
+
+        let nextCalled = false;
+
+        middleware(req, {}, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(true);
+        expect(req.auth).toEqual({
+            userId  : 'canonical-user',
+            username: 'canonical-user',
+            source  : 'proxy-header'
+        })
+    });
+
+    test('dispatches every ConfigProvider-derived built-in in both directions', async () => {
+        const
+            sourceModes     = collectConfiguredAuthModes(),
+            defaultMode     = ConfigBase.config.data.auth.mode.default,
+            dispatchedModes = sourceModes.filter(mode => mode !== defaultMode),
+            methods         = dispatchedModes.map(setupMethodForMode),
+            originals       = Object.fromEntries(methods.map(method => [method, AuthService[method]])),
+            calls           = [];
 
         try {
-            for (const [mode, method] of Object.entries(methodByMode)) {
+            for (const [index, mode] of dispatchedModes.entries()) {
+                const method = methods[index];
+
+                expect(typeof AuthService[method]).toBe('function');
                 AuthService[method] = async () => calls.push(mode)
             }
 
-            for (const mode of Object.keys(methodByMode)) {
+            for (const mode of dispatchedModes) {
                 await AuthService.setup(createOptions({auth: {mode}}))
             }
         } finally {
             Object.assign(AuthService, originals)
         }
 
-        expect(calls).toEqual(Object.keys(methodByMode))
+        expect(calls).toEqual(dispatchedModes);
+        expect(new Set([defaultMode, ...calls])).toEqual(new Set(sourceModes))
     });
 
     test('configured OIDC remains the fifth built-in and installs metadata + bearer middleware', async () => {

--- a/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
@@ -157,109 +157,24 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
         TransportService.destroy();
     });
 
-    test.describe('resolveAuthContext proxy-identity injection', () => {
-        let TransportService;
+    test.describe('authentication ownership boundary', () => {
+        test('Transport contains no authentication interpreter or installer', () => {
+            const source = fs.readFileSync(
+                new URL('../../../../../../../../ai/mcp/server/shared/services/TransportService.mjs', import.meta.url),
+                'utf8'
+            );
 
-        test.beforeAll(async () => {
-            TransportService = (await import('../../../../../../../../ai/mcp/server/shared/services/TransportService.mjs')).default;
-        });
-
-        test('OIDC precedence: native req.auth overrides proxy headers', () => {
-            const req = {
-                auth   : { userId: 'oidc-user', username: 'oidc-user', source: 'jwt' },
-                headers: { 'x-preferred-username': 'spoofed-user' }
-            };
-            const aiConfig = { auth: { trustProxyIdentity: true } };
-
-            const result = TransportService.resolveAuthContext(req, aiConfig);
-
-            expect(result.error).toBeUndefined();
-            expect(result.auth).toEqual({
-                userId  : 'oidc-user',
-                username: 'oidc-user',
-                source  : 'jwt'
-            });
-        });
-
-        test('Active proxy identity injection (canonical header)', () => {
-            const req = {
-                auth   : undefined,
-                headers: { 'x-preferred-username': 'proxy-user' }
-            };
-            const aiConfig = { auth: { trustProxyIdentity: true } };
-
-            const result = TransportService.resolveAuthContext(req, aiConfig);
-
-            expect(result.error).toBeUndefined();
-            expect(result.auth).toEqual({
-                userId  : 'proxy-user',
-                username: 'proxy-user',
-                source  : 'proxy-header'
-            });
-        });
-
-        test('OAuth2-proxy variant header fallback', () => {
-            const req = {
-                auth   : undefined,
-                headers: { 'x-auth-request-preferred-username': 'oauth2-user' }
-            };
-            const aiConfig = { auth: { trustProxyIdentity: true } };
-
-            const result = TransportService.resolveAuthContext(req, aiConfig);
-
-            expect(result.error).toBeUndefined();
-            expect(result.auth).toEqual({
-                userId  : 'oauth2-user',
-                username: 'oauth2-user',
-                source  : 'proxy-header'
-            });
-        });
-
-        test('Gate-disabled behavior: ignores headers when trustProxyIdentity is false', () => {
-            const req = {
-                auth   : undefined,
-                headers: { 'x-preferred-username': 'ignored-user' }
-            };
-            const aiConfig = { auth: { trustProxyIdentity: false } };
-
-            const result = TransportService.resolveAuthContext(req, aiConfig);
-
-            expect(result.error).toBeUndefined();
-            expect(result.auth).toBeUndefined();
-        });
-
-        test('Both headers provided: prioritizes canonical over oauth2-proxy', () => {
-            const req = {
-                auth   : undefined,
-                headers: {
-                    'x-preferred-username'             : 'primary-user',
-                    'x-auth-request-preferred-username': 'secondary-user'
-                }
-            };
-            const aiConfig = { auth: { trustProxyIdentity: true } };
-
-            const result = TransportService.resolveAuthContext(req, aiConfig);
-
-            expect(result.error).toBeUndefined();
-            expect(result.auth).toEqual({
-                userId  : 'primary-user',
-                username: 'primary-user',
-                source  : 'proxy-header'
-            });
-        });
-
-        test('Header-spoof resistance / required identity: returns 401 when enabled but headers are missing', () => {
-            const req = {
-                auth   : undefined,
-                headers: {}
-            };
-            const aiConfig = { auth: { trustProxyIdentity: true } };
-
-            const result = TransportService.resolveAuthContext(req, aiConfig);
-
-            expect(result.error).toBe('Unauthorized: Missing proxy identity header');
-            expect(result.status).toBe(401);
-            expect(result.auth).toBeUndefined();
+            for (const forbidden of [
+                'auth.mode',
+                'authMiddleware',
+                'trustProxyIdentity',
+                'x-preferred-username',
+                'x-auth-request-preferred-username',
+                'resolveAuthContext',
+                'isLocalBearer'
+            ]) {
+                expect(source).not.toContain(forbidden)
+            }
         });
     });
 
@@ -476,6 +391,267 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
                 releaseAuth?.();
                 AuthService.setup = originalSetup
             }
+        });
+    });
+
+    /**
+     * @summary Consumed HTTP proof for non-downgrading OIDC + trusted-proxy composition.
+     *
+     * These four cells cross the real Express route, SDK bearer middleware, OIDC verifier, and
+     * MCP initialize boundary. Authorization presence is terminal: only true absence may reach
+     * trusted proxy identity, and every rejection occurs before connection/session creation.
+     */
+    test.describe('trusted-proxy and OIDC composition HTTP ingress', () => {
+        let TransportService, McpServer, originalFetch, capturedAuth;
+
+        const
+            logger       = {info: () => {}, warn: () => {}, error: () => {}},
+            oidcAudience = 'http://127.0.0.1:43199/mcp';
+
+        function oidcProxyConfig() {
+            return {
+                mcpHttpHost  : '127.0.0.1',
+                mcpListenHost: '127.0.0.1',
+                mcpHttpPort  : 0,
+                publicUrl    : oidcAudience,
+                auth         : {
+                    mode              : 'oidc',
+                    host              : 'https://oidc.test',
+                    port              : 443,
+                    realm             : 'neo',
+                    issuerUrl         : null,
+                    clientId          : 'neo-mcp',
+                    clientSecret      : '',
+                    trustProxyIdentity: true
+                }
+            }
+        }
+
+        function initializeBody() {
+            return JSON.stringify({
+                jsonrpc: '2.0',
+                id     : 1,
+                method : 'initialize',
+                params : {
+                    protocolVersion: '2024-11-05',
+                    capabilities   : {},
+                    clientInfo     : {name: 'oidc-proxy-test', version: '1.0.0'}
+                }
+            })
+        }
+
+        async function setupOidcProxy() {
+            const mcpServer = new McpServer({name: 'oidc-proxy-test', version: '1.0.0'});
+
+            await TransportService.setup({
+                server: {
+                    mcpServer,
+                    onSessionClosed    : () => {},
+                    buildRequestContext: async reqAuth => {
+                        capturedAuth.push(reqAuth);
+                        return {
+                            userId  : reqAuth?.userId,
+                            username: reqAuth?.username,
+                            source  : reqAuth?.source
+                        }
+                    }
+                },
+                aiConfig    : oidcProxyConfig(),
+                logger,
+                resourceName: 'OidcProxyIngressTest'
+            });
+
+            return TransportService.httpServer.address().port
+        }
+
+        async function setupProxyOnly() {
+            const
+                mcpServer       = new McpServer({name: 'proxy-only-test', version: '1.0.0'}),
+                originalConnect = mcpServer.connect.bind(mcpServer);
+
+            let connectCalls = 0;
+
+            mcpServer.connect = async transport => {
+                connectCalls++;
+                return originalConnect(transport)
+            };
+
+            await TransportService.setup({
+                server: {
+                    mcpServer,
+                    onSessionClosed    : () => {},
+                    buildRequestContext: async reqAuth => {
+                        capturedAuth.push(reqAuth);
+                        return {
+                            userId  : reqAuth?.userId,
+                            username: reqAuth?.username,
+                            source  : reqAuth?.source
+                        }
+                    }
+                },
+                aiConfig: {
+                    mcpHttpHost  : '127.0.0.1',
+                    mcpListenHost: '127.0.0.1',
+                    mcpHttpPort  : 0,
+                    auth         : {
+                        mode              : 'oidc',
+                        host              : null,
+                        issuerUrl         : null,
+                        trustProxyIdentity: true
+                    }
+                },
+                logger,
+                resourceName: 'ProxyOnlyIngressTest'
+            });
+
+            return {
+                getConnectCalls: () => connectCalls,
+                port           : TransportService.httpServer.address().port
+            }
+        }
+
+        function initialize(port, headers={}) {
+            return originalFetch(`http://127.0.0.1:${port}/mcp`, {
+                method : 'POST',
+                headers: {
+                    Accept        : 'application/json, text/event-stream',
+                    'Content-Type': 'application/json',
+                    ...headers
+                },
+                body: initializeBody()
+            })
+        }
+
+        test.beforeAll(async () => {
+            TransportService = (await import('../../../../../../../../ai/mcp/server/shared/services/TransportService.mjs')).default;
+            McpServer        = (await import('@modelcontextprotocol/sdk/server/mcp.js')).McpServer
+        });
+
+        test.beforeEach(() => {
+            originalFetch = globalThis.fetch;
+            capturedAuth  = [];
+
+            TransportService.app        = null;
+            TransportService.httpServer = null;
+            TransportService.transports = new Map();
+            TransportService.mcpServers = new Map();
+
+            globalThis.fetch = async (url, options={}) => {
+                if (!String(url).startsWith('https://oidc.test/')) {
+                    return originalFetch(url, options)
+                }
+
+                const token = new URLSearchParams(options.body).get('token');
+
+                return {
+                    ok  : true,
+                    json: async () => token === 'valid-oidc'
+                        ? {
+                            active            : true,
+                            aud               : oidcAudience,
+                            preferred_username: 'oidc-user',
+                            sub               : 'oidc-subject',
+                            client_id         : 'neo-mcp',
+                            exp               : Math.floor(Date.now() / 1000) + 3600
+                        }
+                        : {active: false}
+                }
+            }
+        });
+
+        test.afterEach(async () => {
+            globalThis.fetch = originalFetch;
+
+            if (TransportService.httpServer?.listening) {
+                await new Promise((resolve, reject) => {
+                    TransportService.httpServer.close(error => error ? reject(error) : resolve())
+                })
+            }
+
+            TransportService.app        = null;
+            TransportService.httpServer = null;
+            TransportService.transports.clear();
+            TransportService.mcpServers.clear()
+        });
+
+        test('valid bearer + conflicting proxy identity uses OIDC', async () => {
+            const
+                port     = await setupOidcProxy(),
+                response = await initialize(port, {
+                    Authorization         : 'Bearer valid-oidc',
+                    'X-Preferred-Username': 'proxy-spoof'
+                });
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('mcp-session-id')).toBeTruthy();
+            expect(capturedAuth).toHaveLength(1);
+            expect(capturedAuth[0]).toMatchObject({
+                userId: 'oidc-user',
+                source: 'oidc'
+            })
+        });
+
+        test('invalid or malformed bearer + valid proxy challenges without downgrade', async () => {
+            const port = await setupOidcProxy();
+
+            for (const authorization of ['Bearer invalid-oidc', 'Basic malformed']) {
+                const response = await initialize(port, {
+                    Authorization         : authorization,
+                    'X-Preferred-Username': 'proxy-user'
+                });
+
+                expect(response.status).toBe(401);
+                expect(response.headers.get('mcp-session-id')).toBeNull()
+            }
+
+            expect(capturedAuth).toEqual([]);
+            expect(TransportService.transports.size).toBe(0)
+        });
+
+        test('absent bearer + trusted proxy identity initializes through proxy auth', async () => {
+            const
+                port     = await setupOidcProxy(),
+                response = await initialize(port, {'X-Preferred-Username': 'proxy-user'});
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('mcp-session-id')).toBeTruthy();
+            expect(capturedAuth).toHaveLength(1);
+            expect(capturedAuth[0]).toMatchObject({
+                userId: 'proxy-user',
+                source: 'proxy-header'
+            })
+        });
+
+        test('absent bearer + missing proxy identity rejects before MCP dispatch', async () => {
+            const
+                port     = await setupOidcProxy(),
+                response = await initialize(port);
+
+            expect(response.status).toBe(401);
+            expect(response.headers.get('mcp-session-id')).toBeNull();
+            expect(capturedAuth).toEqual([]);
+            expect(TransportService.transports.size).toBe(0)
+        });
+
+        test('proxy-only rejects before connect, then admits a trusted identity', async () => {
+            const {port, getConnectCalls} = await setupProxyOnly();
+            const missing                 = await initialize(port);
+
+            expect(missing.status).toBe(401);
+            expect(missing.headers.get('mcp-session-id')).toBeNull();
+            expect(getConnectCalls()).toBe(0);
+            expect(TransportService.transports.size).toBe(0);
+
+            const trusted = await initialize(port, {'X-Preferred-Username': 'proxy-only-user'});
+
+            expect(trusted.status).toBe(200);
+            expect(trusted.headers.get('mcp-session-id')).toBeTruthy();
+            expect(getConnectCalls()).toBe(1);
+            expect(capturedAuth).toHaveLength(1);
+            expect(capturedAuth[0]).toMatchObject({
+                userId: 'proxy-only-user',
+                source: 'proxy-header'
+            })
         });
     });
 


### PR DESCRIPTION
Resolves #15992

Related: #15798

Completes Streamable HTTP authentication ownership: `AuthService` now owns every authentication installer and strategy guard, while `TransportService` owns only HTTP/session mechanics and consumes the resulting `req.auth`. OIDC plus trusted-proxy composition is explicit and non-downgrading, and the documented Caddy ingress is exercised as the real strip → authenticate → inject boundary for both Memory Core and Knowledge Base.

Evidence: L3 (real HTTP middleware/session probes plus the exact Dockerized Caddy ingress) → L3 required (runtime ownership, precedence, ingress spoof resistance, and profile admission). No residuals.

## Deltas from ticket

- Corrected the source-derived admission terminology from plane admission to profile admission: `allowedUsers` is a deployment-profile policy, while only seat-token is plane-scoped.
- Added coordinate overrides to the existing reference Caddyfile with unchanged standalone defaults, so integration consumes the production-shaped route instead of maintaining a test-only copy.
- Split authentication installation into a universal pre-CORS phase and the main installer phase. Transport invokes both without interpreting any authentication leaf, preserving the local-bearer guard order while keeping strategy ownership in `AuthService`.
- No second legal-mode registry was introduced; the installer census derives its domain from `ConfigBase` defaults and `requiredFor[].modes`.

## Test Evidence

- Auth ownership and precedence: `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs` — 110 passed.
- Reference ingress / MC / KB: `npm run test-integration-unified -- test/playwright/integration/AuthRejection.integration.spec.mjs` — 2 passed through the exact mounted Caddyfile.
- Compose and Caddy: `docker compose -f ai/deploy/docker-compose.test.yml config --quiet`; `caddy validate` and `caddy fmt --diff` executed through `caddy:2-alpine` — valid and clean.
- Source/static gates: `npm run agent-preflight -- <12 changed files>`; `git diff --check`; focused `node --check` for the mock OIDC server, Compose fixture, and integration spec — passed.
- `SharedDeployment.md`: the precedence and ingress claims are anchored to the consumed HTTP and Docker integration proofs above.

## Post-Merge Validation

- [ ] On the next shared deployment rollout, confirm authenticated MC and KB initialize through the proxy while a caller-supplied identity header remains rejected.

## Evolution

The source step-back changed one material term without changing scope: provider `allowedUsers` governs profile admission, not plane admission. The ingress proof also moved from direct header injection to the exact checked-in reference Caddy route, making the trust claim executable rather than illustrative.

Authored by Euclid (GPT-5.6 SOL, Codex Desktop). Session 019f9b00-d596-7e22-b8f1-31433ddb5838.
