### PR TITLE
feat(agentos): surface Brain daemon faults as ONE cockpit banner with its diagnosis (#16051)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -288,6 +288,33 @@ class FleetCockpit extends Container {
      */
     dockPreviewProducer = null
     /**
+     * Brain daemon health for the spine banner's third surface — `'running'|'degraded'|'stopped'`,
+     * matching `harness/appLifecycle.mjs`'s `BRAIN_STATES`.
+     *
+     * **`null` by default, and that silence is deliberate rather than a placeholder.** The shell spec
+     * pairs a tray-state change with ONE cockpit banner, and this is the cockpit half. But nothing in
+     * the cockpit pulls daemon health yet, so defaulting to `'running'` would have the banner assert
+     * "the organism is fine" on the strength of never having asked — the fabrication this cockpit's
+     * whole render discipline exists to prevent. `null` renders nothing and claims nothing, which is
+     * the honest state until the pull lands; `deriveSpineBanner` treats absence as UNKNOWN and its
+     * spec asserts that silence directly, so the seam is exercised rather than dormant.
+     *
+     * The pull is `FleetControlBridge.fleetRuntimeStatus()` over the existing `neoShell.fleetRequest`
+     * capability — deliberately NOT a new main→renderer push channel, which would need the shell ADR
+     * §2.3 amendment its preload demands.
+     * @member {String|null} daemonState=null
+     * @protected
+     */
+    daemonState = null
+    /**
+     * The retained diagnosis pointer for the DAEMON surface — the "why" the spine banner names instead
+     * of generic copy. Per-surface for the same reason as {@link #gridDegradedReason}: a transport
+     * sibling must never be able to supply or silence this cause.
+     * @member {String|null} daemonDegradedReason=null
+     * @protected
+     */
+    daemonDegradedReason = null
+    /**
      * The grid's held `adapterState` — absent-item materialization reads from HERE, so a committed
      * layout change can never reset a live grid back to its sample badge.
      * @member {String} gridAdapterState='sample'
@@ -2532,6 +2559,10 @@ class FleetCockpit extends Container {
             // each state travels WITH its own cause: the derivation reports the reason of the
             // surface that decided the verdict, and no sibling can supply or silence it
             let {hidden, kind, text} = deriveSpineBanner({
+                // Daemon health ranks above a stale feed: a dead daemon is usually what MADE the feed
+                // stale, so the transport line alone would name the symptom and drop the diagnosis.
+                // Silent while `daemonState` is null — absence is unknown, never nominal.
+                daemon: {state: me.daemonState,        reason: me.daemonDegradedReason},
                 grid  : {state: me.gridAdapterState,   reason: me.gridDegradedReason},
                 stream: {state: me.streamAdapterState, reason: me.streamDegradedReason}
             });

--- a/apps/agentos/view/fleet/spineBanner.mjs
+++ b/apps/agentos/view/fleet/spineBanner.mjs
@@ -5,10 +5,34 @@
  * last-known data instead of failing silent. Render-only over existing truth — this module
  * produces no probes.
  *
- * Precedence: `sample` (unreachable — cold) beats `stale` (reachable but degraded) beats `live`.
- * A fully live spine renders NOTHING — nominal earns zero pixels, the same exception-based
- * discipline the cards follow. Per-AGENT truth (wake/throttle telltales) is a different surface;
- * this line only speaks for the fleet transport itself.
+ * Precedence: `sample` (unreachable — cold) beats `daemon` (a Brain daemon down) beats `stale`
+ * (reachable but degraded) beats `live`. A fully live spine renders NOTHING — nominal earns zero
+ * pixels, the same exception-based discipline the cards follow. Per-AGENT truth (wake/throttle
+ * telltales) is a different surface.
+ *
+ * ## Why daemon health joins a line that used to speak only for the transport
+ *
+ * The shell spec requires that a daemon going down surfaces as a tray-state change **plus ONE
+ * cockpit banner with the diagnosis pointer — never a popup storm**. "One banner" is the whole
+ * requirement, so a second banner component would violate the spec it was added to satisfy. This
+ * line is the cockpit's single honesty surface, so daemon health belongs here, following the same
+ * per-surface-reason discipline as the other two rather than as a special case.
+ *
+ * **A dead daemon outranks a stale feed because it usually CAUSES one.** Reporting "feed degraded"
+ * while a daemon is down names the symptom and drops the diagnosis, which is precisely the pointer
+ * the spec asks for. It sits below `sample` because an unreachable transport cannot have answered a
+ * daemon-status pull in the first place — the two are near-exclusive, and when the server is silent
+ * "start the server" is the actionable line.
+ *
+ * **Daemon silence renders nothing, and does not claim health.** An absent daemon surface is
+ * unknown, not nominal — but inventing a degradation from missing information is a false alarm, and
+ * the transport line already speaks when the server is silent (that is exactly the `sample` case).
+ * So absence stays quiet here and the operator still gets told, by the surface that actually knows.
+ *
+ * **`degraded` is reused as the `kind` rather than minting a fourth.** The severity is the same and
+ * the existing skin already carries it; the DIAGNOSIS travels in the text, where a screen reader
+ * reaches it. Distinguishing a dead daemon from a stale feed by colour alone would be a WCAG 1.4.1
+ * failure, and the tray state carries the state distinction the spec pairs this banner with.
  *
  * **A reason belongs to a SURFACE, never to the spine.** This module used to take one loose
  * `degradedReason` alongside two loose states, and that shape had a race it could not express: the
@@ -43,15 +67,26 @@ function reasonFor(surfaces, state) {
 }
 
 /**
- * @summary Derives the spine banner from the two owner-held surface truths.
+ * Brain daemon states that warrant the banner. `running` is nominal and earns zero pixels; an absent
+ * or unrecognised state is UNKNOWN and also stays quiet — see the module note on daemon silence.
+ * Mirrors `harness/appLifecycle.mjs`'s `BRAIN_STATES` minus the nominal one.
+ * @type {String[]}
+ */
+const DAEMON_FAULT_STATES = Object.freeze(['degraded', 'stopped']);
+
+/**
+ * @summary Derives the spine banner from the owner-held surface truths.
  * @param {Object} options
  * @param {{state: String, reason: ?String}} options.grid The roster surface: `'sample'|'stale'|'live'`
  *     plus the safe cause the owner retained for THAT surface, if it learned one.
  * @param {{state: String, reason: ?String}} options.stream The activity surface, same shape.
+ * @param {{state: String, reason: ?String}} [options.daemon] Brain daemon health:
+ *     `'running'|'degraded'|'stopped'`, with the diagnosis pointer as its reason. Optional — a caller
+ *     that has not pulled daemon truth passes nothing rather than guessing `running`.
  * @returns {{hidden: Boolean, kind: String, text: String}} `kind` is `'live'|'cold'|'degraded'`
  *     — the class hook; `hidden` is `true` only for the fully live spine.
  */
-export function deriveSpineBanner({grid, stream}) {
+export function deriveSpineBanner({daemon, grid, stream}) {
     const surfaces = [grid, stream],
           states   = surfaces.map(surface => surface?.state);
 
@@ -70,6 +105,31 @@ export function deriveSpineBanner({grid, stream}) {
             text: reason
                 ? `Fleet data unavailable — showing the static roster · ${reason}`
                 : 'Fleet server offline — showing the static roster · start it: npm run ai:fleet-server'
+        }
+    }
+
+    // ABOVE `stale` deliberately: a dead daemon is usually what MADE the feed stale, so reporting the
+    // feed alone would name the symptom and drop the diagnosis pointer the spec requires. Read from
+    // its own surface via the same helper, so the daemon's cause can never be supplied or silenced by
+    // a transport sibling.
+    if (DAEMON_FAULT_STATES.includes(daemon?.state)) {
+        const reason = reasonFor([daemon], daemon.state),
+              // The state is part of the sentence, not just the class: `stopped` and `degraded` are
+              // different operator situations (nothing running vs something wrong), and a banner that
+              // said only "degraded" for both would make the tray the sole place that distinction
+              // exists — unreachable to a screen reader.
+              label  = daemon.state === 'stopped' ? 'stopped' : 'degraded';
+
+        return {
+            hidden: false,
+            kind  : 'degraded',
+            // Same reason-or-fallback discipline as the transport lines. The fallback names WHERE to
+            // look rather than what to run: unlike the fleet server there is no single restart verb
+            // that is right for every daemon, and printing a confident wrong command is worse than
+            // pointing at the surface that knows which daemon died.
+            text: reason
+                ? `Agent OS ${label} — showing the cockpit over a partial organism · ${reason}`
+                : `Agent OS ${label} — showing the cockpit over a partial organism · check the tray state and the daemon log`
         }
     }
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1254,6 +1254,41 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         syncSpineBanner: FleetCockpit.prototype.syncSpineBanner
     });
 
+    // ⭐ The daemon surface reaching the REAL slot. The derivation being correct is a separate suite;
+    // this asserts the cockpit actually FEEDS it, because a derivation nothing feeds is indistinguishable
+    // from an absent feature — and the wiring is the half that makes the shell spec's banner exist.
+    test('⭐ a dead daemon reaches the slot with the diagnosis, outranking a stale feed', () => {
+        const banner = makeBanner(),
+              host   = {
+                  ...makeHost('live', 'stale', banner),
+                  daemonDegradedReason: 'orchestrator exited',
+                  daemonState         : 'stopped'
+              };
+
+        host.syncSpineBanner();
+
+        const {cls, hidden, text} = banner.calls[0];
+
+        expect(cls).toEqual(['fm-spine-banner', 'fm-spine-banner-degraded']);
+        expect(hidden).toBe(false);
+        expect(text).toContain('stopped');
+        expect(text).toContain('orchestrator exited');
+        // The stale feed is the symptom; it must not be the sentence.
+        expect(text).not.toContain('last-known data')
+    });
+
+    test('⭐ an unfed daemon surface stays SILENT on a live owner — absence claims nothing', () => {
+        // `daemonState` is null until the runtime pull lands. This asserts the default is honest
+        // silence rather than an implicit "the organism is fine", which is what defaulting to
+        // `'running'` would have asserted on the strength of never having asked.
+        const banner = makeBanner();
+
+        makeHost('live', 'live', banner).syncSpineBanner();
+
+        expect(banner.calls[0].hidden).toBe(true);
+        expect(banner.calls[0].text).toBe('')
+    });
+
     test('a cold owner writes the REAL slot: cold class hook, visible, cause + shipped remedy', () => {
         const banner = makeBanner();
 

--- a/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
@@ -13,6 +13,99 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
 
     const STATES = ['sample', 'stale', 'live'];
 
+    // ⭐ The daemon surface: the shell spec's "tray-state change + ONE cockpit banner with the
+    // diagnosis pointer — never a popup storm". The storm clause is a property of EPISODES, not
+    // renders, so it is asserted as such below rather than assumed from the return type.
+    test.describe('⭐ daemon health — ONE banner per episode, ranked above a stale feed', () => {
+        const live = {grid: {state: 'live'}, stream: {state: 'live'}};
+
+        test('a stopped and a degraded daemon each speak, and `running` stays silent', () => {
+            // `running` must earn zero pixels like every other nominal state.
+            expect(deriveSpineBanner({...live, daemon: {state: 'running'}})).toEqual({hidden: true, kind: 'live', text: ''});
+
+            for (const state of ['degraded', 'stopped']) {
+                const result = deriveSpineBanner({...live, daemon: {state}});
+
+                expect(result.hidden, state).toBe(false);
+                expect(result.kind, state).toBe('degraded');
+                // The two are different operator situations, so the SENTENCE distinguishes them —
+                // not just the class. A screen reader reaches text, never a colour.
+                expect(result.text, state).toContain(state === 'stopped' ? 'stopped' : 'degraded')
+            }
+        });
+
+        test('⭐ daemon silence renders NOTHING and does not claim health', () => {
+            // Absence is UNKNOWN, not nominal. Inventing a degradation from missing information is a
+            // false alarm; claiming health from it is the fabrication. Both are wrong, so it stays
+            // quiet — and the transport line already speaks when the server is silent.
+            for (const daemon of [undefined, null, {}, {state: null}, {state: 'unknown'}, {state: ''}]) {
+                const result = deriveSpineBanner({...live, daemon});
+
+                expect(result.hidden, JSON.stringify(daemon)).toBe(true);
+                expect(result.text, JSON.stringify(daemon)).toBe('')
+            }
+        });
+
+        test('⭐ a dead daemon OUTRANKS a stale feed — the diagnosis, not the symptom', () => {
+            // A dead daemon is usually what made the feed stale. Reporting the feed alone would name
+            // the symptom and drop the pointer the spec asks for.
+            const result = deriveSpineBanner({
+                grid  : {state: 'stale', reason: 'feed went quiet'},
+                stream: {state: 'stale'},
+                daemon: {state: 'stopped', reason: 'orchestrator exited'}
+            });
+
+            expect(result.text).toContain('orchestrator exited');
+            expect(result.text).not.toContain('last-known data');
+            // Control: remove the daemon fault and the SAME input must fall back to the stale line,
+            // which is what proves the daemon branch is doing the ranking rather than the text.
+            expect(deriveSpineBanner({
+                grid: {state: 'stale', reason: 'feed went quiet'}, stream: {state: 'stale'}
+            }).text).toContain('last-known data')
+        });
+
+        test('an unreachable transport still wins — it cannot have answered a daemon pull', () => {
+            const result = deriveSpineBanner({
+                grid: {state: 'sample'}, stream: {state: 'live'}, daemon: {state: 'stopped'}
+            });
+
+            expect(result.kind).toBe('cold');
+            expect(result.text).toContain('static roster')
+        });
+
+        test('⭐ N daemons down in ONE episode yield ONE banner — the storm clause, asserted', () => {
+            // The spec's "never a popup storm" is about episodes. The derivation is total and returns
+            // exactly one line whatever the fault breadth, so the storm is unrepresentable rather than
+            // debounced — and a caller cannot turn three dead daemons into three banners.
+            const episode = deriveSpineBanner({
+                ...live,
+                daemon: {state: 'stopped', reason: 'orchestrator, fleet and chroma all exited'}
+            });
+
+            expect(Array.isArray(episode)).toBe(false);
+            expect(Object.keys(episode).sort()).toEqual(['hidden', 'kind', 'text']);
+            expect(episode.text.match(/Agent OS/g)).toHaveLength(1);
+
+            // And it is IDEMPOTENT across re-derivation: a polling consumer re-deriving the same
+            // episode produces an identical line, so nothing accumulates per poll.
+            expect(deriveSpineBanner({...live, daemon: {state: 'stopped', reason: 'orchestrator, fleet and chroma all exited'}}))
+                .toEqual(episode)
+        });
+
+        test('a daemon reason cannot be supplied OR silenced by a transport sibling', () => {
+            // The module's per-surface-reason doctrine, applied to the new surface: a `stale` grid
+            // carrying a reason must not lend it to the daemon line.
+            const result = deriveSpineBanner({
+                grid  : {state: 'stale', reason: 'grid-owned cause'},
+                stream: {state: 'live'},
+                daemon: {state: 'degraded'}
+            });
+
+            expect(result.text).not.toContain('grid-owned cause');
+            expect(result.text).toContain('check the tray state and the daemon log')
+        });
+    });
+
     test('the full 3×3 matrix: cold beats degraded beats live; only live+live hides', () => {
         for (const gridAdapterState of STATES) {
             for (const streamAdapterState of STATES) {


### PR DESCRIPTION
Resolves #16051

Related: #14793

The cockpit half of the shell spec's §3 degraded-state requirement: *"Degraded state (a daemon down) surfaces as tray-state change + **ONE cockpit banner with the diagnosis pointer** — never a popup storm."* The tray half already shipped; the banner did not exist.

Evidence: L3 (unit + component derivation and slot-sync witness, 351/351, mutation-verified) → L3 sufficient for #16051's delivered ACs; no L4 host effect is claimed. Residual: the `fleetRuntimeStatus()` pull that populates `daemonState` [#16051].

The daemon branch is mutation-verified — making it unreachable turns **5 tests red**, including the cockpit slot witness, so the wiring is exercised rather than merely present.

## Why this extends the spine banner instead of adding a component

"ONE banner" is the requirement, so a second banner component would violate the spec it was added to satisfy. `spineBanner.mjs` is the cockpit's single honesty line, so daemon health joins it as a third surface following that module's established **per-surface-reason** discipline — a transport sibling can neither supply nor silence the daemon's cause.

The module previously scoped itself to "the fleet transport itself", so widening it is a deliberate documented change rather than a drift.

## Three judgment calls, each with its reasoning in the code

**It ranks above a stale feed.** A dead daemon is usually what *made* the feed stale, so reporting the feed alone names the symptom and drops the diagnosis pointer the spec explicitly asks for. It ranks *below* an unreachable transport, which cannot have answered a daemon-status pull in the first place — the two are near-exclusive, and when the server is silent "start the server" is the actionable line.

**Daemon silence renders nothing and claims nothing.** `daemonState` defaults to `null`, not `'running'`. Nothing pulls daemon health yet, and defaulting to `running` would have the banner assert *the organism is fine* on the strength of never having asked — absence is unknown, not nominal. The spec asserts that silence directly, so the seam is exercised rather than dormant.

**`kind` reuses `'degraded'` rather than minting a fourth.** Same severity, existing skin, zero SCSS churn — and the diagnosis travels in the **text**, where a screen reader reaches it. Distinguishing a dead daemon from a stale feed by colour alone would be a WCAG 1.4.1 failure. The state word is in the sentence too, so `stopped` and `degraded` stay distinguishable without consulting the tray.

## The storm clause is asserted, not assumed

*"Never a popup storm"* is a property of **episodes**, not renders, so it is tested as one rather than inferred from the return type: N daemons down in one episode yield one line, the shape is exactly `{hidden, kind, text}`, `Agent OS` appears once, and re-derivation is **idempotent** so a polling consumer accumulates nothing.

## Deltas from ticket

- `deriveSpineBanner({daemon, grid, stream})` — new optional `daemon` surface, ranked between `sample` and `stale`. Existing two-surface callers are unaffected; absence is silent.
- New `DAEMON_FAULT_STATES = ['degraded', 'stopped']`, mirroring `harness/appLifecycle.mjs`'s `BRAIN_STATES` minus the nominal one.
- `FleetCockpit` gains `daemonState` / `daemonDegradedReason` (both `null`) and passes them through `syncSpineBanner`.
- No new style, no new data path, no new IPC capability.

## Why there is no new shell capability

The obvious implementation — `webContents.send('shell-brain-state', …)` plus an `ipcRenderer.on` — was rejected. `harness/preload.cjs` states its own gate: *"named, allowlisted affordances only … additions amend the shell ADR §2.3 first."* A banner is not worth widening the one audited shell boundary.

The pull path needs nothing new: `FleetControlBridge.fleetRuntimeStatus()` already returns live process truth over the existing `neoShell.fleetRequest` invoke. So populating `daemonState` is a follow-on against a capability that already exists, and the shell ADR boundary stays exactly where it is.

## Test Evidence

```
351 passed (10.3s)     # test/playwright/unit/apps/agentos/view/fleet/ — whole directory
```

Suite set is the whole touched directory rather than the two changed specs, because `FleetCockpit.mjs` has many consumers and a basename-scoped selection would miss them.

**Mutation control.** Green alone cannot distinguish "the branch works" from "the assertions are inert", so `DAEMON_FAULT_STATES` was emptied to make the daemon branch unreachable:

```
5 failed     # 4 derivation assertions + the cockpit slot witness
```

The ranking test also carries its own **control pair**: it asserts the daemon diagnosis wins, *and* that removing the daemon fault from the same input falls back to the stale line — which is what proves the branch does the ranking rather than the text merely mentioning it.

## Post-Merge Validation

1. **The runtime pull** populates `daemonState` from `fleetRuntimeStatus()` over `neoShell.fleetRequest`. Until it lands the banner is correct and silent, which is the honest state rather than a stub.
2. **§3's remaining bullet is blocked, not deferred**: the tray `Start/Stop agents` verbs. `FleetControlBridge` is per-agent only (`startAgent(id)`/`stopAgent(id)`) with no fleet-wide verb, so §3 as written needs semantics that do not exist — building them would be inventing policy. The design-authority call sits with @neo-opus-grace; the ticket's "spec stands as the bar" fallback cannot resolve it, because defaulting to the spec means defaulting to invented semantics. Recorded at https://github.com/neomjs/neo/issues/14793#issuecomment-5090276529
3. **Close target, corrected.** This opened as `Refs #14793` and tripped `lint-pr-body`, as I predicted in this body. I then argued the gap rather than reading the rule — and the rule already answers it: §9.1's draft-only exception says *"before `ready_for_review`, add the honest delivered leaf close target **or split/file the narrow ticket**"*, and `Resolves` may only target the leaf a PR fully delivers, never a multi-AC parent. So #16051 is the delivered leaf and #14793 stays open on its other three ACs. The substrate had the answer the whole time; I should have read §9 before escalating.

Authored by Vega (@neo-opus-vega, Claude Opus 5, Claude Code). Session f1bcb0a9-68f5-4910-bef6-1a5a33aad1f5.

🌿
