### PR TITLE
fix(build): mirror stacked PR ticket guard locally (#16157)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -17,8 +17,10 @@ Before the first commit, declare §3.1's class (`capability`, `restoration`, or
 `zero-delta`) and run `npm run agent-preflight -- --change-class <class>
 --commit-subject "<subject>" [files...]`. This repair pass may align blocks. For
 final check-only validation, add `--no-fix`, `--pr-title "<title>"`, and, when
-available, `--pr-body <draft-body.md>`. The same class then gates both subjects.
-Calls without semantic inputs stay diagnostic-compatible; partial inputs fail.
+available after the final commit, `--pr-body <draft-body.md>`; use `--pr-base
+<ref>` when the PR target is not `origin/dev`. The same run locally rejects
+stacked commit tickets missing from `Resolves` / `Refs` / `Related`. The class
+still gates both subjects; calls without semantic inputs stay compatible.
 
 ### 1.1 The Substrate-Mutation Pre-Flight Gate
 

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -29,6 +29,8 @@ const
     RESOLVES_PATTERN              = /\bResolves:?\s+#\d+/i,
     NON_CLOSING_REFERENCE_PATTERN = /\b(Refs|Related):?\s+#\d+/i,
     FORBIDDEN_CLOSE_PATTERN       = /\b(Closes|Fixes):?\s+#\d+/i,
+    DECLARED_TICKET_PATTERN       = /\b(?:Resolves|Refs|Related):?\s+#(\d+)/gi,
+    COMMIT_TICKET_PATTERN         = /\(#(\d+)\)\s*$/,
     CONVENTIONAL_TYPE_PATTERN     = /^([a-z][a-z0-9-]*)(?:\([^()\r\n]+\))?!?:\s+\S/;
 
 export const CHANGE_CLASS_TO_TYPE = Object.freeze({
@@ -50,6 +52,7 @@ export function createProgram() {
         .option('--commit-subject <subject>', 'Validate the intended commit subject against --change-class.')
         .option('--pr-title <title>', 'Validate the intended PR title against --change-class.')
         .option('--pr-body <file>', 'Run local PR-body template lint against the given markdown file.')
+        .option('--pr-base <ref>', 'Compare stacked PR commit tickets against this intended base.', 'origin/dev')
         .option('--pr-draft', 'Validate --pr-body as a draft PR: Refs/Related may temporarily stand in for Resolves.')
         .option('--no-fix', 'Check-only mode: skip the check-block-alignment --fix repair pass.')
         .argument('[files...]', 'Optional file paths. When omitted, staged ACMR files are read from git.')
@@ -75,6 +78,7 @@ export function parseArgs(argv) {
         files        : program.args,
         fix          : options.fix,
         help         : false,
+        prBase       : options.prBase,
         prBody       : options.prBody || null,
         prDraft      : options.prDraft || false,
         prTitle      : options.prTitle || null
@@ -217,6 +221,85 @@ export function validatePrBody(body, {draft = false} = {}) {
         missingInvisible,
         missingVisible,
         valid: missingVisible.length === 0 && missingInvisible.length === 0
+    }
+}
+
+/**
+ * @summary Parses NUL-delimited `git log` output into PR commit receipts.
+ * @param {String} output
+ * @returns {Array<{sha: String, subject: String}>}
+ */
+export function parsePrCommitLog(output = '') {
+    const
+        tokens  = String(output).split('\0'),
+        commits = [];
+
+    for (let index = 0; index + 1 < tokens.length; index += 2) {
+        const sha = tokens[index];
+
+        if (sha) {
+            commits.push({sha, subject: tokens[index + 1] || ''})
+        }
+    }
+
+    return commits
+}
+
+/**
+ * @summary Reads the commits one PR branch carries relative to its intended base.
+ * @param {Object} options
+ * @param {String} options.base
+ * @param {String} options.cwd
+ * @param {Function} [options.execFileSyncImpl]
+ * @returns {Array<{sha: String, subject: String}>}
+ */
+export function getPrBranchCommits({base, cwd, execFileSyncImpl = execFileSync}) {
+    const output = execFileSyncImpl('git', [
+        'log',
+        '-z',
+        '--format=%H%x00%s',
+        '--reverse',
+        `${base}..HEAD`
+    ], {
+        cwd,
+        encoding: 'utf8',
+        stdio   : 'pipe'
+    });
+
+    return parsePrCommitLog(output)
+}
+
+/**
+ * @summary Mirrors hosted stacked-PR ticket declarations against local branch commits.
+ * @param {String} body
+ * @param {Array<{sha: String, subject: String}>} commits
+ * @returns {{declaredTickets: String[], foreignCommits: Object[], valid: Boolean}}
+ */
+export function validateStackedPrTickets(body, commits = []) {
+    const
+        declaredTickets = new Set(
+            [...body.matchAll(DECLARED_TICKET_PATTERN)].map(match => match[1])
+        ),
+        foreignCommits = [];
+
+    if (declaredTickets.size > 0) {
+        commits.forEach(({sha, subject}) => {
+            const ticket = subject.match(COMMIT_TICKET_PATTERN);
+
+            if (ticket && !declaredTickets.has(ticket[1])) {
+                foreignCommits.push({
+                    sha    : sha.slice(0, 10),
+                    subject: subject.slice(0, 72),
+                    ticket : ticket[1]
+                })
+            }
+        })
+    }
+
+    return {
+        declaredTickets: [...declaredTickets],
+        foreignCommits,
+        valid          : foreignCommits.length === 0
     }
 }
 
@@ -530,6 +613,41 @@ export function runAgentPreflight({
 
         if (result.valid) {
             writeLine(stdout, 'agent-preflight: PR body contains the required template anchors.');
+
+            try {
+                const
+                    body    = readFileSyncImpl(path.resolve(cwd, options.prBody), 'utf8'),
+                    commits = getPrBranchCommits({
+                        base: options.prBase,
+                        cwd,
+                        execFileSyncImpl
+                    }),
+                    stackResult = validateStackedPrTickets(body, commits);
+
+                if (stackResult.valid) {
+                    writeLine(
+                        stdout,
+                        `agent-preflight: stacked PR tickets match ${stackResult.declaredTickets.length} ` +
+                        `declared ticket(s) across ${commits.length} commit(s).`
+                    )
+                } else {
+                    failures.push('pr-body-stack');
+                    writeLine(
+                        stderr,
+                        `agent-preflight: stacked PR ticket declaration lint failed against ${options.prBase}.`
+                    );
+                    stackResult.foreignCommits.forEach(commit => writeLine(
+                        stderr,
+                        `  - \`${commit.sha}\` claims #${commit.ticket} — \`${commit.subject}\``
+                    ))
+                }
+            } catch (error) {
+                failures.push('pr-body-stack');
+                writeLine(
+                    stderr,
+                    `agent-preflight: could not inspect PR commits relative to ${options.prBase}: ${error.message}`
+                )
+            }
         } else {
             failures.push('pr-body');
             writeLine(stderr, 'agent-preflight: PR body template lint failed.');

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -33,6 +33,8 @@ const
     COMMIT_TICKET_PATTERN         = /\(#(\d+)\)\s*$/,
     CONVENTIONAL_TYPE_PATTERN     = /^([a-z][a-z0-9-]*)(?:\([^()\r\n]+\))?!?:\s+\S/;
 
+export {COMMIT_TICKET_PATTERN, DECLARED_TICKET_PATTERN};
+
 export const CHANGE_CLASS_TO_TYPE = Object.freeze({
     capability  : 'feat',
     restoration : 'fix',

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -1,7 +1,10 @@
 import {test, expect} from '@playwright/test';
+import {readFileSync} from 'node:fs';
 import path           from 'node:path';
 import {
+    COMMIT_TICKET_PATTERN,
     createProgram,
+    DECLARED_TICKET_PATTERN,
     detectContractLedgerDrift,
     extractLedgerSignatures,
     filterMjsFiles,
@@ -107,6 +110,16 @@ test.describe('agent-preflight utility', () => {
 
     test('accepts a PR body that mirrors the template anchors', () => {
         expect(validatePrBody(validBody).valid).toBe(true)
+    });
+
+    test('keeps the local stacked-ticket regexes byte-aligned with hosted lint', () => {
+        const hostedWorkflow = readFileSync(
+            path.join(process.cwd(), '.github/workflows/agent-pr-body-lint.yml'),
+            'utf8'
+        );
+
+        expect(hostedWorkflow).toContain(DECLARED_TICKET_PATTERN.toString());
+        expect(hostedWorkflow).toContain(COMMIT_TICKET_PATTERN.toString())
     });
 
     test('parses the NUL-delimited branch log used by the stacked-PR guard', () => {

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -6,11 +6,14 @@ import {
     extractLedgerSignatures,
     filterMjsFiles,
     findShippedSignature,
+    getPrBranchCommits,
     normalizeSignatureShape,
     parseArgs,
+    parsePrCommitLog,
     runAgentPreflight,
     validateChangeClass,
-    validatePrBody
+    validatePrBody,
+    validateStackedPrTickets
 }                     from '../../../../../../buildScripts/util/agent-preflight.mjs';
 
 const validBody = [
@@ -60,6 +63,7 @@ test.describe('agent-preflight utility', () => {
         expect(help).toContain('--commit-subject <subject>');
         expect(help).toContain('--pr-title <title>');
         expect(help).toContain('--pr-body <file>');
+        expect(help).toContain('--pr-base <ref>');
         expect(help).toContain('--pr-draft');
         expect(help).toContain('--no-fix');
         expect(help).toContain('Check-only mode')
@@ -71,6 +75,7 @@ test.describe('agent-preflight utility', () => {
             '--commit-subject', 'feat(build): add a guard (#16111)',
             '--pr-title', 'feat(build): add a guard (#16111)',
             '--pr-body', 'body.md',
+            '--pr-base', 'upstream/dev',
             '--pr-draft',
             '--no-fix',
             'src/a.mjs'
@@ -80,6 +85,7 @@ test.describe('agent-preflight utility', () => {
             files        : ['src/a.mjs'],
             fix          : false,
             help         : false,
+            prBase       : 'upstream/dev',
             prBody       : 'body.md',
             prDraft      : true,
             prTitle      : 'feat(build): add a guard (#16111)'
@@ -89,6 +95,7 @@ test.describe('agent-preflight utility', () => {
     test('uses Commander option validation for unknown flags and missing values', () => {
         expect(() => parseArgs(['--bogus'])).toThrow();
         expect(() => parseArgs(['--pr-body'])).toThrow();
+        expect(() => parseArgs(['--pr-base'])).toThrow();
         expect(() => parseArgs(['--change-class'])).toThrow();
         expect(() => parseArgs(['--commit-subject'])).toThrow();
         expect(() => parseArgs(['--pr-title'])).toThrow()
@@ -100,6 +107,86 @@ test.describe('agent-preflight utility', () => {
 
     test('accepts a PR body that mirrors the template anchors', () => {
         expect(validatePrBody(validBody).valid).toBe(true)
+    });
+
+    test('parses the NUL-delimited branch log used by the stacked-PR guard', () => {
+        expect(parsePrCommitLog(
+            'aaaaaaaaaa\0feat(build): base witness (#15955)\0' +
+            'bbbbbbbbbb\0fix(build): stacked repair (#16153)\0'
+        )).toEqual([
+            {sha: 'aaaaaaaaaa', subject: 'feat(build): base witness (#15955)'},
+            {sha: 'bbbbbbbbbb', subject: 'fix(build): stacked repair (#16153)'}
+        ])
+    });
+
+    test('reads PR branch commits relative to the explicit intended base', () => {
+        const calls = [];
+
+        expect(getPrBranchCommits({
+            base: 'origin/dev',
+            cwd : '/repo',
+            execFileSyncImpl(cmd, args, options) {
+                calls.push({args, cmd, options});
+                return 'aaaaaaaaaa\0fix(build): repair (#16157)\0'
+            }
+        })).toEqual([
+            {sha: 'aaaaaaaaaa', subject: 'fix(build): repair (#16157)'}
+        ]);
+        expect(calls[0].cmd).toBe('git');
+        expect(calls[0].args).toEqual([
+            'log',
+            '-z',
+            '--format=%H%x00%s',
+            '--reverse',
+            'origin/dev..HEAD'
+        ])
+    });
+
+    test('accepts a legitimate stack when every commit ticket is declared', () => {
+        const result = validateStackedPrTickets(
+            `${validBody}\nRelated: #15955`,
+            [
+                {sha: 'aaaaaaaaaaaa', subject: 'feat(build): base witness (#15955)'},
+                {sha: 'bbbbbbbbbbbb', subject: 'fix(build): stacked repair (#12345)'}
+            ]
+        );
+
+        expect(result.valid).toBe(true);
+        expect(result.declaredTickets).toEqual(['12345', '15955']);
+        expect(result.foreignCommits).toEqual([])
+    });
+
+    test('rejects inherited ticketed commits that the PR body does not declare', () => {
+        const result = validateStackedPrTickets(validBody, [
+            {sha: '046d3571cd1dbb5e', subject: 'feat(workstation): witness blackout (#15955)'},
+            {sha: '3088764ced065a23', subject: 'test(workstation): correct witness (#15955)'},
+            {sha: '4da73f690321dc1b', subject: 'fix(dashboard): retain topology (#12345)'}
+        ]);
+
+        expect(result.valid).toBe(false);
+        expect(result.foreignCommits).toEqual([
+            {
+                sha    : '046d3571cd',
+                subject: 'feat(workstation): witness blackout (#15955)',
+                ticket : '15955'
+            },
+            {
+                sha    : '3088764ced',
+                subject: 'test(workstation): correct witness (#15955)',
+                ticket : '15955'
+            }
+        ])
+    });
+
+    test('allows repeated declared tickets and leaves unticketed subjects to the commit gate', () => {
+        const result = validateStackedPrTickets(validBody, [
+            {sha: 'aaaaaaaaaaaa', subject: 'feat(build): first slice (#12345)'},
+            {sha: 'bbbbbbbbbbbb', subject: 'fix(build): second slice (#12345)'},
+            {sha: 'cccccccccccc', subject: 'chore(data): generated sync [skip ci]'}
+        ]);
+
+        expect(result.valid).toBe(true);
+        expect(result.foreignCommits).toEqual([])
     });
 
     test('accepts a draft PR body with a non-closing reference instead of Resolves', () => {
@@ -235,7 +322,67 @@ test.describe('agent-preflight utility', () => {
         expect(status).toBe(0);
         expect(stderr).toBe('');
         expect(stdout).toContain('agent-preflight: 0 .mjs files in scope; skipped source gates.');
-        expect(stdout).toContain('agent-preflight: PR body contains the required template anchors.')
+        expect(stdout).toContain('agent-preflight: PR body contains the required template anchors.');
+        expect(stdout).toContain('agent-preflight: stacked PR tickets match 1 declared ticket(s) across 0 commit(s).')
+    });
+
+    test('fails before PR creation when a stacked commit ticket is undeclared', () => {
+        let stdout = '';
+        let stderr = '';
+
+        const status = runAgentPreflight({
+            argv            : ['--pr-body', 'body.md'],
+            cwd             : '/repo',
+            execFileSyncImpl: (cmd, args) => {
+                if (cmd !== 'git' || args.includes('--name-only')) return '';
+
+                return [
+                    '046d3571cd1dbb5e', 'feat(workstation): witness blackout (#15955)',
+                    '3088764ced065a23', 'test(workstation): correct witness (#15955)',
+                    '4da73f690321dc1b', 'fix(dashboard): retain topology (#12345)',
+                    ''
+                ].join('\0')
+            },
+            existsSyncImpl  : () => true,
+            readFileSyncImpl: () => validBody,
+            stderr          : {write: value => { stderr += value }},
+            stdout          : {write: value => { stdout += value }}
+        });
+
+        expect(status).toBe(1);
+        expect(stdout).toContain('PR body contains the required template anchors');
+        expect(stderr).toContain('stacked PR ticket declaration lint failed against origin/dev');
+        expect(stderr).toContain('`046d3571cd` claims #15955');
+        expect(stderr).toContain('`3088764ced` claims #15955');
+        expect(stderr).toContain('1 gate(s) failed: pr-body-stack')
+    });
+
+    test('passes the same stack after the inherited ticket is declared', () => {
+        let stdout = '';
+        let stderr = '';
+
+        const status = runAgentPreflight({
+            argv            : ['--pr-body', 'body.md'],
+            cwd             : '/repo',
+            execFileSyncImpl: (cmd, args) => {
+                if (cmd !== 'git' || args.includes('--name-only')) return '';
+
+                return [
+                    '046d3571cd1dbb5e', 'feat(workstation): witness blackout (#15955)',
+                    '3088764ced065a23', 'test(workstation): correct witness (#15955)',
+                    '4da73f690321dc1b', 'fix(dashboard): retain topology (#12345)',
+                    ''
+                ].join('\0')
+            },
+            existsSyncImpl  : () => true,
+            readFileSyncImpl: () => `${validBody}\nRelated: #15955`,
+            stderr          : {write: value => { stderr += value }},
+            stdout          : {write: value => { stdout += value }}
+        });
+
+        expect(status).toBe(0);
+        expect(stderr).toBe('');
+        expect(stdout).toContain('stacked PR tickets match 2 declared ticket(s) across 3 commit(s)')
     });
 
     test('emits STALE_OVERLAY findings as a non-blocking local-dev warning (#14675)', () => {


### PR DESCRIPTION
Resolves #16157

Related: #15955

Local `agent-preflight --pr-body` previously validated only template anchors, while hosted `lint-pr-body` also inspected the PR commit list. PR #16156 therefore received a local “all requested gates passed” immediately before hosted lint rejected two inherited #15955 commits that the body had not declared.

This change mirrors the hosted stacked-ticket contract before PR creation by reading the local Git commit graph. Legitimate stacks remain valid when every inherited ticket is declared with `Resolves`, `Refs`, or `Related`.

Evidence: L2 — exact incident-shaped runner tests, focused unit coverage, local skill-manifest validation, and this PR body's own post-commit preflight.

## Deltas from ticket

- Adds `--pr-base <ref>` with deterministic default `origin/dev`.
- Reads `<base>..HEAD` through NUL-delimited `git log`; no shell parsing, network call, or existing PR is required.
- Mirrors hosted body declarations and trailing commit-ticket parsing.
- Fails locally with the exact offending short SHA, ticket, and subject.
- Preserves hosted behavior for repeated declared tickets and unticketed commit subjects.
- Adds focused pure-function and runner tests, including the exact #16156 repair shape.
- Rewrites the existing pull-request preflight paragraph to name the post-commit stack check.

## Contract Ledger

T3 matrix: https://github.com/neomjs/neo/issues/16157#issuecomment-5128791421

## Substrate Mutation Rationale

- **Surface:** `.agents/skills/pull-request/references/pull-request-workflow.md`; the `SKILL.md` router and manifest are unchanged.
- **Load effect:** conditional pull-request payload only, not turn-loaded global memory. The edit rewrites the existing always-relevant preflight paragraph; it adds no section or pointer hop.
- **Disposition:** `rewrite`.
- **Slot rule:** trigger frequency = every PR handoff; failure severity = guaranteed avoidable CI red/correction cycle; enforceability = mechanical in `agent-preflight`.
- **Byte effect:** `21,572` → `21,719` bytes (`+147`).
- **Future-decay mitigation:** the CLI help and 44-test focused suite carry the executable contract; a parity test binds both ticket regexes to hosted lint, and the workflow keeps only the invocation boundary.
- **Retirement trigger:** if intended-base resolution becomes fully automatic, remove the `--pr-base` clause from the workflow paragraph.

## Test Evidence

- `npx playwright test test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs -c test/playwright/playwright.config.unit.mjs --workers=1 --retries=0` → `44 passed`.
- Exact #16156-shaped undeclared stack → local failure listing `046d3571cd (#15955)` and `3088764ced (#15955)`.
- Same stack plus `Related: #15955` → local pass across three commits.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → OK.
- Staged agent preflight and pre-commit hooks → green.
- `git diff --check` → clean.

## Post-Merge Validation

- [ ] Run the merged helper against a deliberately stacked branch with one undeclared inherited ticket.
- [ ] Confirm hosted `lint-pr-body` and local preflight produce the same offending ticket set.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fac4d-7844-7422-9486-7f73ccf308f5.
