### PR TITLE
feat(github-workflow): expose PR board freshness fields (#16165)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -180,9 +180,6 @@ paths:
         - Use the current head, review, reviewer-request, and merge-state fields before making a PR-state claim.
         - `reviewRequests: null` means the reviewer source was unavailable or incomplete; `[]` means fetched and empty.
         - Avoid showing the raw JSON output to the user unless they explicitly ask for it.
-
-        **Future Enhancements:**
-        Note that a future feature will sync PR conversations to local markdown files, providing a more detailed way to review historical PRs. For now, this tool is the primary way to browse PR history.
       tags: [Pull Requests]
       parameters:
         - name: limit
@@ -1943,6 +1940,7 @@ components:
 
     PullRequest:
       type: object
+      required: [mergedAt, reviewDecision, reviewRequests, baseRefName, headRefOid, mergeStateStatus]
       properties:
         number:
           type: integer
@@ -1991,6 +1989,10 @@ components:
               login:
                 type: string
                 description: User login or organization/team slug.
+        baseRefName:
+          type: string
+          nullable: true
+          description: Current base branch name, or null when unavailable.
         headRefOid:
           type: string
           nullable: true

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -177,7 +177,8 @@ paths:
 
         **Best Practices:**
         - After calling this tool, summarize the list of PRs for the user.
-        - Highlight key details such as the PR number, title, author, and state.
+        - Use the current head, review, reviewer-request, and merge-state fields before making a PR-state claim.
+        - `reviewRequests: null` means the reviewer source was unavailable or incomplete; `[]` means fetched and empty.
         - Avoid showing the raw JSON output to the user unless they explicitly ask for it.
 
         **Future Enhancements:**
@@ -1967,6 +1968,37 @@ components:
           type: string
           format: date-time
           example: "2025-10-08T12:00:00.000Z"
+        mergedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Merge timestamp, or null when the pull request is not merged.
+        reviewDecision:
+          type: string
+          nullable: true
+          description: GitHub's current aggregate review decision, or null when absent.
+        reviewRequests:
+          type: array
+          nullable: true
+          description: Complete current reviewer requests; null means unavailable, truncated, or structurally unknown.
+          items:
+            type: object
+            required: [kind, login]
+            properties:
+              kind:
+                type: string
+                enum: [user, team]
+              login:
+                type: string
+                description: User login or organization/team slug.
+        headRefOid:
+          type: string
+          nullable: true
+          description: Current head commit object ID, or null when unavailable.
+        mergeStateStatus:
+          type: string
+          nullable: true
+          description: GitHub's current merge-state status, or null when unavailable.
 
     PullRequestListResponse:
       type: object

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -127,6 +127,7 @@ function normalizePullRequestListItem(pullRequest) {
         mergedAt        : pullRequest.mergedAt ?? null,
         reviewDecision  : pullRequest.reviewDecision ?? null,
         reviewRequests  : reviewSourceReady ? reviewers : null,
+        baseRefName     : pullRequest.baseRefName ?? null,
         headRefOid      : pullRequest.headRefOid ?? null,
         mergeStateStatus: pullRequest.mergeStateStatus ?? null
     }

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -100,6 +100,38 @@ function normalizeRequestedReviewer(node) {
     return {kind: 'unknown', login: null};
 }
 
+/**
+ * @summary Projects one PR board row with explicit nulls when GitHub does not prove a freshness field.
+ * @param {Object} pullRequest GitHub pull-request node from the list query.
+ * @returns {Object}
+ */
+function normalizePullRequestListItem(pullRequest) {
+    const
+        reviewConnection = pullRequest.reviewRequests,
+        reviewers        = Array.isArray(reviewConnection?.nodes)
+            ? reviewConnection.nodes.map(normalizeRequestedReviewer)
+                .sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)))
+            : null,
+        reviewSourceReady = Array.isArray(reviewers) &&
+            typeof reviewConnection?.pageInfo?.hasNextPage === 'boolean' &&
+            !reviewConnection.pageInfo.hasNextPage &&
+            reviewers.every(item => item.kind !== 'unknown');
+
+    return {
+        number          : pullRequest.number,
+        title           : pullRequest.title,
+        url             : pullRequest.url,
+        createdAt       : pullRequest.createdAt,
+        author          : pullRequest.author,
+        state           : pullRequest.state,
+        mergedAt        : pullRequest.mergedAt ?? null,
+        reviewDecision  : pullRequest.reviewDecision ?? null,
+        reviewRequests  : reviewSourceReady ? reviewers : null,
+        headRefOid      : pullRequest.headRefOid ?? null,
+        mergeStateStatus: pullRequest.mergeStateStatus ?? null
+    }
+}
+
 function classifyEmittedContext(node) {
     if (node?.__typename === 'CheckRun' && node.name) {
         let state;
@@ -2155,7 +2187,7 @@ class PullRequestService extends Base {
 
         try {
             const data         = await GraphqlService.query(FETCH_PULL_REQUESTS, variables);
-            const pullRequests = data.repository.pullRequests.nodes;
+            const pullRequests = data.repository.pullRequests.nodes.map(normalizePullRequestListItem);
             return {
                 count: pullRequests.length,
                 pullRequests

--- a/ai/services/github-workflow/queries/pullRequestQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestQueries.mjs
@@ -140,6 +140,7 @@ export const FETCH_PULL_REQUESTS = `
           url
           createdAt
           mergedAt
+          baseRefName
           headRefOid
           mergeStateStatus
           reviewDecision

--- a/ai/services/github-workflow/queries/pullRequestQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestQueries.mjs
@@ -139,10 +139,33 @@ export const FETCH_PULL_REQUESTS = `
           title
           url
           createdAt
+          mergedAt
+          headRefOid
+          mergeStateStatus
+          reviewDecision
           author {
             login
           }
           state
+          reviewRequests(first: 100) {
+            pageInfo {
+              hasNextPage
+            }
+            nodes {
+              requestedReviewer {
+                __typename
+                ... on User {
+                  login
+                }
+                ... on Team {
+                  slug
+                  organization {
+                    login
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/learn/agentos/GitHubWorkflow.md
+++ b/learn/agentos/GitHubWorkflow.md
@@ -103,7 +103,7 @@ The full bi-directional sync is intentionally not an agent MCP tool. The Data Sy
 
 ### 4.3 Pull Request Management
 
-*   **`list_pull_requests`**: Lists PRs with status filtering.
+*   **`list_pull_requests`**: Lists PRs with status filtering plus current head, review-decision, reviewer-request, merge-time, and merge-state fields. `reviewRequests: null` means the source was unavailable or incomplete; `[]` means fetched and empty.
 *   **`checkout_pull_request`**: Checks out a PR branch in an explicitly supplied caller workspace using `gh pr checkout`; missing `repoPath` is rejected so a shared MCP server cannot silently mutate its own checkout.
 *   **`get_pull_request_diff`**: Fetches the code difference via `gh pr diff`.
 *   **`get_conversation`**: Retrieves the full conversation (title, body, comments) for a **pull request _or_ an issue** — supply exactly one of `pr_number` / `issue_number`. The same comment selectors (`comment_id` / `since_comment_id` / `last_n`) narrow the result on both.

--- a/learn/agentos/GitHubWorkflow.md
+++ b/learn/agentos/GitHubWorkflow.md
@@ -103,7 +103,7 @@ The full bi-directional sync is intentionally not an agent MCP tool. The Data Sy
 
 ### 4.3 Pull Request Management
 
-*   **`list_pull_requests`**: Lists PRs with status filtering plus current head, review-decision, reviewer-request, merge-time, and merge-state fields. `reviewRequests: null` means the source was unavailable or incomplete; `[]` means fetched and empty.
+*   **`list_pull_requests`**: Lists PRs with status filtering plus current base/head, review-decision, reviewer-request, merge-time, and merge-state fields. `reviewRequests: null` means the source was unavailable or incomplete; `[]` means fetched and empty.
 *   **`checkout_pull_request`**: Checks out a PR branch in an explicitly supplied caller workspace using `gh pr checkout`; missing `repoPath` is rejected so a shared MCP server cannot silently mutate its own checkout.
 *   **`get_pull_request_diff`**: Fetches the code difference via `gh pr diff`.
 *   **`get_conversation`**: Retrieves the full conversation (title, body, comments) for a **pull request _or_ an issue** — supply exactly one of `pr_number` / `issue_number`. The same comment selectors (`comment_id` / `since_comment_id` / `last_n`) narrow the result on both.

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -30,6 +30,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
         state           : 'OPEN',
         mergedAt        : null,
         reviewDecision  : 'REVIEW_REQUIRED',
+        baseRefName     : 'dev',
         headRefOid      : 'a'.repeat(40),
         mergeStateStatus: 'CLEAN',
         reviewRequests  : {
@@ -80,6 +81,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
             'mergedAt',
             'reviewDecision',
             'reviewRequests',
+            'baseRefName',
             'headRefOid',
             'mergeStateStatus'
         ]) {
@@ -108,6 +110,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
                     {kind: 'team', login: 'neomjs/maintainers'},
                     {kind: 'user', login: 'neo-opus-vega'}
                 ],
+                baseRefName     : 'dev',
                 headRefOid      : 'a'.repeat(40),
                 mergeStateStatus: 'CLEAN'
             }]
@@ -151,6 +154,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
                     nodes: [row({
                         mergedAt        : undefined,
                         reviewDecision  : undefined,
+                        baseRefName     : undefined,
                         headRefOid      : undefined,
                         mergeStateStatus: undefined
                     })]
@@ -163,6 +167,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
         expect(result.pullRequests[0]).toMatchObject({
             mergedAt        : null,
             reviewDecision  : null,
+            baseRefName     : null,
             headRefOid      : null,
             mergeStateStatus: null
         })

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -14,6 +14,175 @@ setup({
     }
 });
 
+test.describe('Neo.ai.services.github-workflow.PullRequestService — list freshness fields (#16165)', () => {
+    let GraphqlService;
+    let PullRequestService;
+    let originalQuery;
+    let capturedQuery;
+    let capturedVariables;
+
+    const row = (overrides = {}) => ({
+        number          : 16165,
+        title           : 'Board freshness',
+        url             : 'https://github.com/neomjs/neo/pull/16166',
+        createdAt       : '2026-07-30T11:00:00Z',
+        author          : {login: 'neo-gpt-emmy'},
+        state           : 'OPEN',
+        mergedAt        : null,
+        reviewDecision  : 'REVIEW_REQUIRED',
+        headRefOid      : 'a'.repeat(40),
+        mergeStateStatus: 'CLEAN',
+        reviewRequests  : {
+            pageInfo: {hasNextPage: false},
+            nodes   : [{
+                requestedReviewer: {__typename: 'User', login: 'neo-opus-vega'}
+            }, {
+                requestedReviewer: {
+                    __typename  : 'Team',
+                    slug        : 'maintainers',
+                    organization: {login: 'neomjs'}
+                }
+            }]
+        },
+        ...overrides
+    });
+
+    test.beforeAll(async () => {
+        GraphqlService     = (await import(
+            '../../../../../../ai/services/github-workflow/GraphqlService.mjs'
+        )).default;
+        PullRequestService = (await import(
+            '../../../../../../ai/services/github-workflow/PullRequestService.mjs'
+        )).default;
+        originalQuery      = GraphqlService.query.bind(GraphqlService)
+    });
+
+    test.afterAll(() => {
+        GraphqlService.query = originalQuery
+    });
+
+    test.beforeEach(() => {
+        capturedQuery     = null;
+        capturedVariables = null;
+
+        GraphqlService.query = async (query, variables) => {
+            capturedQuery     = query;
+            capturedVariables = variables;
+
+            return {repository: {pullRequests: {nodes: [row()]}}}
+        }
+    });
+
+    test('requests and returns the full current PR-state row without changing list inputs', async () => {
+        const result = await PullRequestService.listPullRequests({limit: 7, state: 'open'});
+
+        for (const field of [
+            'mergedAt',
+            'reviewDecision',
+            'reviewRequests',
+            'headRefOid',
+            'mergeStateStatus'
+        ]) {
+            expect(capturedQuery).toContain(field)
+        }
+
+        expect(capturedQuery).toContain('reviewRequests(first: 100)');
+        expect(capturedVariables).toEqual({
+            owner : 'neomjs',
+            repo  : 'neo',
+            limit : 7,
+            states: 'OPEN'
+        });
+        expect(result).toEqual({
+            count       : 1,
+            pullRequests: [{
+                number        : 16165,
+                title         : 'Board freshness',
+                url           : 'https://github.com/neomjs/neo/pull/16166',
+                createdAt     : '2026-07-30T11:00:00Z',
+                author        : {login: 'neo-gpt-emmy'},
+                state         : 'OPEN',
+                mergedAt      : null,
+                reviewDecision: 'REVIEW_REQUIRED',
+                reviewRequests: [
+                    {kind: 'team', login: 'neomjs/maintainers'},
+                    {kind: 'user', login: 'neo-opus-vega'}
+                ],
+                headRefOid      : 'a'.repeat(40),
+                mergeStateStatus: 'CLEAN'
+            }]
+        })
+    });
+
+    test('distinguishes complete-empty reviewer requests from unavailable or incomplete sources', async () => {
+        GraphqlService.query = async () => ({
+            repository: {
+                pullRequests: {
+                    nodes: [
+                        row({number: 1, reviewRequests: {pageInfo: {hasNextPage: false}, nodes: []}}),
+                        row({number: 2, reviewRequests: null}),
+                        row({number: 3, reviewRequests: {pageInfo: {hasNextPage: true}, nodes: []}}),
+                        row({
+                            number        : 4,
+                            reviewRequests: {
+                                pageInfo: {hasNextPage: false},
+                                nodes   : [{requestedReviewer: {__typename: 'Bot', login: 'unknown'}}]
+                            }
+                        })
+                    ]
+                }
+            }
+        });
+
+        const result = await PullRequestService.listPullRequests();
+
+        expect(result.pullRequests.map(item => item.reviewRequests)).toEqual([
+            [],
+            null,
+            null,
+            null
+        ])
+    });
+
+    test('emits explicit nulls for unavailable scalar freshness fields', async () => {
+        GraphqlService.query = async () => ({
+            repository: {
+                pullRequests: {
+                    nodes: [row({
+                        mergedAt        : undefined,
+                        reviewDecision  : undefined,
+                        headRefOid      : undefined,
+                        mergeStateStatus: undefined
+                    })]
+                }
+            }
+        });
+
+        const result = await PullRequestService.listPullRequests();
+
+        expect(result.pullRequests[0]).toMatchObject({
+            mergedAt        : null,
+            reviewDecision  : null,
+            headRefOid      : null,
+            mergeStateStatus: null
+        })
+    });
+
+    test('preserves the structured GraphQL error shape', async () => {
+        GraphqlService.query = async () => {
+            throw new Error('source unavailable')
+        };
+
+        const result = await PullRequestService.listPullRequests();
+
+        expect(result).toMatchObject({
+            error  : 'GraphQL API request failed',
+            message: 'source unavailable',
+            code   : 'GRAPHQL_API_ERROR'
+        })
+    })
+});
+
 test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-readiness projection (#16029)', () => {
     let PullRequestService;
 


### PR DESCRIPTION
Resolves #16165

`list_pull_requests` now returns the current merge timestamp, aggregate review decision, requested reviewers, base branch, head object ID, and merge-state status on every board row. Reviewer requests preserve the source boundary: a complete empty connection becomes `[]`, while unavailable, truncated, or structurally unknown data becomes `null`.

The change extends the existing query and response projection only. It adds no MCP operation, request parameter, pagination claim, watermark, or server state.

Evidence: L2 (focused service contracts, OpenAPI/catalog validation, and a live GitHub GraphQL row) → L2 required (additive read projection with explicit completeness semantics). No residuals inside this leaf.

## Deltas from ticket

The live `post-review-pickup` freshness gate also names `baseRefName`; this source-owned scalar was added after the ticket's field list was written so one board row can expose stacked-base state without a per-PR follow-up.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` — 105/105 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs test/playwright/unit/ai/mcp/validation/GuideToolParity.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs` — 54/54 passed.
- The focused GitHub Workflow description/list-tools smoke passed 3/3; the parsed operation description is 845 characters (below the 1,024-character budget). The unfiltered cross-server smoke also reached and passed the GitHub assertions, then hit an unrelated sandbox `EPERM` while a Memory Core test restored `.neo-ai-data/deployment-state/snapshot.json`.
- A live GitHub GraphQL query returned #16164 with `baseRefName=dev`, `headRefOid=3b556fd81dca1fdd921de0a9f813f1d6029c6475`, `mergeStateStatus=CLEAN`, `reviewDecision=null`, and a complete empty `reviewRequests` connection.
- Populated user/team, explicit scalar-null, complete-empty, truncated, missing, structurally unknown, unchanged-input, count, and structured-error branches are pinned in the focused service suite.
- `node --check` passed for both production modules; block-alignment and `git diff --check` passed.

## Post-Merge Validation

- [x] None — the source query, projection, completeness branches, public schema, and live field availability are all observable before merge.

## Evolution

The parent freshness topic combined three concerns, but only field parity had a source-owned current-state contract. Historical deltas and exhaustive bounded-page membership remain with #16136 rather than being inferred from `updatedAt` or caller memory. This leaf therefore adds only facts GitHub can prove now and keeps reviewer completeness explicit instead of collapsing unknown into empty.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex).

Origin Session ID: 019fac4d-7844-7422-9486-7f73ccf308f5
