### PR TITLE
fix(github-workflow): adapt discussion pagination (#15977)

### DIFF
--- a/ai/mcp/server/github-workflow/configBase.mjs
+++ b/ai/mcp/server/github-workflow/configBase.mjs
@@ -125,6 +125,13 @@ class ConfigBase extends ConfigProvider {
                  */
                 discussionsDir: leaf(path.resolve(projectRoot, 'resources/content/discussions')),
                 /**
+                 * Initial number of discussions projected per GraphQL page (1–30). The syncer halves
+                 * this value and retries the same cursor when GitHub reports
+                 * `RESOURCE_LIMITS_EXCEEDED`.
+                 * @type {number}
+                 */
+                discussionOuterPageSize: leaf(30),
+                /**
                  * The path to the directory for pull requests.
                  * @type {string}
                  */

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -282,6 +282,7 @@
         "issueSync.contentRoot",
         "issueSync.discussionDenylist",
         "issueSync.discussionFilenamePrefix",
+        "issueSync.discussionOuterPageSize",
         "issueSync.discussionsDir",
         "issueSync.droppedLabels",
         "issueSync.issueFilenamePrefix",

--- a/ai/services/github-workflow/GraphqlService.mjs
+++ b/ai/services/github-workflow/GraphqlService.mjs
@@ -285,10 +285,10 @@ class GraphqlService extends Base {
     async query(query, variables={}, options=false) {
         const enableSubIssues = typeof options === 'boolean' ? options : Boolean(options?.enableSubIssues);
         const strict          = typeof options === 'object' ? options?.strict !== false : true;
-        const token = await this.#getAuthToken();
+        const token           = await this.#getAuthToken();
 
         const headers = {
-            'Content-Type': 'application/json',
+            'Content-Type' : 'application/json',
             'Authorization': `bearer ${token}`
         };
 
@@ -341,7 +341,14 @@ class GraphqlService extends Base {
             }
 
             logger.error('GitHub API returned errors:', json.errors);
-            throw new Error(`GitHub API error: ${json.errors.map(e => e.message).join(', ')}`);
+            const error = new Error(`GitHub API error: ${json.errors.map(e => e.message).join(', ')}`);
+
+            // Preserve GitHub's typed error payload so bounded callers can react to a specific
+            // provider condition without parsing human-readable messages. Strict mode still throws,
+            // so partial response data never crosses this boundary.
+            error.graphqlErrors = json.errors;
+
+            throw error;
         }
 
         return json.data;

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -19,12 +19,7 @@ import {classifyDiscussionRoutingDisposition}                from '../shared/dis
 import pruneEmptyDirs                                        from '../shared/pruneEmptyDirs.mjs';
 import {verifyDiscussionFrontmatter}                         from './verifyFrontmatterIntegrity.mjs';
 
-const
-    // A clean-slate `first: 50` discussion query exceeds GitHub's GraphQL resource budget once
-    // comments and replies are projected. Thirty is the measured safe outer page size. Cursor
-    // pagination remains unchanged, so this bounds per-query cost without truncating the corpus.
-    discussionOuterPageSize = 30,
-    issueSyncConfig         = aiConfig.issueSync;
+const issueSyncConfig = aiConfig.issueSync;
 
 /**
  * @summary Handles the fetching and local synchronization of GitHub Discussions.
@@ -60,6 +55,17 @@ class DiscussionSyncer extends Base {
      */
     #calculateContentHash(content) {
         return crypto.createHash('sha256').update(content).digest('hex');
+    }
+
+    /**
+     * @summary Detects GitHub's typed GraphQL resource-budget failure.
+     * @param {Error|*} error The strict GraphQL query failure.
+     * @returns {Boolean} Whether GitHub classified the failure as resource-limit exhaustion.
+     * @private
+     */
+    #isResourceLimitError(error) {
+        return Array.isArray(error?.graphqlErrors) &&
+               error.graphqlErrors.some(item => item.type === 'RESOURCE_LIMITS_EXCEEDED');
     }
 
     /**
@@ -405,6 +411,11 @@ class DiscussionSyncer extends Base {
         let allDiscussions = [];
         let hasNextPage    = true;
         let cursor         = null;
+        let pageSize       = issueSyncConfig.discussionOuterPageSize;
+
+        if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 30) {
+            throw new Error('issueSync.discussionOuterPageSize must be an integer between 1 and 30.');
+        }
 
         // Delta cutoff. Mirror the PR/issue delta: the query orders UPDATED_AT DESC and we stop
         // paginating once a batch's oldest discussion predates the cached high-water mark. A
@@ -419,14 +430,33 @@ class DiscussionSyncer extends Base {
         await fs.mkdir(issueSyncConfig.discussionsDir, { recursive: true });
 
         while (hasNextPage) {
-            const data = await GraphqlService.query(FETCH_DISCUSSIONS_FOR_SYNC, {
-                owner      : aiConfig.owner,
-                repo       : aiConfig.repo,
-                limit      : discussionOuterPageSize,
-                cursor,
-                maxComments: 50,
-                maxReplies : 20
-            });
+            let data;
+
+            try {
+                data = await GraphqlService.query(FETCH_DISCUSSIONS_FOR_SYNC, {
+                    owner      : aiConfig.owner,
+                    repo       : aiConfig.repo,
+                    limit      : pageSize,
+                    cursor,
+                    maxComments: 50,
+                    maxReplies : 20
+                });
+            } catch (error) {
+                if (!this.#isResourceLimitError(error) || pageSize === 1) {
+                    throw error;
+                }
+
+                const nextPageSize = Math.max(1, Math.floor(pageSize / 2));
+
+                logger.warn(
+                    `[DiscussionSyncer] GitHub GraphQL resource limit exceeded; retrying the same ` +
+                    `${cursor === null ? 'initial' : 'continuation'} cursor with outer page size ` +
+                    `${nextPageSize} (was ${pageSize}).`
+                );
+
+                pageSize = nextPageSize;
+                continue;
+            }
 
             const discussions = data.repository.discussions;
 

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -36,6 +36,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
     let originalQuery;
     let originalSortedReleases;
     let originalDiscussionDenylist;
+    let originalDiscussionOuterPageSize;
     let tmpRoot;
 
     test.beforeAll(async () => {
@@ -51,6 +52,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         originalQuery          = GraphqlService.query.bind(GraphqlService);
         originalSortedReleases = ReleaseNotesSyncer.sortedReleases;
         originalDiscussionDenylist = aiConfig.issueSync.discussionDenylist;
+        originalDiscussionOuterPageSize = aiConfig.issueSync.discussionOuterPageSize;
     });
 
     test.beforeEach(async () => {
@@ -73,6 +75,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         aiConfig.issueSync.issuesDir       = originalIssuesDir;
         aiConfig.issueSync.contentRoot     = originalContentRoot;
         aiConfig.issueSync.discussionDenylist = originalDiscussionDenylist;
+        aiConfig.issueSync.discussionOuterPageSize = originalDiscussionOuterPageSize;
 
         await fs.remove(tmpRoot).catch(() => {});
     });
@@ -661,6 +664,79 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         expect(calls.map(({limit}) => limit)).toEqual([30, 30]);
         expect(calls.map(({cursor}) => cursor)).toEqual([null, 'page-2']);
         expect(stats.synced).toEqual([26001, 26002])
+    });
+
+    test('rejects an outer page size above the production-proven ceiling (#15977)', async () => {
+        aiConfig.issueSync.discussionOuterPageSize = 31;
+
+        await expect(DiscussionSyncer.syncDiscussions({discussions: {}, lastSync: null}))
+            .rejects.toThrow('issueSync.discussionOuterPageSize must be an integer between 1 and 30.');
+    });
+
+    test('resource-limit recovery halves the page size and retries the same cursor (#15977)', async () => {
+        const
+            first  = buildDiscussion(26003),
+            second = buildDiscussion(26004),
+            calls  = [];
+
+        GraphqlService.query = async (query, variables) => {
+            calls.push({...variables});
+
+            if (calls.length === 1) {
+                const error = new Error('GitHub API error: Resource limits for this query exceeded');
+                error.graphqlErrors = [{type: 'RESOURCE_LIMITS_EXCEEDED'}];
+                throw error;
+            }
+
+            return {
+                repository: {
+                    discussions: variables.cursor === null
+                        ? {nodes: [first], pageInfo: {hasNextPage: true, endCursor: 'page-2'}}
+                        : {nodes: [second], pageInfo: {hasNextPage: false, endCursor: null}}
+                }
+            }
+        };
+
+        const stats = await DiscussionSyncer.syncDiscussions({discussions: {}, lastSync: null});
+
+        expect(calls.map(({limit}) => limit)).toEqual([30, 15, 15]);
+        expect(calls.map(({cursor}) => cursor)).toEqual([null, null, 'page-2']);
+        expect(stats.synced).toEqual([26003, 26004]);
+    });
+
+    test('resource-limit recovery fails loud when one discussion still exceeds the budget (#15977)', async () => {
+        const calls = [];
+
+        GraphqlService.query = async (query, variables) => {
+            calls.push({...variables});
+
+            const error = new Error('GitHub API error: Resource limits for this query exceeded');
+            error.graphqlErrors = [{type: 'RESOURCE_LIMITS_EXCEEDED'}];
+            throw error;
+        };
+
+        await expect(DiscussionSyncer.syncDiscussions({discussions: {}, lastSync: null}))
+            .rejects.toThrow('GitHub API error: Resource limits for this query exceeded');
+
+        expect(calls.map(({limit}) => limit)).toEqual([30, 15, 7, 3, 1]);
+        expect(calls.map(({cursor}) => cursor)).toEqual([null, null, null, null, null]);
+    });
+
+    test('non-resource GraphQL failures do not enter the page-size recovery path (#15977)', async () => {
+        const calls = [];
+
+        GraphqlService.query = async (query, variables) => {
+            calls.push({...variables});
+
+            const error = new Error('GitHub API error: Repository access denied');
+            error.graphqlErrors = [{type: 'FORBIDDEN'}];
+            throw error;
+        };
+
+        await expect(DiscussionSyncer.syncDiscussions({discussions: {}, lastSync: null}))
+            .rejects.toThrow('GitHub API error: Repository access denied');
+
+        expect(calls.map(({limit}) => limit)).toEqual([30]);
     });
 
     test('containment: skips and excludes a denylisted discussion (by number)', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs
@@ -149,6 +149,25 @@ test.describe('Neo.ai.services.github-workflow.GraphqlService — transient retr
         expect(callCount).toBe(1);
     });
 
+    test('preserves typed GraphQL error details for bounded caller recovery (#15977)', async () => {
+        const errors = [{
+            type   : 'RESOURCE_LIMITS_EXCEEDED',
+            path   : ['repository', 'discussions', 'nodes', 29, 'comments'],
+            message: 'Resource limits for this query exceeded'
+        }];
+
+        globalThis.fetch = async () => new Response(JSON.stringify({errors}), {
+            status : 200,
+            headers: {'content-type': 'application/json'}
+        });
+
+        const error = await GraphqlService.query(QUERY).catch(error => error);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toBe('GitHub API error: Resource limits for this query exceeded');
+        expect(error.graphqlErrors).toEqual(errors);
+    });
+
     test('strict mode throws when GraphQL errors include partial data (#10096)', async () => {
         globalThis.fetch = async () => new Response(JSON.stringify({
             data: {


### PR DESCRIPTION
Resolves #15977

The first scheduled Data Sync run after `#16093` proved that a fixed Discussion outer page size of 30 is not generally safe: GitHub returned `RESOURCE_LIMITS_EXCEEDED` while projecting nested comments and replies. This repair preserves GitHub's typed GraphQL error payload, retries the same cursor with a halved page size, and keeps the reduced size for later pages. It never accepts partial response data and rethrows the original failure if a single-discussion page still exceeds GitHub's budget.

Evidence: L2 (focused GraphQL + Discussion sync behavior tests and AiConfig parity) → L4 required (an actual scheduled Data Sync run publishes Discussions, all watchdog facets report fresh, and the canonical generated backlog is then safely discarded). Residual: AC7–AC8 [#15977].

## Deltas from ticket

- Replaces the production-falsified “30 is always safe” premise with bounded adaptive pagination: `30 → 15 → 7 → 3 → 1`.
- Moves the initial page size into the canonical `issueSync` config surface, constrained to the ticket's 1–30 range.
- Adds typed error provenance to strict GraphQL failures without changing their fail-closed behavior.

## Test Evidence

- Discussion sync pagination and failure behavior: `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs` — 99 passed.
- AiConfig authority surface: `node ai/scripts/lint/lint-config-template-ssot.mjs --update-parity`, followed by the parity suite above — passed.
- Source preflight: `npm run agent-preflight -- <six changed files>` — passed.
- Patch hygiene: `git diff --check` — passed.

## Post-Merge Validation

- [ ] Observe an actual scheduled Data Sync run retry the same Discussion cursor at a smaller page size and finish green.
- [ ] Verify the resulting Publisher commit advances Discussion Markdown plus the existing Portal/DevIndex generated surfaces.
- [ ] Verify the watchdog reports issues, pulls, discussions, and releases fresh.
- [ ] Only then discard the canonical checkout's generated backlog, preserving `.neo-ai-data/concepts/nodes.jsonl`.

## Evolution

Run https://github.com/neomjs/neo/actions/runs/30373260238 falsified the earlier measured-safe-size claim at outer node 29. The repair therefore responds to GitHub's typed resource signal instead of substituting another unproven fixed number.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fa530-53d6-7271-bf05-51497720b29c.
