### PR TITLE
feat(ai): add source-owned merge-readiness projection (#16029)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -73,18 +73,19 @@ Fixup commits alone do NOT discharge it (#14735):
 
 ## 5. PR-state freshness gate
 
-Any report, A2A message, or lane declaration that names a PR's review or merge
-status MUST first read live state:
+Before any report/A2A/lane declaration names PR review or merge status, read
+live GitHub; wakes are hints:
 
 ```bash
 gh pr view <N> --json state,mergedAt,baseRefName,reviewRequests
 ```
 
-Wakes are hints, not cache. A non-empty `reviewRequests` is **not** merge-ready
-even at `reviewDecision=APPROVED` — name the outstanding reviewer(s) as the
-remaining gate. For stacked PRs, name base readiness too; a stale base is
-routable, not a terminal. Relay the review body's verdict, not the flattened
-enum. `ai/scripts/lifecycle/validateMergeReady.mjs` encodes this contract.
+A non-empty `reviewRequests` blocks even at `APPROVED`; name each seat. For
+stacked PRs name base readiness. Relay the review verdict, not the flattened
+enum. `validateMergeReady.mjs` remains the predicate; canonical
+`[merge-eligible]` additionally cites the current positive B-prime observation
+marker. Without one use `[merge-readiness-uncertified][no-positive-observation]`;
+cloud mode uses `[merge-readiness-uncertified][issuer-unavailable:cloud-mode]`.
 
 ## 6. Before claiming a lane
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -356,7 +356,13 @@ For multi-cycle reviews, after posting a review comment **capture its `commentId
 
 ### 10.1 PR-State Freshness Gate
 
-Before `manage_pr_review`/relaying any review outcome, merge-eligibility claim, or lane-state naming a PR: the A2A/wake echo is not a cache. If minutes elapsed or the lifecycle action changed, re-run BOTH a PR-scoped `list_messages` and `gh pr view <N> --json state,mergedAt,reviewRequests` — acceptance/handoff can be A2A-only. Authority moved → stand down/hand off. Relay the §9 verdict, not the flattened `reviewDecision`. A non-empty `reviewRequests` isn't strict-merge-ready even at APPROVED — dispose each (formal review / step-out / unrequest; an A2A approval doesn't clear a slot). `validateMergeReady` encodes it.
+Before `manage_pr_review`, review relay, merge claim, or PR lane-state, re-run
+PR-scoped mailbox + live `state,mergedAt,reviewRequests`; wakes are not cache and
+acceptance can be A2A-only. Authority moved → hand off. Relay §9, not flattened
+`reviewDecision`; every requested seat must be disposed. Canonical
+`[merge-eligible]` requires the current positive B-prime observation marker;
+otherwise use `[merge-readiness-uncertified][no-positive-observation]`, or
+`[merge-readiness-uncertified][issuer-unavailable:cloud-mode]` in cloud.
 
 ## 11. Post-Review-Cycle Reviewer Pickup
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -173,6 +173,10 @@ substitute.
 
 A formal `reviewDecision: APPROVED` is necessary but NOT sufficient: a non-empty `reviewRequests`
 blocks merge-handoff until each requested reviewer is disposed. `validateMergeReady` encodes this.
+Canonical `[merge-eligible]` cites a positive B-prime marker; otherwise
+use `[merge-readiness-uncertified][no-positive-observation]`, or
+`[merge-readiness-uncertified][issuer-unavailable:cloud-mode]` in cloud.
+It never grants merge authority.
 
 Exceptions are narrow and must be stated in the PR/review thread:
 - Micro-change: `chore` and `< 20` changed lines, or pure documentation with no runtime impact.

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -356,13 +356,23 @@ paths:
       summary: Get Conversation (Issue or PR)
       operationId: get_conversation
       x-neo-tool-tier: read
-      x-neo-tool-summary: Fetch a pull request or issue conversation with optional comment-window selectors.
+      x-neo-tool-summary: Fetch PR/issue conversation, or an identity-bound source-owned PR readiness projection.
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
       description: |
         Retrieves the conversation (title, body, comments) for a pull request OR an issue.
-        Supply exactly one of `pr_number` or `issue_number`.
+        Supply exactly one of `pr_number` or `issue_number`. The default
+        `projection: conversation` preserves the existing response shape.
+
+        `projection: merge-readiness` is PR-only and accepts no caller-composed readiness
+        fields. GitHub Workflow binds the current AgentIdentity/GitHub/Memory Core principals,
+        reads the PR twice around two effective branch-rules reads, compares the snapshots,
+        derives required-vs-emitted context states, and feeds them to the existing
+        `validateMergeReady()` predicate. Only a positive coherent observation carries a
+        copyable `[merge-eligible][B-prime:...]` marker. Negative or unreadable observations
+        contain diagnostics and no marker. This resident-local observation reports what was
+        merge-ready at `observedAt`; it never grants merge authority or promises later validity.
 
         **When to Use:**
         Use this tool to get the context of a pull request or issue — the initial proposal/body and the discussion history.
@@ -393,6 +403,11 @@ paths:
                   type: integer
                   description: The issue number. Supply either `pr_number` or `issue_number`, not both.
                   example: 10702
+                projection:
+                  type: string
+                  enum: [conversation, merge-readiness]
+                  default: conversation
+                  description: Response projection. `merge-readiness` requires `pr_number`, is identity-bound, and cannot be combined with comment selectors.
                 comment_id:
                   type: string
                   description: Return only the comment whose GitHub global node ID matches. Elides all other comments; PR title/body are still returned.

--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -217,16 +217,28 @@ async function resolveGitHubViewerLogin() {
  * @returns {Promise<Object>}
  */
 async function defaultGitHubIdentityAssertion() {
+    const expectedIdentity = process.env.NEO_AGENT_IDENTITY ||
+        RequestContextService.getAgentIdentityNodeId() ||
+        RequestContextService.getUserId();
     const memoryCoreIdentity = RequestContextService.getAgentIdentityNodeId() ||
         RequestContextService.getUserId();
-
-    return assertExpectedGitHubIdentity({
-        expected: process.env.NEO_AGENT_IDENTITY ||
-            RequestContextService.getAgentIdentityNodeId() ||
-            RequestContextService.getUserId(),
-        actualLogin: await resolveGitHubViewerLogin(),
+    const githubLogin = await resolveGitHubViewerLogin();
+    const assertion   = assertExpectedGitHubIdentity({
+        expected   : expectedIdentity,
+        actualLogin: githubLogin,
         memoryCoreIdentity
     });
+
+    return {
+        ...assertion,
+        principals: {
+            agentIdentity: expectedIdentity
+                ? `@${normalizeGitHubIdentityLogin(expectedIdentity)}`
+                : null,
+            githubLogin,
+            memoryCoreIdentity
+        }
+    };
 }
 
 /**
@@ -236,6 +248,31 @@ async function defaultGitHubIdentityAssertion() {
  */
 function shouldRetryGitHubIdentityAssertion(assertion) {
     return assertion?.code === IdentityAssertionCode.NO_AUTHED_LOGIN;
+}
+
+/**
+ * @summary Resolves one bounded, retry-aware identity assertion for identity-bearing operations.
+ * @param {Object} [options]
+ * @param {Function} [options.assertExpectedIdentity] Shared identity assertion seam.
+ * @param {Number} [options.identityResolutionRetries=1] Empty-login retry count.
+ * @returns {Promise<Object>} Successful assertion including bound principals.
+ * @throws {Error} Structured GitHub identity error when the assertion fails.
+ */
+async function resolveGitHubIdentityAssertion({
+    assertExpectedIdentity    = defaultGitHubIdentityAssertion,
+    identityResolutionRetries = 1
+} = {}) {
+    let assertion = await assertExpectedIdentity();
+
+    for (let retry = 0; !assertion.ok && retry < identityResolutionRetries && shouldRetryGitHubIdentityAssertion(assertion); retry++) {
+        assertion = await assertExpectedIdentity();
+    }
+
+    if (!assertion.ok) {
+        throw createGitHubIdentityError(assertion);
+    }
+
+    return assertion;
 }
 
 /**
@@ -256,15 +293,10 @@ function buildGitHubWriteIdentityGuard(delegate, {
     identityResolutionRetries = 1
 } = {}) {
     return async function githubWriteIdentityGuard(...args) {
-        let assertion = await assertExpectedIdentity();
-
-        for (let retry = 0; !assertion.ok && retry < identityResolutionRetries && shouldRetryGitHubIdentityAssertion(assertion); retry++) {
-            assertion = await assertExpectedIdentity();
-        }
-
-        if (!assertion.ok) {
-            throw createGitHubIdentityError(assertion);
-        }
+        await resolveGitHubIdentityAssertion({
+            assertExpectedIdentity,
+            identityResolutionRetries
+        });
 
         return delegate(...args);
     };
@@ -307,17 +339,18 @@ function guardGitHubWriteTools(mapping, guardOptions) {
  * Exported for unit-test access, mirroring the `buildDevBranchGuard` /
  * `syncAllOnDevOnly` test-surface precedent below.
  *
- * @param {Object|Number} options `pr_number` XOR `issue_number`, plus optional selectors.
+ * @param {Object|Number} options `pr_number` XOR `issue_number`, plus optional selectors/projection.
  *                                A bare number is the backward-compatible positional PR form.
+ * @param {Object} [identityOptions] Injectable identity resolver options for tests.
  * @returns {Promise<Object>} Conversation data or a structured error.
  */
-async function getConversationRouter(options) {
+async function getConversationRouter(options, identityOptions = {}) {
     // Backward-compatible positional number form is always a pull request.
     if (typeof options === 'number') {
         return PullRequestService.getConversation(options);
     }
 
-    const {pr_number, issue_number} = options || {};
+    const {pr_number, issue_number, projection = 'conversation'} = options || {};
 
     if (pr_number && issue_number) {
         return {
@@ -328,10 +361,46 @@ async function getConversationRouter(options) {
     }
 
     if (issue_number) {
+        if (projection === 'merge-readiness') {
+            return {
+                error  : 'Bad Request',
+                message: "The 'merge-readiness' projection requires 'pr_number'.",
+                code   : 'PROJECTION_REQUIRES_PULL_REQUEST'
+            };
+        }
+
         return IssueService.getConversation(options);
     }
 
     if (pr_number) {
+        if (projection === 'merge-readiness') {
+            try {
+                const identityAssertion = await resolveGitHubIdentityAssertion(identityOptions);
+
+                return PullRequestService.getConversation({
+                    ...options,
+                    identityAssertion
+                });
+            } catch (error) {
+                return {
+                    schemaVersion: 'neo.merge-readiness/v1',
+                    projection   : 'merge-readiness',
+                    pr           : pr_number,
+                    observedAt   : new Date().toISOString(),
+                    verdict      : 'unavailable',
+                    blockers     : [{
+                        code   : error.code || 'GITHUB_IDENTITY_ASSERTION_FAILED',
+                        message: error.reason || error.message
+                    }],
+                    audit: [{
+                        source : 'identity-assertion',
+                        outcome: 'failed',
+                        code   : error.code || 'GITHUB_IDENTITY_ASSERTION_FAILED'
+                    }]
+                };
+            }
+        }
+
         return PullRequestService.getConversation(options);
     }
 
@@ -390,7 +459,8 @@ export {
     getConversationRouter,
     guardGitHubWriteTools,
     isPublicGitHubWriteTool,
-    normalizeGitHubIdentityLogin
+    normalizeGitHubIdentityLogin,
+    resolveGitHubIdentityAssertion
 };
 
 const toolService = Neo.create(ToolService, {

--- a/ai/scripts/lifecycle/validateMergeReady.mjs
+++ b/ai/scripts/lifecycle/validateMergeReady.mjs
@@ -26,19 +26,22 @@ export const MERGEABLE_STATES = ['CLEAN', 'UNSTABLE'];
  * @summary Validates whether a PR is STRICT merge-ready against the full review/merge contract.
  *
  * Rules (all must hold for `strictMergeReady`):
- *  1. `reviewDecision === 'APPROVED'`.
- *  2. `checksGreen === true` (all required CI checks pass).
- *  3. `mergeStateStatus` is fetched AND a confirmed-mergeable state (allowlist `CLEAN`/`UNSTABLE`); `UNKNOWN`
+ *  1. The PR source was fetched as `state === 'OPEN'` and `mergedAt === null`.
+ *  2. `reviewDecision === 'APPROVED'`.
+ *  3. `checksGreen === true` (all required CI checks pass).
+ *  4. `mergeStateStatus` is fetched AND a confirmed-mergeable state (allowlist `CLEAN`/`UNSTABLE`); `UNKNOWN`
  *     (mergeability not yet computed) and DIRTY/BEHIND/BLOCKED all fail closed.
- *  4. `reviewRequests` is fetched AND every explicitly-requested reviewer is disposed — i.e. `reviewRequests`
+ *  5. `reviewRequests` is fetched AND every explicitly-requested reviewer is disposed — i.e. `reviewRequests`
  *     minus `disposedReviewers` is empty (the reviewer-contract gate).
  *
- * Fail-CLOSED contract: `checksGreen`, `mergeStateStatus`, and `reviewRequests` that were NOT fetched
- * (`undefined`) each block readiness — an un-queried field cannot certify a green surface, and an
- * omitted `reviewRequests` must never be read as "no outstanding reviewers". Pass `reviewRequests: []`
- * to assert it was fetched-and-empty.
+ * Fail-CLOSED contract: `state`, `mergedAt`, `checksGreen`, `mergeStateStatus`, and `reviewRequests`
+ * that were NOT fetched (`undefined`) each block readiness — an un-queried field cannot certify a
+ * green surface, and an omitted `reviewRequests` must never be read as "no outstanding reviewers".
+ * Pass `mergedAt: null` and `reviewRequests: []` to assert fetched-and-empty values.
  *
  * @param {Object} [pr={}]
+ * @param {String} [pr.state] GitHub PR state; only fetched `OPEN` passes.
+ * @param {String|null} [pr.mergedAt] GitHub merge timestamp; fetched `null` passes.
  * @param {String} [pr.reviewDecision] GitHub flattened review decision (`APPROVED` | `CHANGES_REQUESTED` | `REVIEW_REQUIRED` | null).
  * @param {Boolean} [pr.checksGreen] True when all required CI checks pass; `undefined` (not fetched) fails closed.
  * @param {String} [pr.mergeStateStatus] GitHub mergeStateStatus (`CLEAN` | `UNSTABLE` | `DIRTY` | `BEHIND` | `BLOCKED` | ...); `undefined` (not fetched) fails closed.
@@ -48,6 +51,8 @@ export const MERGEABLE_STATES = ['CLEAN', 'UNSTABLE'];
  */
 export function validateMergeReady(pr = {}) {
     const {
+        state,
+        mergedAt,
         reviewDecision,
         checksGreen,
         mergeStateStatus,
@@ -56,6 +61,18 @@ export function validateMergeReady(pr = {}) {
     } = pr;
 
     const blockers = [];
+
+    if (state === undefined) {
+        blockers.push('state was not fetched — cannot certify the pull request is open; failing closed.');
+    } else if (state !== 'OPEN') {
+        blockers.push(`state is '${state}', not OPEN.`);
+    }
+
+    if (mergedAt === undefined) {
+        blockers.push('mergedAt was not fetched — cannot certify the pull request is unmerged; failing closed.');
+    } else if (mergedAt !== null) {
+        blockers.push(`mergedAt is '${mergedAt}', so the pull request is already merged.`);
+    }
 
     if (reviewDecision !== 'APPROVED') {
         blockers.push(`reviewDecision is '${reviewDecision ?? 'none'}', not APPROVED.`);

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -1,18 +1,24 @@
-import {exec, execFile} from 'child_process';
-import {readFileSync}   from 'fs';
-import path             from 'path';
-import {promisify}      from 'util';
-import Base             from '../../../src/core/Base.mjs';
-import GraphqlService   from './GraphqlService.mjs';
-import aiConfig         from '../../mcp/server/github-workflow/config.mjs';
-import logger           from '../../mcp/server/github-workflow/logger.mjs';
+import {exec, execFile}     from 'child_process';
+import {createHash}         from 'crypto';
+import {readFileSync}       from 'fs';
+import path                 from 'path';
+import {promisify}          from 'util';
+import Base                 from '../../../src/core/Base.mjs';
+import GraphqlService       from './GraphqlService.mjs';
+import aiConfig             from '../../mcp/server/github-workflow/config.mjs';
+import logger               from '../../mcp/server/github-workflow/logger.mjs';
+import {validateMergeReady} from '../../scripts/lifecycle/validateMergeReady.mjs';
 import {
     ADD_PULL_REQUEST_REVIEW,
     GET_PULL_REQUEST_ID,
     GET_PULL_REQUEST_REVIEW,
     UPDATE_PULL_REQUEST_REVIEW
 }                                              from './queries/mutations.mjs';
-import {FETCH_PULL_REQUESTS, GET_CONVERSATION} from './queries/pullRequestQueries.mjs';
+import {
+    FETCH_PULL_REQUESTS,
+    GET_CONVERSATION,
+    GET_MERGE_READINESS
+} from './queries/pullRequestQueries.mjs';
 import {projectConversationTrust}              from './shared/conversationTrust.mjs';
 
 const execAsync                        = promisify(exec);
@@ -44,6 +50,461 @@ const DROP_SUPERSEDE_CONTRACT_FIELDS = [
     'Successor landing pad',
     'Successor map citation'
 ];
+
+const MERGE_READINESS_PROJECTION     = 'merge-readiness';
+const MERGE_READINESS_SCHEMA_VERSION = 'neo.merge-readiness/v1';
+
+function stableStringify(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(stableStringify).join(',')}]`;
+    }
+
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value).sort().map(key =>
+            `${JSON.stringify(key)}:${stableStringify(value[key])}`
+        ).join(',')}}`;
+    }
+
+    return JSON.stringify(value);
+}
+
+function digestValue(value) {
+    return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`;
+}
+
+function deepFreeze(value) {
+    if (!value || typeof value !== 'object' || Object.isFrozen(value)) {
+        return value;
+    }
+
+    Object.values(value).forEach(deepFreeze);
+
+    return Object.freeze(value);
+}
+
+function createCodedError(code, message) {
+    return Object.assign(new Error(message), {code});
+}
+
+function normalizeRequestedReviewer(node) {
+    const reviewer = node?.requestedReviewer;
+
+    if (reviewer?.__typename === 'User' && reviewer.login) {
+        return {kind: 'user', login: reviewer.login};
+    }
+
+    if (reviewer?.__typename === 'Team' && reviewer.slug && reviewer.organization?.login) {
+        return {kind: 'team', login: `${reviewer.organization.login}/${reviewer.slug}`};
+    }
+
+    return {kind: 'unknown', login: null};
+}
+
+function classifyEmittedContext(node) {
+    if (node?.__typename === 'CheckRun' && node.name) {
+        let state;
+
+        if (node.status !== 'COMPLETED') {
+            state = 'pending';
+        } else if (node.conclusion === 'SUCCESS') {
+            state = 'success';
+        } else if (node.conclusion === 'SKIPPED') {
+            state = 'skipped';
+        } else if (node.conclusion === 'NEUTRAL' || node.conclusion == null) {
+            state = 'not-applicable';
+        } else {
+            state = 'failing';
+        }
+
+        return {
+            kind         : 'check-run',
+            name         : node.name,
+            integrationId: node.checkSuite?.app?.databaseId ?? null,
+            integration  : node.checkSuite?.app?.slug ?? null,
+            status       : node.status,
+            conclusion   : node.conclusion,
+            state,
+            url          : node.detailsUrl ?? null
+        };
+    }
+
+    if (node?.__typename === 'StatusContext' && node.context) {
+        const state = node.state === 'SUCCESS'
+            ? 'success'
+            : ['EXPECTED', 'PENDING'].includes(node.state)
+                ? 'pending'
+                : ['ERROR', 'FAILURE'].includes(node.state)
+                    ? 'failing'
+                    : 'not-applicable';
+
+        return {
+            kind         : 'status-context',
+            name         : node.context,
+            integrationId: null,
+            integration  : null,
+            status       : node.state,
+            conclusion   : null,
+            state,
+            url          : node.targetUrl ?? null
+        };
+    }
+
+    return {
+        kind         : 'unknown',
+        name         : null,
+        integrationId: null,
+        integration  : null,
+        status       : null,
+        conclusion   : null,
+        state        : 'not-applicable',
+        url          : null
+    };
+}
+
+function normalizeMergeReadinessSnapshot(pullRequest) {
+    if (!pullRequest) {
+        throw createCodedError('PR_NOT_FOUND', 'The pull request does not exist or is not visible.');
+    }
+
+    const reviewConnection = pullRequest.reviewRequests;
+    const reviewers        = (reviewConnection?.nodes || []).map(normalizeRequestedReviewer)
+        .sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)));
+    const commit            = pullRequest.commits?.nodes?.[0]?.commit || null;
+    const rollup            = commit?.statusCheckRollup;
+    const contextConnection = rollup?.contexts;
+    const emittedContexts   = (contextConnection?.nodes || []).map(classifyEmittedContext)
+        .sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)));
+
+    return {
+        number          : pullRequest.number,
+        state           : pullRequest.state,
+        mergedAt        : pullRequest.mergedAt,
+        baseRefName     : pullRequest.baseRefName,
+        headRefOid      : pullRequest.headRefOid,
+        mergeStateStatus: pullRequest.mergeStateStatus,
+        reviewDecision  : pullRequest.reviewDecision,
+        reviewRequests  : {
+            available  : Boolean(reviewConnection && Array.isArray(reviewConnection.nodes)),
+            hasNextPage: Boolean(reviewConnection?.pageInfo?.hasNextPage),
+            nodes      : reviewers
+        },
+        checks: {
+            commitAvailable: Boolean(commit),
+            commitOid      : commit?.oid ?? null,
+            rollupAvailable: rollup === null || Boolean(contextConnection && Array.isArray(contextConnection.nodes)),
+            hasNextPage    : Boolean(contextConnection?.pageInfo?.hasNextPage),
+            totalCount     : contextConnection?.totalCount ?? emittedContexts.length,
+            nodes          : emittedContexts
+        }
+    };
+}
+
+function parseRequiredContexts(rules) {
+    if (!Array.isArray(rules)) {
+        throw createCodedError('REQUIRED_SET_UNREADABLE', 'Branch-rules response is not an array.');
+    }
+
+    const contexts = [];
+
+    for (const rule of rules.filter(item => item?.type === 'required_status_checks')) {
+        const required = rule?.parameters?.required_status_checks;
+
+        if (!Array.isArray(required)) {
+            throw createCodedError(
+                'REQUIRED_SET_UNREADABLE',
+                'A required_status_checks rule omitted its required_status_checks array.'
+            );
+        }
+
+        for (const item of required) {
+            const context       = typeof item?.context === 'string' ? item.context.trim() : '';
+            const integrationId = item?.integration_id ?? null;
+
+            if (!context || (integrationId !== null && !Number.isInteger(integrationId))) {
+                throw createCodedError(
+                    'REQUIRED_SET_UNREADABLE',
+                    'A required status-check entry has a malformed context or integration_id.'
+                );
+            }
+
+            contexts.push({context, integrationId});
+        }
+    }
+
+    return [...new Map(contexts.map(item => [
+        `${item.context}\u0000${item.integrationId ?? ''}`,
+        item
+    ])).values()].sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)));
+}
+
+function compareRequiredAndEmittedContexts(requiredContexts, emittedContexts) {
+    const requiredStates = requiredContexts.map(required => {
+        const matches = emittedContexts.filter(emitted =>
+            emitted.name === required.context &&
+            (required.integrationId === null || emitted.integrationId === required.integrationId)
+        );
+
+        if (!matches.length) {
+            return {...required, state: 'absent-required', emissions: []};
+        }
+
+        const priority = ['failing', 'pending', 'skipped', 'not-applicable', 'success'];
+        const state    = priority.find(candidate => matches.some(item => item.state === candidate));
+
+        return {...required, state, emissions: matches};
+    });
+    const emittedOnly = emittedContexts.filter(emitted =>
+        !requiredContexts.some(required =>
+            emitted.name === required.context &&
+            (required.integrationId === null || emitted.integrationId === required.integrationId)
+        )
+    );
+
+    return {requiredStates, emittedOnly};
+}
+
+function normalizeBoundPrincipals(identityAssertion) {
+    const principals = identityAssertion?.principals || {};
+
+    return {
+        agentIdentity     : principals.agentIdentity || null,
+        githubLogin       : principals.githubLogin || null,
+        memoryCoreIdentity: principals.memoryCoreIdentity || null
+    };
+}
+
+function createMergeReadinessFailure({
+    owner,
+    repo,
+    prNumber,
+    observedAt,
+    principals,
+    code,
+    message,
+    audit = [],
+    source = {}
+}) {
+    return deepFreeze({
+        schemaVersion: MERGE_READINESS_SCHEMA_VERSION,
+        projection   : MERGE_READINESS_PROJECTION,
+        repo         : `${owner}/${repo}`,
+        pr           : prNumber,
+        observedAt,
+        principals,
+        verdict      : 'unavailable',
+        source,
+        blockers     : [{code, message}],
+        audit
+    });
+}
+
+async function buildMergeReadinessProjection({
+    prNumber,
+    identityAssertion,
+    owner = aiConfig.owner,
+    repo = aiConfig.repo,
+    query = GraphqlService.query.bind(GraphqlService),
+    rest = GraphqlService.rest.bind(GraphqlService),
+    now = () => new Date()
+}) {
+    const observedValue = now();
+    const observedAt    = (observedValue instanceof Date ? observedValue : new Date(observedValue)).toISOString();
+    const principals    = normalizeBoundPrincipals(identityAssertion);
+    const audit         = [];
+    const fail          = options => createMergeReadinessFailure({
+        owner,
+        repo,
+        prNumber,
+        observedAt,
+        principals,
+        audit,
+        ...options
+    });
+
+    if (!identityAssertion?.ok || Object.values(principals).some(value => !value)) {
+        return fail({
+            code   : 'IDENTITY_BINDING_MISSING',
+            message: 'The merge-readiness projection requires bound AgentIdentity, GitHub, and Memory Core principals.',
+            audit  : [{source: 'identity-assertion', outcome: 'failed'}]
+        });
+    }
+
+    const variables = {owner, repo, prNumber};
+    let firstSnapshot;
+
+    try {
+        const data = await query(GET_MERGE_READINESS, variables);
+        firstSnapshot = normalizeMergeReadinessSnapshot(data?.repository?.pullRequest);
+        audit.push({source: 'github-graphql:pull-request-readiness', call: 1, outcome: 'read'});
+    } catch (error) {
+        return fail({
+            code   : error.code || 'PR_SOURCE_UNREADABLE',
+            message: error.message,
+            audit  : [...audit, {source: 'github-graphql:pull-request-readiness', call: 1, outcome: 'failed'}]
+        });
+    }
+
+    const rulesPath = `/repos/${owner}/${repo}/rules/branches/${encodeURIComponent(firstSnapshot.baseRefName)}`;
+    let firstRequiredContexts;
+
+    try {
+        firstRequiredContexts = parseRequiredContexts(await rest('GET', rulesPath));
+        audit.push({source: `github-rest:${rulesPath}`, call: 1, outcome: 'read'});
+    } catch (error) {
+        return fail({
+            code   : 'REQUIRED_SET_UNREADABLE',
+            message: error.message,
+            audit  : [...audit, {source: `github-rest:${rulesPath}`, call: 1, outcome: 'failed'}],
+            source : {base: firstSnapshot.baseRefName, head: firstSnapshot.headRefOid}
+        });
+    }
+
+    let finalSnapshot;
+
+    try {
+        const data = await query(GET_MERGE_READINESS, variables);
+        finalSnapshot = normalizeMergeReadinessSnapshot(data?.repository?.pullRequest);
+        audit.push({source: 'github-graphql:pull-request-readiness', call: 2, outcome: 'read'});
+    } catch (error) {
+        return fail({
+            code   : error.code || 'PR_SOURCE_UNREADABLE',
+            message: error.message,
+            audit  : [...audit, {source: 'github-graphql:pull-request-readiness', call: 2, outcome: 'failed'}],
+            source : {base: firstSnapshot.baseRefName, head: firstSnapshot.headRefOid}
+        });
+    }
+
+    let finalRequiredContexts;
+
+    try {
+        finalRequiredContexts = parseRequiredContexts(await rest('GET', rulesPath));
+        audit.push({source: `github-rest:${rulesPath}`, call: 2, outcome: 'read'});
+    } catch (error) {
+        return fail({
+            code   : 'REQUIRED_SET_UNREADABLE',
+            message: error.message,
+            audit  : [...audit, {source: `github-rest:${rulesPath}`, call: 2, outcome: 'failed'}],
+            source : {base: finalSnapshot.baseRefName, head: finalSnapshot.headRefOid}
+        });
+    }
+
+    if (
+        stableStringify(firstSnapshot) !== stableStringify(finalSnapshot) ||
+        stableStringify(firstRequiredContexts) !== stableStringify(finalRequiredContexts)
+    ) {
+        return fail({
+            code   : 'SOURCE_CHANGED_DURING_READ',
+            message: 'Pull-request readiness state or its effective required-context set changed during the observation.',
+            source : {
+                initial: {
+                    base : firstSnapshot.baseRefName,
+                    head : firstSnapshot.headRefOid,
+                    state: firstSnapshot.state
+                },
+                final: {
+                    base : finalSnapshot.baseRefName,
+                    head : finalSnapshot.headRefOid,
+                    state: finalSnapshot.state
+                }
+            }
+        });
+    }
+
+    const snapshot          = finalSnapshot;
+    const requiredContexts  = finalRequiredContexts;
+    const comparison        = compareRequiredAndEmittedContexts(requiredContexts, snapshot.checks.nodes);
+    const reviewSourceReady = snapshot.reviewRequests.available &&
+        !snapshot.reviewRequests.hasNextPage &&
+        snapshot.reviewRequests.nodes.every(item => item.kind !== 'unknown');
+    const checkSourceReady = snapshot.checks.commitAvailable &&
+        snapshot.checks.rollupAvailable &&
+        !snapshot.checks.hasNextPage &&
+        snapshot.checks.nodes.every(item => item.kind !== 'unknown') &&
+        snapshot.checks.commitOid === snapshot.headRefOid;
+    const checksGreen = checkSourceReady &&
+        comparison.requiredStates.every(item => item.state === 'success');
+    const reviewRequests = reviewSourceReady
+        ? snapshot.reviewRequests.nodes.map(item => item.login)
+        : undefined;
+    const sourceBlockers = [];
+
+    if (!reviewSourceReady) {
+        sourceBlockers.push({
+            code   : 'REVIEW_REQUESTS_UNREADABLE',
+            message: 'The requested-reviewer connection is missing, truncated, or contains an unknown reviewer type.'
+        });
+    }
+
+    if (!checkSourceReady) {
+        sourceBlockers.push({
+            code   : 'EMITTED_CONTEXTS_UNREADABLE',
+            message: 'The head check-rollup is missing, truncated, malformed, or bound to a different commit.'
+        });
+    }
+
+    comparison.requiredStates
+        .filter(item => item.state !== 'success')
+        .forEach(item => sourceBlockers.push({
+            code   : item.state.toUpperCase().replaceAll('-', '_'),
+            message: `Required context '${item.context}' is ${item.state}.`
+        }));
+
+    const predicate = validateMergeReady({
+        state           : snapshot.state,
+        mergedAt        : snapshot.mergedAt,
+        reviewDecision  : snapshot.reviewDecision,
+        checksGreen,
+        mergeStateStatus: snapshot.mergeStateStatus,
+        reviewRequests
+    });
+    const strictMergeReady = predicate.strictMergeReady && sourceBlockers.length === 0;
+    const requiredSet      = {
+        source  : `GET ${rulesPath}`,
+        digest  : digestValue(requiredContexts),
+        contexts: requiredContexts
+    };
+    const observationCore = {
+        schemaVersion: MERGE_READINESS_SCHEMA_VERSION,
+        repo         : `${owner}/${repo}`,
+        pr           : prNumber,
+        base         : snapshot.baseRefName,
+        head         : snapshot.headRefOid,
+        state        : snapshot.state,
+        mergedAt     : snapshot.mergedAt,
+        observedAt,
+        principals,
+        requiredSet,
+        contextStates: comparison.requiredStates,
+        predicate
+    };
+    const observationId = digestValue(observationCore);
+    const result        = {
+        ...observationCore,
+        projection      : MERGE_READINESS_PROJECTION,
+        observationId,
+        mergeStateStatus: snapshot.mergeStateStatus,
+        reviewDecision  : snapshot.reviewDecision,
+        reviewRequests  : reviewRequests ?? null,
+        emittedContexts : snapshot.checks.nodes,
+        emittedOnly     : comparison.emittedOnly,
+        checksGreen,
+        verdict         : strictMergeReady ? 'merge-ready-observed' : 'not-merge-ready',
+        statement       : strictMergeReady
+            ? `Observed strict merge-ready at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`
+            : `Did not observe strict merge-readiness at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`,
+        blockers: [
+            ...sourceBlockers,
+            ...predicate.blockers.map(message => ({code: 'STRICT_MERGE_READINESS', message}))
+        ],
+        audit: [
+            ...audit,
+            {source: 'validateMergeReady', call: 1, outcome: strictMergeReady ? 'positive' : 'negative'}
+        ],
+        ...(strictMergeReady ? {marker: `[merge-eligible][B-prime:${observationId}]`} : {})
+    };
+
+    return deepFreeze(result);
+}
 
 const FULL_PR_REVIEW_TEMPLATE_SKELETON_LABELS = [
     'PR Review Summary',
@@ -1406,6 +1867,9 @@ class PullRequestService extends Base {
      *   only what's new. Scales linearly with new-comment volume, not cumulative thread size.
      * - `last_n` — fetch the last N comments. Coarse-grained alternative when comment IDs
      *   aren't tracked. Useful for quick catch-up scans.
+     * - `projection: 'merge-readiness'` — returns a source-owned, identity-bound exact-head
+     *   readiness observation instead of conversation content. The MCP router injects the
+     *   identity assertion; callers cannot supply readiness fields.
      *
      * Selectors are applied client-side after a single GraphQL fetch (the fetch itself already
      * caps at `aiConfig.pullRequest.maxCommentsPerPullRequest`). Server-side pagination
@@ -1416,6 +1880,7 @@ class PullRequestService extends Base {
      * @param {Object|number} options Either a number (backward-compatible `prNumber` positional form)
      *                                or an object with the shape below.
      * @param {number}        options.pr_number         The pull request number (required when object form).
+     * @param {string}        [options.projection='conversation'] Response projection.
      * @param {string}        [options.comment_id]      Return only the matching comment's data; other
      *                                                  comments elided. PR title/body still returned.
      * @param {string}        [options.since_comment_id] Return comments strictly after the matching
@@ -1423,14 +1888,25 @@ class PullRequestService extends Base {
      *                                                  returns empty comments (callers can interpret as
      *                                                  "nothing new" or "id invalid").
      * @param {number}        [options.last_n]          Return only the last N comments (by createdAt order).
+     * @param {Object}        [dependencies] Internal source seams for deterministic tests.
+     * @param {Function}      [dependencies.query] GitHub GraphQL query function.
+     * @param {Function}      [dependencies.rest] GitHub REST request function.
+     * @param {Function}      [dependencies.now] Observation-clock function.
      * @returns {Promise<object>} Conversation data (optionally filtered) or a structured error. Payloads
      *          are trust-projected: authored nodes carry `authorTrust`, untrusted-author bodies arrive
      *          defanged, and the root carries a `contentTrust` summary (see `shared/conversationTrust.mjs`).
      */
-    async getConversation(options) {
+    async getConversation(options, dependencies = {}) {
         // Accept positional `prNumber` form for backward compatibility.
         // New callers use the object form for filter support.
-        const {pr_number, comment_id, since_comment_id, last_n} = typeof options === 'number'
+        const {
+            pr_number,
+            comment_id,
+            since_comment_id,
+            last_n,
+            projection = 'conversation',
+            identityAssertion
+        } = typeof options === 'number'
             ? {pr_number: options}
             : (options || {});
 
@@ -1442,6 +1918,30 @@ class PullRequestService extends Base {
             };
         }
 
+        if (!['conversation', MERGE_READINESS_PROJECTION].includes(projection)) {
+            return {
+                error  : 'Bad Request',
+                message: `Unsupported projection '${projection}'.`,
+                code   : 'INVALID_PROJECTION'
+            };
+        }
+
+        if (projection === MERGE_READINESS_PROJECTION) {
+            if (comment_id || since_comment_id || last_n) {
+                return {
+                    error  : 'Bad Request',
+                    message: 'Comment selectors cannot be combined with the merge-readiness projection.',
+                    code   : 'INCOMPATIBLE_SELECTORS'
+                };
+            }
+
+            return buildMergeReadinessProjection({
+                prNumber: pr_number,
+                identityAssertion,
+                ...dependencies
+            });
+        }
+
         const variables = {
             owner      : aiConfig.owner,
             repo       : aiConfig.repo,
@@ -1450,7 +1950,8 @@ class PullRequestService extends Base {
         };
 
         try {
-            const data = await GraphqlService.query(GET_CONVERSATION, variables);
+            const query = dependencies.query || GraphqlService.query.bind(GraphqlService);
+            const data  = await query(GET_CONVERSATION, variables);
             // Trust-project at the read boundary: every authored node gains `authorTrust`,
             // untrusted-author bodies are defanged, the root carries a `contentTrust` summary.
             // Applied before selector filtering so all return paths inherit projected nodes.

--- a/ai/services/github-workflow/queries/pullRequestQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestQueries.mjs
@@ -38,6 +38,90 @@ export const GET_CONVERSATION = `
 `;
 
 /**
+ * @summary Fetches every source-owned PR field needed for a merge-readiness observation.
+ *
+ * The caller executes this query twice around the branch-rules read and compares the normalized
+ * payloads. `pageInfo` is part of the contract: either bounded connection truncating at 100 makes
+ * the observation fail closed instead of silently treating the partial collection as complete.
+ *
+ * Variables required:
+ * - $owner: String! - Repository owner
+ * - $repo: String! - Repository name
+ * - $prNumber: Int! - Pull request number
+ */
+export const GET_MERGE_READINESS = `
+  query GetMergeReadiness($owner: String!, $repo: String!, $prNumber: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $prNumber) {
+        number
+        state
+        mergedAt
+        baseRefName
+        headRefOid
+        mergeStateStatus
+        reviewDecision
+        reviewRequests(first: 100) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            requestedReviewer {
+              __typename
+              ... on User {
+                login
+              }
+              ... on Team {
+                slug
+                organization {
+                  login
+                }
+              }
+            }
+          }
+        }
+        commits(last: 1) {
+          nodes {
+            commit {
+              oid
+              statusCheckRollup {
+                contexts(first: 100) {
+                  totalCount
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                  nodes {
+                    __typename
+                    ... on CheckRun {
+                      name
+                      status
+                      conclusion
+                      detailsUrl
+                      checkSuite {
+                        app {
+                          databaseId
+                          slug
+                        }
+                      }
+                    }
+                    ... on StatusContext {
+                      context
+                      state
+                      targetUrl
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
  * Query to fetch a list of pull requests.
  *
  * Variables required:

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -626,7 +626,7 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(handbookTool.annotations.readOnlyHint).toBe(true);
         expect(relationship.description).toBe('Create, replace, or remove issue parent-child and blocked-by relationships.');
         expect(relationship.description).not.toContain('Run `sync_all`');
-        expect(conversation.description).toBe('Fetch a pull request or issue conversation with optional comment-window selectors.');
+        expect(conversation.description).toBe('Fetch PR/issue conversation, or an identity-bound source-owned PR readiness projection.');
         expect(review.description).toBe('Create or update one formal PR review with body and review state validation.');
         expect(review.inputSchema.properties.reviewBudgetOverrideReason).toMatchObject({type: 'string'});
         expect(reviewHandbook.handbook).toContain('reviewBudgetOverrideReason');

--- a/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
@@ -113,4 +113,19 @@ test.describe('GitHub Workflow MCP Server Tool Registration', () => {
         expect(paramNames).toContain('cursor');
         expect(operation.parameters.find(parameter => parameter.name === 'cursor').schema.type).toBe('string');
     });
+
+    test('#16029 extends get_conversation without growing the MCP operation catalog', () => {
+        const filePath   = path.resolve(__dirname, '../../../../../../../ai/mcp/server/github-workflow/openapi.yaml');
+        const doc        = yaml.load(fs.readFileSync(filePath, 'utf8'));
+        const operations = Object.values(doc.paths).flatMap(pathItem =>
+            Object.values(pathItem).filter(value => value?.operationId)
+        );
+        const operation    = operations.find(value => value.operationId === 'get_conversation');
+        const projection   = operation.requestBody.content['application/json'].schema.properties.projection;
+        const operationIds = operations.map(value => value.operationId);
+
+        expect(projection.enum).toEqual(['conversation', 'merge-readiness']);
+        expect(operationIds.filter(id => id === 'get_conversation')).toHaveLength(1);
+        expect(operationIds).not.toContain('certify_merge_readiness');
+    });
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
@@ -11,88 +11,126 @@ import * as core            from '../../../../../../src/core/_export.mjs';
 import {validateMergeReady} from '../../../../../../ai/scripts/lifecycle/validateMergeReady.mjs';
 
 test.describe('validateMergeReady — strict merge-readiness contract', () => {
+    const openSource = overrides => ({state: 'OPEN', mergedAt: null, ...overrides});
+
     test('a fully-disposed approved PR is strict-merge-ready', () => {
-        const result = validateMergeReady({
+        const result = validateMergeReady(openSource({
             reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'CLEAN', reviewRequests: []
-        });
+        }));
         expect(result.strictMergeReady).toBe(true);
         expect(result.blockers).toEqual([]);
     });
 
     test('APPROVED + green + CLEAN with an OUTSTANDING requested reviewer is NOT strict-merge-ready (#13587)', () => {
         // The false-positive class: reviewDecision flattens to APPROVED + CLEAN, but a requested reviewer is outstanding.
-        const result = validateMergeReady({
+        const result = validateMergeReady(openSource({
             reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'CLEAN',
             reviewRequests: ['neo-opus-grace']
-        });
+        }));
         expect(result.strictMergeReady).toBe(false);
         expect(result.blockers.join(' ')).toContain('outstanding requested reviewer');
         expect(result.blockers.join(' ')).toContain('neo-opus-grace');
     });
 
     test('an outstanding reviewer who is later disposed no longer blocks', () => {
-        const result = validateMergeReady({
+        const result = validateMergeReady(openSource({
             reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'CLEAN',
             reviewRequests: ['neo-opus-grace'], disposedReviewers: ['neo-opus-grace']
-        });
+        }));
         expect(result.strictMergeReady).toBe(true);
     });
 
     test('a non-APPROVED reviewDecision blocks', () => {
-        const result = validateMergeReady({reviewDecision: 'REVIEW_REQUIRED', checksGreen: true, mergeStateStatus: 'CLEAN'});
+        const result = validateMergeReady(openSource({
+            reviewDecision: 'REVIEW_REQUIRED', checksGreen: true, mergeStateStatus: 'CLEAN'
+        }));
         expect(result.strictMergeReady).toBe(false);
         expect(result.blockers.join(' ')).toContain('not APPROVED');
     });
 
     test('red CI blocks even when approved', () => {
-        const result = validateMergeReady({reviewDecision: 'APPROVED', checksGreen: false, mergeStateStatus: 'CLEAN'});
+        const result = validateMergeReady(openSource({
+            reviewDecision: 'APPROVED', checksGreen: false, mergeStateStatus: 'CLEAN'
+        }));
         expect(result.strictMergeReady).toBe(false);
         expect(result.blockers.join(' ')).toContain('CI checks');
     });
 
     test('a DIRTY merge state (conflict / stale base) blocks', () => {
-        const result = validateMergeReady({
+        const result = validateMergeReady(openSource({
             reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'DIRTY', reviewRequests: []
-        });
+        }));
         expect(result.strictMergeReady).toBe(false);
         expect(result.blockers.join(' ')).toContain("'DIRTY'");
     });
 
     test('UNSTABLE (mergeable, CI in flux) is not itself a non-mergeable blocker', () => {
         // UNSTABLE is mergeable; checksGreen is the CI gate, not mergeStateStatus.
-        const result = validateMergeReady({
+        const result = validateMergeReady(openSource({
             reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'UNSTABLE', reviewRequests: []
-        });
+        }));
         expect(result.strictMergeReady).toBe(true);
     });
 
     test('fails CLOSED when reviewRequests was not fetched (undefined, not [])', () => {
         // The omission false-positive: APPROVED + green + CLEAN but reviewRequests never queried.
-        const result = validateMergeReady({reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'CLEAN'});
+        const result = validateMergeReady(openSource({
+            reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'CLEAN'
+        }));
         expect(result.strictMergeReady).toBe(false);
         expect(result.blockers.join(' ')).toContain('reviewRequests was not fetched');
     });
 
     test('fails CLOSED when mergeStateStatus was not fetched', () => {
-        const result = validateMergeReady({reviewDecision: 'APPROVED', checksGreen: true, reviewRequests: []});
+        const result = validateMergeReady(openSource({
+            reviewDecision: 'APPROVED', checksGreen: true, reviewRequests: []
+        }));
         expect(result.strictMergeReady).toBe(false);
         expect(result.blockers.join(' ')).toContain('mergeStateStatus was not fetched');
     });
 
     test('an empty-array reviewRequests (fetched-and-empty) does NOT fail closed', () => {
         // [] is the explicit "fetched, none outstanding" assertion — distinct from undefined.
-        const result = validateMergeReady({
+        const result = validateMergeReady(openSource({
             reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'CLEAN', reviewRequests: []
-        });
+        }));
         expect(result.strictMergeReady).toBe(true);
     });
 
     test('UNKNOWN mergeStateStatus fails closed — GitHub has not computed mergeability (#13588 cycle-2)', () => {
         // Allowlist: only CLEAN/UNSTABLE certify; an uncomputed UNKNOWN must NOT certify strict-ready.
-        const result = validateMergeReady({
+        const result = validateMergeReady(openSource({
             reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'UNKNOWN', reviewRequests: []
-        });
+        }));
         expect(result.strictMergeReady).toBe(false);
         expect(result.blockers.join(' ')).toContain('UNKNOWN');
+    });
+
+    test('fails CLOSED when state or mergedAt was not fetched', () => {
+        const result = validateMergeReady({
+            reviewDecision  : 'APPROVED',
+            checksGreen     : true,
+            mergeStateStatus: 'CLEAN',
+            reviewRequests  : []
+        });
+
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.join(' ')).toContain('state was not fetched');
+        expect(result.blockers.join(' ')).toContain('mergedAt was not fetched');
+    });
+
+    test('a closed or already-merged pull request blocks', () => {
+        const result = validateMergeReady(openSource({
+            state           : 'CLOSED',
+            mergedAt        : '2026-07-29T08:00:00Z',
+            reviewDecision  : 'APPROVED',
+            checksGreen     : true,
+            mergeStateStatus: 'CLEAN',
+            reviewRequests  : []
+        }));
+
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.join(' ')).toContain("state is 'CLOSED'");
+        expect(result.blockers.join(' ')).toContain('already merged');
     });
 });

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -14,6 +14,265 @@ setup({
     }
 });
 
+test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-readiness projection (#16029)', () => {
+    let PullRequestService;
+
+    const HEAD       = 'a'.repeat(40);
+    const NEXT_HEAD  = 'b'.repeat(40);
+    const PRINCIPALS = {
+        agentIdentity     : '@neo-gpt',
+        githubLogin       : 'neo-gpt',
+        memoryCoreIdentity: '@neo-gpt'
+    };
+    const IDENTITY = {ok: true, code: 'OK', reason: null, principals: PRINCIPALS};
+    const RULES    = [{
+        type      : 'required_status_checks',
+        parameters: {
+            required_status_checks: [{context: 'integration-parity', integration_id: 15368}]
+        }
+    }];
+
+    const checkRun = (state = 'success', {
+        integrationId = 15368,
+        name = 'integration-parity'
+    } = {}) => {
+        const variants = {
+            success         : {status: 'COMPLETED', conclusion: 'SUCCESS'},
+            pending         : {status: 'IN_PROGRESS', conclusion: null},
+            failing         : {status: 'COMPLETED', conclusion: 'FAILURE'},
+            skipped         : {status: 'COMPLETED', conclusion: 'SKIPPED'},
+            'not-applicable': {status: 'COMPLETED', conclusion: 'NEUTRAL'}
+        };
+
+        return {
+            __typename: 'CheckRun',
+            name,
+            ...variants[state],
+            detailsUrl: `https://example.test/checks/${name}`,
+            checkSuite: {
+                app: {
+                    databaseId: integrationId,
+                    slug      : 'github-actions'
+                }
+            }
+        };
+    };
+
+    const pullRequest = ({
+        baseRefName = 'dev',
+        checkCommit = HEAD,
+        checkHasNextPage = false,
+        contexts = [checkRun()],
+        headRefOid = HEAD,
+        mergeStateStatus = 'CLEAN',
+        mergedAt = null,
+        reviewDecision = 'APPROVED',
+        reviewHasNextPage = false,
+        reviewers = [],
+        state = 'OPEN'
+    } = {}) => ({
+        number        : 16029,
+        state,
+        mergedAt,
+        baseRefName,
+        headRefOid,
+        mergeStateStatus,
+        reviewDecision,
+        reviewRequests: {
+            pageInfo: {hasNextPage: reviewHasNextPage, endCursor: null},
+            nodes   : reviewers.map(login => ({
+                requestedReviewer: {__typename: 'User', login}
+            }))
+        },
+        commits: {
+            nodes: [{
+                commit: {
+                    oid              : checkCommit,
+                    statusCheckRollup: {
+                        contexts: {
+                            totalCount: contexts.length,
+                            pageInfo  : {hasNextPage: checkHasNextPage, endCursor: null},
+                            nodes     : contexts
+                        }
+                    }
+                }
+            }]
+        }
+    });
+
+    const dependencies = ({
+        snapshots = [pullRequest(), pullRequest()],
+        rules = [RULES, RULES],
+        restError = null
+    } = {}) => {
+        let queryCall = 0;
+        let restCall  = 0;
+
+        return {
+            now  : () => new Date('2026-07-29T08:00:00.000Z'),
+            query: async () => ({
+                repository: {
+                    pullRequest: snapshots[Math.min(queryCall++, snapshots.length - 1)]
+                }
+            }),
+            rest: async () => {
+                if (restError) {
+                    throw restError;
+                }
+
+                return rules[Math.min(restCall++, rules.length - 1)];
+            },
+            calls: () => ({queryCall, restCall})
+        };
+    };
+
+    const project = (deps, extra = {}) => PullRequestService.getConversation({
+        pr_number : 16029,
+        projection: 'merge-readiness',
+        ...extra,
+        identityAssertion: IDENTITY
+    }, deps);
+
+    test.beforeAll(async () => {
+        PullRequestService = (await import(
+            '../../../../../../ai/services/github-workflow/PullRequestService.mjs'
+        )).default;
+    });
+
+    test('returns one immutable positive exact-head observation and ignores caller readiness fields', async () => {
+        const deps   = dependencies();
+        const result = await project(deps, {
+            checksGreen     : false,
+            mergeStateStatus: 'DIRTY',
+            reviewDecision  : 'CHANGES_REQUESTED'
+        });
+
+        expect(result.verdict).toBe('merge-ready-observed');
+        expect(result.marker).toMatch(/^\[merge-eligible]\[B-prime:sha256:/);
+        expect(result.head).toBe(HEAD);
+        expect(result.mergeStateStatus).toBe('CLEAN');
+        expect(result.reviewDecision).toBe('APPROVED');
+        expect(result.requiredSet.contexts).toEqual([
+            {context: 'integration-parity', integrationId: 15368}
+        ]);
+        expect(result.principals).toEqual(PRINCIPALS);
+        expect(result.predicate.strictMergeReady).toBe(true);
+        expect(Object.isFrozen(result)).toBe(true);
+        expect(Object.isFrozen(result.requiredSet.contexts)).toBe(true);
+        expect(deps.calls()).toEqual({queryCall: 2, restCall: 2});
+    });
+
+    test('preserves the default conversation projection shape and source count', async () => {
+        let   calls  = 0;
+        const result = await PullRequestService.getConversation({pr_number: 16029}, {
+            query: async () => {
+                calls++;
+                return {
+                    repository: {
+                        pullRequest: {
+                            title   : 'Conversation',
+                            body    : 'Body',
+                            author  : {login: 'neo-gpt'},
+                            comments: {nodes: []}
+                        }
+                    }
+                };
+            }
+        });
+
+        expect(result.title).toBe('Conversation');
+        expect(result.comments.nodes).toEqual([]);
+        expect(result.projection).toBeUndefined();
+        expect(calls).toBe(1);
+    });
+
+    test('distinguishes an unreadable required set from a readable empty set', async () => {
+        const unreadable = await project(dependencies({
+            restError: new Error('403 Forbidden')
+        }));
+        const empty = await project(dependencies({
+            rules: [[], []]
+        }));
+
+        expect(unreadable.verdict).toBe('unavailable');
+        expect(unreadable.blockers[0].code).toBe('REQUIRED_SET_UNREADABLE');
+        expect(unreadable.marker).toBeUndefined();
+        expect(empty.verdict).toBe('merge-ready-observed');
+        expect(empty.requiredSet.contexts).toEqual([]);
+    });
+
+    test('fails closed when the PR source moves during the observation', async () => {
+        const result = await project(dependencies({
+            snapshots: [pullRequest(), pullRequest({headRefOid: NEXT_HEAD, checkCommit: NEXT_HEAD})]
+        }));
+
+        expect(result.verdict).toBe('unavailable');
+        expect(result.blockers[0].code).toBe('SOURCE_CHANGED_DURING_READ');
+        expect(result.marker).toBeUndefined();
+        expect(result.source.initial.head).toBe(HEAD);
+        expect(result.source.final.head).toBe(NEXT_HEAD);
+    });
+
+    test('fails closed when identity binding is absent before any source read', async () => {
+        const deps   = dependencies();
+        const result = await PullRequestService.getConversation({
+            pr_number : 16029,
+            projection: 'merge-readiness'
+        }, deps);
+
+        expect(result.verdict).toBe('unavailable');
+        expect(result.blockers[0].code).toBe('IDENTITY_BINDING_MISSING');
+        expect(result.marker).toBeUndefined();
+        expect(deps.calls()).toEqual({queryCall: 0, restCall: 0});
+    });
+
+    test('fails closed for a missing or wrong-integration required context', async () => {
+        for (const contexts of [[], [checkRun('success', {integrationId: 999})]]) {
+            const result = await project(dependencies({
+                snapshots: [pullRequest({contexts}), pullRequest({contexts})]
+            }));
+
+            expect(result.verdict).toBe('not-merge-ready');
+            expect(result.contextStates[0].state).toBe('absent-required');
+            expect(result.marker).toBeUndefined();
+        }
+    });
+
+    for (const state of ['pending', 'failing', 'skipped', 'not-applicable']) {
+        test(`preserves required context state '${state}' and withholds the marker`, async () => {
+            const contexts = [checkRun(state)];
+            const result   = await project(dependencies({
+                snapshots: [pullRequest({contexts}), pullRequest({contexts})]
+            }));
+
+            expect(result.verdict).toBe('not-merge-ready');
+            expect(result.contextStates[0].state).toBe(state);
+            expect(result.marker).toBeUndefined();
+            expect(result.checksGreen).toBe(false);
+        });
+    }
+
+    test('fails closed on truncated checks or reviewer requests', async () => {
+        const checks = await project(dependencies({
+            snapshots: [
+                pullRequest({checkHasNextPage: true}),
+                pullRequest({checkHasNextPage: true})
+            ]
+        }));
+        const reviewers = await project(dependencies({
+            snapshots: [
+                pullRequest({reviewHasNextPage: true}),
+                pullRequest({reviewHasNextPage: true})
+            ]
+        }));
+
+        expect(checks.blockers.map(item => item.code)).toContain('EMITTED_CONTEXTS_UNREADABLE');
+        expect(reviewers.blockers.map(item => item.code)).toContain('REVIEW_REQUESTS_UNREADABLE');
+        expect(checks.marker).toBeUndefined();
+        expect(reviewers.marker).toBeUndefined();
+    });
+});
+
 import {test, expect}  from '@playwright/test';
 import {execFileSync}  from 'node:child_process';
 import fs              from 'fs';

--- a/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
@@ -114,6 +114,71 @@ test.describe('Neo.ai.services.github-workflow.toolService — getConversationRo
         expect(issueCalls).toBe(0);
         expect(prCalls).toBe(0);
     });
+
+    test('#16029: merge-readiness projection is PR-only', async () => {
+        let issueCalls = 0, prCalls = 0;
+        IssueService.getConversation       = async () => { issueCalls++; };
+        PullRequestService.getConversation = async () => { prCalls++; };
+
+        const result = await getConversationRouter({
+            issue_number: 16029,
+            projection  : 'merge-readiness'
+        });
+
+        expect(result.code).toBe('PROJECTION_REQUIRES_PULL_REQUEST');
+        expect(issueCalls).toBe(0);
+        expect(prCalls).toBe(0);
+    });
+
+    test('#16029: identity drift withholds the projection before the PR service runs', async () => {
+        let prCalls = 0;
+        PullRequestService.getConversation = async () => { prCalls++; };
+
+        const result = await getConversationRouter({
+            pr_number : 16029,
+            projection: 'merge-readiness'
+        }, {
+            assertExpectedIdentity: async () => ({
+                ok    : false,
+                reason: 'identity drift: authed as neo-opus-ada, expected neo-gpt',
+                code  : 'LOGIN_MISMATCH'
+            })
+        });
+
+        expect(result.verdict).toBe('unavailable');
+        expect(result.blockers[0].code).toBe('GITHUB_IDENTITY_MISMATCH');
+        expect(result.marker).toBeUndefined();
+        expect(prCalls).toBe(0);
+    });
+
+    test('#16029: positive identity binding overwrites caller-forged assertion data', async () => {
+        let captured;
+        PullRequestService.getConversation = async options => {
+            captured = options;
+            return {routed: 'merge-readiness'};
+        };
+
+        const principals = {
+            agentIdentity     : '@neo-gpt',
+            githubLogin       : 'neo-gpt',
+            memoryCoreIdentity: '@neo-gpt'
+        };
+        const result = await getConversationRouter({
+            pr_number        : 16029,
+            projection       : 'merge-readiness',
+            identityAssertion: {ok: false, principals: {githubLogin: 'forged'}}
+        }, {
+            assertExpectedIdentity: async () => ({
+                ok    : true,
+                code  : 'OK',
+                reason: null,
+                principals
+            })
+        });
+
+        expect(result).toEqual({routed: 'merge-readiness'});
+        expect(captured.identityAssertion).toMatchObject({ok: true, principals});
+    });
 });
 
 /**


### PR DESCRIPTION
Resolves #16029

Extends the existing `get_conversation` operation with an opt-in, identity-bound `merge-readiness` projection. The GitHub Workflow source boundary derives the PR state, effective required checks, emitted contexts, reviewer requests, and mergeability; compares two complete reads for coherence; and feeds the result to the existing `validateMergeReady()` predicate. Only a positive immutable exact-head observation carries a copyable `[merge-eligible][B-prime:...]` marker. Human-only merge authority is unchanged.

Authored by Euclid (@neo-gpt, OpenAI Codex, GPT-5.6 Sol)

Evidence: L3 (live non-destructive projection probe against current GitHub PR/rules/check state plus focused source-bound tests) → L3 required (all close-target runtime ACs). No residuals.

## Deltas from ticket

None substantive from the amended ticket. The graduated Discussion proposed a dedicated `certify_merge_readiness` operation; operator direction rejected further MCP-catalog growth, so the ticket was corrected before implementation to make this an opt-in projection of existing `get_conversation`. A registration test proves the catalog gained no operation.

## Contract Ledger

| Target | Source of authority | Delivered behavior | Fail-closed path | Evidence |
|---|---|---|---|---|
| `get_conversation` projection | GitHub Workflow PR service | `projection: merge-readiness` derives every decisive input; default conversation response remains unchanged | PR-only; comment selectors rejected | default-shape regression + router specs |
| Identity binding | `assertExpectedIdentity()` | Router injects bound AgentIdentity, GitHub, and Memory Core principals | unresolved/drifted identity yields diagnostics and no marker | drift, retry, and caller-forgery specs |
| Required checks | `GET /repos/{owner}/{repo}/rules/branches/{base}` | Required context plus `integration_id` is compared to emitted Check Run app identity | unreadable/malformed is distinct from readable-empty; missing/wrong app fails | rules and context-state matrix |
| Coherent observation | two PR reads around two rules reads | Full normalized snapshots and required sets must match; observation binds base/head/time | any movement yields `SOURCE_CHANGED_DURING_READ` | moving-head spec |
| Readiness verdict | existing `validateMergeReady()` | Open/unmerged state, review, required checks, merge state, and reviewer seats share one predicate | incomplete/truncated source and every negative state withhold marker | validator + projection specs |

## Test Evidence

- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs` — 137 passed, 6 skipped.
- Live source probe through `getConversationRouter` against PR `#16125` — two GraphQL reads plus two effective-rules reads produced exact head `5a9876c24c51b935647fc51bfac9bb8e7b5ca0a2`; required `integration-parity` from app id `15368` was green; `reviewDecision: CHANGES_REQUESTED` correctly yielded `not-merge-ready` with no marker.
- `node --check` on all four changed runtime/query modules — passed.
- `node ./ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` — passed.
- `npm run ai:lint-agents` — passed.
- `npm run agent-preflight -- --change-class capability --commit-subject "feat(ai): add source-owned merge-readiness projection (#16029)" --no-fix <12 changed files>` — passed.
- Pre-commit whitespace, shorthand, AiConfig-mutation, JSDoc-type, derived-domain, ticket-archaeology, block-alignment, and parse gates — passed.
- Existing non-CI coverage for the directly touched GitHub source surface: live current-repository probe above.

## Skill-Load Audit

- Placement: three existing conditional reference payloads only; no `AGENTS.md`, `SKILL.md`, router, or always-loaded context delta.
- Byte delta against `origin/dev`: `post-review-pickup` +67, `pr-review` -94, `pull-request` +243; net +216 bytes.
- Disposition: compress-to-trigger. The references carry only the decision atom and uncertified markers; OpenAPI owns tool mechanics.
- Decay mitigation: retire these prose atoms when canonical merge-eligibility publication is mechanically derived or guarded at its publication boundary; until then the omission recurrence in AC12 is the revalidation trigger.

## Signal Ledger (sourced from Discussion #16026)

- `gpt`: `AUTHOR_SIGNAL` by @neo-gpt in the [graduated Discussion body](https://github.com/orgs/neomjs/discussions/16026).
- `claude`: `APPROVED` by @neo-opus-grace at [the non-author B-prime Step 2.5 signal](https://github.com/neomjs/neo/discussions/16026#discussioncomment-17790207).

## Unresolved Dissent

None. The final Discussion fold records convergence on B-prime; the operator-directed catalog correction narrows its delivery shape without changing its authority, completeness, or failure semantics.

## Unresolved Liveness

- `gemini`: `operator_benched` in `ai/graph/identityRoots.mjs`; reactivation occurs when the operator confirms a stable Gemini Pro-class harness passes maintainer preflight. This is not a Tier-2 core-value, critical-gate, or consensus-gate mutation.

## Post-Merge Validation

- [ ] Restart a resident GitHub Workflow MCP session and confirm `get_conversation` advertises `projection: merge-readiness` while no new operation appears.
- [ ] Invoke the projection on a current approved, green, clean PR with no requested reviewers and confirm the marker binds the observed exact head.
- [ ] Confirm cloud-mode lifecycle status uses `[merge-readiness-uncertified][issuer-unavailable:cloud-mode]` while GitHub Workflow remains resident-local.

## Evolution

The implementation deliberately rejects tool-catalog proliferation. The certification semantics remain source-owned, but they live behind a new projection on the already-owning single-PR read operation. This preserves the Discussion’s B-prime safety properties while meeting the operator’s smaller-surface constraint.

