### PR TITLE
fix(testing): remove no-op presenting GL probe

### DIFF
--- a/test/playwright/e2e/utils/gpuIntent.mjs
+++ b/test/playwright/e2e/utils/gpuIntent.mjs
@@ -134,3 +134,18 @@ export function activeLaunchArgs() {
 export function claimsGpuAcceleration(args = PRESENTING_LAUNCH_ARGS) {
     return args.some(arg => GPU_INTENT_ARGS.includes(arg))
 }
+
+/**
+ * @summary Whether the active E2E browser contract requires a separate live-GL effect probe.
+ *
+ * A presenting run claims no GPU acceleration, so launching a second branded-Chrome owner merely
+ * to report "nothing demanded" adds a same-bundle application-registration boundary without
+ * protecting a claim. Engine runs retain the probe because their GPU-intent flags make live GL a
+ * measured prerequisite rather than an optional diagnostic.
+ *
+ * @param {String[]} [args=activeLaunchArgs()]
+ * @returns {Boolean}
+ */
+export function requiresGlProbe(args = activeLaunchArgs()) {
+    return claimsGpuAcceleration(args)
+}

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -2,7 +2,7 @@ import './configTemplateResolver.mjs';
 
 import {defineConfig, devices} from '@playwright/test';
 import {resolveFreePortSync}   from './resolveFreePort.mjs';
-import {activeLaunchArgs}      from './e2e/utils/gpuIntent.mjs';
+import {activeLaunchArgs, requiresGlProbe} from './e2e/utils/gpuIntent.mjs';
 
 // Per-process by default: this suite renders ITS OWN checkout (reuseExistingServer:false below), so a
 // fixed default would silently adopt a foreign dev-server squatting on 8080 — that server serves the
@@ -12,6 +12,21 @@ const PORT = resolveFreePortSync(process.env.NEO_E2E_PORT);
 // and resolveFreePortSync returns a FRESH port per call — without pinning, the webServer and a worker's
 // baseURL land on different ports (ERR_CONNECTION_REFUSED). Children inherit this; a real pin is a no-op.
 process.env.NEO_E2E_PORT = String(PORT);
+
+const
+    launchArgs     = activeLaunchArgs(),
+    needsGlProbe   = requiresGlProbe(launchArgs),
+    browserProject = {
+        name: 'chromium',
+        use : {
+            channel: 'chrome', // Use local Google Chrome instead of Playwright's Chromium binary
+            // Declared once in e2e/utils/gpuIntent.mjs so the boot probe reads the same list this
+            // launches with. A second copy here would drift, and drift between two statements of one
+            // fact is how a dead GL flag stayed invisible for five months. The mode selection
+            // (presenting default vs explicit engine profile) lives there for the same reason.
+            launchOptions: {args: launchArgs}
+        }
+    };
 
 export default defineConfig({
     testDir      : './e2e',
@@ -41,23 +56,17 @@ export default defineConfig({
         reuseExistingServer: false
     },
 
-    projects: [{
+    // A presenting run makes no GPU claim, so its plan contains one branded-Chrome owner. The
+    // explicit engine profile keeps the separate live-GL gate and its dependency ordering.
+    projects: needsGlProbe ? [{
         // Boot gate: observes that the GPU-intent flags below actually resolve to hardware
         // GL before a single benchmark attributes a number to acceleration it may not have. Launches
         // with the SAME args as the suite — probing a different browser would prove nothing.
         name     : 'gl-probe',
         testMatch: /gl\.setup\.mjs$/,
-        use      : {channel: 'chrome', launchOptions: {args: activeLaunchArgs()}}
+        use      : {channel: 'chrome', launchOptions: {args: launchArgs}}
     }, {
-        name        : 'chromium',
-        dependencies: ['gl-probe'],
-        use         : {
-            channel      : 'chrome', // Use local Google Chrome instead of Playwright's Chromium binary
-            // Declared once in e2e/utils/gpuIntent.mjs so the boot probe reads the same list this
-            // launches with. A second copy here would drift, and drift between two statements of one
-            // fact is how a dead GL flag stayed invisible for five months. The mode selection
-            // (presenting default vs explicit engine profile) lives there for the same reason.
-            launchOptions: {args: activeLaunchArgs()}
-        }
-    }]
+        ...browserProject,
+        dependencies: ['gl-probe']
+    }] : [browserProject]
 });

--- a/test/playwright/unit/e2e/glState.spec.mjs
+++ b/test/playwright/unit/e2e/glState.spec.mjs
@@ -6,7 +6,8 @@ import {
     GPU_INTENT_ARGS,
     isEngineProfile,
     isFilmTake,
-    PRESENTING_LAUNCH_ARGS
+    PRESENTING_LAUNCH_ARGS,
+    requiresGlProbe
 }                                                from '../../e2e/utils/gpuIntent.mjs';
 import {readGlState, SOFTWARE_RENDERER_MARKERS}   from '../../e2e/utils/glState.mjs';
 
@@ -128,28 +129,34 @@ test.describe('e2e/utils/glState', () => {
             expect(isEngineProfile()).toBe(false);
             expect(isFilmTake()).toBe(false);
             expect(activeLaunchArgs()).toBe(PRESENTING_LAUNCH_ARGS);
+            expect(requiresGlProbe()).toBe(false);
 
             process.env.NEO_E2E_ENGINE_PROFILE = '0';
             expect(isEngineProfile()).toBe(false);
             expect(activeLaunchArgs()).toBe(PRESENTING_LAUNCH_ARGS);
+            expect(requiresGlProbe()).toBe(false);
 
             process.env.NEO_E2E_ENGINE_PROFILE = 'false';
             expect(isEngineProfile()).toBe(false);
             expect(activeLaunchArgs()).toBe(PRESENTING_LAUNCH_ARGS);
+            expect(requiresGlProbe()).toBe(false);
 
             process.env.NEO_E2E_ENGINE_PROFILE = 'engine';
             expect(isEngineProfile()).toBe(false);
             expect(activeLaunchArgs()).toBe(PRESENTING_LAUNCH_ARGS);
+            expect(requiresGlProbe()).toBe(false);
 
             delete process.env.NEO_E2E_ENGINE_PROFILE;
             process.env.NEO_FILM_TAKE = '1';
             expect(isFilmTake()).toBe(true);
             expect(activeLaunchArgs()).toBe(PRESENTING_LAUNCH_ARGS);
+            expect(requiresGlProbe()).toBe(false);
 
             delete process.env.NEO_FILM_TAKE;
             process.env.NEO_E2E_ENGINE_PROFILE = '1';
             expect(isEngineProfile()).toBe(true);
             expect(activeLaunchArgs()).toBe(ENGINE_LAUNCH_ARGS);
+            expect(requiresGlProbe()).toBe(true);
             expect(ENGINE_LAUNCH_ARGS).toContain('--disable-frame-rate-limit');
             expect(PRESENTING_LAUNCH_ARGS).not.toContain('--disable-frame-rate-limit');
 
@@ -168,6 +175,56 @@ test.describe('e2e/utils/glState', () => {
                 delete process.env.NEO_FILM_TAKE
             } else {
                 process.env.NEO_FILM_TAKE = previousFilm
+            }
+        }
+    });
+
+    test('#16151 presenting config has one Chrome owner; engine config retains the GL probe', async () => {
+        const
+            previousEngine = process.env.NEO_E2E_ENGINE_PROFILE,
+            previousFilm   = process.env.NEO_FILM_TAKE,
+            previousPort   = process.env.NEO_E2E_PORT;
+
+        try {
+            delete process.env.NEO_E2E_ENGINE_PROFILE;
+            process.env.NEO_FILM_TAKE = '1';
+
+            const presentingConfig = (
+                await import(`../../playwright.config.e2e.mjs?profile=presenting-${Date.now()}`)
+            ).default;
+
+            expect(presentingConfig.projects.map(project => project.name)).toEqual(['chromium']);
+            expect(presentingConfig.projects[0].dependencies).toBeUndefined();
+            expect(presentingConfig.projects[0].use.launchOptions.args).toBe(PRESENTING_LAUNCH_ARGS);
+
+            delete process.env.NEO_FILM_TAKE;
+            process.env.NEO_E2E_ENGINE_PROFILE = '1';
+
+            const engineConfig = (
+                await import(`../../playwright.config.e2e.mjs?profile=engine-${Date.now()}`)
+            ).default;
+
+            expect(engineConfig.projects.map(project => project.name)).toEqual(['gl-probe', 'chromium']);
+            expect(engineConfig.projects[1].dependencies).toEqual(['gl-probe']);
+            expect(engineConfig.projects[0].use.launchOptions.args).toBe(ENGINE_LAUNCH_ARGS);
+            expect(engineConfig.projects[1].use.launchOptions.args).toBe(ENGINE_LAUNCH_ARGS)
+        } finally {
+            if (previousEngine === undefined) {
+                delete process.env.NEO_E2E_ENGINE_PROFILE
+            } else {
+                process.env.NEO_E2E_ENGINE_PROFILE = previousEngine
+            }
+
+            if (previousFilm === undefined) {
+                delete process.env.NEO_FILM_TAKE
+            } else {
+                process.env.NEO_FILM_TAKE = previousFilm
+            }
+
+            if (previousPort === undefined) {
+                delete process.env.NEO_E2E_PORT
+            } else {
+                process.env.NEO_E2E_PORT = previousPort
             }
         }
     });


### PR DESCRIPTION
Resolves #16159

Related: #16151
Related: #16128
Related: #16150
Related: #15664

The macOS crash receipt on #16151 attributes the latest `_RegisterApplication` / `TransformProcessType` `SIGABRT` to the default run's separate `gl-probe` Chrome owner. That presenting profile makes no GPU-acceleration claim, yet the probe still launched another branded-Chrome lifecycle only to report "nothing demanded."

This patch makes the Playwright project graph proportional to the active launch contract: presenting/default and film runs contain one `chromium` owner; the explicit engine profile retains `gl-probe → chromium` because its GPU-intent flags still require a live effect gate.

Evidence: L3 on the current macOS host — direct config-topology units, Playwright project-plan receipts, and a populated headed Workstation lifecycle with a before/after native crash-report census.

## Deltas from ticket

- Removes the separate `gl-probe` project entirely from presenting/default project plans.
- Retains the probe and dependency ordering for `NEO_E2E_ENGINE_PROFILE=1`.
- Derives probe admission from the same active launch arguments whose GPU claim the probe enforces.
- Adds an import-level config test so the actual project graph cannot drift from the decision helper.
- Adds no sleeps, process-name cleanup, crash-dialog suppression, or changes to operator Chrome owners.
- Leaves #16151 open for the concurrent-launch matrix and pre-transport early-exit provenance work.

## Test Evidence

- `npx playwright test --config=test/playwright/playwright.config.unit.mjs test/playwright/unit/e2e/glState.spec.mjs` → `9 passed`.
- Pre-fix `NEO_FILM_TAKE=1 ... --project=chromium --list` included `[gl-probe]`.
- Exact-head presenting plan with the same `E2E boot` filter → `0` probe tests.
- Exact-head engine plan → one `[gl-probe]` test with `chromium` depending on it.
- Exact-head populated headed Workstation containment witness → `1 passed`, reporter confirms `1 browsers`.
- Native Google Chrome diagnostic reports: `21 → 21`; no new crash receipt.
- Playwright-owned Chrome processes: none retained after the bounded witness.
- Pre-commit parse, whitespace, shorthand, JSDoc-type, ticket-archaeology, and block-alignment hooks → green.
- `git diff --check` → clean.

## Post-Merge Validation

- [ ] Repeat a bounded batch of merged-`dev` presenting lifecycles and retain the crash-report delta.
- [ ] Run the explicit engine profile on a low-pressure seat and confirm its live-GL gate remains fail-loud.
- [ ] Continue #16151 with the concurrent same-bundle and pre-transport early-exit provenance cells.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fac4d-7844-7422-9486-7f73ccf308f5.
