### PR TITLE
fix(ai): fence Dream input revisions (#16115)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -37,8 +37,12 @@ import {
     createRemPhaseState,
     createRemRunStateEntry
 } from '../../../services/memory-core/helpers/remRunStateStore.mjs';
-import {bytesToTokens}              from '../../../services/memory-core/helpers/consumerFrictionHelper.mjs';
-import {resolveTurnDocumentForRead} from '../../../services/memory-core/helpers/turnDocumentText.mjs';
+import {bytesToTokens} from '../../../services/memory-core/helpers/consumerFrictionHelper.mjs';
+import {
+    canonicalizeSessionTurnInput,
+    computeSessionTurnInputRevision,
+    resolveTurnDocumentForRead
+} from '../../../services/memory-core/helpers/turnDocumentText.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -88,6 +92,103 @@ function isImmediateCadenceTerminalFailure(failure) {
  */
 function isSteadyCadenceExcludedDigestState(state) {
     return state === 'deferred' || state === 'undigestible';
+}
+
+/**
+ * @summary Decides whether a summary row still has Dream work for its current raw-input revision.
+ *
+ * Revision-aware rows ignore preserved legacy booleans: completion is current only when
+ * `dreamCompletedRevision` equals the synthesis-owned `dreamInputRevision`. Terminal cadence
+ * states are likewise scoped by `dreamStateRevision`, so an old `undigestible` result cannot hide
+ * a newly synthesized input frontier. Rows predating the revision contract retain the bounded
+ * legacy boolean/state behavior.
+ *
+ * Retire the legacy branch after a migration audit reports zero retained summary rows without
+ * `dreamInputRevision` for one complete summary-retention window.
+ *
+ * @param {Object} meta Session-summary metadata.
+ * @returns {Boolean}
+ */
+function isDreamDigestPending(meta) {
+    const currentRevision = typeof meta?.dreamInputRevision === 'string' && meta.dreamInputRevision
+        ? meta.dreamInputRevision
+        : null;
+
+    if (currentRevision) {
+        if (meta.dreamCompletedRevision === currentRevision) {
+            return false;
+        }
+
+        return !(
+            meta.dreamStateRevision === currentRevision &&
+            isSteadyCadenceExcludedDigestState(meta.digestState)
+        );
+    }
+
+    return meta?.graphDigested !== true &&
+        meta?.graphDigested !== 'true' &&
+        !isSteadyCadenceExcludedDigestState(meta?.digestState);
+}
+
+/**
+ * @summary Reads one complete, de-duplicated raw-turn snapshot for Dream processing.
+ *
+ * The paging contract mirrors SessionService synthesis so both sides observe the same unbounded
+ * input frontier instead of independently accepting Chroma's default result cap. Returned
+ * documents are canonicalized before revision verification and are passed unchanged through the
+ * remaining Dream phases.
+ *
+ * @param {Object} collection Memory Chroma collection.
+ * @param {String} sessionId Session id to fetch.
+ * @returns {Promise<{ids:String[],documents:String[],metadatas:Object[]}>}
+ */
+async function readSessionTurnInputSnapshot(collection, sessionId) {
+    const configuredLimit = aiConfig.summarizationBatchLimit;
+    if (!Number.isFinite(configuredLimit)) {
+        throw new Error('[DreamService] Required AiConfig leaf "summarizationBatchLimit" is missing or invalid. Update ai/mcp/server/memory-core/config.mjs from config.template.mjs.');
+    }
+
+    const
+        limit    = Math.max(1, Math.floor(configuredLimit)),
+        snapshot = {ids: [], documents: [], metadatas: []},
+        seenIds  = new Set();
+    let offset = 0;
+
+    while (true) {
+        const page = await collection.get({
+            where  : {sessionId},
+            include: ['documents', 'metadatas'],
+            limit,
+            offset
+        });
+        const pageCount = page.ids?.length || 0;
+
+        if (pageCount === 0) break;
+
+        let addedThisPage = 0;
+
+        for (let index = 0; index < pageCount; index++) {
+            const id = page.ids[index];
+            if (seenIds.has(id)) continue;
+
+            const metadata = page.metadatas?.[index] || {};
+
+            seenIds.add(id);
+            snapshot.ids.push(id);
+            snapshot.documents.push(resolveTurnDocumentForRead({
+                documents: [page.documents?.[index]],
+                metadata
+            }));
+            snapshot.metadatas.push(metadata);
+            addedThisPage++;
+        }
+
+        if (addedThisPage === 0) break;
+
+        offset += pageCount;
+    }
+
+    return canonicalizeSessionTurnInput(snapshot);
 }
 
 function toErrorMessage(error) {
@@ -153,9 +254,9 @@ function addUndigestedRowsFromBatch(batch, byId) {
     for (let i = 0; i < batch.ids.length; i++) {
         const meta = batch.metadatas?.[i];
 
-        // Exclude digested sessions plus terminal/legacy states that were already bounded out.
-        // `deferred` is kept as a back-compat alias for rows written by the first stop-re-serve kernel.
-        if (meta && meta.graphDigested !== true && meta.graphDigested !== 'true' && !isSteadyCadenceExcludedDigestState(meta.digestState)) {
+        // Revision-aware rows are eligible on current/completed mismatch even when a preserved
+        // legacy `graphDigested:true` or terminal state belongs to an older input frontier.
+        if (meta && isDreamDigestPending(meta)) {
             byId.set(batch.ids[i], {
                 id      : batch.ids[i],
                 document: batch.documents?.[i],
@@ -242,7 +343,9 @@ class DreamService extends Base {
     }
 
     /**
-     * Identifies session summaries that do not have the 'graphDigested' metadata flag set to true.
+     * Identifies session summaries whose current raw-input revision lacks a matching Dream
+     * completion. Revision-aware rows use `dreamInputRevision === dreamCompletedRevision`; the
+     * legacy `graphDigested`/terminal-state gate remains only for rows predating that contract.
      *
      * The scan samples both the fresh head and aged tail of the Chroma summary collection, then splits
      * the returned REM batch across newest and oldest undigested summaries. This mirrors the
@@ -312,10 +415,13 @@ class DreamService extends Base {
      *
      * The DreamService REM pipeline hydrates raw episodic memories, syncs deterministic
      * MEMORY/SESSION graph nodes via `MemorySessionIngestor`, then runs Tri-Vector semantic
-     * extraction and ambient graph ingestion. The `graphDigested` marker is only safe after
-     * both the deterministic memory/session ingestion and the semantic extractor complete
-     * without reported errors; otherwise the next REM cycle must retry the partial graph work
-     * instead of hiding missing nodes behind a completed digest flag.
+     * extraction and ambient graph ingestion. Revision-aware rows first verify that the complete
+     * raw-turn snapshot still matches the synthesis-published `dreamInputRevision`, then pass that
+     * same immutable snapshot to deterministic ingestion. Completion records the exact processed
+     * revision through a Dream-owned partial metadata update, so a late completion for A cannot
+     * overwrite or hide a concurrently published B. The legacy `graphDigested` marker remains a
+     * compatibility overlay and is only written after every required phase completes without
+     * reported errors.
      */
     async processUndigestedSessions() {
         if (this.isProcessing) {
@@ -408,26 +514,48 @@ class DreamService extends Base {
                 for (const session of sessions) {
                     logger.info(`[DreamService] Preparing session ${session.meta.sessionId} ("${session.meta.title}") for REM extraction.`);
 
-                    let rawEpisodicMemory = session.document,
-                        turnDocuments     = [session.document];
+                    const selectedDreamInputRevision = typeof session.meta.dreamInputRevision === 'string'
+                        ? session.meta.dreamInputRevision
+                        : null;
+                    const inputRevisionStartedAt = Date.now();
+                    let   rawEpisodicMemory      = session.document,
+                        turnDocuments            = [session.document],
+                        rawMemories              = null,
+                        processedInputRevision   = null,
+                        inputRevisionError       = null;
                     try {
                         const memoryCollection = await StorageRouter.getMemoryCollection();
                         if (memoryCollection) {
-                            const rawMemories = await memoryCollection.get({
-                                where  : { sessionId: session.meta.sessionId },
-                                include: ['documents', 'metadatas']
-                            });
+                            rawMemories = await readSessionTurnInputSnapshot(
+                                memoryCollection,
+                                session.meta.sessionId
+                            );
                             if (rawMemories?.documents?.length > 0) {
                                 // Send the full raw memory to the LLM. Lossless context tracking is required.
                                 // If local APIs crash, it is a configuration issue with n_ctx, not a client logic error.
-                                // Field↔document de-dup: reconstruct a dropped turn-document from its split metadata
-                                // (resolveTurnDocumentForRead no-ops on summaries via the type discriminator).
-                                turnDocuments     = rawMemories.documents.map((doc, i) => resolveTurnDocumentForRead({documents: [doc], metadata: rawMemories.metadatas?.[i]}));
+                                turnDocuments     = rawMemories.documents;
                                 rawEpisodicMemory = turnDocuments.join('\n\n---\n\n');
+                            }
+                        }
+
+                        if (selectedDreamInputRevision) {
+                            if (!rawMemories?.ids?.length) {
+                                throw new Error('published Dream input revision has no raw-turn snapshot');
+                            }
+
+                            processedInputRevision = computeSessionTurnInputRevision(rawMemories);
+                            if (processedInputRevision !== selectedDreamInputRevision) {
+                                throw new Error(
+                                    `Dream input revision moved before processing ` +
+                                    `(${selectedDreamInputRevision} -> ${processedInputRevision})`
+                                );
                             }
                         }
                     } catch (e) {
                         logger.warn(`[DreamService] Could not fetch raw memories for ${session.meta.sessionId}`, e);
+                        if (selectedDreamInputRevision) {
+                            inputRevisionError = e;
+                        }
                     }
 
                     session.document      = rawEpisodicMemory;
@@ -442,9 +570,23 @@ class DreamService extends Base {
                         topology           : {status: 'skipped', conflictCount: 0},
                         gapSession         : {status: 'skipped'},
                         graphDigestedFlag  : false,
+                        dreamInputRevision : selectedDreamInputRevision,
+                        processedInputRevision,
                         failureReasons     : []
                     };
                     perSessionStates.push(sessionState);
+
+                    if (inputRevisionError) {
+                        const error = toErrorMessage(inputRevisionError);
+
+                        sessionState.failureReasons.push(error);
+                        perPhaseStates.push(finishPhase('inputRevision', inputRevisionStartedAt, 'failed', {
+                            sessionId: session.meta.sessionId,
+                            error
+                        }));
+                        logger.warn(`[DreamService] Session ${session.meta.sessionId} input revision is stale or unavailable; leaving it pending.`, inputRevisionError);
+                        continue;
+                    }
 
                     // Phase 2a: Memory/Session graph ingestion — runs BEFORE SemanticGraphExtractor
                     // so future provenance edges from extracted entities attach to real
@@ -453,7 +595,10 @@ class DreamService extends Base {
                     const ingestStart = Date.now();
                     let ingestStats;
                     try {
-                        ingestStats = await MemorySessionIngestor.syncSessionToGraph(session);
+                        ingestStats = await MemorySessionIngestor.syncSessionToGraph(
+                            session,
+                            rawMemories?.ids?.length ? {rawMemories} : undefined
+                        );
                     } catch (e) {
                         sessionState.memorySessionIngest = {
                             status      : 'failed',
@@ -599,18 +744,33 @@ class DreamService extends Base {
                     logger.info(`[DreamService] Total Session Digest Time: ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
 
                     if (success && ingestErrors === 0) {
+                        const revisionMetadata = processedInputRevision
+                            ? {
+                                dreamCompletedRevision: processedInputRevision,
+                                dreamStateRevision    : processedInputRevision
+                            }
+                            : {};
+
                         await this.sessionsCollection.update({
                             ids      : [session.id],
-                            metadatas: [{ ...session.meta, graphDigested: true, digestState: 'digested' }]
+                            metadatas: [{
+                                graphDigested: true,
+                                digestState  : 'digested',
+                                ...revisionMetadata
+                            }]
                         });
                         sessionState.graphDigestedFlag = true;
-                        logger.info(`[DreamService] Session ${session.meta.sessionId} marked as graphDigested in Memory Core.`);
+                        logger.info(`[DreamService] Session ${session.meta.sessionId} marked as graphDigested in Memory Core${processedInputRevision ? ` at ${processedInputRevision}` : ''}.`);
                     } else {
                         // Digest failed (typed extractor failure OR memory-ingestion errors). Bound the
                         // re-serve immediately for provider-size failures; ingestion errors and legacy
                         // bare-null returns stay retryable so a storage/transient failure never removes
                         // a digestible session from the steady cadence.
-                        const digestAttempts    = (Number(session.meta.digestAttempts) || 0) + 1;
+                        const priorDigestAttempts = selectedDreamInputRevision &&
+                            session.meta.dreamStateRevision !== selectedDreamInputRevision
+                            ? 0
+                            : Number(session.meta.digestAttempts) || 0;
+                        const digestAttempts    = priorDigestAttempts + 1;
                         const maxDigestAttempts = aiConfig.maxDigestAttempts;
                         if (!Number.isFinite(maxDigestAttempts)) {
                             throw new Error('[DreamService] Required AiConfig leaf "maxDigestAttempts" is missing or invalid. Update ai/mcp/server/memory-core/config.mjs from config.template.mjs.');
@@ -626,7 +786,14 @@ class DreamService extends Base {
 
                         await this.sessionsCollection.update({
                             ids      : [session.id],
-                            metadatas: [{ ...session.meta, digestState, digestAttempts, deferReason }]
+                            metadatas: [{
+                                digestState,
+                                digestAttempts,
+                                deferReason,
+                                ...(processedInputRevision
+                                    ? {dreamStateRevision: processedInputRevision}
+                                    : {})
+                            }]
                         });
                         sessionState.digestState        = digestState;
                         sessionState.deferReason        = deferReason;

--- a/ai/services/ingestion/MemorySessionIngestor.mjs
+++ b/ai/services/ingestion/MemorySessionIngestor.mjs
@@ -137,10 +137,15 @@ class MemorySessionIngestor extends Base {
      * @param {Object}   [options.memoryCollection=null] Optional explicit memory collection for
      *     testability — tests inject a stub with seeded data. Production callers pass nothing;
      *     falls back to `StorageRouter.getMemoryCollection()`.
+     * @param {Object}   [options.rawMemories=null] Exact raw-memory snapshot already verified by
+     *     DreamService. When present, ingestion consumes it without a second mutable Chroma read.
      * @returns {Promise<Object>} Ingestion statistics:
      *     `{memoriesProcessed, memoriesUpserted, memoriesSkipped, sessionUpserted, errors}`
      */
-    async syncSessionToGraph(session, {memoryCollection = null} = {}) {
+    async syncSessionToGraph(session, {
+        memoryCollection             = null,
+        rawMemories: suppliedMemories = null
+    } = {}) {
         const stats = {
             memoriesProcessed: 0,
             memoriesUpserted : 0,
@@ -182,10 +187,10 @@ class MemorySessionIngestor extends Base {
             }
 
             const
-                collection  = memoryCollection || await StorageRouter.getMemoryCollection(),
-                rawMemories = collection
+                collection  = memoryCollection || (suppliedMemories ? null : await StorageRouter.getMemoryCollection()),
+                rawMemories = suppliedMemories || (collection
                     ? await collection.get({where: {sessionId: agentSessionId}, include: ['metadatas']})
-                    : null;
+                    : null);
 
             if (!rawMemories?.ids?.length) {
                 logger.info(`[MemorySessionIngestor] Session ${agentSessionId} has no raw memories.`);

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -5,7 +5,11 @@ import {invokeWithGuardrail}                         from './helpers/consumerFri
 import {withTimeout}                                 from './helpers/withTimeout.mjs';
 import {appendWalEmbedMarker, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
 import {verifyPersistedVector}                       from './helpers/verifyPersistedVector.mjs';
-import {resolveTurnDocumentForRead}                  from './helpers/turnDocumentText.mjs';
+import {
+    canonicalizeSessionTurnInput,
+    computeSessionTurnInputRevision,
+    resolveTurnDocumentForRead
+} from './helpers/turnDocumentText.mjs';
 import {
     acknowledgeSessionSummaryReceipt,
     recoverSessionSummaryReceipts,
@@ -569,11 +573,18 @@ class SessionService extends Base {
 
         if (memories.ids.length === 0) return null;
 
+        const canonicalMemories = canonicalizeSessionTurnInput(memories);
+
+        memories.ids       = canonicalMemories.ids;
+        memories.documents = canonicalMemories.documents;
+        memories.metadatas = canonicalMemories.metadatas;
+
         // Natively bypass arbitrary Context Windows or chunking loops.
         // We enforce strict Lossless extraction for local performance consistency.
         // NOTE: Large sessions natively require the backing daemon (MLX/OpenAiCompatible) to have
         // sufficient `n_ctx` capabilities (128k+).
-        const aggregatedContent = memories.documents.join('\n\n---\n\n');
+        const aggregatedContent  = memories.documents.join('\n\n---\n\n');
+        const dreamInputRevision = computeSessionTurnInputRevision(memories);
 
         let   lastActivity    = Date.now();
         let   firstActivity   = lastActivity;
@@ -785,7 +796,7 @@ ${sessionContent}
         const sourceProvenance = this.constructor.resolveSummarySourceProvenance(memories.metadatas);
 
         const summaryMetadata = {
-            sessionId, timestamp: lastActivity, memoryCount: memories.ids.length,
+            sessionId, timestamp: lastActivity, memoryCount: memories.ids.length, dreamInputRevision,
             title, category, quality, productivity, impact, complexity,
             technologies         : (technologies || []).join(','),
             participatingAgents  : participatingAgents.join(','),

--- a/ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs
+++ b/ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs
@@ -14,6 +14,12 @@ import {verifyPersistedVector} from './verifyPersistedVector.mjs';
  * deliberately not an append-only journal.
  */
 
+/**
+ * @summary Stable gzip/JSON transport framing for receipt envelopes.
+ *
+ * The encoding label remains backward-compatible for persisted rows; the decoded envelope's
+ * numeric `version` owns schema evolution inside that framing.
+ */
 export const SESSION_SUMMARY_RECEIPT_ENCODING = 'gzip-json-v1';
 
 /**
@@ -29,6 +35,7 @@ export const SESSION_SUMMARY_RECEIPT_METADATA_KEYS = Object.freeze([
     'sessionId',
     'timestamp',
     'memoryCount',
+    'dreamInputRevision',
     'title',
     'category',
     'quality',
@@ -122,7 +129,7 @@ export function encodeSessionSummaryReceipt(receipt) {
     const validated = validateReceiptIssuance(receipt);
 
     return gzipSync(Buffer.from(JSON.stringify({
-        version  : 1,
+        version  : 2,
         sessionId: validated.sessionId,
         summaryId: validated.summaryId,
         document : validated.document,
@@ -152,7 +159,7 @@ export function decodeSessionSummaryReceipt(envelope, encoding) {
         throw new Error(`Session-summary receipt envelope is corrupt: ${error.message}`, {cause: error});
     }
 
-    if (receipt?.version !== 1) {
+    if (![1, 2].includes(receipt?.version)) {
         throw new Error(`Unsupported session-summary receipt version: ${String(receipt?.version)}.`);
     }
 
@@ -280,7 +287,11 @@ function matchesSessionSummaryReceipt(row, receipt) {
         return false;
     }
 
-    return SESSION_SUMMARY_RECEIPT_METADATA_KEYS.every(key => {
+    const ownedKeys = receipt.version === 1
+        ? Object.keys(receipt.metadata)
+        : SESSION_SUMMARY_RECEIPT_METADATA_KEYS;
+
+    return ownedKeys.every(key => {
         const receiptHasKey = Object.hasOwn(receipt.metadata, key),
               rowHasKey     = Object.hasOwn(row.metadata, key);
 

--- a/ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs
+++ b/ai/services/memory-core/helpers/sessionSummaryReceiptStore.mjs
@@ -274,9 +274,10 @@ export function acknowledgeSessionSummaryReceipt({db, sessionId, now = Date.now(
  *
  * DreamService legitimately adds graph-digestion lifecycle fields to the same metadata
  * object after synthesis. Those downstream-owned overlays do not make the acknowledged
- * synthesis result stale. The receipt remains exact for its document and every declared
- * metadata key present at issuance; a missing or changed receipt-owned value still requires
- * replay.
+ * synthesis result stale. The receipt remains exact for its document and the metadata key set
+ * owned by its envelope version: version 1 uses its frozen issuance-era keys, while current
+ * envelopes enforce the full declared synthesis-owned key set. A missing or changed
+ * receipt-owned value still requires replay.
  *
  * @param {Object|undefined} row
  * @param {Object} receipt
@@ -287,6 +288,10 @@ function matchesSessionSummaryReceipt(row, receipt) {
         return false;
     }
 
+    // Version 1 is a closed issuance schema, so its own frozen metadata keys are authoritative.
+    // Applying the current declared set would require dreamInputRevision, which v1 cannot carry:
+    // recovery would replay, Chroma would preserve that newer overlay, and the next sweep would
+    // mismatch again — #16110's retained-v1 non-convergent loop (ticket-ref-ok: exact failure anchor).
     const ownedKeys = receipt.version === 1
         ? Object.keys(receipt.metadata)
         : SESSION_SUMMARY_RECEIPT_METADATA_KEYS;

--- a/ai/services/memory-core/helpers/turnDocumentText.mjs
+++ b/ai/services/memory-core/helpers/turnDocumentText.mjs
@@ -1,3 +1,5 @@
+import {createHash} from 'node:crypto';
+
 /**
  * @module ai/services/memory-core/helpers/turnDocumentText
  * @summary Single source of the canonical turn-document text — the `User Prompt: … / Agent Thought: … /
@@ -59,4 +61,94 @@ export function resolveTurnDocumentForRead({documents, metadata} = {}) {
     }
 
     return null;
+}
+
+/**
+ * @summary Canonicalizes one raw-turn frontier into stable chronological order.
+ *
+ * Chroma result order is not an input-authority contract. Sorting by the stored turn timestamp
+ * with id as the deterministic tie-breaker makes equivalent frontiers byte-stable across
+ * retrieval permutations while retaining chronological model context.
+ *
+ * @param {Object} input
+ * @param {String[]} input.ids Chroma turn ids.
+ * @param {Array.<String|null>} input.documents Stored turn documents.
+ * @param {Object[]} input.metadatas Turn metadata.
+ * @returns {{ids:String[],documents:String[],metadatas:Object[]}}
+ */
+export function canonicalizeSessionTurnInput({ids, documents, metadatas} = {}) {
+    if (!Array.isArray(ids) || !Array.isArray(documents) || !Array.isArray(metadatas)) {
+        throw new TypeError('Session turn input requires ids, documents, and metadatas arrays.');
+    }
+    if (ids.length !== documents.length || ids.length !== metadatas.length) {
+        throw new TypeError('Session turn input arrays must have equal lengths.');
+    }
+
+    const resolveTimestamp = metadata => {
+        const value   = metadata?.timestamp ?? metadata?.createdAt;
+        const numeric = Number(value);
+
+        if (Number.isFinite(numeric)) return numeric;
+
+        const parsed = Date.parse(value);
+
+        return Number.isFinite(parsed) ? parsed : 0;
+    };
+    const turns = ids.map((id, index) => {
+        const metadata = metadatas[index] || {};
+        const document = resolveTurnDocumentForRead({
+            documents: [documents[index]],
+            metadata
+        });
+
+        if (typeof id !== 'string' || !id) {
+            throw new TypeError(`Session turn input requires a non-empty id at index ${index}.`);
+        }
+        if (typeof document !== 'string') {
+            throw new TypeError(`Session turn input requires canonical document text at index ${index}.`);
+        }
+
+        return {id, document, metadata, timestamp: resolveTimestamp(metadata)};
+    }).sort((a, b) => a.timestamp - b.timestamp || a.id.localeCompare(b.id));
+
+    return {
+        ids      : turns.map(turn => turn.id),
+        documents: turns.map(turn => turn.document),
+        metadatas: turns.map(turn => turn.metadata)
+    };
+}
+
+/**
+ * @summary Computes the deterministic revision of one ordered raw-turn input frontier.
+ *
+ * The revision binds every turn's stable Chroma id, canonical document text, and identity
+ * boundary. A count-only marker would collide when one turn is replaced by another; hashing the
+ * exact ordered envelope lets SessionService publish the input it observed and DreamService
+ * independently attest the raw snapshot it actually processed. Stored and reconstructed forms of
+ * the same canonical turn document intentionally produce the same revision.
+ *
+ * @param {Object} input
+ * @param {String[]} input.ids Ordered Chroma turn ids.
+ * @param {Array.<String|null>} input.documents Ordered stored turn documents.
+ * @param {Object[]} input.metadatas Ordered turn metadata.
+ * @returns {String} Versioned SHA-256 revision.
+ */
+export function computeSessionTurnInputRevision({ids, documents, metadatas} = {}) {
+    const canonical = canonicalizeSessionTurnInput({ids, documents, metadatas});
+    const turns     = canonical.ids.map((id, index) => {
+        const metadata = canonical.metadatas[index];
+        return {
+            id,
+            document     : canonical.documents[index],
+            agentIdentity: metadata.agentIdentity ?? null,
+            sessionId    : metadata.sessionId ?? null,
+            userId       : metadata.userId ?? null
+        };
+    });
+
+    const digest = createHash('sha256')
+        .update(JSON.stringify({version: 1, turns}), 'utf8')
+        .digest('hex');
+
+    return `sha256:${digest}`;
 }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -13,11 +13,12 @@ setup({
     }
 });
 
-import {test, expect}     from '@playwright/test';
-import Neo                from '../../../../../../../src/Neo.mjs';
-import * as core          from '../../../../../../../src/core/_export.mjs';
-import fs                 from 'fs';
-import {snapshotAiConfig} from '../../../services/memory-core/util.mjs';
+import {test, expect}                    from '@playwright/test';
+import Neo                               from '../../../../../../../src/Neo.mjs';
+import * as core                         from '../../../../../../../src/core/_export.mjs';
+import fs                                from 'fs';
+import {snapshotAiConfig}                from '../../../services/memory-core/util.mjs';
+import {computeSessionTurnInputRevision} from '../../../../../../../ai/services/memory-core/helpers/turnDocumentText.mjs';
 
 test.describe('Neo.ai.services.memory-core.DreamService', () => {
     let aiConfig;
@@ -1202,22 +1203,44 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         }
     });
 
-    test('processUndigestedSessions threads complete raw memory turns into topology inference (#12073)', async () => {
+    test('processUndigestedSessions threads and attests one exact raw-turn snapshot (#12073, #16115)', async () => {
         const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
         const AdrIngestor             = (await import('../../../../../../../ai/services/ingestion/AdrIngestor.mjs')).default;
         const ConceptIngestor         = (await import('../../../../../../../ai/services/ingestion/ConceptIngestor.mjs')).default;
         const FileSystemIngestor      = (await import('../../../../../../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
         const TopologyInferenceEngine = (await import('../../../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
 
-        const rawTurns    = ['prompt turn body', 'response turn body'];
+        const rawTurns     = ['prompt turn body', 'response turn body'];
+        const rawIds       = ['raw-turn-1', 'raw-turn-2'];
+        const rawMetadatas = rawIds.map((id, index) => ({
+            agentIdentity: '@neo-gpt',
+            sessionId    : 'agent-session-raw-turns',
+            timestamp    : index + 1,
+            type         : 'agent-interaction'
+        }));
+        const inputRevision = computeSessionTurnInputRevision({
+            ids      : rawIds,
+            documents: rawTurns,
+            metadatas: rawMetadatas
+        });
         const mockSession = {
             id      : 'chroma-summary-raw-turns',
             document: 'summary fallback should not reach topology',
-            meta    : {sessionId: 'agent-session-raw-turns', title: 'Raw turn session'}
+            meta    : {
+                sessionId             : 'agent-session-raw-turns',
+                title                 : 'Raw turn session',
+                dreamInputRevision    : inputRevision,
+                dreamCompletedRevision: `sha256:${'0'.repeat(64)}`,
+                dreamStateRevision    : `sha256:${'0'.repeat(64)}`,
+                graphDigested         : true,
+                digestState           : 'digested'
+            }
         };
 
         let triVectorDocument;
         let topologyArgs;
+        let ingestedSnapshot;
+        let sessionUpdate;
 
         const orig = {
             provider          : aiConfig.modelProvider,
@@ -1244,16 +1267,23 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             DreamService.isProcessing = false;
 
             DreamService.findUndigestedSessions = async () => [mockSession];
-            DreamService.sessionsCollection     = {update: async () => {}};
+            DreamService.sessionsCollection     = {
+                update: async payload => { sessionUpdate = payload; }
+            };
             StorageRouter.getMemoryCollection   = async () => ({
-                get: async () => ({documents: rawTurns})
+                get: async ({offset = 0}) => offset === 0
+                    ? {ids: rawIds, documents: rawTurns, metadatas: rawMetadatas}
+                    : {ids: [], documents: [], metadatas: []}
             });
             DreamService.inferTestGapsFromSession = async () => {};
             DreamService.executeNLActionDigest    = async () => ({status: 'completed'});
             DreamService.inferConceptGraphGaps    = async () => {};
             DreamService.runGarbageCollection     = async () => {};
             DreamService.synthesizeGoldenPath     = async () => {};
-            MemorySessionIngestor.syncSessionToGraph = async () => ({errors: [], memoriesSkipped: 0, memoriesUpserted: rawTurns.length});
+            MemorySessionIngestor.syncSessionToGraph = async (session, {rawMemories}) => {
+                ingestedSnapshot = rawMemories;
+                return {errors: [], memoriesSkipped: 0, memoriesUpserted: rawTurns.length}
+            };
             AdrIngestor.syncAdrsToGraph              = async () => ({});
             ConceptIngestor.syncConceptsToGraph     = async () => ({});
             FileSystemIngestor.syncWorkspaceToGraph = async () => {};
@@ -1275,6 +1305,37 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
                 sessionId  : 'agent-session-raw-turns',
                 options    : {turnDocuments: rawTurns}
             });
+            expect(ingestedSnapshot).toEqual({
+                ids      : rawIds,
+                documents: rawTurns,
+                metadatas: rawMetadatas
+            });
+            expect(sessionUpdate).toEqual({
+                ids      : ['chroma-summary-raw-turns'],
+                metadatas: [{
+                    graphDigested         : true,
+                    digestState           : 'digested',
+                    dreamCompletedRevision: inputRevision,
+                    dreamStateRevision    : inputRevision
+                }]
+            });
+
+            // A selected summary revision that no longer matches the hydrated raw snapshot must
+            // stop before ingestion/extraction and cannot emit any completion metadata.
+            mockSession.meta.dreamInputRevision = `sha256:${'f'.repeat(64)}`;
+            sessionUpdate      = null;
+            ingestedSnapshot   = null;
+            triVectorDocument  = null;
+
+            const mismatch      = await DreamService.processUndigestedSessions();
+            const mismatchState = mismatch.perSessionStates.find(item =>
+                item.sessionId === 'agent-session-raw-turns'
+            );
+
+            expect(mismatchState.failureReasons[0]).toContain('Dream input revision moved before processing');
+            expect(ingestedSnapshot).toBeNull();
+            expect(triVectorDocument).toBeNull();
+            expect(sessionUpdate).toBeNull()
         } finally {
             aiConfig.modelProvider                            = orig.provider;
             DreamService.findUndigestedSessions               = orig.findUndigested;
@@ -1544,7 +1605,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         }
     });
 
-    test('findUndigestedSessions excludes bounded-out sessions and re-serves back-compat undigested rows (#13835)', async () => {
+    test('findUndigestedSessions fences legacy and revision-aware cadence state (#13835, #16115)', async () => {
         const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
         const original = {
             summarizationBatchLimit: aiConfig.summarizationBatchLimit,
@@ -1555,7 +1616,15 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         // Mix: a fresh undigested row, a legacy `deferred` row, a terminal `undigestible` row,
         // a digested row, and a back-compat row that predates digestState (no flag at all — must still
         // be served). The bounded-out states are excluded from the steady cadence.
+        const revisionA = `sha256:${'a'.repeat(64)}`,
+              revisionB = `sha256:${'b'.repeat(64)}`;
         const rows = [
+            // Interleaving witness: Dream selected/completed A after synthesis published B.
+            // Preserved legacy `digested` state cannot hide the B/A mismatch.
+            {id: 'revision-mismatch', document: 'm', meta: {sessionId: 'revision-mismatch', timestamp: 7000, dreamInputRevision: revisionB, dreamCompletedRevision: revisionA, dreamStateRevision: revisionA, graphDigested: true, digestState: 'digested'}},
+            {id: 'revision-current', document: 'n', meta: {sessionId: 'revision-current', timestamp: 6500, dreamInputRevision: revisionB, dreamCompletedRevision: revisionB, dreamStateRevision: revisionB, graphDigested: true, digestState: 'digested'}},
+            {id: 'revision-stale-terminal', document: 'o', meta: {sessionId: 'revision-stale-terminal', timestamp: 6000, dreamInputRevision: revisionB, dreamStateRevision: revisionA, digestState: 'undigestible'}},
+            {id: 'revision-current-terminal', document: 'p', meta: {sessionId: 'revision-current-terminal', timestamp: 5500, dreamInputRevision: revisionB, dreamStateRevision: revisionB, digestState: 'undigestible'}},
             {id: 'undigested-new', document: 'a', meta: {sessionId: 'undigested-new', timestamp: 5000}},
             {id: 'deferred-x',     document: 'b', meta: {sessionId: 'deferred-x', timestamp: 4000, digestState: 'deferred', deferReason: 'skip-over-band', digestAttempts: 3}},
             {id: 'undigestible-x', document: 'c', meta: {sessionId: 'undigestible-x', timestamp: 3000, digestState: 'undigestible', deferReason: 'under-band-choke', digestAttempts: 3}},
@@ -1584,6 +1653,10 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             expect(ids).not.toContain('undigestible-x');
             // Digested stays excluded; back-compat undigested rows (no digestState) are still served.
             expect(ids).not.toContain('digested-x');
+            expect(ids).not.toContain('revision-current');
+            expect(ids).not.toContain('revision-current-terminal');
+            expect(ids).toContain('revision-mismatch');
+            expect(ids).toContain('revision-stale-terminal');
             expect(ids).toContain('undigested-new');
             expect(ids).toContain('undigested-old');
         } finally {
@@ -1949,9 +2022,9 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             expect(goodState.graphDigestedFlag).toBe(true);
 
             expect(sessionUpdatePayloads).toHaveLength(1);
-            expect(sessionUpdatePayloads[0]).toMatchObject({
+            expect(sessionUpdatePayloads[0]).toEqual({
                 ids      : ['chroma-summary-good'],
-                metadatas: [{sessionId: 'agent-session-good', graphDigested: true, digestState: 'digested'}]
+                metadatas: [{graphDigested: true, digestState: 'digested'}]
             });
             expect(nlActionDigestCalls).toBe(1);
             expect(conceptGapCalls).toBe(1);

--- a/test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs
@@ -167,6 +167,46 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
         expect(Array.isArray(stats.errors)).toBe(true);
     });
 
+    test('#16115 consumes a verified raw-memory snapshot without re-reading mutable Chroma state', async () => {
+        const session = {
+            id  : 'chroma-summary-snapshot',
+            meta: {
+                sessionId: 'agent-session-snapshot',
+                title    : 'Snapshot session',
+                createdAt: '2026-07-29T09:00:00Z',
+                userId   : 'neo-gpt'
+            }
+        };
+        const rawMemories = {
+            ids      : ['snapshot-memory'],
+            documents: ['exact processed turn'],
+            metadatas: [{
+                createdAt: '2026-07-29T09:01:00Z',
+                sessionId: 'agent-session-snapshot',
+                userId   : 'neo-gpt'
+            }]
+        };
+        const memoryCollection = {
+            get: async () => {
+                throw new Error('mutable collection must not be re-read')
+            }
+        };
+
+        const stats = await MemorySessionIngestor.syncSessionToGraph(session, {
+            memoryCollection,
+            rawMemories
+        });
+
+        expect(stats).toMatchObject({
+            errors           : [],
+            memoriesProcessed: 1,
+            memoriesUpserted : 1,
+            sessionUpserted  : true
+        });
+        expect(GraphService.db.nodes.get('memory:snapshot-memory')?.properties)
+            .toMatchObject({chromaId: 'snapshot-memory', sessionId: 'agent-session-snapshot'})
+    });
+
     test('should upsert one SESSION node plus N MEMORY nodes plus N ORIGINATES_IN edges', async () => {
         const session = {
             id  : 'chroma-summary-2',

--- a/test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs
@@ -119,6 +119,7 @@ test.describe('SessionService.summarizeSession — memory-fetch pagination (clos
             //    violated (it wrote 2, so the drift never reconciled).
             expect(summaryStore).toHaveLength(1);
             expect(summaryStore[0].memoryCount).toBe(5);
+            expect(summaryStore[0].dreamInputRevision).toMatch(/^sha256:[a-f0-9]{64}$/);
             expect(result?.memoryCount).toBe(5);
 
             // 3. Closed loop: with memoryCount=5 written, the drift selector (count === summaryCount) no

--- a/test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs
@@ -628,6 +628,20 @@ test.describe('sessionSummaryReceiptStore (#16105, #16114, #16115)', () => {
                     dreamInputRevision: newerDreamInputRevision
                 }
             });
+
+            const settled = await recoverSessionSummaryReceipts({
+                db,
+                collection,
+                now: 300
+            });
+
+            expect(settled).toMatchObject({
+                scanned  : 1,
+                present  : 1,
+                replayed : 0,
+                completed: 1
+            });
+            expect(collection.upsertCalls).toBe(1);
             expect(() => encodeSessionSummaryReceipt(receipt))
                 .toThrow(/unowned keys: retiredSynthesisField/);
         } finally {

--- a/test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs
@@ -80,6 +80,7 @@ function createReceipt(sessionId, overrides = {}) {
             sessionId,
             timestamp            : 1_800_000_000_000,
             memoryCount          : 2,
+            dreamInputRevision   : `sha256:${'a'.repeat(64)}`,
             title                : 'Durable summary',
             category             : 'implementation',
             quality              : 80,
@@ -187,7 +188,7 @@ function createReceiptEmbeddingFunction() {
     return embeddingFunction;
 }
 
-test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
+test.describe('sessionSummaryReceiptStore (#16105, #16114, #16115)', () => {
     test.describe.configure({mode: 'serial'});
 
     test('enforces the declared synthesis-owned metadata key set at issuance', () => {
@@ -240,7 +241,7 @@ test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
             expect(decodeSessionSummaryReceipt(
                 stagedRow.result_envelope,
                 stagedRow.result_encoding
-            )).toEqual({version: 1, ...receipt});
+            )).toEqual({version: 2, ...receipt});
 
             expect(acknowledgeSessionSummaryReceipt({
                 db,
@@ -283,7 +284,7 @@ test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
             expect(row.result_acknowledged_at).toBeNull();
             expect(row.result_staged_at).toBe(200);
             expect(decodeSessionSummaryReceipt(row.result_envelope, row.result_encoding))
-                .toEqual({version: 1, ...updated});
+                .toEqual({version: 2, ...updated});
             expect(db.prepare('SELECT COUNT(*) AS count FROM SummarizationJobs').get().count).toBe(1);
         } finally {
             db.close();
@@ -378,8 +379,10 @@ test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
         const collection = createFakeCollection();
         const receipt    = createReceipt('dream-overlay');
         const dreamState = {
-            digestState  : 'digested',
-            graphDigested: true
+            digestState           : 'digested',
+            dreamCompletedRevision: receipt.metadata.dreamInputRevision,
+            dreamStateRevision    : receipt.metadata.dreamInputRevision,
+            graphDigested         : true
         };
 
         try {
@@ -576,8 +579,10 @@ test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
         const db         = createReceiptDb();
         const collection = createFakeCollection();
         const receipt    = createReceipt('historical-shape');
+        const newerDreamInputRevision = `sha256:${'b'.repeat(64)}`;
 
         delete receipt.metadata.rawCanonical;
+        delete receipt.metadata.dreamInputRevision;
         receipt.metadata.retiredSynthesisField = 'historical-value';
 
         db.prepare(`
@@ -597,6 +602,14 @@ test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
         );
 
         try {
+            collection.rows.set(receipt.summaryId, {
+                document: 'Newer unacknowledged summary',
+                metadata: {
+                    ...receipt.metadata,
+                    dreamInputRevision: newerDreamInputRevision
+                }
+            });
+
             const result = await recoverSessionSummaryReceipts({
                 db,
                 collection,
@@ -610,7 +623,10 @@ test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
             });
             expect(collection.rows.get(receipt.summaryId)).toEqual({
                 document: receipt.document,
-                metadata: receipt.metadata
+                metadata: {
+                    ...receipt.metadata,
+                    dreamInputRevision: newerDreamInputRevision
+                }
             });
             expect(() => encodeSessionSummaryReceipt(receipt))
                 .toThrow(/unowned keys: retiredSynthesisField/);
@@ -709,13 +725,15 @@ test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
             });
 
             const dreamState = {
-                digestState  : 'digested',
-                graphDigested: true
+                digestState           : 'digested',
+                dreamCompletedRevision: receipt.metadata.dreamInputRevision,
+                dreamStateRevision    : receipt.metadata.dreamInputRevision,
+                graphDigested         : true
             };
 
             await collection.update({
                 ids      : [receipt.summaryId],
-                metadatas: [{...receipt.metadata, ...dreamState}]
+                metadatas: [dreamState]
             });
 
             const enrichedPresent = await recoverSessionSummaryReceipts({
@@ -733,7 +751,7 @@ test.describe('sessionSummaryReceiptStore (#16105, #16114)', () => {
 
             await collection.update({
                 ids      : [receipt.summaryId],
-                metadatas: [{...receipt.metadata, ...dreamState, memoryCount: 99}]
+                metadatas: [{memoryCount: 99}]
             });
 
             const enrichedRepaired = await recoverSessionSummaryReceipts({

--- a/test/playwright/unit/ai/services/memory-core/helpers/turnDocumentText.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/turnDocumentText.spec.mjs
@@ -1,7 +1,12 @@
 import {test, expect}                                        from '@playwright/test';
 import Neo                                                   from '../../../../../../../src/Neo.mjs';
 import * as core                                             from '../../../../../../../src/core/_export.mjs';
-import {composeTurnDocumentText, resolveTurnDocumentForRead} from '../../../../../../../ai/services/memory-core/helpers/turnDocumentText.mjs';
+import {
+    canonicalizeSessionTurnInput,
+    composeTurnDocumentText,
+    computeSessionTurnInputRevision,
+    resolveTurnDocumentForRead
+} from '../../../../../../../ai/services/memory-core/helpers/turnDocumentText.mjs';
 
 // Pure derivation (no I/O). Composes the canonical turn-document text from a turn's split fields — the
 // single source of the `User Prompt: … / Agent Thought: … / Agent Response: …` representation that the
@@ -77,5 +82,77 @@ test.describe('resolveTurnDocumentForRead — read-side stored-or-reconstruct (#
         expect(resolveTurnDocumentForRead({documents: [null], metadata: null})).toBe(null);
         expect(resolveTurnDocumentForRead({})).toBe(null);
         expect(resolveTurnDocumentForRead()).toBe(null)
+    })
+});
+
+test.describe('computeSessionTurnInputRevision — Dream raw-input frontier (#16115)', () => {
+    const metadata = {
+        type         : 'agent-interaction',
+        prompt       : 'p',
+        thought      : 't',
+        response     : 'r',
+        agentIdentity: '@neo-gpt',
+        sessionId    : 'session-1',
+        userId       : 'neo-gpt'
+    };
+
+    test('is stable across stored and reconstructed forms of equivalent canonical input', () => {
+        const document = composeTurnDocumentText(metadata);
+        const stored   = computeSessionTurnInputRevision({
+            ids      : ['memory-1'],
+            documents: [document],
+            metadatas: [metadata]
+        });
+        const reconstructed = computeSessionTurnInputRevision({
+            ids      : ['memory-1'],
+            documents: [null],
+            metadatas: [metadata]
+        });
+
+        expect(stored).toBe(reconstructed);
+        expect(stored).toMatch(/^sha256:[a-f0-9]{64}$/)
+    });
+
+    test('changes for same-count content, row-identity, or agent-identity replacements', () => {
+        const base = {
+            ids      : ['memory-1'],
+            documents: ['turn body'],
+            metadatas: [metadata]
+        };
+        const revision = computeSessionTurnInputRevision(base);
+
+        expect(computeSessionTurnInputRevision({...base, documents: ['changed body']})).not.toBe(revision);
+        expect(computeSessionTurnInputRevision({...base, ids: ['memory-2']})).not.toBe(revision);
+        expect(computeSessionTurnInputRevision({
+            ...base,
+            metadatas: [{...metadata, agentIdentity: '@neo-opus-grace'}]
+        })).not.toBe(revision)
+    });
+
+    test('is stable across Chroma retrieval permutations while preserving chronological order', () => {
+        const firstMetadata  = {...metadata, timestamp: 1},
+              secondMetadata = {...metadata, timestamp: 2};
+        const forward = {
+            ids      : ['memory-1', 'memory-2'],
+            documents: ['first', 'second'],
+            metadatas: [firstMetadata, secondMetadata]
+        };
+        const reverse = {
+            ids      : [...forward.ids].reverse(),
+            documents: [...forward.documents].reverse(),
+            metadatas: [...forward.metadatas].reverse()
+        };
+
+        expect(computeSessionTurnInputRevision(reverse))
+            .toBe(computeSessionTurnInputRevision(forward));
+        expect(canonicalizeSessionTurnInput(reverse)).toEqual(forward)
+    });
+
+    test('fails loud instead of minting an ambiguous revision from incomplete parallel arrays', () => {
+        expect(() => computeSessionTurnInputRevision({
+            ids      : ['memory-1'],
+            documents: [],
+            metadatas: [metadata]
+        })).toThrow(/equal lengths/)
     })
 });


### PR DESCRIPTION
Resolves #16115

Replaces the stale eternal `graphDigested` gate with a source-owned raw-input revision contract. Session synthesis publishes a deterministic SHA-256 revision over the complete canonical turn frontier; Dream paginates and independently verifies the exact raw snapshot, passes that same snapshot to deterministic memory/session ingestion, and records only the revision that completed every required phase. A late Dream completion for revision A therefore cannot overwrite or hide a concurrently published revision B.

Legacy `graphDigested` and terminal cadence fields remain as a bounded compatibility path for pre-revision rows. Revision-aware completion and terminal state are scoped by `dreamCompletedRevision` and `dreamStateRevision`; the legacy branch retires after a migration audit finds zero retained rows without `dreamInputRevision` for one complete summary-retention window.

Authored by Euclid (@neo-gpt, OpenAI Codex, GPT-5.6 Sol)

Evidence: L3 (deterministic service/interleaving matrix plus disposable production-Chroma merge witness) → L3 required (one naturally re-summarized retained session completes its new revision after deployment). Residual: post-merge runtime observation [#16115].

## Deltas from ticket

- Chose a versioned SHA-256 revision over the canonical timestamp/id-ordered envelope of turn id, canonical content, and identity boundary. Equivalent stored/reconstructed inputs and retrieval permutations are stable; same-count content, id, or agent-identity replacements change the revision.
- Added `dreamStateRevision` alongside the required completion revision so preserved `undigestible`/`deferred` state is also scoped to the input that produced it. Without this, replacing the success boolean alone would leave the same stale-gate defect on terminal failures.
- Kept the persisted gzip/JSON receipt framing backward-compatible while advancing new envelopes to inner schema version 2. Historical version-1 receipts verify only their issuance-era keys; version-2 receipts enforce the full current synthesis-owned key set including `dreamInputRevision`.
- No new MCP tool, service, daemon, or module was added.

## Contract Ledger

| Target | Source of authority | Delivered behavior | Fail-closed / compatibility path | Evidence |
|---|---|---|---|---|
| Raw-input revision | `SessionService.summarizeSession()` | Publishes one deterministic revision over the complete canonical raw-turn frontier | Missing/incomplete parallel arrays fail before summary issuance | canonical helper + pagination specs |
| Dream eligibility | `DreamService.findUndigestedSessions()` | Pending when current and completed revisions differ; terminal state only excludes its own revision | Pre-revision rows retain bounded legacy boolean/state semantics | legacy/revision selection matrix |
| Dream processing | `DreamService.processUndigestedSessions()` | Re-hashes the paginated snapshot and passes it unchanged to graph ingestion | Mismatch/unavailable snapshot stops before ingestion, extraction, or completion | exact-snapshot + mismatch spec |
| Dream completion | Dream-owned summary metadata overlay | Partial update records completed/state revision without spreading stale synthesis metadata | Late A completion merged onto B leaves B/A mismatch eligible | A/B interleaving matrix + Chroma merge witness |
| Synthesis receipt | `sessionSummaryReceiptStore.mjs` | Version-2 issuance owns and verifies `dreamInputRevision` | Version-1 historical envelopes remain replayable without weakening v2 checks | receipt recovery and forced restart specs |

## Test Evidence

- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/turnDocumentText.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/sessionSummaryReceiptStore.spec.mjs` — 80 passed.
- The Dream mismatch falsifier proves a moved raw revision performs zero deterministic ingestion, zero semantic extraction, and zero completion update.
- The A/B selection witness models Dream completing A after synthesis publishes B while preserved `graphDigested:true` / `digestState:'digested'` remain; B is selected.
- The disposable-Chroma test performs Dream-owned partial metadata updates, forces stop/restart receipt recovery, repairs a synthesis-owned field, and proves both Dream overlays and the current input revision survive merge semantics.
- `node --check` passed for all five changed runtime/helper modules.
- `npm run agent-preflight -- --change-class restoration --commit-subject "fix(ai): fence Dream input revisions (#16115)" --no-fix <10 changed files>` — passed.
- Commit gates for whitespace, shorthand, AiConfig mutation, derived-domain, JSDoc types, ticket archaeology, block alignment, and parse — passed.

## Post-Merge Validation

- [ ] Let one retained, already-digested session gain a natural new turn and re-summarize; confirm the preserved legacy overlay does not suppress selection.
- [ ] Confirm that session reaches `dreamCompletedRevision === dreamInputRevision` for the new frontier.
- [ ] Audit retained summaries for missing `dreamInputRevision`; begin the documented legacy-gate retirement window only after the count reaches zero.

## Evolution

The defect came from treating mutable work as an eternal boolean. The repair makes both success and terminal cadence state revision-relative, while keeping producer and consumer ownership separate: synthesis publishes what changed; Dream certifies only what it actually processed. The same source trace also removed Dream’s hidden default-page ceiling and its second mutable raw-memory read, so the new attestation is about the full snapshot rather than a convenient approximation.

