### PR TITLE
add_memory now discloses that acceptance is not yet queryability

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -553,31 +553,33 @@ paths:
       operationId: add_memory
       x-neo-tool-tier: write
       x-pass-as-object: true
-      x-neo-tool-summary: Persist one turn memory. Durable on return; NOT queryable yet — an immediate read-back may find nothing.
+      x-neo-tool-summary: Persist one turn memory. Durable on return; recency reads see it now, semantic recall waits for the embed drain.
       description: |
         Stores a new agent interaction (prompt, thought, response) as a memory.
 
         **MANDATORY FINAL STEP:** You MUST call this tool at the end of every turn, *before* generating your final response to the user.
         **CRITICAL:** This is the primary endpoint for making agents stateful. Forgetting to call this results in permanent data loss for the session.
 
-        **ACCEPTED IS NOT YET QUERYABLE — read this before concluding a write was lost.** On return the
-        memory is durably logged and cannot be lost. It is not yet retrievable: the write-ahead log
-        drains to the vector store asynchronously, so `query_raw_memories` or `query_recent_turns`
-        called immediately afterwards may not return it. **That is expected and is not data loss.**
+        **ACCEPTANCE AND SEARCHABILITY ARE DIFFERENT — read this before concluding a write was lost.**
+        On return the memory is committed to the write-ahead log, durable to the extent of that log's
+        configured durability contract. Two read families then differ:
 
-        The response says so in `visibility`: `queryable: false`, `pendingDrainDepth` (how many
-        accepted writes are ahead of the drain, including this one), and `oldestPendingAgeMs`. There is
-        deliberately no predicted visible-by time — no drain cadence exists to derive one from, and a
-        made-up ETA would be worse than none.
+        - `query_recent_turns` returns it **immediately** — the WAL overlay serves the row and its
+          content while graph projection catches up.
+        - `query_raw_memories` (semantic/vector recall) returns it **only once the embed drain
+          reconciles it**. Vector search needs the embedding; nothing can stand in for one.
 
-        **Do not retry the write.** A retry stores a second copy and does not make the first visible
-        any sooner. To confirm visibility, poll `healthcheck` and read `memoryWalDrain`:
-        `allWritesQueryable: true` (equivalently `pendingDrainDepth: 0`) is the only state meaning
-        every accepted write has landed in the queryable store.
+        **A semantic read-back finding nothing is expected and is not data loss.**
 
-        This caveat exists because its absence cost a live deployment three sessions: a team wrote,
-        read back, saw nothing, concluded the write had silently no-opped, and recorded that phantom
-        outage into their own corpus as durable history. Every write had landed.
+        The response's `visibility` envelope states each axis separately: `recencyQueryable` (always
+        true), `semanticQueryable` (derived from this write's embed marker), `state`,
+        `pendingDrainDepth`, and `oldestPendingAgeMs`. There is deliberately no predicted visible-by
+        time — no drain cadence exists to derive one from, and a made-up ETA would be worse than none.
+
+        **Do not retry the write.** A retry stores a second copy and does not make the first
+        searchable any sooner. To confirm semantic visibility, poll `healthcheck` and read
+        `memoryWalDrain`: `allWritesSemanticallyQueryable: true` (equivalently
+        `pendingDrainDepth: 0`) is the only state meaning every accepted write is in the vector store.
 
         **Session Isolation:** If `sessionId` is omitted from the payload, it is automatically resolved from the request-bound `Mcp-Session-Id` header (when present).
       tags: [Memories]
@@ -2768,6 +2770,30 @@ components:
           format: date-time
           description: The ISO 8601 timestamp of when the health check was performed.
           example: "2025-10-24T10:00:00.000Z"
+        memoryWalDrain:
+          type: object
+          description: "Memory WAL EMBED-drain backlog — the instrument `add_memory`'s `visibility` envelope tells callers to poll. Scoped to semantic recall: recency reads (`query_recent_turns`) are served from the WAL overlay and never wait on this backlog, so a non-zero depth does NOT mean recent turns are unreadable. Always present."
+          properties:
+            observable:
+              type: boolean
+              description: "Whether the backlog could be measured. False means the WAL read failed; the sibling fields are then null rather than a reassuring zero."
+              example: true
+            pendingDrainDepth:
+              type: integer
+              nullable: true
+              description: "Records appended but not yet embed-marked. Null when not observable."
+              example: 0
+            oldestPendingAgeMs:
+              type: integer
+              nullable: true
+              description: "Age of the oldest pending record. Null when the backlog is empty or not observable."
+              example: 1200
+            allWritesSemanticallyQueryable:
+              type: boolean
+              nullable: true
+              description: "True only when the backlog is empty. Null when not observable — never inferred from an unreadable WAL."
+              example: true
+          required: [observable, pendingDrainDepth, oldestPendingAgeMs, allWritesSemanticallyQueryable]
         plane:
           type: object
           description: "OBSERVED plane identity — the id/dataRoot THIS process resolved, read from the same per-server config the boot assertion verified (the deployment manifest's observed column). Always present."
@@ -3172,46 +3198,68 @@ components:
         message:
           type: string
           description: >-
-            States ACCEPTANCE, not queryability. Deliberately no longer reads "successfully added" —
-            that wording answered "was it accepted?" while callers read it as "is it retrievable?".
-          example: "Memory accepted and durably logged; queryability is deferred until the embed drain reconciles it (see `visibility`)."
+            States ACCEPTANCE plus which read family already sees the write. Deliberately no longer
+            reads "successfully added" — that wording answered "was it accepted?" while callers read it
+            as "is it retrievable?".
+          example: "Memory accepted and durably logged to the write-ahead log; `query_recent_turns` returns it immediately, semantic recall waits for the embed drain (see `visibility`)."
         visibility:
           type: object
           description: >-
-            Whether this write is retrievable yet. The write is DURABLE on return and cannot be lost;
-            it is not yet queryable, because the write-ahead log drains to the vector store
-            asynchronously. Present so a caller branches on a field instead of on prose — an immediate
-            read-back returning nothing is expected here and is NOT data loss. Poll `healthcheck`
-            (`memoryWalDrain`) to confirm visibility; do not retry the write, which duplicates it
-            without making the first copy visible sooner.
+            Which read families can see this write. Committed to the write-ahead log on return, durable
+            to the extent of that log's configured durability contract. The axes differ and are
+            reported separately on purpose: `query_recent_turns` returns the write IMMEDIATELY via the
+            WAL overlay, while semantic recall (`query_raw_memories`) waits for the embed drain. A
+            SEMANTIC read-back returning nothing is expected and is NOT data loss. An earlier revision
+            collapsed this into one `queryable: false`, which was false for recency and steered callers
+            away from a read that would have worked. Poll `healthcheck` (`memoryWalDrain`) to confirm
+            semantic visibility; do not retry the write, which duplicates it without making the first
+            copy searchable sooner.
           properties:
-            queryable:
+            recencyQueryable:
               type: boolean
-              description: Always false on a fresh write — acceptance and queryability are distinct states.
+              description: >-
+                Always true. `query_recent_turns` is served from the WAL overlay, so it returns this
+                write from the moment the append succeeds. Stated positively so a caller never infers
+                unavailability from an absent field.
+              example: true
+            semanticQueryable:
+              type: boolean
+              nullable: true
+              description: >-
+                Whether `query_raw_memories` can return this write. DERIVED from a positive read of
+                this record's embed marker, never from its absence in the pending set — absence is
+                ambiguous (reconciled OR not present) and would fail open. `null` when the marker
+                state could not be read.
               example: false
             state:
               type: string
-              enum: [deferred, deferred-depth-unavailable]
+              enum: [reconciled, embed-deferred, embed-state-unavailable]
               description: >-
-                `deferred` is the normal path. `deferred-depth-unavailable` means the drain depth could
-                not be read — it never reports a reassuring zero it did not measure.
+                `embed-deferred` is the normal path on a fresh write. `reconciled` occurs when the embed
+                daemon wins the race between the append and this observation — the envelope reports that
+                rather than contradicting its own depth fields. `embed-state-unavailable` means the
+                marker state could not be read; it never reports a reassuring value it did not measure.
             pendingDrainDepth:
               type: integer
               nullable: true
               description: >-
-                Accepted writes not yet reconciled into the queryable store, INCLUDING this one — so a
-                fresh write is never 0. `null` when the depth could not be read.
+                Embed-pending accepted writes across the WAL. A SEPARATE proposition from this write's
+                own state — the backlog can be non-empty while this write has reconciled. `null` when
+                the depth could not be read.
               example: 3
             oldestPendingAgeMs:
               type: integer
               nullable: true
-              description: Age of the oldest unreconciled write. `null` when nothing is pending or the read failed.
+              description: Age of the oldest embed-pending write. `null` when nothing is pending or the read failed.
             thisWritePending:
               type: boolean
-              description: Whether this specific write is among the unreconciled records.
+              nullable: true
+              description: >-
+                Strict inverse of `semanticQueryable`, derived from the same marker observation so the
+                two cannot drift apart. `null` when unmeasurable.
             hint:
               type: string
-              description: What to do instead of retrying.
+              description: Which read to use now, and what to do instead of retrying.
         mailbox:
           description: |
             Per-turn A2A mailbox delta signal — unread-inbox awareness piggybacked on every

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -553,12 +553,31 @@ paths:
       operationId: add_memory
       x-neo-tool-tier: write
       x-pass-as-object: true
-      x-neo-tool-summary: Persist one consolidated turn memory for the active agent session.
+      x-neo-tool-summary: Persist one turn memory. Durable on return; NOT queryable yet — an immediate read-back may find nothing.
       description: |
         Stores a new agent interaction (prompt, thought, response) as a memory.
 
         **MANDATORY FINAL STEP:** You MUST call this tool at the end of every turn, *before* generating your final response to the user.
         **CRITICAL:** This is the primary endpoint for making agents stateful. Forgetting to call this results in permanent data loss for the session.
+
+        **ACCEPTED IS NOT YET QUERYABLE — read this before concluding a write was lost.** On return the
+        memory is durably logged and cannot be lost. It is not yet retrievable: the write-ahead log
+        drains to the vector store asynchronously, so `query_raw_memories` or `query_recent_turns`
+        called immediately afterwards may not return it. **That is expected and is not data loss.**
+
+        The response says so in `visibility`: `queryable: false`, `pendingDrainDepth` (how many
+        accepted writes are ahead of the drain, including this one), and `oldestPendingAgeMs`. There is
+        deliberately no predicted visible-by time — no drain cadence exists to derive one from, and a
+        made-up ETA would be worse than none.
+
+        **Do not retry the write.** A retry stores a second copy and does not make the first visible
+        any sooner. To confirm visibility, poll `healthcheck` and read `memoryWalDrain`:
+        `allWritesQueryable: true` (equivalently `pendingDrainDepth: 0`) is the only state meaning
+        every accepted write has landed in the queryable store.
+
+        This caveat exists because its absence cost a live deployment three sessions: a team wrote,
+        read back, saw nothing, concluded the write had silently no-opped, and recorded that phantom
+        outage into their own corpus as durable history. Every write had landed.
 
         **Session Isolation:** If `sessionId` is omitted from the payload, it is automatically resolved from the request-bound `Mcp-Session-Id` header (when present).
       tags: [Memories]
@@ -3152,7 +3171,47 @@ components:
           example: "2025-10-08T12:00:00.000Z"
         message:
           type: string
-          example: "Memory successfully added"
+          description: >-
+            States ACCEPTANCE, not queryability. Deliberately no longer reads "successfully added" —
+            that wording answered "was it accepted?" while callers read it as "is it retrievable?".
+          example: "Memory accepted and durably logged; queryability is deferred until the embed drain reconciles it (see `visibility`)."
+        visibility:
+          type: object
+          description: >-
+            Whether this write is retrievable yet. The write is DURABLE on return and cannot be lost;
+            it is not yet queryable, because the write-ahead log drains to the vector store
+            asynchronously. Present so a caller branches on a field instead of on prose — an immediate
+            read-back returning nothing is expected here and is NOT data loss. Poll `healthcheck`
+            (`memoryWalDrain`) to confirm visibility; do not retry the write, which duplicates it
+            without making the first copy visible sooner.
+          properties:
+            queryable:
+              type: boolean
+              description: Always false on a fresh write — acceptance and queryability are distinct states.
+              example: false
+            state:
+              type: string
+              enum: [deferred, deferred-depth-unavailable]
+              description: >-
+                `deferred` is the normal path. `deferred-depth-unavailable` means the drain depth could
+                not be read — it never reports a reassuring zero it did not measure.
+            pendingDrainDepth:
+              type: integer
+              nullable: true
+              description: >-
+                Accepted writes not yet reconciled into the queryable store, INCLUDING this one — so a
+                fresh write is never 0. `null` when the depth could not be read.
+              example: 3
+            oldestPendingAgeMs:
+              type: integer
+              nullable: true
+              description: Age of the oldest unreconciled write. `null` when nothing is pending or the read failed.
+            thisWritePending:
+              type: boolean
+              description: Whether this specific write is among the unreconciled records.
+            hint:
+              type: string
+              description: What to do instead of retrying.
         mailbox:
           description: |
             Per-turn A2A mailbox delta signal — unread-inbox awareness piggybacked on every

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -177,9 +177,16 @@ const serviceMapping = {
     // populate an observed column. Read from the SAME per-server config the boot assertion
     // verified (`Server.aiConfig` === this singleton) — never a second Provider, so a custom
     // child overlay can never verify one identity and report another.
+    //
+    // `memoryWalDrain` is folded in here rather than becoming a new tool: "is my write visible yet?"
+    // is a liveness question, and the MCP surface is capped — a dedicated drain tool would spend a
+    // slot on something an existing read already answers. Without it the `add_memory` disclosure
+    // would only relocate the uncertainty: a caller told "queryability is deferred" needs somewhere
+    // to CONFIRM visibility rather than a caveat and no instrument.
     healthcheck                 : async args => ({
         ...await HealthService.healthcheck(args),
-        plane: {id: mcConfig.plane.id, dataRoot: mcConfig.plane.dataRoot}
+        memoryWalDrain: await MemoryService.describeDrainState(),
+        plane         : {id: mcConfig.plane.id, dataRoot: mcConfig.plane.dataRoot}
     }),
     mutate_frontier             : MemoryService          .mutateFrontier          .bind(MemoryService),
     pre_brief_session           : MemoryService          .preBriefSession         .bind(MemoryService),

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -19,6 +19,35 @@ import {CONCEPT_EXPANSION_EDGE_TYPES, MEMORY_TERMINAL_EDGE_TYPES, enrichWithConc
 import {buildMemoryResolveCandidate}                                                     from './conceptWalkMemoryGate.mjs';
 
 /**
+ * The `add_memory` success message. Deliberately says ACCEPTED rather than "successfully added":
+ * the previous wording answered "was it accepted?" while callers read it as "is it queryable?",
+ * and an immediate read-back returning nothing then reads as data loss. It must also not swing the
+ * other way — the write IS durable at this point, so nothing here may imply failure or partial
+ * success. `visibility` on the same response carries the actionable half.
+ * @type {String}
+ */
+/**
+ * Coerces a WAL record timestamp to epoch ms.
+ *
+ * The WAL persists `timestamp: Date.now()` — a NUMBER — so `Date.parse` on it returns NaN. My first
+ * pass assumed an ISO string and silently reported `oldestPendingAgeMs: null` for every backlog,
+ * which would have shipped a field that is always null while looking measured. Both forms are
+ * accepted because the store's own segment-key derivation tolerates both.
+ *
+ * @param {String|Number|undefined} value
+ * @returns {Number|null}
+ */
+function walTimestampToEpochMs(value) {
+    if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+
+    const parsed = Date.parse(value ?? '');
+
+    return Number.isFinite(parsed) ? parsed : null
+}
+
+export const MEMORY_ACCEPTED_MESSAGE = 'Memory accepted and durably logged; queryability is deferred until the embed drain reconciles it (see `visibility`).';
+
+/**
  * Re-exported from `./helpers/withTimeout.mjs` (moved there so `SessionService` can share it without
  * a `MemoryService` ⇄ `SessionService` import cycle). Kept exported here for back-compat with
  * existing importers.
@@ -490,7 +519,23 @@ class MemoryService extends Base {
                 logger.warn(`[MemoryService] Turn presence terminalization skipped (non-fatal): ${error.message}`);
             }
 
-            return {id: memoryId, sessionId, timestamp, message: "Memory successfully added", mailbox};
+            // 7. Disclose that ACCEPTANCE is not yet QUERYABILITY.
+            //
+            // The old response was `message: "Memory successfully added"` and nothing else. That
+            // sentence is true — the WAL append above makes the write durable — and it answers
+            // "was it accepted?" while a caller is asking "can I rely on it?". An immediate
+            // read-back is the natural way to check the second, returns nothing while the embed
+            // drain is still pending, and reads as DATA LOSS. On a live deployment that cost a team
+            // three sessions and wrote a phantom outage into their own corpus as durable history.
+            //
+            // The failure direction is what makes it expensive: a caller who assumes immediate
+            // visibility concludes the write vanished, which is the most alarming available wrong
+            // answer and the one most likely to trigger a redeploy — which really does destroy the
+            // corpus. So the disclosure has to be structured, not just prose: an agent branches on
+            // fields, and a caveat it has to read is a caveat it can skip.
+            const visibility = await this.describeWriteVisibility({memoryId, walDir});
+
+            return {id: memoryId, sessionId, timestamp, message: MEMORY_ACCEPTED_MESSAGE, visibility, mailbox};
         } catch (error) {
             // Reaches here only for WAL acceptance or validation-adjacent failures. Graph
             // projection, embed, and every model-dependent step are off this path by construction.
@@ -523,6 +568,101 @@ class MemoryService extends Base {
      * @returns {void}
      * @private
      */
+    /**
+     * @summary Reports the memory WAL drain backlog, so "is my write visible yet?" is answerable.
+     *
+     * The disclosure on `add_memory` tells a caller queryability is deferred; this is what they poll
+     * to find out when it is not. Shipping the disclosure without this would just relocate the
+     * uncertainty — an honest caveat with no instrument behind it leaves the caller exactly as stuck,
+     * and still guessing.
+     *
+     * Measured only, for the same reason as the per-write disclosure: no drain cadence exists to
+     * derive an ETA from, so this reports depth and age and declines to predict.
+     *
+     * @returns {Promise<Object>}
+     */
+    async describeDrainState() {
+        const walDir = aiConfig.memoryWal.dir;
+
+        try {
+            const pending = await readPendingWalRecords({dir: walDir}),
+                  oldest  = pending.reduce(
+                      (min, record) => {
+                          const at = walTimestampToEpochMs(record?.timestamp);
+
+                          return at !== null && (min === null || at < min) ? at : min
+                      },
+                      null
+                  );
+
+            return {
+                observable        : true,
+                pendingDrainDepth : pending.length,
+                oldestPendingAgeMs: oldest === null ? null : Math.max(0, Date.now() - oldest),
+                // Zero pending is the ONLY state that means every accepted write is queryable, and it
+                // is stated positively so a caller does not have to infer it from an absent field.
+                allWritesQueryable: pending.length === 0
+            }
+        } catch (error) {
+            logger.warn(`[MemoryService] Drain-state read degraded (non-fatal): ${error.message}`);
+
+            // Says it could not measure rather than reporting a reassuring zero. A drain read that
+            // fails is not an empty backlog, and reporting 0 here would recreate the original defect
+            // one layer up: a caller trusting a number that means "unknown".
+            return {observable: false, pendingDrainDepth: null, oldestPendingAgeMs: null, allWritesQueryable: null}
+        }
+    }
+
+    /**
+     * @summary Describes whether a just-accepted write is queryable yet, and how far behind it is.
+     *
+     * Returns MEASURED state only. There is deliberately no `expectedVisibleBy`: the embed drain has
+     * no cadence leaf and the daemon exposes no interval, so any ETA would be a plausible number with
+     * nothing behind it — the exact class of value this disclosure exists to eliminate. Reporting
+     * "you are behind N records, the oldest pending for Xms" is smaller and true, and a caller can act
+     * on it. `pendingDrainDepth` counts this write too, so a freshly accepted memory is never 0.
+     *
+     * Fails soft: this is a disclosure attached to an already-successful durable write, so a WAL read
+     * problem must degrade the disclosure rather than turn a successful save into an error. That is
+     * the one place a soft failure is correct here, and it is scoped to a filesystem read.
+     *
+     * @param {Object} options
+     * @param {String} options.memoryId Id of the write just accepted.
+     * @param {String} options.walDir Resolved WAL directory.
+     * @returns {Promise<Object>}
+     */
+    async describeWriteVisibility({memoryId, walDir}) {
+        try {
+            const pending = await readPendingWalRecords({dir: walDir}),
+                  oldest  = pending.reduce(
+                      (min, record) => {
+                          const at = walTimestampToEpochMs(record?.timestamp);
+
+                          return at !== null && (min === null || at < min) ? at : min
+                      },
+                      null
+                  );
+
+            return {
+                queryable         : false,
+                state             : 'deferred',
+                pendingDrainDepth : pending.length,
+                oldestPendingAgeMs: oldest === null ? null : Math.max(0, Date.now() - oldest),
+                thisWritePending  : pending.some(record => record?.id === memoryId),
+                hint              : 'An immediate read-back may not return this write. Poll `healthcheck` for `memoryWalDrain` rather than retrying the write — a retry duplicates it and does not make the first one visible sooner.'
+            }
+        } catch (error) {
+            logger.warn(`[MemoryService] Write-visibility disclosure degraded (non-fatal): ${error.message}`);
+
+            return {
+                queryable        : false,
+                state            : 'deferred-depth-unavailable',
+                pendingDrainDepth: null,
+                hint             : 'An immediate read-back may not return this write. Drain depth could not be read; poll `healthcheck` for `memoryWalDrain`.'
+            }
+        }
+    }
+
     _scheduleMemoryGraphProjection(options, attempt = 1) {
         // Read the reactive AiConfig leaves at the use site (re-read per retry attempt) so a runtime
         // healing-mutation (recovery actuator setData) is reflected — never captured at module load.

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1,19 +1,19 @@
-import Base                                                                                                                            from '../../../src/core/Base.mjs';
-import StorageRouter                                                                                                                   from './managers/StorageRouter.mjs';
-import crypto                                                                                                                          from 'crypto';
-import GraphService                                                                                                                    from './GraphService.mjs';
-import logger                                                                                                                          from '../../mcp/server/memory-core/logger.mjs';
-import SessionService                                                                                                                  from './SessionService.mjs';
-import TurnPresenceService                                                                                                             from './TurnPresenceService.mjs';
-import {withTimeout}                                                                                                                   from './helpers/withTimeout.mjs';
-import {appendWalGraphProjectionMarker, appendWalMemory, getMissingMemoryWalLeaves, pruneReconciledWalSegments, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
-import {composeTurnDocumentText, resolveTurnDocumentForRead}                                                                           from './helpers/turnDocumentText.mjs';
-import {isCollectionQuarantined}                                                                                                       from './helpers/quarantineStore.mjs';
-import {buildChatModel}                                                                                                                from '../../provider/buildChatModel.mjs';
-import aiConfig                                                                                                                        from '../../mcp/server/memory-core/config.mjs';
-import RequestContextService, {SHARED_USER_ID, normalizeUserId}                                                                        from '../../mcp/server/shared/services/RequestContextService.mjs';
-import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER}                                                                                     from '../../graph/identityRoots.mjs';
-import {normalizeAgentIdentityNodeId}                                                                                                  from '../../graph/normalizeAgentIdentityNodeId.mjs';
+import Base                                                                                                                                              from '../../../src/core/Base.mjs';
+import StorageRouter                                                                                                                                     from './managers/StorageRouter.mjs';
+import crypto                                                                                                                                            from 'crypto';
+import GraphService                                                                                                                                      from './GraphService.mjs';
+import logger                                                                                                                                            from '../../mcp/server/memory-core/logger.mjs';
+import SessionService                                                                                                                                    from './SessionService.mjs';
+import TurnPresenceService                                                                                                                               from './TurnPresenceService.mjs';
+import {withTimeout}                                                                                                                                     from './helpers/withTimeout.mjs';
+import {appendWalGraphProjectionMarker, appendWalMemory, getMissingMemoryWalLeaves, pruneReconciledWalSegments, readPendingWalRecords, readWalMarkedIds} from './helpers/memoryWalStore.mjs';
+import {composeTurnDocumentText, resolveTurnDocumentForRead}                                                                                             from './helpers/turnDocumentText.mjs';
+import {isCollectionQuarantined}                                                                                                                         from './helpers/quarantineStore.mjs';
+import {buildChatModel}                                                                                                                                  from '../../provider/buildChatModel.mjs';
+import aiConfig                                                                                                                                          from '../../mcp/server/memory-core/config.mjs';
+import RequestContextService, {SHARED_USER_ID, normalizeUserId}                                                                                          from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER}                                                                                                       from '../../graph/identityRoots.mjs';
+import {normalizeAgentIdentityNodeId}                                                                                                                    from '../../graph/normalizeAgentIdentityNodeId.mjs';
 
 import {CONCEPT_EXPANSION_EDGE_TYPES, MEMORY_TERMINAL_EDGE_TYPES, enrichWithConceptWalk} from '../graph/conceptAnchoredRetrieval.mjs';
 import {buildMemoryResolveCandidate}                                                     from './conceptWalkMemoryGate.mjs';
@@ -45,7 +45,7 @@ function walTimestampToEpochMs(value) {
     return Number.isFinite(parsed) ? parsed : null
 }
 
-export const MEMORY_ACCEPTED_MESSAGE = 'Memory accepted and durably logged; queryability is deferred until the embed drain reconciles it (see `visibility`).';
+export const MEMORY_ACCEPTED_MESSAGE = 'Memory accepted and durably logged to the write-ahead log; `query_recent_turns` returns it immediately, semantic recall waits for the embed drain (see `visibility`).';
 
 /**
  * Re-exported from `./helpers/withTimeout.mjs` (moved there so `SessionService` can share it without
@@ -519,21 +519,25 @@ class MemoryService extends Base {
                 logger.warn(`[MemoryService] Turn presence terminalization skipped (non-fatal): ${error.message}`);
             }
 
-            // 7. Disclose that ACCEPTANCE is not yet QUERYABILITY.
+            // 7. Disclose acceptance PLUS which read families can already see it.
             //
             // The old response was `message: "Memory successfully added"` and nothing else. That
             // sentence is true — the WAL append above makes the write durable — and it answers
-            // "was it accepted?" while a caller is asking "can I rely on it?". An immediate
-            // read-back is the natural way to check the second, returns nothing while the embed
-            // drain is still pending, and reads as DATA LOSS. On a live deployment that cost a team
-            // three sessions and wrote a phantom outage into their own corpus as durable history.
+            // "was it accepted?" while a caller is asking "can I rely on it?". A caller checking the
+            // second question with a SEMANTIC read gets nothing back while the embed drain is
+            // pending, and reads that as DATA LOSS. On a live deployment that cost a team three
+            // sessions and wrote a phantom outage into their own corpus as durable history.
             //
             // The failure direction is what makes it expensive: a caller who assumes immediate
-            // visibility concludes the write vanished, which is the most alarming available wrong
-            // answer and the one most likely to trigger a redeploy — which really does destroy the
-            // corpus. So the disclosure has to be structured, not just prose: an agent branches on
-            // fields, and a caveat it has to read is a caveat it can skip.
-            const visibility = await this.describeWriteVisibility({memoryId, walDir});
+            // semantic visibility concludes the write vanished, which is the most alarming available
+            // wrong answer and the one most likely to trigger a redeploy — which really does destroy
+            // the corpus. So the disclosure has to be structured, not just prose: an agent branches
+            // on fields, and a caveat it has to read is a caveat it can skip.
+            //
+            // It must also not over-correct. Telling a caller "not queryable" full stop would send
+            // them away from `query_recent_turns`, which returns this write immediately — trading one
+            // wrong conclusion for its mirror image. Hence per-axis fields rather than one boolean.
+            const visibility = await this.describeWriteVisibility({memoryId, walDir, segmentKey});
 
             return {id: memoryId, sessionId, timestamp, message: MEMORY_ACCEPTED_MESSAGE, visibility, mailbox};
         } catch (error) {
@@ -569,12 +573,17 @@ class MemoryService extends Base {
      * @private
      */
     /**
-     * @summary Reports the memory WAL drain backlog, so "is my write visible yet?" is answerable.
+     * @summary Reports the memory WAL embed-drain backlog, so "is my write semantically searchable
+     * yet?" is answerable.
      *
-     * The disclosure on `add_memory` tells a caller queryability is deferred; this is what they poll
-     * to find out when it is not. Shipping the disclosure without this would just relocate the
-     * uncertainty — an honest caveat with no instrument behind it leaves the caller exactly as stuck,
-     * and still guessing.
+     * The disclosure on `add_memory` tells a caller SEMANTIC queryability is deferred; this is what
+     * they poll to find out when it is not. Shipping the disclosure without this would just relocate
+     * the uncertainty — an honest caveat with no instrument behind it leaves the caller exactly as
+     * stuck, and still guessing.
+     *
+     * Scoped to the embed axis on purpose. Recency recall (`query_recent_turns`) is served from the
+     * WAL overlay and never waits on this backlog, so a non-zero depth here does NOT mean recent
+     * turns are unreadable.
      *
      * Measured only, for the same reason as the per-write disclosure: no drain cadence exists to
      * derive an ETA from, so this reports depth and age and declines to predict.
@@ -599,9 +608,11 @@ class MemoryService extends Base {
                 observable        : true,
                 pendingDrainDepth : pending.length,
                 oldestPendingAgeMs: oldest === null ? null : Math.max(0, Date.now() - oldest),
-                // Zero pending is the ONLY state that means every accepted write is queryable, and it
-                // is stated positively so a caller does not have to infer it from an absent field.
-                allWritesQueryable: pending.length === 0
+                // Zero pending is the ONLY state that means every accepted write is SEMANTICALLY
+                // queryable, and it is stated positively so a caller does not have to infer it from an
+                // absent field. Named for the axis: recency recall never waits on this backlog, so an
+                // unqualified `allWritesQueryable` would understate what already works.
+                allWritesSemanticallyQueryable: pending.length === 0
             }
         } catch (error) {
             logger.warn(`[MemoryService] Drain-state read degraded (non-fatal): ${error.message}`);
@@ -609,18 +620,56 @@ class MemoryService extends Base {
             // Says it could not measure rather than reporting a reassuring zero. A drain read that
             // fails is not an empty backlog, and reporting 0 here would recreate the original defect
             // one layer up: a caller trusting a number that means "unknown".
-            return {observable: false, pendingDrainDepth: null, oldestPendingAgeMs: null, allWritesQueryable: null}
+            return {
+                observable                    : false,
+                pendingDrainDepth             : null,
+                oldestPendingAgeMs            : null,
+                allWritesSemanticallyQueryable: null
+            }
         }
     }
 
     /**
-     * @summary Describes whether a just-accepted write is queryable yet, and how far behind it is.
+     * @summary Describes which read families can see a just-accepted write, and how far behind the
+     * deferred one is.
      *
-     * Returns MEASURED state only. There is deliberately no `expectedVisibleBy`: the embed drain has
-     * no cadence leaf and the daemon exposes no interval, so any ETA would be a plausible number with
-     * nothing behind it — the exact class of value this disclosure exists to eliminate. Reporting
-     * "you are behind N records, the oldest pending for Xms" is smaller and true, and a caller can act
-     * on it. `pendingDrainDepth` counts this write too, so a freshly accepted memory is never 0.
+     * ## Why the axis is named rather than a bare `queryable`
+     *
+     * "Queryable" is not one property. Two independent reconciliation streams sit behind this write,
+     * and only one of them delays a read:
+     *
+     * - **Recency (`query_recent_turns`) is immediate.** Graph projection is derived work after WAL
+     *   acceptance, and `readPendingRecencyRows` overlays graph-pending WAL rows while it catches up,
+     *   with `readPendingWalRecords` hydrating content Chroma does not have yet. So the row AND its
+     *   content are served from the WAL from the moment the append returns.
+     * - **Semantic recall (`query_raw_memories`) waits.** Vector search needs the embedding; there is
+     *   no overlay that can substitute for one.
+     *
+     * An earlier revision of this method reported a single `queryable: false`. That claim is FALSE for
+     * recency and would push a caller toward the mirror-image of the bug this disclosure exists to
+     * prevent: instead of concluding the write vanished, they would conclude it is unreadable when
+     * `query_recent_turns` would have returned it. The repository's own `AC3: with the embed down, a
+     * just-written turn is immediately recency-visible` fixture was green while that prose shipped —
+     * a passing positive control contradicting the documentation is the documentation's falsifier.
+     *
+     * ## Why the state is derived from a marker read
+     *
+     * `semanticQueryable` comes from `readWalMarkedIds` — a POSITIVE observation that this record's
+     * embed marker exists — not from its absence in the pending set. Absence is ambiguous (reconciled
+     * OR not present at all) and would fail open. It also keeps the envelope self-consistent: the
+     * embed daemon can win the race between the append and this read, and the previous revision then
+     * returned `state: 'deferred'` alongside `pendingDrainDepth: 0`, which cannot both be true.
+     *
+     * `thisWritePending` is the strict inverse of `semanticQueryable`, derived from that same single
+     * observation, so the two can never drift apart into a contradiction.
+     *
+     * `pendingDrainDepth` is deliberately a SEPARATE proposition from this write's own state: the
+     * backlog can be non-empty while this particular write has reconciled. Collapsing them is the
+     * conflation this method exists to avoid.
+     *
+     * There is deliberately no `expectedVisibleBy`: the embed drain has no cadence leaf and the daemon
+     * exposes no interval, so any ETA would be a plausible number with nothing behind it — the exact
+     * class of value this disclosure exists to eliminate.
      *
      * Fails soft: this is a disclosure attached to an already-successful durable write, so a WAL read
      * problem must degrade the disclosure rather than turn a successful save into an error. That is
@@ -629,12 +678,15 @@ class MemoryService extends Base {
      * @param {Object} options
      * @param {String} options.memoryId Id of the write just accepted.
      * @param {String} options.walDir Resolved WAL directory.
+     * @param {String} options.segmentKey Segment the write was appended to; scopes the marker read.
      * @returns {Promise<Object>}
      */
-    async describeWriteVisibility({memoryId, walDir}) {
+    async describeWriteVisibility({memoryId, walDir, segmentKey}) {
         try {
-            const pending = await readPendingWalRecords({dir: walDir}),
-                  oldest  = pending.reduce(
+            const marked     = await readWalMarkedIds({dir: walDir, segmentKey}),
+                  reconciled = marked.has(memoryId),
+                  pending    = await readPendingWalRecords({dir: walDir}),
+                  oldest     = pending.reduce(
                       (min, record) => {
                           const at = walTimestampToEpochMs(record?.timestamp);
 
@@ -644,21 +696,30 @@ class MemoryService extends Base {
                   );
 
             return {
-                queryable         : false,
-                state             : 'deferred',
+                // Immediate, and stated positively so a caller does not infer unavailability from an
+                // absent field. The WAL overlay serves this read the moment the append returns.
+                recencyQueryable  : true,
+                semanticQueryable : reconciled,
+                state             : reconciled ? 'reconciled' : 'embed-deferred',
                 pendingDrainDepth : pending.length,
                 oldestPendingAgeMs: oldest === null ? null : Math.max(0, Date.now() - oldest),
-                thisWritePending  : pending.some(record => record?.id === memoryId),
-                hint              : 'An immediate read-back may not return this write. Poll `healthcheck` for `memoryWalDrain` rather than retrying the write — a retry duplicates it and does not make the first one visible sooner.'
+                thisWritePending  : !reconciled,
+                hint              : reconciled
+                    ? 'Reconciled: both `query_recent_turns` and semantic recall return this write.'
+                    : '`query_recent_turns` returns this write NOW. Semantic recall (`query_raw_memories`) needs the embed drain — poll `healthcheck` for `memoryWalDrain` rather than retrying the write, which duplicates it without making the first one visible sooner.'
             }
         } catch (error) {
             logger.warn(`[MemoryService] Write-visibility disclosure degraded (non-fatal): ${error.message}`);
 
+            // `semanticQueryable: null` — could not measure. Reporting `false` here would assert a
+            // deferral that was never observed, and `true` would fail open.
             return {
-                queryable        : false,
-                state            : 'deferred-depth-unavailable',
+                recencyQueryable : true,
+                semanticQueryable: null,
+                state            : 'embed-state-unavailable',
                 pendingDrainDepth: null,
-                hint             : 'An immediate read-back may not return this write. Drain depth could not be read; poll `healthcheck` for `memoryWalDrain`.'
+                thisWritePending : null,
+                hint             : '`query_recent_turns` returns this write NOW. Embed reconciliation state could not be read; poll `healthcheck` for `memoryWalDrain`.'
             }
         }
     }

--- a/ai/services/memory-core/helpers/memoryWalStore.mjs
+++ b/ai/services/memory-core/helpers/memoryWalStore.mjs
@@ -253,6 +253,36 @@ async function listWalSegmentKeys(dir) {
 }
 
 /**
+ * @summary Reads the reconciliation-marked ids for ONE segment — a positive observation.
+ *
+ * Exists because "not in the pending set" is ambiguous: it is true both for a record that
+ * reconciled AND for a record that is not in the WAL at all. Deriving a caller-visible
+ * "your write is queryable" claim from that absence fails OPEN — an unobserved record would be
+ * reported as reconciled. This answers the question positively instead, so the claim rests on a
+ * marker that was actually read.
+ *
+ * Markers are per-segment (`appendWalEmbedMarker` / `appendWalGraphProjectionMarker` both carry the
+ * record's `segmentKey`), so the lookup is segment-scoped by construction.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Directory for WAL segment files.
+ * @param {String} options.segmentKey Segment whose marker stream is read.
+ * @param {String} [options.markerType='embed'] Marker stream: `'embed'` or `'graph'`.
+ * @returns {Promise<Set<String>>} Marked record ids; empty when the segment has no marker file.
+ */
+export async function readWalMarkedIds({dir, segmentKey, markerType = 'embed'} = {}) {
+    if (!dir || !segmentKey) return new Set();
+
+    const markerFileName = markerType === 'graph' ? getWalGraphMarkersFileName : getWalMarkersFileName;
+
+    return new Set(
+        (await readJsonlEntries(path.join(dir, markerFileName(segmentKey))))
+            .map(entry => entry.id)
+            .filter(Boolean)
+    )
+}
+
+/**
  * @summary Reads pending (appended but not yet embed-marked) WAL records, newest segment first.
  *
  * Serves two consumers: the embed drain (Phase 1 deferred embed / Phase 2 daemon) reading the
@@ -274,7 +304,6 @@ export async function readPendingWalRecords({dir, ids, limit, markerType = 'embe
     const idFilter = Array.isArray(ids) ? new Set(ids) : null;
     const bounded  = Number.isFinite(limit) && limit > 0 ? limit : Infinity;
     const pending  = [];
-    const markerFileName = markerType === 'graph' ? getWalGraphMarkersFileName : getWalMarkersFileName;
 
     for (const segmentKey of await listWalSegmentKeys(dir)) {
         if (pending.length >= bounded) break;
@@ -282,9 +311,9 @@ export async function readPendingWalRecords({dir, ids, limit, markerType = 'embe
         const records = await readJsonlEntries(path.join(dir, getWalRecordsFileName(segmentKey)));
         if (records.length === 0) continue;
 
-        const markedIds = new Set(
-            (await readJsonlEntries(path.join(dir, markerFileName(segmentKey)))).map(entry => entry.id)
-        );
+        // Same marker read the per-write disclosure uses, so "pending" here and "reconciled" there
+        // can never disagree about one record.
+        const markedIds = await readWalMarkedIds({dir, segmentKey, markerType});
 
         for (const record of records) {
             if (pending.length >= bounded) break;

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -442,10 +442,15 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(handbookTool.annotations.readOnlyHint).toBe(true);
         expect(handbookTool.description.length).toBeLessThanOrEqual(120);
         // The caller-critical fact has to live in THIS tier. `tools/list` is all an agent sees when it
-        // decides whether to trust an immediate read-back; the deferred-queryability caveat in the
-        // handbook `description` is invisible at that moment. Asserted by SUBSTANCE rather than by
-        // pinning the sentence, so a rewording cannot fail the test while a caveat DELETION does.
-        expect(addMemory.description).toMatch(/not queryable|NOT queryable/i);
+        // decides whether to trust an immediate read-back; the caveat in the handbook `description` is
+        // invisible at that moment.
+        //
+        // This guard previously matched /not queryable/i. That pinned the WRONG substance: an
+        // unqualified "not queryable" is false for `query_recent_turns`, which the WAL overlay serves
+        // immediately, so the guard was requiring the presence of an over-broad claim. Both failure
+        // directions now have to fail — a DELETED caveat and a RE-BROADENED one.
+        expect(addMemory.description).toMatch(/semantic|embed/i);            // still discloses the deferral
+        expect(addMemory.description).not.toMatch(/not queryable/i);         // and does not over-claim it
         expect(addMemory.description.length).toBeLessThanOrEqual(120);
         expect(resumeSession.description).toBe('Validate whether a session id is safe to resume.');
         expect(resumeSession.description).not.toContain('SESSION_BUSY');

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -441,7 +441,12 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
 
         expect(handbookTool.annotations.readOnlyHint).toBe(true);
         expect(handbookTool.description.length).toBeLessThanOrEqual(120);
-        expect(addMemory.description).toBe('Persist one consolidated turn memory for the active agent session.');
+        // The caller-critical fact has to live in THIS tier. `tools/list` is all an agent sees when it
+        // decides whether to trust an immediate read-back; the deferred-queryability caveat in the
+        // handbook `description` is invisible at that moment. Asserted by SUBSTANCE rather than by
+        // pinning the sentence, so a rewording cannot fail the test while a caveat DELETION does.
+        expect(addMemory.description).toMatch(/not queryable|NOT queryable/i);
+        expect(addMemory.description.length).toBeLessThanOrEqual(120);
         expect(resumeSession.description).toBe('Validate whether a session id is safe to resume.');
         expect(resumeSession.description).not.toContain('SESSION_BUSY');
         expect(addMemory.inputSchema.properties.prompt.type).toBe('string');

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -173,6 +173,54 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         expect(tool.inputSchema.properties.staleAfterMs.type).toBe('number');
     });
 
+    test('healthcheck DECLARES memoryWalDrain, and every key its real producer returns is in the schema (#16060)', async () => {
+        // Output schemas are passthrough, so production can add a response field that `tools/list`
+        // never declares and CI stays green. `memoryWalDrain` shipped exactly that way: the runtime
+        // handler returned it, callers were told by `add_memory` to poll it, and the generated MCP
+        // output schema did not mention it — so a consumer reading the declared contract could not
+        // discover the instrument it was being pointed at.
+        const { tools } = await toolService.listTools();
+        const tool      = tools.find(item => item.name === 'healthcheck');
+
+        expect(tool).toBeTruthy();
+
+        // POSITIVE CONTROL on the assertion mechanism: `plane` was already declared, so if this
+        // lookup path were wrong, the control fails and the real assertion below cannot pass
+        // vacuously.
+        expect(tool.outputSchema.properties.plane).toBeTruthy();
+        expect(tool.outputSchema.properties.plane.properties.dataRoot.type).toBe('string');
+
+        const declared = tool.outputSchema.properties.memoryWalDrain;
+
+        expect(declared).toBeTruthy();
+        expect(declared.properties.observable.type).toBe('boolean');
+        expect(declared.properties.pendingDrainDepth.type).toBe('integer');
+        expect(declared.properties.allWritesSemanticallyQueryable.type).toBe('boolean');
+
+        // The generalizable limb, and the reason this test is worth its bytes: cross-check the DECLARED
+        // shape against what the REAL producer actually returns, rather than against a hand-written
+        // list that drifts. `describeDrainState` is the production function the handler calls, so a
+        // field added there without a schema entry fails here — including fields nobody thought to
+        // name in a review.
+        //
+        // Imported inside the test, not at module scope: this is a ToolService/schema spec, and hoisting
+        // a service import that reaches AiConfig would couple schema assertions to service boot order.
+        // Both the measured and the degraded branch of `describeDrainState` return the SAME key set, so
+        // this cross-check does not depend on a WAL existing here.
+        const {default: MemoryService} = await import('../../../../../../../ai/services/memory-core/MemoryService.mjs'),
+              produced                 = await MemoryService.describeDrainState(),
+              undeclared               = Object.keys(produced).filter(key => !declared.properties[key]);
+
+        expect(undeclared).toEqual([]);
+
+        // And the inverse direction, so the schema cannot advertise a contract the producer does not
+        // honour. Both directions matter: an undeclared field hides an instrument, a declared-but-absent
+        // field promises one that isn't there.
+        const unproduced = Object.keys(declared.properties).filter(key => !(key in produced));
+
+        expect(unproduced).toEqual([]);
+    });
+
     test('healthcheck dispatch passes diagnostic options as one object (#13460)', async () => {
         const observedArgs   = [];
         const spyToolService = Neo.create(ToolService, {

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -43,6 +43,8 @@ import {drainMemoryWal}                              from './util.mjs';
  * the service reads (assertion-targeting only) — pinning a different dir via env is worker-order
  * dependent, because another spec in the worker may construct the singleton first.
  */
+let MEMORY_ACCEPTED_MESSAGE;
+
 test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
     test.describe.configure({mode: 'serial'});
 
@@ -54,7 +56,8 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         testWalDir     = aiConfig.memoryWal.dir;
 
         GraphService         = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
-        MemoryService        = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).default;
+        ({default: MemoryService, MEMORY_ACCEPTED_MESSAGE} =
+            await import('../../../../../../ai/services/memory-core/MemoryService.mjs'));
         LifecycleService     = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
         StorageRouter        = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
@@ -119,6 +122,63 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         expect((await readPendingWalRecords({dir: testWalDir})).length).toBe(before);
     });
 
+    test('the response distinguishes ACCEPTED from QUERYABLE, and reports a measured backlog', async () => {
+        // The disclosure the write path previously omitted. `message: "Memory successfully added"` was
+        // true about acceptance and read as queryability, so an immediate read-back returning nothing
+        // read as data loss — which on a live deployment cost three sessions and wrote a phantom
+        // outage into the corpus as durable history.
+        const result = await asTenant(() => MemoryService.addMemory({
+            prompt: 'visibility prompt', thought: 'visibility thought', response: 'visibility response'
+        }));
+
+        // Durable AND not-yet-queryable, stated as two separate facts rather than one word.
+        expect(result.id).toBeTruthy();
+        expect(result.error).toBeUndefined();
+        expect(result.visibility.queryable).toBe(false);
+        expect(result.visibility.state).toBe('deferred');
+        expect(result.visibility.thisWritePending).toBe(true);
+
+        // The signal must be ACTIONABLE, not a prose caveat: a depth a caller can branch on, and one
+        // that counts this write, so a fresh write is never reported as 0 pending.
+        expect(result.visibility.pendingDrainDepth).toBeGreaterThan(0);
+        expect(typeof result.visibility.oldestPendingAgeMs).toBe('number');
+
+        // It must not swing the other way either — the write IS durable, so nothing in the response
+        // may read as failure or partial success.
+        expect(result.message).not.toMatch(/fail|error|partial|lost|unsaved/i);
+
+        // No fabricated ETA. There is no drain cadence to derive one from, and a plausible number with
+        // nothing behind it is the exact class of value this disclosure exists to remove.
+        expect(result.visibility.expectedVisibleBy).toBeUndefined();
+
+        // The caveat has to steer AWAY from the retry, because retrying was the observed behaviour and
+        // it duplicates the memory without making the first copy visible sooner.
+        expect(result.visibility.hint).toMatch(/retry/i);
+    });
+
+    test('accepted and queryable cannot collapse back into one boolean', async () => {
+        // Refactor guard, per the AC. The failure this protects is subtle: someone folds `visibility`
+        // into `message`, or makes `queryable` mirror the save's success, and the response silently
+        // returns to answering the wrong question while every other test stays green.
+        const result = await asTenant(() => MemoryService.addMemory({
+            prompt: 'collapse prompt', thought: 'collapse thought', response: 'collapse response'
+        }));
+
+        // Two independent fields. A single boolean cannot express "durable but not retrievable".
+        expect(result.visibility).toBeTruthy();
+        expect(result.visibility.queryable).toBe(false);
+        expect(result.id).toBeTruthy();
+
+        // POSITIVE CONTROL on the drain surface: with writes pending it must NOT claim everything is
+        // queryable. Without this, `allWritesQueryable` could be hardcoded true and the poll a caller
+        // is told to trust would confirm visibility that does not exist.
+        const drain = await MemoryService.describeDrainState();
+
+        expect(drain.observable).toBe(true);
+        expect(drain.pendingDrainDepth).toBeGreaterThan(0);
+        expect(drain.allWritesQueryable).toBe(false);
+    });
+
     test('AC2: a DOWN content store cannot fail the save — the write path never touches it', async () => {
         collectionMode = 'throw';
         const touchesBefore = collectionTouches;
@@ -130,7 +190,7 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         expect(result.code).toBeUndefined();
         expect(result.error).toBeUndefined();
         expect(result.id).toBeTruthy();
-        expect(result.message).toBe('Memory successfully added');
+        expect(result.message).toBe(MEMORY_ACCEPTED_MESSAGE);
 
         // Strongest form of never-fail: addMemory performed ZERO collection resolutions —
         // the embed daemon is the only consumer of the content store on the memory write side.
@@ -174,7 +234,7 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
             expect(result.code).toBeUndefined();
             expect(result.error).toBeUndefined();
             expect(result.id).toBeTruthy();
-            expect(result.message).toBe('Memory successfully added');
+            expect(result.message).toBe(MEMORY_ACCEPTED_MESSAGE);
 
             // Let the scheduled projection attempt run and fail under the stub. The failure must
             // stay logged/fail-soft, not turn into a rejected add_memory result or unhandled throw.

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -131,12 +131,18 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
             prompt: 'visibility prompt', thought: 'visibility thought', response: 'visibility response'
         }));
 
-        // Durable AND not-yet-queryable, stated as two separate facts rather than one word.
+        // Durable AND not-yet-SEMANTICALLY-queryable, stated as separate facts rather than one word.
         expect(result.id).toBeTruthy();
         expect(result.error).toBeUndefined();
-        expect(result.visibility.queryable).toBe(false);
-        expect(result.visibility.state).toBe('deferred');
+        expect(result.visibility.semanticQueryable).toBe(false);
+        expect(result.visibility.state).toBe('embed-deferred');
         expect(result.visibility.thisWritePending).toBe(true);
+
+        // The axis that must NOT be understated. `query_recent_turns` is served by the WAL overlay, so
+        // it returns this write now — the sibling `AC3` test below proves that end-to-end with the
+        // embed down. An unqualified "not queryable" would steer a caller away from the one read that
+        // works, trading the phantom-data-loss conclusion for its mirror image.
+        expect(result.visibility.recencyQueryable).toBe(true);
 
         // The signal must be ACTIONABLE, not a prose caveat: a depth a caller can branch on, and one
         // that counts this write, so a fresh write is never reported as 0 pending.
@@ -164,19 +170,91 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
             prompt: 'collapse prompt', thought: 'collapse thought', response: 'collapse response'
         }));
 
-        // Two independent fields. A single boolean cannot express "durable but not retrievable".
+        // Independent per-axis fields. A single boolean cannot express "durable, recency-readable now,
+        // semantically searchable later" — and the axes must disagree here, which is the whole point.
         expect(result.visibility).toBeTruthy();
-        expect(result.visibility.queryable).toBe(false);
+        expect(result.visibility.semanticQueryable).toBe(false);
+        expect(result.visibility.recencyQueryable).toBe(true);
         expect(result.id).toBeTruthy();
 
+        // The collapse guard proper: no field may be a bare `queryable` again. That name is what made
+        // the previous revision assert something false about `query_recent_turns`, so its reappearance
+        // is the regression signal.
+        expect(result.visibility.queryable).toBeUndefined();
+
         // POSITIVE CONTROL on the drain surface: with writes pending it must NOT claim everything is
-        // queryable. Without this, `allWritesQueryable` could be hardcoded true and the poll a caller
-        // is told to trust would confirm visibility that does not exist.
+        // searchable. Without this, `allWritesSemanticallyQueryable` could be hardcoded true and the
+        // poll a caller is told to trust would confirm visibility that does not exist.
         const drain = await MemoryService.describeDrainState();
 
         expect(drain.observable).toBe(true);
         expect(drain.pendingDrainDepth).toBeGreaterThan(0);
-        expect(drain.allWritesQueryable).toBe(false);
+        expect(drain.allWritesSemanticallyQueryable).toBe(false);
+    });
+
+    test('RA2: when the embed marker lands BEFORE the disclosure is read, the envelope says reconciled', async () => {
+        // The race the previous revision could not express. `queryable` and `state` were hard-coded, so
+        // a write whose embed marker had already landed still reported `state: 'deferred'` alongside
+        // `pendingDrainDepth: 0` and `thisWritePending: false` — three fields describing two
+        // incompatible worlds. Euclid's exact-head probe reproduced it directly.
+        //
+        // This drives `describeWriteVisibility` on an ALREADY-MARKED record, so a hard-coded
+        // deferral fails here while a marker-derived one passes.
+        const result = await asTenant(() => MemoryService.addMemory({
+            prompt: 'race prompt', thought: 'race thought', response: 'race response'
+        }));
+
+        expect(result.visibility.state).toBe('embed-deferred');
+
+        const pending = await readPendingWalRecords({dir: testWalDir, ids: [result.id]});
+
+        expect(pending).toHaveLength(1);
+
+        // Mark it exactly as the embed daemon would, then re-read the SAME disclosure.
+        await appendWalEmbedMarker(
+            {id: result.id, segmentKey: pending[0].segmentKey, embeddedAt: new Date().toISOString()},
+            {dir: testWalDir}
+        );
+
+        const after = await MemoryService.describeWriteVisibility({
+            memoryId  : result.id,
+            walDir    : testWalDir,
+            segmentKey: pending[0].segmentKey
+        });
+
+        // Derived, and internally consistent: nothing may claim deferral while the marker exists.
+        expect(after.semanticQueryable).toBe(true);
+        expect(after.state).toBe('reconciled');
+        expect(after.thisWritePending).toBe(false);
+        expect(after.recencyQueryable).toBe(true);
+
+        // The coherence invariant stated directly, so any future field added to this envelope has to
+        // respect it rather than merely happening to.
+        expect(after.semanticQueryable).toBe(!after.thisWritePending);
+    });
+
+    test('RA2: semanticQueryable is derived from a marker read, NOT from absence in the pending set', async () => {
+        // Fail-open guard. `pending.some(r => r.id === X)` is false both when X reconciled AND when X
+        // is not in the WAL at all, so deriving "your write is searchable" from that absence would
+        // report an UNOBSERVED record as reconciled. An id that was never written is the cheapest
+        // probe for that: it is absent from the pending set, and must NOT come back queryable.
+        const result = await asTenant(() => MemoryService.addMemory({
+            prompt: 'derive prompt', thought: 'derive thought', response: 'derive response'
+        }));
+
+        const pending = await readPendingWalRecords({dir: testWalDir, ids: [result.id]});
+
+        expect(pending).toHaveLength(1);
+
+        const phantom = await MemoryService.describeWriteVisibility({
+            memoryId  : 'MEMORY:never-written-phantom-id',
+            walDir    : testWalDir,
+            segmentKey: pending[0].segmentKey
+        });
+
+        // Absence must read as "not reconciled", never as "reconciled".
+        expect(phantom.semanticQueryable).toBe(false);
+        expect(phantom.state).toBe('embed-deferred');
     });
 
     test('AC2: a DOWN content store cannot fail the save — the write path never touches it', async () => {

--- a/test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs
@@ -44,6 +44,8 @@ const repoRoot                 = path.resolve(path.dirname(fileURLToPath(import.
  * memory writes. It records an active interval at turn start, refreshes it during long turns, and
  * terminalizes it when a lifecycle terminal proof such as `add_memory` succeeds.
  */
+let MEMORY_ACCEPTED_MESSAGE;
+
 test.describe('Neo.ai.services.memory-core.TurnPresenceService', () => {
     test.describe.configure({mode: 'serial'});
 
@@ -55,7 +57,8 @@ test.describe('Neo.ai.services.memory-core.TurnPresenceService', () => {
     test.beforeAll(async () => {
         GraphService         = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         LifecycleService     = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
-        MemoryService        = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).default;
+        ({default: MemoryService, MEMORY_ACCEPTED_MESSAGE} =
+            await import('../../../../../../ai/services/memory-core/MemoryService.mjs'));
         StorageRouter        = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
         TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
         TurnPresenceService  = (await import('../../../../../../ai/services/memory-core/TurnPresenceService.mjs')).default;
@@ -207,7 +210,7 @@ test.describe('Neo.ai.services.memory-core.TurnPresenceService', () => {
             response: 'turn-presence response'
         }));
 
-        expect(result.message).toBe('Memory successfully added');
+        expect(result.message).toBe(MEMORY_ACCEPTED_MESSAGE);
 
         const node = getNode('memory-turn');
         expect(node.properties.status).toBe('terminal');


### PR DESCRIPTION
Resolves #16060.

**All 6 acceptance criteria delivered.** `add_memory` returned `message: "Memory successfully added"` and nothing else — true about acceptance, read as queryability, and a **semantic** read-back returning nothing then reads as **data loss**.

## What it cost, and why the direction matters

On a live deployment this cost a team three sessions and wrote a phantom outage into their own corpus as durable history. Their summaries record `"embedding provider false-success"` as what happened. **All three writes had landed.** The infrastructure was healthy throughout; the API's silence about drain latency manufactured the outage, and the false diagnosis is now what the next reader finds.

A caller who assumes immediate semantic visibility concludes the write vanished — the most alarming available wrong answer, and the one most likely to trigger a redeploy, which per #16055 really does destroy the corpus.

**Both wrong answers are in scope.** Cycle 1 of this PR shipped a single `queryable: false`, which is FALSE for `query_recent_turns` — so it would have steered a caller away from the one read that returns their write, the mirror image of the bug being fixed. The envelope now names the axis it observed.

## The fix

- **`visibility` block on the response, per read family** — `recencyQueryable` (always `true`), `semanticQueryable` (derived from this write's embed marker), `state`, `pendingDrainDepth`, `oldestPendingAgeMs`, `thisWritePending`, `hint`. **Structured, not prose**: an agent branches on fields, and a caveat it has to read is a caveat it can skip.
- **The two axes are genuinely independent.** Recency is immediate because graph projection is derived work *after* WAL acceptance and the pending-WAL overlay serves both the row and its content while projection catches up. Semantic recall waits because a vector cannot be substituted for.
- **`semanticQueryable` is derived from a POSITIVE marker read** (new `readWalMarkedIds`), never from absence in the pending set. Absence is ambiguous — true both for a reconciled record and for one that was never written — so deriving the claim from it **fails open**. `pendingDrainDepth` stays a separate proposition, because the backlog can be non-empty while this write has reconciled.
- **`message` states ACCEPTANCE**, exported as `MEMORY_ACCEPTED_MESSAGE`. It must not swing the other way either — the write *is* durable, so nothing may imply failure or partial success (AC6). Durability is bound to the write-ahead log's configured contract rather than asserted absolutely.
- **`healthcheck` gains `memoryWalDrain`, declared on `HealthCheckResponse`** — folded into an existing read rather than a new tool, since the MCP surface is capped and "is my write searchable yet?" is a liveness question. Without it the disclosure would only **relocate** the uncertainty: a caller told semantic queryability is deferred needs somewhere to *confirm* it, not a caveat and no instrument (AC3).
- **The caveat is in `x-neo-tool-summary` (112/120), not only the handbook.** The affected caller was reading the description; an agent deciding whether to trust a read-back sees the summary in `tools/list` and nothing else. It also says **do not retry** — retrying was the observed behaviour and it duplicates the memory without making the first copy searchable sooner.

### One AC limb refused rather than faked

AC2 asks for "pending depth **and/or** expected-visible-by". Depth is delivered, measured. **There is deliberately no `expectedVisibleBy`:** the embed drain has no cadence leaf and the daemon exposes no interval, so any ETA would be a plausible number with nothing behind it — the exact class of value this ticket exists to eliminate. Inventing one to fill the field would have reproduced the defect at a different address. Same reasoning makes the drain read report `observable: false` rather than a reassuring zero it never measured, and makes `semanticQueryable` report `null` when the marker state could not be read.

## Test Evidence

Evidence: L2 — **1517 green locally at `649c24815d`** across the full `memory-core` service and MCP trees plus the transitive consumers derived from the changed-file basenames (`drainCycle`, `embedDrainLivenessWatchdog`, `McpServerListToolsSmoke`, `OpenApiValidatorCompliance`); L3 hosted CI running on this push and not claimed here.

**Every new guard was certified by mutation, not by passing:**

| Mutation applied | Fixture that failed |
|---|---|
| Re-hard-code `semanticQueryable: false` / `state: 'embed-deferred'` | reconciled-before-disclosure |
| Derive `semanticQueryable` from pending-absence instead of the marker | phantom-id fail-open guard |
| Rename `memoryWalDrain` in the schema | health schema↔handler guard |

The **reconciled fixture passes under absence-derivation** — it cannot distinguish marker-derivation from absence-derivation. Only the phantom-id fixture can. Either one alone would have looked like coverage while leaving the fail-open path unguarded.

- **AC5 fixtures** assert accepted-vs-searchable cannot collapse back into one boolean (including that a bare `queryable` field never returns), that no fabricated ETA appears, and — as a **positive control on the drain surface** — that `allWritesSemanticallyQueryable` reports `false` while writes are pending, so a hardcoded `true` could not pass the poll a caller is told to trust.
- **The health guard cross-checks both directions** — every key `describeDrainState` returns must be declared, and every declared key must be produced. An undeclared field hides an instrument; a declared-but-absent one promises an instrument that isn't there. So the next undeclared field fails without anyone naming it in a review.
- Three defects my own tests caught, all because I asserted a **positive fact** rather than an absence:
  - `oldestPendingAgeMs` was always `null`. The WAL persists `timestamp: Date.now()` — a **number** — and I wrote `Date.parse(...)`, which is `NaN`. I assumed the field's shape instead of reading it. Asserting `typeof === 'number'` rather than `not.toBeNull()` is what exposed it; one shared coercion now handles both forms.
  - The `listTools` smoke spec pinned the old summary verbatim — exactly the tier that had to change.
  - That re-pointed guard was then **wrong in a second way**: it matched `/not queryable/i` while its own comment claimed it asserted "by SUBSTANCE rather than by pinning the sentence." It was pinning the sentence, and pinning the **over-broad claim** as the required substance — so correcting the caveat would fail it exactly as deleting it would. It now requires the deferral to still be disclosed (`/semantic|embed/i`) **and** the over-broad form to be absent.

## Post-Merge Validation

- Confirm a live `add_memory` returns `recencyQueryable: true` with a non-zero `pendingDrainDepth`, that `query_recent_turns` returns that write immediately, and that `healthcheck.memoryWalDrain.allWritesSemanticallyQueryable` flips to `true` once the embed daemon drains.
- Watch for any harness that string-matched the old `message`; no production consumer does (grep found only three specs and one OpenAPI example, all updated).

## Deltas

- `message` text changed. No production consumer matched on it; the three specs that did now assert the exported constant. The OpenAPI example is updated and its `description` records why the old wording was wrong.
- **`visibility` field names changed within this PR** (`queryable` → `semanticQueryable`, plus the new `recencyQueryable`). Unmerged, so there is no external consumer to break; the rename is the RA1 repair, and a fixture now fails if a bare `queryable` ever returns.
- `visibility` is **additive** on the response; `memoryWalDrain` is additive on `healthcheck` and now **declared** in the generated output schema rather than relying on passthrough. Tolerant readers of either are unaffected.
- `x-neo-tool-summary` for `add_memory` changed, which is a caller-visible tier — deliberate, and the point of AC4.
- 14 lines of the diff are whitespace-only import realignment, produced by the block-alignment checker in response to one longer import.

Authored by @neo-opus-vega
