### PR TITLE
fix(github-workflow): exhaust discussion conversations (#16016)

### DIFF
--- a/ai/services/github-workflow/queries/discussionQueries.mjs
+++ b/ai/services/github-workflow/queries/discussionQueries.mjs
@@ -113,9 +113,10 @@ export const GET_DISCUSSION_CONVERSATION = `
 `;
 
 /**
- * @summary Fetches Discussions for local synchronization, including bounded nested comments and
- * replies plus each connection's `totalCount` / `pageInfo`. Those exhaustion facts let the shared
- * renderer persist explicit incompleteness instead of mistaking a 50/20 cap for a complete mirror.
+ * @summary Fetches Discussions for local synchronization, including the first nested comment/reply
+ * pages plus each connection's `totalCount` / `pageInfo`. The syncer drives those exhaustion facts
+ * through the continuation queries below before rendering, so the 50/20 page sizes never become
+ * corpus caps.
  *
  * Variables required:
  * - $owner: String!
@@ -168,6 +169,7 @@ export const FETCH_DISCUSSIONS_FOR_SYNC = `
               endCursor
             }
             nodes {
+              paginationId: id
               author {
                 login
               }
@@ -244,6 +246,7 @@ export const FETCH_SINGLE_DISCUSSION_FOR_SYNC = `
             endCursor
           }
           nodes {
+            paginationId: id
             author {
               login
             }
@@ -265,6 +268,108 @@ export const FETCH_SINGLE_DISCUSSION_FOR_SYNC = `
                 isAnswer
               }
             }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * @summary Continues the top-level comment connection for one Discussion.
+ *
+ * Every returned comment includes the first reply page plus its exhaustion facts, matching the
+ * nested shape of the bulk and force-refetch queries. `paginationId` is an internal alias used only
+ * to continue a comment's reply connection; the renderer deliberately ignores it so persisted
+ * Markdown and content-trust signal paths keep their existing shape.
+ *
+ * Variables required:
+ * - $owner: String!
+ * - $repo: String!
+ * - $number: Int!
+ * - $cursor: String
+ * - $maxComments: Int!
+ * - $maxReplies: Int!
+ */
+export const FETCH_DISCUSSION_COMMENTS_PAGE = `
+  query FetchDiscussionCommentsPage(
+    $owner: String!
+    $repo: String!
+    $number: Int!
+    $cursor: String
+    $maxComments: Int!
+    $maxReplies: Int!
+  ) {
+    repository(owner: $owner, name: $repo) {
+      discussion(number: $number) {
+        comments(first: $maxComments, after: $cursor) {
+          totalCount
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            paginationId: id
+            author {
+              login
+            }
+            body
+            createdAt
+            isAnswer
+            replies(first: $maxReplies) {
+              totalCount
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              nodes {
+                author {
+                  login
+                }
+                body
+                createdAt
+                isAnswer
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * @summary Continues the reply connection for one Discussion comment.
+ *
+ * The parent comment is addressed by the internal `paginationId` selected by the initial/comment
+ * page queries. Replies retain the exact renderer-facing fields of the first page.
+ *
+ * Variables required:
+ * - $commentId: ID!
+ * - $cursor: String
+ * - $maxReplies: Int!
+ */
+export const FETCH_DISCUSSION_REPLIES_PAGE = `
+  query FetchDiscussionRepliesPage(
+    $commentId: ID!
+    $cursor: String
+    $maxReplies: Int!
+  ) {
+    node(id: $commentId) {
+      ... on DiscussionComment {
+        replies(first: $maxReplies, after: $cursor) {
+          totalCount
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            author {
+              login
+            }
+            body
+            createdAt
+            isAnswer
           }
         }
       }

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -1,15 +1,20 @@
-import aiConfig                                                       from '../../../mcp/server/github-workflow/config.mjs';
-import Base                                                           from '../../../../src/core/Base.mjs';
-import crypto                                                         from 'crypto';
-import fs                                                             from 'fs/promises';
-import logger                                                         from '../../../mcp/server/github-workflow/logger.mjs';
-import matter                                                         from 'gray-matter';
-import path                                                           from 'path';
-import GraphqlService                                                 from '../GraphqlService.mjs';
-import ReleaseNotesSyncer                                             from './ReleaseNotesSyncer.mjs';
-import {FETCH_DISCUSSIONS_FOR_SYNC, FETCH_SINGLE_DISCUSSION_FOR_SYNC} from '../queries/discussionQueries.mjs';
-import contentPath                                                    from '../shared/contentPath.mjs';
-import {buildContentInventory}                                        from '../shared/contentInventory.mjs';
+import aiConfig           from '../../../mcp/server/github-workflow/config.mjs';
+import Base               from '../../../../src/core/Base.mjs';
+import crypto             from 'crypto';
+import fs                 from 'fs/promises';
+import logger             from '../../../mcp/server/github-workflow/logger.mjs';
+import matter             from 'gray-matter';
+import path               from 'path';
+import GraphqlService     from '../GraphqlService.mjs';
+import ReleaseNotesSyncer from './ReleaseNotesSyncer.mjs';
+import {
+    FETCH_DISCUSSION_COMMENTS_PAGE,
+    FETCH_DISCUSSION_REPLIES_PAGE,
+    FETCH_DISCUSSIONS_FOR_SYNC,
+    FETCH_SINGLE_DISCUSSION_FOR_SYNC
+} from '../queries/discussionQueries.mjs';
+import contentPath             from '../shared/contentPath.mjs';
+import {buildContentInventory} from '../shared/contentInventory.mjs';
 import {
     createContentIndexEntry,
     updateContentIndex
@@ -19,7 +24,9 @@ import {classifyDiscussionRoutingDisposition}                from '../shared/dis
 import pruneEmptyDirs                                        from '../shared/pruneEmptyDirs.mjs';
 import {verifyDiscussionFrontmatter}                         from './verifyFrontmatterIntegrity.mjs';
 
-const issueSyncConfig = aiConfig.issueSync;
+const
+    conversationPageSizes = Object.freeze({comments: 50, replies: 20}),
+    issueSyncConfig       = aiConfig.issueSync;
 
 /**
  * @summary Handles the fetching and local synchronization of GitHub Discussions.
@@ -262,9 +269,138 @@ class DiscussionSyncer extends Base {
     }
 
     /**
-     * @summary Projects the bounded GitHub comment/reply connections into explicit mirror-completeness
-     * evidence. Missing connection metadata is unknown, never assumed complete; a cap hit therefore
-     * survives in the artifact as a fail-closed signal for downstream deterministic consumers.
+     * @summary Validates the exhaustion metadata required to paginate one GitHub connection safely.
+     * @param {Object} connection GraphQL connection carrying nodes, totalCount, and pageInfo.
+     * @param {String} label Human-readable connection identity for failures.
+     * @returns {void}
+     * @throws {Error} When nodes/count/pageInfo are missing or a continuation lacks a cursor.
+     * @private
+     */
+    #validateConversationConnection(connection, label) {
+        const valid = Array.isArray(connection?.nodes) &&
+            Number.isInteger(connection?.totalCount) &&
+            connection.totalCount >= 0 &&
+            typeof connection?.pageInfo?.hasNextPage === 'boolean';
+
+        if (!valid) {
+            throw new Error(`${label} returned incomplete pagination metadata.`)
+        }
+
+        if (connection.pageInfo.hasNextPage &&
+            (typeof connection.pageInfo.endCursor !== 'string' || connection.pageInfo.endCursor.length === 0)) {
+            throw new Error(`${label} has another page but no continuation cursor.`)
+        }
+    }
+
+    /**
+     * @summary Appends one validated GraphQL continuation page and advances the connection state.
+     * @param {Object} connection Accumulated target connection.
+     * @param {Object} page Newly fetched continuation page.
+     * @param {String} label Human-readable connection identity for failures.
+     * @param {String} requestedCursor Cursor used to request this page.
+     * @returns {void}
+     * @throws {Error} When a non-terminal page repeats its input cursor.
+     * @private
+     */
+    #appendConversationPage(connection, page, label, requestedCursor) {
+        this.#validateConversationConnection(page, label);
+
+        if (page.pageInfo.hasNextPage && page.pageInfo.endCursor === requestedCursor) {
+            throw new Error(`${label} returned a non-advancing continuation cursor.`)
+        }
+
+        connection.nodes.push(...page.nodes);
+        connection.totalCount = page.totalCount;
+        connection.pageInfo   = {...page.pageInfo}
+    }
+
+    /**
+     * @summary Exhausts the reply connection for one Discussion comment.
+     * @param {Object} comment Discussion comment carrying `paginationId` and its first reply page.
+     * @param {Number} discussionNumber Parent Discussion number for diagnostics.
+     * @returns {Promise<void>}
+     * @throws {Error} When GitHub omits continuation metadata, the parent ID, or a usable page.
+     * @private
+     */
+    async #hydrateCommentReplies(comment, discussionNumber) {
+        const
+            label   = `Discussion #${discussionNumber} comment replies`,
+            replies = comment.replies;
+
+        this.#validateConversationConnection(replies, label);
+
+        while (replies.pageInfo.hasNextPage) {
+            if (!comment.paginationId) {
+                throw new Error(`${label} requires the parent comment paginationId.`)
+            }
+
+            const cursor = replies.pageInfo.endCursor;
+            const data   = await GraphqlService.query(FETCH_DISCUSSION_REPLIES_PAGE, {
+                commentId : comment.paginationId,
+                cursor,
+                maxReplies: conversationPageSizes.replies
+            });
+
+            this.#appendConversationPage(replies, data.node?.replies, label, cursor)
+        }
+    }
+
+    /**
+     * @summary Exhausts every top-level comment and nested reply page for one Discussion.
+     *
+     * The bulk and force-refetch entry points both pass through this primitive before rendering, so
+     * neither can persist a capped conversation. A malformed/non-advancing connection fails loud
+     * instead of turning `conversationComplete: false` into accepted corpus output.
+     *
+     * @param {Object} discussion Discussion sync node carrying the first nested connection pages.
+     * @returns {Promise<void>}
+     * @throws {Error} When pagination cannot prove the full conversation was observed.
+     * @private
+     */
+    async #hydrateDiscussionConversation(discussion) {
+        const
+            comments = discussion.comments,
+            label    = `Discussion #${discussion.number} comments`;
+
+        this.#validateConversationConnection(comments, label);
+
+        while (comments.pageInfo.hasNextPage) {
+            const cursor = comments.pageInfo.endCursor;
+            const data   = await GraphqlService.query(FETCH_DISCUSSION_COMMENTS_PAGE, {
+                owner      : aiConfig.owner,
+                repo       : aiConfig.repo,
+                number     : discussion.number,
+                cursor,
+                maxComments: conversationPageSizes.comments,
+                maxReplies : conversationPageSizes.replies
+            });
+
+            this.#appendConversationPage(
+                comments,
+                data?.repository?.discussion?.comments,
+                label,
+                cursor
+            )
+        }
+
+        for (const comment of comments.nodes) {
+            await this.#hydrateCommentReplies(comment, discussion.number)
+        }
+
+        const completeness = this.#getConversationCompleteness(discussion);
+
+        if (!completeness.conversationComplete) {
+            throw new Error(
+                `Discussion #${discussion.number} conversation pagination ended incomplete ` +
+                `(${completeness.conversationCommentCountObserved}/${completeness.conversationCommentCountTotal} comments, ` +
+                `${completeness.conversationReplyCountObserved}/${completeness.conversationReplyCountTotal} replies).`
+            )
+        }
+    }
+
+    /**
+     * @summary Projects exhausted GitHub comment/reply connections into explicit mirror-completeness
+     * evidence. Missing connection metadata stays unknown rather than being assumed complete.
      * @param {Object} discussion The fetched Discussion sync node.
      * @returns {Object} Stable flat frontmatter fields for the v1 completeness contract.
      * @private
@@ -326,6 +462,7 @@ class DiscussionSyncer extends Base {
     #renderDiscussionMarkdown(discussion) {
         const contentTrust        = createContentTrustSummary();
         const projectedDiscussion = this.#projectAuthoredNode(discussion, contentTrust, 'body');
+        const conversation        = this.#getConversationCompleteness(discussion);
         const routingDisposition  = classifyDiscussionRoutingDisposition({
             author     : discussion.author?.login,
             authorTrust: projectedDiscussion.authorTrust,
@@ -347,8 +484,12 @@ class DiscussionSyncer extends Base {
             routingDispositionReason       : routingDisposition.reasonCode,
             routingDispositionEvidence     : routingDisposition.evidence,
             contentTrust,
-            ...this.#getConversationCompleteness(discussion)
+            ...conversation
         };
+
+        if (!conversation.conversationComplete) {
+            throw new Error(`Discussion #${discussion.number} cannot be rendered from an incomplete conversation.`)
+        }
 
         let body = projectedDiscussion.body || '';
 
@@ -438,8 +579,8 @@ class DiscussionSyncer extends Base {
                     repo       : aiConfig.repo,
                     limit      : pageSize,
                     cursor,
-                    maxComments: 50,
-                    maxReplies : 20
+                    maxComments: conversationPageSizes.comments,
+                    maxReplies : conversationPageSizes.replies
                 });
             } catch (error) {
                 if (!this.#isResourceLimitError(error) || pageSize === 1) {
@@ -516,6 +657,10 @@ class DiscussionSyncer extends Base {
 
         if (deniedFetchedNumbers.size > 0) {
             allDiscussions = allDiscussions.filter(discussion => !deniedFetchedNumbers.has(discussion.number));
+        }
+
+        for (const discussion of allDiscussions) {
+            await this.#hydrateDiscussionConversation(discussion)
         }
 
         const inventory            = await buildContentInventory(issueSyncConfig, {type: 'discussions', filePrefix: issueSyncConfig.discussionFilenamePrefix});
@@ -664,8 +809,8 @@ class DiscussionSyncer extends Base {
                         owner      : aiConfig.owner,
                         repo       : aiConfig.repo,
                         number     : discussionNumber,
-                        maxComments: 50,
-                        maxReplies : 20
+                        maxComments: conversationPageSizes.comments,
+                        maxReplies : conversationPageSizes.replies
                     },
                     true
                 );
@@ -675,6 +820,8 @@ class DiscussionSyncer extends Base {
                     logger.warn(`Discussion #${discussionNumber} not found on GitHub, skipping refetch`);
                     continue;
                 }
+
+                await this.#hydrateDiscussionConversation(discussion);
 
                 const planBuckets = this.#planBuckets(metadata, [discussion], inventory);
                 const targetPath  = this.#getDiscussionPath(discussion, planBuckets);

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -20,6 +20,8 @@ import fs             from 'fs-extra';
 import matter         from 'gray-matter';
 import path           from 'path';
 import {
+    FETCH_DISCUSSION_COMMENTS_PAGE,
+    FETCH_DISCUSSION_REPLIES_PAGE,
     FETCH_DISCUSSIONS_FOR_SYNC,
     FETCH_SINGLE_DISCUSSION_FOR_SYNC
 } from '../../../../../../ai/services/github-workflow/queries/discussionQueries.mjs';
@@ -225,7 +227,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         })
     });
 
-    test('keeps comments and truncated comment pages outside the root-body lifecycle authority', async () => {
+    test('keeps comments outside the root-body lifecycle authority', async () => {
         const discussion = buildDiscussion(24008, {
             category: 'Ideas',
             comments: {
@@ -240,7 +242,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
                     createdAt: '2026-05-02T02:00:00Z',
                     replies  : {nodes: []}
                 }],
-                pageInfo: {hasNextPage: true, endCursor: 'truncated-after-50'}
+                pageInfo: {hasNextPage: false, endCursor: null}
             }
         });
         discussion.author = {login: 'neo-gpt'};
@@ -279,82 +281,124 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         for (const query of [FETCH_DISCUSSIONS_FOR_SYNC, FETCH_SINGLE_DISCUSSION_FOR_SYNC]) {
             expect(query.match(/\btotalCount\b/g)).toHaveLength(2);
             expect(query.match(/\bendCursor\b/g)).toHaveLength(query === FETCH_DISCUSSIONS_FOR_SYNC ? 3 : 2);
-            expect(query.match(/\bhasNextPage\b/g)).toHaveLength(query === FETCH_DISCUSSIONS_FOR_SYNC ? 3 : 2)
+            expect(query.match(/\bhasNextPage\b/g)).toHaveLength(query === FETCH_DISCUSSIONS_FOR_SYNC ? 3 : 2);
+            expect(query).toContain('paginationId: id')
         }
+
+        expect(FETCH_DISCUSSION_COMMENTS_PAGE).toContain('comments(first: $maxComments, after: $cursor)');
+        expect(FETCH_DISCUSSION_COMMENTS_PAGE).toContain('replies(first: $maxReplies)');
+        expect(FETCH_DISCUSSION_REPLIES_PAGE).toContain('node(id: $commentId)');
+        expect(FETCH_DISCUSSION_REPLIES_PAGE).toContain('replies(first: $maxReplies, after: $cursor)')
     });
 
-    test('persists explicit incompleteness when the top-level comment connection is capped', async () => {
+    test('exhausts top-level comment pages before rendering the discussion', async () => {
         const discussion = buildDiscussion(24009, {
             comments: {
-                nodes     : Array.from({length: 50}, (_, index) => ({
-                    author   : {login: 'neo-test'},
-                    body     : `Comment ${index}`,
-                    createdAt: `2026-05-02T01:${String(index).padStart(2, '0')}:00Z`,
-                    replies  : {nodes: [], totalCount: 0, pageInfo: {hasNextPage: false, endCursor: null}}
-                })),
+                nodes     : Array.from({length: 50}, (_, index) => buildComment(index)),
                 totalCount: 51,
                 pageInfo  : {hasNextPage: true, endCursor: 'comment-50'}
             }
         });
+        const calls = [];
 
-        GraphqlService.query = async () => ({
-            repository: {discussions: {nodes: [discussion], pageInfo: {hasNextPage: false, endCursor: null}}}
-        });
+        GraphqlService.query = async (query, variables) => {
+            calls.push({query, variables});
 
-        await DiscussionSyncer.syncDiscussions({discussions: {}});
+            if (query.includes('FetchDiscussionCommentsPage')) {
+                return {
+                    repository: {
+                        discussion: {
+                            comments: {
+                                nodes     : [buildComment(50)],
+                                totalCount: 51,
+                                pageInfo  : {hasNextPage: false, endCursor: null}
+                            }
+                        }
+                    }
+                }
+            }
+
+            return {
+                repository: {discussions: {nodes: [discussion], pageInfo: {hasNextPage: false, endCursor: null}}}
+            }
+        };
+
+        const stats = await DiscussionSyncer.syncDiscussions({discussions: {}});
 
         const parsed = matter(await fs.readFile(
             path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24009.md'),
             'utf8'
         ));
 
+        expect(stats.synced).toEqual([24009]);
+        expect(calls.filter(({query}) => query.includes('FetchDiscussionCommentsPage'))).toHaveLength(1);
+        expect(calls.at(-1).variables).toMatchObject({
+            number: 24009,
+            cursor: 'comment-50'
+        });
         expect(parsed.data).toMatchObject({
-            conversationComplete            : false,
-            conversationCommentCountObserved: 50,
+            conversationComplete            : true,
+            conversationCommentCountObserved: 51,
             conversationCommentCountTotal   : 51,
             conversationReplyCountObserved  : 0,
-            conversationReplyCountTotal     : null
-        })
+            conversationReplyCountTotal     : 0
+        });
+        expect(parsed.content).toContain('Comment 50')
     });
 
-    test('persists explicit incompleteness when a nested reply connection is capped', async () => {
+    test('exhausts nested reply pages before rendering the discussion', async () => {
         const discussion = buildDiscussion(24010, {
             comments: {
-                nodes: [{
-                    author   : {login: 'neo-test'},
-                    body     : 'Parent comment',
-                    createdAt: '2026-05-02T01:00:00Z',
-                    replies  : {
-                        nodes: Array.from({length: 20}, (_, index) => ({
-                            author   : {login: 'neo-test'},
-                            body     : `Reply ${index}`,
-                            createdAt: `2026-05-02T02:${String(index).padStart(2, '0')}:00Z`
-                        })),
-                        totalCount: 21,
-                        pageInfo  : {hasNextPage: true, endCursor: 'reply-20'}
-                    }
-                }]
+                nodes: [buildComment(0, {
+                    replies      : Array.from({length: 20}, (_, index) => buildReply(index)),
+                    replyTotal   : 21,
+                    replyPageInfo: {hasNextPage: true, endCursor: 'reply-20'}
+                })]
             }
         });
+        const calls = [];
 
-        GraphqlService.query = async () => ({
-            repository: {discussions: {nodes: [discussion], pageInfo: {hasNextPage: false, endCursor: null}}}
-        });
+        GraphqlService.query = async (query, variables) => {
+            calls.push({query, variables});
 
-        await DiscussionSyncer.syncDiscussions({discussions: {}});
+            if (query.includes('FetchDiscussionRepliesPage')) {
+                return {
+                    node: {
+                        replies: {
+                            nodes     : [buildReply(20)],
+                            totalCount: 21,
+                            pageInfo  : {hasNextPage: false, endCursor: null}
+                        }
+                    }
+                }
+            }
+
+            return {
+                repository: {discussions: {nodes: [discussion], pageInfo: {hasNextPage: false, endCursor: null}}}
+            }
+        };
+
+        const stats = await DiscussionSyncer.syncDiscussions({discussions: {}});
 
         const parsed = matter(await fs.readFile(
             path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24010.md'),
             'utf8'
         ));
 
+        expect(stats.synced).toEqual([24010]);
+        expect(calls.filter(({query}) => query.includes('FetchDiscussionRepliesPage'))).toHaveLength(1);
+        expect(calls.at(-1).variables).toMatchObject({
+            commentId: 'DC_0',
+            cursor   : 'reply-20'
+        });
         expect(parsed.data).toMatchObject({
-            conversationComplete            : false,
+            conversationComplete            : true,
             conversationCommentCountObserved: 1,
             conversationCommentCountTotal   : 1,
-            conversationReplyCountObserved  : 20,
+            conversationReplyCountObserved  : 21,
             conversationReplyCountTotal     : 21
-        })
+        });
+        expect(parsed.content).toContain('Reply 20')
     });
 
     test('marks accepted Q&A comments with a parseable answer callout', async () => {
@@ -939,6 +983,85 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         expect(stats.refetched).toEqual({count: 0, discussions: []});
         expect(metadata.discussions[discussionNumber]).toBeUndefined();
     });
+
+    test('refetchDiscussionsByNumber exhausts comment and reply pages before writing', async () => {
+        const
+            discussionNumber = 24052,
+            comments         = Array.from({length: 50}, (_, index) => buildComment(index)),
+            metadata         = {discussions: {}},
+            calls            = [];
+
+        comments[0] = buildComment(0, {
+            replies      : Array.from({length: 20}, (_, index) => buildReply(index)),
+            replyTotal   : 21,
+            replyPageInfo: {hasNextPage: true, endCursor: 'reply-20'}
+        });
+
+        const discussion = buildDiscussion(discussionNumber, {
+            comments: {
+                nodes     : comments,
+                totalCount: 51,
+                pageInfo  : {hasNextPage: true, endCursor: 'comment-50'}
+            }
+        });
+
+        GraphqlService.query = async (query, variables) => {
+            calls.push({query, variables});
+
+            if (query.includes('FetchDiscussionCommentsPage')) {
+                return {
+                    repository: {
+                        discussion: {
+                            comments: {
+                                nodes     : [buildComment(50)],
+                                totalCount: 51,
+                                pageInfo  : {hasNextPage: false, endCursor: null}
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (query.includes('FetchDiscussionRepliesPage')) {
+                return {
+                    node: {
+                        replies: {
+                            nodes     : [buildReply(20)],
+                            totalCount: 21,
+                            pageInfo  : {hasNextPage: false, endCursor: null}
+                        }
+                    }
+                }
+            }
+
+            return {repository: {discussion}}
+        };
+
+        const stats  = await DiscussionSyncer.refetchDiscussionsByNumber([discussionNumber], metadata);
+        const parsed = matter(await fs.readFile(
+            path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', `discussion-${discussionNumber}.md`),
+            'utf8'
+        ));
+
+        expect(stats).toEqual({
+            refetched: {count: 1, discussions: [discussionNumber]},
+            errors   : []
+        });
+        expect(calls.map(({query}) => query.match(/\bquery\s+(\w+)/)?.[1])).toEqual([
+            'FetchSingleDiscussionForSync',
+            'FetchDiscussionCommentsPage',
+            'FetchDiscussionRepliesPage'
+        ]);
+        expect(parsed.data).toMatchObject({
+            conversationComplete            : true,
+            conversationCommentCountObserved: 51,
+            conversationCommentCountTotal   : 51,
+            conversationReplyCountObserved  : 21,
+            conversationReplyCountTotal     : 21
+        });
+        expect(parsed.content).toContain('Comment 50');
+        expect(parsed.content).toContain('Reply 20')
+    });
 });
 
 function buildDiscussion(number, config = {}) {
@@ -976,4 +1099,40 @@ function buildDiscussion(number, config = {}) {
         updatedAt: '2026-05-02T00:00:00Z',
         comments : normalizedComments
     };
+}
+
+/**
+ * @summary Creates one Discussion comment fixture with explicit reply-connection exhaustion facts.
+ * @param {Number} index Stable fixture ordinal.
+ * @param {Object} config Optional reply connection overrides.
+ * @returns {Object}
+ */
+function buildComment(index, config = {}) {
+    const replies = config.replies || [];
+
+    return {
+        paginationId: `DC_${index}`,
+        author      : {login: 'neo-test'},
+        body        : config.body || `Comment ${index}`,
+        createdAt   : `2026-05-02T01:${String(index).padStart(2, '0')}:00Z`,
+        replies     : {
+            nodes     : replies,
+            totalCount: config.replyTotal ?? replies.length,
+            pageInfo  : config.replyPageInfo || {hasNextPage: false, endCursor: null}
+        }
+    }
+}
+
+/**
+ * @summary Creates one Discussion reply fixture for continuation-page witnesses.
+ * @param {Number} index Stable fixture ordinal.
+ * @returns {Object}
+ */
+function buildReply(index) {
+    return {
+        author   : {login: 'neo-test'},
+        body     : `Reply ${index}`,
+        createdAt: `2026-05-02T02:${String(index).padStart(2, '0')}:00Z`,
+        isAnswer : false
+    }
 }


### PR DESCRIPTION
Resolves #16016

Discussion synchronization now exhausts every top-level comment page and every nested reply page before rendering. The bulk delta path and `refetchDiscussionsByNumber()` share the same hydration primitive, malformed or non-advancing connections fail loud, and the write boundary refuses any conversation that still cannot prove completeness.

Evidence: L3 (live GitHub GraphQL continuation probes plus a full `DiscussionSyncer.refetchDiscussionsByNumber([15958])` run redirected to an OS temporary root) → L3 required (all close-target completeness and point-cost ACs are observable non-destructively). No residuals.

## Deltas from ticket

- The persisted corpus shape is unchanged. `paginationId: id` is query-internal continuation state and is never rendered; existing completeness frontmatter remains intact.
- `conversationComplete: false` remains representable as fail-closed integrity evidence, but a successful sync can no longer write it.
- The ticket's page-30 cost receipt predated the adaptive outer-page repair in `#16097`. Current live measurements use the production-successful page size 15.

## Test Evidence

- RED: `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs` — the three new comment-overflow, reply-overflow, and recovery witnesses failed before the production change; 28 existing tests passed.
- GREEN/final head: the same focused command — 31/31 passed.
- `npm run agent-preflight -- ai/services/github-workflow/queries/discussionQueries.mjs ai/services/github-workflow/sync/DiscussionSyncer.mjs test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs` — all source gates passed.
- Full `npm run test-unit` — 10,176 passed, 5 skipped, 5 unrelated failures. An isolated rerun cleared four; the remaining untouched `HealthService.spec.mjs` assertion reproducibly expects one collection-timeout string while the runtime returns the memory and temporal-summary timeouts in one detail element.
- Live GraphQL: Discussion 15958 returned 50/74 comments on page 1 and 24/74 on page 2; combined count 74 with `hasNextPage: false`. The reply-continuation query also executed successfully against a live comment node.
- Live service probe: `DiscussionSyncer.refetchDiscussionsByNumber([15958])` wrote only to an OS temporary root and produced `conversationComplete: true`, 74/74 comments, 0/0 replies, with no tracked corpus writes.
- Live rate-limit receipt: old and new outer queries both cost 8 points at page size 15; comment and reply continuation queries cost 1 point each. Across 228 discussions, 16 outer pages cost 128 points; the only current overflows (Discussions 15958 and 11240) add two comment pages, for 130/5,000 points (2.6%). No current comment exceeds 20 replies.
- `git diff --cached --check` and `node --check` on all three touched modules passed.

## Post-Merge Validation

- [ ] Confirm the next successful Data Sync publishes no Discussion artifact with `conversationComplete: false`.
- [ ] Confirm Discussions 15958 and 11240 render their full comment tails in the published corpus.

Authored by Euclid (GPT-5 Codex, Codex Desktop). Session 019fa530-53d6-7271-bf05-51497720b29c.
