### PR TITLE
feat(build): reconcile theme watcher lifecycle (#15585)

### DIFF
--- a/buildScripts/README.md
+++ b/buildScripts/README.md
@@ -331,6 +331,12 @@ Runs the automated test suite using Playwright.
 **Script:** `buildScripts/helpers/watchThemes.mjs`
 
 Watches the `resources/scss` directory and incrementally recompiles themes when files change.
+
+- Run `npm run build-themes -- -n -e dev -t all` once before starting the watcher. It refuses to watch an incomplete or stale development theme tree.
+- Content changes to existing entry files keep the single-file fast path.
+- Add, rename, and delete events reconcile missing/stale outputs, remove retired CSS and source maps, and replace the generated development theme map.
+- Partial changes rebuild their owning theme root; shared-mixin changes rebuild every root and surface compiler failures.
+
 *Note: This script has no CLI options.*
 
 ---

--- a/buildScripts/helpers/watchThemes.mjs
+++ b/buildScripts/helpers/watchThemes.mjs
@@ -1,85 +1,663 @@
-import autoprefixer from 'autoprefixer';
-import chalk        from 'chalk';
-import fs           from 'fs-extra';
-import path         from 'path';
-import postcss      from 'postcss';
-import * as sass    from 'sass';
+import autoprefixer    from 'autoprefixer';
+import chalk           from 'chalk';
+import fs              from 'fs-extra';
+import path            from 'node:path';
+import {pathToFileURL} from 'node:url';
+import postcss         from 'postcss';
+import {
+    DEVELOPMENT_THEME_BUILD_COMMAND,
+    inspectDevelopmentThemeAssets
+} from '../util/developmentThemeAssets.mjs';
 
-let cwd         = process.cwd(),
-    requireJson = path => JSON.parse(fs.readFileSync((path))),
-    packageJson = requireJson(path.resolve(cwd, 'package.json')),
-    neoPath     = packageJson.name.includes('neo.mjs') ? './' : './node_modules/neo.mjs/',
-    mixinPath   = path.resolve(neoPath, 'resources/scss/mixins/_all.scss'),
-    scssPath    = path.resolve(cwd, 'resources/scss');
+const REPO_ROOT = process.cwd();
+let sassModulePromise;
 
-if (path.sep === '\\') {
-    mixinPath = mixinPath.replace(/\\/g, '/');
+/**
+ * @summary Loads Dart Sass once. Successful watcher startup preloads this cached promise so the
+ * first content edit retains the existing single-file latency profile.
+ * @returns {Promise<Object>}
+ */
+function loadSass() {
+    return sassModulePromise ??= import('sass')
 }
 
-fs.watch(scssPath, {
-    recursive: true
-}, (eventType, filename) => {
-    if (filename.endsWith('.scss')) {
-        switch(eventType) {
-            case 'change': {
-                buildFile(filename);
-            }
+/**
+ * @summary Returns the framework and workspace SCSS roots in override order. Framework checkouts
+ * have one root; app workspaces layer their own sources over the installed Neo package.
+ * @param {String} repoRoot Repository root.
+ * @returns {String[]}
+ */
+function getThemeSourceRoots(repoRoot) {
+    const
+        packageJson = fs.readJsonSync(path.join(repoRoot, 'package.json')),
+        neoRoot     = packageJson.name.includes('neo.mjs')
+            ? repoRoot
+            : path.join(repoRoot, 'node_modules/neo.mjs'),
+        roots       = neoRoot === repoRoot ? [repoRoot] : [neoRoot, repoRoot];
+
+    roots.forEach(root => {
+        const scssRoot = path.join(root, 'resources/scss');
+
+        if (!fs.existsSync(scssRoot)) {
+            throw new Error(`[watch-themes] missing SCSS source root: ${scssRoot}`)
         }
+    });
+
+    return roots
+}
+
+/**
+ * @summary Builds the exact effective SCSS entry census for development output. Later workspace
+ * roots replace framework entries with the same output path, matching the full theme builder.
+ * @param {Object} [options]
+ * @param {String} [options.repoRoot] Repository root.
+ * @returns {Array<{className: String, filename: String, outputPath: String, root: String,
+ *                   sourcePath: String}>}
+ */
+export function getThemeSourceCensus({repoRoot = REPO_ROOT} = {}) {
+    const entries = new Map();
+
+    function visit(dir, root, relativePath='') {
+        fs.readdirSync(dir, {withFileTypes: true})
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .forEach(entry => {
+                if (entry.isSymbolicLink()) return;
+
+                const
+                    sourcePath = path.join(dir, entry.name),
+                    relative   = path.join(relativePath, entry.name);
+
+                if (entry.isDirectory()) {
+                    visit(sourcePath, root, relative);
+                    return
+                }
+
+                if (!entry.name.endsWith('.scss') || entry.name.startsWith('_')) return;
+
+                const
+                    filename   = path.join(root, relative),
+                    outputPath = path.join(
+                        repoRoot,
+                        'dist/development/css',
+                        filename.replace(/\.scss$/, '.css')
+                    ),
+                    classPath      = relative
+                        .replace(/\.scss$/, '')
+                        .split(path.sep)
+                        .join('.'),
+                    className      = classPath.startsWith('apps.') ? classPath : `Neo.${classPath}`;
+
+                entries.set(outputPath, {
+                    className,
+                    filename,
+                    outputPath,
+                    root,
+                    sourcePath
+                })
+            })
     }
-});
 
-function buildFile(filename) {
-    console.log('start processing', filename);
+    getThemeSourceRoots(repoRoot).forEach(sourceRoot => {
+        const scssRoot = path.join(sourceRoot, 'resources/scss');
 
-    let filePath  = path.join(scssPath, filename),
-        destPath  = path.join(cwd, 'dist/development/css', filename.replace('.scss', '.css')),
-        startDate = new Date(),
-        map;
+        fs.readdirSync(scssRoot, {withFileTypes: true})
+            .filter(entry => (
+                entry.isDirectory() &&
+                !entry.isSymbolicLink() &&
+                (entry.name === 'src' || entry.name.includes('theme'))
+            ))
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .forEach(entry => visit(path.join(scssRoot, entry.name), entry.name))
+    });
+
+    return [...entries.values()].sort((a, b) => a.outputPath.localeCompare(b.outputPath))
+}
+
+/**
+ * @summary Adds one effective SCSS entry to the nested class-to-theme map used by worker.App.
+ * @param {Object} themeMap Mutable theme map.
+ * @param {Object} entry Effective SCSS census entry.
+ * @returns {void}
+ */
+function addToThemeMap(themeMap, entry) {
+    const
+        classPath = entry.className.split('.'),
+        leafName  = classPath.pop(),
+        namespace = classPath.reduce((scope, segment) => scope[segment] ??= {}, themeMap),
+        targets   = namespace[leafName] ??= [];
+
+    if (!targets.includes(entry.root)) targets.push(entry.root)
+}
+
+/**
+ * @summary Creates the exact nested class-to-theme map for an effective SCSS source census.
+ * @param {Array} census Effective source census.
+ * @returns {Object}
+ */
+function createDevelopmentThemeMap(census) {
+    const themeMap = {};
+
+    census.forEach(entry => addToThemeMap(themeMap, entry));
+
+    return themeMap
+}
+
+/**
+ * @summary Returns whether a generated theme map reaches one effective source-census entry.
+ * @param {Object} themeMap Parsed theme map.
+ * @param {Object} entry Effective source-census entry.
+ * @returns {Boolean}
+ */
+function themeMapHasEntry(themeMap, entry) {
+    const leaf = entry.className.split('.').reduce(
+        (scope, segment) => scope && typeof scope === 'object' ? scope[segment] : undefined,
+        themeMap
+    );
+
+    return Array.isArray(leaf) && leaf.includes(entry.root)
+}
+
+/**
+ * @summary Replaces both development theme-map copies from the effective SCSS source census.
+ * Retired source paths therefore disappear instead of surviving as additive ghost entries.
+ * @param {Object} [options]
+ * @param {Array} [options.census] Effective source census.
+ * @param {String} [options.repoRoot] Repository root.
+ * @returns {Object} The generated theme map.
+ */
+export function regenerateDevelopmentThemeMap({
+    census,
+    repoRoot = REPO_ROOT
+} = {}) {
+    const themeMap = createDevelopmentThemeMap(census ?? getThemeSourceCensus({repoRoot}));
+
+    const serialized = JSON.stringify(themeMap);
+
+    for (const target of [
+        path.join(repoRoot, 'resources/theme-map.json'),
+        path.join(repoRoot, 'dist/development/resources/theme-map.json')
+    ]) {
+        fs.mkdirpSync(path.dirname(target));
+        fs.writeFileSync(target, serialized)
+    }
+
+    return themeMap
+}
+
+/**
+ * @summary Finds the newest partial timestamp per build root and across shared SCSS roots. Partial
+ * edits force these same output boundaries in the live watcher.
+ * @param {String} repoRoot Repository root.
+ * @returns {{byRoot: Map<String, Number>, shared: Number}}
+ */
+function getPartialFreshnessBoundaries(repoRoot) {
+    const byRoot = new Map();
+    let   shared = 0;
+
+    function visit(dir, root) {
+        fs.readdirSync(dir, {withFileTypes: true}).forEach(entry => {
+            if (entry.isSymbolicLink()) return;
+
+            const target = path.join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                visit(target, root)
+            } else if (entry.name.startsWith('_') && entry.name.endsWith('.scss')) {
+                const mtime = fs.statSync(target).mtimeMs;
+
+                if (root === 'src' || root.includes('theme')) {
+                    byRoot.set(root, Math.max(byRoot.get(root) ?? 0, mtime))
+                } else {
+                    shared = Math.max(shared, mtime)
+                }
+            }
+        })
+    }
+
+    getThemeSourceRoots(repoRoot).forEach(sourceRoot => {
+        const scssRoot = path.join(sourceRoot, 'resources/scss');
+
+        fs.readdirSync(scssRoot, {withFileTypes: true})
+            .filter(entry => entry.isDirectory() && !entry.isSymbolicLink())
+            .forEach(entry => visit(path.join(scssRoot, entry.name), entry.name))
+    });
+
+    return {byRoot, shared}
+}
+
+/**
+ * @summary Inspects the watcher's precise startup contract. Entry outputs compare against their
+ * own source plus owning/shared partial boundaries, so a prior valid one-file rebuild does not
+ * falsely stale every unrelated output. Both map copies must reach every effective census entry.
+ * @param {Object} [options]
+ * @param {String} [options.repoRoot] Repository root.
+ * @returns {{census: Array, invalidMap: String|null, mapMissing: String[], missing: String[],
+ *            ready: Boolean, stale: String[], symlinked: String[]}}
+ */
+export function inspectThemeWatcherAssets({repoRoot = REPO_ROOT} = {}) {
+    const
+        census            = getThemeSourceCensus({repoRoot}),
+        boundaries        = getPartialFreshnessBoundaries(repoRoot),
+        conservativeState = inspectDevelopmentThemeAssets({repoRoot}),
+        mapMissing        = [],
+        missing           = [],
+        stale             = [];
+
+    let invalidMap = null;
+
+    census.forEach(entry => {
+        try {
+            const
+                outputStat   = fs.statSync(entry.outputPath),
+                sourceMtime  = fs.statSync(entry.sourcePath).mtimeMs,
+                partialMtime = Math.max(
+                    boundaries.shared,
+                    boundaries.byRoot.get(entry.root) ?? 0
+                );
+
+            if (!outputStat.isFile()) {
+                missing.push(path.relative(repoRoot, entry.outputPath))
+            } else if (outputStat.mtimeMs < Math.max(sourceMtime, partialMtime)) {
+                stale.push(path.relative(repoRoot, entry.outputPath))
+            }
+        } catch {
+            missing.push(path.relative(repoRoot, entry.outputPath))
+        }
+    });
+
+    for (const mapPath of [
+        path.join(repoRoot, 'resources/theme-map.json'),
+        path.join(repoRoot, 'dist/development/resources/theme-map.json')
+    ]) {
+        let themeMap;
+
+        try {
+            themeMap = fs.readJsonSync(mapPath)
+        } catch (error) {
+            if (error.code === 'ENOENT') {
+                missing.push(path.relative(repoRoot, mapPath))
+            } else {
+                invalidMap = `${path.relative(repoRoot, mapPath)}: ${error.message}`
+            }
+            continue
+        }
+
+        census.forEach(entry => {
+            if (!themeMapHasEntry(themeMap, entry)) {
+                mapMissing.push(
+                    `${path.relative(repoRoot, mapPath)}: ${entry.className} (${entry.root})`
+                )
+            }
+        })
+    }
+
+    const symlinked = conservativeState.symlinked ?? [];
+
+    return {
+        census,
+        invalidMap,
+        mapMissing: [...new Set(mapMissing)].sort(),
+        missing   : [...new Set(missing)].sort(),
+        ready     : (
+            census.length > 0 &&
+            !invalidMap &&
+            mapMissing.length === 0 &&
+            missing.length === 0 &&
+            stale.length === 0 &&
+            symlinked.length === 0
+        ),
+        stale     : [...new Set(stale)].sort(),
+        symlinked
+    }
+}
+
+/**
+ * @summary Removes development CSS and source maps with no corresponding effective SCSS entry.
+ * Symbolic-link directories are never traversed.
+ * @param {Object} [options]
+ * @param {Array} [options.census] Effective source census.
+ * @param {String} [options.repoRoot] Repository root.
+ * @returns {String[]} Removed repo-relative artifact paths.
+ */
+export function pruneDevelopmentThemeArtifacts({
+    census,
+    repoRoot = REPO_ROOT
+} = {}) {
+    const
+        cssRoot  = path.join(repoRoot, 'dist/development/css'),
+        expected = new Set(
+            (census ?? getThemeSourceCensus({repoRoot})).map(entry => path.resolve(entry.outputPath))
+        ),
+        removed  = [];
+
+    function visit(dir) {
+        if (!fs.existsSync(dir)) return;
+
+        fs.readdirSync(dir, {withFileTypes: true}).forEach(entry => {
+            const target = path.join(dir, entry.name);
+
+            if (entry.isSymbolicLink()) return;
+
+            if (entry.isDirectory()) {
+                visit(target);
+
+                if (fs.readdirSync(target).length === 0) fs.removeSync(target);
+                return
+            }
+
+            if (!entry.name.endsWith('.css') && !entry.name.endsWith('.css.map')) return;
+
+            const cssTarget = entry.name.endsWith('.css.map') ? target.slice(0, -4) : target;
+
+            if (!expected.has(path.resolve(cssTarget))) {
+                fs.removeSync(target);
+                removed.push(path.relative(repoRoot, target))
+            }
+        })
+    }
+
+    visit(cssRoot);
+
+    return removed.sort()
+}
+
+/**
+ * @summary Compiles one effective SCSS entry to its development CSS and source-map targets.
+ * @param {Object} entry Effective SCSS census entry.
+ * @param {Object} [options]
+ * @param {Object} [options.logger] Console-compatible logger.
+ * @returns {Promise<String>} Absolute CSS output path.
+ */
+async function buildEntry(entry, {logger = console} = {}) {
+    const startTime = Date.now();
 
     try {
-        let result = sass.compile(filePath, {
-            outFile                : destPath,
-            sourceMap              : true,
-            sourceMapIncludeSources: true
-        });
+        const
+            {compile}  = await loadSass(),
+            sassResult = compile(entry.sourcePath, {
+                outFile                : entry.outputPath,
+                sourceMap              : true,
+                sourceMapIncludeSources: true
+            }),
+            postcssResult = await postcss([autoprefixer]).process(sassResult.css, {
+                from: entry.sourcePath,
+                to  : entry.outputPath,
+                map : {
+                    inline: false,
+                    prev  : sassResult.sourceMap && JSON.stringify(sassResult.sourceMap)
+                }
+            });
 
-        map = result.sourceMap;
+        fs.mkdirpSync(path.dirname(entry.outputPath));
+        fs.writeFileSync(entry.outputPath, postcssResult.css);
 
-        postcss([autoprefixer]).process(result.css, {
-            from: filePath,
-            to  : destPath,
-            map : {
-                inline: false,
-                prev  : map && JSON.stringify(map)
-            }
-        }).then(postcssResult => {
-            map = postcssResult.map;
+        if (postcssResult.map) {
+            const sourceMap = JSON.parse(postcssResult.map.toString());
 
-            fs.writeFileSync(destPath, postcssResult.css, () => true);
+            // Sass can emit the same source as an absolute and a relative URL. Runtime debugging
+            // only needs the portable relative entries.
+            sourceMap.sources = sourceMap.sources.filter(source => source.startsWith('../'));
+            fs.writeFileSync(entry.outputPath + '.map', JSON.stringify(sourceMap))
+        }
 
-            if (map) {
-                let mapString = map.toString(),
-                    jsonMap   = JSON.parse(mapString),
-                    sources   = jsonMap.sources;
+        const processTime = ((Date.now() - startTime) / 1000).toFixed(2);
 
-                // Somehow files contain both: a relative & an absolute file url
-                // We only want to keep the relative ones.
-                [...sources].forEach((item, index) => {
-                    if (!item.startsWith('../')) {
-                        sources.splice(index, 1);
-                    }
-                });
+        logger.log('Updated file:', chalk.blue(`${processTime}s`), entry.outputPath);
 
-                map = JSON.stringify(jsonMap);
+        return entry.outputPath
+    } catch (error) {
+        const message = `[watch-themes] SCSS build failed for ${entry.filename}: ${error.message}`;
 
-                fs.writeFileSync(postcssResult.opts.to + '.map', map);
-            }
-
-            const processTime = (Math.round((new Date - startDate) * 100) / 100000).toFixed(2);
-            console.log('Updated file:', (chalk.blue(`${processTime}s`)), destPath);
-        });
-    } catch(error) {
-        console.log('SCSS build failed for', chalk.red(filename));
-        console.log(error);
+        (logger.error ?? logger.log).call(logger, message);
+        throw new Error(message, {cause: error})
     }
+}
+
+/**
+ * @summary Compiles one non-partial workspace SCSS file through the low-latency watcher path.
+ * @param {String} filename Path relative to `resources/scss`.
+ * @param {Object} [options]
+ * @param {Object} [options.logger] Console-compatible logger.
+ * @param {String} [options.repoRoot] Repository root.
+ * @returns {Promise<String>} Absolute CSS output path.
+ */
+export function buildFile(filename, {
+    logger   = console,
+    repoRoot = REPO_ROOT
+} = {}) {
+    const
+        scssRoot   = path.resolve(repoRoot, 'resources/scss'),
+        normalized = path.normalize(String(filename)),
+        sourcePath = path.resolve(scssRoot, normalized);
+
+    if (
+        path.isAbsolute(normalized) ||
+        sourcePath !== scssRoot && !sourcePath.startsWith(scssRoot + path.sep)
+    ) {
+        throw new Error(`[watch-themes] rejected SCSS path outside resources/scss: ${filename}`)
+    }
+
+    if (path.basename(normalized).startsWith('_')) {
+        throw new Error(`[watch-themes] partials require an owning-root rebuild: ${filename}`)
+    }
+
+    return buildEntry({
+        className : '',
+        filename  : normalized,
+        outputPath: path.join(
+            repoRoot,
+            'dist/development/css',
+            normalized.replace(/\.scss$/, '.css')
+        ),
+        root      : normalized.split(path.sep)[0],
+        sourcePath
+    }, {logger})
+}
+
+/**
+ * @summary Reconciles development CSS and the generated theme map against one immutable source
+ * census. Structural events build missing/stale entries, delete ghosts, and replace the map.
+ * Partial events can force their owning root (or every root for shared mixins).
+ * @param {Object} [options]
+ * @param {Function} [options.build] Injectable effective-entry compiler.
+ * @param {String[]} [options.forceFiles] Repo-SCSS-relative entries to rebuild.
+ * @param {String[]} [options.forceRoots] Top-level SCSS roots to rebuild; `*` means every root.
+ * @param {Object} [options.logger] Console-compatible logger.
+ * @param {String} [options.repoRoot] Repository root.
+ * @returns {Promise<{built: String[], removed: String[], themeMap: Object}>}
+ */
+export async function reconcileThemeStructure({
+    build      = buildEntry,
+    forceFiles = [],
+    forceRoots = [],
+    logger     = console,
+    repoRoot   = REPO_ROOT
+} = {}) {
+    const
+        census      = getThemeSourceCensus({repoRoot}),
+        forcedFiles = new Set(forceFiles.map(file => path.normalize(file))),
+        forcedRoots = new Set(forceRoots),
+        built       = [];
+
+    for (const entry of census) {
+        let outputStat;
+
+        try {
+            outputStat = fs.lstatSync(entry.outputPath)
+        } catch {}
+
+        const shouldBuild = (
+            forcedRoots.has('*') ||
+            forcedRoots.has(entry.root) ||
+            forcedFiles.has(entry.filename) ||
+            !outputStat ||
+            outputStat.isSymbolicLink() ||
+            outputStat.mtimeMs < fs.statSync(entry.sourcePath).mtimeMs
+        );
+
+        if (shouldBuild) {
+            if (outputStat?.isSymbolicLink()) fs.removeSync(entry.outputPath);
+
+            await build(entry, {logger});
+            built.push(entry.filename)
+        }
+    }
+
+    return {
+        built,
+        removed : pruneDevelopmentThemeArtifacts({census, repoRoot}),
+        themeMap: regenerateDevelopmentThemeMap({census, repoRoot})
+    }
+}
+
+/**
+ * @summary Handles one fs.watch event. Ordinary entry-file changes stay on the one-file path;
+ * structural and partial events use the wider source-census reconciliation.
+ * @param {String} eventType fs.watch event type.
+ * @param {String|Buffer} filename Path relative to `resources/scss`.
+ * @param {Object} [options]
+ * @param {Function} [options.build] Injectable one-file compiler.
+ * @param {Object} [options.logger] Console-compatible logger.
+ * @param {Function} [options.reconcile] Injectable structural reconciler.
+ * @param {String} [options.repoRoot] Repository root.
+ * @returns {Promise<Object>} Event outcome.
+ */
+export async function handleThemeWatchEvent(eventType, filename, {
+    build     = buildFile,
+    logger    = console,
+    reconcile = reconcileThemeStructure,
+    repoRoot  = REPO_ROOT
+} = {}) {
+    if (!filename) return {action: 'ignored', reason: 'missing-filename'};
+
+    const normalized = path.normalize(String(filename));
+
+    if (!normalized.endsWith('.scss')) return {action: 'ignored', reason: 'not-scss'};
+
+    const
+        sourcePath = path.join(repoRoot, 'resources/scss', normalized),
+        exists     = fs.existsSync(sourcePath),
+        isPartial  = path.basename(normalized).startsWith('_');
+
+    if (eventType === 'change' && exists && !isPartial) {
+        await build(normalized, {logger, repoRoot});
+        return {action: 'built', built: [normalized], removed: []}
+    }
+
+    if (eventType !== 'rename' && eventType !== 'change') {
+        return {action: 'ignored', reason: 'unsupported-event'}
+    }
+
+    const
+        root       = normalized.split(path.sep)[0],
+        forceFiles = exists && !isPartial ? [normalized] : [],
+        forceRoots = isPartial ? [root === 'src' || root.includes('theme') ? root : '*'] : [];
+
+    try {
+        const result = await reconcile({forceFiles, forceRoots, logger, repoRoot});
+        const action = isPartial ? 'rebuilt-root' : exists ? 'built' : 'removed';
+
+        logger.log(
+            `[watch-themes] ${eventType} ${normalized}: ${action}; ` +
+            `${result.built.length} built, ${result.removed.length} removed, theme-map regenerated`
+        );
+
+        return {action, ...result}
+    } catch (error) {
+        throw new Error(
+            `[watch-themes] ${eventType} reconcile failed for ${normalized}: ${error.message}`,
+            {cause: error}
+        )
+    }
+}
+
+/**
+ * @summary Creates a serialized fs.watch listener so lifecycle bursts cannot race map writes or
+ * artifact deletion. A failed event is logged while the queue remains usable for later changes.
+ * @param {Object} [options] Forwarded event-handler options.
+ * @returns {Function}
+ */
+export function createThemeWatchListener(options={}) {
+    const logger = options.logger ?? console;
+    let   queue  = Promise.resolve();
+
+    return (eventType, filename) => {
+        queue = queue
+            .then(() => handleThemeWatchEvent(eventType, filename, options))
+            .catch(error => (logger.error ?? logger.log).call(logger, error.message));
+
+        return queue
+    }
+}
+
+/**
+ * @summary Refuses to watch before a complete initial development theme build has established the
+ * output tree and generated map.
+ * @param {Object} [options]
+ * @param {Function} [options.inspect] Injectable readiness inspector.
+ * @param {String} [options.repoRoot] Repository root.
+ * @returns {Object} Ready inspection state.
+ */
+export function assertThemeWatcherReady({
+    inspect  = inspectThemeWatcherAssets,
+    repoRoot = REPO_ROOT
+} = {}) {
+    const state = inspect({repoRoot});
+
+    if (state.ready) return state;
+
+    const details = [
+        state.invalidMap && `invalid map: ${state.invalidMap}`,
+        state.mapMissing?.length > 0 && `map missing entries: ${state.mapMissing.join(', ')}`,
+        state.missing?.length > 0    && `missing: ${state.missing.join(', ')}`,
+        state.stale?.length > 0      && `stale: ${state.stale.join(', ')}`,
+        state.symlinked?.length > 0  && `symlinked: ${state.symlinked.join(', ')}`
+    ].filter(Boolean).join('; ');
+
+    throw new Error(
+        `[watch-themes] development theme assets are not ready${details ? ` (${details})` : ''}.\n` +
+        `Recovery: ${DEVELOPMENT_THEME_BUILD_COMMAND}`
+    )
+}
+
+/**
+ * @summary Verifies initial build state, reconciles any retired structural artifacts, then starts
+ * the recursive SCSS watcher.
+ * @param {Object} [options]
+ * @param {Function} [options.inspect] Injectable readiness inspector.
+ * @param {Function} [options.loadCompiler] Injectable compiler preload.
+ * @param {Object} [options.logger] Console-compatible logger.
+ * @param {Function} [options.reconcile] Injectable structural reconciler.
+ * @param {String} [options.repoRoot] Repository root.
+ * @param {Function} [options.watch] Injectable fs.watch seam.
+ * @returns {Promise<fs.FSWatcher>}
+ */
+export async function startThemeWatcher({
+    inspect      = inspectThemeWatcherAssets,
+    loadCompiler = loadSass,
+    logger       = console,
+    reconcile    = reconcileThemeStructure,
+    repoRoot     = REPO_ROOT,
+    watch        = fs.watch
+} = {}) {
+    assertThemeWatcherReady({inspect, repoRoot});
+    await reconcile({logger, repoRoot});
+    await loadCompiler();
+
+    const scssRoot = path.join(repoRoot, 'resources/scss');
+
+    logger.log(`[watch-themes] watching ${scssRoot}`);
+
+    return watch(
+        scssRoot,
+        {recursive: true},
+        createThemeWatchListener({logger, reconcile, repoRoot})
+    )
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+    startThemeWatcher().catch(error => {
+        console.error(error.message);
+        process.exitCode = 1
+    })
 }

--- a/learn/guides/uibuildingblocks/StylingAndTheming.md
+++ b/learn/guides/uibuildingblocks/StylingAndTheming.md
@@ -378,9 +378,11 @@ The `theme-map.json` file creates a mapping between every class name and the the
 
 ### `watch-themes`
 
-For development, you can use `npm run watch-themes`. This script will watch the `resources/scss` directory for any changes and recompile only the file that was changed. This provides a much faster feedback loop when you are developing themes.
+For development, you can use `npm run watch-themes`. Existing non-partial files stay on the fast path: the watcher recompiles only the file whose content changed.
 
-**Important Note:** The current version of `watch-themes` only handles changes to *existing* files. It does **not** detect new files, renamed files, or deleted files. As a result, if you add, move, or delete SCSS files while the watcher is running, the `theme-map.json` will not be updated, which can lead to inconsistencies. To apply these kinds of changes, you can run a full `npm run build-themes` command in a separate terminal. Enhancing the watch script to handle these cases is a planned improvement.
+Run `npm run build-themes -- -n -e dev -t all` once before starting the watcher. The watcher refuses to start when the development CSS or generated map is missing, stale, incomplete, or borrowed through a symbolic link.
+
+Structural events use a wider source-census reconciliation. Adding or renaming an entry builds every newly discovered or stale output; deleting or renaming an entry removes retired CSS and source maps; and each structural pass replaces both development copies of `theme-map.json` from the effective framework-plus-workspace SCSS tree. A partial change rebuilds its owning `src` or theme root (shared mixins rebuild all roots), so a broken importer produces a visible error instead of silently retaining stale CSS.
 
 ## 9. Lazy Loading in Action
 

--- a/test/playwright/unit/ai/buildScripts/helpers/watchThemes.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/helpers/watchThemes.spec.mjs
@@ -1,0 +1,288 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+import {
+    handleThemeWatchEvent,
+    inspectThemeWatcherAssets,
+    reconcileThemeStructure,
+    regenerateDevelopmentThemeMap,
+    startThemeWatcher
+} from '../../../../../../buildScripts/helpers/watchThemes.mjs';
+
+/**
+ * @summary Pins watch-themes lifecycle reconciliation: low-latency content changes, exact
+ * add/rename/delete output + map state, partial failure visibility, and startup readiness.
+ */
+test.describe('buildScripts/helpers/watchThemes (#15585)', () => {
+    const roots = [];
+
+    function createRoot(name='neo.mjs-watch-fixture') {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-watch-themes-'));
+
+        roots.push(root);
+        fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+            bugs   : {url: 'https://github.com/neomjs/neo/issues'},
+            name,
+            version: '1.0.0'
+        }));
+        fs.mkdirSync(path.join(root, 'resources/scss/src'), {recursive: true});
+
+        return root
+    }
+
+    function createLogger() {
+        const errors = [],
+              logs   = [];
+
+        return {
+            errors,
+            logger: {
+                error(message) {
+                    errors.push(message)
+                },
+                log(...items) {
+                    logs.push(items.join(' '))
+                }
+            },
+            logs
+        }
+    }
+
+    function mapLeaf(root, className) {
+        const themeMap = JSON.parse(fs.readFileSync(
+            path.join(root, 'resources/theme-map.json'),
+            'utf8'
+        ));
+
+        return className.split('.').reduce((scope, segment) => scope?.[segment], themeMap)
+    }
+
+    async function buildFixtureEntry(entry, {logger}) {
+        const source = fs.readFileSync(entry.sourcePath, 'utf8');
+
+        if (
+            source.includes("@use 'tokens'") &&
+            !fs.existsSync(path.join(path.dirname(entry.sourcePath), '_tokens.scss'))
+        ) {
+            const message = `[watch-themes] SCSS build failed for ${entry.filename}: missing tokens partial`;
+
+            logger.error(message);
+            throw new Error(message)
+        }
+
+        fs.mkdirSync(path.dirname(entry.outputPath), {recursive: true});
+        fs.writeFileSync(entry.outputPath, `/* ${entry.filename} */\n${source}`);
+        fs.writeFileSync(entry.outputPath + '.map', JSON.stringify({
+            sources: [path.relative(path.dirname(entry.outputPath), entry.sourcePath)]
+        }));
+
+        return entry.outputPath
+    }
+
+    function reconcileFixture(options) {
+        return reconcileThemeStructure({...options, build: buildFixtureEntry})
+    }
+
+    function writeScss(root, filename, content='.fixture { color: red; }') {
+        const target = path.join(root, 'resources/scss', filename);
+
+        fs.mkdirSync(path.dirname(target), {recursive: true});
+        fs.writeFileSync(target, content);
+
+        return target
+    }
+
+    test.afterAll(() => {
+        roots.forEach(root => fs.rmSync(root, {force: true, recursive: true}))
+    });
+
+    test('ordinary content changes keep the one-file path', async () => {
+        const
+            root       = createRoot(),
+            calls      = [],
+            {logger}   = createLogger(),
+            sourceFile = writeScss(root, 'src/Panel.scss');
+
+        await handleThemeWatchEvent('change', 'src/Panel.scss', {
+            build    : async filename => calls.push(['build', filename]),
+            logger,
+            reconcile: async () => {
+                calls.push(['reconcile']);
+                return {built: [], removed: [], themeMap: {}}
+            },
+            repoRoot: root
+        });
+
+        expect(fs.existsSync(sourceFile)).toBe(true);
+        expect(calls).toEqual([['build', 'src/Panel.scss']])
+    });
+
+    test('one structural event reconciles add, rename, delete, source maps, and the exact map', async () => {
+        const
+            root     = createRoot(),
+            {logger} = createLogger();
+
+        writeScss(root, 'src/Initial.scss');
+        await reconcileFixture({logger, repoRoot: root});
+
+        writeScss(root, 'src/Added.scss', '.added { display: flex; }');
+        await handleThemeWatchEvent('rename', 'src/Added.scss', {
+            logger,
+            reconcile: reconcileFixture,
+            repoRoot : root
+        });
+
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Added.css'))).toBe(true);
+        expect(mapLeaf(root, 'Neo.Added')).toEqual(['src']);
+
+        fs.renameSync(
+            path.join(root, 'resources/scss/src/Added.scss'),
+            path.join(root, 'resources/scss/src/Renamed.scss')
+        );
+
+        // macOS is allowed to report only the retired filename. The census still discovers and
+        // builds the new path before replacing the map.
+        await handleThemeWatchEvent('rename', 'src/Added.scss', {
+            logger,
+            reconcile: reconcileFixture,
+            repoRoot : root
+        });
+
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Added.css'))).toBe(false);
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Added.css.map'))).toBe(false);
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Renamed.css'))).toBe(true);
+        expect(mapLeaf(root, 'Neo.Added')).toBeUndefined();
+        expect(mapLeaf(root, 'Neo.Renamed')).toEqual(['src']);
+
+        fs.rmSync(path.join(root, 'resources/scss/src/Renamed.scss'));
+        await handleThemeWatchEvent('rename', 'src/Renamed.scss', {
+            logger,
+            reconcile: reconcileFixture,
+            repoRoot : root
+        });
+
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Renamed.css'))).toBe(false);
+        expect(fs.existsSync(path.join(root, 'dist/development/css/src/Renamed.css.map'))).toBe(false);
+        expect(mapLeaf(root, 'Neo.Renamed')).toBeUndefined()
+    });
+
+    test('a deleted partial rebuilds its owning root and fails loudly when an importer breaks', async () => {
+        const
+            root             = createRoot(),
+            {errors, logger} = createLogger(),
+            partial          = writeScss(root, 'src/_tokens.scss', '$color: red;');
+
+        writeScss(root, 'src/Panel.scss', "@use 'tokens';\n.panel { color: tokens.$color; }");
+        await reconcileFixture({logger, repoRoot: root});
+        fs.rmSync(partial);
+
+        await expect(
+            handleThemeWatchEvent('rename', 'src/_tokens.scss', {
+                logger,
+                reconcile: reconcileFixture,
+                repoRoot : root
+            })
+        ).rejects.toThrow('[watch-themes] rename reconcile failed for src/_tokens.scss');
+
+        expect(errors.some(message => message.includes(
+            '[watch-themes] SCSS build failed for src/Panel.scss'
+        ))).toBe(true)
+    });
+
+    test('workspace regeneration preserves framework classes and removes retired local entries', () => {
+        const root = createRoot('theme-workspace');
+
+        writeScss(root, 'src/Local.scss');
+        writeScss(
+            path.join(root, 'node_modules/neo.mjs'),
+            'src/Base.scss'
+        );
+        fs.writeFileSync(path.join(root, 'resources/theme-map.json'), JSON.stringify({
+            Neo: {Retired: ['src']}
+        }));
+
+        regenerateDevelopmentThemeMap({repoRoot: root});
+
+        expect(mapLeaf(root, 'Neo.Base')).toEqual(['src']);
+        expect(mapLeaf(root, 'Neo.Local')).toEqual(['src']);
+        expect(mapLeaf(root, 'Neo.Retired')).toBeUndefined()
+    });
+
+    test('startup freshness preserves a prior valid one-file rebuild', async () => {
+        const
+            root     = createRoot(),
+            {logger} = createLogger(),
+            panel    = writeScss(root, 'src/Panel.scss'),
+            other    = writeScss(root, 'src/Other.scss');
+
+        fs.utimesSync(panel, 1, 1);
+        fs.utimesSync(other, 1, 1);
+        await reconcileFixture({logger, repoRoot: root});
+
+        const
+            panelCss = path.join(root, 'dist/development/css/src/Panel.css'),
+            otherCss = path.join(root, 'dist/development/css/src/Other.css');
+
+        // Panel changed and was rebuilt later. Other remains older than Panel's new source, but
+        // newer than its own source: that is a valid watcher state, not a reason for a full build.
+        fs.utimesSync(otherCss, 1.5, 1.5);
+        fs.utimesSync(panel, 2, 2);
+        fs.utimesSync(panelCss, 3, 3);
+
+        const state = inspectThemeWatcherAssets({repoRoot: root});
+
+        expect(state.ready).toBe(true);
+        expect(state.stale).toEqual([])
+    });
+
+    test('successful startup preloads Sass before opening the watcher', async () => {
+        const
+            root     = createRoot(),
+            calls    = [],
+            {logger} = createLogger(),
+            watcher  = {close() {}};
+
+        const result = await startThemeWatcher({
+            inspect     : () => ({ready: true}),
+            loadCompiler: async () => calls.push('compiler'),
+            logger,
+            reconcile   : async () => calls.push('reconcile'),
+            repoRoot    : root,
+            watch       : () => {
+                calls.push('watch');
+                return watcher
+            }
+        });
+
+        expect(result).toBe(watcher);
+        expect(calls).toEqual(['reconcile', 'compiler', 'watch'])
+    });
+
+    test('startup refuses loudly before the canonical initial build', async () => {
+        const
+            root     = createRoot(),
+            calls    = [],
+            {logger} = createLogger();
+
+        await expect(startThemeWatcher({
+            inspect: () => ({
+                invalidMap: null,
+                mapMissing: [],
+                missing   : ['resources/theme-map.json'],
+                ready     : false,
+                stale     : [],
+                symlinked : []
+            }),
+            loadCompiler: async () => calls.push('compiler'),
+            logger,
+            repoRoot    : root,
+            watch       : () => { throw new Error('watch must not start') }
+        })).rejects.toThrow(
+            'Recovery: npm run build-themes -- -n -e dev -t all'
+        );
+
+        expect(calls).toEqual([])
+    })
+});


### PR DESCRIPTION
Resolves #15585

`watch-themes` now keeps development CSS, source maps, and both generated theme-map copies coherent across SCSS add, rename, delete, and partial lifecycles. Existing non-partial content edits retain the one-file compile path; structural events reconcile one effective framework-plus-workspace source census, and watcher startup refuses incomplete build state without turning a valid prior one-file rebuild into a false stale result.

Evidence: L2 achieved with focused lifecycle units, the adjacent development-theme readiness suite, repository static gates, guide lint, and a real Node/Dart Sass production-path probe. L3 CI remains the merge gate. Residual: none at the #15585 close target.

## Deltas from ticket

- Structural events use an incremental source census rather than invoking a full `build-themes` command: only missing, stale, or explicitly affected entries compile.
- A single retired-filename rename event is sufficient: the census discovers the new path, builds it, removes the old CSS plus map, and then replaces the generated map.
- Workspace sources override installed Neo sources by output path while the regenerated map retains both effective trees.
- Startup freshness is per entry plus owning/shared partial boundaries, preserving the existing content-change latency contract across watcher restarts.

## Test Evidence

- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/buildScripts/helpers/watchThemes.spec.mjs test/playwright/unit/ai/buildScripts/util/developmentThemeAssets.spec.mjs` — 23/23 passed.
- `node --check buildScripts/helpers/watchThemes.mjs` — passed.
- `node --check test/playwright/unit/ai/buildScripts/helpers/watchThemes.spec.mjs` — passed.
- `git diff --cached --check` — passed.
- Pre-commit whitespace, shorthand, JSDoc type, ticket archaeology, block alignment, parse, AiConfig-mutation, and derived-domain gates — passed.
- `npm run ai:lint-guides` — 0 hard failures; pre-existing warnings only.
- Real production compiler probe: imported `buildFile()` in a clean Node process, compiled a temporary SCSS entry through Dart Sass + PostCSS, and observed both `.css` and `.css.map`.
- `watch-themes` lifecycle surface: `test/playwright/unit/ai/buildScripts/helpers/watchThemes.spec.mjs` — add, single-event rename, delete, map replacement, workspace inheritance, partial failure, startup refusal, restart freshness, compiler preload, and one-file fast path passed.
- Adjacent E2E readiness surface: `test/playwright/unit/ai/buildScripts/util/developmentThemeAssets.spec.mjs` — passed unchanged.

## Post-Merge Validation

- [ ] In a fresh checkout, run `npm run build-themes -- -n -e dev -t all`, start `npm run watch-themes`, and confirm one live add → rename → delete cycle updates runtime-loaded styling without a separate full build.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fac51-ddcb-7212-902e-09d3a9d19098.
