### PR TITLE
fix(workstation): eliminate popup bootstrap white flash (#16092)

### DIFF
--- a/apps/workstation/app.mjs
+++ b/apps/workstation/app.mjs
@@ -1,7 +1,35 @@
 import Viewport from './view/Viewport.mjs';
 
-export const onStart = () => Neo.app({
-    appThemeFolder: 'workstation',
-    mainView      : Viewport,
-    name          : 'Workstation'
-});
+/**
+ * @summary Resolves one Workstation window's carried Neo theme against that window's configured themes.
+ * @param {Object} options
+ * @param {String} [options.search=''] Serialized main-thread URL search.
+ * @param {String[]} [options.themes=[]] Themes admitted for this exact window.
+ * @returns {String|undefined} The carried configured theme, or the configured default.
+ */
+export function resolveBootstrapTheme({search='', themes=[]} = {}) {
+    const candidate = new URLSearchParams(search).get('theme');
+
+    return themes.includes(candidate) ? candidate : themes[0]
+}
+
+/**
+ * @summary Starts each Workstation window with its carried theme on the first viewport instance.
+ * @returns {Neo.controller.Application}
+ */
+export const onStart = () => {
+    const
+        windowId = Neo.bootingWindowId,
+        config   = Neo.windowConfigs?.[windowId] || Neo.config,
+        theme    = resolveBootstrapTheme({
+            search: config.url?.search,
+            themes: config.themes
+        });
+
+    return Neo.app({
+        appThemeFolder: 'workstation',
+        mainView      : {module: Viewport, theme},
+        name          : 'Workstation',
+        windowId
+    })
+};

--- a/apps/workstation/index.html
+++ b/apps/workstation/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
+    <meta name="color-scheme" content="dark">
     <title>Neo.mjs Workstation — Living Docking Showcase</title>
 </head>
 <body>

--- a/apps/workstation/index.html
+++ b/apps/workstation/index.html
@@ -3,7 +3,29 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
-    <meta name="color-scheme" content="dark">
+    <script>
+        (() => {
+            const
+                schemes = Object.freeze({
+                    'neo-theme-neo-dark': 'dark',
+                    'neo-theme-neo-light': 'light'
+                }),
+                requestedTheme = new URLSearchParams(location.search).get('theme'),
+                theme          = Object.hasOwn(schemes, requestedTheme)
+                    ? requestedTheme
+                    : 'neo-theme-neo-dark',
+                meta           = document.createElement('meta');
+
+            meta.name    = 'color-scheme';
+            meta.content = schemes[theme];
+            document.currentScript.before(meta);
+
+            globalThis.WorkstationBootstrap = Object.freeze({
+                colorScheme: meta.content,
+                theme
+            })
+        })()
+    </script>
     <title>Neo.mjs Workstation — Living Docking Showcase</title>
 </head>
 <body>

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2243,7 +2243,8 @@ class Workspace extends Container {
                 url               : `./index.html?popout=${itemId}&hostId=${me.id}`
                     + `&vesselFlow=tear-out&vesselGrant=${ownerGrant.token}`
                     + `&vesselGeneration=${ownerGrant.generation}`
-                    + `&vesselAdmission=${admissionToken}`,
+                    + `&vesselAdmission=${admissionToken}`
+                    + `&theme=${encodeURIComponent(me.theme)}`,
                 windowFeatures: `height=${height},left=${left},top=${top},width=${width}`,
                 windowId,
                 windowName

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -420,6 +420,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
     test.use(filmTake
         ? {viewport: null}
         : {
+            colorScheme   : 'dark',
             contextOptions: {screen: ordinaryScreen},
             viewport      : ordinaryViewport
         });
@@ -1123,6 +1124,16 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
     test('scene 2 — the tear-out: a real pointer drag births a vessel MID-GESTURE', async ({page, neuralLink}) => {
         const {app, pageErrors, popupProbe, wsId} = await boot({page, neuralLink});
 
+        await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-light']);
+
+        expect((await app.getComponent(wsId, ['theme'])).theme,
+            'the parent Neo theme, not the host preference, is the popup birth authority')
+            .toBe('neo-theme-neo-light');
+        if (!filmTake) {
+            expect(await page.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches),
+                'ordinary scene 2 must oppose Neo light with a dark host preference').toBe(true)
+        }
+
         const
             heartbeatBefore = await readHeartbeat(app, wsId),
             paneIdBefore    = (await app.callMethod(wsId, 'getPaneIdentity', ['metrics'])),
@@ -1147,6 +1158,46 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         const popup = await popupPromise;
 
         expect(popup.isClosed(), 'the committed vessel must remain open').toBe(false);
+        await popup.waitForSelector('.workstation-viewport', {timeout: 30000});
+
+        const
+            popupWindowId = await popup.evaluate(() => Neo.worker.Manager.windowId),
+            popupBirth    = await popup.evaluate(() => {
+                const viewport = document.querySelector('.workstation-viewport');
+
+                return {
+                    bootstrap      : globalThis.WorkstationBootstrap,
+                    hostPrefersDark: matchMedia('(prefers-color-scheme: dark)').matches,
+                    metaContents   : [...document.querySelectorAll('meta[name="color-scheme"]')]
+                        .map(meta => meta.content),
+                    themeClasses: [...viewport.classList].filter(name => name.startsWith('neo-theme-'))
+                }
+            });
+
+        await expect.poll(async () => {
+            const found = await app.findInstances(
+                {className: 'Workstation.view.Viewport'},
+                ['id', 'theme', 'windowId']
+            );
+
+            return found.find(item => item.properties?.windowId === popupWindowId)?.properties?.theme
+        }, {
+            message: 'the child viewport must be born with the carried Neo light theme',
+            timeout: 15000
+        }).toBe('neo-theme-neo-light');
+
+        expect(new URL(popup.url()).searchParams.get('theme')).toBe('neo-theme-neo-light');
+        expect(popupBirth.bootstrap).toEqual({
+            colorScheme: 'light',
+            theme      : 'neo-theme-neo-light'
+        });
+        expect(popupBirth.metaContents, 'the final document must own exactly one active-theme scheme')
+            .toEqual(['light']);
+        expect(popupBirth.themeClasses).toEqual(['neo-theme-neo-light']);
+        if (!filmTake) {
+            expect(popupBirth.hostPrefersDark,
+                'the popup must retain the opposing host preference used by this matrix row').toBe(true)
+        }
 
         // Third-party truth: the committed document read fresh from the worker.
         const documentAfter = await readDocument(app, wsId);
@@ -1249,7 +1300,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         // assertion above. Flip, then read the same tokens back through the popup.
         const themeBefore = vesselTokens.cellBg;
 
-        await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-light']);
+        await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-dark']);
 
         // Poll the OBSERVABLE transition rather than sleeping a frame count. The flip crosses a
         // worker→two-main-threads boundary and commits through a vdom update the popup does not
@@ -1278,7 +1329,20 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(flipped.cellBg, 'and it must land on the NEW palette, not merely change')
             .toBe(flipped.panel);
 
-        await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-dark']);
+        await expect.poll(async () => {
+            const found = await app.findInstances(
+                {className: 'Workstation.view.Viewport'},
+                ['id', 'theme', 'windowId']
+            );
+
+            return found.find(item => item.properties?.windowId === popupWindowId)?.properties?.theme
+        }, {
+            message: 'the open child viewport must retain live Neo theme authority after birth',
+            timeout: 15000
+        }).toBe('neo-theme-neo-dark');
+        expect(await popup.locator('.workstation-viewport').evaluate(viewport =>
+            [...viewport.classList].filter(name => name.startsWith('neo-theme-'))
+        )).toEqual(['neo-theme-neo-dark']);
 
         // The heartbeat moved FORWARD — nothing reloaded, nothing recreated.
         expect(await readHeartbeat(app, wsId)).toBeGreaterThan(heartbeatBefore);

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1067,6 +1067,50 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('tear-out navigation carries the workspace active theme into each admitted child', async () => {
+        const
+            workspace          = Neo.create(Workspace, {theme: 'neo-theme-neo-light'}),
+            originalWindowData = Neo.Main.getWindowData,
+            originalWindowOpen = Neo.Main.windowOpen,
+            calls              = [];
+
+        Neo.Main.getWindowData = async () => ({
+            innerHeight: 700,
+            outerHeight: 760,
+            screenLeft : 10,
+            screenTop  : 20
+        });
+        Neo.Main.windowOpen = async data => {
+            calls.push(data);
+
+            return true
+        };
+
+        try {
+            await workspace.openTearOutVessel({
+                itemId   : 'alerts',
+                proxyRect: {height: 320, width: 480, x: 40, y: 60}
+            });
+
+            workspace.theme = 'neo-theme-neo-dark';
+
+            await workspace.openTearOutVessel({
+                itemId   : 'security',
+                proxyRect: {height: 320, width: 480, x: 80, y: 100}
+            });
+
+            expect(calls).toHaveLength(2);
+            expect(calls.map(call => new URL(call.url, 'https://example.test').searchParams.get('theme')))
+                .toEqual(['neo-theme-neo-light', 'neo-theme-neo-dark']);
+            expect(calls.map(call => new URL(call.url, 'https://example.test').searchParams.get('vesselFlow')))
+                .toEqual(['tear-out', 'tear-out'])
+        } finally {
+            Neo.Main.getWindowData = originalWindowData;
+            Neo.Main.windowOpen    = originalWindowOpen;
+            workspace.destroy()
+        }
+    });
+
     test('a successor tear-out retries retained retirement before opening a fresh vessel', async () => {
         const
             workspace       = Neo.create(Workspace, {}),

--- a/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
+++ b/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
@@ -1,12 +1,78 @@
 import {test, expect}  from '@playwright/test';
 import {execFile}      from 'child_process';
+import {readFile}      from 'fs/promises';
+import {parse}         from 'parse5';
 import path            from 'path';
 import {promisify}     from 'util';
 import {fileURLToPath} from 'url';
 
-const __dirname     = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT     = path.resolve(__dirname, '../../../..');
-const execFileAsync = promisify(execFile);
+const
+    __dirname             = path.dirname(fileURLToPath(import.meta.url)),
+    REPO_ROOT             = path.resolve(__dirname, '../../../..'),
+    WORKSTATION_HTML_PATH = path.join(REPO_ROOT, 'apps/workstation/index.html'),
+    COLOR_SCHEME_META     = '<meta name="color-scheme" content="dark">',
+    MICRO_LOADER_SCRIPT   = '<script src="../../src/MicroLoader.mjs" type="module"></script>',
+    execFileAsync         = promisify(execFile);
+
+/**
+ * @summary Returns every parsed HTML element in document order.
+ * @param {Object} node
+ * @param {Object[]} [elements=[]]
+ * @returns {Object[]}
+ */
+function collectElements(node, elements=[]) {
+    if (node.tagName) {
+        elements.push(node)
+    }
+
+    node.childNodes?.forEach(child => collectElements(child, elements));
+
+    return elements
+}
+
+/**
+ * @summary Reads one normalized parse5 attribute value.
+ * @param {Object} node
+ * @param {String} name
+ * @returns {String|null}
+ */
+function getAttribute(node, name) {
+    return node.attrs?.find(attribute => attribute.name === name)?.value ?? null
+}
+
+/**
+ * @summary Inspects the Workstation HTML bootstrap ordering without executing application code.
+ * @param {String} source
+ * @returns {Object}
+ */
+function inspectWorkstationBootstrap(source) {
+    const
+        document = parse(source, {sourceCodeLocationInfo: true}),
+        elements = collectElements(document),
+        head     = elements.find(node => node.tagName === 'head'),
+        metas    = elements.filter(node => node.tagName === 'meta'
+            && getAttribute(node, 'name')?.toLowerCase() === 'color-scheme'),
+        loaders  = elements.filter(node => node.tagName === 'script'
+            && getAttribute(node, 'src')?.split(/[?#]/)[0].endsWith('/src/MicroLoader.mjs')),
+        meta     = metas[0],
+        loader   = loaders[0],
+        directHead = metas.length === 1 && meta.parentNode === head,
+        exactDark  = metas.length === 1 && getAttribute(meta, 'content') === 'dark',
+        ordered    = metas.length === 1
+            && loaders.length === 1
+            && meta.sourceCodeLocation.startOffset < loader.sourceCodeLocation.startOffset;
+
+    return {
+        contents    : metas.map(node => getAttribute(node, 'content')),
+        directHead,
+        loaderCount : loaders.length,
+        loaderOffset: loader?.sourceCodeLocation.startOffset ?? null,
+        metaCount   : metas.length,
+        metaOffset  : meta?.sourceCodeLocation.startOffset ?? null,
+        ordered,
+        valid       : directHead && exactDark && loaders.length === 1 && ordered
+    }
+}
 
 /**
  * @summary Runs one native-window authority scenario against the real Main singleton in an isolated process.
@@ -216,6 +282,46 @@ async function runNativeWindowRouteProbe(scenario) {
 
     return JSON.parse(stdout.trim().split('\n').at(-1))
 }
+
+test.describe('Workstation popup canvas bootstrap (#16092)', () => {
+    test('Workstation declares one direct-head dark canvas before MicroLoader bootstrap', async () => {
+        const
+            source   = await readFile(WORKSTATION_HTML_PATH, 'utf8'),
+            contract = inspectWorkstationBootstrap(source);
+
+        expect(contract.metaCount).toBe(1);
+        expect(contract.contents).toEqual(['dark']);
+        expect(contract.directHead).toBe(true);
+        expect(contract.loaderCount).toBe(1);
+        expect(contract.metaOffset).toBeLessThan(contract.loaderOffset);
+        expect(contract.ordered).toBe(true);
+        expect(contract.valid).toBe(true)
+    });
+
+    test('Workstation bootstrap contract rejects removal, duplication, late placement, and a scheme list', async () => {
+        const
+            source    = await readFile(WORKSTATION_HTML_PATH, 'utf8'),
+            metaLine  = `    ${COLOR_SCHEME_META}\n`,
+            mutations = {
+                afterLoader: source
+                    .replace(metaLine, '')
+                    .replace(MICRO_LOADER_SCRIPT, `${MICRO_LOADER_SCRIPT}\n    ${COLOR_SCHEME_META}`),
+                duplicate : source.replace(COLOR_SCHEME_META, `${COLOR_SCHEME_META}\n    ${COLOR_SCHEME_META}`),
+                removal   : source.replace(metaLine, ''),
+                schemeList: source.replace('content="dark"', 'content="dark light"')
+            };
+
+        expect(Object.fromEntries(Object.entries(mutations).map(([name, html]) => [
+            name,
+            inspectWorkstationBootstrap(html).valid
+        ]))).toEqual({
+            afterLoader: false,
+            duplicate  : false,
+            removal    : false,
+            schemeList : false
+        })
+    });
+});
 
 /**
  * @summary Pins exact native-window authority staging and persisted-document cache retirement.

--- a/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
+++ b/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
@@ -1,18 +1,20 @@
-import {test, expect}  from '@playwright/test';
-import {execFile}      from 'child_process';
-import {readFile}      from 'fs/promises';
-import {parse}         from 'parse5';
-import path            from 'path';
-import {promisify}     from 'util';
-import {fileURLToPath} from 'url';
+import {test, expect}    from '@playwright/test';
+import {execFile}        from 'child_process';
+import {readFile}        from 'fs/promises';
+import {parse}           from 'parse5';
+import path              from 'path';
+import {promisify}       from 'util';
+import {runInNewContext} from 'vm';
+import {fileURLToPath}   from 'url';
 
 const
-    __dirname             = path.dirname(fileURLToPath(import.meta.url)),
-    REPO_ROOT             = path.resolve(__dirname, '../../../..'),
-    WORKSTATION_HTML_PATH = path.join(REPO_ROOT, 'apps/workstation/index.html'),
-    COLOR_SCHEME_META     = '<meta name="color-scheme" content="dark">',
-    MICRO_LOADER_SCRIPT   = '<script src="../../src/MicroLoader.mjs" type="module"></script>',
-    execFileAsync         = promisify(execFile);
+    __dirname               = path.dirname(fileURLToPath(import.meta.url)),
+    REPO_ROOT               = path.resolve(__dirname, '../../../..'),
+    WORKSTATION_CONFIG_PATH = path.join(REPO_ROOT, 'apps/workstation/neo-config.json'),
+    WORKSTATION_HTML_PATH   = path.join(REPO_ROOT, 'apps/workstation/index.html'),
+    DARK_SCHEME_MAPPING     = "'neo-theme-neo-dark': 'dark'",
+    MICRO_LOADER_SCRIPT     = '<script src="../../src/MicroLoader.mjs" type="module"></script>',
+    execFileAsync           = promisify(execFile);
 
 /**
  * @summary Returns every parsed HTML element in document order.
@@ -41,6 +43,16 @@ function getAttribute(node, name) {
 }
 
 /**
+ * @summary Reports whether a parsed element explicitly carries one attribute.
+ * @param {Object} node
+ * @param {String} name
+ * @returns {Boolean}
+ */
+function hasAttribute(node, name) {
+    return node.attrs?.some(attribute => attribute.name === name) ?? false
+}
+
+/**
  * @summary Inspects the Workstation HTML bootstrap ordering without executing application code.
  * @param {String} source
  * @returns {Object}
@@ -52,26 +64,143 @@ function inspectWorkstationBootstrap(source) {
         head     = elements.find(node => node.tagName === 'head'),
         metas    = elements.filter(node => node.tagName === 'meta'
             && getAttribute(node, 'name')?.toLowerCase() === 'color-scheme'),
-        loaders  = elements.filter(node => node.tagName === 'script'
+        loaders         = elements.filter(node => node.tagName === 'script'
             && getAttribute(node, 'src')?.split(/[?#]/)[0].endsWith('/src/MicroLoader.mjs')),
-        meta     = metas[0],
-        loader   = loaders[0],
-        directHead = metas.length === 1 && meta.parentNode === head,
-        exactDark  = metas.length === 1 && getAttribute(meta, 'content') === 'dark',
-        ordered    = metas.length === 1
+        bootstrapScripts = elements.filter(node => node.tagName === 'script'
+            && !getAttribute(node, 'src')
+            && node.childNodes?.some(child => child.value?.includes('WorkstationBootstrap'))),
+        bootstrapScript = bootstrapScripts[0],
+        loader          = loaders[0],
+        scriptText      = bootstrapScript?.childNodes?.map(child => child.value || '').join('') || '',
+        directHead      = bootstrapScripts.length === 1 && bootstrapScript.parentNode === head,
+        parserBlocking  = bootstrapScripts.length === 1
+            && !hasAttribute(bootstrapScript, 'async')
+            && !hasAttribute(bootstrapScript, 'defer')
+            && [null, '', 'text/javascript'].includes(getAttribute(bootstrapScript, 'type')),
+        ordered         = bootstrapScripts.length === 1
             && loaders.length === 1
-            && meta.sourceCodeLocation.startOffset < loader.sourceCodeLocation.startOffset;
+            && bootstrapScript.sourceCodeLocation.startOffset < loader.sourceCodeLocation.startOffset;
 
     return {
-        contents    : metas.map(node => getAttribute(node, 'content')),
+        bootstrapCount: bootstrapScripts.length,
         directHead,
-        loaderCount : loaders.length,
-        loaderOffset: loader?.sourceCodeLocation.startOffset ?? null,
-        metaCount   : metas.length,
-        metaOffset  : meta?.sourceCodeLocation.startOffset ?? null,
+        loaderCount   : loaders.length,
+        loaderOffset  : loader?.sourceCodeLocation.startOffset ?? null,
+        metaCount     : metas.length,
         ordered,
-        valid       : directHead && exactDark && loaders.length === 1 && ordered
+        parserBlocking,
+        scriptEnd     : bootstrapScript?.sourceCodeLocation.endOffset ?? null,
+        scriptStart   : bootstrapScript?.sourceCodeLocation.startOffset ?? null,
+        scriptText,
+        valid         : metas.length === 0
+            && directHead
+            && parserBlocking
+            && loaders.length === 1
+            && ordered
     }
+}
+
+/**
+ * @summary Executes the parser-blocking Workstation prepaint contract against a minimal document.
+ * @param {String} source Workstation HTML source.
+ * @param {String} search URL search to expose to the bootstrap.
+ * @returns {Object} Inserted meta and frozen carried authority.
+ */
+function runWorkstationBootstrap(source, search) {
+    const
+        {scriptText} = inspectWorkstationBootstrap(source),
+        inserted     = [],
+        context      = {
+            document: {
+                createElement(tagName) {
+                    if (tagName !== 'meta') throw new Error(`unexpected bootstrap element: ${tagName}`);
+
+                    return {tagName}
+                },
+                currentScript: {
+                    before(node) {
+                        inserted.push(node)
+                    }
+                }
+            },
+            location: {search},
+            URLSearchParams
+        };
+
+    context.globalThis = context;
+    runInNewContext(scriptText, context);
+
+    return {
+        bootstrap: {
+            colorScheme: context.WorkstationBootstrap?.colorScheme,
+            theme      : context.WorkstationBootstrap?.theme
+        },
+        frozen: Object.isFrozen(context.WorkstationBootstrap),
+        metas : inserted.map(({content, name, tagName}) => ({content, name, tagName}))
+    }
+}
+
+/**
+ * @summary Validates structural ordering plus the opposing-theme runtime matrix.
+ * @param {String} source Workstation HTML source.
+ * @returns {Boolean}
+ */
+function validatesWorkstationBootstrap(source) {
+    const contract = inspectWorkstationBootstrap(source);
+
+    if (!contract.valid) return false;
+
+    try {
+        const
+            dark  = runWorkstationBootstrap(source, '?theme=neo-theme-neo-dark'),
+            light = runWorkstationBootstrap(source, '?theme=neo-theme-neo-light');
+
+        return JSON.stringify(dark) === JSON.stringify({
+            bootstrap: {colorScheme: 'dark', theme: 'neo-theme-neo-dark'},
+            frozen   : true,
+            metas    : [{content: 'dark', name: 'color-scheme', tagName: 'meta'}]
+        }) && JSON.stringify(light) === JSON.stringify({
+            bootstrap: {colorScheme: 'light', theme: 'neo-theme-neo-light'},
+            frozen   : true,
+            metas    : [{content: 'light', name: 'color-scheme', tagName: 'meta'}]
+        })
+    } catch {
+        return false
+    }
+}
+
+/**
+ * @summary Executes the App-Worker theme resolver after installing the Neo unit-test realm.
+ * @returns {Promise<Object>} Resolution matrix for carried, absent, and invalid values.
+ */
+async function runWorkstationAppThemeProbe() {
+    const script = `
+        import Neo from './src/Neo.mjs';
+        import * as core from './src/core/_export.mjs';
+        import {setup} from './test/playwright/setup.mjs';
+
+        setup({appConfig: {name: 'WorkstationThemeResolverTest'}});
+
+        const
+            {resolveBootstrapTheme} = await import('./apps/workstation/app.mjs'),
+            themes = ['neo-theme-neo-dark', 'neo-theme-neo-light'],
+            resolve = search => resolveBootstrapTheme({search, themes});
+
+        console.log(JSON.stringify({
+            dark      : resolve('?theme=neo-theme-neo-dark'),
+            invalid   : resolve('?theme=neo-theme-candidate'),
+            light     : resolve('?theme=neo-theme-neo-light'),
+            missing   : resolve(''),
+            schemeList: resolve('?theme=dark%20light')
+        }))
+    `;
+    const {stdout} = await execFileAsync(process.execPath, ['--input-type=module', '-e', script], {
+        cwd     : REPO_ROOT,
+        encoding: 'utf8',
+        timeout : 15_000
+    });
+
+    return JSON.parse(stdout.trim().split('\n').at(-1))
 }
 
 /**
@@ -284,41 +413,76 @@ async function runNativeWindowRouteProbe(scenario) {
 }
 
 test.describe('Workstation popup canvas bootstrap (#16092)', () => {
-    test('Workstation declares one direct-head dark canvas before MicroLoader bootstrap', async () => {
+    test('Workstation resolves one parser-blocking active-theme canvas before MicroLoader', async () => {
         const
-            source   = await readFile(WORKSTATION_HTML_PATH, 'utf8'),
-            contract = inspectWorkstationBootstrap(source);
+            [source, configSource] = await Promise.all([
+                readFile(WORKSTATION_HTML_PATH, 'utf8'),
+                readFile(WORKSTATION_CONFIG_PATH, 'utf8')
+            ]),
+            config   = JSON.parse(configSource),
+            contract = inspectWorkstationBootstrap(source),
+            dark     = runWorkstationBootstrap(source, '?theme=neo-theme-neo-dark'),
+            light    = runWorkstationBootstrap(source, '?theme=neo-theme-neo-light');
 
-        expect(contract.metaCount).toBe(1);
-        expect(contract.contents).toEqual(['dark']);
+        expect(config.themes).toEqual(['neo-theme-neo-dark', 'neo-theme-neo-light']);
+        expect(contract.metaCount, 'the runtime script owns the only color-scheme meta').toBe(0);
+        expect(contract.bootstrapCount).toBe(1);
         expect(contract.directHead).toBe(true);
+        expect(contract.parserBlocking).toBe(true);
         expect(contract.loaderCount).toBe(1);
-        expect(contract.metaOffset).toBeLessThan(contract.loaderOffset);
+        expect(contract.scriptStart).toBeLessThan(contract.loaderOffset);
         expect(contract.ordered).toBe(true);
-        expect(contract.valid).toBe(true)
+        expect(contract.valid).toBe(true);
+        expect(dark).toEqual({
+            bootstrap: {colorScheme: 'dark', theme: 'neo-theme-neo-dark'},
+            frozen   : true,
+            metas    : [{content: 'dark', name: 'color-scheme', tagName: 'meta'}]
+        });
+        expect(light).toEqual({
+            bootstrap: {colorScheme: 'light', theme: 'neo-theme-neo-light'},
+            frozen   : true,
+            metas    : [{content: 'light', name: 'color-scheme', tagName: 'meta'}]
+        })
     });
 
-    test('Workstation bootstrap contract rejects removal, duplication, late placement, and a scheme list', async () => {
+    test('Workstation bootstrap rejects removal, duplication, late placement, scheme lists, and arbitrary themes', async () => {
         const
             source    = await readFile(WORKSTATION_HTML_PATH, 'utf8'),
-            metaLine  = `    ${COLOR_SCHEME_META}\n`,
+            contract  = inspectWorkstationBootstrap(source),
+            script    = source.slice(contract.scriptStart, contract.scriptEnd),
             mutations = {
                 afterLoader: source
-                    .replace(metaLine, '')
-                    .replace(MICRO_LOADER_SCRIPT, `${MICRO_LOADER_SCRIPT}\n    ${COLOR_SCHEME_META}`),
-                duplicate : source.replace(COLOR_SCHEME_META, `${COLOR_SCHEME_META}\n    ${COLOR_SCHEME_META}`),
-                removal   : source.replace(metaLine, ''),
-                schemeList: source.replace('content="dark"', 'content="dark light"')
+                    .replace(script, '')
+                    .replace(MICRO_LOADER_SCRIPT, `${MICRO_LOADER_SCRIPT}\n    ${script}`),
+                duplicate : source.replace(script, `${script}\n    ${script}`),
+                removal   : source.replace(script, ''),
+                schemeList: source.replace(DARK_SCHEME_MAPPING, "'neo-theme-neo-dark': 'dark light'")
             };
 
         expect(Object.fromEntries(Object.entries(mutations).map(([name, html]) => [
             name,
-            inspectWorkstationBootstrap(html).valid
+            validatesWorkstationBootstrap(html)
         ]))).toEqual({
             afterLoader: false,
             duplicate  : false,
             removal    : false,
             schemeList : false
+        });
+        expect(runWorkstationBootstrap(source, '').bootstrap)
+            .toEqual({colorScheme: 'dark', theme: 'neo-theme-neo-dark'});
+        expect(runWorkstationBootstrap(source, '?theme=neo-theme-candidate').bootstrap)
+            .toEqual({colorScheme: 'dark', theme: 'neo-theme-neo-dark'});
+        expect(runWorkstationBootstrap(source, '?theme=dark%20light').bootstrap)
+            .toEqual({colorScheme: 'dark', theme: 'neo-theme-neo-dark'})
+    });
+
+    test('the App Worker resolves the same carried theme before creating its viewport', async () => {
+        await expect(runWorkstationAppThemeProbe()).resolves.toEqual({
+            dark      : 'neo-theme-neo-dark',
+            invalid   : 'neo-theme-neo-dark',
+            light     : 'neo-theme-neo-light',
+            missing   : 'neo-theme-neo-dark',
+            schemeList: 'neo-theme-neo-dark'
         })
     });
 });


### PR DESCRIPTION
Resolves #16092

Workstation tear-outs now carry the exact active `Workspace.me.theme` into the admitted child. That one allowlisted value selects the final document's parser-blocking color scheme before `MicroLoader.mjs` and seeds the child `Viewport` before its first VDOM paint; the existing same-app fan-out remains authoritative for later live toggles.

Evidence: L3 exact-head native macOS proof achieved at `a5ff089b6c0c734a224eab9ff3e43ae6474a261f` → L3 merged-`dev` replay required. Residual: post-merge replay only; the branch-bound opposing-theme matrix, route authority, and full journey are green.

## Deltas from ticket

The original fixed-dark proposal was falsified during implementation. A static `content="dark"` makes an explicitly light Workstation flash dark, while `content="dark light"` delegates the choice to host preference instead of Neo's active theme. The issue and implementation now use `Workspace.me.theme` as the shared prepaint and initial-viewport authority, admit only Workstation's configured dark/light identifiers, and preserve a safe dark-first default for direct boot or a corrupt carrier.

## Test Evidence

- Repository gates: `npm run agent-preflight -- --no-fix` — all requested gates passed; whitespace, shorthand, JSDoc types, parse, ticket archaeology, block alignment, and `git diff --check` are green.
- Popup bootstrap + route authority: `npx playwright test main/MainNativeWindowRoute.spec.mjs apps/workstation/Workspace.spec.mjs -c test/playwright/playwright.config.unit.mjs --workers=1` — 24/24 passed. This includes carried light/dark URLs, parser-blocking order, removal/duplication/late-placement/`dark light`/arbitrary-theme controls, and all #15573 same-origin, navigation-failure, cross-origin, and persisted-pagehide paths.
- Workstation tear-out/docking/reintegration surface: `NEO_E2E_PORT=8143 npx playwright test workstation/WorkstationFiveBeatNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` — 9/9 passed in 1.6 minutes with process exit 0. Scene 2 proves Neo light against a dark host, initial child engine/DOM truth, and a live dark toggle without reload; the two-take semantic receipt remained `19866ad804dbb6d2deeff4a9fd2b8a4dbe7ca3a7db28fbb353c9365f9147ca13`.
- Native retained-frame matrix: 10/10 macOS `screencapture` frames passed with no failures and clean-tree source binding (`diffSha256=e3b0c442…`, head `a5ff089b…`). Neo dark + host light remained luminance `13.7954` from first retained birth frame through settled viewport, then toggled light at `244.8636`; Neo light + host dark remained `244.8636`, then toggled dark at `13.7954`. Each row retained one `navigationStart`. Receipt SHA-256: `2182c1d2a3e882658325f3c91fec696e06805f6e528c0c0e84a1b6cbb9878e23`.

## Post-Merge Validation

- [ ] Re-run the focused 24-test bootstrap/route authority pair against merged `dev`.
- [ ] Repeat the opposing Neo-theme/host-preference native retained-frame matrix against merged `dev`.
- [ ] Re-run the full five-beat Workstation journey against merged `dev`.

## Commits

- `f1653ce41f8fc76828e33ba81c526389cf1d7190` — retained red control: implements and thereby falsifies the dark-only premise.
- `a5ff089b6c0c734a224eab9ff3e43ae6474a261f` — carries the active Neo theme through prepaint, initial viewport, mutation controls, and real multi-window proof.

## Evolution

The first head made the measured white interval dark, but opposing runtime-theme evidence showed that “not white” was weaker than theme parity. The repair therefore moved authority upstream to the already-selected `Workspace.me.theme` and made the host preference an explicit falsifier rather than an input.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex), consuming the film-readiness witness handoff — origin session `019f9e1e-2ef1-72c3-a04d-6bc67a531a8b`, implementation session `019fa906-0873-7e63-aa2b-2728755b3357`.
