### PR TITLE
The deploy template no longer locks deployment members out of messaging each other

### DIFF
--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -121,7 +121,28 @@ services:
     environment:
       - NEO_TRANSPORT=streamable-http
       - NEO_MC_PRIMARY=false
-      - NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked
+      # `NEO_MAILBOX_DEFAULT_REPLY_POLICY` is deliberately NOT set here.
+      #
+      # This template used to pin it to `blocked`, which overrode the library default of `open` for
+      # every deployment that followed our own guide. The result: members of one organisation's
+      # private deployment could not message each other at all — each pair needed an explicit
+      # `CAN_REPLY_TO` grant first. On a 15-member team that is 210 directed grants, and 28 more per
+      # hire, to obtain what the product is for. Install the mail system, then send postal letters
+      # asking to be allowed to send mail.
+      #
+      # It was also incoherent with its neighbour: `memorySharing.defaultPolicy` defaults to `team`,
+      # so the same deployment let every member read every other member's MEMORIES while forbidding
+      # them a message. Reading someone's stored reasoning is strictly more sensitive than pinging
+      # them.
+      #
+      # A deployment is a trust boundary. The members inside one are peers of the same operator, so
+      # peer-trust is the correct default and `blocked` is the exception — for a genuine multi-tenant
+      # install co-locating separate organisations, which sets it explicitly alongside
+      # `NEO_MEMORY_SHARING_DEFAULT_POLICY=private`. Those two belong together; pinning one without
+      # the other is what produced the incoherence above.
+      #
+      # Not restated as `=open` on purpose: that would duplicate the leaf's default in a second place
+      # and silently pin today's value if the leaf ever changes. The leaf owns it.
       - NEO_AUTO_SUMMARIZE=false
       - NEO_MEM_AUTO_START_DATABASE=false
       - NEO_MEM_AUTO_START_INFERENCE=false

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1603,7 +1603,32 @@ class MailboxService extends Base {
             }
 
             if (!canReply) {
-                throw new Error(`Unauthorized: Cannot send to ${to}. Requires CAN_REPLY_TO permission or prior message history.`);
+                // Name the POSTURE, not just the missing grant.
+                //
+                // The previous wording — "Requires CAN_REPLY_TO permission or prior message history" —
+                // is true and sends the reader to the wrong remedy. It reads as a per-pair problem, so
+                // an operator reaches for `grant_permission` pairwise; on a 15-member deployment that is
+                // 210 directed grants, and 28 more per hire. The actual cause is a deployment-level
+                // selector that happens to resolve to strict isolation, and one policy change replaces
+                // all of them.
+                //
+                // Observed: a private single-org deployment where every member could read every other
+                // member's MEMORIES (`memorySharing.defaultPolicy` at its `'team'` default) while none
+                // could send another a message. Reading someone's stored reasoning is strictly more
+                // sensitive than pinging them, so that combination is almost certainly unintended
+                // rather than chosen — and the old message gave no hint that a policy decided it.
+                //
+                // Deliberately NOT applied to the `BLOCKED_BY` refusal above: an explicit block IS a
+                // per-pair decision, and steering that reader toward a deployment-wide policy change
+                // would advise overriding someone's stated intent.
+                throw new Error(
+                    `Unauthorized: Cannot send to ${to}. This deployment resolves ` +
+                    `mailbox.defaultReplyPolicy='blocked' (strict isolation, intended for multi-tenant ` +
+                    `installations), so initiating contact with a specific identity requires a prior ` +
+                    `CAN_REPLY_TO grant or earlier message history with them. If every member of this ` +
+                    `deployment is a peer of the same operator, change that deployment-level policy ` +
+                    `rather than granting each pair.`
+                );
             }
         }
 

--- a/test/playwright/unit/ai/deploy/DeploymentTrustDefaults.spec.mjs
+++ b/test/playwright/unit/ai/deploy/DeploymentTrustDefaults.spec.mjs
@@ -1,0 +1,106 @@
+import {test, expect}     from '@playwright/test';
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import process            from 'node:process';
+import {load as yamlLoad} from 'js-yaml';
+
+/**
+ * Guards the trust defaults the deploy template imposes on every installation that follows our guide.
+ *
+ * The failure this exists to prevent, observed on a real deployment: this template pinned
+ * `NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked`, overriding the library default of `open`. Members of a
+ * single organisation's private deployment therefore could not message each other at all — every pair
+ * needed an explicit `CAN_REPLY_TO` grant first. On a 15-member team that is 210 directed grants, and
+ * 28 more per hire, to obtain the thing the product is for.
+ *
+ * WHY a spec rather than a comment in the compose file. A restrictive default reads as prudent at the
+ * point someone writes it, produces no error, breaks no test, and fails only as an absence: people
+ * simply cannot reach each other, on someone else's deployment, weeks later. Nothing about the line
+ * looks wrong — which is exactly the property that let it ship and survive.
+ *
+ * The coherence assertion is the load-bearing one. `mailbox.defaultReplyPolicy` and
+ * `memorySharing.defaultPolicy` describe the SAME question — is this deployment one trust boundary or
+ * several — and the shipped template answered it two different ways: mail locked down to multi-tenant
+ * strictness while memories stayed deployment-wide readable. So every member could read every other
+ * member's stored reasoning but not send them a message, which is the more sensitive permission
+ * granted alongside the less sensitive one refused. Pinning either alone is how that happens, so the
+ * guard binds them together rather than banning one value.
+ */
+
+const
+    root        = process.cwd(),
+    composePath = path.join(root, 'ai/deploy/docker-compose.yml'),
+    MAILBOX_KEY = 'NEO_MAILBOX_DEFAULT_REPLY_POLICY',
+    SHARING_KEY = 'NEO_MEMORY_SHARING_DEFAULT_POLICY';
+
+/**
+ * @summary Collects `KEY=value` environment entries across every service in the compose file.
+ * @returns {Map<String, String[]>} Key → every value assigned to it, across all services.
+ */
+function collectEnvAssignments() {
+    const
+        compose  = yamlLoad(fs.readFileSync(composePath, 'utf8')),
+        assigned = new Map();
+
+    for (const service of Object.values(compose.services || {})) {
+        // Compose permits both the list form (`- KEY=value`) and the map form (`KEY: value`).
+        const entries = Array.isArray(service?.environment)
+            ? service.environment.map(item => String(item))
+            : Object.entries(service?.environment || {}).map(([key, value]) => `${key}=${value}`);
+
+        for (const entry of entries) {
+            const index = entry.indexOf('=');
+
+            if (index < 1) continue;
+
+            const key = entry.slice(0, index);
+
+            if (!assigned.has(key)) assigned.set(key, []);
+            assigned.get(key).push(entry.slice(index + 1));
+        }
+    }
+
+    return assigned
+}
+
+test.describe('deploy template — trust defaults (#16054)', () => {
+
+    test('the parser actually sees the environment blocks', () => {
+        // The positive control, and it is not ceremony: every assertion below is an ABSENCE check, and
+        // an absence check over an empty map passes for the wrong reason. A renamed service key or a
+        // switch to the map form would silently turn this whole file green.
+        const assigned = collectEnvAssignments();
+
+        expect(assigned.size, 'no environment entries parsed — the guard is looking at nothing').toBeGreaterThan(20);
+        expect([...assigned.keys()].filter(key => key.startsWith('NEO_')).length).toBeGreaterThan(15);
+    });
+
+    test('the template does not lock members out of messaging each other', () => {
+        const values = collectEnvAssignments().get(MAILBOX_KEY) || [];
+
+        expect(
+            values.filter(value => value === 'blocked'),
+            `${MAILBOX_KEY}=blocked in the deploy template forces every pair of members on a private ` +
+            'deployment to exchange CAN_REPLY_TO grants before they can talk. A deployment is a trust ' +
+            'boundary; peer-trust is the default and `blocked` belongs only to a genuine multi-tenant ' +
+            `install, which must also pin ${SHARING_KEY}=private.`
+        ).toEqual([]);
+    });
+
+    test('mail strictness and memory strictness are pinned together or not at all', () => {
+        const
+            assigned      = collectEnvAssignments(),
+            mailStrict    = (assigned.get(MAILBOX_KEY) || []).includes('blocked'),
+            sharingStrict = (assigned.get(SHARING_KEY)  || []).includes('private');
+
+        // Not "never pin them" — a real multi-tenant template SHOULD pin both. The defect is answering
+        // one trust question two ways, which is what shipped: mail at multi-tenant strictness while
+        // memories stayed deployment-wide readable.
+        expect(
+            mailStrict,
+            `${MAILBOX_KEY}=blocked without ${SHARING_KEY}=private: members cannot message each other ` +
+            'while still reading each other\'s memories — the more sensitive permission granted ' +
+            'alongside the less sensitive one refused.'
+        ).toBe(sharingStrict)
+    })
+});

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -323,7 +323,7 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
         expect(compose.services.orchestrator.depends_on['mc-server']).toEqual({condition: 'service_healthy'});
     });
 
-    test('production compose pins cloud-profile local wake and mailbox boundaries', () => {
+    test('production compose pins cloud-profile local wake boundaries, and does NOT pin the mailbox policy', () => {
         const compose         = readProductionCompose();
         const orchestratorEnv = environmentMap(compose.services.orchestrator);
         const memoryCoreEnv   = environmentMap(compose.services['mc-server']);
@@ -339,7 +339,13 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
             NEO_ORCHESTRATOR_OLLAMA_ENABLED                     : 'false'
         });
 
-        expect(memoryCoreEnv.NEO_MAILBOX_DEFAULT_REPLY_POLICY).toBe('blocked');
+        // The cloud profile legitimately pins the wake/model boundaries above — a cloud deployment must
+        // not sync our dev repo or spawn local models. It must NOT pin the mailbox policy: doing so
+        // overrode the library default of `open` and left members of a single-organisation deployment
+        // unable to message each other without a grant per pair. A deployment is a trust boundary, so
+        // peer-trust is the default and `blocked` belongs to a multi-tenant install that sets it
+        // together with `NEO_MEMORY_SHARING_DEFAULT_POLICY=private`.
+        expect(memoryCoreEnv.NEO_MAILBOX_DEFAULT_REPLY_POLICY).toBeUndefined();
     });
 
     test('production compose persists the sandman handoff across its writer and reader', () => {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2056,6 +2056,35 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         });
     });
 
+    test('the strict-mode refusal names the POSTURE, so the reader is not sent to pairwise grants', async () => {
+        // A refusal that says only "requires CAN_REPLY_TO" reads as a per-pair problem, and an operator
+        // acts on it per pair: on a 15-member single-org deployment that is 210 directed grants, plus 28
+        // per new hire, when one deployment-level policy change replaces all of them. The message has to
+        // carry which cause it is.
+        await RequestContextService.run({ agentIdentityNodeId: '@charlie' }, async () => {
+            // `@alice` is registered and charlie's earlier attempt FAILED, so it created no SENT_TO edge
+            // and the pair still has no history — the trust-lift stays unlifted.
+            let message = null;
+
+            try {
+                await MailboxService.addMessage({to: '@alice', subject: 'Hi', body: 'body'})
+            } catch (error) {
+                message = error.message
+            }
+
+            expect(message, 'the send must still be refused').toBeTruthy();
+
+            // The policy is named, so the reader can tell "you need a grant" from "this deployment does
+            // not permit intra-plane initiation" — the distinction the old wording erased.
+            expect(message).toMatch(/mailbox\.defaultReplyPolicy='blocked'/);
+            // And it must steer AWAY from the per-pair remedy rather than merely omitting it.
+            expect(message).toMatch(/rather than granting each pair/);
+            // The grant path stays discoverable — naming the posture must not hide the legitimate
+            // per-pair remedy for a genuinely cross-boundary send.
+            expect(message).toMatch(/CAN_REPLY_TO/)
+        })
+    });
+
     test('#10179 broadcast recipient can DM-reply to broadcaster without explicit grant', async () => {
         // Bob broadcasts (always-permitted — broadcast bypasses the CAN_REPLY_TO gate).
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {


### PR DESCRIPTION
Resolves #16054.

## The actual defect was ours, and it shipped

`ai/deploy/docker-compose.yml` pinned `NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked`, overriding the library leaf default of `open`. **Every deployment that followed our own guide inherited it.** Members of a single organisation's private deployment could not message each other at all — each pair needed an explicit `CAN_REPLY_TO` grant first. On a 15-member team that is **210 directed grants**, and 28 more per hire, to obtain the thing the product is for.

Install the mail system, then send postal letters asking for permission to send mail.

The value found on a live deployment came from this file, rendered into their compose. An earlier revision of this PR recommended that the tenant set an env var to undo it — that was asking a customer to pay for our default, and it is withdrawn.

It was also incoherent with its neighbour. `memorySharing.defaultPolicy` defaults to `team`, so the same template let every member read every other member's **memories** while forbidding them a message: the more sensitive permission granted alongside the less sensitive one refused. Both leaves answer ONE question — is this deployment a single trust boundary or several — and the template answered it two ways.

Removed rather than restated as `=open`: pinning the library default in a second place duplicates it and silently freezes today's value if the leaf changes. The leaf owns it. `blocked` stays correct for a genuine multi-tenant install, which sets it explicitly together with `NEO_MEMORY_SHARING_DEFAULT_POLICY=private`.

The rest of this PR is the message half, below.

## The message half: naming the posture

One refusal message, and it matters more than its size.

Before: `Unauthorized: Cannot send to @x. Requires CAN_REPLY_TO permission or prior message history.`

True, and it sends the reader to the wrong remedy. It reads as a per-pair problem, so an operator acts per pair — on a 15-member single-org deployment that is **210 directed grants**, and 28 more per hire. The actual cause is a deployment-level selector resolving to strict isolation, where one policy change replaces all of them.

Evidence: found live on a private single-org deployment, and the shape is why this is a defect rather than a documentation gap:

| Leaf | Resolved | Meaning |
|---|---|---|
| `memorySharing.defaultPolicy` | `'team'` (default, unset) | every member reads every member's **memories** |
| `mailbox.defaultReplyPolicy` | `'blocked'` | no member may **message** another |

Every member could read every other member's stored reasoning while none could send another a message. Reading memories is strictly more sensitive than pinging someone, so that pairing is almost certainly unintended — and the refusal gave no hint that a policy decided it, so the only visible lever was the grant.

The message now names the resolved policy, says what that posture is for, and points at changing it rather than granting each pair.

## Three deliberate boundaries

- **Names the config path, not the env var.** The env binding is discoverable from the leaf; hard-coding `NEO_MAILBOX_DEFAULT_REPLY_POLICY` into a runtime string would rot the moment the binding is renamed.
- **`CAN_REPLY_TO` stays named.** A genuinely cross-boundary send still wants the per-pair grant, and naming the posture must not hide the legitimate remedy. Asserted.
- **The sibling `BLOCKED_BY` refusal is untouched.** An explicit block *is* a per-pair decision; steering that reader toward a deployment-wide policy change would advise overriding someone's stated intent.

## Test Evidence

- **143 passed** — `ai/deploy/` (incl. the new trust-defaults guard) + `MailboxService.spec.mjs`.
- The trust-defaults guard binds the PAIR rather than banning a value, because banning `blocked` would break the multi-tenant template that legitimately wants it. Its first assertion is a **positive control** that the parser sees the environment blocks at all — the other two are absence checks, which pass over an empty map. Certified by mutation: re-pinning the line fails both invariants while the control stays green.
- **1524 passed** — derived suite: `services/memory-core` + memory-core `Server` + `kb-alerting` + `scripts/lifecycle`.

The fixture asserts all three properties: the policy is named, the per-pair remedy is discouraged, and the grant path stays discoverable. It cannot pass against the old message, which contained neither of the first two strings — so it is non-vacuous by construction rather than by label.

**One honest note.** An earlier run of that suite showed a single failure in `SessionService.ResumeValidation.spec.mjs:314`, and a clean-dev control of the identical batch passed — which looked like attribution to this change. It did not reproduce: the same batch then passed twice with this change present, plus two further passes of the containing directory. **A one-run A/B cannot attribute an intermittent failure, which is what I did initially.** That spec's neighbours assert lease expiry against wall-clock time, so a clock-boundary flake is the likely class. Recorded rather than claimed resolved, and not attributed to this diff.

## Follow-up, not a gap in this PR

#16054's stated problem — members of a private deployment cannot message each other without pairwise grants — is fixed here: the template no longer imposes it, so the library's peer-trust default governs. What remains is a **hardening**, not an unmet AC of this ticket: the **posture-derived default**, deriving `mailbox.defaultReplyPolicy` from `memorySharing.defaultPolicy` (`'team'` ⇒ `'open'`, `'private'` ⇒ `'blocked'`) so the incoherent pairing above becomes unrepresentable rather than merely discouraged. That needs no new axis — `memorySharing.defaultPolicy`'s own documentation already draws the tenancy line ("Multi-tenant SaaS deployments … MUST override to `private`").

It wants its own ticket because it is a cross-leaf derived default that must still let an explicit env override win. `leaf(default, env, type)` cannot reference another leaf at declaration time, so it is either a `formula` honouring an explicit override or a two-leaf shape with the derivation at the use site — ADR-0019 primitive-adjacent, and §6 requires citing `Provider.mjs` / `createHierarchicalDataProxy.mjs` / `ConfigProvider.mjs` before changing the primitive. That is a shape decision, not an implementation detail.

## Deltas

- `ai/services/memory-core/MailboxService.mjs` — the strict-mode refusal names the posture; the `BLOCKED_BY` refusal untouched.
- `test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — one fixture, three assertions.

## Post-Merge Validation

- Takes effect immediately for any deployment resolving `'blocked'`; no migration, no config change required.
- The affected deployment's one-line unblock is independent of this PR and available now: set the mailbox reply policy to `open`. This PR ensures the *next* operator to hit the refusal is told that, instead of discovering it after 210 grants.

Authored by Vega (@neo-opus-vega). Session c038696f-94a6-4788-82bf-747c5672908c.
