### PR TITLE
fix(github): mechanize believed-open contract (#16194)

### DIFF
--- a/ai/mcp/validation/openApiValidator.mjs
+++ b/ai/mcp/validation/openApiValidator.mjs
@@ -198,6 +198,22 @@ function buildZodSchemaFromNode(doc, schema, opts = {}) {
             // {"type":"array","items":{}}, which strict MCP clients accept.
             zodSchema = z.array(z.unknown());
         }
+
+        if (typeof schema.minItems === 'number') {
+            zodSchema = zodSchema.min(schema.minItems)
+        }
+
+        if (typeof schema.maxItems === 'number') {
+            zodSchema = zodSchema.max(schema.maxItems)
+        }
+
+        if (schema.uniqueItems === true) {
+            zodSchema = zodSchema
+                .refine(items => new Set(items).size === items.length, {
+                    message: 'Array items must be unique.'
+                })
+                .meta({uniqueItems: true})
+        }
     } else if (schema.type === 'string') {
         if (Array.isArray(schema.enum) && schema.enum.length > 0) {
             zodSchema = z.enum(schema.enum);

--- a/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
@@ -1,8 +1,17 @@
+import {setup}         from '../../../../../setup.mjs';
 import {test, expect}  from '@playwright/test';
 import fs              from 'fs';
 import path            from 'path';
 import {fileURLToPath} from 'url';
 import * as yaml       from 'js-yaml';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+
+setup({
+    appConfig: {
+        name: 'GitHubWorkflowToolRegistrationTest'
+    }
+});
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -129,7 +138,7 @@ test.describe('GitHub Workflow MCP Server Tool Registration', () => {
         expect(operationIds).not.toContain('certify_merge_readiness');
     });
 
-    test('#16191 extends list_pull_requests with a bounded believed-open falsifier', () => {
+    test('#16191/#16194 publish the bounded believed-open falsifier through tools/list', async () => {
         const filePath   = path.resolve(__dirname, '../../../../../../../ai/mcp/server/github-workflow/openapi.yaml');
         const doc        = yaml.load(fs.readFileSync(filePath, 'utf8'));
         const operations = Object.values(doc.paths).flatMap(pathItem =>
@@ -144,6 +153,21 @@ test.describe('GitHub Workflow MCP Server Tool Registration', () => {
         expect(operation['x-neo-tool-summary'].length).toBeLessThanOrEqual(120);
         expect(operation.description.length).toBeLessThanOrEqual(1024);
         expect(believedOpen.schema).toMatchObject({
+            type       : 'array',
+            maxItems   : 100,
+            uniqueItems: true,
+            items      : {
+                type   : 'integer',
+                minimum: 1
+            }
+        });
+
+        const {listTools} = await import('../../../../../../../ai/mcp/server/github-workflow/toolService.mjs');
+        const toolSchema  = listTools().tools
+            .find(tool => tool.name === 'list_pull_requests')
+            .inputSchema.properties.believedOpen;
+
+        expect(toolSchema).toMatchObject({
             type       : 'array',
             maxItems   : 100,
             uniqueItems: true,

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -454,6 +454,44 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(schema.properties.action.enum).toEqual(['start', 'stop']);
     });
 
+    test('buildZodSchema preserves array bounds and uniqueness in validation and tools/list output (#16194)', () => {
+        const doc = {
+            paths: {
+                '/test': {
+                    get: {
+                        operationId: 'test_array_constraints',
+                        parameters : [{
+                            in      : 'query',
+                            name    : 'ids',
+                            required: true,
+                            schema  : {
+                                type       : 'array',
+                                minItems   : 1,
+                                maxItems   : 3,
+                                uniqueItems: true,
+                                items      : {type: 'integer'}
+                            }
+                        }]
+                    }
+                }
+            }
+        };
+        const zodSchema  = buildZodSchema(doc, doc.paths['/test'].get);
+        const jsonSchema = toOpenApiJsonSchema(zodSchema);
+
+        expect(jsonSchema.properties.ids).toMatchObject({
+            type       : 'array',
+            minItems   : 1,
+            maxItems   : 3,
+            uniqueItems: true,
+            items      : {type: 'integer'}
+        });
+        expect(zodSchema.safeParse({ids: [1, 2, 3]}).success).toBe(true);
+        expect(zodSchema.safeParse({ids: []}).success).toBe(false);
+        expect(zodSchema.safeParse({ids: [1, 2, 3, 4]}).success).toBe(false);
+        expect(zodSchema.safeParse({ids: [1, 1]}).success).toBe(false)
+    });
+
     /**
      * Direct regression for https://github.com/neomjs/neo/issues/10531.
      * The MCP tool-shape compiler must preserve OpenAPI defaults, numeric bounds,

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -1,7 +1,9 @@
 import {setup} from '../../../../setup.mjs';
+import {createHash} from 'node:crypto';
 
 const appName          = 'PullRequestServiceTest';
 const skipCiGitHubAuth = !!process.env.NEO_TEST_SKIP_CI;
+const predecessorListQuerySha256 = '68b60ee57194252d68f3b50f2e174f25ff3859d3ba89bd2a66d7e2d873e1914f';
 
 setup({
     neoConfig: {
@@ -17,7 +19,6 @@ setup({
 test.describe('Neo.ai.services.github-workflow.PullRequestService — list freshness and belief fields (#16165, #16191)', () => {
     let GraphqlService;
     let PullRequestService;
-    let fetchPullRequestsQuery;
     let originalQuery;
     let capturedQuery;
     let capturedVariables;
@@ -58,9 +59,6 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
         PullRequestService = (await import(
             '../../../../../../ai/services/github-workflow/PullRequestService.mjs'
         )).default;
-        fetchPullRequestsQuery = (await import(
-            '../../../../../../ai/services/github-workflow/queries/pullRequestQueries.mjs'
-        )).FETCH_PULL_REQUESTS;
         originalQuery      = GraphqlService.query.bind(GraphqlService)
     });
 
@@ -99,7 +97,8 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
         }
 
         expect(capturedQuery).toContain('reviewRequests(first: 100)');
-        expect(capturedQuery).toBe(fetchPullRequestsQuery);
+        expect(capturedQuery).toHaveLength(987);
+        expect(createHash('sha256').update(capturedQuery).digest('hex')).toBe(predecessorListQuerySha256);
         expect(capturedVariables).toEqual({
             owner : 'neomjs',
             repo  : 'neo',
@@ -195,7 +194,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
         const result = await PullRequestService.listPullRequests({believedOpen: []});
 
         expect(queryCalls).toBe(1);
-        expect(capturedQuery).toBe(fetchPullRequestsQuery);
+        expect(createHash('sha256').update(capturedQuery).digest('hex')).toBe(predecessorListQuerySha256);
         expect(capturedOptions).toEqual({strict: false});
         expect(result.belief).toEqual({
             stillOpen   : [],


### PR DESCRIPTION
Resolves #16194

The published MCP contract now matches its OpenAPI source: the shared compiler preserves array bounds and uniqueness in both runtime validation and generated `tools/list` JSON Schema. The GitHub Workflow registration test proves the real `list_pull_requests` projection, while the default-query regression test now compares captured bytes against an independent predecessor length and SHA-256 oracle instead of importing the production query.

Evidence: L2 (runtime-derived schema, real tool-service projection, and independent query-capture assertions) → L2 required (all #16194 acceptance criteria are executable in the unit substrate). No residuals.

Related: #16136

Related: #16191

Related: #16192

Related: #16170

## Deltas from ticket

None substantive. The shared array compiler preserves `minItems` alongside the ticket's `maxItems` and `uniqueItems` requirements because all three are existing OpenAPI array constraints on the same owned conversion path.

The separate GitHub `response.errors` diagnosability refinement remains out of scope.

## Test Evidence

- MCP OpenAPI compiler + GitHub Workflow publication + default query oracle: `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` — 161 passed.
- Cross-server MCP catalog: `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` — 38 passed.
- JSDoc type integrity: `node ./buildScripts/util/check-jsdoc-types.mjs` — 1,917 files scanned, 0 violations.
- Restoration preflight: `npm run agent-preflight -- --no-fix --change-class restoration ...` — all requested gates passed; one unrelated stale AiConfig overlay warning.
- Patch hygiene: `git diff --check origin/dev...HEAD` — passed.

## Post-Merge Validation

- [ ] Refresh the deployed GitHub Workflow MCP and confirm `list_pull_requests.inputSchema.properties.believedOpen` publishes `maxItems: 100`, `uniqueItems: true`, and item `minimum: 1`.

## Evolution

This successor exists because the resolved feature's raw-YAML assertion certified declarations rather than the emitted agent-consumed schema, and its default-query test shared the production constant it was meant to guard. The repair keeps the resolved predecessor closed and turns both audit findings into independent executable evidence.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session b1ebc46a-5a83-496c-aa8b-385af785e9cb.
