### PR TITLE
Scope get_class_hierarchy to Neo.mjs code on the tools/list tier

### DIFF
--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -694,15 +694,17 @@ paths:
         your own or any tenant's repositories, whatever else this deployment has ingested. Use
         `query_documents` or `ask_knowledge_base` for non-Neo.mjs code.
 
-        Reads a generated build artifact rather than the embedded corpus, so it is independent of
-        ingestion state. A deployment that has not run the Neo.mjs docs build returns an empty or
-        partial map with incomplete `extends` metadata.
+        Reads a generated build artifact, not the embedded corpus, so it is independent of ingestion
+        state. It fails LOUD rather than degrading: an absent artifact errors telling you to sync the
+        knowledge base, instead of returning a thinner map indistinguishable from a complete one.
 
         **Input:**
-        - `root`: (Optional) Filter to subclasses of this class (e.g. 'Neo.component.Base').
+        - `root`: (REQUIRED) Returns this class plus its subclasses (e.g. 'Neo.component.Base').
+          Bounds the payload; omitting it errors.
 
         **Output:**
-        A JSON object keyed by class name, each value carrying metadata (source file, parent class).
+        A JSON object keyed by class name whose value is that class's parent class name, or `null`
+        where it has none. A `root` with no entry and no subclasses returns `{message}` instead.
       tags: [Documents]
       parameters:
         - name: root

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -678,19 +678,31 @@ paths:
     get:
       summary: Get Class Hierarchy
       operationId: get_class_hierarchy
+      # The scope belongs on the DEFAULT-visible tier: `tools/list` shows this line, while the long
+      # `description` below is only served on an explicit `get_mcp_tool_handbook` call. A caller who
+      # never fetches the handbook is exactly the caller who would misread the scope.
+      x-neo-tool-summary: Static class-hierarchy map for Neo.mjs code only — not your own or any tenant's repositories.
       x-neo-tool-tier: read
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
       description: |
-        Retrieves the static class hierarchy from the knowledge base.
-        This tool provides a deterministic map of class relationships (inheritance) derived from source code.
+        Retrieves the static class hierarchy of **Neo.mjs code only** — a deterministic inheritance
+        map derived from the Neo.mjs engine source tree.
+
+        **Scope — read before calling:** this covers Neo.mjs classes exclusively. It does NOT cover
+        your own or any tenant's repositories, whatever else this deployment has ingested. Use
+        `query_documents` or `ask_knowledge_base` for non-Neo.mjs code.
+
+        Reads a generated build artifact rather than the embedded corpus, so it is independent of
+        ingestion state. A deployment that has not run the Neo.mjs docs build returns an empty or
+        partial map with incomplete `extends` metadata.
 
         **Input:**
-        - `root`: (Optional) Filter the hierarchy to show only subclasses of this class (e.g., 'Neo.component.Base').
+        - `root`: (Optional) Filter to subclasses of this class (e.g. 'Neo.component.Base').
 
         **Output:**
-        A JSON object where keys are class names and values contain metadata (source file, parent class).
+        A JSON object keyed by class name, each value carrying metadata (source file, parent class).
       tags: [Documents]
       parameters:
         - name: root

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/classHierarchyScope.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/classHierarchyScope.spec.mjs
@@ -87,5 +87,28 @@ test.describe('knowledge-base get_class_hierarchy — the scope claim reaches th
         // this one tool; the wider sweep across both openapi surfaces is tracked separately.
         expect(tool.description).not.toMatch(/framework/i);
         expect(handbook.handbook).not.toMatch(/framework/i);
+    });
+
+    test('the handbook prose cannot contradict the schema it ships beside', async () => {
+        const
+            handbook   = await callTool('get_mcp_tool_handbook', {toolId: 'get_class_hierarchy'}),
+            openApiDoc = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/knowledge-base/openapi.yaml'), 'utf8')),
+            operation  = openApiDoc.paths['/knowledge/hierarchy'].get,
+            rootParam  = operation.parameters.find(parameter => parameter.name === 'root');
+
+        // DERIVED from the schema rather than restated, so flipping `required` forces the prose to
+        // follow instead of leaving the two to disagree. This caught a real drift: the description
+        // called `root` optional two lines above `required: true`, and claimed a missing build artifact
+        // yields an empty/partial map — which is `ApiSource`'s ingestion-enrichment behaviour, not this
+        // tool's. `QueryService.getClassHierarchy` THROWS on both an absent root and an absent artifact.
+        // Describing a sibling consumer of the same artifact is the same misattribution this whole
+        // surface exists to prevent, so it gets a guard rather than a correction.
+        expect(/\(Optional\)/.test(handbook.handbook)).toBe(!rootParam.required);
+        expect(/REQUIRED/.test(handbook.handbook)).toBe(Boolean(rootParam.required));
+
+        // The fail-loud contract is what a caller plans around; a degrade-to-partial claim would send
+        // them to check for thin results instead of handling an error.
+        expect(handbook.handbook).toMatch(/fails LOUD/);
+        expect(handbook.handbook).not.toMatch(/empty or partial/)
     })
 });

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/classHierarchyScope.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/classHierarchyScope.spec.mjs
@@ -1,0 +1,91 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'KBClassHierarchyScopeTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import * as yaml       from 'js-yaml';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * `get_class_hierarchy` answers for Neo.mjs code EXCLUSIVELY, and a deployment whose Knowledge Base
+ * has ingested a tenant's own repositories makes that non-obvious: a caller reasonably reads "the
+ * class hierarchy from the knowledge base" as covering what that knowledge base contains.
+ *
+ * The scope claim has to live on the tier an agent actually reads. The KB server emits TWO
+ * description tiers (`ToolService.buildToolListDescription` / `buildToolHandbookEntry`): the compact
+ * `tools/list` line — capped at 120 chars, sourced `x-neo-tool-summary` → `summary` → description —
+ * and the long `description`, served only on an explicit `get_mcp_tool_handbook` call. Stating the
+ * scope in `description` alone leaves the default surface reading `Get Class Hierarchy`, which tells
+ * a caller nothing; the caller who never fetches the handbook is exactly the one who misreads it.
+ *
+ * So these guards assert the DERIVED listed description rather than the YAML text, and pin the
+ * precedence: drop `x-neo-tool-summary` and the compact line silently falls back to the bare
+ * `summary` title, which the second assertion in the first test is there to catch.
+ */
+test.describe('knowledge-base get_class_hierarchy — the scope claim reaches the default-visible tier (#16065)', () => {
+
+    const
+        __filename = fileURLToPath(import.meta.url),
+        __dirname  = path.dirname(__filename),
+        repoRoot   = path.resolve(__dirname, '../../../../../../..');
+
+    let listTools, callTool;
+
+    test.beforeAll(async () => {
+        ({listTools, callTool} = await import('../../../../../../../ai/mcp/server/knowledge-base/toolService.mjs'));
+    });
+
+    test('the compact tools/list line states the Neo.mjs-only scope — and is NOT the bare title', async () => {
+        const
+            {tools}    = await listTools(),
+            tool       = tools.find(item => item.name === 'get_class_hierarchy'),
+            openApiDoc = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/knowledge-base/openapi.yaml'), 'utf8')),
+            operation  = openApiDoc.paths['/knowledge/hierarchy'].get;
+
+        expect(tool, 'get_class_hierarchy must be listed').toBeTruthy();
+        expect(tool.description).toContain('Neo.mjs code only');
+        expect(tool.description.length, 'the compact tier is capped at 120').toBeLessThanOrEqual(120);
+
+        // `buildToolListDescription` TRUNCATES past the cap instead of failing, and the scope phrase
+        // sits early enough to survive a cut that would drop the not-covered clause — so asserting
+        // the phrase alone would pass a half-sentence. Pin the tail and the absence of an ellipsis.
+        expect(tool.description, 'an over-long summary is silently truncated, not rejected').not.toContain('...');
+        expect(tool.description).toContain("not your own or any tenant's repositories");
+
+        // The precedence control: `summary` is the fallback source, so a listed description EQUAL to
+        // it proves `x-neo-tool-summary` was dropped and the scope silently left the default tier.
+        expect(tool.description, 'the scope must beat the bare title through x-neo-tool-summary').not.toBe(operation.summary);
+    });
+
+    test('the handbook tier carries the not-covered clause, and neither tier seeds the framework category', async () => {
+        const
+            {tools}  = await listTools(),
+            tool     = tools.find(item => item.name === 'get_class_hierarchy'),
+            handbook = await callTool('get_mcp_tool_handbook', {toolId: 'get_class_hierarchy'});
+
+        expect(handbook.found).toBe(true);
+        expect(handbook.handbook).toContain('does NOT cover');
+        expect(handbook.handbook).toContain('query_documents');
+
+        // §neo_identity_anchor: tool descriptions are loaded into every agent's context as authority
+        // on what a tool operates on, so this surface must not seed the framework prior. Scoped to
+        // this one tool; the wider sweep across both openapi surfaces is tracked separately.
+        expect(tool.description).not.toMatch(/framework/i);
+        expect(handbook.handbook).not.toMatch(/framework/i);
+    })
+});


### PR DESCRIPTION
Resolves #16065.

`get_class_hierarchy` answers for Neo.mjs code exclusively. On a deployment whose Knowledge Base has ingested a tenant's own repositories, a caller reasonably reads "the static class hierarchy from the knowledge base" as covering what that knowledge base contains — and it does not.

## The tier that mattered

The first attempt rewrote the long OpenAPI `description`. That is the wrong tier, and finding out why is the substance of this PR.

The knowledge-base server emits **two** description surfaces:

| Tier | Served by | Source precedence | Cap |
|---|---|---|---|
| compact `tools/list` line | `ToolService.buildToolListDescription` (`ai/mcp/ToolService.mjs:309-320`) | `x-neo-tool-summary` → `summary` → description | **120** (`ai/mcp/server/knowledge-base/toolService.mjs:89`, overriding the base 160) |
| handbook body | `ToolService.buildToolHandbookEntry` (`ai/mcp/ToolService.mjs:330-333`) | `x-neo-tool-handbook` → description → `summary` | 1024 |

`get_class_hierarchy` carried no `x-neo-tool-summary`, so `summary: Get Class Hierarchy` won the default surface. That bare title was the entire scope signal an agent got; the rewritten `description` only ships on an explicit `get_mcp_tool_handbook` call. **The caller who never fetches the handbook is exactly the caller who misreads the scope**, so the fix had landed on the tier that did not need it.

So the scope now lives on both tiers: a 93-char `x-neo-tool-summary` carrying the not-covered clause (27 chars of headroom under the cap), plus the long-form paragraph for the handbook.

## Why the guard is shaped the way it is

Two properties of `buildToolListDescription` keep this failure quiet in both directions:

1. **Fallback, not error** — a missing `x-neo-tool-summary` silently degrades to `summary`.
2. **Truncation, not rejection** — past the cap it emits `slice(0, maxLength - 3) + '...'`, keeping the opening phrase and dropping the tail.

Together those mean the scope claim can be absent *or* half-present with every pre-existing test green. So the guard asserts the **derived** listed description through `listTools()` rather than the YAML text — a source-text grep cannot show which key `ToolService` precedence actually selected — and pins three things a naive assertion would miss: the not-covered tail, the absence of an ellipsis, and a precedence control (a listed description *equal to* `summary` proves the key was dropped).

Evidence: certified by mutation, not by label. With `x-neo-tool-summary` withheld the guard goes red against `Received string: "Get Class Hierarchy"` — which is also the empirical proof of the defect — while the handbook assertion stays **green**. The two tiers fail independently, and that is precisely why a handbook-only fix reads as complete.

## Test Evidence

Local, this exact head (`09b8eb3924`):

```
84 passed (3.4s)
```

(The earlier `dad052657c` run was 92 across four specs; this one drops `McpServerToolLimits`, which was only ever included to show it is unaffected, and adds the schema/prose cross-check below.)

- `test/playwright/unit/ai/mcp/server/knowledge-base/classHierarchyScope.spec.mjs` — new, 2 tests
- `test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` — 38 tests; loads this openapi file and caps every KB listed description at 120
- `test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — the other loader of this file
- `test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs` — included only to show it is unaffected; see the correction below

Mutation control (`x-neo-tool-summary` commented out):

```
✘ 2 … the compact tools/list line states the Neo.mjs-only scope — and is NOT the bare title
    Expected substring: "Neo.mjs code only"
    Received string:    "Get Class Hierarchy"
✓ 3 … the handbook tier carries the not-covered clause
  1 failed, 3 passed
```

**Evidence correction carried in the commit message.** The earlier version of this commit cited `McpServerToolLimits` as its green witness. That spec loads the *memory-core* openapi (`McpServerToolLimits.spec.mjs:179`) and never observes this file — a green test answering about the wrong subject. Suite selection here is derived from which specs actually read `ai/mcp/server/knowledge-base/openapi.yaml`.

**Cycle 2 — `09b8eb3924`, accepting @neo-gpt's REQUEST_CHANGES in full.** The expanded handbook contradicted `QueryService.getClassHierarchy` on three caller-visible points: `root` was described as optional where the service throws without it, an absent artifact was described as yielding an empty/partial map where the service throws (and the response block already documents a 404), and values were described as source-file metadata where both the service and `additionalProperties: {type: string, nullable: true}` say parent-name-or-`null`.

Rather than reword, the correction is guarded: a new test **derives** the expectation from the schema — `required` decides whether the prose may say Optional or must say REQUIRED — so the two cannot drift apart again, and flipping the schema forces the prose to follow. It also pins the fail-loud contract.

Worth naming plainly: I attributed a sibling consumer's behaviour to this tool while writing the PR whose entire subject is that agents read tool descriptions as authority. I verified which *tier* the text lands on and never verified whether the text was *true of the mapped service*. The first correction also ran to 1053 chars, over the 1024 cap, and was trimmed to 998 — measured, not assumed.

## Deltas

- `ai/mcp/server/knowledge-base/openapi.yaml` — one new `x-neo-tool-summary` key on `/knowledge/hierarchy` `get`, plus a reworded `description`: scope clause up front, not-covered clause, and the **fail-loud** contract (an absent build artifact errors — it does not return a partial map; that behaviour belongs to `ApiSource` enriching ingested documents, a sibling consumer of the same artifact, and an earlier revision of this PR wrongly attributed it here). `root` is documented as REQUIRED, agreeing with the parameter's own `required: true`, and values as parent-name-or-`null`, agreeing with the response schema.
- **What changes and what does not:** no `operationId`, schema, parameter, or dispatch change, so the wire contract is untouched and no ingestion path is involved. The **caller** contract is intentionally changed — agent-consumed description semantics are the whole substance of this PR, and saying "the contract is untouched" would understate exactly what it does.
- `test/playwright/unit/ai/mcp/server/knowledge-base/classHierarchyScope.spec.mjs` — new guard, 2 tests.
- Commit message: corrected test citation.

Neither tier says "framework" — Neo is not a framework and the Body is an Engine, and a tool description is read by agents as authority on what Neo is (`AGENTS.md §neo_identity_anchor`). The second test pins that for this tool; the wider four-occurrence sweep across both MCP openapi surfaces is #16063.

## Post-Merge Validation

- The change is served by any KB MCP server process started after merge; a running daemon keeps the old description until restarted, so a post-merge check against a long-lived server needs a restart receipt first.
- Confirm on a deployment that has ingested non-Neo repositories: `tools/list` shows the scoped line, and `get_mcp_tool_handbook({toolId: 'get_class_hierarchy'})` returns the full not-covered clause.
- No migration, no data touch, no config leaf — nothing to roll back beyond the two files.

## Scope boundary

This deliberately does **not** close #16061, which keeps the substantive half: the deploy image never builds `docs/output/class-hierarchy.json`, `healthcheck` reports all features operational beside a known-incomplete capability, and the tool has no **runtime** incompleteness signal. #16061's first AC is a decision about whether cloud deployments should carry the artifact at all — operator authority, not something a description commit can discharge. A static description cannot satisfy a runtime disclosure, so #16061 AC4 stays with #16061.

Also out of scope: the other 7 KB operations lacking `x-neo-tool-summary` (real, but a distinct judgement per tool — bundling them would turn this diff into a vocabulary review).

Related: #16061 · #16063

Authored by Vega (@neo-opus-vega). Session c038696f-94a6-4788-82bf-747c5672908c.
