### PR TITLE
fix(ai): validate live skill section-reference shapes (#16041)

### DIFF
--- a/ai/scripts/lint/lint-skill-manifest.mjs
+++ b/ai/scripts/lint/lint-skill-manifest.mjs
@@ -12,14 +12,14 @@ import path                                                          from 'path'
 import {execFileSync}                                                from 'child_process';
 import {fileURLToPath}                                               from 'url';
 
-const __filename    = fileURLToPath(import.meta.url);
-const __dirname     = path.dirname(__filename);
-const ROOT_DIR      = path.resolve(__dirname, '../../..');
-const SKILLS_DIR    = path.join(ROOT_DIR, '.agents/skills');
-const CLAUDE_DIR    = path.join(ROOT_DIR, '.claude/skills');
-const MANIFEST_PATH = path.join(SKILLS_DIR, 'skills.manifest.json');
-const SCHEMA_PATH   = path.join(SKILLS_DIR, 'skills.manifest.schema.json');
-const REPORT_TOP_N  = 15;
+const __filename                = fileURLToPath(import.meta.url);
+const __dirname                 = path.dirname(__filename);
+const ROOT_DIR                  = path.resolve(__dirname, '../../..');
+const SKILLS_DIR                = path.join(ROOT_DIR, '.agents/skills');
+const CLAUDE_DIR                = path.join(ROOT_DIR, '.claude/skills');
+const MANIFEST_PATH             = path.join(SKILLS_DIR, 'skills.manifest.json');
+const SCHEMA_PATH               = path.join(SKILLS_DIR, 'skills.manifest.schema.json');
+const REPORT_TOP_N              = 15;
 const SKILL_GROWTH_JUSTIFIED_RE = /\[skill-growth-justified:\s*[^\]\n]+\]/i;
 
 function parseArgs(argv = process.argv.slice(2)) {
@@ -152,16 +152,16 @@ async function skillMarkdownSizeReport({top = REPORT_TOP_N} = {}) {
         .sort();
 
     const rows = files.map(filePath => {
-        const text    = requireText(filePath);
-        const bytes   = Buffer.byteLength(text, 'utf8');
-        const lines   = text.split('\n').length;
-        const headings = countMatches(text, /^#{1,6}\s+/gm);
-        const musts   = countMatches(text, /\bMUST\b|\bMANDATORY\b|\bFORBIDDEN\b/g);
-        const history = countMatches(text, /\b(PR|Issue|Discussion)\s+#\d+|#\d{4,}|empirical anchor|lineage|histor/ig);
-        const lineRefs = countMatches(text, /[A-Za-z0-9_.\/-]+\.(mjs|md|js|json):\d+/g);
+        const text       = requireText(filePath);
+        const bytes      = Buffer.byteLength(text, 'utf8');
+        const lines      = text.split('\n').length;
+        const headings   = countMatches(text, /^#{1,6}\s+/gm);
+        const musts      = countMatches(text, /\bMUST\b|\bMANDATORY\b|\bFORBIDDEN\b/g);
+        const history    = countMatches(text, /\b(PR|Issue|Discussion)\s+#\d+|#\d{4,}|empirical anchor|lineage|histor/ig);
+        const lineRefs   = countMatches(text, /[A-Za-z0-9_.\/-]+\.(mjs|md|js|json):\d+/g);
         const provenance = countMatches(text, /archaeolog|provenance|incident|origin|lineage|empirical anchor/ig);
-        const triggers = countMatches(text, /trigger|when to read|read .* before|<!--\s*trigger:/ig);
-        const signals = Math.round(bytes / 1000) + headings + history * 2 + lineRefs * 3 + provenance * 2 + Math.max(0, musts - 10);
+        const triggers   = countMatches(text, /trigger|when to read|read .* before|<!--\s*trigger:/ig);
+        const signals    = Math.round(bytes / 1000) + headings + history * 2 + lineRefs * 3 + provenance * 2 + Math.max(0, musts - 10);
 
         const row = {
             file: path.relative(ROOT_DIR, filePath),
@@ -208,7 +208,7 @@ function formatSkillMarkdownSizeReport(report) {
 
 async function payloadBytes(skillName) {
     const files = await walkFiles(path.join(SKILLS_DIR, skillName, 'references'));
-    let bytes   = 0;
+    let   bytes = 0;
 
     for (const file of files) {
         bytes += statSync(file).size;
@@ -238,7 +238,7 @@ function checkPerFileBudgets(files, perFileBudget) {
 }
 
 function parseSectionTriggers(text) {
-    const index = [];
+    const index    = [];
     const sections = text.split(/^(?=#{2,6}\s)/m);
 
     for (const section of sections) {
@@ -247,7 +247,7 @@ function parseSectionTriggers(text) {
         const headerMatch = section.match(/^(#{2,6})\s+([^\n]+)/);
         if (!headerMatch) continue;
 
-        const anchor = headerMatch[2].trim();
+        const anchor        = headerMatch[2].trim();
         const bodySizeBytes = Buffer.byteLength(section, 'utf8');
 
         const triggerMatch = section.match(/^<!-- trigger:\s+(.+?)\s+→\s+read\s+(.+?\.md)\s*-->$/m);
@@ -266,7 +266,7 @@ function parseSectionTriggers(text) {
 
 function checkSectionTriggers(filePath, text, rarePatterns = []) {
     const errors = [];
-    const index = parseSectionTriggers(text);
+    const index  = parseSectionTriggers(text);
 
     for (const entry of index) {
         if (entry.bodySizeBytes > 5000) {
@@ -297,10 +297,16 @@ function normalizeRelPath(filePath) {
     return path.normalize(filePath).replace(/\\/g, '/').replace(/^\.\//, '');
 }
 
-const NAMED_SECTION_REF_SOURCE   = '[A-Za-z](?:[A-Za-z0-9_.-]*[A-Za-z0-9_-])?';
-const NUMERIC_SECTION_REF_SOURCE = '\\d+\\.\\d+(?:\\.\\d+)*';
-const SECTION_REF_SOURCE         = `${NUMERIC_SECTION_REF_SOURCE}|${NAMED_SECTION_REF_SOURCE}`;
-const SECTION_REF_TARGET_SOURCE  = [
+const NAMED_SECTION_REF_SOURCE         = '[A-Za-z](?:[A-Za-z0-9_.-]*[A-Za-z0-9_-])?';
+const NUMERIC_SECTION_REF_SOURCE       = '\\d+\\.\\d+(?:\\.\\d+)*';
+const DIGIT_LEADING_SECTION_REF_SOURCE = '\\d+(?:\\.\\d+)*[A-Za-z](?:[A-Za-z0-9_.-]*[A-Za-z0-9_-])?';
+const SECTION_REF_SOURCE               = [
+    NUMERIC_SECTION_REF_SOURCE,
+    DIGIT_LEADING_SECTION_REF_SOURCE,
+    NAMED_SECTION_REF_SOURCE
+].join('|');
+const SECTION_REF_CANDIDATE_SOURCE = '[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9_-])?';
+const SECTION_REF_TARGET_SOURCE    = [
     '\\.agents\\/skills\\/[A-Za-z0-9_.\\/-]+',
     '(?:\\.{1,2}\\/|references\\/)[A-Za-z0-9_.\\/-]+',
     '[A-Za-z0-9_.\\/-]+\\.md',
@@ -311,20 +317,25 @@ function isNumericSectionRef(sectionRef) {
     return new RegExp(`^${NUMERIC_SECTION_REF_SOURCE}$`).test(sectionRef);
 }
 
+/**
+ * @summary Reports whether one section id belongs to the lint's shared reference grammar.
+ * @param {String} sectionRef
+ * @returns {Boolean}
+ */
+function isSupportedSectionRef(sectionRef) {
+    return new RegExp(`^(?:${SECTION_REF_SOURCE})$`).test(sectionRef);
+}
+
 function extractHeadingAnchors(text) {
     const anchors = new Set();
 
     for (const line of text.split('\n')) {
-        const numericMatch = line.match(/^#{1,6}\s+(?:§)?(\d+(?:\.\d+)*)(?:\b|[^\d.])/);
+        const match = line.match(new RegExp(
+            `^#{1,6}\\s+(?:§)?(${SECTION_REF_CANDIDATE_SOURCE})(?:\\b|[^A-Za-z0-9_.-])`
+        ));
 
-        if (numericMatch) {
-            anchors.add(numericMatch[1]);
-        }
-
-        const namedMatch = line.match(new RegExp(`^#{1,6}\\s+§(${NAMED_SECTION_REF_SOURCE})(?:\\b|[^A-Za-z0-9_.-])`));
-
-        if (namedMatch) {
-            anchors.add(namedMatch[1]);
+        if (match && isSupportedSectionRef(match[1])) {
+            anchors.add(match[1]);
         }
     }
 
@@ -373,8 +384,8 @@ function resolveSkillMarkdownTarget(rawTarget, sourceRelPath, index) {
     if (rawTarget.includes('*')) return null;
     if (/[<>{}[\]]/.test(rawTarget)) return null;
 
-    const target = rawTarget.replace(/^`|`$/g, '').replace(/[#?].*$/, '');
-    let relPath  = null;
+    const target  = rawTarget.replace(/^`|`$/g, '').replace(/[#?].*$/, '');
+    let   relPath = null;
 
     if (target.startsWith('.agents/skills/')) {
         relPath = target;
@@ -395,7 +406,7 @@ function resolveSkillMarkdownTarget(rawTarget, sourceRelPath, index) {
 }
 
 function collectMarkdownPointerTargets(line) {
-    const targets = new Set();
+    const targets  = new Set();
     const patterns = [
         /\[[^\]]+\]\(([^)\s]+\.md(?:#[^)]+)?)\)/g,
         /<!--\s*trigger:[\s\S]*?\bread\s+([^\s]+\.md)\s*-->/g,
@@ -415,8 +426,11 @@ function collectMarkdownPointerTargets(line) {
 }
 
 function collectMarkdownSectionRefs(line) {
-    const refs = [];
-    const markdownLinkSectionRefPattern = new RegExp(`\\[[^\\]]*?§(${SECTION_REF_SOURCE})[^\\]]*?\\]\\(([^)\\s]+\\.md(?:#[^)]+)?)\\)`, 'g');
+    const refs                          = [];
+    const markdownLinkSectionRefPattern = new RegExp(
+        `\\[[^\\]]*?§(${SECTION_REF_CANDIDATE_SOURCE})[^\\]]*?\\]\\(([^)\\s]+\\.md(?:#[^)]+)?)\\)`,
+        'g'
+    );
     let match;
 
     while ((match = markdownLinkSectionRefPattern.exec(line))) {
@@ -431,6 +445,17 @@ function collectMarkdownSectionRefs(line) {
 
 function stripMarkdownLinks(line) {
     return line.replace(/\[[^\]]+\]\([^)]+\)/g, '');
+}
+
+/**
+ * @summary Makes inline-code and bare Markdown filename targets equivalent for section refs.
+ * @param {String} line
+ * @returns {String}
+ */
+function normalizeInlineCodeSectionTargets(line) {
+    const pattern = new RegExp(`\`(${SECTION_REF_TARGET_SOURCE})\`(?=\\s+§${SECTION_REF_CANDIDATE_SOURCE})`, 'g');
+
+    return line.replace(pattern, '$1');
 }
 
 function ensureChangedLineSet(changedLinesByRelPath, relPath) {
@@ -454,8 +479,8 @@ function ensureChangedLineSet(changedLinesByRelPath, relPath) {
  */
 function parseUnifiedDiffChangedLines(diffText) {
     const changedLinesByRelPath = new Map();
-    let currentRelPath          = null;
-    let newLineNo              = null;
+    let   currentRelPath        = null;
+    let   newLineNo             = null;
 
     for (const line of diffText.split('\n')) {
         if (line.startsWith('diff --git ')) {
@@ -535,11 +560,11 @@ function areSetsEqual(a, b) {
  * @returns {{isPathOnly: Boolean, changedTargets: Set<String>}}
  */
 function analyzeMarkdownLinkPathOnlyDiff(diffText) {
-    const changedTargets = new Set();
-    const blocks         = [];
-    let block            = null;
-    let inHunk           = false;
-    let sawTargetChange  = false;
+    const changedTargets  = new Set();
+    const blocks          = [];
+    let   block           = null;
+    let   inHunk          = false;
+    let   sawTargetChange = false;
 
     const flush = () => {
         if (block && (block.removed.length || block.added.length)) {
@@ -653,6 +678,10 @@ function validateSectionRef({sourceRelPath, lineNo, target, sectionRef, index, e
         errors.push(`${sourceRelPath}:${lineNo} → broken section-ref target ${target} for §${sectionRef}`);
         return;
     }
+    if (!isSupportedSectionRef(sectionRef)) {
+        errors.push(`${sourceRelPath}:${lineNo} → unsupported section ref ${target} §${sectionRef}`);
+        return;
+    }
 
     const anchors = index.headingIndex.get(targetRelPath);
     if (!anchors) return;
@@ -707,8 +736,11 @@ function checkSkillReferenceIntegrity(changedRelPaths, allMarkdownFiles, {change
                 });
             }
 
-            const sectionRefPattern = new RegExp(`(?:(${SECTION_REF_TARGET_SOURCE})\\s+)?§(${SECTION_REF_SOURCE})`, 'g');
-            const lineWithoutMarkdownLinks = stripMarkdownLinks(line);
+            const sectionRefPattern = new RegExp(
+                `(?:(${SECTION_REF_TARGET_SOURCE})\\s+)?§(${SECTION_REF_CANDIDATE_SOURCE})`,
+                'g'
+            );
+            const lineWithoutMarkdownLinks = stripMarkdownLinks(normalizeInlineCodeSectionTargets(line));
             let match;
 
             while ((match = sectionRefPattern.exec(lineWithoutMarkdownLinks))) {
@@ -758,10 +790,14 @@ function checkRemovedSkillFileReferences(removedRelPaths, allTextFiles) {
                 }
             }
 
-            const sectionRefPattern = new RegExp(`(${SECTION_REF_TARGET_SOURCE})\\s+§(?:${SECTION_REF_SOURCE})`, 'g');
+            const sectionRefPattern = new RegExp(
+                `(${SECTION_REF_TARGET_SOURCE})\\s+§(?:${SECTION_REF_CANDIDATE_SOURCE})`,
+                'g'
+            );
+            const normalizedLine = normalizeInlineCodeSectionTargets(line);
             let match;
 
-            while ((match = sectionRefPattern.exec(line))) {
+            while ((match = sectionRefPattern.exec(normalizedLine))) {
                 const targetRelPath = resolveSkillMarkdownTarget(match[1], sourceRelPath, index);
 
                 if (targetRelPath && removed.has(targetRelPath)) {
@@ -775,7 +811,7 @@ function checkRemovedSkillFileReferences(removedRelPaths, allTextFiles) {
 }
 
 function validateManifestSchema(manifest, schema) {
-    const errors = [];
+    const errors   = [];
     const rootKeys = new Set([...schema.required, '$schema']);
 
     for (const key of Object.keys(manifest)) {
@@ -796,7 +832,7 @@ function validateManifestSchema(manifest, schema) {
         errors.push('skills must be an object');
     }
 
-    const defaults = manifest.defaults || {};
+    const defaults    = manifest.defaults || {};
     const defaultKeys = new Set(Object.keys(schema.properties.defaults.properties));
 
     for (const key of Object.keys(defaults)) {
@@ -1055,7 +1091,7 @@ function checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getS
             if (currentSize === null) continue;
 
             const baseSize = getBaseSizeFn(file);
-            const delta = currentSize - baseSize;
+            const delta    = currentSize - baseSize;
 
             if (delta > maxDelta) {
                 errors.push(`Oversized workflow map ${file} grew by ${delta} bytes (max allowed delta is ${maxDelta}). Extract substantive additions to a sibling file behind a one-line trigger pointer.`);
@@ -1112,13 +1148,13 @@ async function lint({base = null} = {}) {
         errors.push(`manifest skill keys must match .agents/skills directories. dirs=${skillDirs.join(', ')} manifest=${manifestKeys.join(', ')}`);
     }
 
-    const changed = new Set(changedFiles(base));
+    const changed           = new Set(changedFiles(base));
     const touchedSkillNames = changedSkillNames(base);
-    const messages = commitMessages(base);
+    const messages          = commitMessages(base);
 
     if (base) {
         const oversizedFiles = manifest.defaults.oversizedWorkflowMaps || [];
-        const maxDelta = manifest.defaults.maxPositiveDeltaBytes || 0;
+        const maxDelta       = manifest.defaults.maxPositiveDeltaBytes || 0;
 
         const oversizedErrors = checkOversizedWorkflowMaps(
             changed,
@@ -1178,7 +1214,7 @@ async function lint({base = null} = {}) {
         }
 
         const perFileBudget = skill.perFilePayloadBudget ?? manifest.defaults.perFilePayloadBudget;
-        const files = await payloadFileSizes(skillName);
+        const files         = await payloadFileSizes(skillName);
 
         if (Number.isInteger(perFileBudget) && perFileBudget > 0) {
             errors.push(...checkPerFileBudgets(files, perFileBudget));
@@ -1186,7 +1222,7 @@ async function lint({base = null} = {}) {
 
         const rarePatterns = manifest.defaults.rareTriggerPatterns || ['openapi', 'audit', 'edge-case', 'deprecation'];
         for (const {path: filePath} of files) {
-            const text = requireText(filePath);
+            const text   = requireText(filePath);
             const result = checkSectionTriggers(filePath, text, rarePatterns);
             errors.push(...result.errors);
         }
@@ -1267,7 +1303,7 @@ async function main() {
         return;
     }
 
-    const errors  = await lint(options);
+    const errors = await lint(options);
 
     if (errors.length) {
         console.error('[lint-skill-manifest] FAILED');

--- a/ai/scripts/lint/lint-skill-manifest.mjs
+++ b/ai/scripts/lint/lint-skill-manifest.mjs
@@ -297,10 +297,11 @@ function normalizeRelPath(filePath) {
     return path.normalize(filePath).replace(/\\/g, '/').replace(/^\.\//, '');
 }
 
-const NAMED_SECTION_REF_SOURCE         = '[A-Za-z](?:[A-Za-z0-9_.-]*[A-Za-z0-9_-])?';
-const NUMERIC_SECTION_REF_SOURCE       = '\\d+\\.\\d+(?:\\.\\d+)*';
-const DIGIT_LEADING_SECTION_REF_SOURCE = '\\d+(?:\\.\\d+)*[A-Za-z](?:[A-Za-z0-9_.-]*[A-Za-z0-9_-])?';
-const SECTION_REF_SOURCE               = [
+const NAMED_SECTION_REF_SOURCE          = '[A-Za-z](?:[A-Za-z0-9_.-]*[A-Za-z0-9_-])?';
+const DOTTED_NUMERIC_SECTION_REF_SOURCE = '\\d+\\.\\d+(?:\\.\\d+)*';
+const NUMERIC_SECTION_REF_SOURCE        = '\\d+(?:\\.\\d+)*';
+const DIGIT_LEADING_SECTION_REF_SOURCE  = '\\d+(?:\\.\\d+)*[A-Za-z](?:[A-Za-z0-9_.-]*[A-Za-z0-9_-])?';
+const SECTION_REF_SOURCE                = [
     NUMERIC_SECTION_REF_SOURCE,
     DIGIT_LEADING_SECTION_REF_SOURCE,
     NAMED_SECTION_REF_SOURCE
@@ -313,8 +314,13 @@ const SECTION_REF_TARGET_SOURCE    = [
     '[A-Za-z0-9_.-]+'
 ].join('|');
 
-function isNumericSectionRef(sectionRef) {
-    return new RegExp(`^${NUMERIC_SECTION_REF_SOURCE}$`).test(sectionRef);
+/**
+ * @summary Keeps unqualified section refs dotted-numeric to avoid bare-number prose collisions.
+ * @param {String} sectionRef
+ * @returns {Boolean}
+ */
+function isUnqualifiedNumericSectionRef(sectionRef) {
+    return new RegExp(`^${DOTTED_NUMERIC_SECTION_REF_SOURCE}$`).test(sectionRef);
 }
 
 /**
@@ -679,7 +685,7 @@ function validateSectionRef({sourceRelPath, lineNo, target, sectionRef, index, e
         return;
     }
     if (!isSupportedSectionRef(sectionRef)) {
-        errors.push(`${sourceRelPath}:${lineNo} → unsupported section ref ${target} §${sectionRef}`);
+        errors.push(`${sourceRelPath}:${lineNo} → unsupported section-ref syntax ${target} §${sectionRef}`);
         return;
     }
 
@@ -744,7 +750,7 @@ function checkSkillReferenceIntegrity(changedRelPaths, allMarkdownFiles, {change
             let match;
 
             while ((match = sectionRefPattern.exec(lineWithoutMarkdownLinks))) {
-                if (!match[1] && !isNumericSectionRef(match[2])) continue;
+                if (!match[1] && !isUnqualifiedNumericSectionRef(match[2])) continue;
 
                 validateSectionRef({
                     sourceRelPath,

--- a/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
@@ -677,6 +677,11 @@ ${padding}
         const targetRelPath = '.agents/skills/example/references/target-workflow.md';
         const sourceRelPath = '.agents/skills/example/SKILL.md';
         const cases         = [{
+            family : 'bare numeric',
+            heading: '### 6. Existing top-level section',
+            valid  : '6',
+            invalid: '7'
+        }, {
             family : 'dotted numeric',
             heading: '### 5.1 Existing numeric section',
             valid  : '5.1',
@@ -717,25 +722,38 @@ ${padding}
         }
     });
 
-    test('checkSkillReferenceIntegrity rejects unsupported target-qualified section ids (#16041)', () => {
+    test('checkSkillReferenceIntegrity distinguishes unsupported syntax from a missing bare-numeric heading (#16041)', () => {
         const targetRelPath = '.agents/skills/example/references/target-workflow.md';
         const sourceRelPath = '.agents/skills/example/SKILL.md';
         const files         = [{
             relPath: targetRelPath,
-            text   : '### 1. Top-level heading remains outside the supported reference grammar'
+            text   : '### 1. Existing top-level heading'
         }, {
             relPath: sourceRelPath,
             text   : [
-                'Unsupported bare target: target-workflow.md §1.',
-                'Unsupported backticked target: `target-workflow.md` §1.'
+                'Unsupported syntax: target-workflow.md §1-invalid.',
+                'Missing heading: `target-workflow.md` §2.'
             ].join('\n')
         }];
 
         const errors = checkSkillReferenceIntegrity([sourceRelPath], files);
 
         expect(errors).toHaveLength(2);
-        expect(errors[0]).toContain('unsupported section ref target-workflow.md §1');
-        expect(errors[1]).toContain('unsupported section ref target-workflow.md §1');
+        expect(errors[0]).toContain('unsupported section-ref syntax target-workflow.md §1-invalid');
+        expect(errors[1]).toContain('dangling section ref target-workflow.md §2');
+    });
+
+    test('checkSkillReferenceIntegrity keeps unqualified bare numeric prose outside the reference grammar (#16041)', () => {
+        const relPath = '.agents/skills/example/references/example-workflow.md';
+        const files   = [{
+            relPath,
+            text: [
+                '### 1. Existing top-level heading',
+                'Descriptive unqualified ref: §2.'
+            ].join('\n')
+        }];
+
+        expect(checkSkillReferenceIntegrity([relPath], files)).toEqual([]);
     });
 
     test('parseUnifiedDiffChangedLines maps base diffs to current-file line numbers (#12557)', () => {

--- a/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
@@ -410,7 +410,7 @@ Just a short body, well under 5000 bytes.
 
     test('checkSectionTriggers returns no errors for large sections without rare triggers (#11320)', () => {
         const padding = 'A'.repeat(6000);
-        const text = `
+        const text    = `
 ## §2 Large Common Section
 <!-- trigger: always relevant → read ./sub-rule.md -->
 ${padding}
@@ -420,7 +420,7 @@ ${padding}
 
     test('checkSectionTriggers returns error for large sections with rare triggers (#11320)', () => {
         const padding = 'B'.repeat(6000);
-        const text = `
+        const text    = `
 ## §3 OpenAPI Edge Case
 <!-- trigger: modifies openapi.yaml → read ./openapi-audit.md -->
 ${padding}
@@ -434,7 +434,7 @@ ${padding}
 
     test('parseSectionTriggers extracts anchor, trigger, subRulePath, and body size (#11320)', () => {
         const padding = 'C'.repeat(100);
-        const text = `
+        const text    = `
 ## §4 Test Section
 <!-- trigger: test condition → read ./test-rule.md -->
 ${padding}
@@ -448,11 +448,11 @@ ${padding}
     });
 
     test('checkOversizedWorkflowMaps passes when one-line pointer addition is within maxPositiveDeltaBytes (#11437)', () => {
-        const changedFiles = new Set(['pr-review-guide.md', 'some-other-file.md']);
+        const changedFiles   = new Set(['pr-review-guide.md', 'some-other-file.md']);
         const oversizedFiles = ['pr-review-guide.md', 'pull-request-workflow.md'];
-        const maxDelta = 250;
+        const maxDelta       = 250;
 
-        const getSizeFn = (file) => file === 'pr-review-guide.md' ? 1200 : 0;
+        const getSizeFn     = (file) => file === 'pr-review-guide.md' ? 1200 : 0;
         const getBaseSizeFn = (file) => file === 'pr-review-guide.md' ? 1000 : 0; // Delta: 200
 
         const errors = checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn);
@@ -460,11 +460,11 @@ ${padding}
     });
 
     test('checkOversizedWorkflowMaps fails when PR #11434-style inline addition exceeds maxPositiveDeltaBytes (#11437)', () => {
-        const changedFiles = new Set(['pull-request-workflow.md']);
+        const changedFiles   = new Set(['pull-request-workflow.md']);
         const oversizedFiles = ['pr-review-guide.md', 'pull-request-workflow.md'];
-        const maxDelta = 250;
+        const maxDelta       = 250;
 
-        const getSizeFn = (file) => 1500;
+        const getSizeFn     = (file) => 1500;
         const getBaseSizeFn = (file) => 1000; // Delta: 500
 
         const errors = checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn);
@@ -474,11 +474,11 @@ ${padding}
     });
 
     test('checkOversizedWorkflowMaps fails when long pr-review-guide.md anti-pattern row exceeds maxPositiveDeltaBytes (#11437)', () => {
-        const changedFiles = new Set(['pr-review-guide.md']);
+        const changedFiles   = new Set(['pr-review-guide.md']);
         const oversizedFiles = ['pr-review-guide.md'];
-        const maxDelta = 250;
+        const maxDelta       = 250;
 
-        const getSizeFn = (file) => 2300;
+        const getSizeFn     = (file) => 2300;
         const getBaseSizeFn = (file) => 1000; // Delta: 1300
 
         const errors = checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn);
@@ -487,11 +487,11 @@ ${padding}
     });
 
     test('checkOversizedWorkflowMaps ignores deleted oversized files', () => {
-        const changedFiles = new Set(['pr-review-guide.md']);
+        const changedFiles   = new Set(['pr-review-guide.md']);
         const oversizedFiles = ['pr-review-guide.md'];
-        const maxDelta = 250;
+        const maxDelta       = 250;
 
-        const getSizeFn = (file) => null; // File deleted
+        const getSizeFn     = (file) => null; // File deleted
         const getBaseSizeFn = (file) => 1000;
 
         const errors = checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn);
@@ -673,6 +673,71 @@ ${padding}
         expect(errors[1]).toContain('dangling section ref consensus-mandate §missing-aggregation');
     });
 
+    test('checkSkillReferenceIntegrity treats bare and backticked targets equally across supported section ids (#16041)', () => {
+        const targetRelPath = '.agents/skills/example/references/target-workflow.md';
+        const sourceRelPath = '.agents/skills/example/SKILL.md';
+        const cases         = [{
+            family : 'dotted numeric',
+            heading: '### 5.1 Existing numeric section',
+            valid  : '5.1',
+            invalid: '5.9'
+        }, {
+            family : 'named',
+            heading: '### §template-block Existing named section',
+            valid  : 'template-block',
+            invalid: 'missing-template'
+        }, {
+            family : 'digit-leading alphanumeric',
+            heading: '### 1d. Existing workflow section',
+            valid  : '1d',
+            invalid: '1x'
+        }];
+
+        for (const item of cases) {
+            const files = [{
+                relPath: targetRelPath,
+                text   : item.heading
+            }, {
+                relPath: sourceRelPath,
+                text   : [
+                    `Valid ${item.family} bare ref: target-workflow.md §${item.valid}.`,
+                    `Invalid ${item.family} bare ref: target-workflow.md §${item.invalid}.`,
+                    `Valid ${item.family} backticked ref: \`target-workflow.md\` §${item.valid}.`,
+                    `Invalid ${item.family} backticked ref: \`target-workflow.md\` §${item.invalid}.`
+                ].join('\n')
+            }];
+
+            const errors = checkSkillReferenceIntegrity([sourceRelPath], files);
+
+            expect(errors, item.family).toHaveLength(2);
+            expect(errors[0]).toContain(`${sourceRelPath}:2`);
+            expect(errors[0]).toContain(`dangling section ref target-workflow.md §${item.invalid}`);
+            expect(errors[1]).toContain(`${sourceRelPath}:4`);
+            expect(errors[1]).toContain(`dangling section ref target-workflow.md §${item.invalid}`);
+        }
+    });
+
+    test('checkSkillReferenceIntegrity rejects unsupported target-qualified section ids (#16041)', () => {
+        const targetRelPath = '.agents/skills/example/references/target-workflow.md';
+        const sourceRelPath = '.agents/skills/example/SKILL.md';
+        const files         = [{
+            relPath: targetRelPath,
+            text   : '### 1. Top-level heading remains outside the supported reference grammar'
+        }, {
+            relPath: sourceRelPath,
+            text   : [
+                'Unsupported bare target: target-workflow.md §1.',
+                'Unsupported backticked target: `target-workflow.md` §1.'
+            ].join('\n')
+        }];
+
+        const errors = checkSkillReferenceIntegrity([sourceRelPath], files);
+
+        expect(errors).toHaveLength(2);
+        expect(errors[0]).toContain('unsupported section ref target-workflow.md §1');
+        expect(errors[1]).toContain('unsupported section ref target-workflow.md §1');
+    });
+
     test('parseUnifiedDiffChangedLines maps base diffs to current-file line numbers (#12557)', () => {
         const diffText = [
             'diff --git a/.agents/skills/pr-review/references/pr-review-guide.md b/.agents/skills/pr-review/references/pr-review-guide.md',
@@ -692,7 +757,7 @@ ${padding}
 
     test('checkSkillReferenceIntegrity only scans changed lines when base ownership is provided (#12557)', () => {
         const relPath = '.agents/skills/pr-review/references/pr-review-guide.md';
-        const files = [{
+        const files   = [{
             relPath,
             text: [
                 '## 9. Strategic Fit',
@@ -717,7 +782,7 @@ ${padding}
 
     test('checkSkillReferenceIntegrity only scans changed named section refs when base ownership is provided (#12582)', () => {
         const relPath = '.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md';
-        const files = [{
+        const files   = [{
             relPath: '.agents/skills/ideation-sandbox/audits/consensus-mandate.md',
             text   : '## §template-block — Graduated-Artifact Required Sections'
         }, {
@@ -739,6 +804,33 @@ ${padding}
         expect(errors).toHaveLength(1);
         expect(errors[0]).toContain('ideation-sandbox-workflow.md:2');
         expect(errors[0]).toContain('dangling section ref consensus-mandate §missing-template');
+    });
+
+    test('checkSkillReferenceIntegrity keeps changed-line ownership for digit-leading section refs (#16041)', () => {
+        const targetRelPath = '.agents/skills/ticket-create/references/ticket-create-workflow.md';
+        const sourceRelPath = '.agents/skills/ideation-sandbox/audits/double-diamond-divergence-guard.md';
+        const files         = [{
+            relPath: targetRelPath,
+            text   : '### 1d. The Ungraduated-Discussion Cross-Check'
+        }, {
+            relPath: sourceRelPath,
+            text   : [
+                'Valid changed ref: ticket-create-workflow.md §1d.',
+                'Pre-existing stale ref: `ticket-create-workflow.md` §1x.'
+            ].join('\n')
+        }];
+
+        expect(checkSkillReferenceIntegrity([sourceRelPath], files, {
+            changedLinesByRelPath: new Map([[sourceRelPath, new Set([1])]])
+        })).toEqual([]);
+
+        const errors = checkSkillReferenceIntegrity([sourceRelPath], files, {
+            changedLinesByRelPath: new Map([[sourceRelPath, new Set([2])]])
+        });
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain(`${sourceRelPath}:2`);
+        expect(errors[0]).toContain('dangling section ref ticket-create-workflow.md §1x');
     });
 
     test('downstream docs skip only applies to link-path-only skill diffs whose docs omit the moved target (#12557)', () => {


### PR DESCRIPTION
Authored by Euclid (@neo-gpt, Codex Desktop). Session 019fa904-9d8c-7f12-94fe-346ae8e54046.

Resolves #16041

Skill-reference integrity now gives heading extraction and prose parsing one compatible section-id contract: target-qualified bare numeric (`6`), dotted numeric (`5.1`), named (`template-block`), and live digit-leading alphanumeric (`1d`) forms. Inline-code-wrapped filename targets normalize to the same target as bare filenames, and target-qualified unsupported tokens fail explicitly instead of disappearing from coverage. Unqualified bare-numeric prose, other descriptive refs, and `--base` changed-line ownership remain unchanged.

Evidence: L1 focused parser tests plus the complete AI lint unit directory. This is an existing-owner repair in `lint-skill-manifest.mjs`; it adds no skill payload, new module, or runtime behavior.

## Contract Ledger

| Surface | Source of authority | Delivered behavior | Compatibility | Evidence |
|---|---|---|---|---|
| Section-id grammar and heading extraction | Existing #12493/#12582 parser plus live skill-workflow headings | Bare numeric, dotted numeric, named, and digit-leading alphanumeric ids share one qualified-ref support predicate | Target-qualified bare numerics change from silently ignored to validated: existing headings pass and missing headings fail as dangling; unqualified bare numerics remain ignored to avoid prose collisions | Four-family positive/negative unit matrix plus explicit unqualified control |
| Prose target association | Existing changed-line reference lint | Bare and inline-code filename targets resolve identically | Markdown links, relative paths, and descriptive unqualified refs retain existing behavior | Bare/backticked controls plus live `§1d` and `§6` probes |
| Error classification | Existing section-ref validator | Invalid identifier syntax and missing target headings produce distinct messages | Existing dangling wording is retained; the unsupported path now names syntax explicitly | Paired unsupported-syntax / missing-heading control |
| Changed-line ownership | `parseUnifiedDiffChangedLines()` and `--base` lint | Newly recognized refs gate only when their source line belongs to the PR | Historical untouched refs stay non-blocking | Digit-leading changed/stale pair |

## Deltas from ticket

No substantive scope delta. The same inline-code target normalization is also reused by the deleted-file reference check so the target-equivalence contract cannot diverge between the two integrity passes.

Vega's review falsifier changed one original design choice: bare top-level numeric ids are now supported when target-qualified. The exact corpus pattern reproduced 65 occurrences across `.agents/` and `learn/`, including 46 under `.agents/skills`; live workflow targets such as `post-review-pickup-workflow.md §6` resolve. The repair deliberately does not broaden unqualified `§N` prose or external files such as `AGENTS.md` into this skill-only index.

Repair-capable preflight applied its required block-alignment normalization to the two touched `.mjs` files. A whitespace-ignoring diff proved that follow-up mechanical-only before it was restaged.

## Test Evidence

- Direct RED→GREEN control: `ticket-create-workflow.md §1d` and the backticked equivalent now pass; both `§1x` forms return actionable dangling-reference errors. Before the patch, all four returned `[]`.
- Review repair control: target-qualified bare and backticked `§6` refs pass against a real top-level heading; `§7` fails as dangling; `§1-invalid` fails as unsupported syntax; unqualified `§2` remains ignored.
- Live repository control: `pre-review-intake-lane-gate.md` resolves its current `post-review-pickup-workflow.md §6` reference with zero errors.
- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs` — **51 passed**.
- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/scripts/lint` — **234 passed**.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` — `[lint-skill-manifest] OK`.
- `git diff --cached --check` and `node --check ai/scripts/lint/lint-skill-manifest.mjs` — passed.
- Repair-capable `npm run agent-preflight`, followed by exact-tree `npm run agent-preflight -- --no-fix` — passed; 2 files scanned, 0 ticket-archaeology violations.

## Post-Merge Validation

- [ ] The next real skill PR that changes a target-qualified bare-numeric or `§1d` reference receives the same pass/fail result locally and in the hosted Skill Manifest Lint.

