### PR TITLE
fix(memory-core): scope receipt equality to owned metadata (#16114)

### DIFF
--- a/ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs
+++ b/ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs
@@ -55,13 +55,13 @@ const OPTIONAL_RECEIPT_METADATA_KEYS = new Set([
     'unclassifiedSourceCount',
     'userId'
 ]);
-const REQUIRED_RECEIPT_METADATA_KEYS = SESSION_SUMMARY_RECEIPT_METADATA_KEYS.filter(
+export const REQUIRED_RECEIPT_METADATA_KEYS = Object.freeze(SESSION_SUMMARY_RECEIPT_METADATA_KEYS.filter(
     key => !OPTIONAL_RECEIPT_METADATA_KEYS.has(key)
-);
+));
 const SESSION_SUMMARY_RECEIPT_METADATA_KEY_SET = new Set(SESSION_SUMMARY_RECEIPT_METADATA_KEYS);
 
 /**
- * @summary Validates the exact deterministic summary row carried by a receipt.
+ * @summary Validates the stable outer structure shared by current and historical receipts.
  * @param {Object} receipt
  * @param {String} receipt.sessionId
  * @param {String} receipt.summaryId
@@ -69,7 +69,7 @@ const SESSION_SUMMARY_RECEIPT_METADATA_KEY_SET = new Set(SESSION_SUMMARY_RECEIPT
  * @param {Object} receipt.metadata
  * @returns {Object} The validated receipt.
  */
-function validateReceipt(receipt) {
+function validateReceiptStructure(receipt) {
     if (typeof receipt?.sessionId !== 'string' || !receipt.sessionId) {
         throw new TypeError('Session-summary receipt requires a non-empty sessionId.');
     }
@@ -83,6 +83,21 @@ function validateReceipt(receipt) {
         throw new TypeError('Session-summary receipt metadata must be an object.');
     }
 
+    return receipt;
+}
+
+/**
+ * @summary Enforces the current synthesis-owned metadata contract when issuing a receipt.
+ *
+ * Decode intentionally uses only structural validation because persisted version-1 envelopes
+ * predate the metadata key-set contract. This strict issuance boundary prevents new drift
+ * without making historical durable recovery dependent on today's metadata schema.
+ *
+ * @param {Object} receipt
+ * @returns {Object} The validated current receipt.
+ */
+function validateReceiptIssuance(receipt) {
+    const validated           = validateReceiptStructure(receipt);
     const unknownMetadataKeys = Object.keys(receipt.metadata)
         .filter(key => !SESSION_SUMMARY_RECEIPT_METADATA_KEY_SET.has(key));
     if (unknownMetadataKeys.length > 0) {
@@ -95,7 +110,7 @@ function validateReceipt(receipt) {
         throw new TypeError(`Session-summary receipt metadata is missing owned keys: ${missingMetadataKeys.join(', ')}.`);
     }
 
-    return receipt;
+    return validated;
 }
 
 /**
@@ -104,7 +119,7 @@ function validateReceipt(receipt) {
  * @returns {Buffer}
  */
 export function encodeSessionSummaryReceipt(receipt) {
-    const validated = validateReceipt(receipt);
+    const validated = validateReceiptIssuance(receipt);
 
     return gzipSync(Buffer.from(JSON.stringify({
         version  : 1,
@@ -141,7 +156,7 @@ export function decodeSessionSummaryReceipt(envelope, encoding) {
         throw new Error(`Unsupported session-summary receipt version: ${String(receipt?.version)}.`);
     }
 
-    return validateReceipt(receipt);
+    return validateReceiptStructure(receipt);
 }
 
 /**

--- a/ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs
+++ b/ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs
@@ -16,7 +16,49 @@ import {verifyPersistedVector} from './verifyPersistedVector.mjs';
 
 export const SESSION_SUMMARY_RECEIPT_ENCODING = 'gzip-json-v1';
 
-const DEFAULT_RECOVERY_BATCH_SIZE = 100;
+/**
+ * @summary Declares the complete metadata write-set owned by session-summary synthesis.
+ *
+ * `unclassifiedSourceCount` and `userId` are conditional at issuance; every other key is
+ * required. Keeping the allowed set explicit makes a new or accidentally dropped synthesis
+ * field fail at the receipt boundary instead of silently narrowing replay verification.
+ * Dream-owned overlays such as `graphDigested` and `digestState` deliberately remain outside
+ * this boundary.
+ */
+export const SESSION_SUMMARY_RECEIPT_METADATA_KEYS = Object.freeze([
+    'sessionId',
+    'timestamp',
+    'memoryCount',
+    'title',
+    'category',
+    'quality',
+    'productivity',
+    'impact',
+    'complexity',
+    'technologies',
+    'participatingAgents',
+    'models',
+    'totalToolCalls',
+    'toolsUsed',
+    'sourceAgentIdentities',
+    'sourceTrustTier',
+    'provenancePolicy',
+    'sourceTier',
+    'degraded',
+    'rawCanonical',
+    'unclassifiedSourceCount',
+    'userId'
+]);
+
+const DEFAULT_RECOVERY_BATCH_SIZE    = 100;
+const OPTIONAL_RECEIPT_METADATA_KEYS = new Set([
+    'unclassifiedSourceCount',
+    'userId'
+]);
+const REQUIRED_RECEIPT_METADATA_KEYS = SESSION_SUMMARY_RECEIPT_METADATA_KEYS.filter(
+    key => !OPTIONAL_RECEIPT_METADATA_KEYS.has(key)
+);
+const SESSION_SUMMARY_RECEIPT_METADATA_KEY_SET = new Set(SESSION_SUMMARY_RECEIPT_METADATA_KEYS);
 
 /**
  * @summary Validates the exact deterministic summary row carried by a receipt.
@@ -39,6 +81,18 @@ function validateReceipt(receipt) {
     }
     if (!receipt.metadata || typeof receipt.metadata !== 'object' || Array.isArray(receipt.metadata)) {
         throw new TypeError('Session-summary receipt metadata must be an object.');
+    }
+
+    const unknownMetadataKeys = Object.keys(receipt.metadata)
+        .filter(key => !SESSION_SUMMARY_RECEIPT_METADATA_KEY_SET.has(key));
+    if (unknownMetadataKeys.length > 0) {
+        throw new TypeError(`Session-summary receipt metadata contains unowned keys: ${unknownMetadataKeys.join(', ')}.`);
+    }
+
+    const missingMetadataKeys = REQUIRED_RECEIPT_METADATA_KEYS
+        .filter(key => !Object.hasOwn(receipt.metadata, key));
+    if (missingMetadataKeys.length > 0) {
+        throw new TypeError(`Session-summary receipt metadata is missing owned keys: ${missingMetadataKeys.join(', ')}.`);
     }
 
     return receipt;
@@ -194,14 +248,30 @@ export function acknowledgeSessionSummaryReceipt({db, sessionId, now = Date.now(
 }
 
 /**
- * @summary Compares one Chroma read-back row with its durable exact envelope.
+ * @summary Compares one Chroma row with the synthesis-owned fields in its durable receipt.
+ *
+ * DreamService legitimately adds graph-digestion lifecycle fields to the same metadata
+ * object after synthesis. Those downstream-owned overlays do not make the acknowledged
+ * synthesis result stale. The receipt remains exact for its document and every declared
+ * metadata key present at issuance; a missing or changed receipt-owned value still requires
+ * replay.
+ *
  * @param {Object|undefined} row
  * @param {Object} receipt
  * @returns {Boolean}
  */
-function isExactSummaryRow(row, receipt) {
-    return row?.document === receipt.document &&
-        isDeepStrictEqual(row.metadata, receipt.metadata);
+function matchesSessionSummaryReceipt(row, receipt) {
+    if (row?.document !== receipt.document || !row.metadata) {
+        return false;
+    }
+
+    return SESSION_SUMMARY_RECEIPT_METADATA_KEYS.every(key => {
+        const receiptHasKey = Object.hasOwn(receipt.metadata, key),
+              rowHasKey     = Object.hasOwn(row.metadata, key);
+
+        return receiptHasKey === rowHasKey &&
+            (!receiptHasKey || isDeepStrictEqual(row.metadata[key], receipt.metadata[key]));
+    });
 }
 
 /**
@@ -351,7 +421,7 @@ export async function recoverSessionSummaryReceipts({
             let liveRows = mapSummaryRows(liveResult);
 
             const toReplay = recoverable.filter(item =>
-                !isExactSummaryRow(liveRows.get(item.receipt.summaryId), item.receipt)
+                !matchesSessionSummaryReceipt(liveRows.get(item.receipt.summaryId), item.receipt)
             );
 
             if (toReplay.length > 0) {
@@ -368,7 +438,7 @@ export async function recoverSessionSummaryReceipts({
                 liveRows = mapSummaryRows(readBack);
 
                 for (const item of toReplay) {
-                    if (!isExactSummaryRow(liveRows.get(item.receipt.summaryId), item.receipt)) {
+                    if (!matchesSessionSummaryReceipt(liveRows.get(item.receipt.summaryId), item.receipt)) {
                         throw new Error(`Session-summary receipt replay verification failed for ${item.receipt.summaryId}.`);
                     }
 

--- a/test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs
@@ -1,6 +1,7 @@
 import fs   from 'node:fs';
 import os   from 'node:os';
 import path from 'node:path';
+import {gzipSync} from 'node:zlib';
 
 import {knownEmbeddingFunctions, registerEmbeddingFunction, ChromaClient} from 'chromadb';
 import Database                                                           from 'better-sqlite3';
@@ -15,6 +16,7 @@ import {
     decodeSessionSummaryReceipt,
     encodeSessionSummaryReceipt,
     recoverSessionSummaryReceipts,
+    REQUIRED_RECEIPT_METADATA_KEYS,
     SESSION_SUMMARY_RECEIPT_ENCODING,
     SESSION_SUMMARY_RECEIPT_METADATA_KEYS,
     stageSessionSummaryReceipt
@@ -192,7 +194,7 @@ test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
         const receipt = createReceipt('owned-key-set');
 
         expect(Object.keys(receipt.metadata))
-            .toEqual(SESSION_SUMMARY_RECEIPT_METADATA_KEYS.slice(0, -2));
+            .toEqual(REQUIRED_RECEIPT_METADATA_KEYS);
         expect(() => encodeSessionSummaryReceipt({
             ...receipt,
             metadata: {
@@ -565,6 +567,53 @@ test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
             expect(row.status).toBe('completed');
             expect(Buffer.from(row.result_envelope).toString()).toBe('not-gzip');
             expect(collection.upsertCalls).toBe(0);
+        } finally {
+            db.close();
+        }
+    });
+
+    test('recovers a shape-drifted historical envelope without weakening current issuance', async () => {
+        const db         = createReceiptDb();
+        const collection = createFakeCollection();
+        const receipt    = createReceipt('historical-shape');
+
+        delete receipt.metadata.rawCanonical;
+        receipt.metadata.retiredSynthesisField = 'historical-value';
+
+        db.prepare(`
+            INSERT INTO SummarizationJobs (
+                session_id,
+                status,
+                result_envelope,
+                result_encoding,
+                result_staged_at
+            )
+            VALUES (?, 'completed', ?, ?, ?)
+        `).run(
+            receipt.sessionId,
+            gzipSync(Buffer.from(JSON.stringify({version: 1, ...receipt}), 'utf8')),
+            SESSION_SUMMARY_RECEIPT_ENCODING,
+            100
+        );
+
+        try {
+            const result = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                now: 200
+            });
+
+            expect(result).toMatchObject({
+                scanned  : 1,
+                replayed : 1,
+                completed: 1
+            });
+            expect(collection.rows.get(receipt.summaryId)).toEqual({
+                document: receipt.document,
+                metadata: receipt.metadata
+            });
+            expect(() => encodeSessionSummaryReceipt(receipt))
+                .toThrow(/unowned keys: retiredSynthesisField/);
         } finally {
             db.close();
         }

--- a/test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs
@@ -8,12 +8,15 @@ import {setup}                                                            from '
 import {test, expect}                                                     from '@playwright/test';
 
 import '../../../../../../../src/Neo.mjs';
+import '../../../../../../../src/core/_export.mjs';
 
 import {
     acknowledgeSessionSummaryReceipt,
     decodeSessionSummaryReceipt,
+    encodeSessionSummaryReceipt,
     recoverSessionSummaryReceipts,
     SESSION_SUMMARY_RECEIPT_ENCODING,
+    SESSION_SUMMARY_RECEIPT_METADATA_KEYS,
     stageSessionSummaryReceipt
 } from '../../../../../../../ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs';
 import {
@@ -73,10 +76,25 @@ function createReceipt(sessionId, overrides = {}) {
         document : `Summary for ${sessionId}`,
         metadata : {
             sessionId,
-            timestamp  : 1_800_000_000_000,
-            memoryCount: 2,
-            title      : 'Durable summary',
-            degraded   : false
+            timestamp            : 1_800_000_000_000,
+            memoryCount          : 2,
+            title                : 'Durable summary',
+            category             : 'implementation',
+            quality              : 80,
+            productivity         : 90,
+            impact               : 70,
+            complexity           : 40,
+            technologies         : 'Neo.mjs',
+            participatingAgents  : 'neo-gpt',
+            models               : 'gpt-5',
+            totalToolCalls       : 12,
+            toolsUsed            : 'run_shell_command',
+            sourceAgentIdentities: '@neo-gpt',
+            sourceTrustTier      : 'trusted',
+            provenancePolicy     : 'most-restrictive-source',
+            sourceTier           : 'raw',
+            degraded             : false,
+            rawCanonical         : true
         },
         ...overrides
     };
@@ -107,10 +125,17 @@ function createFakeCollection() {
         async upsert({ids, documents, metadatas}) {
             this.upsertCalls++;
 
-            ids.forEach((id, index) => rows.set(id, {
-                document: documents[index],
-                metadata: structuredClone(metadatas[index])
-            }));
+            ids.forEach((id, index) => {
+                const current = rows.get(id);
+
+                rows.set(id, {
+                    document: documents[index],
+                    metadata: {
+                        ...(current?.metadata || {}),
+                        ...structuredClone(metadatas[index])
+                    }
+                });
+            });
         }
     };
 }
@@ -160,8 +185,31 @@ function createReceiptEmbeddingFunction() {
     return embeddingFunction;
 }
 
-test.describe('sessionSummaryReceiptStore (#16105)', () => {
+test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
     test.describe.configure({mode: 'serial'});
+
+    test('enforces the declared synthesis-owned metadata key set at issuance', () => {
+        const receipt = createReceipt('owned-key-set');
+
+        expect(Object.keys(receipt.metadata))
+            .toEqual(SESSION_SUMMARY_RECEIPT_METADATA_KEYS.slice(0, -2));
+        expect(() => encodeSessionSummaryReceipt({
+            ...receipt,
+            metadata: {
+                ...receipt.metadata,
+                graphDigested: true
+            }
+        })).toThrow(/unowned keys: graphDigested/);
+
+        const missingTitle = {...receipt.metadata};
+
+        delete missingTitle.title;
+
+        expect(() => encodeSessionSummaryReceipt({
+            ...receipt,
+            metadata: missingTitle
+        })).toThrow(/missing owned keys: title/);
+    });
 
     test('stages one compressed exact envelope and completes only through that durable receipt', () => {
         const db      = createReceiptDb();
@@ -318,6 +366,125 @@ test.describe('sessionSummaryReceiptStore (#16105)', () => {
                 result_acknowledged_at : 101,
                 result_last_replayed_at: 200
             });
+        } finally {
+            db.close();
+        }
+    });
+
+    test('accepts Dream-owned metadata overlays while keeping receipt-owned values strict', async () => {
+        const db         = createReceiptDb();
+        const collection = createFakeCollection();
+        const receipt    = createReceipt('dream-overlay');
+        const dreamState = {
+            digestState  : 'digested',
+            graphDigested: true
+        };
+
+        try {
+            stageSessionSummaryReceipt({db, ...receipt, now: 100});
+            acknowledgeSessionSummaryReceipt({db, sessionId: receipt.sessionId, now: 101});
+
+            collection.rows.set(receipt.summaryId, {
+                document: receipt.document,
+                metadata: {...receipt.metadata, ...dreamState}
+            });
+
+            const present = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                expectedDimension: 3,
+                now              : 200
+            });
+
+            expect(present).toMatchObject({
+                completed: 1,
+                present  : 1,
+                replayed : 0
+            });
+            expect(collection.upsertCalls).toBe(0);
+            expect(collection.rows.get(receipt.summaryId).metadata)
+                .toEqual({...receipt.metadata, ...dreamState});
+
+            collection.rows.get(receipt.summaryId).metadata.memoryCount = 99;
+
+            const repaired = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                expectedDimension: 3,
+                now              : 300
+            });
+
+            expect(repaired).toMatchObject({
+                completed: 1,
+                present  : 0,
+                replayed : 1
+            });
+            expect(collection.upsertCalls).toBe(1);
+            expect(collection.rows.get(receipt.summaryId).metadata)
+                .toEqual({...receipt.metadata, ...dreamState});
+
+            delete collection.rows.get(receipt.summaryId).metadata.title;
+
+            const missingOwnedKey = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                expectedDimension: 3,
+                now              : 400
+            });
+
+            expect(missingOwnedKey.replayed).toBe(1);
+            expect(collection.upsertCalls).toBe(2);
+
+            collection.rows.get(receipt.summaryId).document = 'Unacknowledged summary';
+
+            const changedDocument = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                expectedDimension: 3,
+                now              : 500
+            });
+
+            expect(changedDocument.replayed).toBe(1);
+            expect(collection.upsertCalls).toBe(3);
+            expect(collection.rows.get(receipt.summaryId)).toEqual({
+                document: receipt.document,
+                metadata: {...receipt.metadata, ...dreamState}
+            });
+        } finally {
+            db.close();
+        }
+    });
+
+    test('attests absence for conditional keys inside the synthesis-owned boundary', async () => {
+        const db         = createReceiptDb();
+        const collection = createFakeCollection();
+        const receipt    = createReceipt('conditional-absence');
+
+        try {
+            stageSessionSummaryReceipt({db, ...receipt, now: 100});
+            acknowledgeSessionSummaryReceipt({db, sessionId: receipt.sessionId, now: 101});
+
+            collection.rows.set(receipt.summaryId, {
+                document: receipt.document,
+                metadata: {
+                    ...receipt.metadata,
+                    digestState  : 'digested',
+                    graphDigested: true,
+                    userId       : 'unauthorized-live-owner'
+                }
+            });
+
+            await expect(recoverSessionSummaryReceipts({
+                db,
+                collection,
+                expectedDimension: 3,
+                now              : 200
+            })).rejects.toThrow(
+                `Session-summary receipt replay verification failed for ${receipt.summaryId}.`
+            );
+            expect(collection.upsertCalls).toBe(1);
+            expect(collection.rows.get(receipt.summaryId).metadata.userId)
+                .toBe('unauthorized-live-owner');
         } finally {
             db.close();
         }
@@ -491,6 +658,56 @@ test.describe('sessionSummaryReceiptStore (#16105)', () => {
                 status                 : 'completed',
                 result_last_replayed_at: 200
             });
+
+            const dreamState = {
+                digestState  : 'digested',
+                graphDigested: true
+            };
+
+            await collection.update({
+                ids      : [receipt.summaryId],
+                metadatas: [{...receipt.metadata, ...dreamState}]
+            });
+
+            const enrichedPresent = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                expectedDimension: 3,
+                now              : 300
+            });
+
+            expect(enrichedPresent).toMatchObject({
+                completed: 1,
+                present  : 1,
+                replayed : 0
+            });
+
+            await collection.update({
+                ids      : [receipt.summaryId],
+                metadatas: [{...receipt.metadata, ...dreamState, memoryCount: 99}]
+            });
+
+            const enrichedRepaired = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                expectedDimension: 3,
+                now              : 400
+            });
+            const enrichedExact = await collection.get({
+                ids    : [receipt.summaryId],
+                include: ['documents', 'metadatas']
+            });
+
+            expect(enrichedRepaired).toMatchObject({
+                completed: 1,
+                present  : 0,
+                replayed : 1
+            });
+            expect(enrichedExact.documents).toEqual([receipt.document]);
+            expect(enrichedExact.metadatas).toEqual([{
+                ...receipt.metadata,
+                ...dreamState
+            }]);
         } finally {
             if (chromaPid) {
                 await stopDetachedProcess(chromaPid);


### PR DESCRIPTION
Resolves #16114

Receipt recovery now verifies exactly the synthesis-owned session-summary document and declared metadata write-set while tolerating Dream-owned lifecycle overlays on the same Chroma row. Replay remains strict for missing or changed owned data, and both the fake adapter and disposable-Chroma witness now reproduce production metadata-merge behavior.

Evidence: L3 (live pre-fix production specimen plus current-branch disposable-Chroma merge/replay witness) → L3 required (AC7 natural current-source sweep in the shared production plane). Residual: AC7 [#16114].

## Deltas from ticket

- The synthesis-owned metadata boundary is a named exported key set, not inferred from the last encoded object.
- Receipt issuance rejects unknown metadata keys and missing required synthesis keys; `userId` and `unclassifiedSourceCount` remain explicitly conditional, and their absence is itself attested.
- Durable version-1 receipt decode validates the stable outer envelope only, so historical missing or retired metadata keys remain recoverable while corrupt bytes, unsupported versions, invalid identity, and invalid metadata shape still fail loud.
- The in-memory Chroma double now merges metadata, closing the fidelity gap that made the non-convergent replay loop unobservable.
- Source review exposed a separate Dream input-invalidation defect; it is kept out of this repair and tracked by Related: #16115.

## Test Evidence

- Receipt encoding, ownership, conditional-key absence, merge, replay, corruption, lease, CAS, and forced Chroma restart: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs` — 13 passed.
- Receipt + coordinator resume + SQLite graph regression surface: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs test/playwright/unit/ai/graph/Database.spec.mjs` — 38 passed, 15 skipped.
- Full repository unit matrix: three unchanged `npm run test-unit` samples each passed at least 10,234/10,242 tests but did not produce a clean aggregate:
  - sample 1: unrelated `DragCoordinator` overlap falsifier failed; its exact unchanged rerun passed 1/1;
  - samples 2 and 3: unrelated `MemoryService.Lifecycle` retry-timer test failed (`expected 1`, `received 3`); its exact unchanged rerun passed 3/3.
  - The repeated lifecycle pollution crossed the test tripwire and was routed to the `#13313` owner; exact-head GitHub CI remains the merge/review gate.
- Directly touched runtime surface: disposable production Chroma is exercised by `sessionSummaryReceiptStore.spec.mjs`; no additional app or browser journey applies.
- Mutation witness: temporarily restoring whole-object `isDeepStrictEqual(row.metadata, receipt.metadata)` against the merging mock produced the intended red guard:

```text
Error: Session-summary receipt replay verification failed for summary_dream-overlay.
1 failed — accepts Dream-owned metadata overlays while keeping receipt-owned values strict
2 passed
```

## Post-Merge Validation

- [ ] Observe the next natural current-source summarization sweep complete receipt recovery without `Session-summary receipt replay verification failed`.
- [ ] Confirm the sweep proceeds into ordinary drift detection/synthesis rather than aborting on a Dream-enriched receipt-backed row.
- [ ] Post the runtime receipt to #16017 and #16114 before treating the parent incident as resolved.

## Evolution

The live failure first appeared to be a storage-repair problem. Direct envelope/read-back comparison showed that every receipt-owned value was exact and only Dream overlays differed, moving the fix to issuance authority. Vega's independent source review then exposed the replacing mock and the danger of implicitly deriving ownership from whatever metadata happened to be encoded; both became same-PR regression gates. A source step-back corrected the adjacent Dream concern from “changed summary prose” to “new raw turns skipped” and split it into #16115.

Related: #16017
Related: #16105
Related: #16115
Related PR: #16110

Authored by Euclid (GPT-5 Codex, Codex Desktop). Session 019fac51-ddcb-7212-902e-09d3a9d19098.
