### PR TITLE
fix(test): isolate deployment snapshots per worker (#16171)

### DIFF
--- a/test/playwright/configTemplateResolver.mjs
+++ b/test/playwright/configTemplateResolver.mjs
@@ -130,6 +130,8 @@ function activateStorageScope() {
         process.env.NEO_KB_LOG_PATH                          = path.join(storageRoot, 'knowledge-base-logs');
         process.env.NEO_NL_LOG_PATH                          = path.join(storageRoot, 'neural-link-logs');
         process.env.NEO_TELEMETRY_DB_PATH_TEST               = path.join(storageRoot, 'telemetry.sqlite');
+        process.env.NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH =
+            path.join(storageRoot, 'deployment-state', 'snapshot.json');
         process.env.NEO_RECOVERY_ACTUATOR_HEAL_ATTEMPTS_PATH =
             path.join(storageRoot, 'orchestrator-daemon', 'heal-attempts.json');
         process.env.NEO_RECOVERY_ACTUATOR_RUN_STATE_DIR      =
@@ -143,7 +145,7 @@ function activateStorageScope() {
 
 /**
  * @summary Activates template-only test resolution in this process and all descendant Node
- * processes while routing template-derived writable log defaults to disposable test storage.
+ * processes while routing template-derived writable paths to disposable test storage.
  * @returns {{preloadOption: String, storageRoot: String}}
  */
 export function activateConfigTemplateResolver() {

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -428,9 +428,16 @@ test.describe('Tier 1 Config Immutability', () => {
             vacuum : graphLogCompactionVacuum
         });
 
+        expect(Config._data.orchestrator.deploymentStateBridge.snapshotPath.default)
+            .toContain('.neo-ai-data/deployment-state/snapshot.json');
         expect(Config.orchestrator.deploymentStateBridge).toMatchObject({
-            enabled                 : true,
-            snapshotPath            : expect.stringContaining('.neo-ai-data/deployment-state/snapshot.json'),
+            enabled     : true,
+            snapshotPath: path.join(
+                process.env.NEO_TEST_STORAGE_ROOT,
+                process.env.NEO_TEST_CONFIG_TEMPLATE_SCOPE,
+                'deployment-state',
+                'snapshot.json'
+            ),
             writeIntervalMs         : 30000,
             staleAfterMs            : 2 * 60 * 1000,
             maxSnapshotBytes        : 256 * 1024,

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -16,6 +16,7 @@ setup({
 import {test, expect} from '@playwright/test';
 import {parse}        from 'acorn';
 import fs             from 'fs';
+import os             from 'os';
 import path           from 'path';
 import {fileURLToPath,
         pathToFileURL}   from 'url';
@@ -508,15 +509,16 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
             ]
         });
 
+        const snapshotPathConfig = AiConfig.orchestrator.deploymentStateBridge.snapshotPath;
+
         const
-            snapshotPathConfig = AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
-            testStorageRoot    = process.env.NEO_TEST_STORAGE_ROOT;
-
-        expect(testStorageRoot).toBeTruthy();
-
-        const snapshotRelativePath = path.relative(testStorageRoot, snapshotPathConfig);
+            snapshotRelativePath = path.relative(os.tmpdir(), snapshotPathConfig),
+            snapshotPathParts    = snapshotRelativePath.split(path.sep);
 
         expect(snapshotRelativePath.startsWith('..') || path.isAbsolute(snapshotRelativePath)).toBe(false);
+        expect(snapshotPathParts.some(part => /^neo-playwright-.+/.test(part))).toBe(true);
+        expect(snapshotPathParts.at(-3)).toMatch(/^worker-\d+$/);
+        expect(snapshotPathParts.slice(-2)).toEqual(['deployment-state', 'snapshot.json']);
 
         try {
             await writeDeploymentStateSnapshot({filePath: snapshotPathConfig, snapshot});

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -484,7 +484,7 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         });
     });
 
-    test('knowledge-base and memory-core read deployment-state snapshots through public tools (#13926)', async () => {
+    test('knowledge-base and memory-core read worker-local deployment snapshots (#13926, #16171)', async () => {
         const snapshot = createDeploymentStateSnapshot({
             generatedAt : Date.now(),
             recoveryRuns: {
@@ -510,8 +510,13 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
 
         const
             snapshotPathConfig = AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
-            snapshotExists     = fs.existsSync(snapshotPathConfig),
-            originalSnapshot   = snapshotExists ? fs.readFileSync(snapshotPathConfig) : null;
+            testStorageRoot    = process.env.NEO_TEST_STORAGE_ROOT;
+
+        expect(testStorageRoot).toBeTruthy();
+
+        const snapshotRelativePath = path.relative(testStorageRoot, snapshotPathConfig);
+
+        expect(snapshotRelativePath.startsWith('..') || path.isAbsolute(snapshotRelativePath)).toBe(false);
 
         try {
             await writeDeploymentStateSnapshot({filePath: snapshotPathConfig, snapshot});
@@ -563,11 +568,7 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
                 });
             }
         } finally {
-            if (snapshotExists) {
-                fs.writeFileSync(snapshotPathConfig, originalSnapshot);
-            } else {
-                fs.rmSync(snapshotPathConfig, {force: true});
-            }
+            fs.rmSync(snapshotPathConfig, {force: true});
         }
     });
 

--- a/test/playwright/unit/test/ConfigTemplateResolver.spec.mjs
+++ b/test/playwright/unit/test/ConfigTemplateResolver.spec.mjs
@@ -14,7 +14,7 @@ import {
 /**
  * @summary Proves the Playwright config-template resolver keeps the entire test module graph on
  * tracked templates, preserves exact module identity, excludes non-template/outside-root configs,
- * and never writes the developer's ignored overlay.
+ * and routes writable state away from developer and runtime storage.
  */
 test.describe('test/playwright/configTemplateResolver (#11976)', () => {
     const rootDir      = path.resolve(import.meta.dirname, '../../../..'),
@@ -82,8 +82,47 @@ test.describe('test/playwright/configTemplateResolver (#11976)', () => {
         expect(process.env.NEO_KB_LOG_PATH.startsWith(storageRoot)).toBe(true);
         expect(process.env.NEO_NL_LOG_PATH.startsWith(storageRoot)).toBe(true);
         expect(process.env.NEO_TELEMETRY_DB_PATH_TEST.startsWith(storageRoot)).toBe(true);
+        expect(process.env.NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH).toBe(
+            path.join(storageRoot, 'deployment-state', 'snapshot.json')
+        );
         expect(process.env.NEO_RECOVERY_ACTUATOR_HEAL_ATTEMPTS_PATH.startsWith(storageRoot)).toBe(true);
         expect(process.env.NEO_RECOVERY_ACTUATOR_RUN_STATE_DIR.startsWith(storageRoot)).toBe(true);
+    });
+
+    test('routes deployment snapshots to distinct worker-local paths (#16171)', () => {
+        const
+            boundaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-worker-snapshot-paths-')),
+            probe        = `console.log(process.env.NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH)`;
+
+        storageRoots.push(boundaryRoot);
+
+        const snapshotPaths = [0, 1].map(workerIndex => {
+            const env = {
+                ...process.env,
+                NEO_TEST_CONFIG_TEMPLATES: 'true',
+                NEO_TEST_STORAGE_ROOT    : boundaryRoot,
+                NODE_OPTIONS             : `--import=${pathToFileURL(resolverPath).href}`,
+                TEST_WORKER_INDEX        : String(workerIndex),
+                UNIT_TEST_MODE           : 'true'
+            };
+
+            delete env.NEO_TEST_CONFIG_TEMPLATE_SCOPE;
+
+            const result = spawnSync(process.execPath, ['--input-type=module', '-e', probe], {
+                cwd     : rootDir,
+                encoding: 'utf8',
+                env
+            });
+
+            expect(result.status, result.stderr).toBe(0);
+
+            return result.stdout.trim()
+        });
+
+        expect(snapshotPaths).toEqual([
+            path.join(boundaryRoot, 'worker-0', 'deployment-state', 'snapshot.json'),
+            path.join(boundaryRoot, 'worker-1', 'deployment-state', 'snapshot.json')
+        ])
     });
 
     test('preserves an explicit same-worker child writable-path fixture', () => {


### PR DESCRIPTION
Resolves #16171

Playwright's config-template resolver now binds the deployment-state snapshot beneath each runner or worker's disposable storage root. The cross-server MCP smoke therefore exercises Knowledge Base and Memory Core against a worker-local fixture and no longer saves, overwrites, restores, or removes the canonical plane snapshot.

The change uses the existing `NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH` leaf before AiConfig evaluates. It does not mutate the shared AiConfig singleton, change the production default, or alter either public MCP response.

Evidence: L2 (focused resolver, Tier-1 config, and full cross-server smoke contracts plus a canonical-file non-mutation witness) → L2 required (test-harness restoration with one production-state safety boundary). No residuals.

## Deltas from ticket

None.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/test/ConfigTemplateResolver.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` — 59/59 passed, covering distinct worker paths, the production-default versus active-test override boundary, every cross-server list-tools contract, and the public deployment-state fixture.
- Across that final exact-head run, the canonical deployment snapshot retained SHA-256 `d74c7c1b335550b2c647165b478a02fd04cc3f1b9592719e7e94c9862c700bc4`, mtime `1785414077811.3953`, and size `24289`.
- The initial hosted unit run correctly exposed two test-shape gaps: the Tier-1 default assertion did not distinguish the raw production default from the active Playwright override, and the cleanup guard trusted a mutable environment root. Both now fail closed on the immutable temp/worker path grammar; the exact-head hosted rerun is fully green, including unit (11m50s), components, both integration cells, CodeQL, and the AiConfig/test-location/body/archaeology lints.
- `check-aiconfig-test-mutation` found no new violations.
- `node --check`, block alignment, and `git diff --check` passed for the modified modules.

## Post-Merge Validation

- [x] None — worker separation, sandbox compatibility, public-tool behavior, and canonical-file non-mutation are all observable before merge.

## Evolution

The resolver already owned worker-local writable paths, but one declared plane-member leaf escaped that boundary. The resulting test used live-file backup/restore as an isolation substitute: sandbox permissions made the defect visible, while unrestricted execution would retain a stale-restore race. Routing the existing env-bound leaf at bootstrap fixes the ownership shape and follows ADR 0019's isolation-by-construction rule.

Hosted full-suite execution then caught a completeness gap the seven-worker focused run could not: tests still encoded the canonical path as the active value, and cleanup safety depended on an environment root that config-isolation tests may temporarily rebind. The repair now preserves both truths explicitly—the raw leaf keeps the production default, while Playwright consumes a temp-scoped worker override—and cleanup refuses any path outside the immutable temp/worker grammar before entering `finally`.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex).

Origin Session ID: 019fac4d-7844-7422-9486-7f73ccf308f5
