### PR TITLE
fix(fleet): remove unexercised target migration (#16189)

### DIFF
--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -159,58 +159,6 @@ function normalizeStoredMcpTarget(target) {
     }
 }
 
-// Legacy MCP target migration begin — deletion boundary after the live registry rewrite is proven.
-/**
- * @summary Translate the single retired `mcpTransport` registry shape into target intent. This
- * helper is read-path migration substrate only: it accepts no URLs, headers, credentials, commands,
- * or unknown keys, and every malformed legacy row fails closed to the resident target.
- * @param {*} transport
- * @returns {Object|null}
- */
-function migrateLegacyMcpTransport(transport) {
-    if (transport === null || transport?.mode === 'stdio') {
-        return null
-    }
-
-    if (!transport ||
-        typeof transport !== 'object' ||
-        Array.isArray(transport) ||
-        Object.keys(transport).some(key => !['mode', 'tenantId'].includes(key)) ||
-        transport.mode !== 'remote-http' ||
-        typeof transport.tenantId !== 'string' ||
-        !transport.tenantId.trim()) {
-        return null
-    }
-
-    return {kind: 'tenant', tenantId: transport.tenantId.trim()}
-}
-
-/**
- * @summary Remove the retired registry key and return one canonical target-bearing definition.
- * A row carrying both shapes keeps only its canonical `mcpTarget`; the legacy key can never
- * override a value already written under the new contract.
- * @param {*} definition
- * @returns {{definition: *, migrated: Boolean}}
- */
-function migrateStoredAgentDefinition(definition) {
-    if (!definition || typeof definition !== 'object' || Array.isArray(definition) ||
-        !Object.hasOwn(definition, 'mcpTransport')) {
-        return {definition, migrated: false}
-    }
-
-    const
-        {mcpTransport, ...rest} = definition,
-        target                  = Object.hasOwn(definition, 'mcpTarget')
-            ? normalizeStoredMcpTarget(definition.mcpTarget)
-            : migrateLegacyMcpTransport(mcpTransport);
-
-    return {
-        definition: {...rest, mcpTarget: target},
-        migrated  : true
-    }
-}
-// Legacy MCP target migration end.
-
 /**
  * @class Neo.ai.services.fleet.FleetRegistryService
  * @extends Neo.core.Base
@@ -787,19 +735,7 @@ class FleetRegistryService extends Base {
             return new Map();
         }
 
-        let migrated = false;
-
-        const agents = new Map(Object.entries(data.agents || {}).map(([id, definition]) => {
-            const result = migrateStoredAgentDefinition(definition);
-            migrated ||= result.migrated;
-            return [id, result.definition]
-        }));
-
-        if (migrated) {
-            this.writeRegistry(agents)
-        }
-
-        return agents
+        return new Map(Object.entries(data.agents || {}))
     }
 
     /**

--- a/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
@@ -36,34 +36,6 @@ function sourceFiles(directory) {
     })
 }
 
-function stripVocabularyExceptions(source, filePath) {
-    const markerPairs = [
-        [
-            ['// Legacy MCP target ', 'migration begin'].join(''),
-            ['// Legacy MCP target ', 'migration end.'].join('')
-        ],
-        [
-            ['// Retired MCP target vocabulary ', 'fixture begin'].join(''),
-            ['// Retired MCP target vocabulary ', 'fixture end.'].join('')
-        ]
-    ];
-
-    for (const [beginMarker, endMarker] of markerPairs) {
-        let begin;
-
-        while ((begin = source.indexOf(beginMarker)) >= 0) {
-            const end = source.indexOf(endMarker, begin + beginMarker.length);
-
-            expect(end, `${filePath}: missing ${endMarker}`).toBeGreaterThan(begin);
-            source = source.slice(0, begin) + source.slice(end + endMarker.length)
-        }
-
-        expect(source.includes(endMarker), `${filePath}: orphan ${endMarker}`).toBe(false)
-    }
-
-    return source
-}
-
 // FleetRegistryService is a singleton. Pointing `dataDir` at a fresh temp dir per test makes
 // ensureLoaded reload an empty registry (isolation) and keeps every write off the real
 // ~/.neo-ai-data. No credential is passed, so the crypto/storeCredential path is never exercised.
@@ -490,55 +462,6 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService.configureAgent — the
         expect(FleetRegistryService.getAgent('legacy-wire')).toBeNull()
     });
 
-    // Retired MCP target vocabulary fixture begin
-    test('legacy transport hydration rewrites exact rows once and fails corrupt rows closed', () => {
-        const registryPath = path.join(tmpDir, 'registry.json');
-
-        fs.writeFileSync(registryPath, JSON.stringify({
-            agents: {
-                absent: {
-                    id      : 'absent', githubUsername: 'absent', harnessType: 'codex',
-                    metadata: {}, mcpServers: null
-                },
-                legacy: {
-                    id          : 'legacy', githubUsername: 'legacy', harnessType: 'codex',
-                    metadata    : {}, mcpServers: null,
-                    mcpTransport: {mode: 'remote-http', tenantId: 'tenant-a'}
-                },
-                corrupt: {
-                    id          : 'corrupt', githubUsername: 'corrupt', harnessType: 'codex',
-                    metadata    : {}, mcpServers: null,
-                    mcpTransport: {
-                        mode   : 'remote-http', tenantId: 'tenant-a',
-                        headers: {Authorization: 'Bearer legacy-secret'}
-                    }
-                }
-            }
-        }));
-
-        const reloadDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-fleet-reg-reload-'));
-        FleetRegistryService.dataDir = reloadDir;
-        expect(FleetRegistryService.listAgents()).toEqual([]);
-
-        FleetRegistryService.dataDir = tmpDir;
-
-        expect(FleetRegistryService.getAgent('absent').mcpTarget).toBeNull();
-        expect(FleetRegistryService.getAgent('legacy').mcpTarget)
-            .toEqual({kind: 'tenant', tenantId: 'tenant-a'});
-        expect(FleetRegistryService.getAgent('corrupt').mcpTarget).toBeNull();
-        expect(FleetRegistryService.getDefinition('corrupt').mcpTarget).toBeNull();
-
-        const rewritten = JSON.parse(fs.readFileSync(registryPath, 'utf8')).agents;
-
-        expect(rewritten.legacy).not.toHaveProperty('mcpTransport');
-        expect(rewritten.legacy.mcpTarget).toEqual({kind: 'tenant', tenantId: 'tenant-a'});
-        expect(rewritten.corrupt).not.toHaveProperty('mcpTransport');
-        expect(rewritten.corrupt.mcpTarget).toBeNull();
-
-        fs.rmSync(reloadDir, {recursive: true, force: true})
-    });
-    // Retired MCP target vocabulary fixture end.
-
     test('retired target vocabulary and adapter spellings stay inside their named boundaries', () => {
         const
             roots              = ['ai', 'apps', 'learn', 'src', 'test'].map(name => path.join(PROJECT_ROOT, name)),
@@ -580,7 +503,7 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService.configureAgent — the
         for (const filePath of roots.flatMap(sourceFiles)) {
             const
                 relative = path.relative(PROJECT_ROOT, filePath),
-                source   = stripVocabularyExceptions(fs.readFileSync(filePath, 'utf8'), filePath);
+                source   = fs.readFileSync(filePath, 'utf8');
 
             expect(source, relative).not.toMatch(retiredPattern);
 


### PR DESCRIPTION
Resolves #16189

The one-shot Fleet registry compatibility layer is gone. A bounded runtime census found exactly one Fleet registry, 18 bytes long, whose complete parsed shape contains zero agent rows; the migration therefore never traversed or rewrote a row. `readRegistry()` now hydrates canonical definitions directly, the synthetic legacy fixture and its vocabulary exceptions are deleted, and the live direct and Body↔Brain rejection guards remain executable.

Evidence: L2 (bounded runtime absence receipt plus direct-registry and real-wire executable assertions) → L2 required (the deletion and preserved rejection boundary are fully exercised in the focused unit substrate). No residuals.

Related: #16184

Related: #16190

Related: #15188

Related: #15191

## Deltas from ticket

None substantive after the ticket correction. Before implementation, the original “successful rewrite” gate was replaced with the empirically honest negative receipt: the sole registry contains no rows, so no migration traversal or rewrite is claimed.

## Test Evidence

- Fleet Registry + real Control Bridge boundary: `npm run test-unit -- test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs` — 60 passed.
- JSDoc type integrity: `node ./buildScripts/util/check-jsdoc-types.mjs` — 1,917 files scanned, 0 violations.
- Restoration preflight: `npm run agent-preflight -- --no-fix --change-class restoration ...` — all requested gates passed; one unrelated stale AiConfig overlay warning.
- Retired vocabulary: exact source sweep of the changed Registry/service spec contains no `mcpTransport` or `remote-http` residual.
- Patch hygiene: `git diff --check origin/dev...HEAD` — passed.

## Post-Merge Validation

- [ ] Re-run the bounded Fleet registry census and confirm no pre-cut persisted row appeared between the deletion receipt and merge.

## Evolution

The cleanup ticket originally treated an unchanged empty registry as a successful migration receipt. The pre-implementation falsifier showed that identical output cannot prove traversal. Correcting the authority before editing let this PR delete 143 lines of fictional compatibility substrate while retaining the real rejection contracts.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session b1ebc46a-5a83-496c-aa8b-385af785e9cb.
