### PR TITLE
fix(workstation): bind blackout witness to first tear-out (#15955)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -4847,7 +4847,11 @@ class Workspace extends Container {
                 options : opt(outX, outY, outSX, outSY, 0)
             }]});
 
-            let committed      = await me.waitForTearOutCommit(itemId),
+            let committed = await me.waitForTearOutCommit(itemId);
+
+            committed && await me.refreshPromise;
+
+            let
                 documentAfter  = DockZoneModel.clone(me.dockModel),
                 absentFromTree = !Object.values(documentAfter.nodes).some(zoneNode => zoneNode.items?.includes(itemId)),
                 keptInCatalog  = Boolean(documentAfter.items?.[itemId]);

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -871,11 +871,12 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
      * real window set.
      * @param {Object} data
      * @param {Object} data.app Neural Link app wrapper.
+     * @param {Boolean} [data.captureContinuity=false] Capture only the second cross-window dock leg.
      * @param {Object} data.page Playwright page.
      * @param {String} data.wsId Workspace component id.
      * @returns {Promise<Object>}
      */
-    async function stageMergedVessel({app, page, wsId}) {
+    async function stageMergedVessel({app, captureContinuity=false, page, wsId}) {
         const
             targetPopupPromise = page.waitForEvent('popup', {timeout: 90000}),
             ownerResult        = await app.callMethod(wsId, 'executeTearOutStep', [
@@ -885,7 +886,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             targetPopup        = await targetPopupPromise,
             sourcePopupPromise = page.waitForEvent('popup', {timeout: 90000}),
             showCursor          = filmPace.showCursor ?? false,
-            cursorProofPromise  = captureFilmCursorLifecycle({
+            dockAction          = () => captureFilmCursorLifecycle({
                 action: () => app.callMethod(wsId, 'executeCrossWindowDockStep', [
                     {itemId: 'commits', sourceNodeId: 'right-bottom-tabs', targetItemId: 'metrics'},
                     {
@@ -901,6 +902,9 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
                 sourcePage         : page,
                 targetPage         : targetPopup
             }),
+            cursorProofPromise  = captureContinuity
+                ? captureWorkspaceContinuity(page, dockAction)
+                : dockAction(),
             targetProxy = targetPopup.locator('.workstation-vessel-dragproxy');
 
         await expect(targetProxy, 'exactly one Workstation proxy must render in the target popup')
@@ -911,8 +915,11 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
         expect(computedOpacity, 'the live target proxy must leave the dock preview legible').toBe(.7);
 
-        const [{evidence: cursorEvidence, result: dockResult}, sourcePopup] =
+        const [dockCapture, sourcePopup] =
             await Promise.all([cursorProofPromise, sourcePopupPromise]);
+        const
+            cursorProof                                    = captureContinuity ? dockCapture.result : dockCapture,
+            {evidence: cursorEvidence, result: dockResult} = cursorProof;
 
         dockResult.proof?.remoteSnapshot?.targetProxy &&
             (dockResult.proof.remoteSnapshot.targetProxy.computedOpacity = computedOpacity);
@@ -922,7 +929,15 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             timeout: 15000
         }).toBe(true);
 
-        return {cursorEvidence, dockResult, ownerResult, showCursor, sourcePopup, targetPopup}
+        return {
+            continuity: captureContinuity ? dockCapture : null,
+            cursorEvidence,
+            dockResult,
+            ownerResult,
+            showCursor,
+            sourcePopup,
+            targetPopup
+        }
     }
 
     /**
@@ -1114,6 +1129,53 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         }
     }
 
+    /**
+     * @summary Enforces the dense-workspace presented-frame entropy contract for one action.
+     * @param {Object} config Assertion inputs.
+     * @param {Object} config.continuity Receipt returned by captureWorkspaceContinuity().
+     * @param {String} config.label Stable attachment and log label.
+     * @param {Object} config.testInfo Playwright test metadata.
+     * @param {Boolean} [config.expectedCleared=false] Known-defect red-control direction.
+     * @param {Object} [config.receipt] Additional action-specific log fields.
+     * @returns {Promise<void>}
+     */
+    async function assertWorkspaceContinuity({
+        continuity,
+        expectedCleared=false,
+        label,
+        receipt={},
+        testInfo
+    }) {
+        console.log('[rendered-continuity]', JSON.stringify({
+            baselineEntropy: continuity.baselineEntropy,
+            frameCount     : continuity.frameCount,
+            label,
+            minEntropy     : continuity.minEntropy,
+            minFrameIndex  : continuity.minFrameIndex,
+            ...receipt
+        }));
+
+        expect(continuity.frameCount,
+            `${label} must expose consecutive compositor frames`).toBeGreaterThan(2);
+
+        const entropyFloor = continuity.baselineEntropy * 0.65;
+
+        if (continuity.minEntropy < entropyFloor) {
+            await testInfo.attach(`${label}-minimum-entropy-frame`, {
+                body       : Buffer.from(continuity.frames[continuity.minFrameIndex], 'base64'),
+                contentType: 'image/jpeg'
+            })
+        }
+
+        if (expectedCleared) {
+            expect(continuity.minEntropy,
+                `${label} red control must expose the confirmed cleared-body frame`).toBeLessThan(entropyFloor)
+        } else {
+            expect(continuity.minEntropy,
+                `${label} must not present a cleared dense workspace body`).toBeGreaterThanOrEqual(entropyFloor)
+        }
+    }
+
     test('scene 1 — the room is alive: resize and theme preserve continuity', async ({page, neuralLink}, testInfo) => {
         const logs       = [],
               pageErrors = [];
@@ -1171,28 +1233,12 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
                 spec       = continuity ? continuity.result : await runSpec();
 
             if (continuity) {
-                console.log('[rendered-continuity]', JSON.stringify({
-                    baselineEntropy: continuity.baselineEntropy,
-                    frameCount     : continuity.frameCount,
-                    minEntropy     : continuity.minEntropy,
-                    minFrameIndex  : continuity.minFrameIndex,
-                    run            : run + 1
-                }));
-
-                expect(continuity.frameCount,
-                    'the resize/reset boundary must expose consecutive compositor frames').toBeGreaterThan(2);
-
-                const entropyFloor = continuity.baselineEntropy * 0.65;
-
-                if (continuity.minEntropy < entropyFloor) {
-                    await testInfo.attach(`scene-1-run-${run + 1}-minimum-entropy-frame`, {
-                        body       : Buffer.from(continuity.frames[continuity.minFrameIndex], 'base64'),
-                        contentType: 'image/jpeg'
-                    })
-                }
-
-                expect(continuity.minEntropy,
-                    'no presented frame may clear the dense workspace body').toBeGreaterThanOrEqual(entropyFloor)
+                await assertWorkspaceContinuity({
+                    continuity,
+                    label  : `scene-1-run-${run + 1}-resize`,
+                    receipt: {run: run + 1},
+                    testInfo
+                })
             }
 
             expect(spec.completed, 'the spec-mode replay must complete cleanly').toBe(true);
@@ -1710,6 +1756,27 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(await readHeartbeat(app, wsId)).toBeGreaterThan(heartbeatBefore);
         expect(pageErrors).toEqual([])
     });
+
+    // Flip this red-control direction when the compositor-visible handoff is repaired.
+    test('candidate 2 red control — cross-window dock presents a cleared body',
+        async ({page, neuralLink}, testInfo) => {
+            const {app, pageErrors, wsId} = await boot({page, neuralLink});
+            const
+                {continuity, dockResult, ownerResult} =
+                    await stageMergedVessel({app, captureContinuity: true, page, wsId});
+
+            await assertWorkspaceContinuity({
+                continuity,
+                expectedCleared: true,
+                label          : 'candidate-2-cross-window-dock',
+                testInfo
+            });
+            expect(ownerResult.applied, 'the setup tear-out must commit before the measured leg').toBe(true);
+            expect(dockResult.errors).toEqual([]);
+            expect(dockResult.applied, 'the red control must still complete its remote dock commit').toBe(true);
+            expect(pageErrors).toEqual([])
+        }
+    );
 
     test('scene 2 (native titlebar) — a physical macOS popup drag previews, embodies, and returns home', async ({page, neuralLink}) => {
         test.skip(process.platform !== 'darwin', 'the physical titlebar witness is macOS-only');

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -871,12 +871,11 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
      * real window set.
      * @param {Object} data
      * @param {Object} data.app Neural Link app wrapper.
-     * @param {Boolean} [data.captureContinuity=false] Capture only the second cross-window dock leg.
      * @param {Object} data.page Playwright page.
      * @param {String} data.wsId Workspace component id.
      * @returns {Promise<Object>}
      */
-    async function stageMergedVessel({app, captureContinuity=false, page, wsId}) {
+    async function stageMergedVessel({app, page, wsId}) {
         const
             targetPopupPromise = page.waitForEvent('popup', {timeout: 90000}),
             ownerResult        = await app.callMethod(wsId, 'executeTearOutStep', [
@@ -886,7 +885,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             targetPopup        = await targetPopupPromise,
             sourcePopupPromise = page.waitForEvent('popup', {timeout: 90000}),
             showCursor          = filmPace.showCursor ?? false,
-            dockAction          = () => captureFilmCursorLifecycle({
+            cursorProofPromise  = captureFilmCursorLifecycle({
                 action: () => app.callMethod(wsId, 'executeCrossWindowDockStep', [
                     {itemId: 'commits', sourceNodeId: 'right-bottom-tabs', targetItemId: 'metrics'},
                     {
@@ -902,9 +901,6 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
                 sourcePage         : page,
                 targetPage         : targetPopup
             }),
-            cursorProofPromise  = captureContinuity
-                ? captureWorkspaceContinuity(page, dockAction)
-                : dockAction(),
             targetProxy = targetPopup.locator('.workstation-vessel-dragproxy');
 
         await expect(targetProxy, 'exactly one Workstation proxy must render in the target popup')
@@ -915,11 +911,8 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
         expect(computedOpacity, 'the live target proxy must leave the dock preview legible').toBe(.7);
 
-        const [dockCapture, sourcePopup] =
+        const [{evidence: cursorEvidence, result: dockResult}, sourcePopup] =
             await Promise.all([cursorProofPromise, sourcePopupPromise]);
-        const
-            cursorProof                                    = captureContinuity ? dockCapture.result : dockCapture,
-            {evidence: cursorEvidence, result: dockResult} = cursorProof;
 
         dockResult.proof?.remoteSnapshot?.targetProxy &&
             (dockResult.proof.remoteSnapshot.targetProxy.computedOpacity = computedOpacity);
@@ -929,15 +922,7 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             timeout: 15000
         }).toBe(true);
 
-        return {
-            continuity: captureContinuity ? dockCapture : null,
-            cursorEvidence,
-            dockResult,
-            ownerResult,
-            showCursor,
-            sourcePopup,
-            targetPopup
-        }
+        return {cursorEvidence, dockResult, ownerResult, showCursor, sourcePopup, targetPopup}
     }
 
     /**
@@ -961,9 +946,9 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
                 width : globalThis.innerWidth
             })),
             box      = await page.locator('.workstation-dock-host').boundingBox(),
-            session  = await page.context().newCDPSession(page),
-            frames   = [],
-            acks     = [];
+            session = await page.context().newCDPSession(page),
+            frames  = [],
+            acks    = [];
         let resolveFirstFrame;
 
         expect(box, 'the dock host must expose a measurable compositor region').toBeTruthy();
@@ -1758,22 +1743,36 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
     });
 
     // Flip this red-control direction when the compositor-visible handoff is repaired.
-    test('candidate 2 red control — cross-window dock presents a cleared body',
+    test('first tear-out red control — source projection presents a cleared body',
         async ({page, neuralLink}, testInfo) => {
+            const userAgent = await page.evaluate(() => navigator.userAgent);
+
+            test.skip(
+                userAgent.includes('HeadlessChrome'),
+                'run with --headed because CDP screencast compositor frames are required'
+            );
+
             const {app, pageErrors, wsId} = await boot({page, neuralLink});
             const
-                {continuity, dockResult, ownerResult} =
-                    await stageMergedVessel({app, captureContinuity: true, page, wsId});
+                popupPromise = page.waitForEvent('popup', {timeout: 90000}),
+                continuity   = await captureWorkspaceContinuity(page, () =>
+                    app.callMethod(wsId, 'executeTearOutStep', [
+                        {itemId: 'metrics', sourceNodeId: 'right-top-tabs'},
+                        filmPace
+                    ])
+                ),
+                ownerResult = continuity.result;
+
+            await popupPromise;
 
             await assertWorkspaceContinuity({
                 continuity,
                 expectedCleared: true,
-                label          : 'candidate-2-cross-window-dock',
+                label          : 'first-tear-out-source-projection',
                 testInfo
             });
-            expect(ownerResult.applied, 'the setup tear-out must commit before the measured leg').toBe(true);
-            expect(dockResult.errors).toEqual([]);
-            expect(dockResult.applied, 'the red control must still complete its remote dock commit').toBe(true);
+            expect(ownerResult.errors).toEqual([]);
+            expect(ownerResult.applied, 'the red control must still complete its first tear-out commit').toBe(true);
             expect(pageErrors).toEqual([])
         }
     );


### PR DESCRIPTION
Resolves #15955

The original PR body over-attributed the cleared-body frame to candidate 2. Phase timing falsified that boundary: the minimum frame preceded candidate 2's projection by about 2.11 seconds because `executeTearOutStep()` returned before its projection refresh settled.

This corrected witness awaits that refresh, then binds the red control to the first tear-out's source projection. The production repair remains owned by #16153.

Related: #16153

Evidence: L3 on the current host — headed Playwright, consecutive CDP presented frames, and live Neural Link topology.

## Deltas from ticket

- Extracts the shared continuity assertion used by the five-beat journey.
- Makes `executeTearOutStep()` settle its projection before the next journey beat can begin.
- Rebinds the expected-red control to the first tear-out source projection.
- Makes the headed compositor requirement explicit: headless Chromium skips this witness instead of reporting an instrument failure.
- Keeps the production continuity repair out of this enumeration PR and routes it to #16153.

## Test Evidence

- Exact head: `3088764ced`.
- Headed red control: `2 passed`; baseline entropy `5.362489868987215`, minimum entropy `0.15755374068679046`, and `117` consecutive presented frames.
- GL probe: accelerated ANGLE/Metal; the launch profile carried no GPU-intent flag.
- Headless launch-contract check: `1 passed, 1 skipped`; the continuity witness exits as an intentional headed-only skip before compositor capture.
- After the tear-out executor awaited projection settlement, the separately isolated candidate-2 control remained above its baseline-relative floor. Candidate 2 is therefore excluded from this PR's defect claim.
- Full unit suite on the composed repair stack: `10,351 passed`, `5 skipped`, `0 failed`.

## Post-Merge Validation

- [ ] Run the first-tear-out red control once on merged `dev` and preserve its minimum-entropy attachment receipt.
- [ ] Flip the red-control direction to a positive continuity assertion when #16153 repairs the compositor-visible handoff.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fac4d-7844-7422-9486-7f73ccf308f5.
