### PR TITLE
docs(agentos): bound incident falsifiers (#16076)

### DIFF
--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -120,7 +120,7 @@ Keep titles under ~70 characters. PR titles derive from ticket titles; length di
 
 Skeleton tickets are forbidden. Every ticket body MUST contain:
 
-- **Context** — why this ticket exists now. What prompted it. What observational evidence supports the premise.
+- **Context** — why this exists and its evidence. Incident tickets name the observed operation when known, mark unknowns, and separate observation from inference; quotations are leads, not causes. *(Retire with §8 once lint enforces this without syntax proxies.)*
 - **The Problem** — deep background, insights from recent Memory Core explorations, reproducer if applicable. Historical "why" for the agent picking up the ticket later.
 - **The Architectural Reality** — exactly which Neo.mjs patterns, class topologies, or service boundaries this issue interacts with. Cite file:line when known. Distinguishes intent-level framing (Problem) from structural specificity (Reality).
 - **The Fix** — concrete prescription: files, symbols, architectural primitives touched. What changes, and where.
@@ -159,6 +159,7 @@ When drafting ticket bodies, read [`learn/agentos/process/reference-hygiene.md`]
 | Skipping duplicate sweep | Pollutes Knowledge Base; splits swarm attention |
 | Inventing label names | Breaks label taxonomy; causes silent GitHub API rejections |
 | Precedent-following without skill check | Propagates anti-patterns from prior sessions (e.g., `[enhancement]` prefix spread this way) |
+| Quotation as root cause | Text search tests attribution, not the event |
 | Over-fragmentation | one-PR work split into micro-tickets; bundle by default — a split replaces scope, not adds |
 
 ## 9. When to Escalate to Discussion Instead

--- a/learn/agentos/process/correction-culture.md
+++ b/learn/agentos/process/correction-culture.md
@@ -27,6 +27,12 @@ citation; RUN the inference. The tell for which is which: an inference is anythi
 "therefore", "so", "which means", "hence" in your own draft — grep the connective before
 submitting. A citation you checked is a fact; a connective you wrote is a hypothesis.
 
+**Bound it.** Before writing `FALSIFIED`, state what the instrument can decide and confirm every
+claim is inside that set; give multi-clause gaps separate verdicts. A narrow negative cannot
+overturn a direct observation outside its set. A correction toward *not real*, *not ours*, or
+*smaller than stated* gets one independent check before publication: direction is a trigger, not
+evidence of error. Retire this prose when a mechanical claim-scope gate enforces the same boundary.
+
 **Mine it.** Tickets and PRs carry an `Origin Session ID`, and the session is the *intent
 authority*: a PR can be faithful to its own body while retreating from its filing session's
 conclusion. The review's premise is intent-vs-diff, not claims-vs-diff. Trigger: mine when the PR


### PR DESCRIPTION
Authored by Euclid (@neo-gpt, Codex Desktop). Session 019fa904-9d8c-7f12-94fe-346ae8e54046.

Resolves #16076

Incident-derived ticket Context now keeps the incident—not a quoted document—as its subject: name the observed operation when known, mark unknowns, distinguish observation from inference, and treat quotations as leads rather than causes. Correction Culture now bounds `FALSIFIED` to the instrument's actual decision set, requires separate verdicts for multi-clause gaps, and adds an independent check when a correction moves toward *not real*, *not ours*, or *smaller than stated*.

This captures the measured #16055 correction cycle without manufacturing certainty when the mechanism is not yet known.

Evidence: L1 source/trail inspection and governance-document diff → L1 required for a documentation-only authoring contract. No runtime behavior changes.

## Contract Ledger

The canonical T3 ledger and intake correction are on the [source ticket](https://github.com/neomjs/neo/issues/16076#issuecomment-5107100397).

| Target surface | Source of authority | Delivered behavior | Fallback | Evidence |
| :--- | :--- | :--- | :--- | :--- |
| `ticket-create-workflow.md` §5 `Context` | #16055 correction trail + #16076 | Incident tickets name a known observed operation, mark unknowns, separate observation from inference, and keep quotations as leads | Unknown mechanisms remain explicitly unknown; syntax cannot stand in for knowledge | Exact diff + #16055 positive/negative specimen |
| `ticket-create-workflow.md` §8 | #16076 | Quotation-as-root-cause is a named wrong-subject anti-pattern | Quotations remain valid supporting provenance | Skill-manifest lint |
| `correction-culture.md` execution discipline | #16055 correction trail | `FALSIFIED` is bounded to the instrument's decision set; multi-clause and exculpatory-direction checks are explicit | Narrow negatives cannot overturn direct observations outside that set | Exact diff against #16055 decomposition |

## Deltas from ticket

The literal first-sentence/backtick prescription was narrowed. It was a syntax proxy that assumed the cause was already known, while the ticket simultaneously required a mechanical fix but scoped the actual work to prose. The delivered rule instead names the operation when known and makes “unknown” an honest fallback. No ticket-body lint was added, preserving the stated out-of-scope boundary.

## Load-Runtime-Effect Audit

- `ticket-create-workflow.md` is the existing conditionally loaded workflow Map; the rule lands at the exact Context-authoring step and adds no router, manifest entry, or new section.
- The skill payload grows by **228 bytes**, under the **250-byte** pointer-sized budget. `lint-skill-manifest` verifies that bound.
- `correction-culture.md` is ordinary process documentation, not loaded by the Codex prompt hook.
- Both additions carry a retirement trigger: remove the prose once a mechanical claim-scope/ticket-body gate enforces the distinction without rewarding syntax alone.

## Test Evidence

- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` — `[lint-skill-manifest] OK`; no growth exception.
- Repair-capable `npm run agent-preflight -- <two touched files>` — passed.
- Exact staged-tree `npm run agent-preflight -- --no-fix` — passed.
- `git diff --cached --check` — passed.
- Live load-path inspection: `.codex/hooks.json`, `.codex/hooks/codex-context.mjs`, and `.claude/CLAUDE.md` confirm no changed file is turn-loaded.

## Post-Merge Validation

- [ ] When a mechanical ticket-body gate can enforce the observed/derived distinction without syntax proxies, remove the §5 prose clause and matching §8 row per their inline sunset.
