### PR TITLE
fix(build): cover agent-owned independent clones (#16143)

### DIFF
--- a/buildScripts/util/check-commit-authorship.mjs
+++ b/buildScripts/util/check-commit-authorship.mjs
@@ -4,9 +4,9 @@ import path           from 'node:path';
 import process        from 'node:process';
 
 /**
- * Pre-push authorship check. ticket-ref-ok: implementing ticket #15337
+ * Pre-push authorship check. ticket-ref-ok: implementing tickets #15337 and #16143
  *
- * Refuses to push commits authored with the OPERATOR's identity from an agent worktree.
+ * Refuses to push commits authored with the OPERATOR's identity from an agent checkout.
  *
  * **The empirical anchor.** A full agent shift produced 38 commits across 7 branches, every one
  * authored as the human operator, because the worktree's git config silently resolved to his global
@@ -14,16 +14,19 @@ import process        from 'node:process';
  * the commits succeeded; the PRs rendered normally. It took a peer reading the PR's commit metadata
  * to notice, hours in.
  *
- * **Why it must be mechanical rather than remembered.** Squash-merge PRESERVES the author, so those
- * PRs would have landed on `dev` permanently crediting the operator for code he did not write — a
- * provenance error in the one record that cannot be corrected without rewriting shared history. The
- * repo already gates the adjacent case (`<noreply@*>` co-author footers) mechanically for exactly
- * this reason: an attribution rule that relies on noticing has already failed once.
+ * **Why it must be mechanical rather than remembered.** GitHub's current squash flow rewrites the
+ * `dev` commit author to the PR author, but the pushed branch and PR commit metadata remain false
+ * until then. That corrupts provenance while review is happening, including the family-per-author
+ * accounting that decides whether a cross-family approval is independent. Downstream repair is not
+ * prevention. The repo already gates the adjacent case (`<noreply@*>` co-author footers)
+ * mechanically for the same reason: an attribution rule that relies on noticing has already failed.
  *
- * **The rule.** In a LINKED worktree (`git-dir` !== `git-common-dir` — i.e. `.git/worktrees/<name>`,
- * which is how every agent worktree is created), no pushed commit may carry the identity from the
- * operator's GLOBAL git config. The operator's own checkout is the main working tree, where his
- * identity is correct and this check stays silent.
+ * **The rule.** In an agent-owned checkout, no pushed commit may carry the identity from the
+ * operator's GLOBAL git config. Linked worktrees are agent-owned by topology (`git-dir` !==
+ * `git-common-dir`). Independent clones have no distinct Git topology, so they use the same
+ * `NEO_AGENT_IDENTITY` boot pin that `bootstrapWorktree` requires before binding clone-local Git
+ * identity. The operator's own checkout has neither signal, where his identity is correct and this
+ * check stays silent.
  *
  * Comparing against the global config rather than a hard-coded roster is deliberate: the leak IS the
  * global identity resolving through an unset local one, so that value is exactly the thing to detect.
@@ -97,6 +100,21 @@ function isLinkedWorktree() {
 }
 
 /**
+ * @summary Whether the current checkout is owned by an agent rather than the operator.
+ *
+ * Linked worktrees retain the original topology-owned behavior. An independent clone reports
+ * `git-dir === git-common-dir`, so the bootstrap's existing `NEO_AGENT_IDENTITY` pin is the only
+ * shared ownership authority available before a push. Presence is sufficient here: identity
+ * validation and Git binding remain `bootstrapWorktree`'s job, while this guard only decides whether
+ * the operator-global leak is valid authorship or must fail loud.
+ *
+ * @returns {Boolean}
+ */
+function isAgentCheckout() {
+    return isLinkedWorktree() || Boolean(process.env.NEO_AGENT_IDENTITY?.trim())
+}
+
+/**
  * @summary The operator's global identity — the value that leaks when a worktree sets none.
  * @returns {String} Lower-cased email, or '' when no global identity is configured.
  */
@@ -134,7 +152,7 @@ function commitsAuthoredBy(email, ranges) {
 const operator = operatorEmail();
 
 // No global identity, or the operator's own checkout: nothing this check can or should say.
-if (!operator || !isLinkedWorktree()) {
+if (!operator || !isAgentCheckout()) {
     process.exit(0)
 }
 
@@ -156,17 +174,17 @@ if (offenders.length === 0) {
 
 const local = tryExec('git config user.email') || '(unset — resolving to the global identity)';
 
-console.error(`\x1b[31mcheck-commit-authorship: ${offenders.length} commit(s) authored as the operator from an agent worktree:\x1b[0m`);
+console.error(`\x1b[31mcheck-commit-authorship: ${offenders.length} commit(s) authored as the operator from an agent checkout:\x1b[0m`);
 console.error(offenders.join('\n'));
 console.error(`
-This worktree's user.email is: ${local}
+This checkout's user.email is: ${local}
 The operator's global identity is: ${operator}
 
-Squash-merge preserves the author, so pushing these would credit the operator on \`dev\` for code
-they did not write — in the one record that cannot be corrected afterwards without rewriting shared
-history.
+Pushing these would publish false branch and PR commit provenance, including the author-family
+record used to decide whether review is cross-family. GitHub's current squash flow can repair the
+\`dev\` author from the PR author, but downstream repair does not make the review-time record true.
 
-Set this worktree's identity to your own, then repair the existing commits:
+Set this checkout's identity to your own, then repair the existing commits:
 
   git config user.name  "<Your Name>"
   git config user.email "<you>@neomjs.com"
@@ -178,7 +196,7 @@ equality is the WRONG check:
   git diff --name-only origin/dev...HEAD    # the same file set as before, and only your files
   git log origin/dev..HEAD --format=%an     # every commit is yours
 
-Bypass (an operator genuinely committing from a worktree): git push --no-verify
+Bypass (an operator genuinely committing from an agent checkout): git push --no-verify
 `);
 
 process.exit(1);

--- a/buildScripts/util/check-commit-authorship.mjs
+++ b/buildScripts/util/check-commit-authorship.mjs
@@ -108,6 +108,11 @@ function isLinkedWorktree() {
  * validation and Git binding remain `bootstrapWorktree`'s job, while this guard only decides whether
  * the operator-global leak is valid authorship or must fail loud.
  *
+ * Deliberate boundary: an independent clone without `NEO_AGENT_IDENTITY` is indistinguishable from
+ * the operator's main checkout and therefore remains uncovered. Refusing it would also refuse the
+ * operator's valid commits. `bootstrapWorktree` fails agent-owned clone provisioning without this
+ * pin, so the guard shares that authority rather than inventing a second ownership resolver.
+ *
  * @returns {Boolean}
  */
 function isAgentCheckout() {

--- a/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
@@ -17,9 +17,10 @@ const
  * test invented, and the defect it exists to catch (a real worktree silently resolving a real global
  * identity) lives precisely in the part a stub replaces.
  *
- * So these build throwaway repos on disk: a main checkout, and a linked worktree of it.
+ * So these build throwaway repos on disk: a main checkout, linked worktrees, and an agent-owned
+ * independent clone distinguished by the same `NEO_AGENT_IDENTITY` pin the bootstrap consumes.
  */
-test.describe('check-commit-authorship — the operator must not author from an agent worktree', () => {
+test.describe('check-commit-authorship — the operator must not author from an agent checkout', () => {
     let tmpRoot;
 
     const git = (cwd, args) => execFileSync('git', args, {cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']});
@@ -28,16 +29,28 @@ test.describe('check-commit-authorship — the operator must not author from an 
      * @summary Runs the guard in `cwd` with an injected global identity.
      * @param {String} cwd
      * @param {String} globalEmail The operator identity the guard should treat as the leak source.
+     * @param {String} stdin The pre-push hook payload.
+     * @param {Object} [options]
+     * @param {String} [options.agentIdentity] The agent-ownership pin; absent means operator checkout.
      * @returns {{status: Number, stderr: String}}
      */
-    function runGuard(cwd, globalEmail, stdin = '') {
+    function runGuard(cwd, globalEmail, stdin = '', {agentIdentity} = {}) {
         // HOME is redirected so the guard reads THIS as `git config --global user.email` rather than
         // the real developer's — the global config is an input to the rule, so the test owns it.
-        const home = path.join(tmpRoot, 'home');
+        const
+            home = path.join(tmpRoot, 'home'),
+            env  = {...process.env, HOME: home};
+
         fs.outputFileSync(path.join(home, '.gitconfig'), `[user]\n\temail = ${globalEmail}\n\tname = Operator\n`);
 
+        if (agentIdentity) {
+            env.NEO_AGENT_IDENTITY = agentIdentity
+        } else {
+            delete env.NEO_AGENT_IDENTITY
+        }
+
         try {
-            execFileSync('node', [guardPath], {cwd, encoding: 'utf8', env: {...process.env, HOME: home}, input: stdin, stdio: ['pipe', 'pipe', 'pipe']});
+            execFileSync('node', [guardPath], {cwd, encoding: 'utf8', env, input: stdin, stdio: ['pipe', 'pipe', 'pipe']});
             return {status: 0, stderr: ''}
         } catch (error) {
             return {status: error.status, stderr: `${error.stderr || ''}`}
@@ -91,6 +104,20 @@ test.describe('check-commit-authorship — the operator must not author from an 
         expect(result.stderr).toContain('authored as the operator');
         // naming the commit matters: a count tells nobody which commit to repair
         expect(result.stderr).toContain('feat: work the agent actually did')
+    });
+
+    test('FIRES in an agent-owned independent clone that still resolves the operator identity', () => {
+        const clone = createMainCheckout();
+
+        git(clone, ['checkout', '-b', 'agent/lane', '--quiet']);
+        fs.outputFileSync(path.join(clone, 'work.txt'), 'agent work from a stale clone\n');
+        git(clone, ['add', '.']);
+        git(clone, ['commit', '-m', 'feat: stale independent-clone identity', '--quiet', '--no-verify']);
+
+        const result = runGuard(clone, 'operator@example.com', '', {agentIdentity: 'neo-gpt-emmy'});
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('feat: stale independent-clone identity')
     });
 
     test('SILENT in the operator\'s OWN checkout — his commits there are correct', () => {

--- a/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
@@ -23,7 +23,21 @@ const
 test.describe('check-commit-authorship — the operator must not author from an agent checkout', () => {
     let tmpRoot;
 
-    const git = (cwd, args) => execFileSync('git', args, {cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']});
+    const git = (cwd, args, env=process.env) =>
+        execFileSync('git', args, {cwd, encoding: 'utf8', env, stdio: ['pipe', 'pipe', 'pipe']});
+
+    /**
+     * @summary Writes the test-owned global Git identity and returns its HOME.
+     * @param {String} globalEmail
+     * @returns {String}
+     */
+    function writeGlobalIdentity(globalEmail) {
+        const home = path.join(tmpRoot, 'home');
+
+        fs.outputFileSync(path.join(home, '.gitconfig'), `[user]\n\temail = ${globalEmail}\n\tname = Operator\n`);
+
+        return home
+    }
 
     /**
      * @summary Runs the guard in `cwd` with an injected global identity.
@@ -38,10 +52,8 @@ test.describe('check-commit-authorship — the operator must not author from an 
         // HOME is redirected so the guard reads THIS as `git config --global user.email` rather than
         // the real developer's — the global config is an input to the rule, so the test owns it.
         const
-            home = path.join(tmpRoot, 'home'),
+            home = writeGlobalIdentity(globalEmail),
             env  = {...process.env, HOME: home};
-
-        fs.outputFileSync(path.join(home, '.gitconfig'), `[user]\n\temail = ${globalEmail}\n\tname = Operator\n`);
 
         if (agentIdentity) {
             env.NEO_AGENT_IDENTITY = agentIdentity
@@ -107,12 +119,20 @@ test.describe('check-commit-authorship — the operator must not author from an 
     });
 
     test('FIRES in an agent-owned independent clone that still resolves the operator identity', () => {
-        const clone = createMainCheckout();
+        const
+            clone = createMainCheckout(),
+            home  = writeGlobalIdentity('operator@example.com'),
+            env   = {...process.env, HOME: home};
 
         git(clone, ['checkout', '-b', 'agent/lane', '--quiet']);
+        git(clone, ['config', '--unset', 'user.email']);
+        git(clone, ['config', '--unset', 'user.name']);
+
+        expect(git(clone, ['config', '--local', '--list'], env)).not.toContain('user.email');
+
         fs.outputFileSync(path.join(clone, 'work.txt'), 'agent work from a stale clone\n');
         git(clone, ['add', '.']);
-        git(clone, ['commit', '-m', 'feat: stale independent-clone identity', '--quiet', '--no-verify']);
+        git(clone, ['commit', '-m', 'feat: stale independent-clone identity', '--quiet', '--no-verify'], env);
 
         const result = runGuard(clone, 'operator@example.com', '', {agentIdentity: 'neo-gpt-emmy'});
 


### PR DESCRIPTION
Resolves #16143

The pre-push authorship guard now recognizes agent-owned independent clones through the existing `NEO_AGENT_IDENTITY` bootstrap pin, while retaining linked-worktree topology detection and leaving the operator's unpinned main checkout alone.

The implementation deliberately does not invent a second agent-identity resolver. `bootstrapWorktree` remains the authority that validates and binds the pin; the guard uses its presence only to decide whether operator-global authorship is valid or must fail loud.

Evidence: L3 (real Git checkout/worktree guard execution, including an unbound agent-owned independent clone and operator-main negative control) → L3 required (all close-target ACs are local Git guard contracts). No residuals.

## Deltas from ticket

- No substantive scope change.
- The causal mechanism was narrowed after inspecting `a989e491ba^`: the guard already existed, but its linked-worktree-only early exit made an independently cloned agent checkout invisible. The evidence is recorded in the [ticket root-cause comment](https://github.com/neomjs/neo/issues/16143#issuecomment-5123670138).
- The stale squash rationale was corrected: GitHub's current squash flow repairs the eventual `dev` author from the PR author, but pushed branch/PR commit provenance and family-per-author review accounting remain false until then.
- Deliberate boundary: an independent clone without `NEO_AGENT_IDENTITY` is indistinguishable from the operator's main checkout and remains uncovered. Agent-owned clone provisioning already fails without that pin; refusing every unpinned standalone checkout would block valid operator commits.

## Test Evidence

- Baseline falsifier: 19/20 passed; only the new independent-clone case failed because the guard returned success.
- Exact remote head `d7d416cef57e426f0d38dfef61a21c3c6135368b`: 20/20 passed in `checkCommitAuthorship.spec.mjs`.
- The independent-clone fixture uses a test-owned global Git config, explicitly removes repository-local identity, creates the commit through global fallback, and proves the local config has no `user.email`.
- The existing linked-worktree matrix and operator-main negative control remain green.
- `npx lint-staged --no-stash`: passed.
- `npm run agent-preflight` for the restoration change class, both commit subjects, title, body, and changed files: passed.
- `git diff --check origin/dev...HEAD`: passed.

## Commits

- `e6a56c3bd66292629582bfb7c58c5f2d84955b0b` — cover agent-owned independent clones.
- `d7d416cef57e426f0d38dfef61a21c3c6135368b` — complete the clone-guard contract after independent audit.

## Post-Merge Validation

- [x] No post-merge-only validation remains; the local Git guard contracts are fully covered.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fac4d-7844-7422-9486-7f73ccf308f5.
