### PR TITLE
fix(ci): retry transient CodeQL log availability (#16075)

### DIFF
--- a/buildScripts/util/check-codeql-extraction.mjs
+++ b/buildScripts/util/check-codeql-extraction.mjs
@@ -101,13 +101,26 @@ export function summarizeExtractionAcrossLegs(legs) {
  * @param {String|Number} params.runId `GITHUB_RUN_ID`.
  * @param {String} params.token `GITHUB_TOKEN` with `actions:read`.
  * @param {RegExp} [params.jobNameMatch=/Analyze/] Match for the CodeQL analyze leg names (`Analyze (javascript)`, …).
+ * @param {Function} [params.fetchImpl=globalThis.fetch] Fetch seam for deterministic retry witnesses.
+ * @param {Function} [params.sleep] Backoff seam; defaults to a timer-backed promise.
+ * @param {Number[]} [params.retryDelays=[1000, 2000, 4000]] Delay before each retry, bounding
+ * attempts to `retryDelays.length + 1` and total wait to the delay sum.
  * @returns {Promise<Array<{name: String, log: String}>>} one entry per matching Analyze leg.
  */
-export async function fetchAnalyzeJobLogs({repo, runId, token, jobNameMatch = /Analyze/}) {
-    const base    = 'https://api.github.com',
-          headers = {Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28'};
+export async function fetchAnalyzeJobLogs({
+    repo,
+    runId,
+    token,
+    jobNameMatch = /Analyze/,
+    fetchImpl    = globalThis.fetch,
+    sleep        = delay => new Promise(resolve => setTimeout(resolve, delay)),
+    retryDelays  = [1000, 2000, 4000]
+}) {
+    const base        = 'https://api.github.com',
+          headers     = {Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28'},
+          isRetryable = status => status === 404 || status >= 500;
 
-    const jobsRes = await fetch(`${base}/repos/${repo}/actions/runs/${runId}/jobs?per_page=100`, {headers});
+    const jobsRes = await fetchImpl(`${base}/repos/${repo}/actions/runs/${runId}/jobs?per_page=100`, {headers});
     if (!jobsRes.ok) throw new Error(`fetch run jobs failed: ${jobsRes.status} ${jobsRes.statusText}`);
 
     const {jobs = []} = await jobsRes.json(),
@@ -115,10 +128,30 @@ export async function fetchAnalyzeJobLogs({repo, runId, token, jobNameMatch = /A
     if (!legs.length) throw new Error(`no job matching ${jobNameMatch} in run ${runId} (jobs: ${jobs.map(j => j.name).join(', ')})`);
 
     return Promise.all(legs.map(async leg => {
-        const logRes = await fetch(`${base}/repos/${repo}/actions/jobs/${leg.id}/logs`, {headers, redirect: 'follow'});
-        if (!logRes.ok) throw new Error(`fetch Analyze leg "${leg.name}" log failed: ${logRes.status} ${logRes.statusText}`);
+        if (leg.status !== 'completed') {
+            throw new Error(`Analyze leg "${leg.name}" is ${leg.status || 'missing status'}, not completed`)
+        }
 
-        return {name: leg.name, log: await logRes.text()}
+        let elapsedMs = 0;
+
+        for (let attempt = 1; ; attempt++) {
+            const logRes = await fetchImpl(`${base}/repos/${repo}/actions/jobs/${leg.id}/logs`, {headers, redirect: 'follow'});
+
+            if (logRes.ok) return {name: leg.name, log: await logRes.text()};
+
+            const retryDelay = retryDelays[attempt - 1];
+
+            if (!isRetryable(logRes.status) || retryDelay == null) {
+                const exhausted = isRetryable(logRes.status)
+                    ? ` after ${attempt} attempts over ${elapsedMs}ms`
+                    : '';
+
+                throw new Error(`fetch Analyze leg "${leg.name}" log failed${exhausted}: ${logRes.status} ${logRes.statusText}`)
+            }
+
+            await sleep(retryDelay);
+            elapsedMs += retryDelay
+        }
     }))
 }
 

--- a/test/playwright/unit/ai/buildScripts/util/check-codeql-extraction.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-codeql-extraction.spec.mjs
@@ -1,5 +1,10 @@
 import {test, expect}                                                                       from '@playwright/test';
-import {findCodeqlExtractionErrors, summarizeExtractionAcrossLegs, EXTRACTION_GROUP_MARKER} from '../../../../../../buildScripts/util/check-codeql-extraction.mjs';
+import {
+    fetchAnalyzeJobLogs,
+    findCodeqlExtractionErrors,
+    summarizeExtractionAcrossLegs,
+    EXTRACTION_GROUP_MARKER
+} from '../../../../../../buildScripts/util/check-codeql-extraction.mjs';
 
 /**
  * @summary The discriminating heart of the CodeQL extraction gate: given the raw Analyze-job
@@ -8,9 +13,8 @@ import {findCodeqlExtractionErrors, summarizeExtractionAcrossLegs, EXTRACTION_GR
  * must never pass silently), that a per-file line without the header still fails (format drift), and
  * that a benign "parse error" mention does NOT false-positive on a clean tree.
  *
- * The I/O half (fetching the Analyze-job log) is proven by the PR's own red-proof CI run per the
- * ticket's red-proof AC (a deliberately-unparseable file turns the gate red; removing it turns it green); the
- * fetch cannot be meaningfully unit-tested without mocking the whole Actions API.
+ * The I/O half uses injected fetch and sleep seams, so retry classification and fail-closed exhaustion
+ * are proven without mutating globals or reaching the live Actions API.
  */
 test.describe('buildScripts/util/check-codeql-extraction — findCodeqlExtractionErrors (#15370)', () => {
     // Actions prepends an ISO timestamp + a stream tag to every log line; the fixtures carry it so the
@@ -146,5 +150,108 @@ test.describe('buildScripts/util/check-codeql-extraction — findCodeqlExtractio
     test('empty / non-array legs → no errors, total (never throws certifying an unread matrix)', () => {
         expect(summarizeExtractionAcrossLegs([])).toEqual({hasErrors: false, dropped: [], legCount: 0});
         expect(summarizeExtractionAcrossLegs(undefined)).toEqual({hasErrors: false, dropped: [], legCount: 0})
+    })
+});
+
+test.describe('buildScripts/util/check-codeql-extraction — fetchAnalyzeJobLogs (#16075)', () => {
+    const jobsResponse = status => ({
+        ok  : true,
+        json: async () => ({jobs: [{id: 42, name: 'Analyze (javascript)', status}]})
+    });
+    const logResponse = (status, statusText, log = '') => ({
+        ok  : status >= 200 && status < 300,
+        status,
+        statusText,
+        text: async () => log
+    });
+
+    test('a transient 404 is retried once, then the readable log certifies', async () => {
+        const responses = [
+                  jobsResponse('completed'),
+                  logResponse(404, 'Not Found'),
+                  logResponse(200, 'OK', 'clean log')
+              ],
+              delays    = [],
+              result    = await fetchAnalyzeJobLogs({
+                  repo       : 'neomjs/neo',
+                  runId      : 123,
+                  token      : 'test-token',
+                  fetchImpl  : async () => responses.shift(),
+                  sleep      : async delay => delays.push(delay),
+                  retryDelays: [5]
+              });
+
+        expect(result).toEqual([{name: 'Analyze (javascript)', log: 'clean log'}]);
+        expect(delays).toEqual([5]);
+        expect(responses).toEqual([])
+    });
+
+    test('a terminal 403 fails immediately without sleeping', async () => {
+        const responses = [jobsResponse('completed'), logResponse(403, 'Forbidden')],
+              delays    = [];
+
+        await expect(fetchAnalyzeJobLogs({
+            repo       : 'neomjs/neo',
+            runId      : 123,
+            token      : 'test-token',
+            fetchImpl  : async () => responses.shift(),
+            sleep      : async delay => delays.push(delay),
+            retryDelays: [5, 10]
+        })).rejects.toThrow('fetch Analyze leg "Analyze (javascript)" log failed: 403 Forbidden');
+
+        expect(delays).toEqual([]);
+        expect(responses).toEqual([])
+    });
+
+    test('retry exhaustion stays fail-closed and reports attempts plus elapsed window', async () => {
+        const responses = [
+                  jobsResponse('completed'),
+                  logResponse(503, 'Service Unavailable'),
+                  logResponse(503, 'Service Unavailable'),
+                  logResponse(503, 'Service Unavailable')
+              ],
+              delays    = [];
+
+        await expect(fetchAnalyzeJobLogs({
+            repo       : 'neomjs/neo',
+            runId      : 123,
+            token      : 'test-token',
+            fetchImpl  : async () => responses.shift(),
+            sleep      : async delay => delays.push(delay),
+            retryDelays: [5, 10]
+        })).rejects.toThrow('after 3 attempts over 15ms: 503 Service Unavailable');
+
+        expect(delays).toEqual([5, 10]);
+        expect(responses).toEqual([])
+    });
+
+    test('an incomplete Analyze leg is terminal and never fetches its log', async () => {
+        const responses = [jobsResponse('in_progress')];
+
+        await expect(fetchAnalyzeJobLogs({
+            repo     : 'neomjs/neo',
+            runId    : 123,
+            token    : 'test-token',
+            fetchImpl: async () => responses.shift()
+        })).rejects.toThrow('Analyze leg "Analyze (javascript)" is in_progress, not completed');
+
+        expect(responses).toEqual([])
+    })
+
+    test('a malformed jobs payload is terminal and never enters log-fetch retry', async () => {
+        let fetchCount = 0;
+
+        await expect(fetchAnalyzeJobLogs({
+            repo     : 'neomjs/neo',
+            runId    : 123,
+            token    : 'test-token',
+            fetchImpl: async () => {
+                fetchCount++;
+
+                return {ok: true, json: async () => { throw new SyntaxError('invalid JSON') }}
+            }
+        })).rejects.toThrow('invalid JSON');
+
+        expect(fetchCount).toBe(1)
     })
 });


### PR DESCRIPTION
Resolves #16075

Retries only transient CodeQL Analyze-log availability responses (`404` and `5xx`) across a bounded 1s + 2s + 4s backoff window. Permission failures, malformed job payloads, incomplete Analyze legs, and exhausted retries remain terminal; the existing CLI catch still refuses certification with exit code 2.

Evidence: L2 (injected fetch/sleep fixtures cover transient success, terminal failure, and fail-closed exhaustion) → L2 required (all close-target ACs are deterministic helper and fixture contracts). No residuals.

## Deltas from ticket

- Treats an Analyze leg that has not reached `completed` as an explicit terminal failure before requesting its log.
- Injects `fetchImpl`, `sleep`, and `retryDelays` with unchanged production defaults so retry behavior is testable without global mutation or live Actions API calls.
- Uses four total production attempts over 7 seconds.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-codeql-extraction.spec.mjs` — 20/20 passed.
- `npx lint-staged` — all staged-file gates passed.
- `npm run agent-preflight -- --no-fix buildScripts/util/check-codeql-extraction.mjs test/playwright/unit/ai/buildScripts/util/check-codeql-extraction.spec.mjs` — passed; unrelated local AiConfig overlay warning only.
- CodeQL extraction guard: focused spec exercises 404-then-success, immediate 403 failure, repeated 503 exhaustion with attempt/window diagnostics, incomplete-leg failure, and malformed-jobs-payload failure.

## Post-Merge Validation

- [ ] Observe the next naturally occurring CodeQL extraction-guard run and confirm ordinary successful log retrieval remains green.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 6975360e-8f6b-4f01-b3ab-f380c1c3e68c.
