### PR TITLE
fix(dashboard): embody converted vessels over target popups (#16090)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1,22 +1,25 @@
-import Component                                from '../../../src/component/Base.mjs';
-import Container                                from '../../../src/container/Base.mjs';
-import Feed                                     from '../store/Feed.mjs';
-import FeedPane                                 from './FeedPane.mjs';
-import Scale                                    from '../store/Scale.mjs';
-import ScalePane                                from './ScalePane.mjs';
-import DockDragAffordances                      from '../../../src/dashboard/DockDragAffordances.mjs';
-import DockDropIndicators                       from '../../../src/dashboard/DockDropIndicators.mjs';
-import DockLayoutAdapter                        from '../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal                         from '../../../src/dashboard/DockMotionSignal.mjs';
-import DockPreview                              from '../../../src/dashboard/DockPreview.mjs';
-import DockProjectionReconciler                 from '../../../src/dashboard/DockProjectionReconciler.mjs';
-import DockService                              from '../../../src/ai/client/DockService.mjs';
-import DockZoneModel                            from '../../../src/dashboard/DockZoneModel.mjs';
-import InteractionService                       from '../../../src/ai/client/InteractionService.mjs';
-import StateProvider                            from '../../../src/state/Provider.mjs';
-import TourRunner                               from '../../../src/ai/client/TourRunner.mjs';
-import {createDockTearOutHandlers}              from '../../../src/dashboard/DockTearOut.mjs';
-import {createDockVesselEmbodiment}             from '../../../src/dashboard/DockVesselEmbodiment.mjs';
+import Component                   from '../../../src/component/Base.mjs';
+import Container                   from '../../../src/container/Base.mjs';
+import Feed                        from '../store/Feed.mjs';
+import FeedPane                    from './FeedPane.mjs';
+import Scale                       from '../store/Scale.mjs';
+import ScalePane                   from './ScalePane.mjs';
+import DockDragAffordances         from '../../../src/dashboard/DockDragAffordances.mjs';
+import DockDropIndicators          from '../../../src/dashboard/DockDropIndicators.mjs';
+import DockLayoutAdapter           from '../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal            from '../../../src/dashboard/DockMotionSignal.mjs';
+import DockPreview                 from '../../../src/dashboard/DockPreview.mjs';
+import DockProjectionReconciler    from '../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockService                 from '../../../src/ai/client/DockService.mjs';
+import DockZoneModel               from '../../../src/dashboard/DockZoneModel.mjs';
+import InteractionService          from '../../../src/ai/client/InteractionService.mjs';
+import StateProvider               from '../../../src/state/Provider.mjs';
+import TourRunner                  from '../../../src/ai/client/TourRunner.mjs';
+import {createDockTearOutHandlers} from '../../../src/dashboard/DockTearOut.mjs';
+import {
+    createDockVesselEmbodiment,
+    createDockVesselProxyEmbodiment
+}                                                from '../../../src/dashboard/DockVesselEmbodiment.mjs';
 import {createDockWorkspaceSet}                 from '../../../src/dashboard/DockWorkspaceSet.mjs';
 import {createVesselParkHandlers}               from '../../../src/dashboard/DockVesselPark.mjs';
 import {previewToOperation}                     from '../../../src/dashboard/dockPreviewContract.mjs';
@@ -187,6 +190,13 @@ class Workspace extends Container {
      * @member {Object|null} tearOutEmbodiment=null
      */
     tearOutEmbodiment = null
+    /**
+     * The nested transient embodiment for an admitted converted vessel: the same cached pane
+     * moves from its parked source popup into exactly one target-local DragProxyContainer while a
+     * second hidden placeholder reserves the popup's live slot.
+     * @member {Object|null} vesselProxyEmbodiment=null
+     */
+    vesselProxyEmbodiment = null
     /**
      * The tear-out gesture choreography (admission chain + commit-at-terminal routing).
      * @member {Object|null} tearOutHandlers=null
@@ -414,6 +424,30 @@ class Workspace extends Container {
             resolvePane: itemId => me.paneCache[itemId]
                 ?? (me.dockModel?.items?.[itemId] && me.resolvePane(itemId, me.dockModel.items[itemId])),
             resolveTarget: windowId => Neo.apps[windowId]?.mainView ?? null
+        });
+
+        me.vesselProxyEmbodiment = createDockVesselProxyEmbodiment({
+            resolvePane: itemId => me.paneCache[itemId]
+                ?? (me.dockModel?.items?.[itemId] && me.resolvePane(itemId, me.dockModel.items[itemId])),
+            resolveProxyConfig: ({sourceSortZone, targetWindowId}) => {
+                const
+                    sourceConfig = sourceSortZone?.getDragProxyConfig?.(),
+                    targetApp    = Neo.apps[targetWindowId];
+
+                if (!sourceConfig) return null;
+
+                const cls = [...new Set([
+                    ...(sourceConfig.cls || []),
+                    'neo-dock-dragproxy',
+                    'workstation-vessel-dragproxy'
+                ])];
+
+                return {
+                    ...sourceConfig,
+                    appName: targetApp?.name ?? me.appName,
+                    cls
+                }
+            }
         });
 
         // The gesture tear-out choreography. The composition law (dockdemo sibling): a tear-out
@@ -878,9 +912,21 @@ class Workspace extends Container {
                     windowName: me.resolveTearOutVessel(data.itemId)?.windowName
                 })
             },
-            onDockVesselConversionOut: data => me.vesselParkHandlers.onConversionOut({
-                rect: data.logicalRect ?? data.record?.sourceRect ?? null
-            }),
+            onDockVesselConversionOut: data => {
+                // The live pane is nested source-main → popup → target-proxy. Restore the INNER
+                // target-proxy reservation first; only then may the park owner re-show the exact
+                // popup. Reversing this order produces a visible empty source vessel.
+                if (
+                    me.vesselProxyEmbodiment.isStaged(data.itemId) &&
+                    !me.vesselProxyEmbodiment.restore({itemId: data.itemId})
+                ) {
+                    return false
+                }
+
+                return me.vesselParkHandlers.onConversionOut({
+                    rect: data.logicalRect ?? data.record?.sourceRect ?? null
+                })
+            },
             onDockVesselConversionTerminal: data => me.vesselParkHandlers.onGestureTerminal(data),
             onDockVesselConversionRetired : data => me.vesselParkHandlers.onVesselRetired(data),
             onDockZoneDocumentChange      : me.onDockZoneDocumentChange.bind(me),
@@ -908,15 +954,28 @@ class Workspace extends Container {
         if (me.isDestroyed) return null;
 
         return Neo.create(Participation, {
-            clearPreview      : () => me.clearCrossWindowPreview(workspaceId),
-            commitLocal       : operation => me.commitLocalWorkspaceOperation(workspaceId, operation),
-            commitTransfer    : data => me.commitCrossWindowTransfer(data),
-            getDocument       : () => me.getWorkspaceDocument(workspaceId),
-            getForeignDocument: sourceWorkspaceId => me.getWorkspaceDocument(sourceWorkspaceId),
-            hitTest           : (localX, localY) => me.hitTestCrossWindowTarget(workspaceId, localX, localY),
-            previewFor        : data => me.renderCrossWindowPreview(workspaceId, data),
+            clearPreview         : () => me.clearCrossWindowPreview(workspaceId),
+            commitLocal          : operation => me.commitLocalWorkspaceOperation(workspaceId, operation),
+            commitTransfer       : data => me.commitCrossWindowTransfer(data),
+            getDocument          : () => me.getWorkspaceDocument(workspaceId),
+            getForeignDocument   : sourceWorkspaceId => me.getWorkspaceDocument(sourceWorkspaceId),
+            hitTest              : (localX, localY) => me.hitTestCrossWindowTarget(workspaceId, localX, localY),
+            previewFor           : data => me.renderCrossWindowPreview(workspaceId, data),
             previewToOperation,
-            sortGroup         : Workspace.CROSS_WINDOW_SORT_GROUP,
+            promoteDragEmbodiment: data => me.vesselProxyEmbodiment.promote({
+                itemId        : data.draggedItem?.dockItemId,
+                targetWindowId: windowId
+            }),
+            restoreDragEmbodiment: data => me.vesselProxyEmbodiment.restore({
+                itemId        : data.draggedItem?.dockItemId,
+                targetWindowId: windowId
+            }),
+            sortGroup          : Workspace.CROSS_WINDOW_SORT_GROUP,
+            stageDragEmbodiment: data => me.vesselProxyEmbodiment.move({
+                ...data,
+                sourceWindowId: me.resolveTearOutVessel(data.draggedItem?.dockItemId)?.windowId,
+                targetWindowId: windowId
+            }),
             windowId,
             workspaceId
         })
@@ -2805,6 +2864,10 @@ class Workspace extends Container {
 
         if (me.isDestroyed) return;
 
+        // A disconnect can invalidate either side of the nested popup→target-proxy transaction.
+        // Restore it before the outer main→popup embodiment below decides restore vs promote.
+        me.vesselProxyEmbodiment.restoreByWindow(data.windowId);
+
         // A child can disconnect while its live-pane stage is still awaiting renderer settlement.
         // The connect is not in tearOutConnects yet, so this private generation token is the only
         // exact owner. Retire it now; the stage continuation observes the deleted token and cannot
@@ -3371,6 +3434,7 @@ class Workspace extends Container {
             sensor        = sourceZone?.vesselConversionSensor,
             parkedVessel  = me.vesselParkHandlers?.parkedVessel ?? null,
             sourceVessel  = parkedItemId && me.resolveTearOutVessel(parkedItemId),
+            targetProxy   = parkedItemId && me.vesselProxyEmbodiment.snapshot(parkedItemId),
             snapshot      = {
                 claimCount           : arbiter?.claimCount ?? 0,
                 converted            : sensor?.converted === true && sensor?.transitioning !== true,
@@ -3382,6 +3446,7 @@ class Workspace extends Container {
                     sourceVessel?.windowId && Neo.manager?.Window?.get(sourceVessel.windowId)
                 ),
                 sourceVesselWindowId: sourceVessel?.windowId ?? null,
+                targetProxy,
                 targetWorkspaceId,
                 winnerStableId      : winner?.stableId ?? null
             };
@@ -3393,7 +3458,13 @@ class Workspace extends Container {
             && snapshot.rendered?.previewId === snapshot.preview.previewId
             && (parkedItemId == null || (
                 snapshot.converted && snapshot.parkedItemId === parkedItemId &&
-                snapshot.sourceVesselConnected
+                snapshot.sourceVesselConnected &&
+                targetProxy?.itemId === parkedItemId &&
+                targetProxy.ownsPane &&
+                targetProxy.settled &&
+                targetProxy.sourceWindowId === snapshot.sourceVesselWindowId &&
+                targetProxy.targetWindowId === target?.windowId &&
+                targetProxy.visible
             ));
 
         return snapshot
@@ -3447,13 +3518,17 @@ class Workspace extends Container {
      * @param {String} step.targetItemId Existing detached pane whose vessel becomes the target.
      * @param {Object} [options={}]
      * @param {Number} [options.attempts=240]
+     * @param {Number} [options.dwellDelay=0] Optional headed-witness hold after target readiness.
      * @param {Number} [options.moveDelay=16]
      * @param {Number} [options.moveSteps=4]
      * @param {Boolean} [options.showCursor=false] Film mode: show the synthetic cursor in whichever
      * window currently owns the visible leg of the gesture.
      * @returns {Promise<Object>}
      */
-    async executeCrossWindowDockStep(step, {attempts=240, moveDelay=16, moveSteps=4, showCursor=false}={}) {
+    async executeCrossWindowDockStep(
+        step,
+        {attempts=240, dwellDelay=0, moveDelay=16, moveSteps=4, showCursor=false}={}
+    ) {
         let me                                   = this,
             {itemId, sourceNodeId, targetItemId} = step || {},
             targetWorkspaceId                    = Workspace.vesselWorkspaceId(targetItemId),
@@ -3642,6 +3717,8 @@ class Workspace extends Container {
                     proof  : {cancellation, remoteSnapshot}
                 }
             }
+
+            dwellDelay > 0 && await me.timeout(dwellDelay);
 
             me.lastCrossWindowTransfer = null;
 
@@ -4413,6 +4490,7 @@ class Workspace extends Container {
         me.dockService?.destroy();
         me.dragAffordances?.destroy();
         me.interactionService?.destroy();
+        me.vesselProxyEmbodiment?.destroy();
         me.tearOutEmbodiment?.destroy();
         me.cueSettlements.clear();
 

--- a/resources/scss/src/apps/workstation/Viewport.scss
+++ b/resources/scss/src/apps/workstation/Viewport.scss
@@ -77,6 +77,12 @@
     }
 }
 
+// Keep target affordances legible beneath the SAME live pane while it is transiently embodied in
+// the target window. The class is Workstation-owned so generic drag proxies keep their own skin.
+.workstation-vessel-dragproxy {
+    opacity: .7;
+}
+
 // Pane SKIN — everything a pane keeps when it is torn out of the workspace.
 //
 // The token bridge above made a vessel-hosted pane resolve the right colours; these rules are

--- a/src/dashboard/CrossWindowDragTarget.mjs
+++ b/src/dashboard/CrossWindowDragTarget.mjs
@@ -85,6 +85,18 @@ class CrossWindowDragTarget extends Base {
          */
         previewToOperation: null,
         /**
+         * Optional owner seam: promotes a staged target-local drag embodiment after the semantic
+         * commit succeeds. Receives the exact hover payload captured before the commit.
+         * @member {Function|null} promoteDragEmbodiment=null
+         */
+        promoteDragEmbodiment: null,
+        /**
+         * Optional owner seam: restores a staged target-local drag embodiment on leave, refusal,
+         * cancellation, or a throwing commit. Receives the exact hover payload that staged it.
+         * @member {Function|null} restoreDragEmbodiment=null
+         */
+        restoreDragEmbodiment: null,
+        /**
          * §2.3 registry identity: only targets sharing the drag source's `sortGroup` are
          * arbitration candidates. No `sortGroup` → this target never registers.
          * @member {String|null} sortGroup=null
@@ -99,6 +111,13 @@ class CrossWindowDragTarget extends Base {
          */
         stableTargetId: null,
         /**
+         * Optional owner seam: stages/updates the SAME live dragged component in a target-local
+         * proxy. Invoked only when the coordinator explicitly licenses `embodyProxy:true`; strict
+         * `true` is required before this target can publish its semantic preview.
+         * @member {Function|null} stageDragEmbodiment=null
+         */
+        stageDragEmbodiment: null,
+        /**
          * §2.3 registry identity: the window this surface renders in.
          * @member {String|Number|null} windowId=null
          */
@@ -111,6 +130,13 @@ class CrossWindowDragTarget extends Base {
      * @member {Object|null} currentPreview=null
      */
     currentPreview = null
+
+    /**
+     * The exact hover payload paired with {@link #currentPreview}. Retained so every terminal can
+     * restore or promote the correct target-local embodiment even when the owner clears visuals.
+     * @member {Object|null} currentDragPayload=null
+     */
+    currentDragPayload = null
 
     /**
      * Registers with the coordinator once the §2.3 registry identity is complete.
@@ -143,11 +169,40 @@ class CrossWindowDragTarget extends Base {
      * §2.3 mandatory hook: hover feedback for a remote drag over this target. Delegates the
      * compute+render to the owner's preview machinery and keeps the latest payload for the
      * drop path.
-     * @param {Object} payload {draggedItem, localX, localY, offsetX, offsetY, proxyRect}
+     * @param {Object} payload `{draggedItem, localX, localY, offsetX, offsetY, proxyRect,
+     *     embodyProxy, sourceSortZone}`
      * @returns {Object|null} the owner-computed `dockPreview` (null outside affordances)
      */
     onRemoteDragMove(payload) {
-        return this.currentPreview = this.previewFor?.(payload) ?? null
+        let me = this;
+
+        if (payload?.embodyProxy === true) {
+            let staged = false;
+
+            try {
+                staged = me.stageDragEmbodiment?.(payload) === true
+            } catch {/* fail closed below */}
+
+            if (!staged) {
+                me.restoreDragEmbodiment?.(payload);
+                me.currentDragPayload = null;
+                me.currentPreview     = null;
+                me.clearPreview?.();
+                return null
+            }
+        }
+
+        me.currentDragPayload = payload;
+
+        try {
+            return me.currentPreview = me.previewFor?.(payload) ?? null
+        } catch (error) {
+            payload?.embodyProxy === true && me.restoreDragEmbodiment?.(payload);
+            me.currentDragPayload = null;
+            me.currentPreview     = null;
+            me.clearPreview?.();
+            throw error
+        }
     }
 
     /**
@@ -155,8 +210,13 @@ class CrossWindowDragTarget extends Base {
      * coordinator switches targets.
      */
     onRemoteDragLeave() {
-        this.currentPreview = null;
-        this.clearPreview?.()
+        let me      = this,
+            payload = me.currentDragPayload;
+
+        payload?.embodyProxy === true && me.restoreDragEmbodiment?.(payload);
+        me.currentDragPayload = null;
+        me.currentPreview     = null;
+        me.clearPreview?.()
     }
 
     /**
@@ -169,22 +229,55 @@ class CrossWindowDragTarget extends Base {
      * @returns {*} the owner commit result, or null when nothing committed
      */
     onRemoteDrop(draggedItem) {
-        let me        = this,
-            preview   = me.currentPreview,
-            operation = preview ? me.previewToOperation?.(preview) : null,
-            result    = null;
+        let me      = this,
+            payload = me.currentDragPayload,
+            preview = me.currentPreview,
+            result  = null;
 
         try {
+            const operation = preview ? me.previewToOperation?.(preview) : null;
+
             if (operation) {
                 result = me.commitOperation?.(operation, draggedItem) ?? null
             }
-        } finally {
-            // cleanup is unconditional: a throwing owner commit must not leave hover state
-            // behind — the error stays the owner's to observe, the gesture still ends clean
-            me.onRemoteDragLeave()
+        } catch (error) {
+            payload?.embodyProxy === true && me.restoreDragEmbodiment?.(payload);
+            me.clearRemoteState(payload);
+            throw error
         }
 
-        return result
+        const settle = committed => {
+            if (payload?.embodyProxy === true) {
+                me[committed ? 'promoteDragEmbodiment' : 'restoreDragEmbodiment']?.(payload)
+            }
+
+            me.clearRemoteState(payload);
+
+            return committed
+        };
+
+        return typeof result?.then === 'function'
+            ? result.then(settle, error => {
+                payload?.embodyProxy === true && me.restoreDragEmbodiment?.(payload);
+                me.clearRemoteState(payload);
+                throw error
+            })
+            : settle(result)
+    }
+
+    /**
+     * @summary Clears one exact hover generation without settling its embodiment a second time.
+     * @param {Object|null} payload
+     * @protected
+     */
+    clearRemoteState(payload) {
+        let me = this;
+
+        if (me.currentDragPayload === payload) {
+            me.currentDragPayload = null;
+            me.currentPreview     = null;
+            me.clearPreview?.()
+        }
     }
 
     /**
@@ -196,6 +289,8 @@ class CrossWindowDragTarget extends Base {
         if (me.sortGroup && me.windowId != null) {
             me.dragCoordinator?.unregister(me)
         }
+
+        (me.currentDragPayload || me.currentPreview) && me.onRemoteDragLeave();
 
         super.destroy()
     }

--- a/src/dashboard/DockCrossWindowParticipation.mjs
+++ b/src/dashboard/DockCrossWindowParticipation.mjs
@@ -11,9 +11,8 @@ import DockZoneModel         from './DockZoneModel.mjs';
  * `learn/agentos/decisions/0029-harness-docking-design.md`) over exclusively LANDED machinery.
  *
  * It owns the target registration lifecycle (create on workspace mount, destroy on unmount) and
- * binds the five owner seams of {@link Neo.dashboard.CrossWindowDragTarget} to the workspace's
- * landed pipeline, adding exactly ONE new decision: foreign-vs-local drop discrimination at
- * commit time.
+ * binds the owner seams of {@link Neo.dashboard.CrossWindowDragTarget} to the workspace's landed
+ * pipeline, adding exactly ONE new decision: foreign-vs-local drop discrimination at commit time.
  *
  * - **Local drop** (the payload's source workspace IS this one — two windows may project the
  *   same document): the converted operation rides the owner's landed single-document commit
@@ -116,11 +115,29 @@ class DockCrossWindowParticipation extends Base {
          */
         previewToOperation: null,
         /**
+         * Owner seam forwarded to the target: promotes the target-local live drag embodiment
+         * after a successful semantic commit.
+         * @member {Function|null} promoteDragEmbodiment=null
+         */
+        promoteDragEmbodiment: null,
+        /**
+         * Owner seam forwarded to the target: restores the target-local live drag embodiment on
+         * leave or any non-commit terminal.
+         * @member {Function|null} restoreDragEmbodiment=null
+         */
+        restoreDragEmbodiment: null,
+        /**
          * §2.3 registry identity, forwarded to the target: only targets sharing the drag source's
          * `sortGroup` are arbitration candidates.
          * @member {String|null} sortGroup=null
          */
         sortGroup: null,
+        /**
+         * Owner seam forwarded to the target: stages/updates an explicitly licensed target-local
+         * live drag embodiment.
+         * @member {Function|null} stageDragEmbodiment=null
+         */
+        stageDragEmbodiment: null,
         /**
          * §2.3 registry identity, forwarded to the target: the window this workspace renders in.
          * @member {String|Number|null} windowId=null
@@ -151,13 +168,16 @@ class DockCrossWindowParticipation extends Base {
         let me = this;
 
         me.target = Neo.create(CrossWindowDragTarget, {
-            clearPreview      : me.clearPreview,
-            commitOperation   : me.commitDrop.bind(me),
-            dragCoordinator   : me.dragCoordinator,
-            hitTest           : me.hitTest,
-            previewFor        : me.previewFor,
-            previewToOperation: me.previewToOperation,
-            sortGroup         : me.sortGroup,
+            clearPreview         : me.clearPreview,
+            commitOperation      : me.commitDrop.bind(me),
+            dragCoordinator      : me.dragCoordinator,
+            hitTest              : me.hitTest,
+            previewFor           : me.previewFor,
+            previewToOperation   : me.previewToOperation,
+            promoteDragEmbodiment: me.promoteDragEmbodiment,
+            restoreDragEmbodiment: me.restoreDragEmbodiment,
+            sortGroup            : me.sortGroup,
+            stageDragEmbodiment  : me.stageDragEmbodiment,
             // the workspace id IS the §2.8.1 stable claim identity: it survives re-registration
             // and never encodes windowId or registration order
             stableTargetId: me.workspaceId,

--- a/src/dashboard/DockVesselEmbodiment.mjs
+++ b/src/dashboard/DockVesselEmbodiment.mjs
@@ -1,4 +1,5 @@
-import Component from '../component/Base.mjs';
+import Component          from '../component/Base.mjs';
+import DragProxyContainer from '../draggable/DragProxyContainer.mjs';
 
 /**
  * @module Neo.dashboard.DockVesselEmbodiment
@@ -185,5 +186,344 @@ export function createDockVesselEmbodiment({resolvePane, resolveTarget} = {}) {
         },
 
         stage
+    }
+}
+
+/**
+ * Whether one target-local proxy rectangle is finite and drawable.
+ * @param {Object} rect
+ * @returns {Boolean}
+ * @private
+ */
+function isMeasurableProxyRect(rect) {
+    return Boolean(rect) &&
+        Number.isFinite(rect.x) && Number.isFinite(rect.y) &&
+        Number.isFinite(rect.width) && rect.width > 0 &&
+        Number.isFinite(rect.height) && rect.height > 0
+}
+
+/**
+ * Creates one host-local target-proxy embodiment over {@link createDockVesselEmbodiment}.
+ *
+ * The nested registry preserves the pane's exact slot in the parked source popup while the SAME
+ * live pane renders inside one target-window {@link Neo.draggable.DragProxyContainer}. Its
+ * generation fence makes a late renderer settlement from a restored predecessor unable to retire
+ * a successor proxy. The host remains the lifecycle authority: pointer movement calls
+ * {@link #move}, convert-out/cancel calls {@link #restore}, and a committed transfer calls
+ * {@link #promote}. No document or native-window state enters this helper.
+ *
+ * @param {Object} seams
+ * @param {Function} [seams.createProxy] Injectable proxy factory for focused tests.
+ * @param {Function} seams.resolvePane `(itemId) => Neo.component.Base|null`
+ * @param {Function} seams.resolveProxyConfig `({draggedItem, proxyRect, sourceSortZone,
+ *     sourceWindowId, targetWindowId}) => Object|null`
+ * @returns {Object}
+ */
+export function createDockVesselProxyEmbodiment({
+    createProxy=config => Neo.create(config),
+    resolvePane,
+    resolveProxyConfig
+} = {}) {
+    if (
+        typeof createProxy !== 'function' ||
+        typeof resolvePane !== 'function' ||
+        typeof resolveProxyConfig !== 'function'
+    ) {
+        throw new Error(
+            'createDockVesselProxyEmbodiment requires createProxy, resolvePane, and resolveProxyConfig seams'
+        )
+    }
+
+    let active     = null,
+        generation = 0;
+
+    const embodiment = createDockVesselEmbodiment({
+        resolvePane,
+        resolveTarget: targetWindowId => active?.targetWindowId === targetWindowId
+            ? active.proxy
+            : null
+    });
+
+    /**
+     * @summary Retires one exact proxy without destroying its reusable live pane.
+     * @param {Object} record
+     * @private
+     */
+    const retireProxy = record => {
+        if (!record || active !== record) return false;
+
+        active = null;
+
+        if (!record.proxy?.isDestroyed) {
+            record.proxy.hidden = true;
+            record.proxy.destroy()
+        }
+
+        return true
+    };
+
+    /**
+     * @summary Resolves an optional exact identity against the current generation.
+     * @param {Object} identity
+     * @returns {Object|null}
+     * @private
+     */
+    const resolveRecord = ({itemId, sourceWindowId, targetWindowId} = {}) => {
+        if (
+            !active || active.itemId !== itemId ||
+            (sourceWindowId != null && active.sourceWindowId !== sourceWindowId) ||
+            (targetWindowId != null && active.targetWindowId !== targetWindowId)
+        ) {
+            return null
+        }
+
+        return active
+    };
+
+    return {
+        /**
+         * @summary Restores any active proxy during host teardown, then retires transient state.
+         */
+        destroy() {
+            let record = active;
+
+            if (record && !record.promoted) {
+                embodiment.restore({
+                    itemId  : record.itemId,
+                    windowId: record.targetWindowId
+                })
+            }
+
+            record && active === record && retireProxy(record);
+            embodiment.destroy()
+        },
+
+        /**
+         * @summary Reports whether one pane still has an exact source-slot reservation.
+         * @param {String} itemId
+         * @returns {Boolean}
+         */
+        isStaged(itemId) {
+            return embodiment.isStaged(itemId)
+        },
+
+        /**
+         * @summary Moves or updates one admitted target-local live proxy.
+         *
+         * The move is synchronously fail-closed: by return time the pane either has a recorded
+         * exact source slot and a target proxy parent, or no proxy is admitted. Renderer
+         * settlement continues behind the generation fence and is exposed through
+         * {@link #snapshot} for release gating.
+         * @param {Object} data
+         * @param {Neo.component.Base} data.draggedItem
+         * @param {Object} data.proxyRect Target-window-local `{x,y,width,height}`
+         * @param {Neo.draggable.container.SortZone} data.sourceSortZone
+         * @param {String|Number} [data.sourceWindowId] Exact physical source vessel identity.
+         *     Falls back to the source sort zone's window for ordinary cross-window drags.
+         * @param {String|Number} data.targetWindowId
+         * @returns {Boolean}
+         */
+        move({draggedItem, proxyRect, sourceSortZone, sourceWindowId, targetWindowId} = {}) {
+            const itemId = draggedItem?.dockItemId;
+
+            sourceWindowId ??= sourceSortZone?.windowId;
+
+            if (
+                !itemId || sourceWindowId == null || targetWindowId == null ||
+                !isMeasurableProxyRect(proxyRect)
+            ) {
+                return false
+            }
+
+            if (active && (
+                active.itemId !== itemId ||
+                active.sourceWindowId !== sourceWindowId ||
+                active.targetWindowId !== targetWindowId
+            )) {
+                if (!this.restore({itemId: active.itemId})) return false
+            }
+
+            if (!active) {
+                let proxyConfig;
+
+                try {
+                    proxyConfig = resolveProxyConfig({
+                        draggedItem,
+                        proxyRect,
+                        sourceSortZone,
+                        sourceWindowId,
+                        targetWindowId
+                    })
+                } catch {
+                    return false
+                }
+
+                if (!proxyConfig || typeof proxyConfig !== 'object') return false;
+
+                const record = {
+                    generation: ++generation,
+                    itemId,
+                    promoted  : false,
+                    proxy     : null,
+                    settled   : false,
+                    sourceWindowId,
+                    targetWindowId
+                };
+
+                try {
+                    record.proxy = createProxy({
+                        ...proxyConfig,
+                        module          : DragProxyContainer,
+                        height          : `${proxyRect.height}px`,
+                        items           : [],
+                        moveInMainThread: false,
+                        style           : {
+                            ...(proxyConfig.style || {}),
+                            left: `${proxyRect.x}px`,
+                            top : `${proxyRect.y}px`
+                        },
+                        width   : `${proxyRect.width}px`,
+                        windowId: targetWindowId
+                    })
+                } catch {
+                    return false
+                }
+
+                if (!record.proxy) return false;
+
+                active = record;
+
+                let settlement;
+
+                try {
+                    settlement = embodiment.stage({itemId, windowId: targetWindowId})
+                } catch {
+                    retireProxy(record);
+                    return false
+                }
+
+                if (!embodiment.isStaged(itemId)) {
+                    retireProxy(record);
+                    return false
+                }
+
+                Promise.resolve(settlement).then(admitted => {
+                    if (active !== record) return false;
+
+                    record.settled = admitted === true;
+
+                    if (!record.settled) {
+                        retireProxy(record)
+                    }
+
+                    return record.settled
+                }, () => {
+                    active === record && retireProxy(record);
+                    return false
+                })
+            }
+
+            active.proxy.hidden = false;
+            active.proxy.height = `${proxyRect.height}px`;
+            active.proxy.width  = `${proxyRect.width}px`;
+            active.proxy.style  = {
+                ...(active.proxy.style || {}),
+                left: `${proxyRect.x}px`,
+                top : `${proxyRect.y}px`
+            };
+
+            return embodiment.isStaged(itemId) && resolvePane(itemId)?.parent === active.proxy
+        },
+
+        /**
+         * @summary Promotes one committed pane out of transient source-slot ownership.
+         * @description The proxy is retired without destroying the pane; the queued committed
+         * projection reparents that same cached instance into its document-owned target.
+         * @param {Object} identity
+         * @param {String} identity.itemId
+         * @param {String|Number} [identity.sourceWindowId]
+         * @param {String|Number} [identity.targetWindowId]
+         * @returns {Boolean}
+         */
+        promote(identity = {}) {
+            const record = resolveRecord(identity);
+
+            if (!record || !embodiment.promote({
+                itemId  : record.itemId,
+                windowId: record.targetWindowId
+            })) {
+                return false
+            }
+
+            record.promoted = true;
+            retireProxy(record);
+
+            return true
+        },
+
+        /**
+         * @summary Restores one zero-mutation proxy through the parked popup's live placeholder.
+         * @param {Object} identity
+         * @param {String} identity.itemId
+         * @param {String|Number} [identity.sourceWindowId]
+         * @param {String|Number} [identity.targetWindowId]
+         * @returns {Boolean}
+         */
+        restore(identity = {}) {
+            const record = resolveRecord(identity);
+
+            if (!record || record.promoted || !embodiment.restore({
+                itemId  : record.itemId,
+                windowId: record.targetWindowId
+            })) {
+                return false
+            }
+
+            retireProxy(record);
+
+            return true
+        },
+
+        /**
+         * @summary Restores the active proxy when either participating native window departs.
+         * @param {String|Number} windowId
+         * @returns {Boolean}
+         */
+        restoreByWindow(windowId) {
+            const record = active;
+
+            return record && (
+                record.sourceWindowId === windowId || record.targetWindowId === windowId
+            )
+                ? this.restore({itemId: record.itemId})
+                : false
+        },
+
+        /**
+         * @summary Returns clone-safe target-proxy truth for semantic release witnesses.
+         * @param {String|null} [itemId=null]
+         * @returns {Object|null}
+         */
+        snapshot(itemId=null) {
+            const
+                record = active,
+                pane   = record && resolvePane(record.itemId),
+                proxy  = record?.proxy;
+
+            if (!record || (itemId != null && record.itemId !== itemId)) return null;
+
+            return {
+                cls           : Array.isArray(proxy?.cls) ? [...proxy.cls] : [],
+                generation    : record.generation,
+                itemId        : record.itemId,
+                ownsPane      : pane?.parent === proxy,
+                proxyId       : proxy?.id ?? null,
+                settled       : record.settled,
+                sourceWindowId: record.sourceWindowId,
+                targetWindowId: record.targetWindowId,
+                visible       : Boolean(proxy) && !proxy.isDestroyed && proxy.hidden !== true &&
+                    proxy.style?.display !== 'none' && String(proxy.style?.opacity ?? 1) !== '0'
+            }
+        }
     }
 }

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -181,11 +181,13 @@ class DragCoordinator extends Manager {
 
         await targetSortZone.onRemoteDragMove({
             draggedItem,
+            embodyProxy: true,
             localX,
             localY,
             offsetX,
             offsetY,
-            proxyRect
+            proxyRect,
+            sourceSortZone
         });
 
         // The native-titlebar path answers the same question as the pointer path, so it obeys the same
@@ -562,11 +564,13 @@ class DragCoordinator extends Manager {
 
             targetSortZone.onRemoteDragMove({
                 draggedItem,
+                embodyProxy: transitionOwned,
                 localX,
                 localY,
                 offsetX,
                 offsetY,
-                proxyRect: targetProxyRect
+                proxyRect  : targetProxyRect,
+                sourceSortZone
             });
 
             return
@@ -634,11 +638,16 @@ class DragCoordinator extends Manager {
 
             next.onRemoteDragMove({
                 draggedItem: candidate.draggedItem,
-                localX     : candidate.localX,
-                localY     : candidate.localY,
-                offsetX    : candidate.offsetX,
-                offsetY    : candidate.offsetY,
-                proxyRect  : candidate.proxyRect
+                // Native titlebar geometry does not ride the pointer conversion resolver. Keep
+                // its source popup visible during dwell; only commitNativeWindowDrop may stage
+                // an embodiment, after suspendWindowDrag has strictly settled.
+                embodyProxy   : false,
+                localX        : candidate.localX,
+                localY        : candidate.localY,
+                offsetX       : candidate.offsetX,
+                offsetY       : candidate.offsetY,
+                proxyRect     : candidate.proxyRect,
+                sourceSortZone: candidate.sourceSortZone
             })
         } else {
             me.nativeHoverTargets.delete(windowId)

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -457,16 +457,30 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             ]),
             targetPopup        = await targetPopupPromise,
             sourcePopupPromise = page.waitForEvent('popup', {timeout: 90000}),
-            dockResult         = await app.callMethod(wsId, 'executeCrossWindowDockStep', [
+            dockResultPromise  = app.callMethod(wsId, 'executeCrossWindowDockStep', [
                 {itemId: 'commits', sourceNodeId: 'right-bottom-tabs', targetItemId: 'metrics'},
                 {
                     attempts  : filmPace.birthAttempts ?? 180,
+                    dwellDelay: filmPace.dwellDelay ?? 600,
                     moveDelay : filmPace.moveDelay ?? 16,
                     moveSteps : filmPace.moveSteps ?? 4,
                     showCursor: filmPace.showCursor ?? false
                 }
             ]),
-            sourcePopup = await sourcePopupPromise;
+            targetProxy = targetPopup.locator('.workstation-vessel-dragproxy');
+
+        await expect(targetProxy, 'exactly one Workstation proxy must render in the target popup')
+            .toHaveCount(1, {timeout: 9000});
+
+        const computedOpacity = await targetProxy.evaluate(element =>
+            Number.parseFloat(getComputedStyle(element).opacity));
+
+        expect(computedOpacity, 'the live target proxy must leave the dock preview legible').toBe(.7);
+
+        const [dockResult, sourcePopup] = await Promise.all([dockResultPromise, sourcePopupPromise]);
+
+        dockResult.proof?.remoteSnapshot?.targetProxy &&
+            (dockResult.proof.remoteSnapshot.targetProxy.computedOpacity = computedOpacity);
 
         await expect.poll(() => sourcePopup.isClosed(), {
             message: 'the converted source vessel must retire after its remote commit',
@@ -1229,10 +1243,26 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             engaged              : true,
             parkedItemId         : 'commits',
             sourceVesselConnected: true,
-            targetWorkspaceId    : 'workstation-vessel:metrics',
-            winnerStableId       : 'workstation-vessel:metrics'
+            targetProxy          : {
+                cls: expect.arrayContaining([
+                    'neo-dock-dragproxy',
+                    'workstation-vessel-dragproxy',
+                    'neo-theme-neo-dark'
+                ]),
+                computedOpacity: .7,
+                itemId         : 'commits',
+                ownsPane       : true,
+                settled        : true,
+                visible        : true
+            },
+            targetWorkspaceId: 'workstation-vessel:metrics',
+            winnerStableId   : 'workstation-vessel:metrics'
         });
         expect(snapshot.sourceVesselWindowId, 'the parked physical source vessel must still exist pre-mouseup')
+            .toBeTruthy();
+        expect(snapshot.targetProxy.sourceWindowId, 'the proxy must reserve that exact parked source popup')
+            .toBe(snapshot.sourceVesselWindowId);
+        expect(snapshot.targetProxy.targetWindowId, 'the visible proxy must belong to the target popup')
             .toBeTruthy();
         expect(snapshot.preview.previewId, 'the target must publish one semantic preview').toBeTruthy();
         expect(snapshot.rendered.previewId, 'that same preview must paint inside the target popup')
@@ -1472,9 +1502,23 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
                 engaged              : true,
                 parkedItemId         : 'commits',
                 sourceVesselConnected: true,
-                targetWorkspaceId    : 'workstation-vessel:metrics',
-                winnerStableId       : 'workstation-vessel:metrics'
+                targetProxy          : {
+                    cls: expect.arrayContaining([
+                        'neo-dock-dragproxy',
+                        'workstation-vessel-dragproxy',
+                        'neo-theme-neo-dark'
+                    ]),
+                    computedOpacity: .7,
+                    itemId         : 'commits',
+                    ownsPane       : true,
+                    settled        : true,
+                    visible        : true
+                },
+                targetWorkspaceId: 'workstation-vessel:metrics',
+                winnerStableId   : 'workstation-vessel:metrics'
             });
+            expect(dockResult.proof.remoteSnapshot.targetProxy.sourceWindowId)
+                .toBe(dockResult.proof.remoteSnapshot.sourceVesselWindowId);
             expect(dockResult.proof.remoteSnapshot.rendered.previewId)
                 .toBe(dockResult.proof.remoteSnapshot.preview.previewId);
             expect(dockResult.proof.remoteSnapshot.preview.target.nodeId)

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -351,6 +351,103 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('target-proxy staging uses the physical parked popup instead of the source sort-zone window', async () => {
+        const
+            workspace      = Neo.create(Workspace, {}),
+            originalProxy  = workspace.vesselProxyEmbodiment,
+            stagedPayloads = [];
+        let participation;
+
+        try {
+            workspace.tearOutConnects.audit = {windowId: 'parked-audit-popup'};
+            workspace.vesselProxyEmbodiment = {
+                move: data => {
+                    stagedPayloads.push(data);
+                    return true
+                },
+                promote: () => true,
+                restore: () => true
+            };
+
+            participation = await workspace.createCrossWindowParticipation({
+                windowId   : 'proxy-target-window',
+                workspaceId: 'proxy-target-workspace'
+            });
+
+            const payload = {
+                draggedItem   : {dockItemId: 'audit'},
+                proxyRect     : {height: 80, width: 160, x: 20, y: 30},
+                sourceSortZone: {windowId: workspace.windowId}
+            };
+
+            expect(participation.target.stageDragEmbodiment(payload)).toBe(true);
+            expect(stagedPayloads).toEqual([{
+                ...payload,
+                sourceWindowId: 'parked-audit-popup',
+                targetWindowId: 'proxy-target-window'
+            }])
+        } finally {
+            participation?.destroy();
+            workspace.vesselProxyEmbodiment = originalProxy;
+            workspace.destroy()
+        }
+    });
+
+    test('convert-out restores the target proxy before the exact parked popup is re-shown', () => {
+        const workspace = Neo.create(Workspace, {});
+        const
+            chrome        = readTabChrome(workspace),
+            originalPark  = workspace.vesselParkHandlers,
+            originalProxy = workspace.vesselProxyEmbodiment,
+            order         = [];
+
+        try {
+            workspace.vesselProxyEmbodiment = {
+                isStaged: () => true,
+                restore : data => {
+                    order.push(['proxy-restored', data.itemId]);
+                    return true
+                }
+            };
+            workspace.vesselParkHandlers = {
+                onConversionOut: data => {
+                    order.push(['popup-reshown', data.rect]);
+                    return true
+                }
+            };
+
+            const admitted = {
+                itemId     : 'audit',
+                logicalRect: {height: 120, width: 200, x: 40, y: 60}
+            };
+
+            chrome.get('right-top-tabs').tab.fire('dockVesselConversionOut', admitted);
+
+            expect(admitted.admission).toBe(true);
+            expect(order).toEqual([
+                ['proxy-restored', 'audit'],
+                ['popup-reshown', admitted.logicalRect]
+            ]);
+
+            order.length = 0;
+            workspace.vesselProxyEmbodiment.restore = data => {
+                order.push(['proxy-refused', data.itemId]);
+                return false
+            };
+
+            const refused = {itemId: 'audit', logicalRect: admitted.logicalRect};
+
+            chrome.get('right-top-tabs').tab.fire('dockVesselConversionOut', refused);
+
+            expect(refused.admission).toBe(false);
+            expect(order).toEqual([['proxy-refused', 'audit']])
+        } finally {
+            workspace.vesselParkHandlers      = originalPark;
+            workspace.vesselProxyEmbodiment = originalProxy;
+            workspace.destroy()
+        }
+    });
+
     test('a connected vessel stays unregistered until an accepted drop seeds document ownership', async () => {
         const
             workspace   = Neo.create(Workspace, {}),
@@ -927,6 +1024,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             workspace       = Neo.create(Workspace, {}),
             originalTearOut = workspace.tearOutHandlers,
             originalPark    = workspace.vesselParkHandlers,
+            originalProxy   = workspace.vesselProxyEmbodiment,
             calls           = [];
 
         try {
@@ -941,11 +1039,18 @@ test.describe.serial('Workstation.view.Workspace', () => {
             workspace.vesselParkHandlers = {
                 onVesselRetired: data => calls.push(['park', data])
             };
+            workspace.vesselProxyEmbodiment = {
+                restoreByWindow: windowId => {
+                    calls.push(['proxy', windowId]);
+                    return true
+                }
+            };
 
             workspace.onWindowDisconnect({windowId: 'tear-child'});
 
             expect(workspace.tearOutConnects.alerts).toBeUndefined();
             expect(calls).toEqual([
+                ['proxy', 'tear-child'],
                 ['tear-out', {
                     admissionToken: 7,
                     generation    : 3,
@@ -955,8 +1060,9 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 ['park', {itemId: 'alerts', retirement: true}]
             ])
         } finally {
-            workspace.tearOutHandlers  = originalTearOut;
-            workspace.vesselParkHandlers = originalPark;
+            workspace.tearOutHandlers         = originalTearOut;
+            workspace.vesselParkHandlers      = originalPark;
+            workspace.vesselProxyEmbodiment = originalProxy;
             workspace.destroy()
         }
     });

--- a/test/playwright/unit/dashboard/CrossWindowDragTarget.spec.mjs
+++ b/test/playwright/unit/dashboard/CrossWindowDragTarget.spec.mjs
@@ -81,6 +81,103 @@ test.describe('Neo.dashboard.CrossWindowDragTarget (#14670 / ADR 0029 §2.3)', (
         target.destroy()
     });
 
+    test('an explicitly licensed target proxy stages before preview and restores before leave cleanup', () => {
+        const order  = [];
+        const target = Neo.create(CrossWindowDragTarget, {
+            clearPreview: () => order.push('clear-preview'),
+            previewFor  : () => {
+                order.push('preview');
+                return {feedback: {state: 'accepted'}, itemId: 'pane-a'}
+            },
+            restoreDragEmbodiment: () => {
+                order.push('restore-proxy');
+                return true
+            },
+            sortGroup          : 'dock-main',
+            stageDragEmbodiment: () => {
+                order.push('stage-proxy');
+                return true
+            },
+            windowId: 2
+        });
+
+        target.onRemoteDragMove({
+            draggedItem: {dockItemId: 'pane-a'},
+            embodyProxy: true,
+            localX     : 40,
+            localY     : 8
+        });
+        target.onRemoteDragLeave();
+
+        expect(order).toEqual([
+            'stage-proxy',
+            'preview',
+            'restore-proxy',
+            'clear-preview'
+        ]);
+        expect(target.currentDragPayload).toBeNull();
+        expect(target.currentPreview).toBeNull();
+
+        target.destroy()
+    });
+
+    test('native preview is proxy-free, while a missing licensed stage seam fails closed', () => {
+        const calls  = [];
+        const target = Neo.create(CrossWindowDragTarget, {
+            previewFor: payload => {
+                calls.push(['preview', payload.embodyProxy]);
+                return {feedback: {state: 'accepted'}}
+            },
+            sortGroup: 'dock-main',
+            windowId : 2
+        });
+
+        expect(target.onRemoteDragMove({draggedItem: {}, embodyProxy: false})).toEqual({
+            feedback: {state: 'accepted'}
+        });
+        target.onRemoteDragLeave();
+
+        expect(target.onRemoteDragMove({draggedItem: {}, embodyProxy: true})).toBeNull();
+        expect(calls).toEqual([['preview', false]]);
+        expect(target.currentPreview).toBeNull();
+
+        target.destroy()
+    });
+
+    test('a refused stage and a throwing converter both restore the licensed proxy fail-closed', () => {
+        const
+            restored = [],
+            payload  = {
+                draggedItem: {dockItemId: 'pane-a'},
+                embodyProxy: true,
+                localX     : 4,
+                localY     : 4
+            },
+            target = Neo.create(CrossWindowDragTarget, {
+                previewFor        : () => ({feedback: {state: 'accepted'}, itemId: 'pane-a'}),
+                previewToOperation: () => {
+                    throw new Error('converter failed')
+                },
+                restoreDragEmbodiment: data => restored.push(data.draggedItem.dockItemId),
+                sortGroup            : 'dock-main',
+                stageDragEmbodiment  : () => false,
+                windowId             : 2
+            });
+
+        expect(target.onRemoteDragMove(payload)).toBeNull();
+        expect(restored).toEqual(['pane-a']);
+
+        target.stageDragEmbodiment = () => true;
+        target.onRemoteDragMove(payload);
+
+        expect(() => target.onRemoteDrop(payload.draggedItem)).toThrow('converter failed');
+        expect(restored).toEqual(['pane-a', 'pane-a']);
+        expect(target.currentDragPayload).toBeNull();
+        expect(target.currentPreview).toBeNull();
+
+        target.destroy()
+    });
+
     test('the drop path converts the final preview through the owner previewToOperation → commitOperation pipeline', () => {
         const commits = [];
         const target  = Neo.create(CrossWindowDragTarget, {
@@ -102,6 +199,41 @@ test.describe('Neo.dashboard.CrossWindowDragTarget (#14670 / ADR 0029 §2.3)', (
         }]);
         // the drop consumed the preview — hover state never leaks past the gesture
         expect(target.currentPreview).toBeNull();
+
+        target.destroy()
+    });
+
+    test('a committed target promotes its exact proxy; a refused target restores it', () => {
+        const
+            promoted = [],
+            restored = [],
+            target   = Neo.create(CrossWindowDragTarget, {
+                commitOperation      : () => ({applied: true}),
+                previewFor           : () => ({feedback: {state: 'accepted'}, itemId: 'pane-a'}),
+                previewToOperation   : () => ({operation: 'addTab', itemId: 'pane-a', tabsNodeId: 't1'}),
+                promoteDragEmbodiment: payload => promoted.push(payload.draggedItem.dockItemId),
+                restoreDragEmbodiment: payload => restored.push(payload.draggedItem.dockItemId),
+                sortGroup            : 'dock-main',
+                stageDragEmbodiment  : () => true,
+                windowId             : 2
+            }),
+            payload = {
+                draggedItem: {dockItemId: 'pane-a'},
+                embodyProxy: true,
+                localX     : 4,
+                localY     : 4
+            };
+
+        target.onRemoteDragMove(payload);
+        expect(target.onRemoteDrop(payload.draggedItem)).toEqual({applied: true});
+        expect(promoted).toEqual(['pane-a']);
+        expect(restored).toEqual([]);
+
+        target.commitOperation = () => null;
+        target.onRemoteDragMove(payload);
+        expect(target.onRemoteDrop(payload.draggedItem)).toBeNull();
+        expect(promoted).toEqual(['pane-a']);
+        expect(restored).toEqual(['pane-a']);
 
         target.destroy()
     });

--- a/test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs
@@ -13,10 +13,13 @@ import '../../../../src/manager/Instance.mjs';
 import Component from '../../../../src/component/Base.mjs';
 import Container from '../../../../src/container/Base.mjs';
 
-import {createDockVesselEmbodiment} from '../../../../src/dashboard/DockVesselEmbodiment.mjs';
+import {
+    createDockVesselEmbodiment,
+    createDockVesselProxyEmbodiment
+} from '../../../../src/dashboard/DockVesselEmbodiment.mjs';
 
 test.describe('Neo.dashboard.DockVesselEmbodiment (#15396)', () => {
-    let embodiment, pane, source, target;
+    let embodiment, pane, proxyEmbodiment, source, target;
 
     test.beforeEach(() => {
         source = Neo.create(Container, {
@@ -36,6 +39,8 @@ test.describe('Neo.dashboard.DockVesselEmbodiment (#15396)', () => {
     });
 
     test.afterEach(() => {
+        proxyEmbodiment?.destroy();
+        proxyEmbodiment = null;
         embodiment?.destroy();
         source?.isDestroyed || source?.destroy();
         target?.isDestroyed || target?.destroy()
@@ -111,5 +116,203 @@ test.describe('Neo.dashboard.DockVesselEmbodiment (#15396)', () => {
         expect(source.items.some(item => item.cls?.includes('neo-dashboard-dock-vessel-placeholder'))).toBe(false);
         expect(target.items).toEqual([]);
         expect(embodiment.isStaged('live')).toBe(false)
+    })
+});
+
+test.describe('Neo.dashboard.DockVesselProxyEmbodiment (#16090)', () => {
+    let pane, proxyEmbodiment, source;
+
+    test.beforeEach(() => {
+        source = Neo.create(Container, {
+            items: [
+                {module: Component, html: 'before'},
+                {module: Component, html: 'live'},
+                {module: Component, html: 'after'}
+            ]
+        });
+        pane = source.items[1];
+        pane.dockItemId = 'live'
+    });
+
+    test.afterEach(() => {
+        proxyEmbodiment?.destroy();
+        source?.isDestroyed || source?.destroy()
+    });
+
+    /**
+     * @summary Creates a non-mounted proxy fixture that preserves live children on destroy.
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.deferFirst=false]
+     * @returns {Object}
+     */
+    function createFixture({deferFirst=false}={}) {
+        const
+            proxies        = [],
+            sourceSortZone = {
+                getDragProxyConfig: () => ({
+                    cls: ['neo-tab-header-toolbar', 'neo-dock-dragproxy', 'neo-theme-dark']
+                }),
+                windowId: 'source-window'
+            };
+        let resolveFirst;
+
+        proxyEmbodiment = createDockVesselProxyEmbodiment({
+            createProxy: config => {
+                const proxy = Neo.create(Container, {
+                    cls  : config.cls,
+                    items: []
+                });
+
+                proxy.height   = config.height;
+                proxy.style    = config.style;
+                proxy.width    = config.width;
+                proxy.windowId = config.windowId;
+
+                if (deferFirst && proxies.length === 0) {
+                    proxy.promiseUpdate = () => new Promise(resolve => resolveFirst = resolve)
+                }
+
+                const destroy = proxy.destroy.bind(proxy);
+
+                proxy.destroy = (...args) => {
+                    proxy.items = [];
+                    destroy(...args)
+                };
+
+                proxies.push(proxy);
+
+                return proxy
+            },
+            resolvePane       : itemId => itemId === 'live' ? pane : null,
+            resolveProxyConfig: ({sourceSortZone: zone}) => ({
+                appName: 'DockVesselProxyEmbodimentTest',
+                cls    : zone.getDragProxyConfig().cls
+            })
+        });
+
+        return {
+            move(x=20, sourceWindowId) {
+                return proxyEmbodiment.move({
+                    draggedItem   : pane,
+                    proxyRect     : {height: 80, width: 160, x, y: 30},
+                    sourceSortZone,
+                    sourceWindowId,
+                    targetWindowId: 'target-window'
+                })
+            },
+            proxies,
+            resolveFirst: () => resolveFirst?.()
+        }
+    }
+
+    test('one target-local proxy follows pointer geometry and restores the exact parked-popup slot', async () => {
+        const fixture = createFixture();
+
+        expect(fixture.move()).toBe(true);
+        expect(fixture.move(75)).toBe(true);
+        expect(fixture.proxies).toHaveLength(1);
+
+        await expect.poll(() => proxyEmbodiment.snapshot('live')?.settled).toBe(true);
+
+        expect(proxyEmbodiment.snapshot('live')).toMatchObject({
+            cls           : expect.arrayContaining([
+                'neo-tab-header-toolbar',
+                'neo-dock-dragproxy',
+                'neo-theme-dark'
+            ]),
+            itemId        : 'live',
+            ownsPane      : true,
+            settled       : true,
+            sourceWindowId: 'source-window',
+            targetWindowId: 'target-window',
+            visible       : true
+        });
+        expect(fixture.proxies[0].style).toMatchObject({left: '75px', top: '30px'});
+        expect(fixture.proxies[0].cls).toEqual(expect.arrayContaining([
+            'neo-tab-header-toolbar',
+            'neo-dock-dragproxy',
+            'neo-theme-dark'
+        ]));
+        expect(source.items[1].cls).toContain('neo-dashboard-dock-vessel-placeholder');
+
+        expect(proxyEmbodiment.restore({itemId: 'live'})).toBe(true);
+        expect(source.items[1]).toBe(pane);
+        expect(pane.isDestroyed).toBeFalsy();
+        expect(fixture.proxies[0].isDestroyed).toBe(true);
+        expect(proxyEmbodiment.snapshot('live')).toBeNull();
+        expect(proxyEmbodiment.restore({itemId: 'live'})).toBe(false)
+    });
+
+    test('the parked popup identity overrides the originating sort-zone window', async () => {
+        const fixture = createFixture();
+
+        expect(fixture.move(20, 'parked-popup-window')).toBe(true);
+        await expect.poll(() => proxyEmbodiment.snapshot('live')?.settled).toBe(true);
+
+        expect(proxyEmbodiment.snapshot('live')).toMatchObject({
+            sourceWindowId: 'parked-popup-window',
+            targetWindowId: 'target-window'
+        });
+        expect(proxyEmbodiment.restoreByWindow('source-window')).toBe(false);
+        expect(proxyEmbodiment.restoreByWindow('parked-popup-window')).toBe(true);
+        expect(source.items[1]).toBe(pane)
+    });
+
+    test('commit promotion preserves pane identity while retiring the transient proxy exact-once', async () => {
+        const fixture = createFixture();
+
+        expect(fixture.move()).toBe(true);
+        await expect.poll(() => proxyEmbodiment.snapshot('live')?.settled).toBe(true);
+
+        const placeholder = source.items[1];
+
+        expect(proxyEmbodiment.promote({
+            itemId        : 'live',
+            sourceWindowId: 'source-window',
+            targetWindowId: 'target-window'
+        })).toBe(true);
+        expect(source.items[1]).toBe(placeholder);
+        expect(pane.isDestroyed).toBeFalsy();
+        expect(fixture.proxies[0].isDestroyed).toBe(true);
+        expect(proxyEmbodiment.snapshot('live')).toBeNull();
+        expect(proxyEmbodiment.promote({itemId: 'live'})).toBe(false)
+    });
+
+    test('a late predecessor settlement cannot retire a restored successor generation', async () => {
+        const fixture = createFixture({deferFirst: true});
+
+        expect(fixture.move()).toBe(true);
+        expect(proxyEmbodiment.restore({itemId: 'live'})).toBe(true);
+        expect(fixture.move(90)).toBe(true);
+
+        await expect.poll(() => proxyEmbodiment.snapshot('live')?.settled).toBe(true);
+
+        const successor = proxyEmbodiment.snapshot('live');
+
+        fixture.resolveFirst();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(successor.generation).toBe(2);
+        expect(proxyEmbodiment.snapshot('live')).toMatchObject({
+            generation: 2,
+            ownsPane  : true,
+            settled   : true,
+            visible   : true
+        });
+        expect(fixture.proxies[0].isDestroyed).toBe(true);
+        expect(fixture.proxies[1].isDestroyed).toBeFalsy()
+    });
+
+    test('disconnect cleanup matches either exact participating window and is idempotent', async () => {
+        const fixture = createFixture();
+
+        expect(fixture.move()).toBe(true);
+
+        expect(proxyEmbodiment.restoreByWindow('unrelated-window')).toBe(false);
+        expect(proxyEmbodiment.snapshot('live')).not.toBeNull();
+        expect(proxyEmbodiment.restoreByWindow('source-window')).toBe(true);
+        expect(proxyEmbodiment.restoreByWindow('target-window')).toBe(false);
+        expect(source.items[1]).toBe(pane)
     })
 });

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -289,16 +289,21 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
         // `await onRemoteDrop(...)` and retiring the source anyway. Same defect class, different
         // entry point — fixing the instance the ticket named is not fixing the class.
         const
-            draggedItem = {id: 'tab-1'},
-            target      = {
+            draggedItem  = {id: 'tab-1'},
+            movePayloads = [],
+            order        = [],
+            target       = {
                 ...createTargetZone(null),
                 acceptsRemoteDrag: () => true,
-                onRemoteDragMove : async () => {}
+                onRemoteDragMove : async payload => {
+                    order.push('move');
+                    movePayloads.push(payload)
+                }
             },
             source      = {
                 ...createSourceZone(),
                 getNativeWindowDrag: () => ({draggedItem}),
-                suspendWindowDrag  : async () => {}
+                suspendWindowDrag  : async () => order.push('suspend')
             };
 
         // `commitNativeWindowDrop(windowId, candidate)` is POSITIONAL and guards on the candidate being
@@ -315,7 +320,13 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
 
         // The target declined, so the source keeps the item — exactly as on the pointer path.
         expect(calls).toEqual([['onRemoteDrop', 'tab-1']]);
-        expect(calls.some(([name]) => name === 'onRemoteDropOut')).toBe(false)
+        expect(calls.some(([name]) => name === 'onRemoteDropOut')).toBe(false);
+        expect(order).toEqual(['suspend', 'move']);
+        expect(movePayloads[0]).toMatchObject({
+            draggedItem,
+            embodyProxy   : true,
+            sourceSortZone: source
+        })
     });
 
     test('a THROWING commit still clears the engagement — a REJECTED terminal cannot park the target', () => {
@@ -733,6 +744,7 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
     });
 
     test('NATIVE hover renders CONTINUOUS preview per geometry event — the dwell timer gates only the commit', () => {
+        const nativePayloads = [];
         const
             draggedItem = {id: 'tab-1'},
             source      = {
@@ -746,6 +758,13 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
                 }
             },
             target = createZone('workspace-b', 'win-target');
+
+        const onRemoteDragMove = target.onRemoteDragMove.bind(target);
+
+        target.onRemoteDragMove = payload => {
+            nativePayloads.push(payload);
+            onRemoteDragMove(payload)
+        };
 
         registerWindow('win-source', 2000,   0, 400, 400);
         registerWindow('win-popup',   500, 500, 300, 200);
@@ -761,6 +780,9 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         // preview rendered per event, BEFORE any dwell elapsed; nothing committed
         expect(calls.filter(([name]) => name === 'move').length).toBe(2);
         expect(calls.filter(([name]) => name === 'drop')).toEqual([]);
+        expect(nativePayloads).toHaveLength(2);
+        expect(nativePayloads.every(payload => payload.embodyProxy === false)).toBe(true);
+        expect(nativePayloads.every(payload => payload.sourceSortZone === source)).toBe(true);
 
         // the popup leaves the target: the hover ends exact-once
         WindowManager.get('win-popup').innerRect = new Rectangle(3000, 3000, 300, 200);
@@ -779,9 +801,18 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
     });
 
     test('conversion resolver receives one live INNER-viewport frame and owns engagement without legacy suspension', () => {
-        const frames = [];
+        const
+            frames       = [],
+            movePayloads = [];
         const source = createSource();
         const target = createZone('workspace-a', 'win-a');
+
+        const onRemoteDragMove = target.onRemoteDragMove.bind(target);
+
+        target.onRemoteDragMove = payload => {
+            movePayloads.push(payload);
+            onRemoteDragMove(payload)
+        };
 
         source.isWindowDragging = true;
         source.resolveRemoteDragTransition = frame => {
@@ -807,6 +838,10 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         });
         expect(calls.filter(([name]) => name === 'suspend')).toEqual([]);
         expect(calls.filter(([name]) => name === 'move')).toHaveLength(1);
+        expect(movePayloads[0]).toMatchObject({
+            embodyProxy   : true,
+            sourceSortZone: source
+        });
         expect(DragCoordinator.activeSourceZone).toBe(source);
         expect(DragCoordinator.activeTargetCommitEligible).toBe(true);
         expect(DragCoordinator.activeTransitionOwned).toBe(true);


### PR DESCRIPTION
Resolves #16090

Converted Workstation vessels now keep a visible body over the winning target popup: the same cached pane moves into one target-window `DragProxyContainer` while an exact-slot placeholder reserves its parked source popup. Pointer conversion, convert-out, commit, cancellation, disconnect, and stale-generation terminals now share one stage/restore/promote owner; model operations and claim arbitration remain unchanged.

Evidence: L3 (headed macOS Chromium native-window journey with Playwright DOM opacity and Neural Link semantic receipts) → L3 required (target-window visual embodiment and lifecycle ACs). Residual: none [#16090].

Related: #15252

## Deltas from ticket

- The source identity is the physical parked popup, not the originating main-window sort zone. Convert-out therefore restores the inner target-proxy reservation before the existing park owner re-shows that exact popup.
- Native-titlebar hover remains proxy-free while the OS popup is itself visible. After native suspension settles, the commit path explicitly stages the target proxy; the negative is covered independently from pointer conversion.
- The Workstation-owned proxy class resolves to `opacity: .7`; Playwright reads the computed value from the physical target popup before mouseup, so translucency is browser evidence rather than a source-only inference.
- No parallel drag coordinator, preview language, native alpha dependency, or document/model operation was introduced.

## Test Evidence

- Dashboard and Workstation unit surfaces: `npm run test-unit -- test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs test/playwright/unit/dashboard/CrossWindowDragTarget.spec.mjs test/playwright/unit/manager/DragCoordinator.spec.mjs test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs test/playwright/unit/apps/workstation/Workspace.spec.mjs` — 74 passed.
- Workstation native-window Scene 3: `NEO_E2E_PORT=8138 npx playwright test workstation/WorkstationFiveBeatNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed --grep "scene 3"` — 2 passed, accelerated GL; exactly one target-popup proxy, computed opacity `0.7`, exact parked source identity, semantic/rendered preview equality, and one stable claim.
- Workstation native-window Scene 4: `NEO_E2E_PORT=8140 npx playwright test workstation/WorkstationFiveBeatNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed --grep "scene 4"` — 2 passed, accelerated GL; proxy commit, whole-stack return, target-first projection, commit-before-close, and physical topology exit.
- Scene 5 diagnostic boundary: one complete signature take reached dock, return, and physical topology exit with `NEO_NL_RPC_TIMEOUT=30000`. The two-take wrapper later lost its post-reload App Worker before entering the `#16090` proxy path, so this is not claimed as a terminal full-suite pass.
- Repository gates: `npm run agent-preflight -- <11 changed files>` — all requested source gates passed; final source-plus-body no-fix result is recorded before PR creation.

## Post-Merge Validation

- [ ] Confirm GitHub CI is green on the exact PR head before assigning the primary reviewer.
- [ ] Re-run the two-take Scene 5 wrapper in a fresh-memory host window to observe whether the classified post-reload App Worker disconnect recurs.
- [ ] Let the next production-film capture for `#15252` consume the landed proxy beat; this PR contains no film or media changes.

## Decision Record impact

Depends on ADR 0029 §§2.3 and 2.8.2–2.8.3; no amendment. This completes the recorded detached-moving/hovering-claim embodiment without introducing a new ownership state.

## Evolution

Pre-PR review found that a target-proxy class receipt did not by itself prove computed translucency. A direct cross-window app-worker DOM read then falsified the wrong authority boundary by timing out. The final witness keeps product routing untouched: the app holds one bounded, semantically ready pre-release frame while Playwright—the owner of the native popup pages—counts the proxy and reads its physical computed opacity.

Related witness session: `019f9e1e-2ef1-72c3-a04d-6bc67a531a8b`.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fa906-0873-7e63-aa2b-2728755b3357.
