### PR TITLE
feat(build): validate declared commit type in agent preflight (#16111)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -13,12 +13,12 @@ Before the final `git commit` and `gh pr create`—an irreversible Agent OS hand
 
 *If and only if* you pass this reflection phase, proceed to the Git execution sequence.
 
-Before the first commit or PR-body attempt on an agent-authored PR, run
-`npm run agent-preflight -- [files...]` when you want the repair-capable pass
-that may run `check-block-alignment --fix`. For final validation without file
-mutation, run `npm run agent-preflight -- --no-fix [files...]`; when a local PR
-body draft exists, include `-- --pr-body <draft-body.md>` so local source and
-PR-body gate failures surface before CI.
+Before the first commit, declare §3.1's class (`capability`, `restoration`, or
+`zero-delta`) and run `npm run agent-preflight -- --change-class <class>
+--commit-subject "<subject>" [files...]`. This repair pass may align blocks. For
+final check-only validation, add `--no-fix`, `--pr-title "<title>"`, and, when
+available, `--pr-body <draft-body.md>`. The same class then gates both subjects.
+Calls without semantic inputs stay diagnostic-compatible; partial inputs fail.
 
 ### 1.1 The Substrate-Mutation Pre-Flight Gate
 
@@ -87,15 +87,19 @@ Your commit messages MUST follow Conventional Commits and MUST append the ticket
 
 ### 3.1 Type Selection
 
-- **`feat`** — the change unlocks a new capability that did not exist before. Harness integrations, new workflows, new tooling surfaces, and any agent- or user-facing feature all fall here.
-- **`fix`** — restores broken behavior. Use when a regression, race condition, or incorrect output is being corrected.
-- **`chore`** — pure maintenance with zero behavioral or capability delta. Dependency bumps, auto-generated syncs, typo fixes, and similar housekeeping only.
+Classify the delivered delta in order; the first match wins:
 
-Decision rule: *"Does this enable a new capability that did not exist before?"* → `feat`. When ambiguous, default to `feat`; `chore` is the narrowest category.
+1. **`capability` → `feat`** — adds reusable, operable, or separately testable
+   behavior/path. This wins even when a bug motivated the work.
+2. **`restoration` → `fix`** — adds no capability; corrects defined behavior.
+3. **`zero-delta` → `chore`** — changes neither behavior nor capability.
+
+Ticket labels, filenames, and diff size do not decide the class. The author
+declares it; `agent-preflight` verifies the supplied subjects without inference.
 
 ### 3.2 Commit Message Hygiene
 
-- **FORBIDDEN:** `Co-Authored-By: <name> <noreply@*>` footers. Some AI harnesses (notably Claude Code) inject these by default — you MUST override that behavior. **Canonical agent emails for required Co-Authored-By trailers (real, project-controlled addresses):** `neo-opus-4-7@neomjs.com`, `neo-gemini-3-1-pro@neomjs.com`, `neo-gpt@neomjs.com`. The machine-account primary email is operator-configured (out of agent scope); squash-merge auto-attribution resolves to `@neomjs.com` once accounts use these as primary. Agent participation is tracked across multiple substrates: ticket body, PR labels (`ai`, `ai-generated`), Memory Core origin-session IDs, and `@neomjs.com` Co-authored-by trailers in git history (the long-term distributed memory + RLAIF flywheel substrate per `README.md` §The Evolution).
+- **FORBIDDEN:** `Co-Authored-By: <name> <noreply@*>` footers. Some AI harnesses (notably Claude Code) inject these by default — you MUST override that behavior. **Canonical agent emails for required Co-Authored-By trailers (real, project-controlled addresses):** `neo-opus-4-7@neomjs.com`, `neo-gemini-3-1-pro@neomjs.com`, `neo-gpt@neomjs.com`. The machine-account primary email is operator-configured (out of agent scope); squash-merge auto-attribution resolves to `@neomjs.com` once accounts use these as primary. Agent participation is tracked across multiple substrates: ticket body, PR labels (`ai`, `ai-generated`), Memory Core origin-session IDs, and `@neomjs.com` Co-authored-by trailers in git history (the long-term distributed memory + RLAIF flywheel substrate per [`The Evolution`](../../../../README.md#the-evolution)).
 - **MANDATORY:** append the ticket ID to the subject line in `(#TICKET_ID)` form — e.g. `feat(claude): wire harness (#10059)`. A trailing paragraph like `Refs #N` is non-compliant. The `Resolves #N` keyword belongs in the PR body, not the commit.
 
 ### 3.3 Steps

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -28,7 +28,14 @@ export const INVISIBLE_PR_BODY_ANCHORS = [
 const
     RESOLVES_PATTERN              = /\bResolves:?\s+#\d+/i,
     NON_CLOSING_REFERENCE_PATTERN = /\b(Refs|Related):?\s+#\d+/i,
-    FORBIDDEN_CLOSE_PATTERN       = /\b(Closes|Fixes):?\s+#\d+/i;
+    FORBIDDEN_CLOSE_PATTERN       = /\b(Closes|Fixes):?\s+#\d+/i,
+    CONVENTIONAL_TYPE_PATTERN     = /^([a-z][a-z0-9-]*)(?:\([^()\r\n]+\))?!?:\s+\S/;
+
+export const CHANGE_CLASS_TO_TYPE = Object.freeze({
+    capability  : 'feat',
+    restoration : 'fix',
+    'zero-delta': 'chore'
+});
 
 /**
  * @summary Builds the Commander program for the agent preflight helper.
@@ -39,6 +46,9 @@ export function createProgram() {
         .name('agent-preflight')
         .description('Runs the agent commit/PR preflight gates in one pass; default mode may repair block alignment.')
         .usage('[options] [files...]')
+        .option('--change-class <class>', 'Declare capability, restoration, or zero-delta for subject validation.')
+        .option('--commit-subject <subject>', 'Validate the intended commit subject against --change-class.')
+        .option('--pr-title <title>', 'Validate the intended PR title against --change-class.')
         .option('--pr-body <file>', 'Run local PR-body template lint against the given markdown file.')
         .option('--pr-draft', 'Validate --pr-body as a draft PR: Refs/Related may temporarily stand in for Resolves.')
         .option('--no-fix', 'Check-only mode: skip the check-block-alignment --fix repair pass.')
@@ -60,11 +70,14 @@ export function parseArgs(argv) {
     const options = program.opts();
 
     return {
-        files  : program.args,
-        fix    : options.fix,
-        help   : false,
-        prBody : options.prBody || null,
-        prDraft: options.prDraft || false
+        changeClass  : options.changeClass || null,
+        commitSubject: options.commitSubject || null,
+        files        : program.args,
+        fix          : options.fix,
+        help         : false,
+        prBody       : options.prBody || null,
+        prDraft      : options.prDraft || false,
+        prTitle      : options.prTitle || null
     }
 }
 
@@ -99,6 +112,83 @@ export function filterMjsFiles(files) {
 }
 
 /**
+ * @summary Validates the author's explicit semantic change class against intended Conventional Commit subjects.
+ *
+ * The author owns the semantic classification. This guard deliberately does not inspect issue labels, changed
+ * files, or diff size; it only maps the declared class to its required type and checks the supplied surfaces.
+ *
+ * @param {Object} [options]
+ * @param {String|null} [options.changeClass]
+ * @param {String|null} [options.commitSubject]
+ * @param {String|null} [options.prTitle]
+ * @returns {{errors: String[], expectedType: String|null, skipped: Boolean, valid: Boolean}}
+ */
+export function validateChangeClass({
+    changeClass = null,
+    commitSubject = null,
+    prTitle = null
+} = {}) {
+    const
+        subjects = [
+            {label: 'commit subject', value: commitSubject},
+            {label: 'PR title',       value: prTitle}
+        ].filter(({value}) => Boolean(value)),
+        hasInput = Boolean(changeClass) || subjects.length > 0;
+
+    if (!hasInput) {
+        return {
+            errors      : [],
+            expectedType: null,
+            skipped     : true,
+            valid       : true
+        }
+    }
+
+    const
+        errors       = [],
+        expectedType = Object.hasOwn(CHANGE_CLASS_TO_TYPE, changeClass)
+            ? CHANGE_CLASS_TO_TYPE[changeClass]
+            : null;
+
+    if (!changeClass) {
+        errors.push('`--change-class` is required when `--commit-subject` or `--pr-title` is provided.')
+    } else if (!expectedType) {
+        errors.push(
+            `Unknown change class \`${changeClass}\`; expected capability, restoration, or zero-delta.`
+        )
+    }
+
+    if (subjects.length === 0) {
+        errors.push('`--change-class` requires at least one `--commit-subject` or `--pr-title` to validate.')
+    }
+
+    if (expectedType) {
+        subjects.forEach(({label, value}) => {
+            const match = value.match(CONVENTIONAL_TYPE_PATTERN);
+
+            if (!match) {
+                errors.push(
+                    `${label} is missing a valid Conventional Commit prefix; change class ` +
+                    `\`${changeClass}\` requires \`${expectedType}\`.`
+                )
+            } else if (match[1] !== expectedType) {
+                errors.push(
+                    `${label} declares \`${match[1]}\`, but change class \`${changeClass}\` ` +
+                    `requires \`${expectedType}\`.`
+                )
+            }
+        })
+    }
+
+    return {
+        errors,
+        expectedType,
+        skipped: false,
+        valid  : errors.length === 0
+    }
+}
+
+/**
  * @summary Mirrors the Agent PR Body Lint workflow's local body-shape checks.
  * @param {String} body
  * @param {Object} [options]
@@ -107,10 +197,10 @@ export function filterMjsFiles(files) {
  */
 export function validatePrBody(body, {draft = false} = {}) {
     const
-        missingVisible        = VISIBLE_PR_BODY_ANCHORS.filter(anchor => !body.includes(anchor)),
-        missingInvisible      = INVISIBLE_PR_BODY_ANCHORS.filter(anchor => !body.includes(anchor)),
-        forbiddenClose        = body.match(FORBIDDEN_CLOSE_PATTERN),
-        hasResolves           = RESOLVES_PATTERN.test(body),
+        missingVisible         = VISIBLE_PR_BODY_ANCHORS.filter(anchor => !body.includes(anchor)),
+        missingInvisible       = INVISIBLE_PR_BODY_ANCHORS.filter(anchor => !body.includes(anchor)),
+        forbiddenClose         = body.match(FORBIDDEN_CLOSE_PATTERN),
+        hasResolves            = RESOLVES_PATTERN.test(body),
         hasNonClosingReference = NON_CLOSING_REFERENCE_PATTERN.test(body);
 
     if (forbiddenClose) {
@@ -394,6 +484,24 @@ export function runAgentPreflight({
         }
     }
 
+    const changeClassResult = validateChangeClass(options);
+
+    if (changeClassResult.skipped) {
+        writeLine(stdout, 'agent-preflight: no semantic inputs provided; skipped change-class validation.');
+    } else if (changeClassResult.valid) {
+        const surfaceCount = [options.commitSubject, options.prTitle].filter(Boolean).length;
+
+        writeLine(
+            stdout,
+            `agent-preflight: declared ${options.changeClass} maps to ${changeClassResult.expectedType}; ` +
+            `${surfaceCount} intended subject${surfaceCount === 1 ? '' : 's'} matched.`
+        )
+    } else {
+        failures.push('change-class');
+        writeLine(stderr, 'agent-preflight: change-class validation failed.');
+        changeClassResult.errors.forEach(error => writeLine(stderr, `  - ${error}`))
+    }
+
     // Advisory-only local overlay drift check. Gitignored config.mjs overlays can go stale even when the
     // staged source gates are green; surfacing the exact STALE_OVERLAY rows here prevents false-green PR
     // churn without mutating operator-local files or failing unrelated preflight runs.
@@ -415,7 +523,7 @@ export function runAgentPreflight({
         const result = runPrBodyGate({
             cwd,
             existsSyncImpl,
-            prBody: options.prBody,
+            prBody : options.prBody,
             prDraft: options.prDraft,
             readFileSyncImpl
         });

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -9,6 +9,7 @@ import {
     normalizeSignatureShape,
     parseArgs,
     runAgentPreflight,
+    validateChangeClass,
     validatePrBody
 }                     from '../../../../../../buildScripts/util/agent-preflight.mjs';
 
@@ -54,6 +55,10 @@ test.describe('agent-preflight utility', () => {
         expect(help).toContain('Usage: agent-preflight [options] [files...]');
         expect(help).toContain('default mode may repair');
         expect(help).toContain('block alignment');
+        expect(help).toContain('--change-class <class>');
+        expect(help).toContain('capability, restoration, or zero-delta');
+        expect(help).toContain('--commit-subject <subject>');
+        expect(help).toContain('--pr-title <title>');
         expect(help).toContain('--pr-body <file>');
         expect(help).toContain('--pr-draft');
         expect(help).toContain('--no-fix');
@@ -61,18 +66,32 @@ test.describe('agent-preflight utility', () => {
     });
 
     test('parses files, optional PR body, and fix mode through Commander', () => {
-        expect(parseArgs(['--pr-body', 'body.md', '--pr-draft', '--no-fix', 'src/a.mjs'])).toEqual({
-            files  : ['src/a.mjs'],
-            fix    : false,
-            help   : false,
-            prBody : 'body.md',
-            prDraft: true
+        expect(parseArgs([
+            '--change-class', 'capability',
+            '--commit-subject', 'feat(build): add a guard (#16111)',
+            '--pr-title', 'feat(build): add a guard (#16111)',
+            '--pr-body', 'body.md',
+            '--pr-draft',
+            '--no-fix',
+            'src/a.mjs'
+        ])).toEqual({
+            changeClass  : 'capability',
+            commitSubject: 'feat(build): add a guard (#16111)',
+            files        : ['src/a.mjs'],
+            fix          : false,
+            help         : false,
+            prBody       : 'body.md',
+            prDraft      : true,
+            prTitle      : 'feat(build): add a guard (#16111)'
         });
     });
 
     test('uses Commander option validation for unknown flags and missing values', () => {
         expect(() => parseArgs(['--bogus'])).toThrow();
-        expect(() => parseArgs(['--pr-body'])).toThrow()
+        expect(() => parseArgs(['--pr-body'])).toThrow();
+        expect(() => parseArgs(['--change-class'])).toThrow();
+        expect(() => parseArgs(['--commit-subject'])).toThrow();
+        expect(() => parseArgs(['--pr-title'])).toThrow()
     });
 
     test('filters source gates to .mjs files', () => {
@@ -288,6 +307,113 @@ test.describe('agent-preflight utility', () => {
         expect(stderr).toContain('Visible/body-closing misses:');
         expect(stderr).toContain('Structural template anchors are missing');
         expect(stderr).toContain('agent-preflight: 1 gate(s) failed: pr-body')
+    })
+});
+
+test.describe('agent-preflight — ordered change classes (#16111)', () => {
+    test('remains backward compatible when no semantic inputs are supplied', () => {
+        expect(validateChangeClass()).toEqual({
+            errors      : [],
+            expectedType: null,
+            skipped     : true,
+            valid       : true
+        })
+    });
+
+    test('accepts valid feat, fix, and chore controls', () => {
+        expect(validateChangeClass({
+            changeClass  : 'capability',
+            commitSubject: 'feat(build): add a preflight capability (#16111)',
+            prTitle      : 'feat(build)!: add a preflight capability (#16111)'
+        }).valid).toBe(true);
+        expect(validateChangeClass({
+            changeClass  : 'restoration',
+            commitSubject: 'fix(build): restore existing validation (#16111)'
+        }).valid).toBe(true);
+        expect(validateChangeClass({
+            changeClass: 'zero-delta',
+            prTitle    : 'chore(build): refresh generated metadata (#16111)'
+        }).valid).toBe(true)
+    });
+
+    test('rejects the exact capability misclassification shapes from #10061 and PR #16110', () => {
+        const result = validateChangeClass({
+            changeClass  : 'capability',
+            commitSubject: 'chore(claude): add per-agent skill discovery (#10059)',
+            prTitle      : 'fix(memory-core): make summary receipts replayable (#16105)'
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.expectedType).toBe('feat');
+        expect(result.errors).toEqual([
+            'commit subject declares `chore`, but change class `capability` requires `feat`.',
+            'PR title declares `fix`, but change class `capability` requires `feat`.'
+        ])
+    });
+
+    test('rejects chore for a restoration delta', () => {
+        const result = validateChangeClass({
+            changeClass  : 'restoration',
+            commitSubject: 'chore(core): restore the existing lifecycle (#16111)'
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain('change class `restoration` requires `fix`')
+    });
+
+    test('fails closed for partial inputs, unknown classes, and missing prefixes', () => {
+        expect(validateChangeClass({
+            commitSubject: 'feat(build): add a guard (#16111)'
+        }).errors).toContain(
+            '`--change-class` is required when `--commit-subject` or `--pr-title` is provided.'
+        );
+        expect(validateChangeClass({
+            changeClass: 'capability'
+        }).errors).toContain(
+            '`--change-class` requires at least one `--commit-subject` or `--pr-title` to validate.'
+        );
+        expect(validateChangeClass({
+            changeClass  : 'documentation',
+            commitSubject: 'docs: explain the guard (#16111)'
+        }).errors).toContain(
+            'Unknown change class `documentation`; expected capability, restoration, or zero-delta.'
+        );
+        expect(validateChangeClass({
+            changeClass  : 'toString',
+            commitSubject: 'feat(build): evade an inherited-key check (#16111)'
+        }).errors).toContain(
+            'Unknown change class `toString`; expected capability, restoration, or zero-delta.'
+        );
+        expect(validateChangeClass({
+            changeClass  : 'capability',
+            commitSubject: 'add a guard'
+        }).errors[0]).toContain('missing a valid Conventional Commit prefix')
+    });
+
+    test('checks commit subject and PR title against the same declared class in the CLI path', () => {
+        let stdout = '';
+        let stderr = '';
+
+        const status = runAgentPreflight({
+            argv: [
+                '--change-class', 'capability',
+                '--commit-subject', 'feat(build): add a guard (#16111)',
+                '--pr-title', 'fix(build): add a guard (#16111)'
+            ],
+            collectStaleOverlayFindingsImpl: () => [],
+            cwd                            : '/repo',
+            execFileSyncImpl               : cmd => cmd === 'git' ? '' : '',
+            existsSyncImpl                 : () => false,
+            readFileSyncImpl               : () => '',
+            stderr                         : {write: value => { stderr += value }},
+            stdout                         : {write: value => { stdout += value }}
+        });
+
+        expect(status).toBe(1);
+        expect(stdout).toContain('0 .mjs files in scope');
+        expect(stderr).toContain('change-class validation failed');
+        expect(stderr).toContain('PR title declares `fix`');
+        expect(stderr).toContain('1 gate(s) failed: change-class')
     })
 });
 


### PR DESCRIPTION
Resolves #16111

This makes Conventional Commit type selection an ordered semantic decision and gives `agent-preflight` explicit inputs to verify that decision against the intended commit subject and PR title. The guard validates the author's declaration only; it never infers semantics from issue labels, filenames, or diff size.

Evidence: L2 exact-head local evidence achieved for every ticket AC; L3 repository CI remains the publication boundary. Residual: none identified for #16111.

Source-ticket Contract Ledger: https://github.com/neomjs/neo/issues/16111#issuecomment-5108697732

## Deltas from ticket

- Hardened the class lookup against inherited `Object.prototype` keys such as `toString`.
- Replaced one pre-existing ambiguous `README.md §The Evolution` prose reference with a resolvable heading link because the directly relevant skill-manifest gate exposed it.

## Substrate Slot Rationale

- **Disposition:** `rewrite` of the existing pull-request workflow invocation and §3.1 type-selection contract; no new rule section or skill.
- **Why this slot:** the decision applies specifically at commit/PR lifecycle events, so the existing conditional pull-request skill remains the owning substrate.
- **Frequency × severity × enforceability:** every agent-authored PR × history rewrite/CI-restart cost × high local enforceability through the existing preflight command.
- **Load effect:** `.agents/skills/pull-request/SKILL.md`, the skills manifest, and all always-loaded surfaces are unchanged. The edited reference remains conditionally loaded only when the pull-request skill fires, shrinks by 37 bytes against `origin/dev` (`21,292 → 21,255`), and passes the same base-aware skill-manifest lint used by CI.
- **Mechanical audit:** `.codex/hooks.json` routes prompt injection through `.codex/hooks/codex-context.mjs`; that hook reads only `.codex/CODEX.md`; repository `context.fileName` search found no second Codex load path; `.claude/CLAUDE.md` resolves to `../AGENTS.md`. No duplicate load path reaches this workflow reference.
- **Decision Record impact:** aligned with ADR 0008; this changes an existing World-Atlas payload and adds enforcement in an existing build helper without router growth.

## Test Evidence

- `npm run agent-preflight -- --no-fix --change-class capability --commit-subject "feat(build): validate declared commit type in agent preflight (#16111)" --pr-title "feat(build): validate declared commit type in agent preflight (#16111)" ...` — pass at `812fadf77f9d2819d8746035b8a5b5203d3d451b`; both subjects matched `feat`.
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs` — 85 passed at the exact head.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` — pass; the workflow reference shrank by 37 bytes (`21,292 → 21,255`).
- `git diff --check origin/dev...HEAD` — pass.
- Full `npm run test-unit` diagnostic — 10,208 passed, 9 failed, 5 skipped, 2 did not run. The relevant manifest failure was corrected. Bounded reruns passed for DragCoordinator, Knowledge Base sync, and HealthService; the credential-backed GitHub health/diff pair then passed 92/92. No remaining failure intersected the touched surfaces.

## Post-Merge Validation

- [ ] Confirm the first downstream agent-authored PR uses one declared class for both subjects and fails locally on a deliberate mismatched type.

## Deltas

The implementation stayed within the three ticket-declared files. The inherited-key guard and resolvable README heading link are the only minor hardening deltas noted above.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session `019fa906-0873-7e63-aa2b-2728755b3357`.