### PR TITLE
fix(mcp): bound bridge startup diagnostics (#16185)

### DIFF
--- a/ai/mcp/client/stdioToStreamableHttp.mjs
+++ b/ai/mcp/client/stdioToStreamableHttp.mjs
@@ -5,7 +5,24 @@ import {StdioServerTransport}          from '@modelcontextprotocol/sdk/server/st
 import {Command}                       from 'commander';
 import {pathToFileURL}                 from 'node:url';
 
-const RUNTIME_FAILURE_MESSAGE = 'Neo MCP bridge transport failed.';
+const
+    RUNTIME_FAILURE_MESSAGE = 'Neo MCP bridge transport failed.',
+    STARTUP_FAILURE_MESSAGE = 'Neo MCP bridge failed to start.';
+
+/**
+ * @summary Mark one fixed, locally-authored bridge configuration diagnostic as safe for stderr.
+ */
+class BridgeConfigurationError extends Error {
+    /**
+     * @summary Create a trusted configuration failure before transport startup.
+     * @param {String} message Fixed local diagnostic without raw endpoint or bearer material.
+     */
+    constructor(message) {
+        super(message);
+
+        this.name = 'BridgeConfigurationError'
+    }
+}
 
 /**
  * @summary Build the fail-loud CLI grammar for Neo's deliberately narrow local bridge.
@@ -26,22 +43,43 @@ export function createProgram() {
  * @returns {{endpoint: URL, tokenEnv: String}}
  */
 export function parseArgs(argv) {
-    const program = createProgram().exitOverride();
+    const program = createProgram()
+        .configureOutput({writeErr: () => {}})
+        .exitOverride();
 
     program.parse(argv, {from: 'user'});
 
     const
-        {url, tokenEnv} = program.opts(),
-        endpoint        = new URL(url);
+        {url, tokenEnv} = program.opts();
+    let endpoint;
+
+    try {
+        endpoint = new URL(url)
+    } catch {
+        throw new BridgeConfigurationError('Bridge endpoint must be a valid URL.')
+    }
 
     if (!['http:', 'https:'].includes(endpoint.protocol)) {
-        throw new TypeError("Bridge endpoint protocol must be 'http:' or 'https:'.")
+        throw new BridgeConfigurationError("Bridge endpoint protocol must be 'http:' or 'https:'.")
     }
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(tokenEnv)) {
-        throw new TypeError('Bridge token environment slot must be a valid environment variable name.')
+        throw new BridgeConfigurationError(
+            'Bridge token environment slot must be a valid environment variable name.'
+        )
     }
 
     return {endpoint, tokenEnv}
+}
+
+/**
+ * @summary Select the only startup detail permitted to cross the executable stderr boundary.
+ * @param {*} error Startup rejection.
+ * @returns {String}
+ */
+export function getStartupFailureMessage(error) {
+    return error instanceof BridgeConfigurationError
+        ? error.message
+        : STARTUP_FAILURE_MESSAGE
 }
 
 /**
@@ -161,7 +199,7 @@ export async function startBridge({
     onError
 }) {
     if (typeof token !== 'string' || token.length === 0) {
-        throw new Error('Bridge bearer environment slot is missing or empty.')
+        throw new BridgeConfigurationError('Bridge bearer environment slot is missing or empty.')
     }
 
     remoteTransport ||= new StreamableHTTPClientTransport(endpoint, {
@@ -182,9 +220,16 @@ export async function startBridge({
 export async function main(argv=process.argv.slice(2), env=process.env) {
     const
         {endpoint, tokenEnv} = parseArgs(argv),
+        token                = env[tokenEnv];
+
+    if (typeof token !== 'string' || token.length === 0) {
+        throw new BridgeConfigurationError('Bridge bearer environment slot is missing or empty.')
+    }
+
+    const
         bridge               = await startBridge({
             endpoint,
-            token  : env[tokenEnv],
+            token,
             onError: () => {
                 process.exitCode = 1;
                 process.stderr.write(`${RUNTIME_FAILURE_MESSAGE}\n`)
@@ -203,7 +248,7 @@ export async function main(argv=process.argv.slice(2), env=process.env) {
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
     main().catch(error => {
         if (error?.code !== 'commander.helpDisplayed') {
-            process.stderr.write('Neo MCP bridge failed to start.\n')
+            process.stderr.write(`${getStartupFailureMessage(error)}\n`)
         }
         process.exitCode = error?.code === 'commander.helpDisplayed' ? 0 : 1
     })

--- a/test/playwright/unit/ai/mcp/client/StdioToStreamableHttp.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/StdioToStreamableHttp.spec.mjs
@@ -1,11 +1,12 @@
-import {expect, test}  from '@playwright/test';
-import {spawn}         from 'node:child_process';
-import {once}          from 'node:events';
-import {createServer}  from 'node:http';
-import {fileURLToPath} from 'node:url';
+import {expect, test}     from '@playwright/test';
+import {spawn, spawnSync} from 'node:child_process';
+import {once}             from 'node:events';
+import {createServer}     from 'node:http';
+import {fileURLToPath}    from 'node:url';
 import {
     bridgeTransports,
     createProgram,
+    getStartupFailureMessage,
     parseArgs,
     startBridge
 } from '../../../../../../ai/mcp/client/stdioToStreamableHttp.mjs';
@@ -100,6 +101,29 @@ test.describe('stdioToStreamableHttp', () => {
 
         expect(error?.code).toBe('commander.helpDisplayed');
         expect(output.join('')).toContain('--token-env <name>')
+    });
+
+    test('only closed local configuration errors cross the startup diagnostic boundary', () => {
+        const
+            reflectedBearer = 'remote body echoed Bearer must-not-print',
+            getParseError   = argv => {
+                try {
+                    parseArgs(argv)
+                } catch (error) {
+                    return error
+                }
+            },
+            localError = getParseError([
+                '--url',
+                'not a url',
+                '--token-env',
+                'NEO_MCP_REMOTE_TOKEN'
+            ]);
+
+        expect(getStartupFailureMessage(localError)).toBe('Bridge endpoint must be a valid URL.');
+        expect(getStartupFailureMessage(new Error(reflectedBearer))).toBe('Neo MCP bridge failed to start.');
+        expect(getStartupFailureMessage({message: reflectedBearer})).toBe('Neo MCP bridge failed to start.');
+        expect(getStartupFailureMessage(null)).toBe('Neo MCP bridge failed to start.')
     });
 
     test('forwards both directions, binds the negotiated protocol, and closes once', async () => {
@@ -241,6 +265,90 @@ test.describe('stdioToStreamableHttp', () => {
 
         expect(local.started).toBe(0);
         expect(remote.started).toBe(0)
+    });
+
+    test('reports bounded local CLI configuration failures without echoing secret-shaped input', () => {
+        const
+            secretShapedUrl   = 'not-a-url-with-secret-shaped-input',
+            tokenShapedSlot   = 'ghp_SENTINEL_TOKEN_ENV_VALUE',
+            unknownTokenValue = 'SENTINEL_ARGV_TOKEN_VALUE',
+            subprocessEnv     = Object.fromEntries(
+                Object.entries(process.env).filter(([key]) => !['FORCE_COLOR', 'NO_COLOR'].includes(key))
+            ),
+            cases             = [{
+                args: [
+                    '--url',
+                    'https://mcp.example.test/mc/mcp',
+                    '--token-env',
+                    tokenShapedSlot
+                ],
+                expected: 'Bridge bearer environment slot is missing or empty.',
+                env     : Object.fromEntries(
+                    Object.entries(subprocessEnv).filter(([key]) => key !== tokenShapedSlot)
+                )
+            }, {
+                args: [
+                    '--url',
+                    secretShapedUrl,
+                    '--token-env',
+                    'NEO_MCP_REMOTE_TOKEN'
+                ],
+                expected: 'Bridge endpoint must be a valid URL.'
+            }, {
+                args: [
+                    '--url',
+                    'file:///private/secret-shaped-path',
+                    '--token-env',
+                    'NEO_MCP_REMOTE_TOKEN'
+                ],
+                expected: "Bridge endpoint protocol must be 'http:' or 'https:'."
+            }, {
+                args: [
+                    '--url',
+                    'https://mcp.example.test/mc/mcp',
+                    '--token-env',
+                    'invalid secret-shaped slot'
+                ],
+                expected: 'Bridge token environment slot must be a valid environment variable name.'
+            }, {
+                args: [
+                    '--url',
+                    'https://mcp.example.test/mc/mcp',
+                    '--token-env',
+                    'NEO_MCP_REMOTE_TOKEN',
+                    `--token=${unknownTokenValue}`
+                ],
+                expected: 'Neo MCP bridge failed to start.'
+            }, {
+                args: [
+                    '--url',
+                    'https://mcp.example.test/mc/mcp'
+                ],
+                expected: 'Neo MCP bridge failed to start.'
+            }, {
+                args: [
+                    '--url',
+                    'https://mcp.example.test/mc/mcp',
+                    '--token-env'
+                ],
+                expected: 'Neo MCP bridge failed to start.'
+            }];
+
+        for (const fixture of cases) {
+            const result = spawnSync(process.execPath, [BRIDGE_ENTRYPOINT, ...fixture.args], {
+                encoding: 'utf8',
+                env     : fixture.env || {...subprocessEnv, NEO_MCP_REMOTE_TOKEN: 'must-not-print'}
+            });
+
+            expect(result.status).toBe(1);
+            expect(result.stderr).toBe(`${fixture.expected}\n`);
+            expect(result.stderr).not.toContain(secretShapedUrl);
+            expect(result.stderr).not.toContain('/private/secret-shaped-path');
+            expect(result.stderr).not.toContain('invalid secret-shaped slot');
+            expect(result.stderr).not.toContain(tokenShapedSlot);
+            expect(result.stderr).not.toContain(unknownTokenValue);
+            expect(result.stderr).not.toContain('must-not-print')
+        }
     })
 
     test('a reflected bearer response produces one sanitized error and exits nonzero', async () => {


### PR DESCRIPTION
Resolves #16185

The local stdio-to-Streamable-HTTP bridge now distinguishes fixed Neo-owned
configuration failures from every raw-input, transport-start, and
remote-influenced failure. A private marker admits only bounded diagnostics;
Commander still owns option grammar and help, while its default raw-argv error
writer is suppressed at `parseArgs()`. Unknown failures continue to collapse to
one generic startup line.

Related: #16181
Related: #16182
Related: #16184

Evidence: L3 (real Node subprocess probes exercise the CLI executable boundary) → L3 required (all close-target runtime ACs). No residuals.

## Deltas from ticket

The original missing-slot AC treated a syntactically valid environment
identifier as safe to echo. An executable falsifier proved that token-shaped
strings are valid identifiers, so the ticket and implementation now forbid all
raw argv reflection. The missing-slot diagnostic is fixed text, and Commander
grammar failures are reduced to the generic startup line.

## Test Evidence

- RED: the new bounded-configuration fixture observed the prior generic startup
  line (11 passing, 1 failing).
- `npm run test-unit -- test/playwright/unit/ai/mcp/client/StdioToStreamableHttp.spec.mjs`
  — 13/13 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/client/StdioToStreamableHttp.spec.mjs test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs test/playwright/unit/ai/FleetLifecycleService.spec.mjs test/playwright/unit/ai/startAgentProvisioned.spec.mjs`
  — 119/119 passed on the committed tree.
- `npm run ai:lint-mcp-test-locations` — passed.
- `npm run agent-preflight -- --no-fix --change-class restoration ...` —
  passed.
- Commander falsifier: stock `InvalidArgumentError` wrote the rejected raw URL;
  the shipped executable now suppresses that writer and emits exactly one
  Neo-owned line.
- Directly touched CLI surface:
  `test/playwright/unit/ai/mcp/client/StdioToStreamableHttp.spec.mjs` exercises
  real child processes for malformed URL, invalid protocol, invalid slot,
  token-shaped slot, unknown secret-bearing option, missing option, missing
  value, and a reflected bearer response.

## Post-Merge Validation

- [x] None operator-gated; the close-target executable boundary is covered by
  real local subprocesses and the affected Fleet suite.

## Evolution

The adversarial pre-PR audit found two leaks beyond the first implementation:
Commander's default writer reflected `--token=<value>`, and the missing-slot
message interpolated a token-shaped but grammar-valid slot argument. The final
shape keeps Commander for grammar/help while making Neo the sole stderr writer,
and replaces the slot interpolation with fixed local vocabulary.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session b1ebc46a-5a83-496c-aa8b-385af785e9cb.
