### PR TITLE
fix(docking): materialize popup-over-popup proxies (#16117)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -221,6 +221,13 @@ class Workspace extends Container {
      */
     tearOutPanes = {}
     /**
+     * Exact pre-conversion and target-cover outer geometry for parked tear-out vessels.
+     * Runtime-only physical recovery authority; never persisted workspace state.
+     * @member {Object} tearOutParkGeometries={}
+     * @protected
+     */
+    tearOutParkGeometries = {}
+    /**
      * Exact `{tabsNodeId, index}` placement captured at each detach commit — the return truth.
      * @member {Object} tearOutPlacements={}
      * @protected
@@ -358,6 +365,18 @@ class Workspace extends Container {
      * @member {Object|null} lastTourReceipt=null
      */
     lastTourReceipt = null
+    /**
+     * Most recent exact-handle park admission receipt.
+     * @member {Object|null} lastVesselParkReceipt=null
+     * @protected
+     */
+    lastVesselParkReceipt = null
+    /**
+     * Most recent exact-handle restore admission receipt.
+     * @member {Object|null} lastVesselRestoreReceipt=null
+     * @protected
+     */
+    lastVesselRestoreReceipt = null
     /**
      * Five records every 500ms = an honest 10 records/sec.
      * @member {Number|null} #feedIntervalId=null
@@ -1069,6 +1088,7 @@ class Workspace extends Container {
             disconnected        : false,
             document            : null,
             host                : null,
+            indicators          : null,
             itemId,
             participation       : null,
             participationPromise: null,
@@ -1081,7 +1101,8 @@ class Workspace extends Container {
         me.vesselWorkspaces.set(workspaceId, state);
 
         app.mainView.addCls('workstation-vessel-target');
-        state.preview = app.mainView.add({module: DockPreview});
+        state.preview    = app.mainView.add({module: DockPreview});
+        state.indicators = app.mainView.add({module: DockDropIndicators});
 
         await app.mainView.promiseUpdate();
         state.participationPromise = me.refreshCrossWindowParticipation(workspaceId);
@@ -1315,12 +1336,18 @@ class Workspace extends Container {
                     ? storedHome
                     : Object.entries(me.dockModel.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0])
                 : Workspace.vesselTabsNodeId(state?.itemId),
-            pointer         = {x: data?.localX, y: data?.localY};
+            pointer         = {x: data?.localX, y: data?.localY},
+            renderer        = isMain ? me.dragAffordances?.preview : state?.preview,
+            indicators      = isMain ? null : state?.indicators,
+            producer        = me.dragAffordances.producer,
+            preview;
 
         if (
             !itemId || !targetNodeId || state?.committed || state?.closeRequested ||
             !me.hitTestCrossWindowTarget(workspaceId, pointer.x, pointer.y)
         ) {
+            renderer && (renderer.dockPreview = null);
+            indicators?.clear();
             return null
         }
 
@@ -1329,32 +1356,47 @@ class Workspace extends Container {
         const geometry = me.crossWindowPreviewGeometries.get(workspaceId)?.geometry;
 
         if (!geometry) {
-            let renderer = me.resolveCrossWindowPreviewSurface(workspaceId, targetNodeId)?.renderer;
-
             renderer && (renderer.dockPreview = null);
+            indicators?.clear();
 
             return null
         }
 
         const
+            zone           = {nodeId: targetNodeId, rect: geometry.targetRect},
             previewPointer = isMain
                 ? pointer
                 : {
                     x: geometry.targetRect.x + geometry.targetRect.width / 2,
                     y: geometry.targetRect.y + geometry.targetRect.height / 2
-                },
-            preview = me.dragAffordances.producer.produce({
+                };
+
+        if (indicators) {
+            indicators.hostRect = geometry.hostRect;
+            indicators.candidateSet = producer.produceCandidates({
                 containerId : geometry.host.id,
                 groupNodeId,
                 itemId,
-                pointer     : previewPointer,
+                pointer,
+                root        : zone,
                 sourceNodeId: data?.sourceNodeId,
-                zones       : [{nodeId: targetNodeId, rect: geometry.targetRect}]
+                zones       : [zone]
             });
+            preview = indicators.updatePointer(pointer)?.preview ?? null
+        }
 
-        if (geometry.renderer) {
-            geometry.renderer.dockPreview = preview;
-            preview && geometry.renderer.applyTargetGeometry(geometry.localTargetRect)
+        preview ??= producer.produce({
+            containerId : geometry.host.id,
+            groupNodeId,
+            itemId,
+            pointer     : previewPointer,
+            sourceNodeId: data?.sourceNodeId,
+            zones       : [zone]
+        });
+
+        if (renderer) {
+            renderer.dockPreview = preview;
+            preview && renderer.applyTargetGeometry(geometry.localTargetRect)
         }
 
         return preview
@@ -1375,6 +1417,7 @@ class Workspace extends Container {
                 preview = state?.preview;
 
             preview && (preview.dockPreview = null);
+            state?.indicators?.clear();
             state && !state.committed && (state.document = null)
         }
     }
@@ -1559,6 +1602,7 @@ class Workspace extends Container {
             pane?.parent?.remove(pane, false)
         });
         state.preview?.parent?.remove(state.preview, false);
+        state.indicators?.parent?.remove(state.indicators, false);
 
         state.host = mainView.add({
             module: Container,
@@ -1566,11 +1610,13 @@ class Workspace extends Container {
             flex  : 1,
             items : [
                 me.projectVesselDockModel(workspaceId),
-                state.preview || {module: DockPreview}
+                state.preview    || {module: DockPreview},
+                state.indicators || {module: DockDropIndicators}
             ],
             layout: {ntype: 'fit'}
         });
-        state.preview ??= state.host.down({ntype: 'dock-preview'});
+        state.preview    ??= state.host.down({ntype: 'dock-preview'});
+        state.indicators ??= state.host.down({ntype: 'dashboard-dock-drop-indicators'});
 
         await state.host.promiseUpdate();
         state.participation?.destroy();
@@ -1742,6 +1788,7 @@ class Workspace extends Container {
         state.closeRequested = false;
         state.disconnected   = true;
         state.host           = null;
+        state.indicators     = null;
         state.participation  = null;
         state.preview        = null;
         state.reconciling    = false;
@@ -2375,7 +2422,7 @@ class Workspace extends Container {
                 top     = Math.round((proxyRect?.y ?? 120) + (winData.outerHeight - winData.innerHeight) + winData.screenTop);
 
             let opened = await Neo.Main.windowOpen({
-                nativeCapabilities: {close: true, position: true},
+                nativeCapabilities: {close: true, position: true, resize: true},
                 url               : `./index.html?popout=${itemId}&hostId=${me.id}`
                     + `&vesselFlow=tear-out&vesselGrant=${ownerGrant.token}`
                     + `&vesselGeneration=${ownerGrant.generation}`
@@ -2534,6 +2581,7 @@ class Workspace extends Container {
         }
 
         delete me.tearOutConnects[itemId];
+        delete me.tearOutParkGeometries[itemId];
         me.tearOutConnectAdmissions.delete(itemId);
         me.revokeVesselOwnerGrant('tear-out', itemId);
         me.tearOutRetirements.delete(itemId);
@@ -2578,7 +2626,24 @@ class Workspace extends Container {
      * @protected
      */
     async disposeParkedTearOutVessel({itemId, windowName}) {
-        return this.tearOutHandlers.retireActiveVessel({itemId, windowName})
+        let me    = this,
+            entry = me.resolveTearOutVessel(itemId),
+            route = entry?.nativeRoute;
+
+        const disposed = await me.tearOutHandlers.retireActiveVessel({itemId, windowName});
+
+        if (disposed) {
+            delete me.tearOutParkGeometries[itemId];
+
+            route?.nativeHandleKey && await Neo.main.addon.DragDrop.retireWindowDragOrphanRecovery({
+                nativeHandleKey: route.nativeHandleKey,
+                targetWindowId : route.targetWindowId,
+                windowId       : me.windowId,
+                windowName
+            })
+        }
+
+        return disposed
     }
 
     /**
@@ -2586,8 +2651,9 @@ class Workspace extends Container {
      * the REAL OS window alive while the proxy embodies over the target. Close-and-reopen is a
      * one-way door (mid-gesture popup acquisition reads as unsolicited), so conversion parks
      * instead: the same exact generation re-shows on out-conversion or restore. The focus /
-     * move / refocus chain is the platform-law choreography (z-order hides the parked vessel);
-     * a refocus refusal compensates back to the source rect rather than leaving a hidden window.
+     * resize / move / refocus chain is the platform-law choreography (z-order hides the parked
+     * vessel). A source whose outer frame cannot fit behind the target first shrinks through its
+     * exact native route; a refocus refusal compensates to the original extent and source rect.
      * @param {Object} vessel
      * @param {String} vessel.itemId
      * @param {String} vessel.windowName
@@ -2601,20 +2667,64 @@ class Workspace extends Container {
             sourceWindow = Neo.manager?.Window?.get(entry?.windowId),
             targetWindow = Neo.manager?.Window?.get(me.vesselConversionTargetWindowId),
             targetRoute  = targetWindow?.nativeRoute,
-            // The cover geometry and the authority check both speak published inner-window
-            // geometry; a child omitting outerRect never rejects an authorized live vessel.
             sourceRect   = sourceWindow?.innerRect,
-            targetRect   = targetWindow?.innerRect;
+            sourceOuter  = sourceWindow?.outerRect,
+            targetRect   = targetWindow?.innerRect,
+            needsResize  = Boolean(sourceOuter && targetRect && (
+                sourceOuter.width > targetRect.width || sourceOuter.height > targetRect.height
+            )),
+            parkSize      = needsResize ? {
+                height: Math.min(sourceOuter.height, targetRect.height),
+                width : Math.min(sourceOuter.width, targetRect.width)
+            } : null,
+            restoreRect   = sourceOuter ? {
+                height: sourceOuter.height,
+                width : sourceOuter.width,
+                x     : sourceOuter.x,
+                y     : sourceOuter.y
+            } : null,
+            parkGeometry  = needsResize ? {
+                park   : {...parkSize, x: targetRect?.x, y: targetRect?.y},
+                restore: restoreRect
+            } : null;
+
+        me.lastVesselParkReceipt = {
+            authority: {
+                entryNameMatches     : entry?.windowName === windowName,
+                sourceHasHandle      : Boolean(route?.nativeHandleKey),
+                sourceOwnerMatches   : route?.ownerWindowId === me.windowId,
+                sourcePositionCapable: route?.capabilities?.position === true,
+                sourceResizeCapable  : route?.capabilities?.resize === true,
+                sourceTargetMatches  : route?.targetWindowId === entry?.windowId,
+                targetFocusCapable   : targetRoute?.capabilities?.focus === true,
+                targetHasHandle      : Boolean(targetRoute?.nativeHandleKey),
+                targetOwnerMatches   : targetRoute?.ownerWindowId === me.windowId,
+                targetTargetMatches  : targetRoute?.targetWindowId === me.vesselConversionTargetWindowId
+            },
+            needsResize,
+            parkSize,
+            sourceInner: sourceRect && {
+                height: sourceRect.height, width: sourceRect.width, x: sourceRect.x, y: sourceRect.y
+            },
+            sourceOuter: sourceOuter && {
+                height: sourceOuter.height, width: sourceOuter.width, x: sourceOuter.x, y: sourceOuter.y
+            },
+            targetInner: targetRect && {
+                height: targetRect.height, width: targetRect.width, x: targetRect.x, y: targetRect.y
+            }
+        };
+        me.lastVesselRestoreReceipt = null;
 
         if (
             !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
             route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
+            (needsResize && route.capabilities?.resize !== true) ||
             !targetRoute?.nativeHandleKey || targetRoute.ownerWindowId !== me.windowId ||
             targetRoute.targetWindowId !== me.vesselConversionTargetWindowId ||
             targetRoute.capabilities?.focus !== true ||
-            entry.windowName !== windowName || !sourceRect || !targetRect ||
-            sourceRect.width > targetRect.width || sourceRect.height > targetRect.height
+            entry.windowName !== windowName || !sourceRect || !sourceOuter || !targetRect
         ) {
+            me.lastVesselParkReceipt.reason = 'native route or live cover geometry refused';
             return false
         }
 
@@ -2625,10 +2735,14 @@ class Workspace extends Container {
                     windowId       : me.windowId
                 }) === true;
 
+            me.lastVesselParkReceipt.focused = focused;
+
             if (!focused) return false;
 
             let moved = await Neo.main.addon.DragDrop.parkWindowDrag({
                 nativeHandleKey: route.nativeHandleKey,
+                parkSize,
+                restoreRect,
                 targetWindowId : route.targetWindowId,
                 windowId       : me.windowId,
                 windowName,
@@ -2636,7 +2750,11 @@ class Workspace extends Container {
                 y              : targetRect.y
             }) === true;
 
+            me.lastVesselParkReceipt.moved = moved;
+
             if (!moved) return false;
+
+            parkGeometry && (me.tearOutParkGeometries[itemId] = parkGeometry);
 
             let refocused = await Neo.Main.windowNativeFocus({
                 nativeHandleKey: targetRoute.nativeHandleKey,
@@ -2644,21 +2762,34 @@ class Workspace extends Container {
                 windowId       : me.windowId
             }) === true;
 
+            me.lastVesselParkReceipt.refocused = refocused;
+
             if (!refocused) {
                 let compensated = await Neo.main.addon.DragDrop.resumeWindowDrag({
                     nativeHandleKey: route.nativeHandleKey,
                     targetWindowId : route.targetWindowId,
                     windowId       : me.windowId,
                     windowName,
-                    x              : sourceRect.x,
-                    y              : sourceRect.y
+                    x              : sourceOuter.x,
+                    y              : sourceOuter.y
                 }) === true;
 
-                return !compensated
+                me.lastVesselParkReceipt.compensated = compensated;
+                me.lastVesselParkReceipt.parked      = !compensated;
+                compensated && delete me.tearOutParkGeometries[itemId];
+
+                // Recovery ownership and visual admission are separate: if target refocus failed,
+                // the real source may still cover the target. Never publish conversion-ready on
+                // that frame, even when exact source restoration also needs a later retry.
+                return false
             }
 
+            me.lastVesselParkReceipt.parked = true;
+
             return true
-        } catch {
+        } catch (error) {
+            me.lastVesselParkReceipt.error  = String(error?.message || error);
+            me.lastVesselParkReceipt.reason = 'platform effect threw';
             return false
         }
     }
@@ -2677,16 +2808,27 @@ class Workspace extends Container {
      * @protected
      */
     async reshowTearOutVessel({itemId, rect, terminal=false, windowName}) {
-        let me    = this,
-            entry = me.resolveTearOutVessel(itemId),
-            route = entry?.nativeRoute;
+        let me       = this,
+            entry    = me.resolveTearOutVessel(itemId),
+            route    = entry?.nativeRoute,
+            geometry = me.tearOutParkGeometries[itemId] ?? null;
+
+        me.lastVesselRestoreReceipt = {
+            geometry,
+            rect: rect && {height: rect.height, width: rect.width, x: rect.x, y: rect.y},
+            terminal
+        };
 
         if (
             !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
             route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
+            (geometry && route.capabilities?.resize !== true) ||
             entry.windowName !== windowName ||
             !Number.isFinite(rect?.x) || !Number.isFinite(rect?.y)
-        ) return false;
+        ) {
+            me.lastVesselRestoreReceipt.reason = 'native route or restore geometry refused';
+            return false
+        }
 
         let data = {
             nativeHandleKey: route.nativeHandleKey,
@@ -2698,10 +2840,98 @@ class Workspace extends Container {
         };
 
         try {
-            return terminal
-                ? await Neo.Main.windowNativeMoveTo(data) === true
-                : await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true
-        } catch {
+            if (!terminal) {
+                const admitted = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
+
+                me.lastVesselRestoreReceipt.admitted = admitted;
+                admitted && delete me.tearOutParkGeometries[itemId];
+
+                return admitted
+            }
+
+            const addonRestored = await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true;
+
+            me.lastVesselRestoreReceipt.addonRestored = addonRestored;
+
+            if (addonRestored) {
+                delete me.tearOutParkGeometries[itemId];
+                me.lastVesselRestoreReceipt.admitted = true;
+
+                return true
+            }
+
+            const recoveryPending = await Neo.main.addon.DragDrop.hasWindowDragOrphanRecovery(data) === true;
+
+            me.lastVesselRestoreReceipt.recoveryPending = recoveryPending;
+
+            // A matching predecessor effect still owns exact recovery. Never race it with a second
+            // direct route mutation or degrade a required extent restore into position-only success.
+            if (recoveryPending) return false;
+
+            if (geometry) {
+                const resized = await Neo.Main.windowNativeResizeTo({
+                    nativeHandleKey: route.nativeHandleKey,
+                    targetWindowId : route.targetWindowId,
+                    windowId       : me.windowId,
+                    ...geometry.restore
+                }) === true;
+
+                me.lastVesselRestoreReceipt.resized = resized;
+
+                if (!resized) {
+                    await Neo.Main.windowNativeResizeTo({
+                        nativeHandleKey: route.nativeHandleKey,
+                        targetWindowId : route.targetWindowId,
+                        windowId       : me.windowId,
+                        ...geometry.park
+                    });
+                    return false
+                }
+            }
+
+            const moved = await Neo.Main.windowNativeMoveTo({
+                nativeHandleKey: route.nativeHandleKey,
+                targetWindowId : route.targetWindowId,
+                windowId       : me.windowId,
+                x              : rect.x,
+                y              : rect.y
+            }) === true;
+
+            me.lastVesselRestoreReceipt.moved = moved;
+
+            if (!moved) {
+                if (geometry) {
+                    const compensationResized = await Neo.Main.windowNativeResizeTo({
+                        nativeHandleKey: route.nativeHandleKey,
+                        targetWindowId : route.targetWindowId,
+                        windowId       : me.windowId,
+                        ...geometry.park
+                    }) === true;
+
+                    me.lastVesselRestoreReceipt.compensationResized = compensationResized;
+
+                    if (compensationResized) {
+                        me.lastVesselRestoreReceipt.compensationMoved =
+                            await Neo.Main.windowNativeMoveTo({
+                                nativeHandleKey: route.nativeHandleKey,
+                                targetWindowId : route.targetWindowId,
+                                windowId       : me.windowId,
+                                x              : geometry.park.x,
+                                y              : geometry.park.y
+                            }) === true
+                    }
+                }
+
+                return false
+            }
+
+            me.lastVesselRestoreReceipt.admitted = true;
+            delete me.tearOutParkGeometries[itemId];
+            await Neo.main.addon.DragDrop.acknowledgeWindowDragOrphanRecovery(data);
+
+            return true
+        } catch (error) {
+            me.lastVesselRestoreReceipt.error = String(error?.message || error);
             return false
         }
     }
@@ -3016,6 +3246,7 @@ class Workspace extends Container {
                     windowName = `tearout-${itemId}`;
 
                 me.tearOutConnectAdmissions.delete(itemId);
+                delete me.tearOutParkGeometries[itemId];
                 me.tearOutRetirements.add(itemId);
 
                 if (me.tearOutEmbodiment.isStaged(itemId)) {
@@ -3054,6 +3285,7 @@ class Workspace extends Container {
                 }
 
                 delete me.tearOutConnects[itemId];
+                delete me.tearOutParkGeometries[itemId];
                 me.tearOutHandlers.onVesselRetired({
                     admissionToken: entry.admissionToken,
                     generation    : entry.generation,
@@ -3085,6 +3317,7 @@ class Workspace extends Container {
 
                 delete me.tearOutPanes[itemId];
                 delete me.tearOutConnects[itemId];
+                delete me.tearOutParkGeometries[itemId];
                 me.tearOutRetirements.delete(itemId);
                 me.tearOutHandlers.onVesselRetired({
                     admissionToken: entry.admissionToken,
@@ -3551,12 +3784,15 @@ class Workspace extends Container {
      * `parkedItemId`, which additionally requires the exact source vessel to be strictly parked.
      * @param {Object} context
      * @param {String|null} [context.parkedItemId=null]
-     * @param {Neo.dashboard.DockTabSortZone} context.sourceZone
+     * @param {Neo.dashboard.DockTabSortZone|null} [context.sourceZone=null]
+     * @param {String|null} [context.sourceZoneId=null] Clone-safe Neural Link alternative.
      * @param {String} context.targetWorkspaceId
      * @returns {Object}
      * @protected
      */
-    readCrossWindowGestureSnapshot({parkedItemId=null, sourceZone, targetWorkspaceId}={}) {
+    readCrossWindowGestureSnapshot({parkedItemId=null, sourceZone=null, sourceZoneId=null, targetWorkspaceId}={}) {
+        sourceZone ??= sourceZoneId ? Neo.get(sourceZoneId) : null;
+
         let me            = this,
             isMain        = targetWorkspaceId === Workspace.MAIN_WORKSPACE_ID,
             state         = isMain ? null : me.vesselWorkspaces.get(targetWorkspaceId),
@@ -3568,21 +3804,35 @@ class Workspace extends Container {
             semantic      = target?.currentPreview ?? null,
             renderer      = isMain ? me.dragAffordances?.preview : state?.preview,
             rendered      = renderer?.dockPreview ?? null,
+            indicatorMenu = isMain ? me.dragAffordances?.indicators : state?.indicators,
+            indicatorSet  = indicatorMenu?.candidateSet ?? null,
             sensor        = sourceZone?.vesselConversionSensor,
             parkedVessel  = me.vesselParkHandlers?.parkedVessel ?? null,
             sourceVessel  = parkedItemId && me.resolveTearOutVessel(parkedItemId),
             targetProxy   = parkedItemId && me.vesselProxyEmbodiment.snapshot(parkedItemId),
             snapshot      = {
-                claimCount           : arbiter?.claimCount ?? 0,
-                converted            : sensor?.converted === true && sensor?.transitioning !== true,
-                engaged              : coordinator?.activeTargetZone === target,
-                parkedItemId         : parkedVessel?.itemId ?? null,
+                claimCount: arbiter?.claimCount ?? 0,
+                converted : sensor?.converted === true && sensor?.transitioning !== true,
+                engaged   : coordinator?.activeTargetZone === target,
+                indicators: indicatorSet ? {
+                    activePreviewId: indicatorMenu.activeCandidate?.preview?.previewId ?? null,
+                    candidateCount : (indicatorSet.cross?.length ?? 0) + (indicatorSet.root?.chips?.length ?? 0),
+                    itemId         : indicatorSet.itemId ?? null,
+                    visible        : !indicatorMenu.cls?.includes?.('neo-dashboard-dock-drop-indicators-hidden')
+                } : null,
+                parkedItemId: parkedVessel?.itemId ?? null,
+                parkReceipt : me.lastVesselParkReceipt
+                    ? DockZoneModel.clone(me.lastVesselParkReceipt)
+                    : null,
                 preview              : semantic ? DockZoneModel.clone(semantic) : null,
                 rendered             : rendered ? DockZoneModel.clone(rendered) : null,
                 sourceVesselConnected: Boolean(
                     sourceVessel?.windowId && Neo.manager?.Window?.get(sourceVessel.windowId)
                 ),
                 sourceVesselWindowId: sourceVessel?.windowId ?? null,
+                restoreReceipt      : me.lastVesselRestoreReceipt
+                    ? DockZoneModel.clone(me.lastVesselRestoreReceipt)
+                    : null,
                 targetProxy,
                 targetWorkspaceId,
                 winnerStableId      : winner?.stableId ?? null
@@ -3593,9 +3843,13 @@ class Workspace extends Container {
             && snapshot.winnerStableId === targetWorkspaceId
             && Boolean(snapshot.preview?.previewId)
             && snapshot.rendered?.previewId === snapshot.preview.previewId
+            && snapshot.indicators?.activePreviewId === snapshot.preview.previewId
             && (parkedItemId == null || (
                 snapshot.converted && snapshot.parkedItemId === parkedItemId &&
                 snapshot.sourceVesselConnected &&
+                snapshot.indicators?.itemId === parkedItemId &&
+                snapshot.indicators.candidateCount >= 5 &&
+                snapshot.indicators.visible &&
                 targetProxy?.itemId === parkedItemId &&
                 targetProxy.ownsPane &&
                 targetProxy.settled &&

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1394,9 +1394,9 @@ class Workspace extends Container {
             zones       : [zone]
         });
 
-        if (renderer) {
-            renderer.dockPreview = preview;
-            preview && renderer.applyTargetGeometry(geometry.localTargetRect)
+        if (geometry.renderer) {
+            geometry.renderer.dockPreview = preview;
+            preview && geometry.renderer.applyTargetGeometry(geometry.localTargetRect)
         }
 
         return preview

--- a/learn/agentos/decisions/0029-harness-docking-design.md
+++ b/learn/agentos/decisions/0029-harness-docking-design.md
@@ -359,16 +359,17 @@ Neural Link addresses windows by the connected App-Worker `windowId`, while the 
 handles by the semantic `windowName` passed to `Main.windowOpen()`. Those identities are deliberately distinct:
 
 - `manager.Window` remains the runtime topology and geometry observer. Its private entry may carry the reconnect-bounded
-  `{targetWindowId, ownerWindowId, opaqueHandleKey}` route plus generic capability facts (`focus`, `position`, `close`);
+  `{targetWindowId, ownerWindowId, opaqueHandleKey}` route plus generic capability facts
+  (`focus`, `position`, `resize`, `close`);
   no dock document, workspace, vessel, reintegration, or persistence semantics enter the manager.
 - `Main` remains the physical-handle owner. On open, the opener mints a short-lived one-time capability and a separate
   opaque handle key against the exact `WindowProxy`. The target consumes that capability once during the existing
   `getWindowData()` handshake; only then does the opener bind the private key to the target runtime `windowId`. URL,
   `window.name`, semantic name, `appName`, timing, and same-name reuse are never routing authority. Timeout, reload,
   close, reuse, or a mismatched handle invalidates the generation.
-- `get_window_topology` projects generic capability booleans, not the private route. Focus, position, and close resolve
-  the topology entry inside the App Worker, route the opaque key to the exact owning main thread, and revalidate the
-  live generation before touching the native handle.
+- `get_window_topology` projects generic capability booleans, not the private route. Focus, position, resize, and close
+  resolve the topology entry inside the App Worker, route the opaque key to the exact owning main thread, and revalidate
+  the live generation before touching the native handle.
 - Close remains §2.8.3's **post-commit render-target effect** and is separately owner-granted. Generic popups default
   close-unsupported; a product owner may grant physical close only when its semantic return/disposal contract makes
   that effect safe. The Neural Link receipt is terminal only after the connected `windowId` disappears from topology;
@@ -379,7 +380,7 @@ handles by the semantic `windowName` passed to `Main.windowOpen()`. Those identi
 This is the generic multi-window Possession Interface consumed by inspection tooling. Product code still decides what a
 window *means* and which semantic transaction precedes a physical effect.
 
-#### §2.8.6 In-gesture vessel conversion and park (2026-07-19, #15396)
+#### §2.8.6 In-gesture vessel conversion and park (2026-07-19, #15396; amended 2026-07-29, #16117)
 
 Popup-to-proxy conversion is an admitted transition inside the existing outcome machine, not a new
 terminal state. A source may enter `HOVERING_CLAIM` only after its physical park effect returns strict
@@ -387,26 +388,48 @@ terminal state. A source may enter `HOVERING_CLAIM` only after its physical park
 dispatch is provisional authority: conversion and park owners retain their prior state until settlement,
 and a stale generation cannot mutate a successor gesture.
 
-The browser-runtime park mechanic is **target-cover**, behind generic exact-handle capabilities:
+The Workstation browser-runtime park binding is **target-cover**, behind generic exact-handle capabilities. Its
+admission reads the source's live **outer** extent and the target's live **inner** extent; creation-time dimensions
+and equal-size assumptions are not authority:
 
 1. resolve both connected generations from `manager.Window` and require opener-minted routes;
-2. verify that the target can cover the source vessel;
+2. require exact target focus and exact source position authority; require exact source resize authority only when the
+   source outer frame exceeds the target inner frame on either axis;
 3. focus the exact target route first;
-4. only after focus admission, pause pointer-follow and move the exact source route to the target origin.
+4. only after focus admission, pause pointer-follow, drain already-issued physical moves, preserve the source's exact
+   outer extent and origin, and — when needed — request a best-effort target-origin pre-position before resizing the
+   same exact source handle to
+   `{width: min(sourceOuter.width, targetInner.width), height: min(sourceOuter.height, targetInner.height)}`;
+5. verify the target realm's observed `outerWidth` / `outerHeight`, move the exact source route to the target origin,
+   then refocus the exact target route.
 
-The order is load-bearing. A focus refusal leaves the source untouched and moving; a subsequent move
-refusal makes the DragDrop owner re-enable pointer-follow. No effectful half-park needs semantic-name
-recovery. Offscreen coordinates are not the browser-runtime default: the macOS/Chrome headed falsifier
-clamped a requested far-negative position back onto the visible desktop. Other platform mechanics remain
-host seams and require their own #15243 matrix receipts; they never change the pure conversion or park
-machines. Target-cover admission is also deliberately stricter than the size-neutral geometry predicate:
-when the source cannot fit behind the target, the host returns `false` and the sensor stays
-`DETACHED_MOVING`. The §2.8.4 min-axis metric remains reachable for every size pair; physical admission
-does not overclaim a safe park mechanic for a non-coverable pair. A future matrix-backed resize/hide seam
-may admit that case without changing the metric or state owners.
+The order is load-bearing. A focus refusal leaves the source untouched and moving. The full-size pre-position is
+deliberately non-admitting: Chrome may clamp a frame that cannot yet fit at the requested target origin, so only the
+post-resize exact move can admit cover. A resize refusal restores the original extent before pointer-follow resumes. A
+final move refusal restores the original origin and extent. A final-refocus refusal re-shows the same source generation;
+if that compensation is itself refused, the still-parked generation remains the sole retry authority. Browser
+minimum-size clamping therefore fails closed: requested dimensions are never projected into topology truth, and a
+non-matching observed extent cannot admit conversion. No effectful half-park needs semantic-name recovery.
+
+Offscreen coordinates are not the browser-runtime default: the macOS/Chrome headed falsifier clamped a requested
+far-negative position back onto the visible desktop. The #16117 macOS/Chrome probe instead kept one script-opened popup
+alive, shrank its outer `640×546` frame to `360×260`, and restored the exact original frame with zero additional
+`window.open` calls. Other platform mechanics remain host seams and require their own #15243 matrix receipts; the exact
+observation gate lets an admitting platform use the same state machine and makes a refusing or clamping platform remain
+`DETACHED_MOVING`. The §2.8.4 min-axis metric stays size-neutral; target-cover changes only the reversible physical
+embodiment needed after that metric proposes conversion.
+
+This amendment does not silently broaden every popup owner. Resize remains least-authority by default and the
+Workstation vessel opener grants it explicitly. Demo B keeps its existing source-larger-than-target refusal until its
+own owner contract and headed portability matrix deliberately admit a resize binding.
+
+Park and re-show settlement re-enter the dock-blind `DragCoordinator` with the source zone's latest raw pointer and
+geometry frame. This continuation is source-owned and latest-frame-only: one successful platform settlement must be
+enough to materialize or retire the target proxy even when the hand stops moving; a refusal, reset epoch, or stale
+generation emits no replay and never auto-retries an effect.
 
 Convert-out re-shows the **same** connected window through the same opaque handle generation and resumes
-physical pointer-follow at the live logical drag origin while preserving the pre-conversion extent. If no
+physical pointer-follow at the live logical drag origin after restoring the exact pre-conversion outer extent. If no
 live origin is supplied, the park owner falls back to its recorded pre-conversion rect. The slot clears only
 after strict re-show success. Neither conversion direction owns a popup-acquisition seam, so a continuous
 park → re-show journey has zero mid-gesture `windowOpen` attempts by construction.
@@ -421,13 +444,14 @@ Terminal disposition remains §2.8.2-owned:
 - after an admitted convert-out, `TERMINAL_DETACHED` follows the ordinary tear-out terminal and adopts the
   re-shown vessel — no close and no reacquisition.
 
-The current binding witness is macOS/Chrome headed and gesture-level on the committed #15243 matrix runner:
+The baseline binding witness is macOS/Chrome headed and gesture-level on the committed #15243 matrix runner:
 one real pointer journey acquires one externally observed tear-out `Page`, parks under a still-focused real
 target at the requested physical coordinates, leaves the claim, proves the identical `Page`, runtime
 `windowId`, opaque handle, external restore coordinates, and zero additional browser-realm `window.open`
 calls, then releases through `TERMINAL_DETACHED`. Unit witnesses additionally pin refusal, latest-frame
 replay, stale completion, terminal-during-transition, duplicate terminal, and exact-once retirement
-behavior. Windows/Linux cells and non-coverable park mechanics remain honestly owned by #15243.
+behavior. #16117 adds the ordinary actual-pointer popup-over-popup witness and the non-coverable target-cover matrix;
+Windows/Linux headed cells remain honestly owned by #15243.
 
 ## 3. Rejected Options
 

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -17,7 +17,7 @@ let nativeWindowRoute;
  * creates a new realm and loses the cache; URL/name inference and same-name reuse still cannot reconstruct it.
  * Cross-origin or independently opened windows deliberately remain unaddressable.
  * @param {Window} win
- * @returns {{capabilities: {close: Boolean, focus: Boolean, position: Boolean}, nativeHandleKey: String, ownerWindowId: String, targetWindowId: String}|null}
+ * @returns {{capabilities: {close: Boolean, focus: Boolean, position: Boolean, resize: Boolean}, nativeHandleKey: String, ownerWindowId: String, targetWindowId: String}|null}
  */
 const resolveNativeWindowRoute = win => {
     if (nativeWindowRoute !== undefined) {
@@ -109,7 +109,8 @@ class Main extends core.Base {
         nativeWindowCapabilities: {
             close   : false,
             focus   : true,
-            position: true
+            position: true,
+            resize  : false
         },
         /**
          * @member {Object} openWindows={}
@@ -145,7 +146,9 @@ class Main extends core.Base {
                 'windowMoveTo',
                 'windowNativeClose',
                 'windowNativeFocus',
+                'windowNativeGetGeometry',
                 'windowNativeMoveTo',
+                'windowNativeResizeTo',
                 'windowOpen',
                 'windowResizeTo'
             ]
@@ -641,7 +644,8 @@ class Main extends core.Base {
             capabilities = {
                 close   : entry.nativeCapabilities.close    && typeof win.close  === 'function',
                 focus   : entry.nativeCapabilities.focus    && typeof win.focus  === 'function',
-                position: entry.nativeCapabilities.position && typeof win.moveTo === 'function'
+                position: entry.nativeCapabilities.position && typeof win.moveTo === 'function',
+                resize  : entry.nativeCapabilities.resize   && typeof win.resizeTo === 'function'
             },
             route = {
                 capabilities,
@@ -699,7 +703,7 @@ class Main extends core.Base {
      * @param {Object} data
      * @param {String} data.nativeHandleKey
      * @param {String} data.targetWindowId
-     * @param {'close'|'focus'|'position'} capability
+     * @param {'close'|'focus'|'position'|'resize'} capability
      * @returns {Object|null}
      * @private
      */
@@ -707,7 +711,7 @@ class Main extends core.Base {
         const
             route   = this.#nativeWindowRoutes.get(nativeHandleKey),
             entry   = route?.entry,
-            methods = {close: 'close', focus: 'focus', position: 'moveTo'};
+            methods = {close: 'close', focus: 'focus', position: 'moveTo', resize: 'resizeTo'};
 
         if (
             !route || route.targetWindowId !== targetWindowId ||
@@ -764,18 +768,24 @@ class Main extends core.Base {
     }
 
     /**
-     * @summary Lets the moved render target publish its observed geometry after a programmatic move.
-     * @description Browser window movement has no guaranteed resize or pointer-boundary event. The
-     * target realm's existing change detector therefore closes the mutation-to-observation edge
-     * without ever projecting requested coordinates into manager truth. Cross-origin or not-yet-
+     * @summary Lets a mutated render target publish its complete observed geometry.
+     * @description Browser window movement and resize have no guaranteed matching event. Publishing
+     * the target realm's complete snapshot closes the mutation-to-observation edge without ever
+     * projecting requested coordinates or extents into manager truth. Cross-origin or not-yet-
      * initialized targets remain valid physical handles; geometry publication is best-effort and
-     * cannot change the strict movement verdict.
+     * cannot change the strict platform verdict.
      * @param {Window} win
      * @private
      */
     #publishWindowGeometry(win) {
         try {
-            win.Neo?.main?.addon?.WindowPosition?.checkMovement?.()
+            const observer = win.Neo?.main?.addon?.WindowPosition;
+
+            if (typeof observer?.publishGeometry === 'function') {
+                observer.publishGeometry()
+            } else {
+                observer?.checkMovement?.()
+            }
         } catch {
             // Cross-origin target realms are intentionally opaque.
         }
@@ -809,6 +819,51 @@ class Main extends core.Base {
 
         for (let attempt = 0; attempt < this.windowMovePollAttempts; attempt++) {
             if (Math.abs(win.screenX - x) <= 1 && Math.abs(win.screenY - y) <= 1) {
+                admitted = true;
+                break
+            }
+
+            await new Promise(resolve => setTimeout(resolve, this.windowMovePollDelay))
+        }
+
+        this.#publishWindowGeometry(win);
+
+        return admitted
+    }
+
+    /**
+     * Resizes one exact native handle and verifies the target reached the requested outer extent.
+     * `Window#resizeTo()` speaks outer dimensions, so callers must translate from any inner-layout
+     * geometry before crossing this physical-capability boundary.
+     * @param {Window} win
+     * @param {Number|String} requestedWidth
+     * @param {Number|String} requestedHeight
+     * @returns {Promise<Boolean>}
+     * @private
+     */
+    async #resizeWindow(win, requestedWidth, requestedHeight) {
+        const
+            height = Number(requestedHeight),
+            width  = Number(requestedWidth);
+
+        let admitted = false;
+
+        if (
+            !win || win.closed || typeof win.resizeTo !== 'function' ||
+            !Number.isFinite(width) || width <= 0 || !Number.isFinite(height) || height <= 0
+        ) {
+            return false
+        }
+
+        try {
+            win.resizeTo(width, height)
+        } catch {
+            this.#publishWindowGeometry(win);
+            return false
+        }
+
+        for (let attempt = 0; attempt < this.windowMovePollAttempts; attempt++) {
+            if (Math.abs(win.outerWidth - width) <= 1 && Math.abs(win.outerHeight - height) <= 1) {
                 admitted = true;
                 break
             }
@@ -928,7 +983,36 @@ class Main extends core.Base {
     async windowNativeFocus(data) {
         const route = this.#getNativeWindowRoute(data, 'focus');
 
-        return route ? this.#focusWindow(route.entry.win) : false
+        if (!route || !await this.#focusWindow(route.entry.win)) {
+            return false
+        }
+
+        return this.#getNativeWindowRoute(data, 'focus') === route
+    }
+
+    /**
+     * Reads the exact owner-granted native handle generation's current outer extent and viewport
+     * origin. The caller uses this only as volatile recovery authority immediately before a
+     * physical effect; manager topology remains the shared observation surface.
+     * @param {Object} data
+     * @param {String} data.nativeHandleKey
+     * @param {String} data.targetWindowId
+     * @returns {{height:Number,width:Number,x:Number,y:Number}|null}
+     */
+    windowNativeGetGeometry(data) {
+        const
+            route = this.#getNativeWindowRoute(data, 'position'),
+            win   = route?.entry?.win,
+            value = win && {
+                height: Number(win.outerHeight),
+                width : Number(win.outerWidth),
+                x     : Number(win.screenX),
+                y     : Number(win.screenY)
+            };
+
+        return value && Object.values(value).every(Number.isFinite) && value.height > 0 && value.width > 0
+            ? value
+            : null
     }
 
     /**
@@ -943,7 +1027,32 @@ class Main extends core.Base {
     async windowNativeMoveTo(data) {
         const route = this.#getNativeWindowRoute(data, 'position');
 
-        return route ? this.#moveWindow(route.entry.win, data.x, data.y) : false
+        if (!route || !await this.#moveWindow(route.entry.win, data.x, data.y)) {
+            return false
+        }
+
+        return this.#getNativeWindowRoute(data, 'position') === route
+    }
+
+    /**
+     * Resizes an exact owner-granted native handle generation to verified outer dimensions.
+     * The route is revalidated after the asynchronous platform observation so same-name successor
+     * windows can never inherit a predecessor completion.
+     * @param {Object} data
+     * @param {Number|String} data.height
+     * @param {String} data.nativeHandleKey
+     * @param {String} data.targetWindowId
+     * @param {Number|String} data.width
+     * @returns {Promise<Boolean>}
+     */
+    async windowNativeResizeTo(data) {
+        const route = this.#getNativeWindowRoute(data, 'resize');
+
+        if (!route || !await this.#resizeWindow(route.entry.win, data.width, data.height)) {
+            return false
+        }
+
+        return this.#getNativeWindowRoute(data, 'resize') === route
     }
 
     /**

--- a/src/dashboard/DockDropIndicators.mjs
+++ b/src/dashboard/DockDropIndicators.mjs
@@ -41,6 +41,13 @@ import {isValidCandidateSet} from './dockPreviewContract.mjs';
 class DockDropIndicators extends Container {
     static config = {
         /**
+         * The overlay positioning, visibility, and complete indicator skin live in the shared
+         * dashboard container sheet. Declaring it here keeps every target window paint-complete,
+         * including bare popup viewports whose app shell does not create a dashboard workspace.
+         * @member {String[]} additionalThemeFiles
+         */
+        additionalThemeFiles: ['Neo.dashboard.Container'],
+        /**
          * @member {String} className='Neo.dashboard.DockDropIndicators'
          * @protected
          */

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -232,6 +232,15 @@ class DockTabSortZone extends TabHeaderSortZone {
     vesselConversionEpoch = 0
 
     /**
+     * Latest raw pointer frame accepted by the cross-window coordinator. A successful async
+     * park/re-show settlement re-enters that same coordinator boundary so live claim arbitration,
+     * target engagement, and proxy staging settle without requiring another browser event.
+     * @member {Object|null} vesselConversionCoordinatorFrame=null
+     * @protected
+     */
+    vesselConversionCoordinatorFrame = null
+
+    /**
      * Latest gesture frame observed while a strict platform transition is settling. Only the
      * newest frame is replayed after settlement, so a slow park/re-show can never commit stale
      * geometry merely because the pointer stopped before another browser event arrived.
@@ -515,7 +524,7 @@ class DockTabSortZone extends TabHeaderSortZone {
         const epoch      = me.vesselConversionEpoch,
               transition = sensor.transitionPromise;
 
-        me.vesselConversionReplayPromise = Promise.resolve(transition).then(() => {
+        me.vesselConversionReplayPromise = Promise.resolve(transition).then(admitted => {
             if (me.vesselConversionSensor !== sensor || me.vesselConversionEpoch !== epoch) return false;
 
             const latest = me.vesselConversionReplayFrame;
@@ -523,7 +532,24 @@ class DockTabSortZone extends TabHeaderSortZone {
             me.vesselConversionReplayFrame   = null;
             me.vesselConversionReplayPromise = null;
 
-            if (!latest) return true;
+            if (admitted !== true || !latest || !me.isWindowDragging) return admitted === true;
+
+            const coordinatorFrame = me.vesselConversionCoordinatorFrame;
+
+            if (coordinatorFrame && me.dragCoordinator) {
+                me.dragCoordinator.onDragMove({
+                    ...coordinatorFrame,
+                    proxyRect: coordinatorFrame.proxyRect && {
+                        height: coordinatorFrame.proxyRect.height,
+                        width : coordinatorFrame.proxyRect.width,
+                        x     : coordinatorFrame.proxyRect.x,
+                        y     : coordinatorFrame.proxyRect.y
+                    },
+                    replayAfterTransition: true
+                });
+
+                return true
+            }
 
             me.resolveRemoteDragTransition({...latest, replayAfterTransition: true});
 
@@ -593,8 +619,11 @@ class DockTabSortZone extends TabHeaderSortZone {
      * @param {Object} frame.logicalSourceRect
      * @param {String|null} frame.targetId
      * @param {Object|null} frame.targetRect
-     * @returns {{commitEligible: Boolean, engage: Boolean, retain: Boolean}|null} `null` keeps the
-     *     legacy coordinator path when conversion is disabled or the source is not in a window drag.
+     * @returns {{commitEligible: Boolean, engage: Boolean, retain: Boolean,
+     *     sourceRect: (Object|undefined)}|null}
+     *     An engaged record carries the exact live source extent for target-proxy embodiment;
+     *     `null` keeps the legacy coordinator path when conversion is disabled or the source is not
+     *     in a window drag.
      */
     resolveRemoteDragTransition({
         draggedItem,
@@ -712,10 +741,22 @@ class DockTabSortZone extends TabHeaderSortZone {
                 targetRect     : me.vesselConversionTargetRect
             });
 
+            record.transitioning && me.scheduleVesselConversionReplay({
+                draggedItem,
+                logicalSourceRect,
+                now,
+                pointerInTarget,
+                targetId,
+                targetRect
+            });
+
             return {
                 commitEligible: record.converted && !record.transitioning,
                 engage        : record.converted && !record.transitioning,
-                retain        : false
+                retain        : false,
+                sourceRect    : record.converted && !record.transitioning
+                    ? {...me.vesselConversionSourceRect}
+                    : undefined
             }
         }
 
@@ -733,13 +774,27 @@ class DockTabSortZone extends TabHeaderSortZone {
                 targetRect     : me.vesselConversionTargetRect
             });
 
-            return {commitEligible: false, engage: record.converted, retain: record.converted}
+            return {
+                commitEligible: false,
+                engage        : record.converted,
+                retain        : record.converted,
+                sourceRect    : record.converted ? {...me.vesselConversionSourceRect} : undefined
+            }
         }
 
-        sensor.sample({
+        const record = sensor.sample({
             pointerInTarget: false,
             sourceRect     : me.vesselConversionSourceRect,
             targetRect     : me.vesselConversionTargetRect
+        });
+
+        record.transitioning && me.scheduleVesselConversionReplay({
+            draggedItem,
+            logicalSourceRect,
+            now,
+            pointerInTarget,
+            targetId,
+            targetRect
         });
 
         return {commitEligible: false, engage: false, retain: false}
@@ -754,6 +809,7 @@ class DockTabSortZone extends TabHeaderSortZone {
         me.vesselConversionEpoch++;
         me.vesselConversionSensor?.reset();
         me.vesselConversionCancelPromise   = null;
+        me.vesselConversionCoordinatorFrame = null;
         me.vesselConversionItemId          = null;
         me.vesselConversionLogicalRect     = null;
         me.vesselConversionPointerMissedAt = null;
@@ -1245,15 +1301,23 @@ class DockTabSortZone extends TabHeaderSortZone {
         // independent of the base's local sort result. `dragCoordinator` is preloaded at
         // {@link #construct}, so this is a synchronous field read, never a drag-time import.
         if (me.sortGroup && me.dragComponent && data?.proxyRect && Neo.isNumber(data.screenX)) {
-            me.dragCoordinator?.onDragMove({
-                draggedItem   : me.dragComponent,
-                offsetX       : data.offsetX,
-                offsetY       : data.offsetY,
-                proxyRect     : data.proxyRect,
+            const coordinatorFrame = {
+                draggedItem: me.dragComponent,
+                offsetX    : data.offsetX,
+                offsetY    : data.offsetY,
+                proxyRect  : {
+                    height: data.proxyRect.height,
+                    width : data.proxyRect.width,
+                    x     : data.proxyRect.x,
+                    y     : data.proxyRect.y
+                },
                 screenX       : data.screenX,
                 screenY       : data.screenY,
                 sourceSortZone: me
-            })
+            };
+
+            me.vesselConversionCoordinatorFrame = coordinatorFrame;
+            me.dragCoordinator?.onDragMove(coordinatorFrame)
         }
 
         if (me.stackDragActive) {

--- a/src/dashboard/DockVesselEmbodiment.mjs
+++ b/src/dashboard/DockVesselEmbodiment.mjs
@@ -65,12 +65,14 @@ export function createDockVesselEmbodiment({resolvePane, resolveTarget} = {}) {
                 sourceParent.removeAt(sourceIndex, false, true);
                 sourceParent.insert(sourceIndex, placeholder, true);
                 sourceParent.updateDepth = -1;
-                sourceParent.update();
-                target.add(pane);
+                target.add(pane, true);
+                target.updateDepth = -1;
 
                 // Cross-window insertion is not complete when `add()` returns. The exact vessel
                 // may otherwise be published to gesture logic, parked, and only THEN finish its
                 // pane mount — a late focus/mount side effect that can raise the parked source.
+                // Both structural mutations are silent above so staging owns exactly one
+                // settlement transaction per parent before publishing the embodiment.
                 await Promise.all([
                     sourceParent.promiseUpdate?.(),
                     target.promiseUpdate?.()

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -108,6 +108,41 @@ class DragDrop extends Base {
          */
         windowDragParked: false,
         /**
+         * Exact outer geometry retained while a resized popup is parked. `park` is the
+         * target-cover extent/origin; `restore` is the pre-conversion extent/origin.
+         * @member {Object|null} windowDragParkedGeometry=null
+         * @protected
+         */
+        windowDragParkedGeometry: null,
+        /**
+         * Exact route/restore authority installed before the first native park effect. Unlike
+         * `windowDragParkRecovery`, this clean parked record does not change resume choreography;
+         * it only serializes a pending platform effect and survives reset through orphan promotion.
+         * @member {Object|null} windowDragParkRoute=null
+         * @protected
+         */
+        windowDragParkRoute: null,
+        /**
+         * Retry authority for a failed park/resume compensation. A failed platform call must not
+         * strand `windowDragParked=true` without an exact same-generation path back to the source
+         * rect. The record owns the native route plus the full rect still requiring restoration.
+         * @member {Object|null} windowDragParkRecovery=null
+         * @protected
+         */
+        windowDragParkRecovery: null,
+        /**
+         * Exact physical recovery which outlives the logical drag generation that issued it.
+         *
+         * Native resize/move effects cannot be cancelled. A predecessor effect may therefore settle
+         * after `resetDragState()` has invalidated its gesture. Reset deliberately does not clear
+         * these route-keyed records: each exact route and pre-effect outer rect remains authoritative
+         * until immediate compensation or the worker's terminal restore strictly succeeds. One
+         * record coalesces concurrent retries and revisions without blocking a different opaque route.
+         * @member {Map|null} windowDragOrphanRecoveries=null
+         * @protected
+         */
+        windowDragOrphanRecoveries: null,
+        /**
          * @member {Boolean} moveHorizontal=true
          */
         moveHorizontal: true,
@@ -136,7 +171,10 @@ class DragDrop extends Base {
         remote: {
             app: [
                 'requestWindowManagementPermission',
+                'acknowledgeWindowDragOrphanRecovery',
+                'hasWindowDragOrphanRecovery',
                 'parkWindowDrag',
+                'retireWindowDragOrphanRecovery',
                 'resumeWindowDrag',
                 'setConfigs',
                 'setDragProxyElement',
@@ -315,34 +353,110 @@ class DragDrop extends Base {
     resetDragState() {
         let me = this;
 
+        DragDrop.prototype.promoteWindowDragParkRecovery.call(me);
+
         Object.assign(me, {
-            alwaysFireDragMove    : false,
-            bodyCursorStyle       : null,
-            boundaryContainerRect : null,
-            dragCancelled         : false,
-            dragElementRootId     : null,
-            dragElementRootRect   : null,
-            dragProxyCls          : 'neo-dragproxy',
-            dragProxyElement      : null,
-            dragZoneId            : null,
-            dropZoneIdentifier    : null,
-            initialScrollLeft     : 0,
-            initialScrollTop      : 0,
-            isWindowDragging      : false,
-            moveHorizontal        : true,
-            moveVertical          : true,
-            popupHeight           : null,
-            popupName             : null,
-            popupWidth            : null,
-            scrollContainerElement: null,
-            scrollContainerRect   : null,
-            scrollFactorLeft      : 1,
-            scrollFactorTop       : 1,
-            windowDragGeneration  : (me.windowDragGeneration || 0) + 1,
-            windowDragMovePromises: new Set(),
-            windowDragParked      : false,
-            windowName            : null
+            alwaysFireDragMove      : false,
+            bodyCursorStyle         : null,
+            boundaryContainerRect   : null,
+            dragCancelled           : false,
+            dragElementRootId       : null,
+            dragElementRootRect     : null,
+            dragProxyCls            : 'neo-dragproxy',
+            dragProxyElement        : null,
+            dragZoneId              : null,
+            dropZoneIdentifier      : null,
+            initialScrollLeft       : 0,
+            initialScrollTop        : 0,
+            isWindowDragging        : false,
+            moveHorizontal          : true,
+            moveVertical            : true,
+            popupHeight             : null,
+            popupName               : null,
+            popupWidth              : null,
+            scrollContainerElement  : null,
+            scrollContainerRect     : null,
+            scrollFactorLeft        : 1,
+            scrollFactorTop         : 1,
+            windowDragGeneration    : (me.windowDragGeneration || 0) + 1,
+            windowDragMovePromises  : new Set(),
+            windowDragParked        : false,
+            windowDragParkedGeometry: null,
+            windowDragParkRoute     : null,
+            windowDragParkRecovery  : null,
+            windowName              : null
         })
+    }
+
+    /**
+     * @summary Promotes the current clean route or failed recovery before logical invalidation.
+     * @returns {Object|null}
+     * @protected
+     */
+    promoteWindowDragParkRecovery() {
+        let me          = this,
+            routeRecord = me.windowDragParkRoute,
+            recovery    = me.windowDragParkRecovery ?? routeRecord;
+
+        if (routeRecord?.retired || recovery?.retired) return null;
+
+        return recovery
+            ? DragDrop.prototype.retainWindowDragOrphanRecovery.call(me, {
+                advance        : false,
+                nativeHandleKey: recovery.nativeHandleKey,
+                park           : recovery.park,
+                pendingEffect  : recovery.pendingEffect ?? routeRecord?.pendingEffect,
+                resize         : recovery.resize,
+                restore        : recovery.restore,
+                sourceRoute    : routeRecord,
+                targetWindowId : recovery.targetWindowId,
+                windowName     : recovery.windowName
+            })
+            : null
+    }
+
+    /**
+     * @summary Deletes a strict-close tombstone only after its complete outer route transaction
+     * and any coalesced retry have drained.
+     * @param {Object|null} recovery
+     * @returns {Boolean}
+     * @protected
+     */
+    cleanupRetiredWindowDragOrphanRecovery(recovery) {
+        let me         = this,
+            recoveries = me.windowDragOrphanRecoveries;
+
+        if (
+            !recovery?.retired || recoveries?.get(recovery.key) !== recovery ||
+            recovery.promise || recovery.pendingEffect || (recovery.sourceRoute?.operationCount || 0) > 0
+        ) {
+            return false
+        }
+
+        recoveries.delete(recovery.key);
+        recoveries.size || (me.windowDragOrphanRecoveries = null);
+
+        return true
+    }
+
+    /**
+     * @summary Releases one complete park/resume transaction and then prunes a drained tombstone.
+     * @param {Object|null} routeRecord
+     * @returns {void}
+     * @protected
+     */
+    releaseWindowDragRouteOperation(routeRecord) {
+        if (!routeRecord) return;
+
+        routeRecord.operationCount = Math.max(0, (routeRecord.operationCount || 0) - 1);
+
+        let recovery = this.windowDragOrphanRecoveries?.get(routeRecord.key);
+
+        if (recovery?.pendingEffect && recovery.sourceRoute === routeRecord && !routeRecord.pendingEffect) {
+            recovery.pendingEffect = null
+        }
+
+        recovery && DragDrop.prototype.cleanupRetiredWindowDragOrphanRecovery.call(this, recovery)
     }
 
     /**
@@ -682,57 +796,286 @@ class DragDrop extends Base {
      * then parks the exact opener-minted native handle generation.
      *
      * The pause happens before the first await, while `onDragMove()` continues publishing logical
-     * frames. A false/throwing native move re-enables pointer-follow and refuses admission; a
-     * reset/new start invalidates the completion without touching successor state.
+     * frames. After prior physical moves drain, the exact opaque handle supplies the recovery rect;
+     * a pre-drain Worker snapshot is provisional only. A non-coverable popup then requests a
+     * best-effort full-size pre-position, shrinks to a verified outer extent, and verifies the target
+     * origin again. A refused staging move is tolerable because Chrome can clamp a too-wide frame to
+     * the same display's last safe origin. Resize or final exact-move refusal compensates to the
+     * post-drain exact extent/origin before pointer-follow resumes. A reset/new start invalidates the
+     * completion without touching successor state.
      * @param {Object} data
      * @param {String} data.nativeHandleKey
+     * @param {{height:Number,width:Number}|null} [data.parkSize=null]
+     * @param {{height:Number,width:Number,x:Number,y:Number}|null} [data.restoreRect=null]
      * @param {String} data.targetWindowId
      * @param {String} data.windowName
      * @param {Number} data.x
      * @param {Number} data.y
      * @returns {Promise<Boolean>}
      */
-    async parkWindowDrag({nativeHandleKey, targetWindowId, windowName, x, y} = {}) {
-        let me = this;
+    async parkWindowDrag({
+        nativeHandleKey,
+        parkSize=null,
+        restoreRect=null,
+        targetWindowId,
+        windowName,
+        x,
+        y
+    } = {}) {
+        let me              = this,
+            resizeRequested = parkSize != null;
+
+        const
+            validSize = value => value
+                && Number.isFinite(value.width) && value.width > 0
+                && Number.isFinite(value.height) && value.height > 0,
+            validRestore = value => validSize(value)
+                && Number.isFinite(value.x) && Number.isFinite(value.y);
 
         if (
-            !me.isWindowDragging || me.windowDragParked || windowName !== me.popupName ||
-            !nativeHandleKey || !targetWindowId || !Number.isFinite(x) || !Number.isFinite(y)
+            !me.isWindowDragging || windowName !== me.popupName ||
+            !nativeHandleKey || !targetWindowId || !Number.isFinite(x) || !Number.isFinite(y) ||
+            (resizeRequested && !validSize(parkSize)) ||
+            (restoreRect != null && !validRestore(restoreRect))
         ) {
             return false
         }
 
-        const generation = me.windowDragGeneration;
+        if (me.windowDragParked) {
+            if (me.windowDragParkRecovery) {
+                await DragDrop.prototype.retryWindowDragParkRecovery.call(me, {
+                    nativeHandleKey,
+                    targetWindowId,
+                    windowName
+                })
+            }
 
-        me.windowDragParked = true;
-
-        await Promise.allSettled([...(me.windowDragMovePromises || [])]);
-
-        if (generation !== me.windowDragGeneration || !me.isWindowDragging || !me.windowDragParked) {
+            // A recovery restores the source embodiment; it does not also admit a fresh park in
+            // the same platform-effect turn. The replayed pointer frame may propose that anew.
             return false
         }
 
-        let admitted = false;
+        if (DragDrop.prototype.hasWindowDragOrphanRecovery.call(me, {
+            nativeHandleKey,
+            targetWindowId,
+            windowName
+        })) {
+            await DragDrop.prototype.retryWindowDragOrphanRecovery.call(me, {
+                nativeHandleKey,
+                targetWindowId,
+                windowName
+            });
+
+            // A predecessor's physical compensation is its own platform-effect turn. Even strict
+            // recovery never combines with a fresh park proposal.
+            return false
+        }
+
+        const
+            generation = me.windowDragGeneration,
+            route      = {nativeHandleKey, targetWindowId},
+            routeKey   = JSON.stringify([nativeHandleKey, targetWindowId, windowName]),
+            geometry   = restoreRect ? {
+                park   : {...(resizeRequested ? {height: parkSize.height, width: parkSize.width} : {}), x, y},
+                resize : resizeRequested,
+                restore: {
+                    height: restoreRect.height,
+                    width : restoreRect.width,
+                    x     : restoreRect.x,
+                    y     : restoreRect.y
+                }
+            } : null,
+            moveTo = async rect => {
+                try {
+                    return await Neo.Main.windowNativeMoveTo({...route, x: rect.x, y: rect.y}) === true
+                } catch {
+                    return false
+                }
+            },
+            resizeTo = async size => {
+                try {
+                    return await Neo.Main.windowNativeResizeTo({
+                        ...route,
+                        height: size.height,
+                        width : size.width
+                    }) === true
+                } catch {
+                    return false
+                }
+            };
+
+        let parkRoute = null;
+
+        const routeCurrent = () => (
+            generation === me.windowDragGeneration &&
+            me.isWindowDragging &&
+            parkRoute?.retired !== true
+        );
+
+        const runParkEffect = async effect => {
+            const pending = effect();
+
+            parkRoute && (parkRoute.pendingEffect = pending);
+
+            const result = await pending;
+
+            parkRoute?.pendingEffect === pending && (parkRoute.pendingEffect = null);
+
+            return result
+        };
+
+        me.windowDragParked         = true;
+        me.windowDragParkedGeometry = geometry;
+        me.windowDragParkRoute      = null;
+        me.windowDragParkRecovery   = null;
 
         try {
-            admitted = await Neo.Main.windowNativeMoveTo({nativeHandleKey, targetWindowId, x, y}) === true
-        } catch {
-            admitted = false
+            await Promise.allSettled([...(me.windowDragMovePromises || [])]);
+
+            if (!routeCurrent() || !me.windowDragParked) {
+                return false
+            }
+
+            if (geometry) {
+                let liveRestore = null;
+
+                try {
+                    liveRestore = await Neo.Main.windowNativeGetGeometry(route)
+                } catch {
+                    // A refused/stale opaque route is not recovery authority.
+                }
+
+                if (!routeCurrent() || !me.windowDragParked) {
+                    return false
+                }
+
+                if (!validRestore(liveRestore)) {
+                    me.windowDragParked         = false;
+                    me.windowDragParkedGeometry = null;
+                    return false
+                }
+
+                geometry.restore = {...liveRestore}
+            }
+
+            parkRoute = geometry ? {
+                generation,
+                key           : routeKey,
+                nativeHandleKey,
+                operationCount: 1,
+                park          : {...geometry.park},
+                pendingEffect : null,
+                resize        : false,
+                restore       : {...geometry.restore},
+                retired       : false,
+                revision      : 1,
+                targetWindowId,
+                windowName
+            } : null;
+            me.windowDragParkRoute = parkRoute;
+
+            // Ask the browser to place the still-full-size source as close to the target origin as
+            // its current display permits before shrinking. This pre-position is intentionally
+            // best-effort: when the target cannot yet contain the larger frame, Chrome can clamp
+            // to the last fully visible origin and truthfully return false. That admitted clamp is
+            // still the safe resize anchor; only the post-resize exact move gates conversion.
+            geometry?.resize && await runParkEffect(() => moveTo({x, y}));
+
+            if (!routeCurrent() || !me.windowDragParked) {
+                geometry?.resize && await DragDrop.prototype.recoverInvalidatedWindowDragPark.call(me, {
+                    geometry   : {...geometry, resize: false},
+                    nativeHandleKey,
+                    routeRecord: parkRoute,
+                    targetWindowId,
+                    windowName
+                });
+                return false
+            }
+
+            geometry?.resize && (parkRoute.resize = true);
+
+            if (geometry?.resize && !await runParkEffect(() => resizeTo(geometry.park))) {
+                if (!routeCurrent()) {
+                    await DragDrop.prototype.recoverInvalidatedWindowDragPark.call(me, {
+                        geometry,
+                        nativeHandleKey,
+                        routeRecord: parkRoute,
+                        targetWindowId,
+                        windowName
+                    });
+                    return false
+                }
+
+                me.windowDragParkRecovery = {
+                    ...parkRoute,
+                    pendingEffect: null,
+                    revision     : 1
+                };
+
+                await DragDrop.prototype.retryWindowDragParkRecovery.call(me, {
+                    nativeHandleKey,
+                    targetWindowId,
+                    windowName
+                });
+
+                return false
+            }
+
+            if (!routeCurrent() || !me.windowDragParked) {
+                geometry?.resize && await DragDrop.prototype.recoverInvalidatedWindowDragPark.call(me, {
+                    geometry,
+                    nativeHandleKey,
+                    routeRecord: parkRoute,
+                    targetWindowId,
+                    windowName
+                });
+                return false
+            }
+
+            const moved = await runParkEffect(() => moveTo({x, y}));
+
+            if (!routeCurrent()) {
+                geometry && await DragDrop.prototype.recoverInvalidatedWindowDragPark.call(me, {
+                    geometry,
+                    nativeHandleKey,
+                    routeRecord: parkRoute,
+                    targetWindowId,
+                    windowName
+                });
+                return false
+            }
+
+            if (!moved) {
+                if (geometry) {
+                    me.windowDragParkRecovery = {
+                        ...parkRoute,
+                        pendingEffect: null,
+                        revision     : 1
+                    };
+
+                    await DragDrop.prototype.retryWindowDragParkRecovery.call(me, {
+                        nativeHandleKey,
+                        targetWindowId,
+                        windowName
+                    })
+                } else {
+                    me.windowDragParked = false
+                }
+
+                return false
+            }
+
+            return true
+        } finally {
+            parkRoute && DragDrop.prototype.releaseWindowDragRouteOperation.call(me, parkRoute)
         }
-
-        if (generation !== me.windowDragGeneration || !me.isWindowDragging) {
-            return false
-        }
-
-        admitted || (me.windowDragParked = false);
-
-        return admitted
     }
 
     /**
      * @summary Re-shows the parked exact native generation at the pointer-owned global rect.
-     * Physical pointer-follow resumes only after strict success; refusal retains the parked phase
-     * so the source owner can retry without losing its sole recoverable handle.
+     * A resized vessel regains its exact pre-conversion outer extent before it moves back under
+     * the pointer. Physical pointer-follow resumes only after strict success; refusal compensates
+     * to target-cover geometry and retains the parked phase for an exact retry.
      * @param {Object} data
      * @param {String} data.nativeHandleKey
      * @param {String} data.targetWindowId
@@ -744,30 +1087,654 @@ class DragDrop extends Base {
     async resumeWindowDrag({nativeHandleKey, targetWindowId, windowName, x, y} = {}) {
         let me = this;
 
+        const
+            parkRoute    = me.windowDragParkRoute,
+            requestValid = Boolean(
+                nativeHandleKey && targetWindowId && windowName &&
+                Number.isFinite(x) && Number.isFinite(y)
+            ),
+            active = Boolean(
+                requestValid && me.isWindowDragging && me.windowDragParked &&
+                windowName === me.popupName &&
+                (!parkRoute || (
+                    parkRoute.nativeHandleKey === nativeHandleKey &&
+                    parkRoute.targetWindowId === targetWindowId &&
+                    parkRoute.windowName === windowName
+                ))
+            );
+
+        if (!requestValid) return false;
+
+        if (active && me.windowDragParkRecovery) {
+            // Current-generation recovery owns the orphan serializer record it created. It must
+            // reconcile logical parked state before predecessor-orphan routing can intercept it.
+            return DragDrop.prototype.retryWindowDragParkRecovery.call(me, {
+                nativeHandleKey,
+                restorePosition: {x, y},
+                targetWindowId,
+                windowName
+            })
+        }
+
         if (
-            !me.isWindowDragging || !me.windowDragParked || windowName !== me.popupName ||
-            !nativeHandleKey || !targetWindowId || !Number.isFinite(x) || !Number.isFinite(y)
+            !active &&
+            nativeHandleKey && targetWindowId && windowName &&
+            Number.isFinite(x) && Number.isFinite(y) &&
+            DragDrop.prototype.hasWindowDragOrphanRecovery.call(me, {
+                nativeHandleKey,
+                targetWindowId,
+                windowName
+            })
+        ) {
+            const
+                key      = JSON.stringify([nativeHandleKey, targetWindowId, windowName]),
+                recovery = me.windowDragOrphanRecoveries.get(key);
+
+            DragDrop.prototype.retainWindowDragOrphanRecovery.call(me, {
+                nativeHandleKey,
+                park         : recovery.park,
+                pendingEffect: recovery.pendingEffect,
+                resize       : recovery.resize,
+                restore      : {...recovery.restore, x, y},
+                sourceRoute  : recovery.sourceRoute,
+                targetWindowId,
+                windowName
+            });
+
+            return DragDrop.prototype.retryWindowDragOrphanRecovery.call(me, {
+                nativeHandleKey,
+                targetWindowId,
+                windowName
+            })
+        }
+
+        if (!active) return false;
+
+        const
+            generation = me.windowDragGeneration,
+            geometry   = me.windowDragParkedGeometry,
+            route      = {nativeHandleKey, targetWindowId},
+            moveTo     = async rect => {
+                try {
+                    return await Neo.Main.windowNativeMoveTo({...route, x: rect.x, y: rect.y}) === true
+                } catch {
+                    return false
+                }
+            },
+            resizeTo   = async size => {
+                try {
+                    return await Neo.Main.windowNativeResizeTo({
+                        ...route,
+                        height: size.height,
+                        width : size.width
+                    }) === true
+                } catch {
+                    return false
+                }
+            };
+
+        if (parkRoute?.retired) return false;
+
+        const routeCurrent = () => (
+            generation === me.windowDragGeneration &&
+            me.isWindowDragging &&
+            parkRoute?.retired !== true
+        );
+
+        parkRoute && (parkRoute.operationCount = (parkRoute.operationCount || 0) + 1);
+
+        const runResumeEffect = async effect => {
+            const pending = effect();
+
+            parkRoute && (parkRoute.pendingEffect = pending);
+
+            const result = await pending;
+
+            parkRoute?.pendingEffect === pending && (parkRoute.pendingEffect = null);
+
+            return result
+        };
+
+        try {
+            if (parkRoute) {
+                parkRoute.restore  = {...parkRoute.restore, x, y};
+                parkRoute.revision = (parkRoute.revision || 0) + 1
+            }
+
+            if (geometry?.resize && !await runResumeEffect(() => resizeTo(geometry.restore))) {
+                if (routeCurrent()) {
+                    await runResumeEffect(() => resizeTo(geometry.park))
+                }
+
+                if (!routeCurrent()) {
+                    await DragDrop.prototype.recoverInvalidatedWindowDragPark.call(me, {
+                        geometry: {
+                            park   : geometry.park,
+                            resize : geometry.resize,
+                            restore: {...geometry.restore, x, y}
+                        },
+                        nativeHandleKey,
+                        routeRecord: parkRoute,
+                        targetWindowId,
+                        windowName
+                    });
+                    return false
+                }
+
+                if (routeCurrent()) {
+                    me.windowDragParkRecovery = {
+                        generation,
+                        nativeHandleKey,
+                        park   : {...geometry.park},
+                        resize : geometry.resize,
+                        restore: {...geometry.restore, x, y},
+                        targetWindowId,
+                        windowName
+                    }
+                }
+
+                return false
+            }
+
+            if (!routeCurrent()) {
+                geometry && await DragDrop.prototype.recoverInvalidatedWindowDragPark.call(me, {
+                    geometry: {
+                        park   : geometry.park,
+                        resize : geometry.resize,
+                        restore: {...geometry.restore, x, y}
+                    },
+                    nativeHandleKey,
+                    routeRecord: parkRoute,
+                    targetWindowId,
+                    windowName
+                });
+                return false
+            }
+
+            const admitted = await runResumeEffect(() => moveTo({x, y}));
+
+            if (!routeCurrent()) {
+                geometry && await DragDrop.prototype.recoverInvalidatedWindowDragPark.call(me, {
+                    geometry: {
+                        park   : geometry.park,
+                        resize : geometry.resize,
+                        restore: {...geometry.restore, x, y}
+                    },
+                    nativeHandleKey,
+                    routeRecord: parkRoute,
+                    targetWindowId,
+                    windowName
+                });
+                return false
+            }
+
+            if (!admitted) {
+                if (geometry) {
+                    const sizeParked = !geometry.resize || await runResumeEffect(
+                        () => resizeTo(geometry.park)
+                    );
+
+                    if (sizeParked && routeCurrent()) {
+                        await runResumeEffect(() => moveTo(geometry.park))
+                    }
+                }
+
+                if (!routeCurrent()) {
+                    geometry && await DragDrop.prototype.recoverInvalidatedWindowDragPark.call(me, {
+                        geometry: {
+                            park   : geometry.park,
+                            resize : geometry.resize,
+                            restore: {...geometry.restore, x, y}
+                        },
+                        nativeHandleKey,
+                        routeRecord: parkRoute,
+                        targetWindowId,
+                        windowName
+                    });
+                    return false
+                }
+
+                if (routeCurrent()) {
+                    me.windowDragParkRecovery = {
+                        generation,
+                        nativeHandleKey,
+                        park   : geometry?.park && {...geometry.park},
+                        resize : geometry?.resize === true,
+                        restore: {
+                            ...(geometry?.restore || {}),
+                            x,
+                            y
+                        },
+                        targetWindowId,
+                        windowName
+                    }
+                }
+
+                return false
+            }
+
+            me.windowDragParked         = false;
+            me.windowDragParkedGeometry = null;
+            me.windowDragParkRoute      = null;
+            me.windowDragParkRecovery   = null;
+
+            return admitted
+        } finally {
+            parkRoute && DragDrop.prototype.releaseWindowDragRouteOperation.call(me, parkRoute)
+        }
+    }
+
+    /**
+     * @summary Compensates a physical park effect which settled after its logical gesture died.
+     *
+     * The record is installed before compensation starts so another reset cannot erase the only
+     * exact route/rect. Strict success clears it; refusal leaves the worker terminal or a later
+     * fresh proposal an idempotent retry without reviving predecessor logical state.
+     * @param {Object} data
+     * @param {Object} data.geometry
+     * @param {String} data.nativeHandleKey
+     * @param {Object|null} [data.routeRecord=null]
+     * @param {String} data.targetWindowId
+     * @param {String} data.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async recoverInvalidatedWindowDragPark({
+        geometry,
+        nativeHandleKey,
+        routeRecord=null,
+        targetWindowId,
+        windowName
+    } = {}) {
+        let me = this;
+
+        if (!DragDrop.prototype.retainWindowDragOrphanRecovery.call(me, {
+            advance    : false,
+            nativeHandleKey,
+            park       : geometry?.park,
+            resize     : geometry?.resize === true,
+            restore    : geometry?.restore,
+            sourceRoute: routeRecord,
+            targetWindowId,
+            windowName
+        })) return false;
+
+        return DragDrop.prototype.retryWindowDragOrphanRecovery.call(me, {
+            nativeHandleKey,
+            targetWindowId,
+            windowName
+        })
+    }
+
+    /**
+     * @summary Promotes active exact recovery into reset-surviving, route-keyed ownership.
+     * @param {Object} data
+     * @param {Boolean} [data.advance=true] Current pointer/terminal proposals may advance the
+     *     desired rect; stale completions only ensure the record exists.
+     * @param {String} data.nativeHandleKey
+     * @param {Object|null} [data.park=null] Exact cover geometry used to compensate a refused
+     *     full-size restore.
+     * @param {Promise|null} [data.pendingEffect=null]
+     * @param {Boolean} [data.resize=false]
+     * @param {Object} data.restore
+     * @param {Object|null} [data.sourceRoute=null]
+     * @param {String} data.targetWindowId
+     * @param {String} data.windowName
+     * @returns {Object|null}
+     * @protected
+     */
+    retainWindowDragOrphanRecovery({
+        advance=true,
+        nativeHandleKey,
+        park=null,
+        pendingEffect=null,
+        resize=false,
+        restore,
+        sourceRoute=null,
+        targetWindowId,
+        windowName
+    } = {}) {
+        let me = this;
+
+        if (
+            !nativeHandleKey || !targetWindowId || !windowName ||
+            !Number.isFinite(restore?.x) || !Number.isFinite(restore?.y) ||
+            (resize && (
+                !Number.isFinite(restore.width) || restore.width <= 0 ||
+                !Number.isFinite(restore.height) || restore.height <= 0 ||
+                !Number.isFinite(park?.width) || park.width <= 0 ||
+                !Number.isFinite(park?.height) || park.height <= 0 ||
+                !Number.isFinite(park?.x) || !Number.isFinite(park?.y)
+            ))
+        ) {
+            return null
+        }
+
+        const
+            key        = JSON.stringify([nativeHandleKey, targetWindowId, windowName]),
+            recoveries = me.windowDragOrphanRecoveries ||= new Map(),
+            recovery   = recoveries.get(key);
+
+        if (recovery) {
+            if (recovery.retired) return null;
+
+            pendingEffect && (recovery.pendingEffect = pendingEffect);
+            park && (recovery.park ??= {...park});
+            sourceRoute && (recovery.sourceRoute ??= sourceRoute);
+
+            if (!advance && resize && !recovery.resize) {
+                recovery.restore = {
+                    ...restore,
+                    x: recovery.restore.x,
+                    y: recovery.restore.y
+                }
+            } else if (advance) {
+                recovery.restore = {...restore};
+                recovery.revision++
+            }
+
+            recovery.resize ||= resize
+        } else {
+            if (sourceRoute?.retired) return null;
+
+            recoveries.set(key, {
+                key,
+                nativeHandleKey,
+                park    : park && {...park},
+                pendingEffect,
+                promise : null,
+                resize,
+                retired : false,
+                restore : {...restore},
+                revision: 1,
+                sourceRoute,
+                targetWindowId,
+                windowName
+            })
+        }
+
+        return recoveries.get(key)
+    }
+
+    /**
+     * @summary Retries one reset-surviving exact physical restore without reviving logical drag state.
+     * @param {Object} data
+     * @param {String} data.nativeHandleKey
+     * @param {String} data.targetWindowId
+     * @param {String} data.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async retryWindowDragOrphanRecovery({nativeHandleKey, targetWindowId, windowName} = {}) {
+        let me         = this,
+            recoveries = me.windowDragOrphanRecoveries,
+            key        = JSON.stringify([nativeHandleKey, targetWindowId, windowName]),
+            recovery   = recoveries?.get(key);
+
+        if (!recovery || recovery.retired) return false;
+        if (recovery.promise) return recovery.promise;
+
+        const
+            route    = {nativeHandleKey, targetWindowId},
+            resizeTo = async size => {
+                try {
+                    return await Neo.Main.windowNativeResizeTo({
+                        ...route,
+                        height: size.height,
+                        width : size.width
+                    }) === true
+                } catch {
+                    return false
+                }
+            },
+            moveTo = async rect => {
+                try {
+                    return await Neo.Main.windowNativeMoveTo({...route, x: rect.x, y: rect.y}) === true
+                } catch {
+                    return false
+                }
+            };
+
+        let retryPromise;
+
+        retryPromise = (async() => {
+            while (recoveries.get(key) === recovery && !recovery.retired) {
+                if (recovery.pendingEffect) {
+                    const
+                        pending         = recovery.pendingEffect,
+                        pendingRevision = recovery.revision;
+
+                    await Promise.resolve(pending).catch(() => false);
+
+                    if (recoveries.get(key) !== recovery || recovery.retired) return false;
+
+                    recovery.pendingEffect === pending && (recovery.pendingEffect = null)
+
+                    if (pendingRevision !== recovery.revision) continue
+                }
+
+                const
+                    park         = recovery.park && {...recovery.park},
+                    restore      = {...recovery.restore},
+                    revision     = recovery.revision,
+                    sizeRestored = !recovery.resize || await resizeTo(restore);
+
+                if (recoveries.get(key) !== recovery || recovery.retired) return false;
+                if (!sizeRestored) return false;
+                if (revision !== recovery.revision) continue;
+
+                const positionRestored = await moveTo(restore);
+
+                if (recoveries.get(key) !== recovery || recovery.retired) return false;
+                if (!positionRestored) {
+                    if (recovery.resize) {
+                        const coverSizeRestored = park && await resizeTo(park);
+
+                        if (recoveries.get(key) !== recovery || recovery.retired) return false;
+                        if (!coverSizeRestored) return false;
+
+                        const coverPositionRestored = await moveTo(park);
+
+                        if (recoveries.get(key) !== recovery || recovery.retired) return false;
+                        if (!coverPositionRestored) return false
+                    }
+
+                    return false
+                }
+
+                // A newer pointer-owned rect landed while this exact route was restoring. Serialize
+                // one more attempt; the stale success cannot clear the advanced recovery revision.
+                if (revision !== recovery.revision) continue;
+
+                recoveries.delete(key);
+                recoveries.size || (me.windowDragOrphanRecoveries = null);
+
+                return true
+            }
+
+            return false
+        })().finally(() => {
+            recoveries.get(key) === recovery && (recovery.promise = null)
+            DragDrop.prototype.cleanupRetiredWindowDragOrphanRecovery.call(me, recovery)
+        });
+
+        recovery.promise = retryPromise;
+
+        return retryPromise
+    }
+
+    /**
+     * @summary Reports whether one exact route still owns reset-surviving physical recovery.
+     * @param {Object} data
+     * @param {String} data.nativeHandleKey
+     * @param {String} data.targetWindowId
+     * @param {String} data.windowName
+     * @returns {Boolean}
+     */
+    hasWindowDragOrphanRecovery({nativeHandleKey, targetWindowId, windowName} = {}) {
+        return this.windowDragOrphanRecoveries?.has(
+            JSON.stringify([nativeHandleKey, targetWindowId, windowName])
+        ) === true
+    }
+
+    /**
+     * @summary Retires one matching orphan only after another owner proves the exact restore.
+     * @param {Object} data
+     * @param {String} data.nativeHandleKey
+     * @param {String} data.targetWindowId
+     * @param {String} data.windowName
+     * @returns {Boolean}
+     */
+    acknowledgeWindowDragOrphanRecovery({nativeHandleKey, targetWindowId, windowName} = {}) {
+        let me         = this,
+            recoveries = me.windowDragOrphanRecoveries,
+            key        = JSON.stringify([nativeHandleKey, targetWindowId, windowName]),
+            recovery   = recoveries?.get(key);
+
+        if (
+            !recovery || recovery.retired || recovery.promise || recovery.pendingEffect ||
+            (recovery.sourceRoute?.operationCount || 0) > 0
+        ) return false;
+
+        recoveries.delete(key);
+        recoveries.size || (me.windowDragOrphanRecoveries = null);
+
+        return true
+    }
+
+    /**
+     * @summary Retires one matching recovery after strict close invalidates its exact handle.
+     * @param {Object} data
+     * @param {String} data.nativeHandleKey
+     * @param {String} data.targetWindowId
+     * @param {String} data.windowName
+     * @returns {Boolean}
+     */
+    retireWindowDragOrphanRecovery({nativeHandleKey, targetWindowId, windowName} = {}) {
+        let me           = this,
+            recoveries   = me.windowDragOrphanRecoveries,
+            key          = JSON.stringify([nativeHandleKey, targetWindowId, windowName]),
+            route        = me.windowDragParkRoute,
+            active       = me.windowDragParkRecovery,
+            routeMatches = record => (
+                record?.nativeHandleKey === nativeHandleKey &&
+                record?.targetWindowId === targetWindowId &&
+                record?.windowName === windowName
+            ),
+            routeRecord = routeMatches(route) ? route : null,
+            recovery    = recoveries?.get(key);
+
+        routeRecord && (routeRecord.retired = true);
+        routeMatches(active) && (active.retired = true);
+
+        if (!recovery && routeRecord && (routeRecord.operationCount || 0) > 0) {
+            recoveries = me.windowDragOrphanRecoveries ||= new Map();
+            recovery   = {
+                key,
+                nativeHandleKey,
+                park         : routeRecord.park && {...routeRecord.park},
+                pendingEffect: routeRecord.pendingEffect,
+                promise      : null,
+                resize       : routeRecord.resize,
+                restore      : {...routeRecord.restore},
+                retired      : true,
+                revision     : routeRecord.revision || 1,
+                sourceRoute  : routeRecord,
+                targetWindowId,
+                windowName
+            };
+
+            recoveries.set(key, recovery)
+        } else if (recovery) {
+            recovery.pendingEffect ||= routeRecord?.pendingEffect || null;
+            recovery.retired         = true;
+            recovery.revision++;
+            recovery.sourceRoute   ??= routeRecord
+        }
+
+        recovery && DragDrop.prototype.cleanupRetiredWindowDragOrphanRecovery.call(me, recovery);
+
+        return Boolean(recovery || routeRecord || routeMatches(active))
+    }
+
+    /**
+     * @summary Retries the exact same-generation source restoration after platform compensation
+     * refused. Success atomically clears the parked/recovery phase; any partial refusal retains the
+     * route and full rect so the next park/resume proposal remains actionable.
+     * @param {Object} data
+     * @param {String} data.nativeHandleKey
+     * @param {{x:Number,y:Number}|null} [data.restorePosition=null] Latest pointer-owned resume
+     *     position. Park retries omit it and preserve the captured pre-conversion origin.
+     * @param {String} data.targetWindowId
+     * @param {String} data.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async retryWindowDragParkRecovery({
+        nativeHandleKey,
+        restorePosition=null,
+        targetWindowId,
+        windowName
+    } = {}) {
+        let me       = this,
+            recovery = me.windowDragParkRecovery;
+
+        if (
+            !me.isWindowDragging || !me.windowDragParked || !recovery ||
+            recovery.retired || me.windowDragParkRoute?.retired ||
+            recovery.generation !== me.windowDragGeneration ||
+            recovery.nativeHandleKey !== nativeHandleKey ||
+            recovery.targetWindowId !== targetWindowId ||
+            recovery.windowName !== windowName ||
+            !Number.isFinite(recovery.restore?.x) || !Number.isFinite(recovery.restore?.y)
         ) {
             return false
         }
 
-        const generation = me.windowDragGeneration;
+        if (restorePosition) {
+            if (!Number.isFinite(restorePosition.x) || !Number.isFinite(restorePosition.y)) {
+                return false
+            }
 
-        let admitted = false;
-
-        try {
-            admitted = await Neo.Main.windowNativeMoveTo({nativeHandleKey, targetWindowId, x, y}) === true
-        } catch {
-            admitted = false
+            recovery.restore  = {...recovery.restore, ...restorePosition};
+            recovery.revision = (recovery.revision || 0) + 1
         }
 
-        if (generation !== me.windowDragGeneration || !me.isWindowDragging) {
-            return false
+        const
+            generation = me.windowDragGeneration,
+            revision   = recovery.revision || 0;
+
+        DragDrop.prototype.retainWindowDragOrphanRecovery.call(me, {
+            nativeHandleKey,
+            park         : recovery.park,
+            pendingEffect: recovery.pendingEffect,
+            resize       : recovery.resize,
+            restore      : recovery.restore,
+            sourceRoute  : me.windowDragParkRoute,
+            targetWindowId,
+            windowName
+        });
+
+        const restored = await DragDrop.prototype.retryWindowDragOrphanRecovery.call(me, {
+            nativeHandleKey,
+            targetWindowId,
+            windowName
+        });
+
+        if (
+            restored &&
+            generation === me.windowDragGeneration && me.isWindowDragging &&
+            me.windowDragParkRecovery === recovery && recovery.revision === revision
+        ) {
+            me.windowDragParked         = false;
+            me.windowDragParkedGeometry = null;
+            me.windowDragParkRoute      = null;
+            me.windowDragParkRecovery   = null;
+
+            return true
         }
 
-        admitted && (me.windowDragParked = false);
-
-        return admitted
+        return false
     }
 
     /**
@@ -779,14 +1746,19 @@ class DragDrop extends Base {
     startWindowDrag({popupHeight, popupName, popupWidth}) {
         let me = this;
 
+        DragDrop.prototype.promoteWindowDragParkRecovery.call(me);
+
         Object.assign(me, {
-            isWindowDragging      : true,
+            isWindowDragging        : true,
             popupHeight,
             popupName,
             popupWidth,
-            windowDragGeneration  : (me.windowDragGeneration || 0) + 1,
-            windowDragMovePromises: new Set(),
-            windowDragParked      : false
+            windowDragGeneration    : (me.windowDragGeneration || 0) + 1,
+            windowDragMovePromises  : new Set(),
+            windowDragParked        : false,
+            windowDragParkedGeometry: null,
+            windowDragParkRoute     : null,
+            windowDragParkRecovery  : null
         })
     }
 }

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -1161,7 +1161,14 @@ class DragDrop extends Base {
                     return false
                 }
             },
-            resizeTo   = async size => {
+            readGeometry = async() => {
+                try {
+                    return await Neo.Main.windowNativeGetGeometry(route)
+                } catch {
+                    return null
+                }
+            },
+            resizeTo     = async size => {
                 try {
                     return await Neo.Main.windowNativeResizeTo({
                         ...route,
@@ -1251,7 +1258,7 @@ class DragDrop extends Base {
                 return false
             }
 
-            const admitted = await runResumeEffect(() => moveTo({x, y}));
+            let admitted = await runResumeEffect(() => moveTo({x, y}));
 
             if (!routeCurrent()) {
                 geometry && await DragDrop.prototype.recoverInvalidatedWindowDragPark.call(me, {
@@ -1266,6 +1273,35 @@ class DragDrop extends Base {
                     windowName
                 });
                 return false
+            }
+
+            if (!admitted) {
+                const
+                    actual     = await readGeometry(),
+                    oldOffsetX = me.offsetX || 0,
+                    oldOffsetY = me.offsetY || 0,
+                    pointerX   = x + oldOffsetX,
+                    pointerY   = y + oldOffsetY,
+                    measurable = ['height', 'width', 'x', 'y']
+                        .every(key => Number.isFinite(actual?.[key]))
+                        && actual.height > 0 && actual.width > 0,
+                    extentRestored = Boolean(geometry) && measurable && (
+                        Math.abs(actual.height - geometry.restore.height) <= 1 &&
+                        Math.abs(actual.width  - geometry.restore.width)  <= 1
+                    ),
+                    pointerInside = extentRestored &&
+                        pointerX >= actual.x && pointerX <= actual.x + actual.width &&
+                        pointerY >= actual.y && pointerY <= actual.y + actual.height;
+
+                // Chrome clamps a restored popup at display edges and truthfully refuses the exact
+                // requested origin. The exact native route, restored outer extent, and held pointer
+                // still inside that observed frame are sufficient physical admission. Rebase the
+                // grab offset to the platform-authored origin so the very next move follows 1:1.
+                if (routeCurrent() && pointerInside) {
+                    me.offsetX = pointerX - actual.x;
+                    me.offsetY = pointerY - actual.y;
+                    admitted   = true
+                }
             }
 
             if (!admitted) {

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -434,8 +434,17 @@ class DragCoordinator extends Manager {
      * @param {Neo.draggable.container.SortZone} data.sourceSortZone
      */
     onDragMove(data) {
-        let me                                                                           = this,
-            {draggedItem, offsetX, offsetY, proxyRect, screenX, screenY, sourceSortZone} = data,
+        let me = this,
+            {
+                draggedItem,
+                offsetX,
+                offsetY,
+                proxyRect,
+                replayAfterTransition=false,
+                screenX,
+                screenY,
+                sourceSortZone
+            } = data,
             {sortGroup}                                                                  = sourceSortZone,
             arbiter                                                                      = me.pointerClaimArbiter ??= createGestureClaimArbiter(),
             claimed                                                                      = me.resolveClaimedTarget({arbiter, screenX, screenY, sortGroup, sourceSortZone}),
@@ -481,7 +490,9 @@ class DragCoordinator extends Manager {
                 y     : screenY - offsetY
             };
 
-        let transitionOwned = false;
+        let
+            transitionOwned      = false,
+            transitionSourceRect = null;
 
         if (resolver) {
             let transition;
@@ -491,6 +502,7 @@ class DragCoordinator extends Manager {
                     draggedItem,
                     now            : Date.now(),
                     pointerInTarget: Boolean(claimed?.zone),
+                    replayAfterTransition,
                     logicalSourceRect,
                     targetId       : claimed?.stableId ?? me.activeTargetZone?.stableTargetId ?? null,
                     targetRect     : transitionRect && {
@@ -527,6 +539,19 @@ class DragCoordinator extends Manager {
             } else {
                 transitionOwned = true;
 
+                if (transition.sourceRect != null) {
+                    if (
+                        !Number.isFinite(transition.sourceRect.width) ||
+                        !Number.isFinite(transition.sourceRect.height) ||
+                        transition.sourceRect.width <= 0 || transition.sourceRect.height <= 0
+                    ) {
+                        targetSortZone = null;
+                        sourceSortZone.cancelVesselConversion?.()
+                    } else {
+                        transitionSourceRect = transition.sourceRect
+                    }
+                }
+
                 if (transition.engage !== true || transition.commitEligible !== true || !claimed?.zone) {
                     targetSortZone = null
                 }
@@ -534,14 +559,20 @@ class DragCoordinator extends Manager {
         }
 
         if (targetSortZone) {
-            let targetWindow    = Window.get(targetSortZone.windowId),
-                localX          = screenX - targetWindow.innerRect.x,
-                localY          = screenY - targetWindow.innerRect.y,
-                targetProxyRect = new Rectangle(
+            let targetWindow     = Window.get(targetSortZone.windowId),
+                localX           = screenX - targetWindow.innerRect.x,
+                localY           = screenY - targetWindow.innerRect.y,
+                targetProxyWidth = transitionOwned && transitionSourceRect
+                    ? transitionSourceRect.width
+                    : proxyRect.width,
+                targetProxyHeight = transitionOwned && transitionSourceRect
+                    ? transitionSourceRect.height
+                    : proxyRect.height,
+                targetProxyRect   = new Rectangle(
                     localX - offsetX,
                     localY - offsetY,
-                    proxyRect.width,
-                    proxyRect.height
+                    targetProxyWidth,
+                    targetProxyHeight
                 );
 
             // Entering a new target zone

--- a/src/manager/Window.mjs
+++ b/src/manager/Window.mjs
@@ -147,7 +147,7 @@ class Window extends Manager {
         const
             item = {
             appName,
-            capabilities: nativeRoute?.capabilities || {close: false, focus: false, position: false},
+            capabilities: nativeRoute?.capabilities || {close: false, focus: false, position: false, resize: false},
             chrome,
             id          : windowId,
             innerRect,
@@ -199,7 +199,7 @@ class Window extends Manager {
         } else {
             me.register({
                 chrome,
-                capabilities: {close: false, focus: false, position: false},
+                capabilities: {close: false, focus: false, position: false, resize: false},
                 id          : data.windowId,
                 innerRect,
                 nativeRoute : null,

--- a/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
@@ -581,12 +581,14 @@ async function positionTargetForPartialOverlap({
  * pointer-follow move. Each cell then converts out, restoring the identical popup and exact outer
  * extent before Escape cancels it.
  *
- * This proof intentionally stays on the ordinary E2E profile, which retains
- * `--disable-frame-rate-limit` for engine / OffscreenCanvas coverage. One matrix cell runs per
- * fresh browser process because Chromium's separate native-window churn can terminate the next
- * reused worker browser. `large-over-small` is the representative default; set
- * `NEO_POPUP_CELL` to execute any other named cell. `NEO_POPUP_PROOF_HOLD_MS` optionally holds the
- * proven coexistence frame for native visual capture without changing the gesture.
+ * The ordinary E2E profile retains `--disable-frame-rate-limit` for engine / OffscreenCanvas
+ * coverage. `NEO_FILM_TAKE=1` replays the identical assertions with on-glass compositing; the
+ * always-on Playwright trace records the proven target-popup frame without injecting a screenshot
+ * action into the held gesture. One matrix cell runs per fresh browser process because Chromium's
+ * separate native-window churn can terminate the next reused worker browser. `large-over-small`
+ * is the representative default; set `NEO_POPUP_CELL` to execute any other named cell.
+ * `NEO_POPUP_PROOF_HOLD_MS` optionally holds the proven coexistence frame for native observation
+ * without changing the gesture.
  */
 test.describe('Workstation — human popup-over-popup conversion (#16117)', () => {
     test.setTimeout(240000);
@@ -1181,8 +1183,18 @@ test.describe('Workstation — human popup-over-popup conversion (#16117)', () =
                     }
 
                     const
-                        sourceAfter = await readBrowserGeometry(sourcePage),
-                        followDelta = {x: 24, y: 17};
+                        sourceAfter  = await readBrowserGeometry(sourcePage),
+                        sourceScreen = await readScreenEnvelope(sourcePage),
+                        followDelta  = {
+                            x: sourceAfter.inner.x + sourceAfter.outer.width + 24 <=
+                                sourceScreen.left + sourceScreen.width
+                                ? 24
+                                : -24,
+                            y: sourceAfter.inner.y + sourceAfter.outer.height + 17 <=
+                                sourceScreen.top + sourceScreen.height
+                                ? 17
+                                : -17
+                        };
 
                     expect(sourceAfter.outer, `${cell.name}: exact outer extent returns on the identical Page`)
                         .toEqual(sourceBefore.browser.outer);

--- a/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationHumanPopupOverlapNL.spec.mjs
@@ -1,0 +1,1269 @@
+import {expect, test} from '../../fixtures.mjs';
+
+const MATRIX_CELLS = [
+        {
+            itemId      : 'commits',
+            label       : 'Commits',
+            name        : 'small-over-large',
+            sourceNodeId: 'right-bottom-tabs',
+            sourceSize  : {height: 300, width: 360},
+            targetSize  : {height: 560, width: 760}
+        },
+        {
+            itemId      : 'audit',
+            label       : 'Audit',
+            name        : 'large-over-small',
+            sourceNodeId: 'right-top-tabs',
+            sourceSize  : {height: 560, width: 760},
+            targetSize  : {height: 300, width: 360}
+        },
+        {
+            itemId      : 'feed',
+            label       : 'Live Event Stream',
+            name        : 'near-equal',
+            sourceNodeId: 'bottom-tabs',
+            sourceSize  : {height: 480, width: 620},
+            targetSize  : {height: 460, width: 600}
+        },
+        {
+            itemId       : 'alerts',
+            label        : 'Priority Alert Observatory',
+            name         : 'post-resize-asymmetric',
+            preSourceSize: {height: 400, width: 500},
+            preTargetSize: {height: 480, width: 620},
+            sourceNodeId : 'heavy-tabs',
+            sourceSize   : {height: 520, width: 740},
+            targetSize   : {height: 320, width: 400}
+        }
+    ],
+    MATRIX_CELL         = MATRIX_CELLS.find(cell =>
+        cell.name === (process.env.NEO_POPUP_CELL || 'large-over-small')),
+    TARGET_ITEM_ID      = 'metrics',
+    TARGET_WORKSPACE_ID = 'workstation-vessel:metrics';
+
+if (!MATRIX_CELL) {
+    throw new Error(`Unknown NEO_POPUP_CELL: ${process.env.NEO_POPUP_CELL}`)
+}
+
+/**
+ * @summary Returns clone-safe rectangle fields from browser, manager, or DOM geometry.
+ * @param {Object|null} rect
+ * @returns {Object|null}
+ */
+function pickRect(rect) {
+    return rect && {
+        height: rect.height,
+        width : rect.width,
+        x     : rect.x,
+        y     : rect.y
+    }
+}
+
+/**
+ * @summary Resolves exactly one Neural Link instance.
+ * @param {Object} app
+ * @param {Object} selector
+ * @param {String[]} properties
+ * @returns {Promise<Object>}
+ */
+async function findOne(app, selector, properties) {
+    const
+        found = await app.findInstances(selector, properties),
+        list  = Array.isArray(found) ? found : found ? [found] : [];
+
+    expect(list, `one ${JSON.stringify(selector)}`).toHaveLength(1);
+
+    return list[0]
+}
+
+/**
+ * @summary Reads the current browser-observed inner and outer native geometry.
+ * @param {Object} page
+ * @returns {Promise<Object>}
+ */
+function readBrowserGeometry(page) {
+    return page.evaluate(() => ({
+        inner: {
+            height: globalThis.innerHeight,
+            width : globalThis.innerWidth,
+            x     : globalThis.screenX,
+            y     : globalThis.screenY
+        },
+        outer: {
+            height: globalThis.outerHeight,
+            width : globalThis.outerWidth
+        }
+    }))
+}
+
+/**
+ * @summary Reads the display envelope currently containing one browser window.
+ * @param {Object} page
+ * @returns {Promise<Object>}
+ */
+function readScreenEnvelope(page) {
+    return page.evaluate(() => ({
+        height: globalThis.screen.availHeight,
+        left  : globalThis.screen.availLeft,
+        top   : globalThis.screen.availTop,
+        width : globalThis.screen.availWidth
+    }))
+}
+
+/**
+ * @summary Acquires the Chromium native-window adapter for one real Playwright Page.
+ * @param {Object} page
+ * @returns {Promise<Object>}
+ */
+async function acquireNativeWindow(page) {
+    const
+        cdp        = await page.context().newCDPSession(page),
+        {windowId} = await cdp.send('Browser.getWindowForTarget');
+
+    return {cdp, page, windowId}
+}
+
+/**
+ * @summary Sets real native bounds, then publishes the target realm's observed full geometry.
+ * CDP is deliberately only the physical-window adapter; no gesture or dock semantic rides it.
+ * @param {Object} handle
+ * @param {Object} bounds
+ * @returns {Promise<Object>}
+ */
+async function setNativeBounds(handle, bounds) {
+    await handle.cdp.send('Browser.setWindowBounds', {
+        bounds  : {...bounds, windowState: 'normal'},
+        windowId: handle.windowId
+    });
+
+    if (Number.isFinite(bounds.left) && Number.isFinite(bounds.top)) {
+        await expect.poll(async () => {
+            const observed = (await readBrowserGeometry(handle.page)).inner;
+
+            return Math.max(
+                Math.abs(observed.x - bounds.left),
+                Math.abs(observed.y - bounds.top)
+            )
+        }, {
+            message  : `native window ${handle.windowId} reaches its requested origin`,
+            timeout  : 5000,
+            intervals: [25, 50, 100]
+        }).toBeLessThanOrEqual(80)
+    }
+
+    if (Number.isFinite(bounds.height) || Number.isFinite(bounds.width)) {
+        const current = await handle.cdp.send('Browser.getWindowBounds', {windowId: handle.windowId});
+
+        await handle.cdp.send('Browser.setWindowBounds', {
+            bounds: {
+                ...current.bounds,
+                height     : current.bounds.height + 1,
+                windowState: 'normal'
+            },
+            windowId: handle.windowId
+        });
+        await handle.cdp.send('Browser.setWindowBounds', {
+            bounds  : {...current.bounds, windowState: 'normal'},
+            windowId: handle.windowId
+        })
+    }
+
+    await handle.page.evaluate(() => globalThis.Neo.main.addon.WindowPosition.publishGeometry());
+
+    return readBrowserGeometry(handle.page)
+}
+
+/**
+ * @summary Resizes a real native window without changing its current outer origin.
+ * @param {Object} handle
+ * @param {Object} size
+ * @returns {Promise<Object>}
+ */
+async function setNativeSize(handle, size) {
+    const {bounds} = await handle.cdp.send('Browser.getWindowBounds', {windowId: handle.windowId});
+
+    return setNativeBounds(handle, {...bounds, ...size})
+}
+
+/**
+ * @summary Reads one runtime window's current manager-owned inner rectangle.
+ * @param {Object} app
+ * @param {String} managerId
+ * @param {String} windowId
+ * @returns {Promise<Object|null>}
+ */
+async function readManagerRect(app, managerId, windowId) {
+    const
+        state = await app.callMethod(managerId, 'toJSON'),
+        win   = state.windows.find(candidate => candidate.id === windowId);
+
+    return pickRect(win?.innerRect)
+}
+
+/**
+ * @summary Waits until browser observation and App-Worker topology agree on one live rectangle.
+ * @param {Object} app
+ * @param {String} managerId
+ * @param {Object} page
+ * @param {String} windowId
+ * @returns {Promise<Object>}
+ */
+async function awaitGeometryParity(app, managerId, page, windowId) {
+    let receipt;
+
+    await expect.poll(async () => {
+        const
+            browser = await readBrowserGeometry(page),
+            managed = await readManagerRect(app, managerId, windowId),
+            deltas  = managed && ['x', 'y', 'width', 'height']
+                .map(key => Math.abs(browser.inner[key] - managed[key]));
+
+        receipt = {browser, managed};
+
+        return deltas ? Math.max(...deltas) : Infinity
+    }, {
+        message  : `window ${windowId} publishes current browser geometry`,
+        timeout  : 10000,
+        intervals: [25, 50, 100]
+    }).toBeLessThanOrEqual(2);
+
+    return receipt
+}
+
+/**
+ * @summary Waits for the browser-side pointer owner to reach its between-gestures baseline.
+ * @param {Object} page
+ * @returns {Promise<Object>}
+ */
+async function awaitPointerSessionIdle(page) {
+    let state;
+
+    await expect.poll(async () => {
+        state = await page.evaluate(() => {
+            const addon = globalThis.Neo.main.addon.DragDrop;
+
+            return {
+                dragProxyPresent: Boolean(addon.dragProxyElement),
+                dragZoneId      : addon.dragZoneId,
+                isWindowDragging: addon.isWindowDragging,
+                windowDragParked: addon.windowDragParked
+            }
+        });
+
+        return state
+    }, {
+        message  : 'the browser pointer owner settles before the next trusted gesture',
+        timeout  : 10000,
+        intervals: [25, 50, 100]
+    }).toEqual({
+        dragProxyPresent: false,
+        dragZoneId      : null,
+        isWindowDragging: false,
+        windowDragParked: false
+    });
+    await expect(
+        page.locator('.neo-is-dragging'),
+        'the previous worker-side drag presentation retires before the next trusted gesture'
+    ).toHaveCount(0, {timeout: 10000});
+
+    return state
+}
+
+/**
+ * @summary Reads whether one committed bare popup keeps its pane and overlay in the same viewport.
+ * @param {Object} page
+ * @returns {Promise<Object>}
+ */
+function readBarePopupLayout(page) {
+    return page.evaluate(() => {
+        const
+            viewport   = document.querySelector('.workstation-popout-host'),
+            pane       = viewport?.querySelector(':scope > .workstation-pane'),
+            indicators = viewport?.querySelector(':scope > .neo-dashboard-dock-drop-indicators'),
+            pick       = element => {
+                const rect = element?.getBoundingClientRect();
+
+                return rect && {
+                    height: rect.height,
+                    width : rect.width,
+                    x     : rect.x,
+                    y     : rect.y
+                }
+            };
+
+        return {
+            hasContainerSheet: [...document.styleSheets].some(sheet =>
+                sheet.href?.includes('/dashboard/Container.css')
+            ),
+            indicatorPosition: indicators && getComputedStyle(indicators).position,
+            indicators       : pick(indicators),
+            pane             : pick(pane),
+            viewport         : pick(viewport)
+        }
+    })
+}
+
+/**
+ * @summary Computes the live smaller-extent per-axis conversion metric.
+ * @param {Object} source
+ * @param {Object} target
+ * @returns {Object}
+ */
+function sampleMetric(source, target) {
+    const
+        overlapWidth = Math.max(
+            0,
+            Math.min(source.x + source.width, target.x + target.width) - Math.max(source.x, target.x)
+        ),
+        overlapHeight = Math.max(
+            0,
+            Math.min(source.y + source.height, target.y + target.height) - Math.max(source.y, target.y)
+        ),
+        rx    = overlapWidth  / Math.min(source.width,  target.width),
+        ry    = overlapHeight / Math.min(source.height, target.height),
+        score = Math.min(rx, ry);
+
+    return {overlapHeight, overlapWidth, rx, ry, score}
+}
+
+/**
+ * @summary Drives a genuine trusted tab-header pointer gesture until a real popup connects,
+ * while intentionally retaining the pressed button.
+ * @param {Object} data
+ * @param {Object} data.page
+ * @param {String} data.label
+ * @returns {Promise<Object>}
+ */
+async function beginActualTearOut({page, label}) {
+    const button = page.locator('.neo-tab-header-button.neo-draggable').filter({hasText: label}).first();
+
+    await page.bringToFront();
+    await expect.poll(() => page.evaluate(() => document.hasFocus()), {
+        message  : `the '${label}' source window owns native focus`,
+        timeout  : 5000,
+        intervals: [25, 50]
+    }).toBe(true);
+    await expect(button, `the '${label}' tab header is a visible real pointer source`).toBeVisible();
+
+    let hit, layout;
+
+    await expect.poll(async () => {
+        const locatorBox = await button.boundingBox();
+
+        layout = await button.evaluate(element => {
+            const
+                buttonRect   = element.getBoundingClientRect(),
+                boundaryRect = element.closest('.neo-dashboard-dock-tabs')?.getBoundingClientRect(),
+                pick         = rect => rect && ({
+                    bottom: rect.bottom,
+                    height: rect.height,
+                    left  : rect.left,
+                    right : rect.right,
+                    top   : rect.top,
+                    width : rect.width,
+                    x     : rect.x,
+                    y     : rect.y
+                });
+
+            return {
+                boundary: pick(boundaryRect),
+                button  : pick(buttonRect),
+                viewport: {height: innerHeight, width: innerWidth}
+            }
+        });
+        hit = await button.evaluate((element, {layout, locatorBox}) => {
+            const candidates = [
+                {
+                    coordinateSpace: 'renderer',
+                    x              : layout.button.x + layout.button.width  / 2,
+                    y              : layout.button.y + layout.button.height / 2
+                },
+                locatorBox && {
+                    coordinateSpace: 'locator',
+                    x              : locatorBox.x + locatorBox.width  / 2,
+                    y              : locatorBox.y + locatorBox.height / 2
+                }
+            ].filter(Boolean).map(candidate => {
+                const owner = document.elementFromPoint(candidate.x, candidate.y);
+
+                return {
+                    ...candidate,
+                    ownerClass: owner?.className || null,
+                    ownerId   : owner?.id || null,
+                    ownerTag  : owner?.tagName || null,
+                    within    : owner === element || element.contains(owner)
+                }
+            });
+
+            return {
+                candidates,
+                locatorBox,
+                rendererBox: layout.button,
+                viewport   : layout.viewport,
+                ...candidates.find(candidate => candidate.within)
+            }
+        }, {layout, locatorBox});
+
+        return hit.within === true
+    }, {
+        message  : `the '${label}' tab center becomes a real pointer hit after projection settles`,
+        timeout  : 10000,
+        intervals: [25, 50, 100]
+    }).toBe(true);
+
+    const
+        boundary      = layout.boundary,
+        rendererStart = {
+            x: layout.button.x + layout.button.width  / 2,
+            y: layout.button.y + layout.button.height / 2
+        },
+        start = {x: hit.x, y: hit.y},
+        projectedX = start.x + boundary.right + 40 - rendererStart.x,
+        out = {
+            // A dock-tabs boundary can occupy only one column of the main viewport. Crossing
+            // that local boundary is not a native tear-out; guarantee the trusted pointer
+            // traverses the browser viewport edge for every workstation topology. Keep the
+            // orthogonal coordinate in the usable-screen interior: a bottom-row tab otherwise
+            // asks macOS to birth and later park its popup below the movable window range.
+            x: Math.round(Math.max(projectedX, layout.viewport.width + 40)),
+            y: Math.round(Math.min(360, Math.max(96, start.y)))
+        };
+
+    expect(
+        out.x > layout.viewport.width || out.y > layout.viewport.height,
+        `the '${label}' drag endpoint crosses the source viewport`
+    ).toBe(true);
+
+    const
+        popupWait = page.waitForEvent('popup', {timeout: 30000}),
+        toolbar   = page.locator('.neo-tab-header-toolbar.neo-is-dragging');
+
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.waitForTimeout(130);
+
+    for (let index = 1; index <= 8 && await toolbar.count() === 0; index++) {
+        const ratio = index / 8;
+
+        await page.mouse.move(start.x + 16 * ratio, start.y + 24 * ratio);
+        await page.waitForTimeout(34)
+    }
+
+    await expect(toolbar, `the '${label}' toolbar owns a live pointer drag`).toBeVisible({timeout: 1500});
+
+    for (let index = 1; index <= 14; index++) {
+        const ratio = index / 14;
+
+        await page.mouse.move(
+            start.x + (out.x - start.x) * ratio,
+            start.y + (out.y - start.y) * ratio
+        );
+        await page.waitForTimeout(20)
+    }
+
+    const popup = await popupWait;
+
+    await popup.waitForURL(url => url.searchParams.has('popout'), {
+        timeout  : 30000,
+        waitUntil: 'domcontentloaded'
+    });
+    await popup.waitForSelector('.workstation-viewport', {timeout: 30000});
+
+    for (let index = 1; index <= 3; index++) {
+        await page.mouse.move(out.x, out.y + index * 12);
+        await page.waitForTimeout(30)
+    }
+
+    return {button, hit, out: {x: out.x, y: out.y + 36}, popup}
+}
+
+/**
+ * @summary Reads a vessel runtime window id from pre-terminal or committed ownership.
+ * @param {Object} app
+ * @param {String} wsId
+ * @param {String} itemId
+ * @param {Boolean} committed
+ * @returns {Promise<String>}
+ */
+async function awaitVesselWindowId(app, wsId, itemId, committed) {
+    let windowId;
+
+    await expect.poll(async () => {
+        const state = await app.getComponent(wsId, ['tearOutConnects', 'tearOutPanes']);
+
+        windowId = (committed ? state.tearOutPanes : state.tearOutConnects)?.[itemId]?.windowId ?? null;
+
+        return windowId
+    }, {
+        message  : `${committed ? 'committed' : 'held'} vessel '${itemId}' connects`,
+        timeout  : 15000,
+        intervals: [50, 100]
+    }).toBeTruthy();
+
+    return windowId
+}
+
+/**
+ * @summary Waits for a retired popup generation to leave every App-Worker topology owner.
+ * @param {Object} app
+ * @param {String} managerId
+ * @param {String} wsId
+ * @param {String} itemId
+ * @param {String} windowId
+ * @returns {Promise<Object>}
+ */
+async function awaitVesselRetirement(app, managerId, wsId, itemId, windowId) {
+    let receipt;
+
+    await expect.poll(async () => {
+        const
+            state   = await app.getComponent(wsId, ['tearOutConnects', 'tearOutPanes']),
+            manager = await app.callMethod(managerId, 'toJSON');
+
+        return receipt = {
+            connected : Boolean(state.tearOutConnects?.[itemId]),
+            committed : Boolean(state.tearOutPanes?.[itemId]),
+            registered: manager.windows.some(win => win.id === windowId)
+        }
+    }, {
+        message  : `retired vessel '${itemId}' leaves connection, commit, and window topology`,
+        timeout  : 10000,
+        intervals: [25, 50, 100]
+    }).toEqual({connected: false, committed: false, registered: false});
+
+    return receipt
+}
+
+/**
+ * @summary Positions the target so the still-held pointer yields calibrated partial overlap.
+ * @param {Object} data
+ * @returns {Promise<Object>}
+ */
+async function positionTargetForPartialOverlap({
+    app,
+    managerId,
+    ratio,
+    source,
+    targetHandle,
+    targetWindowId
+}) {
+    let target = await awaitGeometryParity(
+        app,
+        managerId,
+        targetHandle.page,
+        targetWindowId
+    );
+
+    const
+        overlapWidth  = ratio * Math.min(source.managed.width,  target.managed.width),
+        overlapHeight = ratio * Math.min(source.managed.height, target.managed.height),
+        desiredX      = source.managed.x + overlapWidth  - target.managed.width,
+        desiredY      = source.managed.y + overlapHeight - target.managed.height,
+        {bounds}      = await targetHandle.cdp.send('Browser.getWindowBounds', {windowId: targetHandle.windowId});
+
+    await setNativeBounds(targetHandle, {
+        ...bounds,
+        left: Math.round(bounds.left + desiredX - target.managed.x),
+        top : Math.round(bounds.top  + desiredY - target.managed.y)
+    });
+    target = await awaitGeometryParity(app, managerId, targetHandle.page, targetWindowId);
+
+    return {metric: sampleMetric(source.managed, target.managed), target}
+}
+
+/**
+ * @summary Actual-pointer proof that a human popup-over-popup drag materializes early.
+ *
+ * Every gesture input is Playwright's trusted `page.mouse` stream. CDP only controls physical
+ * native window bounds so the matrix is deterministic. The held source is never released until
+ * exactly one target-local proxy, the target indicators, and its preview coexist. The
+ * representative size-asymmetric cell retains renderer and semantic receipts across a live
+ * pointer-follow move. Each cell then converts out, restoring the identical popup and exact outer
+ * extent before Escape cancels it.
+ *
+ * This proof intentionally stays on the ordinary E2E profile, which retains
+ * `--disable-frame-rate-limit` for engine / OffscreenCanvas coverage. One matrix cell runs per
+ * fresh browser process because Chromium's separate native-window churn can terminate the next
+ * reused worker browser. `large-over-small` is the representative default; set
+ * `NEO_POPUP_CELL` to execute any other named cell. `NEO_POPUP_PROOF_HOLD_MS` optionally holds the
+ * proven coexistence frame for native visual capture without changing the gesture.
+ */
+test.describe('Workstation — human popup-over-popup conversion (#16117)', () => {
+    test.setTimeout(240000);
+    test.use({colorScheme: 'dark', viewport: null});
+
+    test(`${MATRIX_CELL.name}: one local proxy plus readable target choices`,
+    async ({page, neuralLink}, testInfo) => {
+        await test.step(MATRIX_CELL.name, async () => {
+            const cell = MATRIX_CELL;
+
+            await page.goto('/apps/workstation/index.html');
+            await page.waitForSelector('.workstation-dock-host', {timeout: 60000});
+            await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
+            await page.waitForFunction(() => {
+                const host = document.querySelector('.workstation-dock-host');
+
+                return host?.getBoundingClientRect().height > 300
+            }, {timeout: 60000});
+            await page.waitForTimeout(1200);
+
+            const
+                app        = await neuralLink.connectToApp('Workstation'),
+                workspace  = await findOne(app, {className: 'Workstation.view.Workspace'}, ['id']),
+                manager    = await findOne(app, {className: 'Neo.manager.Window'}, ['id']),
+                wsId       = workspace.id,
+                managerId  = manager.id,
+                mainHandle = await acquireNativeWindow(page),
+                screen     = await page.evaluate(() => ({
+                    fullHeight: globalThis.screen.height,
+                    fullWidth : globalThis.screen.width,
+                    height    : globalThis.screen.availHeight,
+                    left      : globalThis.screen.availLeft,
+                    top       : globalThis.screen.availTop,
+                    width     : globalThis.screen.availWidth
+                }));
+
+            await setNativeBounds(mainHandle, {
+                height: Math.min(820, screen.height - 80),
+                left  : screen.left + 24,
+                top   : screen.top  + 24,
+                // Keep even the 760px large-source cell centered on this display. A source whose
+                // center crosses onto another display makes Chrome's unpermissioned window.moveTo
+                // clamp to that display; multi-display transport belongs to the portability matrix,
+                // not this same-display asymmetric-size witness.
+                width : Math.min(1080, screen.width - 80)
+            });
+
+            let pointerDown = false,
+                sourcePage,
+                targetPage,
+                targetHandle;
+
+            const receipts = [];
+
+            try {
+                const targetGesture = await beginActualTearOut({label: 'Metrics', page});
+
+                pointerDown = true;
+                targetPage  = targetGesture.popup;
+
+                const targetWindowId = await awaitVesselWindowId(app, wsId, TARGET_ITEM_ID, false);
+
+                await page.mouse.up();
+                pointerDown = false;
+
+                await expect.poll(async () => {
+                    const {dockModel} = await app.getComponent(wsId, ['dockModel']);
+
+                    return Object.values(dockModel.nodes).some(node => node.items?.includes(TARGET_ITEM_ID))
+                }, {
+                    message  : 'the actual-pointer Metrics release commits its detached target vessel',
+                    timeout  : 15000,
+                    intervals: [50, 100]
+                }).toBe(false);
+                expect(await awaitVesselWindowId(app, wsId, TARGET_ITEM_ID, true)).toBe(targetWindowId);
+                await awaitPointerSessionIdle(page);
+
+                targetHandle = await acquireNativeWindow(targetPage);
+
+                await setNativeBounds(targetHandle, {
+                        ...cell.targetSize,
+                        left: screen.left + 10,
+                        top : screen.top  + 10
+                    });
+
+                    let targetLayout,
+                        targetLayoutReceipt;
+
+                    await expect.poll(async () => {
+                        targetLayout = await readBarePopupLayout(targetPage);
+
+                        const edgeDelta = (first, second) => ({
+                            bottom: Math.abs(
+                                ((first?.y ?? Infinity) + (first?.height ?? 0)) -
+                                ((second?.y ?? 0) + (second?.height ?? 0))
+                            ),
+                            left : Math.abs((first?.x ?? Infinity) - (second?.x ?? 0)),
+                            right: Math.abs(
+                                ((first?.x ?? Infinity) + (first?.width ?? 0)) -
+                                ((second?.x ?? 0) + (second?.width ?? 0))
+                            ),
+                            top: Math.abs((first?.y ?? Infinity) - (second?.y ?? 0))
+                        }),
+                        indicatorEdges = edgeDelta(targetLayout.indicators, targetLayout.viewport),
+                        paneEdges      = edgeDelta(targetLayout.pane, targetLayout.viewport);
+
+                        return targetLayoutReceipt = {
+                            hasContainerSheet            : targetLayout.hasContainerSheet,
+                            indicatorEdges,
+                            indicatorEdgesWithinTolerance: Object.values(indicatorEdges)
+                                .every(delta => delta <= 1),
+                            indicatorPosition: targetLayout.indicatorPosition,
+                            nonzero          : [
+                                targetLayout.viewport,
+                                targetLayout.pane,
+                                targetLayout.indicators
+                            ].every(rect => rect?.width > 0 && rect?.height > 0),
+                            paneEdges,
+                            paneEdgesWithinTolerance: Object.values(paneEdges).every(delta => delta <= 1)
+                        }
+                    }, {
+                        message  : `${cell.name}: the committed target pane fills its popup beside an overlay`,
+                        timeout  : 10000,
+                        intervals: [25, 50, 100]
+                    }).toMatchObject({
+                        hasContainerSheet            : true,
+                        indicatorEdgesWithinTolerance: true,
+                        indicatorPosition            : 'absolute',
+                        nonzero                      : true,
+                        paneEdgesWithinTolerance     : true
+                    });
+
+                    for (const edge of ['bottom', 'left', 'right', 'top']) {
+                        expect(
+                            targetLayoutReceipt.paneEdges[edge],
+                            `${cell.name}: pane ${edge} edge tracks its popup viewport`
+                        ).toBeLessThanOrEqual(1);
+                        expect(
+                            targetLayoutReceipt.indicatorEdges[edge],
+                            `${cell.name}: indicator overlay ${edge} edge tracks its popup viewport`
+                        ).toBeLessThanOrEqual(1)
+                    }
+
+                    const sourceGesture = await beginActualTearOut({label: cell.label, page});
+
+                    sourcePage = sourceGesture.popup;
+
+                    pointerDown = true;
+
+                    const
+                        sourceWindowId = await awaitVesselWindowId(app, wsId, cell.itemId, false),
+                        sourceZone     = await findOne(app, {
+                            className       : 'Neo.dashboard.DockTabSortZone',
+                            dockSourceNodeId: cell.sourceNodeId,
+                            dockWorkspaceId : 'workstation-main'
+                        }, ['id']),
+                        sourceZoneId = sourceZone.id,
+                        sourceHandle = await acquireNativeWindow(sourcePage);
+
+                    let resizedFrom = null;
+
+                    if (cell.preSourceSize && cell.preTargetSize) {
+                        await setNativeSize(targetHandle, cell.preTargetSize);
+                        await setNativeSize(sourceHandle, cell.preSourceSize);
+                        resizedFrom = {
+                            source: await awaitGeometryParity(
+                                app,
+                                managerId,
+                                sourcePage,
+                                sourceWindowId
+                            ),
+                            target: await awaitGeometryParity(
+                                app,
+                                managerId,
+                                targetPage,
+                                targetWindowId
+                            )
+                        }
+                    }
+
+                    await setNativeSize(targetHandle, cell.targetSize);
+                    await setNativeSize(sourceHandle, cell.sourceSize);
+
+                    const
+                        sourceBefore = await awaitGeometryParity(
+                            app,
+                            managerId,
+                            sourcePage,
+                            sourceWindowId
+                        ),
+                        positioned = await positionTargetForPartialOverlap({
+                            app,
+                            managerId,
+                            ratio : .68,
+                            source: sourceBefore,
+                            targetHandle,
+                            targetWindowId
+                        });
+
+                    const [sourceScreenEnvelope, targetScreenEnvelope] = await Promise.all([
+                        readScreenEnvelope(sourcePage),
+                        readScreenEnvelope(targetPage)
+                    ]);
+
+                    expect(
+                        sourceScreenEnvelope,
+                        `${cell.name}: the popup-size witness is intentionally same-display`
+                    ).toEqual(targetScreenEnvelope);
+
+                    await page.evaluate(() => {
+                        globalThis.__neoTrustedPointerProjection = null;
+                        addEventListener('mousemove', event => {
+                            globalThis.__neoTrustedPointerProjection = {
+                                clientX: event.clientX,
+                                clientY: event.clientY,
+                                screenX: event.screenX,
+                                screenY: event.screenY
+                            }
+                        }, {capture: true, once: true})
+                    });
+                    await page.mouse.move(sourceGesture.out.x, sourceGesture.out.y);
+
+                    const
+                        pointerProjection = await page.evaluate(() => globalThis.__neoTrustedPointerProjection),
+                        pointerOrigin     = {
+                            x: pointerProjection.screenX - pointerProjection.clientX,
+                            y: pointerProjection.screenY - pointerProjection.clientY
+                        },
+                        pointer = {
+                            x: pointerOrigin.x + sourceGesture.out.x,
+                            y: pointerOrigin.y + sourceGesture.out.y
+                        },
+                        pointerInTarget = {
+                            x: pointer.x - positioned.target.managed.x,
+                            y: pointer.y - positioned.target.managed.y
+                        };
+
+                    expect(positioned.metric.rx, `${cell.name}: horizontal overlap clears convert-in`)
+                        .toBeGreaterThan(.6);
+                    expect(positioned.metric.ry, `${cell.name}: vertical overlap clears convert-in`)
+                        .toBeGreaterThan(.6);
+                    expect(positioned.metric.score, `${cell.name}: composed score clears .55`).toBeGreaterThan(.6);
+                    expect(positioned.metric.score, `${cell.name}: conversion remains partial`).toBeLessThan(.8);
+                    expect(pointerInTarget.x, `${cell.name}: pointer intent is inside target x`).toBeGreaterThan(0);
+                    expect(pointerInTarget.x).toBeLessThan(positioned.target.managed.width);
+                    expect(pointerInTarget.y, `${cell.name}: pointer intent is inside target y`).toBeGreaterThan(0);
+                    expect(pointerInTarget.y).toBeLessThan(positioned.target.managed.height);
+
+                    await page.mouse.move(sourceGesture.out.x + 1, sourceGesture.out.y);
+
+                    let
+                        activePointer  = {...sourceGesture.out},
+                        readyMoveIndex = 0,
+                        snapshotA;
+
+                    try {
+                        await expect.poll(async () => {
+                            await page.mouse.move(
+                                sourceGesture.out.x + readyMoveIndex % 2,
+                                sourceGesture.out.y + readyMoveIndex++ % 2
+                            );
+                            snapshotA = await app.callMethod(wsId, 'readCrossWindowGestureSnapshot', [{
+                                parkedItemId     : cell.itemId,
+                                sourceZoneId,
+                                targetWorkspaceId: TARGET_WORKSPACE_ID
+                            }]);
+
+                            return Boolean(
+                                snapshotA?.claimCount === 1 &&
+                                snapshotA.converted &&
+                                snapshotA.engaged &&
+                                snapshotA.winnerStableId === TARGET_WORKSPACE_ID &&
+                                snapshotA.preview?.previewId &&
+                                snapshotA.rendered?.previewId === snapshotA.preview.previewId &&
+                                snapshotA.parkedItemId === cell.itemId &&
+                                snapshotA.sourceVesselConnected &&
+                                snapshotA.indicators?.itemId === cell.itemId &&
+                                snapshotA.indicators.candidateCount >= 5 &&
+                                snapshotA.indicators.visible &&
+                                snapshotA.targetProxy?.itemId === cell.itemId &&
+                                snapshotA.targetProxy.ownsPane &&
+                                snapshotA.targetProxy.settled &&
+                                snapshotA.targetProxy.sourceWindowId === snapshotA.sourceVesselWindowId &&
+                                snapshotA.targetProxy.targetWindowId === targetWindowId &&
+                                snapshotA.targetProxy.visible
+                            )
+                        }, {
+                            message  : `${cell.name}: park materializes before selecting a target choice`,
+                            timeout  : 10000,
+                            intervals: [25, 50, 100]
+                        }).toBe(true);
+
+                        const
+                            centerChoice = targetPage.locator(
+                                '.neo-dashboard-dock-drop-indicator-center:not(.neo-dashboard-dock-drop-indicator-off)'
+                            ),
+                            centerRect = await centerChoice.evaluate(element => {
+                                const rect = element.getBoundingClientRect();
+
+                                return {height: rect.height, width: rect.width, x: rect.x, y: rect.y}
+                            });
+
+                        expect(centerRect, `${cell.name}: center target choice has rendered geometry`).toBeTruthy();
+                        activePointer = {
+                            x: Math.round(
+                                positioned.target.managed.x + centerRect.x + centerRect.width / 2 -
+                                pointerOrigin.x
+                            ),
+                            y: Math.round(
+                                positioned.target.managed.y + centerRect.y + centerRect.height / 2 -
+                                pointerOrigin.y
+                            )
+                        };
+                        readyMoveIndex = 0;
+
+                        await expect.poll(async () => {
+                            // Keep the ordinary pointer stream alive while the newly-mounted
+                            // target overlays paint. The gesture claim is a short hover lease;
+                            // polling Neural Link alone must not impersonate a stationary user
+                            // while that lease expires.
+                            let delta = 1 + readyMoveIndex++ % 2;
+
+                            await page.mouse.move(activePointer.x + delta, activePointer.y + delta);
+                            snapshotA = await app.callMethod(wsId, 'readCrossWindowGestureSnapshot', [{
+                                parkedItemId     : cell.itemId,
+                                sourceZoneId,
+                                targetWorkspaceId: TARGET_WORKSPACE_ID
+                            }]);
+
+                            return snapshotA?.ready
+                        }, {
+                            message  : `${cell.name}: successful park replays into one ready target-local proxy`,
+                            timeout  : 10000,
+                            intervals: [25, 50, 100]
+                        }).toBe(true)
+                    } catch (error) {
+                        const diagnostic = {
+                            dragDrop: await page.evaluate(() => {
+                                const addon = globalThis.Neo.main.addon.DragDrop;
+
+                                return {
+                                    isWindowDragging        : addon.isWindowDragging,
+                                    offsetX                 : addon.offsetX,
+                                    offsetY                 : addon.offsetY,
+                                    popupHeight             : addon.popupHeight,
+                                    popupName               : addon.popupName,
+                                    popupWidth              : addon.popupWidth,
+                                    windowDragParked        : addon.windowDragParked,
+                                    windowDragParkedGeometry: addon.windowDragParkedGeometry
+                                }
+                            }),
+                            snapshotA,
+                            sourceBrowser: await readBrowserGeometry(sourcePage),
+                            sourceState  : await app.getComponent(sourceZoneId, [
+                                'isWindowDragging',
+                                'vesselConversionLogicalRect',
+                                'vesselConversionSourceRect',
+                                'vesselConversionTargetId',
+                                'vesselConversionTargetRect',
+                                'vesselConversionSensor'
+                            ]),
+                            targetBrowser: await readBrowserGeometry(targetPage),
+                            targetDom    : await targetPage.evaluate(() => ({
+                                indicators: document.querySelectorAll(
+                                    '.neo-dashboard-dock-drop-indicators:not(.neo-dashboard-dock-drop-indicators-hidden)'
+                                ).length,
+                                previews: document.querySelectorAll('.neo-dock-preview-affordance').length,
+                                proxies : document.querySelectorAll('.workstation-vessel-dragproxy').length
+                            })),
+                            workspace: await app.getComponent(wsId, [
+                                'lastVesselParkReceipt',
+                                'lastVesselRestoreReceipt',
+                                'vesselConversionTargetWindowId'
+                            ])
+                        };
+
+                        throw new Error(`${error.message}\nDIAGNOSTIC ${JSON.stringify(diagnostic)}`)
+                    }
+
+                    const
+                        proxy      = targetPage.locator('.workstation-vessel-dragproxy'),
+                        indicators = targetPage.locator(
+                            '.neo-dashboard-dock-drop-indicators:not(.neo-dashboard-dock-drop-indicators-hidden)'
+                        ),
+                        preview       = targetPage.locator('.neo-dock-preview-affordance'),
+                        targetChoices = targetPage.locator([
+                            '.neo-dashboard-dock-drop-indicator:not(.neo-dashboard-dock-drop-indicator-off)',
+                            '.neo-dashboard-dock-drop-chip:not(.neo-dashboard-dock-drop-indicator-off)'
+                        ].join(', ')),
+                        activeChoice  = targetPage.locator('.neo-dashboard-dock-drop-indicator-active');
+
+                    await expect(proxy, `${cell.name}: exactly one target-local proxy`).toHaveCount(1);
+                    await expect(proxy).toBeVisible();
+                    await expect(indicators, `${cell.name}: target choices remain visible`).toBeVisible();
+                    await expect(
+                        targetChoices,
+                        `${cell.name}: exactly five rendered target choices remain readable`
+                    ).toHaveCount(5);
+                    await expect(
+                        activeChoice,
+                        `${cell.name}: exactly one rendered target choice owns pointer intent`
+                    ).toHaveCount(1);
+                    await expect(preview, `${cell.name}: target preview remains visible beside proxy`).toBeVisible();
+
+                    const
+                        proxyRectA = await proxy.evaluate(element => {
+                            const rect = element.getBoundingClientRect();
+
+                            return {height: rect.height, width: rect.width, x: rect.x, y: rect.y}
+                        });
+
+                    expect(
+                        Math.abs(proxyRectA.width - sourceBefore.managed.width),
+                        `${cell.name}: target proxy width follows the live source viewport`
+                    ).toBeLessThanOrEqual(1);
+                    expect(
+                        Math.abs(proxyRectA.height - sourceBefore.managed.height),
+                        `${cell.name}: target proxy height follows the live source viewport`
+                    ).toBeLessThanOrEqual(1);
+
+                    const proofHoldMs = Number(process.env.NEO_POPUP_PROOF_HOLD_MS || 0);
+
+                    if (proofHoldMs > 0) await targetPage.waitForTimeout(proofHoldMs);
+
+                    await page.mouse.move(activePointer.x + 9, activePointer.y + 6);
+
+                    let
+                        followMoveIndex = 0,
+                        snapshotB;
+
+                    await expect.poll(async () => {
+                        let delta = followMoveIndex++ % 2;
+
+                        await page.mouse.move(activePointer.x + 9 + delta, activePointer.y + 6 + delta);
+                        snapshotB = await app.callMethod(wsId, 'readCrossWindowGestureSnapshot', [{
+                            parkedItemId     : cell.itemId,
+                            sourceZoneId,
+                            targetWorkspaceId: TARGET_WORKSPACE_ID
+                        }]);
+
+                        return snapshotB?.ready
+                    }, {
+                        message  : `${cell.name}: second held pointer frame keeps the same conversion ready`,
+                        timeout  : 10000,
+                        intervals: [25, 50]
+                    }).toBe(true);
+
+                    const
+                        proxyRectB = await proxy.evaluate(element => {
+                            const rect = element.getBoundingClientRect();
+
+                            return {height: rect.height, width: rect.width, x: rect.x, y: rect.y}
+                        });
+
+                    expect(
+                        Math.abs(proxyRectB.x - proxyRectA.x) + Math.abs(proxyRectB.y - proxyRectA.y),
+                        `${cell.name}: target-local proxy follows the still-held pointer`
+                    ).toBeGreaterThan(2);
+
+                    expect(sourcePage.isClosed(), `${cell.name}: source popup remains the same live Page`).toBe(false);
+                    expect(targetPage.isClosed(), `${cell.name}: target popup remains live`).toBe(false);
+                    expect(snapshotA).toMatchObject({
+                        claimCount           : 1,
+                        converted            : true,
+                        engaged              : true,
+                        parkedItemId         : cell.itemId,
+                        sourceVesselConnected: true,
+                        indicators           : {
+                            candidateCount: 5,
+                            itemId        : cell.itemId,
+                            visible       : true
+                        },
+                        targetProxy          : {
+                            itemId : cell.itemId,
+                            visible: true
+                        },
+                        targetWorkspaceId: TARGET_WORKSPACE_ID,
+                        winnerStableId   : TARGET_WORKSPACE_ID
+                    });
+                    expect(snapshotA.parkReceipt?.needsResize)
+                        .toBe(sourceBefore.browser.outer.width > positioned.target.browser.inner.width
+                            || sourceBefore.browser.outer.height > positioned.target.browser.inner.height);
+
+                    const targetFar = await targetHandle.cdp.send(
+                        'Browser.getWindowBounds',
+                        {windowId: targetHandle.windowId}
+                    );
+
+                    await setNativeBounds(targetHandle, {
+                        ...targetFar.bounds,
+                        left: screen.left + 10,
+                        top : screen.top  + 10
+                    });
+
+                    const
+                        targetAway = await awaitGeometryParity(
+                            app,
+                            managerId,
+                            targetPage,
+                            targetWindowId
+                        ),
+                        restorePointer = {
+                            x: activePointer.x + 11,
+                            y: activePointer.y + 8
+                        },
+                        restoreScreen = {
+                            x: pointerOrigin.x + restorePointer.x,
+                            y: pointerOrigin.y + restorePointer.y
+                        };
+
+                    expect(
+                        restoreScreen.x >= targetAway.managed.x &&
+                        restoreScreen.x <= targetAway.managed.x + targetAway.managed.width &&
+                        restoreScreen.y >= targetAway.managed.y &&
+                        restoreScreen.y <= targetAway.managed.y + targetAway.managed.height,
+                        `${cell.name}: pointer is outside the relocated target before convert-out`
+                    ).toBe(false);
+                    await page.mouse.move(restorePointer.x, restorePointer.y);
+
+                    let
+                        restore,
+                        restoreMoveIndex = 0;
+
+                    try {
+                        await expect.poll(async () => {
+                            const delta = restoreMoveIndex++ % 2;
+
+                            await page.mouse.move(restorePointer.x + delta, restorePointer.y + delta);
+
+                            const
+                                conversion = await app.callMethod(sourceZoneId, 'getVesselConversionState'),
+                                state      = await app.getComponent(wsId, ['lastVesselRestoreReceipt']);
+
+                            restore = {conversion, receipt: state.lastVesselRestoreReceipt};
+
+                            return {
+                                admitted     : restore.receipt?.admitted === true,
+                                converted    : conversion.converted,
+                                transitioning: conversion.transitioning
+                            }
+                        }, {
+                            message  : `${cell.name}: convert-out restores before pointer-follow resumes`,
+                            timeout  : 15000,
+                            intervals: [25, 50, 100]
+                        }).toEqual({admitted: true, converted: false, transitioning: false})
+                    } catch (error) {
+                        const
+                            coordinator = await findOne(app, {
+                                className: 'Neo.manager.DragCoordinator'
+                            }, [
+                                'activeTargetCommitEligible',
+                                'activeTargetZone',
+                                'activeTransitionOwned',
+                                'pointerClaimArbiter'
+                            ]),
+                            diagnostic = {
+                                coordinator,
+                                dragDrop: await page.evaluate(() => {
+                                    const addon = globalThis.Neo.main.addon.DragDrop;
+
+                                    return {
+                                        isWindowDragging        : addon.isWindowDragging,
+                                        popupName               : addon.popupName,
+                                        windowDragGeneration    : addon.windowDragGeneration,
+                                        windowDragParked        : addon.windowDragParked,
+                                        windowDragParkedGeometry: addon.windowDragParkedGeometry
+                                    }
+                                }),
+                                restore,
+                                sourceBrowser: await readBrowserGeometry(sourcePage),
+                                sourceState  : await app.getComponent(sourceZoneId, [
+                                    'isWindowDragging',
+                                    'vesselConversionCoordinatorFrame',
+                                    'vesselConversionLogicalRect',
+                                    'vesselConversionPointerMissedAt',
+                                    'vesselConversionReplayFrame',
+                                    'vesselConversionSourceRect',
+                                    'vesselConversionTargetId',
+                                    'vesselConversionTargetRect'
+                                ]),
+                                targetAway,
+                                targetBrowser: await readBrowserGeometry(targetPage),
+                                workspace    : await app.getComponent(wsId, [
+                                    'lastVesselParkReceipt',
+                                    'lastVesselRestoreReceipt',
+                                    'tearOutParkGeometries',
+                                    'vesselConversionTargetWindowId'
+                                ])
+                            };
+
+                        throw new Error(`${error.message}\nDIAGNOSTIC ${JSON.stringify(diagnostic)}`)
+                    }
+
+                    const
+                        sourceAfter = await readBrowserGeometry(sourcePage),
+                        followDelta = {x: 24, y: 17};
+
+                    expect(sourceAfter.outer, `${cell.name}: exact outer extent returns on the identical Page`)
+                        .toEqual(sourceBefore.browser.outer);
+                    expect(sourcePage.isClosed()).toBe(false);
+
+                    await page.mouse.move(
+                        restorePointer.x + followDelta.x,
+                        restorePointer.y + followDelta.y
+                    );
+                    await expect.poll(async () => {
+                        const followed = await readBrowserGeometry(sourcePage);
+
+                        return {
+                            x: followed.inner.x - sourceAfter.inner.x,
+                            y: followed.inner.y - sourceAfter.inner.y
+                        }
+                    }, {
+                        message  : `${cell.name}: restored exact popup resumes live pointer-follow`,
+                        timeout  : 5000,
+                        intervals: [25, 50, 100]
+                    }).toEqual(followDelta);
+
+                    await page.keyboard.press('Escape');
+                    await expect.poll(() => sourcePage.isClosed(), {
+                        message  : `${cell.name}: Escape retires the uncommitted exact source popup`,
+                        timeout  : 15000,
+                        intervals: [50, 100]
+                    }).toBe(true);
+                    await awaitVesselRetirement(app, managerId, wsId, cell.itemId, sourceWindowId);
+                    await page.mouse.up();
+                    pointerDown = false;
+                    await awaitPointerSessionIdle(page);
+
+                    await expect(proxy).toHaveCount(0);
+
+                    receipts.push({
+                        hit            : sourceGesture.hit,
+                        itemId         : cell.itemId,
+                        metric         : positioned.metric,
+                        name           : cell.name,
+                        pointer,
+                        pointerInTarget,
+                        proxyRectA,
+                        proxyRectB,
+                        resizedFrom,
+                        restore,
+                        snapshotA,
+                        snapshotB,
+                        sourceBefore,
+                        screenEnvelopes: {
+                            source: sourceScreenEnvelope,
+                            target: targetScreenEnvelope
+                        },
+                        sourceWindowId,
+                        target: positioned.target,
+                        targetWindowId
+                    })
+
+                expect(receipts.map(receipt => receipt.name)).toEqual([cell.name]);
+                expect(receipts.every(receipt => receipt.snapshotA.ready && receipt.snapshotB.ready)).toBe(true);
+
+                const resizedReceipt = receipts.find(receipt => receipt.name === 'post-resize-asymmetric');
+
+                if (resizedReceipt) {
+                    expect(resizedReceipt.resizedFrom?.source.browser.outer)
+                        .not.toEqual(resizedReceipt.sourceBefore.browser.outer)
+                }
+
+                await testInfo.attach(`human-popup-overlap-${cell.name}-receipts`, {
+                    body       : Buffer.from(JSON.stringify(receipts, null, 2)),
+                    contentType: 'application/json'
+                })
+            } finally {
+                if (pointerDown) {
+                    await page.keyboard.press('Escape').catch(() => {});
+                    await page.mouse.up().catch(() => {})
+                }
+
+                if (sourcePage && !sourcePage.isClosed()) await sourcePage.close().catch(() => {});
+                if (targetPage && !targetPage.isClosed()) await targetPage.close().catch(() => {});
+            }
+        })
+    })
+});

--- a/test/playwright/unit/ai/ClientWindowRegistration.spec.mjs
+++ b/test/playwright/unit/ai/ClientWindowRegistration.spec.mjs
@@ -96,7 +96,7 @@ test.describe('Neo.ai.Client — non-SharedWorker window registration', () => {
             originalConnect = client.isConnected;
 
         Neo.manager.Window.get = () => ({
-            capabilities: {close: true, focus: true, position: true},
+            capabilities: {close: true, focus: true, position: true, resize: true},
             nativeRoute : {
                 nativeHandleKey: 'handle-a',
                 ownerWindowId  : 'owner-a',
@@ -118,7 +118,7 @@ test.describe('Neo.ai.Client — non-SharedWorker window registration', () => {
             method: 'window_connected',
             params: {
                 appName     : 'PopupApp',
-                capabilities: {close: true, focus: true, position: true},
+                capabilities: {close: true, focus: true, position: true, resize: true},
                 chrome      : undefined,
                 innerRect   : undefined,
                 outerRect   : undefined,

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -393,6 +393,339 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('large-over-small park uses both live extents and restores the same exact popup', async () => {
+        const
+            workspace          = Neo.create(Workspace, {}),
+            originalDragDrop   = Neo.main.addon.DragDrop,
+            originalFocus      = Neo.Main.windowNativeFocus,
+            originalManagerGet = Neo.manager.Window.get,
+            focusCalls         = [],
+            parkCalls          = [],
+            resumeCalls        = [];
+
+        const
+            sourceRoute = {
+                capabilities   : {close: true, focus: true, position: true, resize: true},
+                nativeHandleKey: 'handle-source',
+                ownerWindowId  : workspace.windowId,
+                targetWindowId : 'source-window'
+            },
+            targetRoute = {
+                capabilities   : {close: true, focus: true, position: true, resize: true},
+                nativeHandleKey: 'handle-target',
+                ownerWindowId  : workspace.windowId,
+                targetWindowId : 'target-window'
+            },
+            records = new Map([
+                ['source-window', {
+                    innerRect  : {height: 479, width: 640, x: 44, y: 128},
+                    nativeRoute: sourceRoute,
+                    outerRect  : {height: 546, width: 640, x: 40, y: 60}
+                }],
+                ['target-window', {
+                    innerRect  : {height: 260, width: 360, x: 800, y: 120},
+                    nativeRoute: targetRoute,
+                    outerRect  : {height: 327, width: 360, x: 800, y: 120}
+                }]
+            ]);
+
+        workspace.tearOutConnects.audit = {
+            nativeRoute: sourceRoute,
+            windowId   : 'source-window',
+            windowName : 'tearout-audit'
+        };
+        workspace.vesselConversionTargetWindowId = 'target-window';
+        Neo.manager.Window.get = id => records.get(id) ?? null;
+        Neo.Main.windowNativeFocus = async data => {
+            focusCalls.push(data);
+            return true
+        };
+        Neo.main.addon.DragDrop = {
+            parkWindowDrag: async data => {
+                parkCalls.push(data);
+                return true
+            },
+            resumeWindowDrag: async data => {
+                resumeCalls.push(data);
+                return true
+            }
+        };
+
+        try {
+            await expect(workspace.parkTearOutVessel({
+                itemId: 'audit', windowName: 'tearout-audit'
+            })).resolves.toBe(true);
+            expect(focusCalls).toEqual([
+                {
+                    nativeHandleKey: 'handle-target',
+                    targetWindowId : 'target-window',
+                    windowId       : workspace.windowId
+                },
+                {
+                    nativeHandleKey: 'handle-target',
+                    targetWindowId : 'target-window',
+                    windowId       : workspace.windowId
+                }
+            ]);
+            expect(parkCalls).toEqual([{
+                nativeHandleKey: 'handle-source',
+                parkSize       : {height: 260, width: 360},
+                restoreRect    : {height: 546, width: 640, x: 40, y: 60},
+                targetWindowId : 'source-window',
+                windowId       : workspace.windowId,
+                windowName     : 'tearout-audit',
+                x              : 800,
+                y              : 120
+            }]);
+            expect(workspace.tearOutParkGeometries.audit).toEqual({
+                park   : {height: 260, width: 360, x: 800, y: 120},
+                restore: {height: 546, width: 640, x: 40, y: 60}
+            });
+            expect(workspace.lastVesselParkReceipt).toMatchObject({
+                needsResize: true,
+                parked     : true,
+                parkSize   : {height: 260, width: 360}
+            });
+
+            await expect(workspace.reshowTearOutVessel({
+                itemId    : 'audit',
+                rect      : {height: 120, width: 200, x: 420, y: 240},
+                windowName: 'tearout-audit'
+            })).resolves.toBe(true);
+            expect(resumeCalls).toEqual([{
+                nativeHandleKey: 'handle-source',
+                targetWindowId : 'source-window',
+                windowId       : workspace.windowId,
+                windowName     : 'tearout-audit',
+                x              : 420,
+                y              : 240
+            }]);
+            expect(workspace.tearOutParkGeometries.audit).toBeUndefined();
+
+            sourceRoute.capabilities.resize = false;
+
+            await expect(workspace.parkTearOutVessel({
+                itemId: 'audit', windowName: 'tearout-audit'
+            })).resolves.toBe(false);
+            expect(focusCalls).toHaveLength(2);
+            expect(parkCalls).toHaveLength(1);
+            expect(workspace.lastVesselParkReceipt).toMatchObject({
+                authority: {sourceResizeCapable: false},
+                reason   : 'native route or live cover geometry refused'
+            })
+        } finally {
+            Neo.main.addon.DragDrop  = originalDragDrop;
+            Neo.Main.windowNativeFocus = originalFocus;
+            Neo.manager.Window.get   = originalManagerGet;
+            workspace.destroy()
+        }
+    });
+
+    test('terminal restore compensates safely until exact extent and position both succeed', async () => {
+        let
+            moveAdmitted       = false,
+            parkResizeAdmitted = true;
+
+        const
+            workspace        = Neo.create(Workspace, {}),
+            originalDragDrop = Neo.main.addon.DragDrop,
+            originalMove     = Neo.Main.windowNativeMoveTo,
+            originalResize   = Neo.Main.windowNativeResizeTo,
+            calls            = [],
+            sourceRoute      = {
+                capabilities   : {close: true, focus: true, position: true, resize: true},
+                nativeHandleKey: 'handle-source',
+                ownerWindowId  : workspace.windowId,
+                targetWindowId : 'source-window'
+            },
+            geometry           = {
+                park   : {height: 260, width: 360, x: 800, y: 120},
+                restore: {height: 546, width: 640, x: 40, y: 60}
+            };
+
+        workspace.tearOutConnects.audit = {
+            nativeRoute: sourceRoute,
+            windowId   : 'source-window',
+            windowName : 'tearout-audit'
+        };
+        workspace.tearOutParkGeometries.audit = geometry;
+        Neo.main.addon.DragDrop = {
+            acknowledgeWindowDragOrphanRecovery: async () => true,
+            hasWindowDragOrphanRecovery        : async () => false,
+            resumeWindowDrag                   : async () => false
+        };
+        Neo.Main.windowNativeResizeTo = async data => {
+            calls.push(['resize', data]);
+            return data.width === geometry.park.width ? parkResizeAdmitted : true
+        };
+        Neo.Main.windowNativeMoveTo = async data => {
+            calls.push(['move', data]);
+            return moveAdmitted
+        };
+
+        const requested = {
+            itemId    : 'audit',
+            rect      : {height: 120, width: 200, x: 420, y: 240},
+            terminal  : true,
+            windowName: 'tearout-audit'
+        };
+
+        try {
+            await expect(workspace.reshowTearOutVessel(requested)).resolves.toBe(false);
+            expect(calls).toEqual([
+                ['resize', {
+                    height         : 546,
+                    nativeHandleKey: 'handle-source',
+                    targetWindowId : 'source-window',
+                    width          : 640,
+                    windowId       : workspace.windowId,
+                    x              : 40,
+                    y              : 60
+                }],
+                ['move', {
+                    nativeHandleKey: 'handle-source',
+                    targetWindowId : 'source-window',
+                    windowId       : workspace.windowId,
+                    x              : 420,
+                    y              : 240
+                }],
+                ['resize', {
+                    height         : 260,
+                    nativeHandleKey: 'handle-source',
+                    targetWindowId : 'source-window',
+                    width          : 360,
+                    windowId       : workspace.windowId,
+                    x              : 800,
+                    y              : 120
+                }],
+                ['move', {
+                    nativeHandleKey: 'handle-source',
+                    targetWindowId : 'source-window',
+                    windowId       : workspace.windowId,
+                    x              : 800,
+                    y              : 120
+                }]
+            ]);
+            expect(workspace.tearOutParkGeometries.audit).toBe(geometry);
+
+            calls.length        = 0;
+            parkResizeAdmitted = false;
+
+            await expect(workspace.reshowTearOutVessel(requested)).resolves.toBe(false);
+            expect(calls.map(([type]) => type)).toEqual(['resize', 'move', 'resize']);
+            expect(calls.some(([type, data]) => (
+                type === 'move' && data.x === geometry.park.x && data.y === geometry.park.y
+            ))).toBe(false);
+            expect(workspace.lastVesselRestoreReceipt).toMatchObject({
+                compensationResized: false,
+                moved              : false
+            });
+
+            calls.length         = 0;
+            moveAdmitted         = true;
+            parkResizeAdmitted   = true;
+
+            await expect(workspace.reshowTearOutVessel(requested)).resolves.toBe(true);
+            expect(calls.map(([type]) => type)).toEqual(['resize', 'move']);
+            expect(workspace.tearOutParkGeometries.audit).toBeUndefined();
+            expect(workspace.lastVesselRestoreReceipt).toMatchObject({
+                admitted: true,
+                moved   : true,
+                resized : true,
+                terminal: true
+            })
+        } finally {
+            Neo.main.addon.DragDrop       = originalDragDrop;
+            Neo.Main.windowNativeMoveTo   = originalMove;
+            Neo.Main.windowNativeResizeTo = originalResize;
+            workspace.destroy()
+        }
+    });
+
+    test('target refocus refusal never admits conversion, regardless of source-restore outcome', async () => {
+        const
+            workspace          = Neo.create(Workspace, {}),
+            originalDragDrop   = Neo.main.addon.DragDrop,
+            originalFocus      = Neo.Main.windowNativeFocus,
+            originalManagerGet = Neo.manager.Window.get,
+            sourceRoute        = {
+                capabilities   : {close: true, focus: true, position: true, resize: true},
+                nativeHandleKey: 'handle-source',
+                ownerWindowId  : workspace.windowId,
+                targetWindowId : 'source-window'
+            },
+            targetRoute = {
+                capabilities   : {close: true, focus: true, position: true, resize: true},
+                nativeHandleKey: 'handle-target',
+                ownerWindowId  : workspace.windowId,
+                targetWindowId : 'target-window'
+            },
+            records = new Map([
+                ['source-window', {
+                    innerRect  : {height: 479, width: 640, x: 44, y: 128},
+                    nativeRoute: sourceRoute,
+                    outerRect  : {height: 546, width: 640, x: 40, y: 60}
+                }],
+                ['target-window', {
+                    innerRect  : {height: 260, width: 360, x: 800, y: 120},
+                    nativeRoute: targetRoute,
+                    outerRect  : {height: 327, width: 360, x: 800, y: 120}
+                }]
+            ]);
+
+        let
+            compensate,
+            focusOutcomes = [],
+            resumeCalls   = [];
+
+        workspace.tearOutConnects.audit = {
+            nativeRoute: sourceRoute,
+            windowId   : 'source-window',
+            windowName : 'tearout-audit'
+        };
+        workspace.vesselConversionTargetWindowId = 'target-window';
+        Neo.manager.Window.get = id => records.get(id) ?? null;
+        Neo.Main.windowNativeFocus = async () => focusOutcomes.shift();
+        Neo.main.addon.DragDrop = {
+            parkWindowDrag  : async () => true,
+            resumeWindowDrag: async data => {
+                resumeCalls.push(data);
+                return compensate
+            }
+        };
+
+        try {
+            for (compensate of [true, false]) {
+                focusOutcomes = [true, false];
+
+                await expect(workspace.parkTearOutVessel({
+                    itemId: 'audit', windowName: 'tearout-audit'
+                })).resolves.toBe(false);
+                expect(workspace.lastVesselParkReceipt).toMatchObject({
+                    compensated: compensate,
+                    focused    : true,
+                    parked     : !compensate,
+                    refocused  : false
+                });
+                expect(resumeCalls.at(-1)).toMatchObject({x: 40, y: 60});
+
+                if (compensate) {
+                    expect(workspace.tearOutParkGeometries.audit).toBeUndefined()
+                } else {
+                    expect(workspace.tearOutParkGeometries.audit).toEqual({
+                        park   : {height: 260, width: 360, x: 800, y: 120},
+                        restore: {height: 546, width: 640, x: 40, y: 60}
+                    })
+                }
+            }
+        } finally {
+            Neo.main.addon.DragDrop    = originalDragDrop;
+            Neo.Main.windowNativeFocus = originalFocus;
+            Neo.manager.Window.get     = originalManagerGet;
+            workspace.destroy()
+        }
+    });
+
     test('convert-out restores the target proxy before the exact parked popup is re-shown', () => {
         const workspace = Neo.create(Workspace, {});
         const
@@ -454,11 +787,23 @@ test.describe.serial('Workstation.view.Workspace', () => {
             workspaceId = Workspace.vesselWorkspaceId('alerts'),
             classes     = [],
             destroyed   = [],
+            indicators  = {
+                activeCandidate: null,
+                candidateSet   : null,
+                clear() {
+                    this.activeCandidate = this.candidateSet = null
+                },
+                hostRect: null,
+                updatePointer() {
+                    return null
+                }
+            },
             preview     = {dockPreview: null, applyTargetGeometry() {}},
+            overlays    = [preview, indicators],
             mainView    = {
                 id         : 'workstation-vessel-view',
                 isDestroyed: false,
-                add        : () => preview,
+                add        : () => overlays.shift(),
                 addCls     : cls => classes.push(cls),
                 getDomRect : async () => [
                     {x: 0, y: 0, width: 480, height: 320},
@@ -533,7 +878,31 @@ test.describe.serial('Workstation.view.Workspace', () => {
                     itemId    : 'security',
                     index     : null,
                     tabsNodeId: Workspace.vesselTabsNodeId('alerts')
-                })
+                });
+                expect(indicators.hostRect).toEqual({height: 320, width: 480, x: 0, y: 0});
+                expect(indicators.candidateSet).toMatchObject({
+                    itemId: 'security',
+                    zone  : {nodeId: Workspace.vesselTabsNodeId('alerts')},
+                    cross : [
+                        {position: 'center'},
+                        {position: 'top'},
+                        {position: 'right'},
+                        {position: 'bottom'},
+                        {position: 'left'}
+                    ]
+                });
+
+                expect(workspace.renderCrossWindowPreview(workspaceId, {
+                    draggedItem: {
+                        dockItemId           : 'security',
+                        dockSourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID
+                    },
+                    localX      : 481,
+                    localY      : 1,
+                    sourceNodeId: 'heavy-tabs'
+                })).toBeNull();
+                expect(preview.dockPreview).toBeNull();
+                expect(indicators.candidateSet).toBeNull()
             } finally {
                 WindowManager.get = originalGet
             }
@@ -542,6 +911,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
             expect(state.document).toBeNull();
             expect(preview.dockPreview).toBeNull();
+            expect(indicators.candidateSet).toBeNull();
             expect(destroyed).toEqual([])
         } finally {
             workspace.destroy()
@@ -1043,6 +1413,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             }),
             order       = [],
             preview     = {parent: {remove: () => order.push('preview-parked')}},
+            indicators  = {parent: {remove: () => order.push('indicators-parked')}},
             host        = {
                 isDestroyed  : false,
                 promiseUpdate: async () => order.push('paint')
@@ -1064,6 +1435,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 committed: true,
                 document : moved.targetDocument,
                 host     : null,
+                indicators,
                 itemId   : 'alerts',
                 participation,
                 preview,
@@ -1075,6 +1447,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             await expect(workspace.mountVesselWorkspace(workspaceId)).resolves.toBe(true);
             expect(order).toEqual([
                 'preview-parked',
+                'indicators-parked',
                 'projection-created',
                 'paint',
                 'target-retired'
@@ -1142,6 +1515,10 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 generation    : 3,
                 windowId      : 'tear-child'
             };
+            workspace.tearOutParkGeometries.alerts = {
+                park   : {height: 260, width: 360, x: 800, y: 120},
+                restore: {height: 546, width: 640, x: 40, y: 60}
+            };
             workspace.tearOutHandlers = {
                 onVesselRetired: data => calls.push(['tear-out', data])
             };
@@ -1158,6 +1535,7 @@ test.describe.serial('Workstation.view.Workspace', () => {
             workspace.onWindowDisconnect({windowId: 'tear-child'});
 
             expect(workspace.tearOutConnects.alerts).toBeUndefined();
+            expect(workspace.tearOutParkGeometries.alerts).toBeUndefined();
             expect(calls).toEqual([
                 ['proxy', 'tear-child'],
                 ['tear-out', {

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -631,6 +631,7 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
                 dockItemIds              : ['graph'],
                 dockSourceNodeId         : 'tabs-main',
                 dragComponent            : {id: 'graph-button', reference: 'graph'},
+                dragCoordinator          : null,
                 enableVesselConversion   : true,
                 getVesselConversionSensor: DockTabSortZone.prototype.getVesselConversionSensor,
                 isWindowDragging         : true,
@@ -655,6 +656,7 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
                 startIndex                           : 0,
                 vesselConversionConvertThreshold     : 0.55,
                 vesselConversionCancelPromise        : null,
+                vesselConversionCoordinatorFrame     : null,
                 vesselConversionEpoch                : 0,
                 vesselConversionItemId               : null,
                 vesselConversionPointerExitGraceMs   : 0,
@@ -699,7 +701,12 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
                 const {calls, zone} = createZone();
                 const decision      = resolve(zone, {logicalSourceRect: source, targetRect: target});
 
-                expect(decision).toEqual({commitEligible: true, engage: true, retain: false});
+                expect(decision).toEqual({
+                    commitEligible: true,
+                    engage        : true,
+                    retain        : false,
+                    sourceRect    : source
+                });
                 expect(calls.map(([name]) => name)).toEqual(['dockVesselConversionIn']);
                 expect(calls[0][1]).toMatchObject({sourceNodeId: 'tabs-main', targetId: 'workspace-a'})
             }
@@ -712,7 +719,12 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
             expect(resolve(zone, {
                 logicalSourceRect: {x: 20, y: 20, width: 40, height: 20},
                 targetRect       : {x: 300, y: 200, width: 420, height: 320}
-            })).toEqual({commitEligible: true, engage: true, retain: false});
+            })).toEqual({
+                commitEligible: true,
+                engage        : true,
+                retain        : false,
+                sourceRect    : liveSourceRect
+            });
             expect(zone.vesselConversionSourceRect).toEqual(liveSourceRect);
             expect(zone.vesselConversionLogicalRect).toEqual({x: 20, y: 20, width: 40, height: 20})
         });
@@ -720,8 +732,12 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
         test('the coordinator frame carries actuator identity when no base reorder index exists', () => {
             const {calls, zone} = createZone({dockItemIds: null, startIndex: null});
 
-            expect(resolve(zone, {draggedItem: {dockItemId: 'workbench'}}))
-                .toEqual({commitEligible: true, engage: true, retain: false});
+            expect(resolve(zone, {draggedItem: {dockItemId: 'workbench'}})).toEqual({
+                commitEligible: true,
+                engage        : true,
+                retain        : false,
+                sourceRect    : {height: 120, width: 200, x: 20, y: 20}
+            });
             expect(calls[0][1].itemId).toBe('workbench')
         });
 
@@ -746,9 +762,127 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
             resolvePark(true);
             await zone.vesselConversionSensor.transitionPromise;
 
-            expect(resolve(zone)).toEqual({commitEligible: true, engage: true, retain: false});
+            expect(resolve(zone)).toEqual({
+                commitEligible: true,
+                engage        : true,
+                retain        : false,
+                sourceRect
+            });
             expect(zone.vesselConversionSourceRect).toEqual(sourceRect);
             expect(calls.map(([name]) => name)).toEqual(['dockVesselConversionIn'])
+        });
+
+        test('settled initial park re-enters the coordinator without a second external pointer frame', async () => {
+            let resolvePark;
+
+            const
+                admission         = new Promise(resolve => resolvePark = resolve),
+                coordinatorFrames = [],
+                proxyRect         = {},
+                {calls, zone}     = createZone({
+                    convertInAdmission: admission,
+                    dragCoordinator   : {
+                        onDragMove(frame) {
+                            coordinatorFrames.push(frame)
+                        }
+                    }
+                });
+
+            Object.defineProperties(proxyRect, {
+                height: {value: 120},
+                width : {value: 200},
+                x     : {value: 20},
+                y     : {value: 20}
+            });
+            zone.vesselConversionCoordinatorFrame = {
+                draggedItem   : {id: 'graph'},
+                offsetX       : 10,
+                offsetY       : 8,
+                proxyRect,
+                screenX       : 180,
+                screenY       : 140,
+                sourceSortZone: zone
+            };
+
+            expect(resolve(zone)).toEqual({commitEligible: false, engage: false, retain: false});
+
+            const replay = zone.vesselConversionReplayPromise;
+
+            resolvePark(true);
+            await replay;
+
+            expect(calls.map(([name]) => name)).toEqual(['dockVesselConversionIn']);
+            expect(coordinatorFrames).toHaveLength(1);
+            expect(coordinatorFrames[0]).toMatchObject({
+                draggedItem          : {id: 'graph'},
+                proxyRect            : {height: 120, width: 200, x: 20, y: 20},
+                replayAfterTransition: true,
+                screenX              : 180,
+                screenY              : 140,
+                sourceSortZone       : zone
+            })
+        });
+
+        test('refused initial park emits no coordinator replay or automatic retry', async () => {
+            let resolvePark;
+
+            const
+                admission         = new Promise(resolve => resolvePark = resolve),
+                coordinatorFrames = [],
+                {calls, zone}     = createZone({
+                    convertInAdmission              : admission,
+                    dragCoordinator                 : {onDragMove: frame => coordinatorFrames.push(frame)},
+                    vesselConversionCoordinatorFrame: {
+                        draggedItem   : {id: 'graph'},
+                        proxyRect     : sourceRect,
+                        screenX       : 180,
+                        screenY       : 140,
+                        sourceSortZone: null
+                    }
+                });
+
+            expect(resolve(zone)).toEqual({commitEligible: false, engage: false, retain: false});
+
+            const replay = zone.vesselConversionReplayPromise;
+
+            resolvePark(false);
+            await replay;
+
+            expect(calls.map(([name]) => name)).toEqual(['dockVesselConversionIn']);
+            expect(coordinatorFrames).toEqual([]);
+            expect(zone.vesselConversionSensor.converted).toBe(false);
+            expect(zone.vesselConversionReplayPromise).toBeNull()
+        });
+
+        test('gesture reset invalidates a successful late park before coordinator replay', async () => {
+            let resolvePark;
+
+            const
+                admission         = new Promise(resolve => resolvePark = resolve),
+                coordinatorFrames = [],
+                {zone}            = createZone({
+                    convertInAdmission              : admission,
+                    dragCoordinator                 : {onDragMove: frame => coordinatorFrames.push(frame)},
+                    vesselConversionCoordinatorFrame: {
+                        draggedItem   : {id: 'graph'},
+                        proxyRect     : sourceRect,
+                        screenX       : 180,
+                        screenY       : 140,
+                        sourceSortZone: null
+                    }
+                });
+
+            resolve(zone);
+
+            const replay = zone.vesselConversionReplayPromise;
+
+            DockTabSortZone.prototype.resetVesselConversion.call(zone);
+            resolvePark(true);
+            await replay;
+
+            expect(coordinatorFrames).toEqual([]);
+            expect(zone.vesselConversionCoordinatorFrame).toBeNull();
+            expect(zone.vesselConversionSensor.converted).toBe(false)
         });
 
         test('the latest low-overlap frame replays after async park so stale admission cannot convert', async () => {
@@ -783,7 +917,12 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
             const restoration   = new Promise(resolve => resolveRestore = resolve),
                   {calls, zone} = createZone({convertOutAdmission: restoration});
 
-            expect(resolve(zone)).toEqual({commitEligible: true, engage: true, retain: false});
+            expect(resolve(zone)).toEqual({
+                commitEligible: true,
+                engage        : true,
+                retain        : false,
+                sourceRect    : {height: 120, width: 200, x: 20, y: 20}
+            });
             expect(resolve(zone, {pointerInTarget: false, targetId: null, targetRect: null}))
                 .toEqual({commitEligible: false, engage: false, retain: false});
 
@@ -810,7 +949,12 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
                       liveSourceRect     : () => physical
                   });
 
-            expect(resolve(zone)).toEqual({commitEligible: true, engage: true, retain: false});
+            expect(resolve(zone)).toEqual({
+                commitEligible: true,
+                engage        : true,
+                retain        : false,
+                sourceRect    : {height: 120, width: 200, x: 20, y: 20}
+            });
             physical = {x: 0, y: 0, width: 200, height: 120};
 
             expect(resolve(zone, {pointerInTarget: false, targetId: null, targetRect: null}))
@@ -835,9 +979,19 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
 
             expect(resolve(zone)).toMatchObject({commitEligible: true, engage: true});
             expect(resolve(zone, {now: 110, pointerInTarget: false, targetId: null, targetRect: null}))
-                .toEqual({commitEligible: false, engage: true, retain: true});
+                .toEqual({
+                    commitEligible: false,
+                    engage        : true,
+                    retain        : true,
+                    sourceRect    : {height: 120, width: 200, x: 20, y: 20}
+                });
             expect(resolve(zone, {now: 159, pointerInTarget: false, targetId: null, targetRect: null}))
-                .toEqual({commitEligible: false, engage: true, retain: true});
+                .toEqual({
+                    commitEligible: false,
+                    engage        : true,
+                    retain        : true,
+                    sourceRect    : {height: 120, width: 200, x: 20, y: 20}
+                });
 
             expect(calls.map(([name]) => name)).toEqual(['dockVesselConversionIn']);
 

--- a/test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs
@@ -154,7 +154,17 @@ test.describe('Neo.dashboard.DockVesselProxyEmbodiment (#16090)', () => {
                 }),
                 windowId: 'source-window'
             };
-        let resolveFirst;
+        let resolveFirst,
+            sourceUpdateCount = 0,
+            targetUpdateCount = 0;
+
+        const sourcePromiseUpdate = source.promiseUpdate.bind(source);
+
+        source.promiseUpdate = (...args) => {
+            sourceUpdateCount++;
+
+            return sourcePromiseUpdate(...args)
+        };
 
         proxyEmbodiment = createDockVesselProxyEmbodiment({
             createProxy: config => {
@@ -168,9 +178,15 @@ test.describe('Neo.dashboard.DockVesselProxyEmbodiment (#16090)', () => {
                 proxy.width    = config.width;
                 proxy.windowId = config.windowId;
 
-                if (deferFirst && proxies.length === 0) {
-                    proxy.promiseUpdate = () => new Promise(resolve => resolveFirst = resolve)
-                }
+                const proxyPromiseUpdate = proxy.promiseUpdate.bind(proxy);
+
+                proxy.promiseUpdate = (...args) => {
+                    targetUpdateCount++;
+
+                    return deferFirst && proxies.length === 0
+                        ? new Promise(resolve => resolveFirst = resolve)
+                        : proxyPromiseUpdate(...args)
+                };
 
                 const destroy = proxy.destroy.bind(proxy);
 
@@ -201,7 +217,8 @@ test.describe('Neo.dashboard.DockVesselProxyEmbodiment (#16090)', () => {
                 })
             },
             proxies,
-            resolveFirst: () => resolveFirst?.()
+            resolveFirst: () => resolveFirst?.(),
+            updateCounts: () => ({source: sourceUpdateCount, target: targetUpdateCount})
         }
     }
 
@@ -214,6 +231,7 @@ test.describe('Neo.dashboard.DockVesselProxyEmbodiment (#16090)', () => {
 
         await expect.poll(() => proxyEmbodiment.snapshot('live')?.settled).toBe(true);
 
+        expect(fixture.updateCounts()).toEqual({source: 1, target: 1});
         expect(proxyEmbodiment.snapshot('live')).toMatchObject({
             cls           : expect.arrayContaining([
                 'neo-tab-header-toolbar',

--- a/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
+++ b/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
@@ -205,7 +205,7 @@ async function runWorkstationAppThemeProbe() {
 
 /**
  * @summary Runs one native-window authority scenario against the real Main singleton in an isolated process.
- * @param {'cross-origin'|'navigation-failure'|'persisted-pagehide'|'same-origin'} scenario
+ * @param {'cross-origin'|'native-focus-stale'|'native-move-stale'|'native-resize'|'native-resize-default-denied'|'native-resize-denied'|'navigation-failure'|'persisted-pagehide'|'same-origin'} scenario
  * @returns {Promise<Object>}
  */
 async function runNativeWindowRouteProbe(scenario) {
@@ -297,7 +297,7 @@ async function runNativeWindowRouteProbe(scenario) {
                             consumed.push({targetWindowId, token});
 
                             return {
-                                capabilities  : {close: false, focus: true, position: true},
+                                capabilities  : {close: false, focus: true, position: true, resize: true},
                                 nativeHandleKey: 'handle-' + token,
                                 ownerWindowId  : 'owner-window',
                                 targetWindowId
@@ -329,11 +329,31 @@ async function runNativeWindowRouteProbe(scenario) {
             const
                 events   = [],
                 openArgs = [],
-                state    = {closed: false, token: null};
+                state    = {
+                    closed   : false,
+                    height   : 600,
+                    published: 0,
+                    token    : null,
+                    width    : 900,
+                    x        : 1355,
+                    y        : 215
+                };
 
             const popup = {
                 get closed() {
                     return state.closed
+                },
+                get outerHeight() {
+                    return state.height
+                },
+                get outerWidth() {
+                    return state.width
+                },
+                get screenX() {
+                    return state.x
+                },
+                get screenY() {
+                    return state.y
                 },
                 close() {
                     events.push('close');
@@ -342,9 +362,22 @@ async function runNativeWindowRouteProbe(scenario) {
                 focus() {},
                 moveTo() {},
                 innerHeight: 600,
-                outerWidth : 900,
-                resizeTo() {
-                    events.push('resize')
+                Neo: {
+                    main: {
+                        addon: {
+                            WindowPosition: {
+                                publishGeometry() {
+                                    events.push('publish');
+                                    state.published++
+                                }
+                            }
+                        }
+                    }
+                },
+                resizeTo(width, height) {
+                    events.push('resize');
+                    state.height = height;
+                    state.width  = width
                 },
                 sessionStorage: {
                     setItem(key, value) {
@@ -381,7 +414,9 @@ async function runNativeWindowRouteProbe(scenario) {
                 ? 'https://other.example.test/popup'
                 : './popup.html?mode=tear-out';
             const success = Main.windowOpen({
-                nativeCapabilities: {close: true},
+                nativeCapabilities: scenario === 'native-resize-default-denied'
+                    ? {close: true}
+                    : {close: true, resize: scenario !== 'native-resize-denied'},
                 url,
                 useTotalHeight: false,
                 windowFeatures: 'popup,width=900,height=600',
@@ -390,16 +425,86 @@ async function runNativeWindowRouteProbe(scenario) {
             const route = state.token
                 ? Main.consumeNativeWindowRoute({targetWindowId: 'child-window', token: state.token, win: popup})
                 : null;
+            let
+                exactCompletion = null,
+                geometry = null,
+                resize   = null;
+
+            if (scenario === 'native-focus-stale') {
+                popup.document = {hasFocus: () => true};
+                popup.focus    = () => Main.releaseNativeWindowRoute({
+                    nativeHandleKey: route.nativeHandleKey,
+                    targetWindowId : route.targetWindowId,
+                    win            : popup
+                });
+                globalThis.setTimeout = callback => {
+                    callback();
+                    return 1
+                };
+                exactCompletion = await Main.windowNativeFocus(route)
+            } else if (scenario === 'native-move-stale') {
+                popup.moveTo = (x, y) => {
+                    state.x = x;
+                    state.y = y;
+                    Main.releaseNativeWindowRoute({
+                        nativeHandleKey: route.nativeHandleKey,
+                        targetWindowId : route.targetWindowId,
+                        win            : popup
+                    })
+                };
+                exactCompletion = await Main.windowNativeMoveTo({...route, x: 420, y: 320})
+            } else if (
+                scenario === 'native-resize' ||
+                scenario === 'native-resize-default-denied' ||
+                scenario === 'native-resize-denied'
+            ) {
+                resize = {
+                    admitted: await Main.windowNativeResizeTo({
+                        height         : 320,
+                        nativeHandleKey: route?.nativeHandleKey,
+                        targetWindowId : 'child-window',
+                        width          : 420
+                    }),
+                    forged: await Main.windowNativeResizeTo({
+                        height         : 200,
+                        nativeHandleKey: 'forged-handle',
+                        targetWindowId : 'child-window',
+                        width          : 200
+                    }),
+                    invalid: await Main.windowNativeResizeTo({
+                        height         : 0,
+                        nativeHandleKey: route?.nativeHandleKey,
+                        targetWindowId : 'child-window',
+                        width          : 420
+                    })
+                };
+                geometry = {
+                    admitted: Main.windowNativeGetGeometry({
+                        nativeHandleKey: route?.nativeHandleKey,
+                        targetWindowId : 'child-window'
+                    }),
+                    forged: Main.windowNativeGetGeometry({
+                        nativeHandleKey: 'forged-handle',
+                        targetWindowId : 'child-window'
+                    })
+                }
+            }
 
             console.log(JSON.stringify({
                 closed   : state.closed,
                 events,
+                exactCompletion,
+                geometry,
                 hasEntry : Object.hasOwn(Main.openWindows, 'tear-out'),
+                height   : state.height,
                 openArgs,
+                published: state.published,
                 replacedUrl: state.replacedUrl ?? null,
+                resize,
                 route,
                 success,
-                tokenMinted: Boolean(state.token)
+                tokenMinted: Boolean(state.token),
+                width    : state.width
             }))
         }
     `;
@@ -501,10 +606,54 @@ test.describe('Neo.Main native window routes (#15396)', () => {
         expect(result.replacedUrl).toBe('https://owner.example.test/apps/demo/popup.html?mode=tear-out');
         expect(result.hasEntry).toBe(true);
         expect(result.route).toMatchObject({
-            capabilities  : {close: true, focus: true, position: true},
+            capabilities  : {close: true, focus: true, position: true, resize: true},
             ownerWindowId : expect.any(String),
             targetWindowId: 'child-window'
         })
+    });
+
+    test('resize authority verifies exact outer dimensions and publishes the observed target geometry', async () => {
+        const result = await runNativeWindowRouteProbe('native-resize');
+
+        expect(result.resize).toEqual({admitted: true, forged: false, invalid: false});
+        expect(result.geometry).toEqual({
+            admitted: {height: 320, width: 420, x: 1355, y: 215},
+            forged  : null
+        });
+        expect(result.route.capabilities.resize).toBe(true);
+        expect({height: result.height, width: result.width}).toEqual({height: 320, width: 420});
+        expect(result.published).toBe(1);
+        expect(result.events).toEqual(['storage', 'replace', 'resize', 'publish'])
+    });
+
+    test('resize remains unavailable when the owner did not grant it', async () => {
+        const result = await runNativeWindowRouteProbe('native-resize-denied');
+
+        expect(result.route.capabilities.resize).toBe(false);
+        expect(result.resize).toEqual({admitted: false, forged: false, invalid: false});
+        expect({height: result.height, width: result.width}).toEqual({height: 600, width: 900});
+        expect(result.published).toBe(0);
+        expect(result.events).toEqual(['storage', 'replace'])
+    });
+
+    test('resize remains least-authority when the owner omits the capability', async () => {
+        const result = await runNativeWindowRouteProbe('native-resize-default-denied');
+
+        expect(result.route.capabilities.resize).toBe(false);
+        expect(result.resize).toEqual({admitted: false, forged: false, invalid: false});
+        expect({height: result.height, width: result.width}).toEqual({height: 600, width: 900});
+        expect(result.published).toBe(0);
+        expect(result.events).toEqual(['storage', 'replace'])
+    });
+
+    test('focus and move reject a predecessor completion after its exact route is invalidated', async () => {
+        const [focus, move] = await Promise.all([
+            runNativeWindowRouteProbe('native-focus-stale'),
+            runNativeWindowRouteProbe('native-move-stale')
+        ]);
+
+        expect(focus.exactCompletion).toBe(false);
+        expect(move.exactCompletion).toBe(false)
     });
 
     test('same-origin navigation failure retires the grant, registry entry, and popup', async () => {

--- a/test/playwright/unit/main/addon/DragDrop.spec.mjs
+++ b/test/playwright/unit/main/addon/DragDrop.spec.mjs
@@ -545,6 +545,49 @@ test.describe('Neo.main.addon.DragDrop — generation-scoped physical window dra
         expect(addon.windowDragParkedGeometry).toBeNull()
     });
 
+    test('a display-edge clamp rebases the held pointer before physical follow resumes', async () => {
+        const
+            geometry = {
+                park   : {height: 260, width: 360, x: 1040, y: 215},
+                resize : true,
+                restore: {height: 560, width: 760, x: 1155, y: 223}
+            },
+            addon    = {
+                isWindowDragging        : true,
+                offsetX                 : 36,
+                offsetY                 : 24,
+                popupName               : 'tearout-audit',
+                windowDragGeneration    : 131,
+                windowDragParked        : true,
+                windowDragParkedGeometry: geometry
+            },
+            route = {
+                nativeHandleKey: 'native-131',
+                targetWindowId : 'popup-131'
+            };
+
+        Neo.Main.windowNativeGetGeometry = async () => ({
+            height: 560,
+            width : 760,
+            x     : 968,
+            y     : 316
+        });
+        Neo.Main.windowNativeMoveTo   = async () => false;
+        Neo.Main.windowNativeResizeTo = async () => true;
+
+        await expect(DragDrop.prototype.resumeWindowDrag.call(addon, {
+            ...route,
+            windowName: 'tearout-audit',
+            x         : 1195,
+            y         : 316
+        })).resolves.toBe(true);
+
+        expect(addon.offsetX).toBe(263);
+        expect(addon.offsetY).toBe(24);
+        expect(addon.windowDragParked).toBe(false);
+        expect(addon.windowDragParkedGeometry).toBeNull()
+    });
+
     test('re-show move refusal shrinks and returns to cover geometry without resuming follow', async () => {
         let moveCall = 0;
 

--- a/test/playwright/unit/main/addon/DragDrop.spec.mjs
+++ b/test/playwright/unit/main/addon/DragDrop.spec.mjs
@@ -51,13 +51,34 @@ const {default: DomEvents} = await import('../../../../../src/main/DomEvents.mjs
  */
 test.describe('Neo.main.addon.DragDrop — generation-scoped physical window drag', () => {
     let originalMoveTo,
+        originalNativeGetGeometry,
         originalNativeMoveTo,
+        originalNativeResizeTo,
         originalSend;
 
     test.beforeEach(() => {
-        originalMoveTo       = Neo.Main.windowMoveTo;
-        originalNativeMoveTo = Neo.Main.windowNativeMoveTo;
-        originalSend         = DomEvents.sendMessageToApp
+        originalMoveTo            = Neo.Main.windowMoveTo;
+        originalNativeGetGeometry = Neo.Main.windowNativeGetGeometry;
+        originalNativeMoveTo      = Neo.Main.windowNativeMoveTo;
+        originalNativeResizeTo    = Neo.Main.windowNativeResizeTo;
+        originalSend              = DomEvents.sendMessageToApp;
+
+        Neo.Main.windowNativeGetGeometry = async ({nativeHandleKey}) => {
+            if (nativeHandleKey === 'native-11') {
+                return {height: 560, width: 760, x: 1155, y: 215}
+            }
+
+            if (nativeHandleKey === 'native-25-b') {
+                return {height: 300, width: 400, x: 80, y: 100}
+            }
+
+            if (['native-12', 'native-15', 'native-23', 'native-121', 'native-122']
+                .includes(nativeHandleKey)) {
+                return {height: 546, width: 640, x: 40, y: 60}
+            }
+
+            return {height: 300, width: 400, x: 40, y: 60}
+        }
     });
 
     test.afterAll(() => {
@@ -68,9 +89,11 @@ test.describe('Neo.main.addon.DragDrop — generation-scoped physical window dra
     });
 
     test.afterEach(() => {
-        Neo.Main.windowMoveTo       = originalMoveTo;
-        Neo.Main.windowNativeMoveTo = originalNativeMoveTo;
-        DomEvents.sendMessageToApp  = originalSend
+        Neo.Main.windowMoveTo            = originalMoveTo;
+        Neo.Main.windowNativeGetGeometry = originalNativeGetGeometry;
+        Neo.Main.windowNativeMoveTo      = originalNativeMoveTo;
+        Neo.Main.windowNativeResizeTo    = originalNativeResizeTo;
+        DomEvents.sendMessageToApp       = originalSend
     });
 
     test('a parked physical vessel emits logical drag frames but performs zero pointer-follow moves', () => {
@@ -196,6 +219,420 @@ test.describe('Neo.main.addon.DragDrop — generation-scoped physical window dra
         ])
     });
 
+    test('a clamped best-effort pre-position anchors resize before the final exact cover move', async () => {
+        let
+            physicalWidth = 760,
+            physicalX     = 1155;
+
+        const
+            calls = [],
+            addon = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 11,
+                windowDragMovePromises  : new Set(),
+                windowDragParked        : false,
+                windowDragParkedGeometry: null
+            },
+            route = {
+                nativeHandleKey: 'native-11',
+                targetWindowId : 'popup-11'
+            };
+
+        Neo.Main.windowNativeResizeTo = async data => {
+            calls.push(['resize', data]);
+
+            // A resize-first implementation can re-home this boundary-straddling frame. The
+            // best-effort pre-position must have established Chrome's same-display safe anchor.
+            physicalX === 1155 && (physicalX = 1728);
+            physicalWidth = data.width;
+
+            return true
+        };
+        Neo.Main.windowNativeMoveTo = async data => {
+            calls.push(['move', data]);
+
+            // Chrome cannot place the still-wide frame at x=1040 on a 1728px display. It clamps
+            // to x=968 and returns false; once resized, that same exact target becomes reachable.
+            if (physicalWidth === 760 && data.x === 1040) {
+                physicalX = 968;
+                return false
+            }
+
+            if (physicalX === 1728 && data.x === 1040) return false;
+
+            physicalX = data.x;
+
+            return true
+        };
+
+        await expect(DragDrop.prototype.parkWindowDrag.call(addon, {
+            ...route,
+            parkSize   : {height: 300, width: 360},
+            restoreRect: {height: 560, width: 760, x: 1155, y: 215},
+            windowName : 'tearout-graph',
+            x          : 1040,
+            y          : 215
+        })).resolves.toBe(true);
+
+        expect(calls).toEqual([
+            ['move',   {...route, x: 1040, y: 215}],
+            ['resize', {...route, height: 300, width: 360}],
+            ['move',   {...route, x: 1040, y: 215}]
+        ]);
+        expect(physicalX).toBe(1040);
+        expect(addon.windowDragParked).toBe(true);
+        expect(addon.windowDragParkedGeometry).toEqual({
+            park   : {height: 300, width: 360, x: 1040, y: 215},
+            resize : true,
+            restore: {height: 560, width: 760, x: 1155, y: 215}
+        })
+    });
+
+    test('park samples the exact route origin after draining pointer-follow', async () => {
+        let releasePrior;
+
+        const
+            prior = new Promise(resolve => releasePrior = resolve),
+            calls = [],
+            addon = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 111,
+                windowDragMovePromises  : new Set([prior]),
+                windowDragParked        : false,
+                windowDragParkedGeometry: null
+            },
+            route = {
+                nativeHandleKey: 'native-111',
+                targetWindowId : 'popup-111'
+            };
+
+        Neo.Main.windowNativeGetGeometry = async data => {
+            calls.push(['geometry', data]);
+            return {height: 560, width: 760, x: 1728, y: 215}
+        };
+        Neo.Main.windowNativeResizeTo = async data => {
+            calls.push(['resize', data]);
+            return true
+        };
+        Neo.Main.windowNativeMoveTo = async data => {
+            calls.push(['move', data]);
+            return data.x === 1728
+        };
+
+        const parked = DragDrop.prototype.parkWindowDrag.call(addon, {
+            ...route,
+            parkSize   : {height: 300, width: 360},
+            // This Worker snapshot predates the pending physical move and must never win recovery.
+            restoreRect: {height: 560, width: 760, x: 1355, y: 215},
+            windowName : 'tearout-graph',
+            x          : 1240,
+            y          : 215
+        });
+
+        expect(calls).toEqual([]);
+
+        releasePrior(true);
+
+        await expect(parked).resolves.toBe(false);
+        expect(calls).toEqual([
+            ['geometry', route],
+            ['move',   {...route, x: 1240, y: 215}],
+            ['resize', {...route, height: 300, width: 360}],
+            ['move',   {...route, x: 1240, y: 215}],
+            ['resize', {...route, height: 560, width: 760}],
+            ['move',   {...route, x: 1728, y: 215}]
+        ]);
+        expect(addon.windowDragParked).toBe(false);
+        expect(addon.windowDragParkedGeometry).toBeNull();
+        expect(addon.windowDragParkRecovery).toBeNull()
+    });
+
+    test('park resize refusal restores the original full rect before releasing physical follow', async () => {
+        let resizeCall = 0;
+
+        const
+            calls = [],
+            addon = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 12,
+                windowDragMovePromises  : new Set(),
+                windowDragParked        : false,
+                windowDragParkedGeometry: null
+            },
+            route = {
+                nativeHandleKey: 'native-12',
+                targetWindowId : 'popup-12'
+            };
+
+        Neo.Main.windowNativeResizeTo = async data => {
+            calls.push(['resize', data]);
+            return ++resizeCall > 1
+        };
+        Neo.Main.windowNativeMoveTo = async data => {
+            calls.push(['move', data]);
+            return true
+        };
+
+        await expect(DragDrop.prototype.parkWindowDrag.call(addon, {
+            ...route,
+            parkSize   : {height: 260, width: 360},
+            restoreRect: {height: 546, width: 640, x: 40, y: 60},
+            windowName : 'tearout-graph',
+            x          : 800,
+            y          : 120
+        })).resolves.toBe(false);
+
+        expect(calls).toEqual([
+            ['move',   {...route, x: 800, y: 120}],
+            ['resize', {...route, height: 260, width: 360}],
+            ['resize', {...route, height: 546, width: 640}],
+            ['move',   {...route, x: 40, y: 60}]
+        ]);
+        expect(addon.windowDragParked).toBe(false);
+        expect(addon.windowDragParkedGeometry).toBeNull();
+        expect(addon.windowDragParkRecovery).toBeNull()
+    });
+
+    test('double resize-compensation refusal retains a same-generation recovery path', async () => {
+        let resizeCall = 0;
+
+        const
+            calls = [],
+            addon = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 121,
+                windowDragMovePromises  : new Set(),
+                windowDragParked        : false,
+                windowDragParkedGeometry: null,
+                windowDragParkRecovery  : null
+            },
+            data = {
+                nativeHandleKey: 'native-121',
+                parkSize       : {height: 260, width: 360},
+                restoreRect    : {height: 546, width: 640, x: 40, y: 60},
+                targetWindowId : 'popup-121',
+                windowName     : 'tearout-graph',
+                x              : 800,
+                y              : 120
+            };
+
+        Neo.Main.windowNativeResizeTo = async request => {
+            calls.push(['resize', request]);
+            return ++resizeCall > 2
+        };
+        Neo.Main.windowNativeMoveTo = async request => {
+            calls.push(['move', request]);
+            return true
+        };
+
+        await expect(DragDrop.prototype.parkWindowDrag.call(addon, data)).resolves.toBe(false);
+        expect(addon.windowDragParked).toBe(true);
+        expect(addon.windowDragParkRecovery).toMatchObject({
+            generation: 121,
+            restore   : {height: 546, width: 640, x: 40, y: 60}
+        });
+
+        // The next proposal first completes exact recovery and intentionally does not combine
+        // that restoration with a fresh park in the same platform-effect turn.
+        await expect(DragDrop.prototype.parkWindowDrag.call(addon, data)).resolves.toBe(false);
+        expect(addon.windowDragParked).toBe(false);
+        expect(addon.windowDragParkRecovery).toBeNull();
+        expect(calls).toEqual([
+            ['move', {
+                nativeHandleKey: 'native-121', targetWindowId: 'popup-121', x: 800, y: 120
+            }],
+            ['resize', {
+                nativeHandleKey: 'native-121', targetWindowId: 'popup-121', height: 260, width: 360
+            }],
+            ['resize', {
+                nativeHandleKey: 'native-121', targetWindowId: 'popup-121', height: 546, width: 640
+            }],
+            ['resize', {
+                nativeHandleKey: 'native-121', targetWindowId: 'popup-121', height: 546, width: 640
+            }],
+            ['move', {
+                nativeHandleKey: 'native-121', targetWindowId: 'popup-121', x: 40, y: 60
+            }]
+        ])
+    });
+
+    test('failed park move and double compensation stay retryable instead of wedging parked state', async () => {
+        let
+            moveCall   = 0,
+            resizeCall = 0;
+
+        const
+            addon = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 122,
+                windowDragMovePromises  : new Set(),
+                windowDragParked        : false,
+                windowDragParkedGeometry: null,
+                windowDragParkRecovery  : null
+            },
+            data = {
+                nativeHandleKey: 'native-122',
+                parkSize       : {height: 260, width: 360},
+                restoreRect    : {height: 546, width: 640, x: 40, y: 60},
+                targetWindowId : 'popup-122',
+                windowName     : 'tearout-graph',
+                x              : 800,
+                y              : 120
+            };
+
+        Neo.Main.windowNativeResizeTo = async () => ++resizeCall !== 2;
+        Neo.Main.windowNativeMoveTo   = async () => ++moveCall !== 2;
+
+        await expect(DragDrop.prototype.parkWindowDrag.call(addon, data)).resolves.toBe(false);
+        expect(addon.windowDragParked).toBe(true);
+        expect(addon.windowDragParkRecovery).toMatchObject({
+            generation: 122,
+            restore   : {height: 546, width: 640, x: 40, y: 60}
+        });
+
+        await expect(DragDrop.prototype.parkWindowDrag.call(addon, data)).resolves.toBe(false);
+        expect(addon.windowDragParked).toBe(false);
+        expect(addon.windowDragParkedGeometry).toBeNull();
+        expect(addon.windowDragParkRecovery).toBeNull()
+    });
+
+    test('re-show restores exact extent before pointer position and clears park only after both succeed', async () => {
+        const
+            calls    = [],
+            geometry = {
+                park   : {height: 260, width: 360, x: 800, y: 120},
+                resize : true,
+                restore: {height: 546, width: 640, x: 40, y: 60}
+            },
+            addon    = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 13,
+                windowDragParked        : true,
+                windowDragParkedGeometry: geometry
+            },
+            route = {
+                nativeHandleKey: 'native-13',
+                targetWindowId : 'popup-13'
+            };
+
+        Neo.Main.windowNativeResizeTo = async data => {
+            calls.push(['resize', data]);
+            return true
+        };
+        Neo.Main.windowNativeMoveTo = async data => {
+            calls.push(['move', data]);
+            return true
+        };
+
+        await expect(DragDrop.prototype.resumeWindowDrag.call(addon, {
+            ...route,
+            windowName: 'tearout-graph',
+            x         : 420,
+            y         : 240
+        })).resolves.toBe(true);
+
+        expect(calls).toEqual([
+            ['resize', {...route, height: 546, width: 640}],
+            ['move',   {...route, x: 420, y: 240}]
+        ]);
+        expect(addon.windowDragParked).toBe(false);
+        expect(addon.windowDragParkedGeometry).toBeNull()
+    });
+
+    test('re-show move refusal shrinks and returns to cover geometry without resuming follow', async () => {
+        let moveCall = 0;
+
+        const
+            calls    = [],
+            geometry = {
+                park   : {height: 260, width: 360, x: 800, y: 120},
+                resize : true,
+                restore: {height: 546, width: 640, x: 40, y: 60}
+            },
+            addon    = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 14,
+                windowDragParked        : true,
+                windowDragParkedGeometry: geometry
+            },
+            route = {
+                nativeHandleKey: 'native-14',
+                targetWindowId : 'popup-14'
+            };
+
+        Neo.Main.windowNativeResizeTo = async data => {
+            calls.push(['resize', data]);
+            return true
+        };
+        Neo.Main.windowNativeMoveTo = async data => {
+            calls.push(['move', data]);
+            return ++moveCall > 1
+        };
+
+        await expect(DragDrop.prototype.resumeWindowDrag.call(addon, {
+            ...route,
+            windowName: 'tearout-graph',
+            x         : 420,
+            y         : 240
+        })).resolves.toBe(false);
+
+        expect(calls).toEqual([
+            ['resize', {...route, height: 546, width: 640}],
+            ['move',   {...route, x: 420, y: 240}],
+            ['resize', {...route, height: 260, width: 360}],
+            ['move',   {...route, x: 800, y: 120}]
+        ]);
+        expect(addon.windowDragParked).toBe(true);
+        expect(addon.windowDragParkedGeometry).toBe(geometry)
+    });
+
+    test('a reset during the initial drain invalidates park before any native effect', async () => {
+        let resolveResize;
+
+        const
+            resize = new Promise(resolve => resolveResize = resolve),
+            moves  = [],
+            addon  = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 15,
+                windowDragMovePromises  : new Set(),
+                windowDragParked        : false,
+                windowDragParkedGeometry: null
+            };
+
+        Neo.Main.windowNativeResizeTo = () => resize;
+        Neo.Main.windowNativeMoveTo   = data => {
+            moves.push(data);
+            return true
+        };
+
+        const parked = DragDrop.prototype.parkWindowDrag.call(addon, {
+            nativeHandleKey: 'native-15',
+            parkSize       : {height: 260, width: 360},
+            restoreRect    : {height: 546, width: 640, x: 40, y: 60},
+            targetWindowId : 'popup-15',
+            windowName     : 'tearout-graph',
+            x              : 800,
+            y              : 120
+        });
+
+        DragDrop.prototype.resetDragState.call(addon);
+        resolveResize(true);
+
+        await expect(parked).resolves.toBe(false);
+        expect(moves).toEqual([]);
+        expect(addon.windowDragParked).toBe(false);
+        expect(addon.windowDragParkedGeometry).toBeNull()
+    });
+
     test('a reset makes the older native completion inert', async () => {
         let resolveMove;
 
@@ -224,5 +661,579 @@ test.describe('Neo.main.addon.DragDrop — generation-scoped physical window dra
         await expect(parked).resolves.toBe(false);
         expect(addon.isWindowDragging).toBe(false);
         expect(addon.windowDragParked).toBe(false)
+    })
+
+    test('reset and successor start both promote a position-only in-flight route before clearing it', async () => {
+        for (const invalidation of ['reset', 'start']) {
+            let resolveMove;
+
+            const
+                move  = new Promise(resolve => resolveMove = resolve),
+                calls = [],
+                addon = {
+                    isWindowDragging        : true,
+                    popupName               : 'tearout-graph',
+                    windowDragGeneration    : 20,
+                    windowDragMovePromises  : new Set(),
+                    windowDragParked        : false,
+                    windowDragParkedGeometry: null
+                },
+                data  = {
+                    nativeHandleKey: `native-20-${invalidation}`,
+                    restoreRect    : {height: 300, width: 400, x: 40, y: 60},
+                    targetWindowId : `popup-20-${invalidation}`,
+                    windowName     : 'tearout-graph',
+                    x              : 800,
+                    y              : 120
+                };
+
+            Neo.Main.windowNativeResizeTo = async () => {
+                throw new Error('position-only recovery must not resize')
+            };
+            Neo.Main.windowNativeMoveTo = request => {
+                calls.push(request);
+                return calls.length === 1 ? move : Promise.resolve(true)
+            };
+
+            const parked = DragDrop.prototype.parkWindowDrag.call(addon, data);
+
+            await expect.poll(() => calls.length).toBe(1);
+
+            if (invalidation === 'reset') {
+                DragDrop.prototype.resetDragState.call(addon)
+            } else {
+                DragDrop.prototype.startWindowDrag.call(addon, {
+                    popupHeight: 240,
+                    popupName  : 'successor',
+                    popupWidth : 320
+                })
+            }
+
+            resolveMove(true);
+
+            await expect(parked).resolves.toBe(false);
+            expect(calls).toEqual([
+                {
+                    nativeHandleKey: data.nativeHandleKey,
+                    targetWindowId : data.targetWindowId,
+                    x              : 800,
+                    y              : 120
+                },
+                {
+                    nativeHandleKey: data.nativeHandleKey,
+                    targetWindowId : data.targetWindowId,
+                    x              : 40,
+                    y              : 60
+                }
+            ]);
+            expect(addon.windowDragOrphanRecoveries).toBeNull()
+        }
+    });
+
+    test('terminal restore joins a stale position move and advances the one serialized destination', async () => {
+        let resolveMove;
+
+        const
+            move  = new Promise(resolve => resolveMove = resolve),
+            calls = [],
+            addon = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 21,
+                windowDragMovePromises  : new Set(),
+                windowDragParked        : false,
+                windowDragParkedGeometry: null
+            },
+            data  = {
+                nativeHandleKey: 'native-21',
+                restoreRect    : {height: 300, width: 400, x: 40, y: 60},
+                targetWindowId : 'popup-21',
+                windowName     : 'tearout-graph',
+                x              : 800,
+                y              : 120
+            };
+
+        Neo.Main.windowNativeResizeTo = async () => {
+            throw new Error('position-only recovery must not resize')
+        };
+        Neo.Main.windowNativeMoveTo = request => {
+            calls.push(request);
+            return calls.length === 1 ? move : Promise.resolve(true)
+        };
+
+        const parked = DragDrop.prototype.parkWindowDrag.call(addon, data);
+
+        await expect.poll(() => calls.length).toBe(1);
+        DragDrop.prototype.resetDragState.call(addon);
+
+        const terminal = DragDrop.prototype.resumeWindowDrag.call(addon, {
+            nativeHandleKey: data.nativeHandleKey,
+            targetWindowId : data.targetWindowId,
+            windowName     : data.windowName,
+            x              : 420,
+            y              : 240
+        });
+
+        resolveMove(true);
+
+        await expect(parked).resolves.toBe(false);
+        await expect(terminal).resolves.toBe(true);
+        expect(calls).toEqual([
+            {
+                nativeHandleKey: 'native-21',
+                targetWindowId : 'popup-21',
+                x              : 800,
+                y              : 120
+            },
+            {
+                nativeHandleKey: 'native-21',
+                targetWindowId : 'popup-21',
+                x              : 420,
+                y              : 240
+            }
+        ]);
+        expect(addon.windowDragOrphanRecoveries).toBeNull()
+    });
+
+    test('a newer terminal revision arriving during resize suppresses the stale position effect', async () => {
+        let resolveResize;
+
+        const
+            resize       = new Promise(resolve => resolveResize = resolve),
+            resizeCalls  = [],
+            moveCalls    = [],
+            addon        = {},
+            recoveryData = {
+                nativeHandleKey: 'native-22',
+                park           : {height: 260, width: 360, x: 800, y: 120},
+                resize         : true,
+                restore        : {height: 546, width: 640, x: 100, y: 150},
+                targetWindowId : 'popup-22',
+                windowName     : 'tearout-graph'
+            };
+
+        Neo.Main.windowNativeResizeTo = request => {
+            resizeCalls.push(request);
+            return resizeCalls.length === 1 ? resize : Promise.resolve(true)
+        };
+        Neo.Main.windowNativeMoveTo = async request => {
+            moveCalls.push(request);
+            return true
+        };
+
+        DragDrop.prototype.retainWindowDragOrphanRecovery.call(addon, recoveryData);
+
+        const first = DragDrop.prototype.retryWindowDragOrphanRecovery.call(addon, recoveryData);
+
+        await expect.poll(() => resizeCalls.length).toBe(1);
+
+        const latest = DragDrop.prototype.resumeWindowDrag.call(addon, {
+            nativeHandleKey: 'native-22',
+            targetWindowId : 'popup-22',
+            windowName     : 'tearout-graph',
+            x              : 200,
+            y              : 250
+        });
+
+        resolveResize(true);
+
+        await expect(first).resolves.toBe(true);
+        await expect(latest).resolves.toBe(true);
+        expect(resizeCalls).toHaveLength(2);
+        expect(moveCalls).toEqual([{
+            nativeHandleKey: 'native-22',
+            targetWindowId : 'popup-22',
+            x              : 200,
+            y              : 250
+        }]);
+        expect(addon.windowDragOrphanRecoveries).toBeNull()
+    });
+
+    test('reset during park resize retains a refused compensation for terminal retry', async () => {
+        let resolveResize;
+
+        const
+            resize      = new Promise(resolve => resolveResize = resolve),
+            resizeCalls = [],
+            moveCalls   = [],
+            addon       = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 23,
+                windowDragMovePromises  : new Set(),
+                windowDragParked        : false,
+                windowDragParkedGeometry: null
+            },
+            data        = {
+                nativeHandleKey: 'native-23',
+                parkSize       : {height: 260, width: 360},
+                restoreRect    : {height: 546, width: 640, x: 40, y: 60},
+                targetWindowId : 'popup-23',
+                windowName     : 'tearout-graph',
+                x              : 800,
+                y              : 120
+            };
+
+        Neo.Main.windowNativeResizeTo = request => {
+            resizeCalls.push(request);
+
+            if (resizeCalls.length === 1) return resize;
+
+            return Promise.resolve(resizeCalls.length > 2)
+        };
+        Neo.Main.windowNativeMoveTo = async request => {
+            moveCalls.push(request);
+            return true
+        };
+
+        const parked = DragDrop.prototype.parkWindowDrag.call(addon, data);
+
+        await expect.poll(() => resizeCalls.length).toBe(1);
+        DragDrop.prototype.resetDragState.call(addon);
+        resolveResize(true);
+
+        await expect(parked).resolves.toBe(false);
+        expect(resizeCalls).toHaveLength(2);
+        expect(moveCalls).toEqual([{
+            nativeHandleKey: 'native-23',
+            targetWindowId : 'popup-23',
+            x              : 800,
+            y              : 120
+        }]);
+        expect(DragDrop.prototype.hasWindowDragOrphanRecovery.call(addon, data)).toBe(true);
+
+        await expect(DragDrop.prototype.resumeWindowDrag.call(addon, {
+            nativeHandleKey: 'native-23',
+            targetWindowId : 'popup-23',
+            windowName     : 'tearout-graph',
+            x              : 420,
+            y              : 240
+        })).resolves.toBe(true);
+
+        expect(resizeCalls).toHaveLength(3);
+        expect(moveCalls).toEqual([
+            {
+                nativeHandleKey: 'native-23',
+                targetWindowId : 'popup-23',
+                x              : 800,
+                y              : 120
+            },
+            {
+                nativeHandleKey: 'native-23',
+                targetWindowId : 'popup-23',
+                x              : 420,
+                y              : 240
+            }
+        ]);
+        expect(addon.windowDragOrphanRecoveries).toBeNull()
+    });
+
+    test('orphan restore returns to exact cover after its full-size move is refused', async () => {
+        let moveCall = 0;
+
+        const
+            calls        = [],
+            addon        = {},
+            recoveryData = {
+                nativeHandleKey: 'native-241',
+                park           : {height: 260, width: 360, x: 800, y: 120},
+                resize         : true,
+                restore        : {height: 546, width: 640, x: 420, y: 240},
+                targetWindowId : 'popup-241',
+                windowName     : 'tearout-graph'
+            };
+
+        Neo.Main.windowNativeResizeTo = async request => {
+            calls.push(['resize', request]);
+            return true
+        };
+        Neo.Main.windowNativeMoveTo = async request => {
+            calls.push(['move', request]);
+            return ++moveCall > 1
+        };
+
+        DragDrop.prototype.retainWindowDragOrphanRecovery.call(addon, recoveryData);
+
+        await expect(DragDrop.prototype.retryWindowDragOrphanRecovery.call(addon, recoveryData))
+            .resolves.toBe(false);
+        expect(calls).toEqual([
+            ['resize', {
+                height         : 546,
+                nativeHandleKey: 'native-241',
+                targetWindowId : 'popup-241',
+                width          : 640
+            }],
+            ['move', {
+                nativeHandleKey: 'native-241',
+                targetWindowId : 'popup-241',
+                x              : 420,
+                y              : 240
+            }],
+            ['resize', {
+                height         : 260,
+                nativeHandleKey: 'native-241',
+                targetWindowId : 'popup-241',
+                width          : 360
+            }],
+            ['move', {
+                nativeHandleKey: 'native-241',
+                targetWindowId : 'popup-241',
+                x              : 800,
+                y              : 120
+            }]
+        ]);
+        expect(DragDrop.prototype.hasWindowDragOrphanRecovery.call(addon, recoveryData)).toBe(true);
+
+        await expect(DragDrop.prototype.retryWindowDragOrphanRecovery.call(addon, recoveryData))
+            .resolves.toBe(true);
+        expect(calls.slice(-2)).toEqual([
+            ['resize', {
+                height         : 546,
+                nativeHandleKey: 'native-241',
+                targetWindowId : 'popup-241',
+                width          : 640
+            }],
+            ['move', {
+                nativeHandleKey: 'native-241',
+                targetWindowId : 'popup-241',
+                x              : 420,
+                y              : 240
+            }]
+        ]);
+        expect(addon.windowDragOrphanRecoveries).toBeNull()
+    });
+
+    test('orphan acknowledgement waits for pending effects and source-route operations', () => {
+        const
+            addon        = {},
+            sourceRoute  = {operationCount: 1},
+            recoveryData = {
+                nativeHandleKey: 'native-242',
+                pendingEffect  : Promise.resolve(true),
+                resize         : false,
+                restore        : {x: 420, y: 240},
+                sourceRoute,
+                targetWindowId : 'popup-242',
+                windowName     : 'tearout-graph'
+            },
+            recovery = DragDrop.prototype.retainWindowDragOrphanRecovery.call(addon, recoveryData);
+
+        expect(DragDrop.prototype.acknowledgeWindowDragOrphanRecovery.call(addon, recoveryData)).toBe(false);
+
+        recovery.pendingEffect = null;
+        expect(DragDrop.prototype.acknowledgeWindowDragOrphanRecovery.call(addon, recoveryData)).toBe(false);
+
+        sourceRoute.operationCount = 0;
+        expect(DragDrop.prototype.acknowledgeWindowDragOrphanRecovery.call(addon, recoveryData)).toBe(true);
+        expect(addon.windowDragOrphanRecoveries).toBeNull()
+    });
+
+    test('reset during cover compensation prevents its stale move from racing exact recovery', async () => {
+        let resolveCoverResize;
+
+        const
+            coverResize = new Promise(resolve => resolveCoverResize = resolve),
+            calls       = [],
+            geometry    = {
+                park   : {height: 260, width: 360, x: 800, y: 120},
+                resize : true,
+                restore: {height: 546, width: 640, x: 40, y: 60}
+            },
+            route       = {
+                generation     : 24,
+                key            : JSON.stringify(['native-24', 'popup-24', 'tearout-graph']),
+                nativeHandleKey: 'native-24',
+                operationCount : 0,
+                pendingEffect  : null,
+                resize         : true,
+                restore        : {...geometry.restore},
+                retired        : false,
+                revision       : 1,
+                targetWindowId : 'popup-24',
+                windowName     : 'tearout-graph'
+            },
+            addon       = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 24,
+                windowDragParked        : true,
+                windowDragParkedGeometry: geometry,
+                windowDragParkRoute     : route,
+                windowDragParkRecovery  : null
+            };
+
+        let resizeCall = 0,
+            moveCall   = 0;
+
+        Neo.Main.windowNativeResizeTo = request => {
+            calls.push(['resize', request]);
+            return ++resizeCall === 2 ? coverResize : Promise.resolve(true)
+        };
+        Neo.Main.windowNativeMoveTo = async request => {
+            calls.push(['move', request]);
+            return ++moveCall > 1
+        };
+
+        const resumed = DragDrop.prototype.resumeWindowDrag.call(addon, {
+            nativeHandleKey: 'native-24',
+            targetWindowId : 'popup-24',
+            windowName     : 'tearout-graph',
+            x              : 420,
+            y              : 240
+        });
+
+        await expect.poll(() => resizeCall).toBe(2);
+        DragDrop.prototype.resetDragState.call(addon);
+        resolveCoverResize(true);
+
+        await expect(resumed).resolves.toBe(false);
+        expect(calls.filter(([type, request]) => (
+            type === 'move' && request.x === 800 && request.y === 120
+        ))).toEqual([]);
+        expect(calls.at(-1)).toEqual(['move', {
+            nativeHandleKey: 'native-24',
+            targetWindowId : 'popup-24',
+            x              : 420,
+            y              : 240
+        }]);
+        expect(addon.windowDragOrphanRecoveries).toBeNull()
+    });
+
+    test('an orphan on route A never blocks a same-name park through opaque route B', async () => {
+        const
+            calls = [],
+            addon = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 25,
+                windowDragMovePromises  : new Set(),
+                windowDragParked        : false,
+                windowDragParkedGeometry: null
+            };
+
+        DragDrop.prototype.retainWindowDragOrphanRecovery.call(addon, {
+            nativeHandleKey: 'native-25-a',
+            resize         : false,
+            restore        : {x: 40, y: 60},
+            targetWindowId : 'popup-25-a',
+            windowName     : 'tearout-graph'
+        });
+
+        Neo.Main.windowNativeMoveTo = async request => {
+            calls.push(request);
+            return true
+        };
+
+        await expect(DragDrop.prototype.parkWindowDrag.call(addon, {
+            nativeHandleKey: 'native-25-b',
+            restoreRect    : {height: 300, width: 400, x: 80, y: 100},
+            targetWindowId : 'popup-25-b',
+            windowName     : 'tearout-graph',
+            x              : 900,
+            y              : 160
+        })).resolves.toBe(true);
+
+        expect(calls).toEqual([{
+            nativeHandleKey: 'native-25-b',
+            targetWindowId : 'popup-25-b',
+            x              : 900,
+            y              : 160
+        }]);
+        expect(DragDrop.prototype.hasWindowDragOrphanRecovery.call(addon, {
+            nativeHandleKey: 'native-25-a',
+            targetWindowId : 'popup-25-a',
+            windowName     : 'tearout-graph'
+        })).toBe(true)
+    });
+
+    test('active resume refuses a same-name request for a different opaque native route', async () => {
+        const
+            calls = [],
+            addon = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 251,
+                windowDragMovePromises  : new Set(),
+                windowDragParked        : false,
+                windowDragParkedGeometry: null
+            };
+
+        Neo.Main.windowNativeMoveTo = async request => {
+            calls.push(request);
+            return true
+        };
+
+        await expect(DragDrop.prototype.parkWindowDrag.call(addon, {
+            nativeHandleKey: 'native-251-a',
+            restoreRect    : {height: 300, width: 400, x: 40, y: 60},
+            targetWindowId : 'popup-251-a',
+            windowName     : 'tearout-graph',
+            x              : 800,
+            y              : 120
+        })).resolves.toBe(true);
+
+        await expect(DragDrop.prototype.resumeWindowDrag.call(addon, {
+            nativeHandleKey: 'native-251-b',
+            targetWindowId : 'popup-251-b',
+            windowName     : 'tearout-graph',
+            x              : 420,
+            y              : 240
+        })).resolves.toBe(false);
+
+        expect(calls).toEqual([{
+            nativeHandleKey: 'native-251-a',
+            targetWindowId : 'popup-251-a',
+            x              : 800,
+            y              : 120
+        }]);
+        expect(addon.windowDragParked).toBe(true);
+        expect(addon.windowDragParkRoute).toMatchObject({
+            nativeHandleKey: 'native-251-a',
+            targetWindowId : 'popup-251-a'
+        })
+    });
+
+    test('strict close tombstones an in-flight route until its stale continuation drains', async () => {
+        let resolveMove;
+
+        const
+            move  = new Promise(resolve => resolveMove = resolve),
+            calls = [],
+            addon = {
+                isWindowDragging        : true,
+                popupName               : 'tearout-graph',
+                windowDragGeneration    : 26,
+                windowDragMovePromises  : new Set(),
+                windowDragParked        : false,
+                windowDragParkedGeometry: null
+            },
+            data  = {
+                nativeHandleKey: 'native-26',
+                restoreRect    : {height: 300, width: 400, x: 40, y: 60},
+                targetWindowId : 'popup-26',
+                windowName     : 'tearout-graph',
+                x              : 800,
+                y              : 120
+            };
+
+        Neo.Main.windowNativeMoveTo = request => {
+            calls.push(request);
+            return calls.length === 1 ? move : Promise.resolve(true)
+        };
+
+        const parked = DragDrop.prototype.parkWindowDrag.call(addon, data);
+
+        await expect.poll(() => calls.length).toBe(1);
+        DragDrop.prototype.resetDragState.call(addon);
+
+        expect(DragDrop.prototype.retireWindowDragOrphanRecovery.call(addon, data)).toBe(true);
+        expect(DragDrop.prototype.hasWindowDragOrphanRecovery.call(addon, data)).toBe(true);
+
+        resolveMove(true);
+
+        await expect(parked).resolves.toBe(false);
+        expect(calls).toHaveLength(1);
+        expect(DragDrop.prototype.hasWindowDragOrphanRecovery.call(addon, data)).toBe(false);
+        expect(addon.windowDragOrphanRecoveries).toBeNull()
     })
 });

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -560,8 +560,9 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
      * @param {Object} source
      * @param {Number} screenX
      * @param {Number} screenY
+     * @param {Object} [overrides={}]
      */
-    function move(source, screenX, screenY) {
+    function move(source, screenX, screenY, overrides={}) {
         DragCoordinator.onDragMove({
             draggedItem   : {id: 'tab-1', reference: 'tab-1'},
             offsetX       : 10,
@@ -569,7 +570,8 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
             proxyRect     : {width: 100, height: 60},
             screenX,
             screenY,
-            sourceSortZone: source
+            sourceSortZone: source,
+            ...overrides
         })
     }
 
@@ -817,7 +819,12 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         source.isWindowDragging = true;
         source.resolveRemoteDragTransition = frame => {
             frames.push(frame);
-            return {commitEligible: true, engage: true, retain: false}
+            return {
+                commitEligible: true,
+                engage        : true,
+                retain        : false,
+                sourceRect    : {height: 520, width: 740, x: frame.logicalSourceRect.x, y: frame.logicalSourceRect.y}
+            }
         };
 
         registerWindow('win-source', 2000, 0, 400, 400);
@@ -840,6 +847,7 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         expect(calls.filter(([name]) => name === 'move')).toHaveLength(1);
         expect(movePayloads[0]).toMatchObject({
             embodyProxy   : true,
+            proxyRect     : {height: 520, width: 740, x: 90, y: 70},
             sourceSortZone: source
         });
         expect(DragCoordinator.activeSourceZone).toBe(source);
@@ -847,9 +855,12 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         expect(DragCoordinator.activeTransitionOwned).toBe(true);
 
         WindowManager.get('win-a').innerRect = new Rectangle(110, 130, 360, 260);
-        move(source, 210, 210);
+        move(source, 210, 210, {replayAfterTransition: true});
 
-        expect(frames[1].targetRect).toEqual({x: 110, y: 130, width: 360, height: 260})
+        expect(frames[1]).toMatchObject({
+            replayAfterTransition: true,
+            targetRect           : {x: 110, y: 130, width: 360, height: 260}
+        })
     });
 
     test('async, throwing, and malformed transition decisions fail closed before preview', () => {

--- a/test/playwright/unit/manager/Window.spec.mjs
+++ b/test/playwright/unit/manager/Window.spec.mjs
@@ -54,7 +54,8 @@ test.describe.serial('Neo.manager.Window connection ordering (#15396)', () => {
             capabilities: {
                 close   : true,
                 focus   : true,
-                position: true
+                position: true,
+                resize  : true
             },
             nativeHandleKey: `handle-${windowId}`,
             ownerWindowId  : 'source-window',
@@ -73,7 +74,7 @@ test.describe.serial('Neo.manager.Window connection ordering (#15396)', () => {
         const provisional = WindowManager.get(windowId);
 
         expect(provisional.nativeRoute).toBeNull();
-        expect(provisional.capabilities).toEqual({close: false, focus: false, position: false});
+        expect(provisional.capabilities).toEqual({close: false, focus: false, position: false, resize: false});
 
         WindowManager.onWindowConnect({
             appName   : 'DockDemo',
@@ -137,6 +138,6 @@ test.describe.serial('Neo.manager.Window connection ordering (#15396)', () => {
 
         expect(WindowManager.items).toHaveLength(1);
         expect(reconnected.nativeRoute).toBeNull();
-        expect(reconnected.capabilities).toEqual({close: false, focus: false, position: false})
+        expect(reconnected.capabilities).toEqual({close: false, focus: false, position: false, resize: false})
     })
 });


### PR DESCRIPTION
Resolves #16117

Human popup-over-popup dragging now materializes early as one target-local proxy while the
physical source vessel is parked, leaving the target pane, five drop choices, and exact preview
geometry readable during partial overlap. Convert-out restores the identical native popup at its
live outer size and resumes pointer-follow immediately, including when macOS clamps the requested
restore origin at a display edge.

Evidence: L3 (actual-pointer headed macOS Chrome across four live size relationships, plus the
identical gesture under pixel-bearing compositing) → L3 required (early conversion, concurrent
proxy/target choices, exact restoration, and continued motion). No product-behavior residuals.
The shared launch-default friction is tracked separately by `#16128`.

Related: #16128

## Deltas from ticket

- Composes the exact target-window geometry owner merged through PR `#16134`; indicator candidates
  and preview paint use the same live geometry/renderer generation.
- Composes the paired worker/main re-entry ownership close merged through PR `#16133`.
- Accepts a platform-clamped restore origin only when the route, preserved outer extent, and held
  pointer all match; it then rebases the pointer offset to the observed native origin.
- Amends ADR 0029 because the repair adds a concrete early materialization/parking transition and
  stale-generation recovery contract.
- The ordinary engine profile was semantically green but is known to present empty physical
  windows on this host. The same assertions and pointer choreography passed under pixel-bearing
  compositing. Ticket `#16128` now owns making that presenting profile the default.

## Test Evidence

- `small-over-large`: headed actual-pointer Chrome — 2/2 passed on fresh process. One prior
  fresh-process attempt failed before the product transition because the second drag sensor did
  not arm; the immediate identical rerun passed.
- `large-over-small`: headed actual-pointer Chrome — 2/2 passed.
- `near-equal`: headed actual-pointer Chrome — 2/2 passed.
- `post-resize-asymmetric`: headed actual-pointer Chrome — 2/2 passed; exact popup restoration and
  inward pointer-follow passed at the display edge.
- Pixel-bearing `large-over-small`: identical headed gesture/assertions — 2/2 passed, with real
  Workstation content visible in the main window and both popup vessels.
- Touched unit matrix: 138/138 passed across Workspace, DockTabSortZone,
  DockVesselEmbodiment, Main native routing, main DragDrop, DragCoordinator, manager.Window, and
  ClientWindowRegistration. The final head differs only by the retained E2E witness choosing an
  inward follow delta at display bounds and a test-local binding rename.
- Source syntax, staged hooks, block alignment, and `git diff --check`: passed.

## Post-Merge Validation

- [ ] Human operator repeats the partial-overlap gesture on merged `dev` with the presenting E2E
      default from `#16128`.

## Commits

- `dd49b92ef7` — materialize the early target-local proxy and preserve exact restoration.
- `bacef9d1ff` — resume pointer-follow from a platform-clamped native origin.

## Evolution

The first proof shape established worker/DOM truth but exposed a launcher that deliberately
suppresses physical compositor frames. Rather than weaken the product witness or retain another
remember-this-flag instruction, `#16128` now inverts that shared default. The docking patch remains
independent of the launcher repair.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fac4d-7844-7422-9486-7f73ccf308f5.
