### PR TITLE
feat(ai): flag maintainer dual-licensing terms (#15615)

### DIFF
--- a/ai/services/shared/contentTrust/astroturfSanitizer.mjs
+++ b/ai/services/shared/contentTrust/astroturfSanitizer.mjs
@@ -62,12 +62,12 @@ const STEALTH_SIGNALS = [
         note   : 'offer to stand up an external endpoint / index our repo (external-infra-on-our-content)'
     },
     {
-        id     : 'self-promotional-licensing-pitch',
+        id     : 'maintainer-dual-licensing-terms',
         // Incident fixture: "I maintain <product> ... free for non-commercial use, while commercial
         // use requires separate permission." Require all three parts in one bounded sentence:
         // self-reference plus both licensing legs. Ordinary maintainer or licensing context stays clean.
         pattern: /\b(?:i|we)\s+(?:also\s+)?maintain\b(?=[^.!?\n]{0,120}\b(?:source[- ]available|free\s+for\s+non[- ]commercial\s+use)\b)(?=[^.!?\n]{0,120}\bcommercial\s+use\s+requires?\s+(?:(?:a\s+)?(?:separate|specific)\s+|a\s+)?(?:permission|licen[cs]e)\b)/i,
-        note   : 'self-promotional product maintenance paired with non-commercial and commercial-use terms'
+        note   : 'first-person product maintenance paired with non-commercial and commercial-use terms'
     }
 ];
 

--- a/ai/services/shared/contentTrust/astroturfSanitizer.mjs
+++ b/ai/services/shared/contentTrust/astroturfSanitizer.mjs
@@ -5,9 +5,10 @@ import {isTrustedTier} from './authorTrustClassifier.mjs';
  *
  * The empirical attack class: an outside automated account posts a credible, peer-toned technical
  * comment, then seeds a marketing payload — a traversable marketing URL, a *link-free* bare product
- * name, or a vendor pitch carrying a reward-conditional engagement bait plus an offer to stand up an
- * external endpoint against our repo. Two harms: an agent traversing the URL walks into a
- * watering-hole / injection payload, and the comment is ingested into the KB (`resources/content/
+ * name, a vendor pitch carrying a reward-conditional engagement bait plus an offer to stand up an
+ * external endpoint against our repo, or a self-promotional product introduction paired with
+ * non-commercial and commercial-use licensing terms. Two harms: an agent traversing the URL walks
+ * into a watering-hole / injection payload, and the comment is ingested into the KB (`resources/content/
  * issues/*.md`) — turning our corpus into an SEO / name-seeding link-farm.
  *
  * This function is the pure transform both boundaries will call (the `get_conversation` read path
@@ -59,6 +60,14 @@ const STEALTH_SIGNALS = [
         // "stand up a hosted MCP endpoint" / "index your repo" — offering to run external infra on our content.
         pattern: /\b(?:host(?:ed)?|stand\s*up|spin\s*up|set\s*up|provide|offer)\b[^.!?\n]{0,60}\b(?:mcp\b|endpoint\b|index(?:ing)?\s+(?:your|the|this)\s+(?:repo|repository|codebase)\b)/i,
         note   : 'offer to stand up an external endpoint / index our repo (external-infra-on-our-content)'
+    },
+    {
+        id     : 'self-promotional-licensing-pitch',
+        // Incident fixture: "I maintain <product> ... free for non-commercial use, while commercial
+        // use requires separate permission." Require all three parts in one bounded sentence:
+        // self-reference plus both licensing legs. Ordinary maintainer or licensing context stays clean.
+        pattern: /\b(?:i|we)\s+(?:also\s+)?maintain\b(?=[^.!?\n]{0,120}\b(?:source[- ]available|free\s+for\s+non[- ]commercial\s+use)\b)(?=[^.!?\n]{0,120}\bcommercial\s+use\s+requires?\s+(?:(?:a\s+)?(?:separate|specific)\s+|a\s+)?(?:permission|licen[cs]e)\b)/i,
+        note   : 'self-promotional product maintenance paired with non-commercial and commercial-use terms'
     }
 ];
 
@@ -113,7 +122,7 @@ export function sanitizeContent(content, {tier, productNameDenylist = []} = {}) 
     }
 
     const redactions = [];
-    let sanitized = content;
+    let   sanitized  = content;
 
     // 1. Markdown links first — preserve the human-readable text, quarantine the target.
     sanitized = sanitized.replace(MD_LINK_RE, (match, text, url) => {

--- a/test/playwright/unit/ai/services/shared/contentTrust/contentTrust.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/contentTrust/contentTrust.spec.mjs
@@ -1,15 +1,16 @@
-import {test, expect}                       from '@playwright/test';
-import {TRUST_TIERS}                        from '../../../../../../../ai/graph/identityRoots.mjs';
+import {test, expect}                                                       from '@playwright/test';
+import {TRUST_TIERS}                                                        from '../../../../../../../ai/graph/identityRoots.mjs';
 import {classifyAuthorTrust, isExternalTier, isTrustedTier, normalizeLogin} from '../../../../../../../ai/services/shared/contentTrust/authorTrustClassifier.mjs';
-import {sanitizeContent}                    from '../../../../../../../ai/services/shared/contentTrust/astroturfSanitizer.mjs';
+import {sanitizeContent}                                                    from '../../../../../../../ai/services/shared/contentTrust/astroturfSanitizer.mjs';
 
 /**
  * @summary Fixtures for the pure content-trust helpers — author-tier classifier + astroturf sanitizer.
  *
  * Covers the branch-ready first slice: a pure author-tier classifier plus a pure sanitizer/defanger
  * with fixtures for both documented attack variants (link-bearing marketing URL, link-free
- * product-name seeding) and the engagement-bait / external-endpoint variant — plus the load-bearing
- * negatives (trusted authors untouched, clean content not over-redacted).
+ * product-name seeding), the engagement-bait / external-endpoint variant, and the self-promotional
+ * licensing-pitch variant — plus the load-bearing negatives (trusted authors untouched, clean
+ * content not over-redacted).
  */
 test.describe('Neo.ai.services.shared.contentTrust.authorTrustClassifier', () => {
     test('normalizeLogin strips @, trims, lowercases; non-strings → empty', () => {
@@ -111,6 +112,42 @@ test.describe('Neo.ai.services.shared.contentTrust.astroturfSanitizer', () => {
         const signalIds = result.signals.map(s => s.id);
         expect(signalIds).toContain('engagement-bait-reward-conditional');
         expect(signalIds).toContain('external-endpoint-offer')
+    });
+
+    test('licensing-pitch variant: self-promotional maintenance + commercial terms are FLAGGED, not redacted', () => {
+        const positives = [
+            'I maintain ExampleGraph, which is source-available and free for non-commercial use, while commercial use requires separate permission.',
+            'We also maintain ExampleTool — free for non commercial use; commercial use requires a separate license.'
+        ];
+
+        positives.forEach(content => {
+            const result = sanitizeContent(content, {tier: TRUST_TIERS.EXTERNAL});
+
+            expect(result.sanitized).toBe(content);
+            expect(result.wasModified).toBe(false);
+            expect(result.redactions).toEqual([]);
+            expect(result.signals).toEqual([{
+                id  : 'self-promotional-licensing-pitch',
+                note: 'self-promotional product maintenance paired with non-commercial and commercial-use terms'
+            }])
+        })
+    });
+
+    test('licensing-pitch signal requires self-promotion and both licensing legs in one bounded sentence', () => {
+        const negatives = [
+            'I maintain ExampleGraph and use it at work.',
+            'This dependency is source-available; check whether commercial use requires separate permission.',
+            'We use ExampleGraph at work, where I maintain our internal adapter.',
+            'I maintain a source-available compatibility fork used by our integration tests.',
+            'I maintain ExampleTool; commercial use requires separate permission.',
+            'We maintain the integration guide. It is free for non-commercial use and commercial use requires permission.',
+            'We maintain the integration guide.\nIt is free for non-commercial use and commercial use requires permission.',
+            `I maintain ${'x'.repeat(121)} free for non-commercial use; commercial use requires permission.`
+        ];
+
+        negatives.forEach(content => {
+            expect(sanitizeContent(content, {tier: TRUST_TIERS.EXTERNAL}).signals).toEqual([])
+        })
     });
 
     test('TRUST GATE: identical hostile content from a TRUSTED author passes through untouched', () => {

--- a/test/playwright/unit/ai/services/shared/contentTrust/contentTrust.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/contentTrust/contentTrust.spec.mjs
@@ -8,8 +8,8 @@ import {sanitizeContent}                                                    from
  *
  * Covers the branch-ready first slice: a pure author-tier classifier plus a pure sanitizer/defanger
  * with fixtures for both documented attack variants (link-bearing marketing URL, link-free
- * product-name seeding), the engagement-bait / external-endpoint variant, and the self-promotional
- * licensing-pitch variant — plus the load-bearing negatives (trusted authors untouched, clean
+ * product-name seeding), the engagement-bait / external-endpoint variant, and the maintainer
+ * dual-licensing variant — plus the load-bearing negatives (trusted authors untouched, clean
  * content not over-redacted).
  */
 test.describe('Neo.ai.services.shared.contentTrust.authorTrustClassifier', () => {
@@ -114,7 +114,7 @@ test.describe('Neo.ai.services.shared.contentTrust.astroturfSanitizer', () => {
         expect(signalIds).toContain('external-endpoint-offer')
     });
 
-    test('licensing-pitch variant: self-promotional maintenance + commercial terms are FLAGGED, not redacted', () => {
+    test('licensing-pitch variant: maintainer disclosure + commercial terms are FLAGGED, not redacted', () => {
         const positives = [
             'I maintain ExampleGraph, which is source-available and free for non-commercial use, while commercial use requires separate permission.',
             'We also maintain ExampleTool — free for non commercial use; commercial use requires a separate license.'
@@ -127,13 +127,13 @@ test.describe('Neo.ai.services.shared.contentTrust.astroturfSanitizer', () => {
             expect(result.wasModified).toBe(false);
             expect(result.redactions).toEqual([]);
             expect(result.signals).toEqual([{
-                id  : 'self-promotional-licensing-pitch',
-                note: 'self-promotional product maintenance paired with non-commercial and commercial-use terms'
+                id  : 'maintainer-dual-licensing-terms',
+                note: 'first-person product maintenance paired with non-commercial and commercial-use terms'
             }])
         })
     });
 
-    test('licensing-pitch signal requires self-promotion and both licensing legs in one bounded sentence', () => {
+    test('licensing-pitch signal requires first-person maintenance and both licensing legs in one bounded sentence', () => {
         const negatives = [
             'I maintain ExampleGraph and use it at work.',
             'This dependency is source-available; check whether commercial use requires separate permission.',


### PR DESCRIPTION
Resolves #15615

Adds a third report-only `STEALTH_SIGNALS` class for first-person maintainer disclosures paired with both a non-commercial/source-available leg and a commercial-permission leg. The match is sentence/newline bounded and capped at 120 characters; matched content remains byte-identical and only gains the additive signal ID.

Related: #10291
Related: #10476

Evidence: focused pure-function unit execution at the committed head covers every close-target AC; no sandbox-unreachable residuals.

## Deltas from ticket

- Tightened the sample pattern to require all three parts together: `I/we [also] maintain`, a non-commercial/source-available term, and a commercial-use permission/license term.
- Kept the existing report-only contract: no redaction, trust-classifier, denylist, moderation, config, or projection-schema changes.
- Contract ledger: `contentTrust.signals` gains one additive ID, `maintainer-dual-licensing-terms`; existing consumers and fallbacks remain unchanged.

Prior-art: Memory Core memory `d2381dfe-b564-4fbb-a046-dc3fa704a7ac` from session `c55aaf95-54df-41eb-8d83-2c4474b0348e`.

## Test Evidence

- Content-trust surface: `npm run test-unit -- test/playwright/unit/ai/services/shared/contentTrust/contentTrust.spec.mjs` — 20/20 passed at `7df86d9045`.
- Repository unit suite on prior head `194e2cf3e0` (before the signal-ID wording-only rename): `npm run test-unit` — 10,357 passed, 17 failed, 5 skipped, 32 did not run. All 17 failures were outside the two touched files (wake/Kimi bridge, deployment revision-pin, lifecycle/lock, and one Memory Core health-timeout family); this PR does not claim a green local full-suite gate. Hosted exact-head CI remains authoritative.
- Agent preflight and commit hooks passed for the two-file capability delta.

## Post-Merge Validation

- [x] None required; every close-target AC is observable before merge in the focused unit suite.

## Evolution

The first candidate allowed `source-available` by itself. A bounded false-positive audit showed that it would flag legitimate contributor-maintainer language, so the final pattern requires the first-person maintenance clause and both licensing legs in the same bounded sentence. The signal deliberately describes the observed language rather than inferring promotional intent.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fac4d-7844-7422-9486-7f73ccf308f5.
