### PR TITLE
feat(ai): bind Fleet OpenCode wake delivery (#15677)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -97,17 +97,21 @@ let DAEMON_DATA_DIR;
 let STATE_FILE;
 let LOG_FILE;
 let WOKEN_WATERMARK_FILE;
-const LOG_RETENTION_DAYS                = 30;
-const POLL_INTERVAL_MS                  = 3000;
-const CODEX_APP_SERVER_ADAPTER          = 'codex-app-server';
-const OPENCODE_SERVER_ADAPTER           = 'opencode-server';
-const KIMI_SERVER_ADAPTER               = 'kimi-server';
-const KIMI_PULL_BRIDGE_ADAPTER          = 'kimi-pull-bridge';
-const CODEX_TURN_START_PROOF_TIMEOUT_MS = Number(process.env.WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS) || 45000;
-const CODEX_TURN_START_PROOF_POLL_MS    = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
-const CODEX_WAKE_SUBMIT_NONCE_PREFIX    = 'NEO_WAKE_SUBMIT_NONCE:';
-const WOKEN_MESSAGE_IDS_STATE_KEY       = '__messageIdsByIdentity';
-const WAKE_PRIORITY_RANKS               = {
+let DELIVERY_FAILURE_STATE_FILE;
+let   terminalDeliveryFailures           = {};
+let   terminalDeliveryFailuresNeedRepair = false;
+const LOG_RETENTION_DAYS                 = 30;
+const POLL_INTERVAL_MS                   = 3000;
+const CODEX_APP_SERVER_ADAPTER           = 'codex-app-server';
+const OPENCODE_SERVER_ADAPTER            = 'opencode-server';
+const OPENCODE_REBIND_SETTLE_MS          = 50;
+const KIMI_SERVER_ADAPTER                = 'kimi-server';
+const KIMI_PULL_BRIDGE_ADAPTER           = 'kimi-pull-bridge';
+const CODEX_TURN_START_PROOF_TIMEOUT_MS  = Number(process.env.WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS) || 45000;
+const CODEX_TURN_START_PROOF_POLL_MS     = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
+const CODEX_WAKE_SUBMIT_NONCE_PREFIX     = 'NEO_WAKE_SUBMIT_NONCE:';
+const WOKEN_MESSAGE_IDS_STATE_KEY        = '__messageIdsByIdentity';
+const WAKE_PRIORITY_RANKS                = {
     low   : 0,
     normal: 1,
     high  : 2
@@ -308,6 +312,121 @@ function writeLog(level, message) {
     }
 }
 
+/**
+ * @summary Load the daemon-owned terminal delivery-failure receipts. A malformed file is left in
+ * place so the independent Fleet observer can report the source as unreadable; the daemon starts
+ * with an empty in-memory set and repairs it on the next authoritative write.
+ * @returns {Object<String,Object>}
+ * @private
+ */
+function loadTerminalDeliveryFailures() {
+    terminalDeliveryFailuresNeedRepair = false;
+    if (!fs.existsSync(DELIVERY_FAILURE_STATE_FILE)) return {};
+
+    try {
+        const parsed = JSON.parse(fs.readFileSync(DELIVERY_FAILURE_STATE_FILE, 'utf8'));
+
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            throw new TypeError('root must be an object');
+        }
+
+        for (const [subscriptionId, receipt] of Object.entries(parsed)) {
+            if (!receipt || typeof receipt !== 'object' || Array.isArray(receipt) ||
+                receipt.subscriptionId !== subscriptionId ||
+                typeof receipt.agentIdentity !== 'string' || receipt.agentIdentity.length === 0 ||
+                typeof receipt.errorClass !== 'string' || !/^[a-z0-9-]{1,80}$/.test(receipt.errorClass) ||
+                typeof receipt.failedAt !== 'string' || Number.isNaN(Date.parse(receipt.failedAt))
+            ) {
+                throw new TypeError(`invalid receipt '${subscriptionId}'`);
+            }
+        }
+
+        return parsed;
+    } catch (error) {
+        terminalDeliveryFailuresNeedRepair = true;
+        writeLog('ERROR', `[Wake Daemon] Terminal delivery-failure receipt file is malformed; preserving it for operator diagnosis (${error.message}).`);
+        return {};
+    }
+}
+
+/**
+ * @summary Persist terminal delivery-failure receipts atomically with owner-only permissions.
+ * Receipt rows contain only seat identity, subscription id, bounded error class, and timestamp —
+ * never adapter errors, coordinates, envelope paths, digests, or credentials.
+ * @returns {void}
+ * @private
+ */
+function persistTerminalDeliveryFailures() {
+    const tmpPath = `${DELIVERY_FAILURE_STATE_FILE}.${process.pid}.tmp`;
+
+    try {
+        fs.writeFileSync(tmpPath, JSON.stringify(terminalDeliveryFailures, null, 2) + '\n', {mode: 0o600});
+        fs.chmodSync(tmpPath, 0o600);
+        fs.renameSync(tmpPath, DELIVERY_FAILURE_STATE_FILE);
+        terminalDeliveryFailuresNeedRepair = false;
+    } catch (error) {
+        try { fs.removeSync(tmpPath); } catch {}
+        writeLog('ERROR', `[Wake Daemon] Could not persist terminal delivery-failure receipts (${error.message}).`);
+    }
+}
+
+/**
+ * @summary Record one retry-cap exhaustion on the independent operator-health surface.
+ * @param {Object} subscription WAKE_SUBSCRIPTION node.
+ * @param {String} identity Recipient seat identity.
+ * @param {String} errorClass Bounded non-secret failure classification.
+ * @returns {void}
+ * @private
+ */
+function recordTerminalDeliveryFailure(subscription, identity, errorClass) {
+    const subscriptionId = subscription.id;
+
+    terminalDeliveryFailures[subscriptionId] = {
+        agentIdentity: subscription.properties?.agentIdentity || identity,
+        subscriptionId,
+        errorClass   : String(errorClass || 'delivery-failed').slice(0, 80),
+        failedAt     : new Date().toISOString()
+    };
+    persistTerminalDeliveryFailures();
+}
+
+/**
+ * @summary Clear a terminal receipt after a confirmed delivery on the same subscription.
+ * @param {String} subscriptionId
+ * @returns {void}
+ * @private
+ */
+function clearTerminalDeliveryFailure(subscriptionId) {
+    if (!Object.hasOwn(terminalDeliveryFailures, subscriptionId)) {
+        if (terminalDeliveryFailuresNeedRepair) persistTerminalDeliveryFailures();
+        return;
+    }
+
+    delete terminalDeliveryFailures[subscriptionId];
+    persistTerminalDeliveryFailures();
+}
+
+/**
+ * @summary Remove receipts whose exact subscriptions are no longer active, preventing a retired
+ * route from suppressing a later subscription for the same seat identity.
+ * @param {Object[]} subscriptions Current active WAKE_SUBSCRIPTION rows.
+ * @returns {void}
+ * @private
+ */
+function pruneTerminalDeliveryFailures(subscriptions) {
+    const activeIds = new Set(subscriptions.map(subscription => subscription.id));
+    let   changed   = false;
+
+    for (const subscriptionId of Object.keys(terminalDeliveryFailures)) {
+        if (!activeIds.has(subscriptionId)) {
+            delete terminalDeliveryFailures[subscriptionId];
+            changed = true;
+        }
+    }
+
+    if (changed) persistTerminalDeliveryFailures();
+}
+
 let PID_FILE;  // assigned in initConfigDerivedState() (← DAEMON_DATA_DIR); the one-shot log prune runs there too
 const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -463,6 +582,7 @@ async function pollLoop() {
             }
 
             const subscriptions = getActiveShapeCSubscriptions(db);
+            pruneTerminalDeliveryFailures(subscriptions);
 
             if (subscriptions.length > 0) {
                 // Fetch the actual node/edge data to evaluate filters
@@ -1026,6 +1146,8 @@ async function flushSubscription(subId) {
         if (deliveryOutcome === 'failed') {
             enqueueDeliveryRetry(subscription, identity, events);
         } else if (deliveryOutcome === 'delivered') {
+            clearTerminalDeliveryFailure(subId);
+            lastDeliveryFailureClassBySub.delete(subId);
             lastFlushAtBySub[subId] = Date.now();
             writeLog('INFO',
                 `[Wake Dispatch] ${identity || subId}: outcome=delivered priority=${getHighestWakePriority(messages)} ` +
@@ -1116,12 +1238,14 @@ async function deliverViaCodexAppServer(subscription, digest, evidenceLabel = ''
  *
  * **First-boot envelope contract** (what an OpenCode seat's self-registration must provide):
  * the seat side writes a JSON envelope, refreshed per session, carrying
- * `{hostname, port, sessionId, username, password, projectId, updatedAt}` — the embedded
+ * `{hostname, port, sessionId, projectId, directory, username, password, updatedAt}` — the embedded
  * server's coordinates (a random localhost port per boot), the live `sessionId`, and the
  * basic-auth credentials the seat was spawned with (`OPENCODE_SERVER_USERNAME` /
  * `OPENCODE_SERVER_PASSWORD`). Default location `~/.local/share/opencode/wake-envelope.json`
  * (mode 0600), overridable via `harnessTargetMetadata.envelopePath`. The daemon re-reads the
  * envelope on every delivery, so port/session rotation needs no graph write.
+ * A connection refusal authorizes at most one re-read within the same adapter invocation, and only
+ * when `sessionId + projectId + directory` remain byte-identical; changed authority fails closed.
  *
  * **Two producers, one contract** — the envelope shape above is the canonical node:
  * 1. the boot hook emitted by the seat-config generator
@@ -1146,35 +1270,100 @@ async function deliverViaCodexAppServer(subscription, digest, evidenceLabel = ''
  * @returns {Promise<void>}
  */
 async function deliverViaOpencodeServer(subscription, digest, evidenceLabel = '', abortSignal = null) {
-    const meta         = subscription.properties?.harnessTargetMetadata || {};
-    const envelopePath = meta.envelopePath || path.join(os.homedir(), '.local', 'share', 'opencode', 'wake-envelope.json');
+    const
+        meta         = subscription.properties?.harnessTargetMetadata || {},
+        envelopePath = meta.envelopePath || path.join(os.homedir(), '.local', 'share', 'opencode', 'wake-envelope.json'),
+        first        = await readOpenCodeWakeEnvelope(envelopePath);
 
-    let envelope;
     try {
-        envelope = JSON.parse(await fs.readFile(envelopePath, 'utf8'));
-    } catch (err) {
-        throw new Error(`opencode-server requires a readable seat envelope at '${envelopePath}' (${err.message})`);
+        await postOpenCodeDigest(first, digest, abortSignal);
+    } catch (error) {
+        if (!isConnectionRefused(error) || abortSignal?.aborted) throw error;
+
+        // A refusal proves only that the old coordinates are dead. Give the authoritative atomic
+        // writer one bounded settle beat, then re-read exactly once. Session/project/directory are
+        // immutable authority; only loopback coordinates + credentials may rotate.
+        writeLog('WARN', `[Wake Daemon] OpenCode route for ${subscription.id} refused its stored coordinates; re-reading the authoritative envelope once.`);
+        await wait(OPENCODE_REBIND_SETTLE_MS);
+
+        const rebound = await readOpenCodeWakeEnvelope(envelopePath);
+
+        if (rebound.sessionId !== first.sessionId ||
+            rebound.projectId !== first.projectId ||
+            rebound.directory !== first.directory
+        ) {
+            throw new Error('opencode-server authority tuple changed during coordinate rebind; refusing session retarget');
+        }
+
+        if (rebound.hostname === first.hostname &&
+            rebound.port === first.port &&
+            rebound.username === first.username &&
+            rebound.password === first.password
+        ) {
+            const unchanged = new Error('opencode-server coordinates did not change after connection refusal');
+            unchanged.code  = 'ECONNREFUSED';
+            throw unchanged;
+        }
+
+        await postOpenCodeDigest(rebound, digest, abortSignal);
     }
 
-    const {hostname, port, sessionId, username, password} = envelope;
+    writeLog('INFO', `[Wake Daemon] Dispatched ${subscription.id} via opencode-server prompt_async${evidenceLabel}`);
+}
 
-    // Typed + authority-checked coordinates: a malformed or hostile envelope must never steer the
-    // daemon's HTTP client off the seat's loopback server. Delivery is globally serialized, so the
-    // fetch is also deadline-bounded — one hung endpoint must not wedge every later wake route.
-    for (const [key, value] of Object.entries({hostname, sessionId, username, password})) {
+/**
+ * @summary Read and validate one OpenCode wake envelope. The authority tuple is mandatory even
+ * though only coordinates drive the HTTP request: it is the no-retarget fence for a stale rebind.
+ * @param {String} envelopePath
+ * @returns {Promise<Object>}
+ * @private
+ */
+async function readOpenCodeWakeEnvelope(envelopePath) {
+    let envelope;
+
+    try {
+        envelope = JSON.parse(await fs.readFile(envelopePath, 'utf8'));
+    } catch (error) {
+        throw new Error(`opencode-server requires a readable seat envelope at '${envelopePath}' (${error.message})`);
+    }
+
+    const {hostname, port, sessionId, projectId, directory, username, password} = envelope;
+
+    for (const [key, value] of Object.entries({
+        hostname,
+        sessionId,
+        projectId,
+        directory,
+        username,
+        password
+    })) {
         if (typeof value !== 'string' || value.length === 0) {
             throw new Error(`opencode-server envelope at '${envelopePath}' requires '${key}' to be a non-empty string`);
         }
     }
 
+    if (!path.isAbsolute(directory)) {
+        throw new Error(`opencode-server envelope at '${envelopePath}' requires 'directory' to be absolute`);
+    }
     if (!Number.isInteger(port) || port < 1 || port > 65535) {
         throw new Error(`opencode-server envelope at '${envelopePath}' requires 'port' to be an integer in 1..65535`);
     }
-
     if (!['127.0.0.1', 'localhost', '::1'].includes(hostname)) {
         throw new Error(`opencode-server envelope at '${envelopePath}' requires a loopback hostname (received '${hostname}')`);
     }
 
+    return {hostname, port, sessionId, projectId, directory, username, password};
+}
+
+/**
+ * @summary Submit one OpenCode digest against already-validated coordinates.
+ * @param {Object} envelope Validated route envelope.
+ * @param {String} digest
+ * @param {AbortSignal|null} abortSignal Shared delivery-owner signal.
+ * @returns {Promise<void>}
+ * @private
+ */
+async function postOpenCodeDigest({hostname, port, sessionId, username, password}, digest, abortSignal) {
     const deliverySignal = abortSignal
         ? AbortSignal.any([abortSignal, AbortSignal.timeout(5000)])
         : AbortSignal.timeout(5000);
@@ -1192,8 +1381,17 @@ async function deliverViaOpencodeServer(subscription, digest, evidenceLabel = ''
     if (response.status !== 204) {
         throw new Error(`opencode-server prompt_async expected HTTP 204, received ${response.status}`);
     }
+}
 
-    writeLog('INFO', `[Wake Daemon] Dispatched ${subscription.id} via opencode-server prompt_async${evidenceLabel}`);
+/**
+ * @summary True only for a transport-level connection refusal. HTTP failures, aborts, malformed
+ * envelopes, and connection resets do not authorize a coordinate re-read.
+ * @param {*} error
+ * @returns {Boolean}
+ * @private
+ */
+function isConnectionRefused(error) {
+    return error?.code === 'ECONNREFUSED' || error?.cause?.code === 'ECONNREFUSED';
 }
 
 /**
@@ -1917,8 +2115,31 @@ let deliveryPromise = Promise.resolve();
 // rebuilds + re-attempts the digest on later poll cycles, independent of the cursor — coalescing
 // repeated same-subscription failures so no earlier wake is overwritten. After the cap the wake is
 // dropped with a terminal error so a persistently-failing target cannot storm or wedge the loop.
-const MAX_DELIVERY_RETRIES   = Number(process.env.WAKE_MAX_DELIVERY_RETRIES) || 5;
-const pendingDeliveryRetries = new Map(); // subscriptionId -> {subscription, identity, events, attempts, nextAttemptAt}
+const MAX_DELIVERY_RETRIES          = Number(process.env.WAKE_MAX_DELIVERY_RETRIES) || 5;
+const pendingDeliveryRetries        = new Map(); // subscriptionId -> {subscription, identity, events, attempts, nextAttemptAt}
+const lastDeliveryFailureClassBySub = new Map();
+
+/**
+ * @summary Collapse an adapter error into a bounded, non-secret operator-health classification.
+ * Raw messages can carry envelope paths, endpoints, or credentials and never enter the receipt.
+ * @param {*} error
+ * @param {String} adapter
+ * @returns {String}
+ * @private
+ */
+function classifyDeliveryFailure(error, adapter) {
+    const
+        code    = error?.code || error?.cause?.code,
+        message = String(error?.message || '');
+
+    if (code === 'ECONNREFUSED') return 'connection-refused';
+    if (error?.name === 'AbortError' || code === 'ABORT_ERR') return 'attempt-aborted';
+    if (message.includes('authority tuple changed')) return 'authority-retarget-refused';
+    if (message.includes('requires a readable seat envelope') || message.includes('envelope at')) return 'invalid-envelope';
+    if (message.includes('HTTP ')) return 'http-status';
+
+    return `${adapter || 'unknown'}-delivery`.slice(0, 80);
+}
 
 /**
  * @summary The adapters whose transport receives — and therefore honours — the attempt-bound
@@ -1996,6 +2217,7 @@ async function deliverDigestBounded(subscription, digest, deliveryEvidence = {})
             // observable co-scheduled (the kimi-pull-bridge outbox-escape spec went red only in a
             // full-suite run, green in isolation).
             if (isTimeoutVerifiable(subscription)) {
+                lastDeliveryFailureClassBySub.set(subscription.id, 'attempt-timeout');
                 writeLog('ERROR',
                     `[Wake Daemon] Delivery attempt for ${subscription.id} exceeded ${timeoutMs}ms — ` +
                     'resolved as failed (retry path); the abort cancelled the in-flight request.'
@@ -2405,6 +2627,7 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}, abortS
         }
         return 'delivered';
     } catch (err) {
+        lastDeliveryFailureClassBySub.set(subscription.id, classifyDeliveryFailure(err, adapter));
         writeLog('ERROR', `[Wake Daemon] Failed to deliver via ${adapter}: ${err.message}`);
         return 'failed';
     }
@@ -2587,6 +2810,12 @@ async function attemptDeliveryRetries() {
             entry.attempts += 1;
             if (entry.attempts >= MAX_DELIVERY_RETRIES) {
                 pendingDeliveryRetries.delete(subId);
+                recordTerminalDeliveryFailure(
+                    entry.subscription,
+                    entry.identity,
+                    lastDeliveryFailureClassBySub.get(subId) || 'delivery-failed'
+                );
+                lastDeliveryFailureClassBySub.delete(subId);
                 writeLog('ERROR',
                     `[Wake Daemon] Giving up wake delivery for ${subId} after ${entry.attempts} failed attempts; wake dropped.`
                 );
@@ -2599,6 +2828,8 @@ async function attemptDeliveryRetries() {
             // stay pending as a fresh cycle (new events, new attempt budget); an unchanged entry
             // retires.
             lastFlushAtBySub[subId] = Date.now();
+            clearTerminalDeliveryFailure(subId);
+            lastDeliveryFailureClassBySub.delete(subId);
             writeLog('INFO',
                 `[Wake Dispatch] ${entry.identity || subId}: outcome=delivered priority=${getHighestWakePriority(liveMessages)} ` +
                 `messages=${liveMessages.length} tasks=${snapshot.tasks.length} permissions=${snapshot.permissions.length} ` +
@@ -2732,8 +2963,8 @@ async function deliverViaWebhookUrl(subscription, digest, webhookUrl, abortSigna
 
 /**
  * @summary Assigns the config-derived module-scope paths (DB_PATH / DAEMON_DATA_DIR / STATE_FILE /
- * LOG_FILE / WOKEN_WATERMARK_FILE / PID_FILE) + runs their one-shot startup side-effects (data-dir
- * ensure, archived-log prune, woken-watermark load). Deferred out of module-load so the
+ * LOG_FILE / WOKEN_WATERMARK_FILE / DELIVERY_FAILURE_STATE_FILE / PID_FILE) + runs their one-shot
+ * startup side-effects (data-dir ensure, archived-log prune, durable-state loads). Deferred out of module-load so the
  * assertConfigFresh guard in main() can fail-fast on a stale memory-core overlay BEFORE any
  * `memoryCoreConfig` deref crashes with a cryptic `undefined` (the stale-overlay fail-fast class).
  * @protected
@@ -2744,6 +2975,7 @@ function initConfigDerivedState() {
     STATE_FILE           = path.join(DAEMON_DATA_DIR, 'lastSyncId');
     LOG_FILE             = path.join(DAEMON_DATA_DIR, 'wake-daemon.log');
     WOKEN_WATERMARK_FILE = path.join(DAEMON_DATA_DIR, 'woken-watermark.json');
+    DELIVERY_FAILURE_STATE_FILE = path.join(DAEMON_DATA_DIR, 'wake-delivery-failures.json');
     PID_FILE             = path.join(DAEMON_DATA_DIR, 'wake-daemon.pid');
 
     fs.ensureDirSync(DAEMON_DATA_DIR);     // data dir must exist before any state-file write
@@ -2751,6 +2983,7 @@ function initConfigDerivedState() {
     const wokenState = loadWokenState();
     wokenWatermark            = wokenState.watermarks;
     wokenMessageIdsByIdentity = wokenState.messageIdsByIdentity;
+    terminalDeliveryFailures  = loadTerminalDeliveryFailures();
 }
 
 // Start loop
@@ -2768,6 +3001,7 @@ async function main() {
     await enforceSingleton();
 
     db = initializeDatabase(DB_PATH);
+    pruneTerminalDeliveryFailures(getActiveShapeCSubscriptions(db));
 
     // Read lastSyncId
     lastSyncId = getLastSyncId(db, STATE_FILE);

--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -1,8 +1,9 @@
-import {execFile, spawn} from 'child_process';
-import fs                from 'fs';
-import path              from 'path';
-import AiConfig          from '../../config.mjs';
-import Base              from '../../../src/core/Base.mjs';
+import {execFile, spawn}          from 'child_process';
+import fs                         from 'fs';
+import path                       from 'path';
+import AiConfig                   from '../../config.mjs';
+import {generateLocalBearerToken} from '../../mcp/server/shared/helpers/localBearer.mjs';
+import Base                       from '../../../src/core/Base.mjs';
 import {
     MCP_SERVERS,
     REMOTE_MCP_CREDENTIAL_ENV_VAR
@@ -127,8 +128,9 @@ const HARNESS_AUTH_MARKERS = {
  * families (claude-desktop / antigravity) are stdin-indifferent — the held pipe is harmless there,
  * and pid/SIGTERM is the supervision handle (probed per family: dual-instance coexistence on
  * distinct `--user-data-dir` homes, SIGTERM-clean exit 0). The launch templates pin the
- * per-family long-lived mode args; stdout is discarded until a protocol consumer lands; stderr is
- * drained byte-counted as below.
+ * per-family long-lived mode args. Stdout is discarded except for Fleet-managed OpenCode, whose
+ * exact listening banner is the authoritative bound-port surface for the supervisor-owned wake
+ * bootstrap; stderr is drained byte-counted as below.
  *
  * **Child env (minimal by construction):** the child receives ONLY the `AMBIENT_ENV_ALLOWLIST`
  * process-runtime vars — never a full parent-env copy, so ambient operator secrets cannot leak into
@@ -257,6 +259,29 @@ class FleetLifecycleService extends Base {
     execFileFn = null
 
     /**
+     * Fetch implementation for the Fleet-owned OpenCode session-creation request. Defaults to the
+     * process-global `fetch`; injectable so unit witnesses can prove the exact request without a
+     * live server.
+     * @member {Function|null} fetchFn=null
+     */
+    fetchFn = null
+
+    /**
+     * Auxiliary-subprocess implementation for the generated OpenCode wake-envelope hook. Kept
+     * distinct from {@link #member-execFileFn}: version probes are best-effort, while this hook is
+     * an awaited boot contract whose failure degrades the route.
+     * @member {Function|null} openCodeHookExecFileFn=null
+     */
+    openCodeHookExecFileFn = null
+
+    /**
+     * Bound for observing the OpenCode listening banner before the wake route degrades fail-closed.
+     * Plain-field test seam; the production default is intentionally fixed rather than env-derived.
+     * @member {Number} openCodeBootstrapTimeoutMs=10000
+     */
+    openCodeBootstrapTimeoutMs = 10000
+
+    /**
      * Installed-bundle capability probe for `codex-desktop`. Defaults to the read-only static
      * bundle inspector; injectable so lifecycle specs never depend on an installed GUI app.
      * @member {Function|null} codexDesktopCapabilityProbeFn=null
@@ -319,7 +344,13 @@ class FleetLifecycleService extends Base {
             throw new Error(`FleetLifecycleService.start: agent '${id}' has no valid githubUsername identity.`)
         }
 
-        const launch                          = this.resolveLaunch(agent, opts),
+        const
+            curatedOpenCode = agent.harnessType === 'opencode' && !agent.metadata?.launch,
+            cwd             = curatedOpenCode
+                ? this.resolveOpenCodeOwnerDirectory(opts.cwd, id)
+                : opts.cwd,
+            serverPassword  = curatedOpenCode ? generateLocalBearerToken() : undefined,
+            launch          = this.resolveLaunch(agent, {...opts, cwd, serverPassword}),
               {command, args, env: launchEnv} = launch;
 
         // Env-key contract guard (fail-fast): each reserved class occupies a DISTINCT child-env slot.
@@ -369,7 +400,7 @@ class FleetLifecycleService extends Base {
         // required (existence alone lets a mode-0644 candidate publish a running status, then flip
         // to failed on the child's asynchronous permission error — a transient false-running state
         // no supervisor may emit).
-        const resolvedCommand = this.resolveExecutable(command, env.PATH, opts.cwd);
+        const resolvedCommand = this.resolveExecutable(command, env.PATH, cwd);
         if (!resolvedCommand) {
             throw new Error(`FleetLifecycleService.start: harness binary '${command}' not found or not executable for agent '${id}' (path-shaped commands resolve against the child cwd; bare commands against the child's PATH; executable permission required). Pin the AiConfig fleet.harnessBinaries leaf or the harnessBinaryPaths field to a real executable.`);
         }
@@ -385,7 +416,7 @@ class FleetLifecycleService extends Base {
 
             if (!authCommand) {
                 const reason = 'bundled Codex CLI auth command is unavailable';
-                this.publishUnavailable({id, launch, resolvedCommand, cwd: opts.cwd, reason});
+                this.publishUnavailable({id, launch, resolvedCommand, cwd, reason});
                 throw new Error(`FleetLifecycleService.start: codex-desktop is unavailable for agent '${id}' — ${reason}.`);
             }
 
@@ -397,7 +428,7 @@ class FleetLifecycleService extends Base {
 
             if (!codexDesktopCapability?.available || !path.isAbsolute(codexDesktopCapability.crashpadExecutable || '')) {
                 const reason = codexDesktopCapability?.reason || 'exact packaged Crashpad helper proof is missing';
-                this.publishUnavailable({id, launch, resolvedCommand, authCommand, cwd: opts.cwd, reason});
+                this.publishUnavailable({id, launch, resolvedCommand, authCommand, cwd, reason});
                 throw new Error(`FleetLifecycleService.start: codex-desktop is unavailable for agent '${id}' — ${reason}.`);
             }
         }
@@ -445,22 +476,50 @@ class FleetLifecycleService extends Base {
         //
         // stdio topology is the LIVENESS contract: stdin MUST be a held-open pipe — both supported
         // harness CLIs treat ignored/EOF'd stdin as session-end and exit immediately (probed on the
-        // exact binaries; see the class summary). stdout is discarded until a protocol consumer
-        // lands; stderr is drained byte-counted below.
-        const spawnOptions = {stdio: ['pipe', 'ignore', 'pipe'], env};
-        if (opts.cwd != null) spawnOptions.cwd = opts.cwd;
+        // exact binaries; see the class summary). Fleet-managed OpenCode is the one stdout consumer:
+        // its listening banner carries the OS-assigned port needed by the owner-session bootstrap.
+        // Every other family retains stdout=ignore; stderr is drained byte-counted below.
+        const spawnOptions = {stdio: ['pipe', curatedOpenCode ? 'pipe' : 'ignore', 'pipe'], env};
+        if (cwd != null) spawnOptions.cwd = cwd;
+
+        let openCodeWakeRoute = null;
+
+        if (curatedOpenCode) {
+            const
+                hookPath     = path.join(launch.instanceHome, 'write-wake-envelope.mjs'),
+                envelopePath = path.join(launch.instanceHome, 'opencode', 'wake-envelope.json');
+
+            if (!fs.existsSync(hookPath) || !fs.statSync(hookPath).isFile()) {
+                throw new Error(`FleetLifecycleService.start: Fleet-managed OpenCode agent '${id}' is missing its generated wake hook at '${hookPath}'. Prepare the managed workspace before launch.`);
+            }
+
+            // A stopped server can never own a live route. Remove its exact prior envelope BEFORE
+            // spawn so a failed new bootstrap cannot leave the daemon targeting stale coordinates.
+            fs.rmSync(envelopePath, {force: true});
+
+            openCodeWakeRoute = {
+                state    : 'starting',
+                reason   : null,
+                port     : null,
+                sessionId: null,
+                projectId: null,
+                directory: cwd,
+                envelopePath,
+                hookPath
+            };
+        }
 
         let child;
         try {
             child = this.getSpawnFn()(resolvedCommand, args, spawnOptions);
         } catch (error) {
-            this.processes.set(id, {id, cwd: opts.cwd ?? null, state: 'failed', pid: null, startedAt: null, exitCode: null, exitedAt: new Date().toISOString(), error: error.message});
+            this.processes.set(id, {id, cwd: cwd ?? null, state: 'failed', pid: null, startedAt: null, exitCode: null, exitedAt: new Date().toISOString(), error: error.message});
             throw error;
         }
 
         const record = {
             id, child,
-            cwd        : opts.cwd ?? null,
+            cwd        : cwd ?? null,
             pid        : child.pid ?? null,
             state      : 'running',
             startedAt  : new Date().toISOString(),
@@ -470,19 +529,26 @@ class FleetLifecycleService extends Base {
             stderrBytes: 0,
             // Curated-launch observability: the family + isolated home let `status` compute the live
             // per-home `authRequired` heuristic; null for raw-launch agents (unknown layout).
-            harnessType       : launch.instanceHome ? agent.harnessType : null,
-            instanceHome      : launch.instanceHome ?? null,
-            authHome          : launch.authHome ?? (HARNESS_AUTH_MARKERS[agent.harnessType] ? launch.instanceHome : null),
+            harnessType             : launch.instanceHome ? agent.harnessType : null,
+            instanceHome            : launch.instanceHome ?? null,
+            authHome                : launch.authHome ?? (HARNESS_AUTH_MARKERS[agent.harnessType] ? launch.instanceHome : null),
             authCommand,
-            electronProfile   : launch.electronProfile ?? null,
-            crashpadExecutable: codexDesktopCapability?.crashpadExecutable ?? null,
-            launchCommand     : launch.instanceHome ? resolvedCommand : null,
-            binaryVersion     : null,
-            failureReason     : null,
-            cleanupUnresolved : false,
-            finalizePromise   : null
+            electronProfile         : launch.electronProfile ?? null,
+            crashpadExecutable      : codexDesktopCapability?.crashpadExecutable ?? null,
+            launchCommand           : launch.instanceHome ? resolvedCommand : null,
+            binaryVersion           : null,
+            failureReason           : null,
+            cleanupUnresolved       : false,
+            finalizePromise         : null,
+            wakeRoute               : openCodeWakeRoute,
+            openCodeBootstrapStarted: false,
+            openCodeBootstrapTimer  : null
         };
         this.processes.set(id, record);
+
+        if (openCodeWakeRoute) {
+            this.observeOpenCodeWakeBootstrap(record, {env});
+        }
 
         // Best-effort version surface (the pin/verify half of the executable preflight): capture
         // the template-owned version-probe argv async onto the record — the status read surfaces
@@ -515,6 +581,16 @@ class FleetLifecycleService extends Base {
 
         child.on?.('exit', (code, signal) => this.finalizeExitedProcess(record, {code, signal}));
         child.on?.('error', error => {
+            if (record.wakeRoute) {
+                clearTimeout(record.openCodeBootstrapTimer);
+                record.openCodeBootstrapTimer = null;
+                try { fs.rmSync(record.wakeRoute.envelopePath, {force: true}); } catch {}
+                record.wakeRoute.state     = 'degraded';
+                record.wakeRoute.reason    = 'OpenCode process failed; wake route unavailable';
+                record.wakeRoute.port      = null;
+                record.wakeRoute.sessionId = null;
+                record.wakeRoute.projectId = null;
+            }
             record.state         = 'failed';
             record.error         = error.message;
             record.failureReason = 'tracked harness process emitted an error';
@@ -626,7 +702,7 @@ class FleetLifecycleService extends Base {
      * @param {String} id
      * @returns {Object} `{id, state, running, pid, startedAt, uptimeMs, exitCode, exitedAt,
      *     stderrBytes, authRequired, instanceHome, authHome, launchCommand, authCommand,
-     *     binaryVersion, failureReason, cleanupUnresolved}` — `authRequired`
+     *     binaryVersion, failureReason, cleanupUnresolved, wakeRoute}` — `authRequired`
      *     is the LIVE per-home
      *     auth-marker heuristic for curated launches (`true` = the operator-owned per-home login has
      *     not happened yet; recomputed each read so a completed login flips it without a restart);
@@ -636,11 +712,13 @@ class FleetLifecycleService extends Base {
      *     safe for the dev-only unauthenticated loopback Fleet bridge: they expose no auth contents.
      *     `binaryVersion` is the best-effort `--version` capture of what actually ran (`null`
      *     until/unless the probe answered); `failureReason` is a bounded lifecycle-owned reason,
-     *     never raw child output.
+     *     never raw child output. Fleet-managed OpenCode additionally carries a non-secret
+     *     `wakeRoute` (`starting | ready | degraded`, owner tuple, envelope path); server
+     *     credentials remain env-only and never enter the record or projection.
      */
     status(id) {
         const record = this.processes.get(id);
-        if (!record) return {id, state: 'stopped', running: false, pid: null, startedAt: null, uptimeMs: null, exitCode: null, exitedAt: null, stderrBytes: 0, authRequired: null, instanceHome: null, authHome: null, launchCommand: null, authCommand: null, binaryVersion: null, failureReason: null, cleanupUnresolved: false};
+        if (!record) return {id, state: 'stopped', running: false, pid: null, startedAt: null, uptimeMs: null, exitCode: null, exitedAt: null, stderrBytes: 0, authRequired: null, instanceHome: null, authHome: null, launchCommand: null, authCommand: null, binaryVersion: null, failureReason: null, cleanupUnresolved: false, wakeRoute: null};
 
         return {
             id,
@@ -659,7 +737,16 @@ class FleetLifecycleService extends Base {
             authCommand      : record.authCommand ?? null,
             binaryVersion    : record.binaryVersion ?? null,
             failureReason    : record.failureReason ?? null,
-            cleanupUnresolved: Boolean(record.cleanupUnresolved)
+            cleanupUnresolved: Boolean(record.cleanupUnresolved),
+            wakeRoute        : record.wakeRoute ? {
+                state       : record.wakeRoute.state,
+                reason      : record.wakeRoute.reason,
+                port        : record.wakeRoute.port,
+                sessionId   : record.wakeRoute.sessionId,
+                projectId   : record.wakeRoute.projectId,
+                directory   : record.wakeRoute.directory,
+                envelopePath: record.wakeRoute.envelopePath
+            } : null
         };
     }
 
@@ -743,6 +830,26 @@ class FleetLifecycleService extends Base {
     finalizeExitedProcess(record, {code, signal}) {
         if (record.finalizePromise) return record.finalizePromise;
 
+        clearTimeout(record.openCodeBootstrapTimer);
+        record.openCodeBootstrapTimer = null;
+        if (record.wakeRoute) {
+            let reason = record.wakeRoute.state === 'starting'
+                ? 'OpenCode server exited before the wake route became ready'
+                : 'OpenCode server exited; wake route unavailable';
+
+            try {
+                fs.rmSync(record.wakeRoute.envelopePath, {force: true});
+            } catch {
+                reason += '; stale envelope cleanup failed';
+            }
+
+            record.wakeRoute.state     = 'degraded';
+            record.wakeRoute.reason    = reason;
+            record.wakeRoute.port      = null;
+            record.wakeRoute.sessionId = null;
+            record.wakeRoute.projectId = null;
+        }
+
         record.exitCode = code;
         record.signal   = signal;
         record.exitedAt = new Date().toISOString();
@@ -818,7 +925,8 @@ class FleetLifecycleService extends Base {
      * and rejects any reserved-key collision fail-fast.
      * @param {Object} agent
      * @param {Object} [opts] Start options; the final provisioned `cwd` is launch input for
-     *                        `codex-desktop` and ignored by other curated families.
+     *                        `codex-desktop` and the owner directory for Fleet-managed OpenCode.
+     * @param {String} [opts.serverPassword] Supervisor-generated OpenCode server credential.
      * @returns {{command: String, args: String[], env: Object}}
      * @private
      */
@@ -843,7 +951,13 @@ class FleetLifecycleService extends Base {
             }
             const instanceHome = deriveAgentInstanceHome({instanceRoot: this.getInstanceRoot(), agentId: agent.id, harnessType: agent.harnessType});
             return {
-                ...deriveHarnessLaunchSpec({harnessType: agent.harnessType, instanceHome, binaryPath, cwd: opts.cwd}),
+                ...deriveHarnessLaunchSpec({
+                    harnessType   : agent.harnessType,
+                    instanceHome,
+                    binaryPath,
+                    cwd           : opts.cwd,
+                    serverPassword: opts.serverPassword
+                }),
                 // carried for observability: `status` computes the live per-home authRequired from it
                 instanceHome
             };
@@ -867,6 +981,242 @@ class FleetLifecycleService extends Base {
         }
 
         return {command: launch.command, args: Array.isArray(launch.args) ? launch.args : [], env, instanceHome: null};
+    }
+
+    /**
+     * @summary Resolve the Fleet-owned OpenCode session directory to one existing canonical
+     * checkout. The supervisor creates the top-level session against this exact directory and
+     * rejects any response that names another one; an inherited or relative cwd would make session
+     * ownership ambiguous.
+     * @param {*} cwd Requested managed checkout.
+     * @param {String} id Agent id for the named error.
+     * @returns {String} Canonical absolute directory.
+     * @private
+     */
+    resolveOpenCodeOwnerDirectory(cwd, id) {
+        if (typeof cwd !== 'string' || !path.isAbsolute(cwd)) {
+            throw new Error(`FleetLifecycleService.start: Fleet-managed OpenCode agent '${id}' requires an absolute provisioned cwd for owner-session binding.`);
+        }
+
+        try {
+            return fs.realpathSync(cwd);
+        } catch {
+            throw new Error(`FleetLifecycleService.start: Fleet-managed OpenCode agent '${id}' requires an existing provisioned cwd for owner-session binding.`);
+        }
+    }
+
+    /**
+     * @summary Drain the supervised OpenCode server stdout and consume exactly its complete
+     * loopback listening-banner line. The first valid port starts the Fleet-owned session bootstrap;
+     * no session-list or child-session discovery exists in this path.
+     * @param {Object} record Tracked OpenCode lifecycle record.
+     * @param {Object} options
+     * @param {Object} options.env Exact child env, including env-only server credentials.
+     * @returns {void}
+     * @private
+     */
+    observeOpenCodeWakeBootstrap(record, {env}) {
+        let buffer = '';
+
+        record.openCodeBootstrapTimer = setTimeout(() => {
+            this.degradeOpenCodeWakeRoute(record, 'OpenCode listening banner was not observed before the bootstrap deadline');
+        }, this.openCodeBootstrapTimeoutMs);
+        record.openCodeBootstrapTimer.unref?.();
+
+        record.child?.stdout?.on?.('data', chunk => {
+            if (record.openCodeBootstrapStarted || record.wakeRoute?.state !== 'starting') return;
+
+            buffer += String(chunk);
+
+            let newlineIndex;
+            while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
+                const line = buffer.slice(0, newlineIndex).replace(/\r$/, '');
+                buffer     = buffer.slice(newlineIndex + 1);
+
+                const match = /^opencode server listening on http:\/\/127\.0\.0\.1:(\d+)$/.exec(line);
+                if (!match) continue;
+
+                const port = Number(match[1]);
+                if (!Number.isInteger(port) || port < 1 || port > 65535) {
+                    this.degradeOpenCodeWakeRoute(record, 'OpenCode listening banner carried an invalid loopback port');
+                    return;
+                }
+
+                record.openCodeBootstrapStarted = true;
+                record.wakeRoute.port            = port;
+                clearTimeout(record.openCodeBootstrapTimer);
+                record.openCodeBootstrapTimer = null;
+                void this.bootstrapOpenCodeWakeRoute(record, {env, port});
+                return;
+            }
+
+            // The banner is short. Retain only the last partial line so untrusted/noisy stdout can
+            // never become an unbounded record; the listener still drains every byte.
+            if (buffer.length > 4096) buffer = buffer.slice(-4096);
+        });
+    }
+
+    /**
+     * @summary Create the Fleet-owned top-level OpenCode session and invoke the already-generated
+     * atomic wake-envelope hook with its exact authority tuple.
+     *
+     * Ordering is strict: listening banner → `POST /api/session?directory=…` with no parent id →
+     * validate `{id,projectID,directory,parentID}` → hook. Any failure removes the exact envelope
+     * and leaves the process running with a degraded route; no session-list fallback exists.
+     * @param {Object} record Tracked OpenCode lifecycle record.
+     * @param {Object} options
+     * @param {Object} options.env Exact child env, including env-only server credentials.
+     * @param {Number} options.port Parsed loopback server port.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async bootstrapOpenCodeWakeRoute(record, {env, port}) {
+        const route = record.wakeRoute;
+        let   stage = 'session creation';
+
+        try {
+            const
+                url           = new URL(`http://127.0.0.1:${port}/api/session`),
+                authorization = 'Basic ' + Buffer.from(
+                    `${env.OPENCODE_SERVER_USERNAME}:${env.OPENCODE_SERVER_PASSWORD}`
+                ).toString('base64');
+
+            url.searchParams.set('directory', route.directory);
+
+            const response = await this.getFetchFn()(url, {
+                method : 'POST',
+                headers: {
+                    'content-type' : 'application/json',
+                    'authorization': authorization
+                },
+                body    : '{}',
+                redirect: 'error',
+                signal  : AbortSignal.timeout(5000)
+            });
+
+            if (!response?.ok) {
+                throw new Error('session creation returned a non-success status');
+            }
+
+            stage = 'session response validation';
+
+            const session = await response.json();
+            if (typeof session?.id !== 'string' || session.id.length === 0 ||
+                typeof session?.projectID !== 'string' || session.projectID.length === 0 ||
+                session.directory !== route.directory ||
+                session.parentID != null
+            ) {
+                throw new Error('session creation returned an invalid owner tuple');
+            }
+
+            // A stopped/replaced record cannot publish a route after its async creation returned.
+            if (this.processes.get(record.id) !== record || record.state !== 'running') return;
+
+            stage = 'wake-envelope hook';
+
+            const args = [
+                route.hookPath,
+                '--data-home', record.instanceHome,
+                '--port', String(port),
+                '--session-id', session.id,
+                '--project-id', session.projectID,
+                '--directory', route.directory
+            ];
+            // The generated hook needs only benign process-runtime vars plus its own server
+            // credential pair. Repository/MCP/Bridge credentials belong to the harness child and
+            // must not fan out into this auxiliary process.
+            const hookEnv = {};
+
+            for (const key of AMBIENT_ENV_ALLOWLIST) {
+                if (env[key] !== undefined) hookEnv[key] = env[key];
+            }
+            hookEnv.OPENCODE_SERVER_USERNAME = env.OPENCODE_SERVER_USERNAME;
+            hookEnv.OPENCODE_SERVER_PASSWORD = env.OPENCODE_SERVER_PASSWORD;
+
+            await new Promise((resolve, reject) => {
+                try {
+                    this.getOpenCodeHookExecFileFn()(
+                        process.execPath,
+                        args,
+                        {cwd: route.directory, env: hookEnv, timeout: 5000},
+                        error => error ? reject(error) : resolve()
+                    );
+                } catch (error) {
+                    reject(error);
+                }
+            });
+
+            stage = 'wake-envelope verification';
+            if (this.processes.get(record.id) !== record || record.state !== 'running') {
+                fs.rmSync(route.envelopePath, {force: true});
+                return;
+            }
+            this.verifyOpenCodeWakeEnvelope(record, {
+                port,
+                sessionId: session.id,
+                projectId: session.projectID,
+                env
+            });
+
+            route.state     = 'ready';
+            route.reason    = null;
+            route.sessionId = session.id;
+            route.projectId = session.projectID;
+            record.failureReason = null;
+        } catch {
+            try {
+                fs.rmSync(route.envelopePath, {force: true});
+            } catch {
+                stage += ' and envelope cleanup';
+            }
+            this.degradeOpenCodeWakeRoute(record, `OpenCode wake bootstrap failed during ${stage}`);
+        }
+    }
+
+    /**
+     * @summary Verify the generated hook actually published the exact owner tuple, credentials, and
+     * 0600 mode before declaring the wake route ready.
+     * @param {Object} record Tracked OpenCode lifecycle record.
+     * @param {Object} expected Expected authority and coordinate fields.
+     * @returns {void}
+     * @throws {Error} On any missing, malformed, mismatched, or over-permissive envelope.
+     * @private
+     */
+    verifyOpenCodeWakeEnvelope(record, {port, sessionId, projectId, env}) {
+        const
+            envelope = JSON.parse(fs.readFileSync(record.wakeRoute.envelopePath, 'utf8')),
+            mode     = fs.statSync(record.wakeRoute.envelopePath).mode & 0o777;
+
+        if (envelope.hostname !== '127.0.0.1' ||
+            envelope.port !== port ||
+            envelope.sessionId !== sessionId ||
+            envelope.projectId !== projectId ||
+            envelope.directory !== record.wakeRoute.directory ||
+            envelope.username !== env.OPENCODE_SERVER_USERNAME ||
+            envelope.password !== env.OPENCODE_SERVER_PASSWORD ||
+            mode !== 0o600
+        ) {
+            throw new Error('generated OpenCode wake envelope did not preserve the owner tuple');
+        }
+    }
+
+    /**
+     * @summary Mark the OpenCode wake route degraded without stopping its supervised server. The
+     * reason is lifecycle-owned and bounded; raw child/fetch/hook output never reaches status.
+     * @param {Object} record Tracked lifecycle record.
+     * @param {String} reason Safe reason.
+     * @returns {void}
+     * @private
+     */
+    degradeOpenCodeWakeRoute(record, reason) {
+        clearTimeout(record.openCodeBootstrapTimer);
+        record.openCodeBootstrapTimer = null;
+
+        if (!record.wakeRoute || record.wakeRoute.state === 'ready') return;
+
+        record.wakeRoute.state  = 'degraded';
+        record.wakeRoute.reason = String(reason).slice(0, 240);
+        record.failureReason    = record.wakeRoute.reason;
     }
 
     /**
@@ -1274,6 +1624,22 @@ class FleetLifecycleService extends Base {
      */
     getExecFileFn() {
         return this.execFileFn || execFile;
+    }
+
+    /**
+     * @returns {Function} the OpenCode session-creation fetch implementation.
+     * @private
+     */
+    getFetchFn() {
+        return this.fetchFn || globalThis.fetch;
+    }
+
+    /**
+     * @returns {Function} the generated OpenCode hook subprocess implementation.
+     * @private
+     */
+    getOpenCodeHookExecFileFn() {
+        return this.openCodeHookExecFileFn || execFile;
     }
 
     /**

--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -203,12 +203,14 @@ class FleetManager extends Base {
      * Delegates to `fleetWakeStateAdapter.readFleetWakeStateSnapshot` with the registry roster (one
      * row per REGISTERED agent, same one-agent-set rule as the sibling views) plus the injected
      * {@link #member-wakeStateOptions}. Observation truth only: subscription intent × daemon PID-file
-     * liveness; the `setWakeEnabled` control verb mutates state this view independently observes.
+     * liveness × the daemon-owned terminal delivery-failure receipts; the `setWakeEnabled` control
+     * verb mutates state this view independently observes.
      * Fail-honest: with no injected options every row reads `unknown` under a `degraded/none`
      * capability — "we cannot see" stays distinguishable from "the fleet is off"; the state is never
      * invented.
      * @returns {Promise<{capability: Object, states: Object[]}>} Adapter snapshot: per-agent
-     * `{agentId, wake, confidence, source}` rows (+ `reason` on `unknown`) and the capability envelope.
+     * `{agentId, wake, confidence, source}` rows (+ a reason/receipt on degraded delivery) and the
+     * capability envelope.
      */
     fleetWakeStatus() {
         return readFleetWakeStateSnapshot({

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -80,6 +80,7 @@ async function boot() {
     // (`ai/daemons/wake/daemon.mjs`) is the one to mirror here.
     FleetManager.wakeStateOptions = {
         pidFilePath                     : path.join(memoryCoreConfig.wakeDaemon.dataDir, 'wake-daemon.pid'),
+        deliveryFailureFilePath         : path.join(memoryCoreConfig.wakeDaemon.dataDir, 'wake-delivery-failures.json'),
         listActiveSubscriptionIdentities: readActiveWakeSubscriptionIdentities
     };
 

--- a/ai/services/fleet/fleetWakeStateAdapter.mjs
+++ b/ai/services/fleet/fleetWakeStateAdapter.mjs
@@ -1,6 +1,7 @@
 import {spawnSync}         from 'node:child_process'
 import {redactCredentials} from './redactCredentials.mjs'
 import fs                  from 'node:fs'
+import path                from 'node:path'
 
 /**
  * @module ai/services/fleet/fleetWakeStateAdapter
@@ -10,7 +11,9 @@ import fs                  from 'node:fs'
  * The adapter reads OBSERVATION truth only, never control intent: subscription state comes through
  * an injected read path (the caller owns identity binding, mirroring `fleetA2AActivityAdapter`),
  * and daemon liveness comes from the wake daemon's exclusive-create PID file plus a
- * `process.kill(pid, 0)` existence probe. Watermark/state-file mtime is deliberately NOT a
+ * `process.kill(pid, 0)` existence probe. Terminal delivery failures come from the daemon-owned
+ * atomic receipt file, independently readable even when the affected seat cannot receive A2A.
+ * Watermark/state-file mtime is deliberately NOT a
  * liveness signal: the watermark advances only on delivery activity, so a quiet fleet would be
  * indistinguishable from a dead daemon. The `setWakeEnabled` control verb mutates state that this
  * producer independently observes — the two never share a source.
@@ -114,6 +117,77 @@ export function resolveDaemonLiveness({
 }
 
 /**
+ * @summary Read the daemon-owned terminal delivery-failure receipts once per Fleet snapshot.
+ * Missing means no terminal failure has ever been recorded; malformed/unreadable means unknown,
+ * never healthy-by-default.
+ * @param {Object} options={}
+ * @param {String|null} [options.deliveryFailureFilePath]
+ * @param {Function} [options.readDeliveryFailureFile]
+ * @returns {{state: 'observed'|'unknown', reason: String|null, byIdentity: Map<String,Object[]>}}
+ * @private
+ */
+function readTerminalDeliveryFailures({
+    deliveryFailureFilePath = null,
+    readDeliveryFailureFile = filePath => fs.readFileSync(filePath, 'utf8')
+} = {}) {
+    const byIdentity = new Map()
+
+    if (!deliveryFailureFilePath) {
+        return {
+            state : 'unknown',
+            reason: 'wake delivery failure file path not configured',
+            byIdentity
+        }
+    }
+
+    let parsed
+
+    try {
+        parsed = JSON.parse(readDeliveryFailureFile(deliveryFailureFilePath))
+    } catch (error) {
+        if (error?.code === 'ENOENT') {
+            return {state: 'observed', reason: null, byIdentity}
+        }
+        return {
+            state : 'unknown',
+            reason: error instanceof SyntaxError
+                ? 'malformed wake delivery failure receipt file'
+                : redactReason(error),
+            byIdentity
+        }
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return {state: 'unknown', reason: 'malformed wake delivery failure receipt file', byIdentity}
+    }
+
+    for (const [subscriptionId, receipt] of Object.entries(parsed)) {
+        if (!receipt || typeof receipt !== 'object' || Array.isArray(receipt) ||
+            receipt.subscriptionId !== subscriptionId ||
+            typeof receipt.agentIdentity !== 'string' || receipt.agentIdentity.length === 0 ||
+            typeof receipt.errorClass !== 'string' || !/^[a-z0-9-]{1,80}$/.test(receipt.errorClass) ||
+            typeof receipt.failedAt !== 'string' || Number.isNaN(Date.parse(receipt.failedAt))
+        ) {
+            return {state: 'unknown', reason: 'malformed wake delivery failure receipt file', byIdentity: new Map()}
+        }
+
+        const rows = byIdentity.get(receipt.agentIdentity) || []
+        rows.push({
+            subscriptionId,
+            errorClass: receipt.errorClass,
+            failedAt  : new Date(receipt.failedAt).toISOString()
+        })
+        byIdentity.set(receipt.agentIdentity, rows)
+    }
+
+    for (const rows of byIdentity.values()) {
+        rows.sort((left, right) => right.failedAt.localeCompare(left.failedAt))
+    }
+
+    return {state: 'observed', reason: null, byIdentity}
+}
+
+/**
  * @summary Default process-identity reader: the probed pid's command line via `ps` (portable across
  * macOS/Linux). Returns `null` when `ps` yields nothing (the identity stays unknown, never guessed).
  * @param {Number} pid
@@ -130,27 +204,33 @@ function readProcessCommandViaPs(pid) {
 }
 
 /**
- * @summary Maps one agent's subscription state × daemon liveness onto the graduated wake taxonomy.
+ * @summary Maps one agent's subscription state × daemon liveness × terminal delivery state onto
+ * the graduated wake taxonomy.
  *
  * The truth table is the S2 registry contract verbatim: no subscription is OBSERVED `off`; an
- * active subscription with a live daemon is `on`; an active subscription with a dead daemon is
- * `suppressed` (intent on, delivery off — the blind-switch incident class); and any unknown input
- * axis makes the output `unknown`, because claiming `on` or `suppressed` without both facts would
- * fabricate precision.
+ * active subscription with a live daemon and no terminal failure is `on`; an active subscription
+ * with a dead daemon OR a terminal failure is `suppressed` (intent on, delivery off — the
+ * blind-switch incident class); and any unknown input axis makes the output `unknown`, because
+ * claiming `on` or `suppressed` without all facts would fabricate precision.
  * @param {Object} options={}
  * @param {'active'|'none'|'unknown'} options.subscriptionState One agent's wake-subscription intent.
  * @param {Boolean|'unknown'} options.daemonAlive Daemon liveness from {@link resolveDaemonLiveness}.
+ * @param {'none'|'failed'|'unknown'} [options.deliveryFailureState='none'] Terminal receipt axis.
  * @returns {'on'|'off'|'suppressed'|'unknown'}
  */
-export function resolveAgentWakeState({subscriptionState, daemonAlive}) {
+export function resolveAgentWakeState({subscriptionState, daemonAlive, deliveryFailureState = 'none'}) {
     if (subscriptionState === 'none') {
         return 'off'
     }
-    if (subscriptionState !== 'active' || daemonAlive === 'unknown') {
+    if (subscriptionState !== 'active') {
         return 'unknown'
     }
+    // Either observed failure axis is independently sufficient to prove suppression. An unreadable
+    // sibling axis cannot erase that stronger fact.
+    if (daemonAlive === false || deliveryFailureState === 'failed') return 'suppressed'
+    if (daemonAlive === 'unknown' || deliveryFailureState !== 'none') return 'unknown'
 
-    return daemonAlive ? 'on' : 'suppressed'
+    return daemonAlive ? 'on' : 'unknown'
 }
 
 /**
@@ -175,7 +255,11 @@ export function resolveAgentWakeState({subscriptionState, daemonAlive}) {
  *     its wake identity. Default: `'@' + (githubUsername ?? id)` — the swarm's mailbox-identity
  *     convention; override at the entrypoint if the deployment maps identities differently.
  * @param {String|null} [options.pidFilePath] Wake daemon PID file path (entrypoint-resolved).
+ * @param {String|null} [options.deliveryFailureFilePath] Daemon-owned terminal receipt path. When
+ *     omitted beside a configured PID path, defaults to `wake-delivery-failures.json` in that same
+ *     injected directory; no config or env is resolved here.
  * @param {Function} [options.readFile] Test seam for {@link resolveDaemonLiveness}.
+ * @param {Function} [options.readDeliveryFailureFile] Test seam for terminal receipt reads.
  * @param {Function} [options.probeProcess] Test seam for {@link resolveDaemonLiveness}.
  * @param {Function} [options.readProcessCommand] Test seam for {@link resolveDaemonLiveness}.
  * @param {Date|String} [options.capturedAt] Capture timestamp.
@@ -188,7 +272,9 @@ export async function readFleetWakeStateSnapshot({
     listActiveSubscriptionIdentities = null,
     wakeIdentityFor = agent => `@${agent.githubUsername ?? agent.id}`,
     pidFilePath = null,
+    deliveryFailureFilePath = null,
     readFile,
+    readDeliveryFailureFile,
     probeProcess,
     readProcessCommand,
     capturedAt = new Date()
@@ -217,6 +303,11 @@ export async function readFleetWakeStateSnapshot({
         ...(readFile           && {readFile}),
         ...(probeProcess       && {probeProcess}),
         ...(readProcessCommand && {readProcessCommand})
+    })
+    const failures = readTerminalDeliveryFailures({
+        deliveryFailureFilePath: deliveryFailureFilePath ||
+            (pidFilePath ? path.join(path.dirname(pidFilePath), 'wake-delivery-failures.json') : null),
+        ...(readDeliveryFailureFile && {readDeliveryFailureFile})
     })
 
     const hasReader = Boolean(resolveSubscriptionState),
@@ -256,7 +347,19 @@ export async function readFleetWakeStateSnapshot({
             }
         }
 
-        const wake = resolveAgentWakeState({subscriptionState, daemonAlive: liveness.alive})
+        const
+            wakeIdentity        = wakeIdentityFor(agent),
+            lastDeliveryFailure = failures.state === 'observed'
+                ? failures.byIdentity.get(wakeIdentity)?.[0] || null
+                : null,
+            deliveryFailureState = failures.state === 'unknown'
+                ? 'unknown'
+                : (lastDeliveryFailure ? 'failed' : 'none'),
+            wake = resolveAgentWakeState({
+                subscriptionState,
+                daemonAlive: liveness.alive,
+                deliveryFailureState
+            })
 
         const row = {
             agentId,
@@ -268,7 +371,12 @@ export async function readFleetWakeStateSnapshot({
         if (wake === 'unknown') {
             row.reason = subscriptionState === 'unknown'
                 ? (rowReason || 'subscription state unreadable')
-                : (redactReason(liveness.reason) || 'wake daemon liveness unknown')
+                : liveness.alive === 'unknown'
+                    ? (redactReason(liveness.reason) || 'wake daemon liveness unknown')
+                    : (redactReason(failures.reason) || 'terminal delivery state unreadable')
+        } else if (wake === 'suppressed' && lastDeliveryFailure) {
+            row.reason              = `terminal wake delivery failure: ${lastDeliveryFailure.errorClass}`
+            row.lastDeliveryFailure = lastDeliveryFailure
         }
 
         states.push(row)
@@ -278,10 +386,11 @@ export async function readFleetWakeStateSnapshot({
     // counts as truth — otherwise a throwing scan plus an unreadable daemon reports `partial`
     // visibility while observing exactly nothing.
     const livenessSourceOk = liveness.alive !== 'unknown',
+          failureSourceOk  = failures.state === 'observed',
           readerUsable     = hasReader && !bulkScanFailed,
           readerClean      = readerUsable && failedRows === 0 && invalidRows === 0,
-          fullyOk          = livenessSourceOk && readerClean,
-          anyTruth         = livenessSourceOk || readerUsable
+          fullyOk          = livenessSourceOk && failureSourceOk && readerClean,
+          anyTruth         = livenessSourceOk || failureSourceOk || readerUsable
 
     return {
         capability: {
@@ -291,6 +400,7 @@ export async function readFleetWakeStateSnapshot({
             capturedAt: toIsoString(capturedAt),
             reason    : fullyOk ? null : [
                 livenessSourceOk ? null : (redactReason(liveness.reason) || 'daemon liveness unknown'),
+                failureSourceOk ? null : (redactReason(failures.reason) || 'terminal delivery state unreadable'),
                 hasReader ? null : 'subscription read path unavailable',
                 failedRows > 0 ? `subscription reader failed for ${failedRows} agent(s)` : null,
                 invalidRows > 0 ? `subscription reader returned out-of-contract values for ${invalidRows} agent(s)` : null

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -34,6 +34,7 @@ class FakeChild extends EventEmitter {
         this.pid     = ++nextPid;
         this.signals = [];
         this.stderr  = new EventEmitter();
+        this.stdout  = new EventEmitter();
     }
 
     kill(signal) {
@@ -103,11 +104,17 @@ function remoteMcpPlan(resources, matrix) {
 /** Reset the singleton + inject fresh test doubles. Returns the spawn stub. */
 function install({agents = {}, creds = {}} = {}) {
     const spawnStub = makeSpawnStub();
+    for (const record of FleetLifecycleService.processes.values()) {
+        clearTimeout(record.openCodeBootstrapTimer);
+    }
     FleetLifecycleService.processes.clear();
     FleetLifecycleService.spawnFn         = spawnStub;
     // Stub the version probe by default so no spec spawns a real auxiliary subprocess; the
     // env-boundary test injects its own recorder.
     FleetLifecycleService.execFileFn      = () => {};
+    FleetLifecycleService.fetchFn         = null;
+    FleetLifecycleService.openCodeHookExecFileFn = null;
+    FleetLifecycleService.openCodeBootstrapTimeoutMs = 10000;
     FleetLifecycleService.registry        = makeRegistry(agents, creds);
     FleetLifecycleService.sigkillTimeoutMs = 50;
     // Reset the configurable env-key fields to their defaults so a collision test cannot bleed into
@@ -371,6 +378,210 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — curated launch + 
         expect(args).toEqual(['app-server']);                                   // the long-lived mode is template-owned
         expect(opts.env.CODEX_HOME.startsWith('/srv/fleet/instances/')).toBe(true);
         expect(opts.env.CODEX_HOME).toContain('peer2');                         // agent.id keys the home, never githubUsername-only grain
+    });
+
+    test('Fleet-managed OpenCode boot creates one top-level owner session before publishing the generated wake envelope', async () => {
+        const
+            root       = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-opencode-owner-')),
+            cwd        = path.join(root, 'repo'),
+            agent      = curatedAgent('open-owner', 'opencode'),
+            spawn      = install({agents: {'open-owner': agent}, creds: {}}),
+            fetchCalls = [],
+            hookCalls  = [];
+
+        fs.mkdirSync(cwd);
+        FleetLifecycleService.instanceRoot       = path.join(root, 'instances');
+        FleetLifecycleService.harnessBinaryPaths = {opencode: process.execPath};
+
+        const launch       = FleetLifecycleService.resolveLaunch(agent, {cwd});
+        const hookPath     = path.join(launch.instanceHome, 'write-wake-envelope.mjs');
+        const envelopePath = path.join(launch.instanceHome, 'opencode', 'wake-envelope.json');
+
+        fs.mkdirSync(launch.instanceHome, {recursive: true});
+        fs.writeFileSync(hookPath, '// generated test hook\n');
+
+        FleetLifecycleService.fetchFn = async (url, opts) => {
+            fetchCalls.push({url, opts});
+            return {
+                ok    : true,
+                status: 200,
+                json  : async () => ({
+                    id       : 'ses_owner',
+                    projectID: 'project_owner',
+                    directory: fs.realpathSync(cwd)
+                })
+            };
+        };
+        FleetLifecycleService.openCodeHookExecFileFn = (command, args, opts, callback) => {
+            hookCalls.push({command, args, opts});
+            fs.mkdirSync(path.dirname(envelopePath), {recursive: true});
+            fs.writeFileSync(envelopePath, JSON.stringify({
+                hostname : '127.0.0.1',
+                port     : 45678,
+                sessionId: 'ses_owner',
+                projectId: 'project_owner',
+                directory: fs.realpathSync(cwd),
+                username : opts.env.OPENCODE_SERVER_USERNAME,
+                password : opts.env.OPENCODE_SERVER_PASSWORD,
+                updatedAt: new Date().toISOString()
+            }));
+            fs.chmodSync(envelopePath, 0o600);
+            callback(null, '', '');
+        };
+
+        const starting = FleetLifecycleService.start('open-owner', {cwd});
+        const call     = spawn.calls[0];
+        const password = call.opts.env.OPENCODE_SERVER_PASSWORD;
+
+        expect(starting.wakeRoute).toMatchObject({state: 'starting', directory: fs.realpathSync(cwd), envelopePath});
+        expect(call.opts.stdio).toEqual(['pipe', 'pipe', 'pipe']);
+        expect(call.opts.env.OPENCODE_SERVER_USERNAME).toBe('opencode');
+        expect(password).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+        expect(JSON.stringify(starting)).not.toContain(password);
+
+        // Chunk boundary is deliberate: only a complete newline-terminated authoritative banner
+        // may start the bootstrap.
+        call.child.stdout.emit('data', Buffer.from('opencode server listening on http://127.0.0.'));
+        expect(fetchCalls).toHaveLength(0);
+        call.child.stdout.emit('data', Buffer.from('1:45678\n'));
+
+        await expect.poll(() => FleetLifecycleService.status('open-owner').wakeRoute?.state).toBe('ready');
+
+        expect(fetchCalls).toHaveLength(1);
+        const createUrl = new URL(fetchCalls[0].url);
+        expect(createUrl.pathname).toBe('/api/session');
+        expect(createUrl.searchParams.get('directory')).toBe(fs.realpathSync(cwd));
+        expect(fetchCalls[0].opts).toMatchObject({method: 'POST', body: '{}', redirect: 'error'});
+        expect(fetchCalls[0].opts.headers.authorization)
+            .toBe('Basic ' + Buffer.from(`opencode:${password}`).toString('base64'));
+
+        expect(hookCalls).toHaveLength(1);
+        expect(hookCalls[0].command).toBe(process.execPath);
+        expect(hookCalls[0].args).toEqual([
+            hookPath,
+            '--data-home', launch.instanceHome,
+            '--port', '45678',
+            '--session-id', 'ses_owner',
+            '--project-id', 'project_owner',
+            '--directory', fs.realpathSync(cwd)
+        ]);
+        expect(JSON.stringify(hookCalls[0].args)).not.toContain(password);
+        expect(hookCalls[0].opts.env.NEO_FLEET_BRIDGE_TOKEN).toBeUndefined();
+        expect(hookCalls[0].opts.env.NEO_MCP_REMOTE_TOKEN).toBeUndefined();
+        expect(hookCalls[0].opts.env.GH_TOKEN).toBeUndefined();
+
+        const ready = FleetLifecycleService.status('open-owner');
+        expect(ready.wakeRoute).toMatchObject({
+            state: 'ready', port: 45678, sessionId: 'ses_owner', projectId: 'project_owner'
+        });
+        expect(JSON.stringify(ready)).not.toContain(password);
+        expect(fs.statSync(envelopePath).mode & 0o777).toBe(0o600);
+
+        call.child.emit('exit', 0, 'SIGTERM');
+        await expect.poll(() => FleetLifecycleService.status('open-owner').state).toBe('stopped');
+        expect(FleetLifecycleService.status('open-owner').wakeRoute).toMatchObject({
+            state: 'degraded', port: null, sessionId: null, projectId: null
+        });
+        expect(fs.existsSync(envelopePath)).toBe(false);
+
+        FleetLifecycleService.processes.clear();
+        fs.rmSync(root, {recursive: true, force: true});
+    });
+
+    test('Fleet-managed OpenCode rejects sibling-workspace, child, or malformed creation tuples and never invokes the hook', async () => {
+        const cases = [
+            {
+                id            : 'open-sibling',
+                response      : {id: 'ses_sibling', projectID: 'project_sibling'},
+                wrongDirectory: true
+            },
+            {
+                id      : 'open-child',
+                response: {id: 'ses_child', projectID: 'project_child', parentID: 'ses_parent'}
+            },
+            {
+                id      : 'open-missing',
+                response: {id: '', projectID: 'project_missing'}
+            }
+        ];
+
+        for (const entry of cases) {
+            const
+                root  = fs.mkdtempSync(path.join(os.tmpdir(), `fleet-${entry.id}-`)),
+                cwd   = path.join(root, 'repo'),
+                agent = curatedAgent(entry.id, 'opencode'),
+                spawn = install({agents: {[entry.id]: agent}, creds: {}});
+
+            fs.mkdirSync(cwd);
+            FleetLifecycleService.instanceRoot       = path.join(root, 'instances');
+            FleetLifecycleService.harnessBinaryPaths = {opencode: process.execPath};
+
+            const launch       = FleetLifecycleService.resolveLaunch(agent, {cwd});
+            const hookPath     = path.join(launch.instanceHome, 'write-wake-envelope.mjs');
+            const envelopePath = path.join(launch.instanceHome, 'opencode', 'wake-envelope.json');
+            let   hookCalls    = 0;
+
+            fs.mkdirSync(launch.instanceHome, {recursive: true});
+            fs.writeFileSync(hookPath, '// generated test hook\n');
+            FleetLifecycleService.fetchFn = async () => ({
+                ok  : true,
+                json: async () => ({
+                    ...entry.response,
+                    directory: entry.wrongDirectory ? path.join(root, 'sibling-repo') : fs.realpathSync(cwd)
+                })
+            });
+            FleetLifecycleService.openCodeHookExecFileFn = () => { hookCalls++ };
+
+            FleetLifecycleService.start(entry.id, {cwd});
+            spawn.calls[0].child.stdout.emit('data', Buffer.from('opencode server listening on http://127.0.0.1:45679\n'));
+
+            await expect.poll(() => FleetLifecycleService.status(entry.id).wakeRoute?.state).toBe('degraded');
+            expect(hookCalls).toBe(0);
+            expect(fs.existsSync(envelopePath)).toBe(false);
+
+            FleetLifecycleService.processes.clear();
+            fs.rmSync(root, {recursive: true, force: true});
+        }
+    });
+
+    test('Fleet-managed OpenCode removes stale coordinates and degrades fail-closed when owner-session creation fails', async () => {
+        const
+            root  = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-opencode-create-fail-')),
+            cwd   = path.join(root, 'repo'),
+            agent = curatedAgent('open-fail', 'opencode'),
+            spawn = install({agents: {'open-fail': agent}, creds: {}});
+
+        fs.mkdirSync(cwd);
+        FleetLifecycleService.instanceRoot       = path.join(root, 'instances');
+        FleetLifecycleService.harnessBinaryPaths = {opencode: process.execPath};
+
+        const launch       = FleetLifecycleService.resolveLaunch(agent, {cwd});
+        const hookPath     = path.join(launch.instanceHome, 'write-wake-envelope.mjs');
+        const envelopePath = path.join(launch.instanceHome, 'opencode', 'wake-envelope.json');
+        let   hookCalls    = 0;
+
+        fs.mkdirSync(path.dirname(envelopePath), {recursive: true});
+        fs.writeFileSync(hookPath, '// generated test hook\n');
+        fs.writeFileSync(envelopePath, '{"port":1234}\n');
+        FleetLifecycleService.fetchFn = async () => { throw new Error('fetch leaked-secret-value') };
+        FleetLifecycleService.openCodeHookExecFileFn = () => { hookCalls++ };
+
+        FleetLifecycleService.start('open-fail', {cwd});
+        expect(fs.existsSync(envelopePath)).toBe(false);
+
+        spawn.calls[0].child.stdout.emit('data', Buffer.from('opencode server listening on http://127.0.0.1:45680\n'));
+
+        await expect.poll(() => FleetLifecycleService.status('open-fail').wakeRoute?.state).toBe('degraded');
+        const status = FleetLifecycleService.status('open-fail');
+
+        expect(hookCalls).toBe(0);
+        expect(fs.existsSync(envelopePath)).toBe(false);
+        expect(status.running).toBe(true);
+        expect(status.failureReason).toBe('OpenCode wake bootstrap failed during session creation');
+        expect(JSON.stringify(status)).not.toContain('leaked-secret-value');
+
+        FleetLifecycleService.processes.clear();
+        fs.rmSync(root, {recursive: true, force: true});
     });
 
     test('curated codex-desktop derivation composes exact cwd, dual homes, typed auth, and direct packaged-main supervision', () => {

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -262,6 +262,16 @@ test.describe('Wake Daemon', () => {
 
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
 
+        const deliveryFailurePath = path.join(DAEMON_DIR, 'wake-delivery-failures.json');
+        fs.writeJsonSync(deliveryFailurePath, {
+            [subId]: {
+                agentIdentity : agentId,
+                subscriptionId: subId,
+                errorClass    : 'connection-refused',
+                failedAt      : '2026-07-29T00:00:00.000Z'
+            }
+        });
+
         // Start the daemon with environment overrides
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
@@ -327,6 +337,7 @@ test.describe('Wake Daemon', () => {
         expect(logContents).toMatch(/\[PID:\d+\]/);                                       // PID prefix
         expect(logContents).toMatch(/\[INFO\]/);                                          // level prefix
         expect(logContents).toContain('[Wake Daemon Test Adapter] Delivered');          // Same delivery line as stdout
+        await expect.poll(() => fs.readJsonSync(deliveryFailurePath)).toEqual({});        // confirmed recovery clears the receipt
     });
 
     test('#14576: priority-filtered subscriptions only deliver high-priority direct and broadcast wakes', async () => {
@@ -794,6 +805,19 @@ test.describe('Wake Daemon', () => {
         expect(failMatches.length).toBeGreaterThanOrEqual(2);   // initial failure + at least one retry
         expect(logContents).toContain('Giving up wake delivery'); // bounded terminal reached
         expect(logContents).toContain('after 2 failed attempts'); // cap respected
+
+        const
+            receiptPath = path.join(DAEMON_DIR, 'wake-delivery-failures.json'),
+            receipts    = fs.readJsonSync(receiptPath);
+
+        expect(receipts[subId]).toMatchObject({
+            agentIdentity : agentId,
+            subscriptionId: subId,
+            errorClass    : 'test-fail-delivery'
+        });
+        expect(Number.isNaN(Date.parse(receipts[subId].failedAt))).toBe(false);
+        expect(fs.statSync(receiptPath).mode & 0o777).toBe(0o600);
+        expect(JSON.stringify(receipts[subId])).not.toContain('simulated delivery failure');
     });
 
     test('#13077: same-subscription consecutive failures COALESCE into one retry digest (no overwrite loss)', async () => {
@@ -2301,6 +2325,8 @@ test.describe('Wake Daemon', () => {
             hostname : '127.0.0.1',
             port     : stubPort,
             sessionId: 'ses_test',
+            projectId: 'project_test',
+            directory: DAEMON_DIR,
             username : 'wake-user',
             password : 'wake-pass'
         });
@@ -2385,6 +2411,194 @@ test.describe('Wake Daemon', () => {
             expect(stdoutLog).toContain('route=opencode-server; adapterSource=metadata');
         } finally {
             stubServer.close();
+        }
+    });
+
+    test('opencode-server rebinds changed coordinates once while preserving the exact owner tuple (#15677)', async () => {
+        const
+            subId   = 'sub_' + crypto.randomUUID(),
+            agentId = '@test-agent-opencode-rebind';
+
+        const deadServer = http.createServer();
+        await new Promise(resolve => deadServer.listen(0, '127.0.0.1', resolve));
+        const deadPort = deadServer.address().port;
+        await new Promise(resolve => deadServer.close(resolve));
+
+        const captured   = [];
+        const liveServer = http.createServer((req, res) => {
+            captured.push({url: req.url, authorization: req.headers.authorization});
+            res.writeHead(204);
+            res.end();
+        });
+        await new Promise(resolve => liveServer.listen(0, '127.0.0.1', resolve));
+        const livePort = liveServer.address().port;
+
+        const
+            envelopePath = path.join(DAEMON_DIR, 'opencode-wake-envelope-rebind.json'),
+            authority    = {
+                sessionId: 'ses_pinned',
+                projectId: 'project_pinned',
+                directory: DAEMON_DIR
+            };
+
+        fs.writeJsonSync(envelopePath, {
+            hostname: '127.0.0.1',
+            port    : deadPort,
+            ...authority,
+            username: 'wake-user-old',
+            password: 'wake-pass-old'
+        });
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'opencode-server',
+                envelopePath,
+                coalesceWindow: 1
+            }
+        });
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {
+                ...process.env,
+                NEO_MEMORY_DB_PATH: DB_PATH,
+                NEO_AI_DAEMON_DIR : DAEMON_DIR
+            }
+        });
+
+        let   output    = '';
+        let   rebound   = false;
+        const delivered = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('OpenCode coordinate rebind did not deliver within timeout')), 15000);
+            const onData  = data => {
+                output += data.toString();
+                if (!rebound && output.includes('re-reading the authoritative envelope once')) {
+                    rebound = true;
+                    fs.writeJsonSync(envelopePath, {
+                        hostname: '127.0.0.1',
+                        port    : livePort,
+                        ...authority,
+                        username: 'wake-user-new',
+                        password: 'wake-pass-new'
+                    });
+                }
+                if (output.includes(`[Wake Dispatch] ${agentId}: outcome=delivered`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+
+            daemonProcess.stdout.on('data', onData);
+            daemonProcess.stderr.on('data', onData);
+            daemonProcess.on('error', reject);
+        });
+
+        try {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            insertMessageWake(db, {agentId, subject: 'OpenCode Coordinate Rebind'});
+            await delivered;
+
+            expect(rebound).toBe(true);
+            expect(captured).toHaveLength(1);
+            expect(captured[0].url).toBe('/session/ses_pinned/prompt_async');
+            expect(captured[0].authorization)
+                .toBe('Basic ' + Buffer.from('wake-user-new:wake-pass-new').toString('base64'));
+            expect(output).toContain(`Dispatched ${subId} via opencode-server prompt_async`);
+        } finally {
+            liveServer.closeAllConnections?.();
+            liveServer.close();
+        }
+    });
+
+    test('opencode-server refuses a stale-coordinate rebind that changes session authority (#15677)', async () => {
+        const
+            subId   = 'sub_' + crypto.randomUUID(),
+            agentId = '@test-agent-opencode-retarget-refusal';
+
+        const deadServer = http.createServer();
+        await new Promise(resolve => deadServer.listen(0, '127.0.0.1', resolve));
+        const deadPort = deadServer.address().port;
+        await new Promise(resolve => deadServer.close(resolve));
+
+        const captured   = [];
+        const liveServer = http.createServer((req, res) => {
+            captured.push(req.url);
+            res.writeHead(204);
+            res.end();
+        });
+        await new Promise(resolve => liveServer.listen(0, '127.0.0.1', resolve));
+        const livePort = liveServer.address().port;
+
+        const envelopePath = path.join(DAEMON_DIR, 'opencode-wake-envelope-retarget.json');
+        fs.writeJsonSync(envelopePath, {
+            hostname : '127.0.0.1',
+            port     : deadPort,
+            sessionId: 'ses_owner',
+            projectId: 'project_owner',
+            directory: DAEMON_DIR,
+            username : 'wake-user',
+            password : 'wake-pass'
+        });
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'opencode-server',
+                envelopePath,
+                coalesceWindow: 1
+            }
+        });
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {
+                ...process.env,
+                NEO_MEMORY_DB_PATH: DB_PATH,
+                NEO_AI_DAEMON_DIR : DAEMON_DIR
+            }
+        });
+
+        let   output  = '';
+        let   rebound = false;
+        const refused = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('OpenCode authority change was not refused within timeout')), 15000);
+            const onData  = data => {
+                output += data.toString();
+                if (!rebound && output.includes('re-reading the authoritative envelope once')) {
+                    rebound = true;
+                    fs.writeJsonSync(envelopePath, {
+                        hostname : '127.0.0.1',
+                        port     : livePort,
+                        sessionId: 'ses_sibling',
+                        projectId: 'project_owner',
+                        directory: DAEMON_DIR,
+                        username : 'wake-user-new',
+                        password : 'wake-pass-new'
+                    });
+                }
+                if (output.includes('authority tuple changed during coordinate rebind')) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+
+            daemonProcess.stdout.on('data', onData);
+            daemonProcess.stderr.on('data', onData);
+            daemonProcess.on('error', reject);
+        });
+
+        try {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            insertMessageWake(db, {agentId, subject: 'OpenCode Retarget Refusal'});
+            await refused;
+
+            expect(rebound).toBe(true);
+            expect(captured).toHaveLength(0);
+            expect(output).toContain('Failed to deliver via opencode-server');
+        } finally {
+            liveServer.closeAllConnections?.();
+            liveServer.close();
         }
     });
 
@@ -2931,6 +3145,8 @@ test.describe('Wake Daemon', () => {
             hostname : '127.0.0.1',
             port     : stubPort,
             sessionId: 'ses_shared_abort',
+            projectId: 'project_shared_abort',
+            directory: DAEMON_DIR,
             username : 'wake-user',
             password : 'wake-pass'
         });
@@ -3070,6 +3286,8 @@ test.describe('Wake Daemon', () => {
             hostname : '127.0.0.1',
             port     : stubPort,
             sessionId: 'ses_hung',
+            projectId: 'project_hung',
+            directory: DAEMON_DIR,
             username : 'wake-user',
             password : 'wake-pass'
         });

--- a/test/playwright/unit/ai/services/fleet/fleetWakeStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeStateAdapter.spec.mjs
@@ -101,6 +101,21 @@ test.describe('fleetWakeStateAdapter — the graduated four-state mapping', () =
     test('active subscription + live daemon is on; + dead daemon is suppressed (the blind-switch incident class)', () => {
         expect(resolveAgentWakeState({subscriptionState: 'active', daemonAlive: true})).toBe('on')
         expect(resolveAgentWakeState({subscriptionState: 'active', daemonAlive: false})).toBe('suppressed')
+        expect(resolveAgentWakeState({
+            subscriptionState   : 'active',
+            daemonAlive         : true,
+            deliveryFailureState: 'failed'
+        })).toBe('suppressed')
+        expect(resolveAgentWakeState({
+            subscriptionState   : 'active',
+            daemonAlive         : 'unknown',
+            deliveryFailureState: 'failed'
+        })).toBe('suppressed')
+        expect(resolveAgentWakeState({
+            subscriptionState   : 'active',
+            daemonAlive         : false,
+            deliveryFailureState: 'unknown'
+        })).toBe('suppressed')
     })
 
     test('any unknown input axis makes the output unknown — no fabricated precision', () => {
@@ -141,6 +156,60 @@ test.describe('fleetWakeStateAdapter — the fleet snapshot + capability envelop
         })
 
         expect(states.map(row => row.wake)).toEqual(['suppressed', 'suppressed', 'suppressed'])
+    })
+
+    test('live daemon + terminal receipt is suppressed with an independent safe failure projection (#15677)', async () => {
+        const failedAt             = '2026-07-29T12:34:56.000Z'
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents                          : [{id: 'grace', githubUsername: 'neo-opus-grace'}],
+            listActiveSubscriptionIdentities: () => ['@neo-opus-grace'],
+            pidFilePath                     : '/x/wake.pid',
+            deliveryFailureFilePath         : '/x/wake-delivery-failures.json',
+            readFile                        : () => '4242',
+            readDeliveryFailureFile         : () => JSON.stringify({
+                'WAKE_SUB:grace': {
+                    agentIdentity : '@neo-opus-grace',
+                    subscriptionId: 'WAKE_SUB:grace',
+                    errorClass    : 'connection-refused',
+                    failedAt
+                }
+            }),
+            probeProcess      : () => {},
+            readProcessCommand: daemonCmd
+        })
+
+        expect(capability).toMatchObject({state: 'wired', confidence: 'observed'})
+        expect(states).toEqual([{
+            agentId            : 'grace',
+            wake               : 'suppressed',
+            confidence         : 'observed',
+            source             : WAKE_SOURCE_LABEL,
+            reason             : 'terminal wake delivery failure: connection-refused',
+            lastDeliveryFailure: {
+                subscriptionId: 'WAKE_SUB:grace',
+                errorClass    : 'connection-refused',
+                failedAt
+            }
+        }])
+    })
+
+    test('malformed terminal-receipt source makes an active route unknown instead of fabricating on', async () => {
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents                  : [{id: 'grace'}],
+            resolveSubscriptionState: () => 'active',
+            pidFilePath             : '/x/wake.pid',
+            readFile                : () => '4242',
+            readDeliveryFailureFile : () => '{broken',
+            probeProcess            : () => {},
+            readProcessCommand      : daemonCmd
+        })
+
+        expect(states[0]).toMatchObject({
+            wake  : 'unknown',
+            reason: 'malformed wake delivery failure receipt file'
+        })
+        expect(capability).toMatchObject({state: 'degraded', confidence: 'partial'})
+        expect(capability.reason).toContain('malformed wake delivery failure receipt file')
     })
 
     test('unknown-on-unreachable: no subscription reader degrades every row honestly, with reasons', async () => {


### PR DESCRIPTION
Resolves #15677

Fleet-managed OpenCode seats now create and bind their own top-level session before publishing the existing generated wake envelope. The supervisor captures the exact loopback port, pins the canonical checkout tuple without a session-list heuristic, keeps server credentials env-only, and surfaces a secret-free route state. The wake daemon now permits one authority-preserving coordinate rebind and persists terminal delivery failures onto Fleet's independent operator-health projection.

Evidence: L2 (exact unit contracts plus real local daemon/HTTP transport witnesses) → L4 required (AC2 live managed-seat restart/wake receipt and AC5 operator-visible terminal-drop receipt). Residual: AC2, AC5 [#15677].

Related: #15684

## Deltas from ticket

- The OpenCode workspace planting/`generateOpenCodeSeatConfig` production caller landed earlier through `#16053`; this PR consumes that baseline-generated hook rather than duplicating it.
- The desktop topology successor is already linked above; no replacement ticket was created.
- The server credential uses Neo's canonical disposable local-token generator, while hook execution receives only benign runtime fields plus the OpenCode credential pair.
- Malformed terminal-receipt state stays visible as unknown and is repaired only by a later confirmed delivery.

## Test Evidence

- `npm run agent-preflight -- --change-class capability --commit-subject "feat(ai): bind Fleet OpenCode wake delivery (#15677)" <changed files>` — all gates passed.
- `npm run test-unit` — 10,284 passed, 5 skipped, 0 failed on the commit candidate.
- Fleet owner-session bootstrap/projection: `FleetLifecycleService.spec.mjs`, `fleetWakeStateAdapter.spec.mjs`, and `FleetManager.spec.mjs` — 104/104 passed.
- Wake delivery/rebind/terminal receipt: `daemon.spec.mjs` — 70/70 passed.
- Post-format combined relevant suite — 172/172 passed.
- `check-jsdoc-types` — 1,911 files scanned, 0 unparseable; `ai:lint-config-template-ssot` and syntax/diff/alignment gates passed.

## Post-Merge Validation

- [ ] Start a Fleet-managed OpenCode seat from a provisioned checkout, confirm the route reaches `ready`, and observe a wake land in the Fleet-owned top-level session without manual envelope repair.
- [ ] Stop the bound route, drive delivery to its retry cap, and confirm Fleet reports the seat `suppressed` with subscription, error class, and timestamp without reading `wake-daemon.log`; restart and confirm a successful delivery clears the receipt.

## Commits

- `3047132756` — bind Fleet-owned OpenCode wake delivery and terminal-failure visibility.

Authored by Euclid (GPT-5.6, Codex Desktop). Session 019fac51-ddcb-7212-902e-09d3a9d19098.
