### PR TITLE
feat(fleet): separate MCP target and transport (#16184)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -206,7 +206,7 @@ class FleetControlBridge extends Base {
      * @param {Object} [definition.metadata]         Free-form non-secret metadata.
      * @param {String} [definition.modelProvider]    The agent's model-provider login; resolves via the AiConfig SSOT leaf when omitted.
      * @param {Object|null} [definition.mcpServers]   Complete sparse MCP overrides; omitted/null follows live defaults, exactly like configureAgent.
-     * @param {Object|null} [definition.mcpTransport] Local stdio or one connected remote tenant id.
+     * @param {Object|null} [definition.mcpTarget] Resident services or one connected tenant id.
      * @returns {Object} The public agent definition (no credential), or a controlled
      *     `{status:'rejected', reason}` outcome for FleetRegistryService validation failures.
      */
@@ -214,14 +214,14 @@ class FleetControlBridge extends Base {
         try {
             const
                 registry        = this.getRegistry(),
-                transport       = definition?.mcpTransport,
-                selectingRemote = transport?.mode === 'remote-http' &&
-                    typeof transport.tenantId === 'string' &&
-                    !!transport.tenantId.trim(),
-                agentId   = definition?.id || definition?.githubUsername,
-                existing  = selectingRemote && agentId ? registry.getAgent(agentId) : null,
-                rejected  = selectingRemote && !existing &&
-                    this.rejectUnavailableRemoteMcpSelection(transport);
+                target          = definition?.mcpTarget,
+                selectingTenant = target?.kind === 'tenant' &&
+                    typeof target.tenantId === 'string' &&
+                    !!target.tenantId.trim(),
+                agentId  = definition?.id || definition?.githubUsername,
+                existing = selectingTenant && agentId ? registry.getAgent(agentId) : null,
+                rejected = selectingTenant && !existing &&
+                    this.rejectUnavailableMcpTarget(target);
 
             if (rejected) return rejected;
 
@@ -265,25 +265,25 @@ class FleetControlBridge extends Base {
      * @summary Configure an existing agent through one serializable curated intent. Validation
      * failures become an explicit domain outcome the Accounts card may render; unexpected service
      * failures still throw and are sanitized by dispatchFleetRequest.
-     * @param {Object} intent `{id, harnessType?, mcpServers?, mcpTransport?}`
+     * @param {Object} intent `{id, harnessType?, mcpServers?, mcpTarget?}`
      * @returns {{status: 'accepted', agent: Object}|{status: 'rejected', reason: String}}
      */
     configureAgent(intent) {
         try {
             const
-                registry  = this.getRegistry(),
-                transport = intent && Object.hasOwn(intent, 'mcpTransport')
-                    ? intent.mcpTransport
+                registry = this.getRegistry(),
+                target   = intent && Object.hasOwn(intent, 'mcpTarget')
+                    ? intent.mcpTarget
                     : null,
-                selectingRemote = transport?.mode === 'remote-http' &&
-                    typeof transport.tenantId === 'string' &&
-                    !!transport.tenantId.trim(),
-                existing  = selectingRemote ? registry.getAgent(intent?.id) : null,
-                unchanged = transport?.mode === 'remote-http' &&
-                    existing?.mcpTransport?.mode === 'remote-http' &&
-                    existing.mcpTransport.tenantId === transport.tenantId,
+                selectingTenant = target?.kind === 'tenant' &&
+                    typeof target.tenantId === 'string' &&
+                    !!target.tenantId.trim(),
+                existing  = selectingTenant ? registry.getAgent(intent?.id) : null,
+                unchanged = target?.kind === 'tenant' &&
+                    existing?.mcpTarget?.kind === 'tenant' &&
+                    existing.mcpTarget.tenantId === target.tenantId,
                 rejected = existing && !unchanged &&
-                    this.rejectUnavailableRemoteMcpSelection(transport);
+                    this.rejectUnavailableMcpTarget(target);
 
             if (rejected) return rejected;
 
@@ -304,26 +304,26 @@ class FleetControlBridge extends Base {
     }
 
     /**
-     * @summary Reject a NEW remote target selection unless the Brain tenant authority can resolve it
+     * @summary Reject a NEW tenant target selection unless the Brain tenant authority can resolve it
      * as connected. Registry persistence remains provider-neutral; this Body→Brain boundary prevents
      * a stale/direct wire intent from bypassing the card's inert-target affordance. An unchanged
      * already-persisted selection is deliberately handled by its normal start-time readiness gate.
-     * @param {Object|null} transport
+     * @param {Object|null} target
      * @returns {Object|null} Controlled rejection or `null`.
      * @protected
      */
-    rejectUnavailableRemoteMcpSelection(transport) {
-        if (transport?.mode !== 'remote-http' ||
-            typeof transport.tenantId !== 'string' ||
-            !transport.tenantId.trim()) {
+    rejectUnavailableMcpTarget(target) {
+        if (target?.kind !== 'tenant' ||
+            typeof target.tenantId !== 'string' ||
+            !target.tenantId.trim()) {
             return null
         }
 
-        if (this.getTenantService().resolveMcpResources(transport.tenantId)) return null;
+        if (this.getTenantService().resolveMcpResources(target.tenantId)) return null;
 
         return {
             status: 'rejected',
-            reason: `Remote MCP tenant '${transport.tenantId}' is unavailable.`
+            reason: `MCP tenant '${target.tenantId}' is unavailable.`
         }
     }
 

--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -1399,7 +1399,7 @@ class FleetLifecycleService extends Base {
      * @param {String} options.repoPath Canonical prepared checkout path.
      * @param {String} options.instanceHome Canonical prepared harness instance home.
      * @param {Object} options.mcpMatrix Effective MCP enabled-state matrix.
-     * @param {Object} options.mcpTransport Resolved non-secret remote transport plan.
+     * @param {Object} options.mcpTarget Resolved non-secret tenant target.
      * @param {Object[]} options.mcpPlan Exact non-secret renderer input returned by workspace preparation.
      * @returns {Promise<Object>} Redacted receipt plus a producer-bound MC/KB capture plan.
      */
@@ -1409,7 +1409,7 @@ class FleetLifecycleService extends Base {
         repoPath,
         instanceHome,
         mcpMatrix,
-        mcpTransport,
+        mcpTarget,
         mcpPlan
     } = {}) {
         const
@@ -1427,9 +1427,9 @@ class FleetLifecycleService extends Base {
             !path.isAbsolute(instanceHome || '') ||
             !mcpMatrix ||
             typeof mcpMatrix !== 'object' ||
-            !mcpTransport ||
-            mcpTransport.mode !== 'remote-http' ||
-            !mcpTransport.resources ||
+            !mcpTarget ||
+            mcpTarget.kind !== 'tenant' ||
+            !mcpTarget.resources ||
             !Array.isArray(mcpPlan) ||
             !/^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})$/.test(agentIdentity)) {
             throw new Error(`FleetLifecycleService.inspectPreparedRemoteMcpAdapter: malformed prepared Codex inspection input for agent '${agent?.id || 'unknown'}'.`)
@@ -1489,21 +1489,24 @@ class FleetLifecycleService extends Base {
 
             if (REMOTE_MCP_SERVER_KEYS.has(key)) {
                 const
-                    resource         = mcpTransport.resources[key],
+                    resource         = mcpTarget.resources[key],
                     staticHeaders    = transport.http_headers,
                     envHeaderAliases = transport.env_http_headers;
 
                 if (transport.type !== 'streamable_http' ||
                     transport.url !== resource?.url ||
                     transport.bearer_token_env_var !== REMOTE_MCP_CREDENTIAL_ENV_VAR ||
-                    planRow.mode !== 'remote-http' ||
+                    planRow.target !== 'tenant' ||
+                    planRow.transport !== 'streamable-http' ||
                     planRow.url !== resource?.url ||
                     planRow.credentialEnvVar !== REMOTE_MCP_CREDENTIAL_ENV_VAR ||
                     (staticHeaders && Object.keys(staticHeaders).length > 0) ||
                     (envHeaderAliases && Object.keys(envHeaderAliases).length > 0)) {
                     throw new Error(`FleetLifecycleService.inspectPreparedRemoteMcpAdapter: installed '${harnessType}' reported a non-canonical remote projection for '${name}'.`)
                 }
-            } else if (transport.type !== 'stdio' || planRow.mode !== 'stdio') {
+            } else if (transport.type !== 'stdio' ||
+                planRow.target !== 'resident' ||
+                planRow.transport !== 'stdio') {
                 throw new Error(`FleetLifecycleService.inspectPreparedRemoteMcpAdapter: installed '${harnessType}' moved local-only '${name}' off stdio.`)
             }
         }

--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -7,13 +7,14 @@ import Base            from '../../../src/core/Base.mjs';
 import {HARNESS_TYPES} from '../../../src/ai/fleet/harnessTypes.mjs';
 import {
     normalizeMcpOverrides,
-    normalizeMcpTransport,
-    supportsRemoteMcpTransport
+    normalizeMcpTarget,
+    supportsTenantMcpTarget
 } from '../../../src/ai/fleet/mcpServers.mjs';
 
 const
     __filename              = fileURLToPath(import.meta.url),
     __dirname               = path.dirname(__filename),
+    RETIRED_TARGET_FIELD    = ['mcp', 'Transport'].join(''),
     PUBLIC_SENSITIVE_KEY_RE = /^(?:credentials?|secrets?|tokens?|(?:github)?pats?|passwords?|authorization|(?:api|client|private)(?:key|token|secret|credential|password)s?|personalaccess(?:key|token|secret|credential|password)s?|(?:access|auth|bearer|github|id|oauth|refresh|session)(?:key|token|secret|credential|password)s?|launch|command|args|argv|env|environment)$/;
 
 /**
@@ -145,18 +146,70 @@ function redactPublicFields(value, seen=new WeakSet()) {
 }
 
 /**
- * @summary Canonicalize one persisted transport without letting a corrupt legacy row acquire
- * remote authority. Absence and invalid stored shapes both fail closed to local stdio.
- * @param {*} transport
+ * @summary Canonicalize one persisted target without letting a corrupt row acquire tenant
+ * authority. Absence and invalid stored shapes both fail closed to the resident target.
+ * @param {*} target
  * @returns {Object|null}
  */
-function normalizeStoredMcpTransport(transport) {
+function normalizeStoredMcpTarget(target) {
     try {
-        return normalizeMcpTransport(transport ?? null)
+        return normalizeMcpTarget(target ?? null)
     } catch {
         return null
     }
 }
+
+// Legacy MCP target migration begin — deletion boundary after the live registry rewrite is proven.
+/**
+ * @summary Translate the single retired `mcpTransport` registry shape into target intent. This
+ * helper is read-path migration substrate only: it accepts no URLs, headers, credentials, commands,
+ * or unknown keys, and every malformed legacy row fails closed to the resident target.
+ * @param {*} transport
+ * @returns {Object|null}
+ */
+function migrateLegacyMcpTransport(transport) {
+    if (transport === null || transport?.mode === 'stdio') {
+        return null
+    }
+
+    if (!transport ||
+        typeof transport !== 'object' ||
+        Array.isArray(transport) ||
+        Object.keys(transport).some(key => !['mode', 'tenantId'].includes(key)) ||
+        transport.mode !== 'remote-http' ||
+        typeof transport.tenantId !== 'string' ||
+        !transport.tenantId.trim()) {
+        return null
+    }
+
+    return {kind: 'tenant', tenantId: transport.tenantId.trim()}
+}
+
+/**
+ * @summary Remove the retired registry key and return one canonical target-bearing definition.
+ * A row carrying both shapes keeps only its canonical `mcpTarget`; the legacy key can never
+ * override a value already written under the new contract.
+ * @param {*} definition
+ * @returns {{definition: *, migrated: Boolean}}
+ */
+function migrateStoredAgentDefinition(definition) {
+    if (!definition || typeof definition !== 'object' || Array.isArray(definition) ||
+        !Object.hasOwn(definition, 'mcpTransport')) {
+        return {definition, migrated: false}
+    }
+
+    const
+        {mcpTransport, ...rest} = definition,
+        target                  = Object.hasOwn(definition, 'mcpTarget')
+            ? normalizeStoredMcpTarget(definition.mcpTarget)
+            : migrateLegacyMcpTransport(mcpTransport);
+
+    return {
+        definition: {...rest, mcpTarget: target},
+        migrated  : true
+    }
+}
+// Legacy MCP target migration end.
 
 /**
  * @class Neo.ai.services.fleet.FleetRegistryService
@@ -169,7 +222,7 @@ function normalizeStoredMcpTransport(transport) {
  * *define agents → start/stop → repos managed under the hood*.
  *
  * An **agent definition** is `{id, githubUsername, harnessType, modelProvider, mcpServers,
- * mcpTransport, metadata, createdAt, updatedAt}` —
+ * mcpTarget, metadata, createdAt, updatedAt}` —
  * never a secret. `modelProvider` (the agent's model-provider login) resolves via the AiConfig
  * `modelProvider` SSOT leaf when not supplied — read-only, no service-local default shadow. The associated **credential** (a GitHub PAT) is stored separately, encrypted at
  * rest, and is the load-bearing security boundary of this service:
@@ -269,11 +322,28 @@ class FleetRegistryService extends Base {
      * @param {Object} [opts.metadata={}]       Free-form non-secret metadata.
      * @param {String} [opts.modelProvider]     The agent's model-provider login (e.g. `openAiCompatible`, `ollama`). Resolves via the AiConfig `modelProvider` SSOT leaf when omitted — no service-local default shadow. Non-secret; carried in the public definition.
      * @param {Object|null} [opts.mcpServers]   Sparse MCP overrides shared with configureAgent; omitted/null follows defaults.
-     * @param {Object|null} [opts.mcpTransport] Local stdio (`null` / `{mode:'stdio'}`) or
-     *     `{mode:'remote-http', tenantId}`. No URL, header, env, command, or credential bag.
+     * @param {Object|null} [opts.mcpTarget] Resident (`null` / `{kind:'resident'}`) or
+     *     `{kind:'tenant', tenantId}`. No transport, URL, header, env, command, or credential bag.
      * @returns {Object} The public agent definition (no credential).
      */
-    defineAgent({githubUsername, harnessType, credential, id, metadata={}, modelProvider, mcpServers, mcpTransport} = {}) {
+    defineAgent(options={}) {
+        if (Object.hasOwn(options || {}, RETIRED_TARGET_FIELD)) {
+            throw new TypeError(
+                "FleetRegistryService.defineAgent: retired target-as-transport input is not accepted; use 'mcpTarget'."
+            )
+        }
+
+        const {
+            githubUsername,
+            harnessType,
+            credential,
+            id,
+            metadata={},
+            modelProvider,
+            mcpServers,
+            mcpTarget
+        } = options || {};
+
         if (!githubUsername) throw new Error("FleetRegistryService.defineAgent: 'githubUsername' is required.");
         if (!harnessType)    throw new Error("FleetRegistryService.defineAgent: 'harnessType' is required.");
 
@@ -291,13 +361,13 @@ class FleetRegistryService extends Base {
         }
 
         const
-            agentId   = id || githubUsername,
-            now       = new Date().toISOString(),
-            matrix    = mcpServers === undefined ? null : normalizeMcpOverrides(mcpServers),
-            transport = mcpTransport === undefined ? null : normalizeMcpTransport(mcpTransport);
+            agentId = id || githubUsername,
+            now     = new Date().toISOString(),
+            matrix  = mcpServers === undefined ? null : normalizeMcpOverrides(mcpServers),
+            target  = mcpTarget === undefined ? null : normalizeMcpTarget(mcpTarget);
 
-        if (transport && !supportsRemoteMcpTransport(harnessType)) {
-            throw new TypeError(`FleetRegistryService.defineAgent: harnessType '${harnessType}' does not support remote MCP transport.`)
+        if (target && !supportsTenantMcpTarget(harnessType)) {
+            throw new TypeError(`FleetRegistryService.defineAgent: harnessType '${harnessType}' does not support tenant MCP targets.`)
         }
 
         this.ensureLoaded();
@@ -306,10 +376,10 @@ class FleetRegistryService extends Base {
             throw new Error(`FleetRegistryService.defineAgent: id '${agentId}' already exists; use a scoped update operation.`)
         }
 
-        const tenantAssignee = transport && this.findMcpTenantAssignee(transport.tenantId);
+        const tenantAssignee = target && this.findMcpTenantAssignee(target.tenantId);
 
         if (tenantAssignee) {
-            throw new Error(`FleetRegistryService.defineAgent: remote MCP tenant '${transport.tenantId}' is already assigned to agent '${tenantAssignee}'.`)
+            throw new Error(`FleetRegistryService.defineAgent: MCP tenant '${target.tenantId}' is already assigned to agent '${tenantAssignee}'.`)
         }
 
         const previousCredentials = this.readCredentials();
@@ -332,7 +402,7 @@ class FleetRegistryService extends Base {
                 modelProvider: modelProvider || aiConfig.modelProvider,
                 metadata,
                 mcpServers   : matrix,
-                mcpTransport : transport,
+                mcpTarget    : target,
                 createdAt    : now,
                 updatedAt    : now
             },
@@ -410,7 +480,7 @@ class FleetRegistryService extends Base {
 
     /**
      * Configure an existing agent through the ONE wire-serializable curated intent. Only `id`,
-     * `harnessType`, sparse `mcpServers` overrides, and the narrow `mcpTransport` intent are accepted;
+     * `harnessType`, sparse `mcpServers` overrides, and the narrow `mcpTarget` intent are accepted;
      * credentials, URLs, headers, launch fields, wake, hooks, identity, and generic config bags are
      * mechanically rejected. Unspecified fields are preserved. The returned public definition is canonical persisted readback, never request
      * echo. Controlled validation failures use the method prefix so FleetControlBridge can expose a
@@ -419,7 +489,7 @@ class FleetRegistryService extends Base {
      * @param {String} intent.id Existing registry id.
      * @param {String} [intent.harnessType] Registered durable harness key.
      * @param {Object|null} [intent.mcpServers] Complete sparse MCP override set; null follows defaults.
-     * @param {Object|null} [intent.mcpTransport] `null`/stdio or `{mode:'remote-http', tenantId}`.
+     * @param {Object|null} [intent.mcpTarget] `null`/resident or `{kind:'tenant', tenantId}`.
      * @returns {Object|null} Updated public definition, or `null` when the id is not registered.
      */
     configureAgent(intent={}) {
@@ -432,9 +502,9 @@ class FleetRegistryService extends Base {
         }
 
         const
-            allowed                                     = new Set(['id', 'harnessType', 'mcpServers', 'mcpTransport']),
-            unknown                                     = Object.keys(intent).find(key => !allowed.has(key)),
-            {id, harnessType, mcpServers, mcpTransport} = intent;
+            allowed                                  = new Set(['id', 'harnessType', 'mcpServers', 'mcpTarget']),
+            unknown                                  = Object.keys(intent).find(key => !allowed.has(key)),
+            {id, harnessType, mcpServers, mcpTarget} = intent;
 
         if (unknown) {
             reject(`unsupported field '${unknown}'.`)
@@ -444,7 +514,7 @@ class FleetRegistryService extends Base {
         }
         if (!Object.hasOwn(intent, 'harnessType') &&
             !Object.hasOwn(intent, 'mcpServers') &&
-            !Object.hasOwn(intent, 'mcpTransport')) {
+            !Object.hasOwn(intent, 'mcpTarget')) {
             reject('at least one configuration field is required.')
         }
 
@@ -458,8 +528,8 @@ class FleetRegistryService extends Base {
         }
 
         let
-            matrix    = existing.mcpServers ?? null,
-            transport = normalizeStoredMcpTransport(existing.mcpTransport);
+            matrix = existing.mcpServers ?? null,
+            target = normalizeStoredMcpTarget(existing.mcpTarget);
 
         if (Object.hasOwn(intent, 'mcpServers')) {
             try {
@@ -469,9 +539,9 @@ class FleetRegistryService extends Base {
             }
         }
 
-        if (Object.hasOwn(intent, 'mcpTransport')) {
+        if (Object.hasOwn(intent, 'mcpTarget')) {
             try {
-                transport = normalizeMcpTransport(mcpTransport)
+                target = normalizeMcpTarget(mcpTarget)
             } catch (error) {
                 reject(error.message)
             }
@@ -479,22 +549,22 @@ class FleetRegistryService extends Base {
 
         const nextHarnessType = Object.hasOwn(intent, 'harnessType') ? harnessType : existing.harnessType;
 
-        if (transport && !supportsRemoteMcpTransport(nextHarnessType)) {
-            reject(`harnessType '${nextHarnessType}' does not support remote MCP transport.`)
+        if (target && !supportsTenantMcpTarget(nextHarnessType)) {
+            reject(`harnessType '${nextHarnessType}' does not support tenant MCP targets.`)
         }
 
-        const tenantAssignee = transport && this.findMcpTenantAssignee(transport.tenantId, id);
+        const tenantAssignee = target && this.findMcpTenantAssignee(target.tenantId, id);
 
         if (tenantAssignee) {
-            reject(`remote MCP tenant '${transport.tenantId}' is already assigned to agent '${tenantAssignee}'.`)
+            reject(`MCP tenant '${target.tenantId}' is already assigned to agent '${tenantAssignee}'.`)
         }
 
         const def = {
             ...existing,
-            harnessType : nextHarnessType,
-            mcpServers  : matrix,
-            mcpTransport: transport,
-            updatedAt   : new Date().toISOString()
+            harnessType: nextHarnessType,
+            mcpServers : matrix,
+            mcpTarget  : target,
+            updatedAt  : new Date().toISOString()
         };
 
         const nextAgents = new Map(this.agents);
@@ -578,7 +648,7 @@ class FleetRegistryService extends Base {
         if (!def) return null;
 
         const {credential, pat, ...rest} = def;
-        return structuredClone({...rest, mcpTransport: normalizeStoredMcpTransport(rest.mcpTransport)});
+        return structuredClone({...rest, mcpTarget: normalizeStoredMcpTarget(rest.mcpTarget)});
     }
 
     /**
@@ -662,9 +732,9 @@ class FleetRegistryService extends Base {
         for (const [agentId, definition] of this.agents) {
             if (agentId === exceptId) continue;
 
-            const transport = normalizeStoredMcpTransport(definition.mcpTransport);
+            const target = normalizeStoredMcpTarget(definition.mcpTarget);
 
-            if (transport?.mode === 'remote-http' && transport.tenantId === tenantId) {
+            if (target?.kind === 'tenant' && target.tenantId === tenantId) {
                 return agentId
             }
         }
@@ -685,7 +755,7 @@ class FleetRegistryService extends Base {
     toPublic(def) {
         return redactPublicFields(structuredClone({
             ...def,
-            mcpTransport: normalizeStoredMcpTransport(def.mcpTransport)
+            mcpTarget: normalizeStoredMcpTarget(def.mcpTarget)
         }))
     }
 
@@ -707,13 +777,29 @@ class FleetRegistryService extends Base {
     readRegistry() {
         const file = this.registryPath();
         if (!fs.existsSync(file)) return new Map();
+
+        let data;
+
         try {
-            const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-            return new Map(Object.entries(data.agents || {}));
+            data = JSON.parse(fs.readFileSync(file, 'utf8'))
         } catch (error) {
             console.warn(`[FleetRegistryService] Unreadable registry at ${file}; starting empty.`, error.message);
             return new Map();
         }
+
+        let migrated = false;
+
+        const agents = new Map(Object.entries(data.agents || {}).map(([id, definition]) => {
+            const result = migrateStoredAgentDefinition(definition);
+            migrated ||= result.migrated;
+            return [id, result.definition]
+        }));
+
+        if (migrated) {
+            this.writeRegistry(agents)
+        }
+
+        return agents
     }
 
     /**

--- a/ai/services/fleet/prepareManagedAgentWorkspace.mjs
+++ b/ai/services/fleet/prepareManagedAgentWorkspace.mjs
@@ -8,7 +8,7 @@ import {
     MCP_SERVERS,
     REMOTE_MCP_CREDENTIAL_ENV_VAR,
     resolveMcpMatrix,
-    supportsRemoteMcpTransport
+    supportsTenantMcpTarget
 } from '../../../src/ai/fleet/mcpServers.mjs';
 import {deriveAgentInstanceHome}                           from './deriveAgentInstanceHome.mjs';
 import {LAUNCHABLE_HARNESS_TYPES}                          from './deriveHarnessLaunchSpec.mjs';
@@ -155,8 +155,8 @@ export class ManagedWorkspacePreparationError extends Error {
  * @param {String}   options.instanceRoot        Absolute Fleet harness-home root.
  * @param {String}  [options.mainCheckout]       Installed canonical checkout; defaults to this module's repo root.
  * @param {String}  [options.nodePath]           Node executable used for installed MCP entrypoints.
- * @param {Object}  [options.mcpTransport]       Resolved non-secret remote plan:
- *     `{mode:'remote-http', credentialEnvVar, resources:{memory-core:{url},knowledge-base:{url}}}`.
+ * @param {Object}  [options.mcpTarget]          Resolved non-secret tenant target:
+ *     `{kind:'tenant', credentialEnvVar, resources:{memory-core:{url},knowledge-base:{url}}}`.
  * @param {Object}  [options.remoteMcpCapability] Exact non-secret installed-adapter proof returned
  *     by `FleetLifecycleService.assertRemoteMcpCapability`.
  * @param {Function}[options.hydrateWorkspace]    Import-safe checkout hydration seam.
@@ -176,7 +176,7 @@ export async function prepareManagedAgentWorkspace({
     hydrateWorkspace = hydrateCurrentWorktree,
     deriveInstanceHome = deriveAgentInstanceHome,
     resolveMatrix = resolveMcpMatrix,
-    mcpTransport = null,
+    mcpTarget = null,
     remoteMcpCapability = null,
     fileSystem = fs,
     log = () => {}
@@ -196,7 +196,7 @@ export async function prepareManagedAgentWorkspace({
         canonicalRepoPath = path.resolve(repoPath),
         installedRoot     = path.resolve(mainCheckout),
         mcpMatrix         = resolveMatrix(agent.mcpServers),
-        plan              = createMcpPlan({mcpMatrix, repoPath: canonicalRepoPath, mainCheckout: installedRoot, nodePath, mcpTransport}),
+        plan              = createMcpPlan({mcpMatrix, repoPath: canonicalRepoPath, mainCheckout: installedRoot, nodePath, mcpTarget}),
         instanceHome      = deriveInstanceHome({instanceRoot, agentId: agent.id, harnessType: agent.harnessType});
 
     // Hardest/unsupported adapter gate runs before hydration or artifact writes. A failed product
@@ -264,21 +264,22 @@ export async function prepareManagedAgentWorkspace({
 }
 
 /** @private */
-function createMcpPlan({mcpMatrix, repoPath, mainCheckout, nodePath, mcpTransport}) {
-    assertMcpTransportPlan(mcpTransport);
+function createMcpPlan({mcpMatrix, repoPath, mainCheckout, nodePath, mcpTarget}) {
+    assertMcpTargetPlan(mcpTarget);
 
     return MCP_SERVERS.map(entry => {
         const
             descriptor = MCP_SERVER_DESCRIPTORS[entry.key],
-            remote     = mcpTransport?.mode === 'remote-http' && mcpTransport.resources[entry.key];
+            resource   = mcpTarget?.kind === 'tenant' && mcpTarget.resources[entry.key];
 
         return {
             key             : entry.key,
             name            : `${NEO_MCP_NAME_PREFIX}${entry.key}`,
             enabled         : mcpMatrix[entry.key] === true,
-            mode            : remote ? 'remote-http' : 'stdio',
-            url             : remote?.url ?? null,
-            credentialEnvVar: remote ? mcpTransport.credentialEnvVar : null,
+            target          : resource ? 'tenant' : 'resident',
+            transport       : resource ? 'streamable-http' : 'stdio',
+            url             : resource?.url ?? null,
+            credentialEnvVar: resource ? mcpTarget.credentialEnvVar : null,
             command         : nodePath,
             sourceRoot      : mainCheckout,
             args            : [
@@ -294,21 +295,21 @@ function createMcpPlan({mcpMatrix, repoPath, mainCheckout, nodePath, mcpTranspor
 }
 
 /** @private */
-function assertMcpTransportPlan(transport) {
-    if (transport === null) return;
+function assertMcpTargetPlan(target) {
+    if (target === null) return;
 
-    const topLevelKeys = new Set(['mode', 'credentialEnvVar', 'resources']);
+    const topLevelKeys = new Set(['kind', 'credentialEnvVar', 'resources']);
 
-    if (!transport ||
-        typeof transport !== 'object' ||
-        Array.isArray(transport) ||
-        Object.keys(transport).some(key => !topLevelKeys.has(key)) ||
-        transport.mode !== 'remote-http' ||
-        transport.credentialEnvVar !== REMOTE_MCP_CREDENTIAL_ENV_VAR ||
-        !transport.resources ||
-        typeof transport.resources !== 'object' ||
-        Array.isArray(transport.resources)) {
-        throw unsupported('remote MCP transport plan is malformed')
+    if (!target ||
+        typeof target !== 'object' ||
+        Array.isArray(target) ||
+        Object.keys(target).some(key => !topLevelKeys.has(key)) ||
+        target.kind !== 'tenant' ||
+        target.credentialEnvVar !== REMOTE_MCP_CREDENTIAL_ENV_VAR ||
+        !target.resources ||
+        typeof target.resources !== 'object' ||
+        Array.isArray(target.resources)) {
+        throw unsupported('tenant MCP target plan is malformed')
     }
 
     const
@@ -319,7 +320,7 @@ function assertMcpTransportPlan(transport) {
         };
     let deploymentBase = null;
 
-    for (const [key, resource] of Object.entries(transport.resources)) {
+    for (const [key, resource] of Object.entries(target.resources)) {
         let url;
 
         try {
@@ -355,8 +356,8 @@ function assertMcpTransportPlan(transport) {
         deploymentBase = candidateBase
     }
 
-    if (![...allowed].every(key => transport.resources[key])) {
-        throw unsupported('remote MCP transport requires both memory-core and knowledge-base resources')
+    if (![...allowed].every(key => target.resources[key])) {
+        throw unsupported('tenant MCP target requires both memory-core and knowledge-base resources')
     }
 }
 
@@ -370,9 +371,9 @@ function assertHarnessSupported({agent, plan}) {
         throw unsupported(`harness '${agent.harnessType}' has no launch/workspace adapter`);
     }
 
-    if (plan.some(server => server.mode === 'remote-http') &&
-        !supportsRemoteMcpTransport(agent.harnessType)) {
-        throw unsupported(`harness '${agent.harnessType}' has no proven secret-safe remote MCP grammar`)
+    if (plan.some(server => server.target === 'tenant') &&
+        !supportsTenantMcpTarget(agent.harnessType)) {
+        throw unsupported(`harness '${agent.harnessType}' has no proven secret-safe tenant MCP grammar`)
     }
 
     const catalogUnsupported = plan.find(server => server.enabled && server.unsupportedReason);
@@ -409,7 +410,7 @@ function assertHarnessSupported({agent, plan}) {
  */
 async function assertRemoteBridgeCapability({agent, plan, capability, mainCheckout, nodePath, fileSystem}) {
     if (agent.harnessType !== 'claude-desktop' ||
-        !plan.some(server => server.enabled && server.mode === 'remote-http')) {
+        !plan.some(server => server.enabled && server.target === 'tenant')) {
         return
     }
 
@@ -452,7 +453,7 @@ async function assertRealDirectory(directoryPath, label, fileSystem) {
 
 /** @private */
 async function assertExecutablePlan({plan, nodePath, fileSystem}) {
-    const localEnabled = plan.filter(server => server.enabled && server.mode === 'stdio');
+    const localEnabled = plan.filter(server => server.enabled && server.transport === 'stdio');
 
     if (localEnabled.length === 0) return;
 
@@ -469,7 +470,7 @@ async function assertExecutablePlan({plan, nodePath, fileSystem}) {
     }
 
     for (const server of plan) {
-        if (!server.enabled || server.mode !== 'stdio') continue;
+        if (!server.enabled || server.transport !== 'stdio') continue;
 
         const
             entrypoint = server.args[0],
@@ -572,7 +573,7 @@ async function prepareCodexArtifacts({agent, repoPath, instanceHome, mainCheckou
         homePath       = path.join(homeRoot, 'config.toml'),
         memoriesPath   = path.join(homeRoot, 'memories'),
         homeContent    = renderCodexHomeConfig(),
-        remote         = plan.some(server => server.mode === 'remote-http'),
+        remote         = plan.some(server => server.target === 'tenant'),
         artifacts      = [];
 
     artifacts.push(...await convergeTransportArtifact({
@@ -647,7 +648,7 @@ async function prepareClaudeJsonArtifact({
         mergeTransport : (existing, desired) => mergeJsonTransport(existing, desired, 'mcpServers'),
         adapter        : agent.harnessType,
         instanceHome   : trustedRoot,
-        remote         : plan.some(server => server.mode === 'remote-http'),
+        remote         : plan.some(server => server.target === 'tenant'),
         ownedLabel     : 'mcpServers.neo-mjs-*',
         trustedRoot,
         fileSystem
@@ -665,7 +666,7 @@ function renderClaudeJsonContent({agent, plan, remoteMcpCapability, interpolateE
     for (const server of plan) {
         if (!server.enabled) continue;
 
-        if (server.mode === 'remote-http') {
+        if (server.transport === 'streamable-http') {
             if (agent.harnessType === 'claude-desktop') {
                 servers[server.name] = {
                     command: remoteMcpCapability.bridge.command,
@@ -937,7 +938,7 @@ function renderCodexProjectConfig(template, plan) {    const
 
 /** @private */
 function renderCodexMcpTable(server) {
-    if (server.mode === 'remote-http') {
+    if (server.transport === 'streamable-http') {
         return [
             `[mcp_servers.\"${server.name}\"]`,
             `url = ${JSON.stringify(server.url)}`,
@@ -1264,15 +1265,15 @@ const TRANSPORT_SERVER_NAMES = Object.freeze([
 
 /** @private */
 function localizePlan(plan) {
-    return plan.map(server => server.mode === 'remote-http'
-        ? {...server, mode: 'stdio', url: null, credentialEnvVar: null}
+    return plan.map(server => server.target === 'tenant'
+        ? {...server, target: 'resident', transport: 'stdio', url: null, credentialEnvVar: null}
         : {...server});
 }
 
 /** @private */
 function createRemoteServerMap(plan) {
     return Object.fromEntries(plan
-        .filter(server => server.mode === 'remote-http')
+        .filter(server => server.target === 'tenant')
         .map(server => [server.name, {
             url             : server.url,
             credentialEnvVar: server.credentialEnvVar

--- a/ai/services/fleet/startAgentProvisioned.mjs
+++ b/ai/services/fleet/startAgentProvisioned.mjs
@@ -99,13 +99,13 @@ export async function startAgentProvisioned({
     if (!agent) throw new Error(`startAgentProvisioned: unknown agent '${agentId}'.`);
 
     const
-        repo      = agent.metadata?.repo,
-        transport = agent.mcpTransport;
+        repo   = agent.metadata?.repo,
+        target = agent.mcpTarget;
 
     // No repo coordinates ⇒ nothing to provision; start in the inherited cwd (backward-compatible).
     if (!repo) {
-        if (transport?.mode === 'remote-http') {
-            throw new Error(`startAgentProvisioned: remote MCP agent '${agentId}' requires a managed repo.`)
+        if (target?.kind === 'tenant') {
+            throw new Error(`startAgentProvisioned: tenant MCP agent '${agentId}' requires a managed repo.`)
         }
 
         return lifecycleService.start(agentId);
@@ -128,21 +128,21 @@ export async function startAgentProvisioned({
         resolvedMcpCredential,
         remoteCapability;
 
-    if (transport?.mode === 'remote-http') {
+    if (target?.kind === 'tenant') {
         const activeTenantService = tenantService ?? (await import('./FleetTenantService.mjs')).default;
 
         resolvedCredential = registry.resolveCredential(agentId);
 
-        remotePlan = activeTenantService.resolveMcpResources(transport.tenantId);
+        remotePlan = activeTenantService.resolveMcpResources(target.tenantId);
 
         if (!remotePlan) {
-            throw new Error(`startAgentProvisioned: remote MCP tenant '${transport.tenantId}' is unavailable for agent '${agentId}'.`)
+            throw new Error(`startAgentProvisioned: MCP tenant '${target.tenantId}' is unavailable for agent '${agentId}'.`)
         }
 
-        resolvedMcpCredential = activeTenantService.resolveMcpCredential(transport.tenantId);
+        resolvedMcpCredential = activeTenantService.resolveMcpCredential(target.tenantId);
 
         if (!resolvedMcpCredential) {
-            throw new Error(`startAgentProvisioned: remote MCP tenant '${transport.tenantId}' has no plane credential for agent '${agentId}'.`)
+            throw new Error(`startAgentProvisioned: MCP tenant '${target.tenantId}' has no plane credential for agent '${agentId}'.`)
         }
 
         remoteCapability = await lifecycleService.assertRemoteMcpCapability(agent, {
@@ -152,7 +152,7 @@ export async function startAgentProvisioned({
 
         const expectedIdentity = expectedAgentIdentity(agent);
         const readiness        = await activeTenantService.probeSeatCredential({
-            tenantId  : transport.tenantId,
+            tenantId  : target.tenantId,
             credential: resolvedMcpCredential,
             expectedIdentity
         });
@@ -187,8 +187,8 @@ export async function startAgentProvisioned({
         mainCheckout,
         nodePath,
         remoteMcpCapability: remoteCapability,
-        mcpTransport       : remotePlan && {
-            mode            : 'remote-http',
+        mcpTarget          : remotePlan && {
+            kind            : 'tenant',
             credentialEnvVar: REMOTE_MCP_CREDENTIAL_ENV_VAR,
             resources       : remotePlan.resources
         }
@@ -198,7 +198,7 @@ export async function startAgentProvisioned({
         throw new Error(`startAgentProvisioned: preparation did not return the canonical provisioned repoPath for agent '${agentId}'.`);
     }
 
-    if (transport?.mode === 'remote-http') {
+    if (target?.kind === 'tenant') {
         await lifecycleService.inspectPreparedRemoteMcpAdapter({
             agent,
             binaryPath  : remoteCapability.binaryPath,
@@ -206,8 +206,8 @@ export async function startAgentProvisioned({
             instanceHome: prepared.instanceHome,
             mcpMatrix   : prepared.mcpMatrix,
             mcpPlan     : prepared.mcpPlan,
-            mcpTransport: {
-                mode     : 'remote-http',
+            mcpTarget   : {
+                kind     : 'tenant',
                 resources: remotePlan.resources
             }
         })
@@ -215,7 +215,7 @@ export async function startAgentProvisioned({
 
     return lifecycleService.start(agentId, {
         cwd: prepared.repoPath,
-        ...(transport?.mode === 'remote-http'
+        ...(target?.kind === 'tenant'
             ? {resolvedCredential, resolvedMcpCredential, remoteMcpCapability: remoteCapability}
             : {})
     });

--- a/apps/agentos/config/mcpServers.mjs
+++ b/apps/agentos/config/mcpServers.mjs
@@ -5,13 +5,13 @@
  */
 export {
     MCP_SERVERS,
-    REMOTE_HTTP_HARNESS_TYPES,
+    TENANT_MCP_HARNESS_TYPES,
     REMOTE_MCP_CREDENTIAL_ENV_VAR,
     defaultMcpMatrix,
     listMcpServers,
     normalizeMcpOverrides,
-    normalizeMcpTransport,
+    normalizeMcpTarget,
     resolveMcpMatrix,
-    supportsRemoteMcpTransport
+    supportsTenantMcpTarget
 } from '../../../src/ai/fleet/mcpServers.mjs';
 export {default} from '../../../src/ai/fleet/mcpServers.mjs';

--- a/apps/agentos/model/AgentDefinition.mjs
+++ b/apps/agentos/model/AgentDefinition.mjs
@@ -8,8 +8,8 @@ import Model from '../../../src/data/Model.mjs';
  * configuration model every account surface binds: identity, ONE harness choice (a registered
  * `config/harnessTypes.mjs` key), the per-agent sparse MCP-server overrides (`mcpServers` — null
  * means every current catalog default applies; resolve via `config/mcpServers.mjs`, never persist
- * the fully resolved matrix), the narrow MCP transport target (`mcpTransport` — null = local
- * stdio; remote is only `{mode:'remote-http', tenantId}`), and the operational toggles (honest
+ * the fully resolved matrix), the narrow MCP target (`mcpTarget` — null = resident services;
+ * a tenant is only `{kind:'tenant', tenantId}`), and the operational toggles (honest
  * readback: null = state not read back yet, never an
  * optimistic guess). This model deliberately contains no credential field: PAT bytes remain
  * Brain-side in FleetRegistryService and may only surface here as redacted state.
@@ -49,8 +49,8 @@ class AgentDefinition extends Model {
             type        : 'Object',
             defaultValue: null
         }, {
-            // null = local stdio; remote shape is only {mode:'remote-http', tenantId}
-            name        : 'mcpTransport',
+            // null = resident services; tenant shape is only {kind:'tenant', tenantId}
+            name        : 'mcpTarget',
             type        : 'Object',
             defaultValue: null
         }, {

--- a/apps/agentos/view/Accounts.mjs
+++ b/apps/agentos/view/Accounts.mjs
@@ -322,7 +322,7 @@ class Accounts extends DashboardPanel {
      * onto the store record, which re-renders the card. Fail-closed: without a bridge nothing
      * mutates locally — a config that did not persist must never render as if it had.
      * @param {Object} intent The one wire shape:
-     *     `{id, harnessType?, mcpServers?, mcpTransport?}`.
+     *     `{id, harnessType?, mcpServers?, mcpTarget?}`.
      * @returns {Promise<void>}
      */
     async onAgentConfigIntent(intent={}) {

--- a/apps/agentos/view/fleet/AgentConfigCard.mjs
+++ b/apps/agentos/view/fleet/AgentConfigCard.mjs
@@ -4,7 +4,7 @@ import {
     listMcpServers,
     normalizeMcpOverrides,
     resolveMcpMatrix,
-    supportsRemoteMcpTransport
+    supportsTenantMcpTarget
 } from '../../config/mcpServers.mjs';
 
 /**
@@ -157,10 +157,10 @@ class AgentConfigCard extends Component {
             me.fire('configIntent', {id: record.id, mcpServers: normalizeMcpOverrides(matrix)})
         } else if (kind === 'harness' && key !== record.harnessType) {
             me.fire('configIntent', {id: record.id, harnessType: key})
-        } else if (kind === 'transport') {
+        } else if (kind === 'target') {
             if (key === 'local') {
-                record.mcpTransport?.mode === 'remote-http' &&
-                    me.fire('configIntent', {id: record.id, mcpTransport: null});
+                record.mcpTarget?.kind === 'tenant' &&
+                    me.fire('configIntent', {id: record.id, mcpTarget: null});
                 return
             }
 
@@ -174,14 +174,14 @@ class AgentConfigCard extends Component {
 
             const tenant = me.tenantStore?.get(tenantId);
 
-            if (supportsRemoteMcpTransport(record.harnessType) &&
+            if (supportsTenantMcpTarget(record.harnessType) &&
                 tenant?.status === 'connected' &&
                 typeof tenant.endpoint === 'string' &&
                 tenant.endpoint &&
-                record.mcpTransport?.tenantId !== tenantId) {
+                record.mcpTarget?.tenantId !== tenantId) {
                 me.fire('configIntent', {
-                    id          : record.id,
-                    mcpTransport: {mode: 'remote-http', tenantId}
+                    id       : record.id,
+                    mcpTarget: {kind: 'tenant', tenantId}
                 })
             }
         }
@@ -296,14 +296,14 @@ class AgentConfigCard extends Component {
     createTargetChoices(record) {
         const
             me               = this,
-            selectedTenantId = record.mcpTransport?.mode === 'remote-http'
-                ? record.mcpTransport.tenantId
+            selectedTenantId = record.mcpTarget?.kind === 'tenant'
+                ? record.mcpTarget.tenantId
                 : null,
-            remoteSupported  = supportsRemoteMcpTransport(record.harnessType),
+            tenantSupported  = supportsTenantMcpTarget(record.harnessType),
             records          = me.tenantStore?.items || [],
             choices          = [{
-                id  : `${me.id}__transport__local`,
-                cls : ['fm-chip', 'fm-transport-choice', selectedTenantId ? 'is-selectable' : 'is-selected'],
+                id  : `${me.id}__target__local`,
+                cls : ['fm-chip', 'fm-target-choice', selectedTenantId ? 'is-selectable' : 'is-selected'],
                 text: 'Local services'
             }];
 
@@ -311,25 +311,25 @@ class AgentConfigCard extends Component {
             const
                 selected  = tenant.id === selectedTenantId,
                 connected = tenant.status === 'connected' && typeof tenant.endpoint === 'string' && !!tenant.endpoint,
-                available = remoteSupported && connected,
+                available = tenantSupported && connected,
                 state     = selected
                     ? ['is-selected', ...(available ? [] : ['is-unavailable'])]
                     : [available ? 'is-selectable' : 'is-unavailable'],
                 suffix    = connected
-                    ? (remoteSupported ? '' : ' · Unavailable for this harness')
+                    ? (tenantSupported ? '' : ' · Unavailable for this harness')
                     : ' · Unavailable';
 
             choices.push({
-                id  : `${me.id}__transport__${encodeURIComponent(tenant.id)}`,
-                cls : ['fm-chip', 'fm-transport-choice', ...state],
+                id  : `${me.id}__target__${encodeURIComponent(tenant.id)}`,
+                cls : ['fm-chip', 'fm-target-choice', ...state],
                 text: `${tenant.endpoint}${suffix}`
             })
         }
 
         if (selectedTenantId && !records.some(tenant => tenant.id === selectedTenantId)) {
             choices.push({
-                id  : `${me.id}__transport__${encodeURIComponent(selectedTenantId)}`,
-                cls : ['fm-chip', 'fm-transport-choice', 'is-selected', 'is-unavailable'],
+                id  : `${me.id}__target__${encodeURIComponent(selectedTenantId)}`,
+                cls : ['fm-chip', 'fm-target-choice', 'is-selected', 'is-unavailable'],
                 text: `${selectedTenantId} · Saved target unavailable`
             })
         }

--- a/apps/agentos/view/fleet/AgentDetail.mjs
+++ b/apps/agentos/view/fleet/AgentDetail.mjs
@@ -572,7 +572,7 @@ class AgentDetail extends Container {
      * response. This owner contributes only its store resolution and its status sink (the card).
      * Fail-closed and readback-only by construction —
      * see {@link module:apps/agentos/view/fleet/configIntentRoundTrip}.
-     * @param {Object} intent `{id, harnessType?, mcpServers?, mcpTransport?}` (+ event envelope,
+     * @param {Object} intent `{id, harnessType?, mcpServers?, mcpTarget?}` (+ event envelope,
      *     stripped by the runner).
      * @returns {Promise<void>}
      */

--- a/apps/agentos/view/fleet/configIntentRoundTrip.mjs
+++ b/apps/agentos/view/fleet/configIntentRoundTrip.mjs
@@ -62,7 +62,7 @@ export function getDefinitionsWriteGeneration(store) {
  * @summary Run one configuration round-trip and render its truth through the caller's sink.
  * @param {Object}        config
  * @param {Function|null} [config.bridgeResolver] Injected bridge resolver (defaults to the global seam) — the DI discipline shared with `addAgentFlow`.
- * @param {Object}        config.intent           The card's `configIntent` payload: `{id, harnessType?, mcpServers?, mcpTransport?}` (+ event envelope noise, stripped here).
+ * @param {Object}        config.intent           The card's `configIntent` payload: `{id, harnessType?, mcpServers?, mcpTarget?}` (+ event envelope noise, stripped here).
  * @param {Object|null}   [config.owner]          The calling view — an opaque identity token for cross-owner supersede honesty. Omitting it degrades stale drops to silent.
  * @param {Function}      config.setSaveStatus    `(agentId, state, reason)` — the caller's ephemeral status sink; states: `pending|accepted|rejected|superseded` (`superseded` is non-terminal and must not latch).
  * @param {Neo.data.Store|null} config.store      The shared definitions store — record resolution, the arbitration keys, and the write-generation bump all derive from it.
@@ -86,7 +86,7 @@ export async function runConfigIntentRoundTrip({
 
     if (Object.hasOwn(intent, 'harnessType')) wireIntent.harnessType = intent.harnessType;
     if (Object.hasOwn(intent, 'mcpServers'))  wireIntent.mcpServers  = intent.mcpServers;
-    if (Object.hasOwn(intent, 'mcpTransport')) wireIntent.mcpTransport = intent.mcpTransport;
+    if (Object.hasOwn(intent, 'mcpTarget')) wireIntent.mcpTarget = intent.mcpTarget;
 
     // supersede-correct ACROSS owners: the arbitration key is the shared record instance, so a
     // newer intent from either surface outranks an older in-flight response from the other. A

--- a/learn/agentos/cloud-deployment/ClientAuthentication.md
+++ b/learn/agentos/cloud-deployment/ClientAuthentication.md
@@ -132,6 +132,26 @@ For a headless agent, inject it the way your platform injects any secret (env va
 
 These assume `NEO_MCP_TOKEN` holds your PAT and the server is reachable at `https://mcp.<your-host>/mc/mcp` (Memory Core) or `https://mcp.<your-host>/kb/mcp` (Knowledge Base).
 
+#### Fleet vocabulary: target, transport, adapter
+
+Fleet keeps three layers explicit. The public agent definition selects an MCP **target**:
+resident services or one connected tenant. Workspace preparation resolves that intent into plan
+rows whose `target` is `resident` or `tenant` and whose canonical MCP `transport` is `stdio` or
+`streamable-http`. Only the final harness adapter translates that plan into product grammar such as
+Codex `streamable_http`, Claude Code `http`, or Claude Desktop's local command bridge. Vendor
+spellings never enter the public registry, and target placement is never named after a wire
+protocol.
+
+```mermaid
+flowchart TD
+    intent["Public intent<br/>mcpTarget: resident or tenant"] --> plan["Resolved plan row<br/>target + canonical transport"]
+    plan --> stdio["stdio"]
+    plan --> streamable["streamable-http"]
+    streamable --> codexAdapter["Codex adapter<br/>streamable_http"]
+    streamable --> claudeAdapter["Claude Code adapter<br/>http"]
+    streamable --> desktopAdapter["Claude Desktop adapter<br/>local stdio bridge"]
+```
+
 For a publicly reachable endpoint, Claude's current default is an account-level native connector:
 open **Settings → Connectors → Add custom connector** and enter the MCP URL. The current
 [custom-connector contract](https://claude.com/docs/connectors/custom/remote-mcp) also supports fixed

--- a/src/ai/fleet/mcpServers.mjs
+++ b/src/ai/fleet/mcpServers.mjs
@@ -28,7 +28,7 @@ export const MCP_SERVERS = Object.freeze([
  * artifact cannot encode it would turn a product selection into a late boot failure.
  * @type {ReadonlyArray<String>}
  */
-export const REMOTE_HTTP_HARNESS_TYPES = Object.freeze([
+export const TENANT_MCP_HARNESS_TYPES = Object.freeze([
     'codex',
     'codex-desktop',
     'claude-code',
@@ -127,64 +127,65 @@ export function normalizeMcpOverrides(overrides, catalog=MCP_SERVERS) {
 }
 
 /**
- * @summary Validate and canonicalize the deliberately tiny MCP transport intent. Local stdio is
- * represented as `null`; remote HTTP carries only a public tenant id. URLs, headers, environment
- * bags, commands, and credentials have no grammar here, so they cannot cross the Body→Brain wire.
- * @param {Object|null} transport
- * @returns {{mode: 'remote-http', tenantId: String}|null}
+ * @summary Validate and canonicalize the deliberately tiny MCP target intent. The resident target
+ * is represented as `null`; a connected tenant carries only its public id. URLs, transports,
+ * headers, environment bags, commands, and credentials have no grammar here, so they cannot cross
+ * the Body→Brain wire.
+ * @param {Object|null} target
+ * @returns {{kind: 'tenant', tenantId: String}|null}
  */
-export function normalizeMcpTransport(transport) {
-    if (transport === null) {
+export function normalizeMcpTarget(target) {
+    if (target === null) {
         return null
     }
 
-    if (!transport || typeof transport !== 'object' || Array.isArray(transport)) {
-        throw new TypeError('MCP transport must be an object or null.')
+    if (!target || typeof target !== 'object' || Array.isArray(target)) {
+        throw new TypeError('MCP target must be an object or null.')
     }
 
     const
-        {mode}  = transport,
-        allowed = mode === 'remote-http'
-            ? new Set(['mode', 'tenantId'])
-            : new Set(['mode']),
-        unknown = Object.keys(transport).find(key => !allowed.has(key));
+        {kind}  = target,
+        allowed = kind === 'tenant'
+            ? new Set(['kind', 'tenantId'])
+            : new Set(['kind']),
+        unknown = Object.keys(target).find(key => !allowed.has(key));
 
     if (unknown) {
-        throw new TypeError(`Unsupported MCP transport field '${unknown}'.`)
+        throw new TypeError(`Unsupported MCP target field '${unknown}'.`)
     }
 
-    if (mode === 'stdio') {
+    if (kind === 'resident') {
         return null
     }
 
-    if (mode !== 'remote-http') {
-        throw new TypeError(`Unsupported MCP transport mode '${mode}'.`)
+    if (kind !== 'tenant') {
+        throw new TypeError(`Unsupported MCP target kind '${kind}'.`)
     }
 
-    if (typeof transport.tenantId !== 'string' || !transport.tenantId.trim()) {
-        throw new TypeError("Remote MCP transport requires a non-empty 'tenantId'.")
+    if (typeof target.tenantId !== 'string' || !target.tenantId.trim()) {
+        throw new TypeError("Tenant MCP target requires a non-empty 'tenantId'.")
     }
 
-    return {mode: 'remote-http', tenantId: transport.tenantId.trim()}
+    return {kind: 'tenant', tenantId: target.tenantId.trim()}
 }
 
 /**
- * @summary Whether a registered harness family can encode the remote HTTP MCP grammar.
+ * @summary Whether a registered harness family can consume a connected tenant MCP target.
  * @param {String} harnessType
  * @returns {Boolean}
  */
-export function supportsRemoteMcpTransport(harnessType) {
-    return REMOTE_HTTP_HARNESS_TYPES.includes(harnessType)
+export function supportsTenantMcpTarget(harnessType) {
+    return TENANT_MCP_HARNESS_TYPES.includes(harnessType)
 }
 
 export default {
     MCP_SERVERS,
-    REMOTE_HTTP_HARNESS_TYPES,
+    TENANT_MCP_HARNESS_TYPES,
     REMOTE_MCP_CREDENTIAL_ENV_VAR,
     defaultMcpMatrix,
     listMcpServers,
     normalizeMcpOverrides,
-    normalizeMcpTransport,
+    normalizeMcpTarget,
     resolveMcpMatrix,
-    supportsRemoteMcpTransport
+    supportsTenantMcpTarget
 };

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -78,8 +78,8 @@ function agentDef(id, extra = {}) {
     return {id, githubUsername: id, harnessType: 'codex', metadata: {launch: LAUNCH}, ...extra};
 }
 
-/** Exact non-secret renderer input returned by prepareManagedAgentWorkspace for a remote Codex seat. */
-function remoteMcpPlan(resources, matrix) {
+/** Exact non-secret renderer input returned by prepareManagedAgentWorkspace for a tenant Codex seat. */
+function tenantMcpPlan(resources, matrix) {
     return Object.entries(matrix).map(([key, enabled]) => {
         const remote = ['memory-core', 'knowledge-base'].includes(key);
 
@@ -87,7 +87,8 @@ function remoteMcpPlan(resources, matrix) {
             key,
             name              : `neo-mjs-${key}`,
             enabled,
-            mode              : remote ? 'remote-http' : 'stdio',
+            target            : remote ? 'tenant' : 'resident',
+            transport         : remote ? 'streamable-http' : 'stdio',
             url               : remote ? resources[key].url : null,
             credentialEnvVar  : remote ? 'NEO_MCP_REMOTE_TOKEN' : null,
             command           : process.execPath,
@@ -1315,8 +1316,8 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — remote MCP capabi
             repoPath    : '/managed/seat-codex/neo',
             instanceHome: '/instances/seat-codex',
             mcpMatrix   : matrix,
-            mcpTransport: {mode: 'remote-http', resources},
-            mcpPlan     : remoteMcpPlan(resources, matrix)
+            mcpTarget   : {kind: 'tenant', resources},
+            mcpPlan     : tenantMcpPlan(resources, matrix)
         })).resolves.toEqual({
             harnessType: 'codex',
             inspected  : true,
@@ -1418,8 +1419,8 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — remote MCP capabi
                 repoPath    : '/managed/seat-codex/neo',
                 instanceHome: '/instances/seat-codex',
                 mcpMatrix   : matrix,
-                mcpTransport: {mode: 'remote-http', resources},
-                mcpPlan     : remoteMcpPlan(resources, matrix)
+                mcpTarget   : {kind: 'tenant', resources},
+                mcpPlan     : tenantMcpPlan(resources, matrix)
             })).rejects.toThrow(/inspectPreparedRemoteMcpAdapter/)
         }
 
@@ -1433,8 +1434,8 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — remote MCP capabi
             repoPath    : '/managed/seat-codex/neo',
             instanceHome: '/instances/seat-codex',
             mcpMatrix   : matrix,
-            mcpTransport: {mode: 'remote-http', resources},
-            mcpPlan     : remoteMcpPlan(resources, matrix)
+            mcpTarget   : {kind: 'tenant', resources},
+            mcpPlan     : tenantMcpPlan(resources, matrix)
         })).rejects.toThrow(/could not consume the generated MCP projection/)
     });
 

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -100,7 +100,25 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
             .toThrow('/secret/storage/path failed')
     });
 
-    test('defineAgent rejects a new unavailable remote target before registry persistence', () => {
+    test('defineAgent rejects retired target-as-transport input through the real registry boundary', () => {
+        const retiredTargetField = ['mcp', 'Transport'].join('');
+
+        FleetControlBridge.registry = FleetRegistryService;
+
+        expect(FleetControlBridge.defineAgent({
+            githubUsername      : 'legacy-wire',
+            harnessType         : 'codex',
+            [retiredTargetField]: {
+                mode    : ['remote', 'http'].join('-'),
+                tenantId: 'tenant-a'
+            }
+        })).toEqual({
+            status: 'rejected',
+            reason: "retired target-as-transport input is not accepted; use 'mcpTarget'."
+        })
+    });
+
+    test('defineAgent rejects a new unavailable tenant target before registry persistence', () => {
         registryStub.getAgent = id => {
             calls.push(['getAgent', id]);
 
@@ -110,12 +128,12 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         const definition = {
             githubUsername: 'new-peer',
             harnessType   : 'codex',
-            mcpTransport  : {mode: 'remote-http', tenantId: 'missing'}
+            mcpTarget     : {kind: 'tenant', tenantId: 'missing'}
         };
 
         expect(FleetControlBridge.defineAgent(definition)).toEqual({
             status: 'rejected',
-            reason: "Remote MCP tenant 'missing' is unavailable."
+            reason: "MCP tenant 'missing' is unavailable."
         });
         expect(calls).toEqual([
             ['getAgent', 'new-peer'],
@@ -149,10 +167,10 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
             .toThrow('/secret/storage/path failed')
     });
 
-    test('configureAgent admits only a connected NEW remote target and never persists an unavailable one', () => {
+    test('configureAgent admits only a connected NEW tenant target and never persists an unavailable one', () => {
         const available = {
-            id          : 'alice',
-            mcpTransport: {mode: 'remote-http', tenantId: 'connected'}
+            id       : 'alice',
+            mcpTarget: {kind: 'tenant', tenantId: 'connected'}
         };
 
         expect(FleetControlBridge.configureAgent(available)).toEqual({
@@ -168,13 +186,13 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         calls.length = 0;
 
         const unavailable = {
-            id          : 'alice',
-            mcpTransport: {mode: 'remote-http', tenantId: 'missing'}
+            id       : 'alice',
+            mcpTarget: {kind: 'tenant', tenantId: 'missing'}
         };
 
         expect(FleetControlBridge.configureAgent(unavailable)).toEqual({
             status: 'rejected',
-            reason: "Remote MCP tenant 'missing' is unavailable."
+            reason: "MCP tenant 'missing' is unavailable."
         });
         expect(calls).toEqual([
             ['getAgent', 'alice'],
@@ -186,12 +204,12 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         registryStub.getAgent = id => {
             calls.push(['getAgent', id]);
 
-            return {id, mcpTransport: {mode: 'remote-http', tenantId: 'stale-saved'}}
+            return {id, mcpTarget: {kind: 'tenant', tenantId: 'stale-saved'}}
         };
 
         const intent = {
-            id          : 'alice',
-            mcpTransport: {mode: 'remote-http', tenantId: 'stale-saved'}
+            id       : 'alice',
+            mcpTarget: {kind: 'tenant', tenantId: 'stale-saved'}
         };
 
         expect(FleetControlBridge.configureAgent(intent).status).toBe('accepted');

--- a/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
@@ -20,6 +20,49 @@ import FleetRegistryService from '../../../../../../ai/services/fleet/FleetRegis
 import fs                   from 'fs';
 import os                   from 'os';
 import path                 from 'path';
+import {fileURLToPath}      from 'url';
+
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
+
+function sourceFiles(directory) {
+    return fs.readdirSync(directory, {withFileTypes: true}).flatMap(entry => {
+        const filePath = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            return sourceFiles(filePath)
+        }
+
+        return /\.(?:md|mjs)$/.test(entry.name) ? [filePath] : []
+    })
+}
+
+function stripVocabularyExceptions(source, filePath) {
+    const markerPairs = [
+        [
+            ['// Legacy MCP target ', 'migration begin'].join(''),
+            ['// Legacy MCP target ', 'migration end.'].join('')
+        ],
+        [
+            ['// Retired MCP target vocabulary ', 'fixture begin'].join(''),
+            ['// Retired MCP target vocabulary ', 'fixture end.'].join('')
+        ]
+    ];
+
+    for (const [beginMarker, endMarker] of markerPairs) {
+        let begin;
+
+        while ((begin = source.indexOf(beginMarker)) >= 0) {
+            const end = source.indexOf(endMarker, begin + beginMarker.length);
+
+            expect(end, `${filePath}: missing ${endMarker}`).toBeGreaterThan(begin);
+            source = source.slice(0, begin) + source.slice(end + endMarker.length)
+        }
+
+        expect(source.includes(endMarker), `${filePath}: orphan ${endMarker}`).toBe(false)
+    }
+
+    return source
+}
 
 // FleetRegistryService is a singleton. Pointing `dataDir` at a fresh temp dir per test makes
 // ensureLoaded reload an empty registry (isolation) and keeps every write off the real
@@ -251,32 +294,32 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService.configureAgent — the
         expect(FleetRegistryService.resolveCredential('neo-gpt')).toBe('ghp_config_secret')
     });
 
-    test('persists the narrow remote transport intent and canonicalizes explicit stdio to local null', () => {
+    test('persists narrow tenant target intent and canonicalizes explicit resident intent to null', () => {
         const created = FleetRegistryService.defineAgent({
             githubUsername: 'remote-seat',
             harnessType   : 'codex',
-            mcpTransport  : {mode: 'remote-http', tenantId: 'tenant-a'}
+            mcpTarget     : {kind: 'tenant', tenantId: 'tenant-a'}
         });
 
-        expect(created.mcpTransport).toEqual({mode: 'remote-http', tenantId: 'tenant-a'});
-        expect(FleetRegistryService.getDefinition('remote-seat').mcpTransport)
-            .toEqual({mode: 'remote-http', tenantId: 'tenant-a'});
+        expect(created.mcpTarget).toEqual({kind: 'tenant', tenantId: 'tenant-a'});
+        expect(FleetRegistryService.getDefinition('remote-seat').mcpTarget)
+            .toEqual({kind: 'tenant', tenantId: 'tenant-a'});
 
         const local = FleetRegistryService.configureAgent({
-            id          : 'remote-seat',
-            mcpTransport: {mode: 'stdio'}
+            id       : 'remote-seat',
+            mcpTarget: {kind: 'resident'}
         });
 
-        expect(local.mcpTransport).toBeNull();
+        expect(local.mcpTarget).toBeNull();
         expect(JSON.parse(fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8'))
-            .agents['remote-seat'].mcpTransport).toBeNull()
+            .agents['remote-seat'].mcpTarget).toBeNull()
     });
 
     test('one tenant descriptor cannot collapse two canonical seats onto the same remote provider subject', () => {
         FleetRegistryService.defineAgent({
             githubUsername: 'first-seat',
             harnessType   : 'codex',
-            mcpTransport  : {mode: 'remote-http', tenantId: 'tenant-a'}
+            mcpTarget     : {kind: 'tenant', tenantId: 'tenant-a'}
         });
 
         const beforeDefine = fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8');
@@ -284,7 +327,7 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService.configureAgent — the
         expect(() => FleetRegistryService.defineAgent({
             githubUsername: 'second-seat',
             harnessType   : 'codex',
-            mcpTransport  : {mode: 'remote-http', tenantId: 'tenant-a'}
+            mcpTarget     : {kind: 'tenant', tenantId: 'tenant-a'}
         })).toThrow(/tenant 'tenant-a' is already assigned to agent 'first-seat'/);
         expect(FleetRegistryService.getAgent('second-seat')).toBeNull();
         expect(fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8')).toBe(beforeDefine);
@@ -293,69 +336,70 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService.configureAgent — the
 
         // The incumbent may re-assert its own canonical target, but another seat may not claim it.
         expect(FleetRegistryService.configureAgent({
-            id          : 'first-seat',
-            mcpTransport: {mode: 'remote-http', tenantId: 'tenant-a'}
-        }).mcpTransport).toEqual({mode: 'remote-http', tenantId: 'tenant-a'});
+            id       : 'first-seat',
+            mcpTarget: {kind: 'tenant', tenantId: 'tenant-a'}
+        }).mcpTarget).toEqual({kind: 'tenant', tenantId: 'tenant-a'});
 
         const beforeConfigure = fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8');
 
         expect(() => FleetRegistryService.configureAgent({
-            id          : 'second-seat',
-            mcpTransport: {mode: 'remote-http', tenantId: 'tenant-a'}
+            id       : 'second-seat',
+            mcpTarget: {kind: 'tenant', tenantId: 'tenant-a'}
         })).toThrow(/tenant 'tenant-a' is already assigned to agent 'first-seat'/);
         expect(fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8')).toBe(beforeConfigure);
 
         // Explicit opt-out releases the credential-bearing subject for a later canonical seat.
         expect(FleetRegistryService.configureAgent({
-            id: 'first-seat', mcpTransport: {mode: 'stdio'}
-        }).mcpTransport).toBeNull();
+            id: 'first-seat', mcpTarget: {kind: 'resident'}
+        }).mcpTarget).toBeNull();
         expect(FleetRegistryService.configureAgent({
-            id          : 'second-seat',
-            mcpTransport: {mode: 'remote-http', tenantId: 'tenant-a'}
-        }).mcpTransport).toEqual({mode: 'remote-http', tenantId: 'tenant-a'})
+            id       : 'second-seat',
+            mcpTarget: {kind: 'tenant', tenantId: 'tenant-a'}
+        }).mcpTarget).toEqual({kind: 'tenant', tenantId: 'tenant-a'})
     });
 
-    test('remote transport follows a harness change only when the target family can encode it', () => {
+    test('tenant target follows a harness change only when the target family can encode it', () => {
         FleetRegistryService.defineAgent({
             githubUsername: 'portable',
             harnessType   : 'codex',
-            mcpTransport  : {mode: 'remote-http', tenantId: 'tenant-a'}
+            mcpTarget     : {kind: 'tenant', tenantId: 'tenant-a'}
         });
 
         expect(FleetRegistryService.configureAgent({
             id         : 'portable',
             harnessType: 'claude-desktop'
-        }).mcpTransport).toEqual({mode: 'remote-http', tenantId: 'tenant-a'});
+        }).mcpTarget).toEqual({kind: 'tenant', tenantId: 'tenant-a'});
 
         const before = fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8');
 
         expect(() => FleetRegistryService.configureAgent({
             id         : 'portable',
             harnessType: 'antigravity'
-        })).toThrow(/does not support remote MCP transport/);
+        })).toThrow(/does not support tenant MCP targets/);
         expect(fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8')).toBe(before);
         expect(FleetRegistryService.getAgent('portable').harnessType).toBe('claude-desktop')
     });
 
-    test('transport grammar rejects every secret-bearing or authority-bearing shape without a write', () => {
-        FleetRegistryService.defineAgent({githubUsername: 'transport-guard', harnessType: 'codex'});
+    test('target grammar rejects every transport, secret, or authority-bearing shape without a write', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'target-guard', harnessType: 'codex'});
         const before = fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8');
 
         const rejected = [
-            {mode: 'remote-http', tenantId: 'tenant-a', url: 'https://tenant.example/mc/mcp'},
-            {mode: 'remote-http', tenantId: 'tenant-a', headers: {Authorization: 'Bearer secret'}},
-            {mode: 'remote-http', tenantId: 'tenant-a', env: {TOKEN: 'secret'}},
-            {mode: 'remote-http', tenantId: 'tenant-a', command: 'proxy'},
-            {mode: 'remote-http', tenantId: 'tenant-a', credential: 'secret'},
-            {mode: 'remote-http', tenantId: '   '},
-            {mode: 'unknown', tenantId: 'tenant-a'},
+            {kind: 'tenant', tenantId: 'tenant-a', transport: 'streamable-http'},
+            {kind: 'tenant', tenantId: 'tenant-a', url: 'https://tenant.example/mc/mcp'},
+            {kind: 'tenant', tenantId: 'tenant-a', headers: {Authorization: 'Bearer secret'}},
+            {kind: 'tenant', tenantId: 'tenant-a', env: {TOKEN: 'secret'}},
+            {kind: 'tenant', tenantId: 'tenant-a', command: 'proxy'},
+            {kind: 'tenant', tenantId: 'tenant-a', credential: 'secret'},
+            {kind: 'tenant', tenantId: '   '},
+            {kind: 'unknown', tenantId: 'tenant-a'},
             [],
-            'remote-http'
+            'tenant'
         ];
 
-        rejected.forEach(mcpTransport => {
+        rejected.forEach(mcpTarget => {
             expect(() => FleetRegistryService.configureAgent({
-                id: 'transport-guard', mcpTransport
+                id: 'target-guard', mcpTarget
             })).toThrow(/FleetRegistryService\.configureAgent/);
             expect(fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8')).toBe(before)
         });
@@ -363,8 +407,8 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService.configureAgent — the
         expect(() => FleetRegistryService.defineAgent({
             githubUsername: 'unsupported-remote',
             harnessType   : 'antigravity',
-            mcpTransport  : {mode: 'remote-http', tenantId: 'tenant-a'}
-        })).toThrow(/does not support remote MCP transport/)
+            mcpTarget     : {kind: 'tenant', tenantId: 'tenant-a'}
+        })).toThrow(/does not support tenant MCP targets/)
     });
 
     test('partial patches preserve unspecified config; all-default and null matrices persist as null', () => {
@@ -431,7 +475,23 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService.configureAgent — the
         fs.rmSync(otherDir, {recursive: true, force: true})
     });
 
-    test('legacy hydration fails absent or corrupt transport rows closed to local null', () => {
+    test('defineAgent rejects retired target-as-transport input instead of degrading it to resident', () => {
+        const retiredTargetField = ['mcp', 'Transport'].join('');
+
+        expect(() => FleetRegistryService.defineAgent({
+            githubUsername      : 'legacy-wire',
+            harnessType         : 'codex',
+            [retiredTargetField]: {
+                mode    : ['remote', 'http'].join('-'),
+                tenantId: 'tenant-a'
+            }
+        })).toThrow("retired target-as-transport input is not accepted; use 'mcpTarget'");
+
+        expect(FleetRegistryService.getAgent('legacy-wire')).toBeNull()
+    });
+
+    // Retired MCP target vocabulary fixture begin
+    test('legacy transport hydration rewrites exact rows once and fails corrupt rows closed', () => {
         const registryPath = path.join(tmpDir, 'registry.json');
 
         fs.writeFileSync(registryPath, JSON.stringify({
@@ -439,6 +499,11 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService.configureAgent — the
                 absent: {
                     id      : 'absent', githubUsername: 'absent', harnessType: 'codex',
                     metadata: {}, mcpServers: null
+                },
+                legacy: {
+                    id          : 'legacy', githubUsername: 'legacy', harnessType: 'codex',
+                    metadata    : {}, mcpServers: null,
+                    mcpTransport: {mode: 'remote-http', tenantId: 'tenant-a'}
                 },
                 corrupt: {
                     id          : 'corrupt', githubUsername: 'corrupt', harnessType: 'codex',
@@ -457,11 +522,80 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService.configureAgent — the
 
         FleetRegistryService.dataDir = tmpDir;
 
-        expect(FleetRegistryService.getAgent('absent').mcpTransport).toBeNull();
-        expect(FleetRegistryService.getAgent('corrupt').mcpTransport).toBeNull();
-        expect(FleetRegistryService.getDefinition('corrupt').mcpTransport).toBeNull();
+        expect(FleetRegistryService.getAgent('absent').mcpTarget).toBeNull();
+        expect(FleetRegistryService.getAgent('legacy').mcpTarget)
+            .toEqual({kind: 'tenant', tenantId: 'tenant-a'});
+        expect(FleetRegistryService.getAgent('corrupt').mcpTarget).toBeNull();
+        expect(FleetRegistryService.getDefinition('corrupt').mcpTarget).toBeNull();
+
+        const rewritten = JSON.parse(fs.readFileSync(registryPath, 'utf8')).agents;
+
+        expect(rewritten.legacy).not.toHaveProperty('mcpTransport');
+        expect(rewritten.legacy.mcpTarget).toEqual({kind: 'tenant', tenantId: 'tenant-a'});
+        expect(rewritten.corrupt).not.toHaveProperty('mcpTransport');
+        expect(rewritten.corrupt.mcpTarget).toBeNull();
 
         fs.rmSync(reloadDir, {recursive: true, force: true})
+    });
+    // Retired MCP target vocabulary fixture end.
+
+    test('retired target vocabulary and adapter spellings stay inside their named boundaries', () => {
+        const
+            roots              = ['ai', 'apps', 'learn', 'src', 'test'].map(name => path.join(PROJECT_ROOT, name)),
+            retiredTargetField = ['mcp', 'Transport'].join(''),
+            retiredTargetMode  = ['remote', 'http'].join('-'),
+            codexAdapterToken  = ['streamable', 'http'].join('_'),
+            claudeAdapterToken = 'http',
+            retiredPattern     = new RegExp(`\\b${retiredTargetField}\\b|${retiredTargetMode}`),
+            codexPattern       = new RegExp(`\\b${codexAdapterToken}\\b`),
+            claudePattern      = new RegExp(
+                `(?:['"]?(?:type|transport)['"]?|transport\\.type)\\s*(?:!==|===|!=|==|=|:)\\s*(['"])${claudeAdapterToken}\\1`
+            ),
+            fleetSurface      = filePath => {
+                const relative = path.relative(PROJECT_ROOT, filePath);
+
+                return [
+                    'ai/services/fleet/',
+                    'apps/agentos/',
+                    'learn/agentos/',
+                    'src/ai/fleet/',
+                    'test/playwright/unit/ai/services/fleet/',
+                    'test/playwright/unit/apps/agentos/'
+                ].some(prefix => relative.startsWith(prefix)) ||
+                    [
+                        'test/playwright/unit/ai/FleetLifecycleService.spec.mjs',
+                        'test/playwright/unit/ai/startAgentProvisioned.spec.mjs'
+                    ].includes(relative)
+            },
+            adapterOwners = new Map([
+                ['ai/services/fleet/FleetLifecycleService.mjs', new Set([codexAdapterToken])],
+                ['ai/services/fleet/prepareManagedAgentWorkspace.mjs', new Set([claudeAdapterToken])],
+                ['learn/agentos/cloud-deployment/ClientAuthentication.md',
+                    new Set([codexAdapterToken, claudeAdapterToken])],
+                ['test/playwright/unit/ai/FleetLifecycleService.spec.mjs', new Set([codexAdapterToken])],
+                ['test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs',
+                    new Set([claudeAdapterToken])]
+            ]);
+
+        for (const filePath of roots.flatMap(sourceFiles)) {
+            const
+                relative = path.relative(PROJECT_ROOT, filePath),
+                source   = stripVocabularyExceptions(fs.readFileSync(filePath, 'utf8'), filePath);
+
+            expect(source, relative).not.toMatch(retiredPattern);
+
+            if (fleetSurface(filePath)) {
+                const allowed = adapterOwners.get(relative) || new Set();
+
+                if (codexPattern.test(source)) {
+                    expect(allowed.has(codexAdapterToken), `${relative}: ${codexAdapterToken}`).toBe(true)
+                }
+
+                if (claudePattern.test(source)) {
+                    expect(allowed.has(claudeAdapterToken), `${relative}: ${claudeAdapterToken}`).toBe(true)
+                }
+            }
+        }
     });
 
     test('a failed atomic publish leaves both cache and registry.json on the prior accepted state', () => {

--- a/test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs
@@ -187,9 +187,9 @@ async function startBridgeFixture(token) {
     }
 }
 
-function remoteTransport(endpoint='https://tenant.example.com/agentos') {
+function tenantTarget(endpoint='https://tenant.example.com/agentos') {
     return {
-        mode            : 'remote-http',
+        kind            : 'tenant',
         credentialEnvVar: 'NEO_MCP_REMOTE_TOKEN',
         resources       : {
             'memory-core'   : {url: `${endpoint}/mc/mcp`},
@@ -239,7 +239,9 @@ test.describe('prepareManagedAgentWorkspace', () => {
             Array.isArray(server.args) &&
             Array.isArray(server.runtimeEnv) &&
             Array.isArray(server.requiredRuntimeEnv) &&
-            Array.isArray(server.secretEnv)
+            Array.isArray(server.secretEnv) &&
+            server.target === 'resident' &&
+            server.transport === 'stdio'
         )).toBe(true);
         expect(result.artifacts.map(item => item.status)).toEqual([
             WORKSPACE_ARTIFACT_STATES.CREATED,
@@ -339,7 +341,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
     test('a remote Codex home refuses a managed-project trust downgrade instead of silently ignoring its generated MCP config', async () => {
         const opts = options(makeAgent('codex'));
 
-        opts.mcpTransport = remoteTransport();
+        opts.mcpTarget = tenantTarget();
 
         const
             first      = await prepareManagedAgentWorkspace(opts),
@@ -788,11 +790,18 @@ test.describe('prepareManagedAgentWorkspace', () => {
         for (const {harnessType, inspect} of cases) {
             const opts = options(makeAgent(harnessType), `remote-${harnessType}`);
 
-            opts.mcpTransport = remoteTransport();
+            opts.mcpTarget = tenantTarget();
 
             const result = await prepareManagedAgentWorkspace(opts);
 
             await inspect(opts, result);
+            expect(result.mcpPlan.find(server => server.key === 'memory-core'))
+                .toMatchObject({target: 'tenant', transport: 'streamable-http'});
+            expect(result.mcpPlan.find(server => server.key === 'knowledge-base'))
+                .toMatchObject({target: 'tenant', transport: 'streamable-http'});
+            expect(result.mcpPlan.find(server => server.key === 'neural-link'))
+                .toMatchObject({target: 'resident', transport: 'stdio'});
+                expect(JSON.stringify(result.mcpPlan)).not.toContain(['remote', 'http'].join('-'));
 
             const receipt = JSON.parse(await read(path.join(result.instanceHome, '.neo-fleet-mcp-transport.json')));
 
@@ -823,7 +832,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
             'utf8'
         );
 
-        opts.mcpTransport = remoteTransport();
+        opts.mcpTarget = tenantTarget();
         const firstRemote = await prepareManagedAgentWorkspace(opts);
         const firstSource = await read(projectPath);
         const receiptPath = path.join(firstRemote.instanceHome, '.neo-fleet-mcp-transport.json');
@@ -835,7 +844,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         expect(await read(homePath)).toContain('# Fleet-managed remote MCP project trust begin');
         expect(JSON.parse(await read(receiptPath)).adapter).toBe('codex');
 
-        opts.mcpTransport = remoteTransport('https://other.example.com/agentos');
+        opts.mcpTarget = tenantTarget('https://other.example.com/agentos');
         await prepareManagedAgentWorkspace(opts);
 
         const secondSource = await read(projectPath);
@@ -845,7 +854,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         expect(secondSource).toContain('https://other.example.com/agentos/mc/mcp');
         expect(secondSource).not.toContain('https://tenant.example.com/agentos/mc/mcp');
 
-        opts.mcpTransport = null;
+        opts.mcpTarget = null;
         const backToLocal = await prepareManagedAgentWorkspace(opts);
         const localSource = await read(projectPath);
 
@@ -893,7 +902,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
 
             await fs.writeFile(artifactPath, localWithOperator, 'utf8');
 
-            opts.mcpTransport = remoteTransport();
+            opts.mcpTarget = tenantTarget();
             const firstRemote = await prepareManagedAgentWorkspace(opts);
             const firstSource = await read(artifactPath);
             const receiptPath = path.join(firstRemote.instanceHome, '.neo-fleet-mcp-transport.json');
@@ -908,7 +917,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
             );
 
             await fs.writeFile(artifactPath, edited, 'utf8');
-            opts.mcpTransport = remoteTransport('https://other.example.com/agentos');
+            opts.mcpTarget = tenantTarget('https://other.example.com/agentos');
 
             await expect(prepareManagedAgentWorkspace(opts), entry.harnessType).rejects.toMatchObject({
                 code: 'FLEET_WORKSPACE_DIVERGENT'
@@ -924,7 +933,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
             expect(secondSource, entry.harnessType).toContain('https://other.example.com/agentos/mc/mcp');
             expect(secondSource, entry.harnessType).not.toContain('https://tenant.example.com/agentos/mc/mcp');
 
-            opts.mcpTransport = null;
+            opts.mcpTarget = null;
             await prepareManagedAgentWorkspace(opts);
 
             expect(await read(artifactPath), entry.harnessType).toBe(localWithOperator);
@@ -937,7 +946,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
             opts        = options(makeAgent('codex'), 'edited-remote'),
             projectPath = path.join(opts.repoPath, '.codex', 'config.toml');
 
-        opts.mcpTransport = remoteTransport();
+        opts.mcpTarget = tenantTarget();
         await prepareManagedAgentWorkspace(opts);
 
         const edited = (await read(projectPath)).replace(
@@ -946,7 +955,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
         );
 
         await fs.writeFile(projectPath, edited, 'utf8');
-        opts.mcpTransport = remoteTransport('https://other.example.com/agentos');
+        opts.mcpTarget = tenantTarget('https://other.example.com/agentos');
 
         await expect(prepareManagedAgentWorkspace(opts)).rejects.toMatchObject({
             code: 'FLEET_WORKSPACE_DIVERGENT'
@@ -956,40 +965,40 @@ test.describe('prepareManagedAgentWorkspace', () => {
 
     test('remote plan grammar rejects extra/secret fields, incomplete resources, and split deployment bases before hydration', async () => {
         const malformed = [{
-            ...remoteTransport(),
+            ...tenantTarget(),
             token: 'secret'
         }, {
-            ...remoteTransport(),
+            ...tenantTarget(),
             resources: {
-                ...remoteTransport().resources,
+                ...tenantTarget().resources,
                 'memory-core': {
                     url    : 'https://tenant.example.com/agentos/mc/mcp',
                     headers: {Authorization: 'Bearer secret'}
                 }
             }
         }, {
-            ...remoteTransport(),
+            ...tenantTarget(),
             resources: {
                 'memory-core': {url: 'https://tenant.example.com/agentos/mc/mcp'}
             }
         }, {
-            ...remoteTransport(),
+            ...tenantTarget(),
             resources: {
                 'memory-core'   : {url: 'https://tenant.example.com/agentos/mc/mcp'},
                 'knowledge-base': {url: 'https://other.example.com/agentos/kb/mcp'}
             }
         }, {
-            ...remoteTransport(),
+            ...tenantTarget(),
             credentialEnvVar: 'GH_TOKEN'
         }, {
-            ...remoteTransport(),
+            ...tenantTarget(),
             credentialEnvVar: 'NOT VALID'
         }];
 
-        for (const [index, mcpTransport] of malformed.entries()) {
+        for (const [index, mcpTarget] of malformed.entries()) {
             const opts = options(makeAgent('codex'), `malformed-${index}`);
 
-            opts.mcpTransport = mcpTransport;
+            opts.mcpTarget = mcpTarget;
 
             await expect(prepareManagedAgentWorkspace(opts)).rejects.toMatchObject({
                 code: 'FLEET_WORKSPACE_UNSUPPORTED'
@@ -1007,7 +1016,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
 
         opts.mainCheckout       = PROJECT_ROOT;
         opts.remoteMcpCapability = claudeDesktopRemoteCapability(PROJECT_ROOT);
-        opts.mcpTransport        = remoteTransport(fixture.baseUrl);
+        opts.mcpTarget           = tenantTarget(fixture.baseUrl);
 
         try {
             const
@@ -1072,7 +1081,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
     test('Claude Desktop remote transport rejects missing or drifted bridge capability before hydration', async () => {
         const missingProof = options(makeAgent('claude-desktop'), 'remote-desktop-missing-proof');
 
-        missingProof.mcpTransport = remoteTransport();
+        missingProof.mcpTarget = tenantTarget();
         delete missingProof.remoteMcpCapability;
 
         await expect(prepareManagedAgentWorkspace(missingProof)).rejects.toMatchObject({
@@ -1081,7 +1090,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
 
         const wrongKind = options(makeAgent('claude-desktop'), 'remote-desktop-wrong-kind');
 
-        wrongKind.mcpTransport = remoteTransport();
+        wrongKind.mcpTarget = tenantTarget();
         wrongKind.remoteMcpCapability.bridge.kind = 'generic-proxy';
 
         await expect(prepareManagedAgentWorkspace(wrongKind)).rejects.toMatchObject({
@@ -1090,7 +1099,7 @@ test.describe('prepareManagedAgentWorkspace', () => {
 
         const missingBridge = options(makeAgent('claude-desktop'), 'remote-desktop-missing-bridge');
 
-        missingBridge.mcpTransport = remoteTransport();
+        missingBridge.mcpTarget = tenantTarget();
         await fs.rm(path.join(mainCheckout, 'ai/mcp/client/stdioToStreamableHttp.mjs'));
 
         await expect(prepareManagedAgentWorkspace(missingBridge)).rejects.toMatchObject({

--- a/test/playwright/unit/ai/startAgentProvisioned.spec.mjs
+++ b/test/playwright/unit/ai/startAgentProvisioned.spec.mjs
@@ -67,15 +67,16 @@ function makeEnsureRepo(repoPath = '/managed/agent/repo', events) {
 
 function buildPreparedMcpPlan(args, mcpMatrix) {
     return Object.entries(mcpMatrix).map(([key, enabled]) => {
-        const remote = args.mcpTransport?.resources?.[key];
+        const resource = args.mcpTarget?.resources?.[key];
 
         return {
             key,
             name              : `neo-mjs-${key}`,
             enabled,
-            mode              : remote ? 'remote-http' : 'stdio',
-            url               : remote?.url || null,
-            credentialEnvVar  : remote ? 'NEO_MCP_REMOTE_TOKEN' : null,
+            target            : resource ? 'tenant' : 'resident',
+            transport         : resource ? 'streamable-http' : 'stdio',
+            url               : resource?.url || null,
+            credentialEnvVar  : resource ? 'NEO_MCP_REMOTE_TOKEN' : null,
             command           : '/usr/bin/node',
             sourceRoot        : '/installed/neo',
             args              : [`/installed/neo/ai/mcp/server/${key}/mcp-server.mjs`],
@@ -122,7 +123,7 @@ function repoAgent(id = 'a') {
 function remoteRepoAgent(id = 'a') {
     const agents = repoAgent(id);
 
-    agents[id].mcpTransport = {mode: 'remote-http', tenantId: 'tenant-a'};
+    agents[id].mcpTarget = {kind: 'tenant', tenantId: 'tenant-a'};
 
     return agents
 }
@@ -269,8 +270,8 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
             credential      : planePat,
             expectedIdentity: '@a'
         }]);
-        expect(prepareWorkspace.calls[0].mcpTransport).toEqual({
-            mode            : 'remote-http',
+        expect(prepareWorkspace.calls[0].mcpTarget).toEqual({
+            kind            : 'tenant',
             credentialEnvVar: 'NEO_MCP_REMOTE_TOKEN',
             resources       : {
                 'memory-core'   : {url: 'https://tenant.example.com/mc/mcp'},
@@ -301,8 +302,8 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
                 'github-workflow': false,
                 'gitlab-workflow': false
             }),
-            mcpTransport: {
-                mode     : 'remote-http',
+            mcpTarget: {
+                kind     : 'tenant',
                 resources: {
                     'memory-core'   : {url: 'https://tenant.example.com/mc/mcp'},
                     'knowledge-base': {url: 'https://tenant.example.com/kb/mcp'}
@@ -389,8 +390,8 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
             lifecycle        = makeLifecycle({
                 agents: {
                     a: {
-                        id          : 'a', harnessType: 'codex', metadata: {},
-                        mcpTransport: {mode: 'remote-http', tenantId: 'tenant-a'}
+                        id       : 'a', harnessType: 'codex', metadata: {},
+                        mcpTarget: {kind: 'tenant', tenantId: 'tenant-a'}
                     }
                 },
                 credentials: {a: 'ghp_x'}

--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -727,22 +727,22 @@ test.describe('AgentOS.view.AgentConfigCard — live same-record propagation + c
         expect(cardText(card)).not.toMatch(/Authorization|Bearer|credentialEnvVar/);
         expect(tenants.get('tenant-a').credential).toBeUndefined();
 
-        card.onCardClick({path: [{id: `${card.id}__transport__tenant-a`}]});
-        card.onCardClick({path: [{id: `${card.id}__transport__tenant-b`}]});
+        card.onCardClick({path: [{id: `${card.id}__target__tenant-a`}]});
+        card.onCardClick({path: [{id: `${card.id}__target__tenant-b`}]});
 
         expect(intents).toHaveLength(1);
         expect(intents[0]).toMatchObject({
-            id          : 'ada',
-            mcpTransport: {mode: 'remote-http', tenantId: 'tenant-a'}
+            id       : 'ada',
+            mcpTarget: {kind: 'tenant', tenantId: 'tenant-a'}
         });
-        expect(record.mcpTransport).toBeNull();
+        expect(record.mcpTarget).toBeNull();
 
-        record.set({mcpTransport: {mode: 'remote-http', tenantId: 'tenant-a'}});
+        record.set({mcpTarget: {kind: 'tenant', tenantId: 'tenant-a'}});
         card.refresh();
-        card.onCardClick({path: [{id: `${card.id}__transport__local`}]});
+        card.onCardClick({path: [{id: `${card.id}__target__local`}]});
 
-        expect(intents[1]).toMatchObject({id: 'ada', mcpTransport: null});
-        expect(record.mcpTransport).toEqual({mode: 'remote-http', tenantId: 'tenant-a'});
+        expect(intents[1]).toMatchObject({id: 'ada', mcpTarget: null});
+        expect(record.mcpTarget).toEqual({kind: 'tenant', tenantId: 'tenant-a'});
 
         card.destroy();
         tenants.destroy();
@@ -755,7 +755,7 @@ test.describe('AgentOS.view.AgentConfigCard — live same-record propagation + c
                 id            : 'desktop',
                 githubUsername: 'desktop',
                 harnessType   : 'antigravity',
-                mcpTransport  : {mode: 'remote-http', tenantId: 'missing-tenant'}
+                mcpTarget     : {kind: 'tenant', tenantId: 'missing-tenant'}
             }]}),
             tenants = Neo.create(FleetTenants, {data: [{
                 id      : 'connected',
@@ -774,9 +774,9 @@ test.describe('AgentOS.view.AgentConfigCard — live same-record propagation + c
         expect(cardText(card)).toContain('Unavailable for this harness');
         expect(cardText(card)).toContain('missing-tenant · Saved target unavailable');
 
-        card.onCardClick({path: [{id: `${card.id}__transport__connected`}]});
-        card.onCardClick({path: [{id: `${card.id}__transport__offline`}]});
-        card.onCardClick({path: [{id: `${card.id}__transport__missing-tenant`}]});
+        card.onCardClick({path: [{id: `${card.id}__target__connected`}]});
+        card.onCardClick({path: [{id: `${card.id}__target__offline`}]});
+        card.onCardClick({path: [{id: `${card.id}__target__missing-tenant`}]});
 
         expect(intents).toEqual([]);
 

--- a/test/playwright/unit/apps/agentos/view/fleet/configIntentRoundTrip.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/configIntentRoundTrip.spec.mjs
@@ -266,7 +266,7 @@ test.describe('configIntentRoundTrip — cross-owner supersession authority (#15
 
     test('remote target intent crosses the wire exactly while event envelopes and credential-shaped noise are stripped', async () => {
         const store = makeStore([
-            {id: 'ada', githubUsername: 'ada', harnessType: 'codex', mcpTransport: null}
+            {id: 'ada', githubUsername: 'ada', harnessType: 'codex', mcpTarget: null}
         ]);
         let received;
 
@@ -277,19 +277,19 @@ test.describe('configIntentRoundTrip — cross-owner supersession authority (#15
                 return {
                     status: 'accepted',
                     agent : {
-                        id          : 'ada',
-                        harnessType : 'codex',
-                        mcpServers  : null,
-                        mcpTransport: {mode: 'remote-http', tenantId: 'tenant-a'}
+                        id         : 'ada',
+                        harnessType: 'codex',
+                        mcpServers : null,
+                        mcpTarget  : {kind: 'tenant', tenantId: 'tenant-a'}
                     }
                 }
             }}),
             intent: {
-                id          : 'ada',
-                mcpTransport: {mode: 'remote-http', tenantId: 'tenant-a'},
-                source      : 'component-event-envelope',
-                credential  : 'must-not-cross',
-                headers     : {Authorization: 'Bearer secret'}
+                id        : 'ada',
+                mcpTarget : {kind: 'tenant', tenantId: 'tenant-a'},
+                source    : 'component-event-envelope',
+                credential: 'must-not-cross',
+                headers   : {Authorization: 'Bearer secret'}
             },
             owner        : {},
             setSaveStatus: () => {},
@@ -297,11 +297,11 @@ test.describe('configIntentRoundTrip — cross-owner supersession authority (#15
         });
 
         expect(received).toEqual({
-            id          : 'ada',
-            mcpTransport: {mode: 'remote-http', tenantId: 'tenant-a'}
+            id       : 'ada',
+            mcpTarget: {kind: 'tenant', tenantId: 'tenant-a'}
         });
         expect(JSON.stringify(received)).not.toMatch(/must-not-cross|Authorization|Bearer secret/);
-        expect(store.get('ada').mcpTransport).toEqual({mode: 'remote-http', tenantId: 'tenant-a'});
+        expect(store.get('ada').mcpTarget).toEqual({kind: 'tenant', tenantId: 'tenant-a'});
 
         store.destroy()
     })


### PR DESCRIPTION
Resolves #16184

Related: #16189

Fleet now models three distinct layers instead of overloading `remote-http`: the public seat selects an `mcpTarget`, resolved plan rows carry independent `target` and canonical `transport` fields, and each harness translates that plan into its own adapter grammar only at the final boundary. Registry, wire, AgentOS UI, lifecycle admission/readback, workspace convergence, receipts, docs, and focused tests move together.

Evidence: L2 (real temp-filesystem registry rewrite + generated adapter artifacts + installed-adapter/readback fixtures + live stdio-to-Streamable-HTTP bridge fixture) → L2 required for the #16184 implementation contract. The active-installation rewrite and deletion are owned by #16189. No residuals for #16184.

## Deltas from ticket

- Chose `null` as the canonical persisted resident target and `{kind:'tenant', tenantId}` for a connected tenant; `{kind:'resident'}` is accepted only as input and canonicalizes to `null`.
- The one-shot persisted-row reader is enclosed by an explicit deletion boundary. #16189 is natively blocked by #16184 and owns its removal only after a redacted live-registry rewrite receipt exists.
- Retired target-as-transport input now rejects at both the direct registry and real Body↔Brain define path; it can no longer silently degrade a tenant request to resident.
- The negative vocabulary guard scans production, docs, and relevant tests. Retired vocabulary is confined to marked migration fixtures, while Codex `streamable_http` and Claude `http` spellings are constrained to named adapter/readback owners.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs test/playwright/unit/ai/FleetLifecycleService.spec.mjs test/playwright/unit/ai/startAgentProvisioned.spec.mjs test/playwright/unit/apps/agentos/Accounts.spec.mjs test/playwright/unit/apps/agentos/view/fleet/configIntentRoundTrip.spec.mjs --workers=1` → **206 passed**, exit 0.
- `node buildScripts/util/check-jsdoc-types.mjs` → **1,917 files**, 0 unparseable JSDoc types.
- `npm run ai:lint-guides -- learn/agentos/cloud-deployment/ClientAuthentication.md --warn-as-error` → 0 hard findings, 0 warnings.
- Explicit `agent-preflight --change-class capability ... --no-fix <20 files>` → ticket archaeology clean; subject/title class valid; all requested gates passed.
- Registry + wire: direct persistence/rewrite, malformed-row fail-closed, post-migration rejection, and real bridge-domain rejection live in the two Fleet Registry/Control Bridge specs above.
- Resolved plan + adapters: exact resident/tenant axes and generated Codex, Claude Code, Claude Desktop, Kimi, and OpenCode artifacts live in `prepareManagedAgentWorkspace.spec.mjs`; the Claude Desktop fixture establishes a real MCP client/server session through the generated command bridge.
- Lifecycle: installed Codex readback, target/transport admission, and spawn-time propagation live in `FleetLifecycleService.spec.mjs` and `startAgentProvisioned.spec.mjs`.
- AgentOS configuration: Store-backed target availability, emitted intent, canonical readback, and cross-owner round-trip live in `Accounts.spec.mjs` and `configIntentRoundTrip.spec.mjs`.
- Guide diagram: Mermaid syntax/shape lint is green. Per the guide-authoring contract, browser-backed GitHub/portal render verification remains a pre-merge reviewer check; no local headless renderer is claimed.

## Post-Merge Validation

- [ ] Let the active Fleet service hydrate once and attach a redacted canonical-registry receipt to #16189.
- [ ] Begin #16189 only after that receipt; delete the marked migration block and fixture without weakening retired-input rejection.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex)
