### PR TITLE
fix(workstation): stage popup theme before navigation (#16113)

### DIFF
--- a/apps/workstation/index.html
+++ b/apps/workstation/index.html
@@ -10,10 +10,11 @@
                     'neo-theme-neo-dark': 'dark',
                     'neo-theme-neo-light': 'light'
                 }),
+                defaultTheme   = 'neo-theme-neo-dark',
                 requestedTheme = new URLSearchParams(location.search).get('theme'),
                 theme          = Object.hasOwn(schemes, requestedTheme)
                     ? requestedTheme
-                    : 'neo-theme-neo-dark',
+                    : defaultTheme,
                 meta           = document.createElement('meta');
 
             meta.name    = 'color-scheme';
@@ -22,6 +23,8 @@
 
             globalThis.WorkstationBootstrap = Object.freeze({
                 colorScheme: meta.content,
+                defaultTheme,
+                schemes,
                 theme
             })
         })()

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2381,7 +2381,8 @@ class Workspace extends Container {
     }
 
     /**
-     * The tear-out admission seam: opens the vessel window for a mid-gesture boundary exit.
+     * @summary Opens one theme-correct vessel window for a mid-gesture boundary exit.
+     *
      * Reuses the workstation viewport's `?popout=` pure-pane-host mode. The granted child
      * immediately carries the same live pane through {@link Neo.dashboard.DockVesselEmbodiment};
      * it owns no workspace document. Fail-closed per the admission contract: `windowOpen` returns
@@ -2415,19 +2416,27 @@ class Workspace extends Container {
         }
 
         try {
-            let winData = await Neo.Main.getWindowData({windowId}),
-                width   = Math.max(Math.round(proxyRect?.width  || 480), 320),
-                height  = Math.max(Math.round(proxyRect?.height || 360), 240),
-                left    = Math.round((proxyRect?.x ?? 120) + winData.screenLeft),
-                top     = Math.round((proxyRect?.y ?? 120) + (winData.outerHeight - winData.innerHeight) + winData.screenTop);
+            let [winData, bootstrap] = await Promise.all([
+                    Neo.Main.getWindowData({windowId}),
+                    Neo.Main.getByPath({path: 'WorkstationBootstrap', windowId}).catch(() => null)
+                ]),
+                schemes       = bootstrap?.schemes || {},
+                selectedTheme = Object.hasOwn(schemes, me.theme)
+                    ? me.theme
+                    : bootstrap?.defaultTheme || me.theme,
+                width  = Math.max(Math.round(proxyRect?.width  || 480), 320),
+                height = Math.max(Math.round(proxyRect?.height || 360), 240),
+                left   = Math.round((proxyRect?.x ?? 120) + winData.screenLeft),
+                top    = Math.round((proxyRect?.y ?? 120) + (winData.outerHeight - winData.innerHeight) + winData.screenTop);
 
             let opened = await Neo.Main.windowOpen({
                 nativeCapabilities: {close: true, position: true, resize: true},
+                stagedColorScheme : schemes[selectedTheme],
                 url               : `./index.html?popout=${itemId}&hostId=${me.id}`
                     + `&vesselFlow=tear-out&vesselGrant=${ownerGrant.token}`
                     + `&vesselGeneration=${ownerGrant.generation}`
                     + `&vesselAdmission=${admissionToken}`
-                    + `&theme=${encodeURIComponent(me.theme)}`,
+                    + `&theme=${encodeURIComponent(selectedTheme)}`,
                 windowFeatures: `height=${height},left=${left},top=${top},width=${width}`,
                 windowId,
                 windowName

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2387,7 +2387,9 @@ class Workspace extends Container {
      * immediately carries the same live pane through {@link Neo.dashboard.DockVesselEmbodiment};
      * it owns no workspace document. Fail-closed per the admission contract: `windowOpen` returns
      * a BOOLEAN (a blocked popup never throws), and any falsy/throwing acquisition returns `null`
-     * so the gesture degrades to its in-window fallback.
+     * so the gesture degrades to its in-window fallback. The theme bootstrap is part of that
+     * acquisition rather than optional presentation: an unavailable authority reaches the outer
+     * diagnostic boundary, revokes the owner grant, and prevents an unthemed child from opening.
      * @param {Object} request
      * @param {Number} request.admissionToken
      * @param {String} request.itemId
@@ -2418,7 +2420,7 @@ class Workspace extends Container {
         try {
             let [winData, bootstrap] = await Promise.all([
                     Neo.Main.getWindowData({windowId}),
-                    Neo.Main.getByPath({path: 'WorkstationBootstrap', windowId}).catch(() => null)
+                    Neo.Main.getByPath({path: 'WorkstationBootstrap', windowId})
                 ]),
                 schemes       = bootstrap?.schemes || {},
                 selectedTheme = Object.hasOwn(schemes, me.theme)

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -1056,16 +1056,17 @@ class Main extends core.Base {
     }
 
     /**
-     * Open a new popup window and return true if successful
+     * @summary Opens a popup and stages any same-origin canvas before its route-bearing navigation.
      * @param {Object}  data
      * @param {Object}  [data.nativeCapabilities] Owner-granted generic physical capabilities.
+     * @param {'dark'|'light'} [data.stagedColorScheme] Admitted scheme for the temporary same-origin document.
      * @param {String}  data.url
      * @param {Boolean} [data.useTotalHeight=true] Using this flag will set outerHeight to innerHeight, ignoring header tools
      * @param {String}  data.windowFeatures
      * @param {String}  data.windowName
      * @return {Boolean}
      */
-    windowOpen({nativeCapabilities, url, useTotalHeight=true, windowFeatures, windowName}) {
+    windowOpen({nativeCapabilities, stagedColorScheme, url, useTotalHeight=true, windowFeatures, windowName}) {
         let existingWin = this.openWindows[windowName],
             stagedUrl   = null,
             targetName;
@@ -1095,6 +1096,16 @@ class Main extends core.Base {
 
         if (success) {
             this.#invalidateNativeWindowEntry(existingWin);
+
+            if (stagedUrl && (stagedColorScheme === 'dark' || stagedColorScheme === 'light')) {
+                try {
+                    const meta = openedWindow.document.createElement('meta');
+
+                    meta.name    = 'color-scheme';
+                    meta.content = stagedColorScheme;
+                    openedWindow.document.head.append(meta)
+                } catch {/* Presentation must not revoke an otherwise valid physical handle. */}
+            }
 
             const
                 entry = {

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1188,8 +1188,10 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
         expect(new URL(popup.url()).searchParams.get('theme')).toBe('neo-theme-neo-light');
         expect(popupBirth.bootstrap).toEqual({
-            colorScheme: 'light',
-            theme      : 'neo-theme-neo-light'
+            colorScheme : 'light',
+            defaultTheme: 'neo-theme-neo-dark',
+            schemes     : {'neo-theme-neo-dark': 'dark', 'neo-theme-neo-light': 'light'},
+            theme       : 'neo-theme-neo-light'
         });
         expect(popupBirth.metaContents, 'the final document must own exactly one active-theme scheme')
             .toEqual(['light']);

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1557,8 +1557,10 @@ test.describe.serial('Workstation.view.Workspace', () => {
     test('tear-out navigation carries the workspace active theme into each admitted child', async () => {
         const
             workspace          = Neo.create(Workspace, {theme: 'neo-theme-neo-light'}),
+            originalGetByPath  = Neo.Main.getByPath,
             originalWindowData = Neo.Main.getWindowData,
             originalWindowOpen = Neo.Main.windowOpen,
+            bootstrapCalls     = [],
             calls              = [];
 
         Neo.Main.getWindowData = async () => ({
@@ -1567,6 +1569,17 @@ test.describe.serial('Workstation.view.Workspace', () => {
             screenLeft : 10,
             screenTop  : 20
         });
+        Neo.Main.getByPath = async data => {
+            bootstrapCalls.push(data);
+
+            return {
+                defaultTheme: 'neo-theme-neo-dark',
+                schemes     : {
+                    'neo-theme-neo-dark' : 'dark',
+                    'neo-theme-neo-light': 'light'
+                }
+            }
+        };
         Neo.Main.windowOpen = async data => {
             calls.push(data);
 
@@ -1586,12 +1599,27 @@ test.describe.serial('Workstation.view.Workspace', () => {
                 proxyRect: {height: 320, width: 480, x: 80, y: 100}
             });
 
-            expect(calls).toHaveLength(2);
+            workspace.theme = 'neo-theme-candidate';
+
+            await workspace.openTearOutVessel({
+                itemId   : 'memory',
+                proxyRect: {height: 320, width: 480, x: 120, y: 140}
+            });
+
+            expect(calls).toHaveLength(3);
             expect(calls.map(call => new URL(call.url, 'https://example.test').searchParams.get('theme')))
-                .toEqual(['neo-theme-neo-light', 'neo-theme-neo-dark']);
+                .toEqual(['neo-theme-neo-light', 'neo-theme-neo-dark', 'neo-theme-neo-dark']);
             expect(calls.map(call => new URL(call.url, 'https://example.test').searchParams.get('vesselFlow')))
-                .toEqual(['tear-out', 'tear-out'])
+                .toEqual(['tear-out', 'tear-out', 'tear-out']);
+            expect(calls.map(call => call.stagedColorScheme))
+                .toEqual(['light', 'dark', 'dark']);
+            expect(bootstrapCalls).toEqual([
+                {path: 'WorkstationBootstrap', windowId: workspace.windowId},
+                {path: 'WorkstationBootstrap', windowId: workspace.windowId},
+                {path: 'WorkstationBootstrap', windowId: workspace.windowId}
+            ])
         } finally {
+            Neo.Main.getByPath   = originalGetByPath;
             Neo.Main.getWindowData = originalWindowData;
             Neo.Main.windowOpen    = originalWindowOpen;
             workspace.destroy()

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1626,6 +1626,50 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('a missing theme bootstrap fails loud before an unthemed tear-out can open', async () => {
+        const
+            workspace          = Neo.create(Workspace, {theme: 'neo-theme-neo-light'}),
+            originalGetByPath  = Neo.Main.getByPath,
+            originalWindowData = Neo.Main.getWindowData,
+            originalWindowOpen = Neo.Main.windowOpen,
+            windowOpenCalls    = [];
+
+        Neo.Main.getWindowData = async () => ({
+            innerHeight: 700,
+            outerHeight: 760,
+            screenLeft : 10,
+            screenTop  : 20
+        });
+        Neo.Main.getByPath = async () => {
+            throw new Error('WorkstationBootstrap unavailable')
+        };
+        Neo.Main.windowOpen = async data => {
+            windowOpenCalls.push(data);
+            return true
+        };
+
+        try {
+            const result = await workspace.openTearOutVessel({
+                itemId   : 'alerts',
+                proxyRect: {height: 320, width: 480, x: 40, y: 60}
+            });
+
+            expect(result).toBeNull();
+            expect(windowOpenCalls).toEqual([]);
+            expect(workspace.lastVesselOpen).toEqual({
+                error : 'WorkstationBootstrap unavailable',
+                itemId: 'alerts',
+                stage : 'threw'
+            });
+            expect(workspace.vesselOwnerGrants.has('tear-out:alerts')).toBe(false)
+        } finally {
+            Neo.Main.getByPath    = originalGetByPath;
+            Neo.Main.getWindowData = originalWindowData;
+            Neo.Main.windowOpen     = originalWindowOpen;
+            workspace.destroy()
+        }
+    });
+
     test('a successor tear-out retries retained retirement before opening a fresh vessel', async () => {
         const
             workspace       = Neo.create(Workspace, {}),

--- a/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
+++ b/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
@@ -132,11 +132,14 @@ function runWorkstationBootstrap(source, search) {
 
     return {
         bootstrap: {
-            colorScheme: context.WorkstationBootstrap?.colorScheme,
-            theme      : context.WorkstationBootstrap?.theme
+            colorScheme : context.WorkstationBootstrap?.colorScheme,
+            defaultTheme: context.WorkstationBootstrap?.defaultTheme,
+            schemes     : {...context.WorkstationBootstrap?.schemes},
+            theme       : context.WorkstationBootstrap?.theme
         },
-        frozen: Object.isFrozen(context.WorkstationBootstrap),
-        metas : inserted.map(({content, name, tagName}) => ({content, name, tagName}))
+        frozen       : Object.isFrozen(context.WorkstationBootstrap),
+        metas        : inserted.map(({content, name, tagName}) => ({content, name, tagName})),
+        schemesFrozen: Object.isFrozen(context.WorkstationBootstrap?.schemes)
     }
 }
 
@@ -156,13 +159,25 @@ function validatesWorkstationBootstrap(source) {
             light = runWorkstationBootstrap(source, '?theme=neo-theme-neo-light');
 
         return JSON.stringify(dark) === JSON.stringify({
-            bootstrap: {colorScheme: 'dark', theme: 'neo-theme-neo-dark'},
-            frozen   : true,
-            metas    : [{content: 'dark', name: 'color-scheme', tagName: 'meta'}]
+            bootstrap: {
+                colorScheme : 'dark',
+                defaultTheme: 'neo-theme-neo-dark',
+                schemes     : {'neo-theme-neo-dark': 'dark', 'neo-theme-neo-light': 'light'},
+                theme       : 'neo-theme-neo-dark'
+            },
+            frozen       : true,
+            metas        : [{content: 'dark', name: 'color-scheme', tagName: 'meta'}],
+            schemesFrozen: true
         }) && JSON.stringify(light) === JSON.stringify({
-            bootstrap: {colorScheme: 'light', theme: 'neo-theme-neo-light'},
-            frozen   : true,
-            metas    : [{content: 'light', name: 'color-scheme', tagName: 'meta'}]
+            bootstrap: {
+                colorScheme : 'light',
+                defaultTheme: 'neo-theme-neo-dark',
+                schemes     : {'neo-theme-neo-dark': 'dark', 'neo-theme-neo-light': 'light'},
+                theme       : 'neo-theme-neo-light'
+            },
+            frozen       : true,
+            metas        : [{content: 'light', name: 'color-scheme', tagName: 'meta'}],
+            schemesFrozen: true
         })
     } catch {
         return false
@@ -205,7 +220,7 @@ async function runWorkstationAppThemeProbe() {
 
 /**
  * @summary Runs one native-window authority scenario against the real Main singleton in an isolated process.
- * @param {'cross-origin'|'native-focus-stale'|'native-move-stale'|'native-resize'|'native-resize-default-denied'|'native-resize-denied'|'navigation-failure'|'persisted-pagehide'|'same-origin'} scenario
+ * @param {'cross-origin'|'invalid-scheme'|'native-focus-stale'|'native-move-stale'|'native-resize'|'native-resize-default-denied'|'native-resize-denied'|'navigation-failure'|'persisted-pagehide'|'same-origin'} scenario
  * @returns {Promise<Object>}
  */
 async function runNativeWindowRouteProbe(scenario) {
@@ -374,6 +389,21 @@ async function runNativeWindowRouteProbe(scenario) {
                         }
                     }
                 },
+                document: {
+                    createElement(tagName) {
+                        return {tagName}
+                    },
+                    head: {
+                        append(node) {
+                            events.push('scheme');
+                            state.stagedMeta = {
+                                content: node.content,
+                                name   : node.name,
+                                tagName: node.tagName
+                            }
+                        }
+                    }
+                },
                 resizeTo(width, height) {
                     events.push('resize');
                     state.height = height;
@@ -417,6 +447,9 @@ async function runNativeWindowRouteProbe(scenario) {
                 nativeCapabilities: scenario === 'native-resize-default-denied'
                     ? {close: true}
                     : {close: true, resize: scenario !== 'native-resize-denied'},
+                stagedColorScheme: scenario === 'invalid-scheme'
+                    ? 'dark light'
+                    : ['navigation-failure', 'same-origin'].includes(scenario) ? 'dark' : null,
                 url,
                 useTotalHeight: false,
                 windowFeatures: 'popup,width=900,height=600',
@@ -502,6 +535,7 @@ async function runNativeWindowRouteProbe(scenario) {
                 replacedUrl: state.replacedUrl ?? null,
                 resize,
                 route,
+                stagedMeta: state.stagedMeta ?? null,
                 success,
                 tokenMinted: Boolean(state.token),
                 width    : state.width
@@ -517,7 +551,7 @@ async function runNativeWindowRouteProbe(scenario) {
     return JSON.parse(stdout.trim().split('\n').at(-1))
 }
 
-test.describe('Workstation popup canvas bootstrap (#16092)', () => {
+test.describe('Workstation popup canvas bootstrap (#16092, #16113)', () => {
     test('Workstation resolves one parser-blocking active-theme canvas before MicroLoader', async () => {
         const
             [source, configSource] = await Promise.all([
@@ -530,6 +564,8 @@ test.describe('Workstation popup canvas bootstrap (#16092)', () => {
             light    = runWorkstationBootstrap(source, '?theme=neo-theme-neo-light');
 
         expect(config.themes).toEqual(['neo-theme-neo-dark', 'neo-theme-neo-light']);
+        expect(Object.keys(dark.bootstrap.schemes)).toEqual(config.themes);
+        expect(dark.bootstrap.defaultTheme).toBe(config.themes[0]);
         expect(contract.metaCount, 'the runtime script owns the only color-scheme meta').toBe(0);
         expect(contract.bootstrapCount).toBe(1);
         expect(contract.directHead).toBe(true);
@@ -539,14 +575,26 @@ test.describe('Workstation popup canvas bootstrap (#16092)', () => {
         expect(contract.ordered).toBe(true);
         expect(contract.valid).toBe(true);
         expect(dark).toEqual({
-            bootstrap: {colorScheme: 'dark', theme: 'neo-theme-neo-dark'},
-            frozen   : true,
-            metas    : [{content: 'dark', name: 'color-scheme', tagName: 'meta'}]
+            bootstrap: {
+                colorScheme : 'dark',
+                defaultTheme: 'neo-theme-neo-dark',
+                schemes     : {'neo-theme-neo-dark': 'dark', 'neo-theme-neo-light': 'light'},
+                theme       : 'neo-theme-neo-dark'
+            },
+            frozen       : true,
+            metas        : [{content: 'dark', name: 'color-scheme', tagName: 'meta'}],
+            schemesFrozen: true
         });
         expect(light).toEqual({
-            bootstrap: {colorScheme: 'light', theme: 'neo-theme-neo-light'},
-            frozen   : true,
-            metas    : [{content: 'light', name: 'color-scheme', tagName: 'meta'}]
+            bootstrap: {
+                colorScheme : 'light',
+                defaultTheme: 'neo-theme-neo-dark',
+                schemes     : {'neo-theme-neo-dark': 'dark', 'neo-theme-neo-light': 'light'},
+                theme       : 'neo-theme-neo-light'
+            },
+            frozen       : true,
+            metas        : [{content: 'light', name: 'color-scheme', tagName: 'meta'}],
+            schemesFrozen: true
         })
     });
 
@@ -574,11 +622,26 @@ test.describe('Workstation popup canvas bootstrap (#16092)', () => {
             schemeList : false
         });
         expect(runWorkstationBootstrap(source, '').bootstrap)
-            .toEqual({colorScheme: 'dark', theme: 'neo-theme-neo-dark'});
+            .toEqual({
+                colorScheme : 'dark',
+                defaultTheme: 'neo-theme-neo-dark',
+                schemes     : {'neo-theme-neo-dark': 'dark', 'neo-theme-neo-light': 'light'},
+                theme       : 'neo-theme-neo-dark'
+            });
         expect(runWorkstationBootstrap(source, '?theme=neo-theme-candidate').bootstrap)
-            .toEqual({colorScheme: 'dark', theme: 'neo-theme-neo-dark'});
+            .toEqual({
+                colorScheme : 'dark',
+                defaultTheme: 'neo-theme-neo-dark',
+                schemes     : {'neo-theme-neo-dark': 'dark', 'neo-theme-neo-light': 'light'},
+                theme       : 'neo-theme-neo-dark'
+            });
         expect(runWorkstationBootstrap(source, '?theme=dark%20light').bootstrap)
-            .toEqual({colorScheme: 'dark', theme: 'neo-theme-neo-dark'})
+            .toEqual({
+                colorScheme : 'dark',
+                defaultTheme: 'neo-theme-neo-dark',
+                schemes     : {'neo-theme-neo-dark': 'dark', 'neo-theme-neo-light': 'light'},
+                theme       : 'neo-theme-neo-dark'
+            })
     });
 
     test('the App Worker resolves the same carried theme before creating its viewport', async () => {
@@ -602,7 +665,8 @@ test.describe('Neo.Main native window routes (#15396)', () => {
         expect(result.success).toBe(true);
         expect(result.openArgs).toHaveLength(1);
         expect(result.openArgs[0].url).toBe('about:blank');
-        expect(result.events).toEqual(['storage', 'replace']);
+        expect(result.events).toEqual(['scheme', 'storage', 'replace']);
+        expect(result.stagedMeta).toEqual({content: 'dark', name: 'color-scheme', tagName: 'meta'});
         expect(result.replacedUrl).toBe('https://owner.example.test/apps/demo/popup.html?mode=tear-out');
         expect(result.hasEntry).toBe(true);
         expect(result.route).toMatchObject({
@@ -661,7 +725,8 @@ test.describe('Neo.Main native window routes (#15396)', () => {
 
         expect(result.success).toBe(false);
         expect(result.openArgs[0].url).toBe('about:blank');
-        expect(result.events).toEqual(['storage', 'replace', 'close']);
+        expect(result.events).toEqual(['scheme', 'storage', 'replace', 'close']);
+        expect(result.stagedMeta).toEqual({content: 'dark', name: 'color-scheme', tagName: 'meta'});
         expect(result.closed).toBe(true);
         expect(result.hasEntry).toBe(false);
         expect(result.route).toBeNull()
@@ -673,11 +738,21 @@ test.describe('Neo.Main native window routes (#15396)', () => {
         expect(result.success).toBe(true);
         expect(result.openArgs[0].url).toBe('https://other.example.test/popup');
         expect(result.events).toEqual(['storage']);
+        expect(result.stagedMeta).toBeNull();
         expect(result.closed).toBe(false);
         expect(result.replacedUrl).toBeNull();
         expect(result.tokenMinted).toBe(false);
         expect(result.route).toBeNull();
         expect(result.hasEntry).toBe(true)
+    });
+
+    test('#16113 invalid staged schemes preserve route navigation without touching the blank document', async () => {
+        const result = await runNativeWindowRouteProbe('invalid-scheme');
+
+        expect(result.success).toBe(true);
+        expect(result.events).toEqual(['storage', 'replace']);
+        expect(result.stagedMeta).toBeNull();
+        expect(result.route).toMatchObject({targetWindowId: 'child-window'})
     });
 
     test('persisted pagehide permanently retires the preserved realm instead of consuming a fresh grant', async () => {

--- a/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
+++ b/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
@@ -449,6 +449,8 @@ async function runNativeWindowRouteProbe(scenario) {
                     : {close: true, resize: scenario !== 'native-resize-denied'},
                 stagedColorScheme: scenario === 'invalid-scheme'
                     ? 'dark light'
+                    : scenario === 'missing-scheme'
+                        ? undefined
                     : ['navigation-failure', 'same-origin'].includes(scenario) ? 'dark' : null,
                 url,
                 useTotalHeight: false,
@@ -753,6 +755,16 @@ test.describe('Neo.Main native window routes (#15396)', () => {
         expect(result.events).toEqual(['storage', 'replace']);
         expect(result.stagedMeta).toBeNull();
         expect(result.route).toMatchObject({targetWindowId: 'child-window'})
+    });
+
+    test('#16113 removing the staged scheme exposes an unstyled blank interval before final navigation', async () => {
+        const result = await runNativeWindowRouteProbe('missing-scheme');
+
+        expect(result.success).toBe(true);
+        expect(result.openArgs[0].url).toBe('about:blank');
+        expect(result.events).toEqual(['storage', 'replace']);
+        expect(result.stagedMeta).toBeNull();
+        expect(result.replacedUrl).toBe('https://owner.example.test/apps/demo/popup.html?mode=tear-out')
     });
 
     test('persisted pagehide permanently retires the preserved realm instead of consuming a fresh grant', async () => {


### PR DESCRIPTION
Resolves #16113

The selected Workstation theme now reaches both native popup prepaint realms from one
validated bootstrap map:

- `Main.windowOpen()` stages an exact `dark` or `light` color-scheme hint into the
  same-origin `about:blank` document before the route token and `location.replace()`;
- the final Workstation document resolves the same frozen theme-to-scheme map before
  `MicroLoader.mjs`;
- `Workspace.openTearOutVessel()` carries the selected theme and its exact scheme from
  that map, while invalid schemes remain inert.

Evidence: L1 (35 focused unit contracts) + L3 (headed native popup pixels on the
successful-path parent; the review repair changes failure/control coverage only).

Related: #16092, #15955

## Deltas from ticket

- No framework-wide bootstrap abstraction was introduced. The repair stays at the
  existing `Workspace` → `Main.windowOpen()` → Workstation document boundary.
- The one-use route authority remains `about:blank` → token storage → final navigation.
  Scheme staging happens before storage without changing admission, failure cleanup,
  resize, focus, or move authority.
- The configured Workstation default is part of the frozen bootstrap record. Missing
  or unknown theme carriers fall back to it; arbitrary scheme strings never reach the
  blank document.
- A failed bootstrap read no longer silently converts to an undefined scheme. It reaches
  the existing acquisition-failure boundary before window birth, records the error,
  and revokes the owner grant.
- Existing live dark↔light propagation remains authoritative after birth. The headed
  scene-2 witness flips the open vessel and verifies the same viewport reaches the new
  palette without reload or replacement.

## Test Evidence

- Published head: `361368418f8b517ac6618023d93237e84fc7b744`.
- `npm run test-unit -- test/playwright/unit/apps/workstation/Workspace.spec.mjs test/playwright/unit/main/MainNativeWindowRoute.spec.mjs`
  — exact published head, 35/35 passed.
- The blank-realm removal control opens `about:blank` without a scheme, observes no
  staged meta, and still observes route storage plus final navigation. This is the
  negative arm proving that final-document repair cannot hide an unstyled birth realm.
- The bootstrap-failure control proves `windowOpen()` is never called, the owner grant
  is revoked, and `lastVesselOpen` records the exact authority error.
- `npx lint-staged --no-stash` and `npm run agent-preflight -- --no-fix
  --change-class restoration ...` passed for the review repair.
- Successful-path parent `4196cea4ddc6bc05defbbf4b6dd25e5a9f8d0af5`
  has tree `99af491c894b0f5e0f1b64559f9908324004ffe5`, byte-identical to tested local
  commit `77a794a0c9d49219f30e03135e738ed90ff834df`.
- `NEO_FILM_TAKE=1 npx playwright test test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --headed --retries=0`
  — 7/9 passed before a second shared-bridge owner joined. Scenes 1–3, including
  both popup births and the live light→dark vessel flip, passed. Scenes 4–5 ended
  only with Neural Link RPC timeouts after the collision; this run is not represented
  as a full-suite green.
- `NEO_FILM_TAKE=1 npx playwright test test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --headed --grep "scene [45]" --retries=0`
  — 1/3 passed in the exclusive follow-up. Scene 4 still timed out in Neural Link.
  Scene 5 reached one converted and engaged remote claim, then failed to settle with
  `sourceVesselRetired:true`, `targetDocument:null`, and `transfer:null`. This matches
  the independently reported parked-source settlement deadlock under #16123; it is
  adjacent evidence, not counted as popup first-paint coverage.
- Parent-head light popup media:
  SHA-256 `5c95325518eba451d8c70d9efc91e7a82f1d325133378f4b5463bf0b469b0ef2`;
  800×600, 25 fps, 46/46 decoded frames. Frame zero already contains the populated
  light Metrics pane. Per-frame average luma range: 91.749–169.345.
- Parent-head default-dark popup media:
  SHA-256 `27acc8581db06f96681abe654490cf849300e9ee5fad5e47468926244638265a`;
  800×600, 25 fps, 150/150 decoded frames. Frame zero is the staged dark blank realm,
  not a white canvas. Per-frame average luma range: 82.427–99.296.
- Parent-head second dark popup media:
  SHA-256 `9c4bf439ffda2e4c1231d55af848447d377ee2af44a5dfb2747a8c5abc638e20`;
  800×600, 25 fps, 53/53 decoded frames. Frame zero already contains the populated
  dark Commit Stream pane. Per-frame average luma range: 77.348–105.409.

The luma scans are whole-stream full-canvas detectors, not a claim that every pixel
in every frame received semantic classification. Birth-interval pixels are directly
retained for the default-dark take; the light and second-dark streams begin after
their panes are already populated.

## Post-Merge Validation

- [ ] Re-run the exact-head five-beat suite after #16123's parked-source settlement
      repair lands; require scenes 4–5 to reach their terminal receipts.
- [ ] Capture the next continuous native five-beat take from merged `dev`, bind its
      source/media hashes, and perform whole-media review before film eligibility.
- [ ] Record the post-merge receipt on #16113; do not reopen resolved #16092.

## Commits

- `4196cea4dd` — stage popup color scheme before navigation.
- `361368418f` — close the blank-realm control and bootstrap-failure review gaps.

## Evolution

The predecessor proved final DOM state but missed a shorter physical presentation
interval. This repair makes the prepaint chain explicit and independently testable:
validated theme → exact scheme → staged blank realm → final document → live viewport.
The removal and invalid-scheme arms keep both omission and input authority falsifiable,
while the retained native streams expose visible regressions that a settled DOM cannot.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fac4d-7844-7422-9486-7f73ccf308f5.
