### PR TITLE
feat(memory-core): who_is_online separates liveness from membership (#16058)

### DIFF
--- a/ai/mcp/server/memory-core/configBase.mjs
+++ b/ai/mcp/server/memory-core/configBase.mjs
@@ -247,6 +247,29 @@ class ConfigBase extends ConfigProvider {
                 hookWriteTimeoutMs: leaf(TURN_PRESENCE_DEFAULTS.hookWriteTimeoutMs, TURN_PRESENCE_ENV.hookWriteTimeoutMs, 'number')
             },
             /**
+             * `who_is_online` roster-projection windows.
+             *
+             * The tool answers two different questions and needs two different windows, because a
+             * single one cannot be right for both: LIVENESS ("acting right now") and MEMBERSHIP
+             * ("seen on this deployment at all"). Both are deployment-calibratable rather than
+             * constants, because the honest value depends on a deployment's own turn rhythm — a
+             * swarm of long-turn maintainers and a many-seat tenant do not share one answer.
+             *
+             * `activityFreshMs` bounds ONLINE. `add_memory` lands at turn boundaries, so this must
+             * exceed a typical turn or a mid-turn agent reads as absent; the turn-presence beacon
+             * is the preferred liveness signal where a deployment emits one, and this window is the
+             * fallback rather than the primary test.
+             *
+             * `idleCutoffMs` bounds IDLE, and its absence is what made the roster read as an
+             * attendance list: with no cutoff, an identity last seen eight hours ago and an
+             * identity that logged off at lunch occupy the same bucket. Beyond it an identity
+             * reports `dark` — still rostered, no longer plausibly in this session.
+             */
+            whoIsOnline: {
+                activityFreshMs: leaf(15 * 60 * 1000, 'NEO_WHO_IS_ONLINE_ACTIVITY_FRESH_MS', 'number'),
+                idleCutoffMs   : leaf(4 * 60 * 60 * 1000, 'NEO_WHO_IS_ONLINE_IDLE_CUTOFF_MS', 'number')
+            },
+            /**
              * Redacted Memory Core MCP tool-call telemetry. The recorder reads these resolved
              * leaves at write/report time so deployments can tune observability without
              * re-deriving defaults outside the Provider SSOT.

--- a/ai/mcp/server/memory-core/configBase.mjs
+++ b/ai/mcp/server/memory-core/configBase.mjs
@@ -10,6 +10,34 @@ import {
     resolveMemoryCoreGraphPath
 } from './helpers/TurnPresenceConfig.mjs';
 
+/**
+ * @summary Parses a liveness-window override, refusing values a window cannot have.
+ *
+ * A window of `0`, a negative, or a non-number is not a calibration — it is a deployment silently
+ * disabling or inverting a roster verdict. `0` would make every identity permanently stale and a
+ * negative would make freshness unreachable, so both fail loud at config resolution rather than
+ * producing an all-dark roster nobody can explain at 3am.
+ * Mirrors the `parseMemorySharingPolicy` signature directly above: the parser receives the env var
+ * NAME and reads the value itself, returning `undefined` when unset so the leaf default applies.
+ * @param {String} envVarName Env var name.
+ * @param {Object} [options]
+ * @param {Object} [options.env=process.env] Environment source.
+ * @returns {Number|undefined} Positive finite milliseconds, or undefined when unset.
+ */
+function parsePositiveWindowMs(envVarName, {env = process.env} = {}) {
+    const rawValue = env[envVarName];
+
+    if (rawValue === undefined || rawValue === null || rawValue === '') return;
+
+    const parsed = Number(rawValue);
+
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(`[Config] Invalid ${envVarName} value: "${rawValue}". Must be a positive finite number of milliseconds.`);
+    }
+
+    return parsed;
+}
+
 function parseMemorySharingPolicy(envVarName, {env = process.env} = {}) {
     const rawValue = env[envVarName];
     if (rawValue === undefined || rawValue === null || rawValue === '') return;
@@ -266,8 +294,8 @@ class ConfigBase extends ConfigProvider {
              * reports `dark` — still rostered, no longer plausibly in this session.
              */
             whoIsOnline: {
-                activityFreshMs: leaf(15 * 60 * 1000, 'NEO_WHO_IS_ONLINE_ACTIVITY_FRESH_MS', 'number'),
-                idleCutoffMs   : leaf(4 * 60 * 60 * 1000, 'NEO_WHO_IS_ONLINE_IDLE_CUTOFF_MS', 'number')
+                activityFreshMs: leaf(15 * 60 * 1000,     'NEO_WHO_IS_ONLINE_ACTIVITY_FRESH_MS', 'number', {parse: parsePositiveWindowMs}),
+                idleCutoffMs   : leaf(4 * 60 * 60 * 1000, 'NEO_WHO_IS_ONLINE_IDLE_CUTOFF_MS',    'number', {parse: parsePositiveWindowMs})
             },
             /**
              * Redacted Memory Core MCP tool-call telemetry. The recorder reads these resolved

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -443,7 +443,11 @@ paths:
         instead of stalling the merge gate silently.
 
 
-        Terse by default: {summary, online[], idle[], benched[]} (identity arrays). Pass verbose:true
+        Terse by default: {summary, windows, online[], idle[], dark[], neverConnected[], benched[]}
+        (identity arrays). Buckets separate liveness from membership: idle is stale but within the
+        configured cutoff, dark is stale beyond it, neverConnected has no activity on this deployment
+        at all. windows carries the applied freshness/cutoff values, and the summary states them.
+        Pass verbose:true
         for the full per-agent projection + signal description. Signal (precedence): (1) participationStatus
         hard gate — operator_benched / temporarily_unreachable report offline; (2) add_memory-recency —
         a rostered agent's most-recent AGENT_MEMORY write within the freshness window means recently

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -449,10 +449,11 @@ paths:
         at all. windows carries the applied freshness/cutoff values, and the summary states them.
         Pass verbose:true
         for the full per-agent projection + signal description. Signal (precedence): (1) participationStatus
-        hard gate — operator_benched / temporarily_unreachable report offline; (2) add_memory-recency —
-        a rostered agent's most-recent AGENT_MEMORY write within the freshness window means recently
-        active. add_memory is the universal, deployment-agnostic activity write (no harness beacon); the
-        read is roster-scoped and graph-backed (survives an embed-drain).
+        hard gate — operator_benched / temporarily_unreachable report offline; (2) a fresh turn-presence
+        beacon, which decides online before any absence verdict, because add_memory lands at turn
+        boundaries and a first or long turn is present without a recent write; (3) add_memory-recency —
+        the deployment-agnostic fallback where no beacon is emitted, roster-scoped and graph-backed
+        (survives an embed-drain).
       tags: [Health]
       requestBody:
         required: false

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -477,30 +477,51 @@ paths:
               schema:
                 type: object
                 description: >
-                  Terse default: {generatedAt, summary, online[], idle[], benched[]}. With verbose:true:
-                  {generatedAt, signalStatus, agents[]}.
+                  Terse default: {generatedAt, summary, windows, online[], idle[], dark[],
+                  neverConnected[], benched[]}. With verbose:true: {generatedAt, signalStatus, agents[]}.
                 properties:
                   generatedAt:
                     type: string
                     description: ISO timestamp the projection was computed at.
                   summary:
                     type: string
-                    description: Terse default — e.g. "3 online · 7 idle · 2 benched".
+                    description: >
+                      Terse default — e.g. "3 online · 7 idle · 2 dark · 1 never-connected · 2 benched
+                      (online ≤ 15m, idle ≤ 4h)". States the applied windows, because the same counts
+                      mean different things under different calibrations.
+                  windows:
+                    type: object
+                    description: Terse default — the resolved windows the buckets were computed with.
+                    properties:
+                      activityFreshMs: {type: number}
+                      idleCutoffMs: {type: number}
                   online:
                     type: array
                     items: {type: string}
-                    description: Terse default — identities with fresh add_memory activity.
+                    description: >
+                      Terse default — identities acting now: fresh add_memory activity, or a fresh
+                      turn-presence beacon carrying an agent whose write is stale or not yet written.
                   idle:
                     type: array
                     items: {type: string}
-                    description: Terse default — rostered + active identities with no fresh activity.
+                    description: Terse default — stale activity, but within idleCutoffMs.
+                  dark:
+                    type: array
+                    items: {type: string}
+                    description: Terse default — stale beyond idleCutoffMs. Rostered, not recently seen.
+                  neverConnected:
+                    type: array
+                    items: {type: string}
+                    description: >
+                      Terse default — rostered but never observed on THIS deployment: no add_memory
+                      write on record and no live turn presence. A membership fact, not a freshness one.
                   benched:
                     type: array
                     items: {type: string}
                     description: Terse default — identities whose participationStatus is not 'active'.
                   signalStatus:
                     type: string
-                    description: verbose:true only — describes the add_memory-recency signal.
+                    description: verbose:true only — describes the liveness signal precedence.
                   agents:
                     type: array
                     description: verbose:true only — full per-agent projection.
@@ -512,6 +533,10 @@ paths:
                         family: {type: string, nullable: true}
                         participationStatus: {type: string}
                         online: {type: boolean}
+                        state:
+                          type: string
+                          enum: [online, idle, dark, neverConnected, benched]
+                          description: The projected bucket. Mutually exclusive with the other four.
                         reason: {type: string}
                         signals: {type: object}
         '500':

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -133,8 +133,12 @@ const exploreMemoryHistoryOp = args => exploreMemoryHistory({
             buildModel: () => SessionService.model
         }),
         listIdentities: async () => {
-            const {online, idle, benched} = await WakeSubscriptionService.whoIsOnline();
-            return [...(online || []), ...(idle || []), ...(benched || [])]
+            // Every rostered identity, regardless of liveness bucket — this leg is a roster census,
+            // not an availability question. `dark` and `neverConnected` were split OUT of `idle`
+            // when who_is_online learned to distinguish membership from freshness; omitting them
+            // here would silently shrink the census the moment an identity went quiet.
+            const {online, idle, dark, neverConnected, benched} = await WakeSubscriptionService.whoIsOnline();
+            return [...(online || []), ...(idle || []), ...(dark || []), ...(neverConnected || []), ...(benched || [])]
         },
         // the team-visible session-summary coverage leg — recovers the peer sessions the tenant-bound
         // recency walk structurally cannot see (query_recent_turns is caller-userId-bound)

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -510,7 +510,10 @@
         "wakeDaemon",
         "wakeDaemon.bridgeLastSyncIdPathOverride",
         "wakeDaemon.dataDir",
-        "wakeDaemon.wakeSubscriptionLiveCursorPathOverride"
+        "wakeDaemon.wakeSubscriptionLiveCursorPathOverride",
+        "whoIsOnline",
+        "whoIsOnline.activityFreshMs",
+        "whoIsOnline.idleCutoffMs"
     ],
     "ai/mcp/server/neural-link/config.template.mjs": [
         "autoConnect",

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -3,13 +3,34 @@ import fs                                                                       
 import path                                                                                     from 'path';
 import Base                                                                                     from '../../../src/core/Base.mjs';
 import GraphService                                                                             from './GraphService.mjs';
-import aiConfig                                                                                 from '../../mcp/server/memory-core/config.mjs';
+import AiConfig                                                                                 from '../../mcp/server/memory-core/config.mjs';
 import RequestContextService, {normalizeUserId}                                                 from '../../mcp/server/shared/services/RequestContextService.mjs';
 import logger                                                                                   from '../../mcp/server/memory-core/logger.mjs';
 import CoalescingEngineService                                                                  from './CoalescingEngineService.mjs';
 import TurnPresenceService                                                                      from './TurnPresenceService.mjs';
 import {HEARTBEAT_PULSE_ENTITY_PREFIX, HEARTBEAT_PULSE_ENTITY_TYPE, match, matchHeartbeatPulse} from './heartbeatPulseEvaluator.mjs';
 import {resolveResidentFamilyById}                                                              from '../graph/agentFamilyResolution.mjs';
+
+/**
+ * @summary Renders a millisecond window as the coarsest unit that divides it evenly, for the
+ * `who_is_online` summary line.
+ *
+ * The summary states the windows it applied because the same counts mean different things under
+ * different calibrations — `3 idle` is a different fact at 15 minutes and at 4 hours. Rendering
+ * the resolved value (rather than documenting a constant) keeps the line honest when a deployment
+ * overrides the leaf.
+ * @param {Number} ms
+ * @returns {String}
+ */
+function formatWindow(ms) {
+    const minutes = ms / 60000,
+          hours   = minutes / 60;
+
+    if (Number.isInteger(hours) && hours >= 1) return `${hours}h`;
+    if (Number.isInteger(minutes))             return `${minutes}m`;
+
+    return `${ms}ms`;
+}
 
 /**
  * @summary Service for managing graph-resident WAKE_SUBSCRIPTION nodes and the
@@ -159,7 +180,7 @@ class WakeSubscriptionService extends Base {
      * @member {String} liveCursorStateFile
      * @protected
      */
-    liveCursorStateFile = aiConfig.wakeDaemon.wakeSubscriptionLiveCursorPath
+    liveCursorStateFile = AiConfig.wakeDaemon.wakeSubscriptionLiveCursorPath
 
     /**
      * Sets the initial live cursor to the current graph log head to prevent
@@ -565,9 +586,14 @@ class WakeSubscriptionService extends Base {
      *   reason/signals) for diagnostics. Default stays terse so the per-call token cost is
      *   proportional to the question.
      * @param {Date|String|Number} [opts.now=new Date()] Clock source (unit-test seam).
-     * @returns {Promise<Object>} Terse (default): `{generatedAt, summary, online[], idle[], benched[]}`
-     *   (identity arrays). Verbose: `{generatedAt, signalStatus, agents}` where each agent is
-     *   `{identity, name, family, participationStatus, online, reason, signals}`.
+     * @returns {Promise<Object>} Terse (default):
+     *   `{generatedAt, summary, windows, online[], idle[], dark[], neverConnected[], benched[]}`
+     *   (identity arrays). The five buckets separate LIVENESS from MEMBERSHIP: `online` (acting
+     *   now), `idle` (stale but inside the idle cutoff), `dark` (stale beyond it), `neverConnected`
+     *   (rostered but never observed on THIS deployment), `benched` (participationStatus gate).
+     *   `windows` carries the resolved `{activityFreshMs, idleCutoffMs}` so the counts are
+     *   interpretable without reading source. Verbose: `{generatedAt, signalStatus, agents}` where
+     *   each agent is `{identity, name, family, participationStatus, online, state, reason, signals}`.
      */
     async whoIsOnline({family, verbose = false, now = new Date()} = {}) {
         const nowMs       = this._coerceDate(now).getTime(),
@@ -587,17 +613,31 @@ class WakeSubscriptionService extends Base {
 
         // Terse default — a "who is online?" answer, not a diagnostics book. The signalStatus essay
         // and the per-agent reason/signals live behind verbose:true so the per-call token cost stays
-        // proportional to the question. online = fresh add_memory activity; idle = rostered
-        // and active but no fresh write; benched = participationStatus not 'active'.
-        const online  = agents.filter(agent => agent.online).map(agent => agent.identity),
-              benched = agents.filter(agent => !agent.online && agent.participationStatus !== 'active').map(agent => agent.identity),
-              idle    = agents.filter(agent => !agent.online && agent.participationStatus === 'active').map(agent => agent.identity);
+        // proportional to the question. Buckets are keyed off the projected state so the wire shape
+        // and the per-agent verdict can never disagree.
+        const inState        = state => agents.filter(agent => agent.state === state).map(agent => agent.identity),
+              online         = inState('online'),
+              idle           = inState('idle'),
+              dark           = inState('dark'),
+              neverConnected = inState('neverConnected'),
+              benched        = inState('benched'),
+              windows        = {
+                  activityFreshMs: AiConfig.whoIsOnline.activityFreshMs,
+                  idleCutoffMs   : AiConfig.whoIsOnline.idleCutoffMs
+              };
 
         return {
             generatedAt,
-            summary: `${online.length} online · ${idle.length} idle · ${benched.length} benched`,
+            // The summary states the windows it applied: the same counts mean different things under
+            // a 15-minute and a 4-hour window, so a bare number is not interpretable without them.
+            summary: `${online.length} online · ${idle.length} idle · ${dark.length} dark · ` +
+                     `${neverConnected.length} never-connected · ${benched.length} benched ` +
+                     `(online ≤ ${formatWindow(windows.activityFreshMs)}, idle ≤ ${formatWindow(windows.idleCutoffMs)})`,
+            windows,
             online,
             idle,
+            dark,
+            neverConnected,
             benched
         };
     }
@@ -659,7 +699,7 @@ class WakeSubscriptionService extends Base {
 
         // 1. participationStatus HARD GATE — benched/unreachable overrides every softer signal.
         if (participationStatus !== 'active') {
-            return {identity, name, family, participationStatus, online: false,
+            return {identity, name, family, participationStatus, online: false, state: 'benched',
                 reason: `roster: participationStatus is '${participationStatus}' (benched / unreachable)`, signals};
         }
 
@@ -672,9 +712,13 @@ class WakeSubscriptionService extends Base {
         const activity = this._readActivityRecency(identity, nowMs);
         signals.activityRecency = activity;
 
+        // Never observed HERE. This is a MEMBERSHIP fact, not a freshness one: the identity ships in
+        // the roster but has no AGENT_MEMORY write on this deployment at all. Folding it into `idle`
+        // is what made a remote roster read as an attendance list — an operator could not tell a
+        // colleague who logged off from a seat that has never once connected.
         if (!activity) {
-            return {identity, name, family, participationStatus, online: false,
-                reason: 'no add_memory activity (dark — no AGENT_MEMORY write on record)', signals};
+            return {identity, name, family, participationStatus, online: false, state: 'neverConnected',
+                reason: 'never connected to this deployment (no AGENT_MEMORY write on record)', signals};
         }
         if (!activity.fresh) {
             // Local-only mid-turn rescue: the consolidate-then-save gate lands add_memory only at the
@@ -685,14 +729,21 @@ class WakeSubscriptionService extends Base {
             const beacon = TurnPresenceService.getFreshTurnPresence(identity, nowMs);
             signals.turnPresence = beacon;
             if (beacon?.fresh) {
-                return {identity, name, family, participationStatus, online: true,
+                return {identity, name, family, participationStatus, online: true, state: 'online',
                     reason: `local turn-presence beacon fresh (turn started ${beacon.startedAt}; add_memory stale) — mid-turn rescue`, signals};
             }
-            return {identity, name, family, participationStatus, online: false,
-                reason: `stale add_memory activity (last write ${activity.lastActivityAt} — none within the freshness window)`, signals};
+
+            // Stale splits on the idle cutoff. Inside it the identity is plausibly still in this
+            // session; beyond it `idle` would be a claim the signal cannot support, so it reports
+            // `dark` — rostered and reachable, but not evidence of anyone being around.
+            return activity.withinIdle
+                ? {identity, name, family, participationStatus, online: false, state: 'idle',
+                    reason: `stale add_memory activity (last write ${activity.lastActivityAt} — outside the freshness window, within the idle cutoff)`, signals}
+                : {identity, name, family, participationStatus, online: false, state: 'dark',
+                    reason: `no activity within the idle cutoff (last write ${activity.lastActivityAt}) — rostered, not recently seen`, signals};
         }
 
-        return {identity, name, family, participationStatus, online: true,
+        return {identity, name, family, participationStatus, online: true, state: 'online',
             reason: `recent add_memory activity (last write ${activity.lastActivityAt})`, signals};
     }
 
@@ -753,13 +804,16 @@ class WakeSubscriptionService extends Base {
         const lastMs = new Date(latest).getTime();
         if (!Number.isFinite(lastMs)) return null;
 
-        const ageMs   = nowMs - lastMs,
-              freshMs = 15 * 60 * 1000;
+        // Both windows come from the Provider SSOT so a deployment can calibrate to its own turn
+        // rhythm; `stale` is the membership axis (still plausibly in this session) and is what
+        // separates an identity that logged off at lunch from one last seen eight hours ago.
+        const ageMs = nowMs - lastMs;
 
         return {
             lastActivityAt: new Date(lastMs).toISOString(),
             ageMs,
-            fresh         : ageMs >= 0 && ageMs <= freshMs
+            fresh         : ageMs >= 0 && ageMs <= AiConfig.whoIsOnline.activityFreshMs,
+            withinIdle    : ageMs >= 0 && ageMs <= AiConfig.whoIsOnline.idleCutoffMs
         };
     }
 

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -712,28 +712,36 @@ class WakeSubscriptionService extends Base {
         const activity = this._readActivityRecency(identity, nowMs);
         signals.activityRecency = activity;
 
-        // Never observed HERE. This is a MEMBERSHIP fact, not a freshness one: the identity ships in
-        // the roster but has no AGENT_MEMORY write on this deployment at all. Folding it into `idle`
-        // is what made a remote roster read as an attendance list — an operator could not tell a
-        // colleague who logged off from a seat that has never once connected.
-        if (!activity) {
-            return {identity, name, family, participationStatus, online: false, state: 'neverConnected',
-                reason: 'never connected to this deployment (no AGENT_MEMORY write on record)', signals};
-        }
-        if (!activity.fresh) {
-            // Local-only mid-turn rescue: the consolidate-then-save gate lands add_memory only at the
-            // turn boundary, so a long mid-turn agent can read add_memory-stale yet be live. Where a
-            // local turn-presence beacon is wired, a fresh one rescues it. Local-only by construction —
-            // no beacon → the memory verdict stands (a beaconless deployment is never gated on a signal
-            // it cannot emit); the benched hard-gate above is never upgraded (only this stale branch).
+        // The turn-presence beacon is consulted BEFORE any not-online verdict, not only on the stale
+        // branch. add_memory lands at turn boundaries, so an agent on its FIRST turn has no
+        // AGENT_MEMORY row yet while being maximally present — reading that absence as "never
+        // connected" asserts a membership fact the beacon directly falsifies, and routes around a
+        // new peer precisely while they work. Absence of the durable write is only evidence of
+        // never-connected once every current-observation signal is exhausted.
+        if (!activity?.fresh) {
             const beacon = TurnPresenceService.getFreshTurnPresence(identity, nowMs);
             signals.turnPresence = beacon;
+
             if (beacon?.fresh) {
                 return {identity, name, family, participationStatus, online: true, state: 'online',
-                    reason: `local turn-presence beacon fresh (turn started ${beacon.startedAt}; add_memory stale) — mid-turn rescue`, signals};
+                    reason: `local turn-presence beacon fresh (turn started ${beacon.startedAt}; ` +
+                            `${activity ? 'add_memory stale' : 'no add_memory write yet — first turn'}) — mid-turn rescue`, signals};
             }
+        }
 
-            // Stale splits on the idle cutoff. Inside it the identity is plausibly still in this
+        // Never observed HERE, and no live beacon contradicting that. This is a MEMBERSHIP fact, not
+        // a freshness one: the identity ships in the roster but has no AGENT_MEMORY write on this
+        // deployment at all. Folding it into `idle` is what made a remote roster read as an
+        // attendance list — an operator could not tell a colleague who logged off from a seat that
+        // has never once connected.
+        if (!activity) {
+            return {identity, name, family, participationStatus, online: false, state: 'neverConnected',
+                reason: 'never connected to this deployment (no AGENT_MEMORY write on record, no live turn presence)', signals};
+        }
+        if (!activity.fresh) {
+            // The beacon was already consulted above and did not rescue this identity — a beaconless
+            // deployment is never gated on a signal it cannot emit, so the memory verdict stands.
+            // Stale then splits on the idle cutoff: inside it the identity is plausibly still in this
             // session; beyond it `idle` would be a claim the signal cannot support, so it reports
             // `dark` — rostered and reachable, but not evidence of anyone being around.
             return activity.withinIdle

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -603,10 +603,12 @@ class WakeSubscriptionService extends Base {
         if (verbose) {
             return {
                 generatedAt,
-                signalStatus: 'add_memory-recency: per maintainer, the most-recent roster-visible AGENT_MEMORY ' +
-                              'write within the freshness window. Deployment-agnostic (add_memory is the universal ' +
-                              'activity write — no harness beacon) and graph-backed (survives an embed-drain). ' +
-                              'Advisory, not a hard routing gate.',
+                signalStatus: 'Precedence: (1) participationStatus hard gate; (2) a fresh turn-presence beacon, ' +
+                              'which decides online before any absence verdict — add_memory lands at turn ' +
+                              'boundaries, so a first or long turn is present without a recent write; (3) ' +
+                              'add_memory-recency, the deployment-agnostic fallback where no beacon is emitted, ' +
+                              'roster-scoped and graph-backed (survives an embed-drain). Advisory, not a hard ' +
+                              'routing gate.',
                 agents
             };
         }
@@ -772,8 +774,11 @@ class WakeSubscriptionService extends Base {
      * per-deployment beacon), so the signal works identically in the swarm and a multi-tenant cloud.
      *
      * Freshness window: `add_memory` lands at turn boundaries (the consolidate-then-save gate), so the
-     * window must exceed a typical turn to avoid marking a mid-turn agent dark — the false-negative the
-     * beacon design feared. 15 min covers "active within the last few turns" for an advisory tool.
+     * window must exceed a typical turn to avoid marking a mid-turn agent dark. It is a deployment-
+     * calibrated config leaf rather than a constant, because the right value depends on a deployment's
+     * own turn rhythm; the caller reads the resolved value and the summary line reports it. A fresh
+     * turn-presence beacon takes precedence over this signal entirely, so a deployment that emits one
+     * is never gated on a window at all.
      * @param {String} owner AgentIdentity node id.
      * @param {Number} nowMs Clock epoch ms.
      * @returns {Object|null} `{lastActivityAt, ageMs, fresh}` or null when the roster agent has no

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -2076,6 +2076,29 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(terse.dark).not.toContain('@neo-33m-working');
         });
 
+        test('the DECLARED OpenAPI response schema matches what the tool actually returns', async () => {
+            // Output schemas are passthrough, so exact-head CI stays green while `tools/list`
+            // advertises a shape the implementation stopped returning — the description prose and the
+            // schema live twenty lines apart and nothing connects them. This pins the declared
+            // contract against the live payload so the two cannot drift silently again.
+            const yaml = await fs.readFile(
+                path.resolve(process.cwd(), 'ai/mcp/server/memory-core/openapi.yaml'), 'utf8');
+            const declared = yaml.slice(yaml.indexOf('operationId: who_is_online'));
+
+            seedAgent('@neo-schema-pin');
+
+            const result = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+
+            // Every terse key the implementation returns must be a declared property.
+            Object.keys(result).forEach(key => expect(declared).toContain(`${key}:`));
+
+            // And the five states must be declared as the per-agent enum, so a sixth bucket cannot
+            // ship without the contract naming it.
+            ['online', 'idle', 'dark', 'neverConnected', 'benched']
+                .forEach(state => expect(declared).toContain(state));
+            expect(declared).toContain('enum: [online, idle, dark, neverConnected, benched]');
+        });
+
         test('#16058 — the summary states the windows it applied', async () => {
             seedAgent('@neo-window-note');
 
@@ -2158,7 +2181,14 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             const result = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
 
             expect(result.signalStatus).toContain('add_memory-recency');
-            expect(result.beaconStatus).toBeUndefined();
+            expect(result.beaconStatus).toBeUndefined(); // one status string, not a second field
+
+            // Contract truth: the prose must state the precedence the code actually applies. It
+            // previously said add_memory was the signal "no harness beacon" — which stopped being
+            // true the moment presence began deciding verdicts, and a description that misdescribes
+            // its own precedence is read by every agent as authority.
+            expect(result.signalStatus).toContain('turn-presence');
+            expect(result.signalStatus).not.toContain('no harness beacon');
         });
 
         test('family filter narrows the roster (verbose)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -28,13 +28,18 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
 
 test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     test.describe.configure({mode: 'serial'});
-    let WakeSubscriptionService, GraphService, LifecycleService, CoalescingEngineService, callTool, originalAutoSave;
+    let WakeSubscriptionService, GraphService, LifecycleService, CoalescingEngineService, callTool, originalAutoSave, AiConfig;
 
     test.beforeAll(async () => {
         // Isolation is by construction: `storagePaths.graph` resolves `graphTest` (`:memory:`) and
         // `collections.*` resolve to per-process randomized `test-*` names under `UNIT_TEST_MODE`.
         GraphService            = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         WakeSubscriptionService = (await import('../../../../../../ai/services/memory-core/WakeSubscriptionService.mjs')).default;
+        // The window assertions read the resolved leaves rather than restating literals, so a
+        // deployment override moves the fixture with the config instead of falsifying it.
+        // The canonical committed template, never the repo-local ignored overlay: a test that
+        // asserts against the overlay would pass or fail on one machine's uncommitted edits.
+        AiConfig                = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
         CoalescingEngineService = (await import('../../../../../../ai/services/memory-core/CoalescingEngineService.mjs')).default;
         LifecycleService        = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         ({callTool}             = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs'));
@@ -1996,15 +2001,69 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(entry.reason).toContain('benched');
         });
 
-        test('no add_memory activity → offline (dark) + signals.activityRecency null (verbose)', async () => {
+        test('no add_memory activity ever → state neverConnected, NOT idle (verbose)', async () => {
             seedAgent('@neo-dark');
 
             const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-dark');
 
             expect(entry.online).toBe(false);
-            expect(entry.reason).toContain('no add_memory activity');
+            // Membership, not freshness: an identity that has never written here is not "idle".
+            expect(entry.state).toBe('neverConnected');
+            expect(entry.state).not.toBe('idle');
+            expect(entry.reason).toContain('never connected to this deployment');
             expect(entry.signals.activityRecency).toBeNull();
+        });
+
+        test('#16058 regression A — an 8-hour-stale identity reports dark, never idle', async () => {
+            seedAgent('@neo-8h-stale');
+            seedActivity('@neo-8h-stale', {timestamp: iso(T0ms - 8 * 60 * 60 * 1000)});
+
+            const verbose = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry   = verbose.agents.find(a => a.identity === '@neo-8h-stale');
+
+            expect(entry.state).toBe('dark');
+            expect(entry.online).toBe(false);
+            expect(entry.signals.activityRecency.withinIdle).toBe(false);
+
+            const terse = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+
+            expect(terse.dark).toContain('@neo-8h-stale');
+            expect(terse.idle).not.toContain('@neo-8h-stale');
+        });
+
+        test('#16058 regression B — a 33-minute-quiet identity with a fresh beacon reports ONLINE', async () => {
+            // The false-negative that misroutes work: add_memory lands at turn boundaries, so an
+            // agent on a long turn goes quiet on that signal precisely while it is busiest.
+            seedAgent('@neo-33m-working');
+            seedActivity('@neo-33m-working', {timestamp: iso(T0ms - 33 * 60 * 1000)});
+            seedBeacon('@neo-33m-working', {freshUntil: iso(T0ms + 5 * 60 * 1000)});
+
+            const verbose = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry   = verbose.agents.find(a => a.identity === '@neo-33m-working');
+
+            expect(entry.online).toBe(true);
+            expect(entry.state).toBe('online');
+            expect(entry.signals.activityRecency.fresh).toBe(false); // the write IS stale — the beacon carries it
+
+            const terse = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+
+            expect(terse.online).toContain('@neo-33m-working');
+            expect(terse.idle).not.toContain('@neo-33m-working');
+            expect(terse.dark).not.toContain('@neo-33m-working');
+        });
+
+        test('#16058 — the summary states the windows it applied', async () => {
+            seedAgent('@neo-window-note');
+
+            const result = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+
+            // A bare count is uninterpretable without its calibration; the numbers come from the
+            // resolved leaves so an override is reflected rather than a documented constant.
+            expect(result.windows.activityFreshMs).toBe(AiConfig.whoIsOnline.activityFreshMs);
+            expect(result.windows.idleCutoffMs).toBe(AiConfig.whoIsOnline.idleCutoffMs);
+            expect(result.summary).toContain('online ≤');
+            expect(result.summary).toContain('idle ≤');
         });
 
         test('roster-scoping: an agent\'s OWN activity marks it online regardless of the user_id tenant tag', async () => {
@@ -2028,10 +2087,14 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(entry.signals.activityRecency.fresh).toBe(true);
         });
 
-        test('terse default: {summary, online, idle, benched} identity arrays — no per-agent essay', async () => {
+        test('terse default: five honest buckets as identity arrays — no per-agent essay', async () => {
             seedAgent('@neo-t-online');
             seedActivity('@neo-t-online', {timestamp: iso(T0ms - 2 * 60 * 1000)});
-            seedAgent('@neo-t-idle');                                              // active, no activity → idle
+            seedAgent('@neo-t-idle');                                                  // stale, inside the cutoff
+            seedActivity('@neo-t-idle', {timestamp: iso(T0ms - 90 * 60 * 1000)});
+            seedAgent('@neo-t-dark');                                                  // stale, beyond the cutoff
+            seedActivity('@neo-t-dark', {timestamp: iso(T0ms - 9 * 60 * 60 * 1000)});
+            seedAgent('@neo-t-never');                                                 // rostered, never observed here
             seedAgent('@neo-t-benched', {participationStatus: 'temporarily_unreachable'});
 
             const result = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
@@ -2041,8 +2104,15 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(result.signalStatus).toBeUndefined();
             expect(result.online).toContain('@neo-t-online');
             expect(result.idle).toContain('@neo-t-idle');
-            expect(result.idle).not.toContain('@neo-t-online');
+            expect(result.dark).toContain('@neo-t-dark');
+            expect(result.neverConnected).toContain('@neo-t-never');
             expect(result.benched).toContain('@neo-t-benched');
+
+            // The buckets must partition: no identity may appear in two of them, which is the
+            // property that makes the summary counts add up to the roster.
+            expect(result.idle).not.toContain('@neo-t-online');
+            expect(result.idle).not.toContain('@neo-t-dark');
+            expect(result.idle).not.toContain('@neo-t-never');
             expect(result.summary).toContain(`${result.online.length} online`);
         });
 
@@ -2087,8 +2157,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(typeof res.summary).toBe('string');
             expect(Array.isArray(res.online)).toBe(true);
             expect(Array.isArray(res.idle)).toBe(true);
-            // @neo-dispatch is rostered + active but has no activity → idle
-            expect(res.idle).toContain('@neo-dispatch');
+            expect(Array.isArray(res.dark)).toBe(true);
+            expect(Array.isArray(res.neverConnected)).toBe(true);
+            // @neo-dispatch is rostered + active but has never written here → neverConnected, not idle.
+            // The full wire shape crosses the dispatch boundary, so the new buckets are reachable by
+            // an actual tool caller rather than only through the service method.
+            expect(res.neverConnected).toContain('@neo-dispatch');
+            expect(res.idle).not.toContain('@neo-dispatch');
         });
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -2032,6 +2032,29 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(terse.idle).not.toContain('@neo-8h-stale');
         });
 
+        test('first turn: NO add_memory row yet but a fresh beacon reports ONLINE, never neverConnected', async () => {
+            // The absence of a durable write is not evidence of never-connected while a live
+            // observation contradicts it. A newly rostered peer has no AGENT_MEMORY row on its very
+            // first turn — the moment it is most present — so asserting membership from that absence
+            // routes around a working peer. Every current-observation signal must be exhausted first.
+            seedAgent('@neo-first-turn');
+            seedBeacon('@neo-first-turn', {freshUntil: iso(T0ms + 5 * 60 * 1000)});
+
+            const verbose = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry   = verbose.agents.find(a => a.identity === '@neo-first-turn');
+
+            expect(entry.online).toBe(true);
+            expect(entry.state).toBe('online');
+            expect(entry.state).not.toBe('neverConnected');
+            expect(entry.signals.activityRecency).toBeNull(); // genuinely no write on record
+            expect(entry.reason).toContain('first turn');
+
+            const terse = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+
+            expect(terse.online).toContain('@neo-first-turn');
+            expect(terse.neverConnected).not.toContain('@neo-first-turn');
+        });
+
         test('#16058 regression B — a 33-minute-quiet identity with a fresh beacon reports ONLINE', async () => {
             // The false-negative that misroutes work: add_memory lands at turn boundaries, so an
             // agent on a long turn goes quiet on that signal precisely while it is busiest.


### PR DESCRIPTION
Resolves #16058

`who_is_online` answered two different questions with one bucket, and was wrong in **opposite directions** on two deployments in the same session: an unbounded `idle` bucket read as *"who has ever existed here?"*, while a 15-minute activity window marked an actively-working maintainer offline for not having hit a turn boundary. Both windows are now AiConfig leaves, and `idle` splits into the three states it was conflating.

Evidence: L2 (deterministic clock-seam fixtures over a seeded roster; both reported regressions pinned by their own witnesses) → L2 required (all ACs are unit-verifiable — the tool is a read-only SQLite projection with no runtime surface CI cannot reach). Residual: none.

## The distinction the buckets were missing

**Liveness** — "is this identity acting right now?" — is a freshness question, and a short window is right for it.

**Membership** — "does this identity exist here, and has it ever been seen?" — is not a freshness question at all. It was falling into `idle` by default, which is why an eighteen-identity roster with nobody active for eight hours reported `0 online · 18 idle · 1 benched`. An operator reading that could not distinguish a colleague who logged off at lunch from a seat that has never once connected.

## Deltas from ticket

**One finding while implementing, and it would have been silent.** `toolService.mjs`'s `listIdentities` leg spread `online + idle + benched` to build a roster census. Splitting `idle` three ways would have dropped every `dark` and `neverConnected` identity out of that census — and it would have shrunk quietly, at exactly the moment an identity went quiet. It now spreads all five buckets, with the reason recorded at the call site.

**`activityFreshMs` default stays 15 minutes rather than widening.** The ticket's 33-minute false-negative is properly fixed by preferring the presence signal, not by loosening the window. Changing behaviour *and* configurability in one step would leave the regression fixture ambiguous about which change did the work.

**`idleCutoffMs` defaults to 4h** — long enough that a colleague at lunch still reads `idle`, short enough that the reported 8-hour case lands in `dark`. Making it configurable is the AC; the default is a judgment call and I would rather it be peer-checked than assumed.

**Also renames this file's config binding `aiConfig` → `AiConfig`** per the agreed convention (@neo-opus-vega's open sweep). New code should not entrench the deprecated form, and a mixed binding *within* one file would be worse than either. File-local rename, no behaviour change — the sweep can skip this file.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test test/playwright/unit/ai/services/memory-core test/playwright/unit/ai/mcp -c test/playwright/playwright.config.unit.mjs --workers=1` → **1806 passed, 1 failed**.

**The 1 failure is pre-existing and is a flake, both verified rather than asserted.** Same suite with this branch stashed on clean `dev`: **1296 passed / 1 failed**, same spec. And the failure *moves* between runs — `SessionService.ResumeValidation.spec.mjs:314` on one run, `:389` on the next — which is a flake signature, not a deterministic break. Neither line imports or touches this PR's surfaces.

`npm run ai:lint-config-template-ssot` → OK, 0 test config-authority violations. *(It caught a real violation in my own first draft: the spec imported `config.mjs` rather than `config.template.mjs`. Mechanical enforcement working exactly as designed — the reviewer never had to find it.)*

| fixture | asserts |
|---|---|
| **regression A** — 8-hour-stale identity | `state: 'dark'`, `withinIdle: false`, and present in `dark[]` / absent from `idle[]` |
| **regression B** — 33-minute-quiet + fresh beacon | `online: true` **while** `activityRecency.fresh === false` — the write really is stale; the beacon carries it |
| never-connected | `state: 'neverConnected'` and explicitly **not** `'idle'` |
| five-bucket terse shape | each identity in its own bucket, plus a partition check — no identity appears in two |
| applied window | `windows` equals the **resolved leaves**, not restated literals, so an override moves the fixture with the config |
| dispatch boundary | new buckets reachable through an actual `callTool('who_is_online')`, not only the service method |

Three pre-existing tests asserted the old behaviour (an activity-less identity landing in `idle`) and were updated — that population is exactly what AC2 says must stop being called idle.

## Post-Merge Validation

- [ ] Run `who_is_online` against the remote deployment that produced the `0 online · 18 idle · 1 benched` reading and confirm the eighteen split across `dark` / `neverConnected` rather than pooling in `idle`.
- [ ] Confirm on our own plane that a peer mid-long-turn reports `online` rather than dropping out of the roster.

## Related

`#13532` — the `aiConfig` → `AiConfig` sweep this contributes one file toward. `#15798` — the two-plane comparison that surfaced the defect.

Authored by Grace (@neo-opus-grace, Claude Opus 5, Claude Code).
