### PR TITLE
fix(ai): restore scheduled corpus publication (#15977)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -32,11 +32,13 @@ jobs:
       # reach `github.token` even when the workflow never passes `GITHUB_TOKEN`, so an unused
       # write grant is still a reachable one, and per-stage env scoping cannot revoke it.
       #
-      # `read` rather than `{}` deliberately: nothing in this job demonstrably needs the implicit
-      # token, but "demonstrably" would require a run to establish and the write authority is the
-      # actual defect. Removing write is the verified fix; removing read as well would be an
-      # unverified extra claim, which is the shape of error this PR has already made twice.
+      # `read` rather than `{}` deliberately: corpus emission and content-index derivation use the
+      # implicit token as their scoped reader. Neither needs write authority; the Publisher App
+      # remains the only identity that can publish the generated commit.
       contents: read
+      # Corpus emission reads pull-request and discussion GraphQL surfaces. These remain read-only
+      # on the implicit token; the Publisher App token is still reserved for the final git push.
+      discussions: read
       # The run above asked for has now happened: the `content indexes and SEO` stage pages this
       # repository's labels over GraphQL and had no credential that could, so every scheduled run
       # since the per-stage scoping landed has failed at that stage. NEITHER App can serve it — the
@@ -49,6 +51,7 @@ jobs:
       # exists so the intake identity cannot publish and the publisher cannot mutate the intake
       # repos, which a read-only grant here does not weaken.
       issues: read
+      pull-requests: read
 
     steps:
       # Two identities, because they hold different authority and `create-github-app-token` scopes

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1150,15 +1150,19 @@ class ConfigBase extends ConfigProvider {
                  * without changing remote graph-backed A2A / Memory Core behavior.
                  * `null` means "use the deployment profile default" (`local` enables,
                  * `cloud` disables); set `true` only when explicitly opting a lane back in.
-                 * Exception: `bridgeDaemonEnabled` + `swarmHeartbeatEnabled` default `false`
-                 * (wake + heartbeat OFF) — the Stop hook makes them redundant flood; see their
-                 * inline notes. Both remain env-overridable to re-enable.
+                 * Exceptions default `false`: `githubWorkflowSyncEnabled` because the Data Sync
+                 * workflow owns scheduled corpus publication, plus `bridgeDaemonEnabled` and
+                 * `swarmHeartbeatEnabled` because the Stop hook makes wake + heartbeat redundant
+                 * flood. All remain env-overridable to re-enable.
                  * @type {Object}
                  */
                 localOnly: {
-                    primaryDevSyncEnabled    : leaf(null, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED', 'boolean'),
-                    kbSyncEnabled            : leaf(null, 'NEO_ORCHESTRATOR_KB_SYNC_ENABLED', 'boolean'),
-                    githubWorkflowSyncEnabled: leaf(null, 'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_ENABLED', 'boolean'),
+                    primaryDevSyncEnabled: leaf(null, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED', 'boolean'),
+                    kbSyncEnabled        : leaf(null, 'NEO_ORCHESTRATOR_KB_SYNC_ENABLED', 'boolean'),
+                    // Scheduled corpus emission belongs to CI's read-only/Publisher split. Local
+                    // checkouts retain the manual CLI but must not regenerate the corpus every two
+                    // hours and accumulate changes they cannot publish through the dev ruleset.
+                    githubWorkflowSyncEnabled: leaf(false, 'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_ENABLED', 'boolean'),
                     // Temporal-pyramid aggregation reads checkout-bound sources (resources/content, git log
                     // origin/dev, learn/agentos/decisions) → local-only. Cloud tenants get their corpus via
                     // push-ingest, not this local scan.

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1020,7 +1020,7 @@ paths:
         **When to Use:**
         Use this tool for a fast, offline-capable way to read the content of an issue that is already present on the local disk. This tool reads directly from the file system and does **not** access the GitHub API.
 
-        **Important:** The content returned reflects the last completed scheduled `githubWorkflowSync` run and may lag GitHub. Use the live GitHub tools when freshness matters.
+        **Important:** The content returned reflects the last completed scheduled Data Sync corpus emission and may lag GitHub. Use the live GitHub tools when freshness matters.
       tags: [Issues]
       parameters:
         - name: issue_number
@@ -1668,7 +1668,7 @@ paths:
 
         **Important Notes:**
         - Changes are made directly on GitHub via the GraphQL API
-        - The local markdown mirror is refreshed by the scheduled `githubWorkflowSync` lane; use live GitHub reads when freshness matters
+        - The local markdown mirror is refreshed by the scheduled Data Sync pipeline; use live GitHub reads when freshness matters
         - For parent_child: An issue can only have ONE parent at a time
         - For blocked_by: An issue can be blocked by MULTIPLE issues
         - Use `replace_parent=true` to replace an existing parent relationship (parent_child only)
@@ -1677,7 +1677,7 @@ paths:
         **Workflow:**
         1. Identify the issue numbers and relationship type
         2. Call this tool to establish or modify the relationship
-        3. Read the updated relationship from live GitHub; the scheduled `githubWorkflowSync` lane refreshes the local markdown mirror
+        3. Read the updated relationship from live GitHub; the scheduled Data Sync pipeline refreshes the local markdown mirror
       tags: [Issues]
       requestBody:
         required: true

--- a/ai/scripts/maintenance/syncGithubWorkflow.mjs
+++ b/ai/scripts/maintenance/syncGithubWorkflow.mjs
@@ -12,15 +12,16 @@ import {
 
 /**
  * @module ai/scripts/maintenance/syncGithubWorkflow
- * @summary CLI wrapper invoking `GH_SyncService.runFullSync()` for full
- * issue / PR / discussion / release-notes substrate emission into
- * `resources/content/`.
+ * @summary CLI wrapper for full manual GitHub Workflow sync and pull-only
+ * scheduled corpus emission into `resources/content/`.
  *
  * **Why this operator CLI is the canonical manual entry point:**
  *
- * The scheduled `githubWorkflowSync` lane and this CLI resolve to the same
- * `GH_SyncService.runFullSync()` orchestration entry point. The long-running sync
- * is deliberately absent from the agent MCP surface: clean-slate emission can span
+ * The scheduled Data Sync pipeline invokes this CLI with `--emit-only`, delegating to
+ * `GH_SyncService.emitGeneratedContentAndDerive({pushLocalChanges: false})`. Operators
+ * retain the default `GH_SyncService.runFullSync()` mode, including its intentional
+ * local-to-GitHub issue push. The long-running sync is deliberately absent from the
+ * agent MCP surface: clean-slate emission can span
  * ~8.5k issues + ~2.8k PRs + ~165 discussions + ~166 release notes and must stay
  * behind the shared heavy-maintenance lease rather than an MCP request timeout.
  *
@@ -28,8 +29,8 @@ import {
  * - avoids an MCP request-timeout ceiling
  * - surfaces full stderr/stdout progress (each syncer logs phase-by-phase via
  *   `ai/mcp/server/github-workflow/logger.mjs`)
- * - leaves the underlying service untouched (no special-case "full vs delta"
- *   code path — the same `runFullSync()` runs in both invocations)
+ * - keeps scheduled CI read-only at the GitHub API boundary while preserving the
+ *   operator's full bi-directional mode
  *
  * **SDK boundary**: imports route through `ai/services.mjs` (the canonical SDK
  * entry point per `Neo.ai.services`), which handles Neo namespace bootstrap +
@@ -39,12 +40,12 @@ import {
  * `ai/mcp/server/...` or `ai/services/...` deep imports.
  *
  * The authority boundary is the regeneratable-cache model: this script exists
- * to rebuild workflow mirrors outside the MCP request-timeout envelope while preserving
- * the same service path as the scheduled `githubWorkflowSync` lane.
+ * to rebuild workflow mirrors outside the MCP request-timeout envelope.
  *
  * @example
  *   npm run ai:sync-github-workflow
  *   npm run ai:sync-github-workflow -- --verbose
+ *   npm run ai:sync-github-workflow -- --emit-only
  *
  *   # Full output streamed to stdout/stderr (no MCP timeout ceiling).
  *   # Exit code 0 on success / 1 on failure.
@@ -66,11 +67,14 @@ async function assertSyncGithubWorkflowDevBranch() {
 }
 
 /**
- * @summary CLI entry point for the full GitHub Workflow mirror sync.
+ * @summary CLI entry point for full manual sync or scheduled pull-only corpus emission.
  * @returns {Promise<void>}
  */
 async function syncGithubWorkflow() {
-    const verbose = process.argv.includes('--verbose');
+    const
+        emitOnly = process.argv.includes('--emit-only'),
+        verbose  = process.argv.includes('--verbose');
+
     GH_Config.data.logLevel = verbose ? 'debug' : 'info';
 
     try {
@@ -80,7 +84,9 @@ async function syncGithubWorkflow() {
         process.exit(1);
     }
 
-    console.log('🔄 Starting full GitHub Workflow sync via GH_SyncService.runFullSync()...');
+    console.log(emitOnly
+        ? '🔄 Starting pull-only GitHub Workflow corpus emission...'
+        : '🔄 Starting full GitHub Workflow sync via GH_SyncService.runFullSync()...');
 
     // Run the full workflow sync under the shared heavy-maintenance lease so this CLI
     // cannot collide with orchestrator maintenance tasks or another manual graph-heavy
@@ -89,13 +95,15 @@ async function syncGithubWorkflow() {
     let outcome;
     try {
         outcome = await withHeavyMaintenanceLease(
-            async () => GH_SyncService.runFullSync(),
+            async () => emitOnly
+                ? GH_SyncService.emitGeneratedContentAndDerive({pushLocalChanges: false})
+                : GH_SyncService.runFullSync(),
             {
                 leasePath   : resolveHeavyMaintenanceLeasePath({dataDir: AiConfig.orchestrator.dataDir}),
                 owner       : 'syncGithubWorkflow',
                 reason      : 'manual-cli',
                 staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs,
-                metadata    : {script: 'ai/scripts/maintenance/syncGithubWorkflow.mjs', verbose}
+                metadata    : {emitOnly, script: 'ai/scripts/maintenance/syncGithubWorkflow.mjs', verbose}
             }
         );
     } catch (e) {
@@ -106,11 +114,11 @@ async function syncGithubWorkflow() {
     if (outcome.status === 'held') {
         const held = outcome.lease;
         console.log(`⏸️  Deferred: heavy-maintenance lease held by '${held.owner}' (reason='${held.reason}', pid=${held.pid}, acquiredAt=${held.acquiredAt}).`);
-        console.log('   This script will not run while another heavy-maintenance task is active. Re-invoke once the active owner completes.');
-        process.exit(0);
+        console.log('   This script will not run while another heavy-maintenance task is active.');
+        process.exit(emitOnly ? 1 : 0);
     }
 
-    console.log('✅ Sync complete:', outcome.result);
+    console.log(emitOnly ? '✅ Corpus emission complete:' : '✅ Sync complete:', outcome.result);
     process.exit(0);
 }
 

--- a/ai/scripts/maintenance/syncGithubWorkflowBranchGuard.mjs
+++ b/ai/scripts/maintenance/syncGithubWorkflowBranchGuard.mjs
@@ -58,7 +58,7 @@ function buildSyncGithubWorkflowDevBranchGuard(delegate, getBranch = defaultSync
             throw new Error(
                 `syncGithubWorkflow REJECTED: working-tree is on branch '${branch || '(detached)'}', not 'dev'. ` +
                 `syncGithubWorkflow writes to resources/content/{issues,pulls,discussions,release-notes}/ and metadata, which would pollute a non-dev branch. ` +
-                `Switch to 'dev' and rerun npm run ai:sync-github-workflow, or let the scheduled githubWorkflowSync lane run from its canonical dev context.`
+                `Switch to 'dev' and rerun npm run ai:sync-github-workflow, or let the scheduled Data Sync pipeline emit from its canonical dev context.`
             );
         }
 

--- a/ai/services/github-workflow/LocalFileService.mjs
+++ b/ai/services/github-workflow/LocalFileService.mjs
@@ -57,7 +57,7 @@ class LocalFileService extends Base {
                 logger.warn(`[LocalFileService] ${label} index entry not found for #${normalizedId}`);
                 return {
                     error  : 'File not found',
-                    message: `No local markdown index entry found for ${label.toLowerCase()} #${normalizedId}. Use live GitHub for current state; the scheduled githubWorkflowSync lane regenerates resources/content/_index.json.`,
+                    message: `No local markdown index entry found for ${label.toLowerCase()} #${normalizedId}. Use live GitHub for current state; the scheduled Data Sync pipeline regenerates resources/content/_index.json.`,
                     code   : 'NOT_FOUND'
                 };
             }
@@ -68,7 +68,7 @@ class LocalFileService extends Base {
                 logger.warn(`[LocalFileService] ${label} indexed path is stale for #${normalizedId}: ${filePath}`);
                 return {
                     error  : 'Stale content index',
-                    message: `Indexed markdown file for ${label.toLowerCase()} #${normalizedId} does not exist. Use live GitHub for current state; the scheduled githubWorkflowSync lane regenerates resources/content/_index.json.`,
+                    message: `Indexed markdown file for ${label.toLowerCase()} #${normalizedId} does not exist. Use live GitHub for current state; the scheduled Data Sync pipeline regenerates resources/content/_index.json.`,
                     code   : 'STALE_INDEX'
                 };
             }

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -138,8 +138,9 @@ class SyncService extends Base {
      * 1. Loads the persistent metadata via `MetadataManager` — one accumulator every facet mutates.
      * 2. Prerequisite `releases`: fetches release data and caches it (`ReleaseNotesSyncer`). Dependent
      *    facets run only if this advanced or a non-empty cached bucketing reference survived.
-     * 3. Facet `issues`: reconciles closed issue locations, **pushes** local changes, then **pulls**
-     *    remote changes, merging the returned metadata into the accumulator (`IssueSyncer`).
+     * 3. Facet `issues`: reconciles closed issue locations, optionally **pushes** local changes, then
+     *    **pulls** remote changes, merging the returned metadata into the accumulator (`IssueSyncer`).
+     *    Scheduled CI emission disables the push half explicitly; the manual full-sync keeps it.
      * 4. Facet `releaseNotes`: syncs release notes into local Markdown (`ReleaseNotesSyncer`).
      * 5. Facet `discussions`: syncs discussions into local Markdown (`DiscussionSyncer`).
      * 6. Facet `pulls`: reconciles closed pull locations, syncs pulls, repairs duplicates, realigns
@@ -148,9 +149,12 @@ class SyncService extends Base {
      * 7. Rebuilds Portal content indexes and SEO artifacts from whatever advanced.
      * 8. Throws one aggregate verdict naming every facet that did not advance — partial progress must
      *    never report as a clean run.
+     * @param {Object} [options]
+     * @param {Boolean} [options.pushLocalChanges=true] Whether locally-authored issue changes may
+     * be pushed to GitHub before the pull. Scheduled CI emission passes `false` and remains read-only.
      * @returns {Promise<object>} Statistics for the emitted generated content, plus `facetOutcomes`.
      */
-    async emitGeneratedContentAndDerive() {
+    async emitGeneratedContentAndDerive({pushLocalChanges = true} = {}) {
         const
             metadata = await MetadataManager.load(),
             outcomes = [],
@@ -224,7 +228,12 @@ class SyncService extends Base {
 
         await dependentFacet('issues', ['issues', 'pushFailures', 'lastSync'], async () => {
             reconcileStats = await IssueSyncer.reconcileClosedIssueLocations(metadata);
-            pushStats      = await IssueSyncer.pushToGitHub(metadata);
+            if (pushLocalChanges) {
+                pushStats = await IssueSyncer.pushToGitHub(metadata)
+            } else {
+                pushStats = {skipped: true, reason: 'pull-only generated-content emission'};
+                logger.info('[SyncService] Pull-only emission: skipping local-to-GitHub issue push.')
+            }
 
             const {newMetadata, stats} = await IssueSyncer.pullFromGitHub(metadata);
 

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -19,7 +19,12 @@ import {classifyDiscussionRoutingDisposition}                from '../shared/dis
 import pruneEmptyDirs                                        from '../shared/pruneEmptyDirs.mjs';
 import {verifyDiscussionFrontmatter}                         from './verifyFrontmatterIntegrity.mjs';
 
-const issueSyncConfig = aiConfig.issueSync;
+const
+    // A clean-slate `first: 50` discussion query exceeds GitHub's GraphQL resource budget once
+    // comments and replies are projected. Thirty is the measured safe outer page size. Cursor
+    // pagination remains unchanged, so this bounds per-query cost without truncating the corpus.
+    discussionOuterPageSize = 30,
+    issueSyncConfig         = aiConfig.issueSync;
 
 /**
  * @summary Handles the fetching and local synchronization of GitHub Discussions.
@@ -417,7 +422,7 @@ class DiscussionSyncer extends Base {
             const data = await GraphqlService.query(FETCH_DISCUSSIONS_FOR_SYNC, {
                 owner      : aiConfig.owner,
                 repo       : aiConfig.repo,
-                limit      : 50,
+                limit      : discussionOuterPageSize,
                 cursor,
                 maxComments: 50,
                 maxReplies : 20

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -20,7 +20,8 @@ export const GENERATED_DATA_PATHS = [
     ':(glob)apps/devindex/resources/data/*.json*',
     'apps/portal/resources/data',
     'apps/portal/sitemap.xml',
-    'apps/portal/llms.txt'
+    'apps/portal/llms.txt',
+    'resources/content'
 ];
 
 /**
@@ -69,6 +70,20 @@ const
             command   : 'npm',
             label     : 'install dependencies',
             tokenScope: 'none'
+        },
+        {
+            // Corpus generation is deliberately pull-only in CI. The child receives the READER
+            // identity, while the Publisher App remains unavailable until the final git push.
+            //
+            // SyncService isolates facets and persists each successful facet before returning one
+            // aggregate failure. An ephemeral runner would lose that progress if this child failure
+            // aborted the parent immediately, so the pipeline publishes the allowlisted progress
+            // first and then reports the original failure.
+            args                             : ['./ai/scripts/maintenance/syncGithubWorkflow.mjs', '--emit-only'],
+            command                          : process.execPath,
+            label                            : 'GitHub Workflow corpus',
+            publishGeneratedProgressOnFailure: true,
+            tokenScope                       : 'reader'
         },
         {
             args      : ['run', 'devindex:optin'],
@@ -267,6 +282,7 @@ export function isGeneratedDataPath(filePath) {
         || filePath === 'apps/portal/sitemap.xml'
         || filePath === 'apps/portal/llms.txt'
         || filePath.startsWith('apps/portal/resources/data/')
+        || filePath.startsWith('resources/content/')
 }
 
 /**
@@ -480,7 +496,8 @@ async function recoverStaleAttempt({
  * @param {String}   options.cwd Repository root.
  * @param {Function} options.execute Child-process executor.
  * @param {Function} options.log Telemetry sink.
- * @returns {Promise<void>}
+ * @returns {Promise<void|{deferredError: Error}>} Deferred corpus failure whose safe generated
+ * progress must be published before the original error is reported.
  */
 export async function emitGeneratedData({
     attempt,
@@ -503,7 +520,15 @@ export async function emitGeneratedData({
         return
     }
 
-    for (const {args, command, label, tokenScope} of emissionCommands) {
+    let deferredError = null;
+
+    for (const {
+        args,
+        command,
+        label,
+        publishGeneratedProgressOnFailure = false,
+        tokenScope
+    } of emissionCommands) {
         log(`[DataSync] emit attempt=${attempt} stage=${label} credential=${tokenScope}`);
 
         try {
@@ -523,8 +548,21 @@ export async function emitGeneratedData({
                 `\`${tokenScope}\`. If this is an authentication failure, the stage requires a scope ` +
                 `that grants it — never an ambient credential.\n${error.message}`;
 
+            if (publishGeneratedProgressOnFailure) {
+                deferredError = error;
+                log(
+                    `[DataSync] emit attempt=${attempt} stage=${label} result=deferred-failure ` +
+                    'action=publish-generated-progress-then-fail'
+                );
+                continue
+            }
+
             throw error
         }
+    }
+
+    if (deferredError) {
+        return {deferredError}
     }
 }
 
@@ -566,7 +604,7 @@ export async function runDataSyncPipeline({
         const baseSha = await readSha(execute, cwd, 'HEAD');
 
         log(`[DataSync] attempt=${attempt}/${maxAttempts} base=${baseSha}`);
-        await emit({attempt, baseSha, cwd, execute, log});
+        const {deferredError = null} = await emit({attempt, baseSha, cwd, execute, log}) || {};
 
         // TERMINAL, not merely quiet. Returning early from `emit` ended the emission loop and then
         // fell straight through to the publish path below, which only stayed harmless because an
@@ -612,6 +650,10 @@ export async function runDataSyncPipeline({
 
         if (!status.trim()) {
             log(`[DataSync] publish attempt=${attempt}/${maxAttempts} result=no-generated-changes`);
+
+            if (deferredError) {
+                throw deferredError
+            }
 
             return {attempts: attempt, baseSha, changed: false, pushed: false}
         }
@@ -710,6 +752,14 @@ export async function runDataSyncPipeline({
         }
 
         log(`[DataSync] publish attempt=${attempt}/${maxAttempts} result=pushed base=${baseSha}`);
+
+        if (deferredError) {
+            log(
+                `[DataSync] publish attempt=${attempt}/${maxAttempts} ` +
+                'result=pushed-generated-progress-before-stage-failure'
+            );
+            throw deferredError
+        }
 
         return {attempts: attempt, baseSha, changed: true, pushed: true}
     }

--- a/learn/agentos/GitHubWorkflow.md
+++ b/learn/agentos/GitHubWorkflow.md
@@ -70,7 +70,7 @@ The core of the server is its ability to maintain state consistency between the 
 *   **Push (Local → Remote):** The server scans for modified local Markdown files. It uses **Content Hashing** (SHA-256) to detect actual changes. If a file has changed, the server pushes updates (Title, Body) to GitHub via GraphQL mutations.
 *   **Pull (Remote → Local):** The server fetches the latest data from GitHub. New issues are created locally, and updated issues overwrite local versions.
 
-When the scheduled `githubWorkflowSync` lane runs—or an operator invokes `npm run ai:sync-github-workflow`—`SyncService` executes a precise 8-step orchestration logic to ensure data integrity:
+When the scheduled Data Sync pipeline emits the corpus—or an operator invokes `npm run ai:sync-github-workflow`—`SyncService` executes a precise 8-step orchestration logic to ensure data integrity. Scheduled CI is pull-only; the manual command retains the full bi-directional issue sync:
 
 1.  **Load Metadata:** Reads `.sync-metadata.json` to understand the previous state.
 2.  **Fetch Releases:** `ReleaseSyncer` fetches the latest release data. This is done *first* because the archive logic depends on knowing available releases.
@@ -90,7 +90,7 @@ The server exposes a comprehensive suite of tools via the Model Context Protocol
 *   **`healthcheck`**: Verifies `gh` CLI status. Returns cached healthy results for speed, but performs immediate checks if the system was previously unhealthy.
 *   **`get_viewer_permission`**: Returns the bot's permission level (`ADMIN`, `WRITE`, `READ`).
 
-The full bi-directional sync is intentionally not an agent MCP tool. The orchestrator owns the scheduled `githubWorkflowSync` lane; operators retain `npm run ai:sync-github-workflow` as the canonical manual rebuild path.
+The full bi-directional sync is intentionally not an agent MCP tool. The Data Sync workflow owns scheduled pull-only corpus publication; operators retain `npm run ai:sync-github-workflow` as the canonical manual rebuild path.
 
 ### 4.2 Issue Management
 

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -55,6 +55,7 @@ async function createRepositoryFixture() {
     await write(seed, 'apps/portal/resources/data/tickets/index.json', '{"version":1}\n');
     await write(seed, 'apps/portal/sitemap.xml', '<urlset />\n');
     await write(seed, 'apps/portal/llms.txt', 'v1\n');
+    await write(seed, 'resources/content/.sync-metadata.json', '{}\n');
     await write(seed, 'source.txt', 'v1\n');
     runGit(seed, ['add', '.']);
     runGit(seed, ['commit', '-m', 'initial']);
@@ -91,13 +92,16 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
             ':(glob)apps/devindex/resources/data/*.json*',
             'apps/portal/resources/data',
             'apps/portal/sitemap.xml',
-            'apps/portal/llms.txt'
+            'apps/portal/llms.txt',
+            'resources/content'
         ]);
         expect(isGeneratedDataPath('apps/devindex/resources/data/users.jsonl')).toBe(true);
         expect(isGeneratedDataPath('apps/devindex/resources/data/nested/users.jsonl')).toBe(false);
         expect(isGeneratedDataPath('apps/portal/resources/data/tickets/index.json')).toBe(true);
         expect(isGeneratedDataPath('apps/portal/sitemap.xml')).toBe(true);
         expect(isGeneratedDataPath('apps/portal/llms.txt')).toBe(true);
+        expect(isGeneratedDataPath('resources/content/.sync-metadata.json')).toBe(true);
+        expect(isGeneratedDataPath('resources/content/archive/pulls/v13.0.0/chunk-1/pull-1.md')).toBe(true);
         expect(isGeneratedDataPath('src/ManualEdit.mjs')).toBe(false)
     });
 
@@ -120,6 +124,7 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
 
         expect(calls.map(({args, command}) => [command, ...args])).toEqual([
             ['npm', 'ci'],
+            [process.execPath, './ai/scripts/maintenance/syncGithubWorkflow.mjs', '--emit-only'],
             ['npm', 'run', 'devindex:optin'],
             ['npm', 'run', 'devindex:optout'],
             ['npm', 'run', 'devindex:spider', '--', '--strategy', 'random'],
@@ -283,6 +288,8 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
         // grant is a reachable one that per-stage env scoping cannot revoke. Leaving it at `write`
         // meant three repository-write credentials were alive while this workflow claimed two.
         expect(workflow).toContain('contents: read');
+        expect(workflow).toContain('discussions: read');
+        expect(workflow).toContain('pull-requests: read');
         expect(workflow).not.toMatch(/permissions:\s*\n\s*#[^\n]*\n(\s*#[^\n]*\n)*\s*contents: write/);
 
         // A preflight-only dispatch must not reach the pages push. Without this guard it did —
@@ -379,7 +386,7 @@ test.describe('emission-stage credential scoping', () => {
         expect(values(env)).not.toContain('ambient-default')
     });
 
-    test('every declared emission stage carries an explicit scope, and only intake/none collect data', async () => {
+    test('every declared emission stage carries an explicit scope and none receives the publisher', async () => {
         // Guards the annotation itself: a new stage added without `tokenScope` would inherit
         // `undefined`, land in the `none` branch, and look deliberate. This makes omission visible.
         const calls = [];
@@ -474,6 +481,68 @@ test.describe('tokenScope validation fails closed', () => {
         expect(labelStage, 'the label stage must still be in the shipped table').toBeTruthy();
         expect(labelStage).toContain('credential=reader');
         expect(labelStage).not.toContain('credential=none')
+    });
+
+    test('the corpus stage is pull-only under the reader identity (#15977)', async () => {
+        const
+            calls             = [],
+            originalPublisher = process.env.DATA_SYNC_PUBLISHER_TOKEN,
+            originalReader    = process.env.DATA_SYNC_READER_TOKEN;
+
+        process.env.DATA_SYNC_PUBLISHER_TOKEN = 'PUBLISHER-corpus-stage-test';
+        process.env.DATA_SYNC_READER_TOKEN    = 'READER-corpus-stage-test';
+
+        try {
+            await emitGeneratedData({
+                attempt  : 1,
+                cwd      : '/tmp',
+                execute  : async (command, args, {env}) => calls.push({args, command, token: env.GITHUB_TOKEN}),
+                log      : () => {},
+                preflight: async () => {}
+            });
+
+            const corpus = calls.find(({args}) => args.includes('--emit-only'));
+
+            expect(corpus).toMatchObject({
+                args   : ['./ai/scripts/maintenance/syncGithubWorkflow.mjs', '--emit-only'],
+                command: process.execPath,
+                token  : 'READER-corpus-stage-test'
+            })
+        } finally {
+            if (originalPublisher === undefined) {
+                delete process.env.DATA_SYNC_PUBLISHER_TOKEN
+            } else {
+                process.env.DATA_SYNC_PUBLISHER_TOKEN = originalPublisher
+            }
+
+            if (originalReader === undefined) {
+                delete process.env.DATA_SYNC_READER_TOKEN
+            } else {
+                process.env.DATA_SYNC_READER_TOKEN = originalReader
+            }
+        }
+    });
+
+    test('defers a corpus-stage failure until safe generated progress is published (#15977)', async () => {
+        const fixture = await createRepositoryFixture();
+
+        try {
+            const corpusFailure = new Error('discussion resource limit');
+
+            await expect(runDataSyncPipeline({
+                cwd : fixture.runner,
+                emit: async ({cwd}) => {
+                    await write(cwd, generatedFile, 'generated:partial-progress\n');
+                    return {deferredError: corpusFailure}
+                },
+                log: () => {}
+            })).rejects.toBe(corpusFailure);
+
+            expect(readRemoteFile(fixture, generatedFile)).toBe('generated:partial-progress');
+            expect(remoteSubjects(fixture)[0]).toBe('chore(data): Hourly data sync pipeline update [skip ci]')
+        } finally {
+            await fs.rm(fixture.root, {recursive: true, force: true})
+        }
     });
 
     test('a failing stage names the scope it was granted, not just the child error', async () => {

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -102,6 +102,7 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
         expect(isGeneratedDataPath('apps/portal/llms.txt')).toBe(true);
         expect(isGeneratedDataPath('resources/content/.sync-metadata.json')).toBe(true);
         expect(isGeneratedDataPath('resources/content/archive/pulls/v13.0.0/chunk-1/pull-1.md')).toBe(true);
+        expect(isGeneratedDataPath('.neo-ai-data/concepts/nodes.jsonl')).toBe(false);
         expect(isGeneratedDataPath('src/ManualEdit.mjs')).toBe(false)
     });
 
@@ -134,7 +135,7 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
         expect(calls.every(call => call.options.cwd === '/repo')).toBe(true)
     });
 
-    test('publishes one atomic generated commit when dev stays unchanged', async () => {
+    test('publishes one atomic corpus and Portal projection commit when dev stays unchanged', async () => {
         const fixture = await createRepositoryFixture();
 
         try {
@@ -144,7 +145,16 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
                 cwd : fixture.runner,
                 emit: async ({attempt, cwd}) => {
                     emissions++;
-                    await write(cwd, generatedFile, `generated:v1:attempt-${attempt}\n`)
+                    await write(cwd, generatedFile, `generated:v1:attempt-${attempt}\n`);
+                    await write(cwd, 'resources/content/issues/chunk-10/issue-15977.md', '# Issue 15977\n');
+                    await write(cwd, 'apps/portal/resources/data/tickets/index.json', '{"version":2}\n');
+                    await write(
+                        cwd,
+                        'apps/portal/resources/data/pulls/latest/active-chunk-5.json',
+                        '{"records":[]}\n'
+                    );
+                    await write(cwd, 'apps/portal/sitemap.xml', '<urlset><url /></urlset>\n');
+                    await write(cwd, 'apps/portal/llms.txt', 'v2\n')
                 },
                 log: () => {}
             });
@@ -152,6 +162,20 @@ test.describe('Data Sync pipeline publisher (#15746)', () => {
             expect(result).toMatchObject({attempts: 1, changed: true, pushed: true});
             expect(emissions).toBe(1);
             expect(readRemoteFile(fixture, generatedFile)).toBe('generated:v1:attempt-1');
+            expect(readRemoteFile(
+                fixture,
+                'resources/content/issues/chunk-10/issue-15977.md'
+            )).toBe('# Issue 15977');
+            expect(readRemoteFile(
+                fixture,
+                'apps/portal/resources/data/tickets/index.json'
+            )).toBe('{"version":2}');
+            expect(readRemoteFile(
+                fixture,
+                'apps/portal/resources/data/pulls/latest/active-chunk-5.json'
+            )).toBe('{"records":[]}');
+            expect(readRemoteFile(fixture, 'apps/portal/sitemap.xml')).toBe('<urlset><url /></urlset>');
+            expect(readRemoteFile(fixture, 'apps/portal/llms.txt')).toBe('v2');
             expect(remoteSubjects(fixture)).toEqual([
                 'chore(data): Hourly data sync pipeline update [skip ci]',
                 'initial'

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -386,7 +386,7 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(Config.orchestrator.localOnly).toEqual({
             primaryDevSyncEnabled          : null,
             kbSyncEnabled                  : null,
-            githubWorkflowSyncEnabled      : null,
+            githubWorkflowSyncEnabled      : false,
             temporalSummaryEnabled         : null,
             chromaDaemonEnabled            : null,
             bridgeDaemonEnabled            : false,

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -620,7 +620,7 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
             found : true,
             source: 'description'
         });
-        expect(handbook.handbook.replace(/\s+/g, ' ')).toContain('scheduled `githubWorkflowSync` lane refreshes the local markdown mirror');
+        expect(handbook.handbook.replace(/\s+/g, ' ')).toContain('scheduled Data Sync pipeline refreshes the local markdown mirror');
         expect(handbook.handbook).not.toContain('sync_all');
 
         expect(missing).toEqual({

--- a/test/playwright/unit/ai/scripts/maintenance/syncGithubWorkflow.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/syncGithubWorkflow.spec.mjs
@@ -49,10 +49,10 @@ test.describe('syncGithubWorkflow CLI dev-branch guard (#12780)', () => {
         expect(delegateCalls).toBe(0);
     });
 
-    test('names the scheduled githubWorkflowSync lane in remediation', async () => {
+    test('names the scheduled Data Sync pipeline in remediation', async () => {
         const guarded = buildSyncGithubWorkflowDevBranchGuard(async () => {}, async () => 'codex/feature');
 
-        await expect(guarded()).rejects.toThrow(/scheduled githubWorkflowSync lane/);
+        await expect(guarded()).rejects.toThrow(/scheduled Data Sync pipeline/);
     });
 
     test('rejects detached HEAD before delegate work begins', async () => {
@@ -87,20 +87,32 @@ test.describe('syncGithubWorkflow CLI dev-branch guard (#12780)', () => {
         const source = await fs.readFile(cliScriptPath, 'utf8');
 
         const
-            guardIndex  = source.indexOf('await assertSyncGithubWorkflowDevBranch();'),
-            startIndex  = source.indexOf('Starting full GitHub Workflow sync'),
-            leaseIndex  = source.indexOf('outcome = await withHeavyMaintenanceLease('),
-            syncIndex   = source.indexOf('async () => GH_SyncService.runFullSync()'),
+            guardIndex = source.indexOf('await assertSyncGithubWorkflowDevBranch();'),
+            startIndex = source.indexOf('Starting full GitHub Workflow sync'),
+            leaseIndex = source.indexOf('outcome = await withHeavyMaintenanceLease('),
+            syncIndex  = source.indexOf(': GH_SyncService.runFullSync()', leaseIndex),
+            emitIndex  = source.indexOf(
+                'GH_SyncService.emitGeneratedContentAndDerive({pushLocalChanges: false})',
+                leaseIndex
+            ),
             autorunGate = source.indexOf("if (import.meta.url === pathToFileURL(process.argv[1] || '').href)");
 
         expect(guardIndex, 'branch guard call must exist').toBeGreaterThan(-1);
         expect(startIndex, 'start log must exist').toBeGreaterThan(-1);
         expect(leaseIndex, 'heavy-maintenance lease call must exist').toBeGreaterThan(-1);
         expect(syncIndex, 'real sync delegate must exist').toBeGreaterThan(-1);
+        expect(emitIndex, 'pull-only emission delegate must exist').toBeGreaterThan(-1);
         expect(autorunGate, 'import-safe CLI autorun gate must exist').toBeGreaterThan(-1);
 
         expect(guardIndex).toBeLessThan(startIndex);
         expect(guardIndex).toBeLessThan(leaseIndex);
         expect(guardIndex).toBeLessThan(syncIndex);
+        expect(guardIndex).toBeLessThan(emitIndex);
+    });
+
+    test('a held lease fails scheduled emission but keeps manual deferral non-erroring', async () => {
+        const source = await fs.readFile(cliScriptPath, 'utf8');
+
+        expect(source).toContain('process.exit(emitOnly ? 1 : 0)')
     });
 });

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -637,6 +637,32 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         expect(queryCalls).toBe(2);
     });
 
+    test('clean-slate bootstrap uses the bounded outer page size and follows every cursor (#15977)', async () => {
+        const
+            first  = buildDiscussion(26001),
+            second = buildDiscussion(26002),
+            calls  = [];
+
+        GraphqlService.query = async (query, variables) => {
+            calls.push({...variables});
+
+            return {
+                repository: {
+                    discussions: variables.cursor === null
+                        ? {nodes: [first], pageInfo: {hasNextPage: true, endCursor: 'page-2'}}
+                        : {nodes: [second], pageInfo: {hasNextPage: false, endCursor: null}}
+                }
+            }
+        };
+
+        const stats = await DiscussionSyncer.syncDiscussions({discussions: {}, lastSync: null});
+
+        expect(calls).toHaveLength(2);
+        expect(calls.map(({limit}) => limit)).toEqual([30, 30]);
+        expect(calls.map(({cursor}) => cursor)).toEqual([null, 'page-2']);
+        expect(stats.synced).toEqual([26001, 26002])
+    });
+
     test('containment: skips and excludes a denylisted discussion (by number)', async () => {
         const allowed = buildDiscussion(25001, {closed: false});
         const denied  = buildDiscussion(25002, {closed: false});

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -227,6 +227,30 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         expect(result.syncStats ?? result).toBeTruthy();
     });
 
+    test('pull-only emission skips local-to-GitHub issue mutation but still pulls (#15977)', async () => {
+        let pushCalls = 0,
+            pullCalls = 0;
+
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-05-10T00:00:00Z'}];
+        IssueSyncer.pushToGitHub = async () => { pushCalls++; return {count: 0} };
+        IssueSyncer.pullFromGitHub = async metadata => {
+            pullCalls++;
+            return {
+                newMetadata: metadata,
+                stats      : {pulled: {count: 0, created: 0, updated: 0, moved: 0}, dropped: {count: 0}}
+            }
+        };
+
+        const result = await SyncService.emitGeneratedContentAndDerive({pushLocalChanges: false});
+
+        expect(pushCalls).toBe(0);
+        expect(pullCalls).toBe(1);
+        expect(result.pushStats).toEqual({
+            skipped: true,
+            reason : 'pull-only generated-content emission'
+        })
+    });
+
     test('runFullSync executes Stage 2 ingestion by dynamically invoking IssueIngestor', async () => {
         const result = await SyncService.runFullSync();
 


### PR DESCRIPTION
Resolves #15977

Restores scheduled publication of the GitHub Workflow corpus and its Portal projection through the existing Data Sync reader/Publisher split. The workflow now runs the canonical generator in explicit pull-only mode, stages `resources/content/**`, `apps/portal/resources/data/**`, `apps/portal/sitemap.xml`, and `apps/portal/llms.txt`, and leaves the Publisher App as the sole identity that can deliver the generated commit. Local scheduled generation defaults off while the guarded manual bi-directional command remains available.

Evidence: L2 (exact-base full unit suite, credential-boundary and mutation-exclusion tests, YAML/source validation) → L4 required (AC7 scheduled Publisher-App commit and AC8 receipt-gated canonical-backlog cleanup). Residual: AC7, AC8 [#15977].

## Deltas from ticket

None substantive. The implementation makes three load-bearing boundaries explicit:

- CI calls `emitGeneratedContentAndDerive({pushLocalChanges: false})`; the manual command retains the default local-to-GitHub issue push.
- A corpus aggregate failure is deferred only long enough to publish allowlisted successful-facet progress, then the workflow reports the original failure.
- Clean-slate discussion bootstrap uses an outer page size of 30 while retaining complete cursor pagination.

Decision Record impact: None. This extends the existing Data Sync reader/Publisher authority split.

Related: #16002
Related: #16016

## Test Evidence

- Full unit gate before the final non-overlapping rebase: `npm run test-unit -- --reporter=dot` — 10,159 passed, 5 skipped; Playwright receipt `status: passed`, `failedTests: []`.
- Post-rebase exact-head focused gates: Data Sync / corpus CLI / maintenance lease / discussion bootstrap / pull-only sync — 112/112 passed; config template — 17/17 passed; MCP handbook smoke — 38/38 passed.
- Exact-head Portal publication coverage exercises modified index/SEO artifacts and a newly created `apps/portal/resources/data/**` chunk in the remote generated commit — 33/33 passed.
- Data Sync publication and local corpus read path: `npm run test-unit -- test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs test/playwright/unit/ai/services/github-workflow/LocalFileService.spec.mjs` — 42/42 passed.
- Pull-only mutation exclusion: `SyncService.Stage2.spec.mjs` — 24/24 passed.
- Discussion bootstrap pagination: `DiscussionSyncer.spec.mjs` — 26/26 passed.
- CLI, config, and MCP handbook contracts: focused suites passed at 11/11, 17/17, and 38/38 respectively.
- Static validation: all changed `.mjs` modules passed `node --check`; both changed YAML files parsed with `js-yaml`; `git diff --check` passed.
- Agent preflight: repair-capable pass completed with 0 ticket-archaeology violations and only mechanical block-alignment changes.

## Post-Merge Validation

- [ ] Observe an actual scheduled Data Sync run on merged `dev` and verify one Publisher-App commit advances both `resources/content/**` and the derived Portal data/index/SEO artifacts.
- [ ] Verify the per-facet corpus watchdog reports issues, pulls, discussions, and release notes fresh.
- [ ] Only after that commit proves publication completeness, discard the canonical checkout's generated backlog while preserving every non-generated change.

## Evolution

The initial implementation path treated the canonical corpus emitter as read-only. Source inspection falsified that premise: the issues facet calls `IssueSyncer.pushToGitHub()` before pulling. The final shape adds an explicit pull-only option and a mutation-exclusion test instead of relying on a missing write permission to fail safely.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fa530-53d6-7271-bf05-51497720b29c.
