### PR TITLE
feat(ai): declare KB resume state as a plane member (#16174)

### DIFF
--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -80,6 +80,7 @@ x-plane-env: &plane-env
   NEO_MEMORY_LOG_PATH: /app/.neo-ai-data-parity/logs
   NEO_LAZY_EDGES_QUEUE_PATH: /app/.neo-ai-data-parity/memory-core/lazy-edges.jsonl
   # Knowledge-base member (ai/mcp/server/knowledge-base/configBase.mjs PLANE_MEMBER_PATHS)
+  NEO_KB_EMBEDDING_RESUME_STATE_DIR: /app/.neo-ai-data-parity/kb-sync
   NEO_KB_LOG_PATH: /app/.neo-ai-data-parity/logs
   # Neural-link member (ai/mcp/server/neural-link/configBase.mjs PLANE_MEMBER_PATHS)
   NEO_NL_LOG_PATH: /app/.neo-ai-data-parity/logs

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -265,6 +265,20 @@ class ConfigBase extends ConfigProvider {
              */
             hierarchyPath: leaf(path.resolve(neoRootDir, 'docs/output/class-hierarchy.json')),
             /**
+             * @summary Durable resume-state directory for Knowledge Base shadow-swap embeddings.
+             *
+             * This is a declared plane member: production defaults derive from the single KB plane
+             * anchor, while relocated profiles place it explicitly through the env binding.
+             * `VectorService.resumeStateDir` remains an explicit test seam, never a second default.
+             * @type {string}
+             */
+            embeddingResumeStateDir: leaf(
+                path.resolve(planeDataRoot, 'kb-sync'),
+                'NEO_KB_EMBEDDING_RESUME_STATE_DIR',
+                'string',
+                {planeMember: true}
+            ),
+            /**
              * Directory for the always-on KB server diagnostic log files. The KB server's
              * `logger.mjs` writes daily-rotated entries here regardless of `debug`, so long-running
              * operations (sync, embedding loops, ChromaDB lifecycle) leave a tail-able diagnostic
@@ -552,6 +566,7 @@ class ConfigBase extends ConfigProvider {
  * and asserted by the Tier-1 member list, not re-claimed here.
  */
 export const PLANE_MEMBER_PATHS = Object.freeze([
+    'embeddingResumeStateDir',
     'logPath'
 ]);
 

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -367,6 +367,7 @@
         "defaultRepoSlug",
         "defaultTenantId",
         "defaultVisibility",
+        "embeddingResumeStateDir",
         "hierarchyPath",
         "host",
         "kbFaqConceptLimit",

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -396,7 +396,7 @@ class VectorService extends Base {
             return [chunk];
         }
 
-        const maxInputBytes = Math.max(1, guardrail.safeProcessingLimitTokens * 3),
+        const maxInputBytes   = Math.max(1, guardrail.safeProcessingLimitTokens * 3),
               prefixBytes     = Buffer.byteLength(`${chunk.type}: ${chunk.name} in ${chunk.className || ''}\n`, 'utf8'),
               maxContentBytes = Math.max(1, maxInputBytes - prefixBytes - 128),
               parts           = this.splitTextByByteBudget(content, maxContentBytes);
@@ -863,11 +863,22 @@ class VectorService extends Base {
     }
 
     /**
-     * @summary Resolves the gitignored directory holding the KB embedding resume-state marker.
+     * @summary Resolves the configured directory holding the KB embedding resume-state marker.
+     *
+     * An explicit instance seam supports isolated tests. Production consumes the resolved KB
+     * config leaf; it never reconstructs the canonical data root from the checkout location.
      * @returns {String}
      */
     getResumeStateDir() {
-        return this.resumeStateDir ?? path.resolve(aiConfig.neoRootDir, '.neo-ai-data', 'kb-sync');
+        const resumeStateDir = this.resumeStateDir ?? aiConfig.embeddingResumeStateDir;
+
+        if (typeof resumeStateDir !== 'string' || resumeStateDir.trim() === '') {
+            throw new Error(
+                'VectorService.getResumeStateDir: aiConfig.embeddingResumeStateDir is required.'
+            )
+        }
+
+        return resumeStateDir
     }
 
     /**
@@ -1118,7 +1129,7 @@ class VectorService extends Base {
 
         const embedResult = await this.embedChunks({collection, chunksToProcess});
 
-        const count = await collection.count();
+        const count   = await collection.count();
         const message = `Embedding complete. Collection now contains ${count} items.`;
         logger.log(message);
         return {message, embedded: embedResult.embedded, deleted: idsToDelete.length};

--- a/test/playwright/configTemplateResolver.mjs
+++ b/test/playwright/configTemplateResolver.mjs
@@ -128,6 +128,7 @@ function activateStorageScope() {
         process.env.NEO_TEST_CONFIG_TEMPLATE_SCOPE           = scope;
         process.env.NEO_MEMORY_LOG_PATH                      = path.join(storageRoot, 'memory-core-logs');
         process.env.NEO_KB_LOG_PATH                          = path.join(storageRoot, 'knowledge-base-logs');
+        process.env.NEO_KB_EMBEDDING_RESUME_STATE_DIR        = path.join(storageRoot, 'kb-sync');
         process.env.NEO_NL_LOG_PATH                          = path.join(storageRoot, 'neural-link-logs');
         process.env.NEO_TELEMETRY_DB_PATH_TEST               = path.join(storageRoot, 'telemetry.sqlite');
         process.env.NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH =

--- a/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
@@ -334,6 +334,8 @@ test.describe('parity profile — volume scoping is the isolation mechanism', ()
 
         // ...and the anchor is the single place the root is declared.
         expect(compose['x-plane-env'].NEO_PLANE_DATA_ROOT).toBe('/app/.neo-ai-data-parity');
+        expect(compose['x-plane-env'].NEO_KB_EMBEDDING_RESUME_STATE_DIR)
+            .toBe(`${compose['x-plane-env'].NEO_PLANE_DATA_ROOT}/kb-sync`);
         expect(compose['x-plane-env'].NEO_NL_LOG_PATH)
             .toBe(`${compose['x-plane-env'].NEO_PLANE_DATA_ROOT}/logs`);
 

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -131,6 +131,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         process.env.NEO_CHROMA_PORT = '8010';
         process.env.NEO_AUTH_REALM  = 'tenant-realm';
         process.env.NEO_BACKUP_PATH = '/tmp/neo-kb-backups';
+        process.env.NEO_KB_EMBEDDING_RESUME_STATE_DIR = '/tmp/neo-kb-resume';
 
         // KB-LOCAL leaves (Chroma host/port) — env applies at the CHILD instance directly.
         // Fresh isolated instance (not the module-cached singleton, whose reactive state is
@@ -151,6 +152,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
             expect(freshKB.debug).toBe(true);                       // KB-local, env at child
             expect(freshKB.host).toBe('chroma');                    // KB-local, env at child
             expect(freshKB.port).toBe(8010);                        // KB-local, env at child
+            expect(freshKB.embeddingResumeStateDir).toBe('/tmp/neo-kb-resume');
             expect(freshKB.auth.realm).toBe('tenant-realm');        // Tier-1-owned, env at owner → inherited
             expect(freshKB.backupPath).toBe('/tmp/neo-kb-backups'); // Tier-1-owned → inherited
         } finally {

--- a/test/playwright/unit/ai/planeConfig.spec.mjs
+++ b/test/playwright/unit/ai/planeConfig.spec.mjs
@@ -164,7 +164,7 @@ test.describe('plane-member derivation witnesses — #15791 seat-variance ground
         expect(data.lazyEdgesQueuePath.default).toBe(path.resolve(anchor, 'memory-core/lazy-edges.jsonl'))
     });
 
-    test('knowledge-base + neural-link log members derive from the same anchor', async () => {
+    test('knowledge-base + neural-link members derive from the same anchor', async () => {
         // The KB config base re-wraps the registered Tier-1 singleton at module scope, so the
         // template must be fully evaluated FIRST — awaited dynamic imports serialize that order
         // (static import order races under worker sharding and fails file-load with "Cannot
@@ -180,6 +180,7 @@ test.describe('plane-member derivation witnesses — #15791 seat-variance ground
         }
         const KbConfigBase = (await import('../../../../ai/mcp/server/knowledge-base/configBase.mjs')).default;
 
+        expect(KbConfigBase.config.data.embeddingResumeStateDir.default).toBe(path.resolve(anchor, 'kb-sync'));
         expect(KbConfigBase.config.data.logPath.default).toBe(path.resolve(anchor, 'logs'));
         expect(NlConfigBase.config.data.logPath.default).toBe(path.resolve(anchor, 'logs'))
     });

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -176,6 +176,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
     let originalThreshold;
     let originalEmbeddingLimits;
     let originalEmbeddingProvider;
+    let originalResumeStateDir;
     let tmpDir, fixturePath;
 
     let TextEmbeddingService;
@@ -204,6 +205,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
             safeProcessingLimitTokens: Number(KB_Config.data.localModels.embedding.safeProcessingLimitTokens)
         };
         originalEmbeddingProvider = Memory_Config.data.embeddingProvider;
+        originalResumeStateDir     = KB_VectorService.resumeStateDir;
 
         tmpDir      = path.resolve(os.tmpdir(), `kb-work-volume-test-${process.pid}-${Date.now()}`);
         fs.mkdirSync(tmpDir, {recursive: true});
@@ -217,6 +219,7 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         KB_Config.data.localModels.embedding.contextLimitTokens        = originalEmbeddingLimits.contextLimitTokens;
         KB_Config.data.localModels.embedding.safeProcessingLimitTokens = originalEmbeddingLimits.safeProcessingLimitTokens;
         Memory_Config.data.embeddingProvider        = originalEmbeddingProvider;
+        KB_VectorService.resumeStateDir              = originalResumeStateDir;
         TextEmbeddingService.embedTexts             = TextEmbeddingService_orig;
         if (tmpDir && fs.existsSync(tmpDir)) {
             fs.rmSync(tmpDir, {recursive: true, force: true});
@@ -236,6 +239,17 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         // Isolate the shadow-swap resume-state marker per test (never touch the real .neo-ai-data tree).
         KB_VectorService.resumeStateDir = path.join(tmpDir, 'kb-resume-state');
         fs.rmSync(KB_VectorService.resumeStateDir, {recursive: true, force: true});
+    });
+
+    test('resume-state storage uses the explicit seam or the resolved KB config leaf', () => {
+        expect(KB_VectorService.getResumeStateDir()).toBe(path.join(tmpDir, 'kb-resume-state'));
+
+        KB_VectorService.resumeStateDir = null;
+        expect(KB_VectorService.getResumeStateDir()).toBe(KB_Config.embeddingResumeStateDir);
+
+        KB_VectorService.resumeStateDir = '';
+        expect(() => KB_VectorService.getResumeStateDir())
+            .toThrow(/aiConfig\.embeddingResumeStateDir is required/)
     });
 
     test('zero-changes fast-path is unchanged (existing chunks dedup to empty queue)', async () => {

--- a/test/playwright/unit/test/ConfigTemplateResolver.spec.mjs
+++ b/test/playwright/unit/test/ConfigTemplateResolver.spec.mjs
@@ -80,6 +80,7 @@ test.describe('test/playwright/configTemplateResolver (#11976)', () => {
         expect(path.relative(os.tmpdir(), storageRoot).startsWith('..')).toBe(false);
         expect(process.env.NEO_MEMORY_LOG_PATH.startsWith(storageRoot)).toBe(true);
         expect(process.env.NEO_KB_LOG_PATH.startsWith(storageRoot)).toBe(true);
+        expect(process.env.NEO_KB_EMBEDDING_RESUME_STATE_DIR).toBe(path.join(storageRoot, 'kb-sync'));
         expect(process.env.NEO_NL_LOG_PATH.startsWith(storageRoot)).toBe(true);
         expect(process.env.NEO_TELEMETRY_DB_PATH_TEST.startsWith(storageRoot)).toBe(true);
         expect(process.env.NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH).toBe(
@@ -89,14 +90,17 @@ test.describe('test/playwright/configTemplateResolver (#11976)', () => {
         expect(process.env.NEO_RECOVERY_ACTUATOR_RUN_STATE_DIR.startsWith(storageRoot)).toBe(true);
     });
 
-    test('routes deployment snapshots to distinct worker-local paths (#16171)', () => {
+    test('routes writable plane members to distinct worker-local paths', () => {
         const
             boundaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-worker-snapshot-paths-')),
-            probe        = `console.log(process.env.NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH)`;
+            probe        = `console.log(JSON.stringify({
+                kbResume: process.env.NEO_KB_EMBEDDING_RESUME_STATE_DIR,
+                snapshot: process.env.NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH
+            }))`;
 
         storageRoots.push(boundaryRoot);
 
-        const snapshotPaths = [0, 1].map(workerIndex => {
+        const workerPaths = [0, 1].map(workerIndex => {
             const env = {
                 ...process.env,
                 NEO_TEST_CONFIG_TEMPLATES: 'true',
@@ -116,12 +120,18 @@ test.describe('test/playwright/configTemplateResolver (#11976)', () => {
 
             expect(result.status, result.stderr).toBe(0);
 
-            return result.stdout.trim()
+            return JSON.parse(result.stdout.trim())
         });
 
-        expect(snapshotPaths).toEqual([
-            path.join(boundaryRoot, 'worker-0', 'deployment-state', 'snapshot.json'),
-            path.join(boundaryRoot, 'worker-1', 'deployment-state', 'snapshot.json')
+        expect(workerPaths).toEqual([
+            {
+                kbResume: path.join(boundaryRoot, 'worker-0', 'kb-sync'),
+                snapshot: path.join(boundaryRoot, 'worker-0', 'deployment-state', 'snapshot.json')
+            },
+            {
+                kbResume: path.join(boundaryRoot, 'worker-1', 'kb-sync'),
+                snapshot: path.join(boundaryRoot, 'worker-1', 'deployment-state', 'snapshot.json')
+            }
         ])
     });
 


### PR DESCRIPTION
Resolves #16174

Related: #15931

Knowledge Base embedding resume markers now participate in the resolved data plane. The owning KB config declares `embeddingResumeStateDir` beneath its plane anchor, parity and Playwright profiles place it explicitly, and `VectorService` consumes the resolved leaf instead of reconstructing `.neo-ai-data` from the checkout root. The existing explicit test seam remains authoritative when supplied, while missing or blank values fail loudly.

Evidence: L2 (resolved-config, profile-placement, worker-isolation, and consumer-path unit contracts) → L2 required (all close-target ACs are unit/config-verifiable). No residuals.

Decision Record impact: aligned with ADR 0019; this applies the existing config-as-SSOT and plane-member coherence rules without amending them.

## Deltas from ticket

None substantive. The config-leaf parity snapshot is included as the required mechanical record of the new public config path.

## Test Evidence

- KB consumer: `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs --reporter=line --workers=1` — 18 passed.
- Plane/profile/worker placement: `npm run test-unit -- test/playwright/unit/ai/planeConfig.spec.mjs test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs test/playwright/unit/test/ConfigTemplateResolver.spec.mjs --reporter=line --workers=1` — 59 passed.
- KB env binding: `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs --grep 'env overrides win' --reporter=line --workers=1` — 3 passed.
- Config SSOT: `npm run ai:lint-config-template-ssot` — passed.
- ADR 0019 guards: `check-aiconfig-antipatterns` and `check-aiconfig-test-mutation` — passed.
- Source boundary: the resume-state path no longer contains a `.neo-ai-data` or `neoRootDir` construction; the remaining `neoRootDir` read in `VectorService` belongs to unrelated operation metadata.
- Full local unit ledger: `npm run test-unit -- --reporter=line` — 10,338 passed; 17 failed; 5 skipped; 32 did not run. The 17 reds are outside the changed files (Wake Daemon Kimi bridge, deploy-pipeline revision fixtures, harness lifecycle fixtures, and one live-state query reranker spec). The full local gate is therefore not claimed green; hosted exact-head CI remains required.
- Baseline falsifier: the unfiltered KB config-template spec reports one older `config.host` assertion failure locally; temporarily removing this PR's KB leaf/assertion additions reproduced the identical failure. The new env-binding test passes independently above.

## Post-Merge Validation

- [x] None required; every close-target AC is covered by pre-merge config/source/unit evidence.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fac4d-7844-7422-9486-7f73ccf308f5.
