### PR TITLE
fix(test): make headed E2E presenting by default (#16128)

### DIFF
--- a/ai/examples/harnessEndurance/README.md
+++ b/ai/examples/harnessEndurance/README.md
@@ -35,10 +35,12 @@ What remains true, and is the honest claim: Neo's value at scale is **correct-by
 ## Reproduce
 
 ```
-npm run test-e2e -- test/playwright/e2e/benchmarks/HarnessEnduranceBenchmark.spec.mjs
+NEO_E2E_ENGINE_PROFILE=1 npm run test-e2e -- test/playwright/e2e/benchmarks/HarnessEnduranceBenchmark.spec.mjs
 ```
 
 The `worker-topology at marathon scale` test logs `[endurance:marathon]` with the numbers above; the small-scale tests log `[endurance:neo|comparator|delta]`.
+The explicit engine profile preserves the uncapped scheduling used for the published benchmark;
+ordinary headed UI runs deliberately default to the presenting profile instead.
 
 ## Public-surface guardrail
 

--- a/test/playwright/e2e/utils/gpuIntent.mjs
+++ b/test/playwright/e2e/utils/gpuIntent.mjs
@@ -43,9 +43,10 @@ export const GPU_INTENT_ARGS = [
 ];
 
 /**
- * @summary Everything else the E2E browser launches with — isolation, memory, throttling, sandbox.
- * (The poison-flag prohibition is module-wide — see the file header — because it is not specific to
- * this list.)
+ * @summary Shared browser isolation, memory, throttling, and sandbox arguments.
+ *
+ * The explicit engine profile uses this list unchanged. The presenting profile removes the
+ * frame-rate override which suppresses compositor frames on headed Retina hosts.
  * @type {String[]}
  */
 export const BASE_LAUNCH_ARGS = [
@@ -63,26 +64,30 @@ export const BASE_LAUNCH_ARGS = [
 ];
 
 /**
- * @summary The full argument list handed to Chrome.
+ * @summary The explicit engine/benchmark launch profile.
+ *
+ * This profile retains the GPU-intent flags and uncapped frame scheduling used by engine and
+ * benchmark investigations. It is deliberately not the default for headed UI work because
+ * `--disable-frame-rate-limit` can leave the application semantically live behind empty windows.
  * @type {String[]}
  */
-export const E2E_LAUNCH_ARGS = [...GPU_INTENT_ARGS, ...BASE_LAUNCH_ARGS];
+export const ENGINE_LAUNCH_ARGS = [...GPU_INTENT_ARGS, ...BASE_LAUNCH_ARGS];
 
 /**
- * @summary The film-take launch profile: capture needs frames ON GLASS.
+ * @summary The default presenting launch profile: headed work needs frames on glass.
  *
  * `--disable-frame-rate-limit` suppresses headed compositing entirely on retina hosts —
  * `page.screenshot` starves for the full test timeout and every screen-capture grain records
- * black while worker-truth stays green — so a filmable run must drop it. The GPU-intent flags
- * are benchmark claims a film take does not make. The backgrounding-disable trio STAYS: a
- * newborn tear-out vessel is an occluded window whose renderer must keep running long enough
- * to join the shared heap, or vessels are never born.
+ * black while worker-truth stays green — so the ordinary headed profile drops it. GPU-intent
+ * flags are benchmark claims a presenting run does not make. The backgrounding-disable trio
+ * STAYS: a newborn tear-out vessel is an occluded window whose renderer must keep running long
+ * enough to join the shared heap, or vessels are never born.
  * @type {String[]}
  */
-export const FILM_LAUNCH_ARGS = BASE_LAUNCH_ARGS.filter(arg => arg !== '--disable-frame-rate-limit');
+export const PRESENTING_LAUNCH_ARGS = BASE_LAUNCH_ARGS.filter(arg => arg !== '--disable-frame-rate-limit');
 
 /**
- * @summary Whether the exact public sentinel selects the native film-take profile.
+ * @summary Whether the exact public sentinel selects film pacing and recording behavior.
  * @returns {Boolean}
  */
 export function isFilmTake() {
@@ -90,22 +95,42 @@ export function isFilmTake() {
 }
 
 /**
- * @summary The launch list the CURRENT run mode actually uses.
+ * @summary Whether the exact public sentinel selects the non-presenting engine profile.
+ * @returns {Boolean}
+ */
+export function isEngineProfile() {
+    return process.env.NEO_E2E_ENGINE_PROFILE === '1'
+}
+
+/**
+ * @summary The launch list the current run mode actually uses.
  *
  * Single selection point for config projects AND the boot probe: the probe must demand GL
  * proportional to the args the suite really launches with — reading intent from one list while
- * launching another is the drift class this module exists to prevent.
+ * launching another is the drift class this module exists to prevent. Film capture remains a
+ * spec-level pacing/recording mode; it no longer selects whether headed windows present pixels.
+ *
+ * Film capture and the engine profile are mutually exclusive. Allowing both would start video
+ * capture under the one profile already known not to present compositor frames, turning a clear
+ * configuration error into a late screenshot timeout or black recording.
  * @returns {String[]}
  */
 export function activeLaunchArgs() {
-    return isFilmTake() ? FILM_LAUNCH_ARGS : E2E_LAUNCH_ARGS
+    if (isFilmTake() && isEngineProfile()) {
+        throw new Error(
+            'NEO_FILM_TAKE=1 cannot be combined with NEO_E2E_ENGINE_PROFILE=1: ' +
+            'film capture requires the presenting browser profile.'
+        )
+    }
+
+    return isEngineProfile() ? ENGINE_LAUNCH_ARGS : PRESENTING_LAUNCH_ARGS
 }
 
 /**
  * @summary Whether a given argument list claims hardware acceleration.
- * @param {String[]} [args=E2E_LAUNCH_ARGS]
+ * @param {String[]} [args=PRESENTING_LAUNCH_ARGS]
  * @returns {Boolean}
  */
-export function claimsGpuAcceleration(args = E2E_LAUNCH_ARGS) {
+export function claimsGpuAcceleration(args = PRESENTING_LAUNCH_ARGS) {
     return args.some(arg => GPU_INTENT_ARGS.includes(arg))
 }

--- a/test/playwright/e2e/workstation/WorkstationDockPreviewSymmetryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockPreviewSymmetryNL.spec.mjs
@@ -1,5 +1,5 @@
-import {test, expect} from '../../fixtures.mjs';
-import {isFilmTake}   from '../utils/gpuIntent.mjs';
+import {test, expect}    from '../../fixtures.mjs';
+import {isEngineProfile} from '../utils/gpuIntent.mjs';
 
 const
     EDGES  = ['top', 'right', 'bottom', 'left'],
@@ -330,11 +330,10 @@ test.describe('Workstation dock-preview four-axis symmetry (Neural Link)', () =>
      * @param {Object} frame
      */
     async function attachFrame(page, testInfo, frame) {
-        // The standard GPU-intent profile deliberately carries `--disable-frame-rate-limit`,
-        // which can starve headed Retina screenshots while DOM/worker truth keeps advancing.
-        // Pixel retention belongs to the repository's canonical film profile; the standard run
-        // still emits the complete JSON geometry matrix below.
-        if (!isFilmTake()) return;
+        // The explicit engine profile carries `--disable-frame-rate-limit`, which can starve
+        // headed Retina screenshots while DOM/worker truth keeps advancing. The presenting
+        // default retains the pixel artifact; engine runs still emit the JSON geometry matrix.
+        if (isEngineProfile()) return;
 
         const
             viewport = page.viewportSize() ?? await page.evaluate(() => ({

--- a/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
@@ -1,8 +1,8 @@
 import {test, expect}                                                                       from '../../fixtures.mjs';
 import {assertAffordanceContainment, assertBootContainmentChain, assertChipHeaderExclusion} from '../utils/dockGeometry.mjs';
-import {isFilmTake}                                                                         from '../utils/gpuIntent.mjs';
+import {isEngineProfile}                                                                    from '../utils/gpuIntent.mjs';
 
-const filmTake = isFilmTake();
+const presentingBrowser = !isEngineProfile();
 
 /**
  * Whitebox-e2e: the FLAGSHIP's drag-affordance journey — the durable real-pointer proof
@@ -443,10 +443,10 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
                 await page.waitForTimeout(160);
                 samples.push({pointer, proxy: (await readDockProxyTreatment(page)).rect});
 
-                if (filmTake) {
+                if (presentingBrowser) {
                     const frame = await page.screenshot();
 
-                    expect(frame.length, 'the film profile retains a non-empty post-conversion frame')
+                    expect(frame.length, 'the presenting profile retains a non-empty post-conversion frame')
                         .toBeGreaterThan(10000);
                     await testInfo.attach(`post-entry-motion-frame-${samples.length}.png`, {
                         body       : frame,

--- a/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs
@@ -1,8 +1,8 @@
 import {test, expect}                                                                       from '../../fixtures.mjs';
 import {assertAffordanceContainment, assertBootContainmentChain, assertChipHeaderExclusion} from '../utils/dockGeometry.mjs';
-import {isEngineProfile}                                                                    from '../utils/gpuIntent.mjs';
+import {isFilmTake}                                                                         from '../utils/gpuIntent.mjs';
 
-const presentingBrowser = !isEngineProfile();
+const filmTake = isFilmTake();
 
 /**
  * Whitebox-e2e: the FLAGSHIP's drag-affordance journey — the durable real-pointer proof
@@ -443,10 +443,10 @@ test.describe('Workstation drag affordances — the flagship journey (Neural Lin
                 await page.waitForTimeout(160);
                 samples.push({pointer, proxy: (await readDockProxyTreatment(page)).rect});
 
-                if (presentingBrowser) {
+                if (filmTake) {
                     const frame = await page.screenshot();
 
-                    expect(frame.length, 'the presenting profile retains a non-empty post-conversion frame')
+                    expect(frame.length, 'the film profile retains a non-empty post-conversion frame')
                         .toBeGreaterThan(10000);
                     await testInfo.attach(`post-entry-motion-frame-${samples.length}.png`, {
                         body       : frame,

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -1,6 +1,6 @@
 import {test, expect}          from '../../fixtures.mjs';
 import {workstationTourScript} from '../../../../apps/workstation/tour/denseWorkstation.mjs';
-import {isFilmTake}            from '../utils/gpuIntent.mjs';
+import {isEngineProfile}       from '../utils/gpuIntent.mjs';
 
 /**
  * @summary Mounted L3 proof for Workstation's dense, living-data workstation.
@@ -9,7 +9,7 @@ import {isFilmTake}            from '../utils/gpuIntent.mjs';
  * and owns what only the App Worker + DOM + Canvas Worker composition can prove: one Provider,
  * two stable Store<Model> identities, an exact 100k renderer-rich grid, a sustained capped
  * feed, one owner-exact overflow surface, two real rails, frame-sampled midpoint continuity,
- * Canvas-worker value change (plus pixel change under the film profile), DevIndex-sized chart
+ * Canvas-worker value change (plus pixel change under the presenting profile), DevIndex-sized chart
  * geometry, honest progress paints, both themes, host-relative edge bands, visible real splitters,
  * user-driven semantic resize, pane-owned chrome, replacement-chrome motion containment,
  * sequential clip-safe fixed staging, and identity preservation.
@@ -37,11 +37,11 @@ const initialTabNodeIds = [
     'right-top-tabs', 'right-bottom-tabs', 'bottom-tabs'
 ];
 
-const asArray  = value => Array.isArray(value) ? value : value ? [value] : [],
-      filmTake = isFilmTake();
+const asArray           = value => Array.isArray(value) ? value : value ? [value] : [],
+      presentingBrowser = !isEngineProfile();
 
 /**
- * @summary Captures the exact Canvas pixels when the film profile presents frames on glass.
+ * @summary Captures the exact Canvas pixels when the browser profile presents frames on glass.
  *
  * @param {import('@playwright/test').Locator} canvas
  * @returns {Promise<String>} Base64-encoded PNG for the current Canvas pixels.
@@ -1237,18 +1237,18 @@ test.describe('Workstation — dense living-data composition', () => {
 
         await page.waitForTimeout(150);
 
-        // The benchmark profile deliberately includes --disable-frame-rate-limit: its worker truth
-        // stays live, but the capture-profile contract exposes no presented frame to screenshots.
-        // Film mode drops that flag and therefore adds the independent on-glass pixel receipt.
+        // The explicit engine profile retains --disable-frame-rate-limit: its worker truth stays
+        // live, but it exposes no presented frame to screenshots on affected headed Retina hosts.
+        // The default presenting profile therefore owns the independent on-glass pixel receipt.
         const targetCanvas = page.locator(`[id="${pulseTarget.id}"]`),
-              beforePixels = filmTake ? await readCanvasPixels(targetCanvas) : null,
+              beforePixels = presentingBrowser ? await readCanvasPixels(targetCanvas) : null,
               beforeValues = pulseTarget.properties.values,
               pulseReceipt = await app.callMethod(workspaceId, 'pulseScaleSparkline', [pulseTarget.id]);
 
         expect(pulseReceipt.componentId).toBe(pulseTarget.id);
         expect(pulseReceipt.recordId).toBeTruthy();
 
-        if (filmTake) {
+        if (presentingBrowser) {
             await expect.poll(() => readCanvasPixels(targetCanvas), {
                 message  : 'the exact scale Canvas changes after its worker receives new data',
                 timeout  : 10000,

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -56,7 +56,7 @@ export default defineConfig({
             // Declared once in e2e/utils/gpuIntent.mjs so the boot probe reads the same list this
             // launches with. A second copy here would drift, and drift between two statements of one
             // fact is how a dead GL flag stayed invisible for five months. The mode selection
-            // (film vs benchmark) lives in the same module for the same reason.
+            // (presenting default vs explicit engine profile) lives there for the same reason.
             launchOptions: {args: activeLaunchArgs()}
         }
     }]

--- a/test/playwright/playwright.config.matrix.mjs
+++ b/test/playwright/playwright.config.matrix.mjs
@@ -17,10 +17,10 @@ process.env.NEO_E2E_PORT = String(PORT);
  * The tear-out portability-matrix runner (see
  * `learn/guides/specificfeatures/TearOutPortabilityMatrix.md` — the evidence ledger).
  *
- * Deliberately SEPARATE from `playwright.config.e2e.mjs`: the e2e config carries benchmark
+ * Deliberately SEPARATE from `playwright.config.e2e.mjs`: that config can opt into engine
  * launch flags (GPU rasterization overrides) calibrated for throughput benchmarks, and any
- * GL/GPU override would distort exactly the native placement semantics this suite measures —
- * the matrix contract requires headed real-browser runs on platform defaults.
+ * GL/GPU override would distort exactly the native placement semantics this suite measures.
+ * The matrix contract requires headed real-browser runs on platform defaults.
  *
  * Measurement-fidelity choices, stated honestly:
  * - **Headed by default** (`headless: false`): headed IS this runner's identity — headless proves

--- a/test/playwright/unit/e2e/glState.spec.mjs
+++ b/test/playwright/unit/e2e/glState.spec.mjs
@@ -2,10 +2,11 @@ import {expect, test}                           from '@playwright/test';
 import {
     activeLaunchArgs,
     claimsGpuAcceleration,
-    E2E_LAUNCH_ARGS,
-    FILM_LAUNCH_ARGS,
+    ENGINE_LAUNCH_ARGS,
     GPU_INTENT_ARGS,
-    isFilmTake
+    isEngineProfile,
+    isFilmTake,
+    PRESENTING_LAUNCH_ARGS
 }                                                from '../../e2e/utils/gpuIntent.mjs';
 import {readGlState, SOFTWARE_RENDERER_MARKERS}   from '../../e2e/utils/glState.mjs';
 
@@ -112,32 +113,61 @@ test.describe('e2e/utils/glState', () => {
 
         // Tuning flags do not by themselves claim acceleration and must not arm the demand.
         expect(claimsGpuAcceleration(['--disable-frame-rate-limit', '--force-gpu-mem-available-mb=4096'])).toBe(false);
+        expect(claimsGpuAcceleration()).toBe(false)
     });
 
-    test('#16046 only the exact film sentinel selects the capture launch profile', () => {
-        const previous = process.env.NEO_FILM_TAKE;
+    test('#16128 presenting is default; only the exact engine sentinel selects the engine profile', () => {
+        const
+            previousEngine = process.env.NEO_E2E_ENGINE_PROFILE,
+            previousFilm   = process.env.NEO_FILM_TAKE;
 
         try {
+            delete process.env.NEO_E2E_ENGINE_PROFILE;
             delete process.env.NEO_FILM_TAKE;
-            expect(isFilmTake()).toBe(false);
-            expect(activeLaunchArgs()).toBe(E2E_LAUNCH_ARGS);
 
-            process.env.NEO_FILM_TAKE = '0';
+            expect(isEngineProfile()).toBe(false);
             expect(isFilmTake()).toBe(false);
-            expect(activeLaunchArgs()).toBe(E2E_LAUNCH_ARGS);
+            expect(activeLaunchArgs()).toBe(PRESENTING_LAUNCH_ARGS);
 
-            process.env.NEO_FILM_TAKE = 'true';
-            expect(isFilmTake()).toBe(false);
-            expect(activeLaunchArgs()).toBe(E2E_LAUNCH_ARGS);
+            process.env.NEO_E2E_ENGINE_PROFILE = '0';
+            expect(isEngineProfile()).toBe(false);
+            expect(activeLaunchArgs()).toBe(PRESENTING_LAUNCH_ARGS);
 
+            process.env.NEO_E2E_ENGINE_PROFILE = 'false';
+            expect(isEngineProfile()).toBe(false);
+            expect(activeLaunchArgs()).toBe(PRESENTING_LAUNCH_ARGS);
+
+            process.env.NEO_E2E_ENGINE_PROFILE = 'engine';
+            expect(isEngineProfile()).toBe(false);
+            expect(activeLaunchArgs()).toBe(PRESENTING_LAUNCH_ARGS);
+
+            delete process.env.NEO_E2E_ENGINE_PROFILE;
             process.env.NEO_FILM_TAKE = '1';
             expect(isFilmTake()).toBe(true);
-            expect(activeLaunchArgs()).toBe(FILM_LAUNCH_ARGS)
+            expect(activeLaunchArgs()).toBe(PRESENTING_LAUNCH_ARGS);
+
+            delete process.env.NEO_FILM_TAKE;
+            process.env.NEO_E2E_ENGINE_PROFILE = '1';
+            expect(isEngineProfile()).toBe(true);
+            expect(activeLaunchArgs()).toBe(ENGINE_LAUNCH_ARGS);
+            expect(ENGINE_LAUNCH_ARGS).toContain('--disable-frame-rate-limit');
+            expect(PRESENTING_LAUNCH_ARGS).not.toContain('--disable-frame-rate-limit');
+
+            process.env.NEO_FILM_TAKE = '1';
+            expect(() => activeLaunchArgs()).toThrow(
+                'NEO_FILM_TAKE=1 cannot be combined with NEO_E2E_ENGINE_PROFILE=1'
+            )
         } finally {
-            if (previous === undefined) {
+            if (previousEngine === undefined) {
+                delete process.env.NEO_E2E_ENGINE_PROFILE
+            } else {
+                process.env.NEO_E2E_ENGINE_PROFILE = previousEngine
+            }
+
+            if (previousFilm === undefined) {
                 delete process.env.NEO_FILM_TAKE
             } else {
-                process.env.NEO_FILM_TAKE = previous
+                process.env.NEO_FILM_TAKE = previousFilm
             }
         }
     });


### PR DESCRIPTION
Resolves #16128

Headed E2E runs now select a compositor-presenting Chrome profile by default. The
existing GPU-intent and frame-limit-disabled arguments remain available only through
the exact `NEO_E2E_ENGINE_PROFILE=1` opt-in for engine and benchmark investigations.

Evidence: L1 (focused selector matrix and source-wired pixel witnesses) plus an L3
headed Workstation witness on the repaired behavior. The published-head retry reached
an environment-only Crashpad/`uv_uptime` denial before page creation; it is not counted
as product evidence.

Related: #15912

## Deltas from ticket

- `NEO_FILM_TAKE=1` remains a pacing/recording signal and no longer decides whether
  Chrome presents pixels.
- Exact film plus engine sentinels fail before browser launch because capture under
  the known non-presenting engine profile is contradictory.
- Package, direct Playwright, and nightly entrypoints reach the same selector. CI and
  the matrix/visual configs do not consume it.
- No current OffscreenCanvas correctness spec requires the frame-limit override.
  Published Harness Endurance benchmark reproduction opts into the engine profile
  explicitly.
- Workstation Canvas, dock-preview, and re-entry screenshot receipts follow presenting
  capability instead of film mode.
- The review repair keeps synchronous screenshots off the ordinary mouse-down drag
  path. Capture during the gesture remains film-only; the `{120, 70}` post-conversion
  motion assertion remains unchanged.

## Test Evidence

- Published head: `c1fce03739ef3174f7a5bc37645c08003d3eb336`.
- Published repair delta from reviewed head `a989e491ba`: one file, four insertions and
  four deletions in `WorkstationDragAffordancesNL.spec.mjs`.
- `npm run test-unit -- test/playwright/unit/e2e/glState.spec.mjs` — 8/8 passed.
- Unit matrix covers unset, `0`, `false`, arbitrary text, film-only, engine-only, and
  both-set rejection; it also pins proportional GL demand.
- `node --check` for the selector and focused unit spec — passed.
- Agent preflight archaeology, JSDoc, parse, whitespace, shorthand, derived-domain,
  and block-alignment gates — passed.
- Pre-publication repaired tree, with both sentinels unset:
  `env -u NEO_FILM_TAKE -u NEO_E2E_ENGINE_PROFILE npx playwright test test/playwright/e2e/workstation/WorkstationDragAffordancesNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --headed --grep "same-gesture tear-out re-entry resumes proxy motion without reacquisition" --retries=0 --trace on`
  — 2/2 passed. The retained final trace frame is a populated 800×450 Workstation
  raster (57,044 bytes).
- Published-head repetition in the restricted harness stopped before page creation:
  Chrome Crashpad `Operation not permitted` plus reporter `uv_uptime EPERM`. No
  product assertion is derived from that attempt.

## Post-Merge Validation

- [ ] Repeat the same-gesture witness on published head `c1fce03739` when the exclusive
      native-window slot is free; require 2/2 and a populated retained frame.

## Commits

- `a989e491ba` — make the presenting browser profile the headed E2E default.
- `c1fce03739` — keep synchronous capture off the default drag path.

## Evolution

The recurring failure was encoded in the default: semantic truth could remain green
behind empty native windows, while a maintainer had to remember a film-only sentinel
to see pixels. The repair makes presentation unsurprising and turns the specialized
non-presenting profile into an explicit choice. The review cycle added a second
guardrail: visual evidence must not perturb the live mouse-down path it is meant to
observe.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session
`019fac4d-7844-7422-9486-7f73ccf308f5`.
