### PR TITLE
feat(github): classify believed-open pull requests (#16191)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -161,6 +161,7 @@ paths:
       summary: List Pull Requests
       operationId: list_pull_requests
       x-neo-tool-tier: read
+      x-neo-tool-summary: List PRs; optionally falsify exact PR numbers supplied through believedOpen.
       x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
@@ -171,6 +172,7 @@ paths:
         - To get a high-level overview of pending work (using the default `state: 'open'`).
         - To research historical context by looking at past work (e.g., using `state: 'closed'` or `state: 'merged'`).
         - To find a specific pull request number for use in other tools.
+        - To falsify an exact caller-owned list of believed-open PR numbers in the same source read.
         - When the user asks questions like:
           - "What pull requests are currently open?"
           - "Show me recently merged PRs."
@@ -179,7 +181,7 @@ paths:
         - After calling this tool, summarize the list of PRs for the user.
         - Use the current head, review, reviewer-request, and merge-state fields before making a PR-state claim.
         - `reviewRequests: null` means the reviewer source was unavailable or incomplete; `[]` means fetched and empty.
-        - Avoid showing the raw JSON output to the user unless they explicitly ask for it.
+        - `believedOpen` resolves each supplied number directly; it never infers terminal state from bounded-page absence.
       tags: [Pull Requests]
       parameters:
         - name: limit
@@ -199,6 +201,17 @@ paths:
             type: string
             enum: [open, closed, merged, all]
             default: open
+        - name: believedOpen
+          in: query
+          required: false
+          description: Up to 100 exact PR numbers currently believed open; over-cap input is rejected before GitHub I/O.
+          schema:
+            type: array
+            maxItems: 100
+            uniqueItems: true
+            items:
+              type: integer
+              minimum: 1
       responses:
         '200':
           description: A list of open pull requests.
@@ -2013,6 +2026,50 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PullRequest'
+        checkedAt:
+          type: string
+          format: date-time
+          description: Source-read completion time; present only when believedOpen is supplied.
+        belief:
+          $ref: '#/components/schemas/PullRequestBelief'
+
+    PullRequestBelief:
+      type: object
+      required: [stillOpen, falsified, unverifiable]
+      properties:
+        stillOpen:
+          type: array
+          description: Submitted numbers whose directly resolved current state is OPEN.
+          items:
+            type: integer
+        falsified:
+          type: array
+          description: Submitted numbers whose directly resolved current state is terminal.
+          items:
+            type: object
+            required: [number, state, mergedAt]
+            properties:
+              number:
+                type: integer
+              state:
+                type: string
+                enum: [CLOSED, MERGED]
+              mergedAt:
+                type: string
+                format: date-time
+                nullable: true
+        unverifiable:
+          type: array
+          description: Submitted numbers the direct lookup could not observe; these are not falsified.
+          items:
+            type: object
+            required: [number, reason]
+            properties:
+              number:
+                type: integer
+              reason:
+                type: string
+                enum: [not-found-or-inaccessible]
 
     PullRequestConversation:
       type: object

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -15,6 +15,7 @@ import {
     UPDATE_PULL_REQUEST_REVIEW
 }                                              from './queries/mutations.mjs';
 import {
+    buildPullRequestsWithBeliefQuery,
     FETCH_PULL_REQUESTS,
     GET_CONVERSATION,
     GET_MERGE_READINESS
@@ -53,6 +54,7 @@ const DROP_SUPERSEDE_CONTRACT_FIELDS = [
 
 const MERGE_READINESS_PROJECTION     = 'merge-readiness';
 const MERGE_READINESS_SCHEMA_VERSION = 'neo.merge-readiness/v1';
+const MAX_BELIEVED_OPEN              = 100;
 
 function stableStringify(value) {
     if (Array.isArray(value)) {
@@ -130,6 +132,72 @@ function normalizePullRequestListItem(pullRequest) {
         baseRefName     : pullRequest.baseRefName ?? null,
         headRefOid      : pullRequest.headRefOid ?? null,
         mergeStateStatus: pullRequest.mergeStateStatus ?? null
+    }
+}
+
+/**
+ * @summary Validates the optional caller-owned believed-open PR coordinate before GitHub I/O.
+ * @param {Number[]|undefined} believedOpen Candidate exact pull-request numbers.
+ * @returns {String|null} A validation message, or null when the coordinate is valid or absent.
+ */
+function getBelievedOpenValidationMessage(believedOpen) {
+    if (believedOpen === undefined) {
+        return null;
+    }
+
+    if (!Array.isArray(believedOpen)) {
+        return 'believedOpen must be an array when provided.'
+    }
+
+    if (believedOpen.length > MAX_BELIEVED_OPEN) {
+        return `believedOpen accepts at most ${MAX_BELIEVED_OPEN} pull-request numbers.`
+    }
+
+    if (!believedOpen.every(number => Number.isInteger(number) && number > 0)) {
+        return 'believedOpen entries must be positive integers.'
+    }
+
+    if (new Set(believedOpen).size !== believedOpen.length) {
+        return 'believedOpen entries must be unique.'
+    }
+
+    return null;
+}
+
+/**
+ * @summary Classifies every submitted PR coordinate from its direct aliased GitHub row.
+ * @param {Object} repository Repository result containing the direct alias fields.
+ * @param {Array<{alias: String, number: Number}>} lookups Ordered alias-to-number lookup plan.
+ * @returns {{stillOpen: Number[], falsified: Object[], unverifiable: Object[]}}
+ */
+function projectBelievedOpen(repository, lookups) {
+    const stillOpen    = [];
+    const falsified    = [];
+    const unverifiable = [];
+
+    lookups.forEach(({alias, number}) => {
+        const pullRequest = repository[alias];
+
+        if (pullRequest?.state === 'OPEN') {
+            stillOpen.push(number);
+        } else if (['CLOSED', 'MERGED'].includes(pullRequest?.state)) {
+            falsified.push({
+                number,
+                state   : pullRequest.state,
+                mergedAt: pullRequest.mergedAt ?? null
+            })
+        } else {
+            unverifiable.push({
+                number,
+                reason: 'not-found-or-inaccessible'
+            })
+        }
+    });
+
+    return {
+        stillOpen,
+        falsified,
+        unverifiable
     }
 }
 
@@ -2172,12 +2240,27 @@ class PullRequestService extends Base {
 
     /**
      * Fetches a list of pull requests from GitHub.
-     * @param {object} [options]                                           The options for listing pull requests
-     * @param {number} [options.limit=aiConfig.pullRequest.defaults.limit] The maximum number of PRs to return
-     * @param {string} [options.state=aiConfig.pullRequest.defaults.state] The state of the pull requests to list (open, closed, merged, all)
+     * @param {object}   [options]                                           The options for listing pull requests
+     * @param {number}   [options.limit=aiConfig.pullRequest.defaults.limit] The maximum number of PRs to return
+     * @param {string}   [options.state=aiConfig.pullRequest.defaults.state] The state of the pull requests to list (open, closed, merged, all)
+     * @param {Number[]} [options.believedOpen]                              Exact PR numbers whose open belief should be falsified
      * @returns {Promise<object>} A promise that resolves to the list of pull requests or a structured error.
      */
-    async listPullRequests({limit=aiConfig.pullRequest.defaults.limit, state=aiConfig.pullRequest.defaults.state} = {}) {
+    async listPullRequests({
+        believedOpen,
+        limit = aiConfig.pullRequest.defaults.limit,
+        state = aiConfig.pullRequest.defaults.state
+    } = {}) {
+
+        const validationMessage = getBelievedOpenValidationMessage(believedOpen);
+
+        if (validationMessage) {
+            return {
+                error  : 'Invalid believedOpen input',
+                message: validationMessage,
+                code   : 'INVALID_BELIEVED_OPEN'
+            }
+        }
 
         const variables = {
             owner : aiConfig.owner,
@@ -2187,12 +2270,28 @@ class PullRequestService extends Base {
         };
 
         try {
-            const data         = await GraphqlService.query(FETCH_PULL_REQUESTS, variables);
+            const beliefPlan = believedOpen === undefined
+                ? null
+                : buildPullRequestsWithBeliefQuery(believedOpen);
+            const response = beliefPlan
+                ? await GraphqlService.query(beliefPlan.query, variables, {strict: false})
+                : await GraphqlService.query(FETCH_PULL_REQUESTS, variables);
+            const data = beliefPlan && response && Object.hasOwn(response, 'data')
+                ? response.data
+                : response;
             const pullRequests = data.repository.pullRequests.nodes.map(normalizePullRequestListItem);
-            return {
+
+            const result = {
                 count: pullRequests.length,
                 pullRequests
             };
+
+            if (beliefPlan) {
+                result.checkedAt = new Date().toISOString();
+                result.belief    = projectBelievedOpen(data.repository, beliefPlan.lookups);
+            }
+
+            return result;
         } catch (error) {
             logger.error('Error fetching pull requests via GraphQL:', error);
             return {

--- a/ai/services/github-workflow/queries/pullRequestQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestQueries.mjs
@@ -174,6 +174,46 @@ export const FETCH_PULL_REQUESTS = `
 `;
 
 /**
+ * @summary Builds one PR-board query with direct lookups for a validated believed-open coordinate.
+ *
+ * The default {@link FETCH_PULL_REQUESTS} string remains the source of the board selection. Each
+ * believed number receives a deterministic GraphQL alias at the repository level, so the caller
+ * can classify exact current state without inferring from the bounded board connection.
+ *
+ * @param {Number[]} believedOpen Prevalidated unique positive pull-request numbers.
+ * @returns {{query: String, lookups: Array<{alias: String, number: Number}>}}
+ */
+export function buildPullRequestsWithBeliefQuery(believedOpen) {
+    const lookups = believedOpen.map((number, index) => ({
+        alias: `believedOpen${index}`,
+        number
+    }));
+
+    if (lookups.length === 0) {
+        return {
+            query: FETCH_PULL_REQUESTS,
+            lookups
+        }
+    }
+
+    const selections = lookups.map(({alias, number}) => `
+      ${alias}: pullRequest(number: ${number}) {
+        number
+        state
+        mergedAt
+      }`
+    ).join('');
+
+    return {
+        query: FETCH_PULL_REQUESTS.replace(
+            /\n    }\n  }\n\s*$/,
+            `${selections}\n    }\n  }\n`
+        ),
+        lookups
+    }
+}
+
+/**
  * @summary Search resolved pull requests for runtime history exploration.
  *
  * The search connection provides the outer resolved-PR census while each pull request includes

--- a/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
@@ -128,4 +128,34 @@ test.describe('GitHub Workflow MCP Server Tool Registration', () => {
         expect(operationIds.filter(id => id === 'get_conversation')).toHaveLength(1);
         expect(operationIds).not.toContain('certify_merge_readiness');
     });
+
+    test('#16191 extends list_pull_requests with a bounded believed-open falsifier', () => {
+        const filePath   = path.resolve(__dirname, '../../../../../../../ai/mcp/server/github-workflow/openapi.yaml');
+        const doc        = yaml.load(fs.readFileSync(filePath, 'utf8'));
+        const operations = Object.values(doc.paths).flatMap(pathItem =>
+            Object.values(pathItem).filter(value => value?.operationId)
+        );
+        const operation    = operations.find(value => value.operationId === 'list_pull_requests');
+        const believedOpen = operation.parameters.find(parameter => parameter.name === 'believedOpen');
+        const response     = doc.components.schemas.PullRequestListResponse.properties;
+        const belief       = doc.components.schemas.PullRequestBelief;
+
+        expect(operation['x-neo-tool-summary']).toContain('believedOpen');
+        expect(operation['x-neo-tool-summary'].length).toBeLessThanOrEqual(120);
+        expect(operation.description.length).toBeLessThanOrEqual(1024);
+        expect(believedOpen.schema).toMatchObject({
+            type       : 'array',
+            maxItems   : 100,
+            uniqueItems: true,
+            items      : {
+                type   : 'integer',
+                minimum: 1
+            }
+        });
+        expect(response.checkedAt.format).toBe('date-time');
+        expect(response.belief.$ref).toBe('#/components/schemas/PullRequestBelief');
+        expect(belief.required).toEqual(['stillOpen', 'falsified', 'unverifiable']);
+        expect(operations.filter(value => value.operationId === 'list_pull_requests')).toHaveLength(1);
+        expect(operations.some(value => value.operationId === 'falsify_pull_request_belief')).toBe(false);
+    });
 });

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -14,12 +14,15 @@ setup({
     }
 });
 
-test.describe('Neo.ai.services.github-workflow.PullRequestService — list freshness fields (#16165)', () => {
+test.describe('Neo.ai.services.github-workflow.PullRequestService — list freshness and belief fields (#16165, #16191)', () => {
     let GraphqlService;
     let PullRequestService;
+    let fetchPullRequestsQuery;
     let originalQuery;
     let capturedQuery;
     let capturedVariables;
+    let capturedOptions;
+    let queryCalls;
 
     const row = (overrides = {}) => ({
         number          : 16165,
@@ -55,6 +58,9 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
         PullRequestService = (await import(
             '../../../../../../ai/services/github-workflow/PullRequestService.mjs'
         )).default;
+        fetchPullRequestsQuery = (await import(
+            '../../../../../../ai/services/github-workflow/queries/pullRequestQueries.mjs'
+        )).FETCH_PULL_REQUESTS;
         originalQuery      = GraphqlService.query.bind(GraphqlService)
     });
 
@@ -65,10 +71,14 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
     test.beforeEach(() => {
         capturedQuery     = null;
         capturedVariables = null;
+        capturedOptions   = null;
+        queryCalls        = 0;
 
-        GraphqlService.query = async (query, variables) => {
+        GraphqlService.query = async (query, variables, options) => {
+            queryCalls++;
             capturedQuery     = query;
             capturedVariables = variables;
+            capturedOptions   = options;
 
             return {repository: {pullRequests: {nodes: [row()]}}}
         }
@@ -89,12 +99,15 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
         }
 
         expect(capturedQuery).toContain('reviewRequests(first: 100)');
+        expect(capturedQuery).toBe(fetchPullRequestsQuery);
         expect(capturedVariables).toEqual({
             owner : 'neomjs',
             repo  : 'neo',
             limit : 7,
             states: 'OPEN'
         });
+        expect(capturedOptions).toBeUndefined();
+        expect(queryCalls).toBe(1);
         expect(result).toEqual({
             count       : 1,
             pullRequests: [{
@@ -115,6 +128,105 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
                 mergeStateStatus: 'CLEAN'
             }]
         })
+    });
+
+    test('classifies exact believed-open numbers in the same read independently of board filters', async () => {
+        GraphqlService.query = async (query, variables, options) => {
+            queryCalls++;
+            capturedQuery     = query;
+            capturedVariables = variables;
+            capturedOptions   = options;
+
+            return {
+                data: {
+                    repository: {
+                        pullRequests : {nodes: [row({number: 700})]},
+                        believedOpen0: {number: 11, state: 'OPEN', mergedAt: null},
+                        believedOpen1: {number: 12, state: 'MERGED', mergedAt: '2026-07-30T12:00:00Z'},
+                        believedOpen2: {number: 13, state: 'CLOSED', mergedAt: null},
+                        believedOpen3: null
+                    }
+                },
+                errors: [{path: ['repository', 'believedOpen3']}]
+            }
+        };
+
+        const result = await PullRequestService.listPullRequests({
+            believedOpen: [11, 12, 13, 999999],
+            limit       : 1,
+            state       : 'closed'
+        });
+
+        expect(queryCalls).toBe(1);
+        expect(capturedOptions).toEqual({strict: false});
+        expect(capturedVariables).toEqual({
+            owner : 'neomjs',
+            repo  : 'neo',
+            limit : 1,
+            states: 'CLOSED'
+        });
+        expect(capturedQuery).toContain('pullRequests(first: $limit');
+        expect(capturedQuery).toContain('believedOpen0: pullRequest(number: 11)');
+        expect(capturedQuery).toContain('believedOpen1: pullRequest(number: 12)');
+        expect(capturedQuery).toContain('believedOpen2: pullRequest(number: 13)');
+        expect(capturedQuery).toContain('believedOpen3: pullRequest(number: 999999)');
+        expect(new Date(result.checkedAt).toISOString()).toBe(result.checkedAt);
+        expect(result.count).toBe(1);
+        expect(result.pullRequests[0].number).toBe(700);
+        expect(result.belief).toEqual({
+            stillOpen: [11],
+            falsified: [{
+                number  : 12,
+                state   : 'MERGED',
+                mergedAt: '2026-07-30T12:00:00Z'
+            }, {
+                number  : 13,
+                state   : 'CLOSED',
+                mergedAt: null
+            }],
+            unverifiable: [{
+                number: 999999,
+                reason: 'not-found-or-inaccessible'
+            }]
+        })
+    });
+
+    test('accepts an explicit empty belief without changing the board query', async () => {
+        const result = await PullRequestService.listPullRequests({believedOpen: []});
+
+        expect(queryCalls).toBe(1);
+        expect(capturedQuery).toBe(fetchPullRequestsQuery);
+        expect(capturedOptions).toEqual({strict: false});
+        expect(result.belief).toEqual({
+            stillOpen   : [],
+            falsified   : [],
+            unverifiable: []
+        });
+        expect(new Date(result.checkedAt).toISOString()).toBe(result.checkedAt)
+    });
+
+    test('rejects invalid believed-open coordinates before GitHub I/O', async () => {
+        const invalidCoordinates = [
+            null,
+            '1',
+            [0],
+            [-1],
+            [1.5],
+            ['1'],
+            [1, 1],
+            Array.from({length: 101}, (_, index) => index + 1)
+        ];
+
+        for (const believedOpen of invalidCoordinates) {
+            const result = await PullRequestService.listPullRequests({believedOpen});
+
+            expect(result).toMatchObject({
+                error: 'Invalid believedOpen input',
+                code : 'INVALID_BELIEVED_OPEN'
+            });
+        }
+
+        expect(queryCalls).toBe(0)
     });
 
     test('distinguishes complete-empty reviewer requests from unavailable or incomplete sources', async () => {


### PR DESCRIPTION
Resolves #16191

Related: #16136

`list_pull_requests` can now receive an exact caller-owned `believedOpen` coordinate and resolve every supplied PR number alongside the existing bounded board in one GraphQL request. The default query, options, and response stay unchanged when the coordinate is absent; the opt-in projection separates observed-open, observed-terminal, and unavailable observations without adding a tool or server state.

Evidence: L2 (focused service/schema tests, real MCP tool-list generation, and a live GitHub GraphQL witness) → L2 required (all close-target ACs). No residuals.

## Deltas from ticket

None substantive relative to the amended ticket. The implementation preserves the existing board selection, rejects malformed or over-100 coordinates before GitHub I/O, and keeps unresolved aliases in `unverifiable` instead of treating absence as refutation.

## Test Evidence

- Live GitHub GraphQL witness at `bae81c3348`: one request with `believedOpen: [16192, 16190, 99999999]` returned board PR #16192, `stillOpen: [16192]`, merged #16190 in `falsified` with merge timestamp `2026-07-30T20:43:44Z`, and the nonexistent coordinate in `unverifiable`.
- GitHub Workflow service + OpenAPI contract: `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs` — 116/116 passed at `bae81c3348`.
- Generated MCP catalog: `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` — 38/38 passed at `bae81c3348`.
- JSDoc type expressions: `node buildScripts/util/check-jsdoc-types.mjs` — 1,917 files scanned, 0 unparseable.
- MCP test placement: `npm run ai:lint-mcp-test-locations` — passed.
- Commit hooks: whitespace, shorthand, AiConfig mutation, derived-domain, JSDoc, ticket archaeology, block alignment, and parse checks passed.
- Branch integrity: rebased onto current `dev`; `git diff --check origin/dev...HEAD` passed.

## Post-Merge Validation

- [ ] After the GitHub Workflow deployment refresh, confirm `list_pull_requests` exposes `believedOpen` in its generated input schema and handbook.

## Evolution

The initial two-bucket ledger placed unresolved aliases in `falsified`. Pre-PR peer challenge showed that an unavailable observation cannot refute a belief, so the ticket and implementation converged on three exhaustive buckets: `stillOpen`, `falsified`, and `unverifiable`. The 100-item cap remains an atomic pre-I/O refusal; no truncation or hidden partition was introduced.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session b1ebc46a-5a83-496c-aa8b-385af785e9cb.