### PR TITLE
fix(testing): retain rejected Chrome launch exits (#16161)

### DIFF
--- a/test/playwright/e2e/custom-reporter.js
+++ b/test/playwright/e2e/custom-reporter.js
@@ -2,26 +2,18 @@ import fs from 'fs-extra';
 import os from 'os';
 import { execSync } from 'child_process';
 import path from 'path';
-import {isEngineProfile, isFilmTake} from './utils/gpuIntent.mjs';
+import {isEngineProfile} from './utils/gpuIntent.mjs';
 
 const
   ANSI_ESCAPE_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/g,
   PROCESS_EXIT_PATTERN = /\[pid=(\d+)]\s+<process did exit: exitCode=([^,>]+), signal=([^>]+)>/;
 
 /**
- * @summary Resolves the human-readable Neo launch profile without duplicating launch-argument policy.
- * @returns {'presenting'|'film'|'engine'|'invalid-film-engine'}
+ * @summary Resolves the Neo browser launch profile without conflating film run mode with launch policy.
+ * @returns {'presenting'|'engine'}
  */
 export function resolveE2eProfileName() {
-  const
-    engine = isEngineProfile(),
-    film   = isFilmTake();
-
-  if (engine && film) return 'invalid-film-engine';
-  if (engine) return 'engine';
-  if (film) return 'film';
-
-  return 'presenting'
+  return isEngineProfile() ? 'engine' : 'presenting'
 }
 
 /**
@@ -61,7 +53,7 @@ export function classifyBrowserLaunchExit(error, {
 
   // The process-exit grammar also appears during normal browser teardown. Only a rejected
   // BrowserType launch proves that Playwright never yielded a usable Browser fixture.
-  if (!/\bbrowserType\.launch(?:PersistentContext)?:/.test(text) || !match) return null;
+  if (!/\bbrowserType\.launch:/.test(text) || !match) return null;
 
   const
     exitValue = match[2].trim(),

--- a/test/playwright/e2e/custom-reporter.js
+++ b/test/playwright/e2e/custom-reporter.js
@@ -2,28 +2,129 @@ import fs from 'fs-extra';
 import os from 'os';
 import { execSync } from 'child_process';
 import path from 'path';
+import {isEngineProfile, isFilmTake} from './utils/gpuIntent.mjs';
 
-class BenchmarkSystemReporter {
-  constructor(options) {
+const
+  ANSI_ESCAPE_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/g,
+  PROCESS_EXIT_PATTERN = /\[pid=(\d+)]\s+<process did exit: exitCode=([^,>]+), signal=([^>]+)>/;
+
+/**
+ * @summary Resolves the human-readable Neo launch profile without duplicating launch-argument policy.
+ * @returns {'presenting'|'film'|'engine'|'invalid-film-engine'}
+ */
+export function resolveE2eProfileName() {
+  const
+    engine = isEngineProfile(),
+    film   = isFilmTake();
+
+  if (engine && film) return 'invalid-film-engine';
+  if (engine) return 'engine';
+  if (film) return 'film';
+
+  return 'presenting'
+}
+
+/**
+ * @summary Reads optional host telemetry without allowing a restricted platform call to erase the run receipt.
+ * @param {Function} read
+ * @param {*} [fallback=null]
+ * @returns {*}
+ */
+export function readOptionalSystemFact(read, fallback=null) {
+  try {
+    return read()
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * @summary Extracts the bounded launch-process receipt Playwright already carries in a rejected browser launch.
+ * @param {Error|Object|String} error
+ * @param {Object} [context]
+ * @param {String|null} [context.channel=null]
+ * @param {String|null} [context.profile=resolveE2eProfileName()]
+ * @param {String|null} [context.project=null]
+ * @returns {Object|null}
+ */
+export function classifyBrowserLaunchExit(error, {
+  channel = null,
+  profile = resolveE2eProfileName(),
+  project = null
+} = {}) {
+  const
+    rawText = typeof error === 'string'
+      ? error
+      : [error?.message, error?.stack, error?.value].filter(Boolean).join('\n'),
+    text    = String(rawText).replace(ANSI_ESCAPE_PATTERN, ''),
+    match   = text.match(PROCESS_EXIT_PATTERN);
+
+  // The process-exit grammar also appears during normal browser teardown. Only a rejected
+  // BrowserType launch proves that Playwright never yielded a usable Browser fixture.
+  if (!/\bbrowserType\.launch(?:PersistentContext)?:/.test(text) || !match) return null;
+
+  const
+    exitValue = match[2].trim(),
+    signal    = match[3].trim(),
+    exitCode  = exitValue === 'null'
+      ? null
+      : /^-?\d+$/.test(exitValue) ? Number(exitValue) : exitValue,
+    exitSignal = signal === 'null' ? null : signal;
+
+  return {
+    classification          : 'browser-launch-process-exit',
+    project,
+    channel,
+    profile,
+    processId               : Number(match[1]),
+    exitCode,
+    signal                  : exitSignal,
+    abnormal                : exitCode !== 0 || exitSignal !== null,
+    browserObjectEstablished: false,
+    // Playwright may construct a pipe before connectToTransport() rejects. Reporter callbacks do
+    // not expose that boundary, so a Boolean here would manufacture certainty.
+    transportState          : 'not-observable'
+  }
+}
+
+/**
+ * @summary Retains benchmark host facts and bounded browser-launch lifecycle evidence for one E2E run.
+ */
+export default class BenchmarkSystemReporter {
+  /**
+   * @summary Initializes one reporter-owned receipt without taking ownership of Playwright browsers.
+   * @param {Object} [options]
+   * @param {String} [options.outputFile='benchmark-system-info.json']
+   */
+  constructor(options={}) {
       this.outputFile = options?.outputFile || 'benchmark-system-info.json';
+      this.receipt = null;
+      this.launchExits = new Map();
   }
 
+  /**
+   * @summary Opens the retained run receipt before test execution begins.
+   * @param {Object} config
+   * @param {Object} suite
+   * @returns {void}
+   */
   onBegin(config, suite) {
     const systemInfo = this.getSystemInfo();
 
-    const fullSystemInfo = {
+    this.receipt = {
       ...systemInfo,
       benchmarkRun: {
         timestamp: new Date().toISOString(),
         playwrightProjects: config.projects?.map(p => p.name) || [],
         totalTests: suite.allTests().length
+      },
+      browserLifecycle: {
+        profile: resolveE2eProfileName(),
+        launchExits: [...this.launchExits.values()]
       }
     };
 
-    const outputDir = path.dirname(this.outputFile);
-    fs.ensureDirSync(outputDir);
-
-    fs.writeJsonSync(this.outputFile, fullSystemInfo, { spaces: 2 });
+    this.flushReceipt();
 
     console.log('');
     console.log('='.repeat(50));
@@ -39,20 +140,137 @@ class BenchmarkSystemReporter {
     console.log('');
   }
 
-  getSystemInfo() {
-    let osVersion = os.release();
-    let cpuModel = 'Unknown';
-    let cpuSpeed = 'Unknown';
+  /**
+   * @summary Persists the bounded run receipt immediately so a later runner failure cannot erase the incident.
+   * @returns {void}
+   */
+  flushReceipt() {
+    if (!this.receipt) return;
 
-    try {
-      if (process.platform === 'darwin') {
-        osVersion = execSync('sw_vers -productVersion', { encoding: 'utf8' }).trim();
-        cpuModel = execSync('sysctl -n machdep.cpu.brand_string', { encoding: 'utf8' }).trim();
-        cpuSpeed = execSync('sysctl -n hw.cpufrequency_max', { encoding: 'utf8' }).trim();
-        cpuSpeed = cpuSpeed ? (parseInt(cpuSpeed) / 1000000000).toFixed(1) : 'Unknown';
+    fs.ensureDirSync(path.dirname(this.outputFile));
+    fs.writeJsonSync(this.outputFile, this.receipt, { spaces: 2 })
+  }
+
+  /**
+   * @summary Deduplicates one Playwright launch exit across reporter error and test-result delivery.
+   * @param {Error|Object|String} error
+   * @param {Object} [context]
+   * @param {String|null} [context.channel=null]
+   * @param {String} [context.observedVia='reporter-error']
+   * @param {String|null} [context.project=null]
+   * @returns {Object|null}
+   */
+  captureBrowserLaunchExit(error, {
+    channel = null,
+    observedVia = 'reporter-error',
+    project = null
+  } = {}) {
+    const incident = classifyBrowserLaunchExit(error, {channel, project});
+
+    if (!incident) return null;
+
+    const
+      key      = [incident.processId, incident.exitCode, incident.signal].join(':'),
+      existing = this.launchExits.get(key);
+
+    if (existing) {
+      if (!existing.observedVia.includes(observedVia)) existing.observedVia.push(observedVia);
+      if (!existing.project && project) existing.project = project;
+      if (!existing.channel && channel) existing.channel = channel;
+      this.flushReceipt();
+
+      return existing
+    }
+
+    const receipt = {
+      ...incident,
+      observedVia: [observedVia]
+    };
+
+    this.launchExits.set(key, receipt);
+
+    if (this.receipt) {
+      this.receipt.browserLifecycle.launchExits = [...this.launchExits.values()];
+      this.flushReceipt()
+    }
+
+    console.error(
+      `[browser-lifecycle] project=${project ?? 'unknown'} profile=${incident.profile} ` +
+      `pid=${incident.processId} exitCode=${incident.exitCode ?? 'null'} ` +
+      `signal=${incident.signal ?? 'null'} browserObjectEstablished=false ` +
+      'transportState=not-observable'
+    );
+
+    return receipt
+  }
+
+  /**
+   * @summary Captures browser-launch failures that occur outside an individual test result.
+   * @param {Object} error
+   * @param {Object} [workerInfo]
+   * @returns {void}
+   */
+  onError(error, workerInfo) {
+    const project = workerInfo?.project;
+
+    this.captureBrowserLaunchExit(error, {
+      channel    : project?.use?.channel ?? null,
+      observedVia: 'reporter-error',
+      project    : project?.name ?? null
+    })
+  }
+
+  /**
+   * @summary Captures fixture-bound launch failures with their exact project and retry identity.
+   * @param {Object} test
+   * @param {Object} result
+   * @returns {void}
+   */
+  onTestEnd(test, result) {
+    const project = test.parent?.project?.();
+
+    for (const error of result.errors || (result.error ? [result.error] : [])) {
+      this.captureBrowserLaunchExit(error, {
+        channel    : project?.use?.channel ?? null,
+        observedVia: 'test-result',
+        project    : project?.name ?? null
+      })
+    }
+  }
+
+  /**
+   * @summary Reads optional benchmark host facts while preserving fallbacks on restricted seats.
+   * @returns {Object}
+   */
+  getSystemInfo() {
+    let
+      osVersion = os.release(),
+      cpuModel  = 'Unknown',
+      cpuSpeed  = 'Unknown';
+
+    if (process.platform === 'darwin') {
+      const commandOptions = {
+        encoding: 'utf8',
+        stdio   : ['ignore', 'pipe', 'ignore']
+      };
+
+      osVersion = readOptionalSystemFact(
+        () => execSync('sw_vers -productVersion', commandOptions).trim(),
+        osVersion
+      );
+      cpuModel = readOptionalSystemFact(
+        () => execSync('sysctl -n machdep.cpu.brand_string', commandOptions).trim(),
+        cpuModel
+      );
+
+      const rawCpuSpeed = readOptionalSystemFact(
+        () => execSync('sysctl -n hw.cpufrequency_max', commandOptions).trim(),
+        null
+      );
+
+      if (rawCpuSpeed) {
+        cpuSpeed = (parseInt(rawCpuSpeed) / 1000000000).toFixed(1)
       }
-    } catch (e) {
-      // Fallback to basic info
     }
 
     return {
@@ -67,11 +285,15 @@ class BenchmarkSystemReporter {
       cpuSpeed,
       nodeVersion: process.version,
       timestamp: new Date().toISOString(),
-      loadAverage: os.loadavg(),
-      uptime: Math.round(os.uptime() / 3600),
+      loadAverage: readOptionalSystemFact(() => os.loadavg(), null),
+      uptime: readOptionalSystemFact(() => Math.round(os.uptime() / 3600), null),
     };
   }
 
+  /**
+   * @summary Maps the Node platform identifier to the reporter's display label.
+   * @returns {String}
+   */
   getOSName() {
     const platform = process.platform;
     switch (platform) {
@@ -82,13 +304,19 @@ class BenchmarkSystemReporter {
     }
   }
 
+  /**
+   * @summary Flushes the final receipt and prints the existing terminal benchmark summary.
+   * @param {Object} result
+   * @returns {void}
+   */
   onEnd(result) {
     const duration = result.duration || 0;
+
+    this.flushReceipt();
+
     console.log(`\n Benchmark completed in ${Math.round(duration / 1000)}s`);
     console.log(`✅ Passed: ${result.stats?.passed || 0}`);
     console.log(`❌ Failed: ${result.stats?.failed || 0}`);
     console.log(`⏭️  Skipped: ${result.stats?.skipped || 0}`);
   }
 }
-
-export default BenchmarkSystemReporter;

--- a/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
+++ b/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
@@ -1,0 +1,169 @@
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+import {expect, test} from '@playwright/test';
+import BenchmarkSystemReporter, {
+    classifyBrowserLaunchExit,
+    readOptionalSystemFact,
+    resolveE2eProfileName
+} from '../../e2e/custom-reporter.js';
+
+const launchExit = ({
+    exitCode = 'null',
+    pid = 4242,
+    prefix = 'Error: browserType.launch: Failed to launch the browser process.',
+    signal = 'SIGABRT'
+} = {}) => [
+    prefix,
+    'Browser logs:',
+    '',
+    `<launched> pid=${pid}`,
+    `[pid=${pid}] <process did exit: exitCode=${exitCode}, signal=${signal}>`
+].join('\n');
+
+/**
+ * @summary Coverage for the bounded E2E browser-launch lifecycle receipt.
+ *
+ * The reporter owns classification and retention only. Playwright still owns the browser and the
+ * failing launch already owns the test result. These units therefore use the exact public error-log
+ * grammar with fakes instead of creating another browser lifecycle merely to test diagnostics.
+ */
+test.describe('e2e/custom-reporter browser lifecycle', () => {
+    test('#16161 classifies SIGABRT without inventing transport state', () => {
+        expect(classifyBrowserLaunchExit(launchExit(), {
+            channel: 'chrome',
+            profile: 'presenting',
+            project: 'chromium'
+        })).toEqual({
+            classification          : 'browser-launch-process-exit',
+            project                 : 'chromium',
+            channel                 : 'chrome',
+            profile                 : 'presenting',
+            processId               : 4242,
+            exitCode                : null,
+            signal                  : 'SIGABRT',
+            abnormal                : true,
+            browserObjectEstablished: false,
+            transportState          : 'not-observable'
+        });
+
+        expect(classifyBrowserLaunchExit(launchExit({exitCode: '0', signal: 'null'}))).toMatchObject({
+            exitCode: 0,
+            signal  : null,
+            abnormal: false
+        })
+    });
+
+    test('#16161 requires launch ownership and strips ANSI before matching', () => {
+        expect(classifyBrowserLaunchExit(
+            '[pid=4242] <process did exit: exitCode=0, signal=null>'
+        )).toBeNull();
+
+        expect(classifyBrowserLaunchExit(
+            'Error: Target page, context or browser has been closed'
+        )).toBeNull();
+
+        const error = launchExit({
+            prefix: '\u001B[31mError: browserType.launch: Target page, context or browser has been closed\u001B[0m'
+        });
+
+        expect(classifyBrowserLaunchExit(error)).toMatchObject({
+            processId: 4242,
+            signal   : 'SIGABRT'
+        })
+    });
+
+    test('#16161 names the canonical presenting, film, and engine profiles', () => {
+        const
+            previousEngine = process.env.NEO_E2E_ENGINE_PROFILE,
+            previousFilm   = process.env.NEO_FILM_TAKE;
+
+        try {
+            delete process.env.NEO_E2E_ENGINE_PROFILE;
+            delete process.env.NEO_FILM_TAKE;
+            expect(resolveE2eProfileName()).toBe('presenting');
+
+            process.env.NEO_FILM_TAKE = '1';
+            expect(resolveE2eProfileName()).toBe('film');
+
+            delete process.env.NEO_FILM_TAKE;
+            process.env.NEO_E2E_ENGINE_PROFILE = '1';
+            expect(resolveE2eProfileName()).toBe('engine');
+
+            process.env.NEO_FILM_TAKE = '1';
+            expect(resolveE2eProfileName()).toBe('invalid-film-engine')
+        } finally {
+            if (previousEngine === undefined) {
+                delete process.env.NEO_E2E_ENGINE_PROFILE
+            } else {
+                process.env.NEO_E2E_ENGINE_PROFILE = previousEngine
+            }
+
+            if (previousFilm === undefined) {
+                delete process.env.NEO_FILM_TAKE
+            } else {
+                process.env.NEO_FILM_TAKE = previousFilm
+            }
+        }
+    });
+
+    test('#16161 optional host telemetry fails soft instead of erasing the receipt', () => {
+        expect(readOptionalSystemFact(() => {
+            const error = new Error('uv_uptime returned EPERM');
+            error.code = 'EPERM';
+            throw error
+        })).toBeNull();
+
+        expect(readOptionalSystemFact(() => {
+            throw new Error('restricted')
+        }, 'Unknown')).toBe('Unknown')
+    });
+
+    test('#16161 deduplicates reporter paths and persists no raw launch command', async () => {
+        const
+            directory  = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-browser-lifecycle-')),
+            outputFile = path.join(directory, 'benchmark-system-info.json'),
+            reporter   = new BenchmarkSystemReporter({outputFile}),
+            project    = {name: 'chromium', use: {channel: 'chrome'}},
+            error      = {
+                message: [
+                    launchExit(),
+                    '<launching> /Applications/Google Chrome.app --user-data-dir=/private/profile',
+                    'https://private.example.test secret-window-title'
+                ].join('\n')
+            };
+
+        try {
+            reporter.onBegin(
+                {projects: [project]},
+                {allTests: () => [{id: 'launch-test'}]}
+            );
+            reporter.onError(error, {project, workerIndex: 3});
+            reporter.onTestEnd(
+                {id: 'launch-test', parent: {project: () => project}},
+                {errors: [error], retry: 1, workerIndex: 3}
+            );
+
+            const
+                receipt = await fs.readJson(outputFile),
+                exits   = receipt.browserLifecycle.launchExits,
+                raw     = JSON.stringify(exits);
+
+            expect(exits).toHaveLength(1);
+            expect(exits[0]).toMatchObject({
+                project       : 'chromium',
+                channel       : 'chrome',
+                profile       : 'presenting',
+                processId     : 4242,
+                observedVia   : ['reporter-error', 'test-result'],
+                transportState: 'not-observable'
+            });
+            expect(raw).not.toContain('<launching>');
+            expect(raw).not.toContain('user-data-dir');
+            expect(raw).not.toContain('private.example.test');
+            expect(raw).not.toContain('secret-window-title')
+        } finally {
+            await fs.remove(directory)
+        }
+    })
+});

--- a/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
+++ b/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
@@ -30,6 +30,12 @@ const launchExit = ({
  * to test diagnostics.
  */
 test.describe('e2e/custom-reporter browser lifecycle', () => {
+    test('#16161 binds the internal launch-exit grammar to Playwright Core 1.61.1', async () => {
+        const manifest = await fs.readJson(path.resolve('node_modules/playwright-core/package.json'));
+
+        expect(manifest.version).toBe('1.61.1')
+    });
+
     test('#16161 classifies SIGABRT without inventing transport state', () => {
         expect(classifyBrowserLaunchExit(launchExit(), {
             channel: 'chrome',

--- a/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
+++ b/test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs
@@ -26,7 +26,8 @@ const launchExit = ({
  *
  * The reporter owns classification and retention only. Playwright still owns the browser and the
  * failing launch already owns the test result. These units therefore use the exact public error-log
- * grammar with fakes instead of creating another browser lifecycle merely to test diagnostics.
+ * version-pinned runner grammar with fakes instead of creating another browser lifecycle merely
+ * to test diagnostics.
  */
 test.describe('e2e/custom-reporter browser lifecycle', () => {
     test('#16161 classifies SIGABRT without inventing transport state', () => {
@@ -63,6 +64,10 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
             'Error: Target page, context or browser has been closed'
         )).toBeNull();
 
+        expect(classifyBrowserLaunchExit(launchExit({
+            prefix: 'Error: browserType.launchPersistentContext: Target page, context or browser has been closed'
+        }))).toBeNull();
+
         const error = launchExit({
             prefix: '\u001B[31mError: browserType.launch: Target page, context or browser has been closed\u001B[0m'
         });
@@ -73,7 +78,7 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
         })
     });
 
-    test('#16161 names the canonical presenting, film, and engine profiles', () => {
+    test('#16161 keeps film as a presenting run mode instead of inventing a third launch profile', () => {
         const
             previousEngine = process.env.NEO_E2E_ENGINE_PROFILE,
             previousFilm   = process.env.NEO_FILM_TAKE;
@@ -84,14 +89,11 @@ test.describe('e2e/custom-reporter browser lifecycle', () => {
             expect(resolveE2eProfileName()).toBe('presenting');
 
             process.env.NEO_FILM_TAKE = '1';
-            expect(resolveE2eProfileName()).toBe('film');
+            expect(resolveE2eProfileName()).toBe('presenting');
 
             delete process.env.NEO_FILM_TAKE;
             process.env.NEO_E2E_ENGINE_PROFILE = '1';
-            expect(resolveE2eProfileName()).toBe('engine');
-
-            process.env.NEO_FILM_TAKE = '1';
-            expect(resolveE2eProfileName()).toBe('invalid-film-engine')
+            expect(resolveE2eProfileName()).toBe('engine')
         } finally {
             if (previousEngine === undefined) {
                 delete process.env.NEO_E2E_ENGINE_PROFILE


### PR DESCRIPTION
Resolves #16161

The E2E reporter now turns Playwright's exact rejected-browser-launch process-exit shape into one immediate, privacy-bounded lifecycle receipt. The record binds the failure to its project and Neo launch profile, preserves exit code/signal without inference, explicitly leaves transport state unobserved, deduplicates the two reporter delivery paths, and lets optional host telemetry fail soft instead of erasing the receipt.

Related: #16151

Evidence: L3 (focused contract units plus a real Playwright runner invoking a controlled non-GUI executable that exits before yielding a `Browser`) → L3 required (all close-target ACs). No residuals.

## Deltas from ticket

None substantive. The implementation preserves the ticket's corrected boundary: a rejected `browserType.launch()` proves that no usable `Browser` object was yielded, while Playwright's internal transport state remains `not-observable`.

## Test Evidence

- E2E lifecycle reporter + current GL/profile contract: `npm run test-unit -- test/playwright/unit/e2e/browserLifecycleReporter.spec.mjs test/playwright/unit/e2e/glState.spec.mjs` — 14/14 passed.
- Dependency grammar guard: the default-unit spec asserts installed `playwright-core` `1.61.1`; any dependency drift now fails CI and forces the internal process-exit grammar to be reverified before the version assertion moves.
- Controlled non-GUI launch exit: `npx playwright test -c /private/tmp/neo-16161-falsifier/playwright.config.mjs` with `executablePath: /usr/bin/false` — exited 1 as required; no Chrome window launched; the JSON receipt recorded `project: controlled-exit`, `profile: presenting`, `exitCode: 1`, `signal: null`, `browserObjectEstablished: false`, and `transportState: not-observable`.
- Serialized privacy boundary: focused units prove duplicate collapse and exclude the raw launch command, user-data path, URLs, titles, and personal browser content.
- Optional-host fallback: focused units prove rejected uptime/platform probes do not prevent receipt creation; the restricted Codex host also exercised the unknown-CPU fallback without shell noise.
- Syntax and tree hygiene: `node --check test/playwright/e2e/custom-reporter.js` and `git diff --check origin/dev...HEAD` passed.
- Commit hook: whitespace, shorthand-property, JSDoc, ticket-archaeology, block-alignment, parse, AiConfig test-mutation, and derived-domain checks passed.

## Post-Merge Validation

- [x] None — every close-target AC is observable and verified before merge. Parent #16151 remains responsible for native macOS crash correlation, dialog behavior, and any deeper transport instrumentation.

## Evolution

Source inspection falsified the initial temptation to record `transportEstablished: false`: Playwright may construct a pipe before `connectToTransport()` rejects. A pre-review exact-head falsifier then caught two adjacent taxonomy errors: film is a run mode on the presenting profile, and `launchPersistentContext()` can create a `Browser` before later context initialization rejects. The implementation therefore exposes only the `presenting|engine` profile vocabulary, restricts `browserObjectEstablished: false` to ordinary `browserType.launch()`, records `transportState: not-observable`, and requires the version-pinned process-exit grammar.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex).

Origin Session ID: 019fac4d-7844-7422-9486-7f73ccf308f5
