### PR TITLE
fix(agentos): separate unit-test review routing (#16068)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -240,13 +240,13 @@ Future-work suggestions, non-blocking observations, and follow-up ideas are revi
 
 10% AC/scope sanity layer unless execution disproves the diff. Verify claims and canonical test placement; green tests cannot override a wrong premise or owner.
 
-Exact-head required CI is routine unit/integration evidence. Do not search for or rerun "related tests" to duplicate green CI. Run and record a targeted falsifier only for a concrete behavior CI does not establish.
+Exact-head required CI is routine unit/integration evidence. Do not search for or rerun "related tests" to duplicate green CI. `NEO_TEST_SKIP_CI` coverage is the mechanical exception: require an exact-head author receipt, validate or challenge it, and run locally only as a named falsifier when your environment has the capability.
 
 **Citation vs inference:** verify the citation; RUN the inference — anything downstream of "therefore / so / which means / hence" in your draft is an inference; grep the connective before submitting (correction-culture).
 
 Deployment proof gates only if it can deploy the exact unmerged head. Consumers limited to merged `dev` / `main` / release artifacts make it Post-Merge Validation; failure becomes a new ticket.
 
-Authors own existing non-CI coverage for touched surfaces. Reviewers validate receipts and challenge obvious omissions, not reconstruct dependency reach. For added/moved tests, verify the canonical directory per `.agents/skills/unit-test/references/unit-test.md`. Docs/template-only changes need no runtime evidence.
+Authors own existing non-CI coverage for touched surfaces. Reviewers validate receipts and challenge obvious omissions, not reconstruct dependency reach. For added/moved tests, inspect only placement and idioms via the unit-test reference's **Review-Only Boundary**; do not enter its author/executor initialization. Docs/template-only changes need no runtime evidence.
 
 ### 7.5.1 Core-Idiom Audit
 

--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -403,7 +403,7 @@
     },
     "unit-test": {
       "name": "unit-test",
-      "description": "Expert QA knowledge on writing, formatting, and executing Playwright tests natively in the Neo.mjs single-thread layout. CRITICAL: Neo.mjs uses Playwright in a highly custom way. Standard Playwright patterns will fail. Triggers: Use this skill before writing, modifying, or executing Playwright unit tests, or if the user asks you to write, fix, or run unit tests.",
+      "description": "Neo.mjs Playwright unit-test author/executor workflow. Standard Playwright patterns will fail. Triggers: Use before writing, modifying, fixing, or explicitly running unit tests. Do not trigger solely because PR review inspects a diff containing, adding, or moving tests, or checks placement; pr-review owns review evidence.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
       "claudeSymlinkRequired": true,

--- a/.agents/skills/unit-test/SKILL.md
+++ b/.agents/skills/unit-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unit-test
-description: "Expert QA knowledge on writing, formatting, and executing Playwright tests natively in the Neo.mjs single-thread layout. CRITICAL: Neo.mjs uses Playwright in a highly custom way. Standard Playwright patterns will fail. Triggers: Use this skill before writing, modifying, or executing Playwright unit tests, or if the user asks you to write, fix, or run unit tests."
+description: "Neo.mjs Playwright unit-test author/executor workflow. Standard Playwright patterns will fail. Triggers: Use before writing, modifying, fixing, or explicitly running unit tests. Do not trigger solely because PR review inspects a diff containing, adding, or moving tests, or checks placement; pr-review owns review evidence."
 ---
 # Unit Test Workflow
-If you are tasked with unit testing, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/unit-test/references/unit-test.md` before writing any code.
+Before writing, modifying, fixing, or explicitly running unit tests, read and follow `.agents/skills/unit-test/references/unit-test.md`. Review-only placement/idiom audits stay under `pr-review` and do not activate this workflow.

--- a/.agents/skills/unit-test/references/unit-test.md
+++ b/.agents/skills/unit-test/references/unit-test.md
@@ -1,37 +1,26 @@
 # Unit Test Specialist Workflow
 
-## 1. Role and Primary Directive
-Your role is that of an **expert Neo.mjs developer and architect** specializing in **Quality Assurance**.
+## 1. Review-Only Boundary
 
-**CRITICAL:** Your training data is outdated regarding Neo.mjs. You **MUST** treat the content within this repository as the single source of truth.
+During a PR review, `pr-review` owns execution-evidence allocation. Merely inspecting a diff that contains, adds, or moves unit tests—or checking their placement/idioms—does **not** activate this author/executor workflow.
 
-## 2. Initialization (Mandatory)
-At the start of the session, you **MUST** perform these steps:
+- Green required CI at the exact head owns routine unit/integration execution; do not rerun it for duplicate evidence.
+- `NEO_TEST_SKIP_CI` coverage is excluded from that claim. The author supplies an exact-head non-CI receipt; the reviewer validates or challenges it and runs locally only for a named falsifier when their environment has the capability.
+- Initialization, grounding, implementation, and execution below apply only when writing, modifying, fixing, or explicitly running unit tests.
 
-### Step 1: Memory Core Check
-1.  Run `neo.mjs-memory-core__healthcheck`.
-2.  If healthy, run `get_all_summaries({ limit: 5 })` to establish project context.
-3.  **Save your initialization turn** using `add_memory` before responding to the user.
+**Review-only fixture:** A PR adds `test/playwright/unit/ai/example.spec.mjs`, exact-head unit CI is green, and no guarded behavior is claimed. Inspect its canonical path and Neo test idioms; do not initialize Memory Core, load authoring examples, or rerun the spec.
 
-### Step 2: Grounding (Read these files)
-1.  **Read `src/Neo.mjs`**. Focus on understanding:
-    - `Neo.setupClass()`: The final processing step for all classes. Pay special attention to its **"first one wins" gatekeeper logic**, which is key to mixed-environment support.
-    - `Neo.create()`: The factory method for creating instances.
-    - The distinction between class namespaces (e.g., `Neo.component.Base`) and `ntype` shortcuts.
-2.  **Read `src/core/Base.mjs`**. Focus on:
-    - **The Static Config System:** Distinguish between **reactive configs** (ending in `_`, generating hooks) and **non-reactive configs** (prototype-based).
-    - **Instance Lifecycle:** `construct()`, `onConstructed()`, `initAsync()`, and `destroy()`.
-    - **Reactivity Hooks:** `beforeGet*`, `beforeSet*`, `afterSet*`.
-3.  **Read `test/playwright/setup.mjs`**. Focus on:
-    - How it mocks the global environment (App/VDom layers wired directly).
-    - The `unitTestMode` flag.
-4.  **Read `learn/guides/testing/UnitTesting.md`**: Your **Single Source of Truth** for testing patterns.
+## 2. Author/Executor Initialization (Mandatory)
 
-### Step 3: Reference Study
-To understand the "Neo.mjs Way", you **MUST** read these examples:
-- **VDOM/Updates:** `test/playwright/unit/vdom/RealWorldUpdates.spec.mjs`
-- **Data/Collections:** `test/playwright/unit/collection/Base.spec.mjs`
-- **Reactivity:** `test/playwright/unit/core/Effect.spec.mjs`
+After this workflow is activated:
+
+1. Run the Memory Core healthcheck and `get_all_summaries({limit: 5})`; save the initialization turn with `add_memory`.
+2. Read the repository sources of truth:
+   - `src/Neo.mjs`: `setupClass()`, `create()`, namespaces, and `ntype`.
+   - `src/core/Base.mjs`: static/reactive configs, lifecycle, and config hooks.
+   - `test/playwright/setup.mjs`: direct App/VDom wiring and `unitTestMode`.
+   - `learn/guides/testing/UnitTesting.md`: canonical testing patterns.
+3. Read the closest examples: `vdom/RealWorldUpdates.spec.mjs`, `collection/Base.spec.mjs`, and `core/Effect.spec.mjs` under `test/playwright/unit/`.
 
 ## 3. Operational Protocols
 

--- a/learn/agentos/ProgressiveDisclosureSkills.md
+++ b/learn/agentos/ProgressiveDisclosureSkills.md
@@ -106,7 +106,7 @@ Beyond lifecycle governance, specialized contexts exist for live action:
 - **`tech-debt-radar`:** A proactive architectural review skill using Frontier Model semantic RAG to sweep historical issues and Memory Core sessions for technical debt. Actively invoked during `ticket-intake` and `pr-review` (especially for fundamental architectural shifts).
 - **`neural-link`:** A tactical manual mapping how to sequence the Neural Link MCP
   tools (e.g., retrieving VDOM trees, finding bounding boxes, simulating DOM clicks) to debug a live browser instance.
-- **`unit-test`:** Patterns for authoring strict Playwright unit tests within the Neo.mjs single-thread architecture.
+- **`unit-test`:** Author/executor patterns for strict Playwright unit tests; PR review-only placement/idiom audits remain under `pr-review`.
 - **`self-repair`:** A strict diagnostic protocol ensuring infrastructure verification across MCP services, Unit Testing, and Historical Forensics using Memory Core states to resolve system lockups.
 - **`debugging-antigravity`:** Antigravity 2.x MCP-authority selection, process-duplication forensics, UI-profile boundary checks, and evidence-first sqlite workspace recovery.
 - **`ideation-sandbox`:** A creative workflow ensuring brainstorming occurs politely in GitHub Discussions rather than polluting the active Issue queue. Also acts as an auto-fire trigger for high-blast-radius proposals.
@@ -145,7 +145,7 @@ ensuring the YAML frontmatter and folder consistency are perfectly formed.
 | `hostile-content-quarantine` | Security | Incident playbook for externally-authored hostile content (astroturfing, spam, injection-bearing artifacts): detect markers, never engage, quarantined read, ingestion clock, moderation matrix + verification triangle |
 | `neo-identity-update` | Tactical | Cross-surface Neo-identity coherence (facts, framing, actions; ADR 0018) |
 | `neural-link` | Tactical | Live application inspection sequences |
-| `unit-test` | Tactical | Custom Playwright test authoring patterns native to the single-thread layout |
+| `unit-test` | Tactical | Custom Playwright author/executor patterns; review-only audits stay under `pr-review` |
 | `self-repair` | Tactical | Systemic infrastructure diagnosis, test execution, and memory core forensics |
 | `debugging-antigravity` | Tactical | Antigravity 2.x MCP authority, duplication forensics, and UI-state recovery |
 | `context-recovery` | Tactical | Post-compaction lane reconstruction from Memory Core recency, semantic recall, session rollups, and A2A |

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -467,7 +467,7 @@ Formalized Anthropic Progressive Disclosure Skills natively used by the swarm. L
 - `identity-firewall`: The L2 Channel Separation and Prompt Firewall defense mechanisms.
 - `hostile-content-quarantine`: Incident playbook for externally-authored hostile content (astroturfing, spam, injection-bearing artifacts) — detect, never engage, quarantined read, ingestion clock, moderation matrix.
 - `neural-link`: Standard operating procedures for traversing the Object-Permanent VDOM structure.
-- `unit-test`: Synthetically driving custom Playwright configs natively within the single-thread architecture.
+- `unit-test`: Authoring or explicitly executing custom Playwright unit tests; review-only placement/idiom audits stay under `pr-review`.
 - `whitebox-e2e`: Neural Link pre-flight workflow for authoring robust end-to-end tests with custom Playwright configs.
 - `self-repair`: Diagnostic workflows utilizing tests and historical Memory Core states to intelligently triage infrastructure degradation.
 - `memory-mining`: Querying Memory Core before diagnosing regressions, proposing architectural claims, or beginning an implementation / PR-review — prevents re-derivation of prior reasoning across sessions and harnesses.


### PR DESCRIPTION
Resolves #16068

Separates PR-review placement/idiom inspection from the `unit-test` author/executor workflow. The router now has an explicit review-only negative trigger, the conditional payload establishes the boundary before mandatory initialization, and `pr-review` remains the sole owner of execution-evidence allocation. Routine exact-head CI stays sufficient; `NEO_TEST_SKIP_CI` coverage stays author-owned with reviewer challenge or a named capability-specific falsifier.

Evidence: L1 (router/payload/manifest/docs contract plus repository lint) → L1 required (skill-routing contract; no runtime-effect ACs). No residuals.

## Deltas from ticket

None substantive. The implementation also updates the two downstream documentation targets declared by the skill manifest; the manifest lint requires those echoes whenever the router changes.

The implementation-bound Contract Ledger is recorded on the source ticket: https://github.com/neomjs/neo/issues/16068#issuecomment-5101516236

## Test Evidence

- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → `[lint-skill-manifest] OK`.
- `npm run agent-preflight -- --no-fix <six changed files>` → all requested gates passed.
- `npm run ai:lint-guides` → 34 guides scanned, 0 hard failures, 27 pre-existing warnings.
- `git diff --check` and `git diff --cached --check` → pass.
- Combined ticket-budgeted surface: 43,886 bytes after versus 44,006 before (net −120 bytes).
- `.github/workflows/test.yml:311` mechanically confirms hosted unit CI sets `NEO_TEST_SKIP_CI=true`; the guarded-spec census confirms that green CI cannot attest those excluded cases.
- The embedded review-only fixture pins the reciprocal route without a new test file: added/moved unit test + green exact-head CI + no guarded claim → inspect placement/idioms, do not initialize or rerun.

No Playwright suite was run for this documentation/skill-routing change. That is deliberate: the acceptance contract is static routing and lint behavior, and duplicating unrelated unit CI would reproduce the friction this ticket removes.

## Load-Effect Audit

- **Map:** `.agents/skills/unit-test/SKILL.md` remains the conditional skill router. It carries only the author/executor trigger and the review-only negative trigger; its byte size decreases from 615 to 614.
- **World Atlas:** `.agents/skills/unit-test/references/unit-test.md` owns mechanics and now places the detailed review boundary before author initialization. It loads only after the router admits the skill.
- **Reciprocal owner:** `.agents/skills/pr-review/references/pr-review-guide.md` owns reviewer evidence allocation and scopes its unit-test cross-link to placement/idioms.
- **Manifest/docs echoes:** `.agents/skills/skills.manifest.json` mirrors the router source; the two declared documentation targets expose the same boundary without creating another rule owner.
- **Net load:** no new skill, payload, audit, static skip registry, classifier, or always-loaded `AGENTS.md` rule. The combined modified skill surface is net −120 bytes.

## Slot Rationale

- **Disposition:** `rewrite` + `compress-to-trigger`.
- **Why placement changed:** the negative trigger must live in the Map because it has to prevent accidental payload activation; the detailed evidence rule and fixture belong in the conditional payload and existing `pr-review` owner.
- **Frequency × severity × enforceability:** review-only test inspection is common; accidental activation burns context and duplicates CI but is reversible; enforcement is discipline-only until the router can carry task-mode metadata.
- **Retirement trigger:** retire the explicit negative-trigger prose when skill routing mechanically distinguishes review-only inspection from author/executor intent and prevents the `unit-test` payload from activating on the former.

Decision Record impact: aligned with ADR 0008; no new primitive or amendment.

## Post-Merge Validation

- [ ] On the next PR that adds or moves a unit test, confirm the reviewer can inspect placement/idioms without entering Memory Core initialization, authoring-example grounding, or local execution.
- [ ] On the next PR claiming `NEO_TEST_SKIP_CI` behavior, confirm the author supplies the exact-head non-CI receipt and the reviewer limits any local run to a named capability-specific challenge.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fa530-53d6-7271-bf05-51497720b29c.
