### PR TITLE
fix(workstation): retire film cursor physical nodes (#16145)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -3543,6 +3543,17 @@ class Workspace extends Container {
     }
 
     /**
+     * @summary Retires one film cursor from component, VDOM, and physical body-node truth.
+     * @param {Neo.component.Base|null} cursorDot
+     * @protected
+     */
+    retireFilmCursorDot(cursorDot) {
+        if (!cursorDot?.isDestroyed) {
+            cursorDot?.destroy(true)
+        }
+    }
+
+    /**
      * @summary Drives the in-window showcase beat through real simulated pointer input.
      *
      * One live tab crosses at least two foreign zones and two placement kinds. Each dwell first
@@ -3918,7 +3929,7 @@ class Workspace extends Container {
             return {applied: false, errors: [error?.message || String(error)]}
         } finally {
             restoreProxyPopupConfig();
-            cursorDot?.destroy()
+            me.retireFilmCursorDot(cursorDot)
         }
     }
 
@@ -4210,7 +4221,7 @@ class Workspace extends Container {
             let remoteSnapshot;
 
             if (showCursor) {
-                cursorDot?.destroy();
+                me.retireFilmCursorDot(cursorDot);
                 cursorDot = null
             }
 
@@ -4297,7 +4308,7 @@ class Workspace extends Container {
 
             return {applied: false, errors: [error?.message || String(error)]}
         } finally {
-            cursorDot?.destroy()
+            me.retireFilmCursorDot(cursorDot)
         }
     }
 
@@ -4428,7 +4439,7 @@ class Workspace extends Container {
             let remoteSnapshot;
 
             if (showCursor) {
-                cursorDot?.destroy();
+                me.retireFilmCursorDot(cursorDot);
                 cursorDot = null
             }
 
@@ -4537,7 +4548,7 @@ class Workspace extends Container {
 
             return {applied: false, errors: [error?.message || String(error)]}
         } finally {
-            cursorDot?.destroy()
+            me.retireFilmCursorDot(cursorDot)
         }
     }
 
@@ -4851,7 +4862,7 @@ class Workspace extends Container {
         } finally {
             // The synthetic cursor is per-gesture presentation: it never outlives the take's
             // gesture, and it never enters worker truth (pointer-events:none, no dock document).
-            cursorDot?.destroy()
+            me.retireFilmCursorDot(cursorDot)
         }
     }
 

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -3545,12 +3545,25 @@ class Workspace extends Container {
     /**
      * @summary Retires one film cursor from component, VDOM, and physical body-node truth.
      * @param {Neo.component.Base|null} cursorDot
+     * @returns {Promise<Boolean>} True after a live cursor's physical removal is acknowledged.
      * @protected
      */
-    retireFilmCursorDot(cursorDot) {
-        if (!cursorDot?.isDestroyed) {
-            cursorDot?.destroy(true)
+    async retireFilmCursorDot(cursorDot) {
+        if (!cursorDot || cursorDot.isDestroyed) {
+            return false
         }
+
+        const removalReceipt = Neo.applyDeltas(cursorDot.windowId, {
+            action: 'removeNode',
+            id    : cursorDot.vdom.id
+        });
+
+        // Retire component truth without dispatching a second physical delta. Awaiting the
+        // explicit receipt keeps cross-window replacement creation behind source-node removal.
+        cursorDot.destroy();
+        await removalReceipt;
+
+        return true
     }
 
     /**
@@ -3929,7 +3942,7 @@ class Workspace extends Container {
             return {applied: false, errors: [error?.message || String(error)]}
         } finally {
             restoreProxyPopupConfig();
-            me.retireFilmCursorDot(cursorDot)
+            await me.retireFilmCursorDot(cursorDot)
         }
     }
 
@@ -4221,7 +4234,7 @@ class Workspace extends Container {
             let remoteSnapshot;
 
             if (showCursor) {
-                me.retireFilmCursorDot(cursorDot);
+                await me.retireFilmCursorDot(cursorDot);
                 cursorDot = null
             }
 
@@ -4308,7 +4321,7 @@ class Workspace extends Container {
 
             return {applied: false, errors: [error?.message || String(error)]}
         } finally {
-            me.retireFilmCursorDot(cursorDot)
+            await me.retireFilmCursorDot(cursorDot)
         }
     }
 
@@ -4439,7 +4452,7 @@ class Workspace extends Container {
             let remoteSnapshot;
 
             if (showCursor) {
-                me.retireFilmCursorDot(cursorDot);
+                await me.retireFilmCursorDot(cursorDot);
                 cursorDot = null
             }
 
@@ -4548,7 +4561,7 @@ class Workspace extends Container {
 
             return {applied: false, errors: [error?.message || String(error)]}
         } finally {
-            me.retireFilmCursorDot(cursorDot)
+            await me.retireFilmCursorDot(cursorDot)
         }
     }
 
@@ -4862,7 +4875,7 @@ class Workspace extends Container {
         } finally {
             // The synthetic cursor is per-gesture presentation: it never outlives the take's
             // gesture, and it never enters worker truth (pointer-events:none, no dock document).
-            me.retireFilmCursorDot(cursorDot)
+            await me.retireFilmCursorDot(cursorDot)
         }
     }
 

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1175,6 +1175,8 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             expect(cancelled.proof.popupConfig.after).toBe(cancelled.proof.popupConfig.before);
             expect(await readDocument(app, wsId), 'fresh worker truth remains byte-identical after cancel')
                 .toEqual(documentBefore);
+            await expect(page.locator('.film-cursor'),
+                'cancel must retire the film cursor from physical DOM, not only component truth').toHaveCount(0);
 
             const committed = await app.callMethod(wsId, 'executeCrossZoneShowcaseStep', [{
                 ...gesture,
@@ -1189,6 +1191,8 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             expect(committed.proof.popupConfig.restored,
                 'commit restores the exact popup-conversion setting before resolving').toBe(true);
             expect(committed.proof.popupConfig.after).toBe(committed.proof.popupConfig.before);
+            await expect(page.locator('.film-cursor'),
+                'a second film gesture in the same app session must not accumulate cursor residue').toHaveCount(0);
             expect(committed.proof.descriptor).toEqual({
                 operation : 'addTab',
                 itemId    : 'audit',

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -744,6 +744,124 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
     }
 
     /**
+     * @summary Samples every live page while one gesture runs so cursor migration is proven across
+     * physical documents, rather than inferred from one terminal page after the gesture settles.
+     * @param {Object} data
+     * @param {Function} data.action Awaited gesture action.
+     * @param {Boolean} [data.observeContinuously=true] Sample between action start and settlement.
+     * @param {Object} data.page Playwright main page.
+     * @param {Object} data.sourcePage Physical document that initially owns the cursor.
+     * @param {Object|null} [data.targetPage=null] Physical replacement document, when migrating.
+     * @returns {Promise<Object>} Gesture result plus aggregate cursor lifecycle evidence.
+     */
+    async function captureFilmCursorLifecycle({
+        action,
+        observeContinuously=true,
+        page,
+        sourcePage,
+        targetPage=null
+    }) {
+        const evidence = {
+            finalTotal           : null,
+            initialTotal         : null,
+            maxParticipatingPages: 0,
+            maxTotal             : 0,
+            overlapSamples       : 0,
+            sampleCount          : 0,
+            sourceSeen           : false,
+            targetSeen           : false,
+            targetSeenWithSource : 0
+        };
+        let running = true;
+
+        const sample = async () => {
+            const pages  = page.context().pages().filter(candidate => !candidate.isClosed());
+            const counts = await Promise.all(pages.map(async candidate => {
+                let count = 0;
+
+                try {
+                    count = await candidate.locator('.film-cursor').count()
+                } catch {
+                    // A popup may close between the page census and its DOM query.
+                }
+
+                return {count, page: candidate}
+            }));
+            const
+                sourceCount = counts.find(entry => entry.page === sourcePage)?.count ?? 0,
+                targetCount = counts.find(entry => entry.page === targetPage)?.count ?? 0,
+                total       = counts.reduce((sum, entry) => sum + entry.count, 0);
+
+            evidence.sampleCount++;
+            evidence.finalTotal            = total;
+            evidence.maxParticipatingPages  = Math.max(evidence.maxParticipatingPages, pages.length);
+            evidence.maxTotal              = Math.max(evidence.maxTotal, total);
+            evidence.overlapSamples       += Number(total > 1);
+            evidence.sourceSeen           ||= sourceCount > 0;
+            evidence.targetSeen           ||= targetCount > 0;
+            evidence.targetSeenWithSource += Number(sourceCount > 0 && targetCount > 0)
+        };
+
+        await sample();
+        evidence.initialTotal = evidence.finalTotal;
+
+        const observer = observeContinuously
+            ? (async () => {
+                while (running) {
+                    await new Promise(resolve => setTimeout(resolve, 16));
+                    running && await sample()
+                }
+            })()
+            : Promise.resolve();
+
+        let result;
+
+        try {
+            result = await action()
+        } finally {
+            running = false;
+            await observer;
+            await sample()
+        }
+
+        return {evidence, result}
+    }
+
+    /**
+     * @summary Applies the shared cursor lifecycle assertions for film migrations and ordinary
+     * cursor-free paths.
+     * @param {Object} evidence Output from captureFilmCursorLifecycle().
+     * @param {Object} options
+     * @param {Boolean} [options.expectMigration=false]
+     * @param {Boolean} options.showCursor
+     */
+    function assertFilmCursorLifecycle(evidence, {expectMigration=false, showCursor}) {
+        expect(evidence.initialTotal, 'each gesture must start without prior cursor residue').toBe(0);
+        expect(evidence.maxTotal, 'aggregate cursors across all participating documents never exceed one')
+            .toBeLessThanOrEqual(1);
+        expect(evidence.overlapSamples, 'no sampled frame may contain source and replacement cursors').toBe(0);
+        expect(evidence.finalTotal, 'the terminal receipt must leave every document cursor-free').toBe(0);
+
+        if (showCursor) {
+            console.log('[film-cursor-lifecycle]', JSON.stringify(evidence));
+            expect(evidence.sourceSeen, 'film mode must expose the source cursor during the gesture').toBe(true);
+
+            if (expectMigration) {
+                expect(evidence.maxParticipatingPages,
+                    'migration evidence must cover at least two physical documents').toBeGreaterThanOrEqual(2);
+                expect(evidence.targetSeen, 'film mode must expose the replacement cursor in its target document')
+                    .toBe(true);
+                expect(evidence.targetSeenWithSource,
+                    'the source document must be physically empty when the replacement is observable').toBe(0)
+            }
+        } else {
+            expect(evidence.maxTotal, 'ordinary mode must never create a film cursor').toBe(0);
+            expect(evidence.sourceSeen).toBe(false);
+            expect(evidence.targetSeen).toBe(false)
+        }
+    }
+
+    /**
      * @summary Creates scene 3's committed A+B vessel through two real pointer gestures.
      *
      * The first gesture tears `metrics` out into the target vessel. The second tears `commits` out
@@ -766,16 +884,23 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             ]),
             targetPopup        = await targetPopupPromise,
             sourcePopupPromise = page.waitForEvent('popup', {timeout: 90000}),
-            dockResultPromise  = app.callMethod(wsId, 'executeCrossWindowDockStep', [
-                {itemId: 'commits', sourceNodeId: 'right-bottom-tabs', targetItemId: 'metrics'},
-                {
-                    attempts  : filmPace.birthAttempts ?? 180,
-                    dwellDelay: filmPace.dwellDelay ?? 600,
-                    moveDelay : filmPace.moveDelay ?? 16,
-                    moveSteps : filmPace.moveSteps ?? 4,
-                    showCursor: filmPace.showCursor ?? false
-                }
-            ]),
+            showCursor          = filmPace.showCursor ?? false,
+            cursorProofPromise  = captureFilmCursorLifecycle({
+                action: () => app.callMethod(wsId, 'executeCrossWindowDockStep', [
+                    {itemId: 'commits', sourceNodeId: 'right-bottom-tabs', targetItemId: 'metrics'},
+                    {
+                        attempts  : filmPace.birthAttempts ?? 180,
+                        dwellDelay: filmPace.dwellDelay ?? 600,
+                        moveDelay : filmPace.moveDelay ?? 16,
+                        moveSteps : filmPace.moveSteps ?? 4,
+                        showCursor
+                    }
+                ]),
+                observeContinuously: showCursor,
+                page,
+                sourcePage         : page,
+                targetPage         : targetPopup
+            }),
             targetProxy = targetPopup.locator('.workstation-vessel-dragproxy');
 
         await expect(targetProxy, 'exactly one Workstation proxy must render in the target popup')
@@ -786,7 +911,8 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
         expect(computedOpacity, 'the live target proxy must leave the dock preview legible').toBe(.7);
 
-        const [dockResult, sourcePopup] = await Promise.all([dockResultPromise, sourcePopupPromise]);
+        const [{evidence: cursorEvidence, result: dockResult}, sourcePopup] =
+            await Promise.all([cursorProofPromise, sourcePopupPromise]);
 
         dockResult.proof?.remoteSnapshot?.targetProxy &&
             (dockResult.proof.remoteSnapshot.targetProxy.computedOpacity = computedOpacity);
@@ -796,7 +922,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             timeout: 15000
         }).toBe(true);
 
-        return {dockResult, ownerResult, sourcePopup, targetPopup}
+        return {cursorEvidence, dockResult, ownerResult, showCursor, sourcePopup, targetPopup}
     }
 
     /**
@@ -1177,6 +1303,33 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
                 .toEqual(documentBefore);
             await expect(page.locator('.film-cursor'),
                 'cancel must retire the film cursor from physical DOM, not only component truth').toHaveCount(0);
+
+            const {evidence: errorCursorEvidence, result: failed} =
+                await captureFilmCursorLifecycle({
+                    action: () => app.callMethod(wsId, 'executeCrossZoneShowcaseStep', [{
+                        ...gesture,
+                        dwells: [{
+                            targetNodeId : 'missing-film-target-a',
+                            placementKind: 'edge-bottom'
+                        }, {
+                            targetNodeId : 'missing-film-target-b',
+                            placementKind: 'tab-into'
+                        }]
+                    }, {
+                        ...filmPace,
+                        showCursor: true
+                    }]),
+                    page,
+                    sourcePage: page
+                });
+
+            expect(failed.applied).toBe(false);
+            expect(failed.errors).toEqual([
+                "cross-zone target 'missing-film-target-a' is not measurable"
+            ]);
+            assertFilmCursorLifecycle(errorCursorEvidence, {showCursor: true});
+            expect(await readDocument(app, wsId),
+                'the thrown film path must cancel cleanly without mutating document truth').toEqual(documentBefore);
 
             const committed = await app.callMethod(wsId, 'executeCrossZoneShowcaseStep', [{
                 ...gesture,
@@ -2067,10 +2220,11 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
     test('scene 3 — the second window learns to dock: convert-while-dragging + exactly one preview', async ({page, neuralLink}) => {
         const {app, pageErrors, wsId} = await boot({page, neuralLink});
         const
-            heartbeatBefore                        = await readHeartbeat(app, wsId),
-            metricsBefore                          = await app.callMethod(wsId, 'getPaneIdentity', ['metrics']),
-            commitsBefore                          = await app.callMethod(wsId, 'getPaneIdentity', ['commits']),
-            {dockResult, ownerResult, targetPopup} = await stageMergedVessel({app, page, wsId});
+            heartbeatBefore = await readHeartbeat(app, wsId),
+            metricsBefore   = await app.callMethod(wsId, 'getPaneIdentity', ['metrics']),
+            commitsBefore   = await app.callMethod(wsId, 'getPaneIdentity', ['commits']),
+            {cursorEvidence, dockResult, ownerResult, showCursor, targetPopup} =
+                await stageMergedVessel({app, page, wsId});
 
         expect(ownerResult.errors).toEqual([]);
         expect(ownerResult.applied, 'pane A must commit into the first real vessel').toBe(true);
@@ -2079,6 +2233,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             `cross-window dock receipt: ${JSON.stringify(dockResult.proof ?? null)}`
         ).toEqual([]);
         expect(dockResult.applied, 'pane B must commit into A through the remote target').toBe(true);
+        assertFilmCursorLifecycle(cursorEvidence, {expectMigration: true, showCursor});
 
         const snapshot = dockResult.proof.remoteSnapshot;
 
@@ -2136,22 +2291,30 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
     test('scene 4 — reintegration: whole stack home, commit precedes the vessel self-close', async ({page, neuralLink}) => {
         const {app, pageErrors, wsId} = await boot({page, neuralLink});
         const
-            heartbeatBefore                        = await readHeartbeat(app, wsId),
-            metricsBefore                          = await app.callMethod(wsId, 'getPaneIdentity', ['metrics']),
-            commitsBefore                          = await app.callMethod(wsId, 'getPaneIdentity', ['commits']),
-            {dockResult, ownerResult, targetPopup} = await stageMergedVessel({app, page, wsId});
+            heartbeatBefore = await readHeartbeat(app, wsId),
+            metricsBefore   = await app.callMethod(wsId, 'getPaneIdentity', ['metrics']),
+            commitsBefore   = await app.callMethod(wsId, 'getPaneIdentity', ['commits']),
+            {cursorEvidence, dockResult, ownerResult, showCursor, targetPopup} =
+                await stageMergedVessel({app, page, wsId});
 
         expect(ownerResult.applied).toBe(true);
         expect(dockResult.applied).toBe(true);
+        assertFilmCursorLifecycle(cursorEvidence, {expectMigration: true, showCursor});
 
-        const result = await app.callMethod(wsId, 'executeStackReturnStep', [
-            {ownerItemId: 'metrics'},
-            {
-                attempts  : filmPace.birthAttempts ?? 180,
-                moveDelay : filmPace.moveDelay ?? 16,
-                showCursor: filmPace.showCursor ?? false
-            }
-        ]);
+        const {evidence: returnCursorEvidence, result} = await captureFilmCursorLifecycle({
+            action: () => app.callMethod(wsId, 'executeStackReturnStep', [
+                {ownerItemId: 'metrics'},
+                {
+                    attempts : filmPace.birthAttempts ?? 180,
+                    moveDelay: filmPace.moveDelay ?? 16,
+                    showCursor
+                }
+            ]),
+            observeContinuously: showCursor,
+            page,
+            sourcePage         : targetPopup,
+            targetPage         : page
+        });
 
         expect(result.errors, JSON.stringify({
             closeReceipt    : result.proof?.closeReceipt,
@@ -2162,6 +2325,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             transfer        : result.proof?.transfer
         })).toEqual([]);
         expect(result.applied, 'the grouped pointer gesture must settle through physical topology exit').toBe(true);
+        assertFilmCursorLifecycle(returnCursorEvidence, {expectMigration: true, showCursor});
         expect(result.proof.remoteSnapshot).toMatchObject({
             claimCount       : 1,
             engaged          : true,

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -152,25 +152,81 @@ test.describe.serial('Workstation.view.Workspace', () => {
         expect(initialDocument.nodes['split-main'].sizes).toEqual([0.6, 0.4])
     });
 
-    test('film cursor retirement requests physical body-node removal exactly once', () => {
+    test('film cursor retirement awaits physical body-node removal before settling', async () => {
         const
-            workspace = Neo.create(Workspace, {}),
-            calls     = [],
-            cursorDot = {
+            realApplyDeltas = Neo.applyDeltas,
+            workspace       = Neo.create(Workspace, {}),
+            calls           = [],
+            cursorDot       = {
                 isDestroyed: false,
-                destroy(updateParentVdom) {
-                    calls.push(updateParentVdom);
+                vdom       : {id: 'film-cursor-1'},
+                windowId   : 'source-window',
+                destroy() {
+                    calls.push({type: 'destroy'});
                     this.isDestroyed = true
                 }
             };
+        let resolveRemoval;
 
         try {
-            workspace.retireFilmCursorDot(cursorDot);
-            workspace.retireFilmCursorDot(cursorDot);
-            workspace.retireFilmCursorDot(null);
+            const removalReceipt = new Promise(resolve => resolveRemoval = resolve);
 
-            expect(calls).toEqual([true])
+            Neo.applyDeltas = (windowId, deltas) => {
+                calls.push({deltas, type: 'remove-dispatched', windowId});
+                return removalReceipt
+            };
+
+            let   settled    = false;
+            const retirement = workspace.retireFilmCursorDot(cursorDot)
+                .then(value => {
+                    settled = true;
+                    return value
+                });
+
+            await Promise.resolve();
+
+            expect(calls).toEqual([{
+                deltas  : {action: 'removeNode', id: 'film-cursor-1'},
+                type    : 'remove-dispatched',
+                windowId: 'source-window'
+            }, {
+                type: 'destroy'
+            }]);
+            expect(settled, 'replacement creation must stay behind the physical removal receipt').toBe(false);
+
+            resolveRemoval();
+
+            await expect(retirement).resolves.toBe(true);
+            await expect(workspace.retireFilmCursorDot(cursorDot)).resolves.toBe(false);
+            expect(calls).toHaveLength(2)
         } finally {
+            Neo.applyDeltas = realApplyDeltas;
+            workspace.destroy()
+        }
+    });
+
+    test('non-film mode keeps all six cursor retirement boundaries side-effect free', async () => {
+        const
+            realApplyDeltas = Neo.applyDeltas,
+            workspace       = Neo.create(Workspace, {}),
+            deltaCalls      = [];
+
+        try {
+            Neo.applyDeltas = (...args) => {
+                deltaCalls.push(args);
+                return Promise.resolve()
+            };
+
+            const results = [];
+
+            for (let boundary = 0; boundary < 6; boundary++) {
+                results.push(await workspace.retireFilmCursorDot(null))
+            }
+
+            expect(results).toEqual([false, false, false, false, false, false]);
+            expect(deltaCalls, 'showCursor=false must not dispatch a physical mutation').toEqual([])
+        } finally {
+            Neo.applyDeltas = realApplyDeltas;
             workspace.destroy()
         }
     });

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -152,6 +152,29 @@ test.describe.serial('Workstation.view.Workspace', () => {
         expect(initialDocument.nodes['split-main'].sizes).toEqual([0.6, 0.4])
     });
 
+    test('film cursor retirement requests physical body-node removal exactly once', () => {
+        const
+            workspace = Neo.create(Workspace, {}),
+            calls     = [],
+            cursorDot = {
+                isDestroyed: false,
+                destroy(updateParentVdom) {
+                    calls.push(updateParentVdom);
+                    this.isDestroyed = true
+                }
+            };
+
+        try {
+            workspace.retireFilmCursorDot(cursorDot);
+            workspace.retireFilmCursorDot(cursorDot);
+            workspace.retireFilmCursorDot(null);
+
+            expect(calls).toEqual([true])
+        } finally {
+            workspace.destroy()
+        }
+    });
+
     test('provider-owned stores and cached data panes survive split + return', async () => {
         const workspace = Neo.create(Workspace, {});
 


### PR DESCRIPTION
Resolves #16145

Workstation film gestures now retire their synthetic cursor through one idempotent
cleanup seam that calls the existing `component.Base.destroy(true)` contract. All six
terminal and source-to-target handoff boundaries use that seam, so component, VDOM,
and directly mounted `document.body` truth retire together instead of accumulating
orange orphan nodes across gestures.

Evidence: L1 (owner-source census plus 22/22 focused units) and L3 (headed film-mode
cancel-then-commit witness) achieved; no close-target residual.

## Deltas from ticket

- The repair stays Workstation-local; `component.Base.destroy()` defaults are unchanged.
- One helper owns idempotence and physical-node removal, and both cursor migration
  boundaries retire the source cursor before creating the target-window replacement.
- The existing dual-mode showcase witness now checks physical `.film-cursor` DOM truth
  after cancel and after a second committed gesture in the same application session.

## Test Evidence

- `node --check apps/workstation/view/Workspace.mjs` — passed.
- `node --check test/playwright/unit/apps/workstation/Workspace.spec.mjs` — passed.
- `node --check test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs` — passed.
- `git diff --check` — passed.
- `npm run test-unit -- test/playwright/unit/apps/workstation/Workspace.spec.mjs` —
  22/22 passed.
- `env -u NEO_E2E_ENGINE_PROFILE NEO_FILM_TAKE=1 NEO_E2E_PORT=8261 npx playwright
  test test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs -c
  test/playwright/playwright.config.e2e.mjs --project=chromium --workers=1 --headed
  --grep 'showcase beat' --retries=0` — 2/2 passed in 23.6s. The same Workstation
  session completed cancel then commit with physical cursor count zero after each
  gesture.
- Workstation app surface: `WorkstationFiveBeatNL.spec.mjs` is the existing non-CI
  journey coverage; the focused headed row above executed its repeated-gesture cell.

## Post-Merge Validation

- [ ] Repeat a full five-beat film take on merged `dev` and visually confirm that no
      cursor dot survives any cross-window beat.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex). Session
`019fac51-ddcb-7212-902e-09d3a9d19098`.
