### PR TITLE
fix(build): verify pre-push dev authority (#16163)

### DIFF
--- a/buildScripts/util/branchFreshness.mjs
+++ b/buildScripts/util/branchFreshness.mjs
@@ -20,3 +20,39 @@ export function detectStaleBranch({twoDotFiles, threeDotFiles, threshold = 5}) {
     const extraFiles = Math.max(0, twoDotFiles - threeDotFiles);
     return {stale: extraFiles > threshold, extraFiles};
 }
+
+/**
+ * @summary Decides whether a local origin/dev object is authoritative after its refresh fails.
+ * @param {Object}       args
+ * @param {Boolean}      args.fetchSucceeded Whether the ordinary origin/dev fetch completed.
+ * @param {String|null} [args.localSha=null]  Full local refs/remotes/origin/dev commit ID.
+ * @param {String|null} [args.remoteSha=null] Full remote refs/heads/dev commit ID.
+ * @returns {{usable: Boolean, status: String}}
+ */
+export function assessDevReferenceAuthority({
+    fetchSucceeded,
+    localSha = null,
+    remoteSha = null
+}) {
+    if (fetchSucceeded) {
+        return {usable: true, status: 'fetched'}
+    }
+
+    const fullObjectIdPattern = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+
+    if (!fullObjectIdPattern.test(localSha || '')) {
+        return {usable: false, status: 'local-unavailable'}
+    }
+
+    if (!remoteSha) {
+        return {usable: false, status: 'remote-unavailable'}
+    }
+
+    if (!fullObjectIdPattern.test(remoteSha)) {
+        return {usable: false, status: 'remote-malformed'}
+    }
+
+    return localSha.toLowerCase() === remoteSha.toLowerCase()
+        ? {usable: true, status: 'verified-local'}
+        : {usable: false, status: 'stale-local'}
+}

--- a/buildScripts/util/check-branch-discipline.mjs
+++ b/buildScripts/util/check-branch-discipline.mjs
@@ -1,8 +1,8 @@
-import { execSync }          from 'node:child_process';
-import process               from 'node:process';
-import path                  from 'node:path';
-import { fileURLToPath }     from 'node:url';
-import { detectStaleBranch } from './branchFreshness.mjs';
+import { execFileSync, execSync }                       from 'node:child_process';
+import process                                          from 'node:process';
+import path                                             from 'node:path';
+import { fileURLToPath }                                from 'node:url';
+import {assessDevReferenceAuthority, detectStaleBranch} from './branchFreshness.mjs';
 
 /**
  * Pre-push branch-discipline check (#11133). ticket-ref-ok: implementing ticket
@@ -84,12 +84,80 @@ if (branch === 'main' || branch === 'dev') {
     process.exit(0);
 }
 
-// Ensure we have a fresh view of origin/dev for the diff range.
+// Ensure we have an authoritative view of origin/dev for every range below. A failed fetch may
+// leave the remote-tracking ref stale even while the push remote remains reachable. In that case,
+// ls-remote is the non-mutating authority check: equality proves the local object is current;
+// anything else must block before this hook makes ancestry or diff claims. The explicit destination
+// also makes a successful fetch update origin/dev even when remote.origin.fetch is nonstandard.
+let fetchSucceeded = true;
+
 try {
-    execSync('git fetch origin dev --quiet', { cwd: gitRoot, encoding: 'utf-8' });
+    execFileSync('git', [
+        'fetch',
+        '--quiet',
+        'origin',
+        '+refs/heads/dev:refs/remotes/origin/dev'
+    ], {
+        cwd     : gitRoot,
+        encoding: 'utf-8',
+        stdio   : 'pipe'
+    })
 } catch (e) {
-    // Network failure is non-fatal — fall back to local origin/dev tip.
-    console.warn('\x1b[33mWarning: git fetch origin dev failed; using last-known local tip.\x1b[0m');
+    fetchSucceeded = false
+}
+
+let localDevSha  = null;
+let remoteDevSha = null;
+
+if (!fetchSucceeded) {
+    const readGit = (args) => {
+        try {
+            return execFileSync('git', args, {
+                cwd     : gitRoot,
+                encoding: 'utf-8',
+                stdio   : 'pipe'
+            }).trim()
+        } catch (e) {
+            return null
+        }
+    };
+
+    const remoteOutput = readGit(['ls-remote', '--exit-code', 'origin', 'refs/heads/dev']);
+
+    localDevSha  = readGit(['rev-parse', '--verify', 'refs/remotes/origin/dev^{commit}']);
+    remoteDevSha = remoteOutput?.split(/\s+/)[0] || null
+}
+
+const authority = assessDevReferenceAuthority({
+    fetchSucceeded,
+    localSha : localDevSha,
+    remoteSha: remoteDevSha
+});
+
+if (!authority.usable) {
+    console.error('\x1b[31mError: Could not establish an authoritative origin/dev for the pre-push checks.\x1b[0m');
+
+    if (authority.status === 'stale-local') {
+        console.error(`Local origin/dev:  ${localDevSha}`);
+        console.error(`Remote dev:        ${remoteDevSha}`);
+        console.error('The local ref is stale, so ancestry and branch-freshness results would be invalid.')
+    } else if (authority.status === 'local-unavailable') {
+        console.error('No full local refs/remotes/origin/dev commit ID is available.')
+    } else if (authority.status === 'remote-malformed') {
+        console.error(`Remote dev returned a malformed object ID: ${remoteDevSha}`)
+    } else {
+        console.error('The remote refs/heads/dev coordinate is unavailable.')
+    }
+
+    console.error('Run `git fetch origin dev` in a Git-authorized shell, rebase if needed, then retry the push.');
+    process.exit(1)
+}
+
+if (authority.status === 'verified-local') {
+    console.warn(
+        `\x1b[33mWarning: git fetch origin dev could not update local metadata; ` +
+        `verified local origin/dev matches remote dev at ${localDevSha}. Continuing.\x1b[0m`
+    )
 }
 
 // Collect commits between origin/dev and HEAD.
@@ -101,8 +169,8 @@ try {
         commitLines = output.split('\n');
     }
 } catch (e) {
-    // If origin/dev doesn't exist locally, skip the check entirely.
-    process.exit(0);
+    console.error('\x1b[31mError: Could not inspect the authoritative origin/dev range.\x1b[0m');
+    process.exit(1);
 }
 
 if (commitLines.length === 0) {
@@ -116,7 +184,7 @@ const CHORE_SYNC_RE = /^chore\(data\):.*(sync|pipeline)/i;
 const choreSyncCommits = [];
 for (const line of commitLines) {
     const [sha, _author, ...subjectParts] = line.split('\t');
-    const subject = subjectParts.join('\t');
+    const subject                         = subjectParts.join('\t');
     if (CHORE_SYNC_RE.test(subject)) {
         choreSyncCommits.push({ sha: sha.slice(0, 9), subject });
     }

--- a/buildScripts/util/check-branch-discipline.mjs
+++ b/buildScripts/util/check-branch-discipline.mjs
@@ -12,6 +12,11 @@ import {assessDevReferenceAuthority, detectStaleBranch} from './branchFreshness.
  * thousands of LOC where actual feature was 10-100 LOC, producing review-surface
  * signal-to-noise asymmetry + squash-merge git-history pollution.
  *
+ * **Runtime scope:** this is Neo's repository-local maintainer hook, installed by this
+ * checkout through `.husky/pre-push`. Its fixed `dev` coordinate is Neo's integration-line
+ * policy. It is not an Agent OS orchestrator task and is not invoked by cloud tenant-repo
+ * mirrors, which select their own configured ref (defaulting to the remote `HEAD`).
+ *
  * **What this hook checks** (on every `git push`):
  *
  * **Chore-sync commits on feature branches.** If `git log origin/dev..HEAD` contains

--- a/test/playwright/unit/ai/buildScripts/util/branchFreshness.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/branchFreshness.spec.mjs
@@ -1,5 +1,5 @@
-import { test, expect }      from '@playwright/test';
-import { detectStaleBranch } from '../../../../../../buildScripts/util/branchFreshness.mjs';
+import { test, expect }                                 from '@playwright/test';
+import {assessDevReferenceAuthority, detectStaleBranch} from '../../../../../../buildScripts/util/branchFreshness.mjs';
 
 test.describe('buildScripts/util/branchFreshness.detectStaleBranch (#13710)', () => {
     test('flags a behind branch whose two-dot diff carries many extra files (the #13708 revert-trap anchor)', () => {
@@ -21,4 +21,67 @@ test.describe('buildScripts/util/branchFreshness.detectStaleBranch (#13710)', ()
     test('clamps extraFiles to zero when three-dot exceeds two-dot', () => {
         expect(detectStaleBranch({ twoDotFiles: 2, threeDotFiles: 5 })).toEqual({ stale: false, extraFiles: 0 });
     });
+});
+
+test.describe('buildScripts/util/branchFreshness.assessDevReferenceAuthority (#16163)', () => {
+    const
+        localSha  = 'a'.repeat(40),
+        remoteSha = 'b'.repeat(40);
+
+    test('successful fetch owns the authority without a fallback coordinate', () => {
+        expect(assessDevReferenceAuthority({fetchSucceeded: true})).toEqual({
+            usable: true,
+            status: 'fetched'
+        })
+    });
+
+    test('equal full local and remote coordinates preserve a proven-current local object', () => {
+        expect(assessDevReferenceAuthority({
+            fetchSucceeded: false,
+            localSha,
+            remoteSha     : localSha.toUpperCase()
+        })).toEqual({
+            usable: true,
+            status: 'verified-local'
+        })
+    });
+
+    test('different local and remote coordinates fail closed as stale', () => {
+        expect(assessDevReferenceAuthority({
+            fetchSucceeded: false,
+            localSha,
+            remoteSha
+        })).toEqual({
+            usable: false,
+            status: 'stale-local'
+        })
+    });
+
+    test('missing local or remote coordinates remain distinguishable', () => {
+        expect(assessDevReferenceAuthority({
+            fetchSucceeded: false,
+            remoteSha
+        })).toEqual({
+            usable: false,
+            status: 'local-unavailable'
+        });
+        expect(assessDevReferenceAuthority({
+            fetchSucceeded: false,
+            localSha
+        })).toEqual({
+            usable: false,
+            status: 'remote-unavailable'
+        })
+    });
+
+    test('malformed remote output never reads as an unchanged branch', () => {
+        expect(assessDevReferenceAuthority({
+            fetchSucceeded: false,
+            localSha,
+            remoteSha     : 'c'.repeat(41)
+        })).toEqual({
+            usable: false,
+            status: 'remote-malformed'
+        })
+    })
 });

--- a/test/playwright/unit/ai/buildScripts/util/check-branch-discipline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-branch-discipline.spec.mjs
@@ -1,30 +1,31 @@
-import { test, expect }           from '@playwright/test';
-import { execSync, execFileSync } from 'node:child_process';
-import path                       from 'node:path';
-import fs                         from 'node:fs';
-import os                         from 'node:os';
-import { fileURLToPath }          from 'node:url';
+import { test, expect }                    from '@playwright/test';
+import {execFileSync, execSync, spawnSync} from 'node:child_process';
+import path                                from 'node:path';
+import fs                                  from 'node:fs';
+import os                                  from 'node:os';
+import { fileURLToPath }                   from 'node:url';
 
-const __filename  = fileURLToPath(import.meta.url);
-const __dirname   = path.dirname(__filename);
-const scriptPath  = path.resolve(__dirname, '../../../../../../buildScripts/util/check-branch-discipline.mjs');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptPath = path.resolve(__dirname, '../../../../../../buildScripts/util/check-branch-discipline.mjs');
 
 test.describe('check-branch-discipline.mjs (#11133)', () => {
     let tempDir;
+    let remoteDir;
     let testScriptPath;
 
     test.beforeEach(() => {
-        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-branch-discipline-test-'));
+        tempDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-branch-discipline-test-'));
+        remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-branch-discipline-remote-'));
+
+        execFileSync('git', ['init', '--bare', remoteDir], {stdio: 'ignore'});
         execSync('git init', { cwd: tempDir, stdio: 'ignore' });
         execSync('git config user.email "test@example.com"', { cwd: tempDir, stdio: 'ignore' });
         execSync('git config user.name "Test User"', { cwd: tempDir, stdio: 'ignore' });
         execSync('git checkout -b dev', { cwd: tempDir, stdio: 'ignore' });
         execSync('git commit --allow-empty -m "Init"', { cwd: tempDir, stdio: 'ignore' });
-
-        // Fake `origin/dev` via local ref (no actual remote needed; script's `git fetch`
-        // catch handles fetch failure non-fatally + uses `git log origin/dev..HEAD`).
-        const devSha = execSync('git rev-parse HEAD', { cwd: tempDir, encoding: 'utf-8' }).trim();
-        execSync(`git update-ref refs/remotes/origin/dev ${devSha}`, { cwd: tempDir, stdio: 'ignore' });
+        execFileSync('git', ['remote', 'add', 'origin', remoteDir], {cwd: tempDir, stdio: 'ignore'});
+        execFileSync('git', ['push', '-u', 'origin', 'dev'], {cwd: tempDir, stdio: 'ignore'});
 
         // Mirror the script into the tempDir so the path-root-equality check (`scriptRoot
         // === gitRoot`) passes inside the temp repo.
@@ -40,19 +41,27 @@ test.describe('check-branch-discipline.mjs (#11133)', () => {
 
     test.afterEach(() => {
         fs.rmSync(tempDir, { recursive: true, force: true });
+        fs.rmSync(remoteDir, { recursive: true, force: true });
     });
 
     const runScript = (cwd = tempDir) => {
-        try {
-            const output = execSync(`node ${testScriptPath}`, {
-                cwd,
-                encoding: 'utf-8',
-                stdio   : 'pipe'
-            });
-            return { status: 0, output };
-        } catch (error) {
-            return { status: error.status, output: error.stderr || error.stdout || '' };
+        const result = spawnSync(process.execPath, [testScriptPath], {
+            cwd,
+            encoding: 'utf-8',
+            stdio   : 'pipe'
+        });
+
+        return {
+            status: result.status,
+            output: `${result.stdout || ''}${result.stderr || ''}`
         }
+    };
+
+    const blockFetchHeadWrites = () => {
+        const fetchHead = path.join(tempDir, '.git', 'FETCH_HEAD');
+
+        fs.rmSync(fetchHead, {recursive: true, force: true});
+        fs.mkdirSync(fetchHead)
     };
 
     // Use execFileSync (no shell) — bypasses string-interpolation escape hazards
@@ -128,4 +137,124 @@ test.describe('check-branch-discipline.mjs (#11133)', () => {
         expect(result.status).toBe(1);
         expect(result.output).toContain('chore-sync commit');
     });
+
+    test('fetch failure continues only when local origin/dev equals the remote coordinate (#16163)', () => {
+        execSync('git checkout -b agent/0000-equal-fallback', {cwd: tempDir, stdio: 'ignore'});
+        featureCommit();
+        blockFetchHeadWrites();
+
+        const
+            localDevSha = execFileSync(
+                'git',
+                ['rev-parse', '--verify', 'refs/remotes/origin/dev'],
+                {cwd: tempDir, encoding: 'utf-8'}
+            ).trim(),
+            result      = runScript();
+
+        expect(result.status).toBe(0);
+        expect(result.output).toContain(`matches remote dev at ${localDevSha}`)
+    });
+
+    test('fetch failure blocks when local origin/dev is behind the remote coordinate (#16163)', () => {
+        const localDevSha = execFileSync(
+            'git',
+            ['rev-parse', '--verify', 'refs/remotes/origin/dev'],
+            {cwd: tempDir, encoding: 'utf-8'}
+        ).trim();
+
+        featureCommit('feat(test): advance remote dev');
+
+        const remoteDevSha = execFileSync(
+            'git',
+            ['rev-parse', 'HEAD'],
+            {cwd: tempDir, encoding: 'utf-8'}
+        ).trim();
+
+        execFileSync('git', ['push', 'origin', 'dev'], {cwd: tempDir, stdio: 'ignore'});
+        execFileSync('git', ['update-ref', 'refs/remotes/origin/dev', localDevSha], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        execFileSync('git', ['checkout', '-b', 'agent/0000-stale-fallback', localDevSha], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        featureCommit();
+        blockFetchHeadWrites();
+
+        const result = runScript();
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('local ref is stale');
+        expect(result.output).toContain(localDevSha);
+        expect(result.output).toContain(remoteDevSha)
+    });
+
+    test('successful fetch updates origin/dev despite a nonstandard configured refspec (#16163)', () => {
+        const localDevSha = execFileSync(
+            'git',
+            ['rev-parse', '--verify', 'refs/remotes/origin/dev'],
+            {cwd: tempDir, encoding: 'utf-8'}
+        ).trim();
+
+        featureCommit('feat(test): advance remote dev outside the feature branch');
+
+        const remoteDevSha = execFileSync(
+            'git',
+            ['rev-parse', 'HEAD'],
+            {cwd: tempDir, encoding: 'utf-8'}
+        ).trim();
+
+        execFileSync('git', ['push', 'origin', 'dev'], {cwd: tempDir, stdio: 'ignore'});
+        execFileSync('git', ['update-ref', 'refs/remotes/origin/dev', localDevSha], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        execFileSync('git', ['config', '--unset-all', 'remote.origin.fetch'], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        execFileSync('git', [
+            'config',
+            '--add',
+            'remote.origin.fetch',
+            '+refs/heads/main:refs/remotes/origin/main'
+        ], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        execFileSync('git', ['checkout', '-b', 'agent/0000-explicit-refspec', localDevSha], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        featureCommit();
+
+        const result          = runScript();
+        const refreshedDevSha = execFileSync(
+            'git',
+            ['rev-parse', '--verify', 'refs/remotes/origin/dev'],
+            {cwd: tempDir, encoding: 'utf-8'}
+        ).trim();
+
+        expect(result.status).toBe(0);
+        expect(refreshedDevSha).toBe(remoteDevSha)
+    });
+
+    test('fetch failure blocks when the remote dev coordinate is unavailable (#16163)', () => {
+        execFileSync('git', ['checkout', '-b', 'agent/0000-unavailable-remote'], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+        featureCommit();
+        execFileSync('git', ['remote', 'set-url', 'origin', path.join(remoteDir, 'missing')], {
+            cwd  : tempDir,
+            stdio: 'ignore'
+        });
+
+        const result = runScript();
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('remote refs/heads/dev coordinate is unavailable');
+        expect(result.output).not.toContain('local ref is stale')
+    })
 });


### PR DESCRIPTION
Resolves #16163

The pre-push branch-discipline guard now establishes an authoritative `origin/dev` before it makes ancestry or diff claims. Its ordinary fetch names the remote-tracking destination explicitly; if Git cannot update local metadata, a non-mutating `ls-remote` comparison permits the existing checks only when the full local and remote object IDs match. Stale, missing, unavailable, and malformed coordinates fail closed with a concrete recovery path.

Scope boundary: this is Neo’s repository-local maintainer hook, installed by this checkout through `.husky/pre-push`; fixed `dev` is Neo’s integration-line policy. It is not an Agent OS orchestrator task and is not invoked by cloud tenant-repo mirrors, whose separate `branchRef` contract defaults to remote `HEAD`.

Successor to #13710 / PR #13713.

Evidence: L3 (focused pure units, script-level real-Git repositories, and an exact-head restricted-seat invocation) → L3 required (all close-target ACs). No residuals.

## Deltas from ticket

None substantive. A pre-commit falsifier strengthened the successful-fetch path: `git fetch origin dev` can exit zero without updating `refs/remotes/origin/dev` when `remote.origin.fetch` is nonstandard. The final command therefore carries the explicit forced destination refspec instead of treating exit zero alone as authority.

## Test Evidence

- Focused authority and hook suite: `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/branchFreshness.spec.mjs test/playwright/unit/ai/buildScripts/util/check-branch-discipline.spec.mjs` — 24/24 passed.
- Successful-fetch falsifier: a real temporary repository with `remote.origin.fetch` redirected away from `dev` proves the hook still advances `refs/remotes/origin/dev` to the remote coordinate.
- Degraded-mode witnesses: real temporary repositories prove equal full coordinates continue, a stale local coordinate blocks with both SHAs, and an unavailable remote blocks with its own reason.
- Exact-head restricted-seat invocation: the ordinary fetch could not update local Git metadata; the fallback verified local and remote `dev` both at `a75aabef808b6b132380476c3f36a528a1077553` and exited zero.
- `node --check` passed for both production modules; block-alignment and `git diff --check origin/dev...HEAD` passed.
- Commit hooks: whitespace, shorthand-property, JSDoc, ticket-archaeology, block-alignment, parse, AiConfig test-mutation, and derived-domain checks passed.

## Post-Merge Validation

- [x] None — the pure classifier, successful explicit fetch, equal degraded fallback, stale mismatch, and unavailable-remote branches are all observable before merge.

## Evolution

An author challenge first separated the repository-local hook from the One Reality container topology: parity moves the Brain services into containers while each seat harness remains in its checkout and points at those services over HTTP. Cloud tenant mirrors have their own configurable-ref acquisition path and never invoke this hook. The JSDoc now records that boundary. The measured restricted-seat failure initially pointed only at the fetch-error fallback. A tactical falsifier then found the symmetric zero-exit hole: Git can refresh `FETCH_HEAD` while leaving `origin/dev` stale under a nonstandard configured refspec. The final shape binds success to an explicit destination update, routes both successful and degraded acquisition through one authority predicate, and retains `ls-remote` solely as the non-mutating fallback proof. The first commit attempt also exercised the archaeology gate, which correctly rejected a decay-prone ticket citation from the durable behavior comment; the final comment explains the invariant without depending on a tracker ID.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex).

Origin Session ID: 019fac4d-7844-7422-9486-7f73ccf308f5