### PR TITLE
feat(memory-core): make summary receipts replayable (#16105)

### DIFF
--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -131,17 +131,25 @@ class SQLite extends Base {
         this.db.exec(`CREATE TRIGGER IF NOT EXISTS edge_update AFTER UPDATE ON Edges BEGIN INSERT INTO GraphLog(entity_id, entity_type) VALUES (NEW.id, 'edges'); END;`);
         this.db.exec(`CREATE TRIGGER IF NOT EXISTS edge_delete AFTER DELETE ON Edges BEGIN INSERT INTO GraphLog(entity_id, entity_type) VALUES (OLD.id, 'edges'); END;`);
 
-        // Summarization coordinator job lease table.
+        // Summarization coordinator job lease + bounded replay receipt. One compressed envelope
+        // is retained per session (overwritten by newer synthesis, removed by purgeSession with
+        // the row), so Chroma recycle recovery never depends on an unbounded append journal.
         this.db.exec(`
             CREATE TABLE IF NOT EXISTS SummarizationJobs (
                 session_id TEXT PRIMARY KEY,
                 status TEXT NOT NULL CHECK(status IN ('pending', 'in_progress', 'completed', 'failed')),
                 lease_token TEXT,
                 expires_at INTEGER,
-                retry_count INTEGER DEFAULT 0
+                retry_count INTEGER DEFAULT 0,
+                result_envelope BLOB,
+                result_encoding TEXT,
+                result_staged_at INTEGER,
+                result_acknowledged_at INTEGER,
+                result_last_replayed_at INTEGER
             );
         `);
 
+        this.migrateLegacySummarizationJobColumns();
         this.stampSchemaVersion();
     }
 
@@ -219,6 +227,27 @@ class SQLite extends Base {
 
         if (!this.hasColumn('GraphLog', 'event_payload')) {
             this.db.exec('ALTER TABLE GraphLog ADD COLUMN event_payload TEXT');
+        }
+    }
+
+    /**
+     * @summary Adds the nullable, backward-compatible durable result envelope to legacy
+     * `SummarizationJobs` tables without rewriting or invalidating existing lease rows.
+     * @protected
+     */
+    migrateLegacySummarizationJobColumns() {
+        const columns = {
+            result_envelope        : 'BLOB',
+            result_encoding        : 'TEXT',
+            result_staged_at       : 'INTEGER',
+            result_acknowledged_at : 'INTEGER',
+            result_last_replayed_at: 'INTEGER'
+        };
+
+        for (const [name, type] of Object.entries(columns)) {
+            if (!this.hasColumn('SummarizationJobs', name)) {
+                this.db.exec(`ALTER TABLE SummarizationJobs ADD COLUMN ${name} ${type}`);
+            }
         }
     }
 

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -6,10 +6,15 @@ import {withTimeout}                                 from './helpers/withTimeout
 import {appendWalEmbedMarker, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
 import {verifyPersistedVector}                       from './helpers/verifyPersistedVector.mjs';
 import {resolveTurnDocumentForRead}                  from './helpers/turnDocumentText.mjs';
-import crypto                                        from 'crypto';
-import GraphService                                  from './GraphService.mjs';
-import {capSessionsForSweep}                         from './capSessionsForSweep.mjs';
-import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER}   from '../../graph/identityRoots.mjs';
+import {
+    acknowledgeSessionSummaryReceipt,
+    recoverSessionSummaryReceipts,
+    stageSessionSummaryReceipt
+} from './helpers/sessionSummaryReceiptStore.mjs';
+import crypto                                      from 'crypto';
+import GraphService                                from './GraphService.mjs';
+import {capSessionsForSweep}                       from './capSessionsForSweep.mjs';
+import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoots.mjs';
 
 import StorageRouter from './managers/StorageRouter.mjs';
 import Json          from '../../../src/util/Json.mjs';
@@ -865,6 +870,16 @@ ${sessionContent}
         // Add a 12-hour buffer window for offline drafting match
         await this.ingestAntigravityArtifacts(sessionId, summaryId, firstActivity - (12 * 3600000), lastActivity + (12 * 3600000));
 
+        // Durable receipt boundary: this is deliberately the final side effect before return.
+        // If SQLite staging fails, summarizeSession throws and the caller cannot count/complete the
+        // result. Once staged, recovery can reconstruct this exact Chroma row without the model.
+        this.stageSessionSummaryReceipt({
+            sessionId,
+            summaryId,
+            document: summary,
+            metadata: summaryMetadata
+        });
+
         return { sessionId, summaryId, title, memoryCount: memories.ids.length };
     }
 
@@ -1300,6 +1315,40 @@ ${sessionContent}
     }
 
     /**
+     * @summary Persists the exact summary result in the durable SQLite coordinator before
+     * `summarizeSession()` may return it to a caller.
+     * @param {Object} receipt
+     * @param {String} receipt.sessionId
+     * @param {String} receipt.summaryId
+     * @param {String} receipt.document
+     * @param {Object} receipt.metadata
+     * @returns {{bytes:Number,encoding:String,stagedAt:Number}}
+     */
+    stageSessionSummaryReceipt(receipt) {
+        return stageSessionSummaryReceipt({
+            db: GraphService.db?.storage?.db,
+            ...receipt
+        });
+    }
+
+    /**
+     * @summary Replays staged/completed exact result envelopes before any drift path may
+     * invoke the summary model. Legacy rows without envelopes remain drift-repair candidates.
+     * @param {Object} [options]
+     * @param {String|null} [options.sessionId=null]
+     * @returns {Promise<Object>} Receipt recovery counters.
+     */
+    async recoverSessionSummaryReceipts({sessionId = null} = {}) {
+        return recoverSessionSummaryReceipts({
+            db               : GraphService.db?.storage?.db,
+            collection       : this.sessionsCollection,
+            sessionId,
+            expectedDimension: aiConfig.vectorDimension,
+            log              : logger
+        });
+    }
+
+    /**
      * Claims an exclusive lease on a summarization job using the SummarizationJobs table.
      * Prevents race conditions across concurrent MCP instances.
      * @summary Provides exclusive lock acquisition for the background summarization coordinator loop.
@@ -1340,7 +1389,15 @@ ${sessionContent}
                     if (allowCompletedRepair) {
                         db.prepare(`
                             UPDATE SummarizationJobs
-                            SET status = 'in_progress', lease_token = ?, expires_at = ?, retry_count = retry_count + 1
+                            SET status                  = 'in_progress',
+                                lease_token             = ?,
+                                expires_at              = ?,
+                                retry_count             = retry_count + 1,
+                                result_envelope         = NULL,
+                                result_encoding         = NULL,
+                                result_staged_at        = NULL,
+                                result_acknowledged_at  = NULL,
+                                result_last_replayed_at = NULL
                             WHERE session_id = ?
                         `).run(leaseToken, expiresAt, sessionId);
                         return true;
@@ -1377,22 +1434,17 @@ ${sessionContent}
     }
 
     /**
-     * Marks a summarization job as completed in the coordinator table.
-     * @summary Finalizes the background summarization job state to prevent duplicate processing.
+     * Marks a durability-qualified summarization job as completed in the coordinator table.
+     * @summary Finalizes only when the exact replay envelope already exists; missing durable
+     * state throws so the caller cannot emit a false completed/processed receipt.
      * @param {String} sessionId
+     * @returns {Boolean}
      */
     completeSummarizationJob(sessionId) {
-        const db = GraphService.db?.storage?.db;
-        if (!db) return;
-        try {
-            db.prepare(`
-                UPDATE SummarizationJobs
-                SET status = 'completed', lease_token = NULL
-                WHERE session_id = ?
-            `).run(sessionId);
-        } catch (e) {
-            logger.warn(`[SessionService] Error completing job for ${sessionId}: ${e.message}`);
-        }
+        return acknowledgeSessionSummaryReceipt({
+            db: GraphService.db?.storage?.db,
+            sessionId
+        });
     }
 
     /**
@@ -1425,6 +1477,11 @@ ${sessionContent}
         try {
             let   processed  = [];
             const leaseToken = crypto.randomUUID();
+
+            // Exact durable replay wins over model re-synthesis. For new receipts, this repairs
+            // Chroma before drift detection; legacy completed rows without an envelope still flow
+            // through the existing allowCompletedRepair fallback below.
+            await this.recoverSessionSummaryReceipts({sessionId: sessionId || null});
 
             if (sessionId) {
                 if (this.claimSummarizationJob(sessionId, leaseToken)) {
@@ -1482,12 +1539,13 @@ ${sessionContent}
 
                         try {
                             const result = await this.summarizeSession(id);
-                            // Per-session completion progress so a 15-30 min run emits output, not silence.
-                            // Direct stderr write (the channel ProcessSupervisor captures into orchestrator.log);
-                            // not the Provider-gated logger, which would need a B4-unsafe config mutation to surface.
-                            console.error(`[INFO] [SessionService] session summarization: ${++completed}/${total} done (${id})`);
                             if (result) {
                                 this.completeSummarizationJob(id);
+                                // Per-session completion progress so a 15-30 min run emits output,
+                                // not silence. This occurs AFTER the durable acknowledgement, so
+                                // "done" cannot get ahead of the recoverable result receipt.
+                                // Direct stderr is captured by ProcessSupervisor into orchestrator.log.
+                                console.error(`[INFO] [SessionService] session summarization: ${++completed}/${total} done (${id})`);
                                 return result;
                             } else {
                                 this.failSummarizationJob(id);

--- a/ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs
+++ b/ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs
@@ -1,0 +1,410 @@
+import {isDeepStrictEqual}    from 'node:util';
+import {gunzipSync, gzipSync} from 'node:zlib';
+
+import {verifyPersistedVector} from './verifyPersistedVector.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/sessionSummaryReceiptStore
+ * @summary Durable, bounded replay receipts for derived session-summary rows.
+ *
+ * Chroma is a disposable projection and may lose a just-acknowledged write when the
+ * supervisor force-recycles the daemon. The SQLite `SummarizationJobs` row therefore
+ * retains exactly one compressed result envelope per session: new synthesis overwrites
+ * the prior envelope, and `purgeSession()` removes it with the coordinator row. This is
+ * deliberately not an append-only journal.
+ */
+
+export const SESSION_SUMMARY_RECEIPT_ENCODING = 'gzip-json-v1';
+
+const DEFAULT_RECOVERY_BATCH_SIZE = 100;
+
+/**
+ * @summary Validates the exact deterministic summary row carried by a receipt.
+ * @param {Object} receipt
+ * @param {String} receipt.sessionId
+ * @param {String} receipt.summaryId
+ * @param {String} receipt.document
+ * @param {Object} receipt.metadata
+ * @returns {Object} The validated receipt.
+ */
+function validateReceipt(receipt) {
+    if (typeof receipt?.sessionId !== 'string' || !receipt.sessionId) {
+        throw new TypeError('Session-summary receipt requires a non-empty sessionId.');
+    }
+    if (receipt.summaryId !== `summary_${receipt.sessionId}`) {
+        throw new TypeError(`Session-summary receipt id must be summary_${receipt.sessionId}.`);
+    }
+    if (typeof receipt.document !== 'string') {
+        throw new TypeError('Session-summary receipt document must be a string.');
+    }
+    if (!receipt.metadata || typeof receipt.metadata !== 'object' || Array.isArray(receipt.metadata)) {
+        throw new TypeError('Session-summary receipt metadata must be an object.');
+    }
+
+    return receipt;
+}
+
+/**
+ * @summary Encodes one exact Chroma summary row as a compact SQLite BLOB.
+ * @param {Object} receipt Exact summary row.
+ * @returns {Buffer}
+ */
+export function encodeSessionSummaryReceipt(receipt) {
+    const validated = validateReceipt(receipt);
+
+    return gzipSync(Buffer.from(JSON.stringify({
+        version  : 1,
+        sessionId: validated.sessionId,
+        summaryId: validated.summaryId,
+        document : validated.document,
+        metadata : validated.metadata
+    }), 'utf8'));
+}
+
+/**
+ * @summary Decodes and validates one durable session-summary result envelope.
+ * @param {Buffer|Uint8Array} envelope
+ * @param {String} encoding
+ * @returns {{version:Number,sessionId:String,summaryId:String,document:String,metadata:Object}}
+ */
+export function decodeSessionSummaryReceipt(envelope, encoding) {
+    if (encoding !== SESSION_SUMMARY_RECEIPT_ENCODING) {
+        throw new Error(`Unsupported session-summary receipt encoding: ${String(encoding)}.`);
+    }
+    if (!envelope) {
+        throw new Error('Session-summary receipt envelope is empty.');
+    }
+
+    let receipt;
+
+    try {
+        receipt = JSON.parse(gunzipSync(Buffer.from(envelope)).toString('utf8'));
+    } catch (error) {
+        throw new Error(`Session-summary receipt envelope is corrupt: ${error.message}`, {cause: error});
+    }
+
+    if (receipt?.version !== 1) {
+        throw new Error(`Unsupported session-summary receipt version: ${String(receipt?.version)}.`);
+    }
+
+    return validateReceipt(receipt);
+}
+
+/**
+ * @summary Atomically stages the exact result envelope before `summarizeSession()` may return.
+ *
+ * The current coordinator status/lease is preserved while an active job is finishing.
+ * A direct re-synthesis over an already-completed row reopens it as `pending`, preventing
+ * the old completion state from acknowledging the newly staged result prematurely.
+ *
+ * @param {Object} options
+ * @param {Object} options.db Open better-sqlite3 connection.
+ * @param {String} options.sessionId
+ * @param {String} options.summaryId
+ * @param {String} options.document
+ * @param {Object} options.metadata
+ * @param {Number} [options.now=Date.now()]
+ * @returns {{bytes:Number,encoding:String,stagedAt:Number}}
+ */
+export function stageSessionSummaryReceipt({
+    db,
+    sessionId,
+    summaryId,
+    document,
+    metadata,
+    now = Date.now()
+} = {}) {
+    if (!db?.open) {
+        throw new Error('Cannot stage session-summary receipt: SQLite graph is unavailable.');
+    }
+
+    const envelope = encodeSessionSummaryReceipt({sessionId, summaryId, document, metadata});
+    const stagedAt = Number(now);
+
+    db.prepare(`
+        INSERT INTO SummarizationJobs (
+            session_id,
+            status,
+            lease_token,
+            expires_at,
+            retry_count,
+            result_envelope,
+            result_encoding,
+            result_staged_at,
+            result_acknowledged_at,
+            result_last_replayed_at
+        )
+        VALUES (?, 'pending', NULL, NULL, 0, ?, ?, ?, NULL, NULL)
+        ON CONFLICT(session_id) DO UPDATE SET
+            status = CASE
+                WHEN SummarizationJobs.status = 'completed' THEN 'pending'
+                ELSE SummarizationJobs.status
+            END,
+            lease_token = CASE
+                WHEN SummarizationJobs.status = 'completed' THEN NULL
+                ELSE SummarizationJobs.lease_token
+            END,
+            expires_at = CASE
+                WHEN SummarizationJobs.status = 'completed' THEN NULL
+                ELSE SummarizationJobs.expires_at
+            END,
+            result_envelope         = excluded.result_envelope,
+            result_encoding         = excluded.result_encoding,
+            result_staged_at        = excluded.result_staged_at,
+            result_acknowledged_at  = NULL,
+            result_last_replayed_at = NULL
+    `).run(sessionId, envelope, SESSION_SUMMARY_RECEIPT_ENCODING, stagedAt);
+
+    return {
+        bytes   : envelope.byteLength,
+        encoding: SESSION_SUMMARY_RECEIPT_ENCODING,
+        stagedAt
+    };
+}
+
+/**
+ * @summary Marks a staged result completed only when its durable envelope exists.
+ * @param {Object} options
+ * @param {Object} options.db Open better-sqlite3 connection.
+ * @param {String} options.sessionId
+ * @param {Number} [options.now=Date.now()]
+ * @returns {Boolean}
+ */
+export function acknowledgeSessionSummaryReceipt({db, sessionId, now = Date.now()} = {}) {
+    if (!db?.open) {
+        throw new Error('Cannot acknowledge session-summary receipt: SQLite graph is unavailable.');
+    }
+
+    const result = db.prepare(`
+        UPDATE SummarizationJobs
+        SET status                 = 'completed',
+            lease_token            = NULL,
+            expires_at             = NULL,
+            result_acknowledged_at = ?
+        WHERE session_id = ?
+          AND result_envelope IS NOT NULL
+          AND result_encoding = ?
+    `).run(Number(now), sessionId, SESSION_SUMMARY_RECEIPT_ENCODING);
+
+    if (result.changes !== 1) {
+        throw new Error(`Cannot acknowledge session summary ${sessionId}: no durable result envelope exists.`);
+    }
+
+    return true;
+}
+
+/**
+ * @summary Compares one Chroma read-back row with its durable exact envelope.
+ * @param {Object|undefined} row
+ * @param {Object} receipt
+ * @returns {Boolean}
+ */
+function isExactSummaryRow(row, receipt) {
+    return row?.document === receipt.document &&
+        isDeepStrictEqual(row.metadata, receipt.metadata);
+}
+
+/**
+ * @summary Converts Chroma's parallel result arrays into an id-keyed row map.
+ * @param {Object} result
+ * @returns {Map<String,{document:String,metadata:Object}>}
+ */
+function mapSummaryRows(result) {
+    const rows = new Map();
+
+    for (let index = 0; index < (result?.ids?.length || 0); index++) {
+        rows.set(result.ids[index], {
+            document: result.documents?.[index],
+            metadata: result.metadatas?.[index]
+        });
+    }
+
+    return rows;
+}
+
+/**
+ * @summary Finalizes one recovered receipt without overwriting a newer staged result.
+ * @param {Object} options
+ * @param {Object} options.db
+ * @param {Object} options.row SQLite receipt row.
+ * @param {Boolean} options.replayed
+ * @param {Number} options.now
+ * @returns {Boolean} Whether this exact receipt still owned the coordinator row.
+ */
+function finalizeRecoveredReceipt({db, row, replayed, now}) {
+    const result = db.prepare(`
+        UPDATE SummarizationJobs
+        SET status                  = 'completed',
+            lease_token             = NULL,
+            expires_at              = NULL,
+            result_acknowledged_at  = COALESCE(result_acknowledged_at, ?),
+            result_last_replayed_at = CASE WHEN ? = 1 THEN ? ELSE result_last_replayed_at END
+        WHERE session_id = ?
+          AND result_envelope = ?
+          AND result_encoding = ?
+          AND result_staged_at = ?
+    `).run(
+        now,
+        replayed ? 1 : 0,
+        now,
+        row.session_id,
+        row.result_envelope,
+        row.result_encoding,
+        row.result_staged_at
+    );
+
+    return result.changes === 1;
+}
+
+/**
+ * @summary Replays durable summary envelopes into Chroma without model synthesis.
+ *
+ * Recovery skips a still-live `in_progress` lease to avoid racing the writer between
+ * staging and its immediate acknowledgement. Completed, pending, failed, and expired
+ * staged receipts are exact-replayed as needed, strictly read back, and finalized.
+ * Corrupt envelopes or failed read-backs throw while retaining the only replay copy.
+ *
+ * @param {Object} options
+ * @param {Object} options.db Open better-sqlite3 connection.
+ * @param {Object} options.collection Chroma summary collection.
+ * @param {String|null} [options.sessionId=null] Optional single-session recovery scope.
+ * @param {Number} [options.expectedDimension] Expected vector dimension for the existing
+ *     fail-soft vector integrity check.
+ * @param {Object} [options.log]
+ * @param {Number} [options.now=Date.now()]
+ * @param {Number} [options.batchSize=100]
+ * @returns {Promise<{scanned:Number,present:Number,replayed:Number,completed:Number,skippedActive:Number,superseded:Number}>}
+ */
+export async function recoverSessionSummaryReceipts({
+    db,
+    collection,
+    sessionId = null,
+    expectedDimension,
+    log,
+    now = Date.now(),
+    batchSize = DEFAULT_RECOVERY_BATCH_SIZE
+} = {}) {
+    if (!db?.open) {
+        throw new Error('Cannot recover session-summary receipts: SQLite graph is unavailable.');
+    }
+    if (!collection?.get || !collection?.upsert) {
+        throw new TypeError('Cannot recover session-summary receipts: Chroma summary collection is unavailable.');
+    }
+
+    const numericBatchSize = Number.isInteger(batchSize) && batchSize > 0
+        ? batchSize
+        : DEFAULT_RECOVERY_BATCH_SIZE;
+    const stats = {
+        scanned      : 0,
+        present      : 0,
+        replayed     : 0,
+        completed    : 0,
+        skippedActive: 0,
+        superseded   : 0
+    };
+    let afterRowId = 0;
+
+    while (true) {
+        const rows = sessionId
+            ? db.prepare(`
+                SELECT rowid AS receipt_rowid, *
+                FROM SummarizationJobs
+                WHERE session_id = ?
+                  AND result_envelope IS NOT NULL
+                LIMIT 1
+            `).all(sessionId)
+            : db.prepare(`
+                SELECT rowid AS receipt_rowid, *
+                FROM SummarizationJobs
+                WHERE rowid > ?
+                  AND result_envelope IS NOT NULL
+                ORDER BY rowid ASC
+                LIMIT ?
+            `).all(afterRowId, numericBatchSize);
+
+        if (rows.length === 0) break;
+        afterRowId = rows.at(-1).receipt_rowid;
+        stats.scanned += rows.length;
+
+        const recoverable = [];
+
+        for (const row of rows) {
+            if (row.status === 'in_progress' && Number(row.expires_at) >= Number(now)) {
+                stats.skippedActive++;
+                continue;
+            }
+
+            const receipt = decodeSessionSummaryReceipt(row.result_envelope, row.result_encoding);
+
+            if (receipt.sessionId !== row.session_id) {
+                throw new Error(`Session-summary receipt row ${row.session_id} contains payload for ${receipt.sessionId}.`);
+            }
+
+            recoverable.push({row, receipt});
+        }
+
+        if (recoverable.length > 0) {
+            const liveResult = await collection.get({
+                ids    : recoverable.map(item => item.receipt.summaryId),
+                include: ['documents', 'metadatas']
+            });
+            let liveRows = mapSummaryRows(liveResult);
+
+            const toReplay = recoverable.filter(item =>
+                !isExactSummaryRow(liveRows.get(item.receipt.summaryId), item.receipt)
+            );
+
+            if (toReplay.length > 0) {
+                await collection.upsert({
+                    ids      : toReplay.map(item => item.receipt.summaryId),
+                    documents: toReplay.map(item => item.receipt.document),
+                    metadatas: toReplay.map(item => item.receipt.metadata)
+                });
+
+                const readBack = await collection.get({
+                    ids    : toReplay.map(item => item.receipt.summaryId),
+                    include: ['documents', 'metadatas']
+                });
+                liveRows = mapSummaryRows(readBack);
+
+                for (const item of toReplay) {
+                    if (!isExactSummaryRow(liveRows.get(item.receipt.summaryId), item.receipt)) {
+                        throw new Error(`Session-summary receipt replay verification failed for ${item.receipt.summaryId}.`);
+                    }
+
+                    await verifyPersistedVector(
+                        collection,
+                        item.receipt.summaryId,
+                        expectedDimension,
+                        log,
+                        'replayed session summary'
+                    );
+                }
+            }
+
+            const replayedIds = new Set(toReplay.map(item => item.receipt.summaryId));
+
+            for (const item of recoverable) {
+                const replayed = replayedIds.has(item.receipt.summaryId);
+
+                if (replayed) {
+                    stats.replayed++;
+                    log?.info?.(`[sessionSummaryReceiptStore] Replayed durable session summary ${item.receipt.summaryId}.`);
+                } else {
+                    stats.present++;
+                }
+
+                if (finalizeRecoveredReceipt({db, row: item.row, replayed, now: Number(now)})) {
+                    stats.completed++;
+                } else {
+                    stats.superseded++;
+                    log?.warn?.(`[sessionSummaryReceiptStore] Receipt ${item.receipt.summaryId} was superseded during recovery; left for the next pass.`);
+                }
+            }
+        }
+
+        if (sessionId || rows.length < numericBatchSize) break;
+    }
+
+    return stats;
+}

--- a/test/playwright/unit/ai/graph/Database.spec.mjs
+++ b/test/playwright/unit/ai/graph/Database.spec.mjs
@@ -363,6 +363,62 @@ test.describe('Neo.ai.graph.Database', () => {
         }
     });
 
+    test('SQLite migrates legacy SummarizationJobs rows with nullable durable receipt columns (#16105)', async () => {
+        seedLegacyGraphFile();
+
+        const legacyDb = new BetterSqlite(dbPath);
+
+        try {
+            legacyDb.exec(`
+                CREATE TABLE SummarizationJobs (
+                    session_id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL CHECK(status IN ('pending', 'in_progress', 'completed', 'failed')),
+                    lease_token TEXT,
+                    expires_at INTEGER,
+                    retry_count INTEGER DEFAULT 0
+                )
+            `);
+            legacyDb.prepare(`
+                INSERT INTO SummarizationJobs (
+                    session_id, status, lease_token, expires_at, retry_count
+                )
+                VALUES ('legacy-summary', 'completed', NULL, NULL, 7)
+            `).run();
+        } finally {
+            legacyDb.close();
+        }
+
+        const storage = Neo.create(SQLite, {dbPath});
+        await storage.initAsync();
+
+        try {
+            const columns = storage.db.prepare('PRAGMA table_info(SummarizationJobs)')
+                .all()
+                .map(column => column.name);
+
+            expect(columns).toEqual(expect.arrayContaining([
+                'result_envelope',
+                'result_encoding',
+                'result_staged_at',
+                'result_acknowledged_at',
+                'result_last_replayed_at'
+            ]));
+            expect(storage.db.prepare(`
+                SELECT session_id, status, retry_count, result_envelope
+                FROM SummarizationJobs
+                WHERE session_id = 'legacy-summary'
+            `).get()).toEqual({
+                session_id     : 'legacy-summary',
+                status         : 'completed',
+                retry_count    : 7,
+                result_envelope: null
+            });
+        } finally {
+            if (storage.db?.open) storage.db.close();
+            storage.destroy();
+        }
+    });
+
     test('SQLite initSchema refuses unsupported graph schema versions without wipe opt-in (#10233)', async () => {
         seedLegacyGraphFile({schemaVersion: 999});
 

--- a/test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs
@@ -231,19 +231,48 @@ test.describe('SessionService validateSessionForResume (#10725)', () => {
         expect(sqlite).toBeTruthy();
 
         sqlite.prepare(`
-            INSERT INTO SummarizationJobs (session_id, status, lease_token, expires_at, retry_count)
-            VALUES (?, 'completed', NULL, NULL, 2)
-        `).run(sessionId);
+            INSERT INTO SummarizationJobs (
+                session_id,
+                status,
+                lease_token,
+                expires_at,
+                retry_count,
+                result_envelope,
+                result_encoding,
+                result_staged_at,
+                result_acknowledged_at,
+                result_last_replayed_at
+            )
+            VALUES (?, 'completed', NULL, NULL, 2, ?, 'gzip-json-v1', 100, 101, 102)
+        `).run(sessionId, Buffer.from('superseded-receipt'));
 
         try {
             expect(SDK.Memory_SessionService.claimSummarizationJob(sessionId, 'repair-token', {allowCompletedRepair: true})).toBe(true);
 
-            const row = sqlite.prepare('SELECT status, lease_token, expires_at, retry_count FROM SummarizationJobs WHERE session_id = ?').get(sessionId);
+            const row = sqlite.prepare(`
+                SELECT
+                    status,
+                    lease_token,
+                    expires_at,
+                    retry_count,
+                    result_envelope,
+                    result_encoding,
+                    result_staged_at,
+                    result_acknowledged_at,
+                    result_last_replayed_at
+                FROM SummarizationJobs
+                WHERE session_id = ?
+            `).get(sessionId);
 
             expect(row.status).toBe('in_progress');
             expect(row.lease_token).toBe('repair-token');
             expect(row.expires_at).toBeGreaterThan(Date.now());
             expect(row.retry_count).toBe(3);
+            expect(row.result_envelope).toBeNull();
+            expect(row.result_encoding).toBeNull();
+            expect(row.result_staged_at).toBeNull();
+            expect(row.result_acknowledged_at).toBeNull();
+            expect(row.result_last_replayed_at).toBeNull();
         } finally {
             sqlite.prepare('DELETE FROM SummarizationJobs WHERE session_id = ?').run(sessionId);
         }
@@ -275,6 +304,84 @@ test.describe('SessionService validateSessionForResume (#10725)', () => {
             SDK.Memory_SessionService.findSessionsToSummarize = originalFind;
             SDK.Memory_SessionService.claimSummarizationJob   = originalClaim;
             SDK.Memory_SessionService.summarizeSession        = originalSummarize;
+        }
+    });
+
+    test('#16105: summarizeSessions recovers an exact receipt before any claim or model path', async () => {
+        const originalRecover   = SDK.Memory_SessionService.recoverSessionSummaryReceipts;
+        const originalClaim     = SDK.Memory_SessionService.claimSummarizationJob;
+        const originalSummarize = SDK.Memory_SessionService.summarizeSession;
+        const order             = [];
+
+        SDK.Memory_SessionService.recoverSessionSummaryReceipts = async ({sessionId}) => {
+            order.push(`recover:${sessionId}`);
+            return {replayed: 1, completed: 1};
+        };
+        SDK.Memory_SessionService.claimSummarizationJob = sessionId => {
+            order.push(`claim:${sessionId}`);
+            return false;
+        };
+        SDK.Memory_SessionService.summarizeSession = async sessionId => {
+            order.push(`model:${sessionId}`);
+            throw new Error('summary model must not run after recovery finalized the job');
+        };
+
+        try {
+            const result = await SDK.Memory_SessionService.summarizeSessions({
+                sessionId: 'receipt-first'
+            });
+
+            expect(result.processed).toBe(0);
+            expect(order).toEqual([
+                'recover:receipt-first',
+                'claim:receipt-first'
+            ]);
+        } finally {
+            SDK.Memory_SessionService.recoverSessionSummaryReceipts = originalRecover;
+            SDK.Memory_SessionService.claimSummarizationJob         = originalClaim;
+            SDK.Memory_SessionService.summarizeSession              = originalSummarize;
+        }
+    });
+
+    test('#16105: missing durable envelope cannot produce processed/completed receipt', async () => {
+        const sessionId       = `receipt-required-${crypto.randomUUID()}`;
+        const GraphService    = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        const sqlite          = GraphService.db?.storage?.db;
+        const originalRecover = SDK.Memory_SessionService.recoverSessionSummaryReceipts;
+        const originalClaim   = SDK.Memory_SessionService.claimSummarizationJob;
+        const originalSummary = SDK.Memory_SessionService.summarizeSession;
+
+        expect(sqlite).toBeTruthy();
+        sqlite.prepare(`
+            INSERT INTO SummarizationJobs (session_id, status)
+            VALUES (?, 'pending')
+        `).run(sessionId);
+
+        SDK.Memory_SessionService.recoverSessionSummaryReceipts = async () => ({replayed: 0});
+        SDK.Memory_SessionService.claimSummarizationJob         = () => true;
+        SDK.Memory_SessionService.summarizeSession              = async () => ({
+            sessionId,
+            summaryId: `summary_${sessionId}`
+        });
+
+        try {
+            const result = await SDK.Memory_SessionService.summarizeSessions({sessionId});
+
+            expect(result.processed).toBe(0);
+            expect(result.sessions).toEqual([]);
+            expect(sqlite.prepare(`
+                SELECT status, result_envelope
+                FROM SummarizationJobs
+                WHERE session_id = ?
+            `).get(sessionId)).toEqual({
+                status         : 'failed',
+                result_envelope: null
+            });
+        } finally {
+            SDK.Memory_SessionService.recoverSessionSummaryReceipts = originalRecover;
+            SDK.Memory_SessionService.claimSummarizationJob         = originalClaim;
+            SDK.Memory_SessionService.summarizeSession              = originalSummary;
+            sqlite.prepare('DELETE FROM SummarizationJobs WHERE session_id = ?').run(sessionId);
         }
     });
 

--- a/test/playwright/unit/ai/services/memory-core/SessionSummaryDegradedFallback.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionSummaryDegradedFallback.spec.mjs
@@ -68,6 +68,7 @@ test.describe('Neo.ai.services.memory-core.SessionService — degraded session-s
         } else {
             await LifecycleService.ready();
         }
+        await SessionService.ready();
 
         // Save originals — sibling specs share the worker; an unrestored mock would leak.
         originalMemoryCollection   = SessionService.memoryCollection;

--- a/test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs
@@ -1,0 +1,507 @@
+import fs   from 'node:fs';
+import os   from 'node:os';
+import path from 'node:path';
+
+import {knownEmbeddingFunctions, registerEmbeddingFunction, ChromaClient} from 'chromadb';
+import Database                                                           from 'better-sqlite3';
+import {setup}                                                            from '../../../../../setup.mjs';
+import {test, expect}                                                     from '@playwright/test';
+
+import '../../../../../../../src/Neo.mjs';
+
+import {
+    acknowledgeSessionSummaryReceipt,
+    decodeSessionSummaryReceipt,
+    recoverSessionSummaryReceipts,
+    SESSION_SUMMARY_RECEIPT_ENCODING,
+    stageSessionSummaryReceipt
+} from '../../../../../../../ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs';
+import {
+    cleanupChromaArtifacts,
+    isDetachedProcessAlive,
+    startChromaProcess,
+    stopDetachedProcess
+} from '../../../../../chromaProcess.mjs';
+import {resolveFreePortSync} from '../../../../../resolveFreePort.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'SessionSummaryReceiptStoreTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+/**
+ * @summary Creates the current coordinator schema in an isolated SQLite connection.
+ * @returns {Database}
+ */
+function createReceiptDb() {
+    const db = new Database(':memory:');
+
+    db.exec(`
+        CREATE TABLE SummarizationJobs (
+            session_id TEXT PRIMARY KEY,
+            status TEXT NOT NULL CHECK(status IN ('pending', 'in_progress', 'completed', 'failed')),
+            lease_token TEXT,
+            expires_at INTEGER,
+            retry_count INTEGER DEFAULT 0,
+            result_envelope BLOB,
+            result_encoding TEXT,
+            result_staged_at INTEGER,
+            result_acknowledged_at INTEGER,
+            result_last_replayed_at INTEGER
+        )
+    `);
+
+    return db;
+}
+
+/**
+ * @summary Builds one deterministic exact summary row fixture.
+ * @param {String} sessionId
+ * @param {Object} [overrides]
+ * @returns {{sessionId:String,summaryId:String,document:String,metadata:Object}}
+ */
+function createReceipt(sessionId, overrides = {}) {
+    return {
+        sessionId,
+        summaryId: `summary_${sessionId}`,
+        document : `Summary for ${sessionId}`,
+        metadata : {
+            sessionId,
+            timestamp  : 1_800_000_000_000,
+            memoryCount: 2,
+            title      : 'Durable summary',
+            degraded   : false
+        },
+        ...overrides
+    };
+}
+
+/**
+ * @summary In-memory Chroma-shaped collection for deterministic receipt unit tests.
+ * @returns {Object}
+ */
+function createFakeCollection() {
+    const rows = new Map();
+
+    return {
+        rows,
+        upsertCalls: 0,
+
+        async get({ids}) {
+            const found = (ids || []).filter(id => rows.has(id));
+
+            return {
+                ids       : found,
+                documents : found.map(id => rows.get(id).document),
+                metadatas : found.map(id => rows.get(id).metadata),
+                embeddings: found.map(() => [1, 0, 0])
+            };
+        },
+
+        async upsert({ids, documents, metadatas}) {
+            this.upsertCalls++;
+
+            ids.forEach((id, index) => rows.set(id, {
+                document: documents[index],
+                metadata: structuredClone(metadatas[index])
+            }));
+        }
+    };
+}
+
+/**
+ * @summary Waits for an explicitly killed disposable Chroma process group to disappear.
+ * @param {Number} pid
+ * @param {Number} [timeoutMs=10000]
+ * @returns {Promise<void>}
+ */
+async function waitForProcessExit(pid, timeoutMs = 10000) {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        if (!isDetachedProcessAlive(pid)) return;
+        await new Promise(resolve => setTimeout(resolve, 100));
+    }
+
+    throw new Error(`Disposable Chroma process ${pid} did not exit after SIGKILL.`);
+}
+
+/**
+ * @summary Registers a deterministic, provider-free embedding function for one disposable
+ * Chroma collection without mutating the shared AiConfig singleton.
+ * @returns {Object}
+ */
+function createReceiptEmbeddingFunction() {
+    const name              = `session_summary_receipt_test_${process.pid}_${Date.now()}`;
+    const embeddingFunction = {
+        name,
+        getConfig: () => ({}),
+        generate : async texts => texts.map(() => [1, 0, 0])
+    };
+
+    class ReceiptEmbeddingFunction {
+        static buildFromConfig() {
+            return embeddingFunction;
+        }
+    }
+
+    embeddingFunction.constructor = ReceiptEmbeddingFunction;
+
+    if (!knownEmbeddingFunctions.has(name)) {
+        registerEmbeddingFunction(name, ReceiptEmbeddingFunction);
+    }
+
+    return embeddingFunction;
+}
+
+test.describe('sessionSummaryReceiptStore (#16105)', () => {
+    test.describe.configure({mode: 'serial'});
+
+    test('stages one compressed exact envelope and completes only through that durable receipt', () => {
+        const db      = createReceiptDb();
+        const receipt = createReceipt('active-job');
+        const expires = 1_800_000_060_000;
+
+        db.prepare(`
+            INSERT INTO SummarizationJobs (session_id, status, lease_token, expires_at, retry_count)
+            VALUES (?, 'in_progress', 'lease-1', ?, 3)
+        `).run(receipt.sessionId, expires);
+
+        try {
+            const staged = stageSessionSummaryReceipt({
+                db,
+                ...receipt,
+                now: 1_800_000_000_000
+            });
+            const stagedRow = db.prepare('SELECT * FROM SummarizationJobs WHERE session_id = ?')
+                .get(receipt.sessionId);
+
+            expect(staged.encoding).toBe(SESSION_SUMMARY_RECEIPT_ENCODING);
+            expect(staged.bytes).toBeGreaterThan(0);
+            expect(stagedRow.status).toBe('in_progress');
+            expect(stagedRow.lease_token).toBe('lease-1');
+            expect(stagedRow.expires_at).toBe(expires);
+            expect(decodeSessionSummaryReceipt(
+                stagedRow.result_envelope,
+                stagedRow.result_encoding
+            )).toEqual({version: 1, ...receipt});
+
+            expect(acknowledgeSessionSummaryReceipt({
+                db,
+                sessionId: receipt.sessionId,
+                now      : 1_800_000_000_100
+            })).toBe(true);
+
+            expect(db.prepare(`
+                SELECT status, lease_token, expires_at, result_acknowledged_at
+                FROM SummarizationJobs
+                WHERE session_id = ?
+            `).get(receipt.sessionId)).toEqual({
+                status                : 'completed',
+                lease_token           : null,
+                expires_at            : null,
+                result_acknowledged_at: 1_800_000_000_100
+            });
+        } finally {
+            db.close();
+        }
+    });
+
+    test('reopens a completed row while replacing, never appending, its single bounded envelope', () => {
+        const db       = createReceiptDb();
+        const original = createReceipt('replacement');
+        const updated  = createReceipt('replacement', {
+            document: 'New exact result',
+            metadata: {...original.metadata, memoryCount: 3}
+        });
+
+        try {
+            stageSessionSummaryReceipt({db, ...original, now: 100});
+            acknowledgeSessionSummaryReceipt({db, sessionId: original.sessionId, now: 101});
+            stageSessionSummaryReceipt({db, ...updated, now: 200});
+
+            const row = db.prepare('SELECT * FROM SummarizationJobs WHERE session_id = ?')
+                .get(original.sessionId);
+
+            expect(row.status).toBe('pending');
+            expect(row.result_acknowledged_at).toBeNull();
+            expect(row.result_staged_at).toBe(200);
+            expect(decodeSessionSummaryReceipt(row.result_envelope, row.result_encoding))
+                .toEqual({version: 1, ...updated});
+            expect(db.prepare('SELECT COUNT(*) AS count FROM SummarizationJobs').get().count).toBe(1);
+        } finally {
+            db.close();
+        }
+    });
+
+    test('fails loud when staging cannot persist or completion has no durable envelope', () => {
+        const db        = createReceiptDb();
+        const sessionId = 'missing-envelope';
+
+        db.prepare(`
+            INSERT INTO SummarizationJobs (session_id, status)
+            VALUES (?, 'in_progress')
+        `).run(sessionId);
+
+        expect(() => acknowledgeSessionSummaryReceipt({db, sessionId}))
+            .toThrow(/no durable result envelope/);
+        expect(db.prepare('SELECT status FROM SummarizationJobs WHERE session_id = ?')
+            .get(sessionId).status).toBe('in_progress');
+
+        db.exec('DROP TABLE SummarizationJobs');
+
+        expect(() => stageSessionSummaryReceipt({
+            db,
+            ...createReceipt('storage-failure')
+        })).toThrow(/no such table: SummarizationJobs/);
+
+        db.close();
+    });
+
+    test('replays a completed-but-missing exact row once and is idempotent on the next pass', async () => {
+        const db         = createReceiptDb();
+        const collection = createFakeCollection();
+        const receipt    = createReceipt('completed-missing');
+
+        try {
+            stageSessionSummaryReceipt({db, ...receipt, now: 100});
+            acknowledgeSessionSummaryReceipt({db, sessionId: receipt.sessionId, now: 101});
+
+            const first = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                expectedDimension: 3,
+                now              : 200
+            });
+
+            expect(first).toMatchObject({
+                scanned  : 1,
+                replayed : 1,
+                present  : 0,
+                completed: 1
+            });
+            expect(collection.rows.get(receipt.summaryId)).toEqual({
+                document: receipt.document,
+                metadata: receipt.metadata
+            });
+            expect(collection.upsertCalls).toBe(1);
+
+            const second = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                expectedDimension: 3,
+                now              : 300
+            });
+
+            expect(second).toMatchObject({
+                scanned  : 1,
+                replayed : 0,
+                present  : 1,
+                completed: 1
+            });
+            expect(collection.upsertCalls).toBe(1);
+
+            const row = db.prepare(`
+                SELECT status, result_acknowledged_at, result_last_replayed_at
+                FROM SummarizationJobs
+                WHERE session_id = ?
+            `).get(receipt.sessionId);
+
+            expect(row).toEqual({
+                status                 : 'completed',
+                result_acknowledged_at : 101,
+                result_last_replayed_at: 200
+            });
+        } finally {
+            db.close();
+        }
+    });
+
+    test('finalizes a staged direct result but skips a still-live writer lease', async () => {
+        const db         = createReceiptDb();
+        const collection = createFakeCollection();
+        const pending    = createReceipt('staged-pending');
+        const active     = createReceipt('staged-active');
+
+        try {
+            stageSessionSummaryReceipt({db, ...pending, now: 100});
+            await collection.upsert({
+                ids      : [pending.summaryId],
+                documents: [pending.document],
+                metadatas: [pending.metadata]
+            });
+
+            db.prepare(`
+                INSERT INTO SummarizationJobs (
+                    session_id, status, lease_token, expires_at, retry_count
+                )
+                VALUES (?, 'in_progress', 'active-lease', ?, 0)
+            `).run(active.sessionId, 500);
+            stageSessionSummaryReceipt({db, ...active, now: 101});
+
+            const result = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                now: 200
+            });
+
+            expect(result).toMatchObject({
+                completed    : 1,
+                present      : 1,
+                replayed     : 0,
+                skippedActive: 1
+            });
+            expect(db.prepare('SELECT status FROM SummarizationJobs WHERE session_id = ?')
+                .get(pending.sessionId).status).toBe('completed');
+            expect(db.prepare('SELECT status FROM SummarizationJobs WHERE session_id = ?')
+                .get(active.sessionId).status).toBe('in_progress');
+            expect(collection.rows.has(active.summaryId)).toBe(false);
+        } finally {
+            db.close();
+        }
+    });
+
+    test('retains a corrupt envelope and refuses to replace it through model-free recovery', async () => {
+        const db         = createReceiptDb();
+        const collection = createFakeCollection();
+
+        db.prepare(`
+            INSERT INTO SummarizationJobs (
+                session_id,
+                status,
+                result_envelope,
+                result_encoding,
+                result_staged_at
+            )
+            VALUES (?, 'completed', ?, ?, ?)
+        `).run('corrupt', Buffer.from('not-gzip'), SESSION_SUMMARY_RECEIPT_ENCODING, 100);
+
+        try {
+            await expect(recoverSessionSummaryReceipts({
+                db,
+                collection,
+                now: 200
+            })).rejects.toThrow(/envelope is corrupt/);
+
+            const row = db.prepare(`
+                SELECT status, result_envelope
+                FROM SummarizationJobs
+                WHERE session_id = 'corrupt'
+            `).get();
+
+            expect(row.status).toBe('completed');
+            expect(Buffer.from(row.result_envelope).toString()).toBe('not-gzip');
+            expect(collection.upsertCalls).toBe(0);
+        } finally {
+            db.close();
+        }
+    });
+
+    test('forced Chroma stop/restart recovers an acknowledged exact row without a summary model', async () => {
+        test.setTimeout(180_000);
+
+        const db                = createReceiptDb();
+        const dataDir           = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-chroma-unit-test-receipt-'));
+        const logPath           = path.join(os.tmpdir(), `neo-chroma-unit-test-receipt-${process.pid}-${Date.now()}.log`);
+        const host              = '127.0.0.1';
+        const port              = resolveFreePortSync();
+        const collectionName    = `receipt-${process.pid}-${Date.now()}`;
+        const embeddingFunction = createReceiptEmbeddingFunction();
+        const receipt           = createReceipt('forced-stop');
+        let   chromaPid         = null;
+
+        try {
+            chromaPid = await startChromaProcess({
+                repoRoot: process.cwd(),
+                dataDir,
+                host,
+                port,
+                logPath
+            });
+
+            let client     = new ChromaClient({host, port, ssl: false});
+            let collection = await client.getOrCreateCollection({
+                name: collectionName,
+                embeddingFunction
+            });
+
+            await collection.upsert({
+                ids      : [receipt.summaryId],
+                documents: [receipt.document],
+                metadatas: [receipt.metadata]
+            });
+            stageSessionSummaryReceipt({db, ...receipt, now: 100});
+            acknowledgeSessionSummaryReceipt({db, sessionId: receipt.sessionId, now: 101});
+
+            expect((await collection.get({
+                ids    : [receipt.summaryId],
+                include: ['documents', 'metadatas']
+            })).ids).toEqual([receipt.summaryId]);
+
+            const killTarget = process.platform === 'win32' ? chromaPid : -chromaPid;
+            process.kill(killTarget, 'SIGKILL');
+            await waitForProcessExit(chromaPid);
+            chromaPid = null;
+
+            chromaPid = await startChromaProcess({
+                repoRoot: process.cwd(),
+                dataDir,
+                host,
+                port,
+                logPath
+            });
+
+            client = new ChromaClient({host, port, ssl: false});
+            collection = await client.getOrCreateCollection({
+                name: collectionName,
+                embeddingFunction
+            });
+
+            // The production incident yielded exactly this post-restart state. Delete only the
+            // disposable fixture row when Chroma happened to flush it before SIGKILL, making the
+            // observed absence deterministic without touching any configured/shared collection.
+            await collection.delete({ids: [receipt.summaryId]});
+
+            const recovered = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                expectedDimension: 3,
+                now              : 200
+            });
+            const exact = await collection.get({
+                ids    : [receipt.summaryId],
+                include: ['documents', 'metadatas']
+            });
+
+            expect(recovered.replayed).toBe(1);
+            expect(exact.ids).toEqual([receipt.summaryId]);
+            expect(exact.documents).toEqual([receipt.document]);
+            expect(exact.metadatas).toEqual([receipt.metadata]);
+            expect(db.prepare(`
+                SELECT status, result_last_replayed_at
+                FROM SummarizationJobs
+                WHERE session_id = ?
+            `).get(receipt.sessionId)).toEqual({
+                status                 : 'completed',
+                result_last_replayed_at: 200
+            });
+        } finally {
+            if (chromaPid) {
+                await stopDetachedProcess(chromaPid);
+            }
+            if (db.open) db.close();
+
+            cleanupChromaArtifacts({
+                dataDir,
+                logPath,
+                ownsDataDir: true
+            });
+        }
+    });
+});


### PR DESCRIPTION
Resolves #16105

Session-summary completion now has a durable replay boundary: the existing SQLite `SummarizationJobs` row stores one compressed exact-result envelope per session, and recovery can reconstruct a missing deterministic Chroma row without invoking the summary model again. A job can only become `completed` after the envelope exists; strict Chroma read-back plus an optimistic envelope match prevents false or stale acknowledgement.

Evidence: L3 (disposable Chroma acknowledgement → SIGKILL → restart → exact replay with no model invocation) → L3 required (all restart and durability ACs). No residuals.

## Deltas from ticket

- The bounded policy is one current gzip-JSON envelope per existing coordinator row: a newer synthesis replaces it, and the existing session purge deletes it with the row. No append-only journal was added.
- Recovery scans bounded SQLite batches, skips live `in_progress` leases, replays exact missing or mismatched rows, verifies document and metadata, and acknowledges only when the staged envelope is still byte-identical.
- `#13462` drift repair remains the legacy fallback. Starting a new drift repair clears any stale prior envelope so recovery cannot replay the obsolete result.
- Envelope staging is the final side effect of `summarizeSession()`. This makes every staged result safe to replay because graph projection, links, and artifact ingestion have already succeeded.
- The disposable-Chroma witness kills and restarts a real process at the production seam. Since Chroma flush timing is nondeterministic, it deletes the disposable row after restart if that row survived, then proves deterministic exact recovery; separate tests cover already-present idempotence and interrupted recovery.
- A pre-existing degraded-fallback fixture now awaits `SessionService.ready()` before replacing the collection, preventing late initialization from reclaiming the fixture.

## Test Evidence

- Session-summary receipt storage/replay, coordinator migration, and resume semantics: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs test/playwright/unit/ai/graph/Database.spec.mjs` — 50 passed.
- Direct summary/degraded/model-routing/pagination regressions: focused four-spec run — 28 passed.
- `SessionService` isolation and purge behavior after the full-suite contention timeouts: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SessionService.spec.mjs` — 9 passed in 16.9s.
- Full unit suite: 10,199 passed, 5 skipped, 7 failed. Four failures were load-sensitive Memory Core/local-model timeouts that passed in the focused runs above; the other three were an unrelated MCP boot check, watchdog timing assertion, and profiling threshold miss (403.2ms vs 400ms).
- Commit-time staged gates passed for all seven files: whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, AiConfig mutation, and derived-domain checks.

## Post-Merge Validation

- [ ] Observe the next natural local Chroma max-runtime recycle and confirm completed deterministic summary IDs remain present or are recovered from their durable envelopes without model synthesis.

Authored by Euclid (GPT-5 Codex, Codex Desktop). Session 019fa530-53d6-7271-bf05-51497720b29c.
