### PR TITLE
fix(workstation): align remote dock previews to exact targets (#16121)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -267,6 +267,14 @@ class Workspace extends Container {
      */
     crossWindowParticipationPromise = null
     /**
+     * Transient exact-node measurements for active cross-window preview targets. Each entry is
+     * generation-checked by component identity plus the live manager.Window inner rectangle;
+     * projection, leave, resize, or teardown retires it. Geometry never enters dock documents.
+     * @member {Map<String,Object>} crossWindowPreviewGeometries
+     * @protected
+     */
+    crossWindowPreviewGeometries = new Map()
+    /**
      * Worker-owned vessel workspace records keyed by stable workspace identity. Entries carry
      * document ownership and render-target refs, never cached geometry.
      * @member {Map<String,Object>} vesselWorkspaces
@@ -939,8 +947,9 @@ class Workspace extends Container {
     }
 
     /**
-     * Creates one target-side adapter over a stable workspace identity. Geometry remains entirely
-     * manager.Window-owned; the app stores documents and render refs only.
+     * Creates one target-side adapter over a stable workspace identity. manager.Window remains the
+     * topology/hit-test authority; the app measures exact target-node geometry transiently for the
+     * preview renderer and never persists it.
      * @param {Object} data
      * @param {String|Number} data.windowId
      * @param {String} data.workspaceId
@@ -999,6 +1008,7 @@ class Workspace extends Container {
 
         me.crossWindowParticipations.get(workspaceId)?.destroy();
         me.crossWindowParticipations.delete(workspaceId);
+        me.crossWindowPreviewGeometries.delete(workspaceId);
         state && (state.participation = null);
 
         const participation = await me.createCrossWindowParticipation({windowId, workspaceId});
@@ -1099,6 +1109,7 @@ class Workspace extends Container {
         me.crossWindowParticipations.delete(workspaceId);
         state.committed && me.workspaceSet.unregister(workspaceId);
 
+        me.crossWindowPreviewGeometries.delete(workspaceId);
         me.vesselWorkspaces.delete(workspaceId);
 
         return true
@@ -1145,8 +1156,9 @@ class Workspace extends Container {
     }
 
     /**
-     * D-013 hit-test: accepts only points inside the live manager.Window inner rect. No app-local
-     * window geometry or per-workspace measurement registry exists.
+     * D-013 hit-test: accepts only points inside the live manager.Window inner rect. Exact node
+     * measurement belongs exclusively to the render path below and never participates in target
+     * arbitration.
      * @param {String} workspaceId
      * @param {Number} localX
      * @param {Number} localY
@@ -1171,8 +1183,118 @@ class Workspace extends Container {
     }
 
     /**
-     * Computes and renders one remote preview from live manager.Window dimensions. A vessel uses
-     * its stable lazy landing node; the main workspace returns a stack to its captured semantic home.
+     * Resolves the render host, exact semantic target component, and preview renderer for one
+     * cross-window workspace. A bare vessel has no projected tabs component yet, so its main view
+     * is the exact landing surface; projected main-workspace nodes always resolve by `dockNodeId`.
+     * @summary Keeps semantic node identity paired with its actual rendered component.
+     * @param {String} workspaceId
+     * @param {String} targetNodeId
+     * @returns {{host: Neo.component.Base, renderer: Neo.dashboard.DockPreview,
+     *     target: Neo.component.Base, windowId: (String|Number)}|null}
+     * @protected
+     */
+    resolveCrossWindowPreviewSurface(workspaceId, targetNodeId) {
+        let me       = this,
+            isMain   = workspaceId === Workspace.MAIN_WORKSPACE_ID,
+            state    = isMain ? null : me.vesselWorkspaces.get(workspaceId),
+            windowId = isMain ? me.windowId : state?.windowId,
+            host     = isMain ? me.dragAffordances?.host : state?.host ?? state?.app?.mainView,
+            target   = state && !state.host ? host : host?.down({dockNodeId: targetNodeId}),
+            renderer = isMain ? me.dragAffordances?.preview : state?.preview;
+
+        return windowId != null && host && target && renderer &&
+            typeof host.getDomRect === 'function' && !host.isDestroyed && !target.isDestroyed
+            ? {host, renderer, target, windowId}
+            : null
+    }
+
+    /**
+     * Measures one exact target component and translates it once into its preview overlay host.
+     * The promise itself is memoized so a move stream cannot stack DOM reads; entry identity makes
+     * late results inert after leave, projection, resize, target replacement, or teardown.
+     * @summary Warms a fail-closed, runtime-only exact-node geometry generation.
+     * @param {String} workspaceId
+     * @param {String} targetNodeId
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    ensureCrossWindowPreviewGeometry(workspaceId, targetNodeId) {
+        let me      = this,
+            surface = me.resolveCrossWindowPreviewSurface(workspaceId, targetNodeId),
+            inner   = surface && Neo.manager?.Window?.get(surface.windowId)?.innerRect;
+
+        if (!surface || !inner) {
+            me.crossWindowPreviewGeometries.delete(workspaceId);
+            return Promise.resolve(null)
+        }
+
+        const
+            signature = [inner.x ?? 0, inner.y ?? 0, inner.width, inner.height].join(':'),
+            current   = me.crossWindowPreviewGeometries.get(workspaceId);
+
+        if (
+            current?.host === surface.host &&
+            current?.target === surface.target &&
+            current?.targetNodeId === targetNodeId &&
+            current?.windowSignature === signature
+        ) {
+            return current.promise
+        }
+
+        const entry = {
+            geometry       : null,
+            host           : surface.host,
+            promise        : null,
+            target         : surface.target,
+            targetNodeId,
+            windowSignature: signature
+        };
+
+        entry.promise = surface.host
+            .getDomRect([surface.host.id, surface.target.id], surface.windowId)
+            .then(([hostRect, targetRect]) => {
+                if (
+                    me.isDestroyed ||
+                    me.crossWindowPreviewGeometries.get(workspaceId) !== entry ||
+                    surface.host.isDestroyed ||
+                    surface.target.isDestroyed
+                ) {
+                    return null
+                }
+
+                if (
+                    !hostRect || !targetRect ||
+                    hostRect.width <= 0 || hostRect.height <= 0 ||
+                    targetRect.width <= 0 || targetRect.height <= 0
+                ) {
+                    me.crossWindowPreviewGeometries.delete(workspaceId);
+                    return null
+                }
+
+                return entry.geometry = {
+                    ...surface,
+                    hostRect,
+                    localTargetRect: me.dragAffordances.localRect(targetRect, hostRect),
+                    targetNodeId,
+                    targetRect
+                }
+            })
+            .catch(() => {
+                me.crossWindowPreviewGeometries.get(workspaceId) === entry &&
+                    me.crossWindowPreviewGeometries.delete(workspaceId);
+
+                return null
+            });
+
+        me.crossWindowPreviewGeometries.set(workspaceId, entry);
+
+        return entry.promise
+    }
+
+    /**
+     * Computes and renders one remote preview from an exact live target-node measurement. A vessel
+     * uses its stable lazy landing surface; the main workspace returns a stack to its captured
+     * semantic home. A missing or in-flight measurement hides the preview for that frame.
      * @param {String} workspaceId
      * @param {Object} data
      * @returns {Object|null}
@@ -1182,8 +1304,6 @@ class Workspace extends Container {
         let me              = this,
             isMain          = workspaceId === Workspace.MAIN_WORKSPACE_ID,
             state           = isMain ? null : me.vesselWorkspaces.get(workspaceId),
-            windowId        = isMain ? me.windowId : state?.windowId,
-            inner           = windowId != null ? Neo.manager?.Window?.get(windowId)?.innerRect : null,
             draggedItem     = data?.draggedItem,
             itemId          = draggedItem?.dockItemId,
             groupNodeId     = draggedItem?.dockGroupNodeId ?? null,
@@ -1195,33 +1315,46 @@ class Workspace extends Container {
                     ? storedHome
                     : Object.entries(me.dockModel.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0])
                 : Workspace.vesselTabsNodeId(state?.itemId),
-            pointer         = {x: data?.localX, y: data?.localY},
-            rect            = inner && {x: 0, y: 0, width: inner.width, height: inner.height},
-            previewPointer  = isMain || !rect
-                ? pointer
-                : {x: rect.width / 2, y: rect.height / 2},
-            renderer        = isMain ? me.dragAffordances?.preview : state?.preview,
-            preview;
+            pointer         = {x: data?.localX, y: data?.localY};
 
         if (
-            !itemId || !targetNodeId || !rect || state?.committed || state?.closeRequested ||
+            !itemId || !targetNodeId || state?.committed || state?.closeRequested ||
             !me.hitTestCrossWindowTarget(workspaceId, pointer.x, pointer.y)
         ) {
             return null
         }
 
-        preview = me.dragAffordances.producer.produce({
-            containerId : isMain ? me.getReference('dock-host')?.id : state.app?.mainView?.id,
-            groupNodeId,
-            itemId,
-            pointer     : previewPointer,
-            sourceNodeId: data?.sourceNodeId,
-            zones       : [{nodeId: targetNodeId, rect}]
-        });
+        me.ensureCrossWindowPreviewGeometry(workspaceId, targetNodeId);
 
-        if (renderer) {
-            renderer.dockPreview = preview;
-            preview && renderer.applyTargetGeometry(rect)
+        const geometry = me.crossWindowPreviewGeometries.get(workspaceId)?.geometry;
+
+        if (!geometry) {
+            let renderer = me.resolveCrossWindowPreviewSurface(workspaceId, targetNodeId)?.renderer;
+
+            renderer && (renderer.dockPreview = null);
+
+            return null
+        }
+
+        const
+            previewPointer = isMain
+                ? pointer
+                : {
+                    x: geometry.targetRect.x + geometry.targetRect.width / 2,
+                    y: geometry.targetRect.y + geometry.targetRect.height / 2
+                },
+            preview = me.dragAffordances.producer.produce({
+                containerId : geometry.host.id,
+                groupNodeId,
+                itemId,
+                pointer     : previewPointer,
+                sourceNodeId: data?.sourceNodeId,
+                zones       : [{nodeId: targetNodeId, rect: geometry.targetRect}]
+            });
+
+        if (geometry.renderer) {
+            geometry.renderer.dockPreview = preview;
+            preview && geometry.renderer.applyTargetGeometry(geometry.localTargetRect)
         }
 
         return preview
@@ -1233,6 +1366,8 @@ class Workspace extends Container {
      * @protected
      */
     clearCrossWindowPreview(workspaceId) {
+        this.crossWindowPreviewGeometries.delete(workspaceId);
+
         if (workspaceId === Workspace.MAIN_WORKSPACE_ID) {
             this.dragAffordances?.clear()
         } else {
@@ -1715,6 +1850,7 @@ class Workspace extends Container {
 
         // Every re-projection retires the active gesture session — a stale geometry promise
         // must never survive a topology change (the controller's generation guards depend on it).
+        me.crossWindowPreviewGeometries.delete(Workspace.MAIN_WORKSPACE_ID);
         me.dragAffordances?.clear();
 
         try {
@@ -4486,6 +4622,7 @@ class Workspace extends Container {
 
         me.crossWindowParticipations.forEach(participation => participation?.destroy());
         me.crossWindowParticipations.clear();
+        me.crossWindowPreviewGeometries.clear();
         me.vesselWorkspaces.clear();
         me.tourRunner?.destroy();
         me.dockService?.destroy();

--- a/test/playwright/e2e/workstation/WorkstationDockPreviewSymmetryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockPreviewSymmetryNL.spec.mjs
@@ -1,0 +1,632 @@
+import {test, expect} from '../../fixtures.mjs';
+import {isFilmTake}   from '../utils/gpuIntent.mjs';
+
+const
+    EDGES  = ['top', 'right', 'bottom', 'left'],
+    THEMES = ['neo-theme-neo-dark', 'neo-theme-neo-light'];
+
+/**
+ * @summary Whitebox E2E contract for exact-target dock-preview symmetry.
+ *
+ * One stable `left-tabs` target is exercised through both landed routes:
+ *
+ * - in-window: a real Audit-tab pointer gesture drives `DockDragAffordances`;
+ * - popup→main: a real Activity tear-out supplies the source window, then the registered
+ *   `CrossWindowDragTarget` drives the main target's remote-preview callback.
+ *
+ * Each route runs in both Workstation themes. The retained matrix binds the semantic node id,
+ * exact target/host/window rectangles, preview rectangle, DPR, zoom, and same-scale crop for
+ * top/right/bottom/left. The test compares the four thicknesses directly; independent maxima
+ * or source-code symmetry are deliberately insufficient.
+ *
+ * Run:
+ * NEO_E2E_PORT=8096 npx playwright test WorkstationDockPreviewSymmetryNL \
+ *   -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Workstation dock-preview four-axis symmetry (Neural Link)', () => {
+    test.setTimeout(240000);
+
+    /**
+     * Normalizes Neural Link query/find result shapes.
+     * @param {Object|null} result
+     * @returns {Object|null}
+     */
+    function properties(result) {
+        return result?.properties ?? result ?? null
+    }
+
+    /**
+     * Reads an id from a direct, wrapped, or array Neural Link result.
+     * @param {Object|Object[]|null} result
+     * @returns {String|null}
+     */
+    function readId(result) {
+        if (Array.isArray(result)) return readId(result[0]);
+
+        return properties(result)?.id ?? null
+    }
+
+    /**
+     * Boots one settled Workstation and resolves the exact target/render-owner ids.
+     * @param {import('@playwright/test').Page} page
+     * @param {Object} neuralLink
+     * @returns {Promise<Object>}
+     */
+    async function boot(page, neuralLink) {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 60000});
+        await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
+        await page.evaluate(() => document.fonts.ready);
+        await page.waitForFunction(() => {
+            const
+                host   = document.querySelector('.workstation-dock-host'),
+                target = [...document.querySelectorAll('.neo-dashboard-dock-tabs')]
+                    .find(element => element.id && element.getBoundingClientRect().width > 100);
+
+            return host?.getBoundingClientRect().height > 300
+                && target?.getBoundingClientRect().height > 100
+        }, {timeout: 60000});
+
+        const
+            app        = await neuralLink.connectToApp('Workstation'),
+            workspaces = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+            wsId       = readId(workspaces);
+
+        expect(wsId, 'one live Workstation Workspace must exist').toBeTruthy();
+
+        // Give the edge-owned target two ordinary visible residents. Tearing the staged Activity
+        // tab out later then leaves Queues behind, so normalization cannot retire `left-tabs`
+        // between the in-window and popup→main routes.
+        const staged = await app.callMethod(wsId, 'commitLocalWorkspaceOperation', [
+            'workstation-main',
+            {operation: 'moveItem', itemId: 'activity', targetNodeId: 'left-tabs', index: 1}
+        ]);
+
+        expect(staged.errors).toEqual([]);
+        await expect.poll(async () => {
+            const {dockModel} = await app.getComponent(wsId, ['dockModel']);
+
+            return dockModel.nodes['left-tabs']?.items?.includes('activity')
+        }, {
+            message: 'the stable target must retain the staged Activity tab',
+            timeout: 15000
+        }).toBe(true);
+        await page.waitForTimeout(700);
+
+        const
+            hostId    = readId(await app.queryComponent({reference: 'dock-host'}, ['id'])),
+            targetId  = readId(await app.queryComponent({dockNodeId: 'left-tabs'}, ['id'])),
+            previewId = readId(await app.queryComponent({reference: 'dock-preview'}, ['id']));
+
+        expect(hostId, 'the preview containing block must resolve by reference').toBeTruthy();
+        expect(targetId, 'left-tabs must resolve to one exact component id').toBeTruthy();
+        expect(previewId, 'the main preview renderer must resolve by reference').toBeTruthy();
+
+        return {app, hostId, previewId, targetId, wsId}
+    }
+
+    /**
+     * Applies and waits for one live Workstation theme.
+     * @param {Object} app
+     * @param {import('@playwright/test').Page} page
+     * @param {String} wsId
+     * @param {String} theme
+     */
+    async function setTheme(app, page, wsId, theme) {
+        await app.callMethod(wsId, 'setWorkspaceTheme', [theme]);
+        await expect.poll(async () => (await app.getComponent(wsId, ['theme'])).theme, {
+            message: `worker theme must settle at ${theme}`,
+            timeout: 15000
+        }).toBe(theme);
+        await expect(page.locator('body > .workstation-viewport')).toHaveClass(new RegExp(theme));
+        await page.waitForTimeout(180)
+    }
+
+    /**
+     * Reads one positive viewport-space rectangle.
+     * @param {import('@playwright/test').Page} page
+     * @param {String} id
+     * @returns {Promise<Object>}
+     */
+    async function readTargetRect(page, id) {
+        const rect = await page.evaluate(componentId => {
+            const value = document.getElementById(componentId)?.getBoundingClientRect();
+
+            return value && {
+                bottom: value.bottom,
+                height: value.height,
+                left  : value.left,
+                right : value.right,
+                top   : value.top,
+                width : value.width,
+                x     : value.x,
+                y     : value.y
+            }
+        }, id);
+
+        expect(rect?.width, 'the target width must be measurable').toBeGreaterThan(0);
+        expect(rect?.height, 'the target height must be measurable').toBeGreaterThan(0);
+
+        return rect
+    }
+
+    /**
+     * Picks four pointer positions within the producer's real edge bands. The top sample stays
+     * below the tab-header carve-out while remaining inside the top edge band.
+     * @param {Object} rect
+     * @returns {Object}
+     */
+    function edgePoints(rect) {
+        const
+            band     = .24 * Math.min(rect.width, rect.height),
+            topInset = Math.min(band - 2, Math.max(37, band * .8)),
+            centerX  = rect.left + rect.width / 2,
+            centerY  = rect.top + rect.height / 2;
+
+        expect(band, 'the stable target must expose a top band below its header carve-out').toBeGreaterThan(38);
+
+        return {
+            top   : {x: centerX, y: rect.top + topInset},
+            right : {x: rect.right - 2, y: centerY},
+            bottom: {x: centerX, y: rect.bottom - 2},
+            left  : {x: rect.left + 2, y: centerY}
+        }
+    }
+
+    /**
+     * Starts the existing physical in-window drag on Audit.
+     * @param {import('@playwright/test').Page} page
+     */
+    async function beginAuditDrag(page) {
+        const header = page.locator('.neo-tab-header-button', {hasText: 'Audit'}).first();
+
+        await expect(header).toBeVisible();
+
+        const rect = await header.boundingBox();
+
+        await page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(rect.x + rect.width / 2 + 12, rect.y + rect.height / 2 + 12, {steps: 4});
+        await expect(page.locator('.neo-tab-header-toolbar.neo-is-dragging')).toBeVisible()
+    }
+
+    /**
+     * Ends the physical gesture without committing.
+     * @param {import('@playwright/test').Page} page
+     */
+    async function cancelPhysicalDrag(page) {
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(120);
+        await page.mouse.up();
+        await page.waitForTimeout(260)
+    }
+
+    /**
+     * Waits until the main renderer carries one exact semantic edge preview.
+     * @param {Object} app
+     * @param {String} previewId
+     * @param {String} edge
+     * @returns {Promise<Object>}
+     */
+    async function waitForMainPreview(app, previewId, edge) {
+        let preview;
+
+        await expect.poll(async () => {
+            preview = (await app.getComponent(previewId, ['dockPreview'])).dockPreview;
+
+            return preview
+                ? `${preview.target?.nodeId}:${preview.placement?.kind}`
+                : 'none'
+        }, {
+            message: `left-tabs must publish edge-${edge}`,
+            timeout: 15000
+        }).toBe(`left-tabs:edge-${edge}`);
+
+        return preview
+    }
+
+    /**
+     * Waits for the renderer's semantic edge plus geometry update, then captures their same-frame
+     * browser receipt. This observes the two-stage reactive paint without timing sleeps.
+     * @param {import('@playwright/test').Page} page
+     * @param {Object} ids
+     * @param {String} route
+     * @param {String} theme
+     * @param {String} edge
+     * @param {Object} preview
+     * @returns {Promise<Object>}
+     */
+    async function readFrame(page, ids, route, theme, edge, preview) {
+        let frame;
+
+        await expect.poll(async () => {
+            frame = await page.evaluate(({edge, hostId, previewId, targetId}) => {
+                const
+                    host       = document.getElementById(hostId),
+                    target     = document.getElementById(targetId),
+                    affordance = document.getElementById(previewId)
+                        ?.querySelector('.neo-dock-preview-affordance'),
+                    pick       = element => {
+                        const rect = element?.getBoundingClientRect();
+
+                        return rect && {
+                            bottom: rect.bottom,
+                            height: rect.height,
+                            left  : rect.left,
+                            right : rect.right,
+                            top   : rect.top,
+                            width : rect.width,
+                            x     : rect.x,
+                            y     : rect.y
+                        }
+                    },
+                    affordanceRect = pick(affordance),
+                    targetRect     = pick(target),
+                    near           = (first, second) => Math.abs(first - second) <= 1,
+                    settled        = affordanceRect && targetRect &&
+                        affordance.classList.contains(`neo-dock-preview-edge-${edge}`) &&
+                        affordance.dataset.dockTarget === 'left-tabs' &&
+                        (edge === 'top'
+                            ? near(affordanceRect.left, targetRect.left) &&
+                                near(affordanceRect.width, targetRect.width) &&
+                                near(affordanceRect.top, targetRect.top)
+                            : edge === 'right'
+                                ? near(affordanceRect.top, targetRect.top) &&
+                                    near(affordanceRect.height, targetRect.height) &&
+                                    near(affordanceRect.right, targetRect.right)
+                                : edge === 'bottom'
+                                    ? near(affordanceRect.left, targetRect.left) &&
+                                        near(affordanceRect.width, targetRect.width) &&
+                                        near(affordanceRect.bottom, targetRect.bottom)
+                                    : near(affordanceRect.top, targetRect.top) &&
+                                        near(affordanceRect.height, targetRect.height) &&
+                                        near(affordanceRect.left, targetRect.left));
+
+                return {
+                    affordanceClass  : affordance?.className ?? null,
+                    affordanceRect,
+                    devicePixelRatio : globalThis.devicePixelRatio,
+                    hostRect         : pick(host),
+                    settled,
+                    targetComponentId: target?.id ?? null,
+                    targetNodeId     : affordance?.dataset.dockTarget ?? null,
+                    targetRect,
+                    windowRect       : {
+                        height: globalThis.innerHeight,
+                        width : globalThis.innerWidth,
+                        x     : globalThis.screenX,
+                        y     : globalThis.screenY
+                    },
+                    zoom: globalThis.visualViewport?.scale ?? 1
+                }
+            }, {...ids, edge});
+
+            return frame.settled
+        }, {
+            message: `${route}/${theme}/${edge} must settle its exact-target renderer geometry`,
+            timeout: 15000
+        }).toBe(true);
+
+        expect(frame.affordanceRect, `${route}/${theme}/${edge} must paint an affordance`).toBeTruthy();
+        expect(preview.target.nodeId).toBe('left-tabs');
+
+        const {settled, ...receipt} = frame;
+
+        return {
+            ...receipt,
+            edge,
+            placement   : preview.placement.kind,
+            previewId   : preview.previewId,
+            route,
+            targetNodeId: preview.target.nodeId,
+            theme
+        }
+    }
+
+    /**
+     * Retains one same-scale target crop as a Playwright artifact.
+     * @param {import('@playwright/test').Page} page
+     * @param {import('@playwright/test').TestInfo} testInfo
+     * @param {Object} frame
+     */
+    async function attachFrame(page, testInfo, frame) {
+        // The standard GPU-intent profile deliberately carries `--disable-frame-rate-limit`,
+        // which can starve headed Retina screenshots while DOM/worker truth keeps advancing.
+        // Pixel retention belongs to the repository's canonical film profile; the standard run
+        // still emits the complete JSON geometry matrix below.
+        if (!isFilmTake()) return;
+
+        const
+            viewport = page.viewportSize() ?? await page.evaluate(() => ({
+                height: globalThis.innerHeight,
+                width : globalThis.innerWidth
+            })),
+            margin = 10,
+            left   = Math.max(0, Math.floor(frame.targetRect.left - margin)),
+            top    = Math.max(0, Math.floor(frame.targetRect.top - margin)),
+            right  = Math.min(viewport.width, Math.ceil(frame.targetRect.right + margin)),
+            bottom = Math.min(viewport.height, Math.ceil(frame.targetRect.bottom + margin)),
+            body   = await page.screenshot({
+                animations: 'disabled',
+                clip      : {x: left, y: top, width: right - left, height: bottom - top}
+            });
+
+        await testInfo.attach(
+            `${frame.route}-${frame.theme.replace('neo-theme-neo-', '')}-${frame.edge}.png`,
+            {body, contentType: 'image/png'}
+        )
+    }
+
+    /**
+     * Enforces exact target reuse, edge containment, and four-way CSS/physical thickness equality.
+     * @param {Object[]} frames
+     */
+    function assertSymmetry(frames) {
+        expect(frames.map(frame => frame.edge)).toEqual(EDGES);
+
+        const
+            reference         = frames[0].targetRect,
+            tolerance         = 1,
+            cssThickness      = {},
+            physicalThickness = {};
+
+        frames.forEach(frame => {
+            const
+                target     = frame.targetRect,
+                affordance = frame.affordanceRect;
+
+            for (const key of ['left', 'top', 'width', 'height']) {
+                expect(Math.abs(target[key] - reference[key]),
+                    `${frame.route}/${frame.theme} must reuse one settled target rect (${key})`)
+                    .toBeLessThanOrEqual(tolerance)
+            }
+
+            if (frame.edge === 'top' || frame.edge === 'bottom') {
+                cssThickness[frame.edge] = affordance.height;
+                expect(Math.abs(affordance.left - target.left)).toBeLessThanOrEqual(tolerance);
+                expect(Math.abs(affordance.width - target.width)).toBeLessThanOrEqual(tolerance)
+            } else {
+                cssThickness[frame.edge] = affordance.width;
+                expect(Math.abs(affordance.top - target.top)).toBeLessThanOrEqual(tolerance);
+                expect(Math.abs(affordance.height - target.height)).toBeLessThanOrEqual(tolerance)
+            }
+
+            if (frame.edge === 'top') {
+                expect(Math.abs(affordance.top - target.top)).toBeLessThanOrEqual(tolerance)
+            } else if (frame.edge === 'right') {
+                expect(Math.abs(affordance.right - target.right)).toBeLessThanOrEqual(tolerance)
+            } else if (frame.edge === 'bottom') {
+                expect(Math.abs(affordance.bottom - target.bottom)).toBeLessThanOrEqual(tolerance)
+            } else {
+                expect(Math.abs(affordance.left - target.left)).toBeLessThanOrEqual(tolerance)
+            }
+
+            physicalThickness[frame.edge] = cssThickness[frame.edge] * frame.devicePixelRatio
+        });
+
+        const
+            cssValues      = Object.values(cssThickness),
+            physicalValues = Object.values(physicalThickness);
+
+        expect(Math.max(...cssValues) - Math.min(...cssValues),
+            `four-axis CSS thicknesses: ${JSON.stringify(cssThickness)}`).toBeLessThanOrEqual(1);
+        expect(Math.max(...physicalValues) - Math.min(...physicalValues),
+            `four-axis rendered thicknesses: ${JSON.stringify(physicalThickness)}`)
+            .toBeLessThanOrEqual(frames[0].devicePixelRatio)
+    }
+
+    /**
+     * Collects one theme's physical in-window four-axis matrix.
+     * @param {Object} data
+     * @returns {Promise<Object[]>}
+     */
+    async function collectInWindow({app, ids, page, testInfo, theme, wsId}) {
+        await setTheme(app, page, wsId, theme);
+
+        const
+            targetRect = await readTargetRect(page, ids.targetId),
+            points     = edgePoints(targetRect),
+            frames     = [];
+
+        await beginAuditDrag(page);
+
+        try {
+            for (const edge of EDGES) {
+                const point = points[edge];
+
+                await page.mouse.move(point.x, point.y, {steps: 14});
+                await page.mouse.move(point.x + 1, point.y, {steps: 1});
+                await page.mouse.move(point.x, point.y, {steps: 1});
+
+                const preview = await waitForMainPreview(app, ids.previewId, edge);
+
+                await expect(page.locator(`#${ids.previewId} .neo-dock-preview-affordance`)).toBeVisible();
+
+                const frame = await readFrame(page, ids, 'in-window', theme, edge, preview);
+
+                frames.push(frame);
+                await attachFrame(page, testInfo, frame)
+            }
+        } finally {
+            await cancelPhysicalDrag(page)
+        }
+
+        assertSymmetry(frames);
+
+        return frames
+    }
+
+    /**
+     * Resolves the registered main-workspace remote target.
+     * @param {Object} app
+     * @returns {Promise<String>}
+     */
+    async function resolveMainRemoteTargetId(app) {
+        let
+            prior    = null,
+            targetId = null;
+
+        await expect.poll(async () => {
+            const targets = await app.findInstances(
+                {className: 'Neo.dashboard.CrossWindowDragTarget'},
+                ['id', 'stableTargetId']
+            );
+
+            targetId = (targets || [])
+                .map(properties)
+                .find(target => target?.stableTargetId === 'workstation-main')?.id ?? null;
+
+            const settled = targetId && targetId === prior ? targetId : null;
+
+            prior = targetId;
+
+            return settled
+        }, {
+            message: 'the main workspace must retain one registered CrossWindowDragTarget generation',
+            timeout: 15000
+        }).toBeTruthy();
+
+        return targetId
+    }
+
+    /**
+     * Collects one theme's popup→main four-axis matrix through the registered remote target.
+     * @param {Object} data
+     * @returns {Promise<Object[]>}
+     */
+    async function collectCrossWindow({
+        app,
+        ids,
+        page,
+        sourceMeta,
+        testInfo,
+        theme,
+        wsId
+    }) {
+        await setTheme(app, page, wsId, theme);
+
+        const
+            remoteTargetId = await resolveMainRemoteTargetId(app),
+            targetRect     = await readTargetRect(page, ids.targetId),
+            points         = edgePoints(targetRect),
+            frames         = [];
+
+        try {
+            for (const edge of EDGES) {
+                const
+                    point   = points[edge],
+                    payload = {
+                        draggedItem: {
+                            dockItemId           : 'activity',
+                            dockSourceWorkspaceId: 'workstation-vessel:activity'
+                        },
+                        localX      : point.x,
+                        localY      : point.y,
+                        sourceNodeId: 'workstation-vessel-tabs:activity'
+                    };
+
+                expect(await app.callMethod(remoteTargetId, 'acceptsRemoteDrag', [point.x, point.y]),
+                    `${edge} must remain inside the manager.Window target`).toBe(true);
+
+                let preview;
+
+                await expect.poll(async () => {
+                    preview = await app.callMethod(remoteTargetId, 'onRemoteDragMove', [payload]);
+
+                    return preview
+                        ? `${preview.target?.nodeId}:${preview.placement?.kind}`
+                        : 'none'
+                }, {
+                    message: `popup→main must publish left-tabs:edge-${edge}`,
+                    timeout: 15000
+                }).toBe(`left-tabs:edge-${edge}`);
+
+                await expect(page.locator(`#${ids.previewId} .neo-dock-preview-affordance`)).toBeVisible();
+
+                const frame = {
+                    ...await readFrame(page, ids, 'popup-to-main', theme, edge, preview),
+                    sourceWindow: sourceMeta
+                };
+
+                frames.push(frame);
+                await attachFrame(page, testInfo, frame)
+            }
+        } finally {
+            await app.callMethod(remoteTargetId, 'onRemoteDragLeave')
+        }
+
+        assertSymmetry(frames);
+
+        return frames
+    }
+
+    test('one exact target stays symmetric across four edges, two routes, and both themes', async ({
+        page,
+        neuralLink
+    }, testInfo) => {
+        const
+            {app, hostId, previewId, targetId, wsId} = await boot(page, neuralLink),
+            ids                                      = {hostId, previewId, targetId},
+            matrix                                   = {inWindow: {}, popupToMain: {}};
+        let popup = null;
+
+        try {
+            for (const theme of THEMES) {
+                matrix.inWindow[theme] = await collectInWindow({
+                    app,
+                    ids,
+                    page,
+                    testInfo,
+                    theme,
+                    wsId
+                })
+            }
+
+            await setTheme(app, page, wsId, THEMES[0]);
+
+            const
+                popupPromise  = page.waitForEvent('popup', {timeout: 90000}),
+                tearOutResult = await app.callMethod(wsId, 'executeTearOutStep', [
+                    {itemId: 'activity', sourceNodeId: 'left-tabs'},
+                    {birthAttempts: 240, moveDelay: 16, moveSteps: 5}
+                ]);
+
+            popup = await popupPromise;
+            await popup.waitForLoadState('domcontentloaded');
+
+            expect(tearOutResult.errors).toEqual([]);
+            expect(tearOutResult.applied, 'Activity must be owned by one real popup source').toBe(true);
+            await expect(popup.locator('.workstation-viewport')).toBeVisible();
+            await page.waitForTimeout(900);
+
+            const
+                sourceMeta = await popup.evaluate(() => ({
+                    devicePixelRatio: globalThis.devicePixelRatio,
+                    height          : globalThis.innerHeight,
+                    width           : globalThis.innerWidth,
+                    x               : globalThis.screenX,
+                    y               : globalThis.screenY,
+                    zoom            : globalThis.visualViewport?.scale ?? 1
+                }));
+
+            for (const theme of THEMES) {
+                matrix.popupToMain[theme] = await collectCrossWindow({
+                    app,
+                    ids,
+                    page,
+                    sourceMeta,
+                    testInfo,
+                    theme,
+                    wsId
+                })
+            }
+
+            await testInfo.attach('dock-preview-symmetry-matrix.json', {
+                body       : Buffer.from(JSON.stringify(matrix, null, 2)),
+                contentType: 'application/json'
+            })
+        } finally {
+            popup && !popup.isClosed() && await popup.close()
+        }
+    })
+});

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -456,10 +456,14 @@ test.describe.serial('Workstation.view.Workspace', () => {
             destroyed   = [],
             preview     = {dockPreview: null, applyTargetGeometry() {}},
             mainView    = {
-                id           : 'workstation-vessel-view',
-                isDestroyed  : false,
-                add          : () => preview,
-                addCls       : cls => classes.push(cls),
+                id         : 'workstation-vessel-view',
+                isDestroyed: false,
+                add        : () => preview,
+                addCls     : cls => classes.push(cls),
+                getDomRect : async () => [
+                    {x: 0, y: 0, width: 480, height: 320},
+                    {x: 0, y: 0, width: 480, height: 320}
+                ],
                 promiseUpdate: async () => {}
             };
 
@@ -509,6 +513,11 @@ test.describe.serial('Workstation.view.Workspace', () => {
             try {
                 WindowManager.get = () => ({innerRect: {width: 480, height: 320}});
 
+                await workspace.ensureCrossWindowPreviewGeometry(
+                    workspaceId,
+                    Workspace.vesselTabsNodeId('alerts')
+                );
+
                 const edgePreview = workspace.renderCrossWindowPreview(workspaceId, {
                     draggedItem: {
                         dockItemId           : 'security',
@@ -534,6 +543,106 @@ test.describe.serial('Workstation.view.Workspace', () => {
             expect(state.document).toBeNull();
             expect(preview.dockPreview).toBeNull();
             expect(destroyed).toEqual([])
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('remote main previews render all four edges against the exact semantic target geometry', async () => {
+        const
+            workspace         = Neo.create(Workspace, {}),
+            sourceWorkspaceId = Workspace.vesselWorkspaceId('queues'),
+            hostRect          = {x: 100, y: 80, width: 900, height: 600},
+            targetRect        = {x: 120, y: 120, width: 260, height: 260},
+            paintedRects      = [],
+            measuredIds       = [];
+
+        try {
+            await workspace.crossWindowParticipationPromise;
+
+            const
+                host                    = workspace.getReference('dock-host'),
+                target                  = host.down({dockNodeId: 'left-tabs'}),
+                renderer                = workspace.dragAffordances.preview,
+                WindowManager           = Neo.manager.Window,
+                originalGet             = WindowManager.get,
+                originalGetDomRect      = host.getDomRect,
+                originalApplyTargetRect = renderer.applyTargetGeometry,
+                originalWindowId        = workspace.windowId;
+
+            workspace.windowId = 'window-main';
+            workspace.vesselWorkspaces.set(sourceWorkspaceId, {itemId: 'queues'});
+            workspace.tearOutPlacements.queues = {index: 0, tabsNodeId: 'left-tabs'};
+
+            try {
+                WindowManager.get = () => ({innerRect: {x: 0, y: 0, width: 1280, height: 720}});
+                host.getDomRect = async ids => {
+                    measuredIds.push(ids);
+                    return [hostRect, targetRect]
+                };
+                renderer.applyTargetGeometry = rect => paintedRects.push(rect);
+
+                await workspace.ensureCrossWindowPreviewGeometry(Workspace.MAIN_WORKSPACE_ID, 'left-tabs');
+
+                expect(measuredIds).toEqual([[host.id, target.id]]);
+
+                const
+                    baseData = {
+                        draggedItem: {
+                            dockItemId           : 'queues',
+                            dockSourceWorkspaceId: sourceWorkspaceId
+                        },
+                        sourceNodeId: Workspace.vesselTabsNodeId('queues')
+                    },
+                    points = {
+                        top   : {localX: 250, localY: 160},
+                        right : {localX: 379, localY: 250},
+                        bottom: {localX: 250, localY: 379},
+                        left  : {localX: 121, localY: 250}
+                    };
+
+                Object.entries(points).forEach(([edge, point]) => {
+                    const preview = workspace.renderCrossWindowPreview(
+                        Workspace.MAIN_WORKSPACE_ID,
+                        {...baseData, ...point}
+                    );
+
+                    expect(preview.target.nodeId).toBe('left-tabs');
+                    expect(preview.placement.kind).toBe(`edge-${edge}`)
+                });
+
+                expect(paintedRects).toEqual(Array(4).fill({
+                    x     : targetRect.x - hostRect.x,
+                    y     : targetRect.y - hostRect.y,
+                    width : targetRect.width,
+                    height: targetRect.height
+                }));
+
+                let settleReplacement;
+
+                WindowManager.get = () => ({innerRect: {x: 0, y: 0, width: 1279, height: 720}});
+                host.getDomRect = async ids => {
+                    measuredIds.push(ids);
+
+                    return new Promise(resolve => settleReplacement = resolve)
+                };
+
+                expect(workspace.renderCrossWindowPreview(
+                    Workspace.MAIN_WORKSPACE_ID,
+                    {...baseData, ...points.top}
+                )).toBeNull();
+                expect(renderer.dockPreview, 'an in-flight replacement must hide stale pixels').toBeNull();
+
+                settleReplacement([hostRect, targetRect]);
+                await workspace.ensureCrossWindowPreviewGeometry(Workspace.MAIN_WORKSPACE_ID, 'left-tabs')
+            } finally {
+                WindowManager.get           = originalGet;
+                host.getDomRect             = originalGetDomRect;
+                renderer.applyTargetGeometry = originalApplyTargetRect;
+                workspace.windowId           = originalWindowId;
+                workspace.vesselWorkspaces.delete(sourceWorkspaceId);
+                delete workspace.tearOutPlacements.queues
+            }
         } finally {
             workspace.destroy()
         }


### PR DESCRIPTION
Resolves #16121

Cross-window dock previews now measure the exact rendered component for their semantic target node instead of painting against a manager.Window-sized surrogate. manager.Window remains the topology and hit-test authority; a runtime-only geometry generation pairs the live host/target identities with the current inner-window signature, translates the target once into the overlay host, and retires on projection, leave, resize, replacement, or teardown. A cold or replacement measurement also clears stale preview pixels while the new generation warms.

The whitebox witness exercises one `left-tabs` target through a physical in-window drag and a real popup-to-main route, in both Workstation themes. It retains the target/host/affordance/window rectangles, DPR, zoom, semantic IDs, source-popup metadata, and same-scale film frames for all four edges.

Evidence: L3 (real Chromium windows, Neural Link worker/DOM receipts, exact component identity, four-axis browser geometry, and retained film frames) -> L3 required by the cross-window visual/behavior contract. No residuals.

## Deltas from ticket

None substantive. The implementation does not persist geometry, change dock documents, or alter drop indicators. The retained frames use Neo's canonical film profile because the standard benchmark profile's `--disable-frame-rate-limit` mode can starve headed Retina screenshot presentation; the same behavior and geometry matrix separately pass under that standard profile.

## Test Evidence

- Exact rebased head: `49719c22f4b75d25640c4ff427ea11158a18c5aa`, one commit atop `origin/dev` `c6ee7652f2b0725cc538e7c879f737b4601d9c16`.
- Workspace unit contract: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/apps/workstation/Workspace.spec.mjs` — 18/18 passed after rebase. The new witness proves exact host+target measurement, all four semantic edge previews against a 260x260 node rather than the mocked 1280x720 window, host-local translation, cache replacement, and stale-pixel clearing while a replacement measurement is in flight.
- Standard-profile Neural Link witness: `node_modules/.bin/playwright test WorkstationDockPreviewSymmetryNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 2/2 passed after rebase; ANGLE/Metal acceleration resolved.
- Canonical film-profile witness: `NEO_FILM_TAKE=1 node_modules/.bin/playwright test WorkstationDockPreviewSymmetryNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed` — 2/2 passed after rebase and retained 16 same-scale route x theme x edge frames plus the JSON geometry matrix.
- Browser matrix: one exact `neo-tab-container-1` target in every frame; top/right/bottom/left measured `24/24/24/24px` for in-window dark, in-window light, popup-to-main dark, and popup-to-main light; DPR 1 and zoom 1 were retained with both window rectangles.
- Commit hooks: whitespace, shorthand, JSDoc types, AiConfig test mutation, derived-domain, ticket archaeology, block alignment, and parse checks passed.

## Post-Merge Validation

- [ ] Re-run the focused standard and film Workstation witnesses from merged `dev`; confirm one exact target component and 24px four-axis parity remain stable after branch integration.

## Evolution

The headed film run caught a receipt race that the faster standard profile did not: worker semantics can advance before the renderer's second geometry update. The witness now polls the renderer's semantic edge, exact target attribute, and aligned browser rect as one converged receipt instead of adding a timing sleep.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fac51-ddcb-7212-902e-09d3a9d19098.
