### PR TITLE
test(harness): probe sandboxed ESM preload support (#16036)

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -48,10 +48,13 @@ real pinned-Electron capability probe. The expected rejection passes; successful
 unexpected errors, silence, or timeout all fail closed.
 
 When that probe reports **“#16036 conversion is unblocked”**, rename `preload.cjs` to `preload.mjs`,
-replace its `require('electron')` with ESM imports, repoint `main.mjs`,
+replace its `require('electron')` with ESM imports, replace the forced `ADAPTER_STATES` duplication
+with an import from `adapterWitness.mjs`, delete its drift guard in
+`test/playwright/unit/harness/adapterWitness.spec.mjs`, repoint `main.mjs`,
 `electron-builder.yml`, and `test/playwright/unit/harness/preload.spec.mjs`, adapt that spec's VM
-loader for ESM, and record the resolved constraint in ADR-0034. Do not disable the sandbox or add a
-bundler to make the probe green.
+loader for ESM, update the harness row in `learn/benefits/ArchitectureOverview.md`, and record the
+resolved constraint in ADR-0034. Do not disable the sandbox or add a bundler to make the probe
+green.
 
 ## The Brain rides supervised (Arm B — the hosting-spike verdict)
 

--- a/harness/README.md
+++ b/harness/README.md
@@ -38,6 +38,21 @@ crashes at import with `ERR_INVALID_ARG_TYPE` on a config path, run
 template; the daemon's own freshness assert fires too late to catch this because the Orchestrator
 singleton constructs at module import).
 
+## Why `preload.cjs` is intentionally CommonJS
+
+Every harness window remains sandboxed, and Electron 43.1.0 currently executes sandboxed preloads
+without an ESM context. An `.mjs` preload using `import {contextBridge} from 'electron'` therefore
+fails with `Cannot use import statement outside a module`; keeping `.cjs` is the honest security-
+preserving shape, not a legacy exception. Both `npm run smoke` and `npm run smoke:brain` first run a
+real pinned-Electron capability probe. The expected rejection passes; successful ESM loading,
+unexpected errors, silence, or timeout all fail closed.
+
+When that probe reports **“#16036 conversion is unblocked”**, rename `preload.cjs` to `preload.mjs`,
+replace its `require('electron')` with ESM imports, repoint `main.mjs`,
+`electron-builder.yml`, and `test/playwright/unit/harness/preload.spec.mjs`, adapt that spec's VM
+loader for ESM, and record the resolved constraint in ADR-0034. Do not disable the sandbox or add a
+bundler to make the probe green.
+
 ## The Brain rides supervised (Arm B — the hosting-spike verdict)
 
 The Electron main supervises system-Node children: the orchestrator daemon (which supervises the

--- a/harness/package.json
+++ b/harness/package.json
@@ -6,8 +6,10 @@
     "main": "main.mjs",
     "scripts": {
         "prestart": "node prepareAssets.mjs",
-        "presmoke": "node prepareAssets.mjs",
+        "presmoke": "node prepareAssets.mjs && npm run probe:preload-esm",
+        "presmoke:brain": "node prepareAssets.mjs && npm run probe:preload-esm",
         "prewitness:lifecycle": "node prepareAssets.mjs",
+        "probe:preload-esm": "electron preloadEsmCapabilityProbe.mjs",
         "start": "electron main.mjs",
         "smoke": "cross-env NEO_HARNESS_SMOKE=1 electron main.mjs",
         "smoke:brain": "cross-env NEO_HARNESS_SMOKE=1 NEO_HARNESS_BRAIN=1 electron main.mjs",

--- a/harness/preloadEsmCapabilityProbe.mjs
+++ b/harness/preloadEsmCapabilityProbe.mjs
@@ -1,7 +1,7 @@
 /**
  * @module harness/preloadEsmCapabilityProbe
- * @summary Boots a temporary sandboxed Electron renderer with an ESM preload and fails the harness
- * smoke preflight as soon as the upstream constraint changes.
+ * @summary Boots a temporary sandboxed Electron renderer with an ESM preload that imports Electron
+ * and a sibling ESM module, then fails the harness smoke preflight when both become supported.
  */
 
 import {app, BrowserWindow}                 from 'electron';
@@ -43,20 +43,27 @@ function waitForDocument(contents, errors) {
 }
 
 /**
- * @summary Executes the real pinned-Electron sandboxed ESM preload capability probe.
+ * @summary Executes the real pinned-Electron sandboxed ESM preload and sibling-import probe.
  * @returns {Promise<{message: String, ok: Boolean, status: String}>}
  */
 async function runProbe() {
     const
-        probeDir    = mkdtempSync(path.join(tmpdir(), 'neo-preload-esm-probe-')),
-        preloadPath = path.join(probeDir, 'preload.mjs'),
-        errors      = [];
+        probeDir       = mkdtempSync(path.join(tmpdir(), 'neo-preload-esm-probe-')),
+        dependencyPath = path.join(probeDir, 'probeDependency.mjs'),
+        preloadPath    = path.join(probeDir, 'preload.mjs'),
+        errors         = [];
     let win;
 
     try {
+        writeFileSync(dependencyPath, [
+            'export const siblingImportLoaded = true;',
+            ''
+        ].join('\n'));
+
         writeFileSync(preloadPath, [
             'import {contextBridge} from \'electron\';',
-            `contextBridge.exposeInMainWorld('${PRELOAD_ESM_PROBE_MARKER}', Object.freeze({loaded: true}));`,
+            'import {siblingImportLoaded} from \'./probeDependency.mjs\';',
+            `contextBridge.exposeInMainWorld('${PRELOAD_ESM_PROBE_MARKER}', Object.freeze({loaded: siblingImportLoaded}));`,
             ''
         ].join('\n'));
 

--- a/harness/preloadEsmCapabilityProbe.mjs
+++ b/harness/preloadEsmCapabilityProbe.mjs
@@ -1,0 +1,134 @@
+/**
+ * @module harness/preloadEsmCapabilityProbe
+ * @summary Boots a temporary sandboxed Electron renderer with an ESM preload and fails the harness
+ * smoke preflight as soon as the upstream constraint changes.
+ */
+
+import {app, BrowserWindow}                 from 'electron';
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir}                             from 'node:os';
+import path                                 from 'node:path';
+
+import {
+    PRELOAD_ESM_PROBE_MARKER,
+    classifyPreloadEsmProbe
+} from './preloadEsmProbeOutcome.mjs';
+
+const PROBE_TIMEOUT_MS = 10000;
+
+/**
+ * @summary Waits for the temporary renderer to finish or fail its document load.
+ * @param {Electron.WebContents} contents
+ * @param {String[]} errors
+ * @returns {Promise<{timedOut: Boolean}>}
+ */
+function waitForDocument(contents, errors) {
+    return new Promise(resolve => {
+        const finish = timedOut => {
+            clearTimeout(timer);
+            contents.removeListener('did-fail-load', onFailure);
+            contents.removeListener('did-finish-load', onSuccess);
+            resolve({timedOut})
+        };
+        const onFailure = (event, code, description, url, isMainFrame) => {
+            isMainFrame && errors.push(`document load failed: ${code} ${description} ${url}`);
+            finish(false)
+        };
+        const onSuccess = () => finish(false);
+        const timer     = setTimeout(() => finish(true), PROBE_TIMEOUT_MS);
+
+        contents.once('did-fail-load', onFailure);
+        contents.once('did-finish-load', onSuccess)
+    })
+}
+
+/**
+ * @summary Executes the real pinned-Electron sandboxed ESM preload capability probe.
+ * @returns {Promise<{message: String, ok: Boolean, status: String}>}
+ */
+async function runProbe() {
+    const
+        probeDir    = mkdtempSync(path.join(tmpdir(), 'neo-preload-esm-probe-')),
+        preloadPath = path.join(probeDir, 'preload.mjs'),
+        errors      = [];
+    let win;
+
+    try {
+        writeFileSync(preloadPath, [
+            'import {contextBridge} from \'electron\';',
+            `contextBridge.exposeInMainWorld('${PRELOAD_ESM_PROBE_MARKER}', Object.freeze({loaded: true}));`,
+            ''
+        ].join('\n'));
+
+        win = new BrowserWindow({
+            show          : false,
+            webPreferences: {
+                backgroundThrottling: false,
+                contextIsolation    : true,
+                nodeIntegration     : false,
+                preload             : preloadPath,
+                sandbox             : true
+            }
+        });
+
+        win.webContents.on('preload-error', (event, observedPath, error) => {
+            errors.push(error?.message ?? String(error))
+        });
+
+        const documentState = waitForDocument(win.webContents, errors);
+
+        // `loadURL()` itself can stay pending when preload evaluation aborts early. The event-owned
+        // timeout above is therefore the authority; awaiting this promise would bypass fail-closed.
+        win.loadURL('data:text/html;charset=utf-8,<title>Neo preload ESM capability probe</title>')
+            .catch(error => errors.push(`loadURL rejected: ${error?.message ?? String(error)}`));
+
+        const {timedOut}   = await documentState;
+        let   markerLoaded = false;
+
+        if (!timedOut) {
+            try {
+                markerLoaded = await win.webContents.executeJavaScript(
+                    `globalThis.${PRELOAD_ESM_PROBE_MARKER}?.loaded === true`
+                )
+            } catch (error) {
+                errors.push(`marker observation failed: ${error?.message ?? String(error)}`)
+            }
+
+            // `preload-error` normally precedes `did-finish-load`; one short turn also captures a
+            // future runtime that reports it immediately after document completion.
+            await new Promise(resolve => setTimeout(resolve, 50))
+        }
+
+        return classifyPreloadEsmProbe({errors, markerLoaded, timedOut})
+    } finally {
+        win && !win.isDestroyed() && win.destroy();
+        rmSync(probeDir, {force: true, recursive: true})
+    }
+}
+
+/**
+ * @summary Runs after Electron readiness without top-level-awaiting that readiness from the ESM
+ * entry module (Electron cannot emit `ready` until entry-module evaluation has completed).
+ * @returns {Promise<void>}
+ */
+async function main() {
+    let exitCode = 1;
+
+    try {
+        console.log(`[preload-esm-probe] testing Electron ${process.versions.electron}`);
+
+        const result = await runProbe();
+
+        (result.ok ? console.log : console.error)(`[preload-esm-probe] ${result.message}`);
+        exitCode = result.ok ? 0 : 1
+    } catch (error) {
+        console.error(`[preload-esm-probe] Probe crashed; failing closed: ${error?.stack ?? error}`)
+    } finally {
+        app.exit(exitCode)
+    }
+}
+
+app.whenReady().then(main, error => {
+    console.error(`[preload-esm-probe] Electron readiness failed; failing closed: ${error?.stack ?? error}`);
+    app.exit(1)
+});

--- a/harness/preloadEsmProbeOutcome.mjs
+++ b/harness/preloadEsmProbeOutcome.mjs
@@ -10,7 +10,9 @@ export const PRELOAD_ESM_PROBE_MARKER      = '__neoSandboxedEsmPreloadProbe';
 const CONVERSION_STEPS = [
     'rename preload.cjs to preload.mjs',
     'replace require(\'electron\') with ESM imports',
+    'replace the forced ADAPTER_STATES duplication with an adapterWitness.mjs import and delete its drift guard in adapterWitness.spec.mjs',
     'repoint main.mjs, electron-builder.yml, and preload.spec.mjs',
+    'update the harness row in learn/benefits/ArchitectureOverview.md',
     'record the resolved constraint in ADR-0034'
 ].join('; ');
 

--- a/harness/preloadEsmProbeOutcome.mjs
+++ b/harness/preloadEsmProbeOutcome.mjs
@@ -1,0 +1,77 @@
+/**
+ * @module harness/preloadEsmProbeOutcome
+ * @summary Classifies the real Electron sandboxed-ESM preload probe without importing Electron,
+ * so every supported, blocked, unexpected, and inconclusive outcome stays unit-testable.
+ */
+
+export const EXPECTED_SANDBOXED_ESM_ERROR = 'Cannot use import statement outside a module';
+export const PRELOAD_ESM_PROBE_MARKER      = '__neoSandboxedEsmPreloadProbe';
+
+const CONVERSION_STEPS = [
+    'rename preload.cjs to preload.mjs',
+    'replace require(\'electron\') with ESM imports',
+    'repoint main.mjs, electron-builder.yml, and preload.spec.mjs',
+    'record the resolved constraint in ADR-0034'
+].join('; ');
+
+/**
+ * @summary Converts one runtime observation into the self-notifying preload-conversion verdict.
+ *
+ * Exactly one known state passes: the pinned runtime rejects the ESM preload with Electron's
+ * documented sandbox error. Support, contradictory evidence, timeouts, silence, and new failure
+ * modes all fail so upstream capability changes cannot hide behind an inconclusive result.
+ * @param {Object} observation
+ * @param {String[]} [observation.errors=[]]
+ * @param {Boolean} [observation.markerLoaded=false]
+ * @param {Boolean} [observation.timedOut=false]
+ * @returns {{message: String, ok: Boolean, status: String}}
+ */
+export function classifyPreloadEsmProbe({errors = [], markerLoaded = false, timedOut = false} = {}) {
+    const messages = errors.map(error => String(error));
+
+    if (timedOut) {
+        return {
+            message: 'Sandboxed ESM preload probe timed out; the result is inconclusive and fails closed.',
+            ok     : false,
+            status : 'inconclusive'
+        }
+    }
+
+    if (markerLoaded && messages.length > 0) {
+        return {
+            message: `Sandboxed ESM preload probe observed both a loaded marker and errors (${messages.join(' | ')}); contradictory evidence fails closed.`,
+            ok     : false,
+            status : 'contradictory'
+        }
+    }
+
+    if (markerLoaded) {
+        return {
+            message: `Electron now supports ESM imports in sandboxed preloads. #16036 conversion is unblocked: ${CONVERSION_STEPS}.`,
+            ok     : false,
+            status : 'support-detected'
+        }
+    }
+
+    if (messages.length === 1 && messages[0].includes(EXPECTED_SANDBOXED_ESM_ERROR)) {
+        return {
+            message: `Constraint confirmed: sandboxed ESM preload rejected with "${EXPECTED_SANDBOXED_ESM_ERROR}".`,
+            ok     : true,
+            status : 'constraint-confirmed'
+        }
+    }
+
+    if (messages.length > 0) {
+        return {
+            message: `Sandboxed ESM preload probe produced unexpected error(s): ${messages.join(' | ')}. Expected "${EXPECTED_SANDBOXED_ESM_ERROR}"; failing closed.`,
+            ok     : false,
+            status : 'unexpected-error'
+        }
+    }
+
+    return {
+        message: 'Sandboxed ESM preload probe produced neither the loaded marker nor the expected rejection; inconclusive and failing closed.',
+        ok     : false,
+        status : 'inconclusive'
+    }
+}

--- a/test/playwright/unit/harness/preloadEsmProbeOutcome.spec.mjs
+++ b/test/playwright/unit/harness/preloadEsmProbeOutcome.spec.mjs
@@ -22,6 +22,9 @@ test.describe('sandboxed ESM preload capability outcome', () => {
         expect(result.status).toBe('support-detected');
         expect(result.message).toContain('#16036 conversion is unblocked');
         expect(result.message).toContain('rename preload.cjs to preload.mjs');
+        expect(result.message).toContain('adapterWitness.mjs import');
+        expect(result.message).toContain('delete its drift guard in adapterWitness.spec.mjs');
+        expect(result.message).toContain('learn/benefits/ArchitectureOverview.md');
         expect(result.message).toContain('ADR-0034')
     });
 

--- a/test/playwright/unit/harness/preloadEsmProbeOutcome.spec.mjs
+++ b/test/playwright/unit/harness/preloadEsmProbeOutcome.spec.mjs
@@ -1,0 +1,55 @@
+import {expect, test} from '@playwright/test';
+import {
+    EXPECTED_SANDBOXED_ESM_ERROR,
+    classifyPreloadEsmProbe
+} from '../../../../harness/preloadEsmProbeOutcome.mjs';
+
+test.describe('sandboxed ESM preload capability outcome', () => {
+    test('passes only the pinned Electron rejection mode', () => {
+        expect(classifyPreloadEsmProbe({
+            errors: [`Unable to load preload: ${EXPECTED_SANDBOXED_ESM_ERROR}`]
+        })).toEqual({
+            message: `Constraint confirmed: sandboxed ESM preload rejected with "${EXPECTED_SANDBOXED_ESM_ERROR}".`,
+            ok     : true,
+            status : 'constraint-confirmed'
+        })
+    });
+
+    test('turns upstream support into an actionable red result', () => {
+        const result = classifyPreloadEsmProbe({markerLoaded: true});
+
+        expect(result.ok).toBe(false);
+        expect(result.status).toBe('support-detected');
+        expect(result.message).toContain('#16036 conversion is unblocked');
+        expect(result.message).toContain('rename preload.cjs to preload.mjs');
+        expect(result.message).toContain('ADR-0034')
+    });
+
+    test('fails closed on an unexpected runtime error', () => {
+        const result = classifyPreloadEsmProbe({errors: ['ERR_MODULE_NOT_FOUND']});
+
+        expect(result.ok).toBe(false);
+        expect(result.status).toBe('unexpected-error');
+        expect(result.message).toContain('ERR_MODULE_NOT_FOUND');
+        expect(result.message).toContain(EXPECTED_SANDBOXED_ESM_ERROR)
+    });
+
+    test('fails closed when the probe is silent or times out', () => {
+        expect(classifyPreloadEsmProbe()).toMatchObject({ok: false, status: 'inconclusive'});
+        expect(classifyPreloadEsmProbe({timedOut: true})).toMatchObject({
+            ok    : false,
+            status: 'inconclusive'
+        })
+    });
+
+    test('fails closed on contradictory marker and error evidence', () => {
+        const result = classifyPreloadEsmProbe({
+            errors      : [EXPECTED_SANDBOXED_ESM_ERROR],
+            markerLoaded: true
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.status).toBe('contradictory');
+        expect(result.message).toContain('both a loaded marker and errors')
+    })
+});


### PR DESCRIPTION
Resolves #16036

Adds a real pinned-Electron capability witness for the one CommonJS file in the
harness. Before either smoke path boots the product, a temporary sandboxed
renderer tries an `.mjs` preload with a native `electron` import. Electron
43.1.0's known rejection is the only passing state; newly working ESM support,
unexpected errors, contradictory observations, silence, and timeout all fail
closed. The failure that signals new support names the concrete conversion
steps, while the harness README explains why `preload.cjs` remains honest today.

Evidence: L3 (real Electron 43.1.0 renderer, UI smoke, and isolated Brain smoke
on exact head) → L3 required (all runtime acceptance criteria in #16036). No
residuals.

## Contract Ledger

| Target surface | Source of authority | Delivered behavior | Fallback | Evidence |
| :--- | :--- | :--- | :--- | :--- |
| Sandboxed preload capability | #16036 and the pinned Electron runtime | A real `.mjs` preload imports `electron` under `sandbox: true`; only the current named rejection passes | Timeout, silence, unexpected errors, and contradictory evidence fail closed | Exact-head `probe:preload-esm` and both smoke legs |
| Upstream-support trigger | #16036 acceptance criteria | A successfully exposed marker fails red and states that conversion is unblocked, including every reference site and ADR update | No quiet skip path | Five classifier branch tests |
| Harness operator guidance | `harness/README.md` | Explains the CommonJS constraint, security boundary, and conversion sequence next to the harness setup | Explicitly rejects disabling sandbox or adding a bundler | README diff and ticket archaeology lint |

## Deltas from ticket

The runtime witness is wired into both `presmoke` hooks and its verdict logic is
split into a pure helper. This preserves a real Electron acceptance path while
making support, expected rejection, unexpected error, contradiction, silence,
and timeout deterministic at unit level. No change to sandboxing, renderer
behavior, or the existing preload contract.

## Test Evidence

- `cd harness && npm run probe:preload-esm` — pass on exact head; Electron
  43.1.0 produced `Cannot use import statement outside a module`.
- `cd harness && npm run smoke` — exit 0 on exact head; two windows booted,
  popup materialized, `assetFailures: []`, `rendererErrors: []`, and
  `requiredAssetsReady: true`.
- `cd harness && npm run smoke:brain` — exit 0 on exact head; Brain and Chroma
  became ready, cross-window Fleet checks passed, forged sender was rejected,
  process groups emptied, and ports were released.
- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/harness` —
  95/95 passed.
- Focused outcome spec — 5/5 passed, covering expected rejection,
  support-detected red, unexpected error, silence/timeout, and contradictory
  evidence.
- Repair-capable `npm run agent-preflight` and check-only
  `npm run agent-preflight -- --no-fix` — passed.
- `git diff --check origin/dev...HEAD` — passed.

## Post-Merge Validation

- [ ] On the next pinned Electron update, run either harness smoke path. If the
  support-detected alarm fires, execute the named `preload.cjs` → `preload.mjs`
  conversion and record the resolved constraint in ADR-0034.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fa904-9d8c-7f12-94fe-346ae8e54046.
