### PR TITLE
fix(agent-os): isolate tenant repo acquisition (#16045)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -10,6 +10,7 @@
  * subsystem prefixes (`KB_GITMIRROR_`, `KB_INGEST_`, `KB_TENANT_REPO_ACCESS_`).
  *
  * @see learn/agentos/cloud-deployment/TenantIngestionModel.md — operator quarantine runbook
+ * @see https://github.com/neomjs/neo/issues/16045
  */
 
 export const KB_TENANT_REPO_SYNC_SYNC_FAILED            = 'KB_TENANT_REPO_SYNC_SYNC_FAILED';
@@ -17,6 +18,7 @@ export const KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED    = 'KB_TENANT_REPO_SYNC_R
 export const KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND       = 'KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND';
 export const KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED = 'KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED';
 export const KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT = 'KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT';
+export const KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION = 'KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION';
 // Non-failure defer reason: another process holds the cross-process tenant-repo-sync
 // lease. Surfaced as a `skipped` reasonCode (never thrown) so the periodic lane and
 // the manual CLI can branch on it without treating operator ownership as an error.
@@ -44,6 +46,7 @@ export const TENANT_REPO_SYNC_ERROR_CODES = Object.freeze([
     KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
+    KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
     KB_TENANT_REPO_SYNC_LEASE_HELD,
     KB_TENANT_REPO_SYNC_LEASE_LOST
 ]);

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -4,7 +4,10 @@ import path                      from 'node:path';
 import Base                      from '../../../../src/core/Base.mjs';
 import AiConfig                  from '../../../config.mjs';
 import GitMirror                 from '../../../services/knowledge-base/helpers/gitMirror.mjs';
-import {buildIngestEnvelope}     from '../../../services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
+import {
+    buildIngestEnvelope,
+    createTenantRepoMaterializationDigest
+} from '../../../services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 import {
     isTenantRepoAccessReadinessOutcome,
     normalizeTenantRepoCredentialRef,
@@ -13,6 +16,7 @@ import {
 } from '../../../services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 import {isRepoDue} from '../scheduling/tenantRepoSync.mjs';
 import {
+    KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
     KB_TENANT_REPO_SYNC_LEASE_HELD,
     KB_TENANT_REPO_SYNC_LEASE_LOST,
@@ -224,6 +228,69 @@ function assertErrorFreeIngestionSummary(summary) {
 }
 
 /**
+ * @summary Verifies a graph receipt against the current full-materialization identity.
+ * @param {*} receipt Candidate graph receipt.
+ * @param {String} expectedDigest Digest of the current manifest-bearing envelope.
+ * @returns {Boolean}
+ */
+function isMatchingMaterializationReceipt(receipt, expectedDigest) {
+    return Boolean(
+        receipt
+        && receipt.ingestContractVersion === TENANT_REPO_INGEST_CONTRACT_VERSION
+        && receipt.envelopeDigest === expectedDigest
+        && /^[a-f0-9]{32}$/u.test(receipt.attemptId)
+        && Number.isSafeInteger(receipt.recordedAt)
+        && receipt.recordedAt > 0
+    )
+}
+
+/**
+ * @summary Requires a durable positive-effect proof before a full materialization can commit.
+ *
+ * A manifest-bearing envelope represents bootstrap, non-linear fallback, manual full
+ * replay, or legacy revalidation. It must reach ingestion before this check so an
+ * empty manifest can reconcile and delete stale rows. A fresh attempt must prove a
+ * safely-counted ingest/delete effect and persist its matching graph receipt. A
+ * zero-effect retry may settle only an unacknowledged receipt left by a prior positive
+ * attempt whose checkpoint commit failed. Incremental envelopes have no manifest and
+ * may remain healthy zero-delta checkpoints.
+ *
+ * @param {Object} envelope Tenant-repo ingestion envelope.
+ * @param {Object} summary Validated error-free ingestion summary.
+ * @param {Object|null} priorState Previous durable checkpoint.
+ * @param {Object|null} materializationAttempt Current opaque full-attempt identity.
+ * @returns {Object|null} Receipt to acknowledge in the final checkpoint.
+ * @throws {TenantRepoSyncError} When a full materialization has no proved effect.
+ */
+function assertFullMaterializationEffect(envelope, summary, priorState, materializationAttempt) {
+    if (envelope?.manifestSnapshot == null) {
+        return null
+    }
+
+    const
+        expectedDigest = createTenantRepoMaterializationDigest(envelope),
+        receipt        = summary.materializationReceipt,
+        validReceipt   = isMatchingMaterializationReceipt(receipt, expectedDigest),
+        hasEffect      = [summary.ingested, summary.deleted]
+            .some(value => Number.isSafeInteger(value) && value > 0),
+        provesCurrentAttempt = validReceipt
+            && receipt.attemptId === materializationAttempt?.attemptId,
+        provesUncommittedRetry = validReceipt
+            && receipt.attemptId !== materializationAttempt?.attemptId
+            && receipt.attemptId !== priorState?.lastCommittedMaterializationAttemptId;
+
+    if ((hasEffect && !provesCurrentAttempt) || (!hasEffect && !provesUncommittedRetry)) {
+        throw new TenantRepoSyncError(
+            KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
+            'Tenant-repo full materialization produced no durable positive-effect proof.',
+            {phase: 'full-materialization'}
+        )
+    }
+
+    return receipt
+}
+
+/**
  * @summary Cloud-deployable scheduler lane that pulls tenant repos into the deployment KB.
  *
  * Bridges the `tenant-repo-sync` Orchestrator periodic lane (registered via
@@ -259,6 +326,7 @@ function assertErrorFreeIngestionSummary(summary) {
  * @see ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
  * @see ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs
  * @see learn/agentos/cloud-deployment/TenantIngestionModel.md
+ * @see https://github.com/neomjs/neo/issues/16045
  */
 class TenantRepoSyncService extends Base {
     static config = {
@@ -514,6 +582,7 @@ class TenantRepoSyncService extends Base {
             probe = await gitMirror.probeRemoteAccess({
                 cloneUrl     : repo.cloneUrl,
                 credentialRef: repo.credentialRef,
+                mirrorRoot   : repo.mirrorRoot,
                 ref          : repo.branchRef || 'HEAD'
             });
         } catch {
@@ -597,8 +666,9 @@ class TenantRepoSyncService extends Base {
      * | Code | Surface | Trigger |
      * |---|---|---|
      * | `KB_TENANT_REPO_SYNC_SYNC_FAILED` | per-repo `lastErrorCode` | underlying clone/fetch/envelope/ingest failure (wraps the original error) |
+     * | `KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION` | per-repo `lastErrorCode` | full materialization lacks a fresh positive effect or matching unacknowledged retry receipt |
      * | `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` | outer `details.reasonCode` | `onlyRepoSlugs` filter requested a slug that is not in `tenantRepos[]` |
-     * | `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` | outer `details.reasonCode` | `tenant-repo-sync-revisions.json` write failure (next cycle retries idempotently) |
+     * | `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` | outer `details.reasonCode` | `tenant-repo-sync-revisions.json` write failure (next cycle settles the unacknowledged graph receipt idempotently) |
      * | `KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND` | reserved | future `--tenant-id` CLI flag; no current emitter |
      * | `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT` | per-repo `lastErrorCode` | concurrency-gate slot-acquisition timeout after `concurrencyGateTimeoutMs` |
      *
@@ -934,11 +1004,12 @@ class TenantRepoSyncService extends Base {
                         ? repo.cadenceMs
                         : globalCadenceMs;
                     persistedRevisions[repoLabel] = {
-                        lastIngestedRev                   : null,
-                        lastRunAttemptAt                  : sweepStartedMs - baseCadenceMs,
-                        consecutiveFailures               : 0,
-                        ingestContractVersion             : null,
-                        lastAttemptedIngestContractVersion: null
+                        lastIngestedRev                      : null,
+                        lastRunAttemptAt                     : sweepStartedMs - baseCadenceMs,
+                        consecutiveFailures                  : 0,
+                        ingestContractVersion                : null,
+                        lastAttemptedIngestContractVersion   : null,
+                        lastCommittedMaterializationAttemptId: null
                     };
                     seededAny = true;
                     writeLog?.('INFO', `[TenantRepoSync] Bootstrap-seeding ${repoLabel} (sync scheduled within jitter window).`);
@@ -1097,21 +1168,63 @@ class TenantRepoSyncService extends Base {
                 // lane protects (the manifest commit being the first).
                 await leaseGuard();
 
-                const ingestResult = assertErrorFreeIngestionSummary(await ingestionService.ingestSourceFiles({
-                    ...envelope,
-                    viaMcp: false // operator-bulk path
-                }));
+                const materializationAttempt = envelope.manifestSnapshot == null
+                    ? null
+                    : {
+                        attemptId            : randomBytes(16).toString('hex'),
+                        ingestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    };
+                const
+                    envelopeDigest = materializationAttempt
+                        ? createTenantRepoMaterializationDigest(envelope)
+                        : null,
+                    existingManifest = materializationAttempt
+                        && typeof ingestionService.getTenantManifest === 'function'
+                        ? await ingestionService.getTenantManifest({
+                            tenantId: repo.tenantId,
+                            repoSlug: repo.repoSlug
+                        })
+                        : null,
+                    retryReceipt = isMatchingMaterializationReceipt(
+                        existingManifest?.materializationReceipt,
+                        envelopeDigest
+                    ) && existingManifest.materializationReceipt.attemptId
+                        !== priorState?.lastCommittedMaterializationAttemptId
+                        ? existingManifest.materializationReceipt
+                        : null,
+                    ingestResult = assertErrorFreeIngestionSummary(retryReceipt
+                        ? {
+                            ingested              : 0,
+                            deleted               : 0,
+                            errors                : [],
+                            materializationReceipt: retryReceipt
+                        }
+                        : await ingestionService.ingestSourceFiles({
+                            ...envelope,
+                            ...(materializationAttempt ? {materializationAttempt} : {}),
+                            viaMcp: false // operator-bulk path
+                        }));
+
+                const materializationReceipt = assertFullMaterializationEffect(
+                    envelope,
+                    ingestResult,
+                    priorState,
+                    materializationAttempt
+                );
 
                 // Persist full per-repo state on success. Reset consecutiveFailures
                 // to 0 (backoff is the multiplier-component of effectiveCadence; reset on
                 // successful sync). lastRunAttemptAt advances to
                 // startedMs so subsequent due-checks measure from the actual attempt.
                 persistedRevisions[repoLabel] = {
-                    lastIngestedRev                   : envelope.headRevision || priorState?.lastIngestedRev || null,
-                    lastRunAttemptAt                  : startedMs,
-                    consecutiveFailures               : 0,
-                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
-                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    lastIngestedRev                      : envelope.headRevision || priorState?.lastIngestedRev || null,
+                    lastRunAttemptAt                     : startedMs,
+                    consecutiveFailures                  : 0,
+                    ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastCommittedMaterializationAttemptId: materializationReceipt?.attemptId
+                        || priorState?.lastCommittedMaterializationAttemptId
+                        || null
                 };
 
                 const durationMs = Date.now() - startedMs;
@@ -1177,11 +1290,12 @@ class TenantRepoSyncService extends Base {
                 // start, not last-success).
                 const nextFailureCount = (priorState?.consecutiveFailures ?? 0) + 1;
                 persistedRevisions[repoLabel] = {
-                    lastIngestedRev                   : priorState?.lastIngestedRev || null,
-                    lastRunAttemptAt                  : startedMs,
-                    consecutiveFailures               : nextFailureCount,
-                    ingestContractVersion             : priorState?.ingestContractVersion ?? null,
-                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    lastIngestedRev                      : priorState?.lastIngestedRev || null,
+                    lastRunAttemptAt                     : startedMs,
+                    consecutiveFailures                  : nextFailureCount,
+                    ingestContractVersion                : priorState?.ingestContractVersion ?? null,
+                    lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastCommittedMaterializationAttemptId: priorState?.lastCommittedMaterializationAttemptId || null
                 };
 
                 const failedRepoState = {
@@ -1342,7 +1456,8 @@ class TenantRepoSyncService extends Base {
      *   lastRunAttemptAt                   : <ms-epoch>,
      *   consecutiveFailures                : <int>,
      *   ingestContractVersion              : <int|null>,
-     *   lastAttemptedIngestContractVersion : <int|null>
+     *   lastAttemptedIngestContractVersion : <int|null>,
+     *   lastCommittedMaterializationAttemptId: <hex|null>
      * }
      * ```
      *

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -4,20 +4,26 @@
  * for the orchestrator-owned tenant-repo ingestion lane.
  *
  * A persisted repository head is trusted as an incremental base only when
- * `ingestContractVersion` proves it was written after an error-free ingestion
- * summary. Older records remain usable recovery evidence, but require one
- * bounded null-base replay before they become current.
+ * `ingestContractVersion` proves it was written after the current ingestion
+ * commit contract. Older records remain usable recovery evidence, but require
+ * one bounded null-base replay before they become current.
+ *
+ * @see https://github.com/neomjs/neo/issues/16045
  */
 
 /**
  * @summary Current success contract for tenant-repo ingestion checkpoints.
  *
- * Version 1 means the persisted head advanced only after
- * `assertErrorFreeIngestionSummary()` accepted the Knowledge Base result.
+ * Version 1 means the persisted head advanced after an error-free Knowledge Base
+ * summary. Version 2 additionally requires a durable positive-effect receipt for
+ * manifest-bearing full materializations; the checkpoint acknowledges its opaque
+ * attempt id so an interrupted commit can retry without stale-proof reuse.
  *
  * @type {Number}
  */
-export const TENANT_REPO_INGEST_CONTRACT_VERSION = 1;
+export const TENANT_REPO_INGEST_CONTRACT_VERSION = 2;
+
+const MATERIALIZATION_ATTEMPT_ID_PATTERN = /^[a-f0-9]{32}$/u;
 
 /**
  * @summary Internal checkpoint-revalidation classifications.
@@ -51,11 +57,12 @@ export const TenantRepoCheckpointStatus = Object.freeze({
 export function normalizeTenantRepoCheckpointState(value) {
     if (typeof value === 'string') {
         return {
-            lastIngestedRev                   : value || null,
-            lastRunAttemptAt                  : 0,
-            consecutiveFailures               : 0,
-            ingestContractVersion             : null,
-            lastAttemptedIngestContractVersion: null
+            lastIngestedRev                      : value || null,
+            lastRunAttemptAt                     : 0,
+            consecutiveFailures                  : 0,
+            ingestContractVersion                : null,
+            lastAttemptedIngestContractVersion   : null,
+            lastCommittedMaterializationAttemptId: null
         };
     }
 
@@ -63,7 +70,7 @@ export function normalizeTenantRepoCheckpointState(value) {
         return null;
     }
 
-    if (hasMalformedContractVersion(value)) {
+    if (hasMalformedContractVersion(value) || hasMalformedMaterializationAttemptId(value)) {
         return null;
     }
 
@@ -71,10 +78,13 @@ export function normalizeTenantRepoCheckpointState(value) {
         lastIngestedRev                    : typeof value.lastIngestedRev === 'string' && value.lastIngestedRev
             ? value.lastIngestedRev
             : null,
-        lastRunAttemptAt                  : normalizeNonNegativeNumber(value.lastRunAttemptAt),
-        consecutiveFailures               : normalizeFailureCount(value.consecutiveFailures),
-        ingestContractVersion             : normalizeContractVersion(value.ingestContractVersion),
-        lastAttemptedIngestContractVersion: normalizeContractVersion(value.lastAttemptedIngestContractVersion)
+        lastRunAttemptAt                     : normalizeNonNegativeNumber(value.lastRunAttemptAt),
+        consecutiveFailures                  : normalizeFailureCount(value.consecutiveFailures),
+        ingestContractVersion                : normalizeContractVersion(value.ingestContractVersion),
+        lastAttemptedIngestContractVersion   : normalizeContractVersion(value.lastAttemptedIngestContractVersion),
+        lastCommittedMaterializationAttemptId: normalizeMaterializationAttemptId(
+            value.lastCommittedMaterializationAttemptId
+        )
     };
 }
 
@@ -90,7 +100,7 @@ export function normalizeTenantRepoCheckpointState(value) {
  * @returns {String} One `TenantRepoCheckpointStatus` value.
  */
 export function classifyTenantRepoCheckpoint(state) {
-    if (hasMalformedContractVersion(state)) {
+    if (hasMalformedContractVersion(state) || hasMalformedMaterializationAttemptId(state)) {
         return TenantRepoCheckpointStatus.INVALID;
     }
 
@@ -101,8 +111,9 @@ export function classifyTenantRepoCheckpoint(state) {
     }
 
     const
-        ingestVersion  = normalizedState?.ingestContractVersion ?? null,
-        attemptVersion = normalizedState?.lastAttemptedIngestContractVersion ?? null;
+        ingestVersion                     = normalizedState?.ingestContractVersion ?? null,
+        attemptVersion                    = normalizedState?.lastAttemptedIngestContractVersion ?? null,
+        committedMaterializationAttemptId = normalizedState?.lastCommittedMaterializationAttemptId ?? null;
 
     if (
         ingestVersion > TENANT_REPO_INGEST_CONTRACT_VERSION
@@ -115,7 +126,10 @@ export function classifyTenantRepoCheckpoint(state) {
         return TenantRepoCheckpointStatus.UNINITIALIZED;
     }
 
-    if (ingestVersion === TENANT_REPO_INGEST_CONTRACT_VERSION) {
+    if (
+        ingestVersion === TENANT_REPO_INGEST_CONTRACT_VERSION
+        && committedMaterializationAttemptId
+    ) {
         return TenantRepoCheckpointStatus.COMPLETE;
     }
 
@@ -166,12 +180,39 @@ function hasMalformedContractVersion(state) {
 }
 
 /**
+ * @summary Detects a present-but-invalid full-materialization receipt acknowledgement.
+ * @param {*} state Candidate persisted checkpoint state.
+ * @returns {Boolean}
+ */
+function hasMalformedMaterializationAttemptId(state) {
+    return Boolean(
+        state
+        && typeof state === 'object'
+        && !Array.isArray(state)
+        && Object.hasOwn(state, 'lastCommittedMaterializationAttemptId')
+        && state.lastCommittedMaterializationAttemptId !== null
+        && normalizeMaterializationAttemptId(state.lastCommittedMaterializationAttemptId) === null
+    );
+}
+
+/**
  * @summary Accepts only positive integer checkpoint-contract versions.
  * @param {*} value Candidate persisted version.
  * @returns {Number|null}
  */
 function normalizeContractVersion(value) {
     return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+/**
+ * @summary Accepts only bounded opaque ids emitted for full-materialization attempts.
+ * @param {*} value Candidate attempt id.
+ * @returns {String|null}
+ */
+function normalizeMaterializationAttemptId(value) {
+    return typeof value === 'string' && MATERIALIZATION_ATTEMPT_ID_PATTERN.test(value)
+        ? value
+        : null;
 }
 
 /**

--- a/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
+++ b/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
@@ -58,7 +58,9 @@ const assertToolTransportAllowed = toolName => {
  *
  * The gate lives at the MCP facade (not threaded into the service) because the batch
  * volume is knowable from the input alone, keeping service-layer ingestion logic
- * unchanged and transport policy localized to the MCP facade.
+ * unchanged and transport policy localized to the MCP facade. This boundary also
+ * strips the pull orchestrator's internal materialization-attempt field, forces MCP
+ * work-volume mode, and never returns a durable pull receipt to a push caller.
  *
  * @param {Object}    args            The `ingest_source_files` tool envelope.
  * @param {String}   [args.tenantId]  Authenticated tenant id.
@@ -68,6 +70,7 @@ const assertToolTransportAllowed = toolName => {
  *     refusal when the work-volume gate fires.
  * @see https://github.com/neomjs/neo/issues/11634
  * @see https://github.com/neomjs/neo/issues/10572
+ * @see https://github.com/neomjs/neo/issues/16045
  */
 const ingestSourceFilesViaMcp = async args => {
     const
@@ -88,7 +91,21 @@ const ingestSourceFilesViaMcp = async args => {
         };
     }
 
-    return IngestionService.ingestSourceFiles(args);
+    const serviceArgs = {...(args || {}), viaMcp: true};
+
+    delete serviceArgs.materializationAttempt;
+
+    const result = await IngestionService.ingestSourceFiles(serviceArgs);
+
+    if (!result || typeof result !== 'object' || !Object.hasOwn(result, 'materializationReceipt')) {
+        return result
+    }
+
+    const publicResult = {...result};
+
+    delete publicResult.materializationReceipt;
+
+    return publicResult
 };
 
 export {

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -12,6 +12,8 @@ import RequestContextService,
 import SourceRegistry       from './source/_export.mjs';
 import {normalizeTenantRepoConfig}
                             from './helpers/tenantRepoAccessContract.mjs';
+import {createTenantRepoMaterializationDigest}
+                            from './helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 import VectorService   from './VectorService.mjs';
 import aiConfig        from '../../mcp/server/knowledge-base/config.mjs';
 import crypto          from 'crypto';
@@ -27,6 +29,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 const LOCAL_EMBEDDING_PROVIDERS           = new Set(['openAiCompatible', 'ollama']);
+const MATERIALIZATION_ATTEMPT_ID_PATTERN  = /^[a-f0-9]{32}$/u;
+const MATERIALIZATION_DIGEST_PATTERN      = /^[a-f0-9]{64}$/u;
 const PARSED_CHUNK_SCHEMA_PATH            = path.join(__dirname, 'parser/parsed-chunk-v1.schema.json');
 const KB_CONFIG_BOOTSTRAP_FAILURE_DETAILS = Object.freeze({
     'read-failed': {
@@ -57,6 +61,7 @@ const KB_CONFIG_BOOTSTRAP_FAILURE_DETAILS = Object.freeze({
  * successful portion of a push, and fully failed pushes still return the contract
  * summary instead of throwing out of the facade boundary.
  *
+ * @see https://github.com/neomjs/neo/issues/16045
  * @class Neo.ai.services.knowledge-base.IngestionService
  * @extends Neo.core.Base
  * @singleton
@@ -139,6 +144,7 @@ class IngestionService extends Base {
      * @param {Object} [payload.manifestSnapshot] Post-push manifest (`{repoSlug, pathsAfterPush}`).
      * @param {String} [payload.baseRevision] Previous revision boundary.
      * @param {String} [payload.headRevision] Current revision boundary.
+     * @param {Object} [payload.materializationAttempt] Opaque pull-attempt id plus checkpoint-contract version.
      * @param {Boolean} [payload.viaMcp=true] Caller-selected work-volume-gate mode. Omitted
      *                                        or truthy values keep `VectorService.embed`
      *                                        MCP-safe. Explicit `false` (the `ai:ingest-tenant`
@@ -217,7 +223,10 @@ class IngestionService extends Base {
 
             this.updateIngestionProgress({phase: 'manifest'});
             await this.persistManifestSnapshot({
-                manifestSnapshot: payload.manifestSnapshot,
+                manifestSnapshot      : payload.manifestSnapshot,
+                files                 : payload.files,
+                headRevision          : payload.headRevision,
+                materializationAttempt: payload.materializationAttempt,
                 tenantContext,
                 summary
             });
@@ -707,7 +716,7 @@ class IngestionService extends Base {
      *
      * @param {Object}  data
      * @param {String} [data.tenantId] Tenant id.
-     * @returns {Promise<Object<String, {repoSlug: String, pathsAfterPush: Array<String>, updatedAt: Number}>>}
+     * @returns {Promise<Object<String, {repoSlug: String, pathsAfterPush: Array<String>, updatedAt: Number, materializationReceipt: Object|null}>>}
      */
     async getTenantManifests({tenantId} = {}) {
         const {tenantId: resolvedTenant} = this.resolveTenantContext({tenantId});
@@ -723,8 +732,16 @@ class IngestionService extends Base {
 
         return Object.fromEntries(Object.entries(source)
             .map(([repoSlug, manifest]) => {
-                const paths = this.normalizeManifestPaths(manifest?.pathsAfterPush);
-                return paths ? [repoSlug, {repoSlug, pathsAfterPush: paths, updatedAt: manifest.updatedAt || 0}] : null;
+                const
+                    paths                  = this.normalizeManifestPaths(manifest?.pathsAfterPush),
+                    materializationReceipt = this.normalizeMaterializationReceipt(manifest?.materializationReceipt);
+
+                return paths ? [repoSlug, {
+                    repoSlug,
+                    pathsAfterPush: paths,
+                    updatedAt     : manifest.updatedAt || 0,
+                    materializationReceipt
+                }] : null;
             })
             .filter(Boolean));
     }
@@ -734,7 +751,7 @@ class IngestionService extends Base {
      * @param {Object} data
      * @param {String} data.tenantId Tenant id.
      * @param {String} data.repoSlug Repo slug.
-     * @returns {Promise<{tenantId: String, repoSlug: String, source: String, pathsAfterPush: Array<String>, updatedAt: Number}>}
+     * @returns {Promise<{tenantId: String, repoSlug: String, source: String, pathsAfterPush: Array<String>, updatedAt: Number, materializationReceipt: Object|null}>}
      */
     async getTenantManifest({tenantId, repoSlug} = {}) {
         const {tenantId: resolvedTenant, repoSlug: resolvedRepo} = this.resolveTenantContext({tenantId, repoSlug});
@@ -742,11 +759,12 @@ class IngestionService extends Base {
         const manifest                                           = manifests[resolvedRepo];
 
         return {
-            tenantId      : resolvedTenant,
-            repoSlug      : resolvedRepo,
-            source        : manifest ? 'graph' : 'empty',
-            pathsAfterPush: manifest?.pathsAfterPush || [],
-            updatedAt     : manifest?.updatedAt || 0
+            tenantId              : resolvedTenant,
+            repoSlug              : resolvedRepo,
+            source                : manifest ? 'graph' : 'empty',
+            pathsAfterPush        : manifest?.pathsAfterPush || [],
+            updatedAt             : manifest?.updatedAt || 0,
+            materializationReceipt: manifest?.materializationReceipt || null
         };
     }
 
@@ -764,18 +782,23 @@ class IngestionService extends Base {
      * @param {String} data.tenantId Tenant id.
      * @param {String} data.repoSlug Repo slug.
      * @param {Array<String>} data.pathsAfterPush Post-push source-path set.
-     * @returns {Promise<{tenantId: String, repoSlug: String, pathsAfterPush: Array<String>, updatedAt: Number}|{error: String, code: String, message: String}>}
+     * @param {Object} [data.materializationReceipt] Optional pull-attempt proof. Omission clears stale proof.
+     * @returns {Promise<{tenantId: String, repoSlug: String, pathsAfterPush: Array<String>, updatedAt: Number, materializationReceipt: Object|null}|{error: String, code: String, message: String}>}
      */
-    async setTenantManifest({tenantId, repoSlug, pathsAfterPush} = {}) {
+    async setTenantManifest({tenantId, repoSlug, pathsAfterPush, materializationReceipt} = {}) {
         try {
-            const tenantContext = this.resolveTenantContext({tenantId, repoSlug}),
-                  paths         = this.normalizeManifestPaths(pathsAfterPush);
+            const
+                tenantContext = this.resolveTenantContext({tenantId, repoSlug}),
+                paths         = this.normalizeManifestPaths(pathsAfterPush),
+                receipt       = this.normalizeMaterializationReceipt(materializationReceipt);
 
-            if (!paths) {
+            if (!paths || (materializationReceipt != null && !receipt)) {
                 return {
                     error  : 'Tenant manifest write failed',
                     code   : 'KB_TENANT_MANIFEST_INVALID',
-                    message: '`pathsAfterPush` must be an array.'
+                    message: !paths
+                        ? '`pathsAfterPush` must be an array.'
+                        : '`materializationReceipt` has an invalid shape.'
                 };
             }
 
@@ -789,7 +812,8 @@ class IngestionService extends Base {
             manifests[tenantContext.repoSlug] = {
                 repoSlug      : tenantContext.repoSlug,
                 pathsAfterPush: paths,
-                updatedAt
+                updatedAt,
+                ...(receipt ? {materializationReceipt: receipt} : {})
             };
 
             await this.graphService.upsertNode({
@@ -803,7 +827,13 @@ class IngestionService extends Base {
                 }
             });
 
-            return {tenantId: tenantContext.tenantId, repoSlug: tenantContext.repoSlug, pathsAfterPush: paths, updatedAt};
+            return {
+                tenantId              : tenantContext.tenantId,
+                repoSlug              : tenantContext.repoSlug,
+                pathsAfterPush        : paths,
+                updatedAt,
+                materializationReceipt: receipt
+            };
         } catch (error) {
             return {
                 error  : 'Tenant manifest write failed',
@@ -819,17 +849,71 @@ class IngestionService extends Base {
      * @returns {Promise<void>}
      * @protected
      */
-    async persistManifestSnapshot({manifestSnapshot, tenantContext, summary}) {
+    async persistManifestSnapshot({
+        manifestSnapshot,
+        files,
+        headRevision,
+        materializationAttempt,
+        tenantContext,
+        summary
+    }) {
         const normalized = this.normalizeManifestSnapshot({manifestSnapshot, tenantContext});
 
         if (!normalized) {
             return;
         }
 
+        const attempt = this.normalizeMaterializationAttempt(materializationAttempt);
+
+        if (materializationAttempt != null && !attempt) {
+            summary.errors.push(this.createError({
+                code   : 'KB_TENANT_MATERIALIZATION_ATTEMPT_INVALID',
+                message: '`materializationAttempt` has an invalid shape.'
+            }));
+            return;
+        }
+
+        let receipt = null;
+
+        if (attempt) {
+            const
+                envelopeDigest = createTenantRepoMaterializationDigest({
+                    repoSlug        : normalized.repoSlug,
+                    headRevision,
+                    manifestSnapshot: normalized,
+                    files
+                }),
+                existing       = await this.getTenantManifest({
+                    tenantId: tenantContext.tenantId,
+                    repoSlug: normalized.repoSlug
+                }),
+                hasEffect      = summary.errors.length === 0
+                    && [summary.ingested, summary.deleted]
+                        .some(value => Number.isSafeInteger(value) && value > 0);
+
+            if (hasEffect) {
+                receipt = {
+                    attemptId            : attempt.attemptId,
+                    ingestContractVersion: attempt.ingestContractVersion,
+                    envelopeDigest,
+                    recordedAt           : Date.now()
+                };
+            } else if (
+                summary.errors.length === 0
+                && existing.materializationReceipt?.ingestContractVersion === attempt.ingestContractVersion
+                && existing.materializationReceipt.envelopeDigest === envelopeDigest
+            ) {
+                // Preserve a prior positive receipt so a crash or checkpoint-write
+                // failure after KB mutation can settle idempotently on the retry.
+                receipt = existing.materializationReceipt;
+            }
+        }
+
         const result = await this.setTenantManifest({
-            tenantId      : tenantContext.tenantId,
-            repoSlug      : normalized.repoSlug,
-            pathsAfterPush: normalized.pathsAfterPush
+            tenantId              : tenantContext.tenantId,
+            repoSlug              : normalized.repoSlug,
+            pathsAfterPush        : normalized.pathsAfterPush,
+            materializationReceipt: receipt
         });
 
         if (result?.error) {
@@ -837,7 +921,62 @@ class IngestionService extends Base {
                 code   : result.code,
                 message: result.message
             }));
+        } else if (result.materializationReceipt) {
+            summary.materializationReceipt = result.materializationReceipt;
         }
+    }
+
+    /**
+     * @summary Normalizes the opaque identity assigned by the pull orchestrator to one full attempt.
+     * @param {*} attempt Candidate attempt.
+     * @returns {{attemptId: String, ingestContractVersion: Number}|null}
+     * @protected
+     */
+    normalizeMaterializationAttempt(attempt) {
+        if (
+            !attempt
+            || typeof attempt !== 'object'
+            || Array.isArray(attempt)
+            || !MATERIALIZATION_ATTEMPT_ID_PATTERN.test(attempt.attemptId)
+            || !Number.isSafeInteger(attempt.ingestContractVersion)
+            || attempt.ingestContractVersion <= 0
+        ) {
+            return null;
+        }
+
+        return {
+            attemptId            : attempt.attemptId,
+            ingestContractVersion: attempt.ingestContractVersion
+        };
+    }
+
+    /**
+     * @summary Normalizes one durable positive-effect receipt from the tenant manifest graph.
+     * @param {*} receipt Candidate receipt.
+     * @returns {{attemptId: String, ingestContractVersion: Number, envelopeDigest: String, recordedAt: Number}|null}
+     * @protected
+     */
+    normalizeMaterializationReceipt(receipt) {
+        if (
+            !receipt
+            || typeof receipt !== 'object'
+            || Array.isArray(receipt)
+            || !MATERIALIZATION_ATTEMPT_ID_PATTERN.test(receipt.attemptId)
+            || !Number.isSafeInteger(receipt.ingestContractVersion)
+            || receipt.ingestContractVersion <= 0
+            || !MATERIALIZATION_DIGEST_PATTERN.test(receipt.envelopeDigest)
+            || !Number.isSafeInteger(receipt.recordedAt)
+            || receipt.recordedAt <= 0
+        ) {
+            return null;
+        }
+
+        return {
+            attemptId            : receipt.attemptId,
+            ingestContractVersion: receipt.ingestContractVersion,
+            envelopeDigest       : receipt.envelopeDigest,
+            recordedAt           : receipt.recordedAt
+        };
     }
 
     /**

--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -30,10 +30,12 @@ export {
  *
  * @see https://github.com/neomjs/neo/issues/11788
  * @see https://github.com/neomjs/neo/issues/11787
+ * @see https://github.com/neomjs/neo/issues/16045
  */
 
 const GIT_TERMINAL_PROMPT_DISABLED = '0';
 const ACCESS_PROBE_TIMEOUT_MS      = 15_000;
+const GIT_MAX_OUTPUT_BYTES         = 50 * 1024 * 1024;
 const CREDENTIAL_FINGERPRINT_KEY   = randomBytes(32);
 const ASKPASS_SCRIPT               = `#!/bin/sh
 case "$1" in
@@ -69,24 +71,42 @@ function createGitMirrorError(code, message, details = {}) {
     }
 
     if (details.cause) {
-        error.cause = details.cause;
+        const causeMessage = details.cause instanceof Error
+            ? details.cause.message
+            : String(details.cause);
+        const cause = new Error(redactTenantRepoSecrets(causeMessage, {secretHints}));
+
+        if (typeof details.cause.code === 'string' && /^[A-Z0-9_]+$/u.test(details.cause.code)) {
+            cause.code = details.cause.code;
+        }
+
+        error.cause = cause;
     }
 
     return error;
 }
 
 /**
- * @summary Returns a narrow subprocess environment instead of inheriting credential-bearing shell state.
- * @param {Object} overrides Git-specific environment overrides.
+ * @summary Returns a narrow subprocess environment rooted in a disposable home directory.
+ * @param {Object} options
+ * @param {String} options.homePath Disposable process home.
+ * @param {String} options.sshCommand Deterministic SSH command for this invocation.
+ * @param {Object} [options.overrides={}] Explicit credential-mode overrides.
  * @returns {Object}
  * @private
  */
-function createGitEnv(overrides = {}) {
+function createGitEnv({homePath, sshCommand, overrides = {}} = {}) {
     const env = {
-        GIT_TERMINAL_PROMPT: GIT_TERMINAL_PROMPT_DISABLED
+        GIT_CONFIG_GLOBAL  : path.join(homePath, '.gitconfig'),
+        GIT_CONFIG_NOSYSTEM: '1',
+        GIT_SSH_COMMAND    : sshCommand,
+        GIT_TERMINAL_PROMPT: GIT_TERMINAL_PROMPT_DISABLED,
+        HOME               : homePath,
+        USERPROFILE        : homePath,
+        XDG_CONFIG_HOME    : path.join(homePath, '.config')
     };
 
-    for (const key of ['PATH', 'HOME', 'TMPDIR', 'TEMP', 'SystemRoot', 'USERPROFILE']) {
+    for (const key of ['PATH', 'TMPDIR', 'TEMP', 'SystemRoot']) {
         if (process.env[key]) {
             env[key] = process.env[key];
         }
@@ -142,6 +162,44 @@ function shellQuote(value) {
 }
 
 /**
+ * @summary Builds an SSH command that cannot consult ambient config, agents, or default identities.
+ * @param {Object} options
+ * @param {String} options.homePath Disposable process home.
+ * @param {String} options.knownHostsPath GitMirror-owned persistent host-key ledger.
+ * @param {String} [options.identityPath] Explicit `ssh:` credential key.
+ * @returns {String}
+ * @private
+ */
+function createIsolatedSshCommand({homePath, knownHostsPath, identityPath} = {}) {
+    const sshDir = path.join(homePath, '.ssh');
+    const tokens = [
+        'ssh',
+        '-F',
+        shellQuote(path.join(sshDir, 'config')),
+        '-o',
+        'BatchMode=yes',
+        '-o',
+        'IdentitiesOnly=yes',
+        '-o',
+        'IdentityAgent=none',
+        '-o',
+        'IdentityFile=none',
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        '-o',
+        shellQuote(`UserKnownHostsFile=${knownHostsPath}`),
+        '-o',
+        'GlobalKnownHostsFile=none'
+    ];
+
+    if (identityPath) {
+        tokens.push('-i', shellQuote(identityPath));
+    }
+
+    return tokens.join(' ');
+}
+
+/**
  * @summary Builds the transient askpass environment for HTTPS git credentials.
  * @param {Object} options
  * @param {String} options.secret Resolved credential material.
@@ -150,21 +208,39 @@ function shellQuote(value) {
  * @private
  */
 async function createAskPassCredentialEnvironment({secret, username = 'x-access-token'} = {}) {
-    const askPassDir  = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-gitmirror-askpass-'));
-    const askPassPath = path.join(askPassDir, 'askpass.sh');
-    const gitUsername = username || 'x-access-token';
+    let askPassDir;
 
-    await fs.writeFile(askPassPath, ASKPASS_SCRIPT, {mode: 0o700});
+    try {
+        askPassDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-gitmirror-askpass-'));
 
-    return {
-        env: {
-            GIT_ASKPASS           : askPassPath,
-            NEO_GITMIRROR_PASSWORD: secret,
-            NEO_GITMIRROR_USERNAME: gitUsername
-        },
-        secretHints: [secret],
-        cleanup    : () => fs.remove(askPassDir)
-    };
+        const
+            askPassPath = path.join(askPassDir, 'askpass.sh'),
+            gitUsername = username || 'x-access-token';
+
+        await fs.writeFile(askPassPath, ASKPASS_SCRIPT, {mode: 0o700});
+
+        return {
+            env: {
+                GIT_ASKPASS           : askPassPath,
+                NEO_GITMIRROR_PASSWORD: secret,
+                NEO_GITMIRROR_USERNAME: gitUsername
+            },
+            secretHints: [secret, askPassDir],
+            cleanup    : () => fs.remove(askPassDir)
+        };
+    } catch {
+        if (askPassDir) {
+            try {
+                await fs.remove(askPassDir);
+            } catch {}
+        }
+
+        throw createGitMirrorError(
+            'KB_GITMIRROR_ENVIRONMENT_FAILED',
+            'GitMirror failed to prepare its isolated credential environment',
+            {secretHints: [secret, askPassDir]}
+        )
+    }
 }
 
 /**
@@ -217,7 +293,7 @@ async function resolveCredentialMaterial({credentialRef} = {}) {
             throw createGitMirrorError(
                 'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
                 'GitMirror file credentialRef could not be resolved',
-                {cause: error}
+                {cause: error, secretHints: [ref.filePath]}
             );
         }
 
@@ -245,7 +321,7 @@ async function resolveCredentialMaterial({credentialRef} = {}) {
             throw createGitMirrorError(
                 'KB_GITMIRROR_CREDENTIAL_REF_INVALID',
                 'GitMirror ssh credentialRef could not be resolved',
-                {cause: error}
+                {cause: error, secretHints: [ref.keyPath]}
             );
         }
 
@@ -271,10 +347,13 @@ async function resolveCredentialMaterial({credentialRef} = {}) {
 /**
  * @summary Builds transient Git environment overrides from already-validated credential material.
  * @param {Object} material Resolved credential material.
+ * @param {Object} options
+ * @param {String} options.homePath Disposable process home.
+ * @param {String} options.knownHostsPath GitMirror-owned persistent host-key ledger.
  * @returns {Promise<{env: Object, secretHints: String[], cleanup: Function}>}
  * @private
  */
-async function createCredentialEnvironment(material) {
+async function createCredentialEnvironment(material, {homePath, knownHostsPath} = {}) {
     const {ref, secret} = material;
 
     if (!ref || ref.type === 'none') {
@@ -287,19 +366,106 @@ async function createCredentialEnvironment(material) {
 
     return {
         env: {
-            GIT_SSH_COMMAND: [
-                'ssh',
-                '-i',
-                shellQuote(ref.keyPath),
-                '-o',
-                'IdentitiesOnly=yes',
-                '-o',
-                'StrictHostKeyChecking=accept-new'
-            ].join(' ')
+            GIT_SSH_COMMAND: createIsolatedSshCommand({
+                homePath,
+                knownHostsPath,
+                identityPath: ref.keyPath
+            })
         },
-        secretHints: [],
+        secretHints: [ref.keyPath],
         cleanup    : async () => {}
     };
+}
+
+/**
+ * @summary Creates and later removes one fully isolated Git subprocess environment.
+ * @param {Object} material Resolved credential material.
+ * @param {Object} options={}
+ * @param {String} [options.knownHostsPath] Durable GitMirror-owned host-key ledger.
+ * @returns {Promise<{env: Object, secretHints: String[], cleanup: Function}>}
+ * @private
+ */
+async function createGitExecutionEnvironment(material, {knownHostsPath} = {}) {
+    let homePath;
+    let credential;
+
+    try {
+        homePath = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-gitmirror-home-'));
+
+        const
+            sshDir                  = path.join(homePath, '.ssh'),
+            effectiveKnownHostsPath = knownHostsPath || path.join(sshDir, 'known_hosts');
+
+        await fs.ensureDir(sshDir);
+        await fs.ensureDir(path.dirname(effectiveKnownHostsPath));
+        await Promise.all([
+            fs.writeFile(path.join(homePath, '.gitconfig'), ''),
+            fs.writeFile(path.join(sshDir, 'config'), ''),
+            fs.ensureFile(effectiveKnownHostsPath)
+        ]);
+        await fs.chmod(effectiveKnownHostsPath, 0o600);
+
+        credential = await createCredentialEnvironment(material, {
+            homePath,
+            knownHostsPath: effectiveKnownHostsPath
+        });
+
+        return {
+            env: createGitEnv({
+                homePath,
+                sshCommand: createIsolatedSshCommand({
+                    homePath,
+                    knownHostsPath: effectiveKnownHostsPath
+                }),
+                overrides : credential.env
+            }),
+            secretHints: [
+                ...credential.secretHints,
+                homePath,
+                ...(knownHostsPath ? [knownHostsPath] : [])
+            ],
+            cleanup    : async () => {
+                const results = await Promise.allSettled([
+                    Promise.resolve().then(() => credential.cleanup()),
+                    Promise.resolve().then(() => fs.remove(homePath))
+                ]);
+
+                if (results.some(result => result.status === 'rejected')) {
+                    throw createGitMirrorError(
+                        'KB_GITMIRROR_CLEANUP_FAILED',
+                        'GitMirror failed to remove its isolated subprocess environment'
+                    )
+                }
+            }
+        };
+    } catch (error) {
+        try {
+            await credential?.cleanup?.();
+        } catch {}
+
+        if (homePath) {
+            try {
+                await fs.remove(homePath);
+            } catch {}
+        }
+
+        if (error.code?.startsWith?.('KB_GITMIRROR_')) {
+            throw error
+        }
+
+        throw createGitMirrorError(
+            'KB_GITMIRROR_ENVIRONMENT_FAILED',
+            'GitMirror failed to prepare its isolated subprocess environment',
+            {
+                secretHints: [
+                    homePath,
+                    knownHostsPath,
+                    material?.ref?.filePath,
+                    material?.ref?.keyPath
+                ]
+            }
+        )
+    }
 }
 
 /**
@@ -316,22 +482,31 @@ async function runGit(args, {
     credentialMaterial,
     failureCode = 'KB_GITMIRROR_GIT_FAILED',
     failureMessage = 'GitMirror git command failed',
+    knownHostsPath,
+    maxOutputBytes = GIT_MAX_OUTPUT_BYTES,
+    outputLimitCode = 'KB_GITMIRROR_OUTPUT_LIMIT',
+    outputLimitMessage = 'GitMirror git command exceeded its output limit',
     timeoutCode = 'KB_GITMIRROR_GIT_TIMEOUT',
     timeoutMessage = 'GitMirror git command timed out',
     timeoutMs = 0
 } = {}) {
-    const material   = credentialMaterial || await resolveCredentialMaterial({credentialRef});
-    const credential = await createCredentialEnvironment(material);
+    let execution;
+    let primaryError;
 
     try {
+        const material = credentialMaterial || await resolveCredentialMaterial({credentialRef});
+
+        execution = await createGitExecutionEnvironment(material, {knownHostsPath});
+
         const result = await new Promise((resolve, reject) => {
-            const child = spawn('git', args, {
+            const child = spawn('git', ['-c', 'credential.helper=', ...args], {
                 cwd,
-                env  : createGitEnv(credential.env),
+                env  : execution.env,
                 stdio: ['ignore', 'pipe', 'pipe']
             });
             let stdout = '';
             let stderr = '';
+            let outputBytes = 0;
             let settled = false;
             let timeoutId;
 
@@ -350,13 +525,40 @@ async function runGit(args, {
             };
             const resolveOnce = settle(resolve);
             const rejectOnce  = settle(reject);
+            const appendOutput = (current, data) => {
+                const nextBytes = Buffer.byteLength(data);
+
+                if (
+                    Number.isFinite(maxOutputBytes)
+                    && maxOutputBytes > 0
+                    && outputBytes + nextBytes > maxOutputBytes
+                ) {
+                    try {
+                        child.kill('SIGKILL');
+                    } catch {}
+
+                    rejectOnce(createGitMirrorError(outputLimitCode, outputLimitMessage, {
+                        secretHints: execution.secretHints
+                    }));
+
+                    return current;
+                }
+
+                outputBytes += nextBytes;
+
+                return current + data;
+            };
 
             child.stdout.on('data', data => {
-                stdout += data;
+                if (!settled) {
+                    stdout = appendOutput(stdout, data);
+                }
             });
 
             child.stderr.on('data', data => {
-                stderr += data;
+                if (!settled) {
+                    stderr = appendOutput(stderr, data);
+                }
             });
 
             child.on('error', rejectOnce);
@@ -369,7 +571,7 @@ async function runGit(args, {
                     } catch {}
 
                     rejectOnce(createGitMirrorError(timeoutCode, timeoutMessage, {
-                        secretHints: credential.secretHints
+                        secretHints: execution.secretHints
                     }));
                 }, timeoutMs);
             }
@@ -378,26 +580,39 @@ async function runGit(args, {
         if (!acceptedExitCodes.includes(result.exitCode)) {
             throw createGitMirrorError(failureCode, failureMessage, {
                 ...result,
-                secretHints: credential.secretHints
+                secretHints: execution.secretHints
             });
         }
 
         return {
             exitCode: result.exitCode,
-            stdout  : redactTenantRepoSecrets(result.stdout, {secretHints: credential.secretHints}),
-            stderr  : redactTenantRepoSecrets(result.stderr, {secretHints: credential.secretHints})
+            stdout  : redactTenantRepoSecrets(result.stdout, {secretHints: execution.secretHints}),
+            stderr  : redactTenantRepoSecrets(result.stderr, {secretHints: execution.secretHints})
         };
     } catch (error) {
-        if (error.code?.startsWith?.('KB_GITMIRROR_')) {
-            throw error;
-        }
+        primaryError = error.code?.startsWith?.('KB_GITMIRROR_')
+            ? error
+            : createGitMirrorError(failureCode, failureMessage, {
+                cause      : error,
+                secretHints: execution?.secretHints || []
+            });
 
-        throw createGitMirrorError(failureCode, failureMessage, {
-            cause      : error,
-            secretHints: credential.secretHints
-        });
+        throw primaryError
     } finally {
-        await credential.cleanup();
+        if (execution) {
+            try {
+                await execution.cleanup();
+            } catch (cleanupError) {
+                if (!primaryError) {
+                    throw cleanupError.code?.startsWith?.('KB_GITMIRROR_')
+                        ? cleanupError
+                        : createGitMirrorError(
+                            'KB_GITMIRROR_CLEANUP_FAILED',
+                            'GitMirror failed to remove its isolated subprocess environment'
+                        )
+                }
+            }
+        }
     }
 }
 
@@ -472,6 +687,7 @@ export async function inspectCredentialReadiness({credentialRef} = {}) {
  * @param {String} options.cloneUrl Clean repository URL.
  * @param {String|Object|null} options.credentialRef Durable credential reference.
  * @param {String} [options.ref='HEAD'] Configured branch, tag, or ref.
+ * @param {String} [options.mirrorRoot] Durable mirror root for SSH host-key continuity.
  * @param {Number} [options.timeoutMs=15000] Positive subprocess deadline.
  * @returns {Promise<{status: String, code: String, checkedAt: String, cacheFingerprint: String|null}>}
  */
@@ -479,6 +695,7 @@ export async function probeRemoteAccess({
     cloneUrl,
     credentialRef,
     ref = 'HEAD',
+    mirrorRoot,
     timeoutMs = ACCESS_PROBE_TIMEOUT_MS
 } = {}) {
     const checkedAt = new Date().toISOString();
@@ -525,6 +742,7 @@ export async function probeRemoteAccess({
             credentialMaterial: material,
             failureCode      : 'KB_GITMIRROR_ACCESS_PROBE_FAILED',
             failureMessage   : 'GitMirror repository access probe failed',
+            ...(mirrorRoot ? {knownHostsPath: getKnownHostsPath(mirrorRoot)} : {}),
             timeoutCode      : 'KB_GITMIRROR_ACCESS_PROBE_TIMEOUT',
             timeoutMessage   : 'GitMirror repository access probe timed out',
             timeoutMs        : effectiveTimeoutMs
@@ -590,6 +808,16 @@ function getMirrorPath({mirrorRoot, tenantId, repoSlug} = {}) {
             {cause: error}
         );
     }
+}
+
+/**
+ * @summary Returns the durable GitMirror-owned SSH host-key ledger beside mirror data.
+ * @param {String} mirrorRoot Root directory for tenant repo mirrors.
+ * @returns {String}
+ * @private
+ */
+function getKnownHostsPath(mirrorRoot) {
+    return path.join(path.resolve(mirrorRoot), '.gitmirror-ssh', 'known_hosts');
 }
 
 /**
@@ -705,7 +933,8 @@ export async function cloneIfMissing({mirrorRoot, tenantId, repoSlug, cloneUrl, 
     await runGit(['clone', '--mirror', cleanCloneUrl, mirrorPath], {
         credentialRef,
         failureCode   : 'KB_GITMIRROR_CLONE_FAILED',
-        failureMessage: 'GitMirror clone failed'
+        failureMessage: 'GitMirror clone failed',
+        knownHostsPath: getKnownHostsPath(mirrorRoot)
     });
 
     return {mirrorPath, cloned: true};
@@ -727,7 +956,8 @@ export async function fetch({mirrorRoot, tenantId, repoSlug, credentialRef} = {}
         cwd           : mirrorPath,
         credentialRef,
         failureCode   : 'KB_GITMIRROR_FETCH_FAILED',
-        failureMessage: 'GitMirror fetch failed'
+        failureMessage: 'GitMirror fetch failed',
+        knownHostsPath: getKnownHostsPath(mirrorRoot)
     });
 
     const after = await listRefs(mirrorPath);
@@ -847,13 +1077,65 @@ export async function diffRevisions({mirrorRoot, tenantId, repoSlug, baseRevisio
     };
 }
 
+/**
+ * @summary Lists all repo-relative paths present at one mirror revision.
+ * @param {Object} options
+ * @param {String} options.mirrorRoot Root directory for tenant repo mirrors.
+ * @param {String} options.tenantId Tenant id.
+ * @param {String} options.repoSlug Repository slug.
+ * @param {String} options.revision Resolved revision.
+ * @returns {Promise<Array<String>>}
+ */
+export async function listRevisionPaths({mirrorRoot, tenantId, repoSlug, revision} = {}) {
+    const mirrorPath = getMirrorPath({mirrorRoot, tenantId, repoSlug});
+
+    const result = await runGit(['ls-tree', '-r', '-z', '--name-only', revision], {
+        cwd           : mirrorPath,
+        failureCode   : 'KB_GITMIRROR_LIST_FAILED',
+        failureMessage: 'GitMirror failed to list revision paths'
+    });
+
+    return result.stdout.split('\0').filter(Boolean).sort();
+}
+
+/**
+ * @summary Reads one text file from a mirror revision.
+ * @param {Object} options
+ * @param {String} options.mirrorRoot Root directory for tenant repo mirrors.
+ * @param {String} options.tenantId Tenant id.
+ * @param {String} options.repoSlug Repository slug.
+ * @param {String} options.revision Resolved revision.
+ * @param {String} options.sourcePath Repo-relative source path.
+ * @returns {Promise<String>}
+ */
+export async function readRevisionFile({mirrorRoot, tenantId, repoSlug, revision, sourcePath} = {}) {
+    if (!sourcePath || sourcePath.includes('\0')) {
+        throw createGitMirrorError(
+            'KB_GITMIRROR_PATH_INVALID',
+            'GitMirror received an invalid sourcePath'
+        );
+    }
+
+    const mirrorPath = getMirrorPath({mirrorRoot, tenantId, repoSlug});
+
+    const result = await runGit(['show', `${revision}:${sourcePath}`], {
+        cwd           : mirrorPath,
+        failureCode   : 'KB_GITMIRROR_FILE_READ_FAILED',
+        failureMessage: 'GitMirror failed to read a revision file'
+    });
+
+    return result.stdout;
+}
+
 const GitMirror = {
     cloneIfMissing,
     diffRevisions,
     fetch,
     inspectCredentialReadiness,
     isAncestor,
+    listRevisionPaths,
     probeRemoteAccess,
+    readRevisionFile,
     resolveHead
 };
 

--- a/ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs
@@ -9,11 +9,13 @@ import path from 'path';
  * injected later by the Git mirror worker, not stored in the Knowledge Base config node.
  *
  * @see https://github.com/neomjs/neo/issues/11787
+ * @see https://github.com/neomjs/neo/issues/16045
  */
 
 const URL_WITH_USERINFO_RE   = /^[a-z][a-z0-9+.-]*:\/\/[^/\s@]+@/iu;
 const SCP_LIKE_USERINFO_RE   = /^[^/\s@:]+@[^/\s@:]+:/u;
 const ENV_CREDENTIAL_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+const SSH_USERNAME_RE        = /^[A-Za-z0-9._-]+$/u;
 const SECRET_REPLACEMENT     = '[REDACTED]';
 
 export const TenantRepoAccessStatus = Object.freeze({
@@ -141,6 +143,29 @@ export function hasCloneUrlUserInfo(cloneUrl) {
 }
 
 /**
+ * @summary Returns true only for a non-secret SSH login name in a clone endpoint.
+ * @param {String} cloneUrl Candidate clone URL.
+ * @returns {Boolean}
+ * @private
+ */
+function hasCleanSshUsername(cloneUrl) {
+    const value = String(cloneUrl || '').trim();
+
+    try {
+        const url      = new URL(value);
+        const username = decodeURIComponent(url.username);
+
+        return url.protocol === 'ssh:'
+            && !url.password
+            && SSH_USERNAME_RE.test(username);
+    } catch {
+        const match = value.match(/^([^/\s@:]+)@([^/\s@:]+):(.+)$/u);
+
+        return Boolean(match && SSH_USERNAME_RE.test(match[1]));
+    }
+}
+
+/**
  * @summary Throws when a clone URL contains credential-shaped material.
  * @param {String} cloneUrl Candidate clone URL.
  * @returns {String} Trimmed clone URL.
@@ -155,7 +180,7 @@ export function assertCleanCloneUrl(cloneUrl) {
         );
     }
 
-    if (hasCloneUrlUserInfo(value)) {
+    if (hasCloneUrlUserInfo(value) && !hasCleanSshUsername(value)) {
         throw createContractError(
             'KB_TENANT_REPO_CLONE_URL_CREDENTIALS',
             'Tenant repo cloneUrl must not embed userinfo or credentials'
@@ -194,7 +219,7 @@ export function deriveRepoSlugFromCloneUrl(cloneUrl) {
 
         return normalizeRepoSlug(`${url.hostname}/${stripRepoSuffix(url.pathname)}`);
     } catch (error) {
-        const scpLike = value.match(/^([^/\s@:]+):(.+)$/u);
+        const scpLike = value.match(/^(?:[^/\s@:]+@)?([^/\s@:]+):(.+)$/u);
 
         if (scpLike) {
             return normalizeRepoSlug(`${scpLike[1]}/${stripRepoSuffix(scpLike[2])}`);

--- a/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
@@ -101,7 +101,17 @@ export function createTenantRepoMaterializationDigest({
                 parserId     : typeof file.parserId === 'string' ? file.parserId : null,
                 parserVersion: typeof file.parserVersion === 'string' ? file.parserVersion : null
             }))
-            .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+            .sort((left, right) => {
+                const
+                    leftKey  = JSON.stringify(left),
+                    rightKey = JSON.stringify(right);
+
+                if (leftKey === rightKey) {
+                    return 0;
+                }
+
+                return leftKey < rightKey ? -1 : 1;
+            });
 
     return createHash('sha256')
         .update(JSON.stringify({

--- a/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
@@ -1,6 +1,5 @@
-import {execFile}  from 'child_process';
-import fs          from 'fs-extra';
-import {promisify} from 'util';
+import {createHash} from 'node:crypto';
+import fs           from 'fs-extra';
 
 import GitMirror from './gitMirror.mjs';
 import {
@@ -9,20 +8,18 @@ import {
     redactTenantRepoSecrets
 } from './tenantRepoAccessContract.mjs';
 
-const execFileAsync = promisify(execFile);
-const GIT_MAX_BUFFER = 50 * 1024 * 1024;
-
 /**
  * @summary Builds `KnowledgeBaseIngestionService.ingestSourceFiles()` envelopes from tenant Git mirrors.
  *
- * `TenantRepoIngestEnvelopeBuilder` is the #11789 adapter between the low-level
- * persistent mirror primitive (#11788) and the tenant KB ingestion payload contract.
+ * `TenantRepoIngestEnvelopeBuilder` is the adapter between the low-level
+ * persistent mirror primitive and the tenant KB ingestion payload contract.
  * Linear history advances emit bounded raw-file deltas plus tombstones; bootstrap,
  * missing-baseline, and force-push cases fall back to a full manifest-carrying
  * snapshot so the ingestion service can reconcile the claimed live path set without
  * relying on a stale revision boundary.
  *
  * @see https://github.com/neomjs/neo/issues/11789
+ * @see https://github.com/neomjs/neo/issues/16045
  * @see ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
  */
 
@@ -59,6 +56,65 @@ function createIngestEnvelopeError(code, message, details = {}) {
 }
 
 /**
+ * @summary Creates the bounded identity digest for one manifest-bearing pull materialization.
+ *
+ * The Git head binds source bytes while the manifest and parser bindings distinguish
+ * the corpus/parser shape being materialized. The digest intentionally excludes
+ * credential and filesystem data so it is safe to persist in the shared manifest graph.
+ *
+ * @param {Object} envelope Manifest-bearing tenant-repo ingestion envelope.
+ * @returns {String} Lowercase SHA-256 digest.
+ */
+export function createTenantRepoMaterializationDigest({
+    repoSlug,
+    headRevision,
+    manifestSnapshot,
+    files = []
+} = {}) {
+    const
+        normalizedRepoSlug = normalizeRepoSlug(manifestSnapshot?.repoSlug || repoSlug),
+        normalizedHead     = typeof headRevision === 'string' ? headRevision.trim() : '';
+
+    if (!normalizedHead) {
+        throw createIngestEnvelopeError(
+            'KB_INGEST_ENVELOPE_REF_NOT_FOUND',
+            'Tenant repo materialization identity requires a head revision'
+        );
+    }
+
+    if (!Array.isArray(manifestSnapshot?.pathsAfterPush)) {
+        throw createIngestEnvelopeError(
+            'KB_INGEST_ENVELOPE_MANIFEST_INVALID',
+            'Tenant repo materialization identity requires manifestSnapshot.pathsAfterPush'
+        );
+    }
+
+    const
+        pathsAfterPush = [...new Set(manifestSnapshot.pathsAfterPush
+            .filter(sourcePath => typeof sourcePath === 'string' && sourcePath.length > 0))]
+            .sort(),
+        parserBindings = (Array.isArray(files) ? files : [])
+            .filter(file => typeof file?.sourcePath === 'string' && file.sourcePath.length > 0)
+            .map(file => ({
+                sourcePath   : file.sourcePath,
+                rootKind     : typeof file.rootKind === 'string' ? file.rootKind : null,
+                parserId     : typeof file.parserId === 'string' ? file.parserId : null,
+                parserVersion: typeof file.parserVersion === 'string' ? file.parserVersion : null
+            }))
+            .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+
+    return createHash('sha256')
+        .update(JSON.stringify({
+            formatVersion: 1,
+            repoSlug     : normalizedRepoSlug,
+            headRevision : normalizedHead,
+            pathsAfterPush,
+            parserBindings
+        }))
+        .digest('hex');
+}
+
+/**
  * @summary Returns the mirror path while converting contract errors into builder errors.
  * @param {Object} options
  * @returns {String}
@@ -73,35 +129,6 @@ function getMirrorPath({mirrorRoot, tenantId, repoSlug} = {}) {
             error.message,
             {cause: error}
         );
-    }
-}
-
-/**
- * @summary Runs read-only git commands against an existing bare mirror.
- * @param {String} mirrorPath Local mirror path.
- * @param {String[]} args Git arguments.
- * @param {Object} options={}
- * @returns {Promise<String>}
- * @private
- */
-async function runMirrorGit(mirrorPath, args, {
-    failureCode = 'KB_INGEST_ENVELOPE_GIT_FAILED',
-    failureMessage = 'Tenant repo ingest envelope git command failed'
-} = {}) {
-    try {
-        const {stdout} = await execFileAsync('git', args, {
-            cwd      : mirrorPath,
-            maxBuffer: GIT_MAX_BUFFER
-        });
-
-        return stdout;
-    } catch (error) {
-        throw createIngestEnvelopeError(failureCode, failureMessage, {
-            cause   : error,
-            exitCode: error.code,
-            stdout  : error.stdout,
-            stderr  : error.stderr
-        });
     }
 }
 
@@ -140,29 +167,40 @@ async function resolveRevision({gitMirror, identity, ref, fallbackToFull = false
 /**
  * @summary Lists all repo-relative paths present at a revision.
  * @param {Object} options
+ * @param {Object} options.gitMirror GitMirror-compatible primitive.
+ * @param {Object} options.identity Tenant-repo mirror identity.
+ * @param {String} options.revision Resolved revision.
  * @returns {Promise<Array<String>>}
  * @private
  */
-async function listRevisionPaths({mirrorPath, revision}) {
-    const stdout = await runMirrorGit(
-        mirrorPath,
-        ['ls-tree', '-r', '-z', '--name-only', revision],
-        {
-            failureCode   : 'KB_INGEST_ENVELOPE_LIST_FAILED',
-            failureMessage: 'Tenant repo ingest envelope failed to list revision paths'
-        }
-    );
-
-    return stdout.split('\0').filter(Boolean).sort();
+async function listRevisionPaths({gitMirror, identity, revision}) {
+    try {
+        return await gitMirror.listRevisionPaths({...identity, revision});
+    } catch (error) {
+        throw createIngestEnvelopeError(
+            'KB_INGEST_ENVELOPE_LIST_FAILED',
+            'Tenant repo ingest envelope failed to list revision paths',
+            {
+                cause   : error,
+                exitCode: error.exitCode,
+                stdout  : error.stdout,
+                stderr  : error.stderr
+            }
+        );
+    }
 }
 
 /**
  * @summary Reads one text file from a revision.
  * @param {Object} options
+ * @param {Object} options.gitMirror GitMirror-compatible primitive.
+ * @param {Object} options.identity Tenant-repo mirror identity.
+ * @param {String} options.revision Resolved revision.
+ * @param {String} options.sourcePath Repo-relative source path.
  * @returns {Promise<String>}
  * @private
  */
-async function readRevisionFile({mirrorPath, revision, sourcePath}) {
+async function readRevisionFile({gitMirror, identity, revision, sourcePath}) {
     if (!sourcePath || sourcePath.includes('\0')) {
         throw createIngestEnvelopeError(
             'KB_INGEST_ENVELOPE_PATH_INVALID',
@@ -170,14 +208,20 @@ async function readRevisionFile({mirrorPath, revision, sourcePath}) {
         );
     }
 
-    return await runMirrorGit(
-        mirrorPath,
-        ['show', `${revision}:${sourcePath}`],
-        {
-            failureCode   : 'KB_INGEST_ENVELOPE_FILE_READ_FAILED',
-            failureMessage: `Tenant repo ingest envelope failed to read '${sourcePath}'`
-        }
-    );
+    try {
+        return await gitMirror.readRevisionFile({...identity, revision, sourcePath});
+    } catch (error) {
+        throw createIngestEnvelopeError(
+            'KB_INGEST_ENVELOPE_FILE_READ_FAILED',
+            `Tenant repo ingest envelope failed to read '${sourcePath}'`,
+            {
+                cause   : error,
+                exitCode: error.exitCode,
+                stdout  : error.stdout,
+                stderr  : error.stderr
+            }
+        );
+    }
 }
 
 /**
@@ -186,15 +230,15 @@ async function readRevisionFile({mirrorPath, revision, sourcePath}) {
  * @returns {Promise<Array<Object>>}
  * @private
  */
-async function buildFilePayloads({mirrorPath, revision, paths, repoSlug, rootKind, parserId, parserVersion}) {
+async function buildFilePayloads({gitMirror, identity, revision, paths, rootKind, parserId, parserVersion}) {
     const files = [];
 
     for (const sourcePath of paths) {
         files.push({
             sourcePath,
-            repoSlug,
+            repoSlug: identity.repoSlug,
             rootKind,
-            content: await readRevisionFile({mirrorPath, revision, sourcePath}),
+            content : await readRevisionFile({gitMirror, identity, revision, sourcePath}),
             ...(parserId ? {parserId} : {}),
             ...(parserVersion ? {parserVersion} : {})
         });
@@ -209,21 +253,21 @@ async function buildFilePayloads({mirrorPath, revision, paths, repoSlug, rootKin
  * @returns {Promise<Object>}
  * @private
  */
-async function buildFullEnvelope({identity, mirrorPath, headRevision, rootKind, parserId, parserVersion}) {
-    const paths = await listRevisionPaths({mirrorPath, revision: headRevision});
+async function buildFullEnvelope({gitMirror, identity, headRevision, rootKind, parserId, parserVersion}) {
+    const paths = await listRevisionPaths({gitMirror, identity, revision: headRevision});
     const files = await buildFilePayloads({
-        mirrorPath,
+        gitMirror,
+        identity,
         revision: headRevision,
         paths,
-        repoSlug: identity.repoSlug,
         rootKind,
         parserId,
         parserVersion
     });
 
     return {
-        tenantId: identity.tenantId,
-        repoSlug : identity.repoSlug,
+        tenantId        : identity.tenantId,
+        repoSlug        : identity.repoSlug,
         files,
         headRevision,
         manifestSnapshot: {
@@ -281,7 +325,7 @@ export async function buildIngestEnvelope({
     });
 
     if (!baseRevision) {
-        return await buildFullEnvelope({identity, mirrorPath, headRevision, rootKind, parserId, parserVersion});
+        return await buildFullEnvelope({gitMirror, identity, headRevision, rootKind, parserId, parserVersion});
     }
 
     const linear = await gitMirror.isAncestor({
@@ -291,7 +335,7 @@ export async function buildIngestEnvelope({
     });
 
     if (!linear) {
-        return await buildFullEnvelope({identity, mirrorPath, headRevision, rootKind, parserId, parserVersion});
+        return await buildFullEnvelope({gitMirror, identity, headRevision, rootKind, parserId, parserVersion});
     }
 
     const diff = await gitMirror.diffRevisions({
@@ -303,12 +347,12 @@ export async function buildIngestEnvelope({
 
     return {
         tenantId: identity.tenantId,
-        repoSlug : identity.repoSlug,
-        files: await buildFilePayloads({
-            mirrorPath,
+        repoSlug: identity.repoSlug,
+        files   : await buildFilePayloads({
+            gitMirror,
+            identity,
             revision: headRevision,
             paths,
-            repoSlug: identity.repoSlug,
             rootKind,
             parserId,
             parserVersion
@@ -322,7 +366,8 @@ export async function buildIngestEnvelope({
 }
 
 const TenantRepoIngestEnvelopeBuilder = {
-    buildIngestEnvelope
+    buildIngestEnvelope,
+    createTenantRepoMaterializationDigest
 };
 
 export default TenantRepoIngestEnvelopeBuilder;

--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -111,7 +111,7 @@ tenants:
     customParsers: [...]
     sourcePaths: {...}
     tenantRepos:
-      - cloneUrl: https://github.com/neomjs/create-app.git  # clean URL; no userinfo@
+      - cloneUrl: https://github.com/neomjs/create-app.git  # SSH may carry a non-secret login name
         credentialRef: env:GIT_TOKEN                          # reference-only pointer; token lives outside the repo
         branchRef: dev                                        # optional; defaults to 'HEAD' = remote default branch
 ```
@@ -123,6 +123,9 @@ legacy bare environment-variable name). The object equivalents use `type: none|e
 with `name`, `filePath`, or `keyPath`; `env` and `file` may also specify a non-empty
 `username`. An unknown scheme such as `helper:*` is rejected during effective-config
 resolution instead of being reinterpreted as an environment-variable name.
+`none` is anonymous and never inherits host-user Git/SSH authority. For `ssh:`, put the
+non-secret remote login name in the clean endpoint (`ssh://git@host/org/repo.git` or
+`git@host:org/repo.git`); passwords and tokens remain forbidden in `cloneUrl`.
 
 The YAML is bootstrap-only — the graph node is canonical once written. Runtime resolution stays
 fail-soft: a missing, empty, unreadable, malformed, or invalid-shape file cannot block a valid graph

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -67,7 +67,8 @@ The push-based MVP path is credential-free from the KB server's perspective:
 - The tenant push client reads local files and sends content or parsed chunks.
 - The KB server receives ingestion payloads, not Git credentials.
 - The repo-push automation identity token authorizes the tenant to call the KB MCP endpoint; it is not a Git credential and is never folded into `repoSlug`, manifests, or chunk metadata.
-- Optional server-side pull config uses `tenantRepos[]` entries with clean `cloneUrl`, reference-only `credentialRef`, and normalized `repoSlug` (#11787). Credential-bearing `userinfo@` clone URLs are rejected before graph persistence; credential injection belongs to the `GitMirror` primitive (#11788). `GitMirror` resolves the credential reference only for the git subprocess invocation (`GIT_ASKPASS` for HTTPS, `GIT_SSH_COMMAND` for SSH) and keeps mirror contents on the deployment `tenant-repo-mirrors` volume mounted at `NEO_TENANT_REPO_MIRROR_ROOT`.
+- Optional server-side pull config uses `tenantRepos[]` entries with clean `cloneUrl`, reference-only `credentialRef`, and normalized `repoSlug` (#11787). Credential-bearing HTTP userinfo is rejected before graph persistence; a non-secret SSH login name (`ssh://git@host/...` or `git@host:path`) remains endpoint metadata, while key injection belongs to the `GitMirror` primitive (#11788). `GitMirror` resolves the credential reference only for the git subprocess invocation (`GIT_ASKPASS` for HTTPS, `GIT_SSH_COMMAND` for SSH) and keeps mirror contents on the deployment `tenant-repo-mirrors` volume mounted at `NEO_TENANT_REPO_MIRROR_ROOT`.
+- `credentialRef: none` means anonymous access, never “inherit the orchestrator account.” Every pull-path Git subprocess ignores system/global Git config, URL rewrites, credential helpers, `.netrc`, user SSH config, agents, and default identities; the selected `env`, `file`, or `ssh` authority is added back explicitly. SSH host-key continuity is kept separately in the GitMirror-owned mirror-volume ledger rather than in the host user's home.
 - For the pull-based follow-up path, `TenantRepoIngestEnvelopeBuilder` adapts the Git mirror into the same ingestion service envelope (#11789). Linear history advances emit raw-file `files`, explicit `deleted` tombstones, `baseRevision`, and `headRevision`; bootstrap, missing-baseline, and non-linear history cases emit a full `files` snapshot plus `manifestSnapshot` so `KnowledgeBaseIngestionService.ingestSourceFiles()` can reconcile the claimed live file set without re-pointing the local `kbSync` lane.
 - Pull-mode **file selection** comes from the git mirror itself (`git ls-tree` / revision diff in `TenantRepoIngestEnvelopeBuilder`) and is independent of `kb-config.yaml`'s Source/Parser registration. In particular, `sourcePaths.RawRepoSource.root` is **not** honored on the pull path — the whole tracked tree is ingested. `rawRepoSource` / `sourcePaths` drive the full-corpus Source build (`kbSync` lane / `npm run ai:sync-kb`), a different path from pull mode.
 
@@ -193,7 +194,7 @@ The orchestrator's pull-mode sync (`TenantRepoSyncService.resolveTenantReposConf
 {
     tenantId      : 'neomjs',                           // server-derived; must match the authenticated tenant for stamping
     repoSlug      : 'neomjs/create-app',                // tenant-owned, namespaced, never credential-bearing
-    cloneUrl      : 'https://github.com/neomjs/create-app.git',  // clean URL; no userinfo@
+    cloneUrl      : 'https://github.com/neomjs/create-app.git',  // clean URL; SSH may carry a non-secret login name
     credentialRef : 'file:/run/secrets/neomjs_repo_token', // env:VAR and ssh:/path remain supported
     branchRef     : 'dev',                              // optional; git ref (branch/tag/sha) to ingest from. Default: 'HEAD' = remote default branch
     rootKind      : 'external-source',                  // 'neo-workspace' | 'bare-repo' | 'external-source'
@@ -202,7 +203,7 @@ The orchestrator's pull-mode sync (`TenantRepoSyncService.resolveTenantReposConf
 }
 ```
 
-**Credential-bearing `cloneUrl` strings (`https://user:token@...`) are rejected at config normalization.** The `credentialRef` is a reference that uses one shared grammar: `none`, `env:NAME`, `file:/path`, or `ssh:/path` (a legacy bare environment-variable name remains accepted). The same normalized grammar feeds `GitMirror`; unknown schemes such as `helper:*` fail during effective-config resolution rather than becoming delayed environment lookups. `GitMirror` resolves credential material only at its local validation or git-subprocess boundary (`GIT_ASKPASS` for HTTPS, `GIT_SSH_COMMAND` for SSH). The deployment graph never persists resolved credentials.
+**Credential-bearing `cloneUrl` strings (`https://user:token@...`) are rejected at config normalization.** A clean SSH login name is not credential material and may remain in the endpoint (`ssh://git@host/org/repo.git` or `git@host:org/repo.git`); this keeps the remote user deterministic after ambient SSH config is removed. The `credentialRef` is a reference that uses one shared grammar: `none`, `env:NAME`, `file:/path`, or `ssh:/path` (a legacy bare environment-variable name remains accepted). The same normalized grammar feeds `GitMirror`; unknown schemes such as `helper:*` fail during effective-config resolution rather than becoming delayed environment lookups. `none` is deliberately anonymous. `GitMirror` resolves explicit credential material only at its local validation or isolated git-subprocess boundary (`GIT_ASKPASS` for HTTPS, `GIT_SSH_COMMAND` for SSH). The deployment graph never persists resolved credentials.
 
 Use `file:/run/secrets/<name>` when the deployment mounts Git credentials through Docker `secrets:` or a Kubernetes Secret volume. `GitMirror` reads and trims the file at resolution time, then feeds the value through the same transient `GIT_ASKPASS` path as `env:` credentials; empty, missing, or unreadable files fail before git runs. `ssh:` references likewise require a present, readable, non-empty key before Git constructs `GIT_SSH_COMMAND`.
 
@@ -267,7 +268,7 @@ Exit code: `0` on `completed`, `1` on `failed` or `skipped` (no-tenant-repos-con
 
 The env var names the **parent** of `tenant-repos/`; `deriveTenantRepoMirrorPath` appends the `tenant-repos/<tenant>/<repo>` segment so the same root can host other gitignored substrate-data subdirs. Per-repo `tenantRepos[].mirrorRoot` overrides this Tier-1 default when present.
 
-The mirror directory is a deployment cache, not authoritative state. Per-repo `lastIngestedRev` is stored separately in `<orchestrator-data-dir>/tenant-repo-sync-revisions.json` (sibling to the orchestrator state file) so the next sync can compute the incremental diff.
+The repository mirrors are deployment caches, not authoritative corpus state. The same durable volume also carries `.gitmirror-ssh/known_hosts`, GitMirror's isolated SSH host-key ledger; probe, clone, and fetch share it so `accept-new` remains TOFU rather than accepting a new key on every process. Per-repo `lastIngestedRev` is stored separately in `<orchestrator-data-dir>/tenant-repo-sync-revisions.json` (sibling to the orchestrator state file) so the next sync can compute the incremental diff.
 
 Two invariants protect that manifest. First, every sync — the daemon's periodic
 sweep and the manual CLI alike — must acquire the dedicated cross-process lease
@@ -298,10 +299,28 @@ every repo's checkpoint and backoff state untouched, and never commits a
 partial sweep.
 
 Each checkpoint also carries `ingestContractVersion`, written together with the
-head only after the Knowledge Base returns an explicit error-free summary, and
-`lastAttemptedIngestContractVersion`, which records a failed revalidation
-attempt without advancing the head. A head without the current success marker
-has unknown historical validity and is never used as an incremental base.
+head only after the Knowledge Base returns an explicit error-free summary. The
+current v2 contract makes every manifest-bearing full materialization
+(bootstrap, non-linear fallback, manual full replay, or legacy revalidation)
+write an attempt-bound positive-effect receipt into the tenant manifest graph
+before the local checkpoint acknowledges that attempt id. A fresh full attempt
+must report a positive safe-integer `ingested` or `deleted` effect. The check
+runs after ingestion so an empty manifest can still delete stale rows; a
+delete-only full reconciliation is valid.
+
+If the Knowledge Base effect and graph receipt succeeded but the later local
+checkpoint write crashed, the next run settles the matching unacknowledged
+receipt before re-running Knowledge Base mutation. Its bookkeeping result is
+therefore `ingested=0, deleted=0`. Once a checkpoint acknowledges the attempt
+id, that receipt is stale and cannot excuse a later manual full replay at the
+same head. The receipt field is pull-internal: the public `ingest_source_files`
+facade strips caller-supplied attempts and never returns graph receipts. A
+current incremental envelope may legitimately report `ingested=0, deleted=0`.
+`lastAttemptedIngestContractVersion` records a failed revalidation attempt
+without advancing the head. A head without the current v2 success marker has
+unknown historical validity and is never used as an incremental base; v1
+checkpoints therefore receive the same bounded null-base revalidation as older
+unversioned records.
 
 After an upgrade, the periodic lane automatically replays such legacy
 checkpoints from a null base. It admits at most `concurrencyLimit` legacy
@@ -386,8 +405,9 @@ Per-repo failures carry a stable `lastErrorCode` field on the health payload; op
 | Code | Where it surfaces | Trigger |
 |---|---|---|
 | `KB_TENANT_REPO_SYNC_SYNC_FAILED` | per-repo `lastErrorCode` | Underlying clone/fetch/envelope/ingest failure (wraps the original error after secret redaction at the GitMirror boundary) |
+| `KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION` | per-repo `lastErrorCode` | A manifest-bearing full materialization returned an error-free summary but proved neither a fresh positive ingest/delete effect nor a matching unacknowledged retry receipt. The previous checkpoint is retained. |
 | `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` | outer `details.reasonCode` | Manual CLI requested a `--repo-slug` that is not present in `tenantRepos[]` config. CLI exits with code `3`. |
-| `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` | outer `details.reasonCode` | `tenant-repo-sync-revisions.json` write failure. Next cycle re-detects the same diff and retries idempotently — no manual recovery needed if the underlying filesystem issue is resolved. |
+| `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` | outer `details.reasonCode` | `tenant-repo-sync-revisions.json` write failure. Next cycle settles the matching unacknowledged graph receipt without repeating KB mutation — no manual recovery needed if the underlying filesystem issue is resolved. |
 | `KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND` | reserved | Future `--tenant-id` CLI flag; no current emitter. |
 | `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT` | reserved | Future concurrency-limit gate (tracked in [#11942](https://github.com/neomjs/neo/issues/11942) AC2); no current emitter. |
 
@@ -413,6 +433,7 @@ When a repo enters `quarantined`, the lane stops attempting it on periodic cycle
 3. Common cases:
    - `lastSourceErrorCode: KB_GITMIRROR_CREDENTIAL_REF_INVALID` → confirm the env var or secret file named by `credentialRef` exists and is non-empty.
    - `lastSourceErrorCode: KB_GITMIRROR_CLONE_FAILED` / `KB_GITMIRROR_FETCH_FAILED` → verify upstream access, token read scope, repo path, and network egress.
+   - `lastErrorCode: KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION` → inspect parser/ingestion output. A fresh full attempt needs a positive ingest/delete effect; only an interrupted checkpoint commit may recover through its matching unacknowledged graph receipt.
    - Persistent network/DNS error → the deployment can't reach the upstream remote; verify network egress.
    - Repository deleted / renamed upstream → update the `tenantRepos[]` config or remove the entry.
 4. Once the underlying issue is resolved, retry via `node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <slug>`. Current releases preserve the last known-good checkpoint on any returned ingestion error.
@@ -446,7 +467,7 @@ A single `repoSlug` can be served by both surfaces, but the operational rules ar
 - **Deployment compose / volume:** add `tenant-repo-mirrors` to the `cloud` profile and mount at `NEO_TENANT_REPO_MIRROR_ROOT`. See [`DeploymentCookbook.md`](../DeploymentCookbook.md) for the canonical compose shape.
 - **Tenant config storage:** `tenantRepos[]` is persisted via `KnowledgeBaseIngestionService.setTenantConfig({tenantId, config})` when a tenant-config operator tool is added. Cross-tenant writes remain rejected by the existing RLS gate; missing/invalid `credentialRef` or credential-bearing `cloneUrl` surfaces stable rejection errors at normalization.
 - **Parser/source-family dispatch:** pull-mode files enter the same parser/source-family model as push/bulk ingestion. No new parser contract is introduced by server-side git acquisition; the [Parser Dispatch](#parser-dispatch) and [Source-Family Inventory](#source-family-inventory) tables above apply unchanged. Unsupported source families use [`CustomSources.md`](./CustomSources.md) / [`CustomParsers.md`](./CustomParsers.md) guidance, not a pull-specific path.
-- **Deletion telemetry:** the `lastSyncDeletedCount` health field surfaces the per-cycle deletion count from the ingestion summary. The pull caller accepts only a summary with an array-valued, empty `errors` field; partial ingest, malformed summary, or manifest update failure leaves `lastIngestedRev` unchanged so the next cycle re-detects and retries deletion idempotently.
+- **Deletion telemetry:** the `lastSyncDeletedCount` health field surfaces the per-cycle deletion count from the ingestion summary. The pull caller accepts only a summary with an array-valued, empty `errors` field; a fresh full materialization additionally requires an attempt-bound positive safe-integer ingest/delete receipt. Partial ingest, malformed or fresh zero-effect full summary leaves `lastIngestedRev` unchanged. A post-ingest checkpoint-write failure also leaves the local head unchanged, but its unacknowledged graph receipt lets the next cycle settle the already-applied deletion idempotently.
 
 ## Evidence Boundary
 

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -217,6 +217,14 @@ identities, clone URLs, credentials, tokens, stacks, and raw filesystem/parser m
 
 For pull-mode deployments with configured `tenantRepos[]`, call `inspect_deployment` or `get_deployment_state_snapshot` and inspect the `tenantRepoSync` section before taking manual action. It distinguishes disabled, true no-configured-repos, not-due, running, completed, failed, and degraded/unreadable state without exposing credentials or raw logs. A degraded config-read error means the graph/YAML/default config resolver could not prove the effective `tenantRepos`; treat that differently from a real empty config. If the task is configured but has not advanced, use the stable reason code and per-repo hashed state there to decide whether to wait for the next due sweep, fix credentials/config, or run `node ./ai/scripts/maintenance/syncTenantRepos.mjs --repo-slug <slug>` inside the orchestrator container. When `lastErrorCode` is `KB_TENANT_REPO_SYNC_SYNC_FAILED`, check `lastSourceErrorCode`: `KB_GITMIRROR_CREDENTIAL_REF_INVALID`, `KB_GITMIRROR_CLONE_FAILED`, or `KB_GITMIRROR_FETCH_FAILED` points to the credential/ref/upstream access path before generic ingestion debugging. `KB_VECTOR_EMBED_FAILED` means the repository fetch and envelope reached the ingestion layer but vector writes failed; correct the embedding path before retrying.
 
+`credentialRef: none` is genuinely anonymous: GitMirror does not consult the
+orchestrator account's Git config, URL rewrites, helpers, `.netrc`, SSH config,
+agent, or default keys. Configure `env:`, `file:`, or `ssh:` explicitly when the
+remote is private. SSH endpoints should carry their non-secret login name (for
+example `ssh://git@host/org/repo.git`); the key remains in `credentialRef`.
+GitMirror preserves TOFU continuity in
+`<mirrorRoot>/.gitmirror-ssh/known_hosts`, not in the host user's home.
+
 Read `tenantRepoSync.accessReadiness` before waiting for cadence. `ready` means every enabled
 repo passed the process-local credential check and bounded remote capability probe; `degraded`
 means at least one proved failure; `unknown` means the current process has not produced valid
@@ -236,9 +244,18 @@ required repos. Inspection reads cached evidence and never triggers network work
 | `KB_TENANT_REPO_ACCESS_SYNC_FAILED` | A later authoritative clone/fetch failed after or without the cached probe. | Use `lastSourceErrorCode` and the normal GitMirror acquisition runbook; clone/fetch supersedes older probe evidence. |
 
 Current releases accept a tenant-repo ingest as successful only when the returned summary contains
-an array-valued, empty `errors` field. A failed attempt keeps the last known-good revision. If the
+an array-valued, empty `errors` field. Under checkpoint contract v2, a manifest-bearing bootstrap,
+non-linear fallback, manual full replay, or legacy revalidation must also persist an attempt-bound
+graph receipt for a positive safe-integer `ingested` or `deleted` count. The one zero-effect
+exception is checkpoint recovery: when the matching receipt is still unacknowledged because the
+prior local checkpoint write failed or crashed, the next run settles it before repeating KB
+mutation. An acknowledged receipt cannot be reused by a later manual full replay. The receipt is
+pull-internal; `ingest_source_files` cannot submit or receive it. Otherwise
+`KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION` preserves the last known-good revision. Incremental
+no-op remains valid, as does a full reconciliation whose only effect is deletion. A failed attempt
+keeps the last known-good revision. If the
 deployment was upgraded after an older release had already advanced its checkpoint on an
-error-bearing summary, the stored head has no current success proof. The periodic lane classifies
+error-bearing or zero-effect v1 summary, the stored head has no current success proof. The periodic lane classifies
 that repo as `checkpointStatus: pending` and performs one bounded null-base replay automatically.
 Only `concurrencyLimit` legacy checkpoints are admitted per one-minute scheduler sweep; failures
 become `checkpointStatus: failed`, preserve the old head, and retry through normal backoff.
@@ -260,8 +277,10 @@ node ./ai/scripts/maintenance/syncTenantRepos.mjs --full --repo-slug <slug>
 ```
 
 `--full` is rejected without an explicit repo selector. It does not delete the stored checkpoint:
-a failed replay preserves it, while an error-free replay advances it to the current head and writes
-the current success-contract marker.
+a failed or fresh zero-effect replay preserves it, while an error-free replay with a positive
+ingest/delete effect advances it to the current head and writes the current success-contract
+marker. A zero-effect retry can advance only when it settles the matching unacknowledged receipt
+from an interrupted post-ingest checkpoint commit before repeating Knowledge Base mutation.
 
 The CLI and the daemon's periodic sweep serialize through a cross-process lease next to the
 revisions manifest. Exit code `4` (reason `KB_TENANT_REPO_SYNC_LEASE_HELD`) means another sync is

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -747,11 +747,12 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                 async readPersistedRevisions() {
                     return {
                         'tenant-a/private/repo': {
-                            lastIngestedRev                   : 'abcdef1234567890',
-                            lastRunAttemptAt                  : OBSERVED_AT - 1_000,
-                            consecutiveFailures               : 0,
-                            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
-                            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                            lastIngestedRev                      : 'abcdef1234567890',
+                            lastRunAttemptAt                     : OBSERVED_AT - 1_000,
+                            consecutiveFailures                  : 0,
+                            ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                            lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                            lastCommittedMaterializationAttemptId: 'a'.repeat(32)
                         }
                     };
                 },
@@ -1053,11 +1054,12 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                             lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
                         },
                         'tenant-c/private/complete': {
-                            lastIngestedRev                   : 'cccccccccccccccc',
-                            lastRunAttemptAt                  : OBSERVED_AT - 10_000,
-                            consecutiveFailures               : 0,
-                            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
-                            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                            lastIngestedRev                      : 'cccccccccccccccc',
+                            lastRunAttemptAt                     : OBSERVED_AT - 10_000,
+                            consecutiveFailures                  : 0,
+                            ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                            lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                            lastCommittedMaterializationAttemptId: 'c'.repeat(32)
                         },
                         'tenant-e/private/unsupported': {
                             lastIngestedRev                   : 'eeeeeeeeeeeeeeee',

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
@@ -7,6 +7,7 @@ import {
     KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
+    KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
     TENANT_REPO_SYNC_ERROR_CODES,
     TenantRepoSyncError,
     isTenantRepoSyncErrorCode
@@ -21,7 +22,8 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
             KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED,
             KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND,
             KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
-            KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT
+            KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
+            KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION
         ];
 
         codes.forEach(code => {
@@ -31,7 +33,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
 
     test('TENANT_REPO_SYNC_ERROR_CODES array contains exactly the exported codes', () => {
         expect(Array.isArray(TENANT_REPO_SYNC_ERROR_CODES)).toBe(true);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(7);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(8);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_SYNC_FAILED);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_LEASE_HELD);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_LEASE_LOST);
@@ -39,6 +41,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT);
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION);
     });
 
     test('TENANT_REPO_SYNC_ERROR_CODES is truly immutable — external mutation rejected', () => {
@@ -50,7 +53,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         expect(() => TENANT_REPO_SYNC_ERROR_CODES.push('KB_TENANT_REPO_SYNC_MUTATED')).toThrow(TypeError);
         expect(() => { TENANT_REPO_SYNC_ERROR_CODES[TENANT_REPO_SYNC_ERROR_CODES.length] = 'KB_TENANT_REPO_SYNC_MUTATED'; }).toThrow(TypeError);
         expect(() => { TENANT_REPO_SYNC_ERROR_CODES.length = 0; }).toThrow(TypeError);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(7);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(8);
         expect(TENANT_REPO_SYNC_ERROR_CODES).not.toContain('KB_TENANT_REPO_SYNC_MUTATED');
         expect(isTenantRepoSyncErrorCode('KB_TENANT_REPO_SYNC_MUTATED')).toBe(false);
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -29,6 +29,8 @@ import {
     TENANT_REPO_INGEST_CONTRACT_VERSION
 } from '../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
 import {deriveTenantRepoMirrorPath} from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
+import {createTenantRepoMaterializationDigest}
+    from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 import {
     LIFECYCLE_GUARD_SUFFIX,
     acquireHeavyMaintenanceLease,
@@ -87,7 +89,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         };
     }
 
-    function makeFakeEnvelopeBuilder({captureCalls = []} = {}) {
+    function makeFakeEnvelopeBuilder({captureCalls = [], includeManifest = false} = {}) {
         return async function buildIngestEnvelope(args) {
             captureCalls.push({op: 'buildIngestEnvelope', args});
             return {
@@ -96,21 +98,32 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 files       : [{sourcePath: 'fake.txt', repoSlug: args.repoSlug, content: 'x'}],
                 deleted     : [],
                 headRevision: `sha-head-${args.repoSlug}`,
+                ...(includeManifest ? {
+                    manifestSnapshot: {
+                        repoSlug      : args.repoSlug,
+                        pathsAfterPush: ['fake.txt']
+                    }
+                } : {}),
                 ...(args.lastIngestedRev ? {baseRevision: args.lastIngestedRev} : {})
             };
         };
     }
 
     function makeFakeIngestionService({captureCalls = [], summaryFactory} = {}) {
+        const materializationReceipts = new Map();
+
         return {
+            async getTenantManifest({tenantId, repoSlug}) {
+                return {
+                    tenantId,
+                    repoSlug,
+                    materializationReceipt: materializationReceipts.get(`${tenantId}/${repoSlug}`) || null
+                }
+            },
             async ingestSourceFiles(payload) {
                 captureCalls.push({op: 'ingestSourceFiles', payload});
 
-                if (summaryFactory) {
-                    return summaryFactory(payload)
-                }
-
-                return {
+                const summary = summaryFactory ? await summaryFactory(payload) : {
                     ingested           : payload.files?.length || 0,
                     deleted            : payload.deleted?.length || 0,
                     embeddingsGenerated: 0,
@@ -118,6 +131,38 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                     tenantId           : payload.tenantId,
                     durationMs         : 1
                 };
+
+                if (payload.manifestSnapshot) {
+                    const
+                        key            = `${payload.tenantId}/${payload.repoSlug}`,
+                        envelopeDigest = createTenantRepoMaterializationDigest(payload),
+                        existing       = materializationReceipts.get(key),
+                        hasEffect      = Array.isArray(summary.errors)
+                            && summary.errors.length === 0
+                            && [summary.ingested, summary.deleted]
+                                .some(value => Number.isSafeInteger(value) && value > 0);
+
+                    if (payload.materializationAttempt && hasEffect) {
+                        const receipt = {
+                            ...payload.materializationAttempt,
+                            envelopeDigest,
+                            recordedAt: Date.now()
+                        };
+
+                        materializationReceipts.set(key, receipt);
+                        summary.materializationReceipt = receipt;
+                    } else if (
+                        payload.materializationAttempt
+                        && existing?.ingestContractVersion === payload.materializationAttempt.ingestContractVersion
+                        && existing.envelopeDigest === envelopeDigest
+                    ) {
+                        summary.materializationReceipt = existing;
+                    } else if (!payload.materializationAttempt) {
+                        materializationReceipts.delete(key);
+                    }
+                }
+
+                return summary
             }
         };
     }
@@ -227,11 +272,12 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             filePath : revisionsFile,
             revisions: {
                 'tenant-a/private/repo': {
-                    lastIngestedRev                   : 'abcdef1234567890',
-                    lastRunAttemptAt                  : Date.now(),
-                    consecutiveFailures               : 0,
-                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
-                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    lastIngestedRev                      : 'abcdef1234567890',
+                    lastRunAttemptAt                     : Date.now(),
+                    consecutiveFailures                  : 0,
+                    ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastCommittedMaterializationAttemptId: 'f'.repeat(32)
                 }
             }
         });
@@ -516,16 +562,17 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/seeded'});
 
         // Seed the revisions file with a checkpoint proved by the current
-        // error-free ingestion contract.
+        // ingestion commit contract.
         await fs.ensureDir(path.dirname(revisionsFile));
         await fs.writeJson(revisionsFile, {
             revisions: {
                 't1/org/seeded': {
-                    lastIngestedRev                   : 'sha-prior-run',
-                    lastRunAttemptAt                  : 0,
-                    consecutiveFailures               : 0,
-                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
-                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    lastIngestedRev                      : 'sha-prior-run',
+                    lastRunAttemptAt                     : 0,
+                    consecutiveFailures                  : 0,
+                    ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastCommittedMaterializationAttemptId: 'f'.repeat(32)
                 }
             }
         });
@@ -572,6 +619,391 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         expect(result.status).toBe('completed');
         expect(capturedLastIngestedRev).toBe('sha-prior-run');
+
+        const persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions['t1/org/seeded']).toMatchObject({
+            lastIngestedRev                   : 'sha-new-head',
+            consecutiveFailures               : 0,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        });
+    });
+
+    for (const scenario of [
+        {
+            label        : 'bootstrap',
+            fullReplay   : false,
+            priorState   : null,
+            expectedBase : null,
+            manifestPaths: []
+        },
+        {
+            label     : 'non-linear fallback',
+            fullReplay: false,
+            priorState: {
+                lastIngestedRev                      : 'sha-nonlinear-good',
+                lastRunAttemptAt                     : 0,
+                consecutiveFailures                  : 0,
+                ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastCommittedMaterializationAttemptId: 'a'.repeat(32)
+            },
+            expectedBase : 'sha-nonlinear-good',
+            manifestPaths: ['README.md']
+        },
+        {
+            label     : 'manual full replay',
+            fullReplay: true,
+            priorState: {
+                lastIngestedRev                      : 'sha-full-good',
+                lastRunAttemptAt                     : 0,
+                consecutiveFailures                  : 0,
+                ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastCommittedMaterializationAttemptId: 'b'.repeat(32)
+            },
+            expectedBase : null,
+            manifestPaths: ['README.md']
+        },
+        {
+            label     : 'legacy revalidation',
+            fullReplay: false,
+            priorState: {
+                lastIngestedRev    : 'sha-legacy-good',
+                lastRunAttemptAt   : 0,
+                consecutiveFailures: 0
+            },
+            expectedBase : null,
+            manifestPaths: ['README.md']
+        },
+        {
+            label     : 'v1 checkpoint migration',
+            fullReplay: false,
+            priorState: {
+                lastIngestedRev                   : 'sha-v1-good',
+                lastRunAttemptAt                  : 0,
+                consecutiveFailures               : 0,
+                ingestContractVersion             : 1,
+                lastAttemptedIngestContractVersion: 1
+            },
+            expectedBase : null,
+            manifestPaths: ['README.md']
+        },
+        {
+            label     : 'v2 checkpoint without receipt acknowledgement',
+            fullReplay: false,
+            priorState: {
+                lastIngestedRev                   : 'sha-v2-unproved',
+                lastRunAttemptAt                  : 0,
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            },
+            expectedBase : null,
+            manifestPaths: ['README.md']
+        }
+    ]) {
+        test(`${scenario.label} fails closed when full materialization has zero effect (#16045)`, async () => {
+            const
+                taskStateService = createInMemoryTaskStateService(),
+                repoSlug         = `org/${scenario.label.replaceAll(' ', '-')}`,
+                envelopeCalls    = [],
+                healthCalls      = [];
+
+            if (scenario.priorState) {
+                await fs.writeJson(revisionsFile, {
+                    revisions: {
+                        [`t1/${repoSlug}`]: scenario.priorState
+                    }
+                });
+            }
+
+            await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+            const result = await TenantRepoSyncService.runTask({
+                reason           : 'manual',
+                taskStateService,
+                tenantReposConfig: {tenantRepos: [{
+                    tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/private.git'
+                }]},
+                gitMirror      : makeFakeGitMirror(),
+                envelopeBuilder: async args => {
+                    envelopeCalls.push(args);
+
+                    return {
+                        tenantId: args.tenantId,
+                        repoSlug: args.repoSlug,
+                        files   : scenario.manifestPaths.map(sourcePath => ({
+                            sourcePath,
+                            repoSlug: args.repoSlug,
+                            content : 'source exists but parser materialized nothing'
+                        })),
+                        headRevision    : `sha-empty-${scenario.label}`,
+                        manifestSnapshot: {
+                            repoSlug      : args.repoSlug,
+                            pathsAfterPush: scenario.manifestPaths
+                        }
+                    };
+                },
+                knowledgeBaseIngestionService: makeFakeIngestionService({
+                    summaryFactory: () => ({ingested: 0, deleted: 0, errors: []})
+                }),
+                healthService: {
+                    recordTaskOutcome(...args) {
+                        healthCalls.push(args)
+                    }
+                },
+                onlyRepoSlugs    : [repoSlug],
+                fullReplay       : scenario.fullReplay,
+                revisionsFilePath: revisionsFile,
+                seedBootstrap    : false
+            });
+
+            expect(result.status).toBe('failed');
+            expect(result.details.completedCount).toBe(0);
+            expect(result.details.failedCount).toBe(1);
+            expect(result.details.repos[0]).toMatchObject({
+                status             : 'degraded',
+                lastErrorCode      : 'KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION',
+                consecutiveFailures: 1
+            });
+            expect(envelopeCalls).toHaveLength(1);
+            expect(envelopeCalls[0].lastIngestedRev).toBe(scenario.expectedBase);
+            expect(JSON.stringify(result)).not.toContain('example.invalid');
+            expect(healthCalls.some(([, outcome, details]) =>
+                outcome === 'failed'
+                && details.code === 'KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION'
+            )).toBe(true);
+
+            const persisted = await fs.readJson(revisionsFile);
+            expect(persisted.revisions[`t1/${repoSlug}`]).toMatchObject({
+                lastIngestedRev                   : scenario.priorState?.lastIngestedRev || null,
+                consecutiveFailures               : 1,
+                ingestContractVersion             : scenario.priorState?.ingestContractVersion ?? null,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            });
+        });
+    }
+
+    test('zero-effect full materialization cannot echo the current attempt as durable proof (#16045)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/echoed-current-receipt';
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/echoed.git'
+            }]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId        : args.tenantId,
+                repoSlug        : args.repoSlug,
+                files           : [{sourcePath: 'README.md', repoSlug: args.repoSlug, content: 'source'}],
+                headRevision    : 'sha-echoed-receipt',
+                manifestSnapshot: {
+                    repoSlug      : args.repoSlug,
+                    pathsAfterPush: ['README.md']
+                }
+            }),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory(payload) {
+                    return {
+                        ingested              : 0,
+                        deleted               : 0,
+                        errors                : [],
+                        materializationReceipt: {
+                            ...payload.materializationAttempt,
+                            envelopeDigest: createTenantRepoMaterializationDigest(payload),
+                            recordedAt    : Date.now()
+                        }
+                    }
+                }
+            }),
+            onlyRepoSlugs    : [repoSlug],
+            revisionsFilePath: revisionsFile,
+            seedBootstrap    : false
+        });
+
+        expect(result).toMatchObject({
+            status : 'failed',
+            details: {
+                completedCount: 0,
+                failedCount   : 1,
+                repos         : [{
+                    lastErrorCode: 'KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION'
+                }]
+            }
+        });
+    });
+
+    test('full delete-only reconciliation remains a successful checkpoint effect (#16045)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/delete-only-full';
+
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                [`t1/${repoSlug}`]: {
+                    lastIngestedRev                   : 'sha-before-delete',
+                    lastRunAttemptAt                  : 0,
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                }
+            }
+        });
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/delete-only.git'
+            }]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId        : args.tenantId,
+                repoSlug        : args.repoSlug,
+                files           : [],
+                headRevision    : 'sha-after-delete',
+                manifestSnapshot: {
+                    repoSlug      : args.repoSlug,
+                    pathsAfterPush: []
+                }
+            }),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory: () => ({ingested: 0, deleted: 1, errors: []})
+            }),
+            onlyRepoSlugs    : [repoSlug],
+            fullReplay       : true,
+            revisionsFilePath: revisionsFile
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details.completedCount).toBe(1);
+        expect(result.details.repos[0]).toMatchObject({
+            status              : 'active',
+            lastIngestedRev     : 'sha-afte',
+            checkpointStatus    : 'complete',
+            lastSyncDeletedCount: 1
+        });
+
+        const persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions[`t1/${repoSlug}`].lastIngestedRev).toBe('sha-after-delete');
+    });
+
+    test('delete-only full replay settles an unacknowledged receipt after checkpoint-write failure exactly once (#16045)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/delete-only-retry',
+            ingestCalls      = [];
+        let ingestAttempt = 0;
+
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                [`t1/${repoSlug}`]: {
+                    lastIngestedRev                      : 'sha-before-delete',
+                    lastRunAttemptAt                     : 0,
+                    consecutiveFailures                  : 0,
+                    ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastCommittedMaterializationAttemptId: 'e'.repeat(32)
+                }
+            }
+        });
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const options = {
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/delete-only-retry.git'
+            }]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId        : args.tenantId,
+                repoSlug        : args.repoSlug,
+                files           : [],
+                headRevision    : 'sha-after-delete',
+                manifestSnapshot: {
+                    repoSlug      : args.repoSlug,
+                    pathsAfterPush: []
+                }
+            }),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                captureCalls: ingestCalls,
+                summaryFactory() {
+                    ingestAttempt++;
+                    return {
+                        ingested: 0,
+                        deleted : ingestAttempt === 1 ? 1 : 0,
+                        errors  : []
+                    };
+                }
+            }),
+            onlyRepoSlugs    : [repoSlug],
+            fullReplay       : true,
+            revisionsFilePath: revisionsFile,
+            seedBootstrap    : false
+        };
+
+        const originalWritePersistedRevisions = TenantRepoSyncService.writePersistedRevisions;
+        TenantRepoSyncService.writePersistedRevisions = async () => {
+            const error = new Error('injected post-ingest checkpoint failure');
+            error.code  = 'KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED';
+            throw error;
+        };
+
+        let interrupted;
+        try {
+            interrupted = await TenantRepoSyncService.runTask(options);
+        } finally {
+            TenantRepoSyncService.writePersistedRevisions = originalWritePersistedRevisions;
+        }
+
+        expect(interrupted).toMatchObject({
+            status : 'failed',
+            details: {reasonCode: 'KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED'}
+        });
+        expect((await fs.readJson(revisionsFile)).revisions[`t1/${repoSlug}`]).toMatchObject({
+            lastIngestedRev                      : 'sha-before-delete',
+            lastCommittedMaterializationAttemptId: 'e'.repeat(32)
+        });
+
+        const recovered = await TenantRepoSyncService.runTask(options);
+
+        expect(recovered).toMatchObject({
+            status : 'completed',
+            details: {completedCount: 1, failedCount: 0}
+        });
+        expect(ingestCalls).toHaveLength(1);
+        expect(ingestAttempt).toBe(1);
+
+        const recoveredState = (await fs.readJson(revisionsFile)).revisions[`t1/${repoSlug}`];
+        expect(recoveredState).toMatchObject({
+            lastIngestedRev                      : 'sha-after-delete',
+            lastCommittedMaterializationAttemptId: ingestCalls[0].payload.materializationAttempt.attemptId
+        });
+
+        const staleReceiptReplay = await TenantRepoSyncService.runTask(options);
+
+        expect(staleReceiptReplay).toMatchObject({
+            status : 'failed',
+            details: {
+                completedCount: 0,
+                failedCount   : 1,
+                repos         : [{
+                    lastErrorCode: 'KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION'
+                }]
+            }
+        });
+        expect(ingestCalls).toHaveLength(2);
+        expect(ingestCalls[1].payload.materializationAttempt.attemptId)
+            .not.toBe(ingestCalls[0].payload.materializationAttempt.attemptId);
     });
 
     test('error-bearing ingestion summary fails closed and the next run reuses the last good revision (#15748)', async () => {
@@ -585,11 +1017,12 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await fs.writeJson(revisionsFile, {
             revisions: {
                 [`t1/${repoSlug}`]: {
-                    lastIngestedRev                   : 'sha-good',
-                    lastRunAttemptAt                  : 0,
-                    consecutiveFailures               : 0,
-                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
-                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    lastIngestedRev                      : 'sha-good',
+                    lastRunAttemptAt                     : 0,
+                    consecutiveFailures                  : 0,
+                    ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastCommittedMaterializationAttemptId: 'c'.repeat(32)
                 }
             }
         });
@@ -803,11 +1236,15 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             envelopeBuilder: async args => {
                 envelopeCalls.push(args);
                 return {
-                    tenantId    : args.tenantId,
-                    repoSlug    : args.repoSlug,
-                    files       : [{sourcePath: 'fake.txt', repoSlug: args.repoSlug, content: 'x'}],
-                    deleted     : [],
-                    headRevision: envelopeCalls.length === 1 ? 'sha-replay-failed' : 'sha-replay-clean'
+                    tenantId        : args.tenantId,
+                    repoSlug        : args.repoSlug,
+                    files           : [{sourcePath: 'fake.txt', repoSlug: args.repoSlug, content: 'x'}],
+                    deleted         : [],
+                    headRevision    : envelopeCalls.length === 1 ? 'sha-replay-failed' : 'sha-replay-clean',
+                    manifestSnapshot: {
+                        repoSlug      : args.repoSlug,
+                        pathsAfterPush: ['fake.txt']
+                    }
                 }
             },
             knowledgeBaseIngestionService: makeFakeIngestionService({
@@ -943,11 +1380,12 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 't1/org/legacy-b': {lastIngestedRev: 'sha-b', lastRunAttemptAt: 0, consecutiveFailures: 0},
                 't1/org/legacy-c': {lastIngestedRev: 'sha-c', lastRunAttemptAt: 0, consecutiveFailures: 0},
                 't1/org/current' : {
-                    lastIngestedRev                   : 'sha-current',
-                    lastRunAttemptAt                  : 0,
-                    consecutiveFailures               : 0,
-                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
-                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    lastIngestedRev                      : 'sha-current',
+                    lastRunAttemptAt                     : 0,
+                    consecutiveFailures                  : 0,
+                    ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastCommittedMaterializationAttemptId: 'd'.repeat(32)
                 }
             }
         });
@@ -958,8 +1396,23 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             tenantReposConfig: {tenantRepos: [...legacySlugs, currentSlug].map(repoSlug => ({
                 tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: `https://github.com/neomjs/${repoSlug}.git`
             }))},
-            gitMirror                    : makeFakeGitMirror(),
-            envelopeBuilder              : makeFakeEnvelopeBuilder({captureCalls: envelopeCalls}),
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => {
+                envelopeCalls.push({op: 'buildIngestEnvelope', args});
+
+                return {
+                    tenantId        : args.tenantId,
+                    repoSlug        : args.repoSlug,
+                    files           : [{sourcePath: 'fake.txt', repoSlug: args.repoSlug, content: 'x'}],
+                    deleted         : [],
+                    headRevision    : `sha-head-${args.repoSlug}`,
+                    manifestSnapshot: {
+                        repoSlug      : args.repoSlug,
+                        pathsAfterPush: ['fake.txt']
+                    },
+                    ...(args.lastIngestedRev ? {baseRevision: args.lastIngestedRev} : {})
+                };
+            },
             knowledgeBaseIngestionService: makeFakeIngestionService(),
             revisionsFilePath            : revisionsFile,
             globalCadenceMs              : 0,
@@ -1016,11 +1469,12 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await fs.writeJson(revisionsFile, {
             revisions: {
                 [`t1/${currentSlug}`]: {
-                    lastIngestedRev                   : 'sha-current',
-                    lastRunAttemptAt                  : 0,
-                    consecutiveFailures               : 0,
-                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
-                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    lastIngestedRev                      : 'sha-current',
+                    lastRunAttemptAt                     : 0,
+                    consecutiveFailures                  : 0,
+                    ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastCommittedMaterializationAttemptId: 'e'.repeat(32)
                 },
                 [`t1/${legacySlug}`]: {
                     lastIngestedRev    : 'sha-legacy',
@@ -1058,8 +1512,11 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 {tenantId: 't1', repoSlug: currentSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/current.git'},
                 {tenantId: 't1', repoSlug: legacySlug,  mirrorRoot, cloneUrl: 'https://github.com/neomjs/legacy.git'}
             ]},
-            gitMirror                    : slowCurrentMirror,
-            envelopeBuilder              : makeFakeEnvelopeBuilder({captureCalls: envelopeCalls}),
+            gitMirror      : slowCurrentMirror,
+            envelopeBuilder: makeFakeEnvelopeBuilder({
+                captureCalls   : envelopeCalls,
+                includeManifest: true
+            }),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
             revisionsFilePath            : revisionsFile,
             globalCadenceMs              : 0,
@@ -1102,11 +1559,12 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         await fs.writeJson(revisionsFile, {
             revisions: {
                 [`t1/${currentSlug}`]: {
-                    lastIngestedRev                   : 'sha-current',
-                    lastRunAttemptAt                  : 0,
-                    consecutiveFailures               : 0,
-                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
-                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    lastIngestedRev                      : 'sha-current',
+                    lastRunAttemptAt                     : 0,
+                    consecutiveFailures                  : 0,
+                    ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastCommittedMaterializationAttemptId: 'f'.repeat(32)
                 },
                 [`t1/${legacySlug}`]: {
                     lastIngestedRev    : 'sha-legacy',
@@ -1141,8 +1599,11 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 {tenantId: 't1', repoSlug: currentSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/current.git'},
                 {tenantId: 't1', repoSlug: legacySlug,  mirrorRoot, cloneUrl: 'https://github.com/neomjs/legacy.git'}
             ]},
-            gitMirror                    : slowLegacyMirror,
-            envelopeBuilder              : makeFakeEnvelopeBuilder({captureCalls: envelopeCalls}),
+            gitMirror      : slowLegacyMirror,
+            envelopeBuilder: makeFakeEnvelopeBuilder({
+                captureCalls   : envelopeCalls,
+                includeManifest: true
+            }),
             knowledgeBaseIngestionService: makeFakeIngestionService(),
             revisionsFilePath            : revisionsFile,
             globalCadenceMs              : 0,
@@ -1169,7 +1630,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         {label: 'string success marker',     marker: {ingestContractVersion: '2'}},
         {label: 'fractional success marker', marker: {ingestContractVersion: 1.5}},
         {label: 'negative attempt marker',   marker: {lastAttemptedIngestContractVersion: -1}},
-        {label: 'zero attempt marker',       marker: {lastAttemptedIngestContractVersion: 0}}
+        {label: 'zero attempt marker',       marker: {lastAttemptedIngestContractVersion: 0}},
+        {label: 'malformed receipt ack',     marker: {lastCommittedMaterializationAttemptId: 'not-an-attempt'}}
     ]) {
         test(`malformed ${label} fails closed without authorizing legacy replay (#15761)`, async () => {
             const
@@ -1747,11 +2209,12 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // Persistence reflects the failure increment for next cycle's backoff calculation.
         const persisted = await fs.readJson(revisionsFile);
         expect(persisted.revisions['t1/neomjs/failing-repo']).toEqual({
-            lastIngestedRev                   : null,
-            lastRunAttemptAt                  : expect.any(Number),
-            consecutiveFailures               : 1,
-            ingestContractVersion             : null,
-            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            lastIngestedRev                      : null,
+            lastRunAttemptAt                     : expect.any(Number),
+            consecutiveFailures                  : 1,
+            ingestContractVersion                : null,
+            lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastCommittedMaterializationAttemptId: null
         });
     });
 
@@ -1820,7 +2283,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             revisionsFilePath            : revisionsFile
         });
 
-        // A bare SHA has no error-free success proof. The upgrade therefore performs
+        // A bare SHA has no current success proof. The upgrade therefore performs
         // one harmless null-base replay before persisting the current contract marker.
         expect(result.status).toBe('completed');
         expect(envelopeCalls[0].args.lastIngestedRev).toBeNull();

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -629,6 +629,67 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         });
     });
 
+    test('legacy null-contract checkpoint bootstraps an empty target after the first positive materialization (#16045)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/legacy-empty-bootstrap',
+            envelopeCalls    = [],
+            ingestCalls      = [];
+
+        await fs.writeJson(revisionsFile, {
+            revisions: {
+                [`t1/${repoSlug}`]: {
+                    lastIngestedRev                   : 'sha-before-contracts',
+                    lastRunAttemptAt                  : 0,
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : null,
+                    lastAttemptedIngestContractVersion: null
+                }
+            }
+        });
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/private.git'
+            }]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder({captureCalls: envelopeCalls, includeManifest: true}),
+            knowledgeBaseIngestionService: makeFakeIngestionService({captureCalls: ingestCalls}),
+            onlyRepoSlugs                : [repoSlug],
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details.completedCount).toBe(1);
+        expect(result.details.failedCount).toBe(0);
+        expect(envelopeCalls).toHaveLength(1);
+        expect(envelopeCalls[0].args.lastIngestedRev).toBeNull();
+        expect(ingestCalls).toHaveLength(1);
+        expect(ingestCalls[0].payload).toMatchObject({
+            tenantId: 't1',
+            repoSlug,
+            viaMcp  : false
+        });
+        expect(ingestCalls[0].payload.manifestSnapshot.pathsAfterPush).toEqual(['fake.txt']);
+        expect(ingestCalls[0].payload.materializationAttempt).toMatchObject({
+            ingestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        });
+
+        const persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions[`t1/${repoSlug}`]).toMatchObject({
+            lastIngestedRev                   : `sha-head-${repoSlug}`,
+            consecutiveFailures               : 0,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastCommittedMaterializationAttemptId:
+                ingestCalls[0].payload.materializationAttempt.attemptId
+        });
+    });
+
     for (const scenario of [
         {
             label        : 'bootstrap',

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
@@ -142,6 +142,41 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
         expect('error' in result).toBe(false);
     });
 
+    test('push callers cannot inject or receive pull-materialization authority (#16045)', async () => {
+        let dispatchedArgs;
+
+        IngestionService.ingestSourceFiles = async args => {
+            dispatchedArgs = args;
+
+            return {
+                ingested              : 1,
+                deleted               : 0,
+                errors                : [],
+                materializationReceipt: {
+                    attemptId            : 'a'.repeat(32),
+                    ingestContractVersion: 2,
+                    envelopeDigest       : 'b'.repeat(64),
+                    recordedAt           : Date.now()
+                }
+            };
+        };
+
+        const result = await ingestSourceFilesViaMcp({
+            tenantId              : 'neo-shared',
+            files                 : [{path: 'README.md', content: 'source'}],
+            viaMcp                : false,
+            materializationAttempt: {
+                attemptId            : 'c'.repeat(32),
+                ingestContractVersion: 2
+            }
+        });
+
+        expect(dispatchedArgs.viaMcp).toBe(true);
+        expect(dispatchedArgs).not.toHaveProperty('materializationAttempt');
+        expect(result).not.toHaveProperty('materializationReceipt');
+        expect(result).toMatchObject({ingested: 1, deleted: 0, errors: []});
+    });
+
     test('ingest_source_files is listed for the remote Streamable HTTP transport profile', () => {
         aiConfig.transport = 'streamable-http';
 

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -454,6 +454,137 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         });
     });
 
+    test('persists and replays an attempt-bound positive full-materialization receipt (#16045)', async () => {
+        collection = createSpyCollection([
+            {id: 'stale', metadata: {tenantId: 'tenant-a', repoSlug: 'repo-a', sourcePath: 'src/stale.js'}}
+        ]);
+        Service.chromaManager = {
+            getKnowledgeBaseCollection: async () => collection
+        };
+
+        const envelope = {
+            tenantId        : 'tenant-a',
+            repoSlug        : 'repo-a',
+            files           : [],
+            headRevision    : 'head-delete-only',
+            manifestSnapshot: {repoSlug: 'repo-a', pathsAfterPush: []}
+        };
+        const first = await Service.ingestSourceFiles({
+            ...envelope,
+            materializationAttempt: {
+                attemptId            : 'a'.repeat(32),
+                ingestContractVersion: 2
+            }
+        });
+
+        expect(first).toMatchObject({
+            deleted               : 1,
+            errors                : [],
+            materializationReceipt: {
+                attemptId            : 'a'.repeat(32),
+                ingestContractVersion: 2
+            }
+        });
+        expect(first.materializationReceipt.envelopeDigest).toMatch(/^[a-f0-9]{64}$/u);
+
+        const retry = await Service.ingestSourceFiles({
+            ...envelope,
+            materializationAttempt: {
+                attemptId            : 'b'.repeat(32),
+                ingestContractVersion: 2
+            }
+        });
+
+        expect(retry).toMatchObject({
+            deleted               : 0,
+            errors                : [],
+            materializationReceipt: {
+                attemptId            : 'a'.repeat(32),
+                ingestContractVersion: 2,
+                envelopeDigest       : first.materializationReceipt.envelopeDigest
+            }
+        });
+
+        await Service.setTenantManifest({
+            tenantId      : 'tenant-a',
+            repoSlug      : 'repo-a',
+            pathsAfterPush: []
+        });
+        expect((await Service.getTenantManifest({
+            tenantId: 'tenant-a',
+            repoSlug: 'repo-a'
+        })).materializationReceipt).toBeNull();
+    });
+
+    test('error-bearing retries clear rather than preserve an older materialization receipt (#16045)', async () => {
+        collection = createSpyCollection([
+            {id: 'stale', metadata: {tenantId: 'tenant-a', repoSlug: 'repo-a', sourcePath: 'src/stale.js'}}
+        ]);
+        Service.chromaManager = {
+            getKnowledgeBaseCollection: async () => collection
+        };
+
+        const envelope = {
+            tenantId        : 'tenant-a',
+            repoSlug        : 'repo-a',
+            files           : [],
+            headRevision    : 'head-error-retry',
+            manifestSnapshot: {repoSlug: 'repo-a', pathsAfterPush: []}
+        };
+        const first = await Service.ingestSourceFiles({
+            ...envelope,
+            materializationAttempt: {
+                attemptId            : 'e'.repeat(32),
+                ingestContractVersion: 2
+            }
+        });
+
+        expect(first.materializationReceipt).toBeTruthy();
+
+        const errored = await Service.ingestSourceFiles({
+            ...envelope,
+            baseRevision          : 'base-requiring-unavailable-resolver',
+            materializationAttempt: {
+                attemptId            : 'f'.repeat(32),
+                ingestContractVersion: 2
+            }
+        });
+
+        expect(errored.errors).toContainEqual(expect.objectContaining({
+            code: 'KB_REVISION_BOUNDARY_UNAVAILABLE'
+        }));
+        expect(errored.materializationReceipt).toBeUndefined();
+        expect((await Service.getTenantManifest({
+            tenantId: 'tenant-a',
+            repoSlug: 'repo-a'
+        })).materializationReceipt).toBeNull();
+    });
+
+    test('fresh zero-effect full attempts never manufacture a replay receipt (#16045)', async () => {
+        const envelope = {
+            tenantId        : 'tenant-a',
+            repoSlug        : 'repo-empty',
+            files           : [],
+            headRevision    : 'head-empty',
+            manifestSnapshot: {repoSlug: 'repo-empty', pathsAfterPush: []}
+        };
+
+        for (const attemptId of ['c'.repeat(32), 'd'.repeat(32)]) {
+            const summary = await Service.ingestSourceFiles({
+                ...envelope,
+                materializationAttempt: {attemptId, ingestContractVersion: 2}
+            });
+
+            expect(summary).toMatchObject({ingested: 0, deleted: 0, errors: []});
+            expect(summary.materializationReceipt).toBeUndefined();
+        }
+
+        expect((await Service.getTenantManifest({
+            tenantId: 'tenant-a',
+            repoSlug: 'repo-empty'
+        })).materializationReceipt).toBeNull();
+    });
+
     test('records reconcile telemetry when one push ingests and deletes chunks', async () => {
         collection = createSpyCollection([
             {id: 'deleted', metadata: {tenantId: 'tenant-a', repoSlug: 'repo-a', sourcePath: 'src/deleted.js'}}

--- a/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
@@ -1,10 +1,11 @@
 import {test, expect} from '@playwright/test';
 
-import fs          from 'fs-extra';
-import os          from 'os';
-import path        from 'path';
-import {execFile}  from 'child_process';
-import {promisify} from 'util';
+import fs              from 'fs-extra';
+import os              from 'os';
+import path            from 'path';
+import {execFile}      from 'child_process';
+import {promisify}     from 'util';
+import {pathToFileURL} from 'url';
 
 import GitMirror, {
     cloneIfMissing,
@@ -93,8 +94,13 @@ test.describe('GitMirror (#11788)', () => {
         await fs.writeFile(gitPath, `#!/bin/sh
 {
     printf '%s\\n' "GIT_ASKPASS=$GIT_ASKPASS"
+    printf '%s\\n' "GIT_CONFIG_GLOBAL=$GIT_CONFIG_GLOBAL"
+    printf '%s\\n' "GIT_CONFIG_NOSYSTEM=$GIT_CONFIG_NOSYSTEM"
+    printf '%s\\n' "GIT_SSH_COMMAND=$GIT_SSH_COMMAND"
+    printf '%s\\n' "HOME=$HOME"
     printf '%s\\n' "NEO_GITMIRROR_PASSWORD=$NEO_GITMIRROR_PASSWORD"
     printf '%s\\n' "NEO_GITMIRROR_USERNAME=$NEO_GITMIRROR_USERNAME"
+    printf '%s\\n' "USERPROFILE=$USERPROFILE"
 } > ${JSON.stringify(capturePath)}
 printf 'fatal: token %s\\n' "$NEO_GITMIRROR_PASSWORD" >&2
 exit 1
@@ -339,17 +345,158 @@ exit 1
         });
     });
 
+    test('ignores ambient HOME authority for probe, clone, and fetch (#16045)', async () => {
+        const
+            source          = await createSourceRepo(),
+            ambientHome     = path.join(root, 'ambient-home'),
+            ambientConfig   = path.join(ambientHome, '.gitconfig'),
+            fakeCloneUrl    = 'https://127.0.0.1:1/private.git',
+            sourceUrl       = pathToFileURL(source).href,
+            originalHome    = process.env.HOME,
+            originalProfile = process.env.USERPROFILE;
+
+        await fs.ensureDir(ambientHome);
+        await git([
+            'config',
+            '--file',
+            ambientConfig,
+            `url.${sourceUrl}.insteadOf`,
+            fakeCloneUrl
+        ], root);
+
+        process.env.HOME        = ambientHome;
+        process.env.USERPROFILE = ambientHome;
+
+        try {
+            await expect(probeRemoteAccess({
+                cloneUrl     : fakeCloneUrl,
+                credentialRef: 'none',
+                ref          : 'main',
+                timeoutMs    : 1000
+            })).resolves.toMatchObject({
+                status: 'degraded',
+                code  : TenantRepoAccessCode.TRANSPORT_FAILED
+            });
+
+            await expect(cloneIfMissing({
+                cloneUrl     : fakeCloneUrl,
+                credentialRef: 'none',
+                mirrorRoot   : path.join(root, 'ambient-clone-mirrors'),
+                repoSlug     : 'ambient/clone',
+                tenantId     : 'tenant-a'
+            })).rejects.toMatchObject({code: 'KB_GITMIRROR_CLONE_FAILED'});
+
+            const fetchOptions = {
+                cloneUrl     : source,
+                credentialRef: 'none',
+                mirrorRoot   : path.join(root, 'ambient-fetch-mirrors'),
+                repoSlug     : 'ambient/fetch',
+                tenantId     : 'tenant-a'
+            };
+            const {mirrorPath} = await cloneIfMissing(fetchOptions);
+
+            await git(['remote', 'set-url', 'origin', fakeCloneUrl], mirrorPath);
+            await expect(fetch(fetchOptions))
+                .rejects.toMatchObject({code: 'KB_GITMIRROR_FETCH_FAILED'});
+        } finally {
+            if (originalHome === undefined) {
+                delete process.env.HOME;
+            } else {
+                process.env.HOME = originalHome;
+            }
+
+            if (originalProfile === undefined) {
+                delete process.env.USERPROFILE;
+            } else {
+                process.env.USERPROFILE = originalProfile;
+            }
+        }
+    });
+
+    test('redacts isolated-environment setup failures before they cross GitMirror (#16045)', async () => {
+        const
+            source            = await createSourceRepo(),
+            originalWriteFile = fs.writeFile;
+        let leakedHomePath;
+        let setupError;
+
+        fs.writeFile = async (filePath, ...args) => {
+            if (String(filePath).includes('neo-gitmirror-home-')) {
+                leakedHomePath = path.dirname(String(filePath));
+                throw new Error(`injected setup failure at ${filePath}`);
+            }
+
+            return originalWriteFile.call(fs, filePath, ...args)
+        };
+
+        try {
+            await cloneIfMissing(mirrorOptions(source));
+        } catch (error) {
+            setupError = error;
+        } finally {
+            fs.writeFile = originalWriteFile;
+        }
+
+        expect(setupError).toMatchObject({
+            code   : 'KB_GITMIRROR_ENVIRONMENT_FAILED',
+            message: 'GitMirror failed to prepare its isolated subprocess environment'
+        });
+        expect(leakedHomePath).toContain('neo-gitmirror-home-');
+        expect(setupError.message).not.toContain(leakedHomePath);
+        expect(setupError.cause?.message || '').not.toContain(leakedHomePath);
+        await expect(fs.pathExists(leakedHomePath)).resolves.toBe(false);
+    });
+
+    test('bounds cleanup-only failures and preserves an earlier Git failure (#16045)', async () => {
+        const
+            source         = await createSourceRepo(),
+            originalRemove = fs.remove,
+            isolatedHomes  = [];
+
+        fs.remove = async targetPath => {
+            if (String(targetPath).includes('neo-gitmirror-home-')) {
+                isolatedHomes.push(String(targetPath));
+                throw new Error(`injected cleanup failure at ${targetPath}`);
+            }
+
+            return originalRemove.call(fs, targetPath)
+        };
+
+        try {
+            await expect(cloneIfMissing({
+                ...mirrorOptions(source),
+                repoSlug: 'cleanup/success'
+            })).rejects.toMatchObject({
+                code   : 'KB_GITMIRROR_CLEANUP_FAILED',
+                message: 'GitMirror failed to remove its isolated subprocess environment'
+            });
+
+            await expect(cloneIfMissing({
+                ...mirrorOptions(path.join(root, 'missing-source')),
+                repoSlug: 'cleanup/primary-failure'
+            })).rejects.toMatchObject({
+                code   : 'KB_GITMIRROR_CLONE_FAILED',
+                message: 'GitMirror clone failed'
+            });
+        } finally {
+            fs.remove = originalRemove;
+            await Promise.all(isolatedHomes.map(homePath => fs.remove(homePath)));
+        }
+
+        expect(isolatedHomes).toHaveLength(2);
+    });
+
     test('classifies denied, transport, and timeout probe failures without returning Git prose', async () => {
         const cases = [
             {
                 script : "printf '%s\\n' 'fatal: Authentication failed for https://example.invalid/private.git' >&2\nexit 128",
                 code   : TenantRepoAccessCode.DENIED_OR_NOT_FOUND,
-                timeout: 1000
+                timeout: 3000
             },
             {
                 script : "printf '%s\\n' 'fatal: Could not resolve host: example.invalid' >&2\nexit 128",
                 code   : TenantRepoAccessCode.TRANSPORT_FAILED,
-                timeout: 1000
+                timeout: 3000
             },
             {
                 script : 'sleep 1\nexit 0',
@@ -391,9 +538,23 @@ exit 1
                 expect(error).toMatchObject({code: 'KB_GITMIRROR_CLONE_FAILED'});
                 expect(error.stderr).toContain('[REDACTED]');
                 expect(error.stderr).not.toContain('file-secret-token');
+                expect(captured.GIT_CONFIG_NOSYSTEM).toBe('1');
+                expect(captured.GIT_CONFIG_GLOBAL).toBe(path.join(captured.HOME, '.gitconfig'));
+                expect(captured.GIT_SSH_COMMAND).toContain('IdentitiesOnly=yes');
+                expect(captured.GIT_SSH_COMMAND).toContain('IdentityAgent=none');
+                expect(captured.GIT_SSH_COMMAND).toContain('IdentityFile=none');
+                expect(captured.GIT_SSH_COMMAND).toContain(
+                    path.join(root, 'mirrors', '.gitmirror-ssh', 'known_hosts')
+                );
+                expect(captured.HOME).not.toBe(process.env.HOME);
+                expect(captured.USERPROFILE).toBe(captured.HOME);
                 expect(captured.NEO_GITMIRROR_PASSWORD).toBe('file-secret-token');
                 expect(captured.NEO_GITMIRROR_USERNAME).toBe('x-access-token');
                 await expect(fs.pathExists(path.dirname(captured.GIT_ASKPASS))).resolves.toBe(false);
+                await expect(fs.pathExists(captured.HOME)).resolves.toBe(false);
+                await expect(fs.pathExists(
+                    path.join(root, 'mirrors', '.gitmirror-ssh', 'known_hosts')
+                )).resolves.toBe(true);
                 return;
             }
 
@@ -420,6 +581,26 @@ exit 1
 
             expect(captured.NEO_GITMIRROR_PASSWORD).toBe('object-secret-token');
             expect(captured.NEO_GITMIRROR_USERNAME).toBe('deploy-token');
+        });
+    });
+
+    test('passes only the explicit SSH key through the isolated runner (#16045)', async () => {
+        const keyPath = path.join(root, 'tenant-ssh-key');
+
+        await fs.writeFile(keyPath, '-----BEGIN PRIVATE KEY-----\nfixture\n-----END PRIVATE KEY-----\n');
+
+        await withFakeGitCapture(async capturePath => {
+            await expect(cloneIfMissing({
+                ...mirrorOptions('ssh://git@example.com/tenant/repo.git'),
+                credentialRef: `ssh:${keyPath}`
+            })).rejects.toMatchObject({code: 'KB_GITMIRROR_CLONE_FAILED'});
+
+            const captured = parseCapturedEnv(await fs.readFile(capturePath, 'utf-8'));
+
+            expect(captured.GIT_SSH_COMMAND).toContain('IdentityAgent=none');
+            expect(captured.GIT_SSH_COMMAND).toContain('IdentityFile=none');
+            expect(captured.GIT_SSH_COMMAND).toContain(`-i '${keyPath}'`);
+            expect(captured.GIT_SSH_COMMAND).not.toContain(process.env.HOME);
         });
     });
 

--- a/test/playwright/unit/ai/services/knowledge-base/tenantRepoAccessContract.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/tenantRepoAccessContract.spec.mjs
@@ -30,7 +30,9 @@ test.describe('TenantRepoAccessContract (#11787)', () => {
     test('derives a deterministic repoSlug from a clean URL cloneUrl', () => {
         expect(deriveRepoSlugFromCloneUrl('https://github.com/neomjs/neo.git')).toBe('github.com/neomjs/neo');
         expect(deriveRepoSlugFromCloneUrl('ssh://github.com/neomjs/neo.git')).toBe('github.com/neomjs/neo');
+        expect(deriveRepoSlugFromCloneUrl('ssh://git@github.com/neomjs/neo.git')).toBe('github.com/neomjs/neo');
         expect(deriveRepoSlugFromCloneUrl('github.com:neomjs/neo.git')).toBe('github.com/neomjs/neo');
+        expect(deriveRepoSlugFromCloneUrl('git@github.com:neomjs/neo.git')).toBe('github.com/neomjs/neo');
     });
 
     test('normalizes tenant repo entries while preserving supported credentialRef values as references only', () => {
@@ -154,6 +156,10 @@ test.describe('TenantRepoAccessContract (#11787)', () => {
             cloneUrl     : 'https://token:secret@github.com/neomjs/neo.git',
             credentialRef: 'env:GITHUB_TOKEN'
         })).toThrow(/must not embed userinfo/u);
+        expect(assertCleanCloneUrl('ssh://git@github.com/neomjs/neo.git'))
+            .toBe('ssh://git@github.com/neomjs/neo.git');
+        expect(assertCleanCloneUrl('git@github.com:neomjs/neo.git'))
+            .toBe('git@github.com:neomjs/neo.git');
 
         expect(() => assertCleanCloneUrl('https://github.com/neomjs/neo.git?token=secret'))
             .toThrow(/query strings or fragments/u);

--- a/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
@@ -1,21 +1,22 @@
 import {test, expect} from '@playwright/test';
 
-import fs             from 'fs-extra';
-import os             from 'os';
-import path           from 'path';
-import {execFile}     from 'child_process';
-import {promisify}    from 'util';
+import fs          from 'fs-extra';
+import os          from 'os';
+import path        from 'path';
+import {execFile}  from 'child_process';
+import {promisify} from 'util';
 
 import {cloneIfMissing, fetch, resolveHead}
                        from '../../../../../../ai/services/knowledge-base/helpers/gitMirror.mjs';
 import TenantRepoIngestEnvelopeBuilder, {
-    buildIngestEnvelope
+    buildIngestEnvelope,
+    createTenantRepoMaterializationDigest
 } from '../../../../../../ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 
 const execFileAsync = promisify(execFile);
 
 /**
- * @summary Contract tests for the tenant GitMirror to KB ingest envelope adapter (#11789).
+ * @summary Contract tests for the tenant GitMirror to KB ingest envelope adapter.
  *
  * The builder emits the live `KnowledgeBaseIngestionService.ingestSourceFiles()`
  * payload shape: `files`, `deleted`, `manifestSnapshot`, `baseRevision`, and
@@ -58,6 +59,40 @@ test.describe('TenantRepoIngestEnvelopeBuilder (#11789)', () => {
         return source;
     }
 
+    test('materialization digest is order-stable and head/parser bound (#16045)', () => {
+        const envelope = {
+            repoSlug        : 'org/repo',
+            headRevision    : 'head-a',
+            manifestSnapshot: {
+                repoSlug      : 'org/repo',
+                pathsAfterPush: ['src/b.js', 'src/a.js', 'src/a.js']
+            },
+            files: [
+                {sourcePath: 'src/b.js', rootKind: 'bare-repo', parserId: 'beta', parserVersion: '2'},
+                {sourcePath: 'src/a.js', rootKind: 'bare-repo', parserId: 'alpha', parserVersion: '1'}
+            ]
+        };
+        const digest = createTenantRepoMaterializationDigest(envelope);
+
+        expect(digest).toMatch(/^[a-f0-9]{64}$/u);
+        expect(createTenantRepoMaterializationDigest({
+            ...envelope,
+            manifestSnapshot: {
+                ...envelope.manifestSnapshot,
+                pathsAfterPush: ['src/a.js', 'src/b.js']
+            },
+            files: [...envelope.files].reverse()
+        })).toBe(digest);
+        expect(createTenantRepoMaterializationDigest({...envelope, headRevision: 'head-b'})).not.toBe(digest);
+        expect(createTenantRepoMaterializationDigest({
+            ...envelope,
+            files: [{...envelope.files[0], parserVersion: '3'}, envelope.files[1]]
+        })).not.toBe(digest);
+        expect(TenantRepoIngestEnvelopeBuilder.createTenantRepoMaterializationDigest).toBe(
+            createTenantRepoMaterializationDigest
+        );
+    });
+
     async function commitSecondRevision(source) {
         await fs.writeFile(path.join(source, 'alpha.txt'), 'alpha v2\n');
         await fs.writeFile(path.join(source, 'beta.txt'), 'beta\n');
@@ -80,9 +115,9 @@ test.describe('TenantRepoIngestEnvelopeBuilder (#11789)', () => {
     }
 
     test('builds a manifest-carrying full envelope when no baseline exists', async () => {
-        const source  = await createSourceRepo();
-        const options = await createMirror(source);
-        const newHead = await resolveHead({...options, ref: 'main'});
+        const source   = await createSourceRepo();
+        const options  = await createMirror(source);
+        const newHead  = await resolveHead({...options, ref: 'main'});
         const envelope = await buildIngestEnvelope({
             ...options,
             newHead,
@@ -90,9 +125,9 @@ test.describe('TenantRepoIngestEnvelopeBuilder (#11789)', () => {
         });
 
         expect(envelope).toMatchObject({
-            tenantId    : 'tenant-a',
-            repoSlug    : 'local/source',
-            headRevision: newHead,
+            tenantId        : 'tenant-a',
+            repoSlug        : 'local/source',
+            headRevision    : newHead,
             manifestSnapshot: {
                 repoSlug      : 'local/source',
                 pathsAfterPush: ['alpha.txt', 'docs/guide.md', 'remove-me.txt']
@@ -104,13 +139,74 @@ test.describe('TenantRepoIngestEnvelopeBuilder (#11789)', () => {
         expect(envelope.files.find(file => file.sourcePath === 'docs/guide.md')).toMatchObject({
             repoSlug: 'local/source',
             rootKind: 'bare-repo',
-            content: '# Guide\n'
+            content : '# Guide\n'
         });
     });
 
+    test('routes revision reads through the isolated GitMirror subprocess boundary (#16045)', async () => {
+        const
+            source                  = await createSourceRepo(),
+            options                 = await createMirror(source),
+            ambientHome             = path.join(root, 'host-home'),
+            capturePath             = path.join(root, 'git-environments.tsv'),
+            binDir                  = path.join(root, 'capture-bin'),
+            wrapperPath             = path.join(binDir, 'git'),
+            originalPath            = process.env.PATH,
+            originalHome            = process.env.HOME,
+            originalProfile         = process.env.USERPROFILE,
+            {stdout: gitPathOutput} = await execFileAsync('which', ['git']),
+            realGitPath             = gitPathOutput.trim();
+
+        await fs.ensureDir(ambientHome);
+        await fs.ensureDir(binDir);
+        await fs.writeFile(wrapperPath, `#!/bin/sh
+printf '%s\\t%s\\t%s\\t%s\\n' "$HOME" "$GIT_CONFIG_GLOBAL" "$GIT_CONFIG_NOSYSTEM" "$GIT_SSH_COMMAND" >> ${JSON.stringify(capturePath)}
+exec ${JSON.stringify(realGitPath)} "$@"
+`);
+        await fs.chmod(wrapperPath, 0o755);
+
+        process.env.PATH        = `${binDir}${path.delimiter}${originalPath}`;
+        process.env.HOME        = ambientHome;
+        process.env.USERPROFILE = ambientHome;
+
+        try {
+            await buildIngestEnvelope({...options, newHead: 'main'});
+        } finally {
+            process.env.PATH = originalPath;
+
+            if (originalHome === undefined) {
+                delete process.env.HOME;
+            } else {
+                process.env.HOME = originalHome;
+            }
+
+            if (originalProfile === undefined) {
+                delete process.env.USERPROFILE;
+            } else {
+                process.env.USERPROFILE = originalProfile;
+            }
+        }
+
+        const observations = (await fs.readFile(capturePath, 'utf-8'))
+            .trim()
+            .split('\n')
+            .map(line => line.split('\t'));
+
+        expect(observations.length).toBeGreaterThan(0);
+
+        for (const [home, globalConfig, noSystem, sshCommand] of observations) {
+            expect(home).not.toBe(ambientHome);
+            expect(globalConfig).toBe(path.join(home, '.gitconfig'));
+            expect(noSystem).toBe('1');
+            expect(sshCommand).toContain('IdentityAgent=none');
+            expect(sshCommand).toContain('IdentityFile=none');
+            await expect(fs.pathExists(home)).resolves.toBe(false);
+        }
+    });
+
     test('builds a bounded delta envelope for linear history advances', async () => {
-        const source  = await createSourceRepo();
-        const options = await createMirror(source);
+        const source       = await createSourceRepo();
+        const options      = await createMirror(source);
         const baseRevision = await resolveHead({...options, ref: 'main'});
 
         await commitSecondRevision(source);
@@ -126,11 +222,11 @@ test.describe('TenantRepoIngestEnvelopeBuilder (#11789)', () => {
         });
 
         expect(envelope).toMatchObject({
-            tenantId    : 'tenant-a',
-            repoSlug    : 'local/source',
+            tenantId: 'tenant-a',
+            repoSlug: 'local/source',
             baseRevision,
             headRevision,
-            deleted: [{sourcePath: 'remove-me.txt', repoSlug: 'local/source'}]
+            deleted : [{sourcePath: 'remove-me.txt', repoSlug: 'local/source'}]
         });
         expect(envelope.manifestSnapshot).toBeUndefined();
         expect(envelope.files.map(file => [file.sourcePath, file.content])).toEqual([
@@ -144,8 +240,8 @@ test.describe('TenantRepoIngestEnvelopeBuilder (#11789)', () => {
     });
 
     test('falls back to a full manifest snapshot when history is non-linear', async () => {
-        const source  = await createSourceRepo();
-        const options = await createMirror(source);
+        const source       = await createSourceRepo();
+        const options      = await createMirror(source);
         const baseRevision = await resolveHead({...options, ref: 'main'});
 
         await commitSecondRevision(source);

--- a/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
@@ -1,5 +1,6 @@
 import {test, expect} from '@playwright/test';
 
+import {createHash} from 'node:crypto';
 import fs          from 'fs-extra';
 import os          from 'os';
 import path        from 'path';
@@ -65,21 +66,38 @@ test.describe('TenantRepoIngestEnvelopeBuilder (#11789)', () => {
             headRevision    : 'head-a',
             manifestSnapshot: {
                 repoSlug      : 'org/repo',
-                pathsAfterPush: ['src/b.js', 'src/a.js', 'src/a.js']
+                pathsAfterPush: ['z.md', 'a_b.md', 'aB.md', 'ä.md', 'a_b.md']
             },
             files: [
-                {sourcePath: 'src/b.js', rootKind: 'bare-repo', parserId: 'beta', parserVersion: '2'},
-                {sourcePath: 'src/a.js', rootKind: 'bare-repo', parserId: 'alpha', parserVersion: '1'}
+                {sourcePath: 'z.md', rootKind: 'bare-repo', parserId: 'markdown', parserVersion: '1'},
+                {sourcePath: 'a_b.md', rootKind: 'bare-repo', parserId: 'markdown', parserVersion: '1'},
+                {sourcePath: 'aB.md', rootKind: 'bare-repo', parserId: 'markdown', parserVersion: '1'},
+                {sourcePath: 'ä.md', rootKind: 'bare-repo', parserId: 'markdown', parserVersion: '1'}
             ]
         };
-        const digest = createTenantRepoMaterializationDigest(envelope);
+        const
+            digest         = createTenantRepoMaterializationDigest(envelope),
+            expectedDigest = createHash('sha256')
+                .update(JSON.stringify({
+                    formatVersion : 1,
+                    repoSlug      : 'org/repo',
+                    headRevision  : 'head-a',
+                    pathsAfterPush: ['aB.md', 'a_b.md', 'z.md', 'ä.md'],
+                    parserBindings: [
+                        {sourcePath: 'aB.md', rootKind: 'bare-repo', parserId: 'markdown', parserVersion: '1'},
+                        {sourcePath: 'a_b.md', rootKind: 'bare-repo', parserId: 'markdown', parserVersion: '1'},
+                        {sourcePath: 'z.md', rootKind: 'bare-repo', parserId: 'markdown', parserVersion: '1'},
+                        {sourcePath: 'ä.md', rootKind: 'bare-repo', parserId: 'markdown', parserVersion: '1'}
+                    ]
+                }))
+                .digest('hex');
 
-        expect(digest).toMatch(/^[a-f0-9]{64}$/u);
+        expect(digest).toBe(expectedDigest);
         expect(createTenantRepoMaterializationDigest({
             ...envelope,
             manifestSnapshot: {
                 ...envelope.manifestSnapshot,
-                pathsAfterPush: ['src/a.js', 'src/b.js']
+                pathsAfterPush: ['ä.md', 'z.md', 'a_b.md', 'aB.md']
             },
             files: [...envelope.files].reverse()
         })).toBe(digest);


### PR DESCRIPTION
Authored by GPT-5.6 (Codex Desktop).

Origin Session ID: `019f9b00-d596-7e22-b8f1-31433ddb5838`

Resolves #16045

## Summary

Tenant-repo pull acquisition now proves two things before it can certify a checkpoint:

1. Git used only the credential mode declared by the tenant, never ambient host-user authority.
2. A bootstrap/full/revalidation materialization produced a durable positive Knowledge Base effect.

Current-checkpoint incremental no-ops remain healthy, and delete-only full reconciliation remains valid.

Evidence: real Git ambient-authority falsification, production-shaped checkpoint falsification, and the focused exact-head suite are recorded below.

## Implementation

- Centralizes every tenant-repo Git subprocess behind an isolated runner:
  - disposable `HOME`, `USERPROFILE`, and `XDG_CONFIG_HOME`;
  - system/global Git config disabled;
  - credential helpers reset;
  - SSH config, agents, and default identities disabled;
  - only the selected `none`, `env`, `file`, or `ssh` authority added back;
  - persistent GitMirror-owned SSH TOFU ledger;
  - bounded output plus path/secret-safe setup, execution, and cleanup failures.
- Moves mirror listing/file reads onto that same runner so probe, clone, fetch, and envelope construction share one authority boundary.
- Advances the checkpoint contract to v2:
  - full materializations write an attempt/head/envelope/parser-bound graph receipt only after an error-free positive ingest/delete effect;
  - the local checkpoint acknowledges that attempt;
  - a post-ingest checkpoint-write failure settles the matching unacknowledged receipt before repeating KB mutation;
  - acknowledged, current-attempt, malformed, error-bearing, and stale receipts fail closed.
- Keeps the receipt protocol pull-internal: the public `ingest_source_files` facade strips caller attempts, forces MCP work-volume mode, and never returns receipts.
- Adds the bounded `KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION` diagnostic and updates cloud tenant-ingestion documentation.

## Deltas from the ticket

The ticket prescribed a positive-effect gate. Adversarial testing exposed one prerequisite for its existing retry/backoff AC: a delete-only full run can mutate the KB successfully and then lose its later local checkpoint write. Replaying that deletion reports `0/0`, so a bare non-zero predicate would quarantine the repo forever.

The v2 attempt-bound graph receipt closes that crash window without weakening the ticket invariant. It is acknowledged exactly once, cannot be minted through the public push facade, and cannot excuse a later manual full replay.

The Git isolation also retains non-secret SSH login names in clean endpoints and stores host-key continuity in a GitMirror-owned ledger. Those are implementation refinements required once ambient SSH config is removed; no new credential scheme was added.

## Test Evidence

- `209 passed` across the focused unit surface:
  - deployment-state projection;
  - tenant-repo checkpoint/error/sync services;
  - MCP ingestion facade;
  - KB ingestion receipts;
  - GitMirror;
  - credential contract;
  - ingest-envelope builder.
- Reviewer-delta verification: 8 focused tests passed; the en-US and sv-SE digest falsifiers now converge byte-identically.
- Real Git ambient-authority falsifier: a fake HTTPS URL readable only through temporary `HOME/.gitconfig url.*.insteadOf` now returns `KB_TENANT_REPO_ACCESS_TRANSPORT_FAILED`.
- Legacy null-contract + empty-target positive control completes the first authenticated full materialization and persists its exact v2 receipt acknowledgement.
- Production-shaped empty-initial and changeful-zero full-materialization falsifiers both return:
  - `status: failed`;
  - `completedCount: 0`;
  - `KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION`;
  - no advanced revision.
- Injected Git environment setup, cleanup-only, and primary-error-preservation tests pass.
- `check-jsdoc-types`: 1,894 files, 0 unparseable expressions.
- `ai:lint-guides`: 0 hard failures (28 pre-existing repository warnings).
- Repository pre-commit suite passed: whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, AiConfig test mutation, and derived-domain checks.
- Rebased onto `origin/dev@62e5669c0f`; `merge-base HEAD origin/dev == origin/dev`.

## ADR Alignment

- ADR 0014: preserves the cloud-deployable `tenant-repo-sync` lane while making its credential and checkpoint boundaries deterministic.
- ADR 0019: no AiConfig leaf, hidden fallback, runtime mutation, or alternate config authority was introduced.

## Contract Ledger

| Surface | Authority | Result | Evidence |
|---|---|---|---|
| Git subprocesses | `GitMirror` isolated runner | Ambient config/helpers/HOME/SSH identity cannot grant access | Real `insteadOf` probe/clone/fetch negatives plus explicit/local positives |
| Full materialization | Manifest-bearing envelope + KB graph receipt | Fresh positive effect or matching unacknowledged recovery receipt required | Bootstrap/full/v1/v2-without-ack/current-attempt/stale-receipt negatives |
| Incremental sync | Current v2 checkpoint | `0/0` no-op remains completed | Current-checkpoint positive control |
| Delete-only sync | KB deletion count + durable receipt | Positive deletion advances; interrupted local commit recovers exactly once | Three-run delete-only recovery test |
| Public push | MCP facade | Cannot inject or receive pull receipt authority | Direct facade regression |
| Diagnostics | Bounded GitMirror/sync codes | No secret, URL authority, home, askpass, or known-host path crosses health/log surfaces | Redaction and injected filesystem-failure tests |

## Post-Merge Validation

- [ ] In a hosted pull deployment, verify a private repository configured with `credentialRef: none` remains degraded.
- [ ] Verify the same repository becomes ready only with its explicit credential reference.
- [ ] Run one full tenant sync and confirm a non-empty corpus plus v2 checkpoint acknowledgement.
- [ ] Interrupt a post-ingest checkpoint write once and confirm the next run settles the unacknowledged receipt without repeating KB mutation.

## Commits

- `d89994b35c` — `fix(agent-os): isolate tenant repo acquisition (#16045)`
- `be70e0d567` — `test(agent-os): cover legacy empty-target bootstrap (#16045)`
- 7292bf0fdc — fix(agent-os): make tenant digest locale-independent (#16045)
