### PR TITLE
feat(ai): stamp WAL plane provenance for clean demotion (#16169)

### DIFF
--- a/ai/planeConfig.mjs
+++ b/ai/planeConfig.mjs
@@ -27,7 +27,7 @@ import path from 'node:path';
  */
 
 /**
- * @summary The institution's canonical local plane identity — the ONE exported literal.
+ * @summary The institution's canonical local plane identity — the ONE exported configured identity literal.
  *
  * It crosses the module boundary because two consumers must compare against the same value: the
  * `plane.id` leaf declares it as its default, and {@link assertPlaneCoherence} treats it as the
@@ -36,10 +36,21 @@ import path from 'node:path';
  * consumers, not a defaults copy kept in step.
  *
  * Overlays, cloud deployments and ephemeral isolation planes override it through the leaf's env
- * binding — a stable literal, deliberately carrying no path or checkout content.
+ * binding — a stable literal, deliberately carrying no path or checkout content. The exported
+ * `UNKNOWN_PLANE_ID` below is a read-side non-identity sentinel, not a competing configured identity.
  * @type {String}
  */
 export const CANONICAL_PLANE_ID = 'neo-local-canonical';
+
+/**
+ * @summary Read-side sentinel for durable records written before plane provenance existed.
+ *
+ * This is deliberately NOT a valid configured plane identity. A missing historical value must surface
+ * honestly without becoming a plane a new writer can claim; otherwise a deployment configured as
+ * `unknown` would be indistinguishable from legacy evidence whose producer cannot be attributed.
+ * @type {String}
+ */
+export const UNKNOWN_PLANE_ID = 'unknown';
 
 /**
  * Module-internal only. `dataRootRelative` is consumed by the opacity predicate and the anchor
@@ -61,7 +72,8 @@ const PLANE_DEFAULTS = Object.freeze({
  * @returns {Boolean}
  */
 export function isOpaquePlaneId(value) {
-    return typeof value === 'string' && value.length > 0 &&
+    return typeof value === 'string' && value.length > 0 && value.trim() === value &&
+        value !== UNKNOWN_PLANE_ID &&
         !value.includes('/') && !value.includes('\\') &&
         !value.includes(PLANE_DEFAULTS.dataRootRelative)
 }

--- a/ai/scripts/diagnostics/pilotPlaneTerminal.mjs
+++ b/ai/scripts/diagnostics/pilotPlaneTerminal.mjs
@@ -38,25 +38,21 @@
  * it never closed it, because the pilot never mutated the durable plane. Modelling that as `unchanged`
  * keeps the strictness intact instead of quietly widening it.
  *
- * ## Both certifying terminals are currently unreachable, and that is the finding
+ * ## Demotion now has an invoked producer; promotion remains closed
  *
- * `demoted-clean` and `committed` are each unreachable, and neither is held closed by a validation rule. In both
- * cases the missing thing is a **producer of fact**, and no amount of argument validation substitutes for one:
- * clean demotion needs a plane id the WAL appender never writes; promotion needs a complete ordered mutation
- * source that nothing in the running system reads.
+ * Memory and message accepted-write boundaries now stamp the resolved plane identity after caller fields,
+ * and their owning stores expose strict evidence readers. {@link evaluateDemotion} invokes both readers and
+ * derives the scan itself, so `demoted-clean` is reachable only from durable provenance — never from a
+ * caller-authored receipt.
  *
- * They are closed **differently**, and the difference is a lesson rather than an inconsistency. Demotion
- * consults {@link OVERLAY_TAGGING_PRODUCER} as a gate, because the logic behind it is complete and only its
- * input is missing. Promotion has **no gate and no branch at all** — {@link evaluatePromotion} settles contained
- * unconditionally and takes no argument. A gate was tried there first and was wrong: type-checking a capability
- * proves it exists, never that it ran, so a no-op stub satisfied the check and handed caller observations to the
- * derivation behind it. Where a capability must *do* something rather than merely *be* something, a conditional
- * is a dormant success path pretending to be a guard.
+ * Promotion still has **no gate and no branch at all** — {@link evaluatePromotion} settles contained
+ * unconditionally and takes no argument. A gate was tried there first and was wrong: type-checking a
+ * capability proves it exists, never that it ran, so a no-op stub satisfied the check and handed caller
+ * observations to the derivation behind it. Where a capability must *do* something rather than merely *be*
+ * something, a conditional is a dormant success path pretending to be a guard.
  *
- * So today every pilot settles `failed-contained` — eligibility denied, overlay quarantined. That is not this
- * module failing to do its job; it *is* the job. The honest statement about pilot-plane promotion at this head
- * is "cannot be certified", and a module that returned anything else would be manufacturing the certification
- * the acceptance criterion asks it to earn. Each closure names the adapter that would open it.
+ * So clean demotion is now evidence-reachable while promotion remains honestly `failed-contained` until a
+ * complete dual-corpus replay adapter owns the source denominator and target observations.
  *
  * ## Where the authority is recorded
  *
@@ -65,27 +61,21 @@
  * reader gets one citation that is maintained, instead of decaying references scattered through code.
  */
 
+import {UNKNOWN_PLANE_ID, isOpaquePlaneId}     from '../../planeConfig.mjs';
+import {readMemoryWalProvenanceSegments}       from '../../services/memory-core/helpers/memoryWalStore.mjs';
+import {readMessageWalProvenanceSegments}      from '../../services/memory-core/helpers/messageWalStore.mjs';
 import {planWalReplay, verifyReplayContinuity} from './walReplayPlan.mjs';
 
 /**
- * Whether the substrate can attribute a durable WAL segment to the plane that wrote it.
+ * @summary Names the server-stamped durable source used by the demotion evidence producer.
  *
- * **`null` because no such producer exists.** The WAL appender writes `{...record, segmentKey}` and carries
- * no plane id, and nothing downstream supplies one — so no scan can distinguish an overlay-written segment
- * from a natively-written one.
- *
- * This is a **constant, not a parameter**, and that is the point. An earlier shape asked the caller to name
- * a `planeIdSource`, which only checked that a *string was present* — so an invented one unlocked
- * `demoted-clean`. Requiring a field is not proving a fact, and the fabricable field was worse than no
- * check because it made the impossibility look satisfied. Holding the capability here makes clean demotion
- * **mechanically unreachable** until a real producer lands, whatever a caller passes.
- *
- * When a producer exists, set this to a string naming it. The validation and set-inclusion logic behind the
- * gate is already written and directly tested, so opening the path is a one-line change with coverage
- * already in place.
- * @type {String|null}
+ * This is no longer a caller assertion. {@link produceOverlayScan} invokes the strict readers owned by the
+ * memory and message WAL stores, and those readers surface the `planeId` written after caller fields at the
+ * accepted-write boundary. `evaluateDemotion` invokes that producer itself; callers supply roots and the
+ * cutover boundary, never a receipt-shaped scan.
+ * @type {String}
  */
-export const OVERLAY_TAGGING_PRODUCER = null;
+export const OVERLAY_TAGGING_PRODUCER = 'wal-record.planeId';
 
 /**
  * Whether an executable producer exists that can replay the plane's complete mutation source.
@@ -381,13 +371,269 @@ export function deriveReplayCompletion(spec) {
 }
 
 /**
+ * @summary Verifies one WAL family's replay math for a composite receipt, including an honestly empty family.
+ *
+ * `deriveReplayCompletion` correctly refuses an empty corpus as a standalone promotion. In a complete
+ * two-family plane, however, either the memory or message family may genuinely be empty while the other
+ * carries work. The composite proof therefore permits a zero-row family only inside a non-empty dual-corpus
+ * receipt and still binds its stage pre/post state.
+ * @param {Object} spec Family replay evidence.
+ * @param {String[]} requiredStages Stages this WAL family requires.
+ * @returns {Object} `{ok, reason, receipt?}`.
+ * @private
+ */
+function deriveFamilyReplayForComposite(spec, requiredStages) {
+    const {payloadEntries, appliedStagesBefore, appliedStagesAfter} = spec ?? {};
+
+    if (!Array.isArray(payloadEntries)) {
+        return {ok: false, reason: 'payloadEntries must be an array'}
+    }
+
+    const plan = planWalReplay({payloadEntries, appliedStages: appliedStagesBefore, requiredStages});
+
+    if (!plan.ok) return {ok: false, reason: plan.reason};
+
+    const continuity = verifyReplayContinuity({appliedStagesBefore, appliedStagesAfter, plan});
+
+    if (!continuity.ok) return {ok: false, reason: continuity.reason};
+    if (continuity.monotonic !== true) {
+        return {ok: false, reason: 'continuity verification did not establish monotonic replay'}
+    }
+
+    const receiptFault = validateContinuityReceipt(continuity);
+
+    return receiptFault
+        ? {ok: false, reason: receiptFault}
+        : {ok: true, receipt: continuity.receipt}
+}
+
+/**
+ * @summary Derives a source/target-bound fork-then-replay receipt across memory and message WAL families.
+ *
+ * This remains a component proof, never a promotion terminal: the complete-corpus producer is still absent.
+ * It closes the provenance seam the later producer will consume by requiring every source row to carry the
+ * source plane, every selected target row to carry the target plane, and by retaining the exact family-typed
+ * record sets beside the existing stage-continuity receipts. Replayed source provenance is therefore never
+ * mistaken for the identity of the plane that accepted the target write.
+ * @param {Object} spec
+ * @param {String} spec.sourcePlaneId Overlay/source plane identity.
+ * @param {String} spec.targetPlaneId Durable target plane identity.
+ * @param {Object} spec.memory Memory family `{payloadEntries,targetEntriesAfter,appliedStagesBefore,appliedStagesAfter}`.
+ * @param {Object} spec.messages Message family with the same fields (graph stage only).
+ * @returns {Object} `{ok, reason, receipt?}` without terminal or eligibility authority.
+ */
+export function deriveDualCorpusReplayReceipt({sourcePlaneId, targetPlaneId, memory, messages} = {}) {
+    const refuse = reason => ({ok: false, reason});
+
+    if (!isOpaquePlaneId(sourcePlaneId) || !isOpaquePlaneId(targetPlaneId)) {
+        return refuse('sourcePlaneId and targetPlaneId must be valid opaque plane identities');
+    }
+    if (sourcePlaneId === targetPlaneId) {
+        return refuse('sourcePlaneId and targetPlaneId must be distinct for a fork-then-replay receipt');
+    }
+
+    const families = [
+        ['memory', memory, ['embedded', 'graph']],
+        ['messages', messages, ['graph']]
+    ];
+
+    if (families.every(([, family]) => Array.isArray(family?.payloadEntries) && family.payloadEntries.length === 0)) {
+        return refuse('the dual-corpus source is empty, so a zero-effect replay receipt would certify nothing');
+    }
+
+    const familyReceipts = {};
+
+    for (const [familyName, family, requiredStages] of families) {
+        const {payloadEntries, targetEntriesAfter} = family ?? {};
+
+        if (!Array.isArray(payloadEntries) || !Array.isArray(targetEntriesAfter)) {
+            return refuse(`${familyName} payloadEntries and targetEntriesAfter must be arrays`);
+        }
+
+        const badSourcePlane = payloadEntries.findIndex(entry => entry?.planeId !== sourcePlaneId);
+
+        if (badSourcePlane !== -1) {
+            return refuse(
+                `${familyName} source row at index ${badSourcePlane} is not stamped by source plane ` +
+                `"${sourcePlaneId}" — unknown or mixed source provenance cannot be replay-certified`
+            );
+        }
+
+        const targetById = new Map();
+
+        for (let index = 0; index < targetEntriesAfter.length; index++) {
+            const targetEntry = targetEntriesAfter[index],
+                  id          = targetEntry?.id;
+
+            if (typeof id !== 'string' || id === '') {
+                return refuse(`${familyName} target row at index ${index} has no usable id`);
+            }
+            if (targetById.has(id)) {
+                return refuse(`${familyName} target corpus repeats id "${id}", so double-apply cannot be excluded`);
+            }
+            targetById.set(id, targetEntry);
+        }
+
+        for (const sourceEntry of payloadEntries) {
+            const targetEntry = targetById.get(sourceEntry.id);
+
+            if (!targetEntry) {
+                return refuse(`${familyName} source id "${sourceEntry.id}" is absent from the target WAL`);
+            }
+            if (targetEntry.planeId !== targetPlaneId) {
+                return refuse(
+                    `${familyName} target id "${sourceEntry.id}" carries planeId ` +
+                    `${JSON.stringify(targetEntry.planeId)} instead of accepting plane "${targetPlaneId}" — ` +
+                    'replayed origin identity must not masquerade as target write identity'
+                );
+            }
+        }
+
+        const continuity = deriveFamilyReplayForComposite(family, requiredStages);
+
+        if (!continuity.ok) {
+            return refuse(`${familyName} continuity refused: ${continuity.reason}`)
+        }
+
+        const sourceRecordIds = payloadEntries.map(entry => entry.id).sort(),
+              selectedSet     = new Set(sourceRecordIds);
+
+        familyReceipts[familyName] = {
+            sourceRecordIds,
+            targetRecordIds         : [...selectedSet].sort(),
+            unrelatedTargetRecordIds: [...targetById.keys()].filter(id => !selectedSet.has(id)).sort(),
+            continuity              : continuity.receipt
+        };
+    }
+
+    return {
+        ok     : true,
+        reason : 'memory and message replay continuity is bound to exact source/target plane record sets',
+        receipt: {
+            sourcePlaneId,
+            targetPlaneId,
+            families: familyReceipts
+        }
+    }
+}
+
+/**
+ * @summary Reads both durable WAL families and produces the cutover-bounded plane-provenance scan.
+ *
+ * The strict readers are owned by their respective stores, so this function never guesses file grammars or
+ * plane identity from paths. Records before `cutoverStartedAt` may honestly remain legacy `unknown`; an
+ * unknown/invalid timestamp cannot prove that exemption and therefore joins the blocking unknown set.
+ * @param {Object} spec
+ * @param {String} spec.memoryWalDir Durable memory WAL directory.
+ * @param {String} spec.messageWalDir Durable message WAL directory.
+ * @param {String} spec.overlayPlaneId Plane identity whose durable writes would be a pilot leak.
+ * @param {Number} spec.cutoverStartedAt Inclusive epoch-ms start of the pilot cutover evidence window.
+ * @returns {Promise<Object>} `{ok, ...overlayScan}` or `{ok:false, reason}`.
+ */
+export async function produceOverlayScan({
+    memoryWalDir,
+    messageWalDir,
+    overlayPlaneId,
+    cutoverStartedAt
+} = {}) {
+    const refuse = reason => ({ok: false, reason});
+
+    if (!memoryWalDir || !messageWalDir) {
+        return refuse('memoryWalDir and messageWalDir are required for a dual-WAL provenance scan');
+    }
+    if (!isOpaquePlaneId(overlayPlaneId)) {
+        return refuse('overlayPlaneId must be a valid opaque plane identity');
+    }
+    if (!Number.isFinite(cutoverStartedAt)) {
+        return refuse('cutoverStartedAt must be a finite epoch-ms boundary');
+    }
+
+    let memory, messages;
+
+    try {
+        [memory, messages] = await Promise.all([
+            readMemoryWalProvenanceSegments({dir: memoryWalDir}),
+            readMessageWalProvenanceSegments({dir: messageWalDir})
+        ]);
+    } catch (e) {
+        return refuse(`dual-WAL provenance scan failed: ${e?.message || String(e)}`)
+    }
+
+    if (!memory.ok) return refuse(`memory WAL provenance scan failed: ${memory.reason}`);
+    if (!messages.ok) return refuse(`message WAL provenance scan failed: ${messages.reason}`);
+
+    const taggedSegments   = new Set(),
+          unknownRecords   = [],
+          legacyUnknown    = [],
+          recordIds        = {memory: [], messages: []},
+          knownPlaneCounts = new Map(),
+          segments         = [
+              ...memory.segments.map(segment => ({...segment, family: 'memory'})),
+              ...messages.segments.map(segment => ({
+                  ...segment,
+                  family   : 'messages',
+                  segmentId: `messages/${segment.segmentId}`
+              }))
+          ];
+
+    let scannedRecordCount = 0;
+
+    for (const segment of segments) {
+        for (let index = 0; index < segment.records.length; index++) {
+            const record    = segment.records[index],
+                  hasId     = typeof record?.id === 'string' && record.id !== '',
+                  recordId  = hasId ? record.id : `${segment.segmentId}#row-${index + 1}`,
+                  recordKey = `${segment.family}:${recordId}`,
+                  timestamp = record?.timestamp,
+                  knownTime = Number.isFinite(timestamp),
+                  inWindow  = knownTime && timestamp >= cutoverStartedAt;
+
+            scannedRecordCount++;
+
+            if (!knownTime || !hasId || record.planeId === UNKNOWN_PLANE_ID) {
+                if (knownTime && timestamp < cutoverStartedAt) {
+                    legacyUnknown.push(recordKey);
+                } else {
+                    unknownRecords.push(recordKey);
+                }
+                continue;
+            }
+
+            if (!inWindow) continue;
+
+            recordIds[segment.family].push(recordId);
+            knownPlaneCounts.set(record.planeId, (knownPlaneCounts.get(record.planeId) ?? 0) + 1);
+
+            if (record.planeId === overlayPlaneId) {
+                taggedSegments.add(segment.segmentId);
+            }
+        }
+    }
+
+    return {
+        ok                  : true,
+        planeIdSource       : OVERLAY_TAGGING_PRODUCER,
+        scannedSegmentCount : segments.length,
+        scannedRecordCount,
+        segmentIds          : segments.map(segment => segment.segmentId).sort(),
+        taggedSegments      : [...taggedSegments].sort(),
+        unknownRecords      : unknownRecords.sort(),
+        legacyUnknownRecords: legacyUnknown.sort(),
+        knownPlaneCounts    : Object.fromEntries([...knownPlaneCounts].sort(([a], [b]) => a.localeCompare(b))),
+        recordIds           : {
+            memory  : recordIds.memory.sort(),
+            messages: recordIds.messages.sort()
+        }
+    }
+}
+
+/**
  * @summary Validates the overlay-leak scan and returns a refusal reason, or `null`.
  *
- * Exported so the logic behind the capability gate stays directly testable with positive controls. It is
- * deliberately **not** the thing that decides a terminal: while {@link OVERLAY_TAGGING_PRODUCER} is `null`
- * no caller can reach this at all, because a well-formed scan structure is still only a *claim* that a scan
- * happened. Shape is checkable; provenance is not.
- * @param {Object} overlayScan `{planeIdSource, scannedSegmentCount, taggedSegments}`
+ * Exported so the pure derivation remains directly testable, but validation does not mint provenance:
+ * {@link evaluateDemotion} invokes {@link produceOverlayScan} and never accepts this structure from a caller.
+ * Shape is checkable; source authority comes only from that call graph.
+ * @param {Object} overlayScan Producer-owned scan returned by {@link produceOverlayScan}.
  * @returns {String|null}
  */
 export function validateOverlayScan(overlayScan) {
@@ -402,7 +648,16 @@ export function validateOverlayScan(overlayScan) {
                'this argument exists to force.';
     }
 
-    const {planeIdSource, scannedSegmentCount, taggedSegments} = overlayScan;
+    const {
+        planeIdSource,
+        scannedSegmentCount,
+        scannedRecordCount,
+        segmentIds,
+        taggedSegments,
+        unknownRecords,
+        legacyUnknownRecords,
+        recordIds
+    } = overlayScan;
 
     if (typeof planeIdSource !== 'string' || planeIdSource.trim() === '') {
         return 'overlayScan.planeIdSource must name where each durable segment\'s plane id was read from';
@@ -426,6 +681,18 @@ export function validateOverlayScan(overlayScan) {
     if (!Array.isArray(taggedSegments)) {
         return 'overlayScan.taggedSegments must be an array (empty when the scan found no overlay-tagged segment)';
     }
+    if (!Number.isInteger(scannedRecordCount) || scannedRecordCount < 0) {
+        return 'overlayScan.scannedRecordCount must be a non-negative integer';
+    }
+    if (!Array.isArray(segmentIds) || segmentIds.length !== scannedSegmentCount) {
+        return 'overlayScan.segmentIds must name exactly every scanned payload segment';
+    }
+    if (!Array.isArray(unknownRecords) || !Array.isArray(legacyUnknownRecords)) {
+        return 'overlayScan must distinguish blocking unknownRecords from pre-cutover legacyUnknownRecords';
+    }
+    if (!recordIds || !Array.isArray(recordIds.memory) || !Array.isArray(recordIds.messages)) {
+        return 'overlayScan.recordIds must retain exact memory and message record sets';
+    }
 
     return null;
 }
@@ -433,7 +700,7 @@ export function validateOverlayScan(overlayScan) {
 /**
  * @summary Compares pre-clone and post-pilot segment id sets, returning `{lost, gained}` or a refusal reason.
  *
- * Exported for direct testing behind the capability gate. **Identity, not cardinality:** `3 → 3` looks stable
+ * Exported for direct testing behind the invoked producer. **Identity, not cardinality:** `3 → 3` looks stable
  * while a delete-old-and-add-new has destroyed committed history, so the claim "no committed history was
  * lost" is set inclusion over every pre-clone id and nothing weaker.
  * @param {String[]} preCloneSegmentIds
@@ -476,42 +743,22 @@ export function diffSegmentIdentity(preCloneSegmentIds, postPilotSegmentIds) {
  * delete-old-and-add-new has silently destroyed committed history. So the check is **set inclusion** — every
  * pre-clone segment must still be present by id — which is what "no committed history was lost" actually
  * asserts. Growth beyond that is other seats' work and is reported, not judged.
- * ## `demoted-clean` is currently unreachable, by construction
- *
- * The **capability gate fires first**, before any caller input is consulted. While
- * {@link OVERLAY_TAGGING_PRODUCER} is `null` there is no honest scan, so no argument combination can produce
- * a clean terminal. An earlier shape asked the caller to *name* a `planeIdSource` and only checked that a
- * string was present — so an invented name unlocked `demoted-clean`. **Requiring a field is not proving a
- * fact**, and a fabricable field is worse than no field, because it makes an impossibility look satisfied.
+ * This pure derivation accepts only the producer's complete scan shape and carries no source authority by
+ * itself. The authoritative entry point is {@link evaluateDemotion}, which invokes
+ * {@link produceOverlayScan} rather than accepting a caller-authored scan.
  * @param {Object} spec
- * @param {Object} spec.overlayScan           `{planeIdSource, scannedSegmentCount, taggedSegments}`.
+ * @param {Object} spec.overlayScan           Producer-owned dual-WAL provenance scan.
  * @param {String[]} spec.preCloneSegmentIds  Durable segment ids recorded at clone time.
  * @param {String[]} spec.postPilotSegmentIds Durable segment ids at demotion.
  * @returns {Object} `{terminal, reason, eligibility, receipt}`
  */
-export function evaluateDemotion(spec) {
-    // THE CAPABILITY GATE, FIRST AND UNCONDITIONALLY. Placed ahead of every other check so that no
-    // caller-supplied value is even read while the producer is absent: a gate that ran after input validation
-    // would still let the shape of the input decide which refusal a reader sees, and the honest message here
-    // is about the substrate, not about the caller.
-    if (typeof OVERLAY_TAGGING_PRODUCER !== 'string' || OVERLAY_TAGGING_PRODUCER === '') {
-        return settle(
-            'failed-contained',
-            'the substrate cannot attribute a durable WAL segment to the plane that wrote it: the WAL appender ' +
-            'writes {...record, segmentKey} with no plane id, so no scan can distinguish an overlay-written ' +
-            'segment from a natively-written one. A clean demotion is therefore UNPROVABLE, not merely ' +
-            'unproven, and no argument can change that — the blocker is the missing producer. Quarantine the ' +
-            'overlay and leave eligibility closed until one exists.'
-        );
-    }
-
-    // See `evaluatePromotion`: nullish-coalesced so a null argument settles contained instead of throwing.
+export function deriveDemotionTerminal(spec) {
     const {overlayScan, preCloneSegmentIds, postPilotSegmentIds} = spec ?? {},
           scanFault                                              = validateOverlayScan(overlayScan);
 
     if (scanFault) return settle('failed-contained', scanFault);
 
-    const {taggedSegments} = overlayScan;
+    const {taggedSegments, unknownRecords} = overlayScan;
 
     if (taggedSegments.length > 0) {
         return settle(
@@ -520,6 +767,20 @@ export function evaluateDemotion(spec) {
             `write reached the durable plane: ${taggedSegments.slice(0, 5).join(', ')}. Quarantine the ` +
             'overlay rather than deleting it — it is the only remaining evidence of what leaked.',
             {overlayTaggedTotal: taggedSegments.length, planeIdSource: overlayScan.planeIdSource}
+        );
+    }
+
+    if (unknownRecords.length > 0) {
+        return settle(
+            'failed-contained',
+            `${unknownRecords.length} durable record(s) inside the cutover window have unknown plane ` +
+            `provenance (e.g. ${unknownRecords[0]}). Legacy ignorance may be context before cutover, but ` +
+            'inside the proof window it cannot be turned into a clean claim.',
+            {
+                planeIdSource     : overlayScan.planeIdSource,
+                unknownRecordTotal: unknownRecords.length,
+                unknownSample     : unknownRecords.slice(0, 5)
+            }
         );
     }
 
@@ -549,8 +810,57 @@ export function evaluateDemotion(spec) {
             // reader can sanity-check that a pilot-length window of institutional writing shows up at all.
             concurrentGainTotal: identity.gained.length,
             overlayTaggedTotal : 0,
+            unknownRecordTotal : 0,
+            legacyUnknownTotal : overlayScan.legacyUnknownRecords.length,
             planeIdSource      : overlayScan.planeIdSource,
-            scannedSegmentCount: overlayScan.scannedSegmentCount
+            scannedSegmentCount: overlayScan.scannedSegmentCount,
+            scannedRecordCount : overlayScan.scannedRecordCount,
+            knownPlaneCounts   : overlayScan.knownPlaneCounts,
+            recordIds          : overlayScan.recordIds
         }
     );
+}
+
+/**
+ * @summary Settles demotion from a scan this module obtains from both WAL stores itself.
+ *
+ * Callers provide configured roots, the overlay identity, the cutover boundary, and the clone-time segment
+ * ids. They cannot provide `overlayScan` or the post-pilot segment set: both are observed by the invoked
+ * producer, closing the earlier receipt-shaped-input loophole.
+ * @param {Object} spec
+ * @param {String} spec.memoryWalDir Durable memory WAL directory.
+ * @param {String} spec.messageWalDir Durable message WAL directory.
+ * @param {String} spec.overlayPlaneId Overlay identity under test.
+ * @param {Number} spec.cutoverStartedAt Inclusive epoch-ms evidence boundary.
+ * @param {String[]} spec.preCloneSegmentIds Clone-time durable payload segment identities.
+ * @returns {Promise<Object>} `{terminal, reason, eligibility, receipt}`.
+ */
+export async function evaluateDemotion(spec) {
+    const {
+        memoryWalDir,
+        messageWalDir,
+        overlayPlaneId,
+        cutoverStartedAt,
+        preCloneSegmentIds
+    } = spec ?? {};
+    const overlayScan = await produceOverlayScan({
+        memoryWalDir,
+        messageWalDir,
+        overlayPlaneId,
+        cutoverStartedAt
+    });
+
+    if (!overlayScan.ok) {
+        return settle(
+            'failed-contained',
+            `${overlayScan.reason}. The overlay remains quarantined because an unproduced scan is unproven, ` +
+            'not clean.'
+        );
+    }
+
+    return deriveDemotionTerminal({
+        overlayScan,
+        preCloneSegmentIds,
+        postPilotSegmentIds: overlayScan.segmentIds
+    })
 }

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1740,7 +1740,10 @@ class MailboxService extends Base {
             to
         });
 
-        await appendWalMessage(walRecord, {dir: aiConfig.messageWal.dir});
+        await appendWalMessage(walRecord, {
+            dir    : aiConfig.messageWal.dir,
+            planeId: aiConfig.plane.id
+        });
 
         let projectionStatus = 'projected';
 

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -471,7 +471,7 @@ class MemoryService extends Base {
                         memoryProperties
                     }
                 },
-                {dir: walDir}
+                {dir: walDir, planeId: aiConfig.plane.id}
             );
 
             this._scheduleMemoryGraphProjection({

--- a/ai/services/memory-core/helpers/memoryWalStore.mjs
+++ b/ai/services/memory-core/helpers/memoryWalStore.mjs
@@ -1,6 +1,7 @@
-import fs               from 'fs/promises';
-import path             from 'path';
-import {withAppendLock} from './walAppendLock.mjs';
+import fs                                  from 'fs/promises';
+import path                                from 'path';
+import {UNKNOWN_PLANE_ID, isOpaquePlaneId} from '../../../planeConfig.mjs';
+import {withAppendLock}                    from './walAppendLock.mjs';
 
 /**
  * @summary Durable JSONL write-ahead store for `add_memory` payloads.
@@ -111,24 +112,29 @@ export function getWalGraphMarkersFileName(segmentKey) {
  * @param {String} record.document  The combined text the embedder will index.
  * @param {Object} options
  * @param {String} options.dir Directory for WAL segment files.
+ * @param {String} options.planeId Resolved server plane identity; stamped after caller fields.
  * @param {Date|Number} [options.now] Clock source for the segment key (defaults to record.timestamp).
  * @param {Object} [options.lockOptions] Forwarded to {@link withAppendLock} (tuning + spec injection of
  *     fs/clock/liveness/sleep). Omit for the default per-append serialization.
  * @returns {Promise<{filePath: String, segmentKey: String}>}
  */
-export async function appendWalMemory(record, {dir, now, lockOptions} = {}) {
+export async function appendWalMemory(record, {dir, planeId, now, lockOptions} = {}) {
     if (!dir) {
         throw new TypeError('appendWalMemory: dir is required');
     }
     if (typeof record?.id !== 'string' || record.id.length === 0) {
         throw new TypeError('appendWalMemory: record.id is required');
     }
+    if (!isOpaquePlaneId(planeId)) {
+        throw new TypeError('appendWalMemory: planeId must be an opaque resolved plane identity');
+    }
 
     await fs.mkdir(dir, {recursive: true});
 
     const segmentKey = getWalSegmentKey(now ?? record.timestamp ?? new Date());
     const filePath   = path.join(dir, getWalRecordsFileName(segmentKey));
-    const line       = `${JSON.stringify({...record, segmentKey})}\n`;
+    // Server provenance is LAST so a caller-owned record.planeId can never spoof the accepting plane.
+    const line = `${JSON.stringify({...record, segmentKey, planeId})}\n`;
 
     // Serialize cross-process writers so a SHARED WAL dir cannot interleave multi-KB records; on a
     // bounded acquire-timeout it falls through and writes UNLOCKED, so the never-fail turn-save
@@ -233,6 +239,54 @@ async function readJsonlEntries(filePath) {
 }
 
 /**
+ * @summary Surfaces absent or invalid historical provenance as the explicit read-side `unknown` sentinel.
+ *
+ * No durable row is rewritten. Current valid provenance is preserved byte-for-byte in the returned object;
+ * only rows whose writer cannot be attributed receive the sentinel in memory.
+ * @param {Object} record Parsed WAL record.
+ * @returns {Object} Record with a usable `planeId` or `unknown`.
+ */
+function surfaceWalPlaneProvenance(record) {
+    return isOpaquePlaneId(record?.planeId) ? record : {...record, planeId: UNKNOWN_PLANE_ID}
+}
+
+/**
+ * @summary Strictly parses one JSONL payload file for parity evidence.
+ *
+ * Operational readers deliberately skip torn rows so serving remains available. A demotion proof cannot:
+ * an unreadable row may be the overlay write under investigation, so this evidence reader refuses the
+ * whole segment on the first malformed line.
+ * @param {String} filePath JSONL payload path.
+ * @returns {Promise<Object>} `{ok, records}` or `{ok:false, reason}`.
+ */
+async function readJsonlEntriesStrict(filePath) {
+    let text;
+
+    try {
+        text = await fs.readFile(filePath, 'utf8');
+    } catch (e) {
+        return {ok: false, reason: `${filePath}: ${e?.message || String(e)}`}
+    }
+
+    const records = [];
+
+    for (const [index, rawLine] of text.split('\n').entries()) {
+        if (!rawLine.trim()) continue;
+
+        try {
+            records.push(surfaceWalPlaneProvenance(JSON.parse(rawLine)));
+        } catch (e) {
+            return {
+                ok    : false,
+                reason: `${filePath}: line ${index + 1} is not valid JSON (${e?.message || String(e)})`
+            }
+        }
+    }
+
+    return {ok: true, records}
+}
+
+/**
  * @summary Lists segment keys present in the WAL directory, newest first.
  * @param {String} dir Directory for WAL segment files.
  * @returns {Promise<String[]>} Sorted segment keys (lexicographic desc === chronological desc).
@@ -250,6 +304,34 @@ async function listWalSegmentKeys(dir) {
         .map(name => name.match(SEGMENT_RE)?.[1])
         .filter(Boolean)
         .sort((a, b) => b.localeCompare(a));
+}
+
+/**
+ * @summary Strictly enumerates memory WAL payload segments with normalized plane provenance.
+ *
+ * This is the Memory WAL store's evidence-producing boundary for pilot demotion. Segment identities are
+ * canonical payload file names, never inferred checkout paths, and malformed rows fail the scan closed.
+ * @param {Object} options
+ * @param {String} options.dir Directory for memory WAL payload segments.
+ * @returns {Promise<Object>} `{ok, segments}` or `{ok:false, reason}`.
+ */
+export async function readMemoryWalProvenanceSegments({dir} = {}) {
+    if (!dir) {
+        return {ok: false, reason: 'readMemoryWalProvenanceSegments: dir is required'}
+    }
+
+    const segments = [];
+
+    for (const segmentKey of await listWalSegmentKeys(dir)) {
+        const segmentId = getWalRecordsFileName(segmentKey),
+              parsed    = await readJsonlEntriesStrict(path.join(dir, segmentId));
+
+        if (!parsed.ok) return parsed;
+
+        segments.push({segmentId, segmentKey, records: parsed.records});
+    }
+
+    return {ok: true, segments}
 }
 
 /**
@@ -308,7 +390,8 @@ export async function readPendingWalRecords({dir, ids, limit, markerType = 'embe
     for (const segmentKey of await listWalSegmentKeys(dir)) {
         if (pending.length >= bounded) break;
 
-        const records = await readJsonlEntries(path.join(dir, getWalRecordsFileName(segmentKey)));
+        const records = (await readJsonlEntries(path.join(dir, getWalRecordsFileName(segmentKey))))
+            .map(surfaceWalPlaneProvenance);
         if (records.length === 0) continue;
 
         // Same marker read the per-write disclosure uses, so "pending" here and "reconciled" there

--- a/ai/services/memory-core/helpers/messageWalStore.mjs
+++ b/ai/services/memory-core/helpers/messageWalStore.mjs
@@ -1,6 +1,7 @@
-import fs               from 'fs/promises';
-import path             from 'path';
-import {withAppendLock} from './walAppendLock.mjs';
+import fs                                  from 'fs/promises';
+import path                                from 'path';
+import {UNKNOWN_PLANE_ID, isOpaquePlaneId} from '../../../planeConfig.mjs';
+import {withAppendLock}                    from './walAppendLock.mjs';
 
 /**
  * @summary Durable JSONL write-ahead store for accepted A2A mailbox messages.
@@ -72,23 +73,28 @@ export function getMessageWalGraphMarkersFileName(segmentKey) {
  * @param {Number} record.timestamp Epoch-ms write time.
  * @param {Object} options
  * @param {String} options.dir Message WAL directory.
+ * @param {String} options.planeId Resolved server plane identity; stamped after caller fields.
  * @param {Date|Number} [options.now] Clock source for the segment key.
  * @param {Object} [options.lockOptions] Forwarded to {@link withAppendLock}.
  * @returns {Promise<{filePath: String, segmentKey: String}>}
  */
-export async function appendWalMessage(record, {dir, now, lockOptions} = {}) {
+export async function appendWalMessage(record, {dir, planeId, now, lockOptions} = {}) {
     if (!dir) {
         throw new TypeError('appendWalMessage: dir is required');
     }
     if (typeof record?.id !== 'string' || !record.id.startsWith('MESSAGE:')) {
         throw new TypeError('appendWalMessage: record.id must be a MESSAGE:* id');
     }
+    if (!isOpaquePlaneId(planeId)) {
+        throw new TypeError('appendWalMessage: planeId must be an opaque resolved plane identity');
+    }
 
     await fs.mkdir(dir, {recursive: true});
 
     const segmentKey = getMessageWalSegmentKey(now ?? record.timestamp ?? new Date());
     const filePath   = path.join(dir, getMessageWalRecordsFileName(segmentKey));
-    const line       = `${JSON.stringify({...record, segmentKey})}\n`;
+    // Server provenance is LAST so a caller-owned record.planeId can never spoof the accepting plane.
+    const line = `${JSON.stringify({...record, segmentKey, planeId})}\n`;
 
     await withAppendLock(filePath, () => fs.appendFile(filePath, line, 'utf8'), lockOptions);
 
@@ -159,6 +165,53 @@ async function readJsonlEntries(filePath) {
 }
 
 /**
+ * @summary Surfaces absent or invalid historical provenance as the explicit read-side `unknown` sentinel.
+ *
+ * This is a read projection only; legacy files stay untouched. A valid stamped identity is returned
+ * unchanged so drains and repair paths preserve the accepted-write evidence.
+ * @param {Object} record Parsed message WAL record.
+ * @returns {Object} Record with a usable `planeId` or `unknown`.
+ */
+function surfaceWalPlaneProvenance(record) {
+    return isOpaquePlaneId(record?.planeId) ? record : {...record, planeId: UNKNOWN_PLANE_ID}
+}
+
+/**
+ * @summary Strictly parses one message JSONL payload for parity evidence.
+ *
+ * Serving readers skip torn lines; demotion evidence refuses them because an unreadable row cannot be
+ * proven older than the cutover window or unrelated to the overlay.
+ * @param {String} filePath JSONL payload path.
+ * @returns {Promise<Object>} `{ok, records}` or `{ok:false, reason}`.
+ */
+async function readJsonlEntriesStrict(filePath) {
+    let text;
+
+    try {
+        text = await fs.readFile(filePath, 'utf8');
+    } catch (e) {
+        return {ok: false, reason: `${filePath}: ${e?.message || String(e)}`}
+    }
+
+    const records = [];
+
+    for (const [index, rawLine] of text.split('\n').entries()) {
+        if (!rawLine.trim()) continue;
+
+        try {
+            records.push(surfaceWalPlaneProvenance(JSON.parse(rawLine)));
+        } catch (e) {
+            return {
+                ok    : false,
+                reason: `${filePath}: line ${index + 1} is not valid JSON (${e?.message || String(e)})`
+            }
+        }
+    }
+
+    return {ok: true, records}
+}
+
+/**
  * @summary Builds a cacheable signature for graph-projection marker files.
  * @param {String} dir Message WAL directory.
  * @param {String[]} segmentKeys Segment keys newest first.
@@ -210,6 +263,34 @@ async function listMessageWalSegmentKeys(dir) {
 }
 
 /**
+ * @summary Strictly enumerates message WAL payload segments with normalized plane provenance.
+ *
+ * This is the Message WAL store's half of the pilot demotion evidence producer. It owns the canonical
+ * file grammar, keeps message and memory families distinct, and refuses malformed payload rows.
+ * @param {Object} options
+ * @param {String} options.dir Directory for message WAL payload segments.
+ * @returns {Promise<Object>} `{ok, segments}` or `{ok:false, reason}`.
+ */
+export async function readMessageWalProvenanceSegments({dir} = {}) {
+    if (!dir) {
+        return {ok: false, reason: 'readMessageWalProvenanceSegments: dir is required'}
+    }
+
+    const segments = [];
+
+    for (const segmentKey of await listMessageWalSegmentKeys(dir)) {
+        const segmentId = getMessageWalRecordsFileName(segmentKey),
+              parsed    = await readJsonlEntriesStrict(path.join(dir, segmentId));
+
+        if (!parsed.ok) return parsed;
+
+        segments.push({segmentId, segmentKey, records: parsed.records});
+    }
+
+    return {ok: true, segments}
+}
+
+/**
  * @summary Reads message WAL records from newest segment to oldest, skipping corrupt lines.
  * @param {Object} options
  * @param {String} options.dir Message WAL directory.
@@ -223,7 +304,8 @@ export async function readWalMessages({dir} = {}) {
     const records = [];
 
     for (const segmentKey of await listMessageWalSegmentKeys(dir)) {
-        records.push(...await readJsonlEntries(path.join(dir, getMessageWalRecordsFileName(segmentKey))));
+        records.push(...(await readJsonlEntries(path.join(dir, getMessageWalRecordsFileName(segmentKey))))
+            .map(surfaceWalPlaneProvenance));
     }
 
     return records;
@@ -297,9 +379,9 @@ export async function readWalMessagesByIds({dir, ids, limit} = {}) {
 
     if (!Array.isArray(ids) || ids.length === 0) return [];
 
-    const idFilter  = new Set(ids.filter(id => typeof id === 'string' && id.startsWith('MESSAGE:')));
-    const bounded   = Number.isFinite(Number(limit)) && Number(limit) > 0 ? Number(limit) : Infinity;
-    const records   = [];
+    const idFilter      = new Set(ids.filter(id => typeof id === 'string' && id.startsWith('MESSAGE:')));
+    const bounded       = Number.isFinite(Number(limit)) && Number(limit) > 0 ? Number(limit) : Infinity;
+    const records       = [];
     const {segmentById} = await getMessageWalGraphProjectionStats({dir});
     const idsBySegment  = new Map();
 
@@ -316,7 +398,8 @@ export async function readWalMessagesByIds({dir, ids, limit} = {}) {
     for (const [segmentKey, segmentIds] of idsBySegment) {
         if (records.length >= bounded) break;
 
-        const segmentRecords = await readJsonlEntries(path.join(dir, getMessageWalRecordsFileName(segmentKey)));
+        const segmentRecords = (await readJsonlEntries(path.join(dir, getMessageWalRecordsFileName(segmentKey))))
+            .map(surfaceWalPlaneProvenance);
 
         for (const record of segmentRecords) {
             if (records.length >= bounded) break;
@@ -348,7 +431,8 @@ export async function readPendingMessageWalRecords({dir, ids, limit} = {}) {
     for (const segmentKey of await listMessageWalSegmentKeys(dir)) {
         if (pending.length >= bounded) break;
 
-        const records = await readJsonlEntries(path.join(dir, getMessageWalRecordsFileName(segmentKey)));
+        const records = (await readJsonlEntries(path.join(dir, getMessageWalRecordsFileName(segmentKey))))
+            .map(surfaceWalPlaneProvenance);
         if (records.length === 0) continue;
 
         const markedIds = new Set(

--- a/learn/agentos/tooling/PilotPlaneRunbook.md
+++ b/learn/agentos/tooling/PilotPlaneRunbook.md
@@ -36,16 +36,14 @@ reading of it.
 | Terminal | Meaning | Eligibility effect | Reachable today |
 |---|---|---|---|
 | `committed` | Replay onto the durable plane verified monotonic by a receipt — no loss, no double-apply | `opened` | ❌ no branch reaches it; needs an invoked replay adapter |
-| `demoted-clean` | No overlay-tagged segment reached the durable corpus, no committed history lost | `unchanged` | ❌ gated on `OVERLAY_TAGGING_PRODUCER` |
-| `failed-contained` | The claim could not be proven, whatever the cause | `denied` | ✅ the only terminal any run reaches |
+| `demoted-clean` | No overlay-stamped or provenance-unknown cutover-window write reached the durable corpus; no committed history lost | `unchanged` | ✅ through the invoked dual-WAL provenance producer |
+| `failed-contained` | The claim could not be proven, whatever the cause | `denied` | ✅ |
 
-**Both certifying terminals are closed**, and neither by a validation rule. In both cases the missing thing is
-a **producer of fact**, and no amount of argument validation substitutes for one. They are closed
-*differently* — demotion by a capability gate, promotion by having no branch at all — and the section below
-explains why that asymmetry is the right shape rather than an inconsistency. So today *every* pilot settles
-`failed-contained` — eligibility denied, overlay quarantined. That is not the tooling failing to do its job;
-it is the honest statement about pilot-plane transitions at this head, and each section below names the
-adapter that would open its path.
+Demotion now has a **producer of fact**: both accepted-write services pass resolved `AiConfig.plane.id`,
+both WAL appenders stamp it after caller fields, and `evaluateDemotion` invokes strict readers owned by
+the memory and message stores. Promotion remains closed because a complete ordered mutation-source actor
+still does not exist. The distinction is source authority, not stronger validation: a caller cannot submit
+an `overlayScan`, and no receipt-shaped argument can open `committed`.
 
 Eligibility is **three-valued on purpose.** Only a strict `committed` *opens* data-consuming eligibility.
 A clean demotion does not open it — it never closed it, because the pilot never mutated the durable plane.
@@ -65,14 +63,14 @@ reach for instead: deleting the overlay ("it's over anyway") or asserting succes
 > 1. **No consumed source-read boundary.** No production caller exists for `evaluatePromotion`,
 >    `planWalReplay`, `verifyReplayContinuity` or `parseJsonl` — nothing in the running system reads the
 >    corpus and could issue a receipt for having read all of it.
-> 2. **The owning store readers cannot become that authority.** Their operational reads deliberately *skip*
->    malformed and torn rows. Correct for serving; fatal for a completeness proof, which must refuse on a row
->    it cannot parse — that row is potentially the one that was lost.
-> 3. **The plane has two WAL families.** `messageWal.dir` derives to `path.join(memoryWal.dir, 'messages')`,
->    so a corpus scan returns memory and message segments in one undifferentiated list. Replay assumes
->    `embedded + graph`; the message family is graph-only. A receipt over memory records alone certifies an
->    **incomplete** plane — and because that family's `dirProd` is a nullable override, a deployment can move
->    it out of the scanned root, so the denominator moves with configuration.
+> 2. **Strict store readers now exist, but no actor consumes them as a complete source.** Operational reads
+>    still correctly skip malformed/torn rows; each store now also owns a strict provenance reader for
+>    demotion. Promotion still lacks the actor that resolves both configured roots, fences writers, consumes
+>    every strict row, and binds content digests.
+> 3. **The plane has two WAL families.** `messageWal.dir` derives to `path.join(memoryWal.dir, 'messages')`
+>    by default but may be explicitly relocated. `deriveDualCorpusReplayReceipt` now keeps memory
+>    (`embedded + graph`) and message (`graph`) records distinct and binds exact ids plus source/target plane
+>    identities; no invoked executor yet proves that those arrays were the complete configured plane.
 > 4. **Naïve message replay emits stale wakes.** `MailboxService._projectMessageWalRecord` defaults
 >    `pumpWake = true`; its own recovery path passes `pumpWake: false` explicitly. A replay reaching the
 >    default re-fires historical wakes as if they were new.
@@ -95,9 +93,8 @@ reach for instead: deleting the overlay ("it's over anyway") or asserting succes
 > whatever the thing's type.** Where a capability must *act* rather than merely *exist*, a conditional is a
 > dormant success path pretending to be a guard, so the branch is gone entirely.
 >
-> This is why the two closures differ, and the asymmetry is deliberate rather than untidy. Demotion keeps a
-> gate because its logic is complete and only its *input* is missing. Promotion has no branch because what is
-> missing is an *actor*.
+> Demotion demonstrates the required shape: it invokes the producer and owns the scan. Promotion has no
+> branch because its complete source-and-replay actor is still missing.
 >
 > **Why a gate and not a stricter check.** The previous shape settled `committed` on a one-entry corpus with an
 > unchanged before/after — a truthful, self-consistent, entirely zero-effect certification. Refusing that
@@ -137,58 +134,45 @@ reach for instead: deleting the overlay ("it's over anyway") or asserting succes
    bound to this pre-state — without it there is no baseline and nothing can be proven.
 4. **Apply** the planned entries to the durable plane.
 5. **Record the applied-stage sets again**, after.
-6. **Settle.** `evaluatePromotion({payloadEntries, appliedStagesBefore, appliedStagesAfter})` → the terminal
-   and the receipt. Record both. (Today this returns `failed-contained` from the capability gate above,
-   whatever you pass.)
+6. **Bind the component receipt.** `deriveDualCorpusReplayReceipt(...)` verifies separate memory/message
+   continuity, exact record sets, and source/target plane identities. It deliberately emits no terminal.
+7. **Settle only through the future invoked actor.** `evaluatePromotion()` still returns
+   `failed-contained`; it accepts no observations until that actor owns the complete source and target reads.
 
-> **There is no separate "plan" or "verify" step, deliberately.** `evaluatePromotion` takes the **source
-> corpus** and derives the plan itself, then runs the continuity verification — rather than accepting either.
-> Both were once arguments, and both were forgeable. A structurally complete continuity verdict is a thing a
-> caller can simply type; and a self-consistent *plan* proved only that its own projection matched its own
-> receipt, never that it was derived from the corpus it claimed to describe — a forged empty plan with a
-> `targetStateDigest` computed from the real pre-state reconciled cleanly, landed nothing, and settled
-> `committed`. Validating a claim's shape checks the shape, never the provenance.
+> **There is no caller-supplied plan or verification verdict, deliberately.** The component helpers derive
+> the plan from each source corpus and run continuity verification internally. Both intermediates were once
+> arguments, and both were forgeable. A structurally complete continuity verdict is a thing a caller can
+> simply type; and a self-consistent *plan* proved only that its own projection matched its own receipt, never
+> that it was derived from the corpus it claimed to describe.
 >
-> Deriving from the corpus removes both forgeable intermediates: a `committed` now needs a corpus whose every
-> planned id appears in the after-state, which is *doing* the replay rather than claiming it. What it does
-> **not** remove is the unknown denominator — hence the gate above.
+> Deriving from the corpus removes both forgeable intermediates. What it does **not** remove is the unknown
+> denominator — hence `evaluatePromotion()` remains unconditionally contained.
 >
 > Concurrent gains from other seats are permitted and reported separately, not treated as corruption.
 
 ## Demotion
 
-> ### ⚠️ `demoted-clean` is MECHANICALLY UNREACHABLE today, and that is the honest state
->
-> The leak scan needs each durable segment's **plane id**. No producer for it exists: the WAL appender writes
-> `{...record, segmentKey}` and carries no plane id, so nothing can distinguish an overlay-written segment
-> from a natively-written one.
->
-> `evaluateDemotion` therefore consults `OVERLAY_TAGGING_PRODUCER` **before it reads a single argument**, and
-> while that constant is `null` **every demotion settles `failed-contained` regardless of what you pass.**
-> This is a gate, not a validation: there is no input that unlocks a clean terminal.
->
-> **That is deliberate, and it replaced two weaker attempts** — each of which asked the *caller* to assert
-> the fact rather than establishing it. First a bare `[]` was accepted as "no leak". Then a named
-> `planeIdSource` was required — but only checked for being a non-empty string, so an invented name unlocked
-> `demoted-clean`. **Requiring a field is not proving a fact**, and a fabricable field is worse than none,
-> because it makes an impossibility look satisfied.
->
-> Do not try to satisfy the gate. A green terminal here would be false and its receipt would attest to
-> nothing. When a producer lands, set the constant to name it: the validation and set-inclusion logic behind
-> the gate is already written and directly tested, so opening the path is a one-line change with coverage in
-> place.
+Newly accepted memory and message WAL records carry immutable `planeId` provenance:
 
-The procedure below is what runs **once a producer exists**:
+- `MemoryService` / `MailboxService` supply resolved `AiConfig.plane.id`;
+- the store validates it and serializes `{...record, segmentKey, planeId}`, so a caller field loses;
+- missing/invalid identities reject before append;
+- operational readers surface an absent historical field as `unknown` without rewriting the file.
 
-1. **Scan the durable corpus for overlay-tagged segments.** The evaluator requires a *structure*, not a
-   list: `{planeIdSource, scannedSegmentCount, taggedSegments}`, and `planeIdSource` must **be** the
-   substrate's producer rather than merely a non-empty string. A bare array is refused, because `[]` is
-   indistinguishable from "nobody looked". **Unscanned is unproven, not clean.**
-2. **Record durable segment IDs** at clone time and now — *ids*, not counts. Cardinality is not identity:
-   `3 → 3` looks stable while a delete-and-add has destroyed committed history, so the check is set
-   inclusion over every pre-clone id.
-3. **Settle.** `evaluateDemotion({overlayScan, preCloneSegmentIds, postPilotSegmentIds})`.
-4. **Retire the overlay** — only on `demoted-clean`.
+The demotion procedure is now:
+
+1. **Invoke the producer.** `evaluateDemotion` takes the two configured WAL roots, overlay plane id,
+   cutover start, and clone-time segment ids. It does **not** accept `overlayScan` or post-pilot ids.
+2. **Strictly scan both WAL families.** Store-owned readers refuse malformed/torn rows. The producer retains
+   exact memory/message record sets and obtains post-pilot segment ids from the scan itself.
+3. **Bound legacy ignorance.** An unstamped record proven older than `cutoverStartedAt` is reported as legacy
+   context. An unknown identity inside the window—or an unknown timestamp that cannot prove it predates the
+   window—forces `failed-contained`.
+4. **Reject overlay writes.** Any in-window record stamped with the overlay plane id names its containing
+   segment and forces `failed-contained`. Concurrent canonical-plane writes are allowed and counted.
+5. **Prove no segment loss.** Clone-time ids must remain a subset of the producer-observed post-pilot ids.
+   Cardinality is not identity: `3 → 3` can hide delete-and-add.
+6. **Retire the overlay** only on `demoted-clean`.
 
 > ### Why demotion does NOT compare durable-plane fingerprints
 >

--- a/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
@@ -57,7 +57,7 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
     });
 
     const seed = async (id, timestampMs = Date.now()) =>
-        (await appendWalMemory(record(id, timestampMs), {dir: tmpDir})).segmentKey;
+        (await appendWalMemory(record(id, timestampMs), {dir: tmpDir, planeId: 'test-memory-plane'})).segmentKey;
 
     // The post-add atomic-write verify reads vectors back and classifies them at this dimension.
     const VECTOR_DIMENSION = 4;

--- a/test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs
@@ -42,7 +42,7 @@ test.describe('Neo.ai.daemons.message.drainCycle', () => {
         optionalEdges: {relatedTickets: [], relatedSessions: [], taggedConcepts: []}
     });
 
-    const seed = id => appendWalMessage(record(id), {dir: tmpDir});
+    const seed = id => appendWalMessage(record(id), {dir: tmpDir, planeId: 'test-message-plane'});
 
     test('without a replay processor, the cycle skips WAL reads instead of doing active no-op work', async () => {
         await seed('MESSAGE:deferred');

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
@@ -55,8 +55,8 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — getEmbedDr
         const oldest = now - 5 * HOUR_MS;       // 5h old (the oldest pending)
         const newer  = now - 1 * HOUR_MS;       // 1h old
 
-        await appendWalMemory(record('m-old', oldest), {dir: walDir});
-        await appendWalMemory(record('m-new', newer),  {dir: walDir});
+        await appendWalMemory(record('m-old', oldest), {dir: walDir, planeId: 'test-memory-plane'});
+        await appendWalMemory(record('m-new', newer),  {dir: walDir, planeId: 'test-memory-plane'});
 
         const result = await getEmbedDrainPendingAge({walDir, now});
 
@@ -70,8 +70,11 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — getEmbedDr
         const oldest = now - 5 * HOUR_MS;
         const newer  = now - 1 * HOUR_MS;
 
-        const {segmentKey: oldKey} = await appendWalMemory(record('m-old', oldest), {dir: walDir});
-        await appendWalMemory(record('m-new', newer), {dir: walDir});
+        const {segmentKey: oldKey} = await appendWalMemory(
+            record('m-old', oldest),
+            {dir: walDir, planeId: 'test-memory-plane'}
+        );
+        await appendWalMemory(record('m-new', newer), {dir: walDir, planeId: 'test-memory-plane'});
 
         // Embed the OLDEST record → only the newer record stays pending.
         await appendWalEmbedMarker({id: 'm-old', segmentKey: oldKey}, {dir: walDir});
@@ -269,7 +272,10 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
 
     test('(c) a stalled backlog records a failed outcome AND fires the one-shot alarm', async () => {
         const now = Date.now();
-        await appendWalMemory(record('m-stale', now - 8 * HOUR_MS), {dir: walDir}); // 8h > 6h threshold
+        await appendWalMemory(
+            record('m-stale', now - 8 * HOUR_MS),
+            {dir: walDir, planeId: 'test-memory-plane'}
+        ); // 8h > 6h threshold
 
         const outcomes = [];
         const alarmCalls = [];
@@ -294,7 +300,10 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
 
     test('(d) a fresh backlog records a completed outcome and fires NO alarm', async () => {
         const now = Date.now();
-        await appendWalMemory(record('m-fresh', now - 1 * HOUR_MS), {dir: walDir}); // 1h < 6h threshold
+        await appendWalMemory(
+            record('m-fresh', now - 1 * HOUR_MS),
+            {dir: walDir, planeId: 'test-memory-plane'}
+        ); // 1h < 6h threshold
 
         const outcomes = [];
         const alarmCalls = [];
@@ -311,7 +320,10 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
 
     test('(e) consecutive stalled checks fire the alarm exactly once until a healthy check resets it', async () => {
         const now = Date.now();
-        await appendWalMemory(record('m-stale', now - 9 * HOUR_MS), {dir: walDir});
+        await appendWalMemory(
+            record('m-stale', now - 9 * HOUR_MS),
+            {dir: walDir, planeId: 'test-memory-plane'}
+        );
 
         const outcomes = [];
         const alarmCalls = [];
@@ -333,14 +345,20 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
         expect(taskStateService.getTaskState('embed-drain-liveness-watchdog').embedDrainAlarm.alarmed).toBe(false);
 
         // A NEW stall re-alarms (latch was cleared by the healthy check).
-        await appendWalMemory(record('m-stale-2', Date.now() - 9 * HOUR_MS), {dir: walDir});
+        await appendWalMemory(
+            record('m-stale-2', Date.now() - 9 * HOUR_MS),
+            {dir: walDir, planeId: 'test-memory-plane'}
+        );
         await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime: makeRuntime()});
         expect(alarmCalls).toHaveLength(2);
     });
 
     test('(d/gate) alarm is suppressed when embedDaemonEnabled is false (no local drainer to blame)', async () => {
         const now = Date.now();
-        await appendWalMemory(record('m-stale', now - 8 * HOUR_MS), {dir: walDir});
+        await appendWalMemory(
+            record('m-stale', now - 8 * HOUR_MS),
+            {dir: walDir, planeId: 'test-memory-plane'}
+        );
 
         const outcomes = [];
         const alarmCalls = [];
@@ -359,7 +377,10 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
 
     test('(f) a health-service that throws does NOT propagate and fires no alarm', async () => {
         const now = Date.now();
-        await appendWalMemory(record('m-stale', now - 8 * HOUR_MS), {dir: walDir});
+        await appendWalMemory(
+            record('m-stale', now - 8 * HOUR_MS),
+            {dir: walDir, planeId: 'test-memory-plane'}
+        );
 
         const alarmCalls = [];
         const dispatcher = async payload => { alarmCalls.push(payload); };

--- a/test/playwright/unit/ai/planeConfig.spec.mjs
+++ b/test/playwright/unit/ai/planeConfig.spec.mjs
@@ -9,6 +9,7 @@ import '../../../../src/core/_export.mjs';
 import ConfigProvider, {createConfigProxy} from '../../../../ai/ConfigProvider.mjs';
 import {
     CANONICAL_PLANE_ID,
+    UNKNOWN_PLANE_ID,
     assertPlaneCoherence,
     assertPlaneMemberCoherence,
     collectPlaneMembers,
@@ -46,7 +47,7 @@ test.describe('ai/planeConfig — the config layer\'s plane helpers', () => {
                                             line < source.split('\n').findIndex(l => l.includes('export function resolvePlaneDataRoot')))).toBe(true)
     });
 
-    test('CANONICAL_PLANE_ID is the single exported literal, and it is opaque', () => {
+    test('CANONICAL_PLANE_ID is the single configured identity literal, and it is opaque', () => {
         expect(CANONICAL_PLANE_ID).toBe('neo-local-canonical');
         expect(CANONICAL_PLANE_ID).not.toContain('/');
         expect(CANONICAL_PLANE_ID).not.toContain(path.sep);
@@ -98,13 +99,19 @@ test.describe('resolved-value opacity — the invariant on the values that vary'
         for (const bad of pathShapedRows) {
             expect(() => parsePlaneIdEnv('NEO_PLANE_ID', {env: {NEO_PLANE_ID: bad}}), bad).toThrow('opaque')
         }
+
+        expect(() => parsePlaneIdEnv('NEO_PLANE_ID', {env: {NEO_PLANE_ID: UNKNOWN_PLANE_ID}}))
+            .toThrow('opaque')
     });
 
     test('isOpaquePlaneId: one predicate behind the load guard and the leaf env layer', () => {
         expect(isOpaquePlaneId(CANONICAL_PLANE_ID)).toBe(true);
         expect(isOpaquePlaneId('cloud-tenant-plane')).toBe(true);
         expect(isOpaquePlaneId('')).toBe(false);
+        expect(isOpaquePlaneId('   ')).toBe(false);
+        expect(isOpaquePlaneId(' padded-plane ')).toBe(false);
         expect(isOpaquePlaneId(null)).toBe(false);
+        expect(isOpaquePlaneId(UNKNOWN_PLANE_ID)).toBe(false);
 
         for (const bad of pathShapedRows) {
             expect(isOpaquePlaneId(bad), bad).toBe(false)

--- a/test/playwright/unit/ai/scripts/diagnostics/pilotPlaneTerminal.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/pilotPlaneTerminal.spec.mjs
@@ -1,17 +1,32 @@
 import {test, expect} from '@playwright/test';
+import fs             from 'node:fs/promises';
+import {mkdtemp, rm}  from 'node:fs/promises';
+import os             from 'node:os';
+import path           from 'node:path';
 import {
     ELIGIBILITY_EFFECT,
     OVERLAY_TAGGING_PRODUCER,
     PILOT_TERMINALS,
     PROMOTION_REPLAY_PRODUCER,
+    deriveDemotionTerminal,
+    deriveDualCorpusReplayReceipt,
     deriveReplayCompletion,
     diffSegmentIdentity,
     eligibilityEffect,
     evaluateDemotion,
     evaluatePromotion,
+    produceOverlayScan,
     validateOverlayScan
 } from '../../../../../../ai/scripts/diagnostics/pilotPlaneTerminal.mjs';
 import {digestAppliedStages} from '../../../../../../ai/scripts/diagnostics/walReplayPlan.mjs';
+import {
+    appendWalMemory,
+    getWalRecordsFileName
+} from '../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
+import {
+    appendWalMessage,
+    getMessageWalRecordsFileName
+} from '../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs';
 
 // AC5's parenthetical — "never a silent abandon" — is the whole specification. So most assertions here are
 // about the ABSENCE of exits: every path names a terminal, an unprovable claim never opens eligibility, and
@@ -21,22 +36,22 @@ import {digestAppliedStages} from '../../../../../../ai/scripts/diagnostics/walR
 // every one of them checked the SHAPE of a claim and mistook that for checking the claim.
 //   * two caller booleans passed as proof of replay        -> verification runs HERE
 //   * a structurally valid typed receipt passed as proof   -> verification runs HERE
-//   * a bare [] claiming an impossible scan                -> capability gate
-//   * an invented planeIdSource string unlocking clean     -> capability gate
+//   * a bare [] claiming an impossible scan                -> invoked dual-WAL producer
+//   * an invented planeIdSource string unlocking clean     -> caller can no longer supply the scan
 //   * segment COUNTS offered as proof of no-loss           -> set inclusion by id
 //   * a self-consistent SUBSET of the corpus certifying    -> unconditional containment
 //   * a NO-OP FUNCTION satisfying the promotion gate       -> unconditional containment
 //
-// The last two are why BOTH certifying terminals are now unreachable, and why they are closed DIFFERENTLY.
+// Promotion remains mechanically unreachable until a complete replay adapter owns its observations.
 // Deriving the plan here closed the forged plan but not the unknown denominator: a caller passing part of the
 // corpus verifies as cleanly as one passing all of it, and no validation rule can tell them apart. What was
 // missing was never a stricter check — it was a producer of fact.
 //
 // The first attempt at that repair was itself the same defect: a `typeof PROMOTION_REPLAY_PRODUCER !== 'function'`
 // gate type-checked the capability but never INVOKED it, so a no-op stub fell through to caller-owned
-// observations. Demotion keeps a gate because its logic is complete and only its input is missing; promotion has
-// no branch and no parameter, because a capability that must *act* cannot be verified by checking that it
-// *exists*. Requiring a thing is not proving a fact — the recurring shape in every row above.
+// observations. Demotion is now open only through an invoked producer that reads both WAL stores strictly;
+// promotion has no branch and no parameter, because a capability that must *act* cannot be verified by checking
+// that it *exists*. Requiring a thing is not proving a fact — the recurring shape in every row above.
 
 const S         = ids => new Set(ids),
       allStages = ids => ({embedded: S(ids), graph: S(ids)});
@@ -336,73 +351,241 @@ test.describe('⭐ deriveReplayCompletion — the math, directly executed, minti
     });
 });
 
-test.describe('⭐ evaluateDemotion — clean is MECHANICALLY unreachable while the producer is absent', () => {
-    test('the substrate has no plane-id producer, and that is recorded as a constant', () => {
-        // A constant, not a parameter. Asking the caller to NAME a source only checked that a string was
-        // present, so an invented name unlocked a clean terminal: requiring a field is not proving a fact.
-        expect(OVERLAY_TAGGING_PRODUCER).toBeNull();
+test.describe('deriveDualCorpusReplayReceipt — plane-bound memory + message replay component proof', () => {
+    const sourcePlaneId = 'neo-pilot-source',
+          targetPlaneId = 'neo-local-canonical',
+          memorySource  = [{id: 'memory-a', timestamp: 1, planeId: sourcePlaneId}],
+          messageSource = [{id: 'MESSAGE:a', timestamp: 2, planeId: sourcePlaneId}],
+          validSpec     = () => ({
+              sourcePlaneId,
+              targetPlaneId,
+              memory: {
+                  payloadEntries     : memorySource,
+                  targetEntriesAfter : [{...memorySource[0], planeId: targetPlaneId}, {id: 'other-memory', planeId: targetPlaneId}],
+                  appliedStagesBefore: allStages(['seed']),
+                  appliedStagesAfter : allStages(['seed', 'memory-a', 'other-memory'])
+              },
+              messages: {
+                  payloadEntries     : messageSource,
+                  targetEntriesAfter : [{...messageSource[0], planeId: targetPlaneId}, {id: 'MESSAGE:other', planeId: targetPlaneId}],
+                  appliedStagesBefore: {graph: S(['MESSAGE:seed'])},
+                  appliedStagesAfter : {graph: S(['MESSAGE:seed', 'MESSAGE:a', 'MESSAGE:other'])}
+              }
+          });
+
+    test('binds distinct source/target planes and exact family-typed record sets', () => {
+        const result = deriveDualCorpusReplayReceipt(validSpec());
+
+        expect(result.ok).toBe(true);
+        expect(result.receipt.sourcePlaneId).toBe(sourcePlaneId);
+        expect(result.receipt.targetPlaneId).toBe(targetPlaneId);
+        expect(result.receipt.families.memory.sourceRecordIds).toEqual(['memory-a']);
+        expect(result.receipt.families.memory.targetRecordIds).toEqual(['memory-a']);
+        expect(result.receipt.families.memory.unrelatedTargetRecordIds).toEqual(['other-memory']);
+        expect(result.receipt.families.messages.sourceRecordIds).toEqual(['MESSAGE:a']);
+        expect(result.receipt.families.messages.targetRecordIds).toEqual(['MESSAGE:a']);
+        expect(result.receipt.families.messages.continuity.requiredStages).toEqual(['graph']);
     });
 
-    test('⭐ NO argument combination yields demoted-clean — including a plausible invented scan', () => {
-        // Euclid's exact falsifier: a non-empty planeIdSource with zero scanned and zero tagged segments.
-        const candidates = [
-            {overlayScan: {planeIdSource: 'segment header planeId', scannedSegmentCount: 0, taggedSegments: []},
-             preCloneSegmentIds: [], postPilotSegmentIds: []},
-            {overlayScan: {planeIdSource: 'wal-store', scannedSegmentCount: 140, taggedSegments: []},
-             preCloneSegmentIds: ['s1'], postPilotSegmentIds: ['s1', 's2']},
-            {overlayScan: {planeIdSource: null, scannedSegmentCount: 1, taggedSegments: []},
-             preCloneSegmentIds: ['s1'], postPilotSegmentIds: ['s1']},
-            {overlayScan: []}, {overlayScan: {}}, {}, null, undefined
-        ];
+    test('replayed origin identity cannot masquerade as the target accepting plane', () => {
+        const spec = validSpec();
 
-        for (const spec of candidates) {
-            const result = evaluateDemotion(spec);
+        spec.messages.targetEntriesAfter[0] = {...messageSource[0]};
 
-            expect(result.terminal).toBe('failed-contained');
-            expect(result.eligibility).toBe('denied');
-        }
+        const result = deriveDualCorpusReplayReceipt(spec);
+
+        expect(result.ok).toBe(false);
+        expect(result.reason).toContain('origin identity must not masquerade as target write identity');
     });
 
-    test('the refusal blames the SUBSTRATE, not the caller, and says quarantine', () => {
-        // The message a real operator will read mid-demotion. It must not send them hunting for a bad argument.
-        const result = evaluateDemotion({
-            overlayScan       : {planeIdSource: 'segment header planeId', scannedSegmentCount: 140, taggedSegments: []},
-            preCloneSegmentIds: ['s1'], postPilotSegmentIds: ['s1']
-        });
+    test('unknown source provenance, missing target rows, and non-monotonic stage state fail closed', () => {
+        const unknown = validSpec();
+        unknown.memory.payloadEntries = [{...memorySource[0], planeId: 'unknown'}];
+        expect(deriveDualCorpusReplayReceipt(unknown).reason).toContain('unknown or mixed source provenance');
 
-        expect(result.reason).toContain('UNPROVABLE, not merely');
-        expect(result.reason).toContain('no argument can change that');
-        expect(result.reason).toContain('missing producer');
-        expect(result.reason).toContain('Quarantine');
+        const missing = validSpec();
+        missing.messages.targetEntriesAfter = [];
+        expect(deriveDualCorpusReplayReceipt(missing).reason).toContain('absent from the target WAL');
+
+        const lost = validSpec();
+        lost.memory.appliedStagesAfter = allStages(['memory-a']);
+        expect(deriveDualCorpusReplayReceipt(lost).reason).toContain('lost');
     });
 });
 
-// POSITIVE CONTROLS for the logic behind the capability gate. Without these the gate would hide whether the
-// demotion reasoning works at all, and opening the path later would be an untested one-line change.
-test.describe('validateOverlayScan — the logic behind the gate, tested directly', () => {
-    test('a bare array is not a scan', () => {
-        expect(validateOverlayScan([])).toContain('not a bare array');
-        expect(validateOverlayScan(['x'])).toContain('not a bare array');
+test.describe('evaluateDemotion — invoked dual-WAL provenance producer', () => {
+    const CUTOVER   = Date.UTC(2026, 6, 30, 0);
+    const BEFORE    = CUTOVER - 24 * 60 * 60 * 1000;
+    const AFTER     = CUTOVER + 1000;
+    const CANONICAL = 'neo-local-canonical';
+    const OVERLAY   = 'neo-pilot-overlay';
+
+    let memoryWalDir, messageWalDir;
+
+    const memoryRecord = (id, timestamp) => ({
+        id,
+        timestamp,
+        metadata: {prompt: id, thought: id, response: id},
+        document: id
+    });
+    const messageRecord = (id, timestamp) => ({
+        id,
+        timestamp,
+        graphProjectionVersion: 1,
+        message               : {id, type: 'MESSAGE', name: id, properties: {subject: id}},
+        routing               : {sentBy: '@alice', to: '@bob', senderUserId: 'alice', broadcastRecipients: []},
+        optionalEdges         : {relatedTickets: [], relatedSessions: [], taggedConcepts: []}
     });
 
-    test('an absent scan is unproven, not clean', () => {
-        for (const value of [undefined, null, 'scan', 42]) {
-            expect(validateOverlayScan(value)).toContain('unproven, not clean');
-        }
+    test.beforeEach(async () => {
+        memoryWalDir  = await mkdtemp(path.join(os.tmpdir(), 'neo-pilot-memory-'));
+        messageWalDir = await mkdtemp(path.join(os.tmpdir(), 'neo-pilot-message-'));
     });
 
-    test('⭐ an INVENTED planeIdSource is rejected against the substrate\'s producer', () => {
-        // Not merely "is a string" — it must BE the producer the substrate provides. While that is null,
-        // every named source is invented by construction.
-        const invented = validateOverlayScan({planeIdSource: 'segment header planeId', scannedSegmentCount: 1, taggedSegments: []});
-
-        expect(invented).toContain('is not the substrate\'s plane-id producer');
-        expect(invented).toContain('naming a field is not producing the fact');
+    test.afterEach(async () => {
+        await Promise.all([
+            rm(memoryWalDir, {recursive: true, force: true}),
+            rm(messageWalDir, {recursive: true, force: true})
+        ]);
     });
 
-    test('a missing planeIdSource is named as such', () => {
-        expect(validateOverlayScan({scannedSegmentCount: 1, taggedSegments: []})).toContain('must name where');
-        expect(validateOverlayScan({planeIdSource: '  ', scannedSegmentCount: 1, taggedSegments: []})).toContain('must name where');
+    test('the source names the actual immutable WAL field, not a caller assertion', () => {
+        expect(OVERLAY_TAGGING_PRODUCER).toBe('wal-record.planeId');
+    });
+
+    test('reaches demoted-clean with concurrent canonical writes and pre-cutover legacy context', async () => {
+        const legacyKey  = '2026-07-29',
+              legacyPath = path.join(memoryWalDir, getWalRecordsFileName(legacyKey));
+
+        await fs.writeFile(
+            legacyPath,
+            `${JSON.stringify({...memoryRecord('legacy-memory', BEFORE), segmentKey: legacyKey})}\n`,
+            'utf8'
+        );
+        await appendWalMemory(memoryRecord('canonical-memory', AFTER), {
+            dir    : memoryWalDir,
+            planeId: CANONICAL
+        });
+        await appendWalMessage(messageRecord('MESSAGE:canonical', AFTER + 1), {
+            dir    : messageWalDir,
+            planeId: CANONICAL
+        });
+
+        const result = await evaluateDemotion({
+            memoryWalDir,
+            messageWalDir,
+            overlayPlaneId    : OVERLAY,
+            cutoverStartedAt  : CUTOVER,
+            preCloneSegmentIds: [getWalRecordsFileName(legacyKey)]
+        });
+
+        expect(result.terminal).toBe('demoted-clean');
+        expect(result.eligibility).toBe('unchanged');
+        expect(result.receipt.legacyUnknownTotal).toBe(1);
+        expect(result.receipt.concurrentGainTotal).toBe(2);
+        expect(result.receipt.knownPlaneCounts).toEqual({[CANONICAL]: 2});
+        expect(result.receipt.recordIds).toEqual({
+            memory  : ['canonical-memory'],
+            messages: ['MESSAGE:canonical']
+        });
+    });
+
+    test('one overlay-stamped durable record forces failed-contained with the segment named', async () => {
+        await appendWalMemory(memoryRecord('overlay-memory', AFTER), {
+            dir    : memoryWalDir,
+            planeId: OVERLAY
+        });
+
+        const result = await evaluateDemotion({
+            memoryWalDir,
+            messageWalDir,
+            overlayPlaneId    : OVERLAY,
+            cutoverStartedAt  : CUTOVER,
+            preCloneSegmentIds: []
+        });
+
+        expect(result.terminal).toBe('failed-contained');
+        expect(result.reason).toContain('overlay-tagged segment');
+        expect(result.reason).toContain(getWalRecordsFileName('2026-07-30'));
+    });
+
+    test('one provenance-unknown record inside the cutover window forces failed-contained', async () => {
+        const segmentKey = '2026-07-30';
+
+        await fs.writeFile(
+            path.join(messageWalDir, getMessageWalRecordsFileName(segmentKey)),
+            `${JSON.stringify({...messageRecord('MESSAGE:unknown', AFTER), segmentKey})}\n`,
+            'utf8'
+        );
+
+        const result = await evaluateDemotion({
+            memoryWalDir,
+            messageWalDir,
+            overlayPlaneId    : OVERLAY,
+            cutoverStartedAt  : CUTOVER,
+            preCloneSegmentIds: []
+        });
+
+        expect(result.terminal).toBe('failed-contained');
+        expect(result.reason).toContain('inside the cutover window');
+        expect(result.reason).toContain('messages:MESSAGE:unknown');
+    });
+
+    test('a torn row fails the invoked strict scan instead of disappearing from evidence', async () => {
+        const {filePath} = await appendWalMessage(messageRecord('MESSAGE:valid', AFTER), {
+            dir    : messageWalDir,
+            planeId: CANONICAL
+        });
+
+        await fs.appendFile(filePath, '{"id":"MESSAGE:torn"', 'utf8');
+
+        const result = await evaluateDemotion({
+            memoryWalDir,
+            messageWalDir,
+            overlayPlaneId    : OVERLAY,
+            cutoverStartedAt  : CUTOVER,
+            preCloneSegmentIds: []
+        });
+
+        expect(result.terminal).toBe('failed-contained');
+        expect(result.reason).toContain('line 2 is not valid JSON');
+        expect(result.reason).toContain('quarantined');
+    });
+
+    test('a caller-authored clean scan is ignored; only configured roots reach the producer', async () => {
+        const result = await evaluateDemotion({
+            overlayScan: {
+                planeIdSource      : OVERLAY_TAGGING_PRODUCER,
+                scannedSegmentCount: 0,
+                taggedSegments     : []
+            }
+        });
+
+        expect(result.terminal).toBe('failed-contained');
+        expect(result.reason).toContain('memoryWalDir and messageWalDir are required');
+    });
+
+    test('the pure derivation validates a scan shape but carries no producer authority', async () => {
+        await appendWalMemory(memoryRecord('canonical-memory', AFTER), {
+            dir    : memoryWalDir,
+            planeId: CANONICAL
+        });
+
+        const scan = await produceOverlayScan({
+            memoryWalDir,
+            messageWalDir,
+            overlayPlaneId  : OVERLAY,
+            cutoverStartedAt: CUTOVER
+        });
+
+        expect(validateOverlayScan(scan)).toBeNull();
+        expect(validateOverlayScan({...scan, planeIdSource: 'invented'}))
+            .toContain('is not the substrate\'s plane-id producer');
+        expect(deriveDemotionTerminal({
+            overlayScan        : scan,
+            preCloneSegmentIds : [],
+            postPilotSegmentIds: scan.segmentIds
+        }).terminal).toBe('demoted-clean');
     });
 });
 
@@ -438,7 +621,7 @@ test.describe('diffSegmentIdentity — identity, not cardinality', () => {
 });
 
 test.describe('no path exits without a named terminal', () => {
-    test('both evaluators always return a member of PILOT_TERMINALS', () => {
+    test('both evaluators always return a member of PILOT_TERMINALS', async () => {
         const inputs = [
             undefined, null, {}, 'string', 42, [],
             {plan: {}}, {continuity: {ok: true, monotonic: true}},
@@ -447,23 +630,23 @@ test.describe('no path exits without a named terminal', () => {
             {preCloneSegmentIds: ['s1'], postPilotSegmentIds: ['s1']}
         ];
 
-        for (const input of inputs) {
-            for (const evaluate of [evaluatePromotion, evaluateDemotion]) {
-                const result = evaluate(input);
+        const assertNamedTerminal = result => {
+            expect(PILOT_TERMINALS).toContain(result.terminal);
+            expect(typeof result.reason).toBe('string');
+            expect(result.reason.length).toBeGreaterThan(0);
+            expect(result.eligibility).toBe(eligibilityEffect(result.terminal));
+            if (result.eligibility === 'opened') expect(result.terminal).toBe('committed');
+        };
 
-                expect(PILOT_TERMINALS).toContain(result.terminal);
-                expect(typeof result.reason).toBe('string');
-                expect(result.reason.length).toBeGreaterThan(0);
-                expect(result.eligibility).toBe(eligibilityEffect(result.terminal));
-                // Only a commit may carry an opened eligibility, whatever the input.
-                if (result.eligibility === 'opened') expect(result.terminal).toBe('committed');
-                // ⭐ And at THIS head neither evaluator can reach a certifying terminal at all: both are held
-                // shut by a capability constant. This is the whole-module statement of the two gates — if a
-                // future edit opens either without landing its producer, this fails regardless of which
-                // argument path the edit took.
-                expect(result.terminal).toBe('failed-contained');
-                expect(result.eligibility).toBe('denied');
-            }
+        for (const input of inputs) {
+            const promotion = evaluatePromotion(input),
+                  demotion  = await evaluateDemotion(input);
+
+            assertNamedTerminal(promotion);
+            assertNamedTerminal(demotion);
+            // Promotion remains closed; malformed demotion calls fail contained because no producer scan ran.
+            expect(promotion.terminal).toBe('failed-contained');
+            expect(demotion.terminal).toBe('failed-contained');
         }
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -227,6 +227,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(records[0].id).toBe(res.messageId);
         expect(records[0].message.properties.subject).toBe('Hello');
         expect(records[0].routing).toMatchObject({sentBy: '@alice', to: '@bob', senderUserId: 'alice'});
+        expect(records[0].planeId).toBe(mailboxAiConfig.plane.id);
 
         const pending = await readPendingMessageWalRecords({dir: messageWalDir});
         expect(pending).toHaveLength(0);

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -49,11 +49,13 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
     test.describe.configure({mode: 'serial'});
 
     let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter,
-        originalGetMemoryCollection, originalEmbedText, memStore, collectionMode, collectionTouches, testWalDir;
+        originalGetMemoryCollection, originalEmbedText, memStore, collectionMode, collectionTouches,
+        testPlaneId, testWalDir;
 
     test.beforeAll(async () => {
         const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
         testWalDir     = aiConfig.memoryWal.dir;
+        testPlaneId    = aiConfig.plane.id;
 
         GraphService         = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         ({default: MemoryService, MEMORY_ACCEPTED_MESSAGE} =
@@ -148,6 +150,10 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         // that counts this write, so a fresh write is never reported as 0 pending.
         expect(result.visibility.pendingDrainDepth).toBeGreaterThan(0);
         expect(typeof result.visibility.oldestPendingAgeMs).toBe('number');
+
+        const [acceptedRecord] = await readPendingWalRecords({dir: testWalDir, ids: [result.id]});
+
+        expect(acceptedRecord.planeId).toBe(testPlaneId);
 
         // It must not swing the other way either — the write IS durable, so nothing in the response
         // may read as failure or partial success.

--- a/test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs
@@ -16,6 +16,7 @@ import {
     getWalRecordsFileName,
     getWalSegmentKey,
     pruneReconciledWalSegments,
+    readMemoryWalProvenanceSegments,
     readPendingWalRecords
 } from '../../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
 
@@ -59,7 +60,10 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
     });
 
     test('appendWalMemory writes the full payload into its day segment and reports the key', async () => {
-        const {filePath, segmentKey} = await appendWalMemory(record('m1', DAY1), {dir: tmpDir});
+        const {filePath, segmentKey} = await appendWalMemory(
+            {...record('m1', DAY1), planeId: 'spoofed-caller-plane'},
+            {dir: tmpDir, planeId: 'test-memory-plane'}
+        );
 
         expect(segmentKey).toBe('2026-06-01');
         expect(filePath).toBe(path.join(tmpDir, 'wal-2026-06-01.jsonl'));
@@ -72,18 +76,26 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
         expect(entry.segmentKey).toBe('2026-06-01');
         expect(entry.metadata.prompt).toBe('p-m1');
         expect(entry.document).toBe('doc-m1');
+        expect(entry.planeId).toBe('test-memory-plane');
     });
 
     test('appendWalMemory and appendWalEmbedMarker reject missing required inputs', async () => {
         await expect(appendWalMemory(record('m1', DAY1), {})).rejects.toThrow('dir is required');
-        await expect(appendWalMemory({timestamp: DAY1}, {dir: tmpDir})).rejects.toThrow('record.id is required');
+        await expect(appendWalMemory({timestamp: DAY1}, {dir: tmpDir, planeId: 'test-memory-plane'}))
+            .rejects.toThrow('record.id is required');
+        await expect(appendWalMemory(record('m1', DAY1), {dir: tmpDir}))
+            .rejects.toThrow('planeId must be an opaque resolved plane identity');
+        await expect(appendWalMemory(record('m1', DAY1), {dir: tmpDir, planeId: '../spoof'}))
+            .rejects.toThrow('planeId must be an opaque resolved plane identity');
+        await expect(appendWalMemory(record('m1', DAY1), {dir: tmpDir, planeId: 'unknown'}))
+            .rejects.toThrow('planeId must be an opaque resolved plane identity');
         await expect(appendWalEmbedMarker({id: 'm1'}, {dir: tmpDir})).rejects.toThrow('id and segmentKey are required');
         await expect(appendWalGraphProjectionMarker({id: 'm1'}, {dir: tmpDir})).rejects.toThrow('id and segmentKey are required');
     });
 
     test('readPendingWalRecords returns appended records until their embed marker lands', async () => {
-        await appendWalMemory(record('m1', DAY1), {dir: tmpDir});
-        await appendWalMemory(record('m2', DAY1), {dir: tmpDir});
+        await appendWalMemory(record('m1', DAY1), {dir: tmpDir, planeId: 'test-memory-plane'});
+        await appendWalMemory(record('m2', DAY1), {dir: tmpDir, planeId: 'test-memory-plane'});
 
         expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['m1', 'm2']);
 
@@ -93,8 +105,11 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
     });
 
     test('graph-projection pending state is tracked independently from embed reconciliation', async () => {
-        await appendWalMemory(record('legacy', DAY1), {dir: tmpDir});
-        await appendWalMemory({...record('m1', DAY1), graphProjectionVersion: 1}, {dir: tmpDir});
+        await appendWalMemory(record('legacy', DAY1), {dir: tmpDir, planeId: 'test-memory-plane'});
+        await appendWalMemory(
+            {...record('m1', DAY1), graphProjectionVersion: 1},
+            {dir: tmpDir, planeId: 'test-memory-plane'}
+        );
 
         await appendWalEmbedMarker({id: 'm1', segmentKey: '2026-06-01'}, {dir: tmpDir});
 
@@ -107,9 +122,9 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
     });
 
     test('readPendingWalRecords filters by ids, bounds by limit, and reads newest segments first', async () => {
-        await appendWalMemory(record('old', DAY1), {dir: tmpDir});
-        await appendWalMemory(record('new-a', DAY2), {dir: tmpDir});
-        await appendWalMemory(record('new-b', DAY2), {dir: tmpDir});
+        await appendWalMemory(record('old', DAY1), {dir: tmpDir, planeId: 'test-memory-plane'});
+        await appendWalMemory(record('new-a', DAY2), {dir: tmpDir, planeId: 'test-memory-plane'});
+        await appendWalMemory(record('new-b', DAY2), {dir: tmpDir, planeId: 'test-memory-plane'});
 
         expect((await readPendingWalRecords({dir: tmpDir, ids: ['new-b']})).map(r => r.id)).toEqual(['new-b']);
 
@@ -118,21 +133,51 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
     });
 
     test('reads tolerate a torn line and a missing directory', async () => {
-        const {filePath} = await appendWalMemory(record('m1', DAY1), {dir: tmpDir});
+        const {filePath} = await appendWalMemory(
+            record('m1', DAY1),
+            {dir: tmpDir, planeId: 'test-memory-plane'}
+        );
         await fs.appendFile(filePath, '{"id":"torn-mid-append', 'utf8');
 
         expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['m1']);
         expect(await readPendingWalRecords({dir: path.join(tmpDir, 'missing')})).toEqual([]);
     });
 
+    test('legacy rows remain readable as unknown while strict evidence retains current provenance', async () => {
+        const segmentKey = getWalSegmentKey(DAY1),
+              filePath   = path.join(tmpDir, getWalRecordsFileName(segmentKey));
+
+        await fs.writeFile(filePath, `${JSON.stringify({...record('legacy', DAY1), segmentKey})}\n`, 'utf8');
+        await appendWalMemory(record('current', DAY1), {dir: tmpDir, planeId: 'test-memory-plane'});
+
+        const pending = await readPendingWalRecords({dir: tmpDir}),
+              strict  = await readMemoryWalProvenanceSegments({dir: tmpDir});
+
+        expect(pending.map(({id, planeId}) => ({id, planeId}))).toEqual([
+            {id: 'legacy', planeId: 'unknown'},
+            {id: 'current', planeId: 'test-memory-plane'}
+        ]);
+        expect(strict.ok).toBe(true);
+        expect(strict.segments[0].records.map(({id, planeId}) => ({id, planeId}))).toEqual([
+            {id: 'legacy', planeId: 'unknown'},
+            {id: 'current', planeId: 'test-memory-plane'}
+        ]);
+    });
+
     test('pruning removes only fully-reconciled, non-active segments beyond the retention bound', async () => {
         // Three reconciled segments + one with a pending record.
         for (const [id, ms, key] of [['a', DAY1, '2026-06-01'], ['b', DAY2, '2026-06-02'], ['c', DAY3, '2026-06-03']]) {
-            await appendWalMemory({...record(id, ms), graphProjectionVersion: 1}, {dir: tmpDir});
+            await appendWalMemory(
+                {...record(id, ms), graphProjectionVersion: 1},
+                {dir: tmpDir, planeId: 'test-memory-plane'}
+            );
             await appendWalEmbedMarker({id, segmentKey: key}, {dir: tmpDir});
             await appendWalGraphProjectionMarker({id, segmentKey: key}, {dir: tmpDir});
         }
-        await appendWalMemory(record('pending', Date.UTC(2026, 4, 30, 12)), {dir: tmpDir}); // 2026-05-30
+        await appendWalMemory(
+            record('pending', Date.UTC(2026, 4, 30, 12)),
+            {dir: tmpDir, planeId: 'test-memory-plane'}
+        ); // 2026-05-30
 
         const removed = await pruneReconciledWalSegments({dir: tmpDir, retentionLimit: 1, activeSegmentKey: '2026-06-03'});
 
@@ -150,12 +195,21 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
     });
 
     test('pruning preserves graph-projection-pending records even after embed reconciliation', async () => {
-        await appendWalMemory({...record('graph-pending', DAY1), graphProjectionVersion: 1}, {dir: tmpDir});
+        await appendWalMemory(
+            {...record('graph-pending', DAY1), graphProjectionVersion: 1},
+            {dir: tmpDir, planeId: 'test-memory-plane'}
+        );
         await appendWalEmbedMarker({id: 'graph-pending', segmentKey: '2026-06-01'}, {dir: tmpDir});
 
-        await appendWalMemory(record('old-style-reconciled-a', DAY2), {dir: tmpDir});
+        await appendWalMemory(
+            record('old-style-reconciled-a', DAY2),
+            {dir: tmpDir, planeId: 'test-memory-plane'}
+        );
         await appendWalEmbedMarker({id: 'old-style-reconciled-a', segmentKey: '2026-06-02'}, {dir: tmpDir});
-        await appendWalMemory(record('old-style-reconciled-b', DAY3), {dir: tmpDir});
+        await appendWalMemory(
+            record('old-style-reconciled-b', DAY3),
+            {dir: tmpDir, planeId: 'test-memory-plane'}
+        );
         await appendWalEmbedMarker({id: 'old-style-reconciled-b', segmentKey: '2026-06-03'}, {dir: tmpDir});
 
         const removed = await pruneReconciledWalSegments({dir: tmpDir, retentionLimit: 1, activeSegmentKey: '2026-06-04'});

--- a/test/playwright/unit/ai/services/memory-core/helpers/messageWalStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/messageWalStore.spec.mjs
@@ -1,0 +1,124 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import fs             from 'fs/promises';
+import {mkdtemp, rm}  from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+
+import {
+    appendMessageWalGraphProjectionMarker,
+    appendWalMessage,
+    getMessageWalGraphMarkersFileName,
+    getMessageWalRecordsFileName,
+    getMessageWalSegmentKey,
+    readMessageWalProvenanceSegments,
+    readPendingMessageWalRecords,
+    readWalMessages,
+    readWalMessagesByIds
+} from '../../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs';
+
+/**
+ * @summary Focused accepted-message WAL contract: immutable server plane provenance, honest legacy
+ * projection, strict parity evidence, and unchanged graph-drain reconciliation.
+ */
+test.describe('Neo.ai.services.memory-core.helpers.messageWalStore', () => {
+    let tmpDir;
+
+    const DAY      = Date.UTC(2026, 6, 30, 12);
+    const PLANE_ID = 'test-message-plane';
+    const record   = id => ({
+        id,
+        timestamp             : DAY,
+        graphProjectionVersion: 1,
+        message               : {id, type: 'MESSAGE', name: id, properties: {subject: id}},
+        routing               : {sentBy: '@alice', to: '@bob', senderUserId: 'alice', broadcastRecipients: []},
+        optionalEdges         : {relatedTickets: [], relatedSessions: [], taggedConcepts: []}
+    });
+
+    test.beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), 'neo-message-wal-store-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(tmpDir, {recursive: true, force: true});
+    });
+
+    test('derives UTC segment names for payload and graph receipt files', () => {
+        expect(getMessageWalSegmentKey(DAY)).toBe('2026-07-30');
+        expect(getMessageWalRecordsFileName('2026-07-30')).toBe('message-wal-2026-07-30.jsonl');
+        expect(getMessageWalGraphMarkersFileName('2026-07-30')).toBe('message-wal-2026-07-30.graph.jsonl');
+    });
+
+    test('server plane provenance overrides a caller spoof and survives every read path', async () => {
+        const {filePath, segmentKey} = await appendWalMessage(
+            {...record('MESSAGE:stamped'), planeId: 'caller-spoof'},
+            {dir: tmpDir, planeId: PLANE_ID}
+        );
+        const durable = JSON.parse((await fs.readFile(filePath, 'utf8')).trim()),
+              serving = await readWalMessages({dir: tmpDir}),
+              pending = await readPendingMessageWalRecords({dir: tmpDir}),
+              strict  = await readMessageWalProvenanceSegments({dir: tmpDir});
+
+        expect(segmentKey).toBe('2026-07-30');
+        expect(durable.planeId).toBe(PLANE_ID);
+        expect(serving[0].planeId).toBe(PLANE_ID);
+        expect(pending[0].planeId).toBe(PLANE_ID);
+        expect(strict.ok).toBe(true);
+        expect(strict.segments[0].records[0].planeId).toBe(PLANE_ID);
+
+        await appendMessageWalGraphProjectionMarker(
+            {id: durable.id, segmentKey},
+            {dir: tmpDir}
+        );
+        expect((await readWalMessagesByIds({dir: tmpDir, ids: [durable.id]}))[0].planeId).toBe(PLANE_ID);
+    });
+
+    test('missing, reserved, or path-shaped resolved plane identities reject before append', async () => {
+        await expect(appendWalMessage(record('MESSAGE:missing'), {dir: tmpDir}))
+            .rejects.toThrow('planeId must be an opaque resolved plane identity');
+        await expect(appendWalMessage(record('MESSAGE:unknown'), {dir: tmpDir, planeId: 'unknown'}))
+            .rejects.toThrow('planeId must be an opaque resolved plane identity');
+        await expect(appendWalMessage(record('MESSAGE:path'), {dir: tmpDir, planeId: '../overlay'}))
+            .rejects.toThrow('planeId must be an opaque resolved plane identity');
+        expect(await fs.readdir(tmpDir)).toEqual([]);
+    });
+
+    test('legacy rows remain readable and drainable as unknown without rewriting durable history', async () => {
+        const segmentKey = getMessageWalSegmentKey(DAY),
+              filePath   = path.join(tmpDir, getMessageWalRecordsFileName(segmentKey)),
+              legacy     = {...record('MESSAGE:legacy'), segmentKey};
+
+        await fs.writeFile(filePath, `${JSON.stringify(legacy)}\n`, 'utf8');
+
+        const serving = await readWalMessages({dir: tmpDir}),
+              pending = await readPendingMessageWalRecords({dir: tmpDir}),
+              durable = JSON.parse((await fs.readFile(filePath, 'utf8')).trim());
+
+        expect(serving[0].planeId).toBe('unknown');
+        expect(pending[0].planeId).toBe('unknown');
+        expect(durable).not.toHaveProperty('planeId');
+
+        await appendMessageWalGraphProjectionMarker(
+            {id: legacy.id, segmentKey},
+            {dir: tmpDir}
+        );
+        expect(await readPendingMessageWalRecords({dir: tmpDir})).toEqual([]);
+    });
+
+    test('strict evidence refuses a torn row while operational serving keeps valid records available', async () => {
+        const {filePath} = await appendWalMessage(record('MESSAGE:valid'), {
+            dir    : tmpDir,
+            planeId: PLANE_ID
+        });
+
+        await fs.appendFile(filePath, '{"id":"MESSAGE:torn"', 'utf8');
+
+        expect((await readWalMessages({dir: tmpDir})).map(item => item.id)).toEqual(['MESSAGE:valid']);
+
+        const strict = await readMessageWalProvenanceSegments({dir: tmpDir});
+
+        expect(strict.ok).toBe(false);
+        expect(strict.reason).toContain('line 2 is not valid JSON');
+    });
+});


### PR DESCRIPTION
Resolves #16169

Related: #15798
Related: #15806
Related: #16167

Stamps every newly accepted memory and message WAL record with the resolved server `planeId` after caller fields, reserves `unknown` for unstamped legacy evidence, and preserves provenance through serving/drain reads without rewriting history. The pilot demotion evaluator now invokes strict readers owned by both WAL stores, derives its own post-pilot segment set, permits bounded pre-cutover legacy context, and fails contained on overlay or unknown in-window writes. A dual-corpus replay component receipt binds distinct source/target planes, exact memory/message record sets, and the existing stage-continuity proof while leaving promotion authority closed.

Evidence: L2 (accepted-write, store, strict-scan, demotion-terminal, dual-replay, drain, and service contract tests) → L2 required (durable provenance and fail-closed evaluator behavior without the explicitly downstream maintainer-machine cutover). No residuals.

## Deltas from ticket

- Reserved `unknown` as a read-side non-identity sentinel so no configured writer can impersonate legacy ignorance.
- Added strict evidence readers beside the deliberately tolerant operational readers; serving still skips torn rows, while demotion proof refuses them.
- Removed caller-authored `overlayScan` and post-pilot segment inputs from `evaluateDemotion`; the invoked producer reads both configured WAL roots and owns those observations.
- Added a component-only dual-corpus replay receipt, including graph-only message semantics and target-write provenance, without reopening the still-missing complete promotion adapter.

## Decision Record impact

Aligned with ADR 0019; no amendment required. The implementation consumes the existing `plane.id` leaf at Memory Core accepted-write entrypoints and adds no env read, fallback, derived identity, or runtime config mutation. `PilotPlaneRunbook.md` now documents the reachable demotion producer and keeps promotion mechanically contained.

## Test Evidence

- Plane identity, both WAL stores, demotion, replay planning, and snapshot contracts: `npm run test-unit -- test/playwright/unit/ai/planeConfig.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/messageWalStore.spec.mjs test/playwright/unit/ai/scripts/diagnostics/pilotPlaneTerminal.spec.mjs test/playwright/unit/ai/scripts/diagnostics/walReplayPlan.spec.mjs test/playwright/unit/ai/scripts/diagnostics/walSnapshotClone.spec.mjs` — 140 passed on current `origin/dev`.
- Memory/message drain and embed-watchdog compatibility: `npm run test-unit -- test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs test/playwright/unit/ai/daemons/message/drainCycle.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs` — 51 passed.
- Memory accepted-write boundary: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs` — 16 passed.
- Mailbox accepted-write and replay boundary: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — 140 passed.
- Repository staged-file validators: `npx lint-staged` — whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, AiConfig test-mutation, and derived-domain checks passed.
- AiConfig contract: `node ./ai/scripts/lint/lint-config-template-ssot.mjs` — passed with zero inline-env defaults and zero test config-authority violations.

## Post-Merge Validation

- [ ] Restart the canonical Memory Core process before selecting the pilot cutover timestamp, then prove new live memory and message WAL rows carry `AiConfig.plane.id`.
- [ ] Under #16167, run the demotion producer against the real configured memory/message roots and retain its exact segment/record receipt; one overlay or in-window unknown row must settle `failed-contained`.
- [ ] Keep promotion closed until a future invoked adapter owns the complete dual-corpus source, writer fence, wake-suppressed message replay, and target observations.

Authored by Euclid (GPT-5, Codex Desktop). Session 71ff2f5e-17d6-47b2-90db-82bc1773b0a0.
