### PR TITLE
feat(ai): add carrier-aware mailbox read-state diagnostic (#16084)

### DIFF
--- a/ai/scripts/diagnostics/mailboxReadStateProbe.mjs
+++ b/ai/scripts/diagnostics/mailboxReadStateProbe.mjs
@@ -156,14 +156,25 @@ function validateOptions({dbPath, messageId, recipient}={}) {
 }
 
 /**
- * @summary Enumerates the bounded legacy SQLite spellings accepted by MailboxService comparisons.
- * @param {String} recipient Canonical direct identity.
- * @returns {String[]}
+ * @summary Canonicalizes a stored mailbox target using MailboxService's comparison rules.
+ *
+ * Direct `AGENT:<identity>` wrappers remain comparison-compatible, while persisted
+ * `AGENT:<family>/<model>` aliases stay untouched because roster-based alias resolution belongs to
+ * send-time validation. Direct values without an address-kind colon and legacy
+ * `AGENT:<identity>` wrappers flow through `normalizeAgentIdentityNodeId`, which trims whitespace
+ * and collapses any run of leading `@` characters.
+ *
+ * @param {*} identity Stored edge target.
+ * @returns {*} Canonical direct identity or unchanged non-direct mailbox address.
  * @private
  */
-function getRecipientStorageVariants(recipient) {
-    const bare = recipient.slice(1);
-    return [...new Set([recipient, bare, `@${recipient}`, `AGENT:${recipient}`, `AGENT:${bare}`])]
+function normalizeMailboxIdentityForComparison(identity) {
+    if (typeof identity !== 'string') return identity;
+    if (identity.startsWith('AGENT:') && identity.includes('/')) return identity;
+    if (identity === 'AGENT:*') return identity;
+    if (identity.startsWith('AGENT:')) return normalizeAgentIdentityNodeId(identity.slice('AGENT:'.length));
+    if (!identity.includes(':')) return normalizeAgentIdentityNodeId(identity);
+    return identity
 }
 
 /**
@@ -365,12 +376,13 @@ export function inspectMailboxReadState({dbPath, messageId, recipient, DatabaseC
         }
 
         const
-            variants            = new Set(getRecipientStorageVariants(validated.recipient)),
-            sentTo              = edges.filter(edge => edge.type === 'SENT_TO'),
-            deliveries          = edges.filter(edge => edge.type === 'DELIVERED_TO'),
-            directRoutes        = sentTo.filter(edge => variants.has(edge.target)),
+            sentTo       = edges.filter(edge => edge.type === 'SENT_TO'),
+            deliveries   = edges.filter(edge => edge.type === 'DELIVERED_TO'),
+            directRoutes = sentTo.filter(edge =>
+                normalizeMailboxIdentityForComparison(edge.target) === validated.recipient),
             broadcastRoutes     = sentTo.filter(edge => edge.target === 'AGENT:*'),
-            recipientDeliveries = deliveries.filter(edge => variants.has(edge.target));
+            recipientDeliveries = deliveries.filter(edge =>
+                normalizeMailboxIdentityForComparison(edge.target) === validated.recipient);
 
         if (
             directRoutes.length > 1 ||

--- a/ai/scripts/diagnostics/mailboxReadStateProbe.mjs
+++ b/ai/scripts/diagnostics/mailboxReadStateProbe.mjs
@@ -1,0 +1,496 @@
+import Database                       from 'better-sqlite3';
+import path                           from 'node:path';
+import {fileURLToPath}                from 'node:url';
+import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
+
+/**
+ * @module ai/scripts/diagnostics/mailboxReadStateProbe
+ * @summary Classifies one mailbox recipient's durable read-state carrier directly from an
+ * explicitly named graph SQLite file, without loading AiConfig, repairing graph state, or
+ * mutating the inspected database.
+ *
+ * Direct messages carry `readAt` on the shared `MESSAGE` node. Receipt-backed broadcasts
+ * carry it on the recipient's `DELIVERED_TO` edge. The probe resolves that route before
+ * reading state so a missing direct-message delivery edge can never be misreported as loss.
+ *
+ * @example
+ * node ai/scripts/diagnostics/mailboxReadStateProbe.mjs \
+ *   --db-path /absolute/path/to/graph.sqlite \
+ *   --message-id MESSAGE:8ccca595-55e8-4923-a13c-88c990588230 \
+ *   --recipient @neo-gpt
+ */
+
+export const HELP_TEXT = `Usage:
+  node ai/scripts/diagnostics/mailboxReadStateProbe.mjs \\
+    --db-path <graph.sqlite> \\
+    --message-id <MESSAGE:id> \\
+    --recipient <agent-identity>
+
+The database path is mandatory and is opened read-only. The probe never infers an active
+AiConfig path, repairs graph state, or marks a message read.`;
+
+/**
+ * @summary Creates a stable failed-execution result for invalid inputs or an unreadable database.
+ * @param {'input-error'|'open-error'} state Failure class.
+ * @param {String} error Operator-facing failure detail.
+ * @param {Object} [context] Validated identifiers available at the failure boundary.
+ * @returns {Object}
+ * @private
+ */
+function failureResult(state, error, context={}) {
+    return {
+        ok: false,
+        state,
+        ...context,
+        error
+    }
+}
+
+/**
+ * @summary Creates a stable successful-inspection result, including anomaly observations.
+ *
+ * `ok: true` means the requested database was opened and classified. It does not mean the
+ * stored state is healthy: missing, malformed, and conflicting carriers are diagnostic results.
+ *
+ * @param {Object} context Common database, message, and recipient identifiers.
+ * @param {String} state Observed storage state.
+ * @param {Object} [details] Route, carrier, or anomaly detail.
+ * @returns {Object}
+ * @private
+ */
+function observation(context, state, details={}) {
+    return {
+        ok: true,
+        state,
+        ...context,
+        ...details
+    }
+}
+
+/**
+ * @summary Parses the diagnostic CLI's three explicit inputs without consulting process config.
+ * @param {String[]} argv CLI arguments excluding node and script path.
+ * @returns {Object} Parsed options, or `{help: true}`.
+ * @throws {Error} For missing, duplicate, unknown, or malformed arguments.
+ */
+export function parseArgs(argv=[]) {
+    if (!Array.isArray(argv)) {
+        throw new Error('Arguments must be an array.');
+    }
+
+    if (argv.includes('--help') || argv.includes('-h')) {
+        return {help: true}
+    }
+
+    const names = new Map([
+        ['--db-path', 'dbPath'],
+        ['--message-id', 'messageId'],
+        ['--recipient', 'recipient']
+    ]);
+    const options = {};
+
+    for (let index = 0; index < argv.length; index++) {
+        const name = argv[index],
+            key    = names.get(name);
+
+        if (!key) {
+            throw new Error(`Unknown argument: ${name}`);
+        }
+        if (Object.hasOwn(options, key)) {
+            throw new Error(`Duplicate argument: ${name}`);
+        }
+
+        const value = argv[++index];
+        if (!value || value.startsWith('--')) {
+            throw new Error(`Missing value for ${name}`);
+        }
+
+        options[key] = value;
+    }
+
+    for (const [name, key] of names) {
+        if (!options[key]) {
+            throw new Error(`Missing required argument: ${name}`);
+        }
+    }
+
+    return options
+}
+
+/**
+ * @summary Validates and canonicalizes one explicit probe request.
+ * @param {Object} options
+ * @param {String} options.dbPath Explicit SQLite path.
+ * @param {String} options.messageId MESSAGE node id.
+ * @param {String} options.recipient Direct recipient identity.
+ * @returns {{dbPath:String,messageId:String,recipient:String}}
+ * @throws {Error} For invalid identifiers or a non-explicit path.
+ * @private
+ */
+function validateOptions({dbPath, messageId, recipient}={}) {
+    if (typeof dbPath !== 'string' || !dbPath.trim()) {
+        throw new Error('dbPath must be an explicit non-empty path.');
+    }
+    if (typeof messageId !== 'string' || !/^MESSAGE:[^\s]+$/.test(messageId)) {
+        throw new Error('messageId must use the MESSAGE:<id> graph-node form.');
+    }
+    if (typeof recipient !== 'string' || !recipient.trim()) {
+        throw new Error('recipient must be a non-empty direct agent identity.');
+    }
+
+    const canonicalRecipient = normalizeAgentIdentityNodeId(recipient);
+    if (
+        typeof canonicalRecipient !== 'string' ||
+        !canonicalRecipient.startsWith('@') ||
+        canonicalRecipient === '@' ||
+        canonicalRecipient.includes(':')
+    ) {
+        throw new Error('recipient must be a direct agent identity, not a role, human, or broadcast address.');
+    }
+
+    return {
+        dbPath   : path.resolve(dbPath),
+        messageId,
+        recipient: canonicalRecipient
+    }
+}
+
+/**
+ * @summary Enumerates the bounded legacy SQLite spellings accepted by MailboxService comparisons.
+ * @param {String} recipient Canonical direct identity.
+ * @returns {String[]}
+ * @private
+ */
+function getRecipientStorageVariants(recipient) {
+    const bare = recipient.slice(1);
+    return [...new Set([recipient, bare, `@${recipient}`, `AGENT:${recipient}`, `AGENT:${bare}`])]
+}
+
+/**
+ * @summary Parses one persisted graph JSON record and classifies malformed or column-conflicting data.
+ * @param {Object} row SQLite row.
+ * @param {'node'|'edge'} kind Graph record kind.
+ * @returns {Object} Parsed record or a classified storage error.
+ * @private
+ */
+function parseGraphRecord(row, kind) {
+    let record;
+
+    try {
+        record = JSON.parse(row.data);
+    } catch (error) {
+        return {
+            errorState: 'malformed-storage',
+            error     : `${kind} row ${row.id} contains malformed JSON: ${error.message}`
+        }
+    }
+
+    if (!record || typeof record !== 'object' || Array.isArray(record)) {
+        return {
+            errorState: 'malformed-storage',
+            error     : `${kind} row ${row.id} data must be a JSON object.`
+        }
+    }
+
+    if (record.id !== row.id) {
+        return {
+            errorState: 'conflicting-storage',
+            error     : `${kind} row ${row.id} disagrees with data.id ${String(record.id)}.`
+        }
+    }
+
+    if (kind === 'edge') {
+        for (const field of ['source', 'target', 'type']) {
+            if (record[field] !== row[field]) {
+                return {
+                    errorState: 'conflicting-storage',
+                    error     : `edge row ${row.id} column ${field}=${String(row[field])} disagrees with data.${field}=${String(record[field])}.`
+                }
+            }
+        }
+    }
+
+    return {record}
+}
+
+/**
+ * @summary Classifies a resolved carrier's `readAt` property without collapsing absence into null.
+ * @param {Object} context Common inspection identifiers.
+ * @param {'direct'|'broadcast'} route Resolved mailbox route.
+ * @param {Object} carrier Machine-readable carrier identity.
+ * @param {Object} properties Persisted carrier properties.
+ * @returns {Object}
+ * @private
+ */
+function classifyCarrierReadAt(context, route, carrier, properties) {
+    if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
+        return observation(context, 'malformed-storage', {
+            route,
+            carrier,
+            error: `${carrier.kind} ${carrier.rowId} has no object-shaped properties payload.`
+        })
+    }
+
+    if (!Object.hasOwn(properties, 'readAt')) {
+        return observation(context, 'malformed-storage', {
+            route,
+            carrier,
+            error: `${carrier.kind} ${carrier.rowId} is missing properties.readAt; absence is not an explicit unread receipt.`
+        })
+    }
+
+    const {readAt} = properties;
+    if (readAt === null) {
+        return observation(context, 'unread', {
+            route,
+            carrier: {...carrier, readAt: null}
+        })
+    }
+
+    if (typeof readAt !== 'string') {
+        return observation(context, 'malformed-storage', {
+            route,
+            carrier: {...carrier, readAt},
+            error  : `${carrier.kind} ${carrier.rowId} properties.readAt must be null or an ISO timestamp string.`
+        })
+    }
+
+    let canonical;
+    try {
+        canonical = new Date(readAt).toISOString();
+    } catch {
+        canonical = null;
+    }
+
+    if (canonical !== readAt) {
+        return observation(context, 'malformed-storage', {
+            route,
+            carrier: {...carrier, readAt},
+            error  : `${carrier.kind} ${carrier.rowId} properties.readAt is not a canonical ISO timestamp.`
+        })
+    }
+
+    return observation(context, 'read', {
+        route,
+        carrier: {...carrier, readAt}
+    })
+}
+
+/**
+ * @summary Inspects one recipient's durable mailbox read-state from an explicit SQLite file.
+ *
+ * The database is opened with both `readonly` and `fileMustExist`, then `query_only` is enabled
+ * on the connection. Direct and broadcast routes are resolved from `SENT_TO` before the matching
+ * carrier is inspected. No active configuration, graph cache, WAL repair, or mailbox mutation is
+ * reachable from this module.
+ *
+ * @param {Object} options
+ * @param {String} options.dbPath Explicit graph SQLite file.
+ * @param {String} options.messageId MESSAGE node id.
+ * @param {String} options.recipient Affected direct recipient identity.
+ * @param {Function} [options.DatabaseCtor=Database] Injectable better-sqlite3 constructor.
+ * @returns {Object} Stable execution/result envelope.
+ */
+export function inspectMailboxReadState({dbPath, messageId, recipient, DatabaseCtor=Database}={}) {
+    let validated;
+
+    try {
+        validated = validateOptions({dbPath, messageId, recipient});
+    } catch (error) {
+        return failureResult('input-error', error.message)
+    }
+
+    const context = {...validated};
+    let db;
+
+    try {
+        db = new DatabaseCtor(validated.dbPath, {
+            readonly     : true,
+            fileMustExist: true
+        });
+        db.pragma('query_only = ON');
+
+        const messageRows = db.prepare('SELECT id, data FROM Nodes WHERE id = ?').all(validated.messageId);
+        if (messageRows.length === 0) {
+            return observation(context, 'message-missing', {
+                route  : null,
+                carrier: null
+            })
+        }
+        if (messageRows.length !== 1) {
+            return observation(context, 'conflicting-storage', {
+                route  : null,
+                carrier: null,
+                error  : `Expected one MESSAGE row for ${validated.messageId}; found ${messageRows.length}.`
+            })
+        }
+
+        const messageParsed = parseGraphRecord(messageRows[0], 'node');
+        if (messageParsed.errorState) {
+            return observation(context, messageParsed.errorState, {
+                route  : null,
+                carrier: null,
+                error  : messageParsed.error
+            })
+        }
+
+        const message = messageParsed.record;
+        if (message.label !== 'MESSAGE') {
+            return observation(context, 'conflicting-storage', {
+                route  : null,
+                carrier: null,
+                error  : `Node ${validated.messageId} is stored with label ${String(message.label)}, not MESSAGE.`
+            })
+        }
+
+        const edgeRows = db.prepare(`
+            SELECT id, source, target, type, data
+            FROM Edges
+            WHERE source = ? AND type IN ('SENT_TO', 'DELIVERED_TO')
+            ORDER BY id
+        `).all(validated.messageId);
+        const edges = [];
+
+        for (const row of edgeRows) {
+            const parsed = parseGraphRecord(row, 'edge');
+            if (parsed.errorState) {
+                return observation(context, parsed.errorState, {
+                    route  : null,
+                    carrier: null,
+                    error  : parsed.error
+                })
+            }
+
+            edges.push(parsed.record);
+        }
+
+        const
+            variants            = new Set(getRecipientStorageVariants(validated.recipient)),
+            sentTo              = edges.filter(edge => edge.type === 'SENT_TO'),
+            deliveries          = edges.filter(edge => edge.type === 'DELIVERED_TO'),
+            directRoutes        = sentTo.filter(edge => variants.has(edge.target)),
+            broadcastRoutes     = sentTo.filter(edge => edge.target === 'AGENT:*'),
+            recipientDeliveries = deliveries.filter(edge => variants.has(edge.target));
+
+        if (
+            directRoutes.length > 1 ||
+            broadcastRoutes.length > 1 ||
+            (directRoutes.length > 0 && broadcastRoutes.length > 0) ||
+            sentTo.length > 1
+        ) {
+            return observation(context, 'conflicting-storage', {
+                route  : null,
+                carrier: null,
+                error  : `Message ${validated.messageId} has an ambiguous SENT_TO topology: ${sentTo.map(edge => edge.target).join(', ')}.`
+            })
+        }
+
+        if (directRoutes.length === 1) {
+            if (deliveries.length > 0) {
+                return observation(context, 'conflicting-storage', {
+                    route  : 'direct',
+                    carrier: null,
+                    error  : `Direct message ${validated.messageId} also has ${deliveries.length} DELIVERED_TO carrier(s).`
+                })
+            }
+
+            return classifyCarrierReadAt(
+                context,
+                'direct',
+                {kind: 'MESSAGE', rowId: validated.messageId},
+                message.properties
+            )
+        }
+
+        if (broadcastRoutes.length === 1) {
+            if (recipientDeliveries.length === 0) {
+                return observation(context, 'recipient-carrier-missing', {
+                    route  : 'broadcast',
+                    carrier: {
+                        kind     : 'DELIVERED_TO',
+                        rowId    : null,
+                        recipient: validated.recipient
+                    }
+                })
+            }
+            if (recipientDeliveries.length > 1) {
+                return observation(context, 'conflicting-storage', {
+                    route  : 'broadcast',
+                    carrier: null,
+                    error  : `Broadcast ${validated.messageId} has ${recipientDeliveries.length} DELIVERED_TO carriers for ${validated.recipient}.`
+                })
+            }
+
+            const delivery = recipientDeliveries[0];
+            return classifyCarrierReadAt(
+                context,
+                'broadcast',
+                {
+                    kind     : 'DELIVERED_TO',
+                    rowId    : delivery.id,
+                    recipient: validated.recipient
+                },
+                delivery.properties
+            )
+        }
+
+        if (deliveries.length > 0) {
+            return observation(context, 'conflicting-storage', {
+                route  : null,
+                carrier: null,
+                error  : `Message ${validated.messageId} has DELIVERED_TO carrier(s) but no SENT_TO broadcast route.`
+            })
+        }
+
+        return observation(context, 'recipient-carrier-missing', {
+            route  : null,
+            carrier: null
+        })
+    } catch (error) {
+        return failureResult('open-error', `Unable to inspect ${validated.dbPath}: ${error.message}`, context)
+    } finally {
+        db?.close();
+    }
+}
+
+/**
+ * @summary Executes the probe CLI and writes exactly one result document.
+ * @param {String[]} [argv=process.argv.slice(2)] CLI arguments.
+ * @param {Object} [io] Injectable output sinks.
+ * @param {Function} [io.stdout] Standard-output writer.
+ * @param {Function} [io.stderr] Standard-error writer.
+ * @returns {Number} Process exit code: zero for help or a completed inspection, one for execution failure.
+ */
+export function runCli(
+    argv=process.argv.slice(2),
+    {
+        stdout = value => process.stdout.write(value),
+        stderr = value => process.stderr.write(value)
+    }={}
+) {
+    let options;
+
+    try {
+        options = parseArgs(argv);
+    } catch (error) {
+        const result = failureResult('input-error', error.message);
+        stderr(`${JSON.stringify(result, null, 2)}\n`);
+        return 1
+    }
+
+    if (options.help) {
+        stdout(`${HELP_TEXT}\n`);
+        return 0
+    }
+
+    const result = inspectMailboxReadState(options),
+        write    = result.ok ? stdout : stderr;
+
+    write(`${JSON.stringify(result, null, 2)}\n`);
+    return result.ok ? 0 : 1
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === currentFile) {
+    process.exitCode = runCli();
+}

--- a/test/playwright/unit/ai/scripts/diagnostics/mailboxReadStateProbe.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mailboxReadStateProbe.spec.mjs
@@ -1,0 +1,398 @@
+import {test, expect} from '@playwright/test';
+import Database       from 'better-sqlite3';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+import {
+    inspectMailboxReadState,
+    parseArgs,
+    runCli
+} from '../../../../../../ai/scripts/diagnostics/mailboxReadStateProbe.mjs';
+
+/**
+ * The read-state probe exists to distinguish a lost receipt from looking at the wrong carrier.
+ * These tests therefore build real SQLite graph rows for both carrier shapes and retain the
+ * negative controls: a direct message has no delivery edge, while a broadcast recipient must.
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('mailboxReadStateProbe — carrier-first durable read-state classification', () => {
+    let db, dbPath, workRoot;
+
+    /**
+     * @summary Inserts one graph node using the production SQLite JSON shape.
+     * @param {Object} node Graph node.
+     * @returns {void}
+     */
+    function insertNode(node) {
+        db.prepare('INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)')
+            .run(node.id, node.properties?.userId || null, JSON.stringify(node));
+    }
+
+    /**
+     * @summary Inserts one graph edge using the production SQLite JSON shape.
+     * @param {Object} edge Graph edge.
+     * @returns {void}
+     */
+    function insertEdge(edge) {
+        db.prepare('INSERT INTO Edges (id, user_id, source, target, type, data) VALUES (?, ?, ?, ?, ?, ?)')
+            .run(
+                edge.id,
+                edge.properties?.userId || null,
+                edge.source,
+                edge.target,
+                edge.type,
+                JSON.stringify(edge)
+            );
+    }
+
+    /**
+     * @summary Inserts one MESSAGE row with an explicit direct-carrier `readAt` value.
+     * @param {*} readAt Null or an ISO timestamp.
+     * @param {Object} [overrides] Message record overrides.
+     * @returns {Object}
+     */
+    function insertMessage(readAt=null, overrides={}) {
+        const message = {
+            id        : 'MESSAGE:probe',
+            label     : 'MESSAGE',
+            properties: {
+                subject: 'probe',
+                readAt
+            },
+            ...overrides
+        };
+
+        insertNode(message);
+        return message
+    }
+
+    /**
+     * @summary Inserts one SENT_TO or DELIVERED_TO edge for the probe message.
+     * @param {Object} options
+     * @param {String} options.id Edge id.
+     * @param {String} options.target Edge target.
+     * @param {String} options.type Edge type.
+     * @param {Object} [options.properties] Edge properties.
+     * @returns {Object}
+     */
+    function insertRoute({id, target, type, properties={}}) {
+        const edge = {
+            id,
+            source: 'MESSAGE:probe',
+            target,
+            type,
+            properties
+        };
+
+        insertEdge(edge);
+        return edge
+    }
+
+    /**
+     * @summary Runs the probe against the current temporary database and canonical recipient.
+     * @returns {Object}
+     */
+    function inspect() {
+        db.close();
+        db = null;
+
+        return inspectMailboxReadState({
+            dbPath,
+            messageId: 'MESSAGE:probe',
+            recipient: '@neo-gpt'
+        })
+    }
+
+    test.beforeEach(() => {
+        workRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-mailbox-read-state-'));
+        dbPath   = path.join(workRoot, 'graph.sqlite');
+        db       = new Database(dbPath);
+
+        db.exec(`
+            CREATE TABLE Nodes (
+                id TEXT PRIMARY KEY,
+                user_id TEXT,
+                data TEXT NOT NULL
+            );
+            CREATE TABLE Edges (
+                id TEXT PRIMARY KEY,
+                user_id TEXT,
+                source TEXT NOT NULL,
+                target TEXT NOT NULL,
+                type TEXT NOT NULL,
+                data TEXT NOT NULL
+            );
+        `);
+    });
+
+    test.afterEach(() => {
+        db?.close();
+        fs.rmSync(workRoot, {recursive: true, force: true});
+    });
+
+    test('requires all three explicit CLI inputs', () => {
+        expect(() => parseArgs(['--db-path', dbPath])).toThrow(/--message-id/);
+        expect(() => parseArgs([
+            '--db-path', dbPath,
+            '--message-id', 'MESSAGE:probe',
+            '--recipient', '@neo-gpt'
+        ])).not.toThrow();
+    });
+
+    test('reports a missing MESSAGE row separately from a missing recipient carrier', () => {
+        const result = inspect();
+
+        expect(result).toMatchObject({
+            ok     : true,
+            state  : 'message-missing',
+            route  : null,
+            carrier: null
+        });
+    });
+
+    test('classifies a direct MESSAGE with readAt:null as unread without inventing a delivery edge', () => {
+        insertMessage(null);
+        insertRoute({id: 'EDGE:sent-to', target: '@neo-gpt', type: 'SENT_TO'});
+
+        const result = inspect();
+
+        expect(result).toMatchObject({
+            ok     : true,
+            state  : 'unread',
+            route  : 'direct',
+            carrier: {
+                kind  : 'MESSAGE',
+                rowId : 'MESSAGE:probe',
+                readAt: null
+            }
+        });
+    });
+
+    test('classifies a direct MESSAGE timestamp from the node carrier', () => {
+        insertMessage('2026-07-28T08:00:00.000Z');
+        insertRoute({id: 'EDGE:sent-to', target: 'neo-gpt', type: 'SENT_TO'});
+
+        expect(inspect()).toMatchObject({
+            ok     : true,
+            state  : 'read',
+            route  : 'direct',
+            carrier: {
+                kind  : 'MESSAGE',
+                readAt: '2026-07-28T08:00:00.000Z'
+            }
+        });
+    });
+
+    test('classifies a receipt-backed broadcast with delivery readAt:null as unread', () => {
+        insertMessage(null);
+        insertRoute({id: 'EDGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'});
+        insertRoute({
+            id        : 'EDGE:delivery',
+            target    : '@neo-gpt',
+            type      : 'DELIVERED_TO',
+            properties: {readAt: null}
+        });
+
+        expect(inspect()).toMatchObject({
+            ok     : true,
+            state  : 'unread',
+            route  : 'broadcast',
+            carrier: {
+                kind     : 'DELIVERED_TO',
+                rowId    : 'EDGE:delivery',
+                recipient: '@neo-gpt',
+                readAt   : null
+            }
+        });
+    });
+
+    test('classifies a receipt-backed broadcast timestamp from the recipient edge', () => {
+        insertMessage(null);
+        insertRoute({id: 'EDGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'});
+        insertRoute({
+            id        : 'EDGE:delivery',
+            target    : 'AGENT:neo-gpt',
+            type      : 'DELIVERED_TO',
+            properties: {readAt: '2026-07-28T08:01:00.000Z'}
+        });
+
+        expect(inspect()).toMatchObject({
+            ok     : true,
+            state  : 'read',
+            route  : 'broadcast',
+            carrier: {
+                kind  : 'DELIVERED_TO',
+                readAt: '2026-07-28T08:01:00.000Z'
+            }
+        });
+    });
+
+    test('reports a broadcast with no affected-recipient delivery edge as carrier missing, not unread', () => {
+        insertMessage(null);
+        insertRoute({id: 'EDGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'});
+        insertRoute({
+            id        : 'EDGE:other-delivery',
+            target    : '@neo-opus-vega',
+            type      : 'DELIVERED_TO',
+            properties: {readAt: null}
+        });
+
+        expect(inspect()).toMatchObject({
+            ok     : true,
+            state  : 'recipient-carrier-missing',
+            route  : 'broadcast',
+            carrier: {
+                kind     : 'DELIVERED_TO',
+                rowId    : null,
+                recipient: '@neo-gpt'
+            }
+        });
+    });
+
+    test('reports absent readAt as malformed instead of silently folding it into unread', () => {
+        insertMessage(null, {
+            properties: {
+                subject: 'probe'
+            }
+        });
+        insertRoute({id: 'EDGE:sent-to', target: '@neo-gpt', type: 'SENT_TO'});
+
+        expect(inspect()).toMatchObject({
+            ok   : true,
+            state: 'malformed-storage',
+            route: 'direct'
+        });
+    });
+
+    test('reports malformed graph JSON without throwing or mutating the file', () => {
+        db.prepare('INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)')
+            .run('MESSAGE:probe', null, '{"id":"MESSAGE:probe",');
+        insertRoute({id: 'EDGE:sent-to', target: '@neo-gpt', type: 'SENT_TO'});
+
+        expect(inspect()).toMatchObject({
+            ok   : true,
+            state: 'malformed-storage',
+            route: null
+        });
+    });
+
+    test('reports a direct plus broadcast route as conflicting storage', () => {
+        insertMessage(null);
+        insertRoute({id: 'EDGE:direct', target: '@neo-gpt', type: 'SENT_TO'});
+        insertRoute({id: 'EDGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'});
+
+        expect(inspect()).toMatchObject({
+            ok   : true,
+            state: 'conflicting-storage',
+            route: null
+        });
+    });
+
+    test('reports any delivery cohort on a direct route as conflicting storage', () => {
+        insertMessage(null);
+        insertRoute({id: 'EDGE:direct', target: '@neo-gpt', type: 'SENT_TO'});
+        insertRoute({
+            id        : 'EDGE:wrong-delivery',
+            target    : '@neo-opus-vega',
+            type      : 'DELIVERED_TO',
+            properties: {readAt: null}
+        });
+
+        expect(inspect()).toMatchObject({
+            ok   : true,
+            state: 'conflicting-storage',
+            route: 'direct'
+        });
+    });
+
+    test('reports duplicate recipient delivery carriers as conflicting storage', () => {
+        insertMessage(null);
+        insertRoute({id: 'EDGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'});
+        insertRoute({
+            id        : 'EDGE:delivery-1',
+            target    : '@neo-gpt',
+            type      : 'DELIVERED_TO',
+            properties: {readAt: null}
+        });
+        insertRoute({
+            id        : 'EDGE:delivery-2',
+            target    : 'neo-gpt',
+            type      : 'DELIVERED_TO',
+            properties: {readAt: '2026-07-28T08:02:00.000Z'}
+        });
+
+        expect(inspect()).toMatchObject({
+            ok   : true,
+            state: 'conflicting-storage',
+            route: 'broadcast'
+        });
+    });
+
+    test('reports input and open failures as failed executions', () => {
+        const invalidInput = inspectMailboxReadState({
+            dbPath,
+            messageId: 'not-a-message',
+            recipient: '@neo-gpt'
+        });
+        const missingDb = inspectMailboxReadState({
+            dbPath   : path.join(workRoot, 'missing.sqlite'),
+            messageId: 'MESSAGE:probe',
+            recipient: '@neo-gpt'
+        });
+
+        expect(invalidInput).toMatchObject({ok: false, state: 'input-error'});
+        expect(missingDb).toMatchObject({ok: false, state: 'open-error'});
+    });
+
+    test('leaves the SQLite file byte-identical after a successful inspection', () => {
+        insertMessage('2026-07-28T08:03:00.000Z');
+        insertRoute({id: 'EDGE:sent-to', target: '@neo-gpt', type: 'SENT_TO'});
+        db.close();
+        db = null;
+
+        const before = fs.readFileSync(dbPath),
+            result   = inspectMailboxReadState({
+                dbPath,
+                messageId: 'MESSAGE:probe',
+                recipient: '@neo-gpt'
+            }),
+            after = fs.readFileSync(dbPath);
+
+        expect(result.state).toBe('read');
+        expect(after.equals(before)).toBe(true);
+    });
+
+    test('CLI returns zero for a completed anomaly observation and one for an execution failure', () => {
+        insertMessage(null);
+        insertRoute({id: 'EDGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'});
+        db.close();
+        db = null;
+
+        const stdout = [],
+            stderr   = [],
+            okCode   = runCli([
+                '--db-path', dbPath,
+                '--message-id', 'MESSAGE:probe',
+                '--recipient', '@neo-gpt'
+            ], {
+                stdout: value => stdout.push(value),
+                stderr: value => stderr.push(value)
+            }),
+            errorCode = runCli([], {
+                stdout: value => stdout.push(value),
+                stderr: value => stderr.push(value)
+            });
+
+        expect(okCode).toBe(0);
+        expect(JSON.parse(stdout[0])).toMatchObject({
+            ok   : true,
+            state: 'recipient-carrier-missing'
+        });
+        expect(errorCode).toBe(1);
+        expect(JSON.parse(stderr[0])).toMatchObject({
+            ok   : false,
+            state: 'input-error'
+        });
+    });
+});

--- a/test/playwright/unit/ai/scripts/diagnostics/mailboxReadStateProbe.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mailboxReadStateProbe.spec.mjs
@@ -184,6 +184,26 @@ test.describe('mailboxReadStateProbe — carrier-first durable read-state classi
         });
     });
 
+    for (const [label, target] of [
+        ['padded', '  @neo-gpt  '],
+        ['multi-@', '@@@@neo-gpt']
+    ]) {
+        test(`matches a ${label} direct target using the production identity comparison`, () => {
+            insertMessage(null);
+            insertRoute({id: 'EDGE:sent-to', target, type: 'SENT_TO'});
+
+            expect(inspect()).toMatchObject({
+                ok     : true,
+                state  : 'unread',
+                route  : 'direct',
+                carrier: {
+                    kind : 'MESSAGE',
+                    rowId: 'MESSAGE:probe'
+                }
+            });
+        });
+    }
+
     test('classifies a receipt-backed broadcast with delivery readAt:null as unread', () => {
         insertMessage(null);
         insertRoute({id: 'EDGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'});
@@ -227,6 +247,33 @@ test.describe('mailboxReadStateProbe — carrier-first durable read-state classi
             }
         });
     });
+
+    for (const [label, target] of [
+        ['padded', '  @neo-gpt  '],
+        ['multi-@', '@@@@neo-gpt']
+    ]) {
+        test(`matches a ${label} broadcast receipt using the production identity comparison`, () => {
+            insertMessage(null);
+            insertRoute({id: 'EDGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'});
+            insertRoute({
+                id        : 'EDGE:delivery',
+                target,
+                type      : 'DELIVERED_TO',
+                properties: {readAt: null}
+            });
+
+            expect(inspect()).toMatchObject({
+                ok     : true,
+                state  : 'unread',
+                route  : 'broadcast',
+                carrier: {
+                    kind     : 'DELIVERED_TO',
+                    rowId    : 'EDGE:delivery',
+                    recipient: '@neo-gpt'
+                }
+            });
+        });
+    }
 
     test('reports a broadcast with no affected-recipient delivery edge as carrier missing, not unread', () => {
         insertMessage(null);


### PR DESCRIPTION
Resolves #16084

Refs #15825

Adds a carrier-aware, read-only mailbox diagnostic that classifies one explicit, directly accessible graph SQLite store without loading AiConfig or mutating the incident specimen. The CLI resolves `SENT_TO` first, then reads direct state from the `MESSAGE` node or receipt-backed broadcast state from the affected recipient's `DELIVERED_TO` edge. Its JSON envelope separates completed anomaly observations from input/open failures.

Evidence: L3 (live read-only direct and broadcast carrier probes against the current graph SQLite) → L3 required (ACs 1–6). No residuals [#16084].

## Deltas from ticket

None substantive to the implementation. The leaf was split from #15825 after the mechanism investigation remained intentionally open; the implementation matches #16084's read-only diagnostic boundary and does not change mailbox behavior.

## Deployment boundary

This is a filesystem-level forensic probe: `--db-path` must name a SQLite file accessible inside the process namespace. A host-side invocation therefore cannot inspect a database that exists only inside a Docker container, managed volume, or remote cloud host. Target deployments provide neither host nor Docker-shell access, so invoking this CLI in-container is not an operational fallback; copying or exposing the volume is only an offline/local handling path, not local/cloud Agent OS parity.

The cloud equivalent must run inside the deployment and report the same carrier-aware classification outward through an already-exposed diagnostic service boundary. Sharing the classifier between this CLI and that server-side surface, rather than re-deriving recipient/carrier rules, is follow-up scope and deliberately not part of `#16084` or this PR.

## Test Evidence

- Diagnostic CLI: `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/mailboxReadStateProbe.spec.mjs` → 21/21 passed through the custom unit runner (19 focused cases plus run-scoped Chroma setup/teardown).
- JSDoc surface: `node ./buildScripts/util/check-jsdoc-types.mjs` → 1,908 files scanned, 0 unparseable type expressions.
- Source shape: `node --check ai/scripts/diagnostics/mailboxReadStateProbe.mjs` → passed.
- Commit gates: whitespace, shorthand, AiConfig test-mutation, derived-domain, JSDoc, ticket archaeology, block-alignment, and parse hooks → passed.
- Live direct control: the fresh D#16083 direct wake classified `route: direct`, `carrier.kind: MESSAGE`, `state: unread`.
- Live broadcast control: the current mailbox-interpretation broadcast classified `route: broadcast`, `carrier.kind: DELIVERED_TO`, `state: unread`.
- Read-only control: the focused spec compares the SQLite file byte-for-byte before and after inspection.

## Post-Merge Validation

- [ ] On the next #15825 recurrence, run the probe before any mark-read, repair, restart, or config change and attach its JSON observation to the parent mechanism ticket. This is parent-investigation evidence, not a #16084 residual.

## Commits

- `371a237cfc` — add the carrier-aware, read-only probe and its SQLite contract suite.
- `21c9d65635` — align recipient matching with production normalization and add the four legacy-spelling controls.

## Evolution

The original plan used `Refs #15825` because a diagnostic cannot close an unobserved mechanism. The ready-PR close-target gate made the clean scope split explicit: #16084 closes the independently reviewable instrument, while #15825 stays open for a positive carrier-loss capture and mechanism fix.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fa530-53d6-7271-bf05-51497720b29c.
