### PR TITLE
Persist the tenant-repo failure cause so a wedged lane stays diagnosable

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
@@ -16,6 +16,25 @@ export const DEPLOYMENT_RUNTIME_LIFECYCLE_OPERATIONS = Object.freeze([
     'restart'
 ]);
 
+/**
+ * The orchestrator's own Compose service key.
+ *
+ * Needed because the orchestrator has to be READABLE through the bridge it publishes — it is the only
+ * process holding the tenant-repo-sync failure text, and excluding it made a wedged deployment
+ * undiagnosable from a remote client — while never becoming a LIFECYCLE target of that same bridge.
+ *
+ * That asymmetry is structural rather than a policy preference, which is why it is a constant here and
+ * not a config knob: restarting the orchestrator through its own bridge kills the process serving the
+ * request, so the caller cannot observe the outcome and the audit entry dies with it. There is no
+ * deployment for which self-restart-via-self-bridge is the right behaviour, so it is not offered.
+ *
+ * Kept honest by a fixture asserting this string equals the orchestrator service key in
+ * `ai/deploy/docker-compose.yml` — a rename there must fail a test rather than silently disarm the
+ * lifecycle refusal by making it match nothing.
+ * @type {String}
+ */
+export const DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY = 'orchestrator';
+
 const DEFAULT_RESPONSE_MAX_BYTES      = 1024 * 1024;
 const DOCKER_SOCKET_FORBIDDEN_CODES   = new Set(['EACCES', 'EPERM']);
 const DOCKER_SOCKET_UNAVAILABLE_CODES = new Set(['ENOENT', 'ECONNREFUSED']);
@@ -218,6 +237,7 @@ export class DeploymentRuntimeAccessService extends Base {
         this.assertEnabled();
         this.assertMechanismSupported();
         this.assertOperationAllowed('lifecycle-write', operation);
+        this.assertNotSelfLifecycleTarget(serviceKey);
 
         const target = await this.resolveServiceTarget(serviceKey);
 
@@ -420,6 +440,39 @@ export class DeploymentRuntimeAccessService extends Base {
                 reason : 'compose-service-mismatch',
                 message: 'Docker target did not prove the requested Compose service identity',
                 details: this.createLookupDetails({serviceKey, filters, matchCount: 1})
+            });
+        }
+    }
+
+    /**
+     * Refuses a lifecycle operation aimed at the orchestrator itself.
+     *
+     * The allowlist is one list for both envelopes — `readObserve` and `applyLifecycle` both resolve
+     * through `resolveServiceTarget` — so allowlisting the orchestrator for reads necessarily
+     * allowlists it for restart as well. This is the asymmetry that makes "readable but not
+     * restartable" expressible without a second config surface to keep in sync.
+     *
+     * Deliberately NOT configurable. Restarting the orchestrator through the bridge the orchestrator
+     * publishes kills the process serving the request mid-flight: the caller gets a dropped connection
+     * rather than an outcome, and the audit record dies with the writer. A knob here would only offer
+     * a way to be wrong.
+     *
+     * @param {String} serviceKey Compose service key.
+     * @returns {void}
+     * @throws When `serviceKey` names this orchestrator.
+     */
+    assertNotSelfLifecycleTarget(serviceKey) {
+        if (serviceKey === DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY) {
+            throw createRuntimeAccessError({
+                reason : 'runtime-self-lifecycle-refused',
+                message: `Deployment runtime lifecycle operations cannot target '${serviceKey}' — it publishes `
+                    + 'this bridge, so restarting it through the bridge would kill the process serving the '
+                    + 'request before any outcome could be reported. Read operations on it ARE permitted; '
+                    + 'restart it from the host.',
+                details: {
+                    ...this.createEffectiveConfigSummary(),
+                    serviceKey
+                }
             });
         }
     }

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1080,19 +1080,39 @@ class TenantRepoSyncService extends Base {
                 });
 
                 if (!dueState.due) {
-                    const nextDueAtMs = (priorState?.lastRunAttemptAt ?? 0) + dueState.effectiveCadenceMs;
+                    const
+                        nextDueAtMs  = (priorState?.lastRunAttemptAt ?? 0) + dueState.effectiveCadenceMs,
+                        failureCount = priorState?.consecutiveFailures ?? 0,
+                        // A repo held back because it FAILED is not the same state as one that simply ran
+                        // recently, and reporting both as `not-due` is what made a wedged lane read as an
+                        // idle one. Backoff is the only reason a failing repo stops being retried, so it
+                        // is also the only place the distinction can be drawn.
+                        backoffSuppressed = failureCount > 0;
+
                     notDueCount++;
-                    writeLog?.('INFO', `[TenantRepoSync] ${repoLabel} not yet due (next ~${new Date(nextDueAtMs).toISOString()}, consecutiveFailures=${priorState?.consecutiveFailures ?? 0}, backoffX=${dueState.backoffMultiplier}).`);
+                    writeLog?.('INFO', `[TenantRepoSync] ${repoLabel} ${backoffSuppressed ? 'suppressed by backoff' : 'not yet due'} (next ~${new Date(nextDueAtMs).toISOString()}, consecutiveFailures=${failureCount}, backoffX=${dueState.backoffMultiplier}${backoffSuppressed ? `, lastErrorCode=${priorState?.lastErrorCode ?? 'none'}` : ''}).`);
                     repoStates.push({
                         tenantId           : repo.tenantId,
                         repoSlug           : repo.repoSlug,
                         lastIngestedRev    : priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : null,
                         lastSyncAt         : priorState?.lastRunAttemptAt ? new Date(priorState.lastRunAttemptAt).toISOString() : null,
-                        status             : 'not-due',
+                        status             : backoffSuppressed ? 'backoff-suppressed' : 'not-due',
                         checkpointStatus,
                         nextDueAt          : new Date(nextDueAtMs).toISOString(),
                         effectiveCadenceMs : dueState.effectiveCadenceMs,
-                        consecutiveFailures: priorState?.consecutiveFailures ?? 0
+                        consecutiveFailures: failureCount,
+                        // Carry the RETAINED cause forward. The failure path already persists these
+                        // (see the per-repo catch below); this branch used to rebuild a record without
+                        // them, so the reason a lane was wedged existed on disk and vanished from the
+                        // one surface an operator can read — exactly when it mattered most. Only
+                        // attached while a failure is outstanding, so a healthy repo stays quiet.
+                        ...(backoffSuppressed ? {
+                            lastErrorCode      : priorState?.lastErrorCode ?? null,
+                            lastSourceErrorCode: priorState?.lastSourceErrorCode ?? null,
+                            lastErrorAt        : priorState?.lastErrorAt
+                                ? new Date(priorState.lastErrorAt).toISOString()
+                                : null
+                        } : {})
                     });
                     return; // skip semaphore + work entirely
                 }
@@ -1224,7 +1244,14 @@ class TenantRepoSyncService extends Base {
                     lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
                     lastCommittedMaterializationAttemptId: materializationReceipt?.attemptId
                         || priorState?.lastCommittedMaterializationAttemptId
-                        || null
+                        || null,
+                    // Cleared explicitly, not merely omitted. The retained cause is now durable, so a
+                    // repo that heals would otherwise keep publishing the reason it used to fail —
+                    // a stale cause beside a zero failure count is worse than none, because it reads
+                    // as a live fault. Written as nulls so the shape stays uniform across both paths.
+                    lastErrorCode      : null,
+                    lastSourceErrorCode: null,
+                    lastErrorAt        : null
                 };
 
                 const durationMs = Date.now() - startedMs;
@@ -1295,7 +1322,20 @@ class TenantRepoSyncService extends Base {
                     consecutiveFailures                  : nextFailureCount,
                     ingestContractVersion                : priorState?.ingestContractVersion ?? null,
                     lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
-                    lastCommittedMaterializationAttemptId: priorState?.lastCommittedMaterializationAttemptId || null
+                    lastCommittedMaterializationAttemptId: priorState?.lastCommittedMaterializationAttemptId || null,
+                    // PERSIST the cause, not just the count. Before this, `lastErrorCode` existed only
+                    // on the in-memory record for the sweep that failed: it was published for one
+                    // cadence and then overwritten by the next sweep, which — once backoff parked the
+                    // repo — reported it as merely not-due with no reason at all. So a lane could fail
+                    // four times and present as `consecutiveFailures: 4, lastErrorCode: null`, which is
+                    // what made a wedged deployment undiagnosable from a remote client. Counters
+                    // survived because they were persisted; the reason did not because it was not.
+                    //
+                    // Codes only. `getSourceErrorCode` admits nothing outside `^KB_[A-Z0-9_]+$`, so no
+                    // stderr, URL, credential or free-text message can reach durable state through here.
+                    lastErrorCode      : code ?? null,
+                    lastSourceErrorCode: sourceErrorCode ?? null,
+                    lastErrorAt        : Date.now()
                 };
 
                 const failedRepoState = {

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -9,6 +9,7 @@ import {
     createTenantRepoMaterializationDigest
 } from '../../../services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 import {
+    classifyTenantRepoAccessFailure,
     isTenantRepoAccessReadinessOutcome,
     normalizeTenantRepoCredentialRef,
     TenantRepoAccessCode,
@@ -107,6 +108,29 @@ function createConcurrencySemaphore({limit, timeoutMs = 0}) {
             handoffSlot();
         }
     };
+}
+
+/**
+ * Classifies a SYNC-path failure into the access vocabulary.
+ *
+ * Delegates to the shared lane classifier so a discriminating cause — under-scoped credential,
+ * rejected credential, absent-or-denied repository, unreachable host — survives into the readiness
+ * cache and the persisted checkpoint instead of being flattened.
+ *
+ * The one remapping: `PROBE_FAILED` means "no exit status, unclassifiable", which is honest on the
+ * probe path but would over-claim here, since it names a probe that did not run. On this path we DO
+ * know the sync failed, so an unclassifiable cause is `SYNC_FAILED` — the fallback stays accurate
+ * while everything the classifier can actually name comes through intact.
+ *
+ * @param {Error} error Redacted failure.
+ * @returns {String} A `TenantRepoAccessCode` value.
+ */
+function classifySyncFailure(error) {
+    const classified = classifyTenantRepoAccessFailure(error);
+
+    return classified === TenantRepoAccessCode.PROBE_FAILED
+        ? TenantRepoAccessCode.SYNC_FAILED
+        : classified;
 }
 
 function getSourceErrorCode(error, outerCode) {
@@ -632,11 +656,14 @@ class TenantRepoSyncService extends Base {
             previous  = this.accessReadinessCache.get(key) || {},
             checkedAt = new Date().toISOString(),
             maxAgeMs  = getAccessReadinessMaxAgeMs(repo, globalCadenceMs),
+            // Classified through the shared lane classifier, NOT flattened to SYNC_FAILED. This
+            // previously recognised one error code and collapsed every other cause, so an
+            // under-scoped credential, an absent repository and an unreachable host all persisted
+            // as "sync failed" — three different operator fixes behind one indistinguishable code,
+            // which is exactly the state that left a wedged deployment undiagnosable from outside.
             code      = ready
                 ? TenantRepoAccessCode.READY
-                : (error?.code === 'KB_GITMIRROR_CREDENTIAL_REF_INVALID'
-                    ? TenantRepoAccessCode.CREDENTIAL_INVALID
-                    : TenantRepoAccessCode.SYNC_FAILED);
+                : classifySyncFailure(error);
 
         this.accessReadinessCache.set(key, {
             ...previous,
@@ -1109,6 +1136,7 @@ class TenantRepoSyncService extends Base {
                         ...(backoffSuppressed ? {
                             lastErrorCode      : priorState?.lastErrorCode ?? null,
                             lastSourceErrorCode: priorState?.lastSourceErrorCode ?? null,
+                            lastAccessCode     : priorState?.lastAccessCode ?? null,
                             lastErrorAt        : priorState?.lastErrorAt
                                 ? new Date(priorState.lastErrorAt).toISOString()
                                 : null
@@ -1251,6 +1279,7 @@ class TenantRepoSyncService extends Base {
                     // as a live fault. Written as nulls so the shape stays uniform across both paths.
                     lastErrorCode      : null,
                     lastSourceErrorCode: null,
+                    lastAccessCode     : null,
                     lastErrorAt        : null
                 };
 
@@ -1333,8 +1362,18 @@ class TenantRepoSyncService extends Base {
                     //
                     // Codes only. `getSourceErrorCode` admits nothing outside `^KB_[A-Z0-9_]+$`, so no
                     // stderr, URL, credential or free-text message can reach durable state through here.
+                    //
+                    // Three fields because they answer three different questions, and collapsing them
+                    // loses the one an operator acts on: `lastErrorCode` is the stable OUTER code a
+                    // caller branches on, `lastSourceErrorCode` names the OPERATION that failed
+                    // (`KB_GITMIRROR_FETCH_FAILED`), and `lastAccessCode` is the CAUSE — under-scoped
+                    // credential vs rejected credential vs absent-or-denied repository vs unreachable
+                    // host. Operation plus counter told an operator that acquisition failed; only the
+                    // cause tells them which fix to apply, and without host access it is the only thing
+                    // that can.
                     lastErrorCode      : code ?? null,
                     lastSourceErrorCode: sourceErrorCode ?? null,
+                    lastAccessCode     : classifySyncFailure(e),
                     lastErrorAt        : Date.now()
                 };
 

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -26,6 +26,28 @@ export const TENANT_REPO_INGEST_CONTRACT_VERSION = 2;
 const MATERIALIZATION_ATTEMPT_ID_PATTERN = /^[a-f0-9]{32}$/u;
 
 /**
+ * Bounded diagnostic-code vocabulary for the retained failure cause.
+ *
+ * This is the read-side half of the redaction boundary, and it is deliberately redundant with the
+ * writer's own filter. A failure's underlying error carries `stderr`, a remote URL and — for a
+ * credential-bearing clone URL — the credential itself, so the cause has to travel as a CODE and
+ * nothing else. Validating on read as well as on write means a record hand-edited on disk, or written
+ * by an older build with a looser writer, still cannot project free text into a diagnostic surface.
+ * @type {RegExp}
+ */
+const BOUNDED_ERROR_CODE_PATTERN = /^KB_[A-Z0-9_]{1,120}$/u;
+
+/**
+ * @summary Admits a bounded `KB_*` diagnostic code, or nothing.
+ * @param {*} value Candidate code from persisted state.
+ * @returns {String|null}
+ * @private
+ */
+function normalizeBoundedErrorCode(value) {
+    return typeof value === 'string' && BOUNDED_ERROR_CODE_PATTERN.test(value) ? value : null;
+}
+
+/**
  * @summary Internal checkpoint-revalidation classifications.
  *
  * `INVALID` is a fail-closed reader sentinel, not a per-repo deployment
@@ -62,7 +84,11 @@ export function normalizeTenantRepoCheckpointState(value) {
             consecutiveFailures                  : 0,
             ingestContractVersion                : null,
             lastAttemptedIngestContractVersion   : null,
-            lastCommittedMaterializationAttemptId: null
+            lastCommittedMaterializationAttemptId: null,
+            // A bare SHA predates the retained-cause contract, so there is no cause to recover.
+            lastErrorCode      : null,
+            lastSourceErrorCode: null,
+            lastErrorAt        : null
         };
     }
 
@@ -84,7 +110,12 @@ export function normalizeTenantRepoCheckpointState(value) {
         lastAttemptedIngestContractVersion   : normalizeContractVersion(value.lastAttemptedIngestContractVersion),
         lastCommittedMaterializationAttemptId: normalizeMaterializationAttemptId(
             value.lastCommittedMaterializationAttemptId
-        )
+        ),
+        // The retained failure cause. Absent on records written before it existed, which normalizes to
+        // null rather than dropping the record — a missing reason is not a malformed checkpoint.
+        lastErrorCode      : normalizeBoundedErrorCode(value.lastErrorCode),
+        lastSourceErrorCode: normalizeBoundedErrorCode(value.lastSourceErrorCode),
+        lastErrorAt        : normalizeNonNegativeNumber(value.lastErrorAt) || null
     };
 }
 

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -88,6 +88,7 @@ export function normalizeTenantRepoCheckpointState(value) {
             // A bare SHA predates the retained-cause contract, so there is no cause to recover.
             lastErrorCode      : null,
             lastSourceErrorCode: null,
+            lastAccessCode     : null,
             lastErrorAt        : null
         };
     }
@@ -113,8 +114,13 @@ export function normalizeTenantRepoCheckpointState(value) {
         ),
         // The retained failure cause. Absent on records written before it existed, which normalizes to
         // null rather than dropping the record — a missing reason is not a malformed checkpoint.
+        // `lastAccessCode` carries the DISCRIMINATING cause (under-scoped credential vs rejected
+        // credential vs absent-or-denied repository vs unreachable host); the other two name the outer
+        // code and the failed operation. All three pass the same bounded-code gate, so the additional
+        // discrimination costs no widening of what may reach a remote client.
         lastErrorCode      : normalizeBoundedErrorCode(value.lastErrorCode),
         lastSourceErrorCode: normalizeBoundedErrorCode(value.lastSourceErrorCode),
+        lastAccessCode     : normalizeBoundedErrorCode(value.lastAccessCode),
         lastErrorAt        : normalizeNonNegativeNumber(value.lastErrorAt) || null
     };
 }

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -226,7 +226,18 @@ services:
       - NEO_ORCHESTRATOR_RUNTIME_ACCESS_MECHANISM=docker-socket
       - NEO_ORCHESTRATOR_RUNTIME_ACCESS_SOCKET_PATH=/var/run/docker.sock
       - NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT=${NEO_DEPLOY_PROJECT_NAME:-neo-agent-os}
-      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES=chroma,kb-server,mc-server,local-model
+      # `orchestrator` is in this list deliberately, and it is the reason the list needed changing.
+      #
+      # The tenant-repo-sync lane runs IN the orchestrator, so the orchestrator is the only process that
+      # holds the failure text when that lane wedges. Omitting it from its own bridge made a stalled
+      # deployment undiagnosable from a remote MCP client — not difficult, impossible — which defeats
+      # the purpose of publishing a bridge at all. Observed exactly that way on a live deployment.
+      #
+      # It does NOT become restartable by appearing here. This one list gates both the read and the
+      # lifecycle envelope, so `DeploymentRuntimeAccessService.assertNotSelfLifecycleTarget` refuses
+      # lifecycle operations aimed at the orchestrator structurally — restarting it through the bridge
+      # it publishes would kill the process serving the request before any outcome could be reported.
+      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES=chroma,kb-server,mc-server,local-model,orchestrator
       - NEO_ORCHESTRATOR_RUNTIME_ACCESS_READ_OPERATIONS=inspect,logs,stats
       - NEO_ORCHESTRATOR_RUNTIME_ACCESS_LIFECYCLE_OPERATIONS=restart
     volumes:

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -74,11 +74,23 @@ paths:
       x-neo-tool-tier: extended
       x-annotations:
         readOnlyHint: true
-      x-neo-tool-summary: Inspect active or last ingestion progress.
+      x-neo-tool-summary: Ingestion progress for THIS PROCESS only; pull-mode tenant lanes run elsewhere.
       description: |
         Returns a read-only snapshot for the active ingestion run, or an idle state with the last
         completed run summary. This diagnostics tool stays separate from `healthcheck` so liveness
         payloads remain compact.
+
+        SCOPE — read before trusting a negative answer. The progress ledgers are in-memory instance
+        state, so this answers only for the process serving the call, and every response says so in
+        `observedScope`. `never-attempted` therefore means "no ledger in THIS process", never "this
+        deployment has never ingested". Pull-mode tenant-repo ingestion runs inside the orchestrator
+        and is invisible here; a wedged pull lane is visible in the deployment-state snapshot's
+        `tenantRepoSync` section, which `crossProcessHint` points at.
+
+        `status` distinguishes three idle-path outcomes that were previously all reported as `idle`:
+        `never-attempted` (no ledger), `failed` (the last run failed — including a run that died
+        before progress tracking began), and `idle` (a clean run finished). Top-level `errorCount`
+        carries the last run's count rather than a pinned zero.
       tags: [Health]
       parameters:
         - in: query
@@ -1202,13 +1214,35 @@ components:
 
     IngestionProgressResponse:
       type: object
-      description: Read-only active/idle ingestion progress snapshot.
+      description: >-
+        Read-only ingestion progress snapshot, scoped to THE PROCESS SERVING THE CALL. The progress
+        ledgers are in-memory instance state, so this response can never describe another process:
+        a Knowledge Base server reporting `never-attempted` is not evidence that the deployment has
+        never ingested. Pull-mode tenant-repo ingestion runs in the orchestrator and is invisible
+        here; read the deployment-state snapshot (`tenantRepoSync`) for that lane.
       additionalProperties: true
       properties:
         status:
           type: string
-          enum: [idle, running, completed, completed_with_errors, failed]
-          description: Current progress state.
+          enum: [idle, never-attempted, running, completed, completed_with_errors, failed]
+          description: >-
+            Current progress state. `never-attempted` means THIS PROCESS has no ingestion ledger at
+            all, which is distinct from `idle` (a run finished and nothing is in flight). `failed` at
+            this level reflects the LAST run's outcome while nothing is active — including a run that
+            died before progress tracking started, which previously reported `idle` with
+            `errorCount: 0` while the nested `lastRunSummary` recorded the failure.
+        observedScope:
+          type: string
+          enum: [this-process-only]
+          description: >-
+            The observation boundary of this response. Always `this-process-only` — declared as a
+            field rather than left implicit so a caller cannot mistake a process-local answer for a
+            deployment-wide one. Present on every response state, active and idle alike.
+        crossProcessHint:
+          type: string
+          description: >-
+            Where cross-process ingestion state can actually be read, since this response cannot
+            carry it. Present on every response state.
         active:
           type: boolean
           description: True when an ingestion run is currently executing.

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -28,6 +28,38 @@ import {fileURLToPath} from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
+/**
+ * Scope disclosure carried on EVERY `getIngestionProgress` response state. The progress ledgers are
+ * in-memory instance state, so this surface can only ever answer for the process serving the call.
+ * @type {String}
+ */
+export const INGESTION_PROGRESS_OBSERVED_SCOPE = 'this-process-only';
+
+/**
+ * The companion pointer to where cross-process ingestion state actually lives. Stating the scope
+ * without naming the alternative leaves a caller correctly informed and still stuck.
+ * @type {String}
+ */
+export const INGESTION_PROGRESS_CROSS_PROCESS_HINT = 'Pull-mode tenant-repo ingestion runs in the '
+    + 'orchestrator process and is NOT reflected here; read the deployment-state snapshot for that lane.';
+
+/**
+ * Resolves the top-level idle-path status from the last run's outcome.
+ *
+ * Separated out because the three outcomes are genuinely different operator situations and the
+ * previous single `idle` answered for all of them. `failed` is surfaced at the top level rather than
+ * left nested in `lastRunSummary`, where a caller reading the obvious field never saw it.
+ *
+ * @param {Object|null} lastRunSummary Normalized last-run snapshot, or null when this process has
+ * never ingested.
+ * @returns {String} `never-attempted` | `failed` | `idle`
+ */
+export function resolveIdleProgressStatus(lastRunSummary) {
+    if (!lastRunSummary)                    return 'never-attempted';
+    if (lastRunSummary.status === 'failed') return 'failed';
+    return 'idle';
+}
+
 const LOCAL_EMBEDDING_PROVIDERS           = new Set(['openAiCompatible', 'ollama']);
 const MATERIALIZATION_ATTEMPT_ID_PATTERN  = /^[a-f0-9]{32}$/u;
 const MATERIALIZATION_DIGEST_PATTERN      = /^[a-f0-9]{64}$/u;
@@ -476,12 +508,20 @@ class IngestionService extends Base {
         const now = Date.now();
 
         if (this.activeIngestionProgress) {
-            return this.createIngestionProgressSnapshot({
-                progress: this.activeIngestionProgress,
-                active  : true,
-                now,
-                staleAfterMs
-            });
+            return {
+                ...this.createIngestionProgressSnapshot({
+                    progress: this.activeIngestionProgress,
+                    active  : true,
+                    now,
+                    staleAfterMs
+                }),
+                // Carried on the ACTIVE state too, not only the idle one. Scope is a property of this
+                // surface itself, so disclosing it on one branch would mean a caller that happens to
+                // poll during a run cannot tell what the number covers — and a partial disclosure is
+                // read as a complete one.
+                observedScope   : INGESTION_PROGRESS_OBSERVED_SCOPE,
+                crossProcessHint: INGESTION_PROGRESS_CROSS_PROCESS_HINT
+            };
         }
 
         const lastRunSummary = this.lastIngestionProgress
@@ -494,11 +534,17 @@ class IngestionService extends Base {
             : null;
 
         return {
-            // `idle` conflated two facts an operator must be able to tell apart: a run finished and
-            // nothing is in flight, versus THIS PROCESS has never ingested at all. Observed on a live
-            // deployment where four tenant repos had failed four times each and this surface reported
-            // `status: "idle", errorCount: 0` with every timestamp null — which reads as healthy.
-            status: lastRunSummary ? 'idle' : 'never-attempted',
+            // Three distinct facts an operator must be able to tell apart, previously all reported as
+            // `idle`: nothing in flight after a CLEAN run, nothing in flight after a FAILED run, and
+            // THIS PROCESS has never ingested at all.
+            //
+            // The failed case is the sharp one. A run that dies before `startIngestionProgress()` — a
+            // tenant-context resolution throw, say — still records a synthetic failed ledger, so the
+            // outcome was reachable all along; it just was not reported at this level. The top level
+            // said `status: "idle", errorCount: 0` while the nested `lastRunSummary` said `failed` with
+            // a non-zero count, and a caller reading the top level saw health. Observed on a live
+            // deployment where four tenant repos had failed four times each.
+            status: resolveIdleProgressStatus(lastRunSummary),
             active: false,
             phase : 'idle',
             // The scope disclosure is the load-bearing half, and it is why a better status alone would
@@ -508,9 +554,8 @@ class IngestionService extends Base {
             // `never-attempted` is not evidence that the deployment has never ingested — it cannot see
             // that lane at all. Cross-process ingestion state lives in the deployment-state bridge
             // snapshot (`tenantRepoSync`), which is where a wedged pull lane is actually visible.
-            observedScope   : 'this-process-only',
-            crossProcessHint: 'Pull-mode tenant-repo ingestion runs in the orchestrator process and is '
-                + 'NOT reflected here; read the deployment-state snapshot for that lane.',
+            observedScope   : INGESTION_PROGRESS_OBSERVED_SCOPE,
+            crossProcessHint: INGESTION_PROGRESS_CROSS_PROCESS_HINT,
             startedAt     : null,
             updatedAt     : lastRunSummary?.updatedAt ?? null,
             lastProgressAt: null,
@@ -525,7 +570,9 @@ class IngestionService extends Base {
             skippedChunks : 0,
             remaining     : 0,
             deletedRows   : 0,
-            errorCount    : 0,
+            // Carried from the last run rather than pinned to 0. A zero count beside a failed run is
+            // the same false reassurance as the status was.
+            errorCount    : lastRunSummary?.errorCount ?? 0,
             lastRunSummary
         };
     }

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -494,9 +494,23 @@ class IngestionService extends Base {
             : null;
 
         return {
-            status        : 'idle',
-            active        : false,
-            phase         : 'idle',
+            // `idle` conflated two facts an operator must be able to tell apart: a run finished and
+            // nothing is in flight, versus THIS PROCESS has never ingested at all. Observed on a live
+            // deployment where four tenant repos had failed four times each and this surface reported
+            // `status: "idle", errorCount: 0` with every timestamp null — which reads as healthy.
+            status: lastRunSummary ? 'idle' : 'never-attempted',
+            active: false,
+            phase : 'idle',
+            // The scope disclosure is the load-bearing half, and it is why a better status alone would
+            // not be enough. `activeIngestionProgress` / `lastIngestionProgress` are IN-MEMORY instance
+            // state, so this answers only for the process serving the call. The pull-mode tenant-repo
+            // lane ingests inside the ORCHESTRATOR, so a Knowledge Base server reporting
+            // `never-attempted` is not evidence that the deployment has never ingested — it cannot see
+            // that lane at all. Cross-process ingestion state lives in the deployment-state bridge
+            // snapshot (`tenantRepoSync`), which is where a wedged pull lane is actually visible.
+            observedScope   : 'this-process-only',
+            crossProcessHint: 'Pull-mode tenant-repo ingestion runs in the orchestrator process and is '
+                + 'NOT reflected here; read the deployment-state snapshot for that lane.',
             startedAt     : null,
             updatedAt     : lastRunSummary?.updatedAt ?? null,
             lastProgressAt: null,

--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -7,6 +7,7 @@ import path                       from 'path';
 
 import {
     assertCleanCloneUrl,
+    classifyTenantRepoAccessFailure,
     deriveTenantRepoMirrorPath,
     normalizeTenantRepoCredentialRef,
     redactTenantRepoSecrets,
@@ -616,36 +617,6 @@ async function runGit(args, {
     }
 }
 
-/**
- * @summary Classifies a redacted Git probe failure into the public access-readiness vocabulary.
- * @param {Error} error Redacted GitMirror error.
- * @returns {String}
- * @private
- */
-function classifyAccessProbeFailure(error) {
-    if (error.code === 'KB_GITMIRROR_ACCESS_PROBE_TIMEOUT') {
-        return TenantRepoAccessCode.TIMEOUT;
-    }
-
-    if (error.code === 'KB_GITMIRROR_CREDENTIAL_REF_INVALID') {
-        return TenantRepoAccessCode.CREDENTIAL_INVALID;
-    }
-
-    const stderr = String(error.stderr || '');
-
-    if (
-        /could not resolve host|temporary failure in name resolution|network is unreachable|failed to connect|connection (?:timed out|refused|reset)|ssh: connect to host/iu
-            .test(stderr)
-    ) {
-        return TenantRepoAccessCode.TRANSPORT_FAILED;
-    }
-
-    if (Number.isInteger(error.exitCode)) {
-        return TenantRepoAccessCode.DENIED_OR_NOT_FOUND;
-    }
-
-    return TenantRepoAccessCode.PROBE_FAILED;
-}
 
 /**
  * @summary Validates local credential resolution and returns only a process-local cache fingerprint.
@@ -785,7 +756,7 @@ export async function probeRemoteAccess({
     } catch (error) {
         return {
             status          : TenantRepoAccessStatus.DEGRADED,
-            code            : classifyAccessProbeFailure(error),
+            code            : classifyTenantRepoAccessFailure(error),
             checkedAt,
             cacheFingerprint: material.cacheFingerprint
         };

--- a/ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs
@@ -27,6 +27,8 @@ export const TenantRepoAccessStatus = Object.freeze({
 export const TenantRepoAccessCode = Object.freeze({
     CREDENTIAL_RESOLVED: 'KB_TENANT_REPO_ACCESS_CREDENTIAL_RESOLVED',
     CREDENTIAL_INVALID : 'KB_TENANT_REPO_ACCESS_CREDENTIAL_INVALID',
+    CREDENTIAL_REJECTED: 'KB_TENANT_REPO_ACCESS_CREDENTIAL_REJECTED',
+    INSUFFICIENT_SCOPE : 'KB_TENANT_REPO_ACCESS_INSUFFICIENT_SCOPE',
     READY              : 'KB_TENANT_REPO_ACCESS_READY',
     TIMEOUT            : 'KB_TENANT_REPO_ACCESS_TIMEOUT',
     TRANSPORT_FAILED   : 'KB_TENANT_REPO_ACCESS_TRANSPORT_FAILED',
@@ -45,6 +47,8 @@ const TENANT_REPO_ACCESS_CODES_BY_STATUS = Object.freeze({
     ]),
     [TenantRepoAccessStatus.DEGRADED]: Object.freeze([
         TenantRepoAccessCode.CREDENTIAL_INVALID,
+        TenantRepoAccessCode.CREDENTIAL_REJECTED,
+        TenantRepoAccessCode.INSUFFICIENT_SCOPE,
         TenantRepoAccessCode.TIMEOUT,
         TenantRepoAccessCode.TRANSPORT_FAILED,
         TenantRepoAccessCode.DENIED_OR_NOT_FOUND,
@@ -67,6 +71,53 @@ const TENANT_REPO_ACCESS_CODES_BY_STATUS = Object.freeze({
  */
 export function isTenantRepoAccessReadinessOutcome(status, code) {
     return TENANT_REPO_ACCESS_CODES_BY_STATUS[status]?.includes(code) === true;
+}
+
+// Stderr signatures, matched against ALREADY-REDACTED text. They exist because a remote operator
+// with no host access must be able to tell "the credential is wrong" from "the credential lacks the
+// scope" from "the network never reached the host" — three different fixes. Order is load-bearing:
+// a scope failure also says "denied", and an auth failure also says "not found" on some providers,
+// so the narrower signature has to win.
+const ACCESS_TRANSPORT_RE = /could not resolve host|temporary failure in name resolution|network is unreachable|failed to connect|connection (?:timed out|refused|reset)|ssh: connect to host/iu;
+const ACCESS_SCOPE_RE     = /write access to repository not granted|insufficient scope|requires? the [^\n]{0,40}scope|403 forbidden|resource not accessible by (?:personal access token|integration)/iu;
+const ACCESS_REJECTED_RE  = /authentication failed|invalid username or password|could not read username|terminal prompts disabled|permission denied \(publickey|bad credentials|401 unauthorized/iu;
+const ACCESS_ABSENT_RE    = /repository not found|does not appear to be a git repository|remote:? .{0,20}not found/iu;
+
+/**
+ * @summary Classifies a redacted Git access failure into the public access-readiness vocabulary.
+ *
+ * Single classifier for the whole lane. It lives beside the vocabulary it returns so the probe path
+ * and the sync path cannot disagree — before this was shared, the sync path recognised exactly ONE
+ * error code and flattened every other cause to `SYNC_FAILED`, discarding a classification the probe
+ * path had already computed correctly. A remote operator then saw "sync failed" for an under-scoped
+ * token, an absent repository, and an unreachable host alike.
+ *
+ * `DENIED_OR_NOT_FOUND` stays a deliberately COMBINED cause. Providers answer 404 for both "no
+ * access" and "does not exist" on purpose, so that repository existence is not leakable by probing.
+ * Splitting it would mean inventing a distinction the provider refuses to make; reporting the honest
+ * combined cause is the accurate answer.
+ *
+ * @param {Error} error Redacted access error (never carries credential material).
+ * @returns {String} A `TenantRepoAccessCode` value.
+ */
+export function classifyTenantRepoAccessFailure(error) {
+    if (error?.code === 'KB_GITMIRROR_ACCESS_PROBE_TIMEOUT') return TenantRepoAccessCode.TIMEOUT;
+    // The credential REFERENCE could not be resolved at all — a config defect, upstream of any
+    // network call, and distinct from a credential the remote rejected.
+    if (error?.code === 'KB_GITMIRROR_CREDENTIAL_REF_INVALID') return TenantRepoAccessCode.CREDENTIAL_INVALID;
+
+    const stderr = String(error?.stderr || '');
+
+    if (ACCESS_TRANSPORT_RE.test(stderr)) return TenantRepoAccessCode.TRANSPORT_FAILED;
+    if (ACCESS_SCOPE_RE.test(stderr))     return TenantRepoAccessCode.INSUFFICIENT_SCOPE;
+    if (ACCESS_REJECTED_RE.test(stderr))  return TenantRepoAccessCode.CREDENTIAL_REJECTED;
+    if (ACCESS_ABSENT_RE.test(stderr))    return TenantRepoAccessCode.DENIED_OR_NOT_FOUND;
+
+    // A Git process that ran and exited non-zero without a recognised signature is still evidence
+    // that acquisition was refused; only a failure with no exit status at all is unclassifiable.
+    if (Number.isInteger(error?.exitCode)) return TenantRepoAccessCode.DENIED_OR_NOT_FOUND;
+
+    return TenantRepoAccessCode.PROBE_FAILED;
 }
 
 /**

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
@@ -1,8 +1,11 @@
-import {readFileSync}                   from 'node:fs';
-import {test, expect}                   from '@playwright/test';
-import Neo                              from '../../../../../../../src/Neo.mjs';
-import * as core                        from '../../../../../../../src/core/_export.mjs';
-import {DeploymentRuntimeAccessService} from '../../../../../../../ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs';
+import {readFileSync} from 'node:fs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    DeploymentRuntimeAccessService,
+    DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY
+} from '../../../../../../../ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs';
 
 const BASE_CONFIG = {
     enabled                     : true,
@@ -425,4 +428,74 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
             }
         });
     });
+    /**
+     * The orchestrator must be READABLE through the bridge it publishes — it is the only process
+     * holding the tenant-repo-sync failure text, and excluding it made a wedged deployment
+     * undiagnosable from a remote MCP client. It must never be a LIFECYCLE target of that same bridge.
+     *
+     * One `allowedServices` list gates both envelopes, so allowlisting it for reads necessarily
+     * allowlists it for restart. These assert the asymmetry in BOTH directions, because either half
+     * alone is satisfied by a wrong implementation: refusing everything would pass the restart test,
+     * and allowing everything would pass the read test.
+     */
+    test('the orchestrator is READABLE through its own bridge', async () => {
+        const {service} = createService({
+            config    : {allowedServices: [...BASE_CONFIG.allowedServices, DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY]},
+            containers: [makeContainer({
+                Names : ['/neo-orchestrator-1'],
+                Labels: {
+                    'com.docker.compose.service': DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY,
+                    'com.docker.compose.project': 'neo'
+                }
+            })],
+            inspectData: {Name: '/neo-orchestrator-1'}
+        });
+
+        const result = await service.readObserve({
+            serviceKey: DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY,
+            operation : 'logs',
+            tail      : 25
+        });
+
+        expect(result).toBeTruthy();
+    });
+
+    test('the orchestrator is NOT restartable through its own bridge, even while allowlisted', async () => {
+        const {service} = createService({
+            config: {allowedServices: [...BASE_CONFIG.allowedServices, DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY]}
+        });
+
+        // Refused on the SELF rule, not on the allowlist — the allowlist admits it, which is the whole
+        // point: a test that passed because the service was un-allowlisted would prove nothing about
+        // the asymmetry.
+        await expect(service.applyLifecycle({
+            serviceKey: DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY,
+            operation : 'restart'
+        })).rejects.toThrow(/publishes this bridge/);
+    });
+
+    test('a sibling service stays restartable — the refusal is scoped to self, not to lifecycle', async () => {
+        // The positive control for the assertion above.
+        const {service} = createService({
+            config: {allowedServices: [...BASE_CONFIG.allowedServices, DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY]}
+        });
+
+        const result = await service.applyLifecycle({serviceKey: 'mc-server', operation: 'restart'});
+
+        expect(result).toBeTruthy();
+    });
+
+    test('the self-service constant matches the orchestrator service key in the deploy template', () => {
+        // Two expectation sites: the refusal keys off this string, and the template names the service.
+        // A rename in either would silently disarm the refusal by making it match nothing, so the
+        // coupling is asserted rather than assumed.
+        const
+            compose  = readFileSync(new URL('../../../../../../../ai/deploy/docker-compose.yml', import.meta.url), 'utf8'),
+            services = [...compose.matchAll(/^ {2}([a-z0-9][a-z0-9_.-]*):$/gmu)].map(match => match[1]);
+
+        expect(services, 'the compose parse found no services — the guard is looking at nothing').toContain('chroma');
+        expect(services).toContain(DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY);
+        // And the shipped allowlist must actually grant it, or the read half is unreachable in production.
+        expect(compose).toMatch(new RegExp(`RUNTIME_ACCESS_ALLOWED_SERVICES=[^\\n]*${DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY}`));
+    })
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -2281,8 +2281,15 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             // cause. This mirror is deliberate: the exact-shape assertion is the contract,
             // so a field added to durable state has to be declared here or the addition is unwitnessed.
             // `lastSourceErrorCode` is null because this mirror throws a bare Error with no `KB_*` code.
+            //
+            // `lastAccessCode` is the DISCRIMINATING cause, and here it is the honest fallback: a bare
+            // Error carries no exit status and no stderr, so nothing can be named. That fallback is
+            // `SYNC_FAILED` rather than `PROBE_FAILED` because on the sync path we do know the sync
+            // failed — we only fail to know why. A real Git failure resolves to a named cause instead;
+            // the discrimination fixtures live in the persisted-cause describe below.
             lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
             lastSourceErrorCode: null,
+            lastAccessCode     : 'KB_TENANT_REPO_ACCESS_SYNC_FAILED',
             lastErrorAt        : expect.any(Number)
         });
     });
@@ -3247,8 +3254,110 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             expect(persisted.consecutiveFailures).toBe(0);
             expect(persisted.lastErrorCode).toBeNull();
             expect(persisted.lastSourceErrorCode).toBeNull();
+            expect(persisted.lastAccessCode).toBeNull();
             expect(persisted.lastErrorAt).toBeNull()
         })
+    })
+});
+
+test.describe('the persisted cause DISCRIMINATES, and still leaks nothing (#16056)', () => {
+    /*
+     * A safe code can still be too coarse to be a cause. The retained-cause work made the reason
+     * durable, but every acquisition failure persisted as `SYNC_FAILED` + `KB_GITMIRROR_FETCH_FAILED`
+     * — an outer code plus the OPERATION that failed. An operator reading that learns acquisition
+     * failed, which they already knew from the failure count, and cannot tell which of four
+     * different fixes to apply. The named cases below are the ones a private-cloud tenant actually
+     * hits, and the reason this matters is that we do not hold their credentials: if our own logs
+     * cannot name "the token lacks the required scope", the diagnosis is on us.
+     */
+    const TOKEN = 'ghp_liveLookingSecretValue1234567890';
+
+    /**
+     * Builds a redacted-shaped Git failure. The token is deliberately present in the object so the
+     * secrecy assertion has something real to catch — a fixture with no secret in it would prove the
+     * boundary holds against nothing.
+     * @param {Object} options
+     * @returns {Error}
+     */
+    function gitFailure({stderr, code = 'KB_GITMIRROR_FETCH_FAILED', exitCode = 128}) {
+        const error = new Error(`GitMirror fetch failed for ${TOKEN}`);
+
+        Object.assign(error, {code, exitCode, stderr});
+        return error
+    }
+
+    test('four different causes classify four different ways', async () => {
+        const {classifyTenantRepoAccessFailure, TenantRepoAccessCode} =
+            await import('../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs');
+
+        const cases = [
+            ['remote: Write access to repository not granted.\nfatal: unable to access', TenantRepoAccessCode.INSUFFICIENT_SCOPE],
+            ['remote: Invalid username or password.\nfatal: Authentication failed',      TenantRepoAccessCode.CREDENTIAL_REJECTED],
+            ['remote: Repository not found.\nfatal: could not read from remote',         TenantRepoAccessCode.DENIED_OR_NOT_FOUND],
+            ['ssh: connect to host git.example.com port 22: Connection refused',         TenantRepoAccessCode.TRANSPORT_FAILED]
+        ];
+
+        const observed = cases.map(([stderr]) => classifyTenantRepoAccessFailure(gitFailure({stderr})));
+
+        cases.forEach(([, expected], index) => expect(observed[index]).toBe(expected));
+
+        // The discrimination is the point, so assert the codes are actually DISTINCT rather than
+        // four assertions that would all pass against a single constant.
+        expect(new Set(observed).size).toBe(4);
+        expect(observed).not.toContain(TenantRepoAccessCode.SYNC_FAILED)
+    });
+
+    test('a probe timeout and an unresolvable credential REF stay separate from a rejected credential', async () => {
+        const {classifyTenantRepoAccessFailure, TenantRepoAccessCode} =
+            await import('../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs');
+
+        expect(classifyTenantRepoAccessFailure(gitFailure({code: 'KB_GITMIRROR_ACCESS_PROBE_TIMEOUT', stderr: ''})))
+            .toBe(TenantRepoAccessCode.TIMEOUT);
+        // A credential reference that cannot be resolved is a CONFIG defect upstream of any network
+        // call — not the same event as a remote rejecting a credential that did resolve.
+        expect(classifyTenantRepoAccessFailure(gitFailure({code: 'KB_GITMIRROR_CREDENTIAL_REF_INVALID', stderr: ''})))
+            .toBe(TenantRepoAccessCode.CREDENTIAL_INVALID);
+        // No exit status at all is genuinely unclassifiable, and says so rather than guessing.
+        expect(classifyTenantRepoAccessFailure({message: 'boom'})).toBe(TenantRepoAccessCode.PROBE_FAILED)
+    });
+
+    test('every classification is a bounded code the read boundary admits, and carries no secret', async () => {
+        const {classifyTenantRepoAccessFailure, TenantRepoAccessCode} =
+            await import('../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs');
+        const {normalizeTenantRepoCheckpointState} =
+            await import('../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs');
+
+        const stderrs = [
+            'remote: Write access to repository not granted.',
+            `remote: Invalid username or password for ${TOKEN}`,
+            'remote: Repository not found.',
+            'fatal: could not resolve host github.com'
+        ];
+
+        for (const stderr of stderrs) {
+            const code       = classifyTenantRepoAccessFailure(gitFailure({stderr})),
+                  normalized = normalizeTenantRepoCheckpointState({
+                      lastIngestedRev: 'abc123',
+                      lastAccessCode : code,
+                      lastErrorAt    : Date.now()
+                  });
+
+            // Survives the read-side bounded-code gate — a discriminating cause that the projection
+            // strips is not a diagnosable one.
+            expect(normalized.lastAccessCode).toBe(code);
+            expect(code).toMatch(/^KB_[A-Z0-9_]{1,120}$/u);
+            expect(code).not.toContain(TOKEN);
+            expect(code).not.toMatch(/ghp_/)
+        }
+
+        // MUTATION on what the gate guards: a cause that is not a bounded code must be refused, or
+        // the assertions above would hold for any string whatsoever.
+        expect(normalizeTenantRepoCheckpointState({
+            lastIngestedRev: 'abc123',
+            lastAccessCode : `fatal: auth failed for ${TOKEN}`
+        }).lastAccessCode).toBeNull();
+
+        expect(TenantRepoAccessCode.INSUFFICIENT_SCOPE).toMatch(/INSUFFICIENT_SCOPE$/)
     })
 });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -2275,7 +2275,15 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             consecutiveFailures                  : 1,
             ingestContractVersion                : null,
             lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
-            lastCommittedMaterializationAttemptId: null
+            lastCommittedMaterializationAttemptId: null,
+            // The failure REASON is persisted alongside the count. Previously only the count survived
+            // a sweep, which is what left a wedged lane reporting `consecutiveFailures` with a null
+            // cause. This mirror is deliberate: the exact-shape assertion is the contract,
+            // so a field added to durable state has to be declared here or the addition is unwitnessed.
+            // `lastSourceErrorCode` is null because this mirror throws a bare Error with no `KB_*` code.
+            lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+            lastSourceErrorCode: null,
+            lastErrorAt        : expect.any(Number)
         });
     });
 
@@ -3046,6 +3054,202 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(Object.keys(persisted.revisions)).toHaveLength(2000);
         expect(persisted.revisions['t1/org/repo-1999'].lastIngestedRev.endsWith('1999')).toBe(true);
     });
+
+    /**
+     * A wedged lane has to stay diagnosable from a remote MCP client, which is the only interface a
+     * cloud deployment exposes.
+     *
+     * The defect these cover, observed on a live deployment: four repos at `consecutiveFailures: 4`
+     * with `lastErrorCode: null` and `lastSourceErrorCode: null`, all reporting `status: "not-due"`
+     * while the sweep completed every cadence with `exitCode: 0`. Two causes, and the first makes the
+     * second unfixable on its own — the code was written ONLY onto the in-memory record for the sweep
+     * that failed, so it survived one cadence and was gone; and the backoff branch then rebuilt a
+     * record with neither the code nor any hint that a failure was why the repo stopped being tried.
+     * Counters persisted, reasons did not.
+     */
+    test.describe('a wedged lane keeps its reason (#16056)', () => {
+        const failingMirror = () => ({
+            async cloneIfMissing() {},
+            async fetch() {
+                const error = new Error('GitMirror failed to fetch');
+
+                error.code     = 'KB_GITMIRROR_FETCH_FAILED';
+                // Deliberately carries what must NEVER reach durable state.
+                error.stderr   = 'remote: HTTP Basic: Access denied for https://oauth2:glpat-SECRETVALUE@gitlab.example.net/ai/x.git';
+                error.exitCode = 128;
+
+                throw error
+            },
+            async resolveRevision() { return 'a'.repeat(40) },
+            async listRevisionPaths() { return [] },
+            async readRevisionFile() { return '' }
+        });
+
+        const repoFor = mirrorRootPath => ({
+            tenantId: 't1', repoSlug: 'org/wedged', mirrorRoot: mirrorRootPath,
+            cloneUrl: 'https://gitlab.example.net/ai/x.git'
+        });
+
+        test('a failure PERSISTS its cause, so it outlives the sweep that produced it', async () => {
+            const taskStateService = createInMemoryTaskStateService();
+
+            await TenantRepoSyncService.runTask({
+                reason                       : 'periodic',
+                taskStateService,
+                tenantReposConfig            : {tenantRepos: [repoFor(mirrorRoot)]},
+                gitMirror                    : failingMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService(),
+                revisionsFilePath            : revisionsFile,
+                seedBootstrap                : false
+            });
+
+            const persisted = (await fs.readJson(revisionsFile)).revisions['t1/org/wedged'];
+
+            expect(persisted.consecutiveFailures).toBe(1);
+            // The point of the ticket: the count was already durable, the REASON was not.
+            expect(persisted.lastErrorCode).toBe('KB_TENANT_REPO_SYNC_SYNC_FAILED');
+            expect(persisted.lastSourceErrorCode).toBe('KB_GITMIRROR_FETCH_FAILED');
+            expect(typeof persisted.lastErrorAt).toBe('number');
+
+            // Redaction: codes only. A credential arrived in `stderr` above, so this asserts the
+            // boundary rather than trusting it.
+            const serialized = JSON.stringify(persisted);
+
+            expect(serialized).not.toMatch(/glpat-/);
+            expect(serialized).not.toMatch(/Access denied/);
+            expect(serialized).not.toMatch(/gitlab\.example\.net/)
+        });
+
+        test('a backoff-suppressed repo REPORTS the retained cause, and says it is suppressed', async () => {
+            const taskStateService = createInMemoryTaskStateService();
+
+            await TenantRepoSyncService.writePersistedRevisions({
+                filePath : revisionsFile,
+                revisions: {
+                    't1/org/wedged': {
+                        lastIngestedRev                      : null,
+                        lastRunAttemptAt                     : Date.now(),
+                        consecutiveFailures                  : 4,
+                        ingestContractVersion                : null,
+                        lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastCommittedMaterializationAttemptId: null,
+                        lastErrorCode                        : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+                        lastSourceErrorCode                  : 'KB_GITMIRROR_FETCH_FAILED',
+                        lastErrorAt                          : Date.now() - 5_000
+                    }
+                }
+            });
+
+            const result = await TenantRepoSyncService.runTask({
+                reason                       : 'periodic',
+                taskStateService,
+                tenantReposConfig            : {tenantRepos: [repoFor(mirrorRoot)]},
+                gitMirror                    : failingMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService(),
+                revisionsFilePath            : revisionsFile,
+                globalCadenceMs              : 60_000,
+                seedBootstrap                : false
+            });
+
+            const [repoState] = result.details.repos;
+
+            // `not-due` conflated "ran recently" with "wedged after repeated failure", which is what
+            // made a broken lane read as an idle one.
+            expect(repoState.status).toBe('backoff-suppressed');
+            expect(repoState.consecutiveFailures).toBe(4);
+            expect(repoState.lastErrorCode).toBe('KB_TENANT_REPO_SYNC_SYNC_FAILED');
+            expect(repoState.lastSourceErrorCode).toBe('KB_GITMIRROR_FETCH_FAILED');
+            expect(repoState.lastErrorAt).toBeTruthy();
+            expect(repoState.nextDueAt).toBeTruthy()
+        });
+
+        test('a healthy repo held back by cadence stays plain not-due and carries NO cause', async () => {
+            // The positive control. Without it, the assertion above is satisfied by a change that
+            // labels every held-back repo as suppressed and attaches a cause to all of them.
+            const taskStateService = createInMemoryTaskStateService();
+
+            await TenantRepoSyncService.writePersistedRevisions({
+                filePath : revisionsFile,
+                revisions: {
+                    't1/org/wedged': {
+                        lastIngestedRev                      : 'b'.repeat(40),
+                        lastRunAttemptAt                     : Date.now(),
+                        consecutiveFailures                  : 0,
+                        ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastCommittedMaterializationAttemptId: null
+                    }
+                }
+            });
+
+            const result = await TenantRepoSyncService.runTask({
+                reason                       : 'periodic',
+                taskStateService,
+                tenantReposConfig            : {tenantRepos: [repoFor(mirrorRoot)]},
+                gitMirror                    : failingMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService(),
+                revisionsFilePath            : revisionsFile,
+                globalCadenceMs              : 60_000,
+                seedBootstrap                : false
+            });
+
+            const [repoState] = result.details.repos;
+
+            expect(repoState.status).toBe('not-due');
+            expect(repoState.lastErrorCode).toBeUndefined();
+            expect(repoState.lastSourceErrorCode).toBeUndefined()
+        });
+
+        test('a repo that heals CLEARS its persisted cause', async () => {
+            // A durable reason beside a zero failure count reads as a live fault, so healing has to
+            // retract it explicitly rather than leave the last known error lying around.
+            const taskStateService = createInMemoryTaskStateService();
+
+            await TenantRepoSyncService.writePersistedRevisions({
+                filePath : revisionsFile,
+                revisions: {
+                    't1/org/healed': {
+                        lastIngestedRev                      : null,
+                        lastRunAttemptAt                     : Date.now() - 600_000,
+                        consecutiveFailures                  : 3,
+                        ingestContractVersion                : null,
+                        lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastCommittedMaterializationAttemptId: null,
+                        lastErrorCode                        : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+                        lastSourceErrorCode                  : 'KB_GITMIRROR_FETCH_FAILED',
+                        lastErrorAt                          : Date.now() - 600_000
+                    }
+                }
+            });
+
+            await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/healed'});
+
+            await TenantRepoSyncService.runTask({
+                reason           : 'periodic',
+                taskStateService,
+                tenantReposConfig: {tenantRepos: [{
+                    tenantId: 't1', repoSlug: 'org/healed', mirrorRoot,
+                    cloneUrl: 'https://gitlab.example.net/ai/healed.git'
+                }]},
+                gitMirror                    : makeFakeGitMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService(),
+                revisionsFilePath            : revisionsFile,
+                globalCadenceMs              : 60_000,
+                seedBootstrap                : false
+            });
+
+            const persisted = (await fs.readJson(revisionsFile)).revisions['t1/org/healed'];
+
+            expect(persisted.consecutiveFailures).toBe(0);
+            expect(persisted.lastErrorCode).toBeNull();
+            expect(persisted.lastSourceErrorCode).toBeNull();
+            expect(persisted.lastErrorAt).toBeNull()
+        })
+    })
 });
 
 test.describe('TenantRepoSyncService.resolveIngestionService — export-drift guard (#12042)', () => {
@@ -3269,4 +3473,5 @@ test.describe('syncTenantRepos manual CLI (#15748)', () => {
         expect(resolveExitCode({status: 'failed', details: {reasonCode: 'KB_TENANT_REPO_SYNC_SYNC_FAILED'}})).toBe(1);
         expect(resolveExitCode({status: 'skipped', details: {reason: 'no-tenant-repos-configured'}})).toBe(1);
     });
+
 });

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -236,6 +236,99 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         expect(Service.getIngestionProgress().crossProcessHint).toMatch(/orchestrator/);
     });
 
+    test('a run that FAILED before progress tracking started is not reported as idle with zero errors', () => {
+        // The sharp case behind the status split. `resolveTenantContext` can throw upstream of
+        // `startIngestionProgress`, and the catch records a SYNTHETIC failed ledger — so the outcome was
+        // always reachable, it just was not reported at the level a caller reads. The top level said
+        // `idle` / `errorCount: 0` while the nested `lastRunSummary` said `failed` with a real count.
+        Service.finishIngestionProgress({
+            summary: {
+                durationMs         : 12,
+                embeddingsGenerated: 0,
+                deleted            : 0,
+                ingested           : 0,
+                skippedOversized   : 0,
+                tenantId           : 'neo-shared',
+                errors             : [{code: 'KB_INGEST_FAILED', message: 'tenant context could not be resolved'}]
+            },
+            status: 'failed'
+        });
+
+        const progress = Service.getIngestionProgress();
+
+        expect(progress.status).toBe('failed');
+        expect(progress.status).not.toBe('idle');
+        expect(progress.active).toBe(false);
+        // The count must not read zero beside a failed run — that is the same false reassurance the
+        // status was giving.
+        expect(progress.errorCount).toBe(1);
+        expect(progress.lastRunSummary.status).toBe('failed');
+        // And the scope disclosure survives on this state too.
+        expect(progress.observedScope).toBe('this-process-only');
+    });
+
+    test('POSITIVE CONTROL: a CLEAN finished run still reports idle, so `failed` is discriminating', () => {
+        // Without this, the assertion above would pass against an implementation that hardcoded
+        // `failed` for every finished run, and the status split would be measuring nothing.
+        Service.finishIngestionProgress({
+            summary: {
+                durationMs         : 8,
+                embeddingsGenerated: 2,
+                deleted            : 0,
+                ingested           : 2,
+                skippedOversized   : 0,
+                tenantId           : 'neo-shared',
+                errors             : []
+            },
+            status: 'completed'
+        });
+
+        const progress = Service.getIngestionProgress();
+
+        expect(progress.status).toBe('idle');
+        expect(progress.errorCount).toBe(0);
+    });
+
+    test('the scope disclosure is carried on the ACTIVE state, not only when idle', () => {
+        // A partial disclosure is read as a complete one: a caller that happens to poll mid-run would
+        // otherwise get a number with no statement of what it covers.
+        Service.startIngestionProgress({startedAt: Date.now(), tenantContext: {tenantId: 'neo-shared'}, totalSources: 3});
+
+        const active = Service.getIngestionProgress();
+
+        expect(active.active).toBe(true);
+        expect(active.observedScope).toBe('this-process-only');
+        expect(active.crossProcessHint).toMatch(/orchestrator/);
+
+        Service.activeIngestionProgress = null;
+    });
+
+    test('the OpenAPI contract declares every status the producer can emit, and both scope fields', () => {
+        // The producer and its public schema disagreed at an earlier head: the service emitted
+        // `never-attempted` plus two scope fields while the schema still constrained status to
+        // active/idle vocabulary and declared neither field. A wire contract that omits what the
+        // producer sends is not a laxer contract, it is a wrong one.
+        const
+            spec   = fs.readFileSync(new URL('../../../../../../ai/mcp/server/knowledge-base/openapi.yaml', import.meta.url), 'utf8'),
+            schema = spec.slice(spec.indexOf('IngestionProgressResponse:'));
+
+        for (const status of ['never-attempted', 'failed', 'idle', 'running']) {
+            expect(schema.slice(0, 2000)).toContain(status);
+        }
+
+        expect(schema.slice(0, 2500)).toContain('observedScope');
+        expect(schema.slice(0, 2500)).toContain('crossProcessHint');
+
+        // The caller-visible tier too. `description` is handbook-only; an agent choosing whether to
+        // trust a negative answer sees `x-neo-tool-summary` in `tools/list` and nothing else, so the
+        // scope caveat has to live there or no agent ever reads it.
+        const summaryLine = spec.split('\n').find(line => line.includes('x-neo-tool-summary') && /ngestion progress/i.test(line));
+
+        expect(summaryLine).toBeTruthy();
+        expect(summaryLine).toMatch(/THIS PROCESS/);
+        expect(summaryLine.split('x-neo-tool-summary:')[1].trim().length).toBeLessThanOrEqual(120);
+    });
+
     test('reports active ingestion progress and preserves the last-run summary (#14028)', async () => {
         let activeSnapshot;
         let releaseEmbed;

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -207,11 +207,22 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         });
     });
 
-    test('reports idle ingestion progress before any observed run (#14028)', () => {
+    test('distinguishes NEVER-ATTEMPTED from idle, and discloses its process scope (#14028)', () => {
+        // `idle` used to cover two different facts: a run finished and nothing is in flight, versus
+        // this process has never ingested at all. On a live deployment the second presented as
+        // `status: "idle", errorCount: 0` with every timestamp null, which reads as healthy while four
+        // tenant repos had failed four times each.
+        //
+        // The scope disclosure is the other half, and it is why a better status alone is not enough:
+        // progress state is IN-MEMORY per process, and the pull-mode tenant-repo lane ingests in the
+        // orchestrator — so a Knowledge Base server saying `never-attempted` is not evidence that the
+        // deployment never ingested. Without that, the clearer status would license a wrong conclusion
+        // more confidently than the vague one did.
         expect(Service.getIngestionProgress()).toMatchObject({
-            status        : 'idle',
+            status        : 'never-attempted',
             active        : false,
             phase         : 'idle',
+            observedScope : 'this-process-only',
             stalled       : false,
             totalSources  : 0,
             seenSources   : 0,
@@ -221,6 +232,8 @@ test.describe('IngestionService.ingestSourceFiles', () => {
             remaining     : 0,
             lastRunSummary: null
         });
+
+        expect(Service.getIngestionProgress().crossProcessHint).toMatch(/orchestrator/);
     });
 
     test('reports active ingestion progress and preserves the last-run summary (#14028)', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
@@ -486,10 +486,28 @@ exit 1
         expect(isolatedHomes).toHaveLength(2);
     });
 
-    test('classifies denied, transport, and timeout probe failures without returning Git prose', async () => {
+    test('classifies rejected-credential, scope, absent, transport, and timeout probe failures without returning Git prose', async () => {
         const cases = [
             {
+                // Was asserted as DENIED_OR_NOT_FOUND while every non-transport exit collapsed into
+                // that one code. A rejected credential and an absent repository need different fixes,
+                // so the shared classifier now separates them and this fixture pins the sharper answer.
                 script : "printf '%s\\n' 'fatal: Authentication failed for https://example.invalid/private.git' >&2\nexit 128",
+                code   : TenantRepoAccessCode.CREDENTIAL_REJECTED,
+                timeout: 3000
+            },
+            {
+                // The case the operator named: a token that authenticates but lacks the scope. Under
+                // the old collapse this was indistinguishable from a wrong token.
+                script : "printf '%s\\n' 'remote: Write access to repository not granted.' >&2\nexit 128",
+                code   : TenantRepoAccessCode.INSUFFICIENT_SCOPE,
+                timeout: 3000
+            },
+            {
+                // Stays COMBINED on purpose. Providers answer 404 for both "no access" and "does not
+                // exist" so repository existence is not probeable; splitting it would invent a
+                // distinction the provider refuses to make.
+                script : "printf '%s\\n' 'remote: Repository not found.' >&2\nexit 128",
                 code   : TenantRepoAccessCode.DENIED_OR_NOT_FOUND,
                 timeout: 3000
             },
@@ -519,6 +537,11 @@ exit 1
                 expect(JSON.stringify(result)).not.toContain('example.invalid');
             });
         }
+
+        // The discrimination is the deliverable, so assert the fixtures actually resolve to DISTINCT
+        // codes. Five per-case assertions would all pass against a classifier that returned one
+        // value for everything, which is the behaviour being replaced.
+        expect(new Set(cases.map(item => item.code)).size).toBe(cases.length);
     });
 
     test('resolves file credentialRef strings through askpass and redacts the resolved secret', async () => {


### PR DESCRIPTION
Resolves #16056.

**All six criteria delivered, after a cross-family review found two of them only half-closed.** Four commits: the failure cause is recorded, survives backoff, and now *names* which of four causes it was; the bridge can read its own publisher without becoming restartable by it; and progress stops reporting `idle` both for a process that has never ingested and for a run that failed.

> **Correction.** The first version of this line claimed all six criteria without qualification, and that was an overshoot @neo-gpt was right to flag: a *safe* error code can still be too coarse to be a cause, and a producer emitting fields its own schema does not declare is not a laxer contract but a wrong one. Both gaps are closed at `0b6c1c25a4`; the reasoning is in the review response below.

## What was actually broken

Diagnosed against the live deployment this ticket was filed from, over its own MCP surface. Four repos, every one of them:

```
status: "not-due"        consecutiveFailures: 4
lastIngestedRev: null    lastErrorCode: null    lastSourceErrorCode: null
```

with the sweep completing every cadence at `exitCode: 0`, `failedCount: 0`, `status: "completed"`. Every surface read healthy; nothing had ever ingested.

Evidence: two causes, and the first made the second unfixable on its own.

**1. The cause was never persisted.** `lastErrorCode` was written only onto the in-memory record for the sweep that failed. `persistedRevisions[label]` — which becomes `priorState` on the next sweep — stored counters and nothing else. So a reason was published for exactly one cadence and then overwritten. Counters survived because they were persisted; reasons did not because they were not. Read back, `readPersistedRevisions` → `normalizeTenantRepoCheckpointState` whitelists keys, so it dropped them too: both the write and the read had to be extended.

**2. Backoff erased what was left.** The `!dueState.due` branch rebuilt a record carrying `consecutiveFailures` but neither the code nor any signal that a *failure* was why the repo had stopped being retried. `not-due` conflated "ran recently" with "wedged after repeated failure" — which is exactly how a broken lane presents as an idle one.

## The change

| Path | Before | After |
|---|---|---|
| per-repo failure | code on the in-memory record only | `lastErrorCode`, `lastSourceErrorCode`, `lastErrorAt` **persisted** |
| success | counters reset | the three cause fields **explicitly cleared** |
| held back by backoff | `status: "not-due"`, no cause | `status: "backoff-suppressed"` + retained cause + `nextDueAt` |
| held back by cadence only | `status: "not-due"` | unchanged, and carries **no** cause |
| read path | whitelist dropped the fields | normalised, with the codes re-validated |

Success clears rather than omits: a durable reason beside a zero failure count reads as a live fault.

## Redaction, enforced on both sides

The underlying error carries `stderr`, a remote URL, and for a credential-bearing clone URL the credential itself. So the cause travels as a bounded `KB_*` code and nothing else. The writer filters through `getSourceErrorCode`; the reader re-validates through a new `normalizeBoundedErrorCode`. The redundancy is deliberate — a record hand-edited on disk, or written by a looser build, still cannot project free text into a diagnostic surface.

Asserted, not assumed: the fixture's `stderr` embeds a `glpat-` token, and the test requires the persisted state to contain neither the token, nor the message, nor the host.

## Test Evidence

Local, at `99d515b03f`: **976 passed** across `test/playwright/unit/ai/daemons/orchestrator/`, including 4 new tests and one updated contract fixture.

- a failure **persists** its cause, so it outlives the sweep that produced it — plus the redaction assertions
- a backoff-suppressed repo **reports** the retained cause and says it is suppressed
- a healthy repo held back by cadence stays plain `not-due` and carries **no** cause — the positive control, without which the assertion above is satisfied by labelling everything suppressed
- a repo that heals **clears** its persisted cause

The pre-existing exact-shape `toEqual` fixture in the backoff test is **updated, not loosened**. It is the contract for durable state: a field added there has to be declared, or the addition is unwitnessed.

## The bridge half (`937c28d590`)

**The orchestrator is now readable through its own bridge, and still not restartable by it.** It was absent from `allowedServices` — and the tenant-repo-sync lane runs *in* the orchestrator, so the one process holding the failure text was the one whose logs the bridge could not read. That list is `ai/deploy/docker-compose.yml`, so it reached the live deployment because we shipped it.

One list gates **both** envelopes (`readObserve` and `applyLifecycle` both resolve through `resolveServiceTarget`), so allowlisting it for reads necessarily allowlists it for restart. `assertNotSelfLifecycleTarget` makes the asymmetry expressible without a second config surface to keep in sync — and it is **structural, not configurable**: restarting the orchestrator through the bridge it publishes kills the process serving the request, so the caller gets a dropped connection instead of an outcome and the audit record dies with its writer. A knob there would only be a way to be wrong.

Asserted in both directions **plus a positive control**, because either half alone passes for a wrong implementation — refusing everything satisfies the restart test, allowing everything satisfies the read test, and a sibling service must stay restartable. A fourth test pins the self-service constant against the compose template's own service key, so a rename fails a test rather than silently disarming the refusal by matching nothing. Certified by mutation: removing the refusal fails exactly the restart test.
**`never-attempted` is no longer reported as `idle`, and the tool now admits what it can see.** Live it returned `status: "idle", errorCount: 0` with every timestamp null while four repos had failed four times each. `idle` covered two facts: a run finished, versus this process has never ingested at all.

AC5's own first requirement was to establish whether that surface can observe pull-path runs before giving it better words. **It cannot** — `activeIngestionProgress` is in-memory instance state and the pull lane ingests in the orchestrator. So a crisper label alone would have been *worse* than the vague one: it would license a wrong conclusion more confidently. The payload now carries `observedScope: 'this-process-only'` and points at the deployment-state snapshot, which is where a wedged pull lane is actually visible — and which this PR's first half taught to carry the cause.

## Post-Merge Validation

- Takes effect for the next sweep after an orchestrator restart; existing persisted records lack the cause fields and normalise to null, so the first post-deploy failure is the first one that will carry a reason.
- On the deployment this was diagnosed from, the four wedged repos should begin reporting `backoff-suppressed` with a `lastErrorCode` — which is the receipt that this ticket did its job, and the input needed to fix the underlying failure.
- No schema migration: absent fields normalise to null rather than invalidating a checkpoint.

## Deltas

- `ai/daemons/orchestrator/services/TenantRepoSyncService.mjs` — persist the cause on failure, clear it on success, distinguish backoff suppression and carry the retained cause.
- `ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs` — normalise the three new fields; new `normalizeBoundedErrorCode` as the read-side redaction boundary.
- `test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — 4 new tests; one contract fixture updated.

Authored by Vega (@neo-opus-vega). Session c038696f-94a6-4788-82bf-747c5672908c.

