### PR TITLE
feat(workstation): reintegrate native popup titlebar drags (#16123)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -254,6 +254,13 @@ class Workspace extends Container {
      */
     vesselParkHandlers = null
     /**
+     * Post-terminal native-titlebar park/restore authority. Separate from pointer conversion:
+     * the generic DragDrop addon has no active pointer-follow session after a dropped popup.
+     * @member {Object|null} nativeVesselParkHandlers=null
+     * @protected
+     */
+    nativeVesselParkHandlers = null
+    /**
      * The worker-owned cross-window workspace registry — `{workspaceId → document accessors}`.
      * @member {Object|null} workspaceSet=null
      * @protected
@@ -458,10 +465,8 @@ class Workspace extends Container {
                 ?? (me.dockModel?.items?.[itemId] && me.resolvePane(itemId, me.dockModel.items[itemId])),
             resolveProxyConfig: ({sourceSortZone, targetWindowId}) => {
                 const
-                    sourceConfig = sourceSortZone?.getDragProxyConfig?.(),
+                    sourceConfig = sourceSortZone?.getDragProxyConfig?.() ?? {cls: []},
                     targetApp    = Neo.apps[targetWindowId];
-
-                if (!sourceConfig) return null;
 
                 const cls = [...new Set([
                     ...(sourceConfig.cls || []),
@@ -512,6 +517,11 @@ class Workspace extends Container {
         me.vesselParkHandlers = createVesselParkHandlers({
             disposeVessel: vessel => me.disposeParkedTearOutVessel(vessel),
             parkVessel   : vessel => me.parkTearOutVessel(vessel),
+            reshowVessel : vessel => me.reshowTearOutVessel(vessel)
+        });
+        me.nativeVesselParkHandlers = createVesselParkHandlers({
+            disposeVessel: ({itemId}) => me.retireReturnedVessel(Workspace.vesselWorkspaceId(itemId)),
+            parkVessel   : vessel => me.parkTearOutVessel({...vessel, nativeTitlebar: true}),
             reshowVessel : vessel => me.reshowTearOutVessel(vessel)
         });
 
@@ -977,6 +987,7 @@ class Workspace extends Container {
      */
     async createCrossWindowParticipation({windowId, workspaceId}) {
         let me            = this,
+            isMain        = workspaceId === Workspace.MAIN_WORKSPACE_ID,
             Participation = (await import('../../../src/dashboard/DockCrossWindowParticipation.mjs')).default;
 
         if (me.isDestroyed) return null;
@@ -994,19 +1005,108 @@ class Workspace extends Container {
                 itemId        : data.draggedItem?.dockItemId,
                 targetWindowId: windowId
             }),
-            restoreDragEmbodiment: data => me.vesselProxyEmbodiment.restore({
+            resolveNativeWindowDrag: isMain ? movingWindowId => me.resolveNativeTearOutDrag(movingWindowId) : null,
+            restoreDragEmbodiment  : data => me.vesselProxyEmbodiment.restore({
                 itemId        : data.draggedItem?.dockItemId,
                 targetWindowId: windowId
             }),
+            resumeNativeWindowDrag: isMain ? itemId => me.nativeVesselParkHandlers.onGestureTerminal({
+                itemId,
+                outcome: 'rejected'
+            }) : null,
+            retireNativeWindowDrag: isMain ? draggedItem => me.nativeVesselParkHandlers.onGestureTerminal({
+                itemId : draggedItem?.dockItemId,
+                outcome: 'committed'
+            }) : null,
             sortGroup          : Workspace.CROSS_WINDOW_SORT_GROUP,
             stageDragEmbodiment: data => me.vesselProxyEmbodiment.move({
                 ...data,
                 sourceWindowId: me.resolveTearOutVessel(data.draggedItem?.dockItemId)?.windowId,
                 targetWindowId: windowId
             }),
+            awaitDragEmbodiment: async data => {
+                const
+                    itemId   = data.draggedItem?.dockItemId,
+                    renderer = isMain
+                        ? me.dragAffordances?.preview
+                        : me.vesselWorkspaces.get(workspaceId)?.preview;
+
+                if (!renderer?.dockPreview) return false;
+
+                const [embodied] = await Promise.all([
+                    me.vesselProxyEmbodiment.whenSettled({
+                        itemId,
+                        sourceWindowId: me.resolveTearOutVessel(itemId)?.windowId,
+                        targetWindowId: windowId
+                    }),
+                    renderer.promiseUpdate?.()
+                ]);
+
+                return embodied === true && Boolean(renderer.dockPreview)
+            },
+            suspendNativeWindowDrag: isMain ? (itemId, data) => {
+                me.vesselConversionTargetWindowId = data?.targetWindowId ?? null;
+
+                return me.nativeVesselParkHandlers.onConversionIn({
+                    itemId,
+                    sourceRect: me.resolveVesselConversionSourceRect({itemId}),
+                    windowName: me.resolveTearOutVessel(itemId)?.windowName
+                })
+            } : null,
             windowId,
             workspaceId
         })
+    }
+
+    /**
+     * @summary Resolves one dropped bare Workstation popup into its exact live native drag record.
+     *
+     * The root workspace owns both registries, so native source discovery remains independent of
+     * whichever dock tab zone last occupied a window's coordinator slot. Whole-stack vessels,
+     * disconnected topology, and panes no longer catalogued as detached all fail closed.
+     * @param {String|Number} windowId The physical moving popup window.
+     * @returns {Object|null}
+     * @protected
+     */
+    resolveNativeTearOutDrag(windowId) {
+        let me = this;
+
+        for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
+            const
+                workspaceId = Workspace.vesselWorkspaceId(itemId),
+                state       = me.vesselWorkspaces.get(workspaceId),
+                pane        = me.paneCache[itemId],
+                vesselItems = Object.keys(state?.document?.items || {});
+
+            if (
+                entry?.windowId !== windowId ||
+                state?.windowId !== windowId ||
+                state.committed ||
+                state.closeRequested ||
+                state.disconnected ||
+                state.app?.mainView?.isDestroyed ||
+                vesselItems.length > 0 ||
+                !pane ||
+                pane.isDestroyed ||
+                !me.dockModel?.items?.[itemId] ||
+                DockZoneModel.findContainingTabsId(me.dockModel, itemId)
+            ) {
+                continue
+            }
+
+            delete pane.dockGroupNodeId;
+            pane.dockItemId            = itemId;
+            pane.dockSourceWorkspaceId = Workspace.MAIN_WORKSPACE_ID;
+
+            return {
+                draggedItem      : pane,
+                embodyNativeHover: true,
+                sourceWindowId   : windowId,
+                widgetName       : itemId
+            }
+        }
+
+        return null
     }
 
     /**
@@ -1330,7 +1430,10 @@ class Workspace extends Container {
             groupNodeId     = draggedItem?.dockGroupNodeId ?? null,
             sourceWorkspace = draggedItem?.dockSourceWorkspaceId,
             sourceState     = me.vesselWorkspaces.get(sourceWorkspace),
-            storedHome      = sourceState && me.tearOutPlacements[sourceState.itemId]?.tabsNodeId,
+            sourceItemId    = sourceWorkspace === Workspace.MAIN_WORKSPACE_ID
+                ? itemId
+                : sourceState?.itemId,
+            storedHome      = sourceItemId && me.tearOutPlacements[sourceItemId]?.tabsNodeId,
             targetNodeId    = isMain
                 ? (me.dockModel.nodes?.[storedHome]?.type === 'tabs'
                     ? storedHome
@@ -2467,6 +2570,8 @@ class Workspace extends Container {
      * @param {Number} [vessel.generation]
      * @param {String} vessel.itemId
      * @param {Object} [vessel.nativeRoute] Exact opener-minted physical route when available.
+     * @param {Boolean} [vessel.nativeTitlebar=false] Use the exact Main native route rather than
+     *     pointer-follow DragDrop state after a terminal popup was dropped.
      * @param {String} vessel.windowName
      * @returns {Promise<Boolean>}
      * @protected
@@ -2660,17 +2765,20 @@ class Workspace extends Container {
      * @returns {Promise<Boolean>}
      * @protected
      */
-    async parkTearOutVessel({itemId, windowName}) {
+    async parkTearOutVessel({itemId, nativeTitlebar=false, windowName}) {
         let me           = this,
             entry        = me.resolveTearOutVessel(itemId),
             route        = entry?.nativeRoute,
             sourceWindow = Neo.manager?.Window?.get(entry?.windowId),
             targetWindow = Neo.manager?.Window?.get(me.vesselConversionTargetWindowId),
             targetRoute  = targetWindow?.nativeRoute,
+            targetIsMain = me.vesselConversionTargetWindowId === me.windowId,
+            // The cover geometry and the authority check both speak published inner-window
+            // geometry; a child omitting outerRect never rejects an authorized live vessel.
             sourceRect   = sourceWindow?.innerRect,
-            sourceOuter  = sourceWindow?.outerRect,
+            sourceOuter  = sourceWindow?.outerRect ?? sourceRect,
             targetRect   = targetWindow?.innerRect,
-            needsResize  = Boolean(sourceOuter && targetRect && (
+            needsResize  = !nativeTitlebar && Boolean(sourceOuter && targetRect && (
                 sourceOuter.width > targetRect.width || sourceOuter.height > targetRect.height
             )),
             parkSize      = needsResize ? {
@@ -2719,36 +2827,55 @@ class Workspace extends Container {
             !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
             route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
             (needsResize && route.capabilities?.resize !== true) ||
-            !targetRoute?.nativeHandleKey || targetRoute.ownerWindowId !== me.windowId ||
-            targetRoute.targetWindowId !== me.vesselConversionTargetWindowId ||
-            targetRoute.capabilities?.focus !== true ||
-            entry.windowName !== windowName || !sourceRect || !sourceOuter || !targetRect
+            (!targetIsMain && (
+                !targetRoute?.nativeHandleKey || targetRoute.ownerWindowId !== me.windowId ||
+                targetRoute.targetWindowId !== me.vesselConversionTargetWindowId ||
+                targetRoute.capabilities?.focus !== true
+            )) ||
+            entry.windowName !== windowName || !sourceRect || !sourceOuter || !targetRect ||
+            (nativeTitlebar && (
+                sourceRect.width > targetRect.width || sourceRect.height > targetRect.height
+            ))
         ) {
             me.lastVesselParkReceipt.reason = 'native route or live cover geometry refused';
             return false
         }
 
+        const focusTarget = () => targetIsMain
+            // The root window has no opener-minted nativeRoute. Route the focus verb through the
+            // exact popup Main actor instead: a popup may focus its opener under the user
+            // activation carried by the titlebar gesture.
+            ? Neo.Main.windowFocus({windowId: entry.windowId})
+            : Neo.Main.windowNativeFocus({
+                nativeHandleKey: targetRoute.nativeHandleKey,
+                targetWindowId : targetRoute.targetWindowId,
+                windowId       : me.windowId
+            });
+
         try {
-            let focused = await Neo.Main.windowNativeFocus({
-                    nativeHandleKey: targetRoute.nativeHandleKey,
-                    targetWindowId : targetRoute.targetWindowId,
-                    windowId       : me.windowId
-                }) === true;
+            let focused = await focusTarget() === true;
 
             me.lastVesselParkReceipt.focused = focused;
 
             if (!focused) return false;
 
-            let moved = await Neo.main.addon.DragDrop.parkWindowDrag({
+            const moveData = {
                 nativeHandleKey: route.nativeHandleKey,
-                parkSize,
-                restoreRect,
                 targetWindowId : route.targetWindowId,
                 windowId       : me.windowId,
                 windowName,
                 x              : targetRect.x,
                 y              : targetRect.y
-            }) === true;
+            };
+
+            if (!nativeTitlebar) {
+                moveData.parkSize    = parkSize;
+                moveData.restoreRect = restoreRect
+            }
+
+            let moved = await (nativeTitlebar
+                ? Neo.Main.windowNativeMoveTo(moveData)
+                : Neo.main.addon.DragDrop.parkWindowDrag(moveData)) === true;
 
             me.lastVesselParkReceipt.moved = moved;
 
@@ -2756,23 +2883,22 @@ class Workspace extends Container {
 
             parkGeometry && (me.tearOutParkGeometries[itemId] = parkGeometry);
 
-            let refocused = await Neo.Main.windowNativeFocus({
-                nativeHandleKey: targetRoute.nativeHandleKey,
-                targetWindowId : targetRoute.targetWindowId,
-                windowId       : me.windowId
-            }) === true;
+            let refocused = await focusTarget() === true;
 
             me.lastVesselParkReceipt.refocused = refocused;
 
             if (!refocused) {
-                let compensated = await Neo.main.addon.DragDrop.resumeWindowDrag({
+                const restoreData = {
                     nativeHandleKey: route.nativeHandleKey,
                     targetWindowId : route.targetWindowId,
                     windowId       : me.windowId,
                     windowName,
                     x              : sourceOuter.x,
                     y              : sourceOuter.y
-                }) === true;
+                };
+                let compensated = await (nativeTitlebar
+                    ? Neo.Main.windowNativeMoveTo(restoreData)
+                    : Neo.main.addon.DragDrop.resumeWindowDrag(restoreData)) === true;
 
                 me.lastVesselParkReceipt.compensated = compensated;
                 me.lastVesselParkReceipt.parked      = !compensated;
@@ -3231,6 +3357,14 @@ class Workspace extends Container {
 
         if (me.isDestroyed) return;
 
+        // Physical source death is the one cancellation that must NOT attempt a restore. Retire
+        // the coordinator's exact candidate/retry generation before the app-owned vessel machines
+        // clear their matching slots below.
+        Neo.manager.DragCoordinator?.clearNativeWindowDropCandidate(data.windowId, {
+            restoreSource: false
+        });
+        Neo.manager.DragCoordinator?.endNativeGesture(data.windowId);
+
         // A disconnect can invalidate either side of the nested popup→target-proxy transaction.
         // Restore it before the outer main→popup embodiment below decides restore vs promote.
         me.vesselProxyEmbodiment.restoreByWindow(data.windowId);
@@ -3260,6 +3394,7 @@ class Workspace extends Container {
                     windowName
                 });
                 me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
+                me.nativeVesselParkHandlers.onVesselRetired({itemId, retirement: true});
                 me.revokeVesselOwnerGrant('tear-out', itemId);
                 me.retireVesselWorkspaceTarget(itemId);
                 me.tearOutRetirements.delete(itemId);
@@ -3293,6 +3428,7 @@ class Workspace extends Container {
                     windowName
                 });
                 me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
+                me.nativeVesselParkHandlers.onVesselRetired({itemId, retirement: true});
                 me.revokeVesselOwnerGrant('tear-out', itemId);
                 me.retireVesselWorkspaceTarget(itemId);
                 me.tearOutRetirements.delete(itemId);
@@ -3326,6 +3462,7 @@ class Workspace extends Container {
                     windowName
                 });
                 me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
+                me.nativeVesselParkHandlers.onVesselRetired({itemId, retirement: true});
 
                 if (workspaceSettled) {
                     if (

--- a/src/dashboard/CrossWindowDragTarget.mjs
+++ b/src/dashboard/CrossWindowDragTarget.mjs
@@ -13,7 +13,9 @@ import DragCoordinator from '../manager/DragCoordinator.mjs';
  * in a sibling window on the same App-Worker heap; this class is what a dock workspace registers
  * to participate. It fulfils the §2.3 target-side contract — registry identity (`sortGroup`,
  * `windowId`) plus the four mandatory hooks (`acceptsRemoteDrag`, `onRemoteDragMove`,
- * `onRemoteDragLeave`, `onRemoteDrop`) — and deliberately owns NOTHING else:
+ * `onRemoteDragLeave`, `onRemoteDrop`). A product owner may additionally bind the optional native
+ * popup source seams, letting the SAME stable registration describe a physical popup gesture
+ * without competing for the coordinator's one target slot:
  *
  * - **No parallel drag system** (the inherited §2.3 guardrail): the hover path produces
  *   `dockPreview` payloads through the owner's landed preview machinery, and the drop path
@@ -70,6 +72,23 @@ class CrossWindowDragTarget extends Base {
          */
         hitTest: null,
         /**
+         * Optional owner seam: resolves a physical native popup window into its exact live drag
+         * record. The returned record remains product-owned; this carrier adds no dock semantics.
+         * @member {Function|null} resolveNativeWindowDrag=null
+         */
+        resolveNativeWindowDrag: null,
+        /**
+         * Optional owner seam: resumes the exact source popup after a native target handoff is
+         * refused or cancelled.
+         * @member {Function|null} resumeNativeWindowDrag=null
+         */
+        resumeNativeWindowDrag: null,
+        /**
+         * Optional owner seam: retires the exact source popup after the target semantic commit.
+         * @member {Function|null} retireNativeWindowDrag=null
+         */
+        retireNativeWindowDrag: null,
+        /**
          * Owner seam: maps a remote-drag hover payload
          * (`{draggedItem, localX, localY, offsetX, offsetY, proxyRect}`) to a runtime-only
          * `dockPreview` payload (or null outside affordances) AND renders the owner's hover
@@ -117,6 +136,19 @@ class CrossWindowDragTarget extends Base {
          * @member {Function|null} stageDragEmbodiment=null
          */
         stageDragEmbodiment: null,
+        /**
+         * Optional owner seam: resolves only after the exact staged proxy generation has settled
+         * in its target renderer. Native-titlebar commitment requires strict `true` before its
+         * retained readability interval can begin.
+         * @member {Function|null} awaitDragEmbodiment=null
+         */
+        awaitDragEmbodiment: null,
+        /**
+         * Optional owner seam: parks/relegates the physical source popup before target-local
+         * embodiment. Strict `true` admits the native handoff.
+         * @member {Function|null} suspendNativeWindowDrag=null
+         */
+        suspendNativeWindowDrag: null,
         /**
          * §2.3 registry identity: the window this surface renders in.
          * @member {String|Number|null} windowId=null
@@ -166,6 +198,25 @@ class CrossWindowDragTarget extends Base {
     }
 
     /**
+     * @summary Resolves an optional native-popup source through the registered participation.
+     * @param {String|Number} windowId The physical moving popup.
+     * @returns {Object|null}
+     */
+    getNativeWindowDrag(windowId) {
+        return this.resolveNativeWindowDrag?.(windowId) ?? null
+    }
+
+    /**
+     * @summary Retires a native popup only after the target reports a semantic commit.
+     * @param {Object} draggedItem
+     * @param {Object} [context]
+     * @returns {*}
+     */
+    onRemoteDropOut(draggedItem, context) {
+        return this.retireNativeWindowDrag?.(draggedItem, context)
+    }
+
+    /**
      * §2.3 mandatory hook: hover feedback for a remote drag over this target. Delegates the
      * compute+render to the owner's preview machinery and keeps the latest payload for the
      * drop path.
@@ -206,6 +257,28 @@ class CrossWindowDragTarget extends Base {
     }
 
     /**
+     * @summary Awaits renderer settlement for the exact active target-local embodiment.
+     *
+     * The dragged item must still own this target's current licensed payload. This generation
+     * fence keeps a late renderer acknowledgement from authorizing a restored successor.
+     * @param {Object} draggedItem The coordinator's exact dragged component.
+     * @returns {Boolean|Promise<Boolean>}
+     */
+    async awaitRemoteDragEmbodiment(draggedItem) {
+        const
+            payload = this.currentDragPayload,
+            current = payload?.embodyProxy === true && payload.draggedItem === draggedItem;
+
+        if (!current) return false;
+
+        const settled = await (this.awaitDragEmbodiment?.(payload) ?? false);
+
+        return settled === true &&
+            !this.isDestroyed &&
+            this.currentDragPayload === payload
+    }
+
+    /**
      * §2.3 mandatory hook: clear hover feedback when the drag exits this target or the
      * coordinator switches targets.
      */
@@ -217,6 +290,27 @@ class CrossWindowDragTarget extends Base {
         me.currentDragPayload = null;
         me.currentPreview     = null;
         me.clearPreview?.()
+    }
+
+    /**
+     * @summary Restores the physical native source after target-local state has been released.
+     * @param {String} widgetName
+     * @param {Object} proxyRect
+     * @param {Object} [context]
+     * @returns {*}
+     */
+    resumeWindowDrag(widgetName, proxyRect, context) {
+        return this.resumeNativeWindowDrag?.(widgetName, proxyRect, context)
+    }
+
+    /**
+     * @summary Parks/relegates the physical native source before a target-local embodiment.
+     * @param {String} widgetName
+     * @param {Object} [context]
+     * @returns {*}
+     */
+    suspendWindowDrag(widgetName, context) {
+        return this.suspendNativeWindowDrag?.(widgetName, context)
     }
 
     /**
@@ -241,24 +335,35 @@ class CrossWindowDragTarget extends Base {
                 result = me.commitOperation?.(operation, draggedItem) ?? null
             }
         } catch (error) {
-            payload?.embodyProxy === true && me.restoreDragEmbodiment?.(payload);
+            me.currentDragPayload === payload &&
+                !me.isDestroyed &&
+                payload?.embodyProxy === true &&
+                me.restoreDragEmbodiment?.(payload);
             me.clearRemoteState(payload);
             throw error
         }
 
         const settle = committed => {
-            if (payload?.embodyProxy === true) {
+            const current = me.currentDragPayload === payload && !me.isDestroyed;
+
+            // A target can unregister while an async owner commit is pending. Its leave path has
+            // already restored this exact embodiment; a late completion must neither promote that
+            // stale generation nor advertise a commit to the coordinator/source disposer.
+            if (current && payload?.embodyProxy === true) {
                 me[committed ? 'promoteDragEmbodiment' : 'restoreDragEmbodiment']?.(payload)
             }
 
             me.clearRemoteState(payload);
 
-            return committed
+            return current ? committed : null
         };
 
         return typeof result?.then === 'function'
             ? result.then(settle, error => {
-                payload?.embodyProxy === true && me.restoreDragEmbodiment?.(payload);
+                me.currentDragPayload === payload &&
+                    !me.isDestroyed &&
+                    payload?.embodyProxy === true &&
+                    me.restoreDragEmbodiment?.(payload);
                 me.clearRemoteState(payload);
                 throw error
             })

--- a/src/dashboard/DockCrossWindowParticipation.mjs
+++ b/src/dashboard/DockCrossWindowParticipation.mjs
@@ -115,6 +115,22 @@ class DockCrossWindowParticipation extends Base {
          */
         previewToOperation: null,
         /**
+         * Optional product-owned native-popup resolver forwarded through the SAME stable target
+         * registration. It never creates a second coordinator entry.
+         * @member {Function|null} resolveNativeWindowDrag=null
+         */
+        resolveNativeWindowDrag: null,
+        /**
+         * Optional product-owned native-popup restore seam forwarded to the stable participation.
+         * @member {Function|null} resumeNativeWindowDrag=null
+         */
+        resumeNativeWindowDrag: null,
+        /**
+         * Optional product-owned native-popup retirement seam forwarded to the stable participation.
+         * @member {Function|null} retireNativeWindowDrag=null
+         */
+        retireNativeWindowDrag: null,
+        /**
          * Owner seam forwarded to the target: promotes the target-local live drag embodiment
          * after a successful semantic commit.
          * @member {Function|null} promoteDragEmbodiment=null
@@ -138,6 +154,18 @@ class DockCrossWindowParticipation extends Base {
          * @member {Function|null} stageDragEmbodiment=null
          */
         stageDragEmbodiment: null,
+        /**
+         * Owner seam forwarded to the target: settles the exact staged target renderer before a
+         * native-titlebar handoff begins its retained readability interval.
+         * @member {Function|null} awaitDragEmbodiment=null
+         */
+        awaitDragEmbodiment: null,
+        /**
+         * Optional product-owned native-popup park/relegation seam forwarded to the stable
+         * participation.
+         * @member {Function|null} suspendNativeWindowDrag=null
+         */
+        suspendNativeWindowDrag: null,
         /**
          * §2.3 registry identity, forwarded to the target: the window this workspace renders in.
          * @member {String|Number|null} windowId=null
@@ -168,16 +196,21 @@ class DockCrossWindowParticipation extends Base {
         let me = this;
 
         me.target = Neo.create(CrossWindowDragTarget, {
-            clearPreview         : me.clearPreview,
-            commitOperation      : me.commitDrop.bind(me),
-            dragCoordinator      : me.dragCoordinator,
-            hitTest              : me.hitTest,
-            previewFor           : me.previewFor,
-            previewToOperation   : me.previewToOperation,
-            promoteDragEmbodiment: me.promoteDragEmbodiment,
-            restoreDragEmbodiment: me.restoreDragEmbodiment,
-            sortGroup            : me.sortGroup,
-            stageDragEmbodiment  : me.stageDragEmbodiment,
+            clearPreview           : me.clearPreview,
+            commitOperation        : me.commitDrop.bind(me),
+            dragCoordinator        : me.dragCoordinator,
+            hitTest                : me.hitTest,
+            previewFor             : me.previewFor,
+            previewToOperation     : me.previewToOperation,
+            promoteDragEmbodiment  : me.promoteDragEmbodiment,
+            resolveNativeWindowDrag: me.resolveNativeWindowDrag,
+            restoreDragEmbodiment  : me.restoreDragEmbodiment,
+            resumeNativeWindowDrag : me.resumeNativeWindowDrag,
+            retireNativeWindowDrag : me.retireNativeWindowDrag,
+            sortGroup              : me.sortGroup,
+            stageDragEmbodiment    : me.stageDragEmbodiment,
+            awaitDragEmbodiment    : me.awaitDragEmbodiment,
+            suspendNativeWindowDrag: me.suspendNativeWindowDrag,
             // the workspace id IS the §2.8.1 stable claim identity: it survives re-registration
             // and never encodes windowId or registration order
             stableTargetId: me.workspaceId,

--- a/src/dashboard/DockVesselEmbodiment.mjs
+++ b/src/dashboard/DockVesselEmbodiment.mjs
@@ -70,13 +70,16 @@ export function createDockVesselEmbodiment({resolvePane, resolveTarget} = {}) {
 
                 // Cross-window insertion is not complete when `add()` returns. The exact vessel
                 // may otherwise be published to gesture logic, parked, and only THEN finish its
-                // pane mount — a late focus/mount side effect that can raise the parked source.
+                // pane mount — a late focus/mount side effect could raise the parked source.
                 // Both structural mutations are silent above so staging owns exactly one
-                // settlement transaction per parent before publishing the embodiment.
-                await Promise.all([
-                    sourceParent.promiseUpdate?.(),
-                    target.promiseUpdate?.()
-                ]);
+                // settlement transaction per parent before publishing the embodiment. A parked
+                // source renderer may reject OR never acknowledge another frame after physical
+                // parking. Start that source-slot transaction, but do not let it veto or deadlock
+                // the target renderer's independently provable readability.
+                Promise.resolve()
+                    .then(() => sourceParent.promiseUpdate?.())
+                    .catch(() => {});
+                await Promise.resolve().then(() => target.promiseUpdate?.());
 
                 return records.get(itemId) === record
             } catch {
@@ -367,6 +370,7 @@ export function createDockVesselProxyEmbodiment({
                     itemId,
                     promoted  : false,
                     proxy     : null,
+                    settlement: null,
                     settled   : false,
                     sourceWindowId,
                     targetWindowId
@@ -409,7 +413,7 @@ export function createDockVesselProxyEmbodiment({
                     return false
                 }
 
-                Promise.resolve(settlement).then(admitted => {
+                record.settlement = Promise.resolve(settlement).then(admitted => {
                     if (active !== record) return false;
 
                     record.settled = admitted === true;
@@ -499,6 +503,32 @@ export function createDockVesselProxyEmbodiment({
             )
                 ? this.restore({itemId: record.itemId})
                 : false
+        },
+
+        /**
+         * @summary Waits for the exact active proxy generation to finish cross-window rendering.
+         *
+         * Synchronous staging reserves source ownership, but target `promiseUpdate()` settlement is
+         * the first point at which a retained handoff interval may honestly begin. A restored,
+         * promoted, or superseded generation resolves false.
+         * @param {Object} identity
+         * @param {String} identity.itemId
+         * @param {String|Number} [identity.sourceWindowId]
+         * @param {String|Number} [identity.targetWindowId]
+         * @returns {Promise<Boolean>}
+         */
+        async whenSettled(identity = {}) {
+            const record = resolveRecord(identity);
+
+            if (!record?.settlement) return false;
+
+            const admitted = await record.settlement;
+
+            return admitted === true &&
+                active === record &&
+                resolveRecord(identity) === record &&
+                embodiment.isStaged(record.itemId) &&
+                resolvePane(record.itemId)?.parent === record.proxy
         },
 
         /**

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -27,6 +27,18 @@ class DragCoordinator extends Manager {
          */
         nativeWindowDropDwellMs: 450,
         /**
+         * Retained target-local embodiment interval after native settle and before semantic commit.
+         * This guarantees at least one painted handoff frame without inventing a browser mouseup.
+         * @member {Number} nativeWindowDropHandoffMs=180
+         */
+        nativeWindowDropHandoffMs: 180,
+        /**
+         * Base delay for retrying a strict physical source restore/retirement refusal. The target
+         * semantic terminal runs once; only the retained native disposition is retried.
+         * @member {Number} nativeWindowDispositionRetryMs=250
+         */
+        nativeWindowDispositionRetryMs: 250,
+        /**
          * Quiescence delay after the last native window-position update before committing
          * a geometry-only drop. The browser has no mouseup during OS-titlebar drags.
          * @member {Number} nativeWindowDropSettleMs=250
@@ -104,13 +116,41 @@ class DragCoordinator extends Manager {
      *
      * Clears a pending geometry-only native window-drop candidate.
      * @param {String} windowId
+     * @param {Object} [options]
+     * @param {Boolean} [options.restoreSource=true] False only when the physical source already
+     *     disconnected and therefore cannot be restored.
      */
-    clearNativeWindowDropCandidate(windowId) {
-        let candidate = this.nativeWindowDropCandidates.get(windowId);
+    clearNativeWindowDropCandidate(windowId, {restoreSource=true}={}) {
+        let me        = this,
+            candidate = me.nativeWindowDropCandidates.get(windowId);
 
         if (candidate) {
+            candidate.cancelled = true;
+            candidate.registrationRefreshes?.clear();
+            candidate.registrationRefreshes = null;
             clearTimeout(candidate.timeoutId);
-            this.nativeWindowDropCandidates.delete(windowId)
+            candidate.resolveHandoff?.();
+
+            if (candidate.embodied) {
+                candidate.embodied = false;
+
+                if (me.nativeHoverTargets.get(windowId) === candidate.targetSortZone) {
+                    candidate.targetSortZone?.onRemoteDragLeave?.();
+                    me.nativeHoverTargets.delete(windowId)
+                }
+            }
+
+            if (candidate.sourceSuspended && restoreSource) {
+                candidate.phase = 'settling-rejected';
+                me.endNativeGesture(windowId);
+                me.settleNativeWindowDisposition(windowId, candidate, false).catch(error => {
+                    (Neo.logError || console.error)('Native window restore failed', error)
+                });
+                return
+            }
+
+            candidate.sourceSuspended = false;
+            me.nativeWindowDropCandidates.delete(windowId)
         }
     }
 
@@ -139,6 +179,79 @@ class DragCoordinator extends Manager {
     }
 
     /**
+     * @summary Settles only the physical source half of an already-decided native terminal.
+     *
+     * Workstation's embodied titlebar route is strict: `true` alone admits close or restore.
+     * A refusal retains this candidate as exact retry authority and backs off without replaying
+     * the target model operation. Legacy sources keep their historical fire-and-forget contract.
+     * @param {String} windowId Moving popup identity.
+     * @param {Object} candidate Retained native candidate.
+     * @param {Boolean} committed Whether the target semantic operation committed.
+     * @returns {Promise<Boolean>} Strict physical-settlement outcome.
+     */
+    async settleNativeWindowDisposition(windowId, candidate, committed) {
+        let me = this;
+
+        if (me.nativeWindowDropCandidates.get(windowId) !== candidate) {
+            return false
+        }
+
+        clearTimeout(candidate.timeoutId);
+        candidate.dispositionAttempts = (candidate.dispositionAttempts || 0) + 1;
+        candidate.phase = committed ? 'settling-committed' : 'settling-rejected';
+
+        let result,
+            threw = false;
+
+        try {
+            result = await (committed
+                ? candidate.sourceSortZone?.onRemoteDropOut?.(candidate.draggedItem, candidate)
+                : candidate.sourceSortZone?.resumeWindowDrag?.(
+                    candidate.widgetName,
+                    candidate.proxyRect,
+                    candidate
+                ))
+        } catch (error) {
+            threw = true;
+            (Neo.logError || console.error)(
+                committed ? 'Native window retirement failed' : 'Native window restore failed',
+                error
+            )
+        }
+
+        // A successful physical close can synchronously trigger source disconnect cleanup while
+        // the effect Promise is settling. That cleanup already consumed this generation.
+        if (me.nativeWindowDropCandidates.get(windowId) !== candidate) {
+            return result === true
+        }
+
+        const admitted = !threw && (candidate.embodyNativeHover === true
+            ? result === true
+            : true);
+
+        if (admitted) {
+            candidate.sourceSuspended = false;
+            me.nativeWindowDropCandidates.delete(windowId);
+            me.endNativeGesture(windowId);
+            return true
+        }
+
+        const delay = Math.min(
+            5000,
+            Math.max(1, me.nativeWindowDispositionRetryMs) *
+                2 ** Math.min(candidate.dispositionAttempts - 1, 4)
+        );
+
+        candidate.timeoutId = setTimeout(() => {
+            me.settleNativeWindowDisposition(windowId, candidate, committed).catch(error => {
+                (Neo.logError || console.error)('Native window disposition retry failed', error)
+            })
+        }, delay);
+
+        return false
+    }
+
+    /**
      * @summary Commits an inferred native-titlebar popup drop into the remote dashboard path.
      *
      * Commits a conservative geometry-only native titlebar drop into the existing remote
@@ -155,10 +268,9 @@ class DragCoordinator extends Manager {
             return
         }
 
-        me.nativeWindowDropCandidates.delete(windowId);
-
         let {
             draggedItem,
+            embodyNativeHover,
             localX,
             localY,
             offsetX,
@@ -170,42 +282,159 @@ class DragCoordinator extends Manager {
         } = candidate;
 
         if (sourceSortZone.getNativeWindowDrag?.(windowId)?.draggedItem !== draggedItem) {
+            me.clearNativeWindowDropCandidate(windowId);
+            me.endNativeGesture(windowId);
             return
         }
 
         if (!targetSortZone.acceptsRemoteDrag(localX, localY)) {
+            me.clearNativeWindowDropCandidate(windowId);
+            me.endNativeGesture(windowId);
             return
         }
 
-        await sourceSortZone.suspendWindowDrag(widgetName);
+        candidate.phase = 'parking';
 
-        await targetSortZone.onRemoteDragMove({
-            draggedItem,
-            embodyProxy: true,
-            localX,
-            localY,
-            offsetX,
-            offsetY,
-            proxyRect,
-            sourceSortZone
-        });
+        let suspended;
 
-        // The native-titlebar path answers the same question as the pointer path, so it obeys the same
-        // rule: the target's return IS the commit decision, and a null means it declined. Retiring the
-        // source anyway arms `remoteDropCommitted` and suppresses the source's own restore, leaving the
-        // item with no owner — identical to the pointer defect, reached through a different door.
-        const operation = await targetSortZone.onRemoteDrop(draggedItem);
+        try {
+            suspended = await sourceSortZone.suspendWindowDrag(widgetName, candidate);
 
-        if (operation) {
-            sourceSortZone.onRemoteDropOut(draggedItem)
-        }
+            if (me.nativeWindowDropCandidates.get(windowId) !== candidate || candidate.cancelled) {
+                if (suspended !== false) {
+                    candidate.sourceSuspended = true;
 
-        // The commit is a gesture terminal: the popup's token and hover bookkeeping die here.
-        // Ordered AFTER the drop — the preview is the drop's input and must outlive it.
-        me.endNativeGesture(windowId);
+                    if (!me.nativeWindowDropCandidates.has(windowId)) {
+                        me.nativeWindowDropCandidates.set(windowId, candidate)
+                    }
+                    if (me.nativeWindowDropCandidates.get(windowId) === candidate) {
+                        await me.settleNativeWindowDisposition(windowId, candidate, false)
+                    }
+                }
+                return
+            }
 
-        if (me.activeTargetZone === targetSortZone) {
-            me.activeTargetZone = null
+            if (embodyNativeHover === true && suspended !== true) {
+                me.clearNativeWindowDropCandidate(windowId);
+                me.endNativeGesture(windowId);
+                return
+            }
+
+            candidate.sourceSuspended = suspended !== false;
+
+            const preview = await targetSortZone.onRemoteDragMove({
+                draggedItem,
+                embodyProxy   : true,
+                localX,
+                localY,
+                offsetX,
+                offsetY,
+                proxyRect,
+                sourceSortZone,
+                sourceWindowId: candidate.sourceWindowId
+            });
+
+            if (embodyNativeHover === true && !preview) {
+                me.clearNativeWindowDropCandidate(windowId);
+                me.endNativeGesture(windowId);
+                return
+            }
+
+            candidate.embodied = embodyNativeHover === true;
+
+            if (embodyNativeHover === true) {
+                const settled = await targetSortZone.awaitRemoteDragEmbodiment?.(draggedItem);
+
+                if (
+                    me.nativeWindowDropCandidates.get(windowId) !== candidate ||
+                    candidate.cancelled
+                ) {
+                    return
+                }
+
+                if (settled !== true) {
+                    me.clearNativeWindowDropCandidate(windowId);
+                    me.endNativeGesture(windowId);
+                    return
+                }
+
+                candidate.phase = 'embodied';
+
+                await new Promise(resolve => {
+                    candidate.resolveHandoff = resolve;
+                    candidate.timeoutId       = setTimeout(resolve, me.nativeWindowDropHandoffMs)
+                });
+
+                candidate.resolveHandoff = null;
+
+                if (me.nativeWindowDropCandidates.get(windowId) !== candidate || candidate.cancelled) {
+                    return
+                }
+            }
+
+            if (
+                sourceSortZone.getNativeWindowDrag?.(windowId)?.draggedItem !== draggedItem ||
+                !targetSortZone.acceptsRemoteDrag(localX, localY)
+            ) {
+                me.clearNativeWindowDropCandidate(windowId);
+                me.endNativeGesture(windowId);
+                return
+            }
+
+            clearTimeout(candidate.timeoutId);
+            candidate.phase = 'settling-target';
+
+            // The native-titlebar path answers the same question as the pointer path, so the
+            // target's return IS the commit decision. Target settlement (promote or restore)
+            // precedes the matching physical source disposition on both branches.
+            const operation = await targetSortZone.onRemoteDrop(draggedItem);
+
+            if (
+                me.nativeWindowDropCandidates.get(windowId) !== candidate ||
+                candidate.cancelled
+            ) {
+                return
+            }
+
+            candidate.embodied = false;
+
+            if (me.nativeHoverTargets.get(windowId) === targetSortZone) {
+                me.nativeHoverTargets.delete(windowId)
+            }
+
+            // Target semantic settlement is exact-once. The claim/hover generation dies now;
+            // strict physical close/restore may remain as separately retained retry authority.
+            me.endNativeGesture(windowId);
+
+            if (me.activeTargetZone === targetSortZone) {
+                me.activeTargetZone = null
+            }
+
+            await me.settleNativeWindowDisposition(windowId, candidate, Boolean(operation))
+        } catch (error) {
+            if (me.nativeWindowDropCandidates.get(windowId) === candidate) {
+                candidate.cancelled = true;
+
+                if (
+                    candidate.embodied &&
+                    me.nativeHoverTargets.get(windowId) === targetSortZone
+                ) {
+                    targetSortZone.onRemoteDragLeave?.();
+                    me.nativeHoverTargets.delete(windowId)
+                }
+
+                candidate.embodied = false;
+                me.endNativeGesture(windowId);
+
+                if (candidate.sourceSuspended) {
+                    await me.settleNativeWindowDisposition(windowId, candidate, false)
+                } else {
+                    me.nativeWindowDropCandidates.delete(windowId)
+                }
+            }
+
+            me.endNativeGesture(windowId);
+            throw error
         }
     }
 
@@ -267,6 +496,7 @@ class DragCoordinator extends Manager {
             popupWindow      = Window.get(data.windowId),
             popupRect        = popupWindow?.innerRect,
             {sortGroup}      = sourceSortZone,
+            sourceWindowId   = sourceDrag.sourceWindowId ?? sourceSortZone.windowId,
             targetWindowId, targetSortZone, targetWindow, localX, localY, width, height, arbiter, claimed, excludedWindowIds;
 
         if (!popupRect || !sortGroup) {
@@ -276,7 +506,7 @@ class DragCoordinator extends Manager {
         localX = popupRect.x + popupRect.width  / 2;
         localY = popupRect.y + popupRect.height / 2;
 
-        excludedWindowIds = new Set([data.windowId, sourceSortZone.windowId]);
+        excludedWindowIds = new Set([data.windowId, sourceWindowId]);
         arbiter           = me.nativeClaimArbiters.get(data.windowId);
 
         if (!arbiter) {
@@ -290,7 +520,8 @@ class DragCoordinator extends Manager {
             screenX: localX,
             screenY: localY,
             sortGroup,
-            sourceSortZone
+            sourceSortZone,
+            sourceWindowId
         });
 
         if (claimed) {
@@ -386,7 +617,15 @@ class DragCoordinator extends Manager {
      * @param {Neo.draggable.container.SortZone} data.sourceSortZone
      * @returns {Object|null} `{stableId, zone}` of the winning claim, or null (fail closed)
      */
-    resolveClaimedTarget({arbiter, excludedWindowIds = null, screenX, screenY, sortGroup, sourceSortZone}) {
+    resolveClaimedTarget({
+        arbiter,
+        excludedWindowIds = null,
+        screenX,
+        screenY,
+        sortGroup,
+        sourceSortZone,
+        sourceWindowId=sourceSortZone.windowId
+    }) {
         let group = this.sortZones.get(sortGroup);
 
         if (!group) {
@@ -395,10 +634,10 @@ class DragCoordinator extends Manager {
 
         for (const [windowId, zone] of group) {
             if (
-                zone === sourceSortZone              ||
-                windowId === sourceSortZone.windowId ||
+                windowId === sourceWindowId ||
                 excludedWindowIds?.has(windowId)
             ) {
+                zone.stableTargetId != null && arbiter.release(zone.stableTargetId);
                 continue
             }
 
@@ -699,8 +938,21 @@ class DragCoordinator extends Manager {
     onWindowPositionChange(data) {
         let me         = this,
             {windowId} = data,
-            sourceDrag = me.getNativeWindowDragSource(windowId),
-            candidate, current, dwellRemaining, firstSeenAt, delay, now;
+            current    = me.nativeWindowDropCandidates.get(windowId),
+            sourceDrag, candidate, dwellRemaining, firstSeenAt, delay, now;
+
+        // Parking, embodiment, target settlement, and strict source retry can all publish geometry
+        // of their own. Their retained generation owns the terminal; never reinterpret those
+        // effects as a fresh titlebar gesture.
+        if (
+            current?.phase === 'parking' ||
+            current?.phase === 'embodied' ||
+            current?.phase?.startsWith('settling-')
+        ) {
+            return
+        }
+
+        sourceDrag = me.getNativeWindowDragSource(windowId);
 
         if (!sourceDrag) {
             me.clearNativeWindowDropCandidate(windowId);
@@ -825,6 +1077,38 @@ class DragCoordinator extends Manager {
 
             me.sortZones.get(sortGroup).set(windowId, sortZone)
         }
+
+        // A committed semantic terminal can outlive one projection generation while strict
+        // physical popup retirement retries. Rebind that disposition-only authority to the
+        // successor carrying the same stable registration identity; never replay the target drop.
+        if (sortZone.stableTargetId != null) {
+            const replaces = current =>
+                current !== sortZone &&
+                current?.stableTargetId === sortZone.stableTargetId &&
+                current?.sortGroup === sortGroup &&
+                current?.windowId === windowId;
+
+            for (const candidate of me.nativeWindowDropCandidates.values()) {
+                const refreshes = candidate.registrationRefreshes;
+
+                if (refreshes) {
+                    for (const departedZone of refreshes.keys()) {
+                        if (departedZone === sortZone || replaces(departedZone)) {
+                            refreshes.delete(departedZone);
+                            candidate.sourceSortZone === departedZone && (candidate.sourceSortZone = sortZone);
+                            candidate.targetSortZone === departedZone && (candidate.targetSortZone = sortZone)
+                        }
+                    }
+
+                    refreshes.size === 0 && (candidate.registrationRefreshes = null)
+                }
+
+                if (candidate.phase === 'settling-committed') {
+                    replaces(candidate.sourceSortZone) && (candidate.sourceSortZone = sortZone);
+                    replaces(candidate.targetSortZone) && (candidate.targetSortZone = sortZone)
+                }
+            }
+        }
     }
 
     /**
@@ -868,6 +1152,42 @@ class DragCoordinator extends Manager {
             me.activeTransitionOwned      = false
         }
 
+        // Workstation projection refresh destroys and recreates one stable participation in the
+        // same turn. During `onRemoteDrop()` that unregister can land after model mutation but
+        // before the coordinator receives the synchronous commit receipt. Give the matching
+        // identity one microtask to re-register; a genuine disconnect consumes the pending
+        // departure and restores the suspended source before any async target can resolve.
+        if (sortZone.stableTargetId != null) {
+            for (const [windowId, candidate] of me.nativeWindowDropCandidates.entries()) {
+                if (
+                    candidate.phase === 'settling-target' &&
+                    (candidate.sourceSortZone === sortZone || candidate.targetSortZone === sortZone)
+                ) {
+                    const
+                        refreshes = candidate.registrationRefreshes ??= new Map(),
+                        refresh   = {};
+
+                    refreshes.set(sortZone, refresh);
+
+                    queueMicrotask(() => {
+                        if (candidate.registrationRefreshes?.get(sortZone) !== refresh) return;
+
+                        candidate.registrationRefreshes.delete(sortZone);
+                        candidate.registrationRefreshes.size === 0 &&
+                            (candidate.registrationRefreshes = null);
+
+                        if (
+                            me.nativeWindowDropCandidates.get(windowId) === candidate &&
+                            candidate.phase === 'settling-target'
+                        ) {
+                            me.clearNativeWindowDropCandidate(windowId);
+                            me.endNativeGesture(windowId)
+                        }
+                    })
+                }
+            }
+        }
+
         // Claim hygiene mirrors the activeTargetZone rule above: a departed zone must not stay
         // reachable as a WINNING CLAIM either — a later resolve would hand the gesture a commit
         // destination whose vessel is gone. Release is identity-scoped across every live arbiter.
@@ -883,6 +1203,10 @@ class DragCoordinator extends Manager {
         // while the reference can still reach it (same reasoning as the activeTargetZone leave).
         for (const [windowId, hover] of me.nativeHoverTargets.entries()) {
             if (hover === sortZone) {
+                const candidate = me.nativeWindowDropCandidates.get(windowId);
+
+                if (candidate?.registrationRefreshes?.has(sortZone)) continue;
+
                 hover.onRemoteDragLeave?.();
                 me.nativeHoverTargets.delete(windowId)
             }
@@ -890,7 +1214,19 @@ class DragCoordinator extends Manager {
 
         for (const [windowId, candidate] of me.nativeWindowDropCandidates.entries()) {
             if (candidate.sourceSortZone === sortZone || candidate.targetSortZone === sortZone) {
-                me.clearNativeWindowDropCandidate(windowId)
+                if (candidate.registrationRefreshes?.has(sortZone)) {
+                    continue
+                }
+
+                // The model has already committed and target hover is gone. A registration refresh
+                // must not reinterpret the retained close-only retry as rejection and resume the
+                // popup over committed truth; register() rebinds this authority to the successor.
+                if (candidate.phase === 'settling-committed') {
+                    continue
+                }
+
+                me.clearNativeWindowDropCandidate(windowId);
+                me.endNativeGesture(windowId)
             }
         }
     }

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1,6 +1,9 @@
+import {execFile}                                       from 'node:child_process';
 import {createHash}                                     from 'node:crypto';
 import path                                             from 'node:path';
+import {promisify}                                      from 'node:util';
 import fs                                               from 'fs-extra';
+import {previewToOperation}                             from '../../../../src/dashboard/dockPreviewContract.mjs';
 import {test, expect}                                   from '../../fixtures.mjs';
 import {assertPreviewZoneAlignment, readComponentRects} from '../utils/dockGeometry.mjs';
 import {isFilmTake}                                     from '../utils/gpuIntent.mjs';
@@ -55,10 +58,11 @@ import {isFilmTake}                                     from '../utils/gpuIntent
 // inside the window; birth is absence-not-slowness when it fails, so a longer gate buys
 // nothing but a worse error.
 const
-    filmTake    = isFilmTake(),
-    journeyRuns = filmTake ? 1 : 2,
-    themeDwell  = filmTake ? 3200 : 0,
-    filmPace    = filmTake
+    execFileAsync = promisify(execFile),
+    filmTake      = isFilmTake(),
+    journeyRuns   = filmTake ? 1 : 2,
+    themeDwell    = filmTake ? 3200 : 0,
+    filmPace      = filmTake
         ? {birthAttempts: 240, curve: 0.18, dwellDelay: 700, moveDelay: 33, moveSteps: 24, showCursor: true}
         : {},
     filmControl      = resolveFilmControl(),
@@ -363,6 +367,175 @@ async function pinToCaptureDisplay(page) {
 }
 
 /**
+ * @summary Places one exact headed Chrome target through CDP, then republishes the browser-observed
+ * landing through Workstation's ordinary WindowPosition authority. CDP is setup only; it never
+ * stands in for the native titlebar gesture proved below.
+ * @param {import('@playwright/test').Page} page Exact main or popup page.
+ * @param {Object} requested Requested outer-window `{left, top, width, height}`.
+ * @returns {Promise<Object>} Browser and CDP observations plus the Neo window id.
+ */
+async function placeNativeWindow(page, requested) {
+    const
+        session    = await page.context().newCDPSession(page),
+        {windowId} = await session.send('Browser.getWindowForTarget');
+
+    try {
+        await session.send('Browser.setWindowBounds', {
+            bounds: {...requested, windowState: 'normal'},
+            windowId
+        });
+
+        const {bounds} = await session.send('Browser.getWindowBounds', {windowId});
+        let browser;
+
+        await expect.poll(async () => {
+            browser = await readBrowserSurface(page);
+
+            return {
+                positioned: Math.max(
+                    Math.abs(browser.inner.x - bounds.left),
+                    Math.abs(browser.inner.y - bounds.top)
+                ) <= 80,
+                sized: Math.max(
+                    Math.abs(browser.outer.width  - bounds.width),
+                    Math.abs(browser.outer.height - bounds.height)
+                ) <= 2
+            }
+        }, {
+            message  : 'the exact headed Chrome target must adopt its native staging bounds',
+            timeout  : 5000,
+            intervals: [25, 50, 100]
+        }).toEqual({positioned: true, sized: true});
+
+        await expect.poll(() => page.evaluate(() =>
+            Boolean(globalThis.Neo?.main?.addon?.WindowPosition?.publishGeometry)
+        ), {
+            message  : 'the staged window must retain the product geometry publisher',
+            timeout  : 5000,
+            intervals: [25, 50, 100]
+        }).toBe(true);
+
+        const neoWindowId = await page.evaluate(() => {
+            globalThis.Neo.main.addon.WindowPosition.publishGeometry();
+
+            return globalThis.Neo.worker.Manager.windowId
+        });
+
+        return {bounds, browser, neoWindowId}
+    } finally {
+        await session.detach()
+    }
+}
+
+/**
+ * @summary Performs one literal macOS HID titlebar drag with CoreGraphics mouse events.
+ *
+ * The path first enters popup content and exits through its titlebar so the product's ordinary
+ * mouseout-owned movement observer is live. It then holds the OS mouse button throughout the
+ * cross-window move and dwell. No CDP or Neo method moves the popup during this gesture.
+ * @param {Object} data
+ * @param {{x:Number,y:Number}} data.end Global release coordinate over the target window.
+ * @param {{x:Number,y:Number}} data.prime Global point inside popup content.
+ * @param {{x:Number,y:Number}} data.start Global popup-titlebar press coordinate.
+ * @returns {Promise<Object>} Accessibility and physical mouse timing receipt.
+ */
+async function dragNativeTitlebar({end, prime, start}) {
+    const points = [end, prime, start];
+
+    if (!points.every(point => Number.isFinite(point?.x) && Number.isFinite(point?.y))) {
+        throw new Error('native titlebar drag requires finite global coordinates')
+    }
+
+    const
+        literal = value => Number(value).toFixed(3),
+        script  = `
+import Cocoa
+import Darwin
+import Foundation
+
+func post(_ type: CGEventType, x: Double, y: Double) {
+    let point = CGPoint(x: x, y: y)
+    let event = CGEvent(
+        mouseEventSource: nil,
+        mouseType: type,
+        mouseCursorPosition: point,
+        mouseButton: .left
+    )!
+    event.post(tap: .cghidEventTap)
+}
+
+let access = CGPreflightPostEventAccess()
+print("access=\\(access)")
+if !access {
+    exit(77)
+}
+
+let primeX = ${literal(prime.x)}
+let primeY = ${literal(prime.y)}
+let startX = ${literal(start.x)}
+let startY = ${literal(start.y)}
+let endX = ${literal(end.x)}
+let endY = ${literal(end.y)}
+
+post(.mouseMoved, x: primeX, y: primeY)
+Thread.sleep(forTimeInterval: 0.18)
+post(.mouseMoved, x: startX, y: startY)
+Thread.sleep(forTimeInterval: 0.18)
+post(.leftMouseDown, x: startX, y: startY)
+print("mouseDownMs=\\(Int(Date().timeIntervalSince1970 * 1000))")
+
+for step in 1...28 {
+    let progress = Double(step) / 28.0
+    let eased = progress * progress * (3.0 - 2.0 * progress)
+    post(
+        .leftMouseDragged,
+        x: startX + (endX - startX) * eased,
+        y: startY + (endY - startY) * eased
+    )
+    Thread.sleep(forTimeInterval: 0.025)
+}
+
+Thread.sleep(forTimeInterval: 0.14)
+print("mouseUpMs=\\(Int(Date().timeIntervalSince1970 * 1000))")
+post(.leftMouseUp, x: endX, y: endY)
+Thread.sleep(forTimeInterval: 0.12)
+`,
+        moduleCache = path.join(process.env.TMPDIR || '/tmp', 'neo-native-titlebar-swift-cache');
+
+    await fs.ensureDir(moduleCache);
+
+    try {
+        const {stderr, stdout} = await execFileAsync('/usr/bin/swift', ['-e', script], {
+            env: {
+                ...process.env,
+                CLANG_MODULE_CACHE_PATH: moduleCache,
+                SWIFT_MODULE_CACHE_PATH: moduleCache
+            },
+            timeout: 60000
+        });
+        const receipt = Object.fromEntries(stdout.trim().split('\n').map(line => {
+            const index = line.indexOf('=');
+
+            return [line.slice(0, index), line.slice(index + 1)]
+        }));
+
+        stderr.trim() && console.log(`[native-titlebar][swift] ${stderr.trim()}`);
+
+        return {
+            access     : receipt.access === 'true',
+            mouseDownMs: Number(receipt.mouseDownMs),
+            mouseUpMs  : Number(receipt.mouseUpMs)
+        }
+    } catch (error) {
+        throw new Error(
+            'physical native-titlebar input failed; grant Accessibility to the active Codex/terminal host'
+            + `\nstdout: ${String(error.stdout || '').trim()}`
+            + `\nstderr: ${String(error.stderr || '').trim()}`
+        )
+    }
+}
+
+/**
  * @summary Proves the CDP adapter's observed geometry reached the ordinary App-Worker window map.
  * @param {Object} app Neural Link app wrapper.
  * @param {Object} stageReceipt Result from {@link pinToCaptureDisplay}.
@@ -408,6 +581,36 @@ async function assertStageGeometryPublished(app, stageReceipt) {
     console.log(`[film-stage] manager.Window parity: ${JSON.stringify(receipt)}`);
 
     return {...stageReceipt, managed: receipt.managed}
+}
+
+/**
+ * @summary Resolves the one surviving semantic tear-out page after transient popup generations.
+ * @param {import('@playwright/test').Page} page
+ * @param {String} itemId
+ * @returns {Promise<import('@playwright/test').Page>}
+ */
+async function waitForTearOutPopup(page, itemId) {
+    let popups;
+
+    await expect.poll(() => {
+        popups = page.context().pages().filter(candidate => {
+            if (candidate === page || candidate.isClosed()) return false;
+
+            try {
+                return new URL(candidate.url()).searchParams.get('popout') === itemId
+            } catch {
+                return false
+            }
+        });
+
+        return popups.length
+    }, {
+        message  : `one live popout=${itemId} page must survive terminal acquisition`,
+        timeout  : 30000,
+        intervals: [25, 50, 100]
+    }).toBe(1);
+
+    return popups[0]
 }
 
 // `video` must live at file level (a describe-scoped use() would force a new worker).
@@ -1346,6 +1549,469 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
         // The heartbeat moved FORWARD — nothing reloaded, nothing recreated.
         expect(await readHeartbeat(app, wsId)).toBeGreaterThan(heartbeatBefore);
+        expect(pageErrors).toEqual([])
+    });
+
+    test('scene 2 (native titlebar) — a physical macOS popup drag previews, embodies, and returns home', async ({page, neuralLink}) => {
+        test.skip(process.platform !== 'darwin', 'the physical titlebar witness is macOS-only');
+        test.skip(!filmTake, 'run with NEO_FILM_TAKE=1 and --headed for literal native input');
+
+        const userAgent = await page.evaluate(() => navigator.userAgent);
+
+        expect(userAgent, 'a headless browser cannot witness an OS titlebar gesture')
+            .not.toContain('HeadlessChrome');
+
+        const {default: DockZoneModel} = await import('../../../../src/dashboard/DockZoneModel.mjs');
+
+        const
+            {app, pageErrors, popupProbe, wsId} = await boot({page, neuralLink}),
+            readStoreIds                        = async () => {
+                const listed = await app.listStores(),
+                      stores = Array.isArray(listed?.stores)
+                          ? listed.stores
+                          : Array.isArray(listed) ? listed : [];
+
+                return stores.map(store => store?.id).filter(id =>
+                    id?.endsWith('__feed') || id?.endsWith('__scale')).sort()
+            },
+            heartbeatBefore = await readHeartbeat(app, wsId),
+            paneIdBefore    = await app.callMethod(wsId, 'getPaneIdentity', ['metrics']),
+            storeIdsBefore = await readStoreIds(),
+            tearOut         = await app.callMethod(wsId, 'executeTearOutStep', [
+                {itemId: 'metrics', sourceNodeId: 'right-top-tabs'},
+                filmPace
+            ]),
+            popup           = await waitForTearOutPopup(page, 'metrics');
+
+        expect(tearOut.errors).toEqual([]);
+        expect(tearOut.applied, 'setup must leave one real terminal metrics popup').toBe(true);
+        expect(paneIdBefore).toBeTruthy();
+        expect(storeIdsBefore).toHaveLength(2);
+        await popup.waitForSelector('.workstation-viewport', {timeout: 30000});
+
+        const documentBeforeReturn = await readDocument(app, wsId);
+
+        expect(Object.values(documentBeforeReturn.nodes)
+            .flatMap(node => node.items ?? [])
+            .filter(itemId => itemId === 'metrics'),
+        'setup must leave metrics detached from the main document tree').toHaveLength(0);
+
+        const screen = await page.evaluate(() => ({
+            availHeight: globalThis.screen.availHeight,
+            availLeft  : globalThis.screen.availLeft,
+            availTop   : globalThis.screen.availTop,
+            availWidth : globalThis.screen.availWidth
+        }));
+
+        expect(screen.availWidth, 'the physical witness needs room for source and target windows')
+            .toBeGreaterThanOrEqual(1200);
+        expect(screen.availHeight).toBeGreaterThanOrEqual(700);
+
+        const
+            gap         = 24,
+            popupWidth  = Math.min(460, Math.floor(screen.availWidth * .32)),
+            mainWidth   = Math.min(1000, screen.availWidth - popupWidth - gap - 60),
+            mainHeight  = Math.min(760, screen.availHeight - 80),
+            popupHeight = Math.min(420, mainHeight - 120),
+            mainBounds  = {
+                height: mainHeight,
+                left  : screen.availLeft + 20,
+                top   : screen.availTop + 40,
+                width : mainWidth
+            },
+            popupBounds = {
+                height: popupHeight,
+                left  : mainBounds.left + mainBounds.width + gap,
+                top   : mainBounds.top + 120,
+                width : popupWidth
+            },
+            mainPlacement = await placeNativeWindow(page, mainBounds);
+
+        // Do not move the now-discoverable source popup until the worker has consumed the target's
+        // smaller landing. Otherwise the popup's setup geometry can intersect the OLD main rect
+        // and falsely become the native gesture this test is meant to prove.
+        await assertStageGeometryPublished(app, {
+            after      : mainPlacement.browser,
+            neoWindowId: mainPlacement.neoWindowId
+        });
+
+        const popupPlacement = await placeNativeWindow(popup, popupBounds);
+
+        await assertStageGeometryPublished(app, {
+            after      : popupPlacement.browser,
+            neoWindowId: popupPlacement.neoWindowId
+        });
+
+        await popup.bringToFront();
+
+        const
+            readId = result =>
+                result?.properties?.id ?? result?.id ?? (Array.isArray(result) ? readId(result[0]) : null),
+            targetMatches = await app.findInstances(
+                {dockNodeId: 'right-top-tabs'},
+                ['id', 'windowId']
+            ),
+            targetRecord = targetMatches.find(item =>
+                (item.properties?.windowId ?? item.windowId) === mainPlacement.neoWindowId),
+            targetId = readId(targetRecord);
+
+        expect(targetId,
+            `the exact main-window return target must remain projected; matches=${JSON.stringify(targetMatches)}`)
+            .toBeTruthy();
+
+        let targetBox;
+
+        await expect.poll(async () => {
+            targetBox = await page.locator(`#${targetId}`).boundingBox();
+
+            return Boolean(
+                targetBox &&
+                targetBox.x >= 0 &&
+                targetBox.y >= 0 &&
+                targetBox.x + targetBox.width <= mainPlacement.browser.inner.width &&
+                targetBox.y + targetBox.height <= mainPlacement.browser.inner.height
+            )
+        }, {
+            message: 'the exact main-window target must settle inside its physical viewport',
+            timeout: 10000
+        }).toBe(true);
+
+        expect(targetBox, 'the physical target must expose live rendered geometry').toBeTruthy();
+
+        const candidateLocalPoint = {
+            x: targetBox.x + targetBox.width / 2,
+            y: targetBox.y + targetBox.height / 2
+        };
+
+        expect(await app.callMethod(wsId, 'hitTestCrossWindowTarget', [
+            'workstation-main',
+            candidateLocalPoint.x,
+            candidateLocalPoint.y
+        ]), 'the exact physical target point must pass the lower-layer workspace hit test').toBe(true);
+
+        const
+            mainChromeHeight  = mainPlacement.browser.outer.height - mainPlacement.browser.inner.height,
+            popupChromeHeight = popupPlacement.browser.outer.height - popupPlacement.browser.inner.height,
+            titlebarOffset    = Math.max(8, Math.min(18, popupChromeHeight / 2)),
+            targetCenter      = {
+                x: mainPlacement.bounds.left
+                    + (mainPlacement.browser.outer.width - mainPlacement.browser.inner.width) / 2
+                    + targetBox.x + targetBox.width / 2,
+                y: mainPlacement.bounds.top + mainChromeHeight + targetBox.y + targetBox.height / 2
+            },
+            start = {
+                x: popupPlacement.bounds.left + popupPlacement.bounds.width / 2,
+                y: popupPlacement.bounds.top + titlebarOffset
+            },
+            prime = {
+                x: start.x,
+                y: popupPlacement.bounds.top + popupChromeHeight
+                    + Math.min(80, popupPlacement.browser.inner.height / 3)
+            },
+            desiredPopupTop = targetCenter.y - popupPlacement.bounds.height / 2,
+            end = {
+                x: targetCenter.x,
+                y: desiredPopupTop + titlebarOffset
+            },
+            popupStart = await popup.evaluate(() => ({
+                x: globalThis.screenX,
+                y: globalThis.screenY
+            }));
+
+        await page.evaluate(() => {
+            const
+                state = globalThis.__nativeTitlebarWitness = {
+                    activeBothSince  : null,
+                    firstBothAt      : null,
+                    firstPreviewAt   : null,
+                    firstProxyAt     : null,
+                    lastVisibility   : null,
+                    maxBothDurationMs: 0,
+                    presence         : [],
+                    samples          : [],
+                    stopped          : false
+                },
+                visible = element => {
+                    if (!element) return false;
+
+                    const
+                        rect  = element.getBoundingClientRect(),
+                        style = getComputedStyle(element);
+
+                    return rect.width > 0 && rect.height > 0
+                        && style.display !== 'none'
+                        && style.visibility !== 'hidden'
+                        && Number.parseFloat(style.opacity || '1') > 0
+                },
+                pickRect = element => {
+                    const {height, left, top, width} = element.getBoundingClientRect();
+
+                    return {height, left, top, width}
+                },
+                sample = () => {
+                    if (state.stopped) return;
+
+                    const
+                        previews       = [...document.querySelectorAll('.neo-dock-preview-affordance')],
+                        proxies        = [...document.querySelectorAll('.workstation-vessel-dragproxy')],
+                        preview        = previews.find(visible) ?? previews[0] ?? null,
+                        proxy          = proxies.find(visible) ?? proxies[0] ?? null,
+                        previewVisible = visible(preview),
+                        proxyVisible   = visible(proxy),
+                        now            = Date.now(),
+                        visibility     = `${previewVisible}:${proxyVisible}`;
+
+                    previewVisible && (state.firstPreviewAt ??= now);
+                    proxyVisible && (state.firstProxyAt ??= now);
+
+                    if (state.lastVisibility !== visibility && state.presence.length < 20) {
+                        state.lastVisibility = visibility;
+                        state.presence.push({
+                            at          : now,
+                            previewClass: preview?.className ?? null,
+                            previewCount: previews.length,
+                            previewVisible,
+                            proxyClass  : proxy?.className ?? null,
+                            proxyCount  : proxies.length,
+                            proxyVisible
+                        })
+                    }
+
+                    if (previewVisible && proxyVisible) {
+                        state.firstBothAt ??= now;
+                        state.activeBothSince ??= now;
+                        state.maxBothDurationMs = Math.max(
+                            state.maxBothDurationMs,
+                            now - state.activeBothSince
+                        );
+
+                        const previous = state.samples.at(-1);
+
+                        (!previous || now - previous.at >= 16) && state.samples.length < 12 &&
+                            state.samples.push({
+                            at     : now,
+                            preview: pickRect(preview),
+                            proxy  : pickRect(proxy)
+                        })
+                    } else if (state.activeBothSince != null) {
+                        state.maxBothDurationMs = Math.max(
+                            state.maxBothDurationMs,
+                            now - state.activeBothSince
+                        );
+                        state.activeBothSince = null
+                    }
+                };
+
+            state.observer = new MutationObserver(sample);
+            state.observer.observe(document.body, {
+                attributes: true,
+                childList : true,
+                subtree   : true
+            });
+            state.sample = sample;
+            sample()
+        });
+
+        let popupClosedAt = null;
+
+        popup.on('close', () => popupClosedAt = Date.now());
+
+        const
+            movedPromise = popup.waitForFunction(({x, y}) => {
+                const moved = Math.max(
+                    Math.abs(globalThis.screenX - x),
+                    Math.abs(globalThis.screenY - y)
+                ) > 40;
+
+                return moved ? {x: globalThis.screenX, y: globalThis.screenY} : false
+            }, popupStart, {polling: 'raf', timeout: 15000}).then(async handle => {
+                const value = await handle.jsonValue();
+
+                await handle.dispose();
+                return value
+            }),
+            retainedPromise = (async () => {
+                const deadline         = Date.now() + 15000;
+                let   semanticSnapshot = null;
+
+                while (Date.now() < deadline) {
+                    const coexistence = await page.evaluate(() => {
+                        const witness = globalThis.__nativeTitlebarWitness;
+
+                        witness.sample();
+                        return {
+                            firstBothAt      : witness.firstBothAt,
+                            maxBothDurationMs: witness.maxBothDurationMs
+                        }
+                    });
+
+                    if (coexistence.firstBothAt && !semanticSnapshot) {
+                        semanticSnapshot = await app.callMethod(wsId, 'readCrossWindowGestureSnapshot', [{
+                            parkedItemId     : 'metrics',
+                            targetWorkspaceId: 'workstation-main'
+                        }])
+                    }
+
+                    if (coexistence.firstBothAt && coexistence.maxBothDurationMs >= 32) {
+                        return {
+                            ...coexistence,
+                            firstBothSeen: true,
+                            semanticSnapshot,
+                            sourceOpen   : !popup.isClosed()
+                        }
+                    }
+
+                    await new Promise(resolve => setTimeout(resolve, 10))
+                }
+
+                return {
+                    error        : 'no proxy/preview coexistence within 15000ms',
+                    firstBothSeen: false,
+                    semanticSnapshot,
+                    sourceOpen   : !popup.isClosed()
+                }
+            })(),
+            [nativeInput, moved, retainedAtFirst] = await Promise.all([
+                dragNativeTitlebar({end, prime, start}),
+                movedPromise,
+                retainedPromise
+            ]),
+            retained = {
+                ...retainedAtFirst,
+                receipt: await page.evaluate(() => {
+                    const witness = globalThis.__nativeTitlebarWitness;
+
+                    witness.sample();
+
+                    return {
+                        firstBothAt      : witness.firstBothAt,
+                        firstPreviewAt   : witness.firstPreviewAt,
+                        firstProxyAt     : witness.firstProxyAt,
+                        maxBothDurationMs: witness.maxBothDurationMs,
+                        presence         : witness.presence,
+                        samples          : witness.samples
+                    }
+                }),
+                popupClosedAt
+            };
+
+        console.log('[native-titlebar][physical-receipt]', JSON.stringify({
+            end,
+            moved,
+            nativeInput,
+            popupStart,
+            retained: retained.receipt,
+            targetCenter
+        }));
+
+        expect(nativeInput.access, 'the OS accepted literal HID event authority').toBe(true);
+        expect(nativeInput.mouseUpMs).toBeGreaterThan(nativeInput.mouseDownMs);
+        expect(Math.max(
+            Math.abs(moved.x - popupStart.x),
+            Math.abs(moved.y - popupStart.y)
+        ), 'the browser must observe its exact OS window physically moving').toBeGreaterThan(40);
+        expect(retained.sourceOpen,
+            'the source popup must still exist while proxy and preview share retained frames').toBe(true);
+        expect(retained.receipt.firstBothAt,
+            `the settled proxy and preview must coexist; witness=${JSON.stringify(retained)}`).toBeTruthy();
+        expect(retained.receipt.firstPreviewAt,
+            'continuous target preview must paint during the physical move').toBeLessThan(nativeInput.mouseUpMs);
+        expect(retained.receipt.firstProxyAt,
+            'the target-local live proxy must paint before semantic settlement').toBeTruthy();
+        expect(retained.receipt.firstPreviewAt,
+            'continuous preview must precede the inferred terminal embodiment').toBeLessThan(retained.receipt.firstBothAt);
+        expect(retained.receipt.maxBothDurationMs,
+            'proxy and readable preview must coexist across at least two 60 Hz frame intervals')
+            .toBeGreaterThanOrEqual(32);
+
+        const committedPreview = retained.semanticSnapshot?.preview;
+
+        expect(committedPreview,
+            `retained visual frames must carry semantic target truth; snapshot=${JSON.stringify(retained.semanticSnapshot)}`)
+            .toMatchObject({
+                feedback: {state: 'accepted'},
+                itemId  : 'metrics',
+                target  : {nodeId: 'right-top-tabs'}
+            });
+        expect(retained.semanticSnapshot?.rendered?.previewId,
+            'the target renderer must display the exact semantic preview').toBe(committedPreview.previewId);
+
+        const
+            expectedOperation = previewToOperation(committedPreview),
+            expectedReturn    = DockZoneModel.applyOperation(documentBeforeReturn, expectedOperation);
+
+        expect(expectedOperation, 'the retained accepted preview must convert through the production contract')
+            .toBeTruthy();
+        expect(expectedReturn.errors, 'the retained preview operation must be valid against pre-return truth')
+            .toEqual([]);
+
+        let closeReceipt   = null,
+            nativeSnapshot = null;
+
+        await expect.poll(async () => {
+            closeReceipt = (await app.getComponent(wsId, ['lastTearOutClose']))?.lastTearOutClose ?? null;
+            nativeSnapshot = await app.callMethod(wsId, 'readCrossWindowGestureSnapshot', [{
+                parkedItemId     : 'metrics',
+                targetWorkspaceId: 'workstation-main'
+            }]);
+
+            return popup.isClosed()
+        }, {
+            message: 'semantic commit must settle before retiring the exact source popup',
+            timeout: 15000
+        }).toBe(true).catch(error => {
+            error.message += `\ncloseReceipt=${JSON.stringify(closeReceipt)}`
+                + `\nnativeSnapshot=${JSON.stringify(nativeSnapshot)}`;
+            throw error
+        });
+
+        const documentAfter = await readDocument(app, wsId);
+
+        expect(documentAfter,
+            `the exact physical landing must commit its retained ${committedPreview.placement.kind} preview`)
+            .toEqual(expectedReturn.document);
+        expect(Object.values(documentAfter.nodes)
+            .flatMap(node => node.items ?? [])
+            .filter(itemId => itemId === 'metrics')).toHaveLength(1);
+        expect(await app.callMethod(wsId, 'getPaneIdentity', ['metrics']),
+            'the same live pane must cross the native boundary').toBe(paneIdBefore);
+        expect(await readStoreIds(), 'provider store identities must survive the native return')
+            .toEqual(storeIdsBefore);
+        expect(await readHeartbeat(app, wsId), 'the workspace must stay alive across the return')
+            .toBeGreaterThan(heartbeatBefore);
+
+        await page.evaluate(() => {
+            const witness = globalThis.__nativeTitlebarWitness;
+
+            witness.stopped = true;
+            witness.observer.disconnect()
+        });
+        await expect.poll(() => page.evaluate(() => {
+            const visible = element => {
+                if (!element) return false;
+
+                const
+                    rect  = element.getBoundingClientRect(),
+                    style = getComputedStyle(element);
+
+                return rect.width > 0 && rect.height > 0
+                    && style.display !== 'none'
+                    && style.visibility !== 'hidden'
+                    && Number.parseFloat(style.opacity || '1') > 0
+            };
+
+            return {
+                preview: visible(document.querySelector('.neo-dock-preview-affordance')),
+                proxy  : visible(document.querySelector('.workstation-vessel-dragproxy'))
+            }
+        }), {
+            message  : 'native terminal cleanup must leave no preview or proxy residue',
+            timeout  : 5000,
+            intervals: [25, 50, 100]
+        }).toEqual({preview: false, proxy: false});
+
+        expect(popupProbe).toHaveLength(1);
+        expect(popupProbe[0].closed).toBe(true);
         expect(pageErrors).toEqual([])
     });
 

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -353,20 +353,33 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
     test('target-proxy staging uses the physical parked popup instead of the source sort-zone window', async () => {
         const
-            workspace      = Neo.create(Workspace, {}),
-            originalProxy  = workspace.vesselProxyEmbodiment,
-            stagedPayloads = [];
+            workspace       = Neo.create(Workspace, {}),
+            originalProxy   = workspace.vesselProxyEmbodiment,
+            settledPayloads = [],
+            stagedPayloads  = [];
         let participation;
 
         try {
             workspace.tearOutConnects.audit = {windowId: 'parked-audit-popup'};
+            workspace.vesselWorkspaces.set('proxy-target-workspace', {
+                preview: {
+                    dockPreview: {itemId: 'audit'},
+                    promiseUpdate() {
+                        settledPayloads.push('preview-rendered')
+                    }
+                }
+            });
             workspace.vesselProxyEmbodiment = {
                 move: data => {
                     stagedPayloads.push(data);
                     return true
                 },
                 promote: () => true,
-                restore: () => true
+                restore: () => true,
+                whenSettled(data) {
+                    settledPayloads.push(data);
+                    return true
+                }
             };
 
             participation = await workspace.createCrossWindowParticipation({
@@ -385,7 +398,13 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 ...payload,
                 sourceWindowId: 'parked-audit-popup',
                 targetWindowId: 'proxy-target-window'
-            }])
+            }]);
+            await expect(participation.target.awaitDragEmbodiment(payload)).resolves.toBe(true);
+            expect(settledPayloads).toEqual([{
+                itemId        : 'audit',
+                sourceWindowId: 'parked-audit-popup',
+                targetWindowId: 'proxy-target-window'
+            }, 'preview-rendered'])
         } finally {
             participation?.destroy();
             workspace.vesselProxyEmbodiment = originalProxy;
@@ -988,6 +1007,39 @@ test.describe.serial('Workstation.view.Workspace', () => {
                     height: targetRect.height
                 }));
 
+                const
+                    nativeHomeId = 'right-top-tabs',
+                    nativeTarget = host.down({dockNodeId: nativeHomeId});
+
+                workspace.tearOutPlacements.queues = {index: 1, tabsNodeId: nativeHomeId};
+                workspace.crossWindowPreviewGeometries.delete(Workspace.MAIN_WORKSPACE_ID);
+
+                await workspace.ensureCrossWindowPreviewGeometry(
+                    Workspace.MAIN_WORKSPACE_ID,
+                    nativeHomeId
+                );
+
+                expect(measuredIds.at(-1)).toEqual([host.id, nativeTarget.id]);
+
+                const nativeReturnPreview = workspace.renderCrossWindowPreview(
+                    Workspace.MAIN_WORKSPACE_ID,
+                    {
+                        draggedItem: {
+                            dockItemId           : 'queues',
+                            dockSourceWorkspaceId: Workspace.MAIN_WORKSPACE_ID
+                        },
+                        localX      : 250,
+                        localY      : 160,
+                        sourceNodeId: Workspace.vesselTabsNodeId('queues')
+                    }
+                );
+
+                expect(nativeReturnPreview?.target.nodeId,
+                    'a main-origin native popup must recover its own saved semantic home')
+                    .toBe(nativeHomeId);
+
+                workspace.tearOutPlacements.queues = {index: 0, tabsNodeId: 'left-tabs'};
+
                 let settleReplacement;
 
                 WindowManager.get = () => ({innerRect: {x: 0, y: 0, width: 1279, height: 720}});
@@ -1033,6 +1085,181 @@ test.describe.serial('Workstation.view.Workspace', () => {
             expect(workspace.getPaneIdentity('alerts')).toBe(alertsIdentity);
             expect(workspace.getPaneIdentity('security')).toBe(securityIdentity)
         } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('native-titlebar source discovery resolves the exact live bare-vessel pane and rejects stale topology', () => {
+        const
+            workspace   = Neo.create(Workspace, {}),
+            itemId      = 'alerts',
+            pane        = workspace.paneCache[itemId],
+            workspaceId = Workspace.vesselWorkspaceId(itemId),
+            detached    = DockZoneModel.applyOperation(workspace.dockModel, {
+                operation: 'detachItem',
+                itemId
+            }),
+            state       = {
+                app           : {mainView: {isDestroyed: false}},
+                closeRequested: false,
+                committed     : false,
+                disconnected  : false,
+                document      : null,
+                itemId,
+                windowId      : 'window-alerts',
+                workspaceId
+            };
+
+        try {
+            expect(detached.errors).toEqual([]);
+            workspace.dockModel = detached.document;
+            workspace.tearOutPanes[itemId] = {
+                windowId  : 'window-alerts',
+                windowName: 'tearout-alerts'
+            };
+            workspace.vesselWorkspaces.set(workspaceId, state);
+
+            const source = workspace.resolveNativeTearOutDrag('window-alerts');
+
+            expect(source).toMatchObject({
+                draggedItem      : pane,
+                embodyNativeHover: true,
+                sourceWindowId   : 'window-alerts',
+                widgetName       : itemId
+            });
+            expect(source.draggedItem).toBe(pane);
+            expect(pane.dockItemId).toBe(itemId);
+            expect(pane.dockSourceWorkspaceId).toBe(Workspace.MAIN_WORKSPACE_ID);
+            expect(pane.dockGroupNodeId).toBeUndefined();
+            expect(workspace.resolveNativeTearOutDrag('window-other')).toBeNull();
+
+            state.disconnected = true;
+            expect(workspace.resolveNativeTearOutDrag('window-alerts')).toBeNull();
+
+            state.disconnected = false;
+            state.committed    = true;
+            expect(workspace.resolveNativeTearOutDrag('window-alerts')).toBeNull();
+
+            state.committed = false;
+            state.windowId  = 'window-mismatch';
+            expect(workspace.resolveNativeTearOutDrag('window-alerts')).toBeNull()
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('native-titlebar parking uses the exact native route and compensates without pointer drag state', async () => {
+        const
+            workspace           = Neo.create(Workspace, {}),
+            originalDragDrop    = Neo.main.addon.DragDrop,
+            originalManagerGet  = Neo.manager.Window.get,
+            originalNativeFocus = Neo.Main.windowNativeFocus,
+            originalNativeMove  = Neo.Main.windowNativeMoveTo,
+            originalWindowFocus = Neo.Main.windowFocus,
+            focusResults        = [true, true, true, false],
+            focusCalls          = [],
+            nativeFocusCalls    = [],
+            nativeMoveCalls     = [],
+            pointerCalls        = [],
+            ownerWindowId       = workspace.windowId,
+            sourceWindowId      = 'window-alerts',
+            targetWindowId      = ownerWindowId,
+            sourceRect          = {height: 320, width: 480, x: 420, y: 240},
+            targetRect          = {height: 700, width: 1000, x: 30, y: 50},
+            routeFor            = (targetWindowId, capabilities) => ({
+                capabilities,
+                nativeHandleKey: `handle-${targetWindowId}`,
+                ownerWindowId,
+                targetWindowId
+            });
+
+        try {
+            workspace.tearOutPanes.alerts = {
+                windowId  : sourceWindowId,
+                windowName: 'tearout-alerts'
+            };
+            workspace.vesselConversionTargetWindowId = targetWindowId;
+
+            Neo.manager.Window.get = windowId => ({
+                [sourceWindowId]: {
+                    innerRect  : sourceRect,
+                    nativeRoute: routeFor(sourceWindowId, {position: true})
+                },
+                [targetWindowId]: {
+                    innerRect  : targetRect,
+                    nativeRoute: null
+                }
+            })[windowId] ?? null;
+            Neo.Main.windowFocus = async data => {
+                focusCalls.push(data);
+                return focusResults.shift()
+            };
+            Neo.Main.windowNativeFocus = async data => {
+                nativeFocusCalls.push(data);
+                return true
+            };
+            Neo.Main.windowNativeMoveTo = async data => {
+                nativeMoveCalls.push(data);
+                return true
+            };
+            Neo.main.addon.DragDrop = {
+                parkWindowDrag: async data => {
+                    pointerCalls.push(['park', data]);
+                    return true
+                },
+                resumeWindowDrag: async data => {
+                    pointerCalls.push(['resume', data]);
+                    return true
+                }
+            };
+
+            await expect(workspace.parkTearOutVessel({
+                itemId        : 'alerts',
+                nativeTitlebar: true,
+                windowName    : 'tearout-alerts'
+            })).resolves.toBe(true);
+
+            expect(nativeMoveCalls).toEqual([{
+                nativeHandleKey: `handle-${sourceWindowId}`,
+                targetWindowId : sourceWindowId,
+                windowId       : ownerWindowId,
+                windowName     : 'tearout-alerts',
+                x              : targetRect.x,
+                y              : targetRect.y
+            }]);
+            expect(pointerCalls, 'a terminal titlebar drag has no live pointer DragDrop session').toEqual([]);
+            expect(focusCalls).toEqual([
+                {windowId: sourceWindowId},
+                {windowId: sourceWindowId}
+            ]);
+            expect(nativeFocusCalls,
+                'the root target has no opener-minted native route; the popup focuses its opener').toEqual([]);
+
+            nativeMoveCalls.length = 0;
+
+            await expect(workspace.parkTearOutVessel({
+                itemId        : 'alerts',
+                nativeTitlebar: true,
+                windowName    : 'tearout-alerts'
+            })).resolves.toBe(false);
+
+            expect(nativeMoveCalls.map(({x, y}) => ({x, y}))).toEqual([
+                {x: targetRect.x, y: targetRect.y},
+                {x: sourceRect.x, y: sourceRect.y}
+            ]);
+            expect(focusCalls).toEqual([
+                {windowId: sourceWindowId},
+                {windowId: sourceWindowId},
+                {windowId: sourceWindowId},
+                {windowId: sourceWindowId}
+            ]);
+            expect(pointerCalls).toEqual([])
+        } finally {
+            Neo.main.addon.DragDrop     = originalDragDrop;
+            Neo.manager.Window.get      = originalManagerGet;
+            Neo.Main.windowNativeFocus  = originalNativeFocus;
+            Neo.Main.windowNativeMoveTo = originalNativeMove;
+            Neo.Main.windowFocus        = originalWindowFocus;
             workspace.destroy()
         }
     });

--- a/test/playwright/unit/dashboard/CrossWindowDragTarget.spec.mjs
+++ b/test/playwright/unit/dashboard/CrossWindowDragTarget.spec.mjs
@@ -81,9 +81,15 @@ test.describe('Neo.dashboard.CrossWindowDragTarget (#14670 / ADR 0029 §2.3)', (
         target.destroy()
     });
 
-    test('an explicitly licensed target proxy stages before preview and restores before leave cleanup', () => {
-        const order  = [];
+    test('an explicitly licensed target proxy stages, settles, then restores before leave cleanup', async () => {
+        const
+            draggedItem = {dockItemId: 'pane-a'},
+            order       = [];
         const target = Neo.create(CrossWindowDragTarget, {
+            awaitDragEmbodiment: payload => {
+                order.push('await-proxy');
+                return Promise.resolve(payload.draggedItem === draggedItem)
+            },
             clearPreview: () => order.push('clear-preview'),
             previewFor  : () => {
                 order.push('preview');
@@ -102,16 +108,20 @@ test.describe('Neo.dashboard.CrossWindowDragTarget (#14670 / ADR 0029 §2.3)', (
         });
 
         target.onRemoteDragMove({
-            draggedItem: {dockItemId: 'pane-a'},
+            draggedItem,
             embodyProxy: true,
             localX     : 40,
             localY     : 8
         });
+        await expect(target.awaitRemoteDragEmbodiment(draggedItem)).resolves.toBe(true);
+        await expect(target.awaitRemoteDragEmbodiment({dockItemId: 'pane-a'}),
+            'equal-looking payloads cannot borrow the active generation').resolves.toBe(false);
         target.onRemoteDragLeave();
 
         expect(order).toEqual([
             'stage-proxy',
             'preview',
+            'await-proxy',
             'restore-proxy',
             'clear-preview'
         ]);
@@ -236,6 +246,84 @@ test.describe('Neo.dashboard.CrossWindowDragTarget (#14670 / ADR 0029 §2.3)', (
         expect(restored).toEqual(['pane-a']);
 
         target.destroy()
+    });
+
+    test('a target destroyed during an async commit never promotes or reports its stale embodiment', async () => {
+        const
+            promoted = [],
+            restored = [];
+        let resolveCommit;
+
+        const
+            target = Neo.create(CrossWindowDragTarget, {
+                commitOperation   : () => new Promise(resolve => resolveCommit = resolve),
+                previewFor        : () => ({feedback: {state: 'accepted'}, itemId: 'pane-a'}),
+                previewToOperation: () => ({
+                    operation : 'addTab',
+                    itemId    : 'pane-a',
+                    tabsNodeId: 't1'
+                }),
+                promoteDragEmbodiment: payload => promoted.push(payload.draggedItem.dockItemId),
+                restoreDragEmbodiment: payload => restored.push(payload.draggedItem.dockItemId),
+                sortGroup            : 'dock-main',
+                stageDragEmbodiment  : () => true,
+                windowId             : 2
+            }),
+            payload = {
+                draggedItem: {dockItemId: 'pane-a'},
+                embodyProxy: true,
+                localX     : 4,
+                localY     : 4
+            };
+
+        target.onRemoteDragMove(payload);
+
+        const dropping = target.onRemoteDrop(payload.draggedItem);
+
+        target.destroy();
+        resolveCommit({applied: true});
+
+        expect(await dropping,
+            'a completion whose target generation departed must not advertise a source-retiring commit').toBeNull();
+        expect(promoted).toEqual([]);
+        expect(restored, 'destroy restores the staged generation exactly once').toEqual(['pane-a'])
+    });
+
+    test('a target destroyed during an async rejection restores its staged generation exactly once', async () => {
+        const restored = [];
+        let rejectCommit;
+
+        const
+            target = Neo.create(CrossWindowDragTarget, {
+                commitOperation   : () => new Promise((resolve, reject) => rejectCommit = reject),
+                previewFor        : () => ({feedback: {state: 'accepted'}, itemId: 'pane-a'}),
+                previewToOperation: () => ({
+                    operation : 'addTab',
+                    itemId    : 'pane-a',
+                    tabsNodeId: 't1'
+                }),
+                restoreDragEmbodiment: payload => restored.push(payload.draggedItem.dockItemId),
+                sortGroup            : 'dock-main',
+                stageDragEmbodiment  : () => true,
+                windowId             : 2
+            }),
+            payload = {
+                draggedItem: {dockItemId: 'pane-a'},
+                embodyProxy: true,
+                localX     : 4,
+                localY     : 4
+            },
+            error = new Error('commit failed after target departure');
+
+        target.onRemoteDragMove(payload);
+
+        const dropping = target.onRemoteDrop(payload.draggedItem);
+
+        target.destroy();
+        rejectCommit(error);
+
+        await expect(dropping).rejects.toBe(error);
+        expect(restored, 'destroy owns the sole exact-generation restore').toEqual(['pane-a'])
     });
 
     test('a throwing owner commit still ends the gesture clean — cleanup is unconditional', () => {

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -98,6 +98,66 @@ test.describe('Neo.dashboard.DockCrossWindowParticipation (ADR 0029 §2.3 — wo
         expect(participation.target ?? null).toBeNull()
     });
 
+    test('native-titlebar source seams ride the SAME stable participation registration', async () => {
+        const
+            calls           = [],
+            draggedItem     = {id: 'terminal'},
+            awaitEmbodiment = payload => {
+                calls.push(['await-embodiment', payload]);
+                return true
+            },
+            source      = {
+                draggedItem,
+                embodyNativeHover: true,
+                sourceWindowId   : 'window-popup',
+                widgetName       : 'terminal'
+            };
+
+        const participation = Neo.create(DockCrossWindowParticipation, {
+            awaitDragEmbodiment    : awaitEmbodiment,
+            dragCoordinator        : createCoordinatorStub(calls),
+            getDocument            : () => targetDoc(),
+            resolveNativeWindowDrag: windowId => windowId === 'window-popup' ? source : null,
+            resumeNativeWindowDrag : (widgetName, proxyRect) => {
+                calls.push(['resume', widgetName, proxyRect]);
+                return 'resumed'
+            },
+            retireNativeWindowDrag : item => {
+                calls.push(['retire', item]);
+                return 'retired'
+            },
+            sortGroup              : 'dock-demo',
+            suspendNativeWindowDrag: (widgetName, context) => {
+                calls.push(['suspend', widgetName, context]);
+                return true
+            },
+            windowId   : 'window-main',
+            workspaceId: 'main'
+        });
+
+        const target = participation.target;
+
+        expect(calls.filter(([name]) => name === 'register')).toEqual([['register', target]]);
+        expect(target.awaitDragEmbodiment).toBe(awaitEmbodiment);
+        expect(target.getNativeWindowDrag('window-popup')).toBe(source);
+        expect(target.getNativeWindowDrag('window-other')).toBeNull();
+
+        const context = {targetWindowId: 'window-main'};
+
+        expect(target.suspendWindowDrag('terminal', context)).toBe(true);
+        expect(target.resumeWindowDrag('terminal', {x: 10, y: 20})).toBe('resumed');
+        expect(target.onRemoteDropOut(draggedItem)).toBe('retired');
+        expect(calls.slice(1)).toEqual([
+            ['suspend', 'terminal', context],
+            ['resume', 'terminal', {x: 10, y: 20}],
+            ['retire', draggedItem]
+        ]);
+
+        participation.destroy();
+
+        expect(calls.filter(([name]) => name === 'unregister')).toEqual([['unregister', target]])
+    });
+
     test('seam binding: the registered target rides the owner preview pipeline — previewFor on hover, previewToOperation + commit on drop', () => {
         const seen  = {previews: [], conversions: [], commits: []};
         const calls = [];

--- a/test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs
@@ -117,6 +117,39 @@ test.describe('Neo.dashboard.DockVesselEmbodiment (#15396)', () => {
         expect(target.items).toEqual([]);
         expect(embodiment.isStaged('live')).toBe(false)
     })
+
+    test('a parked source renderer cannot veto the target readability settlement', async () => {
+        source.promiseUpdate = () => {
+            throw new Error('parked source renderer does not acknowledge frames')
+        };
+
+        await expect(embodiment.stage({
+            itemId  : 'live',
+            windowId: 'admitted-window'
+        })).resolves.toBe(true);
+
+        expect(target.items).toEqual([pane]);
+        expect(source.items[1].cls).toContain('neo-dashboard-dock-vessel-placeholder');
+        expect(embodiment.isStaged('live')).toBe(true)
+    })
+
+    test('publication does not wait forever on a parked source transaction', async () => {
+        let sourceStarted = false;
+
+        source.promiseUpdate = () => {
+            sourceStarted = true;
+
+            return new Promise(() => {})
+        };
+
+        await expect(embodiment.stage({
+            itemId  : 'live',
+            windowId: 'admitted-window'
+        })).resolves.toBe(true);
+        expect(sourceStarted).toBe(true);
+        expect(target.items).toEqual([pane]);
+        expect(embodiment.isStaged('live')).toBe(true)
+    })
 });
 
 test.describe('Neo.dashboard.DockVesselProxyEmbodiment (#16090)', () => {
@@ -261,6 +294,31 @@ test.describe('Neo.dashboard.DockVesselProxyEmbodiment (#16090)', () => {
         expect(proxyEmbodiment.restore({itemId: 'live'})).toBe(false)
     });
 
+    test('retained readability begins only after the exact proxy renderer generation settles', async () => {
+        const fixture = createFixture({deferFirst: true});
+        let observed;
+
+        expect(fixture.move()).toBe(true);
+
+        const settlement = proxyEmbodiment.whenSettled({
+            itemId        : 'live',
+            sourceWindowId: 'source-window',
+            targetWindowId: 'target-window'
+        }).then(value => observed = value);
+
+        await Promise.resolve();
+        expect(observed, 'synchronous staging is not renderer settlement').toBeUndefined();
+
+        fixture.resolveFirst();
+
+        await expect(settlement).resolves.toBe(true);
+        expect(proxyEmbodiment.snapshot('live')).toMatchObject({
+            ownsPane: true,
+            settled : true,
+            visible : true
+        })
+    });
+
     test('the parked popup identity overrides the originating sort-zone window', async () => {
         const fixture = createFixture();
 
@@ -312,6 +370,11 @@ test.describe('Neo.dashboard.DockVesselProxyEmbodiment (#16090)', () => {
         await Promise.resolve();
 
         expect(successor.generation).toBe(2);
+        await expect(proxyEmbodiment.whenSettled({
+            itemId        : 'live',
+            sourceWindowId: 'source-window',
+            targetWindowId: 'target-window'
+        })).resolves.toBe(true);
         expect(proxyEmbodiment.snapshot('live')).toMatchObject({
             generation: 2,
             ownsPane  : true,

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -802,6 +802,739 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         expect(DragCoordinator.nativeClaimArbiters.size).toBe(0)
     });
 
+    test('a native source may name its physical popup separately so the originating main participation can claim', () => {
+        const
+            draggedItem = {id: 'terminal'},
+            main        = createZone('workspace-main', 'win-main');
+
+        main.getNativeWindowDrag = windowId => windowId === 'win-popup'
+            ? {
+                draggedItem,
+                sourceWindowId: 'win-popup',
+                widgetName    : 'terminal'
+            }
+            : null;
+
+        registerWindow('win-main',  0,   0, 1000, 800);
+        registerWindow('win-popup', 200, 200,  300, 200);
+        DragCoordinator.register(main);
+
+        const source    = DragCoordinator.getNativeWindowDragSource('win-popup'),
+              candidate = DragCoordinator.getNativeWindowDropCandidate({windowId: 'win-popup'}, source);
+
+        expect(source).toMatchObject({
+            draggedItem,
+            sourceSortZone: main,
+            sourceWindowId: 'win-popup'
+        });
+        expect(candidate?.targetSortZone).toBe(main);
+        expect(candidate?.targetWindowId).toBe('win-main');
+
+        main.getNativeWindowDrag = () => ({draggedItem, widgetName: 'terminal'});
+
+        expect(DragCoordinator.getNativeWindowDropCandidate(
+            {windowId: 'win-popup'},
+            DragCoordinator.getNativeWindowDragSource('win-popup')
+        )).toBeNull()
+    });
+
+    test('native embodiment is retained before semantic commit, then target commit precedes source retirement', async () => {
+        let resolveRenderer;
+
+        const
+            draggedItem     = {id: 'terminal'},
+            order           = [],
+            rendererSettled = new Promise(resolve => resolveRenderer = resolve),
+            source          = {
+                getNativeWindowDrag: () => ({
+                    draggedItem,
+                    embodyNativeHover: true,
+                    sourceWindowId   : 'win-popup',
+                    widgetName       : 'terminal'
+                }),
+                onRemoteDropOut() {
+                    order.push('retire');
+                    return true
+                },
+                resumeWindowDrag() {
+                    order.push('resume');
+                    return true
+                },
+                sortGroup: 'dock',
+                suspendWindowDrag() {
+                    order.push('suspend');
+                    return true
+                },
+                windowId: 'win-main'
+            },
+            target      = {
+                acceptsRemoteDrag: () => true,
+                awaitRemoteDragEmbodiment() {
+                    order.push('await-renderer');
+                    return rendererSettled
+                },
+                onRemoteDragLeave() {
+                    order.push('leave')
+                },
+                onRemoteDragMove(payload) {
+                    order.push(payload.embodyProxy ? 'embody' : 'preview');
+                    return {itemId: 'terminal'}
+                },
+                onRemoteDrop() {
+                    order.push('commit');
+                    return {type: 'addTab'}
+                }
+            },
+            candidate   = {
+                draggedItem,
+                embodyNativeHover: true,
+                localX           : 20,
+                localY           : 30,
+                offsetX          : 10,
+                offsetY          : 10,
+                proxyRect        : {},
+                sourceSortZone   : source,
+                sourceWindowId   : 'win-popup',
+                targetSortZone   : target,
+                targetWindowId   : 'win-main',
+                widgetName       : 'terminal'
+            },
+            oldHandoff = DragCoordinator.nativeWindowDropHandoffMs;
+
+        DragCoordinator.nativeWindowDropHandoffMs = 20;
+        DragCoordinator.nativeWindowDropCandidates.set('win-popup', candidate);
+
+        try {
+            const committing = DragCoordinator.commitNativeWindowDrop('win-popup', candidate);
+
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(order).toEqual(['suspend', 'embody', 'await-renderer']);
+            expect(DragCoordinator.nativeWindowDropCandidates.get('win-popup')).toBe(candidate);
+
+            await new Promise(resolve => setTimeout(resolve, 25));
+            expect(order, 'the handoff timer cannot start before renderer settlement')
+                .toEqual(['suspend', 'embody', 'await-renderer']);
+
+            resolveRenderer(true);
+            await committing;
+
+            expect(order).toEqual(['suspend', 'embody', 'await-renderer', 'commit', 'retire']);
+            expect(order.indexOf('commit')).toBeLessThan(order.indexOf('retire'));
+            expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup')).toBe(false)
+        } finally {
+            DragCoordinator.nativeWindowDropHandoffMs = oldHandoff
+        }
+    });
+
+    test('native model refusal restores the target before the physical popup and never retires it', async () => {
+        const
+            draggedItem = {id: 'terminal'},
+            order       = [],
+            source      = {
+                getNativeWindowDrag: () => ({
+                    draggedItem,
+                    embodyNativeHover: true,
+                    sourceWindowId   : 'win-popup',
+                    widgetName       : 'terminal'
+                }),
+                onRemoteDropOut() {
+                    order.push('retire')
+                },
+                resumeWindowDrag() {
+                    order.push('source-restored');
+                    return true
+                },
+                suspendWindowDrag() {
+                    order.push('suspend');
+                    return true
+                }
+            },
+            target      = {
+                acceptsRemoteDrag        : () => true,
+                awaitRemoteDragEmbodiment: () => true,
+                onRemoteDragLeave() {},
+                onRemoteDragMove() {
+                    order.push('embody');
+                    return {itemId: 'terminal'}
+                },
+                onRemoteDrop() {
+                    order.push('target-restored');
+                    return null
+                }
+            },
+            candidate   = {
+                draggedItem,
+                embodyNativeHover: true,
+                localX           : 20,
+                localY           : 30,
+                offsetX          : 10,
+                offsetY          : 10,
+                proxyRect        : {},
+                sourceSortZone   : source,
+                sourceWindowId   : 'win-popup',
+                targetSortZone   : target,
+                targetWindowId   : 'win-main',
+                widgetName       : 'terminal'
+            },
+            oldHandoff = DragCoordinator.nativeWindowDropHandoffMs;
+
+        DragCoordinator.nativeWindowDropHandoffMs = 0;
+        DragCoordinator.nativeWindowDropCandidates.set('win-popup', candidate);
+
+        try {
+            await DragCoordinator.commitNativeWindowDrop('win-popup', candidate);
+
+            expect(order).toEqual(['suspend', 'embody', 'target-restored', 'source-restored']);
+            expect(order).not.toContain('retire');
+            expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup')).toBe(false)
+        } finally {
+            DragCoordinator.nativeWindowDropHandoffMs = oldHandoff
+        }
+    });
+
+    test('candidate cancellation during async native parking compensates the exact source and never embodies', async () => {
+        const
+            draggedItem = {id: 'terminal'},
+            order       = [];
+        let resolveSuspend;
+
+        const
+            source    = {
+                getNativeWindowDrag: () => ({
+                    draggedItem,
+                    embodyNativeHover: true,
+                    sourceWindowId   : 'win-popup',
+                    widgetName       : 'terminal'
+                }),
+                resumeWindowDrag() {
+                    order.push('source-restored');
+                    return true
+                },
+                suspendWindowDrag() {
+                    order.push('suspend');
+                    return new Promise(resolve => resolveSuspend = resolve)
+                }
+            },
+            target    = {
+                acceptsRemoteDrag        : () => true,
+                awaitRemoteDragEmbodiment: () => true,
+                onRemoteDragLeave() {
+                    order.push('leave')
+                },
+                onRemoteDragMove() {
+                    order.push('embody');
+                    return {itemId: 'terminal'}
+                },
+                onRemoteDrop() {
+                    order.push('commit');
+                    return {type: 'addTab'}
+                }
+            },
+            candidate = {
+                draggedItem,
+                embodyNativeHover: true,
+                localX           : 20,
+                localY           : 30,
+                offsetX          : 10,
+                offsetY          : 10,
+                proxyRect        : {},
+                sourceSortZone   : source,
+                sourceWindowId   : 'win-popup',
+                targetSortZone   : target,
+                targetWindowId   : 'win-main',
+                widgetName       : 'terminal'
+            };
+
+        DragCoordinator.nativeWindowDropCandidates.set('win-popup', candidate);
+
+        const committing = DragCoordinator.commitNativeWindowDrop('win-popup', candidate);
+
+        await Promise.resolve();
+
+        DragCoordinator.clearNativeWindowDropCandidate('win-popup');
+        resolveSuspend(true);
+        await committing;
+
+        expect(order).toEqual(['suspend', 'source-restored']);
+        expect(order).not.toContain('embody');
+        expect(order).not.toContain('commit');
+        expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup')).toBe(false)
+    });
+
+    test('a throwing native park releases its candidate instead of freezing future geometry', async () => {
+        const
+            draggedItem = {id: 'terminal'},
+            order       = [],
+            source      = {
+                getNativeWindowDrag: () => ({
+                    draggedItem,
+                    embodyNativeHover: true,
+                    sourceWindowId   : 'win-popup',
+                    widgetName       : 'terminal'
+                }),
+                suspendWindowDrag() {
+                    order.push('suspend');
+                    throw new Error('native park failed')
+                }
+            },
+            target      = {
+                acceptsRemoteDrag: () => true,
+                onRemoteDragMove() {
+                    order.push('embody')
+                }
+            },
+            candidate   = {
+                draggedItem,
+                embodyNativeHover: true,
+                localX           : 20,
+                localY           : 30,
+                offsetX          : 10,
+                offsetY          : 10,
+                proxyRect        : {},
+                sourceSortZone   : source,
+                sourceWindowId   : 'win-popup',
+                targetSortZone   : target,
+                targetWindowId   : 'win-main',
+                widgetName       : 'terminal'
+            };
+
+        DragCoordinator.nativeWindowDropCandidates.set('win-popup', candidate);
+
+        await expect(DragCoordinator.commitNativeWindowDrop('win-popup', candidate))
+            .rejects.toThrow('native park failed');
+
+        expect(order).toEqual(['suspend']);
+        expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup')).toBe(false)
+    });
+
+    test('a strict native retirement refusal retries only the physical close, never the target commit', async () => {
+        const
+            draggedItem = {id: 'terminal'},
+            order       = [];
+        let retireCalls = 0;
+
+        const
+            source    = {
+                getNativeWindowDrag: () => ({
+                    draggedItem,
+                    embodyNativeHover: true,
+                    sourceWindowId   : 'win-popup',
+                    widgetName       : 'terminal'
+                }),
+                onRemoteDropOut() {
+                    order.push('retire');
+                    return ++retireCalls > 1
+                },
+                resumeWindowDrag() {
+                    order.push('resume');
+                    return true
+                },
+                suspendWindowDrag() {
+                    order.push('suspend');
+                    return true
+                }
+            },
+            target    = {
+                acceptsRemoteDrag        : () => true,
+                awaitRemoteDragEmbodiment: () => true,
+                onRemoteDragLeave() {},
+                onRemoteDragMove() {
+                    order.push('embody');
+                    return {itemId: 'terminal'}
+                },
+                onRemoteDrop() {
+                    order.push('commit');
+                    return {type: 'addTab'}
+                }
+            },
+            candidate = {
+                draggedItem,
+                embodyNativeHover: true,
+                localX           : 20,
+                localY           : 30,
+                offsetX          : 10,
+                offsetY          : 10,
+                proxyRect        : {},
+                sourceSortZone   : source,
+                sourceWindowId   : 'win-popup',
+                targetSortZone   : target,
+                targetWindowId   : 'win-main',
+                widgetName       : 'terminal'
+            },
+            oldHandoff = DragCoordinator.nativeWindowDropHandoffMs,
+            oldRetry   = DragCoordinator.nativeWindowDispositionRetryMs;
+
+        DragCoordinator.nativeWindowDropHandoffMs      = 0;
+        DragCoordinator.nativeWindowDispositionRetryMs = 20;
+        DragCoordinator.nativeWindowDropCandidates.set('win-popup', candidate);
+
+        try {
+            await DragCoordinator.commitNativeWindowDrop('win-popup', candidate);
+
+            expect(order).toEqual(['suspend', 'embody', 'commit', 'retire']);
+            expect(DragCoordinator.nativeWindowDropCandidates.get('win-popup'),
+                'strict false retains the exact popup settlement generation').toBe(candidate);
+
+            await expect.poll(() => retireCalls, {timeout: 1000}).toBe(2);
+
+            expect(order).toEqual(['suspend', 'embody', 'commit', 'retire', 'retire']);
+            expect(order.filter(value => value === 'commit')).toHaveLength(1);
+            expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup')).toBe(false)
+        } finally {
+            DragCoordinator.nativeWindowDropHandoffMs      = oldHandoff;
+            DragCoordinator.nativeWindowDispositionRetryMs = oldRetry
+        }
+    });
+
+    test('a committed close retry survives same-participation unregister and rebinds to its successor', async () => {
+        const
+            draggedItem         = {id: 'terminal'},
+            order               = [],
+            createParticipation = ({successor=false}={}) => ({
+                acceptsRemoteDrag        : () => true,
+                awaitRemoteDragEmbodiment: () => true,
+                getNativeWindowDrag      : () => ({
+                    draggedItem,
+                    embodyNativeHover: true,
+                    sourceWindowId   : 'win-popup',
+                    widgetName       : 'terminal'
+                }),
+                onRemoteDragLeave() {},
+                onRemoteDragMove() {
+                    order.push('embody');
+                    return {itemId: 'terminal'}
+                },
+                onRemoteDrop() {
+                    order.push('commit');
+                    return {type: 'addTab'}
+                },
+                onRemoteDropOut() {
+                    order.push(successor ? 'retire-successor' : 'retire-original');
+                    return successor
+                },
+                resumeWindowDrag() {
+                    order.push('resume');
+                    return true
+                },
+                sortGroup     : 'dock-main',
+                stableTargetId: 'workspace-main',
+                suspendWindowDrag() {
+                    order.push('suspend');
+                    return true
+                },
+                windowId: 'win-main'
+            }),
+            original    = createParticipation(),
+            successor   = createParticipation({successor: true}),
+            candidate   = {
+                draggedItem,
+                embodyNativeHover: true,
+                localX           : 20,
+                localY           : 30,
+                offsetX          : 10,
+                offsetY          : 10,
+                proxyRect        : {},
+                sourceSortZone   : original,
+                sourceWindowId   : 'win-popup',
+                targetSortZone   : original,
+                targetWindowId   : 'win-main',
+                widgetName       : 'terminal'
+            },
+            oldHandoff  = DragCoordinator.nativeWindowDropHandoffMs,
+            oldRetry    = DragCoordinator.nativeWindowDispositionRetryMs;
+
+        DragCoordinator.nativeWindowDropHandoffMs      = 0;
+        DragCoordinator.nativeWindowDispositionRetryMs = 10000;
+        DragCoordinator.register(original);
+        DragCoordinator.nativeWindowDropCandidates.set('win-popup', candidate);
+
+        try {
+            await DragCoordinator.commitNativeWindowDrop('win-popup', candidate);
+
+            expect(order).toEqual(['suspend', 'embody', 'commit', 'retire-original']);
+            expect(candidate.phase).toBe('settling-committed');
+
+            DragCoordinator.unregister(original);
+
+            expect(DragCoordinator.nativeWindowDropCandidates.get('win-popup')).toBe(candidate);
+            expect(order).not.toContain('resume');
+
+            DragCoordinator.register(successor);
+
+            expect(candidate.sourceSortZone).toBe(successor);
+            expect(candidate.targetSortZone).toBe(successor);
+            await expect(DragCoordinator.settleNativeWindowDisposition(
+                'win-popup',
+                candidate,
+                true
+            )).resolves.toBe(true);
+
+            expect(order).toEqual([
+                'suspend',
+                'embody',
+                'commit',
+                'retire-original',
+                'retire-successor'
+            ]);
+            expect(order.filter(value => value === 'commit')).toHaveLength(1);
+            expect(order).not.toContain('resume');
+            expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup')).toBe(false)
+        } finally {
+            DragCoordinator.nativeWindowDropHandoffMs      = oldHandoff;
+            DragCoordinator.nativeWindowDispositionRetryMs = oldRetry
+        }
+    });
+
+    test('same-object registration refresh during commit preserves the committed terminal', async () => {
+        const
+            draggedItem = {id: 'terminal'},
+            order       = [],
+            zone        = {
+                acceptsRemoteDrag        : () => true,
+                awaitRemoteDragEmbodiment: () => true,
+                getNativeWindowDrag      : () => ({
+                    draggedItem,
+                    embodyNativeHover: true,
+                    sourceWindowId   : 'win-popup',
+                    widgetName       : 'terminal'
+                }),
+                onRemoteDragLeave() {
+                    order.push('leave')
+                },
+                onRemoteDragMove() {
+                    order.push('embody');
+                    return {itemId: 'terminal'}
+                },
+                onRemoteDrop() {
+                    order.push('commit');
+                    DragCoordinator.unregister(zone);
+                    DragCoordinator.register(zone);
+                    return {type: 'addTab'}
+                },
+                onRemoteDropOut() {
+                    order.push('retire');
+                    return true
+                },
+                resumeWindowDrag() {
+                    order.push('restore');
+                    return true
+                },
+                sortGroup     : 'dock-main',
+                stableTargetId: 'workspace-main',
+                suspendWindowDrag() {
+                    order.push('suspend');
+                    return true
+                },
+                windowId: 'win-main'
+            },
+            candidate = {
+                draggedItem,
+                embodyNativeHover: true,
+                localX           : 20,
+                localY           : 30,
+                offsetX          : 10,
+                offsetY          : 10,
+                proxyRect        : {},
+                sourceSortZone   : zone,
+                sourceWindowId   : 'win-popup',
+                targetSortZone   : zone,
+                targetWindowId   : 'win-main',
+                widgetName       : 'terminal'
+            },
+            oldHandoff = DragCoordinator.nativeWindowDropHandoffMs;
+
+        DragCoordinator.nativeWindowDropHandoffMs = 0;
+        DragCoordinator.register(zone);
+        DragCoordinator.nativeWindowDropCandidates.set('win-popup', candidate);
+        DragCoordinator.nativeHoverTargets.set('win-popup', zone);
+
+        try {
+            await DragCoordinator.commitNativeWindowDrop('win-popup', candidate);
+
+            expect(order).toEqual(['suspend', 'embody', 'commit', 'retire']);
+            expect(order).not.toContain('restore');
+            expect(order).not.toContain('leave');
+            expect(DragCoordinator.sortZones.get('dock-main')?.get('win-main')).toBe(zone);
+            expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup')).toBe(false)
+        } finally {
+            DragCoordinator.nativeWindowDropHandoffMs = oldHandoff
+        }
+    });
+
+    test('a strict native restore refusal retains and retries the exact parked source generation', async () => {
+        const
+            draggedItem = {id: 'terminal'},
+            order       = [];
+        let restoreCalls = 0;
+
+        const
+            source    = {
+                getNativeWindowDrag: () => ({
+                    draggedItem,
+                    embodyNativeHover: true,
+                    sourceWindowId   : 'win-popup',
+                    widgetName       : 'terminal'
+                }),
+                onRemoteDropOut() {
+                    order.push('retire');
+                    return true
+                },
+                resumeWindowDrag() {
+                    order.push('restore');
+                    return ++restoreCalls > 1
+                },
+                suspendWindowDrag() {
+                    order.push('suspend');
+                    return true
+                }
+            },
+            target    = {
+                acceptsRemoteDrag        : () => true,
+                awaitRemoteDragEmbodiment: () => true,
+                onRemoteDragLeave() {},
+                onRemoteDragMove() {
+                    order.push('embody');
+                    return {itemId: 'terminal'}
+                },
+                onRemoteDrop() {
+                    order.push('target-refused');
+                    return null
+                }
+            },
+            candidate = {
+                draggedItem,
+                embodyNativeHover: true,
+                localX           : 20,
+                localY           : 30,
+                offsetX          : 10,
+                offsetY          : 10,
+                proxyRect        : {},
+                sourceSortZone   : source,
+                sourceWindowId   : 'win-popup',
+                targetSortZone   : target,
+                targetWindowId   : 'win-main',
+                widgetName       : 'terminal'
+            },
+            oldHandoff = DragCoordinator.nativeWindowDropHandoffMs,
+            oldRetry   = DragCoordinator.nativeWindowDispositionRetryMs;
+
+        DragCoordinator.nativeWindowDropHandoffMs      = 0;
+        DragCoordinator.nativeWindowDispositionRetryMs = 20;
+        DragCoordinator.nativeWindowDropCandidates.set('win-popup', candidate);
+
+        try {
+            await DragCoordinator.commitNativeWindowDrop('win-popup', candidate);
+
+            expect(order).toEqual(['suspend', 'embody', 'target-refused', 'restore']);
+            expect(DragCoordinator.nativeWindowDropCandidates.get('win-popup')).toBe(candidate);
+
+            await expect.poll(() => restoreCalls, {timeout: 1000}).toBe(2);
+
+            expect(order).toEqual(['suspend', 'embody', 'target-refused', 'restore', 'restore']);
+            expect(order).not.toContain('retire');
+            expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup')).toBe(false)
+        } finally {
+            DragCoordinator.nativeWindowDropHandoffMs      = oldHandoff;
+            DragCoordinator.nativeWindowDispositionRetryMs = oldRetry
+        }
+    });
+
+    test('same-object target disconnect cancels async settlement exact-once and restores the source generation', async () => {
+        const
+            draggedItem = {id: 'terminal'},
+            order       = [];
+        let resolveDrop, signalDrop;
+
+        const dropStarted = new Promise(resolve => signalDrop = resolve),
+              zone        = {
+                  acceptsRemoteDrag        : () => true,
+                  awaitRemoteDragEmbodiment: () => true,
+                  getNativeWindowDrag      : () => ({
+                      draggedItem,
+                      embodyNativeHover: true,
+                      sourceWindowId   : 'win-popup',
+                      widgetName       : 'terminal'
+                  }),
+                  onRemoteDragLeave() {
+                      order.push('leave')
+                  },
+                  onRemoteDragMove() {
+                      order.push('embody');
+                      return {itemId: 'terminal'}
+                  },
+                  onRemoteDrop() {
+                      order.push('target-settling');
+                      signalDrop();
+                      return new Promise(resolve => resolveDrop = resolve)
+                  },
+                  onRemoteDropOut() {
+                      order.push('retire');
+                      return true
+                  },
+                  resumeWindowDrag() {
+                      order.push('restore');
+                      return true
+                  },
+                  sortGroup: 'dock',
+                  suspendWindowDrag() {
+                      order.push('suspend');
+                      return true
+                  },
+                  windowId: 'win-main'
+              },
+              candidate = {
+                  draggedItem,
+                  embodyNativeHover: true,
+                  localX           : 20,
+                  localY           : 30,
+                  offsetX          : 10,
+                  offsetY          : 10,
+                  proxyRect        : {},
+                  sourceSortZone   : zone,
+                  sourceWindowId   : 'win-popup',
+                  targetSortZone   : zone,
+                  targetWindowId   : 'win-main',
+                  widgetName       : 'terminal'
+              },
+              oldHandoff = DragCoordinator.nativeWindowDropHandoffMs;
+
+        DragCoordinator.nativeWindowDropHandoffMs = 0;
+        DragCoordinator.register(zone);
+        DragCoordinator.nativeWindowDropCandidates.set('win-popup', candidate);
+        DragCoordinator.nativeHoverTargets.set('win-popup', zone);
+        DragCoordinator.nativeClaimArbiters.set('win-popup', {
+            reset() {
+                order.push('reset')
+            }
+        });
+
+        try {
+            const settling = DragCoordinator.commitNativeWindowDrop('win-popup', candidate);
+
+            await dropStarted;
+            DragCoordinator.unregister(zone);
+            resolveDrop({type: 'addTab'});
+            await settling;
+
+            expect(order).toEqual([
+                'suspend',
+                'embody',
+                'target-settling',
+                'leave',
+                'reset',
+                'restore'
+            ]);
+            expect(order.filter(value => value === 'leave')).toHaveLength(1);
+            expect(order).not.toContain('retire');
+            expect(DragCoordinator.nativeWindowDropCandidates.has('win-popup')).toBe(false);
+            expect(DragCoordinator.nativeClaimArbiters.has('win-popup')).toBe(false);
+            expect(DragCoordinator.nativeHoverTargets.has('win-popup')).toBe(false)
+        } finally {
+            DragCoordinator.nativeWindowDropHandoffMs = oldHandoff
+        }
+    });
+
     test('conversion resolver receives one live INNER-viewport frame and owns engagement without legacy suspension', () => {
         const
             frames       = [],


### PR DESCRIPTION
Resolves #16123

Workstation can now discover a dropped terminal popup as a native-titlebar drag without replacing its stable cross-window target registration. Real `WindowPosition` frames drive continuous target preview, an exact native park hands the live pane into a settled target-local proxy for a retained readable interval, and the existing semantic operation commits before the source popup retires. Refusal, cancellation, disconnect, and registration refresh retain exact-generation restore/close authority without replaying or reversing model truth.

Evidence: L3 (headed macOS real-popup HID titlebar drag plus App Worker model, visual-frame, topology, and identity receipts) → L3 required (physical return and retained visual ACs). No residuals.

## Deltas from ticket

- The post-#16137 composition starts exactly one silent render transaction per parent, but only the target transaction gates publication. A parked source renderer may reject or never acknowledge another frame without deadlocking a readable target; because the synchronous source mutation replaces the pane with a hidden placeholder before either transaction starts, a late source acknowledgement can only materialize that removal, never mount the pane.
- Native-titlebar parking and addon-driven popup conversion now have separate geometry effects: the native route keeps the narrow `windowNativeMoveTo` payload, while addon conversion retains resize plus outer-geometry restore.
- Strict physical close/restore retries and successor-registration rebinding preserve exact disposition authority after semantic commit. A same-turn stable-registration refresh is fenced separately from a genuine async disconnect, so normal reprojection cannot downgrade a committed terminal while real departure still restores fail-closed.
- `record.settlement` is an internal generation fence implementing ADR 0029 §§2.8.1–2.8.3; it does not introduce a new recorded gesture state, so the ticket's conditional ADR-amendment trigger does not fire.

## Test Evidence

- AC2 red control: untouched `origin/dev` produced zero `.workstation-vessel-dragproxy` targets and timed out in `stageMergedVessel`; the matched journey failed scenes 3–5 while scene 2 remained green. Recorded at https://github.com/neomjs/neo/pull/16140#issuecomment-5122236397.
- Exact-head focused unit coverage: `npm run test-unit -- test/playwright/unit/apps/workstation/Workspace.spec.mjs test/playwright/unit/dashboard/CrossWindowDragTarget.spec.mjs test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs test/playwright/unit/manager/DragCoordinator.spec.mjs` — 97 passed, including source-transaction start without terminal dependency, target-only readability settlement, same-turn registration refresh, genuine async disconnect, native park/restore, and commit-before-close.
- Full unit matrix on the composed candidate: 10,322 passed / 5 skipped / 2 unrelated MemoryService concurrency failures; both failing files then passed 10/10 in isolation. The final composition rebase changed none of the 11 PR files byte-for-byte. After the physical run, `dev` advanced by the unrelated #16141 merge (only `ai/` files); GitHub still reports exactly these same 11 PR files with no revert payload.
- Physical native-titlebar witness: `NEO_FILM_TAKE=1 npx playwright test test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --project=chromium --workers=1 --headed --grep 'scene 2 \(native titlebar\)'` — 2 passed in 12.7s (accelerated-GL setup + exact scene). The real macOS HID route retained target preview and target-local proxy together, committed the semantic return, closed the source popup, preserved pane/store/feed continuity, and reported zero page errors.
- Static and author gates: `node --check` across all 11 changed `.mjs` files and `git diff --check` passed; final `agent-preflight --no-fix` passed against this body and staged candidate.

## Post-Merge Validation

- [ ] Confirm the exact-head CI unit and lint matrix remains green.
- [ ] Repeat the headed macOS native-titlebar scene from a clean checkout and retain its physical receipt.

## Evolution

The physical witness falsified two tempting shortcuts: the returning popup's valid edge preview can produce a split rather than an `addTab`, so proof binds the exact retained preview operation to final worker truth; and target readability cannot wait on a parked source renderer. The sibling-PR composition then exposed a third: independently green branches can carry contradictory settlement premises. Re-deriving against merged #16137 produced the start-both/await-target rule; a never-settling-source RED unit reproduced the physical deadlock before the correction. A separate adversarial residual probe found that a same-object registration refresh could otherwise be mistaken for departure during semantic commit.

Authored by Euclid (GPT-5.6, Codex Desktop). Session 019fac51-ddcb-7212-902e-09d3a9d19098.
