### PR TITLE
feat(mcp): agent-facing tool descriptions stop calling Neo a framework (#16063)

### DIFF
--- a/.github/workflows/identity-vocabulary-lint.yml
+++ b/.github/workflows/identity-vocabulary-lint.yml
@@ -1,0 +1,46 @@
+name: Identity Vocabulary Lint
+
+# MCP tool descriptions are loaded into every agent's context as the authoritative statement of
+# what a tool operates on — including agents that never read a guide, other model families, and any
+# external consumer of the OpenAPI surface. A category noun stated there is not wording drift; it is
+# a claim about what Neo IS, delivered on every call.
+#
+# That is why this needs a machine and not a reading discipline: the identity anchor is enforced by
+# reading it, which works for prose an agent WRITES and fails for substrate an agent INHERITS. Four
+# instances accumulated in exactly the surface with the widest agent reach.
+#
+# Path-filtered to the agent-facing surfaces plus the guard itself: a PR touching neither cannot
+# introduce the drift, so running it there would be noise.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'ai/mcp/server/*/openapi.yaml'
+      - 'ai/scripts/lint/lint-identity-vocabulary.mjs'
+      - '.github/workflows/identity-vocabulary-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'ai/mcp/server/*/openapi.yaml'
+      - 'ai/scripts/lint/lint-identity-vocabulary.mjs'
+      - '.github/workflows/identity-vocabulary-lint.yml'
+
+concurrency:
+  group: identity-vocabulary-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Lint identity vocabulary in agent-facing tool descriptions
+        run: node ai/scripts/lint/lint-identity-vocabulary.mjs

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -403,7 +403,7 @@ paths:
               conceptual_query:
                 summary: Broad Conceptual Query
                 value:
-                  query: "framework benefits and architecture"
+                  query: "Neo.mjs benefits and architecture"
               specific_component_query:
                 summary: Specific Component Query
                 value:
@@ -467,7 +467,7 @@ paths:
         entire indexed codebase (source code, guides, examples, tickets, release notes), retrieves
         the top-scoring documents, and uses an LLM to synthesize a grounded answer with cited
         references. Even lightweight local models (e.g., Gemma4-31B via MLX) can invoke this tool
-        to access frontier-quality framework knowledge.
+        to access frontier-quality Neo.mjs knowledge.
 
         **Input:**
         - `query`: The question to ask. Natural language works best — ask it like you would ask a senior developer.
@@ -501,7 +501,7 @@ paths:
         ## Anti-Pattern Warning
 
         **Do NOT attempt to answer Neo.mjs questions from training data.** Always ask the
-        knowledge base first. The framework evolves rapidly — your training data is almost
+        knowledge base first. Neo.mjs evolves rapidly — your training data is almost
         certainly outdated for syntax-level details.
       tags: [Documents]
       requestBody:

--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -2185,7 +2185,7 @@ paths:
         Manages the global Neo.config object (get/set).
 
         **When to Use:**
-        To inspect or modify the global configuration of the framework at runtime.
+        To inspect or modify the global configuration of the engine at runtime.
       tags: [Configuration]
       requestBody:
         required: true

--- a/ai/scripts/lint/lint-identity-vocabulary.mjs
+++ b/ai/scripts/lint/lint-identity-vocabulary.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * @summary Fails when an agent-facing MCP tool description calls Neo a framework.
+ *
+ * ## Why this surface specifically
+ *
+ * Tool descriptions are loaded into every agent's context as the authoritative statement of what a
+ * tool operates on. They reach agents that never read a single guide — including fresh sessions,
+ * other model families, and any external consumer of the OpenAPI surface. A category noun stated
+ * there is not wording drift; it is a claim about what Neo *is*, delivered on every call.
+ *
+ * That matters because the identity anchor exists to nullify a pre-training prior: all three model
+ * families reduce Neo to a web framework unless something local says otherwise. A description that
+ * says "framework" feeds exactly the prior the anchor is built to cancel, from inside the substrate,
+ * where re-reading the anchor cannot reach it.
+ *
+ * Correct vocabulary: Neo is a self-evolving software organism; the Body (`/src/`) is a
+ * multi-threaded application ENGINE; the Brain (`/ai/`) is the Agent OS.
+ *
+ * ## The rule, and why it is default-deny
+ *
+ * Any `framework` token in these files is a violation UNLESS it names a specific external one —
+ * `React framework`, `Playwright framework`. The carve-out is deliberately narrow and mechanical:
+ * an external framework is always *named*, so the qualifier is a reliable signal, while an
+ * unqualified `framework` in a Neo-owned description can only mean Neo.
+ *
+ * Default-deny is the right polarity because the failure this guards against is a category claim
+ * arriving by omission — nobody writes "Neo is a framework"; they write "the framework", and the
+ * claim rides in on the definite article. An allowlist-of-bad-phrases would have to enumerate the
+ * ways one can imply it, which is unbounded; enumerating the ways to name an external framework is
+ * not.
+ *
+ * There is no `--fix`. The correct substitution depends on which hemisphere a line is about —
+ * "engine" for runtime-facing text, "Neo.mjs" for text about knowledge of the project — and a flag
+ * that guessed would launder one category error into another.
+ */
+
+import fs   from 'node:fs';
+import path from 'node:path';
+
+const ROOT        = path.resolve(import.meta.dirname, '../../..'),
+      SERVER_ROOT = path.join(ROOT, 'ai/mcp/server'),
+      /**
+       * A `framework` token counts as external — and therefore legal — only when the word directly
+       * before it is a capitalized NAME. `Vue framework` passes; `the framework` does not.
+       *
+       * Determiners are excluded explicitly because capitalization alone is not evidence of a name:
+       * a sentence-initial "The framework evolves rapidly" is capitalized and is the most explicit
+       * category claim of all. That exact line survived the first draft of this guard, which is why
+       * the stoplist exists rather than a bare `[A-Z]` test.
+       */
+      DETERMINERS = new Set(['a', 'an', 'the', 'this', 'that', 'these', 'those', 'our', 'its',
+                             'their', 'his', 'her', 'any', 'each', 'every', 'no', 'some', 'one']),
+      EXTERNAL    = /\b([A-Z][A-Za-z0-9.+-]*)\s+frameworks?\b/,
+      TOKEN       = /\bframeworks?\b/i;
+
+/**
+ * @summary Whether the line's `framework` token names a specific external framework.
+ * @param {String} text Source line.
+ * @returns {Boolean}
+ */
+function namesExternalFramework(text) {
+    const match = EXTERNAL.exec(text);
+
+    return Boolean(match) && !DETERMINERS.has(match[1].toLowerCase());
+}
+
+/**
+ * @summary Collects every `openapi.yaml` under the MCP server tree.
+ * @returns {String[]} Absolute file paths.
+ */
+function collectSurfaces() {
+    if (!fs.existsSync(SERVER_ROOT)) return [];
+
+    return fs.readdirSync(SERVER_ROOT, {withFileTypes: true})
+        .filter(entry => entry.isDirectory())
+        .map(entry => path.join(SERVER_ROOT, entry.name, 'openapi.yaml'))
+        .filter(file => fs.existsSync(file));
+}
+
+/**
+ * @summary Reports every line whose `framework` token is not a named external one.
+ * @param {String} file Absolute path.
+ * @returns {Object[]} `{file, line, text}` violations.
+ */
+function findViolations(file) {
+    return fs.readFileSync(file, 'utf8').split('\n')
+        .map((text, index) => ({text, line: index + 1}))
+        .filter(({text}) => TOKEN.test(text) && !namesExternalFramework(text))
+        .map(({text, line}) => ({file: path.relative(ROOT, file), line, text: text.trim()}));
+}
+
+const violations = collectSurfaces().flatMap(findViolations);
+
+if (violations.length) {
+    console.error(`\x1b[31mlint-identity-vocabulary: ${violations.length} framework-category claim(s) in agent-facing tool descriptions:\x1b[0m`);
+    violations.forEach(({file, line, text}) => console.error(`  ${file}:${line}: ${text}`));
+    console.error(
+        'Neo is not a framework — the Body is an ENGINE, the Brain is the Agent OS. Tool descriptions\n' +
+        'are read by every agent as authority on what Neo is, including agents that never read a guide.\n' +
+        'Use "engine" for runtime-facing text and "Neo.mjs" for text about knowledge of the project.\n' +
+        'Naming a specific external framework (e.g. "React framework") is legal and passes.'
+    );
+    process.exit(1);
+}
+
+console.log(`lint-identity-vocabulary: ${collectSurfaces().length} agent-facing surface(s) scanned, 0 violations.`);

--- a/ai/scripts/lint/lint-identity-vocabulary.mjs
+++ b/ai/scripts/lint/lint-identity-vocabulary.mjs
@@ -35,8 +35,9 @@
  * that guessed would launder one category error into another.
  */
 
-import fs   from 'node:fs';
-import path from 'node:path';
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const ROOT        = path.resolve(import.meta.dirname, '../../..'),
       SERVER_ROOT = path.join(ROOT, 'ai/mcp/server'),
@@ -59,24 +60,27 @@ const ROOT        = path.resolve(import.meta.dirname, '../../..'),
        * subject is worse than no guard, because it certifies the thing it was built to stop.
        */
       NEO_TOKENS  = new Set(['neo', 'neo.mjs', 'neomjs']),
-      EXTERNAL    = /\b([A-Z][A-Za-z0-9.+-]*)\s+frameworks?\b/,
-      TOKEN       = /\bframeworks?\b/i;
+      /**
+       * Every `framework` token with its immediately preceding word, if any. Global and
+       * occurrence-scoped so each token is judged on its own qualifier.
+       */
+      OCCURRENCE  = /(?:([A-Za-z0-9.+-]+)\s+)?\bframeworks?\b/gi;
 
 /**
- * @summary Whether the line's `framework` token names a specific external framework.
+ * @summary Whether one `framework` occurrence's qualifier names a specific external framework.
  *
- * Legal requires all three: a capitalized qualifier, not a determiner, and not Neo itself.
- * @param {String} text Source line.
+ * Legal requires all three: a capitalized qualifier, not a determiner, and not Neo itself. A bare
+ * token with no qualifier at all is never legal — an unqualified `framework` in a Neo-owned
+ * description can only mean Neo.
+ * @param {String|undefined} qualifier The word directly before the token.
  * @returns {Boolean}
  */
-export function namesExternalFramework(text) {
-    const match = EXTERNAL.exec(text);
+export function isExternalQualifier(qualifier) {
+    if (!qualifier) return false;
 
-    if (!match) return false;
+    const lower = qualifier.toLowerCase();
 
-    const qualifier = match[1].toLowerCase();
-
-    return !DETERMINERS.has(qualifier) && !NEO_TOKENS.has(qualifier);
+    return /^[A-Z]/.test(qualifier) && !DETERMINERS.has(lower) && !NEO_TOKENS.has(lower);
 }
 
 /**
@@ -89,7 +93,12 @@ export function namesExternalFramework(text) {
  * @returns {Boolean}
  */
 export function claimsNeoIsAFramework(text) {
-    return TOKEN.test(text) && !namesExternalFramework(text);
+    // Evaluated per OCCURRENCE, not per line. A line-level carve-out let one legal mention launder
+    // every other token beside it — `Vue framework adapter; Neo.mjs framework internals` passed,
+    // because the first match was legal and the whole line was then exempt. The claim is made by an
+    // occurrence, so the occurrence is what must be judged.
+    return Array.from(text.matchAll(OCCURRENCE))
+        .some(match => !isExternalQualifier(match[1]));
 }
 
 /**
@@ -117,18 +126,33 @@ function findViolations(file) {
         .map(({text, line}) => ({file: path.relative(ROOT, file), line, text: text.trim()}));
 }
 
-const violations = collectSurfaces().flatMap(findViolations);
+/**
+ * @summary Scans the surfaces and exits non-zero on any violation.
+ *
+ * Runs ONLY when this module is the entrypoint. Importing the predicate for a spec must have no
+ * side effect — an import-time scan would `process.exit(1)` inside the test runner the moment the
+ * tree had a real violation, so the guard's own coverage would die exactly when it mattered.
+ * @returns {void}
+ */
+function main() {
+    const surfaces   = collectSurfaces(),
+          violations = surfaces.flatMap(findViolations);
 
-if (violations.length) {
-    console.error(`\x1b[31mlint-identity-vocabulary: ${violations.length} framework-category claim(s) in agent-facing tool descriptions:\x1b[0m`);
-    violations.forEach(({file, line, text}) => console.error(`  ${file}:${line}: ${text}`));
-    console.error(
-        'Neo is not a framework — the Body is an ENGINE, the Brain is the Agent OS. Tool descriptions\n' +
-        'are read by every agent as authority on what Neo is, including agents that never read a guide.\n' +
-        'Use "engine" for runtime-facing text and "Neo.mjs" for text about knowledge of the project.\n' +
-        'Naming a specific external framework (e.g. "React framework") is legal and passes.'
-    );
-    process.exit(1);
+    if (violations.length) {
+        console.error(`\x1b[31mlint-identity-vocabulary: ${violations.length} framework-category claim(s) in agent-facing tool descriptions:\x1b[0m`);
+        violations.forEach(({file, line, text}) => console.error(`  ${file}:${line}: ${text}`));
+        console.error(
+            'Neo is not a framework — the Body is an ENGINE, the Brain is the Agent OS. Tool descriptions\n' +
+            'are read by every agent as authority on what Neo is, including agents that never read a guide.\n' +
+            'Use "engine" for runtime-facing text and "Neo.mjs" for text about knowledge of the project.\n' +
+            'Naming a specific external framework (e.g. "React framework") is legal and passes.'
+        );
+        process.exit(1);
+    }
+
+    console.log(`lint-identity-vocabulary: ${surfaces.length} agent-facing surface(s) scanned, 0 violations.`);
 }
 
-console.log(`lint-identity-vocabulary: ${collectSurfaces().length} agent-facing surface(s) scanned, 0 violations.`);
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    main();
+}

--- a/ai/scripts/lint/lint-identity-vocabulary.mjs
+++ b/ai/scripts/lint/lint-identity-vocabulary.mjs
@@ -51,18 +51,45 @@ const ROOT        = path.resolve(import.meta.dirname, '../../..'),
        */
       DETERMINERS = new Set(['a', 'an', 'the', 'this', 'that', 'these', 'those', 'our', 'its',
                              'their', 'his', 'her', 'any', 'each', 'every', 'no', 'some', 'one']),
+      /**
+       * The qualifier that makes a `framework` token legal must name something OTHER than Neo.
+       * Without this, the carve-out exempted the exact phrase the guard exists to catch: `Neo` is
+       * capitalized and is not a determiner, so `Neo framework` and `Neo.mjs framework` read as
+       * "external product name + framework" and passed. A guard whose escape hatch admits its own
+       * subject is worse than no guard, because it certifies the thing it was built to stop.
+       */
+      NEO_TOKENS  = new Set(['neo', 'neo.mjs', 'neomjs']),
       EXTERNAL    = /\b([A-Z][A-Za-z0-9.+-]*)\s+frameworks?\b/,
       TOKEN       = /\bframeworks?\b/i;
 
 /**
  * @summary Whether the line's `framework` token names a specific external framework.
+ *
+ * Legal requires all three: a capitalized qualifier, not a determiner, and not Neo itself.
  * @param {String} text Source line.
  * @returns {Boolean}
  */
-function namesExternalFramework(text) {
+export function namesExternalFramework(text) {
     const match = EXTERNAL.exec(text);
 
-    return Boolean(match) && !DETERMINERS.has(match[1].toLowerCase());
+    if (!match) return false;
+
+    const qualifier = match[1].toLowerCase();
+
+    return !DETERMINERS.has(qualifier) && !NEO_TOKENS.has(qualifier);
+}
+
+/**
+ * @summary Whether one line states a framework-category claim about Neo.
+ *
+ * Exported so the carve-out matrix is pinned in CI rather than living only in the reviewer's head:
+ * this predicate is the entire policy, and its first two drafts each had a hole that a clean-tree
+ * run could not reveal.
+ * @param {String} text Source line.
+ * @returns {Boolean}
+ */
+export function claimsNeoIsAFramework(text) {
+    return TOKEN.test(text) && !namesExternalFramework(text);
 }
 
 /**
@@ -86,7 +113,7 @@ function collectSurfaces() {
 function findViolations(file) {
     return fs.readFileSync(file, 'utf8').split('\n')
         .map((text, index) => ({text, line: index + 1}))
-        .filter(({text}) => TOKEN.test(text) && !namesExternalFramework(text))
+        .filter(({text}) => claimsNeoIsAFramework(text))
         .map(({text, line}) => ({file: path.relative(ROOT, file), line, text: text.trim()}));
 }
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "ai:lint-config-template-ssot"         : "node ./ai/scripts/lint/lint-config-template-ssot.mjs",
         "ai:lint-guides"                       : "node ./ai/scripts/lint/lint-guides.mjs",
         "ai:lint-identity-engine-coherence"    : "node ./ai/scripts/lint/lint-identity-engine-coherence.mjs",
+        "ai:lint-identity-vocabulary"          : "node ./ai/scripts/lint/lint-identity-vocabulary.mjs",
         "ai:lint-mcp-test-locations"           : "node ./ai/scripts/lint/lint-mcp-test-locations.mjs",
         "ai:lint-skill-manifest"               : "node ./ai/scripts/lint/lint-skill-manifest.mjs",
         "ai:lint-tree-json"                    : "node ./ai/scripts/lint/lint-tree-json.mjs",

--- a/test/playwright/unit/ai/scripts/lint/identityVocabulary.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/identityVocabulary.spec.mjs
@@ -32,6 +32,23 @@ test.describe('lint-identity-vocabulary carve-out', () => {
         ].forEach(line => expect(claimsNeoIsAFramework(line), line).toBe(true));
     });
 
+    test('a legal mention does NOT launder a Neo claim beside it on the same line', () => {
+        // The carve-out is per-occurrence, not per-line. Judging the line let the first legal match
+        // exempt every token after it, so a description could name React once and then say anything.
+        [
+            'React framework interop, and the framework evolves rapidly',
+            'Vue framework adapter; Neo.mjs framework internals',
+            'compatible with the Express framework — our framework differs'
+        ].forEach(line => expect(claimsNeoIsAFramework(line), line).toBe(true));
+    });
+
+    test('importing the predicate has no side effect', () => {
+        // The module scans and process.exit(1)s when run as an entrypoint. If that ran at import,
+        // this spec would die inside the runner exactly when the tree had a real violation — the
+        // guard's own coverage would fail at the only moment it mattered.
+        expect(typeof claimsNeoIsAFramework).toBe('function');
+    });
+
     test('permits a NAMED external framework', () => {
         [
             'React framework interop',

--- a/test/playwright/unit/ai/scripts/lint/identityVocabulary.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/identityVocabulary.spec.mjs
@@ -1,0 +1,51 @@
+import {test, expect}          from '@playwright/test';
+import {claimsNeoIsAFramework} from '../../../../../../ai/scripts/lint/lint-identity-vocabulary.mjs';
+
+/**
+ * The guard's carve-out IS the policy, and a clean-tree run cannot exercise it — every draft passed
+ * green against a tree with nothing to find. Two drafts each shipped a hole that only a case matrix
+ * exposed: the first read sentence-initial "The framework" as an external product name, and the
+ * second exempted "Neo framework" itself, because `Neo` is capitalized and is not a determiner.
+ *
+ * The second is the one worth pinning hardest. A guard whose escape hatch admits its own subject is
+ * worse than no guard: it certifies the exact claim it was built to stop, and it does so silently.
+ */
+test.describe('lint-identity-vocabulary carve-out', () => {
+    test('flags framework-category claims about Neo', () => {
+        [
+            'The framework evolves rapidly',
+            'This framework is fast',
+            'Our framework ships weekly',
+            'to access frontier-quality framework knowledge',
+            'query: "framework benefits and architecture"',
+            'configuration of the framework at runtime'
+        ].forEach(line => expect(claimsNeoIsAFramework(line), line).toBe(true));
+    });
+
+    test('flags Neo named explicitly — the escape hatch must not admit its own subject', () => {
+        [
+            'Neo framework',
+            'Neo.mjs framework',
+            'the Neo framework',
+            'NeoMjs framework',
+            'the Neo.mjs framework internals'
+        ].forEach(line => expect(claimsNeoIsAFramework(line), line).toBe(true));
+    });
+
+    test('permits a NAMED external framework', () => {
+        [
+            'React framework interop',
+            'the Playwright framework',
+            'Vue framework adapter',
+            'compatible with the Express framework'
+        ].forEach(line => expect(claimsNeoIsAFramework(line), line).toBe(false));
+    });
+
+    test('silent on lines with no framework token', () => {
+        [
+            'Reports per-maintainer live availability',
+            'the engine evolves rapidly',
+            ''
+        ].forEach(line => expect(claimsNeoIsAFramework(line), line).toBe(false));
+    });
+});


### PR DESCRIPTION
Resolves #16063

Four occurrences across two agent-facing OpenAPI surfaces told every agent that Neo is a framework. Reworded, plus a guard so the class stays closed.

Evidence: L2 (guard red-proved against the four real occurrences in the untouched tree, then green after; carve-out matrix over external-vs-Neo phrasings; `McpServerToolLimits` green for the 1024-char cap) → L2 required (description-only change with a static guard — no runtime surface exists to reach). Residual: none.

## Why this is not ordinary wording drift

Tool descriptions load into every agent's context as the **authoritative statement of what a tool operates on**. They reach agents that never read a guide, other model families, and any external consumer of the OpenAPI surface. A category noun stated there is a claim about what Neo *is*, delivered on every call.

The identity anchor exists because pre-training data reduces Neo to a web framework and all three model families regress without a local anchor. These four lines fed that exact prior — from inside the substrate, where re-reading the anchor cannot reach them.

| file:line | was | now |
|---|---|---|
| `knowledge-base/openapi.yaml:406` | `query: "framework benefits and architecture"` | `query: "Neo.mjs benefits and architecture"` |
| `knowledge-base/openapi.yaml:470` | frontier-quality **framework** knowledge | frontier-quality **Neo.mjs** knowledge |
| `knowledge-base/openapi.yaml:504` | **The framework** evolves rapidly | **Neo.mjs** evolves rapidly |
| `neural-link/openapi.yaml:2188` | configuration of the **framework** at runtime | configuration of the **engine** at runtime |

Line 406 is an **example**, and examples get copied — it taught the category rather than merely stating it. `engine` for the runtime-facing line, `Neo.mjs` for the two about knowledge *of* the project.

## Deltas from ticket

**A new lint rather than extending `lint-identity-engine-coherence.mjs`.** The names are adjacent and the temptation was real, but that guard checks which *engine version* a resident runs across three registry files — its own header is careful that green means "these three FILES agree, nothing more." Folding a category-vocabulary check into it would conflate two disjoint concerns and blur a scope statement that was written deliberately.

**The guard is default-deny.** Any `framework` token in these files is a violation *unless* the preceding word is a capitalized name — `React framework` passes, `the framework` does not. That polarity is the load-bearing choice: nobody writes "Neo is a framework", they write "the framework", so the claim arrives by omission. An allowlist of bad phrasings would have to enumerate the ways one can *imply* a category, which is unbounded; enumerating the ways to name an external framework is not.

No `--fix`. The correct substitution depends on which hemisphere a line is about, and a flag that guessed would launder one category error into another.

## Test Evidence

**Red proof — against the four real occurrences, not a synthetic fixture.** The guard was run against the untouched tree before the rewordings landed:

```
lint-identity-vocabulary: 4 framework-category claim(s) in agent-facing tool descriptions:
  ai/mcp/server/knowledge-base/openapi.yaml:406: query: "framework benefits and architecture"
  ai/mcp/server/knowledge-base/openapi.yaml:470: to access frontier-quality framework knowledge.
  ai/mcp/server/knowledge-base/openapi.yaml:504: knowledge base first. The framework evolves rapidly …
  ai/mcp/server/neural-link/openapi.yaml:2188: To inspect or modify the global configuration of the framework at runtime.
exit=1
```

Green after: `6 agent-facing surface(s) scanned, 0 violations.`

**The red proof earned its keep — the first draft caught 3 of 4.** Sentence-initial `"The framework evolves rapidly"` matched the "capitalized word before `framework`" test and read as an external product name, so the most explicit category claim of the four was precisely the one that escaped. Hence the determiner stoplist rather than a bare `[A-Z]` test. A guard that had only been run against a clean tree would have shipped looking correct.

**Carve-out matrix** — external frameworks must pass, Neo claims must fail:

| input | flagged | |
|---|---|---|
| `React framework interop` | no | ✅ |
| `the Playwright framework` | no | ✅ |
| `Vue framework adapter` | no | ✅ |
| `The framework evolves rapidly` | yes | ✅ |
| `This framework is fast` | yes | ✅ |
| `Our framework ships weekly` | yes | ✅ |
| `framework benefits and architecture` | yes | ✅ |
| `no mention at all` | no | ✅ |

`McpServerToolLimits.spec.mjs` → **11 passed** (1024-char per-description cap holds; the rewordings are shorter than what they replaced).

`npm run agent-preflight` → all gates passed.

## Post-Merge Validation

- [ ] Confirm the workflow fires on a PR touching `ai/mcp/server/*/openapi.yaml` and stays silent on one that does not — the path filter is the difference between a guard and noise.

## Related

`AGENTS.md §neo_identity_anchor` · ADR 0018 (two-hemisphere topology) · #16061, where the same violation was found and fixed in `get_class_hierarchy`.

Authored by Grace (@neo-opus-grace, Claude Opus 5, Claude Code).
