### PR TITLE
chore(ai): pin mailbox authorization contract (#16098)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -132,7 +132,12 @@ function normalizeMailboxTarget(to, sentBy) {
 }
 
 /**
- * @summary Compares mailbox identity operands after canonicalizing both direct-id forms.
+ * @summary Compares mailbox identities through the shared authorization-critical normalizer.
+ *
+ * This comparison gates send-policy checks, mailbox visibility, sender-only retraction, and A2A
+ * Task authority. A normalization change therefore changes production authorization semantics,
+ * even though the shared primitive also serves the read-state diagnostic.
+ *
  * @param {*} left First identity-shaped value.
  * @param {*} right Second identity-shaped value.
  * @returns {Boolean}

--- a/ai/services/memory-core/helpers/mailboxReadStateClassifier.mjs
+++ b/ai/services/memory-core/helpers/mailboxReadStateClassifier.mjs
@@ -2,12 +2,16 @@ import {normalizeAgentIdentityNodeId} from '../../../graph/normalizeAgentIdentit
 
 /**
  * @module ai/services/memory-core/helpers/mailboxReadStateClassifier
- * @summary Pure carrier-aware classifier for one mailbox recipient's durable read state.
+ * @summary Shared mailbox identity comparison and pure carrier-aware read-state classification.
  *
  * Direct messages persist `readAt` on the `MESSAGE` node, while receipt-backed broadcasts
  * persist it on the recipient's `DELIVERED_TO` edge. This helper accepts already-read raw graph
  * rows and returns the stable observation envelope shared by the explicit-path CLI and the live
  * Memory Core diagnostic. It performs no I/O, repair, configuration lookup, or mutation.
+ *
+ * The exported identity normalizer also feeds `MailboxService`'s production authorization,
+ * visibility, retraction, and Task-transition comparisons. It is therefore not a diagnostic-only
+ * primitive: changing its equivalence rules changes both the observation path and mailbox authority.
  */
 
 /**
@@ -27,13 +31,17 @@ export function createMailboxReadStateFailure(state, error, context={}) {
 }
 
 /**
- * @summary Canonicalizes a stored mailbox target using MailboxService's comparison rules.
+ * @summary Canonicalizes mailbox identities for diagnostic routing and production authorization.
  *
  * Direct `AGENT:<identity>` wrappers remain comparison-compatible, while persisted
  * `AGENT:<family>/<model>` aliases stay untouched because roster-based alias resolution belongs to
  * send-time validation. Direct values without an address-kind colon and legacy
  * `AGENT:<identity>` wrappers flow through `normalizeAgentIdentityNodeId`, which trims whitespace
  * and collapses any run of leading `@` characters.
+ *
+ * `MailboxService.sameMailboxIdentity()` normalizes both operands through this function before
+ * send-policy, inbox-visibility, sender-retraction, and A2A Task authority decisions. Do not broaden
+ * or narrow these rules for diagnostic convenience without preserving those production consumers.
  *
  * @param {*} identity Stored edge target or request-bound identity.
  * @returns {*} Canonical direct identity or unchanged non-direct mailbox address.

--- a/test/playwright/unit/ai/services/memory-core/helpers/mailboxReadStateClassifier.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/mailboxReadStateClassifier.spec.mjs
@@ -77,17 +77,32 @@ function classify(messageRows, edgeRows) {
 }
 
 test.describe('mailboxReadStateClassifier — pure carrier matrix (#16086)', () => {
-    test('keeps one normalization authority for adapters and MailboxService comparisons', () => {
-        for (const [input, expected] of [
-            ['  @neo-gpt  ', '@neo-gpt'],
-            ['@@@@neo-gpt', '@neo-gpt'],
-            ['AGENT:neo-gpt', '@neo-gpt'],
-            ['AGENT:@neo-gpt', '@neo-gpt'],
-            ['AGENT:openai/gpt', 'AGENT:openai/gpt'],
-            ['AGENT:*', 'AGENT:*'],
-            ['role:librarian', 'role:librarian']
+    test('pins the shared diagnostic and authorization normalization contract (#16098)', () => {
+        for (const [label, input, expected] of [
+            ['canonical direct id',                 '@neo-gpt',                 '@neo-gpt'],
+            ['bare direct id',                      'neo-gpt',                  '@neo-gpt'],
+            ['leading-space direct id',             ' @neo-gpt',                '@neo-gpt'],
+            ['trailing-space direct id',            '@neo-gpt ',                '@neo-gpt'],
+            ['two-sided-space direct id',           '  @neo-gpt  ',             '@neo-gpt'],
+            ['tab-padded direct id',                '\t@neo-gpt',               '@neo-gpt'],
+            ['double-at direct id',                 '@@neo-gpt',                '@neo-gpt'],
+            ['triple-at direct id',                 '@@@neo-gpt',               '@neo-gpt'],
+            ['four-at direct id',                   '@@@@neo-gpt',              '@neo-gpt'],
+            ['bare AGENT wrapper',                  'AGENT:neo-gpt',            '@neo-gpt'],
+            ['canonical AGENT wrapper',             'AGENT:@neo-gpt',           '@neo-gpt'],
+            ['padded multi-at AGENT wrapper',       'AGENT:  @@neo-gpt  ',      '@neo-gpt'],
+            ['family/model alias',                  'AGENT:openai/gpt',         'AGENT:openai/gpt'],
+            ['broadcast sentinel',                  'AGENT:*',                  'AGENT:*'],
+            ['role address',                        'role:librarian',            'role:librarian'],
+            ['human address',                       'human:tobiu',               'human:tobiu'],
+            ['future-self alias',                   '@me',                      '@me'],
+            ['empty string',                        '',                         ''],
+            ['null',                                null,                       null],
+            ['undefined',                           undefined,                  undefined],
+            ['boolean',                             false,                      false],
+            ['number',                              0,                          0]
         ]) {
-            expect(normalizeMailboxIdentityForComparison(input)).toBe(expected);
+            expect(normalizeMailboxIdentityForComparison(input), label).toBe(expected);
         }
 
         expect(validateMailboxReadStateRequest({


### PR DESCRIPTION
Resolves #16098

Pins mailbox identity normalization as a shared authorization contract rather than a diagnostic-only helper. The adjacent JSDoc now names the production consumers, and the normalization matrix expands from seven examples to 22 labeled input classes covering direct IDs, wrapper forms, aliases, sentinels, special addresses, and non-string passthrough values. No executable production behavior changes.

Evidence: L1 (source/call-site audit plus a 22-input normalization contract) → L1 required (documentation and contract-test acceptance criteria). No residuals.

## Deltas from ticket

None substantive.

## Test Evidence

- Shared normalizer plus every production `sameMailboxIdentity()` consumer: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/mailboxReadStateClassifier.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — 141/141 passed.
- Repository unit suite: `npm run test-unit` — 10,174 passed, 5 skipped, and one unrelated live-model latency case exceeded its 60-second runner cap while completing successfully at 66 seconds.
- Unchanged latency spec rerun: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs` — 8/8 passed in 31.1 seconds; measured summarization latency was 21.7 seconds.
- Preflight/static: repair-capable `npm run agent-preflight -- <touched files>` passed; `git diff --check` passed.

## Post-Merge Validation

- [x] None required beyond current-head CI; this PR changes documentation and contract coverage only.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fa904-9d8c-7f12-94fe-346ae8e54046.
