### PR TITLE
fix(deploy): use one canonical revision pin (#16087)

### DIFF
--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -88,8 +88,8 @@ ENV SERVER_ENTRYPOINT=${SERVICE_ENTRYPOINT}
 #      LABEL can only read a build ARG and Docker cannot populate a later-stage ARG
 #      from a file written in an earlier stage. Empty means "not asserted"; it must
 #      never contain a channel name. To get a spec-correct value, resolve the channel
-#      to a full SHA first and pass NEO_REVISION — which is exactly the resolve-once
-#      contract the rollout-authority design calls for.
+#      to a full SHA first and pass NEO_REVISION — Compose maps that one operator pin
+#      to both internal arguments.
 #   3. /app/.neo-revision — the build-time RESOLVED commit, written by the source stage.
 #      The only surface that is always populated and always true, so it is the primary
 #      provenance fact; the label above is its machine-readable echo when the caller
@@ -105,6 +105,16 @@ ENV SERVER_ENTRYPOINT=${SERVICE_ENTRYPOINT}
 ARG NEO_REF
 ARG NEO_REPO_URL
 ARG NEO_REVISION=
+
+# The label is an assertion, while /app/.neo-revision is measured artifact truth.
+# Fail the build before stamping a non-empty assertion that disagrees with the source
+# stage. This also rejects a revision claim on `NEO_SOURCE=local` (`local-build`).
+RUN actual_revision="$(cat /app/.neo-revision)" \
+    && if [ -n "${NEO_REVISION}" ] && [ "${NEO_REVISION}" != "${actual_revision}" ]; then \
+        echo "[deploy] FATAL: NEO_REVISION integrity mismatch: asserted '${NEO_REVISION}', packaged '${actual_revision}'." >&2; \
+        exit 1; \
+    fi
+
 LABEL org.neomjs.image.requested-ref="${NEO_REF}"
 LABEL org.opencontainers.image.revision="${NEO_REVISION}"
 LABEL org.opencontainers.image.source="${NEO_REPO_URL}"

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -52,11 +52,11 @@ services:
       dockerfile: Dockerfile
       args:
         TARGET_SERVER: knowledge-base
-        # Pin the deployed revision declaratively (#15774): export NEO_REF=<full-sha>
-        # for a reproducible rollout. The `:-dev` default is load-bearing — a bare
-        # `${NEO_REF}` passes an EMPTY string when unset, which would override the
-        # Dockerfile's `ARG NEO_REF=dev` and break `git fetch origin ""`.
-        NEO_REF: ${NEO_REF:-dev}
+        # One operator-facing resolved pin (#16087): export NEO_REVISION=<full-sha>.
+        # Compose maps it to both internal Docker arguments so source acquisition and
+        # the OCI revision assertion cannot disagree. The `:-dev` default preserves
+        # the unpinned path without passing an empty ref to `git fetch`.
+        NEO_REF: ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_TRANSPORT=streamable-http
@@ -115,8 +115,8 @@ services:
       dockerfile: Dockerfile
       args:
         TARGET_SERVER: memory-core
-        # Cohort invariant (#15774): every Neo service builds from the SAME ref.
-        NEO_REF: ${NEO_REF:-dev}
+        # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
+        NEO_REF: ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_TRANSPORT=streamable-http
@@ -216,8 +216,8 @@ services:
       dockerfile: Dockerfile
       args:
         SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
-        # Cohort invariant (#15774): every Neo service builds from the SAME ref.
-        NEO_REF: ${NEO_REF:-dev}
+        # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
+        NEO_REF: ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_AI_DEPLOYMENT_MODE=cloud

--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -48,11 +48,10 @@ compose() { docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" "${profile_args
 # there is deliberately no unpinned path, because this is the reference pipeline
 # and its default is what propagates to every downstream deployment.
 #
-# BOTH args are exported, not just NEO_REVISION. NEO_REVISION only feeds the OCI
-# revision LABEL; the source stage fetches ${NEO_REF}. Exporting only NEO_REVISION
-# would stamp a resolved SHA onto an image whose source stage fetched a mutable
-# channel — a label asserting a fact the artifact does not hold, and the cache
-# input would not change, so `--build` might not even re-fetch.
+# NEO_REF is the selector input at this pre-resolution boundary. After resolution,
+# Compose accepts ONE canonical NEO_REVISION pin and maps it to both internal Docker
+# arguments: source acquisition and the OCI revision assertion. Unset the selector
+# before Docker so it cannot survive as a second, potentially conflicting build input.
 NEO_SELECTOR="${NEO_REF:-dev}"
 NEO_REPO_URL="${NEO_REPO_URL:-https://github.com/neomjs/neo.git}"
 
@@ -135,7 +134,7 @@ else
     resolved_revision="$matches"
 fi
 
-export NEO_REF="$resolved_revision"
+unset NEO_REF
 export NEO_REVISION="$resolved_revision"
 
 echo "[deploy] selector:     $NEO_SELECTOR"

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -48,15 +48,16 @@ The script resolves that selector to a full commit id before Docker runs, and **
 
 Release-gating chooses *which* revision to deploy. This section is how the deployment **proves** which revision it actually runs — a separate problem, and the one that lets a stale stack look healthy.
 
-**Resolve the channel, then pin.** Every Neo service in [`ai/deploy/docker-compose.yml`](../../../ai/deploy/docker-compose.yml) forwards two build arguments: `NEO_REF` (what you are *asking for*) and `NEO_REVISION` (the *resolved* commit). Resolve once, pass both, build once:
+**Resolve the channel, then pin once.** Every Neo service in [`ai/deploy/docker-compose.yml`](../../../ai/deploy/docker-compose.yml) still receives two internal build arguments — `NEO_REF` for source acquisition and `NEO_REVISION` for the OCI assertion — but Compose derives both from one operator-facing resolved pin. Resolve once, pass `NEO_REVISION` once, build once:
 
 ```bash
-export NEO_REF=$(git ls-remote https://github.com/neomjs/neo.git dev | cut -f1)
-export NEO_REVISION="$NEO_REF"
+export NEO_REVISION=$(git ls-remote https://github.com/neomjs/neo.git dev | cut -f1)
 docker compose -f ai/deploy/docker-compose.yml [--profile …] build
 ```
 
-Left unset, `NEO_REF` defaults to `dev` and `NEO_REVISION` stays empty — the pre-existing behaviour, with no revision asserted.
+Compose maps that one full SHA to both Docker arguments for `kb-server`, `mc-server`, and `orchestrator`. The reference pipeline keeps `NEO_REF` as its pre-resolution selector input, resolves it once, then removes it before handing the canonical `NEO_REVISION` to Compose.
+
+Left unset, the internal `NEO_REF` defaults to `dev` and `NEO_REVISION` stays empty — the pre-existing behaviour, with no revision asserted.
 
 **Pass the full 40-character SHA.** An abbreviated SHA fails closed at `git fetch`, before any checkout — correct behaviour, since an abbreviated ref is not a reproducible pin, but the error surfaces as a fetch failure rather than as anything mentioning provenance. Observed in a live rehearsal run against a 12-character SHA. The `git ls-remote` form above avoids this by construction, which is why it is the documented path rather than prose asking you to be careful.
 
@@ -72,8 +73,8 @@ docker compose -f ai/deploy/docker-compose.yml --profile cloud config | grep -E 
 
 | Fact | Surface | Contract |
 |---|---|---|
-| Requested selector | `org.neomjs.image.requested-ref` label | Policy input — what the build was *asked* for. Legitimately a mutable channel. Vendor-namespaced because no OCI standard key means "what was asked for". |
-| Packaged revision | `org.opencontainers.image.revision` label | The OCI-specified source-control revision of the packaged software. Caller-supplied via `NEO_REVISION`; **empty when not supplied**, which reads as *not asserted*. It must never contain a channel name. |
+| Requested source ref | `org.neomjs.image.requested-ref` label | What the Docker source stage was *asked* to fetch: `dev` on the unpinned path, or the same full SHA as `NEO_REVISION` on the pinned path. Vendor-namespaced because no OCI standard key means "what was asked for". |
+| Packaged revision | `org.opencontainers.image.revision` label | The OCI-specified source-control revision of the packaged software. Caller-supplied once via `NEO_REVISION`; **empty when not supplied**, which reads as *not asserted*. It must never contain a channel name, and the Docker build fails if it differs from `/app/.neo-revision`. |
 | Resolved commit | `/app/.neo-revision` | The commit the build actually checked out, written at build time. Always populated, always true — so this is the **primary** provenance fact; the label above is its machine-readable echo when the caller resolved properly. |
 
 ```bash
@@ -90,7 +91,7 @@ Read the requested selector against the resolved commit — the *direction* of a
 | a pinned SHA | the same SHA | The pin held. Promote this image. |
 | a pinned SHA | a **different** SHA | **Build-integrity failure.** Not an oddity — the build did not produce what was asked for. Do not promote; rebuild and investigate. |
 
-Two rules that follow from the table. A **non-empty** `org.opencontainers.image.revision` that disagrees with `/app/.neo-revision` is the same build-integrity failure, detectable without the requested selector at all. And a **`local-build`** marker means the image came from `NEO_SOURCE=local` (the dev-iteration escape hatch): nothing upstream was packaged, so `NEO_REVISION` must not be passed for such a build and the image must never be promoted.
+Two rules that follow from the table. A **non-empty** `org.opencontainers.image.revision` cannot disagree with `/app/.neo-revision`: the Docker build now fails before labeling when the asserted and measured revisions differ. And a **`local-build`** marker means the image came from `NEO_SOURCE=local` (the dev-iteration escape hatch): nothing upstream was packaged, so `NEO_REVISION` must not be passed for such a build; the same integrity gate rejects that fabricated claim.
 
 Two honest bounds. First, a missing label or missing `/app/.neo-revision` means the image predates this contract — treat it as unknown-revision, not as current. Second, these are container-local reads: they answer "which revision" but they are served from inside the deployed set, so they cannot by themselves distinguish *a failed rollout* from *a succeeded rollout whose reporter died*. Durable out-of-cohort receipts are open design work, tracked on [Discussion #15758](https://github.com/orgs/neomjs/discussions/15758).
 

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -4,6 +4,7 @@ import fs                        from 'node:fs/promises';
 import os                        from 'node:os';
 import path                      from 'node:path';
 import process                   from 'node:process';
+import {load as yamlLoad}        from 'js-yaml';
 
 /**
  * Guards the revision-pinning contract of `ai/examples/cloud-deployment/deploy-pipeline.sh`.
@@ -19,16 +20,17 @@ import process                   from 'node:process';
  * than one that fails, because it produces an image whose provenance labels assert a revision nobody
  * chose. `fakeDocker` therefore appends to a log file, and the failure cases assert that log is empty.
  *
- * The positive case guards the other half of the contract: BOTH `NEO_REF` and `NEO_REVISION` must reach
- * Compose as the resolved SHA. Exporting only `NEO_REVISION` would label the image with a resolved
- * revision while the Dockerfile's source stage still fetched `${NEO_REF}` — a label asserting a fact
- * the artifact does not hold, and an unchanged cache input so `--build` might not even re-fetch.
+ * The positive case guards the other half of the contract: one canonical `NEO_REVISION` reaches
+ * Compose after resolution, and Compose maps it to both internal Docker arguments. Letting the
+ * selector survive as `NEO_REF` would recreate the two-input mismatch state this contract removes.
  */
 
 const
-    repoRoot   = path.resolve(process.cwd()),
-    scriptPath = path.join(repoRoot, 'ai/examples/cloud-deployment/deploy-pipeline.sh'),
-    FULL_SHA   = '6be5afc1c30000000000000000000000000000aa';
+    repoRoot       = path.resolve(process.cwd()),
+    composePath    = path.join(repoRoot, 'ai/deploy/docker-compose.yml'),
+    dockerfilePath = path.join(repoRoot, 'ai/deploy/Dockerfile'),
+    scriptPath     = path.join(repoRoot, 'ai/examples/cloud-deployment/deploy-pipeline.sh'),
+    FULL_SHA       = '6be5afc1c30000000000000000000000000000aa';
 
 /**
  * Builds a throwaway bin dir whose `git` and `docker` shadow the real ones on `PATH`.
@@ -41,7 +43,7 @@ const
  * slipped through cycle 1: the earlier stub proved the code against input git never produces.
  *
  * `fake-docker` records every invocation plus the environment, so "Docker was never called" and
- * "both variables reached Compose" are assertable facts rather than inferences.
+ * "only the canonical pin reached Compose" are assertable facts rather than inferences.
  *
  * @param {String} peelLine  Peel line to advertise, or '' for none (branch / lightweight tag).
  * @param {String} plainLines Non-peel lines always advertised (tag object, branches, or '').
@@ -81,9 +83,9 @@ async function createFakeBin(plainLines, peelLine = '') {
         'exit 0'
     ].join('\n'), {mode: 0o755});
 
-    // Record the ENVIRONMENT, not only argv. NEO_REF / NEO_REVISION reach Compose as exported
-    // env, never as arguments — so a docker stub logging `$*` alone can never falsify
-    // "both variables reach Compose", which is the claim the pinning contract rests on.
+    // Record the ENVIRONMENT, not only argv. The selector enters as NEO_REF, while the canonical
+    // pin exits as NEO_REVISION. A docker stub logging `$*` alone cannot prove that the selector
+    // was removed before Compose.
     await fs.writeFile(path.join(bin, 'docker'), [
         '#!/usr/bin/env bash',
         `echo "invoked: $* | NEO_REF=${'$'}{NEO_REF-<unset>} NEO_REVISION=${'$'}{NEO_REVISION-<unset>}" >> ${JSON.stringify(dockerLog)}`,
@@ -205,6 +207,86 @@ async function dockerInvocations(dockerLog) {
     return contents.split('\n').filter(Boolean).length
 }
 
+/**
+ * @summary Executes the Dockerfile's actual revision-integrity RUN body against a temporary receipt.
+ * @param {String} assertedRevision Value exposed to the RUN instruction as `NEO_REVISION`.
+ * @param {String} actualRevision Value stored in the stand-in `.neo-revision` receipt.
+ * @returns {Promise<Object>} Spawn result with numeric status and captured streams.
+ */
+async function runRevisionIntegrityGate(assertedRevision, actualRevision) {
+    const
+        dockerfile = await fs.readFile(dockerfilePath, 'utf8'),
+        start      = dockerfile.indexOf('RUN actual_revision='),
+        end        = dockerfile.indexOf('\nLABEL org.neomjs.image.requested-ref', start);
+
+    expect(start, 'Dockerfile revision-integrity RUN instruction is missing').toBeGreaterThan(-1);
+    expect(end, 'Dockerfile revision-integrity RUN instruction has no label boundary').toBeGreaterThan(start);
+
+    const
+        tempDir      = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-revision-integrity-')),
+        revisionFile = path.join(tempDir, '.neo-revision'),
+        command      = dockerfile.slice(start + 4, end)
+            .replace(/\\\n\s*/g, ' ')
+            .replace('/app/.neo-revision', JSON.stringify(revisionFile));
+
+    await fs.writeFile(revisionFile, actualRevision);
+
+    const result = spawnSync('sh', ['-c', command], {
+        encoding: 'utf8',
+        env     : {...process.env, NEO_REVISION: assertedRevision},
+        stdio   : ['ignore', 'pipe', 'pipe']
+    });
+
+    await fs.rm(tempDir, {force: true, recursive: true});
+
+    return result
+}
+
+test.describe('deploy revision boundary (#16087)', () => {
+    test('one operator pin maps to both Docker arguments for the full service cohort', async () => {
+        const
+            compose  = yamlLoad(await fs.readFile(composePath, 'utf8')),
+            services = Object.entries(compose.services || {})
+                .filter(([, service]) => service?.build?.args?.TARGET_SERVER ||
+                    service?.build?.args?.SERVICE_ENTRYPOINT);
+
+        expect(services.map(([name]) => name).sort()).toEqual(['kb-server', 'mc-server', 'orchestrator']);
+
+        for (const [name, service] of services) {
+            expect(
+                service.build.args.NEO_REF,
+                `${name} does not derive source acquisition from the one resolved operator pin`
+            ).toBe('${NEO_REVISION:-dev}');
+            expect(
+                service.build.args.NEO_REVISION,
+                `${name} does not derive the OCI assertion from the same operator pin`
+            ).toBe('${NEO_REVISION:-}')
+        }
+    });
+
+    test('the Docker integrity gate accepts an unset assertion', async () => {
+        const result = await runRevisionIntegrityGate('', FULL_SHA);
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('')
+    });
+
+    test('the Docker integrity gate accepts an assertion matching measured artifact truth', async () => {
+        const result = await runRevisionIntegrityGate(FULL_SHA, FULL_SHA);
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('')
+    });
+
+    test('the Docker integrity gate rejects a mismatched assertion with a clear error', async () => {
+        const result = await runRevisionIntegrityGate('a'.repeat(40), FULL_SHA);
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('NEO_REVISION integrity mismatch');
+        expect(result.stderr).toContain(FULL_SHA)
+    })
+});
+
 test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
     test('a selector matching zero refs fails closed without invoking Docker', async () => {
         const fake   = await createFakeBin(''),
@@ -323,7 +405,7 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         const log = await fs.readFile(fake.dockerLog, 'utf8');
 
         expect(log).toContain(`NEO_REVISION=${PEELED_COMMIT}`);
-        expect(log).toContain(`NEO_REF=${PEELED_COMMIT}`);
+        expect(log).toContain('NEO_REF=<unset>');
         // The tag object must never be attested, and the substitution must be stated out loud.
         expect(log).not.toContain(TAG_OBJECT_ID);
         expect(result.output).toContain('peeled to commit')
@@ -352,20 +434,19 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         expect(await dockerInvocations(fake.dockerLog)).toBeGreaterThan(0)
     });
 
-    test('BOTH NEO_REF and NEO_REVISION reach Compose as the resolved commit', async () => {
+    test('one canonical NEO_REVISION reaches Compose after the selector is removed', async () => {
         const
             fake   = await createFakeBin(`${FULL_SHA}\trefs/heads/dev`),
             result = runPipeline(fake, 'dev');
 
         expect(result.code).toBe(0);
 
-        // The env, not argv: NEO_REVISION alone would label the image while the source stage
-        // still fetched ${NEO_REF} — a label attesting a commit the build never checked out.
+        // Compose maps this one value to both Docker args. Keeping NEO_REF in the outgoing
+        // environment would preserve the conflicting second input at the boundary.
         const log = await fs.readFile(fake.dockerLog, 'utf8');
 
-        expect(log).toContain(`NEO_REF=${FULL_SHA}`);
+        expect(log).toContain('NEO_REF=<unset>');
         expect(log).toContain(`NEO_REVISION=${FULL_SHA}`);
-        expect(log).not.toContain('NEO_REF=dev');
         expect(log).not.toContain('NEO_REVISION=<unset>')
     });
 
@@ -390,7 +471,7 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         const log = await fs.readFile(fake.dockerLog, 'utf8');
 
         expect(log).toContain(`NEO_REVISION=${PEELED_COMMIT}`);
-        expect(log).toContain(`NEO_REF=${PEELED_COMMIT}`);
+        expect(log).toContain('NEO_REF=<unset>');
         // The tag object must never be attested as the deployed revision.
         expect(log).not.toContain(TAG_OBJECT);
         expect(result.output).not.toContain(TAG_OBJECT)


### PR DESCRIPTION
Resolves #16087

Collapses the manual deployment boundary to one resolved `NEO_REVISION` pin. Compose maps that value to both internal Docker arguments for `kb-server`, `mc-server`, and `orchestrator`; the reference pipeline removes its pre-resolution `NEO_REF` selector before invoking Compose; and the Dockerfile now fails before labeling when the asserted revision differs from `/app/.neo-revision`.

Evidence: L3 (real production-Dockerfile pinned build, OCI label and artifact-receipt parity, plus a real mismatched build rejected at the integrity gate) → L3 required (the close-target runtime and provenance ACs). No residuals.

## Deltas from ticket

None substantive. The unit suite executes the Dockerfile's actual inline integrity `RUN` body without requiring a Docker daemon; a separate real-daemon build supplies the image-level receipt.

## Test Evidence

- Revision boundary and reference pipeline: `npm run test-unit -- test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs` — 20/20 passed.
- Compose cohort, unpinned: `docker compose ... config --format json` — all three services rendered `NEO_REF=dev` and empty `NEO_REVISION`.
- Compose cohort, pinned: the same render with one `NEO_REVISION=6be5af...` — all three services rendered identical full-SHA `NEO_REF` and `NEO_REVISION` values.
- Production Dockerfile positive path: built `kb-server` with `NEO_REVISION=ae6b87c...`; requested-ref label, OCI revision label, and `/app/.neo-revision` all matched.
- Production Dockerfile mutation: built with valid `NEO_REF=ae6b87c...` and mismatched asserted revision; build failed at the new integrity gate with both values named.
- Documentation: `npm run ai:lint-guides` — 0 hard errors (27 pre-existing repository-wide warnings).
- Static checks: `node --check`, `bash -n`, and `git diff --check` passed.
- Preflight: `npm run agent-preflight -- <touched files>` passed after one mechanical alignment repair.

## Post-Merge Validation

- [ ] The first downstream deployment using this contract records matching requested-ref, OCI revision, and `/app/.neo-revision` receipts across the full three-service cohort.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fa904-9d8c-7f12-94fe-346ae8e54046.
