### PR TITLE
fix(dashboard): reconcile re-entry drag ownership (#16122)

### DIFF
--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -318,13 +318,16 @@ class DockTabSortZone extends TabHeaderSortZone {
      * reorder un-parks. Two callers, both host-choreographed: a boundary re-entry (the gesture
      * continues in-window) and a FAILED vessel admission (the base arms `isWindowDragging` BEFORE
      * firing the exit event, so a blocked popup must actively restore the in-window gesture or the
-     * zone stays parked with a dead detached state).
+     * zone stays parked with a dead detached state). Worker and main movement ownership must close
+     * together; otherwise the next pointer frame still routes through the retired native vessel.
      */
     endWindowDrag() {
         let me = this;
 
         me.dragProxy && (me.dragProxy.style = {opacity: 1});
-        me.isWindowDragging = false
+        me.isWindowDragging = false;
+
+        Neo.main.addon.DragDrop.setConfigs({isWindowDragging: false, windowId: me.windowId})
     }
 
     /**

--- a/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
@@ -382,6 +382,104 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
         await runThemeWitness('neo-light')
     });
 
+    test('same-gesture tear-out re-entry resumes proxy motion without reacquisition', async ({page, neuralLink}, testInfo) => {
+        const
+            {app, wsId} = await bootFlagship(page, neuralLink),
+            header      = page.locator('.neo-tab-header-button', {hasText: 'Audit'}).first(),
+            headerBox   = await header.boundingBox(),
+            hostBox     = await page.locator('.workstation-dock-host').boundingBox(),
+            viewport    = await page.evaluate(() => ({height: innerHeight, width: innerWidth})),
+            start       = {x: headerBox.x + headerBox.width / 2, y: headerBox.y + headerBox.height / 2},
+            outside     = {x: viewport.width + 180, y: viewport.height + 180},
+            reentry     = {
+                x: hostBox.x + hostBox.width * .35,
+                y: hostBox.y + hostBox.height * .35
+            },
+            documentBefore  = (await app.getComponent(wsId, ['dockModel'])).dockModel,
+            heartbeatBefore = (await app.getComponent(wsId, ['feedSequence'])).feedSequence,
+            paneIdBefore    = await app.callMethod(wsId, 'getPaneIdentity', ['audit']),
+            popupPromise    = page.waitForEvent('popup', {timeout: 30000});
+
+        try {
+            await page.mouse.move(start.x, start.y);
+            await page.mouse.down();
+            await page.waitForTimeout(120);
+            await page.mouse.move(start.x + 12, start.y + 4, {steps: 4});
+            await page.mouse.move(start.x + 20, start.y + 28, {steps: 4});
+            await expect(page.locator('.neo-dock-dragproxy')).toBeVisible();
+
+            await page.mouse.move(outside.x, outside.y, {steps: 36});
+
+            const popup = await popupPromise;
+
+            await popup.waitForLoadState('domcontentloaded');
+            await page.mouse.move(outside.x, outside.y + 24, {steps: 3});
+            await page.mouse.move(reentry.x, reentry.y, {steps: 40});
+
+            const proxy = page.locator('.neo-dock-dragproxy');
+
+            await expect(proxy).toBeVisible();
+            await expect.poll(() => popup.isClosed(), {
+                message: 'the real popup retires while the original pointer remains down',
+                timeout: 15000
+            }).toBe(true);
+
+            const
+                positions = [
+                    {x: reentry.x + 70,  y: reentry.y + 35},
+                    {x: reentry.x + 170, y: reentry.y + 95}
+                ],
+                samples = [];
+
+            for (const pointer of positions) {
+                await page.mouse.move(pointer.x, pointer.y, {steps: 10});
+                await page.waitForTimeout(160);
+                samples.push({pointer, proxy: (await readDockProxyTreatment(page)).rect})
+            }
+
+            const
+                [first, second] = samples,
+                firstOffset     = {
+                    x: first.pointer.x - first.proxy.left,
+                    y: first.pointer.y - first.proxy.top
+                },
+                secondOffset    = {
+                    x: second.pointer.x - second.proxy.left,
+                    y: second.pointer.y - second.proxy.top
+                };
+
+            expect(second.proxy.left - first.proxy.left,
+                'the resumed proxy follows the second post-entry pointer delta on x')
+                .toBeCloseTo(second.pointer.x - first.pointer.x, 0);
+            expect(second.proxy.top - first.proxy.top,
+                'the resumed proxy follows the second post-entry pointer delta on y')
+                .toBeCloseTo(second.pointer.y - first.pointer.y, 0);
+            expect(secondOffset.x, 'the source grab offset survives the native-to-local morph')
+                .toBeCloseTo(firstOffset.x, 0);
+            expect(secondOffset.y, 'the source grab offset survives the native-to-local morph')
+                .toBeCloseTo(firstOffset.y, 0);
+
+            const
+                documentAfter  = (await app.getComponent(wsId, ['dockModel'])).dockModel,
+                heartbeatAfter = (await app.getComponent(wsId, ['feedSequence'])).feedSequence;
+
+            expect(documentAfter, 're-entry is a zero-document-mutation transition').toEqual(documentBefore);
+            expect(await app.callMethod(wsId, 'getPaneIdentity', ['audit']),
+                'the live pane is resumed, never cloned or recreated').toBe(paneIdBefore);
+            expect(heartbeatAfter, 'live pane production advances throughout the morph')
+                .toBeGreaterThan(heartbeatBefore);
+
+            await testInfo.attach('post-entry-motion-receipt.json', {
+                body       : Buffer.from(JSON.stringify({firstOffset, secondOffset, samples}, null, 2)),
+                contentType: 'application/json'
+            })
+        } finally {
+            await page.keyboard.press('Escape').catch(() => {});
+            await page.waitForTimeout(120);
+            await page.mouse.up().catch(() => {})
+        }
+    });
+
     /**
      * The systematic rect layer's flagship home — the boot containment chain and the
      * per-child affordance families, read through component ids (restyle-proof), complementing

--- a/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
@@ -1,5 +1,8 @@
 import {test, expect}                                                                       from '../../fixtures.mjs';
 import {assertAffordanceContainment, assertBootContainmentChain, assertChipHeaderExclusion} from '../utils/dockGeometry.mjs';
+import {isFilmTake}                                                                         from '../utils/gpuIntent.mjs';
+
+const filmTake = isFilmTake();
 
 /**
  * Whitebox-e2e: the FLAGSHIP's drag-affordance journey — the durable real-pointer proof
@@ -434,7 +437,18 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
             for (const pointer of positions) {
                 await page.mouse.move(pointer.x, pointer.y, {steps: 10});
                 await page.waitForTimeout(160);
-                samples.push({pointer, proxy: (await readDockProxyTreatment(page)).rect})
+                samples.push({pointer, proxy: (await readDockProxyTreatment(page)).rect});
+
+                if (filmTake) {
+                    const frame = await page.screenshot();
+
+                    expect(frame.length, 'the film profile retains a non-empty post-conversion frame')
+                        .toBeGreaterThan(10000);
+                    await testInfo.attach(`post-entry-motion-frame-${samples.length}.png`, {
+                        body       : frame,
+                        contentType: 'image/png'
+                    })
+                }
             }
 
             const

--- a/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
@@ -403,6 +403,8 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
             paneIdBefore    = await app.callMethod(wsId, 'getPaneIdentity', ['audit']),
             popupPromise    = page.waitForEvent('popup', {timeout: 30000});
 
+        let reexitPopup = null;
+
         try {
             await page.mouse.move(start.x, start.y);
             await page.mouse.down();
@@ -416,6 +418,8 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
             const popup = await popupPromise;
 
             await popup.waitForLoadState('domcontentloaded');
+            const firstVesselGeneration = new URL(popup.url()).searchParams.get('vesselGeneration');
+
             await page.mouse.move(outside.x, outside.y + 24, {steps: 3});
             await page.mouse.move(reentry.x, reentry.y, {steps: 40});
 
@@ -474,6 +478,54 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
                 .toBeCloseTo(firstOffset.y, 0);
 
             const
+                reexitStart        = {x: outside.x + 40, y: outside.y + 40},
+                reexitDrive        = {x: outside.x + 160, y: outside.y + 110},
+                reexitPopupPromise = page.waitForEvent('popup', {timeout: 30000});
+
+            await page.mouse.move(reexitStart.x, reexitStart.y, {steps: 40});
+            reexitPopup = await reexitPopupPromise;
+            await reexitPopup.waitForLoadState('domcontentloaded');
+
+            const
+                secondVesselGeneration = new URL(reexitPopup.url()).searchParams.get('vesselGeneration'),
+                firstWindowPosition    = await reexitPopup.evaluate(() => ({x: screenX, y: screenY})),
+                pointerDelta           = {
+                    x: reexitDrive.x - reexitStart.x,
+                    y: reexitDrive.y - reexitStart.y
+                };
+
+            await page.mouse.move(reexitDrive.x, reexitDrive.y, {steps: 12});
+            await expect.poll(async () => {
+                const current = await reexitPopup.evaluate(() => ({x: screenX, y: screenY}));
+
+                return {
+                    x: current.x - firstWindowPosition.x,
+                    y: current.y - firstWindowPosition.y
+                }
+            }, {
+                message: 'the fresh vessel follows the continuing pointer',
+                timeout: 15000
+            }).toEqual(pointerDelta);
+
+            const
+                secondWindowPosition = await reexitPopup.evaluate(() => ({x: screenX, y: screenY})),
+                reexitReceipt        = {
+                    firstVesselGeneration,
+                    firstWindowPosition,
+                    pointerDelta,
+                    secondVesselGeneration,
+                    secondWindowPosition,
+                    windowDelta: {
+                        x: secondWindowPosition.x - firstWindowPosition.x,
+                        y: secondWindowPosition.y - firstWindowPosition.y
+                    }
+                };
+
+            expect(secondVesselGeneration, 're-exit mints a fresh vessel generation')
+                .not.toBe(firstVesselGeneration);
+            expect(reexitReceipt.windowDelta).toEqual(reexitReceipt.pointerDelta);
+
+            const
                 documentAfter  = (await app.getComponent(wsId, ['dockModel'])).dockModel,
                 heartbeatAfter = (await app.getComponent(wsId, ['feedSequence'])).feedSequence;
 
@@ -484,13 +536,16 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
                 .toBeGreaterThan(heartbeatBefore);
 
             await testInfo.attach('post-entry-motion-receipt.json', {
-                body       : Buffer.from(JSON.stringify({firstOffset, secondOffset, samples}, null, 2)),
+                body       : Buffer.from(JSON.stringify({firstOffset, reexitReceipt, secondOffset, samples}, null, 2)),
                 contentType: 'application/json'
             })
         } finally {
             await page.keyboard.press('Escape').catch(() => {});
             await page.waitForTimeout(120);
-            await page.mouse.up().catch(() => {})
+            await page.mouse.up().catch(() => {});
+            if (reexitPopup && !reexitPopup.isClosed()) {
+                await reexitPopup.close().catch(() => {})
+            }
         }
     });
 

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -558,20 +558,37 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
             expect(addonCalls).toEqual([{popupHeight: 480, popupName: 'graph', popupWidth: 640, windowId: 7}])
         });
 
-        test('endWindowDrag is the symmetric close: proxy visible, base reorder un-parked — the failed-admission degrade path', () => {
+        test('endWindowDrag closes worker + main movement ownership before the next pointer frame', () => {
+            const addonCalls  = [];
             const proxyStyles = [];
             const zone        = {
                 dragProxy       : {set style(value) { proxyStyles.push(value) }},
-                isWindowDragging: true
+                isWindowDragging: true,
+                windowId        : 7
             };
 
-            DockTabSortZone.prototype.endWindowDrag.call(zone);
+            const hadDragDrop = Object.hasOwn(Neo.main.addon, 'DragDrop'),
+                  original    = Neo.main.addon.DragDrop;
+
+            Neo.main.addon.DragDrop = {setConfigs: data => addonCalls.push(data)};
+
+            try {
+                DockTabSortZone.prototype.endWindowDrag.call(zone);
+
+                // Proxy-less close (torn down mid-gesture) still reconciles both owners.
+                DockTabSortZone.prototype.endWindowDrag.call({
+                    dragProxy: null, isWindowDragging: true, windowId: 8
+                })
+            } finally {
+                if (hadDragDrop) { Neo.main.addon.DragDrop = original } else { delete Neo.main.addon.DragDrop }
+            }
 
             expect(proxyStyles).toEqual([{opacity: 1}]);
             expect(zone.isWindowDragging).toBe(false);
-
-            // proxy-less call (torn down mid-gesture) stays safe — the flag still resets
-            DockTabSortZone.prototype.endWindowDrag.call({dragProxy: null, isWindowDragging: true})
+            expect(addonCalls).toEqual([
+                {isWindowDragging: false, windowId: 7},
+                {isWindowDragging: false, windowId: 8}
+            ])
         })
 
         test('a winning remote pointer claim outranks popup-scale source-boundary overlap for that frame', () => {


### PR DESCRIPTION
Resolves #16122

Related: #16117

Re-entry now closes both owners of the same drag generation at the existing
`DockTabSortZone#endWindowDrag()` boundary. The worker restores the live DOM proxy and un-parks
base sorting, while the main addon leaves native-window movement before the next pointer frame can
route toward the retired popup. A headed physical-pointer regression now keeps one pointer gesture
down across popup birth, source-window re-entry, popup retirement, and two later proxy moves.

Evidence: L3 (exact-head headed physical-pointer journey with accelerated GL, pointer/proxy rect
receipt, two retained post-conversion frames, and a fresh re-exit vessel driven by the continuing
gesture) → L3 required for the frozen-proxy repair. Residual: none.

## Deltas from ticket

The product repair remains the narrow worker/main ownership reconciliation. The regression proves
the previously missing temporal contract: after re-entry, a `(100, 60)` pointer delta produced the
same `(100, 60)` proxy delta, while both samples preserved the source grab offset at
`(35.9765625, 24.7)`.

The journey also pins zero dock-document mutation, same pane identity, continuing feed heartbeat,
and popup retirement during the uninterrupted gesture. Under the established film-capture profile,
the same two post-entry samples now attach independent PNG frames; decoded visual inspection shows
the `Audit` proxy at two distinct positions after the real popup retires.

## Test Evidence

- Exact current `dev` `8fc1d8c16c`: the same ordinary headed one-gesture measurement reproduced the defect after popup retirement — pointer x delta `100`, proxy x delta `0`; accelerated Apple M5 Max GL. The temporary falsifier was removed after retaining the failure trace.
- Exact PR head `ae30ca0dc5`: `npx playwright test test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --grep "same-gesture tear-out re-entry" --workers=1 --headed` — 2/2 passed, including accelerated Apple M5 Max GL; journey 6.7s.
- The ordinary E2E launch profile carries the required `--disable-frame-rate-limit`; it remains the behavioral authority.
- Exact receipt: pointer `(518, 350.7) → (618, 410.7)`; proxy `(482.0234375, 326) → (582.0234375, 386)`; identical grab offsets before and after.
- The uninterrupted gesture then re-exited: vessel generation `1 → 2`; pointer delta `(120,70)` produced native-window delta `(120,70)`, proving the main addon drives the fresh generation.
- Exact PR head `ae30ca0dc5`: `NEO_FILM_TAKE=1 npx playwright test test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --grep "same-gesture tear-out re-entry" --workers=1 --headed` — 2/2 passed with accelerated Metal; journey 4.4s.
- The film result retains `post-entry-motion-frame-1.png` (265,966 bytes) and `post-entry-motion-frame-2.png` (264,995 bytes). Both decoded frames are non-empty and visibly place the same proxy at the two measured positions.
- Exact PR head `ae30ca0dc5`: `npm run test-unit -- test/playwright/unit/dashboard/DockTabSortZone.spec.mjs test/playwright/unit/dashboard/DockTearOut.spec.mjs test/playwright/unit/main/addon/DragDrop.spec.mjs` — 56/56 passed. The matrix pins in-window release/cancel, detached release/cancel, exact-once retirement/terminal suppression, and stale native completion after reset. The headed witness binds the counted close seam to the exact popup observed closing.
- Current-head CI: pending after the branch update.

## Post-Merge Validation

- [ ] Re-run the headed one-gesture journey against merged `dev`.

## Commits

- `4e3c1ed758` — reconcile worker and main drag ownership on re-entry.
- `5ce257663f` — add the uninterrupted physical-pointer motion receipt.
- `151ecce121` — retain two film-profile post-conversion motion frames.
- `ae30ca0dc5` — prove fresh re-exit generation and native-window movement.

## Evolution

The implementation lane was deliberately narrowed after the sibling popup-over-popup experiment
proved too broad for an honest single handoff. The first review candidate isolated the split-brain
repair; the motion follow-up replaced its L1-only boundary with an exact-head L3 receipt; and the
pixel follow-up uses the already-established benchmark/film evidence split instead of pretending
that a compositor-starved default-profile capture is visual proof.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session f0894e41-9fa7-4660-9c6e-d127e2d123f7.
