### PR TITLE
feat(ai): expose mailbox read-state diagnostic (#16086)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -302,7 +302,9 @@ paths:
         log tails, current diagnoses, and recent recovery-run ledger entries without exposing
         Docker, shell, exec, restart, or any public daemon/orchestrator route. Fresh snapshots
         missing current-schema sections return a degraded status with stable schemaDiagnostics
-        reason codes.
+        reason codes. An optional mailboxReadState request adds one carrier-aware observation
+        read directly by the Memory Core graph owner before any normal mailbox repair path.
+        The caller may inspect its own recipient state or an inbox covered by CAN_READ_INBOX_OF.
       tags: [Diagnostics]
       requestBody:
         required: false
@@ -314,13 +316,60 @@ paths:
                 staleAfterMs:
                   type: number
                   description: Optional freshness window override in milliseconds.
+                mailboxReadState:
+                  type: object
+                  additionalProperties: false
+                  description: |
+                    Optional message-scoped durable carrier observation. Omitting this property
+                    preserves the deployment-snapshot response shape exactly.
+                  required: [messageId, recipient]
+                  properties:
+                    messageId:
+                      type: string
+                      pattern: '^MESSAGE:[^\s]+$'
+                      description: Exact MESSAGE graph node id to inspect.
+                    recipient:
+                      type: string
+                      minLength: 1
+                      description: Direct recipient identity whose MESSAGE or DELIVERED_TO carrier is inspected.
       responses:
         '200':
-          description: Inspection status and payload when available.
+          description: |
+            Inspection status and payload when available. When mailboxReadState was requested,
+            the response also contains a mailboxReadState observation with ok, state, messageId,
+            recipient, route, and carrier fields; malformed/conflicting observations may add error.
           content:
             application/json:
               schema:
                 type: object
+                properties:
+                  mailboxReadState:
+                    type: object
+                    properties:
+                      ok:
+                        type: boolean
+                      state:
+                        type: string
+                        enum:
+                          - message-missing
+                          - recipient-carrier-missing
+                          - unread
+                          - read
+                          - malformed-storage
+                          - conflicting-storage
+                      messageId:
+                        type: string
+                      recipient:
+                        type: string
+                      route:
+                        type: string
+                        nullable: true
+                        enum: [direct, broadcast]
+                      carrier:
+                        type: object
+                        nullable: true
+                      error:
+                        type: string
 
   /handoff/sandman:
     post:

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -44,6 +44,25 @@ const readDeploymentInspection = args => readDeploymentStateSnapshot({
     maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
 });
 
+/**
+ * @summary Extends the deployment inspection with an opt-in, identity-authorized mailbox
+ * read-state observation while preserving the snapshot-only shape when the request is absent.
+ * @param {Object} [args]
+ * @returns {Promise<Object>}
+ */
+const inspectDeployment = async args => {
+    const inspection = await readDeploymentInspection(args);
+
+    if (!args?.mailboxReadState) {
+        return inspection
+    }
+
+    return {
+        ...inspection,
+        mailboxReadState: await MailboxService.inspectReadState(args.mailboxReadState)
+    }
+};
+
 // `get_sandman_handoff` — serves the Dream Pipeline's morning surface to agents with no repo
 // checkout. The path rides the resolved `handoffFilePath` formula leaf (prod/test by
 // construction; `NEO_HANDOFF_FILE_PATH` is honored inside the leaf) — never a second path source.
@@ -207,7 +226,7 @@ const serviceMapping = {
     get_sqlite_holder_diagnostics:
                               HealthService          .getSqliteHolderDiagnostics.bind(HealthService),
     get_deployment_state_snapshot: readDeploymentInspection,
-    inspect_deployment           : readDeploymentInspection,
+    inspect_deployment           : inspectDeployment,
     get_sandman_handoff          : readSandmanHandoffTool,
     mark_read                    : MailboxService         .markRead                .bind(MailboxService),
     archive_message              : MailboxService         .archiveMessage          .bind(MailboxService),

--- a/ai/scripts/diagnostics/mailboxReadStateProbe.mjs
+++ b/ai/scripts/diagnostics/mailboxReadStateProbe.mjs
@@ -1,7 +1,11 @@
-import Database                       from 'better-sqlite3';
-import path                           from 'node:path';
-import {fileURLToPath}                from 'node:url';
-import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
+import Database        from 'better-sqlite3';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {
+    classifyMailboxReadState,
+    createMailboxReadStateFailure,
+    validateMailboxReadStateRequest
+} from '../../services/memory-core/helpers/mailboxReadStateClassifier.mjs';
 
 /**
  * @module ai/scripts/diagnostics/mailboxReadStateProbe
@@ -37,36 +41,6 @@ AiConfig path, repairs graph state, or marks a message read.`;
  * @returns {Object}
  * @private
  */
-function failureResult(state, error, context={}) {
-    return {
-        ok: false,
-        state,
-        ...context,
-        error
-    }
-}
-
-/**
- * @summary Creates a stable successful-inspection result, including anomaly observations.
- *
- * `ok: true` means the requested database was opened and classified. It does not mean the
- * stored state is healthy: missing, malformed, and conflicting carriers are diagnostic results.
- *
- * @param {Object} context Common database, message, and recipient identifiers.
- * @param {String} state Observed storage state.
- * @param {Object} [details] Route, carrier, or anomaly detail.
- * @returns {Object}
- * @private
- */
-function observation(context, state, details={}) {
-    return {
-        ok: true,
-        state,
-        ...context,
-        ...details
-    }
-}
-
 /**
  * @summary Parses the diagnostic CLI's three explicit inputs without consulting process config.
  * @param {String[]} argv CLI arguments excluding node and script path.
@@ -131,160 +105,12 @@ function validateOptions({dbPath, messageId, recipient}={}) {
     if (typeof dbPath !== 'string' || !dbPath.trim()) {
         throw new Error('dbPath must be an explicit non-empty path.');
     }
-    if (typeof messageId !== 'string' || !/^MESSAGE:[^\s]+$/.test(messageId)) {
-        throw new Error('messageId must use the MESSAGE:<id> graph-node form.');
-    }
-    if (typeof recipient !== 'string' || !recipient.trim()) {
-        throw new Error('recipient must be a non-empty direct agent identity.');
-    }
-
-    const canonicalRecipient = normalizeAgentIdentityNodeId(recipient);
-    if (
-        typeof canonicalRecipient !== 'string' ||
-        !canonicalRecipient.startsWith('@') ||
-        canonicalRecipient === '@' ||
-        canonicalRecipient.includes(':')
-    ) {
-        throw new Error('recipient must be a direct agent identity, not a role, human, or broadcast address.');
-    }
+    const validated = validateMailboxReadStateRequest({messageId, recipient});
 
     return {
         dbPath   : path.resolve(dbPath),
-        messageId,
-        recipient: canonicalRecipient
+        ...validated
     }
-}
-
-/**
- * @summary Canonicalizes a stored mailbox target using MailboxService's comparison rules.
- *
- * Direct `AGENT:<identity>` wrappers remain comparison-compatible, while persisted
- * `AGENT:<family>/<model>` aliases stay untouched because roster-based alias resolution belongs to
- * send-time validation. Direct values without an address-kind colon and legacy
- * `AGENT:<identity>` wrappers flow through `normalizeAgentIdentityNodeId`, which trims whitespace
- * and collapses any run of leading `@` characters.
- *
- * @param {*} identity Stored edge target.
- * @returns {*} Canonical direct identity or unchanged non-direct mailbox address.
- * @private
- */
-function normalizeMailboxIdentityForComparison(identity) {
-    if (typeof identity !== 'string') return identity;
-    if (identity.startsWith('AGENT:') && identity.includes('/')) return identity;
-    if (identity === 'AGENT:*') return identity;
-    if (identity.startsWith('AGENT:')) return normalizeAgentIdentityNodeId(identity.slice('AGENT:'.length));
-    if (!identity.includes(':')) return normalizeAgentIdentityNodeId(identity);
-    return identity
-}
-
-/**
- * @summary Parses one persisted graph JSON record and classifies malformed or column-conflicting data.
- * @param {Object} row SQLite row.
- * @param {'node'|'edge'} kind Graph record kind.
- * @returns {Object} Parsed record or a classified storage error.
- * @private
- */
-function parseGraphRecord(row, kind) {
-    let record;
-
-    try {
-        record = JSON.parse(row.data);
-    } catch (error) {
-        return {
-            errorState: 'malformed-storage',
-            error     : `${kind} row ${row.id} contains malformed JSON: ${error.message}`
-        }
-    }
-
-    if (!record || typeof record !== 'object' || Array.isArray(record)) {
-        return {
-            errorState: 'malformed-storage',
-            error     : `${kind} row ${row.id} data must be a JSON object.`
-        }
-    }
-
-    if (record.id !== row.id) {
-        return {
-            errorState: 'conflicting-storage',
-            error     : `${kind} row ${row.id} disagrees with data.id ${String(record.id)}.`
-        }
-    }
-
-    if (kind === 'edge') {
-        for (const field of ['source', 'target', 'type']) {
-            if (record[field] !== row[field]) {
-                return {
-                    errorState: 'conflicting-storage',
-                    error     : `edge row ${row.id} column ${field}=${String(row[field])} disagrees with data.${field}=${String(record[field])}.`
-                }
-            }
-        }
-    }
-
-    return {record}
-}
-
-/**
- * @summary Classifies a resolved carrier's `readAt` property without collapsing absence into null.
- * @param {Object} context Common inspection identifiers.
- * @param {'direct'|'broadcast'} route Resolved mailbox route.
- * @param {Object} carrier Machine-readable carrier identity.
- * @param {Object} properties Persisted carrier properties.
- * @returns {Object}
- * @private
- */
-function classifyCarrierReadAt(context, route, carrier, properties) {
-    if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
-        return observation(context, 'malformed-storage', {
-            route,
-            carrier,
-            error: `${carrier.kind} ${carrier.rowId} has no object-shaped properties payload.`
-        })
-    }
-
-    if (!Object.hasOwn(properties, 'readAt')) {
-        return observation(context, 'malformed-storage', {
-            route,
-            carrier,
-            error: `${carrier.kind} ${carrier.rowId} is missing properties.readAt; absence is not an explicit unread receipt.`
-        })
-    }
-
-    const {readAt} = properties;
-    if (readAt === null) {
-        return observation(context, 'unread', {
-            route,
-            carrier: {...carrier, readAt: null}
-        })
-    }
-
-    if (typeof readAt !== 'string') {
-        return observation(context, 'malformed-storage', {
-            route,
-            carrier: {...carrier, readAt},
-            error  : `${carrier.kind} ${carrier.rowId} properties.readAt must be null or an ISO timestamp string.`
-        })
-    }
-
-    let canonical;
-    try {
-        canonical = new Date(readAt).toISOString();
-    } catch {
-        canonical = null;
-    }
-
-    if (canonical !== readAt) {
-        return observation(context, 'malformed-storage', {
-            route,
-            carrier: {...carrier, readAt},
-            error  : `${carrier.kind} ${carrier.rowId} properties.readAt is not a canonical ISO timestamp.`
-        })
-    }
-
-    return observation(context, 'read', {
-        route,
-        carrier: {...carrier, readAt}
-    })
 }
 
 /**
@@ -308,7 +134,7 @@ export function inspectMailboxReadState({dbPath, messageId, recipient, DatabaseC
     try {
         validated = validateOptions({dbPath, messageId, recipient});
     } catch (error) {
-        return failureResult('input-error', error.message)
+        return createMailboxReadStateFailure('input-error', error.message)
     }
 
     const context = {...validated};
@@ -322,144 +148,22 @@ export function inspectMailboxReadState({dbPath, messageId, recipient, DatabaseC
         db.pragma('query_only = ON');
 
         const messageRows = db.prepare('SELECT id, data FROM Nodes WHERE id = ?').all(validated.messageId);
-        if (messageRows.length === 0) {
-            return observation(context, 'message-missing', {
-                route  : null,
-                carrier: null
-            })
-        }
-        if (messageRows.length !== 1) {
-            return observation(context, 'conflicting-storage', {
-                route  : null,
-                carrier: null,
-                error  : `Expected one MESSAGE row for ${validated.messageId}; found ${messageRows.length}.`
-            })
-        }
-
-        const messageParsed = parseGraphRecord(messageRows[0], 'node');
-        if (messageParsed.errorState) {
-            return observation(context, messageParsed.errorState, {
-                route  : null,
-                carrier: null,
-                error  : messageParsed.error
-            })
-        }
-
-        const message = messageParsed.record;
-        if (message.label !== 'MESSAGE') {
-            return observation(context, 'conflicting-storage', {
-                route  : null,
-                carrier: null,
-                error  : `Node ${validated.messageId} is stored with label ${String(message.label)}, not MESSAGE.`
-            })
-        }
-
-        const edgeRows = db.prepare(`
+        const edgeRows    = db.prepare(`
             SELECT id, source, target, type, data
             FROM Edges
             WHERE source = ? AND type IN ('SENT_TO', 'DELIVERED_TO')
             ORDER BY id
         `).all(validated.messageId);
-        const edges = [];
 
-        for (const row of edgeRows) {
-            const parsed = parseGraphRecord(row, 'edge');
-            if (parsed.errorState) {
-                return observation(context, parsed.errorState, {
-                    route  : null,
-                    carrier: null,
-                    error  : parsed.error
-                })
-            }
-
-            edges.push(parsed.record);
-        }
-
-        const
-            sentTo       = edges.filter(edge => edge.type === 'SENT_TO'),
-            deliveries   = edges.filter(edge => edge.type === 'DELIVERED_TO'),
-            directRoutes = sentTo.filter(edge =>
-                normalizeMailboxIdentityForComparison(edge.target) === validated.recipient),
-            broadcastRoutes     = sentTo.filter(edge => edge.target === 'AGENT:*'),
-            recipientDeliveries = deliveries.filter(edge =>
-                normalizeMailboxIdentityForComparison(edge.target) === validated.recipient);
-
-        if (
-            directRoutes.length > 1 ||
-            broadcastRoutes.length > 1 ||
-            (directRoutes.length > 0 && broadcastRoutes.length > 0) ||
-            sentTo.length > 1
-        ) {
-            return observation(context, 'conflicting-storage', {
-                route  : null,
-                carrier: null,
-                error  : `Message ${validated.messageId} has an ambiguous SENT_TO topology: ${sentTo.map(edge => edge.target).join(', ')}.`
-            })
-        }
-
-        if (directRoutes.length === 1) {
-            if (deliveries.length > 0) {
-                return observation(context, 'conflicting-storage', {
-                    route  : 'direct',
-                    carrier: null,
-                    error  : `Direct message ${validated.messageId} also has ${deliveries.length} DELIVERED_TO carrier(s).`
-                })
-            }
-
-            return classifyCarrierReadAt(
-                context,
-                'direct',
-                {kind: 'MESSAGE', rowId: validated.messageId},
-                message.properties
-            )
-        }
-
-        if (broadcastRoutes.length === 1) {
-            if (recipientDeliveries.length === 0) {
-                return observation(context, 'recipient-carrier-missing', {
-                    route  : 'broadcast',
-                    carrier: {
-                        kind     : 'DELIVERED_TO',
-                        rowId    : null,
-                        recipient: validated.recipient
-                    }
-                })
-            }
-            if (recipientDeliveries.length > 1) {
-                return observation(context, 'conflicting-storage', {
-                    route  : 'broadcast',
-                    carrier: null,
-                    error  : `Broadcast ${validated.messageId} has ${recipientDeliveries.length} DELIVERED_TO carriers for ${validated.recipient}.`
-                })
-            }
-
-            const delivery = recipientDeliveries[0];
-            return classifyCarrierReadAt(
-                context,
-                'broadcast',
-                {
-                    kind     : 'DELIVERED_TO',
-                    rowId    : delivery.id,
-                    recipient: validated.recipient
-                },
-                delivery.properties
-            )
-        }
-
-        if (deliveries.length > 0) {
-            return observation(context, 'conflicting-storage', {
-                route  : null,
-                carrier: null,
-                error  : `Message ${validated.messageId} has DELIVERED_TO carrier(s) but no SENT_TO broadcast route.`
-            })
-        }
-
-        return observation(context, 'recipient-carrier-missing', {
-            route  : null,
-            carrier: null
+        return classifyMailboxReadState({
+            messageId: validated.messageId,
+            recipient: validated.recipient,
+            messageRows,
+            edgeRows,
+            context  : {dbPath: validated.dbPath}
         })
     } catch (error) {
-        return failureResult('open-error', `Unable to inspect ${validated.dbPath}: ${error.message}`, context)
+        return createMailboxReadStateFailure('open-error', `Unable to inspect ${validated.dbPath}: ${error.message}`, context)
     } finally {
         db?.close();
     }
@@ -485,7 +189,7 @@ export function runCli(
     try {
         options = parseArgs(argv);
     } catch (error) {
-        const result = failureResult('input-error', error.message);
+        const result = createMailboxReadStateFailure('input-error', error.message);
         stderr(`${JSON.stringify(result, null, 2)}\n`);
         return 1
     }

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -27,9 +27,14 @@ import {IDENTITIES}                   from '../../graph/identityRoots.mjs';
 import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
 import {resolveResidentFamilyById}    from '../graph/agentFamilyResolution.mjs';
 import {getMissingMemoryWalLeaves}    from './helpers/memoryWalStore.mjs';
-import {execFile}                     from 'child_process';
-import {promisify}                    from 'util';
-import crypto                         from 'crypto';
+import {
+    classifyMailboxReadState,
+    normalizeMailboxIdentityForComparison,
+    validateMailboxReadStateRequest
+} from './helpers/mailboxReadStateClassifier.mjs';
+import {execFile}  from 'child_process';
+import {promisify} from 'util';
+import crypto      from 'crypto';
 
 const
     execFileAsync                        = promisify(execFile),
@@ -124,26 +129,6 @@ function normalizeMailboxTarget(to, sentBy) {
     }
     if (!to.includes(':')) return normalizeAgentIdentityNodeId(to);
     return to;
-}
-
-/**
- * @summary Canonicalizes direct mailbox identities for authorization comparisons.
- *
- * Direct legacy `AGENT:<identity>` wrappers remain comparison-compatible, but graph-backed
- * `AGENT:<family>/<model>` aliases are intentionally not re-resolved after persistence: send-time
- * validation owns alias resolution and stores the canonical recipient id. Re-resolving a persisted
- * family alias could change authorization when the roster changes.
- *
- * @param {*} identity Stored edge target or request-bound identity.
- * @returns {*} Canonical direct identity or unchanged non-direct mailbox address.
- * @private
- */
-function normalizeMailboxIdentityForComparison(identity) {
-    if (typeof identity === 'string' && identity.startsWith('AGENT:') && identity.includes('/')) {
-        return identity;
-    }
-
-    return normalizeMailboxTarget(identity);
 }
 
 /**
@@ -2315,6 +2300,61 @@ class MailboxService extends Base {
             if (relatedPullRequests.length > 0) result.relatedPullRequests = relatedPullRequests;
         }
         return result;
+    }
+
+    /**
+     * @summary Observes one mailbox recipient's durable read-state carrier without invoking a
+     * normal mailbox read, repair, mark-read, archive, WAL replay, or graph mutation.
+     *
+     * This is the database-owner adapter for the optional `inspect_deployment.mailboxReadState`
+     * branch. The Memory Core server already owns the live graph SQLite in both production Compose
+     * and local-parity layouts, so it reads only the named `MESSAGE` row plus its bounded
+     * `SENT_TO`/`DELIVERED_TO` cohort and delegates every classification decision to the shared
+     * pure helper. Own-inbox reads are allowed; cross-inbox reads require `CAN_READ_INBOX_OF`.
+     *
+     * @param {Object} args
+     * @param {String} args.messageId MESSAGE node id.
+     * @param {String} args.recipient Affected direct recipient identity.
+     * @returns {Promise<Object>} Stable carrier-classification observation envelope.
+     */
+    async inspectReadState({messageId, recipient}={}) {
+        const boundIdentity = RequestContextService.getAgentIdentityNodeId();
+        if (!boundIdentity) {
+            throw RequestContextService.unboundIdentityError('inspect mailbox read state');
+        }
+
+        const
+            me        = normalizeMailboxIdentityForComparison(boundIdentity),
+            validated = validateMailboxReadStateRequest({messageId, recipient});
+
+        if (!sameMailboxIdentity(me, validated.recipient)) {
+            if (!PermissionService.hasPermission(me, validated.recipient, 'CAN_READ_INBOX_OF')) {
+                throw new Error(`Unauthorized: no CAN_READ_INBOX_OF permission for ${validated.recipient}`);
+            }
+        }
+
+        const
+            db     = GraphService.requireDb('MailboxService.inspectReadState'),
+            sqlite = db.storage?.db;
+
+        if (!sqlite) {
+            throw new Error('[MailboxService.inspectReadState] graph SQLite owner is unavailable');
+        }
+
+        const
+            messageRows = sqlite.prepare('SELECT id, data FROM Nodes WHERE id = ?').all(validated.messageId),
+            edgeRows    = sqlite.prepare(`
+                SELECT id, source, target, type, data
+                FROM Edges
+                WHERE source = ? AND type IN ('SENT_TO', 'DELIVERED_TO')
+                ORDER BY id
+            `).all(validated.messageId);
+
+        return classifyMailboxReadState({
+            ...validated,
+            messageRows,
+            edgeRows
+        })
     }
 
     /**

--- a/ai/services/memory-core/helpers/mailboxReadStateClassifier.mjs
+++ b/ai/services/memory-core/helpers/mailboxReadStateClassifier.mjs
@@ -1,0 +1,360 @@
+import {normalizeAgentIdentityNodeId} from '../../../graph/normalizeAgentIdentityNodeId.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/mailboxReadStateClassifier
+ * @summary Pure carrier-aware classifier for one mailbox recipient's durable read state.
+ *
+ * Direct messages persist `readAt` on the `MESSAGE` node, while receipt-backed broadcasts
+ * persist it on the recipient's `DELIVERED_TO` edge. This helper accepts already-read raw graph
+ * rows and returns the stable observation envelope shared by the explicit-path CLI and the live
+ * Memory Core diagnostic. It performs no I/O, repair, configuration lookup, or mutation.
+ */
+
+/**
+ * @summary Creates a stable failed-execution result for invalid inputs or an unavailable adapter.
+ * @param {'input-error'|'open-error'} state Failure class.
+ * @param {String} error Operator-facing failure detail.
+ * @param {Object} [context] Validated identifiers available at the failure boundary.
+ * @returns {Object}
+ */
+export function createMailboxReadStateFailure(state, error, context={}) {
+    return {
+        ok: false,
+        state,
+        ...context,
+        error
+    }
+}
+
+/**
+ * @summary Canonicalizes a stored mailbox target using MailboxService's comparison rules.
+ *
+ * Direct `AGENT:<identity>` wrappers remain comparison-compatible, while persisted
+ * `AGENT:<family>/<model>` aliases stay untouched because roster-based alias resolution belongs to
+ * send-time validation. Direct values without an address-kind colon and legacy
+ * `AGENT:<identity>` wrappers flow through `normalizeAgentIdentityNodeId`, which trims whitespace
+ * and collapses any run of leading `@` characters.
+ *
+ * @param {*} identity Stored edge target or request-bound identity.
+ * @returns {*} Canonical direct identity or unchanged non-direct mailbox address.
+ */
+export function normalizeMailboxIdentityForComparison(identity) {
+    if (typeof identity !== 'string') return identity;
+    if (identity.startsWith('AGENT:') && identity.includes('/')) return identity;
+    if (identity === 'AGENT:*') return identity;
+    if (identity.startsWith('AGENT:')) return normalizeAgentIdentityNodeId(identity.slice('AGENT:'.length));
+    if (!identity.includes(':')) return normalizeAgentIdentityNodeId(identity);
+    return identity
+}
+
+/**
+ * @summary Validates and canonicalizes the message-scoped portion of a read-state request.
+ * @param {Object} options
+ * @param {String} options.messageId MESSAGE node id.
+ * @param {String} options.recipient Direct recipient identity.
+ * @returns {{messageId:String,recipient:String}}
+ * @throws {Error} For invalid message or recipient identifiers.
+ */
+export function validateMailboxReadStateRequest({messageId, recipient}={}) {
+    if (typeof messageId !== 'string' || !/^MESSAGE:[^\s]+$/.test(messageId)) {
+        throw new Error('messageId must use the MESSAGE:<id> graph-node form.');
+    }
+    if (typeof recipient !== 'string' || !recipient.trim()) {
+        throw new Error('recipient must be a non-empty direct agent identity.');
+    }
+
+    const canonicalRecipient = normalizeAgentIdentityNodeId(recipient);
+    if (
+        typeof canonicalRecipient !== 'string' ||
+        !canonicalRecipient.startsWith('@') ||
+        canonicalRecipient === '@' ||
+        canonicalRecipient.includes(':')
+    ) {
+        throw new Error('recipient must be a direct agent identity, not a role, human, or broadcast address.');
+    }
+
+    return {messageId, recipient: canonicalRecipient}
+}
+
+/**
+ * @summary Creates a stable completed-inspection result, including anomaly observations.
+ * @param {Object} context Common inspection identifiers.
+ * @param {String} state Observed storage state.
+ * @param {Object} [details] Route, carrier, or anomaly detail.
+ * @returns {Object}
+ * @private
+ */
+function observation(context, state, details={}) {
+    return {
+        ok: true,
+        state,
+        ...context,
+        ...details
+    }
+}
+
+/**
+ * @summary Parses one persisted graph JSON record and classifies malformed or column-conflicting data.
+ * @param {Object} row Raw SQLite row.
+ * @param {'node'|'edge'} kind Graph record kind.
+ * @returns {Object} Parsed record or a classified storage error.
+ * @private
+ */
+function parseGraphRecord(row, kind) {
+    let record;
+
+    try {
+        record = JSON.parse(row.data);
+    } catch (error) {
+        return {
+            errorState: 'malformed-storage',
+            error     : `${kind} row ${row.id} contains malformed JSON: ${error.message}`
+        }
+    }
+
+    if (!record || typeof record !== 'object' || Array.isArray(record)) {
+        return {
+            errorState: 'malformed-storage',
+            error     : `${kind} row ${row.id} data must be a JSON object.`
+        }
+    }
+
+    if (record.id !== row.id) {
+        return {
+            errorState: 'conflicting-storage',
+            error     : `${kind} row ${row.id} disagrees with data.id ${String(record.id)}.`
+        }
+    }
+
+    if (kind === 'edge') {
+        for (const field of ['source', 'target', 'type']) {
+            if (record[field] !== row[field]) {
+                return {
+                    errorState: 'conflicting-storage',
+                    error     : `edge row ${row.id} column ${field}=${String(row[field])} disagrees with data.${field}=${String(record[field])}.`
+                }
+            }
+        }
+    }
+
+    return {record}
+}
+
+/**
+ * @summary Classifies a resolved carrier's `readAt` property without collapsing absence into null.
+ * @param {Object} context Common inspection identifiers.
+ * @param {'direct'|'broadcast'} route Resolved mailbox route.
+ * @param {Object} carrier Machine-readable carrier identity.
+ * @param {Object} properties Persisted carrier properties.
+ * @returns {Object}
+ * @private
+ */
+function classifyCarrierReadAt(context, route, carrier, properties) {
+    if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
+        return observation(context, 'malformed-storage', {
+            route,
+            carrier,
+            error: `${carrier.kind} ${carrier.rowId} has no object-shaped properties payload.`
+        })
+    }
+
+    if (!Object.hasOwn(properties, 'readAt')) {
+        return observation(context, 'malformed-storage', {
+            route,
+            carrier,
+            error: `${carrier.kind} ${carrier.rowId} is missing properties.readAt; absence is not an explicit unread receipt.`
+        })
+    }
+
+    const {readAt} = properties;
+    if (readAt === null) {
+        return observation(context, 'unread', {
+            route,
+            carrier: {...carrier, readAt: null}
+        })
+    }
+
+    if (typeof readAt !== 'string') {
+        return observation(context, 'malformed-storage', {
+            route,
+            carrier: {...carrier, readAt},
+            error  : `${carrier.kind} ${carrier.rowId} properties.readAt must be null or an ISO timestamp string.`
+        })
+    }
+
+    let canonical;
+    try {
+        canonical = new Date(readAt).toISOString();
+    } catch {
+        canonical = null;
+    }
+
+    if (canonical !== readAt) {
+        return observation(context, 'malformed-storage', {
+            route,
+            carrier: {...carrier, readAt},
+            error  : `${carrier.kind} ${carrier.rowId} properties.readAt is not a canonical ISO timestamp.`
+        })
+    }
+
+    return observation(context, 'read', {
+        route,
+        carrier: {...carrier, readAt}
+    })
+}
+
+/**
+ * @summary Classifies one recipient's read-state from already-read raw message and edge rows.
+ *
+ * The adapters own bounded reads and authorization; this function owns every carrier, identity,
+ * malformed-record, and topology decision. `context` may add adapter provenance such as the CLI's
+ * explicit `dbPath`, but cannot override the validated message or recipient identifiers.
+ *
+ * @param {Object} options
+ * @param {String} options.messageId MESSAGE node id.
+ * @param {String} options.recipient Affected direct recipient identity.
+ * @param {Object[]} [options.messageRows=[]] Raw `Nodes` rows containing `id` and `data`.
+ * @param {Object[]} [options.edgeRows=[]] Raw `Edges` rows containing canonical columns and `data`.
+ * @param {Object} [options.context={}] Adapter-specific result context.
+ * @returns {Object} Stable completed-inspection observation envelope.
+ */
+export function classifyMailboxReadState({
+    messageId,
+    recipient,
+    messageRows=[],
+    edgeRows=[],
+    context={}
+}={}) {
+    const validated        = validateMailboxReadStateRequest({messageId, recipient}),
+        observationContext = {...context, ...validated};
+
+    if (messageRows.length === 0) {
+        return observation(observationContext, 'message-missing', {
+            route  : null,
+            carrier: null
+        })
+    }
+    if (messageRows.length !== 1) {
+        return observation(observationContext, 'conflicting-storage', {
+            route  : null,
+            carrier: null,
+            error  : `Expected one MESSAGE row for ${validated.messageId}; found ${messageRows.length}.`
+        })
+    }
+
+    const messageParsed = parseGraphRecord(messageRows[0], 'node');
+    if (messageParsed.errorState) {
+        return observation(observationContext, messageParsed.errorState, {
+            route  : null,
+            carrier: null,
+            error  : messageParsed.error
+        })
+    }
+
+    const message = messageParsed.record;
+    if (message.label !== 'MESSAGE') {
+        return observation(observationContext, 'conflicting-storage', {
+            route  : null,
+            carrier: null,
+            error  : `Node ${validated.messageId} is stored with label ${String(message.label)}, not MESSAGE.`
+        })
+    }
+
+    const edges = [];
+    for (const row of edgeRows) {
+        const parsed = parseGraphRecord(row, 'edge');
+        if (parsed.errorState) {
+            return observation(observationContext, parsed.errorState, {
+                route  : null,
+                carrier: null,
+                error  : parsed.error
+            })
+        }
+
+        edges.push(parsed.record);
+    }
+
+    const
+        sentTo       = edges.filter(edge => edge.type === 'SENT_TO'),
+        deliveries   = edges.filter(edge => edge.type === 'DELIVERED_TO'),
+        directRoutes = sentTo.filter(edge =>
+            normalizeMailboxIdentityForComparison(edge.target) === validated.recipient),
+        broadcastRoutes     = sentTo.filter(edge => edge.target === 'AGENT:*'),
+        recipientDeliveries = deliveries.filter(edge =>
+            normalizeMailboxIdentityForComparison(edge.target) === validated.recipient);
+
+    if (
+        directRoutes.length > 1 ||
+        broadcastRoutes.length > 1 ||
+        (directRoutes.length > 0 && broadcastRoutes.length > 0) ||
+        sentTo.length > 1
+    ) {
+        return observation(observationContext, 'conflicting-storage', {
+            route  : null,
+            carrier: null,
+            error  : `Message ${validated.messageId} has an ambiguous SENT_TO topology: ${sentTo.map(edge => edge.target).join(', ')}.`
+        })
+    }
+
+    if (directRoutes.length === 1) {
+        if (deliveries.length > 0) {
+            return observation(observationContext, 'conflicting-storage', {
+                route  : 'direct',
+                carrier: null,
+                error  : `Direct message ${validated.messageId} also has ${deliveries.length} DELIVERED_TO carrier(s).`
+            })
+        }
+
+        return classifyCarrierReadAt(
+            observationContext,
+            'direct',
+            {kind: 'MESSAGE', rowId: validated.messageId},
+            message.properties
+        )
+    }
+
+    if (broadcastRoutes.length === 1) {
+        if (recipientDeliveries.length === 0) {
+            return observation(observationContext, 'recipient-carrier-missing', {
+                route  : 'broadcast',
+                carrier: {
+                    kind     : 'DELIVERED_TO',
+                    rowId    : null,
+                    recipient: validated.recipient
+                }
+            })
+        }
+        if (recipientDeliveries.length > 1) {
+            return observation(observationContext, 'conflicting-storage', {
+                route  : 'broadcast',
+                carrier: null,
+                error  : `Broadcast ${validated.messageId} has ${recipientDeliveries.length} DELIVERED_TO carriers for ${validated.recipient}.`
+            })
+        }
+
+        const delivery = recipientDeliveries[0];
+        return classifyCarrierReadAt(
+            observationContext,
+            'broadcast',
+            {
+                kind     : 'DELIVERED_TO',
+                rowId    : delivery.id,
+                recipient: validated.recipient
+            },
+            delivery.properties
+        )
+    }
+
+    if (deliveries.length > 0) {
+        return observation(observationContext, 'conflicting-storage', {
+            route  : null,
+            carrier: null,
+            error  : `Message ${validated.messageId} has DELIVERED_TO carrier(s) but no SENT_TO broadcast route.`
+        })
+    }
+
+    return observation(observationContext, 'recipient-carrier-missing', {
+        route  : null,
+        carrier: null
+    })
+}

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -436,6 +436,7 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
             handbook      = await callTool('get_mcp_tool_handbook', {toolId: 'resume_session'}),
             missing       = await callTool('get_mcp_tool_handbook', {toolId: 'missing_tool'}),
             addMemory     = byName.add_memory,
+            inspectDeploy = byName.inspect_deployment,
             resumeSession = byName.resume_session,
             handbookTool  = byName.get_mcp_tool_handbook;
 
@@ -455,6 +456,14 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(resumeSession.description).toBe('Validate whether a session id is safe to resume.');
         expect(resumeSession.description).not.toContain('SESSION_BUSY');
         expect(addMemory.inputSchema.properties.prompt.type).toBe('string');
+        expect(inspectDeploy.inputSchema.properties.mailboxReadState).toMatchObject({
+            type    : 'object',
+            required: ['messageId', 'recipient']
+        });
+        expect(inspectDeploy.inputSchema.properties.mailboxReadState.properties).toMatchObject({
+            messageId: {type: 'string'},
+            recipient: {type: 'string'}
+        });
 
         for (const tool of tools) {
             expect(tool.description.length, `memory-core.${tool.name} description is not compact`).toBeLessThanOrEqual(120);
@@ -515,6 +524,18 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
                 mcSnapshot       = await memoryCoreApi.callTool('get_deployment_state_snapshot', args),
                 kbInspection     = await knowledgeBaseApi.callTool('inspect_deployment', args),
                 mcInspection     = await memoryCoreApi.callTool('inspect_deployment', args);
+
+            const
+                {ageMs: kbSnapshotAge, ...kbSnapshotShape}     = kbSnapshot,
+                {ageMs: kbInspectionAge, ...kbInspectionShape} = kbInspection,
+                {ageMs: mcSnapshotAge, ...mcSnapshotShape}     = mcSnapshot,
+                {ageMs: mcInspectionAge, ...mcInspectionShape} = mcInspection;
+
+            expect(kbInspectionShape).toEqual(kbSnapshotShape);
+            expect(mcInspectionShape).toEqual(mcSnapshotShape);
+            for (const age of [kbSnapshotAge, kbInspectionAge, mcSnapshotAge, mcInspectionAge]) {
+                expect(age).toEqual(expect.any(Number));
+            }
 
             for (const result of [kbSnapshot, mcSnapshot, kbInspection, mcInspection]) {
                 expect(result).toMatchObject({

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -1,4 +1,5 @@
 import {test, expect}  from '@playwright/test';
+import Ajv             from 'ajv';
 import fs              from 'fs';
 import path            from 'path';
 import {fileURLToPath} from 'url';
@@ -482,6 +483,21 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(coalesceWindow.type).toBe('integer');
         expect(coalesceWindow.minimum).toBe(0);
         expect(coalesceWindow.maximum).toBe(300);
+    });
+
+    test('memory-core inspect_deployment output compiles for AJV clients (#16086)', () => {
+        const
+            doc       = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/memory-core/openapi.yaml'), 'utf8')),
+            operation = doc.paths['/deployment/inspect'].post,
+            schema    = toOpenApiJsonSchema(buildOutputZodSchema(doc, operation)),
+            route     = schema.properties.mailboxReadState.properties.route;
+
+        expect(route).toEqual({
+            nullable: true,
+            type    : 'string',
+            enum    : ['direct', 'broadcast']
+        });
+        expect(() => new Ajv({strict: false}).compile(schema)).not.toThrow();
     });
 
     test('knowledge-base query schemas expose skill, adr, and concept content types', async () => {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -132,6 +132,33 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     }
 
     /**
+     * @summary Seeds one MESSAGE and its bounded carrier topology through the live graph owner.
+     * @param {Object} options
+     * @param {String} options.messageId
+     * @param {String} [options.recipient='@bob']
+     * @param {Boolean} [options.broadcast=false]
+     * @param {*} [options.readAt=null]
+     * @returns {void}
+     */
+    function seedReadStateCarrier({messageId, recipient='@bob', broadcast=false, readAt=null}) {
+        GraphService.upsertNode({
+            id        : messageId,
+            type      : 'MESSAGE',
+            name      : 'read-state diagnostic fixture',
+            properties: {
+                subject: 'diagnostic fixture',
+                readAt
+            }
+        });
+
+        GraphService.linkNodes(messageId, broadcast ? 'AGENT:*' : recipient, 'SENT_TO', 1, {});
+
+        if (broadcast) {
+            GraphService.linkNodes(messageId, recipient, 'DELIVERED_TO', 1, {readAt});
+        }
+    }
+
+    /**
      * Damages one edge type of a message's GRAPH PROJECTION — cache and storage both — while leaving
      * the message WAL record intact. That is the state the repair path exists for: the WAL holds the
      * truth, the projection has lost a piece, and `repairMessageGraphIntegrity` rebuilds the piece
@@ -189,6 +216,119 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         const pending = await readPendingMessageWalRecords({dir: messageWalDir});
         expect(pending).toHaveLength(0);
+    });
+
+    test('#16086: inspectReadState reads the owner SQLite without normal mailbox reads, repair, or mutation', async () => {
+        const messageId = 'MESSAGE:inspect-read-state-direct';
+        seedReadStateCarrier({messageId});
+
+        const
+            sqlite       = GraphService.db.storage.db,
+            graphLogRows = sqlite.prepare('SELECT COUNT(*) AS count FROM GraphLog').get().count,
+            beforeNode   = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(messageId).data,
+            beforeEdges  = sqlite.prepare('SELECT data FROM Edges WHERE source = ? ORDER BY id').all(messageId),
+            forbidden    = [
+                'getMessage',
+                'listMessages',
+                'repairMessageGraphIntegrity',
+                'drainPendingMessageGraphProjections',
+                'markRead',
+                'archiveMessage'
+            ],
+            originals    = Object.fromEntries(forbidden.map(name => [name, MailboxService[name]]));
+
+        try {
+            for (const name of forbidden) {
+                MailboxService[name] = () => {
+                    throw new Error(`forbidden diagnostic dependency: ${name}`);
+                };
+            }
+
+            const result = await RequestContextService.run(
+                {agentIdentityNodeId: '@bob', userId: 'bob', source: 'env-var'},
+                () => MailboxService.inspectReadState({messageId, recipient: '@bob'})
+            );
+
+            expect(result).toMatchObject({
+                ok       : true,
+                state    : 'unread',
+                messageId,
+                recipient: '@bob',
+                route    : 'direct',
+                carrier  : {kind: 'MESSAGE', rowId: messageId, readAt: null}
+            });
+        } finally {
+            Object.assign(MailboxService, originals);
+        }
+
+        expect(sqlite.prepare('SELECT COUNT(*) AS count FROM GraphLog').get().count).toBe(graphLogRows);
+        expect(sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(messageId).data).toBe(beforeNode);
+        expect(sqlite.prepare('SELECT data FROM Edges WHERE source = ? ORDER BY id').all(messageId)).toEqual(beforeEdges);
+    });
+
+    test('#16086: inspectReadState enforces own/delegated inbox authority for broadcast carriers', async () => {
+        const messageId = 'MESSAGE:inspect-read-state-broadcast';
+        seedReadStateCarrier({
+            messageId,
+            broadcast: true,
+            readAt   : '2026-07-28T08:01:00.000Z'
+        });
+
+        await expect(RequestContextService.run(
+            {agentIdentityNodeId: '@alice', userId: 'alice', source: 'oidc'},
+            () => MailboxService.inspectReadState({messageId, recipient: '@bob'})
+        )).rejects.toThrow(/CAN_READ_INBOX_OF/);
+
+        await RequestContextService.run(
+            {agentIdentityNodeId: '@bob', userId: 'bob', source: 'oidc'},
+            () => PermissionService.grantPermission({to: '@alice', scope: 'CAN_READ_INBOX_OF'})
+        );
+
+        const result = await RequestContextService.run(
+            {agentIdentityNodeId: '@alice', userId: 'alice', source: 'oidc'},
+            () => MailboxService.inspectReadState({messageId, recipient: '@bob'})
+        );
+
+        expect(result).toMatchObject({
+            ok       : true,
+            state    : 'read',
+            messageId,
+            recipient: '@bob',
+            route    : 'broadcast',
+            carrier  : {
+                kind     : 'DELIVERED_TO',
+                recipient: '@bob',
+                readAt   : '2026-07-28T08:01:00.000Z'
+            }
+        });
+    });
+
+    test('#16086: inspect_deployment returns identical classifier output for stdio and HTTP identity contexts', async () => {
+        const messageId = 'MESSAGE:inspect-deployment-read-state';
+        seedReadStateCarrier({messageId});
+
+        const {callTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
+        const outputs    = [];
+
+        for (const source of ['env-var', 'oidc']) {
+            outputs.push(await RequestContextService.run(
+                {agentIdentityNodeId: '@bob', userId: 'bob', source},
+                () => callTool('inspect_deployment', {
+                    mailboxReadState: {messageId, recipient: '@bob'}
+                })
+            ));
+        }
+
+        expect(outputs[0].mailboxReadState).toMatchObject({
+            ok       : true,
+            state    : 'unread',
+            messageId,
+            recipient: '@bob',
+            route    : 'direct'
+        });
+        expect(outputs[1].mailboxReadState).toEqual(outputs[0].mailboxReadState);
+        await expect(MailboxService.inspectReadState({messageId, recipient: '@bob'}))
+            .rejects.toThrow(/no agent identity context bound/);
     });
 
     test('addMessage stamps the normalized canonical user_id, keeping @-form only as the sender label (#13578)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/helpers/mailboxReadStateClassifier.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/mailboxReadStateClassifier.spec.mjs
@@ -1,0 +1,209 @@
+import {test, expect} from '@playwright/test';
+import {
+    classifyMailboxReadState,
+    normalizeMailboxIdentityForComparison,
+    validateMailboxReadStateRequest
+} from '../../../../../../../ai/services/memory-core/helpers/mailboxReadStateClassifier.mjs';
+
+const MESSAGE_ID = 'MESSAGE:classifier';
+const RECIPIENT  = '@neo-gpt';
+
+/**
+ * @summary Encodes one graph node as the raw row shape consumed by the classifier.
+ * @param {Object} record Graph node record.
+ * @returns {Object}
+ */
+function nodeRow(record) {
+    return {id: record.id, data: JSON.stringify(record)}
+}
+
+/**
+ * @summary Encodes one graph edge as the raw row shape consumed by the classifier.
+ * @param {Object} record Graph edge record.
+ * @returns {Object}
+ */
+function edgeRow(record) {
+    return {
+        id    : record.id,
+        source: record.source,
+        target: record.target,
+        type  : record.type,
+        data  : JSON.stringify(record)
+    }
+}
+
+/**
+ * @summary Creates the canonical MESSAGE row with an explicit direct-carrier readAt value.
+ * @param {*} readAt Persisted receipt value.
+ * @param {Object} [properties] Full properties override.
+ * @returns {Object}
+ */
+function messageRow(readAt=null, properties={subject: 'classifier', readAt}) {
+    return nodeRow({
+        id   : MESSAGE_ID,
+        label: 'MESSAGE',
+        properties
+    })
+}
+
+/**
+ * @summary Creates one raw mailbox route row for the classifier matrix.
+ * @param {Object} options
+ * @returns {Object}
+ */
+function routeRow({id, target, type, properties={}}) {
+    return edgeRow({
+        id,
+        source: MESSAGE_ID,
+        target,
+        type,
+        properties
+    })
+}
+
+/**
+ * @summary Runs the pure classifier with canonical request identifiers.
+ * @param {Object[]} messageRows Raw node rows.
+ * @param {Object[]} edgeRows Raw edge rows.
+ * @returns {Object}
+ */
+function classify(messageRows, edgeRows) {
+    return classifyMailboxReadState({
+        messageId: MESSAGE_ID,
+        recipient: RECIPIENT,
+        messageRows,
+        edgeRows
+    })
+}
+
+test.describe('mailboxReadStateClassifier — pure carrier matrix (#16086)', () => {
+    test('keeps one normalization authority for adapters and MailboxService comparisons', () => {
+        for (const [input, expected] of [
+            ['  @neo-gpt  ', '@neo-gpt'],
+            ['@@@@neo-gpt', '@neo-gpt'],
+            ['AGENT:neo-gpt', '@neo-gpt'],
+            ['AGENT:@neo-gpt', '@neo-gpt'],
+            ['AGENT:openai/gpt', 'AGENT:openai/gpt'],
+            ['AGENT:*', 'AGENT:*'],
+            ['role:librarian', 'role:librarian']
+        ]) {
+            expect(normalizeMailboxIdentityForComparison(input)).toBe(expected);
+        }
+
+        expect(validateMailboxReadStateRequest({
+            messageId: MESSAGE_ID,
+            recipient: '@@@neo-gpt'
+        })).toEqual({
+            messageId: MESSAGE_ID,
+            recipient: RECIPIENT
+        });
+        expect(() => validateMailboxReadStateRequest({
+            messageId: MESSAGE_ID,
+            recipient: 'role:librarian'
+        })).toThrow(/direct agent identity/);
+    });
+
+    for (const [label, readAt, expectedState] of [
+        ['unread', null, 'unread'],
+        ['read', '2026-07-28T08:00:00.000Z', 'read']
+    ]) {
+        test(`classifies a direct MESSAGE carrier as ${label}`, () => {
+            const result = classify(
+                [messageRow(readAt)],
+                [routeRow({id: 'EDGE:direct', target: '  @@neo-gpt  ', type: 'SENT_TO'})]
+            );
+
+            expect(result).toMatchObject({
+                ok       : true,
+                state    : expectedState,
+                messageId: MESSAGE_ID,
+                recipient: RECIPIENT,
+                route    : 'direct',
+                carrier  : {
+                    kind : 'MESSAGE',
+                    rowId: MESSAGE_ID,
+                    readAt
+                }
+            });
+        });
+    }
+
+    for (const [label, readAt, expectedState] of [
+        ['unread', null, 'unread'],
+        ['read', '2026-07-28T08:01:00.000Z', 'read']
+    ]) {
+        test(`classifies a receipt-backed broadcast carrier as ${label}`, () => {
+            const result = classify(
+                [messageRow(null)],
+                [
+                    routeRow({id: 'EDGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'}),
+                    routeRow({
+                        id        : 'EDGE:delivery',
+                        target    : 'AGENT:neo-gpt',
+                        type      : 'DELIVERED_TO',
+                        properties: {readAt}
+                    })
+                ]
+            );
+
+            expect(result).toMatchObject({
+                ok       : true,
+                state    : expectedState,
+                messageId: MESSAGE_ID,
+                recipient: RECIPIENT,
+                route    : 'broadcast',
+                carrier  : {
+                    kind     : 'DELIVERED_TO',
+                    rowId    : 'EDGE:delivery',
+                    recipient: RECIPIENT,
+                    readAt
+                }
+            });
+        });
+    }
+
+    test('distinguishes missing message from missing broadcast recipient carrier', () => {
+        expect(classify([], [])).toMatchObject({
+            ok     : true,
+            state  : 'message-missing',
+            route  : null,
+            carrier: null
+        });
+
+        expect(classify(
+            [messageRow(null)],
+            [routeRow({id: 'EDGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'})]
+        )).toMatchObject({
+            ok     : true,
+            state  : 'recipient-carrier-missing',
+            route  : 'broadcast',
+            carrier: {
+                kind     : 'DELIVERED_TO',
+                rowId    : null,
+                recipient: RECIPIENT
+            }
+        });
+    });
+
+    test('keeps malformed and conflicting graph state as completed observations', () => {
+        const malformed = classify(
+            [{id: MESSAGE_ID, data: `{"id":"${MESSAGE_ID}",`}],
+            []
+        );
+        const conflicting = classify(
+            [messageRow(null)],
+            [
+                routeRow({id: 'EDGE:direct', target: RECIPIENT, type: 'SENT_TO'}),
+                routeRow({id: 'EDGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'})
+            ]
+        );
+        const absentReadAt = classify(
+            [messageRow(undefined, {subject: 'missing readAt'})],
+            [routeRow({id: 'EDGE:direct', target: RECIPIENT, type: 'SENT_TO'})]
+        );
+
+        expect(malformed).toMatchObject({ok: true, state: 'malformed-storage', route: null});
+        expect(conflicting).toMatchObject({ok: true, state: 'conflicting-storage', route: null});
+        expect(absentReadAt).toMatchObject({ok: true, state: 'malformed-storage', route: 'direct'});
+    });
+});


### PR DESCRIPTION
Resolves #16086

Exposes carrier-aware mailbox read-state diagnosis through the existing `inspect_deployment` tool without changing its snapshot-only response when the optional request is absent. One pure classifier now owns direct `MESSAGE` and broadcast `DELIVERED_TO` semantics for both the explicit-path CLI and the live Memory Core adapter; the server-side path performs two bounded owner-SQLite reads, enforces bound/delegated inbox authority, and never enters an ordinary mailbox read or repair path.

Evidence: L3 (live Streamable HTTP container probe plus live stdio tool call and a 200-sample latency receipt) → L3 required (deployment-owner path, transport reachability, and timing ACs). No residuals.

## Deltas from ticket

The ticket correctly required topology proof before selecting an adapter boundary. The supported production, local-parity, and integration Compose layouts all run `TARGET_SERVER=memory-core` with `NEO_MEMORY_DB_PATH` inside `mc-server`; there is no supported split-database service. The implementation therefore executes at the existing in-process graph owner and adds no RPC, shared-path assumption, volume mount, shell dependency, or tool slot.

## Contract Ledger

| Surface | Delivered contract | Evidence |
|---|---|---|
| Shared classifier | Pure raw-row classifier owns normalization plus direct, broadcast, missing, unread, read, malformed, and conflicting outcomes | classifier matrix and retained CLI suite |
| Local CLI | Explicit database path, read-only/file-must-exist/query-only SQLite, result states, exit codes, and no-mutation behavior remain intact | `mailboxReadStateProbe.spec.mjs` |
| Owner adapter | Bound identity or `CAN_READ_INBOX_OF`; exact `MESSAGE` plus `SENT_TO`/`DELIVERED_TO` reads only; no normal read, repair, archive, WAL drain, or graph write | `MailboxService.spec.mjs` forbidden-call spies and before/after graph controls |
| MCP contract | Optional `inspect_deployment.mailboxReadState`; absent request preserves the prior snapshot shape; `get_deployment_state_snapshot` is unchanged | tool-list smoke, AJV compilation, live stdio and HTTP receipts |
| Execution budget | No model call, polling, retry, sleep, timeout change, or new tool | source audit and live timing receipt |

## Test Evidence

- Carrier/classifier, CLI, mailbox owner adapter, tool schema, and AJV contract: `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/mailboxReadStateClassifier.spec.mjs test/playwright/unit/ai/scripts/diagnostics/mailboxReadStateProbe.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` — 240/240 passed.
- Server and transport regression slice: `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs` — 104/104 passed.
- Live container topology: built the repository integration `mc-server` image from this checkout, with `NEO_MEMORY_DB_PATH=/tmp/neo-integration/memory-core-graph.sqlite` owned by that same process, then called `inspect_deployment` through Streamable HTTP against a self-addressed direct message.
- Live container latency: 10 warm-ups plus 200 measured calls — p50 2.542 ms, p95 3.189 ms, max 4.237 ms. Every sample returned `state: unread`, `route: direct`; the unchanged MCP SDK default request timeout is 60,000 ms.
- Live stdio: the Memory Core MCP client booted from this checkout and `inspect_deployment` classified the `#16086` broadcast lane claim as `recipient-carrier-missing` on its `DELIVERED_TO` route, matching sender-excluded broadcast topology.
- Preflight/static: repair-capable `npm run agent-preflight -- <touched files>` passed after mechanical alignment; `git diff --cached --check` passed.

## Post-Merge Validation

- [ ] On the next production rollout, call the optional `mailboxReadState` branch once through the deployed `inspect_deployment` ingress and record the deployed revision with the observation.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fa904-9d8c-7f12-94fe-346ae8e54046.
