### PR TITLE
Redeploy data survivability: a cloud deployment can no longer report a missing off-host backup as benign

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1215,7 +1215,19 @@ class ConfigBase extends ConfigProvider {
                     // ORTHOGONAL to `recoveryActuator.blockedComposeServices` (ADR-26): this mode-gate is
                     // "is B1 active in this deployment at all"; the blocklist is the per-service opt-out
                     // WITHIN an active mode. They compose; do not overload the blocklist to express the mode gate.
-                    composeServiceRecoveryEnabled: leaf(null, 'NEO_ORCHESTRATOR_COMPOSE_SERVICE_RECOVERY_ENABLED', 'boolean')
+                    composeServiceRecoveryEnabled: leaf(null, 'NEO_ORCHESTRATOR_COMPOSE_SERVICE_RECOVERY_ENABLED', 'boolean'),
+                    // Whether an off-host copy of the backup bundle is REQUIRED for this deployment.
+                    // Cloud profile defaults required (the named volumes and the host that carries them
+                    // are the same failure domain); local profile defaults not-required (the operator's
+                    // own machine is not a durability boundary we can reason about).
+                    //
+                    // This gate exists because off-host sync CANNOT be defaulted on: enablement is a
+                    // non-empty `maintenance.backup.offHostSync.command` naming an executable
+                    // (`validateOffHostSyncConfig`), and no default command is knowable for a given
+                    // deployment. So the deployment declares the REQUIREMENT here and the durability
+                    // posture reports whether it is met — an explicit `false` is a deliberate opt-out,
+                    // which is what distinguishes it from an unconfigured hook nobody noticed.
+                    offHostBackupRequired: leaf(null, 'NEO_ORCHESTRATOR_OFF_HOST_BACKUP_REQUIRED', 'boolean')
                 },
                 /**
                  * Recovery actuator envelope. Enabled by default so deployed immune-system

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -803,7 +803,7 @@ export class Orchestrator extends Base {
         // The bridge derives its heal-ledger dir from dataDir at construction — keep it coherent when dataDir
         // changes at runtime, else the actuator writes the NEW ledger while the bridge keeps reading the OLD one.
         if (this.deploymentStateBridgeService) {
-            this.deploymentStateBridgeService.healLedgerDir = path.join(value, 'data-heal-events');
+            this.deploymentStateBridgeService.healLedgerDir = path.join(value, HEAL_LEDGER_DIR_NAME);
         }
     }
     afterSetTaskDefinitions(value, oldValue) {

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -77,6 +77,7 @@ import {
     inspectHeavyMaintenanceLeaseSync,
     withHeavyMaintenanceLease
 } from './services/heavyMaintenanceLeasePrimitives.mjs';
+import {resolveCloudOnlyDefault} from './services/deploymentDurabilityPosture.mjs';
 
 /** @summary Opens/creates the orchestrator sqlite DB via the shared Memory Core schema bootstrap. */
 export async function initializeDatabaseSelfBootstrap(dbPath) {
@@ -116,9 +117,7 @@ function resolveDeploymentEnabled(key) {
 // point) can consult a cloudOnly mode-gate without scattering raw `deploymentMode` reads — the
 // reactive-config-as-single-source-of-truth pattern: read resolved leaves at the use site, never re-derive.
 export function resolveCloudOnlyEnabled(key) {
-    const cfg = AiConfig.orchestrator.cloudOnly[key];
-    if (cfg != null) return cfg;
-    return AiConfig.orchestrator.deploymentMode === 'cloud';
+    return resolveCloudOnlyDefault(AiConfig.orchestrator.cloudOnly[key], AiConfig.orchestrator.deploymentMode);
 }
 
 const LOG_RETENTION_DAYS = 30;

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -42,7 +42,7 @@ import DataRecoveryActuatorService                                              
 import {auditChromaVectorCoverage}                                                from '../../scripts/maintenance/checkChromaIntegrity.mjs';
 import {createReEmbedMissingHeal, createReEmbedMissingHealOperation}              from '../../services/memory-core/helpers/reEmbedMissingHeal.mjs';
 import {appendHealEvent, healEventsToRecentRuns, queryHealLedger, readHealLedger} from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
-import {validateHealLedgerRetention}                                              from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
+import {validateHealLedgerRetention, HEAL_LEDGER_DIR_NAME}                        from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {detectChronicUnsafeInput}                                                 from '../../services/memory-core/helpers/healActionDispatch.mjs';
 import {quarantineCollection, storeFenceTargets, unquarantineCollection}          from '../../services/memory-core/helpers/quarantineStore.mjs';
 import {createFreezeHealOperation, createStoreFenceOperations, runFreezeReprobe}  from '../../services/memory-core/helpers/freezeReprobeRunner.mjs';
@@ -436,7 +436,7 @@ export class Orchestrator extends Base {
             taskStateService           : this.taskStateService,
             tenantRepoSyncService      : this.tenantRepoSyncService,
             tenantRepoSyncEnabledReader: () => this.tenantRepoSyncEnabled,
-            healLedgerDir              : path.join(this.dataDir, 'data-heal-events'),
+            healLedgerDir              : path.join(this.dataDir, HEAL_LEDGER_DIR_NAME),
             writeLog                   : this.deploymentStateBridgeWriteLog
         });
     }
@@ -480,7 +480,7 @@ export class Orchestrator extends Base {
             expectedDimension: AiConfig.vectorDimension
         });
 
-        const healLedgerDir      = path.join(this.dataDir, 'data-heal-events');
+        const healLedgerDir      = path.join(this.dataDir, HEAL_LEDGER_DIR_NAME);
         const freezeRecordsDir   = path.join(this.dataDir, 'data-freeze-records');
         const restoreLedgerDir   = path.join(this.dataDir, 'restore-empty-target-ledger');
         const restoreStagingRoot = path.join(this.dataDir, 'restore-empty-target-staging');
@@ -741,7 +741,7 @@ export class Orchestrator extends Base {
     async runFreezeReprobeCycleIfActive(now = Date.now()) {
         return runFreezeReprobe({
             freezeRecordsDir   : path.join(this.dataDir, 'data-freeze-records'),
-            healLedgerDir      : path.join(this.dataDir, 'data-heal-events'),
+            healLedgerDir      : path.join(this.dataDir, HEAL_LEDGER_DIR_NAME),
             healLedgerRetention: validateHealLedgerRetention(
                 AiConfig.orchestrator.recoveryActuator.healLedger.maxEvents,
                 AiConfig.orchestrator.recoveryActuator.healLedger.pruneTriggerBytes
@@ -769,7 +769,7 @@ export class Orchestrator extends Base {
             // Systemic circuit-breaker: fold the heal-ledger → decide whether a cross-collection embedder outage
             // should suppress this cycle's heals (bounds read FRESH from the AiConfig recovery-actuator leaf).
             systemicCircuitGate: async ({now}) => {
-                const dir                               = path.join(this.dataDir, 'data-heal-events'),
+                const dir                               = path.join(this.dataDir, HEAL_LEDGER_DIR_NAME),
                       bounds                            = AiConfig.orchestrator.recoveryActuator.systemicCircuit,
                       {recentFailures, circuitOpenedAt} = foldSystemicCircuitState(await readHealLedger({dir}), {now, windowMs: bounds.windowMs});
                 return decideSystemicCircuit({recentFailures, circuitOpenedAt, now, bounds});
@@ -777,7 +777,7 @@ export class Orchestrator extends Base {
             recordCircuitEvent: async ({type, at, detail}) => appendHealEvent(
                 {type, collection: '*', status: type === 'circuit-open' ? 'open' : 'close', detail},
                 {
-                    dir: path.join(this.dataDir, 'data-heal-events'),
+                    dir: path.join(this.dataDir, HEAL_LEDGER_DIR_NAME),
                     now: at,
                     ...validateHealLedgerRetention(
                         AiConfig.orchestrator.recoveryActuator.healLedger.maxEvents,
@@ -788,7 +788,7 @@ export class Orchestrator extends Base {
             // Chronic unsafe-input mis-wire detector (observability): fold the heal-ledger for sustained
             // unsafe-input per (action, collection); bounds read FRESH from the AiConfig recovery-actuator leaf.
             chronicUnsafeInputDetector: async ({now}) => {
-                const dir    = path.join(this.dataDir, 'data-heal-events'),
+                const dir    = path.join(this.dataDir, HEAL_LEDGER_DIR_NAME),
                       bounds = AiConfig.orchestrator.recoveryActuator.chronicUnsafeInput;
                 return detectChronicUnsafeInput(await readHealLedger({dir}), {threshold: bounds.threshold, windowMs: bounds.windowMs, now});
             }

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -755,25 +755,24 @@ export class DeploymentStateBridgeService extends Base {
  * `validateOffHostSyncConfig` owns that contract, because the `offHostSync` keys are plain nested
  * values inside the `maintenance` object leaf rather than leaves of their own.
  *
- * Fails soft to an `unreadable` posture rather than throwing: this is one section of a diagnostic
- * snapshot, and a snapshot that cannot be produced at all is strictly worse than one honestly
- * reporting that it could not resolve this section. `unreadable` is a declared member of
- * `DURABILITY_POSTURES` precisely because this caller can emit it.
+ * Deliberately NOT wrapped in a catch. An earlier revision fell back to `posture: 'unreadable'` on
+ * any throw, reasoning that a degraded section beats an unproducible snapshot. That reasoning is
+ * wrong here, and the reactive-config SSOT says why: the tree is guaranteed, so the only things this can throw
+ * on are a missing leaf or a programming defect — precisely the failures that must fail loud rather
+ * than be laundered into a plausible-looking diagnostic value. A posture reading `unreadable` would
+ * have been indistinguishable from a real deployment condition, which is the same wrong-subject
+ * failure this whole projection exists to remove.
+ *
+ * Invalid OPERATOR config is a different case and stays non-throwing: it already has an explicit
+ * representation via `unmet` plus `offHostSyncConfigValid: false`.
  * @returns {Object}
  */
 function resolveConfiguredDurabilityPosture() {
-    try {
-        return resolveDurabilityPosture({
-            deploymentMode       : AiConfig.orchestrator.deploymentMode,
-            offHostBackupRequired: AiConfig.orchestrator.cloudOnly.offHostBackupRequired,
-            validationOutcome    : validateOffHostSyncConfig(AiConfig.maintenance.backup.offHostSync)
-        })
-    } catch (error) {
-        return {
-            posture: 'unreadable',
-            reason : 'The off-host durability posture could not be resolved from config.'
-        }
-    }
+    return resolveDurabilityPosture({
+        deploymentMode       : AiConfig.orchestrator.deploymentMode,
+        offHostBackupRequired: AiConfig.orchestrator.cloudOnly.offHostBackupRequired,
+        validationOutcome    : validateOffHostSyncConfig(AiConfig.maintenance.backup.offHostSync)
+    })
 }
 
 function summarizeInspect(inspect) {

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -12,7 +12,11 @@ import {
     createDeploymentStateSnapshot,
     writeDeploymentStateSnapshot
 } from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
-import {readBackupReceipt}           from '../../../services/memory-core/helpers/offHostSyncStore.mjs';
+import {
+    readBackupReceipt,
+    validateOffHostSyncConfig
+} from '../../../services/memory-core/helpers/offHostSyncStore.mjs';
+import {resolveDurabilityPosture}    from './deploymentDurabilityPosture.mjs';
 import {readRecentRecoveryRunStates} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {
     queryHealLedger,
@@ -239,22 +243,36 @@ export class DeploymentStateBridgeService extends Base {
 
     /**
      * Projects the durable backup receipt (`AiConfig.backupPath/last-backup-receipt.json`) into the
-     * snapshot with explicit freshness semantics: absent-before-first-run omits the block entirely
-     * (never fabricated); unreadable/corrupt/oversize/wrong-version receipts project a stable
-     * `{status: 'unreadable', kind, finishedAt}` shape so consumers never infer corruption from an
-     * absent block. The receipt file survives orchestrator restart by construction; the projection
-     * is last-known, never refreshed-on-read.
+     * snapshot with explicit freshness semantics: unreadable/corrupt/oversize/wrong-version receipts
+     * project a stable `{status: 'unreadable', kind, finishedAt}` shape so consumers never infer
+     * corruption from an absent `lastBackup`. The receipt file survives orchestrator restart by
+     * construction; the projection is last-known, never refreshed-on-read.
+     *
+     * The `durability` block is projected UNCONDITIONALLY, including when no receipt exists yet.
+     * That is deliberate and is the point of the block: a posture is a property of the deployment's
+     * CONFIGURATION, not of its last run, so it is exactly knowable before any backup has ever
+     * happened — which is when it matters most. Returning `null` for a never-backed-up deployment
+     * (the previous behaviour) omitted the whole maintenance section, making "no backup has ever
+     * run here" indistinguishable from "nothing about maintenance is worth reporting". A deployment
+     * one command away from unrecoverable data loss read as silence.
+     *
+     * `lastBackup` keeps its absent-before-first-run semantics and is simply omitted in that case.
      * @returns {Promise<Object|null>}
      */
     async collectMaintenanceSnapshot({receiptPath = path.join(AiConfig.backupPath, 'last-backup-receipt.json')} = {}) {
+        // Module-scope, deliberately not a method: this projection depends only on resolved config
+        // and its own argument, never on instance state, and the contract spec asserts that by
+        // invoking it detached.
+        const durability = resolveConfiguredDurabilityPosture();
 
         try {
             const outcome = await readBackupReceipt({filePath: receiptPath});
 
-            if (outcome.status === 'missing') return null;
+            if (outcome.status === 'missing') return {durability};
 
             if (outcome.status === 'unreadable') {
                 return {
+                    durability,
                     lastBackup: {
                         finishedAt: outcome.finishedAt,
                         kind      : outcome.kind,
@@ -263,9 +281,10 @@ export class DeploymentStateBridgeService extends Base {
                 }
             }
 
-            return {lastBackup: outcome.receipt}
+            return {durability, lastBackup: outcome.receipt}
         } catch (error) {
             return {
+                durability,
                 lastBackup: {
                     finishedAt: null,
                     kind      : 'corrupt',
@@ -274,6 +293,7 @@ export class DeploymentStateBridgeService extends Base {
             }
         }
     }
+
 
     /**
      * Collects one bounded per-service state envelope.
@@ -726,6 +746,33 @@ export class DeploymentStateBridgeService extends Base {
      */
     now() {
         return this.nowFn ? this.nowFn() : Date.now();
+    }
+}
+
+/**
+ * Resolves the off-host durability posture by reading the resolved leaves at this use site and
+ * handing them to the pure derivation. The enablement predicate is NOT re-implemented here —
+ * `validateOffHostSyncConfig` owns that contract, because the `offHostSync` keys are plain nested
+ * values inside the `maintenance` object leaf rather than leaves of their own.
+ *
+ * Fails soft to an `unreadable` posture rather than throwing: this is one section of a diagnostic
+ * snapshot, and a snapshot that cannot be produced at all is strictly worse than one honestly
+ * reporting that it could not resolve this section. `unreadable` is a declared member of
+ * `DURABILITY_POSTURES` precisely because this caller can emit it.
+ * @returns {Object}
+ */
+function resolveConfiguredDurabilityPosture() {
+    try {
+        return resolveDurabilityPosture({
+            deploymentMode       : AiConfig.orchestrator.deploymentMode,
+            offHostBackupRequired: AiConfig.orchestrator.cloudOnly.offHostBackupRequired,
+            validationOutcome    : validateOffHostSyncConfig(AiConfig.maintenance.backup.offHostSync)
+        })
+    } catch (error) {
+        return {
+            posture: 'unreadable',
+            reason : 'The off-host durability posture could not be resolved from config.'
+        }
     }
 }
 

--- a/ai/daemons/orchestrator/services/deploymentDurabilityPosture.mjs
+++ b/ai/daemons/orchestrator/services/deploymentDurabilityPosture.mjs
@@ -24,10 +24,18 @@
  */
 
 /**
- * Upper bound for the human-readable `reason`. The reason may quote a config validation error,
- * which echoes an offending `argv` token — bounded so a pathological config cannot inflate the
- * snapshot. Credential VALUES never reach here: the off-host contract keeps secrets in the
- * process environment and the config carries only allowlisted env NAMES.
+ * Upper bound for the human-readable `reason`.
+ *
+ * The reason is now assembled from FIXED sentences per posture and never interpolates config
+ * content, so the bound is defence-in-depth rather than the primary control.
+ *
+ * An earlier revision of this file claimed *"Credential VALUES never reach here: the off-host
+ * contract keeps secrets in the process environment and the config carries only allowlisted env
+ * NAMES."* That was reasoning about `envAllowlist` and it was wrong about `argv`: a hostile-config
+ * probe fed `argv: ['--password=ghp_…{bad}']`, the validator echoed the offending token into its
+ * prose, and the token appeared verbatim in the projected posture that `inspect_deployment` returns.
+ * The claim was a convention, not an enforced property — which is exactly why the enforcement now
+ * lives in the code path and a witness test asserts it.
  * @type {Number}
  */
 export const MAX_POSTURE_REASON_LENGTH = 240;
@@ -40,18 +48,18 @@ export const MAX_POSTURE_REASON_LENGTH = 240;
  * intent, never that the last sync succeeded — that is the backup receipt's `offHostSync.status`,
  * and conflating the two would let a declaration stand in as evidence of an outcome.
  *
- * `unreadable` is not a posture the derivation below returns; it is what a CALLER projects when the
- * config could not be read at all. It is listed here because a consumer validating this field must
- * accept every value that can appear in it — an enum omitting a value its own producers emit is
- * exactly the kind of false completeness claim this ticket is about.
+ * An earlier revision also listed `unreadable`, for a caller that caught any throw while reading
+ * config. That caller is gone: a missing leaf or programming defect must fail loud rather than be
+ * laundered into a diagnostic value a consumer cannot distinguish from a real deployment condition.
+ * With no producer left, keeping it would be the mirror of the mistake that put it here — an enum
+ * advertising a state the system cannot actually be in.
  * @type {String[]}
  */
 export const DURABILITY_POSTURES = Object.freeze([
     'configured',
     'not-required',
     'opted-out',
-    'unmet',
-    'unreadable'
+    'unmet'
 ]);
 
 /**
@@ -119,8 +127,13 @@ export function resolveDurabilityPosture({deploymentMode, offHostBackupRequired,
     } else if (!configValid) {
         // Invalid config is reported even when the deployment does not require off-host backup:
         // a malformed hook is a defect regardless of whether anything depends on it.
+        //
+        // The validator's PROSE is deliberately not interpolated here. It echoes the offending token,
+        // and an operator can put a credential in `argv`, so quoting it would publish that value on a
+        // remotely readable surface. `configErrorCode` below classifies the defect instead; the prose
+        // stays available to whoever holds the config locally.
         posture = required ? 'unmet' : 'not-required';
-        reason  = `The off-host sync config is invalid and will never run: ${validationOutcome.error}`;
+        reason  = 'The off-host sync config is invalid and will never run; see `configErrorCode` for the defect class.';
     } else if (optedOut) {
         posture = 'opted-out';
         reason  = 'Off-host backup is explicitly not required for this deployment (deliberate opt-out).';
@@ -136,6 +149,9 @@ export function resolveDurabilityPosture({deploymentMode, offHostBackupRequired,
 
     return {
         cloudDeployment,
+        // The stable classification of a config defect, or null when the config is valid. This is the
+        // ONLY failure detail that crosses into the remotely readable snapshot.
+        configErrorCode       : validationOutcome?.errorCode ?? null,
         offHostBackupRequired : required,
         offHostSyncConfigured : configured,
         offHostSyncConfigValid: configValid,

--- a/ai/daemons/orchestrator/services/deploymentDurabilityPosture.mjs
+++ b/ai/daemons/orchestrator/services/deploymentDurabilityPosture.mjs
@@ -1,0 +1,145 @@
+/**
+ * @summary Pure deployment-profile mode gate and off-host durability posture derivation.
+ *
+ * Kept free of Agent OS config imports for the same reason as `heavyMaintenanceLeasePrimitives`:
+ * a shared pure FUNCTION is ordinary reuse, whereas a second module reading `AiConfig` would be a
+ * second resolution path able to disagree with the first. The test is direction — a helper the
+ * caller declares FROM is fine; one an entrypoint calls INSTEAD of reading the resolved leaf is the
+ * duplicate resolver. Every caller reads its own leaves at its use site and passes them in.
+ *
+ * ## Why a posture exists at all
+ *
+ * Off-host sync cannot be defaulted ON. Enablement is a non-empty
+ * `maintenance.backup.offHostSync.command` naming an executable, and no default command is
+ * knowable for a given deployment — one team syncs with `aws`, another `rclone`, another a bespoke
+ * script. A default naming a binary absent from the image would fail on every deployment.
+ *
+ * So the deployment declares the REQUIREMENT (`orchestrator.cloudOnly.offHostBackupRequired`) and
+ * this module reports whether it is MET. That converts a silently-benign reading into a checkable
+ * claim: `offHostSync.status: 'disabled'` on a cloud deployment is not a neutral fact, it is an
+ * unmet durability requirement — and today it is indistinguishable from a deliberate opt-out.
+ * A posture that cannot tell those two apart is an instrument answering about the wrong subject.
+ *
+ * @module ai/daemons/orchestrator/services/deploymentDurabilityPosture
+ */
+
+/**
+ * Upper bound for the human-readable `reason`. The reason may quote a config validation error,
+ * which echoes an offending `argv` token — bounded so a pathological config cannot inflate the
+ * snapshot. Credential VALUES never reach here: the off-host contract keeps secrets in the
+ * process environment and the config carries only allowlisted env NAMES.
+ * @type {Number}
+ */
+export const MAX_POSTURE_REASON_LENGTH = 240;
+
+/**
+ * The closed set of durability postures — every value any producer may emit in the snapshot's
+ * `maintenance.durability.posture` field.
+ *
+ * `configured` is deliberately not named "satisfied": the config declaring a sync command attests
+ * intent, never that the last sync succeeded — that is the backup receipt's `offHostSync.status`,
+ * and conflating the two would let a declaration stand in as evidence of an outcome.
+ *
+ * `unreadable` is not a posture the derivation below returns; it is what a CALLER projects when the
+ * config could not be read at all. It is listed here because a consumer validating this field must
+ * accept every value that can appear in it — an enum omitting a value its own producers emit is
+ * exactly the kind of false completeness claim this ticket is about.
+ * @type {String[]}
+ */
+export const DURABILITY_POSTURES = Object.freeze([
+    'configured',
+    'not-required',
+    'opted-out',
+    'unmet',
+    'unreadable'
+]);
+
+/**
+ * Applies the cloud-profile deployment default to a `cloudOnly`-style tri-state config value.
+ * `null`/`undefined` means "use the deployment-profile default" (cloud = true, local = false);
+ * an explicit boolean overrides. This is the single home for that rule — `Orchestrator`'s
+ * `resolveCloudOnlyEnabled` delegates here rather than restating it.
+ *
+ * @param {Boolean|null|undefined} configValue Raw tri-state leaf value.
+ * @param {String} deploymentMode Resolved `orchestrator.deploymentMode`.
+ * @returns {Boolean}
+ */
+export function resolveCloudOnlyDefault(configValue, deploymentMode) {
+    if (configValue != null) return configValue;
+    return deploymentMode === 'cloud';
+}
+
+/**
+ * Bounds a posture reason without splitting a multi-byte character.
+ * @param {String} reason
+ * @returns {String}
+ */
+function boundReason(reason) {
+    const text = String(reason ?? '');
+    return text.length <= MAX_POSTURE_REASON_LENGTH ? text : `${text.slice(0, MAX_POSTURE_REASON_LENGTH - 1)}…`;
+}
+
+/**
+ * Derives the off-host durability posture from resolved config plus the off-host contract's own
+ * validation outcome.
+ *
+ * The validation outcome is INJECTED rather than computed here, so this module never becomes a
+ * second implementation of the enablement predicate: `validateOffHostSyncConfig` in
+ * `ai/scripts/maintenance/offHostSync.mjs` owns that contract (it is the module the owning ticket
+ * assigned it to, because the keys are plain nested values inside the `maintenance` object leaf).
+ *
+ * A configured-but-INVALID hook resolves to `unmet` when required, not `configured` — a malformed
+ * command will never run, so reporting it as configured would be the same wrong-subject error this
+ * posture exists to remove. The reason names the validation error in that case.
+ *
+ * @param {Object} options
+ * @param {String} options.deploymentMode Resolved `orchestrator.deploymentMode`.
+ * @param {Boolean|null|undefined} options.offHostBackupRequired Resolved
+ * `orchestrator.cloudOnly.offHostBackupRequired` (tri-state; `null` = profile default).
+ * @param {{enabled: Boolean, error: String|null}} options.validationOutcome The result of
+ * `validateOffHostSyncConfig` against `maintenance.backup.offHostSync`.
+ * @returns {{cloudDeployment: Boolean, offHostBackupRequired: Boolean, offHostSyncConfigured: Boolean, offHostSyncConfigValid: Boolean, posture: String, reason: String}}
+ */
+export function resolveDurabilityPosture({deploymentMode, offHostBackupRequired, validationOutcome} = {}) {
+    const
+        cloudDeployment = deploymentMode === 'cloud',
+        configured      = validationOutcome?.enabled === true,
+        configValid     = !validationOutcome?.error,
+        required        = resolveCloudOnlyDefault(offHostBackupRequired, deploymentMode),
+        // An explicit `false` is a HUMAN decision and stays distinguishable from the profile
+        // default; that distinction is the whole point — an unconfigured hook nobody noticed must
+        // not read the same as one somebody deliberately switched off.
+        optedOut        = offHostBackupRequired === false;
+
+    let posture, reason;
+
+    if (configured) {
+        posture = 'configured';
+        reason  = 'An off-host sync command is configured; the backup receipt reports whether it last succeeded.';
+    } else if (!configValid) {
+        // Invalid config is reported even when the deployment does not require off-host backup:
+        // a malformed hook is a defect regardless of whether anything depends on it.
+        posture = required ? 'unmet' : 'not-required';
+        reason  = `The off-host sync config is invalid and will never run: ${validationOutcome.error}`;
+    } else if (optedOut) {
+        posture = 'opted-out';
+        reason  = 'Off-host backup is explicitly not required for this deployment (deliberate opt-out).';
+    } else if (required) {
+        posture = 'unmet';
+        reason  = cloudDeployment
+            ? 'This cloud deployment requires an off-host copy of the backup bundle, but no off-host sync command is configured. The bundle and the data it protects share one failure domain.'
+            : 'Off-host backup is required for this deployment, but no off-host sync command is configured.';
+    } else {
+        posture = 'not-required';
+        reason  = 'Off-host backup is not required for this deployment profile.';
+    }
+
+    return {
+        cloudDeployment,
+        offHostBackupRequired : required,
+        offHostSyncConfigured : configured,
+        offHostSyncConfigValid: configValid,
+        posture,
+        reason                : boundReason(reason)
+    };
+}

--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -141,6 +141,32 @@ echo "[deploy] compose:  $COMPOSE_FILE"
 echo "[deploy] project:  $PROJECT_NAME"
 echo "[deploy] profiles: ${profile_args[*]}"
 
+# SURVIVABILITY GATE — runs BEFORE anything touches containers.
+#
+# Refuses unless a verified, non-empty, restorable pre-transition bundle exists. `up -d --build`
+# recreates containers, and a redeploy that crosses into an unrecoverable plane is exactly the
+# failure this guards: a deployment lost its Memory Core corpus, and the only bundle in its ledger
+# completed 25 minutes AFTER the new stack came up, capturing an already-empty plane.
+#
+# On a GENUINE first install there is no bundle yet and nothing to protect, so pass --initialize:
+#
+#     NEO_DEPLOY_INITIALIZE=1 ai/examples/cloud-deployment/deploy-pipeline.sh
+#
+# That is an explicit declaration on purpose. A first deployment and a plane that was destroyed or
+# relocated both present as ABSENCE, and no heuristic separates them — so refusing on absence alone
+# would block the first legitimate deploy, while proceeding on absence is how the incident happened.
+# The gate records a marker beside the bundles (on the bind-mount `down -v` does not touch), so a
+# later absence is informative rather than ambiguous. --initialize on an already-initialized host is
+# REFUSED: the escape hatch must not become the bypass.
+#
+# Scope, stated honestly: this guards the path we ship. It cannot intercept a hand-typed
+# `docker compose down -v`.
+preflight_args=()
+if [ "${NEO_DEPLOY_INITIALIZE:-0}" = "1" ]; then preflight_args+=(--initialize); fi
+
+echo "[deploy] running redeploy survivability preflight..."
+node "$SCRIPT_DIR/../../ai/scripts/maintenance/redeployPreflight.mjs" "${preflight_args[@]}"
+
 # Build + recreate containers, KEEPING named volumes and the backup bind-mount.
 # `--wait` blocks until every service with a healthcheck reports healthy and
 # exits non-zero if one does not — this is the deploy health gate. `set -e`

--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -21,7 +21,11 @@ set -euo pipefail
 # tied to the caller's working directory. Deploy from a STABLE host checkout —
 # the backup-bundle bind-mount is a relative path; see PipelineWiring.md.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-COMPOSE_FILE="${NEO_DEPLOY_COMPOSE_FILE:-$SCRIPT_DIR/../../ai/deploy/docker-compose.yml}"
+# `$SCRIPT_DIR` is `ai/examples/cloud-deployment`, so `../..` is ALREADY `ai/` — re-adding `ai/`
+# here produced `ai/ai/deploy/...`, a path that has never existed. It went unnoticed because the
+# spec fakes `docker`, and a fake docker ignores `-f`, so a wrong compose path could not fail a
+# test. Any operator who did not set NEO_DEPLOY_COMPOSE_FILE was relying on a broken default.
+COMPOSE_FILE="${NEO_DEPLOY_COMPOSE_FILE:-$SCRIPT_DIR/../../deploy/docker-compose.yml}"
 
 # A stable project name pins named-volume identity across redeploys. Export the
 # same value consumed by docker-compose.yml for its top-level project name and
@@ -165,7 +169,7 @@ preflight_args=()
 if [ "${NEO_DEPLOY_INITIALIZE:-0}" = "1" ]; then preflight_args+=(--initialize); fi
 
 echo "[deploy] running redeploy survivability preflight..."
-node "$SCRIPT_DIR/../../ai/scripts/maintenance/redeployPreflight.mjs" "${preflight_args[@]}"
+node "$SCRIPT_DIR/../../scripts/maintenance/redeployPreflight.mjs" "${preflight_args[@]}"
 
 # Build + recreate containers, KEEPING named volumes and the backup bind-mount.
 # `--wait` blocks until every service with a healthcheck reports healthy and

--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -165,11 +165,18 @@ echo "[deploy] profiles: ${profile_args[*]}"
 #
 # Scope, stated honestly: this guards the path we ship. It cannot intercept a hand-typed
 # `docker compose down -v`.
-preflight_args=()
-if [ "${NEO_DEPLOY_INITIALIZE:-0}" = "1" ]; then preflight_args+=(--initialize); fi
+# No array. Under `set -u`, expanding an EMPTY bash array as `"${arr[@]}"` is an unbound-variable
+# error on bash 3.2 — which macOS ships and CI does not, so this failed on maintainer machines while
+# hosted CI stayed green on it. Two explicit invocations are clearer than the `${arr[@]+...}`
+# incantation that works around it, and they cannot regress the same way.
+PREFLIGHT="$SCRIPT_DIR/../../scripts/maintenance/redeployPreflight.mjs"
 
 echo "[deploy] running redeploy survivability preflight..."
-node "$SCRIPT_DIR/../../scripts/maintenance/redeployPreflight.mjs" "${preflight_args[@]}"
+if [ "${NEO_DEPLOY_INITIALIZE:-0}" = "1" ]; then
+    node "$PREFLIGHT" --initialize
+else
+    node "$PREFLIGHT"
+fi
 
 # Build + recreate containers, KEEPING named volumes and the backup bind-mount.
 # `--wait` blocks until every service with a healthcheck reports healthy and

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -118,6 +118,7 @@
         "orchestrator.chroma.maxRuntimeMs",
         "orchestrator.cloudOnly",
         "orchestrator.cloudOnly.composeServiceRecoveryEnabled",
+        "orchestrator.cloudOnly.offHostBackupRequired",
         "orchestrator.cloudOnly.tenantRepoSyncEnabled",
         "orchestrator.dataDir",
         "orchestrator.dbPath",

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -27,7 +27,8 @@ import {
     resolveHeavyMaintenanceLeasePath,
     withHeavyMaintenanceLease
 } from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
-import {HEAL_LEDGER_DIR_NAME} from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
+import {HEAL_LEDGER_DIR_NAME}           from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
+import {INCIDENT_LEDGER_BUNDLE_MEMBERS} from '../../services/memory-core/helpers/incidentLedgerBundle.mjs';
 import {
     buildBackupReceipt,
     buildSyncChildEnv,
@@ -620,12 +621,17 @@ export async function cleanOldBackups(backupRoot, logger, retention = {}) {
 async function copyIncidentLedgers({destDir, sources, logger = console}) {
     // `recovery-runs` keeps its own subfolder because it is a directory of per-run files; flattening
     // it into `ledgers/` alongside the two singletons would make a run id collide with a ledger name.
-    const recoveryRunsDest = path.join(destDir, 'recovery-runs');
+    const recoveryRunsDest = path.join(destDir, INCIDENT_LEDGER_BUNDLE_MEMBERS.recoveryRuns);
 
     await fs.ensureDir(recoveryRunsDest);
 
+    // Stored under the STABLE logical member name, never `path.basename(source)`. `healAttemptsPath`
+    // is an env-relocatable full path, so a host pointing it at `custom-attempts.json` would have
+    // written that name into the bundle while restore looked for the default — finding nothing and
+    // reporting success having restored no incident record. A member name belongs to the bundle
+    // FORMAT, not to the host that wrote it.
     const [healAttempts, healEvents, recoveryRuns] = await Promise.all([
-        copyJsonlSource(sources.healAttemptsFile, destDir, logger),
+        copyJsonlSource(sources.healAttemptsFile, destDir, logger, INCIDENT_LEDGER_BUNDLE_MEMBERS.healAttempts),
         copyJsonlSource(sources.healEventsDir, destDir, logger),
         copyJsonlSource(sources.recoveryRunsDir, recoveryRunsDest, logger)
     ]);
@@ -638,7 +644,7 @@ async function copyIncidentLedgers({destDir, sources, logger = console}) {
     }
 }
 
-async function copyJsonlSource(source, destDir, logger=console) {
+async function copyJsonlSource(source, destDir, logger=console, destFileName=null) {
     if (!await fs.pathExists(source)) {
         return {copied: 0, note: `source not present: ${source}`};
     }
@@ -662,11 +668,11 @@ async function copyJsonlSource(source, destDir, logger=console) {
 
     if (stat.size === 0) {
         logger.warn(`[Backup] source file is 0 bytes: ${source}`);
-        await fs.copy(source, path.join(destDir, path.basename(source)));
+        await fs.copy(source, path.join(destDir, destFileName ?? path.basename(source)));
         return {copied: 0, note: 'source file empty'};
     }
 
-    await fs.copy(source, path.join(destDir, path.basename(source)));
+    await fs.copy(source, path.join(destDir, destFileName ?? path.basename(source)));
     return {copied: 1};
 }
 

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -27,6 +27,7 @@ import {
     resolveHeavyMaintenanceLeasePath,
     withHeavyMaintenanceLease
 } from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
+import {HEAL_LEDGER_DIR_NAME} from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {
     buildBackupReceipt,
     buildSyncChildEnv,
@@ -50,7 +51,9 @@ const execFileAsync = promisify(execFile);
  * ├── mc/                 # Memory Core memories + summaries as JSONL
  * ├── graph/              # Memory Core SQLite graph as JSONL
  * ├── concepts/           # Concept Ontology JSONL (nodes, edges)
- * └── trajectories/       # RLAIF training trajectories JSONL
+ * ├── trajectories/       # RLAIF training trajectories JSONL
+ * ├── mailbox/            # Mailbox sent-to-cull archive JSONL
+ * └── ledgers/            # Incident ledgers: heal-attempts.json, heal-events.jsonl, recovery-runs/
  * ```
  *
  * This script does NOT defrag; it captures the current state whatever shape it is in.
@@ -197,6 +200,9 @@ export function buildEmbeddingContract({subsystems}) {
  * @param {String}  [options.bundleRoot=null]            Absolute bundle path. If null, a timestamped dir under the default root is used.
  * @param {String}  [options.conceptsSourceDir]          Override for the Concept Ontology source directory.
  * @param {String}  [options.trajectoriesSourceFile]     Override for the RLAIF trajectories source file.
+ * @param {Object}  [options.ledgerSources]              Override for the incident-ledger source paths
+ *                                                       (`{healAttemptsFile, healEventsDir, recoveryRunsDir}`).
+ *                                                       Omitted in production — resolved from AiConfig at the use site.
  * @param {Object}  [options.logger=console]             Log sink; useful for tests.
  * @returns {Promise<{bundleRoot: String, timestamp: String, subsystems: Object}>}
  */
@@ -205,10 +211,19 @@ export async function runBackup({
     conceptsSourceDir      = DEFAULT_CONCEPTS_DIR,
     trajectoriesSourceFile = DEFAULT_TRAJECTORIES_FILE,
     sentToCullSourceFile   = DEFAULT_SENT_TO_CULL_FILE,
+    ledgerSources,
     logger                 = console
 } = {}) {
     const timestamp    = new Date().toISOString().replace(/:/g, '-');
     const resolvedRoot = bundleRoot ?? path.join(AiConfig.backupPath, `backup-${timestamp}`);
+    // Resolved leaves read HERE rather than captured at module scope: `healAttemptsPath` and
+    // `recoveryRunStateDir` are plane members and therefore env-relocatable per deployment, so a
+    // module-scope capture would bundle whatever the path was at import time.
+    const resolvedLedgerSources = ledgerSources ?? {
+        healAttemptsFile: AiConfig.orchestrator.recoveryActuator.healAttemptsPath,
+        healEventsDir   : path.join(AiConfig.orchestrator.dataDir, HEAL_LEDGER_DIR_NAME),
+        recoveryRunsDir : AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir
+    };
 
     const layout = {
         kb          : path.join(resolvedRoot, 'kb'),
@@ -216,7 +231,13 @@ export async function runBackup({
         graph       : path.join(resolvedRoot, 'graph'),
         concepts    : path.join(resolvedRoot, 'concepts'),
         trajectories: path.join(resolvedRoot, 'trajectories'),
-        mailbox     : path.join(resolvedRoot, 'mailbox')
+        mailbox     : path.join(resolvedRoot, 'mailbox'),
+        // The incident ledgers. They live in the orchestrator data directory, which on the cloud
+        // profile IS a named volume — so a volume replacement destroys the self-heal and recovery
+        // record together with the data whose loss they exist to explain, and the bundle did not
+        // cover them. Post-mortem capability co-located with its subject means the one class of
+        // event it most needs to describe is the one it can never describe.
+        ledgers     : path.join(resolvedRoot, 'ledgers')
     };
 
     await Promise.all(Object.values(layout).map(dir => fs.ensureDir(dir)));
@@ -228,36 +249,43 @@ export async function runBackup({
 
     const subsystems = {};
 
-    logger.log('[1/7] Exporting Knowledge Base...');
+    logger.log('[1/8] Exporting Knowledge Base...');
     subsystems.kb = await KB_DatabaseService.manageDatabaseBackup({
         action    : 'export',
         backupPath: layout.kb
     });
 
-    logger.log('[2/7] Exporting Memory Core (memories + summaries)...');
+    logger.log('[2/8] Exporting Memory Core (memories + summaries)...');
     subsystems.mc = await Memory_DatabaseService.manageDatabaseBackup({
         action    : 'export',
         include   : ['memories', 'summaries'],
         backupPath: layout.mc
     });
 
-    logger.log('[3/7] Exporting Memory Core graph...');
+    logger.log('[3/8] Exporting Memory Core graph...');
     subsystems.graph = await Memory_DatabaseService.manageDatabaseBackup({
         action    : 'export',
         include   : ['graph'],
         backupPath: layout.graph
     });
 
-    logger.log('[4/7] Copying Concept Ontology...');
+    logger.log('[4/8] Copying Concept Ontology...');
     subsystems.concepts = await copyJsonlSource(conceptsSourceDir, layout.concepts, logger);
 
-    logger.log('[5/7] Copying RLAIF trajectories...');
+    logger.log('[5/8] Copying RLAIF trajectories...');
     subsystems.trajectories = await copyJsonlSource(trajectoriesSourceFile, layout.trajectories, logger);
 
-    logger.log('[6/7] Copying mailbox sent-to-cull archive...');
+    logger.log('[6/8] Copying mailbox sent-to-cull archive...');
     subsystems.mailbox = await copyJsonlSource(sentToCullSourceFile, layout.mailbox, logger);
 
-    logger.log('[7/7] Applying retention sweep...');
+    logger.log('[7/8] Copying incident ledgers (self-heal + recovery runs)...');
+    subsystems.ledgers = await copyIncidentLedgers({
+        destDir: layout.ledgers,
+        logger,
+        sources: resolvedLedgerSources
+    });
+
+    logger.log('[8/8] Applying retention sweep...');
     // Retention comes from Tier-1 AI maintenance policy; missing keys fail loud
     // at the direct resolved-leaf read site. Bundle root, retention sweep, receipt, and
     // snapshot-root all resolve from the same `AiConfig.backupPath` leaf (the CLI wrapper
@@ -569,6 +597,47 @@ export async function cleanOldBackups(backupRoot, logger, retention = {}) {
  * @param {Object} [logger=console] Log sink; receives `.warn(message)` calls for empty sources.
  * @returns {Promise<{copied: Number, note: String}>} `note` only present when the source is absent or empty.
  */
+/**
+ * Copies the three incident ledgers into the bundle's `ledgers/` subfolder.
+ *
+ * Why they are bundled rather than relocated: on the cloud profile the orchestrator data directory
+ * IS a named volume, so a volume replacement destroys the self-heal and recovery record together
+ * with the data whose loss they exist to explain. Relocating them to a surviving mount would decide
+ * the data-plane placement election that a separate ticket owns, so survival is obtained here by
+ * inclusion — the bundle already lands on a host bind-mount that a volume wipe does not touch.
+ *
+ * Each ledger is independently optional. A deployment that has never healed has no ledger, and that
+ * is not a backup failure — `copyJsonlSource` reports absence via `note` without throwing. The
+ * per-ledger breakdown is preserved in the returned shape so `bundle-meta.subsystems.ledgers` says
+ * WHICH ledger was empty rather than collapsing three answers into one count.
+ *
+ * @param {Object} options
+ * @param {String} options.destDir Absolute `ledgers/` path inside the bundle.
+ * @param {Object} options.sources Resolved `{healAttemptsFile, healEventsDir, recoveryRunsDir}`.
+ * @param {Object} [options.logger=console] Log sink.
+ * @returns {Promise<{copied: Number, healAttempts: Object, healEvents: Object, recoveryRuns: Object}>}
+ */
+async function copyIncidentLedgers({destDir, sources, logger = console}) {
+    // `recovery-runs` keeps its own subfolder because it is a directory of per-run files; flattening
+    // it into `ledgers/` alongside the two singletons would make a run id collide with a ledger name.
+    const recoveryRunsDest = path.join(destDir, 'recovery-runs');
+
+    await fs.ensureDir(recoveryRunsDest);
+
+    const [healAttempts, healEvents, recoveryRuns] = await Promise.all([
+        copyJsonlSource(sources.healAttemptsFile, destDir, logger),
+        copyJsonlSource(sources.healEventsDir, destDir, logger),
+        copyJsonlSource(sources.recoveryRunsDir, recoveryRunsDest, logger)
+    ]);
+
+    return {
+        copied: (healAttempts.copied ?? 0) + (healEvents.copied ?? 0) + (recoveryRuns.copied ?? 0),
+        healAttempts,
+        healEvents,
+        recoveryRuns
+    }
+}
+
 async function copyJsonlSource(source, destDir, logger=console) {
     if (!await fs.pathExists(source)) {
         return {copied: 0, note: `source not present: ${source}`};

--- a/ai/scripts/maintenance/offHostSync.mjs
+++ b/ai/scripts/maintenance/offHostSync.mjs
@@ -8,6 +8,10 @@ import {
 
 export {buildBackupReceipt, writeBackupReceipt};
 export {readBackupReceipt, OFFHOST_SYNC_SCHEMA_VERSION} from '../../services/memory-core/helpers/offHostSyncStore.mjs';
+// Re-exported, not re-implemented. The config contract lives in the store so the read-only
+// deployment-state bridge can reach it without importing this CLI module, which would pull
+// `node:child_process` into the diagnostic path. Callers of this script are unaffected.
+export {validateOffHostSyncConfig} from '../../services/memory-core/helpers/offHostSyncStore.mjs';
 
 /**
  * @module ai/scripts/maintenance/offHostSync
@@ -27,68 +31,8 @@ export {readBackupReceipt, OFFHOST_SYNC_SCHEMA_VERSION} from '../../services/mem
  * cannot attest remote object state.
  */
 
-const BASE_ENV_NAMES      = ['PATH', 'HOME', 'USER', 'TMPDIR'],
-      ENV_NAME_PATTERN    = /^[A-Z_][A-Z0-9_]*$/,
-      MAX_TAIL_BYTES      = 4 * 1024,
-      PLACEHOLDER_PATTERN = /^\{(bundleDir|bundleName)\}$/,
-      ANY_PLACEHOLDER     = /\{[^}]*\}/,
-      TIMEOUT_MIN_MS      = 1000,
-      TIMEOUT_MAX_MS      = 30 * 60 * 1000,
-      GRACE_MAX_MS        = 60000;
-
-/**
- * Validates the nested offHostSync config keys. This module owns the contract because the keys are
- * plain nested values inside the `maintenance.backup` object leaf (ADR-0019: no leaf() nodes here; ticket-ref-ok: decision-record authority for the config SSOT).
- * @param {Object} [config={}] The `AiConfig.maintenance.backup.offHostSync` subtree (may be undefined).
- * @returns {{enabled: Boolean, error: String|null, value: Object}}
- */
-export function validateOffHostSyncConfig(config = {}) {
-    const {
-        argv          = [],
-        command       = '',
-        envAllowlist  = [],
-        killGraceMs   = 5000,
-        timeoutMs     = 600000
-    } = config ?? {};
-
-    const fail = error => ({enabled: false, error, value: null});
-
-    // Validate EVERY key before the disabled early-return: a disabled hook with malformed keys is a
-    // validation failure, not a silent pass.
-    if (config === null || typeof config !== 'object' || Array.isArray(config)) return fail('config must be an object');
-    if (typeof command !== 'string') return fail('command must be a string');
-    // Array-shape before any traversal: null/object/number argv must return a validation outcome,
-    // never a thrown TypeError.
-    if (!Array.isArray(argv) || argv.some(token => typeof token !== 'string')) return fail('argv must be an array of strings');
-    if (command.includes('\0') || argv.some(token => token.includes('\0'))) {
-        return fail('command/argv must not contain NUL bytes')
-    }
-
-    for (const token of argv) {
-        if (ANY_PLACEHOLDER.test(token) && !PLACEHOLDER_PATTERN.test(token)) {
-            return fail(`argv token must be a whole-token placeholder {bundleDir} or {bundleName}, got: ${token}`)
-        }
-    }
-
-    if (!Array.isArray(envAllowlist) || envAllowlist.some(name => typeof name !== 'string' || !ENV_NAME_PATTERN.test(name))) {
-        return fail('envAllowlist entries must match /^[A-Z_][A-Z0-9_]*$/')
-    }
-
-    if (!Number.isInteger(timeoutMs) || timeoutMs < TIMEOUT_MIN_MS || timeoutMs > TIMEOUT_MAX_MS) {
-        return fail(`timeoutMs must be an integer between ${TIMEOUT_MIN_MS} and ${TIMEOUT_MAX_MS}`)
-    }
-    if (!Number.isInteger(killGraceMs) || killGraceMs < 0 || killGraceMs > GRACE_MAX_MS) {
-        return fail(`killGraceMs must be an integer between 0 and ${GRACE_MAX_MS}`)
-    }
-
-    if (command.trim() === '') return {enabled: false, error: null, value: null};
-
-    return {
-        enabled: true,
-        error  : null,
-        value  : {argv, command: command.trim(), envAllowlist, killGraceMs, timeoutMs}
-    }
-}
+const BASE_ENV_NAMES = ['PATH', 'HOME', 'USER', 'TMPDIR'],
+      MAX_TAIL_BYTES = 4 * 1024;
 
 /**
  * Builds the sync child's environment: minimal base set + exactly the allowlisted names that are

--- a/ai/scripts/maintenance/redeployPreflight.mjs
+++ b/ai/scripts/maintenance/redeployPreflight.mjs
@@ -1,0 +1,251 @@
+import fs              from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+// Neo namespace bootstrap (entry-point invariant) — this is an operator-runnable driver, and the
+// restorability probe it consumes reaches config-backed services.
+import Neo             from '../../../src/Neo.mjs';
+import * as core       from '../../../src/core/_export.mjs';
+import InstanceManager from '../../../src/manager/Instance.mjs';
+import AiConfig        from '../../config.mjs';
+
+import {verifyLatestBackupRestorable} from './restore.mjs';
+
+/**
+ * @module ai/scripts/maintenance/redeployPreflight
+ * @summary Refuses a container-affecting deploy unless a verified, non-empty, restorable
+ * pre-transition bundle exists — or the operator has explicitly declared initialization.
+ *
+ * ## What this can and cannot protect
+ *
+ * We own no destructive path. `DEPLOYMENT_RUNTIME_LIFECYCLE_OPERATIONS` is frozen to `['restart']`
+ * and `docker compose down` appears in no script in this repository. The data loss that produced
+ * this work came from an operator command driven by a tenant-authored checklist, and **no guard
+ * here can intercept that.**
+ *
+ * So the refusal goes where we do have leverage: the reference deploy script is the CI-neutral
+ * substrate teams adapt, so a preflight that exits non-zero there is inherited by everyone who
+ * adapts it. It also correctly guards `up -d --build`, which recreates containers. A guarantee that
+ * lives only in a runbook binds only readers of that runbook — and in the incident, the runbook that
+ * was actually followed was one we do not own and cannot edit.
+ *
+ * ## Why an explicit initialization mode rather than a heuristic
+ *
+ * A genuine first deployment and a plane that was destroyed or relocated **both present as
+ * absence**. Nothing about "no bundle here" says which one it is, so keying the refusal on absence
+ * alone would block the very first legitimate deploy. The operator therefore DECLARES
+ * initialization, and a durable marker records that this host has deployed before.
+ *
+ * The marker lives beside the bundles on the host bind-mount, which is precisely the mount
+ * `docker compose down -v` does not touch. That is the point: it has to survive the operation whose
+ * aftermath it exists to describe. `verifyLatestBackupRestorable` only enumerates `backup-*`
+ * directories, so a dotfile marker can never be mistaken for a bundle.
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+/**
+ * Marker filename. A dotfile beside the bundles: same surviving mount, invisible to bundle
+ * enumeration.
+ * @type {String}
+ */
+export const INITIALIZATION_MARKER_FILENAME = '.deployment-initialized';
+
+/**
+ * Verdicts this preflight can return. `PROCEED_*` variants are distinct so a deploy log records WHY
+ * it was allowed — "it proceeded" and "it proceeded because the operator declared a first install"
+ * are different facts, and an audit that cannot tell them apart cannot answer whether a wipe was
+ * authorised.
+ * @type {Object}
+ */
+export const REDEPLOY_PREFLIGHT_DECISION = Object.freeze({
+    PROCEED_INITIALIZING      : 'PROCEED_INITIALIZING',
+    PROCEED_MARKER_RECOVERED  : 'PROCEED_MARKER_RECOVERED',
+    PROCEED_VERIFIED          : 'PROCEED_VERIFIED',
+    REFUSE_ALREADY_INITIALIZED: 'REFUSE_ALREADY_INITIALIZED',
+    REFUSE_NO_VERIFIED_BUNDLE : 'REFUSE_NO_VERIFIED_BUNDLE'
+});
+
+/**
+ * @summary The truth table. PURE — no filesystem, no config, no probe.
+ *
+ * Separated so the decision is testable without a deployment and reviewable without reading IO
+ * plumbing. Every ambiguous state fails closed; the only paths that proceed are a declared
+ * initialization, a verified bundle, or a verified bundle recovering a lost marker.
+ *
+ * @param {Object} options
+ * @param {Boolean} options.markerPresent Whether this host has recorded a prior deployment.
+ * @param {Boolean} options.initializeRequested Whether the operator passed the explicit flag.
+ * @param {String} options.verdictCode A `verifyLatestBackupRestorable` code.
+ * @returns {{decision: String, proceed: Boolean, writeMarker: Boolean, reason: String}}
+ */
+export function evaluateRedeployPreconditions({markerPresent, initializeRequested, verdictCode}) {
+    const restorable = verdictCode === 'RESTORABLE';
+
+    // Row 6 first. `--initialize` on a host that has already deployed is an operator mistake worth
+    // catching, never a licence to wipe — checking it before the restorable fast-path is what stops
+    // the escape hatch from becoming the bypass.
+    if (markerPresent && initializeRequested) {
+        return {
+            decision   : REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED,
+            proceed    : false,
+            writeMarker: false,
+            reason     : 'This host has deployed before, so --initialize cannot apply. Remove the flag to run an ordinary redeploy; if you intend to discard the existing plane, do that deliberately and separately.'
+        }
+    }
+
+    // Row 1 — declared first deployment. The one path that proceeds without a bundle, and it
+    // requires a human to have said so.
+    if (initializeRequested) {
+        return {
+            decision   : REDEPLOY_PREFLIGHT_DECISION.PROCEED_INITIALIZING,
+            proceed    : true,
+            writeMarker: true,
+            reason     : 'Initialization declared by the operator and no prior deployment is recorded on this host.'
+        }
+    }
+
+    // Row 4 — the ordinary verified redeploy.
+    if (markerPresent && restorable) {
+        return {
+            decision   : REDEPLOY_PREFLIGHT_DECISION.PROCEED_VERIFIED,
+            proceed    : true,
+            writeMarker: false,
+            reason     : 'A verified, non-empty, restorable pre-transition bundle exists.'
+        }
+    }
+
+    // Row 2 — no marker but a verified bundle. The bundle PROVES prior state, so the missing marker
+    // is the anomaly rather than the deployment. Recorded rather than refused, otherwise a host that
+    // lost its marker independently of its bundles could never deploy again.
+    if (restorable) {
+        return {
+            decision   : REDEPLOY_PREFLIGHT_DECISION.PROCEED_MARKER_RECOVERED,
+            proceed    : true,
+            writeMarker: true,
+            reason     : 'No initialization marker, but a verified restorable bundle proves a prior deployment; recording the marker.'
+        }
+    }
+
+    // Rows 3 and 5 — every remaining state. Absent root, no bundles, empty bundle, torn bundle: all
+    // indistinguishable from a destroyed or relocated plane, and this is the state the incident was
+    // in. Fail closed.
+    return {
+        decision   : REDEPLOY_PREFLIGHT_DECISION.REFUSE_NO_VERIFIED_BUNDLE,
+        proceed    : false,
+        writeMarker: false,
+        reason     : markerPresent
+            ? `This host has deployed before and has no usable pre-transition bundle (${verdictCode}). Proceeding could cross into an unrecoverable plane.`
+            : `No prior deployment is recorded and no usable bundle exists (${verdictCode}). This is indistinguishable from a destroyed or relocated plane. If this is genuinely a first install, pass --initialize to say so.`
+    }
+}
+
+/**
+ * @summary Reads the initialization marker.
+ * @param {Object} options
+ * @param {String} options.backupRoot Bundle root on the surviving host mount.
+ * @param {Object} [options.fsModule=fs] Filesystem seam.
+ * @returns {Promise<Boolean>}
+ */
+export async function readInitializationMarker({backupRoot, fsModule = fs}) {
+    return fsModule.pathExists(path.join(backupRoot, INITIALIZATION_MARKER_FILENAME))
+}
+
+/**
+ * @summary Records that this host has deployed, so a later absence is informative.
+ * @param {Object} options
+ * @param {String} options.backupRoot Bundle root on the surviving host mount.
+ * @param {String} options.decision Decision that authorised the write.
+ * @param {Object} [options.fsModule=fs] Filesystem seam.
+ * @returns {Promise<void>}
+ */
+export async function writeInitializationMarker({backupRoot, decision, fsModule = fs}) {
+    await fsModule.ensureDir(backupRoot);
+    await fsModule.writeJson(
+        path.join(backupRoot, INITIALIZATION_MARKER_FILENAME),
+        {decision, initializedAt: new Date().toISOString()},
+        {spaces: 2}
+    )
+}
+
+/**
+ * @summary Runs the preflight: probe, marker, decision, and the marker write on success.
+ *
+ * The marker is written only AFTER the decision authorises it, and never on a refusal — a refused
+ * deploy must leave the host exactly as it found it, or the next run would read a marker recording a
+ * deployment that never happened.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.backupRoot] Bundle root. Defaults to the resolved leaf.
+ * @param {Boolean} [options.initializeRequested=false] Explicit initialization declaration.
+ * @param {Object} [options.logger=console] Log sink.
+ * @param {Function} [options.probeFn=verifyLatestBackupRestorable] Probe seam.
+ * @param {Object} [options.fsModule=fs] Filesystem seam.
+ * @returns {Promise<Object>}
+ */
+export async function runRedeployPreflight({
+    backupRoot,
+    initializeRequested = false,
+    logger              = console,
+    probeFn             = verifyLatestBackupRestorable,
+    fsModule            = fs
+} = {}) {
+    const resolvedRoot  = backupRoot ?? AiConfig.backupPath,
+          markerPresent = await readInitializationMarker({backupRoot: resolvedRoot, fsModule}),
+          verdict       = await probeFn({backupRoot: resolvedRoot, logger}),
+          outcome       = evaluateRedeployPreconditions({
+              initializeRequested,
+              markerPresent,
+              verdictCode: verdict.code
+          });
+
+    if (outcome.proceed && outcome.writeMarker) {
+        await writeInitializationMarker({backupRoot: resolvedRoot, decision: outcome.decision, fsModule});
+    }
+
+    return {
+        ...outcome,
+        backupRoot: resolvedRoot,
+        bundleRoot: verdict.bundleRoot ?? null,
+        markerPresent,
+        // The probe's own verdict travels with the decision so a deploy log records WHY, not just
+        // whether. `rowTotal` is what `RESTORABLE` was decided on.
+        verdictCode  : verdict.code,
+        verdictReason: verdict.reason ?? null,
+        rowTotal     : verdict.rowTotal ?? null
+    }
+}
+
+/**
+ * @summary CLI entrypoint. Exit 0 proceeds; exit 1 refuses.
+ * @returns {Promise<void>}
+ */
+async function main() {
+    const initializeRequested = process.argv.includes('--initialize'),
+          asJson              = process.argv.includes('--json'),
+          result              = await runRedeployPreflight({initializeRequested});
+
+    if (asJson) {
+        console.log(JSON.stringify(result, null, 2));
+    } else {
+        console.log(`[preflight] ${result.decision}`);
+        console.log(`[preflight] ${result.reason}`);
+        console.log(`[preflight] bundle root: ${result.backupRoot} (marker ${result.markerPresent ? 'present' : 'absent'}, probe ${result.verdictCode}${result.rowTotal === null ? '' : `, ${result.rowTotal} rows`})`);
+    }
+
+    if (!result.proceed) {
+        console.error('[preflight] REFUSING to proceed. Docker was NOT invoked.');
+        process.exit(1);
+    }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
+    main().catch(error => {
+        // A preflight that cannot decide must REFUSE. Failing open here would make an unreadable
+        // bundle root indistinguishable from a verified one, which is the whole defect inverted.
+        console.error(`[preflight] FATAL: ${error.message}`);
+        console.error('[preflight] REFUSING to proceed. Docker was NOT invoked.');
+        process.exit(1);
+    });
+}

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -13,7 +13,8 @@ import kbConfig from '../../mcp/server/knowledge-base/config.mjs';
 import mcConfig from '../../mcp/server/memory-core/config.mjs';
 import AiConfig from '../../config.mjs';
 
-import {classifyRowVector} from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
+import {classifyRowVector}                          from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
+import {HEAL_LEDGER_DIR_NAME, HEAL_LEDGER_FILENAME} from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {
     KB_DatabaseService,
     KB_LifecycleService,
@@ -153,7 +154,11 @@ const DEFAULT_TRAJECTORIES_FILE = path.join(PROJECT_ROOT, '.neo-ai-data', 'datas
 const DEFAULT_SENT_TO_CULL_FILE = path.join(path.dirname(mcConfig.storagePaths.graph), 'sent-to-cull.jsonl');
 
 const REQUIRED_BUNDLE_SUBDIRS = ['kb', 'mc', 'graph', 'concepts', 'trajectories'];
-const OPTIONAL_BUNDLE_SUBDIRS = ['mailbox'];
+// `ledgers` is OPTIONAL, not required, and that is a compatibility decision rather than a hedge:
+// every bundle written before incident ledgers were captured lacks the subfolder, and promoting it
+// to required would make those bundles unrestorable — turning a durability improvement into a
+// recovery regression for exactly the archives an operator reaches for first.
+const OPTIONAL_BUNDLE_SUBDIRS = ['mailbox', 'ledgers'];
 
 /**
  * Executes a full-substrate restore from a previously-produced bundle.
@@ -169,7 +174,7 @@ const OPTIONAL_BUNDLE_SUBDIRS = ['mailbox'];
  * @param {String}  [options.sentToCullTargetFile]         Override the default sent-to-cull target file.
  * @param {String[]}[options.filterLabels=[]]              Per-incident customization: drop graph nodes with these labels. Orphan-edge guard auto-fires (drops edges whose endpoint was filtered). Empty list = no filter. Example today's-incident set: `['FILE', 'DIRECTORY', 'KB_GAP', 'TOOLING_GAP']` (FILE/DIRECTORY are regenerable via FileSystemIngestor; KB_GAP/TOOLING_GAP are operator-classified garbage from per-file hallucination).
  * @param {String[]}[options.filterEdgeTypes=[]]           Per-incident customization: drop graph edges with these types. Example today's-incident set: `['CONTAINS', 'DISCOVERED_IN', 'EVALUATED_BY']`.
- * @param {String[]}[options.onlySubstrate=null]           If provided, restore ONLY these substrates (subset of `['kb','mc','graph','concepts','trajectories','mailbox']`). Null = all (existing behavior).
+ * @param {String[]}[options.onlySubstrate=null]           If provided, restore ONLY these substrates (subset of `['kb','mc','graph','concepts','trajectories','mailbox','ledgers']`). Null = all (existing behavior).
  * @param {String}  [options.postRestoreHook=null]         Post-restore hook name. Currently supported: `'filesystem-ingestor'` (regenerates FILE/DIRECTORY/CONTAINS deterministically from current filesystem). Null = none.
  * @param {Boolean} [options.preserveReadState=false]      Selects the read-state policy for a `'replace'` graph restore, because the two operations that share this CLI need opposite ones. `false` (default) is DISASTER RECOVERY: the bundle is reproduced exactly, and mailbox read receipts committed after the bundle was captured are discarded with everything else. `true` is an OPERATIONAL RE-SEED: committed `DELIVERED_TO` `readAt`/`archivedAt` are captured inside the truncate transaction and re-applied wherever the bundle left them null, so acknowledged `mark_read` writes survive rebuilding the graph from a lagged snapshot. Only null-in-bundle rows are touched, so a fresher bundle is never regressed. No-op under `'merge'`, which never truncates. Forwarded as `preserveDeliveryReadState`.
  * @param {Object}  [options.logger=console]               Log sink; useful for tests.
@@ -184,6 +189,7 @@ export async function runRestore({
     conceptsTargetDir       = DEFAULT_CONCEPTS_DIR,
     trajectoriesTargetFile  = DEFAULT_TRAJECTORIES_FILE,
     sentToCullTargetFile    = DEFAULT_SENT_TO_CULL_FILE,
+    ledgerTargets,
     filterLabels            = [],
     filterEdgeTypes         = [],
     onlySubstrate           = null,
@@ -208,6 +214,7 @@ export async function runRestore({
     const resolvedRoot = path.resolve(bundleRoot);
 
     const layout = {
+        ledgers     : path.join(resolvedRoot, 'ledgers'),
         kb          : path.join(resolvedRoot, 'kb'),
         mc          : path.join(resolvedRoot, 'mc'),
         graph       : path.join(resolvedRoot, 'graph'),
@@ -244,7 +251,10 @@ export async function runRestore({
     // Per-substrate gate: null `onlySubstrate` = all subsystems (existing behavior).
     // Non-null array restricts to listed names. Validates against the known substrate set
     // so typos fail fast instead of silently no-op'ing the entire restore.
-    const ALL_SUBSTRATES = ['kb', 'mc', 'graph', 'concepts', 'trajectories', 'mailbox'];
+    // Adding a `shouldRestore('x')` branch without registering `x` here makes the substrate
+    // unreachable by `--only-substrate` AND rejects any operator who names it — the branch runs only
+    // on the all-substrates path. Declaration and handling are one act.
+    const ALL_SUBSTRATES = ['kb', 'mc', 'graph', 'concepts', 'trajectories', 'mailbox', 'ledgers'];
     if (Array.isArray(onlySubstrate)) {
         const unknown = onlySubstrate.filter(s => !ALL_SUBSTRATES.includes(s));
         if (unknown.length > 0) {
@@ -349,6 +359,24 @@ export async function runRestore({
             confirmation,
             subsystem : 'mailbox',
             logger
+        });
+    }
+
+    if (shouldRestore('ledgers') && await fs.pathExists(layout.ledgers)) {
+        // The point of bundling the ledgers is that they come BACK. A volume replacement wipes the
+        // orchestrator data directory; restore is what makes the incident record readable again, so
+        // without this half the bundle would carry evidence nobody could retrieve.
+        subsystems.ledgers = await restoreIncidentLedgers({
+            confirmation,
+            force,
+            logger,
+            mode,
+            sourceDir: layout.ledgers,
+            targets  : ledgerTargets ?? {
+                healAttemptsFile: AiConfig.orchestrator.recoveryActuator.healAttemptsPath,
+                healEventsDir   : path.join(AiConfig.orchestrator.dataDir, HEAL_LEDGER_DIR_NAME),
+                recoveryRunsDir : AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir
+            }
         });
     }
 
@@ -795,6 +823,76 @@ async function assessTargetOccupancy({trajectoriesTargetFile, sentToCullTargetFi
  * @param {Object} options
  * @returns {Promise<{copied: Number, skipped: Number, mode: String}>}
  */
+/**
+ * Restores the three incident ledgers from the bundle's `ledgers/` subfolder.
+ *
+ * Bundling the ledgers is only half the guarantee — a volume replacement wipes the orchestrator data
+ * directory, so restore is what makes the incident record readable again. Without this the bundle
+ * would carry evidence nobody could retrieve.
+ *
+ * Singletons are addressed by their EXACT filename rather than by "the first `.jsonl` in the
+ * folder", which is what `restoreFlatFile` does and which would silently pick the wrong file once a
+ * second ledger lands beside them. `heal-attempts.json` is not `.jsonl` at all, so neither existing
+ * flat helper reaches it.
+ *
+ * @param {Object} options
+ * @param {String} options.sourceDir Absolute `ledgers/` path inside the bundle.
+ * @param {Object} options.targets Resolved `{healAttemptsFile, healEventsDir, recoveryRunsDir}`.
+ * @returns {Promise<{healAttempts: Object, healEvents: Object, recoveryRuns: Object, mode: String}>}
+ */
+async function restoreIncidentLedgers({sourceDir, targets, mode, force, confirmation, logger}) {
+    /**
+     * Copies one named ledger file, honouring the same merge/replace/force contract the flat
+     * helpers use so the ledgers cannot become a hole in the destructive-guard coverage.
+     * @param {String} fileName
+     * @param {String} targetFile
+     * @param {String} subsystem
+     * @returns {Promise<Object>}
+     */
+    const copyNamed = async (fileName, targetFile, subsystem) => {
+        const source = path.join(sourceDir, fileName);
+
+        if (!await fs.pathExists(source)) {
+            return {copied: false, mode, note: `source absent: ${fileName}`}
+        }
+
+        if (mode === 'replace') {
+            await Shared_DestructiveOperationGuard.assertDestructiveTargetAllowed({
+                confirmation,
+                mode     : 'replace',
+                operation: `restore.${subsystem}.replace`,
+                source   : {path: source},
+                subsystem,
+                target   : {path: targetFile, repoRoot: PROJECT_ROOT}
+            });
+        } else if (!force && await fs.pathExists(targetFile)) {
+            logger.log?.(`[Restore][${subsystem}] preserved existing ${fileName} (merge mode without --force)`);
+            return {copied: false, skipped: true, mode}
+        }
+
+        await fs.ensureDir(path.dirname(targetFile));
+        await fs.copy(source, targetFile, {overwrite: true});
+
+        return {copied: true, mode}
+    };
+
+    const [healAttempts, healEvents, recoveryRuns] = await Promise.all([
+        copyNamed(path.basename(targets.healAttemptsFile), targets.healAttemptsFile, 'ledgers.healAttempts'),
+        copyNamed(HEAL_LEDGER_FILENAME, path.join(targets.healEventsDir, HEAL_LEDGER_FILENAME), 'ledgers.healEvents'),
+        restoreFlatDir({
+            confirmation,
+            force,
+            logger,
+            mode,
+            sourceDir: path.join(sourceDir, 'recovery-runs'),
+            subsystem: 'ledgers.recoveryRuns',
+            targetDir: targets.recoveryRunsDir
+        })
+    ]);
+
+    return {healAttempts, healEvents, mode, recoveryRuns}
+}
+
 async function restoreFlatDir({sourceDir, targetDir, mode, force, confirmation, subsystem, logger}) {
     if (!await fs.pathExists(sourceDir)) {
         return {copied: 0, skipped: 0, mode, note: `source absent: ${sourceDir}`}

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -762,7 +762,7 @@ export async function verifyLatestBackupRestorable({
     // `ledgers` belongs in the probe's layout because the probe ATTESTS a restore that will write
     // them. Omitting it meant malformed ledger content passed unexamined while the verdict still said
     // `RESTORABLE` — the probe vouching for a member it never looked at.
-    const layout     = {
+    const layout = {
         kb          : path.join(bundleRoot, 'kb'),
         mc          : path.join(bundleRoot, 'mc'),
         graph       : path.join(bundleRoot, 'graph'),
@@ -953,18 +953,25 @@ async function assessTargetOccupancy({trajectoriesTargetFile, sentToCullTargetFi
  */
 async function restoreIncidentLedgers({sourceDir, targets, mode, force, confirmation, logger}) {
     /**
-     * Copies one named ledger file, honouring the same merge/replace/force contract the flat
-     * helpers use so the ledgers cannot become a hole in the destructive-guard coverage.
+     * Authorizes one named ledger WITHOUT mutating anything, returning the plan its mutation phase
+     * will execute.
+     *
+     * Split from the copy on purpose. The three ledgers previously ran through `Promise.all` while
+     * each did guard-check-THEN-mutate, so a guard that refused SLOWLY on one ledger let a sibling
+     * whose guard resolved quickly complete its overwrite before `runRestore` rejected. The run
+     * reported failure having already destroyed data — worse than either outcome alone, because an
+     * operator seeing a refusal reasonably concludes nothing happened.
+     *
      * @param {String} fileName
      * @param {String} targetFile
      * @param {String} subsystem
      * @returns {Promise<Object>}
      */
-    const copyNamed = async (fileName, targetFile, subsystem) => {
+    const planNamed = async (fileName, targetFile, subsystem) => {
         const source = path.join(sourceDir, fileName);
 
         if (!await fs.pathExists(source)) {
-            return {copied: false, mode, note: `source absent: ${fileName}`}
+            return {outcome: {copied: false, mode, note: `source absent: ${fileName}`}}
         }
 
         if (mode === 'replace') {
@@ -978,36 +985,65 @@ async function restoreIncidentLedgers({sourceDir, targets, mode, force, confirma
             });
         } else if (!force && await fs.pathExists(targetFile)) {
             logger.log?.(`[Restore][${subsystem}] preserved existing ${fileName} (merge mode without --force)`);
-            return {copied: false, skipped: true, mode}
+            return {outcome: {copied: false, skipped: true, mode}}
         }
 
-        await fs.ensureDir(path.dirname(targetFile));
-        await fs.copy(source, targetFile, {overwrite: true});
+        return {apply: async () => {
+            await fs.ensureDir(path.dirname(targetFile));
+            await fs.copy(source, targetFile, {overwrite: true});
 
-        return {copied: true, mode}
+            return {copied: true, mode}
+        }}
     };
 
+    // PHASE 1 — authorize EVERY ledger before ANY of them mutates. Sequential, so the first refusal
+    // returns while the filesystem is still untouched; concurrency here would reintroduce the exact
+    // race this split exists to close.
+    //
     // Looked up by the STABLE bundle member name and written to the RESOLVED host path. Searching by
     // `path.basename(target)` coupled the bundle's contents to the reading host's config: a relocated
     // `healAttemptsPath` made a perfectly good bundle read as `source absent`.
+    const attemptsPlan = await planNamed(
+              INCIDENT_LEDGER_BUNDLE_MEMBERS.healAttempts, targets.healAttemptsFile, 'ledgers.healAttempts'
+          ),
+          eventsPlan   = await planNamed(
+              HEAL_LEDGER_FILENAME, path.join(targets.healEventsDir, HEAL_LEDGER_FILENAME), 'ledgers.healEvents'
+          ),
+          runsSource   = path.join(sourceDir, INCIDENT_LEDGER_BUNDLE_MEMBERS.recoveryRuns);
+
+    // `restoreFlatDir` fires its own guard as step one, so its authorization is hoisted here and the
+    // call below runs pre-authorized rather than re-asking mid-mutation.
+    if (mode === 'replace' && await fs.pathExists(runsSource)) {
+        await Shared_DestructiveOperationGuard.assertDestructiveTargetAllowed({
+            confirmation,
+            mode     : 'replace',
+            operation: 'restore.ledgers.recoveryRuns.replace',
+            source   : {path: runsSource},
+            subsystem: 'ledgers.recoveryRuns',
+            target   : {path: targets.recoveryRunsDir, repoRoot: PROJECT_ROOT}
+        });
+    }
+
+    // PHASE 2 — every authorization has passed; now mutate.
     const [healAttempts, healEvents, recoveryRuns] = await Promise.all([
-        copyNamed(INCIDENT_LEDGER_BUNDLE_MEMBERS.healAttempts, targets.healAttemptsFile, 'ledgers.healAttempts'),
-        copyNamed(HEAL_LEDGER_FILENAME, path.join(targets.healEventsDir, HEAL_LEDGER_FILENAME), 'ledgers.healEvents'),
+        attemptsPlan.apply ? attemptsPlan.apply() : attemptsPlan.outcome,
+        eventsPlan.apply   ? eventsPlan.apply()   : eventsPlan.outcome,
         restoreFlatDir({
             confirmation,
             force,
             logger,
             mode,
-            sourceDir: path.join(sourceDir, INCIDENT_LEDGER_BUNDLE_MEMBERS.recoveryRuns),
-            subsystem: 'ledgers.recoveryRuns',
-            targetDir: targets.recoveryRunsDir
+            preAuthorized: true,
+            sourceDir    : runsSource,
+            subsystem    : 'ledgers.recoveryRuns',
+            targetDir    : targets.recoveryRunsDir
         })
     ]);
 
     return {healAttempts, healEvents, mode, recoveryRuns}
 }
 
-async function restoreFlatDir({sourceDir, targetDir, mode, force, confirmation, subsystem, logger}) {
+async function restoreFlatDir({sourceDir, targetDir, mode, force, confirmation, subsystem, logger, preAuthorized = false}) {
     if (!await fs.pathExists(sourceDir)) {
         return {copied: 0, skipped: 0, mode, note: `source absent: ${sourceDir}`}
     }
@@ -1015,7 +1051,10 @@ async function restoreFlatDir({sourceDir, targetDir, mode, force, confirmation, 
     const sourceEntries = await fs.readdir(sourceDir);
     const sourceFiles   = sourceEntries.filter(f => f.endsWith('.jsonl'));
 
-    if (mode === 'replace') {
+    // `preAuthorized` exists for callers that must authorize a GROUP of targets before any member
+    // mutates — asking again here would be redundant, not safer. It never skips the emptyDir below:
+    // the authorization moved earlier, it did not disappear.
+    if (mode === 'replace' && !preAuthorized) {
         await Shared_DestructiveOperationGuard.assertDestructiveTargetAllowed({
             operation: `restore.${subsystem}.replace`,
             subsystem,
@@ -1024,6 +1063,8 @@ async function restoreFlatDir({sourceDir, targetDir, mode, force, confirmation, 
             source   : {path: sourceDir},
             confirmation
         });
+        await fs.emptyDir(targetDir);
+    } else if (mode === 'replace') {
         await fs.emptyDir(targetDir);
     } else {
         await fs.ensureDir(targetDir);

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -15,6 +15,7 @@ import AiConfig from '../../config.mjs';
 
 import {classifyRowVector}                          from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
 import {HEAL_LEDGER_DIR_NAME, HEAL_LEDGER_FILENAME} from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
+import {INCIDENT_LEDGER_BUNDLE_MEMBERS}             from '../../services/memory-core/helpers/incidentLedgerBundle.mjs';
 import {
     KB_DatabaseService,
     KB_LifecycleService,
@@ -235,8 +236,22 @@ export async function runRestore({
         Memory_LifecycleService.ready()
     ]);
 
+    // Resolved ONCE, above the replace preflight, so the occupancy check and the restore itself
+    // cannot disagree about which paths are the targets — a preflight that guards different files
+    // from the ones the run writes guards nothing.
+    const resolvedLedgerTargets = ledgerTargets ?? {
+        healAttemptsFile: AiConfig.orchestrator.recoveryActuator.healAttemptsPath,
+        healEventsDir   : path.join(AiConfig.orchestrator.dataDir, HEAL_LEDGER_DIR_NAME),
+        recoveryRunsDir : AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir
+    };
+
     if (mode === 'replace' && !force) {
-        const occupancy = await assessTargetOccupancy({trajectoriesTargetFile, sentToCullTargetFile, conceptsTargetDir});
+        const occupancy = await assessTargetOccupancy({
+            conceptsTargetDir,
+            ledgerTargets: resolvedLedgerTargets,
+            sentToCullTargetFile,
+            trajectoriesTargetFile
+        });
         const populated = occupancy.filter(o => o.nonEmpty).map(o => `${o.subsystem}=${o.size}`);
         if (populated.length > 0) {
             throw new Error(
@@ -372,11 +387,7 @@ export async function runRestore({
             logger,
             mode,
             sourceDir: layout.ledgers,
-            targets  : ledgerTargets ?? {
-                healAttemptsFile: AiConfig.orchestrator.recoveryActuator.healAttemptsPath,
-                healEventsDir   : path.join(AiConfig.orchestrator.dataDir, HEAL_LEDGER_DIR_NAME),
-                recoveryRunsDir : AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir
-            }
+            targets  : resolvedLedgerTargets
         });
     }
 
@@ -514,6 +525,42 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
     // evidence the bundle itself proves (schema shape, declared-vs-streamed counts, declared-vs-
     // expected dimension, per-row vectors). Provider/model identity is advisory: no write-time
     // vector provenance exists in the substrate, and admission never contacts a provider.
+    // The two ledger members the top-level scan cannot reach: `heal-attempts.json` is not `.jsonl`, and
+    // the recovery-run files are NESTED. Both were accepted malformed while the verdict still read
+    // `RESTORABLE`. A probe may only attest what it has actually parsed.
+    if (await fs.pathExists(layout.ledgers)) {
+        const attemptsPath = path.join(layout.ledgers, INCIDENT_LEDGER_BUNDLE_MEMBERS.healAttempts);
+
+        if (await fs.pathExists(attemptsPath)) {
+            try {
+                JSON.parse(await fs.readFile(attemptsPath, 'utf8'))
+            } catch (err) {
+                throw new Error(`Bundle JSON parse error at ledgers/${INCIDENT_LEDGER_BUNDLE_MEMBERS.healAttempts}: ${err.message}`);
+            }
+        }
+
+        const runsDir = path.join(layout.ledgers, INCIDENT_LEDGER_BUNDLE_MEMBERS.recoveryRuns);
+
+        if (await fs.pathExists(runsDir)) {
+            for (const file of (await fs.readdir(runsDir)).filter(name => name.endsWith('.jsonl'))) {
+                const stream = fs.createReadStream(path.join(runsDir, file), {encoding: 'utf8'}),
+                      rl     = readline.createInterface({crlfDelay: Infinity, input: stream});
+                let   lineNo = 0;
+
+                for await (const line of rl) {
+                    if (!line.trim()) continue;
+                    lineNo++;
+
+                    try {
+                        JSON.parse(line)
+                    } catch (err) {
+                        throw new Error(`Bundle JSONL parse error at ledgers/${INCIDENT_LEDGER_BUNDLE_MEMBERS.recoveryRuns}/${file} (line ${lineNo}): ${err.message}`);
+                    }
+                }
+            }
+        }
+    }
+
     validateEmbeddingContractSchema({expectedDimension, meta, streamedCounts});
     const embeddingAdvisories = assessEmbeddingCompatibility({expectedDimension, logger, meta});
 
@@ -712,13 +759,17 @@ export async function verifyLatestBackupRestorable({
     }
 
     const bundleRoot = path.join(backupRoot, bundleNames[0]);
+    // `ledgers` belongs in the probe's layout because the probe ATTESTS a restore that will write
+    // them. Omitting it meant malformed ledger content passed unexamined while the verdict still said
+    // `RESTORABLE` — the probe vouching for a member it never looked at.
     const layout     = {
         kb          : path.join(bundleRoot, 'kb'),
         mc          : path.join(bundleRoot, 'mc'),
         graph       : path.join(bundleRoot, 'graph'),
         concepts    : path.join(bundleRoot, 'concepts'),
         trajectories: path.join(bundleRoot, 'trajectories'),
-        mailbox     : path.join(bundleRoot, 'mailbox')
+        mailbox     : path.join(bundleRoot, 'mailbox'),
+        ledgers     : path.join(bundleRoot, 'ledgers')
     };
 
     try {
@@ -798,7 +849,7 @@ export async function checkTopology({meta, forceTopologyMismatch, logger}) {
  * @param {String} options.conceptsTargetDir
  * @returns {Promise<Array<{subsystem: String, nonEmpty: Boolean, size: Number}>>}
  */
-async function assessTargetOccupancy({trajectoriesTargetFile, sentToCullTargetFile, conceptsTargetDir}) {
+async function assessTargetOccupancy({trajectoriesTargetFile, sentToCullTargetFile, conceptsTargetDir, ledgerTargets}) {
     const results = [];
 
     try {
@@ -837,6 +888,35 @@ async function assessTargetOccupancy({trajectoriesTargetFile, sentToCullTargetFi
         results.push({subsystem: 'mailbox', nonEmpty: stat.size > 0, size: stat.size});
     } else {
         results.push({subsystem: 'mailbox', nonEmpty: false, size: 0});
+    }
+
+    // The incident ledgers are replace targets too, and were initially omitted here. The omission was
+    // invisible because `assertDestructiveTargetAllowed` still fired on them — but that guard
+    // classifies target LOCATION and confirmation; it does not enforce `--force`. So a populated
+    // ledger on a disposable path could be overwritten with `force: false`, contrary to this
+    // function's whole purpose. A test asserting "the guard was called" proved the wrong
+    // proposition; what has to hold is that the run REFUSES.
+    if (ledgerTargets) {
+        for (const [subsystem, target] of [
+            ['ledgers.healAttempts', ledgerTargets.healAttemptsFile],
+            ['ledgers.healEvents',   ledgerTargets.healEventsDir],
+            ['ledgers.recoveryRuns', ledgerTargets.recoveryRunsDir]
+        ]) {
+            if (!target || !await fs.pathExists(target)) {
+                results.push({subsystem, nonEmpty: false, size: 0});
+                continue
+            }
+
+            const stat = await fs.stat(target);
+
+            if (stat.isDirectory()) {
+                const entries = (await fs.readdir(target)).filter(name => name.endsWith('.jsonl'));
+
+                results.push({subsystem, nonEmpty: entries.length > 0, size: entries.length})
+            } else {
+                results.push({subsystem, nonEmpty: stat.size > 0, size: stat.size})
+            }
+        }
     }
 
     return results
@@ -907,15 +987,18 @@ async function restoreIncidentLedgers({sourceDir, targets, mode, force, confirma
         return {copied: true, mode}
     };
 
+    // Looked up by the STABLE bundle member name and written to the RESOLVED host path. Searching by
+    // `path.basename(target)` coupled the bundle's contents to the reading host's config: a relocated
+    // `healAttemptsPath` made a perfectly good bundle read as `source absent`.
     const [healAttempts, healEvents, recoveryRuns] = await Promise.all([
-        copyNamed(path.basename(targets.healAttemptsFile), targets.healAttemptsFile, 'ledgers.healAttempts'),
+        copyNamed(INCIDENT_LEDGER_BUNDLE_MEMBERS.healAttempts, targets.healAttemptsFile, 'ledgers.healAttempts'),
         copyNamed(HEAL_LEDGER_FILENAME, path.join(targets.healEventsDir, HEAL_LEDGER_FILENAME), 'ledgers.healEvents'),
         restoreFlatDir({
             confirmation,
             force,
             logger,
             mode,
-            sourceDir: path.join(sourceDir, 'recovery-runs'),
+            sourceDir: path.join(sourceDir, INCIDENT_LEDGER_BUNDLE_MEMBERS.recoveryRuns),
             subsystem: 'ledgers.recoveryRuns',
             targetDir: targets.recoveryRunsDir
         })

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -521,10 +521,13 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
     // self-diagnostic probe and the later orchestrator always receive the structured unknown.
     if (meta) {
         meta.embeddingAdvisories = embeddingAdvisories;
+        // Surfaced so a caller can decide NON-EMPTINESS from this same streaming pass instead of
+        // re-reading metadata or writing a second predicate that could disagree with this one.
+        meta.streamedCounts      = streamedCounts;
         return meta
     }
 
-    return {embeddingAdvisories, legacy: true}
+    return {embeddingAdvisories, legacy: true, streamedCounts}
 }
 
 /**
@@ -664,8 +667,13 @@ export function assessEmbeddingCompatibility({expectedDimension, logger = consol
  * @param {Object}   [options.fsModule=fs] Filesystem seam (test injection).
  * @param {Function} [options.validateFn=validateBundle] Bundle validator seam (test injection).
  * @returns {Promise<{restorable: Boolean, code: String, bundleRoot: String|null, reason: String|null, checkedAt: String, embeddingAdvisories: Object[]}>}
- * `code` is the machine-readable verdict — `RESTORABLE`, `BUNDLE_ROOT_MISSING`, `NO_BUNDLES`, or
- * `BUNDLE_INVALID`. It exists so a caller gating on this probe branches on a value rather than
+ * `code` is the machine-readable verdict — `RESTORABLE`, `BUNDLE_ROOT_MISSING`, `NO_BUNDLES`,
+ * `BUNDLE_EMPTY`, or `BUNDLE_INVALID`. `RESTORABLE` asserts the bundle is BOTH structurally valid
+ * and non-empty; `rowTotal` reports the row count it was decided on. That strength lives here rather
+ * than in a caller so a shell gate consumes one authoritative verdict instead of re-reading metadata
+ * and growing a second predicate able to disagree with this one.
+ *
+ * It exists so a caller gating on this probe branches on a value rather than
  * pattern-matching English out of `reason`, which would silently stop working the moment the prose
  * is reworded. `BUNDLE_ROOT_MISSING` and `NO_BUNDLES` are deliberately separate: the bundle root is
  * bind-mounted from a path relative to the compose project directory, so a run from a different host
@@ -714,8 +722,31 @@ export async function verifyLatestBackupRestorable({
     };
 
     try {
-        const meta = await validateFn(bundleRoot, layout, logger);
-        return {restorable: true, code: 'RESTORABLE', bundleRoot, reason: null, checkedAt, embeddingAdvisories: meta?.embeddingAdvisories ?? []};
+        const meta = await validateFn(bundleRoot, layout, logger),
+              // Non-emptiness is decided HERE, from the validator's own streaming pass, because a
+              // structurally-parseable bundle is not the same thing as a usable recovery source.
+              // A bundle carrying only the six required directories and a minimal meta parsed clean
+              // and returned `RESTORABLE` — the ticket's explicitly forbidden precondition, and the
+              // exact shape of the incident: the one bundle in the ledger completed after the plane
+              // was already empty. `code` has to be stronger than the prose it replaced.
+              //
+              // Vector-collection rows are the measure because they ARE the recovery payload. A
+              // bundle whose corpus is empty cannot restore a corpus, whatever else it contains.
+              rowTotal = Object.values(meta?.streamedCounts ?? {}).reduce((sum, count) => sum + count, 0);
+
+        if (rowTotal === 0) {
+            return {
+                restorable         : false,
+                code               : 'BUNDLE_EMPTY',
+                bundleRoot,
+                reason             : `bundle parses but carries zero recoverable rows: ${bundleRoot}`,
+                checkedAt,
+                rowTotal,
+                embeddingAdvisories: meta?.embeddingAdvisories ?? []
+            }
+        }
+
+        return {restorable: true, code: 'RESTORABLE', bundleRoot, reason: null, checkedAt, rowTotal, embeddingAdvisories: meta?.embeddingAdvisories ?? []};
     } catch (error) {
         return {restorable: false, code: 'BUNDLE_INVALID', bundleRoot, reason: error.message, checkedAt, embeddingAdvisories: error.embeddingAdvisories ?? []};
     }

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -635,7 +635,14 @@ export function assessEmbeddingCompatibility({expectedDimension, logger = consol
  * @param {Object}   [options.logger=console] Log sink.
  * @param {Object}   [options.fsModule=fs] Filesystem seam (test injection).
  * @param {Function} [options.validateFn=validateBundle] Bundle validator seam (test injection).
- * @returns {Promise<{restorable: Boolean, bundleRoot: String|null, reason: String|null, checkedAt: String, embeddingAdvisories: Object[]}>}
+ * @returns {Promise<{restorable: Boolean, code: String, bundleRoot: String|null, reason: String|null, checkedAt: String, embeddingAdvisories: Object[]}>}
+ * `code` is the machine-readable verdict — `RESTORABLE`, `BUNDLE_ROOT_MISSING`, `NO_BUNDLES`, or
+ * `BUNDLE_INVALID`. It exists so a caller gating on this probe branches on a value rather than
+ * pattern-matching English out of `reason`, which would silently stop working the moment the prose
+ * is reworded. `BUNDLE_ROOT_MISSING` and `NO_BUNDLES` are deliberately separate: the bundle root is
+ * bind-mounted from a path relative to the compose project directory, so a run from a different host
+ * checkout finds a directory that never existed — reporting "no bundle" for bundles sitting safely
+ * in a prior checkout is the wrong answer to the operator's actual question.
  */
 export async function verifyLatestBackupRestorable({
     backupRoot,
@@ -650,7 +657,11 @@ export async function verifyLatestBackupRestorable({
     const checkedAt = new Date().toISOString();
 
     if (!await fsModule.pathExists(backupRoot)) {
-        return {restorable: false, bundleRoot: null, reason: `backup root not found: ${backupRoot}`, checkedAt};
+        // Distinct from NO_BUNDLES on purpose. The cloud profile bind-mounts the bundle root from a
+        // path RELATIVE to the compose project directory, so a deployment run from a different host
+        // checkout addresses a directory that never existed rather than an empty one. Reporting "no
+        // bundle" for bundles sitting safely in a prior checkout would answer about the wrong subject.
+        return {restorable: false, code: 'BUNDLE_ROOT_MISSING', bundleRoot: null, reason: `backup root not found: ${backupRoot}`, checkedAt};
     }
 
     // backup-<ISO-ts> names sort lexically by their ISO timestamp, so reverse-sort yields newest-first.
@@ -661,7 +672,7 @@ export async function verifyLatestBackupRestorable({
         .reverse();
 
     if (bundleNames.length === 0) {
-        return {restorable: false, bundleRoot: null, reason: `no backup-* bundles under ${backupRoot}`, checkedAt};
+        return {restorable: false, code: 'NO_BUNDLES', bundleRoot: null, reason: `no backup-* bundles under ${backupRoot}`, checkedAt};
     }
 
     const bundleRoot = path.join(backupRoot, bundleNames[0]);
@@ -676,9 +687,9 @@ export async function verifyLatestBackupRestorable({
 
     try {
         const meta = await validateFn(bundleRoot, layout, logger);
-        return {restorable: true, bundleRoot, reason: null, checkedAt, embeddingAdvisories: meta?.embeddingAdvisories ?? []};
+        return {restorable: true, code: 'RESTORABLE', bundleRoot, reason: null, checkedAt, embeddingAdvisories: meta?.embeddingAdvisories ?? []};
     } catch (error) {
-        return {restorable: false, bundleRoot, reason: error.message, checkedAt, embeddingAdvisories: error.embeddingAdvisories ?? []};
+        return {restorable: false, code: 'BUNDLE_INVALID', bundleRoot, reason: error.message, checkedAt, embeddingAdvisories: error.embeddingAdvisories ?? []};
     }
 }
 

--- a/ai/services/memory-core/helpers/healEventLedgerStore.mjs
+++ b/ai/services/memory-core/helpers/healEventLedgerStore.mjs
@@ -12,7 +12,26 @@ import path                                           from 'path';
  * JSONL shape: I/O at the edge only, deterministic content.
  */
 
-const HEAL_LEDGER_FILENAME = 'heal-events.jsonl';
+/**
+ * Filename of the heal-event ledger inside its directory. Exported for the same reason as the
+ * directory name: the backup/restore lane must address this file by its exact name rather than
+ * guessing "the first `.jsonl` in the folder", which silently picks the wrong file the moment a
+ * second ledger lands beside it.
+ * @type {String}
+ */
+export const HEAL_LEDGER_FILENAME = 'heal-events.jsonl';
+
+/**
+ * Directory name holding the heal-event ledger, relative to the orchestrator data directory.
+ *
+ * Exported because the ledger has no config leaf of its own — its location is derived from the
+ * resolved `orchestrator.dataDir` by every consumer. That derivation was written out longhand at
+ * three separate sites, and the backup lane needs a fourth: a producer and a backup that disagree
+ * about where the ledger lives would not fail, it would silently bundle nothing, which is precisely
+ * the class of defect the ledger exists to make visible. One name, one home.
+ * @type {String}
+ */
+export const HEAL_LEDGER_DIR_NAME = 'data-heal-events';
 
 /**
  * Event types the ledger recognises for the folded status surface. `freeze` adds a collection to the

--- a/ai/services/memory-core/helpers/incidentLedgerBundle.mjs
+++ b/ai/services/memory-core/helpers/incidentLedgerBundle.mjs
@@ -1,0 +1,37 @@
+import {HEAL_LEDGER_FILENAME} from './healEventLedgerStore.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/incidentLedgerBundle
+ * @summary Stable LOGICAL member names for the incident ledgers inside a backup bundle, decoupled
+ * from wherever those ledgers happen to live on a given host.
+ *
+ * ## Why this is not just `path.basename(source)`
+ *
+ * The first version of the ledger bundling stored each ledger under the basename of its SOURCE path
+ * and looked it up on restore under the basename of its DESTINATION path. Both are derived from
+ * `orchestrator.recoveryActuator.healAttemptsPath`, which is an env-relocatable full path — so a
+ * deployment that pointed it at `custom-attempts.json` produced a bundle containing
+ * `custom-attempts.json`, and a restore under the default configuration looked for
+ * `heal-attempts.json`, found nothing, and reported `source absent`.
+ *
+ * That failure is silent and it fails in the worst direction: the restore reports success having
+ * restored no incident record, which is the same "evidence nobody can retrieve" problem the bundling
+ * exists to fix, reintroduced one layer down. A bundle member name must be a property of the BUNDLE
+ * FORMAT, never of the host that happened to write it.
+ *
+ * This module is deliberately its own file rather than more surface on `offHostSyncStore`: that store
+ * already owns receipt persistence plus config validation, and bundle-layout naming is a third
+ * concern. Keeping it separate is cheaper than splitting a grab-bag later.
+ */
+
+/**
+ * Bundle-relative member names for the three incident ledgers. `healEvents` reuses the ledger's own
+ * filename because that name is already a format constant rather than a host path; the other two are
+ * pinned here.
+ * @type {{healAttempts: String, healEvents: String, recoveryRuns: String}}
+ */
+export const INCIDENT_LEDGER_BUNDLE_MEMBERS = Object.freeze({
+    healAttempts: 'heal-attempts.json',
+    healEvents  : HEAL_LEDGER_FILENAME,
+    recoveryRuns: 'recovery-runs'
+});

--- a/ai/services/memory-core/helpers/offHostSyncStore.mjs
+++ b/ai/services/memory-core/helpers/offHostSyncStore.mjs
@@ -27,6 +27,22 @@ const ANY_PLACEHOLDER     = /\{[^}]*\}/,
       TIMEOUT_MAX_MS      = 30 * 60 * 1000,
       TIMEOUT_MIN_MS      = 1000;
 
+/**
+ * Stable classification of an off-host-sync config defect. Projected remotely INSTEAD of the
+ * human-readable `error`, which interpolates the offending value.
+ * @type {Object}
+ */
+export const OFFHOST_SYNC_ERROR_CODE = Object.freeze({
+    ARGV_NOT_STRING_ARRAY   : 'KB_OFFHOST_SYNC_ARGV_NOT_STRING_ARRAY',
+    ARGV_PLACEHOLDER_INVALID: 'KB_OFFHOST_SYNC_ARGV_PLACEHOLDER_INVALID',
+    COMMAND_NOT_STRING      : 'KB_OFFHOST_SYNC_COMMAND_NOT_STRING',
+    CONFIG_NOT_OBJECT       : 'KB_OFFHOST_SYNC_CONFIG_NOT_OBJECT',
+    ENV_ALLOWLIST_INVALID   : 'KB_OFFHOST_SYNC_ENV_ALLOWLIST_INVALID',
+    KILL_GRACE_OUT_OF_RANGE : 'KB_OFFHOST_SYNC_KILL_GRACE_OUT_OF_RANGE',
+    NUL_BYTE                : 'KB_OFFHOST_SYNC_NUL_BYTE',
+    TIMEOUT_OUT_OF_RANGE    : 'KB_OFFHOST_SYNC_TIMEOUT_OUT_OF_RANGE'
+});
+
 const now = () => new Date().toISOString();
 
 /**
@@ -44,7 +60,10 @@ const now = () => new Date().toISOString();
  * The script re-exports it, so its callers and its owning ticket's spec are unaffected.
  *
  * @param {Object} [config={}] The `AiConfig.maintenance.backup.offHostSync` subtree (may be undefined).
- * @returns {{enabled: Boolean, error: String|null, value: Object}}
+ * @returns {{enabled: Boolean, error: String|null, errorCode: String|null, value: Object}}
+ * `error` is operator-facing prose that MAY interpolate the offending config value; `errorCode` is a
+ * stable classification that never does. A caller writing to a remotely readable surface must carry
+ * the code and drop the prose.
  */
 export function validateOffHostSyncConfig(config = {}) {
     const {
@@ -55,42 +74,48 @@ export function validateOffHostSyncConfig(config = {}) {
         timeoutMs     = 600000
     } = config ?? {};
 
-    const fail = error => ({enabled: false, error, value: null});
+    // `errorCode` is the ONLY half of a failure that is safe to project remotely. `error` carries
+    // the operator-facing detail, which for the placeholder and NUL cases interpolates the offending
+    // `argv` token verbatim — and an operator can put a credential in argv. A caller that projects
+    // `error` into a remotely readable surface leaks it; the code says the same thing about the
+    // DEFECT while saying nothing about the VALUE.
+    const fail = (errorCode, error) => ({enabled: false, error, errorCode, value: null});
 
     // Validate EVERY key before the disabled early-return: a disabled hook with malformed keys is a
     // validation failure, not a silent pass.
-    if (config === null || typeof config !== 'object' || Array.isArray(config)) return fail('config must be an object');
-    if (typeof command !== 'string') return fail('command must be a string');
+    if (config === null || typeof config !== 'object' || Array.isArray(config)) return fail(OFFHOST_SYNC_ERROR_CODE.CONFIG_NOT_OBJECT, 'config must be an object');
+    if (typeof command !== 'string') return fail(OFFHOST_SYNC_ERROR_CODE.COMMAND_NOT_STRING, 'command must be a string');
     // Array-shape before any traversal: null/object/number argv must return a validation outcome,
     // never a thrown TypeError.
-    if (!Array.isArray(argv) || argv.some(token => typeof token !== 'string')) return fail('argv must be an array of strings');
+    if (!Array.isArray(argv) || argv.some(token => typeof token !== 'string')) return fail(OFFHOST_SYNC_ERROR_CODE.ARGV_NOT_STRING_ARRAY, 'argv must be an array of strings');
     if (command.includes('\0') || argv.some(token => token.includes('\0'))) {
-        return fail('command/argv must not contain NUL bytes')
+        return fail(OFFHOST_SYNC_ERROR_CODE.NUL_BYTE, 'command/argv must not contain NUL bytes')
     }
 
     for (const token of argv) {
         if (ANY_PLACEHOLDER.test(token) && !PLACEHOLDER_PATTERN.test(token)) {
-            return fail(`argv token must be a whole-token placeholder {bundleDir} or {bundleName}, got: ${token}`)
+            return fail(OFFHOST_SYNC_ERROR_CODE.ARGV_PLACEHOLDER_INVALID, `argv token must be a whole-token placeholder {bundleDir} or {bundleName}, got: ${token}`)
         }
     }
 
     if (!Array.isArray(envAllowlist) || envAllowlist.some(name => typeof name !== 'string' || !ENV_NAME_PATTERN.test(name))) {
-        return fail('envAllowlist entries must match /^[A-Z_][A-Z0-9_]*$/')
+        return fail(OFFHOST_SYNC_ERROR_CODE.ENV_ALLOWLIST_INVALID, 'envAllowlist entries must match /^[A-Z_][A-Z0-9_]*$/')
     }
 
     if (!Number.isInteger(timeoutMs) || timeoutMs < TIMEOUT_MIN_MS || timeoutMs > TIMEOUT_MAX_MS) {
-        return fail(`timeoutMs must be an integer between ${TIMEOUT_MIN_MS} and ${TIMEOUT_MAX_MS}`)
+        return fail(OFFHOST_SYNC_ERROR_CODE.TIMEOUT_OUT_OF_RANGE, `timeoutMs must be an integer between ${TIMEOUT_MIN_MS} and ${TIMEOUT_MAX_MS}`)
     }
     if (!Number.isInteger(killGraceMs) || killGraceMs < 0 || killGraceMs > GRACE_MAX_MS) {
-        return fail(`killGraceMs must be an integer between 0 and ${GRACE_MAX_MS}`)
+        return fail(OFFHOST_SYNC_ERROR_CODE.KILL_GRACE_OUT_OF_RANGE, `killGraceMs must be an integer between 0 and ${GRACE_MAX_MS}`)
     }
 
-    if (command.trim() === '') return {enabled: false, error: null, value: null};
+    if (command.trim() === '') return {enabled: false, error: null, errorCode: null, value: null};
 
     return {
-        enabled: true,
-        error  : null,
-        value  : {argv, command: command.trim(), envAllowlist, killGraceMs, timeoutMs}
+        enabled  : true,
+        error    : null,
+        errorCode: null,
+        value    : {argv, command: command.trim(), envAllowlist, killGraceMs, timeoutMs}
     }
 }
 

--- a/ai/services/memory-core/helpers/offHostSyncStore.mjs
+++ b/ai/services/memory-core/helpers/offHostSyncStore.mjs
@@ -17,7 +17,82 @@ const MAX_RECEIPT_BYTES     = 64 * 1024,
       MAX_TAIL_BYTES        = 4 * 1024,
       STALE_TEMP_HORIZON_MS = 60_000;
 
+// Config-contract bounds for the `maintenance.backup.offHostSync` subtree, living beside the
+// validator that enforces them. See `validateOffHostSyncConfig` below for why the contract belongs
+// to this layer rather than to the maintenance script that runs the sync.
+const ANY_PLACEHOLDER     = /\{[^}]*\}/,
+      ENV_NAME_PATTERN    = /^[A-Z_][A-Z0-9_]*$/,
+      GRACE_MAX_MS        = 60000,
+      PLACEHOLDER_PATTERN = /^\{(bundleDir|bundleName)\}$/,
+      TIMEOUT_MAX_MS      = 30 * 60 * 1000,
+      TIMEOUT_MIN_MS      = 1000;
+
 const now = () => new Date().toISOString();
+
+/**
+ * Validates the nested offHostSync config keys. The contract is owned here rather than by a leaf
+ * because the keys are plain nested values inside the `maintenance.backup` object leaf, which
+ * declares no per-key `leaf()` nodes and therefore binds no per-key env override or type parser.
+ *
+ * **Why this lives in the store rather than the maintenance script:** the off-host durability
+ * posture on the deployment-state snapshot must answer "is this hook configured
+ * and valid?", and the orchestrator's `DeploymentStateBridgeService` is a READ-ONLY projector that
+ * deliberately never imports `ai/scripts/maintenance/offHostSync.mjs` — that script's module body is
+ * CLI machinery and pulls `node:child_process` into the diagnostic path. Duplicating the predicate
+ * for the bridge would have created two enablement resolvers able to disagree, so the single
+ * implementation moved to this shared, side-effect-free layer that both consumers already import.
+ * The script re-exports it, so its callers and its owning ticket's spec are unaffected.
+ *
+ * @param {Object} [config={}] The `AiConfig.maintenance.backup.offHostSync` subtree (may be undefined).
+ * @returns {{enabled: Boolean, error: String|null, value: Object}}
+ */
+export function validateOffHostSyncConfig(config = {}) {
+    const {
+        argv          = [],
+        command       = '',
+        envAllowlist  = [],
+        killGraceMs   = 5000,
+        timeoutMs     = 600000
+    } = config ?? {};
+
+    const fail = error => ({enabled: false, error, value: null});
+
+    // Validate EVERY key before the disabled early-return: a disabled hook with malformed keys is a
+    // validation failure, not a silent pass.
+    if (config === null || typeof config !== 'object' || Array.isArray(config)) return fail('config must be an object');
+    if (typeof command !== 'string') return fail('command must be a string');
+    // Array-shape before any traversal: null/object/number argv must return a validation outcome,
+    // never a thrown TypeError.
+    if (!Array.isArray(argv) || argv.some(token => typeof token !== 'string')) return fail('argv must be an array of strings');
+    if (command.includes('\0') || argv.some(token => token.includes('\0'))) {
+        return fail('command/argv must not contain NUL bytes')
+    }
+
+    for (const token of argv) {
+        if (ANY_PLACEHOLDER.test(token) && !PLACEHOLDER_PATTERN.test(token)) {
+            return fail(`argv token must be a whole-token placeholder {bundleDir} or {bundleName}, got: ${token}`)
+        }
+    }
+
+    if (!Array.isArray(envAllowlist) || envAllowlist.some(name => typeof name !== 'string' || !ENV_NAME_PATTERN.test(name))) {
+        return fail('envAllowlist entries must match /^[A-Z_][A-Z0-9_]*$/')
+    }
+
+    if (!Number.isInteger(timeoutMs) || timeoutMs < TIMEOUT_MIN_MS || timeoutMs > TIMEOUT_MAX_MS) {
+        return fail(`timeoutMs must be an integer between ${TIMEOUT_MIN_MS} and ${TIMEOUT_MAX_MS}`)
+    }
+    if (!Number.isInteger(killGraceMs) || killGraceMs < 0 || killGraceMs > GRACE_MAX_MS) {
+        return fail(`killGraceMs must be an integer between 0 and ${GRACE_MAX_MS}`)
+    }
+
+    if (command.trim() === '') return {enabled: false, error: null, value: null};
+
+    return {
+        enabled: true,
+        error  : null,
+        value  : {argv, command: command.trim(), envAllowlist, killGraceMs, timeoutMs}
+    }
+}
 
 /**
  * Bounds a string to the LAST maxBytes bytes with UTF-8-safe output: partial lead sequences are

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -105,7 +105,7 @@ The deployment's persistent state (`ai/deploy/docker-compose.yml`):
 | Memory Core graph + sessions — the **primary store** | `shared-sqlite-data` named volume → `/app/.neo-ai-data/sqlite` | `down -v`, or the Compose project name changes |
 | Chroma vectors | `chroma-data` named volume → `/chroma/unified` (set via `PERSIST_DIRECTORY`) | `down -v`, or the project name changes (recoverable by re-sync/re-push, at cost) |
 | Sandman handoff + derived route artifacts | `shared-handoff-data` named volume → `/app/.neo-ai-data/handoff` (writer and reader share `NEO_HANDOFF_FILE_PATH`) | `down -v`, or the Compose project name changes |
-| Orchestrator task, tenant-repo revision/backoff, recovery, and diagnostic state | `orchestrator-state` named volume → `/app/.neo-ai-data/orchestrator-daemon` (bound through `NEO_AI_ORCHESTRATOR_DIR`) | `down -v`, or the Compose project name changes |
+| Orchestrator task, tenant-repo revision/backoff, recovery, and diagnostic state | `orchestrator-state` named volume → `/app/.neo-ai-data/orchestrator-daemon` (bound through `NEO_AI_ORCHESTRATOR_DIR`) | `down -v`, or the Compose project name changes. **The incident ledgers within it — `heal-attempts.json`, `heal-events.jsonl`, `recovery-runs/` — are now captured in the backup bundle's `ledgers/` folder and restorable (`--only-substrate ledgers`). Task state and tenant-repo revisions are not.** |
 | Backup bundles | host bind-mount `./.neo-ai-data/backups` on the `cloud`-profile `orchestrator` | the compose file's host location changes between runs |
 | TLS certs / CA | `caddy-data` / `caddy-config` named volumes (`ingress` profile) | `down -v` (re-issued on next start — watch ACME rate limits) |
 | Local model store — opt-in `local-model` profile | `local-model-data` named volume → `/root/.ollama` | `down -v`, or the project name changes (recoverable — re-pull the models) |
@@ -120,10 +120,21 @@ Three rules keep a redeploy job safe:
 
 Off-site copy is the disaster-recovery layer *above* redeploy-safety:
 redeploy-safety keeps named-volume state across a container *recreate*, while
-host-loss recovery requires exporting every load-bearing named volume. The
-current logical backup bundle does not include `orchestrator-state`; copy or
-export that volume separately before claiming that its task/revision/recovery
-state is off-host backed up.
+host-loss recovery requires exporting every load-bearing named volume.
+
+The bundle now covers the **incident ledgers** inside `orchestrator-state` —
+`heal-attempts.json`, `heal-events.jsonl`, and `recovery-runs/` land in the
+bundle's `ledgers/` folder and restore with `--only-substrate ledgers`. That
+closes a specific hole: the self-heal and recovery record used to be destroyed by
+the same operation whose cause it existed to explain, so the one class of event
+post-mortem capability most needed to describe was the one it never could.
+
+It does **not** cover the rest of the volume. Orchestrator task state and
+tenant-repo revision/backoff state are still bundle-absent, so copy or export
+`orchestrator-state` separately before claiming *those* are off-host backed up.
+The distinction matters: "the ledgers survive" is not "the volume survives", and
+treating the narrower guarantee as the broader one is how an operator discovers
+the gap during a recovery rather than before one.
 
 **Verification:** the redeploy-survival check is [Day-0 Tutorial Milestone 7](./Day0Tutorial.md) — a `docker compose down && docker compose up --build` cycle, then confirm the Memory Core store, Sandman handoff, orchestrator task/revision state, and backup bundles are intact. Run that check once when the pipeline is first wired; subsequent redeploys rely on the named-volume + project-name + bind-mount contract above.
 

--- a/learn/agentos/tooling/RestorationRunbook.md
+++ b/learn/agentos/tooling/RestorationRunbook.md
@@ -9,13 +9,14 @@ Backups are stored in `.neo-ai-data/backups/backup-<timestamp>/` and contain the
 - `graph/`: Memory Core SQLite graph as JSONL
 - `concepts/`: Concept Ontology JSONL
 - `trajectories/`: RLAIF training trajectories JSONL
+- `ledgers/`: incident ledgers — `heal-attempts.json`, `heal-events.jsonl`, `recovery-runs/`. Present only on bundles taken after ledger capture landed; a bundle without it restores normally.
 
 ## Prerequisites
 Before initiating any restoration, ensure that all AI MCP servers and daemon processes are stopped (terminate any running `npm run ai:server` processes).
 
 ## Atomic-Bundle Restore CLI (`ai:restore`)
 
-`npm run ai:restore -- <bundle-path>` (entrypoint `ai/scripts/maintenance/restore.mjs`) inverts the Daily Snapshot Pipeline: it reads a bundle, validates structure + JSONL parseability + topology compatibility, then restores each subsystem (KB, MC memories/summaries, graph, concepts, RLAIF trajectories) through the canonical Zod-validated SDK boundary. Use this for a full-bundle restore; the per-subsystem procedures below are the manual fallback when you need to recover a single store.
+`npm run ai:restore -- <bundle-path>` (entrypoint `ai/scripts/maintenance/restore.mjs`) inverts the Daily Snapshot Pipeline: it reads a bundle, validates structure + JSONL parseability + topology compatibility, then restores each subsystem (KB, MC memories/summaries, graph, concepts, RLAIF trajectories, mailbox archive, incident ledgers) through the canonical Zod-validated SDK boundary — flat members via direct file restore. Use this for a full-bundle restore; the per-subsystem procedures below are the manual fallback when you need to recover a single store.
 
 ### Flags
 
@@ -36,7 +37,7 @@ Two operations share this CLI and need **opposite** read-state policies. Read-st
 |---|---|---|
 | **Operation** | Disaster recovery | Live operational re-seed |
 | **Meaning** | The bundle IS the new state; reproduce it exactly | The graph is rebuilt from a lagged snapshot, **with writers quiesced first** |
-| **Scope** | Whatever you ask for (all six substrates by default) | **Graph only** — pinned |
+| **Scope** | Whatever you ask for (every substrate by default; `--only-substrate` narrows it, e.g. `--only-substrate ledgers`) | **Graph only** — pinned |
 | **Read receipts** | Discarded with everything else | **Preserved** — pinned |
 | **Mode** | Yours to state | `replace` — pinned |
 | **`--force`** | Yours | Yours — deliberately *not* pinned; the destructive acknowledgment never rides inside a convenience name |
@@ -57,7 +58,9 @@ Two operations share this CLI and need **opposite** read-state policies. Read-st
 
 ### Pre-flight validation
 
-Before any write touches a service, the orchestrator validates the bundle: the required subdirectories exist, each `.jsonl` is parseable (a torn write / corruption fails fast), and `bundle-meta.json` (when present) parses and passes the topology check. A torn or partial bundle aborts with a clear error and zero side effects on the live substrate.
+Before any write touches a service, the orchestrator validates the bundle: the required subdirectories exist, every `.jsonl` in each declared bundle member is parseable (a torn write / corruption fails fast), the incident ledgers' non-JSONL `heal-attempts.json` and nested `recovery-runs/*.jsonl` are parsed too, and `bundle-meta.json` (when present) parses and passes the topology check. A torn or partial bundle aborts with a clear error and zero side effects on the live substrate.
+
+**Scope of that promise, stated precisely:** validation covers files reachable from the declared bundle layout. It is not a guarantee about arbitrary content an operator drops into a bundle directory, and the restorability probe (`verifyLatestBackupRestorable`) reports `RESTORABLE` only when the bundle is both structurally valid **and** carries a non-zero row count — a bundle that parses cleanly while containing nothing is not a recovery source.
 
 ### Production-target safeguard
 

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -122,7 +122,14 @@ async function createFakeBin(plainLines, peelLine = '') {
  */
 function preflightEnv(fake, declareInitialization) {
     return {
-        NEO_BACKUP_PATH      : path.join(fake.bin, '..', 'preflight-backups'),
+        // INSIDE the per-test temp dir, never `fake.bin/..` — that resolved to `os.tmpdir()` itself, so
+        // every test AND every run on the machine shared one backup root. The gate's own contract is
+        // that `--initialize` works once per host, so a shared root made the first initializing test
+        // write a marker that made all the later ones refuse. Diagnosed by @neo-gpt.
+        //
+        // It also made the suite non-idempotent in a way a single local run cannot show: the first run
+        // passed because the marker did not exist yet, and created the state that failed the second.
+        NEO_BACKUP_PATH      : path.join(fake.bin, 'preflight-backups'),
         NEO_DEPLOY_INITIALIZE: declareInitialization ? '1' : '0'
     }
 }

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -103,7 +103,31 @@ async function createFakeBin(plainLines, peelLine = '') {
  * @param {Object} probe `{fetchFails, peelTo}` — the remote's answers.
  * @returns {Object} `{code, output}`.
  */
-function runPipelineWithProbe(fake, selector, {fetchFails = false, peelTo = ''} = {}) {
+/**
+ * Environment that lets a revision-pinning fixture past the survivability preflight.
+ *
+ * The script now refuses to touch containers without a verified pre-transition bundle. A test
+ * fixture has none — it is a GENUINE first deployment — so the honest way through is the same
+ * explicit declaration a real first install uses, not a skip flag. `NEO_BACKUP_PATH` is redirected
+ * into the fake-bin temp dir so the marker the gate writes never touches real deployment state.
+ *
+ * Passing `declareInitialization: false` runs the pipeline with the gate fully armed, which is how
+ * the refusal itself is asserted below. This spec's subject is revision resolution, so it must not
+ * become a bundle-construction harness — but it also must not silently disarm a safety gate, and an
+ * env var that turned the preflight off would be exactly the bypass the gate refuses to have.
+ *
+ * @param {Object} fake The `createFakeBin` result.
+ * @param {Boolean} declareInitialization
+ * @returns {Object}
+ */
+function preflightEnv(fake, declareInitialization) {
+    return {
+        NEO_BACKUP_PATH      : path.join(fake.bin, '..', 'preflight-backups'),
+        NEO_DEPLOY_INITIALIZE: declareInitialization ? '1' : '0'
+    }
+}
+
+function runPipelineWithProbe(fake, selector, {declareInitialization = true, fetchFails = false, peelTo = ''} = {}) {
     // `spawnSync` rather than `execFileSync`, and NO shell. Both streams are needed on the SUCCESS
     // path too — the peel note is a stderr WARNING, and `execFileSync` discards stderr when the
     // command succeeds, so an assertion about it could never pass even when the script emits it
@@ -122,7 +146,8 @@ function runPipelineWithProbe(fake, selector, {fetchFails = false, peelTo = ''} 
             FAKE_LS_PLAIN   : '',
             FAKE_PEEL_TO    : peelTo,
             NEO_REF         : selector,
-            PATH            : `${fake.bin}:${process.env.PATH}`
+            PATH            : `${fake.bin}:${process.env.PATH}`,
+            ...preflightEnv(fake, declareInitialization)
         },
         stdio: ['ignore', 'pipe', 'pipe']
     });
@@ -141,7 +166,7 @@ function runPipelineWithProbe(fake, selector, {fetchFails = false, peelTo = ''} 
  * @param {String} selector Value for `NEO_REF`.
  * @returns {Object} `{code, output}`.
  */
-function runPipeline(fake, selector) {
+function runPipeline(fake, selector, {declareInitialization = true} = {}) {
     try {
         const output = execFileSync('bash', [scriptPath], {
             cwd     : repoRoot,
@@ -151,7 +176,8 @@ function runPipeline(fake, selector) {
                 FAKE_LS_PEEL : fake.peelLine,
                 FAKE_LS_PLAIN: fake.plainLines,
                 NEO_REF      : selector,
-                PATH         : `${fake.bin}:${process.env.PATH}`
+                PATH         : `${fake.bin}:${process.env.PATH}`,
+                ...preflightEnv(fake, declareInitialization)
             },
             stdio: ['ignore', 'pipe', 'pipe']
         });
@@ -201,6 +227,26 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
               result = runPipeline(fake, FULL_SHA.slice(0, 10));
 
         expect(result.code).not.toBe(0);
+        expect(await dockerInvocations(fake.dockerLog)).toBe(0)
+    });
+
+    test('the survivability preflight refuses BEFORE Docker, even with a perfectly resolvable revision', async () => {
+        // My change to this script broke the six positive-path tests here, and the honest repair is not
+        // just to hand the fixture a declaration — it is to assert at this seam what the gate does.
+        //
+        // Revision resolution succeeding is precisely the dangerous case: everything about the deploy
+        // looks correct, and the only thing standing between it and an unrecoverable plane is this
+        // gate. So the assertion is ordering, proven by the strongest available witness — Docker was
+        // never invoked at all.
+        const fake   = await createFakeBin(''),
+              result = runPipelineWithProbe(fake, FULL_SHA, {declareInitialization: false, peelTo: FULL_SHA});
+
+        expect(result.code).toBe(1);
+        expect(result.output).toMatch(/REFUSING to proceed/);
+        expect(result.output).toMatch(/REFUSE_NO_VERIFIED_BUNDLE/);
+        // The resolvable revision is not what stopped it — the revision resolved fine.
+        expect(result.output).toContain(FULL_SHA);
+        // The load-bearing half: nothing touched containers.
         expect(await dockerInvocations(fake.dockerLog)).toBe(0)
     });
 

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -1,9 +1,9 @@
-import {test, expect} from '@playwright/test';
+import {test, expect}            from '@playwright/test';
 import {execFileSync, spawnSync} from 'node:child_process';
-import fs             from 'node:fs/promises';
-import os             from 'node:os';
-import path           from 'node:path';
-import process        from 'node:process';
+import fs                        from 'node:fs/promises';
+import os                        from 'node:os';
+import path                      from 'node:path';
+import process                   from 'node:process';
 
 /**
  * Guards the revision-pinning contract of `ai/examples/cloud-deployment/deploy-pipeline.sh`.
@@ -228,6 +228,32 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
 
         expect(result.code).not.toBe(0);
         expect(await dockerInvocations(fake.dockerLog)).toBe(0)
+    });
+
+    test('every SCRIPT_DIR-relative path in the script actually RESOLVES', async () => {
+        // Both instances of one bug shipped here: `$SCRIPT_DIR` is `ai/examples/cloud-deployment`, so
+        // `../..` is ALREADY `ai/`, and two lines re-added `ai/` on top of it. Mine broke CI loudly.
+        // The pre-existing `COMPOSE_FILE` default pointed at `ai/ai/deploy/docker-compose.yml` and broke
+        // NOTHING — because the spec fakes `docker`, and a fake docker ignores `-f`. A path that only a
+        // real deployment would exercise is exactly the path a faked harness cannot witness.
+        //
+        // So this asserts resolution directly rather than trusting the next author to count `../`.
+        const source    = await fs.readFile(scriptPath, 'utf8'),
+              scriptRel = path.dirname(scriptPath),
+              refs      = [...source.matchAll(/\$SCRIPT_DIR\/([A-Za-z0-9/._-]+)/g)].map(match => match[1]),
+              unique    = [...new Set(refs)];
+
+        // Positive control: if the regex stops matching, this test silently asserts nothing.
+        expect(unique.length).toBeGreaterThan(1);
+
+        for (const ref of unique) {
+            const resolved = path.resolve(scriptRel, ref);
+
+            await expect(
+                fs.access(resolved),
+                `deploy-pipeline.sh references $SCRIPT_DIR/${ref}, which resolves to a path that does not exist: ${resolved}`
+            ).resolves.toBeUndefined();
+        }
     });
 
     test('the survivability preflight refuses BEFORE Docker, even with a perfectly resolvable revision', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/deploymentDurabilityPosture.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/deploymentDurabilityPosture.spec.mjs
@@ -1,6 +1,9 @@
-import {readFileSync}              from 'node:fs';
-import {test, expect}              from '@playwright/test';
-import {validateOffHostSyncConfig} from '../../../../../../../ai/scripts/maintenance/offHostSync.mjs';
+import {readFileSync} from 'node:fs';
+import {test, expect} from '@playwright/test';
+import {
+    OFFHOST_SYNC_ERROR_CODE,
+    validateOffHostSyncConfig
+} from '../../../../../../../ai/services/memory-core/helpers/offHostSyncStore.mjs';
 import {
     DURABILITY_POSTURES,
     MAX_POSTURE_REASON_LENGTH,
@@ -123,6 +126,62 @@ test.describe('off-host durability posture (#16055)', () => {
         for (const value of emitted) expect(DURABILITY_POSTURES).toContain(value)
     });
 
+    test('HOSTILE CONFIG: a secret-like argv token never reaches the projected posture', () => {
+        // Reviewer falsifier, reproduced before the fix: `argv: ['--password=ghp_…{bad}']` failed the
+        // placeholder grammar, the validator echoed the offending token into its prose, and the
+        // posture interpolated that prose into `reason` — which `inspect_deployment` returns
+        // unfiltered. The module had asserted in JSDoc that credential values "never reach here";
+        // that was reasoning about `envAllowlist` and simply untrue of `argv`. A convention is not an
+        // enforced property, so the enforcement is in the code path and this is its witness.
+        const secret = 'ghp_SUPERSECRET_VALUE',
+              result = posture({
+                  deploymentMode: 'cloud',
+                  offHostSync   : {command: 'rclone', argv: [`--password=${secret}{bad}`]}
+              });
+
+        // The WHOLE projection, not just `reason` — a leak anywhere in the object is a leak.
+        expect(JSON.stringify(result)).not.toContain(secret);
+        expect(JSON.stringify(result)).not.toContain('ghp_');
+
+        // POSITIVE CONTROL: the validator really did see this config and really did reject it, so the
+        // clean projection above is redaction rather than the config having been ignored.
+        const outcome = validateOffHostSyncConfig({command: 'rclone', argv: [`--password=${secret}{bad}`]});
+
+        expect(outcome.enabled).toBe(false);
+        expect(outcome.error).toContain(secret);           // the prose DOES carry it, by design
+        expect(outcome.errorCode).toBe(OFFHOST_SYNC_ERROR_CODE.ARGV_PLACEHOLDER_INVALID);
+
+        // And the defect is still classified, so redaction did not cost diagnosability.
+        expect(result.posture).toBe('unmet');
+        expect(result.configErrorCode).toBe(OFFHOST_SYNC_ERROR_CODE.ARGV_PLACEHOLDER_INVALID);
+        expect(result.offHostSyncConfigValid).toBe(false)
+    });
+
+    test('a valid config carries no configErrorCode, so the field discriminates', () => {
+        expect(posture({deploymentMode: 'cloud', offHostSync: {command: 'rclone'}}).configErrorCode).toBeNull();
+        expect(posture({deploymentMode: 'cloud'}).configErrorCode).toBeNull()
+    });
+
+    test('the resolved-config path does NOT swallow a throw into a plausible posture', () => {
+        // The reactive-config SSOT guarantees the tree, so the only reachable throws are a missing leaf
+        // or a programming defect — failures that must fail loud. A previous revision returned
+        // `posture: 'unreadable'` on any throw, which a consumer could not tell apart from a real
+        // deployment condition. With the catch gone, the enum must not advertise the state either.
+        // Asserted STRUCTURALLY, on the resolver's body, rather than by scanning the file for the
+        // string — the JSDoc explains the removed behaviour and therefore quotes it, so a text guard
+        // would trip on its own explanation and prove nothing about the code.
+        const source = readFileSync(BRIDGE_PATH, 'utf8'),
+              start  = source.indexOf('function resolveConfiguredDurabilityPosture()'),
+              body   = source.slice(start, source.indexOf('\n}', start));
+
+        expect(start).toBeGreaterThan(-1);
+        expect(body).not.toContain('catch');
+        expect(body).not.toContain('try');
+        expect(DURABILITY_POSTURES).not.toContain('unreadable');
+        // The narrower, genuinely-fallible case stays non-throwing: invalid OPERATOR config.
+        expect(posture({deploymentMode: 'cloud', offHostSync: {timeoutMs: 1}}).posture).toBe('unmet')
+    });
+
     test('the reason is bounded, so a pathological config cannot inflate the snapshot', () => {
         const result = posture({
             deploymentMode: 'cloud',
@@ -167,12 +226,4 @@ test.describe('off-host durability posture (#16055)', () => {
         expect(source).not.toContain("if (outcome.status === 'missing') return null;")
     });
 
-    test('`unreadable` is in the declared set because a caller can emit it', () => {
-        // An enum omitting a value its own producers write is a false completeness claim: a consumer
-        // validating against it would reject a legitimate snapshot.
-        const source = readFileSync(BRIDGE_PATH, 'utf8');
-
-        expect(source).toContain("posture: 'unreadable'");
-        expect(DURABILITY_POSTURES).toContain('unreadable')
-    })
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/deploymentDurabilityPosture.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/deploymentDurabilityPosture.spec.mjs
@@ -1,0 +1,178 @@
+import {readFileSync}              from 'node:fs';
+import {test, expect}              from '@playwright/test';
+import {validateOffHostSyncConfig} from '../../../../../../../ai/scripts/maintenance/offHostSync.mjs';
+import {
+    DURABILITY_POSTURES,
+    MAX_POSTURE_REASON_LENGTH,
+    resolveCloudOnlyDefault,
+    resolveDurabilityPosture
+} from '../../../../../../../ai/daemons/orchestrator/services/deploymentDurabilityPosture.mjs';
+
+const
+    CONFIG_BASE_PATH  = new URL('../../../../../../../ai/configBase.mjs', import.meta.url),
+    ORCHESTRATOR_PATH = new URL('../../../../../../../ai/daemons/orchestrator/Orchestrator.mjs', import.meta.url),
+    PARITY_PATH       = new URL('../../../../../../../ai/scripts/lint/config-leaf-parity.json', import.meta.url),
+    BRIDGE_PATH       = new URL('../../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs', import.meta.url);
+
+/**
+ * Resolves a posture from a raw `offHostSync` config subtree, routing it through the contract owner's
+ * validator exactly as the production caller does. Tests must not hand-roll the enablement predicate,
+ * or they would certify a second implementation rather than the shipped one.
+ * @param {Object} options
+ * @returns {Object}
+ */
+function posture({deploymentMode, offHostBackupRequired = null, offHostSync = {}}) {
+    return resolveDurabilityPosture({
+        deploymentMode,
+        offHostBackupRequired,
+        validationOutcome: validateOffHostSyncConfig(offHostSync)
+    })
+}
+
+test.describe('off-host durability posture (#16055)', () => {
+
+    test('POSITIVE CONTROL: the validator this derivation depends on actually discriminates', () => {
+        // Without this, every posture assertion below could pass against a validator that returns a
+        // constant. A configured command must read enabled, an empty one must not, and a malformed
+        // argv token must surface an error — if any of these three collapse, the postures are
+        // measuring nothing and the rest of this file is decoration.
+        expect(validateOffHostSyncConfig({command: 'rclone'}).enabled).toBe(true);
+        expect(validateOffHostSyncConfig({}).enabled).toBe(false);
+        expect(validateOffHostSyncConfig({}).error).toBe(null);
+
+        const malformed = validateOffHostSyncConfig({command: 'rclone', argv: ['x{bundleDir}y']});
+
+        expect(malformed.enabled).toBe(false);
+        expect(malformed.error).toBeTruthy()
+    });
+
+    test('a cloud deployment with no off-host command is UNMET, not benign', () => {
+        // The incident state. Previously this deployment reported `offHostSync.status: 'disabled'`
+        // and nothing else — a value that reads as a settled configuration choice.
+        const result = posture({deploymentMode: 'cloud'});
+
+        expect(result.posture).toBe('unmet');
+        expect(result.cloudDeployment).toBe(true);
+        expect(result.offHostBackupRequired).toBe(true);
+        expect(result.offHostSyncConfigured).toBe(false);
+        expect(result.reason).toContain('failure domain')
+    });
+
+    test('a deliberate opt-out is DISTINGUISHABLE from an unnoticed gap', () => {
+        // The whole point of the requirement leaf. Both states have no sync command and both are
+        // "not going to sync"; only one of them was a decision. A posture that returned the same
+        // value for both would be unable to tell a considered trade-off from an oversight.
+        const optedOut = posture({deploymentMode: 'cloud', offHostBackupRequired: false}),
+              unmet    = posture({deploymentMode: 'cloud', offHostBackupRequired: null});
+
+        expect(optedOut.posture).toBe('opted-out');
+        expect(unmet.posture).toBe('unmet');
+        expect(optedOut.posture).not.toBe(unmet.posture);
+        expect(optedOut.offHostSyncConfigured).toBe(unmet.offHostSyncConfigured)
+    });
+
+    test('the local profile does not require off-host backup, and can opt in', () => {
+        expect(posture({deploymentMode: 'local'}).posture).toBe('not-required');
+        expect(posture({deploymentMode: 'local', offHostBackupRequired: true}).posture).toBe('unmet')
+    });
+
+    test('a configured command reports `configured` and never claims the sync SUCCEEDED', () => {
+        const result = posture({deploymentMode: 'cloud', offHostSync: {command: 'rclone', argv: ['copy', '{bundleDir}']}});
+
+        expect(result.posture).toBe('configured');
+        expect(result.offHostSyncConfigured).toBe(true);
+        // `configured` attests intent only. The outcome lives on the backup receipt, and this field
+        // must not be readable as an attestation the config layer cannot make.
+        expect(DURABILITY_POSTURES).not.toContain('satisfied');
+        expect(result.reason).toContain('receipt')
+    });
+
+    test('a configured-but-INVALID hook does not masquerade as configured', () => {
+        // A malformed command will never run, so reporting it as configured would reproduce exactly
+        // the wrong-subject failure this posture exists to remove.
+        const result = posture({
+            deploymentMode: 'cloud',
+            offHostSync   : {command: 'rclone', argv: ['x{bundleDir}y']}
+        });
+
+        expect(result.posture).toBe('unmet');
+        expect(result.offHostSyncConfigured).toBe(false);
+        expect(result.offHostSyncConfigValid).toBe(false);
+        expect(result.reason).toContain('invalid')
+    });
+
+    test('an invalid hook is still reported when the deployment does not require off-host backup', () => {
+        const result = posture({deploymentMode: 'local', offHostSync: {command: 'rclone', argv: ['x{bundleDir}y']}});
+
+        expect(result.offHostSyncConfigValid).toBe(false);
+        expect(result.posture).toBe('not-required')
+    });
+
+    test('every posture the derivation can emit is inside the declared set', () => {
+        const emitted = new Set();
+
+        for (const deploymentMode of ['cloud', 'local', 'unset']) {
+            for (const offHostBackupRequired of [null, true, false]) {
+                for (const offHostSync of [{}, {command: 'aws'}, {command: 'aws', argv: ['x{bundleName}y']}, {timeoutMs: 1}]) {
+                    emitted.add(posture({deploymentMode, offHostBackupRequired, offHostSync}).posture)
+                }
+            }
+        }
+
+        expect(emitted.size).toBeGreaterThan(1);
+        for (const value of emitted) expect(DURABILITY_POSTURES).toContain(value)
+    });
+
+    test('the reason is bounded, so a pathological config cannot inflate the snapshot', () => {
+        const result = posture({
+            deploymentMode: 'cloud',
+            offHostSync   : {command: 'rclone', argv: [`${'z'.repeat(4096)}{bundleDir}tail`]}
+        });
+
+        expect(result.offHostSyncConfigValid).toBe(false);
+        expect(result.reason.length).toBeLessThanOrEqual(MAX_POSTURE_REASON_LENGTH)
+    });
+
+    test('the tri-state gate keeps ONE home — Orchestrator delegates rather than restating the rule', () => {
+        // Two copies of "null means cloud" can drift, and the drift would be silent: each side would
+        // look correct in isolation while a deployment resolved one gate enabled and the other not.
+        const source = readFileSync(ORCHESTRATOR_PATH, 'utf8');
+
+        expect(source).toContain("import {resolveCloudOnlyDefault} from './services/deploymentDurabilityPosture.mjs'");
+        expect(source).toContain('return resolveCloudOnlyDefault(AiConfig.orchestrator.cloudOnly[key], AiConfig.orchestrator.deploymentMode)');
+
+        expect(resolveCloudOnlyDefault(null,  'cloud')).toBe(true);
+        expect(resolveCloudOnlyDefault(null,  'local')).toBe(false);
+        expect(resolveCloudOnlyDefault(false, 'cloud')).toBe(false);
+        expect(resolveCloudOnlyDefault(true,  'local')).toBe(true)
+    });
+
+    test('the requirement is a real leaf with an env binding AND a parity-manifest entry', () => {
+        // AC1 asks for all three in one commit. The parity gate is what makes the manifest half
+        // load-bearing: a declared path missing from the snapshot fails the build.
+        const configBase = readFileSync(CONFIG_BASE_PATH, 'utf8'),
+              parity     = JSON.parse(readFileSync(PARITY_PATH, 'utf8'));
+
+        expect(configBase).toContain("offHostBackupRequired: leaf(null, 'NEO_ORCHESTRATOR_OFF_HOST_BACKUP_REQUIRED', 'boolean')");
+        expect(parity['ai/config.template.mjs']).toContain('orchestrator.cloudOnly.offHostBackupRequired')
+    });
+
+    test('the bridge projects the posture even when no backup receipt exists', () => {
+        // The structural half of the fix: a posture is a property of CONFIG, so it is knowable before
+        // any backup has run — which is precisely the deployment most at risk. The previous
+        // `return null` omitted the entire maintenance section for that case.
+        const source = readFileSync(BRIDGE_PATH, 'utf8');
+
+        expect(source).toContain("if (outcome.status === 'missing') return {durability};");
+        expect(source).not.toContain("if (outcome.status === 'missing') return null;")
+    });
+
+    test('`unreadable` is in the declared set because a caller can emit it', () => {
+        // An enum omitting a value its own producers write is a false completeness claim: a consumer
+        // validating against it would reject a legitimate snapshot.
+        const source = readFileSync(BRIDGE_PATH, 'utf8');
+
+        expect(source).toContain("posture: 'unreadable'");
+        expect(DURABILITY_POSTURES).toContain('unreadable')
+    })
+});

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -348,4 +348,77 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
 
         expect(await countNonEmptyJsonlLines(file)).toBe(3);
     });
+
+    test('the bundle captures all three incident ledgers, reporting WHICH one was empty', async () => {
+        // The other half of ledger survival. Before this, `orchestrator-state` was excluded from the
+        // bundle — a fact the runbook already admitted as a standing caveat — so a volume replacement
+        // destroyed the self-heal and recovery record with no copy anywhere.
+        const silentLogger  = {error: () => {}, log: () => {}, warn: () => {}},
+              ledgerRoot    = path.join(workRoot, 'ledger-src', 'orchestrator-daemon'),
+              altBundleRoot = path.join(workRoot, 'bundle-with-ledgers'),
+              ledgerSources = {
+                  healAttemptsFile: path.join(ledgerRoot, 'heal-attempts.json'),
+                  healEventsDir   : path.join(ledgerRoot, 'data-heal-events'),
+                  recoveryRunsDir : path.join(ledgerRoot, 'recovery-runs')
+              };
+
+        fs.mkdirSync(ledgerSources.healEventsDir, {recursive: true});
+        fs.mkdirSync(ledgerSources.recoveryRunsDir, {recursive: true});
+        fs.writeFileSync(ledgerSources.healAttemptsFile, JSON.stringify({'kb:chunks': {attempts: 2}}));
+        fs.writeFileSync(path.join(ledgerSources.healEventsDir, 'heal-events.jsonl'), '{"type":"freeze"}\n');
+        // recovery-runs deliberately left EMPTY, so the per-ledger breakdown has something to
+        // discriminate: a single aggregate count could not say which ledger had nothing in it.
+
+        const result = await runBackup({
+            bundleRoot: altBundleRoot,
+            conceptsSourceDir,
+            ledgerSources,
+            logger    : silentLogger,
+            trajectoriesSourceFile
+        });
+
+        const ledgersDir = path.join(altBundleRoot, 'ledgers');
+
+        expect(fs.existsSync(path.join(ledgersDir, 'heal-attempts.json'))).toBe(true);
+        expect(fs.existsSync(path.join(ledgersDir, 'heal-events.jsonl'))).toBe(true);
+        expect(JSON.parse(fs.readFileSync(path.join(ledgersDir, 'heal-attempts.json'), 'utf8'))['kb:chunks'].attempts).toBe(2);
+
+        // `recovery-runs` keeps its own subfolder — flattening per-run files beside the two singletons
+        // would let a run id collide with a ledger filename.
+        expect(fs.existsSync(path.join(ledgersDir, 'recovery-runs'))).toBe(true);
+
+        // The per-ledger breakdown is the point: an aggregate of 2 would not tell an operator that the
+        // recovery-run ledger specifically had nothing to bundle.
+        expect(result.subsystems.ledgers.healAttempts.copied).toBe(1);
+        expect(result.subsystems.ledgers.healEvents.copied).toBe(1);
+        expect(result.subsystems.ledgers.recoveryRuns.copied).toBe(0);
+        expect(result.subsystems.ledgers.copied).toBe(2);
+    });
+
+    test('an absent ledger is a note, not a backup failure', async () => {
+        // A deployment that has never healed has no ledger. That is not a defect and must not fail a
+        // backup — the same non-fatal contract concepts and trajectories already have.
+        const silentLogger  = {error: () => {}, log: () => {}, warn: () => {}},
+              altBundleRoot = path.join(workRoot, 'bundle-no-ledgers'),
+              missingRoot   = path.join(workRoot, 'never-existed', 'orchestrator-daemon');
+
+        const result = await runBackup({
+            bundleRoot   : altBundleRoot,
+            conceptsSourceDir,
+            ledgerSources: {
+                healAttemptsFile: path.join(missingRoot, 'heal-attempts.json'),
+                healEventsDir   : path.join(missingRoot, 'data-heal-events'),
+                recoveryRunsDir : path.join(missingRoot, 'recovery-runs')
+            },
+            logger       : silentLogger,
+            trajectoriesSourceFile
+        });
+
+        expect(result.subsystems.ledgers.copied).toBe(0);
+        expect(result.subsystems.ledgers.healAttempts.note).toMatch(/source not present/);
+        expect(result.subsystems.ledgers.healEvents.note).toMatch(/source not present/);
+        // The subfolder still exists, so a consumer never has to distinguish "no ledgers" from
+        // "this bundle predates ledger capture" by the absence of a directory.
+        expect(fs.existsSync(path.join(altBundleRoot, 'ledgers'))).toBe(true);
+    });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -28,7 +28,11 @@ import {
     validateOffHostSyncConfig,
     writeBackupReceipt
 } from '../../../../../../ai/scripts/maintenance/offHostSync.mjs';
-import {__private__, readBackupReceipt} from '../../../../../../ai/services/memory-core/helpers/offHostSyncStore.mjs';
+import {
+    __private__,
+    OFFHOST_SYNC_ERROR_CODE,
+    readBackupReceipt
+} from '../../../../../../ai/services/memory-core/helpers/offHostSyncStore.mjs';
 
 const VALID_CONFIG = {
     argv        : ['-e', 'process.exit(0)'],
@@ -42,8 +46,42 @@ const makeTmp = () => mkdtempSync(path.join(tmpdir(), 'neo-offhost-'));
 
 test.describe('offHostSync config validation (ticket-owned contract)', () => {
     test('empty command is disabled, not an error', () => {
-        expect(validateOffHostSyncConfig({command: ''})).toEqual({enabled: false, error: null, value: null});
-        expect(validateOffHostSyncConfig(undefined)).toEqual({enabled: false, error: null, value: null});
+        // `errorCode` is declared here because this exact-shape assertion IS the contract: a field
+        // added to the outcome has to be named or the addition goes unwitnessed. Disabled-but-valid
+        // carries a null code, so the field discriminates a defect rather than merely existing.
+        expect(validateOffHostSyncConfig({command: ''})).toEqual({enabled: false, error: null, errorCode: null, value: null});
+        expect(validateOffHostSyncConfig(undefined)).toEqual({enabled: false, error: null, errorCode: null, value: null});
+    });
+
+    test('every validation failure carries a stable code that never quotes the offending value', () => {
+        // The code is what a remotely readable surface may carry; the prose is not, because the
+        // placeholder and NUL branches interpolate the token and an operator can put a credential in
+        // `argv`. Asserted as a set so the codes are DISTINCT rather than one constant reused.
+        const secret = 'ghp_LEAK_CANARY',
+              cases  = [
+                  [null,                                            'CONFIG_NOT_OBJECT'],
+                  [{command: 42},                                   'COMMAND_NOT_STRING'],
+                  [{command: 'aws', argv: 7},                       'ARGV_NOT_STRING_ARRAY'],
+                  [{command: `aws\0${secret}`},                     'NUL_BYTE'],
+                  [{command: 'aws', argv: [`--pw=${secret}{bad}`]}, 'ARGV_PLACEHOLDER_INVALID'],
+                  [{command: 'aws', envAllowlist: ['lower']},       'ENV_ALLOWLIST_INVALID'],
+                  [{command: 'aws', timeoutMs: 1},                  'TIMEOUT_OUT_OF_RANGE'],
+                  [{command: 'aws', killGraceMs: -1},               'KILL_GRACE_OUT_OF_RANGE']
+              ];
+
+        const observed = cases.map(([config, expected]) => {
+            const outcome = validateOffHostSyncConfig(config);
+
+            expect(outcome.enabled).toBe(false);
+            expect(outcome.errorCode).toBe(OFFHOST_SYNC_ERROR_CODE[expected]);
+            // The CODE is safe to project even when the prose is not.
+            expect(outcome.errorCode).not.toContain(secret);
+            expect(outcome.errorCode).toMatch(/^KB_OFFHOST_SYNC_[A-Z_]+$/u);
+
+            return outcome.errorCode
+        });
+
+        expect(new Set(observed).size).toBe(cases.length);
     });
 
     test('a disabled hook with malformed keys is a validation failure, not a silent pass', () => {

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -561,7 +561,7 @@ test.describe('wrapper + projection behavioral witnesses', () => {
         }
     });
 
-    test('projection: missing → null; unreadable → stable shape; valid → the validated envelope; custom root round trip', async () => {
+    test('projection: missing omits lastBackup but KEEPS the durability posture; unreadable → stable shape; valid → the validated envelope; custom root round trip', async () => {
         const root = makeTmp();
         try {
             const bridge  = (await import('../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs')).default;
@@ -569,7 +569,16 @@ test.describe('wrapper + projection behavioral witnesses', () => {
 
             const receiptPath = path.join(root, 'last-backup-receipt.json');
 
-            expect(await collect({receiptPath})).toBe(null);
+            // A missing receipt still omits `lastBackup` — that absent-before-first-run semantic is
+            // unchanged — but the section is no longer dropped wholesale, because the durability
+            // posture is a property of CONFIG and is therefore knowable before any backup has run.
+            // Returning `null` here made "no backup has ever run on this deployment"
+            // indistinguishable from "nothing about maintenance is reportable".
+            const beforeFirstRun = await collect({receiptPath});
+
+            expect(beforeFirstRun).not.toBe(null);
+            expect(beforeFirstRun.lastBackup).toBeUndefined();
+            expect(beforeFirstRun.durability.posture).toBeTruthy();
 
             await writeBackupReceipt({
                 filePath: receiptPath,

--- a/test/playwright/unit/ai/scripts/maintenance/redeployPreflight.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/redeployPreflight.spec.mjs
@@ -1,0 +1,223 @@
+import {readFileSync} from 'node:fs';
+import {test, expect} from '@playwright/test';
+import fsExtra        from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+
+import {
+    evaluateRedeployPreconditions,
+    INITIALIZATION_MARKER_FILENAME,
+    readInitializationMarker,
+    REDEPLOY_PREFLIGHT_DECISION,
+    runRedeployPreflight
+} from '../../../../../../ai/scripts/maintenance/redeployPreflight.mjs';
+
+const DEPLOY_SCRIPT = new URL('../../../../../../ai/examples/cloud-deployment/deploy-pipeline.sh', import.meta.url);
+
+const silent = {error: () => {}, log: () => {}, warn: () => {}};
+
+/**
+ * Every refusal code the probe can return. Rows 3 and 5 must hold for ALL of them — a gate that
+ * refuses on a missing bundle but proceeds on an EMPTY one would have passed the incident.
+ * @type {String[]}
+ */
+const REFUSAL_CODES = ['BUNDLE_ROOT_MISSING', 'NO_BUNDLES', 'BUNDLE_EMPTY', 'BUNDLE_INVALID'];
+
+test.describe('redeploy preflight — the truth table (#16055 AC2/AC3/AC4)', () => {
+
+    test('row 1: declared initialization proceeds, and is the ONLY path that proceeds without a bundle', () => {
+        for (const verdictCode of REFUSAL_CODES) {
+            const declared = evaluateRedeployPreconditions({
+                initializeRequested: true,
+                markerPresent      : false,
+                verdictCode
+            });
+
+            expect(declared.proceed).toBe(true);
+            expect(declared.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.PROCEED_INITIALIZING);
+            expect(declared.writeMarker).toBe(true);
+
+            // POSITIVE CONTROL on the same input: without the declaration the identical state
+            // refuses. If this passed too, the gate would be permitting absence rather than
+            // permitting a declaration, and a genuine first install would be indistinguishable from
+            // the incident.
+            expect(evaluateRedeployPreconditions({
+                initializeRequested: false,
+                markerPresent      : false,
+                verdictCode
+            }).proceed).toBe(false);
+        }
+    });
+
+    test('row 3: an un-declared absence REFUSES for every refusal code, not just a missing root', () => {
+        // The gate has to be uniform here. "No bundles" and "an empty bundle that parses" are
+        // different codes and the same danger — the incident's own bundle parsed clean and carried
+        // nothing, so a gate keyed only on absence would have waved it through.
+        for (const verdictCode of REFUSAL_CODES) {
+            const outcome = evaluateRedeployPreconditions({
+                initializeRequested: false,
+                markerPresent      : false,
+                verdictCode
+            });
+
+            expect(outcome.proceed).toBe(false);
+            expect(outcome.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_NO_VERIFIED_BUNDLE);
+            expect(outcome.writeMarker).toBe(false);
+            // It must tell the operator how to proceed legitimately, or the gate is a wall.
+            expect(outcome.reason).toMatch(/--initialize/);
+        }
+    });
+
+    test('row 4: an ordinary verified redeploy proceeds without rewriting the marker', () => {
+        const outcome = evaluateRedeployPreconditions({
+            initializeRequested: false,
+            markerPresent      : true,
+            verdictCode        : 'RESTORABLE'
+        });
+
+        expect(outcome.proceed).toBe(true);
+        expect(outcome.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.PROCEED_VERIFIED);
+        expect(outcome.writeMarker).toBe(false);
+    });
+
+    test('row 5: an initialized host with no usable bundle REFUSES — the dangerous case, not the new one', () => {
+        for (const verdictCode of REFUSAL_CODES) {
+            const outcome = evaluateRedeployPreconditions({
+                initializeRequested: false,
+                markerPresent      : true,
+                verdictCode
+            });
+
+            expect(outcome.proceed).toBe(false);
+            expect(outcome.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_NO_VERIFIED_BUNDLE);
+            // An already-initialized host must NOT be told to pass --initialize; that would be
+            // advice to wipe, and row 6 refuses it anyway.
+            expect(outcome.reason).not.toMatch(/--initialize/);
+        }
+    });
+
+    test('row 6: --initialize on an ALREADY-INITIALIZED host is refused — the hatch is not a bypass', () => {
+        // The load-bearing safety property. If `--initialize` short-circuited the gate, then every
+        // refusal in rows 3 and 5 would be one flag away from proceeding, and an operator hitting a
+        // refusal at 2am would reach for exactly that flag.
+        for (const verdictCode of [...REFUSAL_CODES, 'RESTORABLE']) {
+            const outcome = evaluateRedeployPreconditions({
+                initializeRequested: true,
+                markerPresent      : true,
+                verdictCode
+            });
+
+            expect(outcome.proceed).toBe(false);
+            expect(outcome.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED);
+        }
+    });
+
+    test('row 2: a verified bundle with no marker proceeds AND records the marker', () => {
+        // The deliberate recovery path: the bundle proves prior state, so a missing marker is the
+        // anomaly rather than the deployment. Without this a host that lost its marker independently
+        // of its bundles could never deploy again.
+        const outcome = evaluateRedeployPreconditions({
+            initializeRequested: false,
+            markerPresent      : false,
+            verdictCode        : 'RESTORABLE'
+        });
+
+        expect(outcome.proceed).toBe(true);
+        expect(outcome.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.PROCEED_MARKER_RECOVERED);
+        expect(outcome.writeMarker).toBe(true);
+    });
+
+    test('every (marker × flag × code) combination resolves to a declared decision', () => {
+        // Completeness rather than spot-checks: an unhandled combination would fall through to
+        // whatever the last branch happens to be, and the failure would be silent.
+        const decisions = new Set();
+
+        for (const markerPresent of [true, false]) {
+            for (const initializeRequested of [true, false]) {
+                for (const verdictCode of [...REFUSAL_CODES, 'RESTORABLE']) {
+                    const outcome = evaluateRedeployPreconditions({initializeRequested, markerPresent, verdictCode});
+
+                    expect(Object.values(REDEPLOY_PREFLIGHT_DECISION)).toContain(outcome.decision);
+                    expect(typeof outcome.proceed).toBe('boolean');
+                    // A refusal may never authorise a marker write: a refused deploy has to leave the
+                    // host exactly as it found it, or the next run reads a deployment that never was.
+                    if (!outcome.proceed) expect(outcome.writeMarker).toBe(false);
+                    decisions.add(outcome.decision);
+                }
+            }
+        }
+
+        // All five decisions reachable — otherwise the table has dead rows and the coverage above is
+        // measuring less than it appears to.
+        expect(decisions.size).toBe(Object.keys(REDEPLOY_PREFLIGHT_DECISION).length);
+    });
+});
+
+test.describe('redeploy preflight — wiring and marker durability (#16055 AC2)', () => {
+    let workRoot;
+
+    test.beforeEach(() => {
+        workRoot = fsExtra.mkdtempSync(path.join(os.tmpdir(), 'neo-preflight-'));
+    });
+
+    test.afterEach(() => {
+        fsExtra.removeSync(workRoot);
+    });
+
+    test('a refused run writes NO marker, so a later absence stays informative', async () => {
+        const backupRoot = path.join(workRoot, 'backups'),
+              result     = await runRedeployPreflight({
+                  backupRoot,
+                  initializeRequested: false,
+                  logger             : silent,
+                  probeFn            : async () => ({code: 'NO_BUNDLES', reason: 'none', restorable: false})
+              });
+
+        expect(result.proceed).toBe(false);
+        expect(await readInitializationMarker({backupRoot})).toBe(false);
+    });
+
+    test('an initializing run records the marker, and the SAME command then refuses', async () => {
+        const backupRoot = path.join(workRoot, 'backups'),
+              probeFn    = async () => ({code: 'NO_BUNDLES', reason: 'none', restorable: false});
+
+        const first = await runRedeployPreflight({backupRoot, initializeRequested: true, logger: silent, probeFn});
+
+        expect(first.proceed).toBe(true);
+        expect(await readInitializationMarker({backupRoot})).toBe(true);
+
+        // Re-running the identical initialization command must now REFUSE. This is the property that
+        // stops `--initialize` becoming a habit: it works exactly once per host, and a second use is
+        // caught rather than silently repeating a wipe-authorising flag.
+        const second = await runRedeployPreflight({backupRoot, initializeRequested: true, logger: silent, probeFn});
+
+        expect(second.proceed).toBe(false);
+        expect(second.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED);
+    });
+
+    test('the marker is a DOTFILE beside the bundles, so bundle enumeration cannot see it', async () => {
+        // It has to live on the bind-mount `down -v` spares — that is the whole reason it survives
+        // the operation it describes — which means it sits in the directory the probe enumerates.
+        // `verifyLatestBackupRestorable` only accepts `backup-*` entries, and this asserts the
+        // filename keeps that true rather than trusting it.
+        expect(INITIALIZATION_MARKER_FILENAME.startsWith('.')).toBe(true);
+        expect(INITIALIZATION_MARKER_FILENAME.startsWith('backup-')).toBe(false);
+    });
+
+    test('the reference deploy script gates BEFORE it touches containers', () => {
+        // Ordering is the whole guarantee. A preflight that runs after `up -d --build` has already
+        // recreated the containers it was meant to protect.
+        const source      = readFileSync(DEPLOY_SCRIPT, 'utf8'),
+              preflightAt = source.indexOf('redeployPreflight.mjs'),
+              composeUpAt = source.indexOf('compose up -d --build');
+
+        expect(preflightAt).toBeGreaterThan(-1);
+        expect(composeUpAt).toBeGreaterThan(-1);
+        expect(preflightAt).toBeLessThan(composeUpAt);
+
+        // `set -e` is what makes a non-zero preflight abort the job rather than log and continue.
+        expect(source).toMatch(/set -euo pipefail/);
+        // And the escape hatch has to be reachable, or a genuine first install cannot deploy at all.
+        expect(source).toMatch(/NEO_DEPLOY_INITIALIZE/);
+    })
+});

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -625,4 +625,31 @@ test.describe('verifyLatestBackupRestorable — read-only restorability probe (#
         expect(ok.bundleRoot).toContain('backup-2026-06-02T00-00-00');
         expect(ok.reason).toBeNull();
     });
+
+    test('the verdict carries a machine-readable code, and an ABSENT root is not the same as an empty one', async () => {
+        // A caller gating a redeploy on this probe must branch on a value, not pattern-match English
+        // out of `reason` — a prose reword would silently stop matching and the gate would pass.
+        const absent = await verifyLatestBackupRestorable({
+            backupRoot: path.join(probeRoot, 'never-existed'),
+            logger    : silent
+        });
+        const emptyRoot = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        // The distinction is the point. The bundle root is bind-mounted from a path RELATIVE to the
+        // compose project directory, so a deployment run from a different host checkout addresses a
+        // directory that never existed while its bundles sit safely in the prior checkout. Answering
+        // "no bundle" there sends an operator to recreate backups they already have.
+        expect(absent.code).toBe('BUNDLE_ROOT_MISSING');
+        expect(emptyRoot.code).toBe('NO_BUNDLES');
+        expect(absent.code).not.toBe(emptyRoot.code);
+        expect(absent.restorable).toBe(false);
+        expect(emptyRoot.restorable).toBe(false);
+
+        writeBundle('backup-2026-06-03T00-00-00', {torn: true});
+        expect((await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent})).code).toBe('BUNDLE_INVALID');
+
+        fsExtra.removeSync(path.join(probeRoot, 'backup-2026-06-03T00-00-00'));
+        writeBundle('backup-2026-06-04T00-00-00');
+        expect((await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent})).code).toBe('RESTORABLE');
+    });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -759,4 +759,43 @@ test.describe('verifyLatestBackupRestorable — read-only restorability probe (#
         writeBundle('backup-2026-06-04T00-00-00');
         expect((await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent})).code).toBe('RESTORABLE');
     });
+
+    test('RESTORABLE means non-empty, not merely parseable — an empty bundle is refused', async () => {
+        // Reviewer falsifier, reproduced before the fix: a bundle carrying only the six required
+        // directories plus a minimal meta parsed clean and returned `{restorable: true, code:
+        // 'RESTORABLE'}`. That is the ticket's explicitly forbidden precondition, and the exact shape
+        // of the incident — the one bundle in the ledger completed 25 minutes AFTER the new stack came
+        // up, capturing an already-empty plane. A machine-readable code is only worth having when its
+        // predicate is stronger than the prose it replaced.
+        const emptyBundle = path.join(probeRoot, 'backup-2026-07-01T00-00-00');
+
+        for (const sub of ['kb', 'mc', 'graph', 'concepts', 'trajectories', 'mailbox']) {
+            fs.mkdirSync(path.join(emptyBundle, sub), {recursive: true});
+        }
+        fsExtra.writeJsonSync(path.join(emptyBundle, 'bundle-meta.json'), {
+            bundleVersion: 1,
+            integrity    : [],
+            subsystems   : {},
+            topology     : {chromaUnified: true, shared_topology: true}
+        });
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.restorable).toBe(false);
+        expect(verdict.code).toBe('BUNDLE_EMPTY');
+        expect(verdict.rowTotal).toBe(0);
+        // Distinct from every other refusal, so a gate can tell "nothing to restore from" apart from
+        // "nothing here at all" and "here but torn".
+        expect(verdict.code).not.toBe('NO_BUNDLES');
+        expect(verdict.code).not.toBe('BUNDLE_INVALID');
+
+        // POSITIVE CONTROL: a populated bundle in the same root still passes, so the new predicate
+        // discriminates rather than refusing everything.
+        writeBundle('backup-2026-07-02T00-00-00');
+
+        const populated = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(populated.code).toBe('RESTORABLE');
+        expect(populated.rowTotal).toBeGreaterThan(0);
+    });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -752,6 +752,58 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         expect(allowed.subsystems.ledgers.healAttempts.copied).toBe(true);
     });
 
+    test('a REFUSED authorization on one ledger leaves its siblings unmutated', async () => {
+        // Atomicity. The three ledgers were restored in `Promise.all`, and each did
+        // guard-check-THEN-mutate — so a guard that refuses SLOWLY on one ledger let a sibling whose
+        // guard resolved quickly finish its overwrite before `runRestore` rejected. The run reported
+        // failure having already destroyed data, which is worse than either outcome on its own: an
+        // operator who sees a refusal reasonably concludes nothing happened.
+        //
+        // Authorization for every ledger must complete before any mutation begins.
+        const bundleRoot = buildSyntheticBundle({bundleName: 'ledger-atomic', shared_topology: true}),
+              dataRoot   = path.join(workRoot, 'ledger-atomic-plane', 'orchestrator-daemon'),
+              targets    = {
+                  healAttemptsFile: path.join(dataRoot, 'heal-attempts.json'),
+                  healEventsDir   : path.join(dataRoot, 'data-heal-events'),
+                  recoveryRunsDir : path.join(dataRoot, 'recovery-runs')
+              };
+
+        fs.mkdirSync(path.join(bundleRoot, 'ledgers', 'recovery-runs'), {recursive: true});
+        fs.writeFileSync(path.join(bundleRoot, 'ledgers', 'heal-attempts.json'), JSON.stringify({fromBundle: true}));
+        fs.writeFileSync(path.join(bundleRoot, 'ledgers', 'heal-events.jsonl'), '{"type":"freeze"}\n');
+        fs.mkdirSync(targets.healEventsDir, {recursive: true});
+        fs.writeFileSync(targets.healAttemptsFile, JSON.stringify({mustSurvive: true}));
+
+        // healAttempts authorizes immediately; healEvents refuses only after a tick. Under the old
+        // concurrent shape that delay is the whole exploit.
+        Shared_DestructiveOperationGuard.assertDestructiveTargetAllowed = async (args) => {
+            calls.guard.push(args);
+
+            if (args.subsystem === 'ledgers.healEvents') {
+                await new Promise(resolve => setTimeout(resolve, 25));
+                throw new Error('refused by policy: ledgers.healEvents');
+            }
+
+            return {allowed: true, classification: 'disposable'}
+        };
+
+        await expect(runRestore({
+            expectedDimension     : 1,
+            bundleRoot,
+            conceptsTargetDir     : path.join(workRoot, 'ledger-atomic-empty', 'concepts'),
+            force                 : true,
+            ledgerTargets         : targets,
+            logger                : silentLogger,
+            mode                  : 'replace',
+            onlySubstrate         : ['ledgers'],
+            sentToCullTargetFile  : path.join(workRoot, 'ledger-atomic-empty', 'sent-to-cull.jsonl'),
+            trajectoriesTargetFile: path.join(workRoot, 'ledger-atomic-empty', 'trajectories.jsonl')
+        })).rejects.toThrow(/refused by policy/);
+
+        // The sibling must be untouched. This is the assertion the concurrent shape failed.
+        expect(JSON.parse(fs.readFileSync(targets.healAttemptsFile, 'utf8')).mustSurvive).toBe(true);
+    });
+
     test('a bundle written under a RELOCATED ledger path still restores', async () => {
         // The member name was coupled to the host path at both ends: backup stored under
         // `path.basename(source)` and restore searched `path.basename(target)`. Because

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -677,6 +677,111 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         expect(JSON.parse(fs.readFileSync(targets.healAttemptsFile, 'utf8')).fromBundle).toBe(true);
         expect(calls.guard.some(call => call.operation?.startsWith('restore.ledgers.'))).toBe(true);
     });
+
+    test('replace WITHOUT --force REFUSES a populated ledger target', async () => {
+        // My earlier assertion here proved the wrong proposition. It checked that
+        // `assertDestructiveTargetAllowed` was CALLED on the ledgers — but that guard classifies
+        // target location and confirmation; it does not enforce `--force`. The ledgers were missing
+        // from `assessTargetOccupancy`, so a populated ledger on a disposable path could be
+        // overwritten with `force: false`, contrary to the whole point of that preflight.
+        //
+        // "The guard fired" and "the run refused" are different claims, and only the second is the
+        // contract. This asserts the refusal.
+        const bundleRoot = buildSyntheticBundle({bundleName: 'ledger-force', shared_topology: true}),
+              dataRoot   = path.join(workRoot, 'ledger-force-plane', 'orchestrator-daemon'),
+              targets    = {
+                  healAttemptsFile: path.join(dataRoot, 'heal-attempts.json'),
+                  healEventsDir   : path.join(dataRoot, 'data-heal-events'),
+                  recoveryRunsDir : path.join(dataRoot, 'recovery-runs')
+              };
+
+        fs.mkdirSync(path.join(bundleRoot, 'ledgers'), {recursive: true});
+        fs.writeFileSync(path.join(bundleRoot, 'ledgers', 'heal-attempts.json'), JSON.stringify({fromBundle: true}));
+        fs.mkdirSync(dataRoot, {recursive: true});
+        fs.writeFileSync(targets.healAttemptsFile, JSON.stringify({mustNotBeLost: true}));
+
+        // The other occupancy subsystems are pointed at EMPTY paths. Without this the refusal fires on
+        // the repo's real `concepts`/`trajectories` data and the test passes while proving nothing
+        // about the ledgers — a confounded positive, which is what the first draft of this test was.
+        const isolate = {
+            conceptsTargetDir     : path.join(workRoot, 'ledger-force-empty', 'concepts'),
+            sentToCullTargetFile  : path.join(workRoot, 'ledger-force-empty', 'sent-to-cull.jsonl'),
+            trajectoriesTargetFile: path.join(workRoot, 'ledger-force-empty', 'trajectories.jsonl')
+        };
+
+        let refusal;
+
+        try {
+            await runRestore({
+                expectedDimension: 1,
+                bundleRoot,
+                force            : false,
+                ledgerTargets    : targets,
+                logger           : silentLogger,
+                mode             : 'replace',
+                onlySubstrate    : ['ledgers'],
+                ...isolate
+            })
+        } catch (error) {
+            refusal = error
+        }
+
+        expect(refusal?.message).toMatch(/Refusing replace mode without --force/);
+        // It must refuse BECAUSE of the ledger, naming it — otherwise another subsystem's occupancy
+        // could be carrying the assertion.
+        expect(refusal.message).toMatch(/ledgers\.healAttempts/);
+
+        // The refusal has to be real: the host file is untouched.
+        expect(JSON.parse(fs.readFileSync(targets.healAttemptsFile, 'utf8')).mustNotBeLost).toBe(true);
+
+        // POSITIVE CONTROL: with the ledger target EMPTY and nothing else occupied, the same call
+        // proceeds — so the refusal keys on ledger occupancy, not on the ledgers merely being listed.
+        fs.rmSync(targets.healAttemptsFile);
+
+        const allowed = await runRestore({
+            expectedDimension: 1,
+            bundleRoot,
+            force            : false,
+            ledgerTargets    : targets,
+            logger           : silentLogger,
+            mode             : 'replace',
+            onlySubstrate    : ['ledgers'],
+            ...isolate
+        });
+
+        expect(allowed.subsystems.ledgers.healAttempts.copied).toBe(true);
+    });
+
+    test('a bundle written under a RELOCATED ledger path still restores', async () => {
+        // The member name was coupled to the host path at both ends: backup stored under
+        // `path.basename(source)` and restore searched `path.basename(target)`. Because
+        // `healAttemptsPath` is env-relocatable, a bundle written by a host using
+        // `custom-attempts.json` read as `source absent` on a default host — a restore reporting
+        // success having restored no incident record, which is the same "evidence nobody can
+        // retrieve" failure one layer down.
+        const bundleRoot = buildSyntheticBundle({bundleName: 'ledger-relocated', shared_topology: true}),
+              dataRoot   = path.join(workRoot, 'ledger-relocated-plane', 'orchestrator-daemon'),
+              targets    = {
+                  // DIFFERENT basename from the bundle member on purpose.
+                  healAttemptsFile: path.join(dataRoot, 'custom-attempts.json'),
+                  healEventsDir   : path.join(dataRoot, 'data-heal-events'),
+                  recoveryRunsDir : path.join(dataRoot, 'recovery-runs')
+              };
+
+        fs.mkdirSync(path.join(bundleRoot, 'ledgers'), {recursive: true});
+        fs.writeFileSync(path.join(bundleRoot, 'ledgers', 'heal-attempts.json'), JSON.stringify({survived: true}));
+
+        const result = await runRestore({
+            expectedDimension: 1,
+            bundleRoot,
+            ledgerTargets    : targets,
+            logger           : silentLogger,
+            onlySubstrate    : ['ledgers']
+        });
+
+        expect(result.subsystems.ledgers.healAttempts.copied).toBe(true);
+        expect(JSON.parse(fs.readFileSync(targets.healAttemptsFile, 'utf8')).survived).toBe(true);
+    });
 });
 
 test.describe('verifyLatestBackupRestorable — read-only restorability probe (#14030 AC2)', () => {
@@ -797,5 +902,41 @@ test.describe('verifyLatestBackupRestorable — read-only restorability probe (#
 
         expect(populated.code).toBe('RESTORABLE');
         expect(populated.rowTotal).toBeGreaterThan(0);
+    });
+
+    test('the probe validates the LEDGER members it attests, including the non-JSONL and nested ones', async () => {
+        // The probe vouched for a member it never looked at. `ledgers` was absent from its layout, and
+        // even with it present the streaming scan reaches only top-level `*.jsonl` — so
+        // `heal-attempts.json` (not `.jsonl`) and `recovery-runs/*.jsonl` (nested) both passed
+        // malformed while the verdict read `RESTORABLE`. A probe may only attest what it parsed.
+        const bundle = path.join(probeRoot, 'backup-2026-08-01T00-00-00');
+
+        writeBundle('backup-2026-08-01T00-00-00');
+        fs.mkdirSync(path.join(bundle, 'ledgers', 'recovery-runs'), {recursive: true});
+
+        // (1) malformed JSON object
+        fs.writeFileSync(path.join(bundle, 'ledgers', 'heal-attempts.json'), '{NOT VALID JSON');
+
+        const brokenAttempts = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(brokenAttempts.restorable).toBe(false);
+        expect(brokenAttempts.code).toBe('BUNDLE_INVALID');
+        expect(brokenAttempts.reason).toMatch(/heal-attempts\.json/);
+
+        // (2) malformed NESTED recovery-run JSONL
+        fsExtra.writeJsonSync(path.join(bundle, 'ledgers', 'heal-attempts.json'), {ok: true});
+        fs.writeFileSync(path.join(bundle, 'ledgers', 'recovery-runs', 'run-bad.jsonl'), '{BROKEN\n');
+
+        const brokenRun = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(brokenRun.restorable).toBe(false);
+        expect(brokenRun.code).toBe('BUNDLE_INVALID');
+        expect(brokenRun.reason).toMatch(/recovery-runs\/run-bad\.jsonl/);
+
+        // POSITIVE CONTROL: well-formed ledgers restore the RESTORABLE verdict, so the new validation
+        // discriminates rather than rejecting any bundle that carries ledgers at all.
+        fs.writeFileSync(path.join(bundle, 'ledgers', 'recovery-runs', 'run-bad.jsonl'), `${JSON.stringify({recoveryRunId: 'ok'})}\n`);
+
+        expect((await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent})).code).toBe('RESTORABLE');
     });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -570,6 +570,113 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         expect(meta.bundleVersion).toBe(1);
         expect(meta.topology.chromaUnified).toBe(true);
     });
+
+    test('the incident ledgers survive a volume replacement — bundled, then readable again after the data dir is gone', async () => {
+        // The load-bearing gap this ticket exists to close. On the cloud profile the orchestrator data
+        // directory IS a named volume, so `docker compose down -v` destroys the self-heal and recovery
+        // record together with the data whose loss they exist to explain — and the bundle did not cover
+        // them. Post-mortem capability co-located with its subject can never describe the one class of
+        // event it most needs to.
+        const bundleRoot = buildSyntheticBundle({bundleName: 'ledger-survival', shared_topology: true}),
+              dataRoot   = path.join(workRoot, 'ledger-survival-plane', 'orchestrator-daemon'),
+              targets    = {
+                  healAttemptsFile: path.join(dataRoot, 'heal-attempts.json'),
+                  healEventsDir   : path.join(dataRoot, 'data-heal-events'),
+                  recoveryRunsDir : path.join(dataRoot, 'recovery-runs')
+              },
+              ledgersDir = path.join(bundleRoot, 'ledgers');
+
+        fs.mkdirSync(path.join(ledgersDir, 'recovery-runs'), {recursive: true});
+        fs.writeFileSync(path.join(ledgersDir, 'heal-attempts.json'), JSON.stringify({'kb:chunks': {attempts: 3}}));
+        fs.writeFileSync(path.join(ledgersDir, 'heal-events.jsonl'), `${JSON.stringify({collection: 'kb:chunks', type: 'freeze'})}\n`);
+        fs.writeFileSync(path.join(ledgersDir, 'recovery-runs', 'run-a.jsonl'), `${JSON.stringify({recoveryRunId: 'run-a', status: 'failed'})}\n`);
+
+        // POSITIVE CONTROL for the whole assertion: the plane is GONE, not merely empty. That is what
+        // `-v` does. Every read below therefore proves the restore produced it, not that a fixture was
+        // sitting there already.
+        expect(fs.existsSync(dataRoot)).toBe(false);
+
+        const result = await runRestore({
+            expectedDimension: 1,
+            bundleRoot,
+            ledgerTargets    : targets,
+            logger           : silentLogger,
+            onlySubstrate    : ['ledgers']
+        });
+
+        // Readable again, with content intact — the evidence is retrievable, not merely archived.
+        expect(JSON.parse(fs.readFileSync(targets.healAttemptsFile, 'utf8'))['kb:chunks'].attempts).toBe(3);
+        expect(fs.readFileSync(path.join(targets.healEventsDir, 'heal-events.jsonl'), 'utf8')).toContain('freeze');
+        expect(fs.readdirSync(targets.recoveryRunsDir)).toEqual(['run-a.jsonl']);
+
+        expect(result.subsystems.ledgers.healAttempts.copied).toBe(true);
+        expect(result.subsystems.ledgers.healEvents.copied).toBe(true);
+        expect(result.subsystems.ledgers.recoveryRuns.copied).toBe(1);
+    });
+
+    test('a legacy bundle with no ledgers/ still restores — the durability gain is not a recovery regression', async () => {
+        // `ledgers` is OPTIONAL by deliberate decision. Every bundle written before this change lacks
+        // the subfolder, and making it required would render exactly the archives an operator reaches
+        // for first unrestorable.
+        const bundleRoot = buildSyntheticBundle({bundleName: 'legacy-no-ledgers', shared_topology: true});
+
+        expect(fs.existsSync(path.join(bundleRoot, 'ledgers'))).toBe(false);
+
+        const result = await runRestore({
+            expectedDimension: 1,
+            bundleRoot,
+            logger           : silentLogger,
+            onlySubstrate    : ['ledgers']
+        });
+
+        // No throw, and no fabricated ledger section for a bundle that never carried one.
+        expect(result.subsystems.ledgers).toBeUndefined();
+    });
+
+    test('merge mode preserves an existing ledger; replace mode fires the destructive guard', async () => {
+        // The ledgers must not become a hole in the destructive-guard coverage just because they were
+        // added later than the substrates the guard was written for.
+        const bundleRoot = buildSyntheticBundle({bundleName: 'ledger-modes', shared_topology: true}),
+              dataRoot   = path.join(workRoot, 'ledger-modes-plane', 'orchestrator-daemon'),
+              targets    = {
+                  healAttemptsFile: path.join(dataRoot, 'heal-attempts.json'),
+                  healEventsDir   : path.join(dataRoot, 'data-heal-events'),
+                  recoveryRunsDir : path.join(dataRoot, 'recovery-runs')
+              },
+              ledgersDir = path.join(bundleRoot, 'ledgers');
+
+        fs.mkdirSync(path.join(ledgersDir, 'recovery-runs'), {recursive: true});
+        fs.writeFileSync(path.join(ledgersDir, 'heal-attempts.json'), JSON.stringify({fromBundle: true}));
+        fs.mkdirSync(dataRoot, {recursive: true});
+        fs.writeFileSync(targets.healAttemptsFile, JSON.stringify({liveOnHost: true}));
+
+        await runRestore({
+            expectedDimension: 1,
+            bundleRoot,
+            ledgerTargets    : targets,
+            logger           : silentLogger,
+            onlySubstrate    : ['ledgers']
+        });
+
+        // merge without --force keeps what is on the host: a restore must not silently overwrite a
+        // ledger that has recorded events since the bundle was taken.
+        expect(JSON.parse(fs.readFileSync(targets.healAttemptsFile, 'utf8')).liveOnHost).toBe(true);
+
+        calls.guard.length = 0;
+
+        await runRestore({
+            expectedDimension: 1,
+            bundleRoot,
+            force            : true,
+            ledgerTargets    : targets,
+            logger           : silentLogger,
+            mode             : 'replace',
+            onlySubstrate    : ['ledgers']
+        });
+
+        expect(JSON.parse(fs.readFileSync(targets.healAttemptsFile, 'utf8')).fromBundle).toBe(true);
+        expect(calls.guard.some(call => call.operation?.startsWith('restore.ledgers.'))).toBe(true);
+    });
 });
 
 test.describe('verifyLatestBackupRestorable — read-only restorability probe (#14030 AC2)', () => {


### PR DESCRIPTION
Resolves #16055.

## ⚠️ Read this first — what review is being asked for

**6 of 7 acceptance criteria are delivered: AC1–AC6.** Only AC7 remains, and it is post-merge by construction — a rehearsal on a disposable deployment cannot run against an unmerged artifact.

> **Corrected downward.** This said "4 of 7", counting the restorability-probe work as delivering AC4. It does not. AC4 requires *the refusal* to distinguish an absent bundle root from a moved one — the probe distinguishes them, but no refusal exists yet, so that is groundwork for AC3/AC4 rather than either of them. @neo-gpt's Rhetorical-Drift Audit left this box unchecked and I discharged the code half without going back for the claim half. Counting groundwork as delivery is the drift he named. It was opened early and deliberately, on the operator's routing call: a **first look at the SHAPE** is worth more than a later confirmation that an RC ticked boxes. The three remaining ACs are all one deliverable — the preflight refusal — and they rest directly on question 1 below, so catching a wrong answer there still saves that work.

**An RC listing the missing ACs would spend budget on something I already know.** The gap is stated here, not hidden. The PR stays non-draft and keeps receiving commits until all seven land — ready means reviewable, not complete.

**What is worth your judgment, in priority order.** Each is a decision the remaining work rests on.

### 1. Does the refusal belong in the reference script? (blocks ACs 2–4, none of them written yet)

**We own no destructive path.** `DEPLOYMENT_RUNTIME_LIFECYCLE_OPERATIONS` is frozen to `['restart']`, and `docker compose down` appears in **no script in this repo** — the reference script runs `up -d --build` plus a healthcheck wait. The data loss came from an operator command driven by a *tenant-authored* checklist. No guard we write can intercept that.

So my plan puts the preflight refusal in `ai/examples/cloud-deployment/deploy-pipeline.sh`, on the reasoning that it **is** the CI-neutral substrate teams adapt (`PipelineWiring.md:154`), so every team adapting it inherits the refusal, and it also guards `up -d --build` which recreates containers.

**Is that real leverage or a dead end?** If a team's pipeline diverged from our reference the day they wrote it, the refusal reaches nobody and I would be building three ACs on a comfortable assumption. I could not falsify this from inside the repo — it is a claim about how tenants actually deploy. This is the single highest-value thing to challenge before I write the code.

### 2. Posture instead of enablement (AC1, delivered here)

Off-host sync **cannot** be defaulted on: enablement is a non-empty `offHostSync.command` naming an executable, and no default command is knowable — `aws`, `rclone`, `rsync`, a bespoke script. So the deployment declares the **requirement** (`orchestrator.cloudOnly.offHostBackupRequired`) and the posture reports whether it is met.

Challenge worth making: is "declare the requirement, report the gap" genuinely the defaultable half, or is it an elaborate way of admitting we cannot fix this and logging about it? I believe it is the former — an unmet posture is remotely readable without host access, which is the whole diagnostic problem — but it is the load-bearing premise of AC1 and I would rather it be attacked now.

### 3. Bundle inclusion, not relocation (AC5 + AC6 — now DELIVERED)

The heal/recovery ledgers (`configBase.mjs:1232-1233`) resolve into the `orchestrator-state` **named volume**, which `-v` removes, **and** the bundle excludes it — `PipelineWiring.md:124-126` already admits this. I plan to satisfy survival by **including them in the bundle**, deliberately *not* by relocating them, because #15800 (@neo-opus-grace) owns the bind-mount vs named-volume placement election and relocating would pre-decide her call.

Is that boundary right, or is inclusion a workaround that makes her election harder to land later?

### 4. The premise itself was wrong twice, and is now corrected

I authored #16055 and **two of its three claimed gaps did not survive contact with `dev`**. Worse, my first correction *over*-corrected — I grepped for a phrase the body quoted, got zero hits, and published "FALSIFIED", which reduced an observed data-loss event to a citation error. @tobiu caught the downplaying. The [correction trail](https://github.com/neomjs/neo/issues/16055#issuecomment-5098650269) decomposes every claim.

The corrected premise now leads with the operation rather than a quotation: **`docker compose down -v` removed the named volumes; the corpus and the ledgers went with them.** Worth a sanity check that the third gap — the surviving, load-bearing one — is stated accurately, given my record on this ticket. The friction is filed separately as #16076.

## What is delivered

**AC1 — a cloud deployment can no longer report a missing off-host backup as benign.**
`offHostSync.status: 'disabled'` read as a settled choice; it means the bundle and the data it protects share one failure domain, indistinguishable from a deliberate opt-out.

- `orchestrator.cloudOnly.offHostBackupRequired` — real leaf, env binding, parity-manifest entry, tri-state so an explicit `false` stays distinguishable from the profile default. It could not live inside `maintenance`, which is one object leaf whose `offHostSync` keys are plain nested values.
- `deploymentDurabilityPosture.mjs` — pure derivation, no config import, for the same reason `heavyMaintenanceLeasePrimitives` has none: a second module reading `AiConfig` is a second resolution path able to disagree. `Orchestrator.resolveCloudOnlyEnabled` now delegates to it, so "null means cloud" has one home.
- The posture projects **unconditionally**, including when no receipt exists — it is a property of config, not of the last run, so it is knowable before any backup has happened, which is the deployment most at risk. The previous `return null` dropped the whole maintenance section for exactly that case.
- `configured` is deliberately **not** `satisfied`: a declared command attests intent, never that the last sync succeeded. A configured-but-invalid hook resolves to `unmet`.

**Groundwork for AC3 + AC4 (neither delivered) — the restorability probe answers with a code, and `RESTORABLE` now means non-empty.**
`verifyLatestBackupRestorable` already existed, already ran the restore path's own validation, and had **zero production callers** — the check written because backups are *"assumed-restorable-but-never-checked"* was itself never invoked. It needed to become consumable, not written: its verdict was prose only, so a caller would have had to regex English. Now `RESTORABLE` / `BUNDLE_ROOT_MISSING` / `NO_BUNDLES` / `BUNDLE_INVALID`, with the first two kept apart because the bundle root is bind-mounted **relative to the compose project directory** — a run from a different host checkout finds a directory that never existed while its bundles sit safely in the prior one.

## Still to come

- Post-merge rehearsal on a disposable deployment (AC7) — the only outstanding item

## Added: ACs 2–4, the preflight refusal (`bb570b6973`)

The deliverable question 1 was about, now built against the truth table rather than my assumptions.

`ai/scripts/maintenance/redeployPreflight.mjs` refuses unless a verified, non-empty, restorable pre-transition bundle exists, and is wired **ahead of `up -d --build`** in the reference script — a spec asserts that ordering, because a preflight running after the containers were recreated protects nothing.

**The initialization contract is the part I would have got wrong without your review.** A genuine first deployment and a destroyed-or-relocated plane both present as absence:

- The operator **declares** initialization (`--initialize` / `NEO_DEPLOY_INITIALIZE=1`).
- A **dotfile marker beside the bundles** records that this host has deployed — on the bind-mount `down -v` does not touch, so it survives the operation it exists to describe. `verifyLatestBackupRestorable` only enumerates `backup-*`, and a test pins the filename rather than trusting that.
- **`--initialize` on an already-initialized host is REFUSED.** Without it, every refusal is one flag away from proceeding, and a flag is exactly what an operator reaches for at 2am. It works once per host.
- One deliberate recovery path: a verified bundle with no marker proceeds *and* records the marker, since the bundle proves prior state. Otherwise a host that lost its marker independently of its bundles could never deploy again.
- Everything else fails closed — including `BUNDLE_EMPTY`, because the incident's own bundle parsed clean and carried nothing.

The truth table is a **pure function**, so the decision is testable without a deployment and reviewable without reading IO plumbing. A refusal never authorises the marker write. The CLI refuses on an unexpected throw rather than failing open — an unreadable bundle root must not become indistinguishable from a verified one.

Coverage walks **all (marker × flag × code) combinations**, asserts each resolves to a declared decision, that all five decisions are reachable (no dead rows), and that no refusal authorises a marker write. Rows 3 and 5 are asserted for **every** refusal code, and row 1 carries a positive control that the same state *without* the declaration refuses — otherwise the gate would be permitting absence rather than permitting a declaration.

Verified end-to-end against the real CLI, one invocation per state: row 1 exits **0**, rows 3/5/6 exit **1**. My first attempt at that check ran each command twice and measured the second run's exit code against the first run's printed output; the marker write in between made them different states. Re-measured per state.

## Added since opening — AC5 + AC6 (`29354393a0`)

The load-bearing gap is closed. The ledgers now land in the bundle's `ledgers/` folder and restore with `--only-substrate ledgers`; the survival test asserts the plane directory is **GONE** before restoring, so every read afterwards proves restore produced it rather than a fixture being present. `ledgers` is OPTIONAL by deliberate decision — promoting it to required would make every pre-existing bundle unrestorable, turning a durability gain into a recovery regression.

Two defects surfaced while building it, both the same class of a declaration drifting from its handling:

- `healLedgerDir` had no config leaf and was derived longhand at **six** sites in `Orchestrator.mjs` — I measured three, then found three more without the variable name — and the backup lane needed a seventh. A producer and a backup disagreeing about where the ledger lives would not fail; it would **silently bundle nothing**, which is exactly what the ledger exists to make visible. Now one exported constant.
- My own first pass added a `shouldRestore('ledgers')` branch without registering `ledgers` in `ALL_SUBSTRATES`, so the substrate was unreachable by `--only-substrate` and any operator naming it was rejected outright. The test caught it; that is the only reason it is not shipping.

AC6 states the boundary rather than overclaiming: the ledgers are covered, orchestrator task state and tenant-repo revisions are **not**. "The ledgers survive" is not "the volume survives".

## Test Evidence

Evidence: L2 — focused unit suites green locally at `c6027e962f`; L3 hosted CI is running on this push and is not claimed here.

- **76 green** across `deploymentDurabilityPosture.spec.mjs` (15 new), `restore.spec.mjs`, `offHostSync.spec.mjs`.
- **Mutation-certified parity gate**: removing the manifest entry fails the build with `1 declared path(s) ADDED`, naming the exact path — the gate demonstrably reads the new leaf rather than passing vacuously.
- **Positive control** in the posture suite: the injected validator is asserted to discriminate (configured/empty/malformed), so the posture assertions cannot pass against a constant.
- The probe test asserts the four codes are **distinct**, not four assertions that would each hold against one value.
- `daemon.spec.mjs:24` fails in large batches on clean `dev` as well (2/2 runs, stashed tree) — pre-existing order dependency, not from this branch.

## Post-Merge Validation

- AC7's rehearsal on a disposable deployment: populate, update, confirm the corpus survived and the ledgers explain the transition. Not performed here — an unmerged artifact is not deployed.
- Confirm a cloud deployment with no off-host command reports `posture: 'unmet'` through `get_deployment_state_snapshot` against a live orchestrator.

## Deltas

- `validateOffHostSyncConfig` **moved** from `ai/scripts/maintenance/offHostSync.mjs` to `offHostSyncStore.mjs` and is re-exported. The read-only bridge deliberately never imports that CLI module — a shipped guard asserts it — because doing so pulls `node:child_process` into the diagnostic path, and duplicating the predicate would have created two enablement resolvers. Callers unaffected.
- `collectMaintenanceSnapshot` no longer returns `null` for a missing receipt; it returns `{durability}` and omits `lastBackup`. The absent-before-first-run semantic for `lastBackup` is unchanged. One expectation in `offHostSync.spec.mjs` updated accordingly.
- `verifyLatestBackupRestorable` gains an additive `code` field. No existing field changed.
- Branch rebased onto `dev` after #16073 merged; three already-upstream commits dropped.

Authored by @neo-opus-vega



