### PR TITLE
fix(backup): fail unmet required off-host sync (#16199)

### DIFF
--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -27,6 +27,7 @@ import {
     resolveHeavyMaintenanceLeasePath,
     withHeavyMaintenanceLease
 } from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
+import {resolveCloudOnlyDefault}        from '../../daemons/orchestrator/services/deploymentDurabilityPosture.mjs';
 import {HEAL_LEDGER_DIR_NAME}           from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {INCIDENT_LEDGER_BUNDLE_MEMBERS} from '../../services/memory-core/helpers/incidentLedgerBundle.mjs';
 import {
@@ -120,6 +121,45 @@ const DEFAULT_CONCEPTS_DIR      = path.join(PROJECT_ROOT, '.neo-ai-data', 'conce
 const DEFAULT_TRAJECTORIES_FILE = path.join(PROJECT_ROOT, '.neo-ai-data', 'datasets', 'rlaif', 'trajectories.jsonl');
 const DEFAULT_SENT_TO_CULL_FILE = path.join(path.dirname(mcConfig.storagePaths.graph), 'sent-to-cull.jsonl');
 export const LOCAL_AI_CONFIG_FILE = path.join(PROJECT_ROOT, 'ai', 'config.mjs');
+
+/**
+ * Stable terminal classification when a completed local bundle did not satisfy the deployment's
+ * required off-host durability gate.
+ * @type {String}
+ */
+export const REQUIRED_OFFHOST_BACKUP_ERROR_CODE = 'BACKUP_REQUIRED_OFFHOST_SYNC_UNMET';
+
+/**
+ * @summary Builds the status-only terminal error for a required off-host durability failure.
+ * Receipt diagnostics retain the detailed/redacted child outcome; the thrown boundary exposes
+ * neither config values, argv, stderr, paths, nor credentials.
+ * @param {String} offHostSyncStatus
+ * @returns {Error}
+ */
+function createRequiredOffHostBackupError(offHostSyncStatus) {
+    const error = new Error(`Required off-host backup was not satisfied (status=${offHostSyncStatus}).`);
+
+    error.code              = REQUIRED_OFFHOST_BACKUP_ERROR_CODE;
+    error.offHostSyncStatus = offHostSyncStatus;
+
+    return error
+}
+
+/**
+ * @summary Writes the CLI terminal for a backup failure.
+ * Required off-host refusals expose only their stable code/status; unrelated backup failures keep
+ * the existing full Error diagnostic.
+ * @param {Error} error
+ * @param {Object} [logger=console]
+ * @returns {void}
+ */
+export function reportBackupTerminalFailure(error, logger=console) {
+    if (error?.code === REQUIRED_OFFHOST_BACKUP_ERROR_CODE) {
+        logger.error(`❌ Backup failed: ${error.code} (status=${error.offHostSyncStatus}).`)
+    } else {
+        logger.error('❌ Backup failed:', error)
+    }
+}
 
 /**
  * Loads the gitignored Tier-1 AI config for operator-run scripts when present.
@@ -684,15 +724,27 @@ async function copyJsonlSource(source, destDir, logger=console, destFileName=nul
  *
  * Lease semantics: the sync lifetime extends the exclusive-heavy backup lease; the lease remains
  * held through the bounded-size receipt fsync/rename and releases afterward (no exact wall-clock
- * bound — local filesystem completion is not a hard real-time guarantee).
+ * bound — local filesystem completion is not a hard real-time guarantee). When the deployment
+ * requires off-host durability, a non-success sync rejects only AFTER that truthful receipt attempt;
+ * the completed local bundle remains `backup.status: 'success'`.
  *
+ * @param {Object} [options]
+ * @param {Function} [options.runBackupImpl=runBackup] Local bundle primitive.
+ * @param {Function|null} [options.withLeaseImpl=null] Heavy-maintenance lease seam.
+ * @param {String|null} [options.backupRoot=null] Receipt-root override.
+ * @param {Object} [options.syncConfig] Off-host config override.
+ * @param {Function} [options.runOffHostSyncImpl=runOffHostSync] Sync runner seam.
+ * @param {Boolean} [options.offHostBackupRequired] Resolved requirement override; omitted reads
+ * AiConfig through the canonical cloud-only resolver.
  * @returns {Promise<Object>} the lease outcome (same shape as `withHeavyMaintenanceLease`'s)
  */
 export async function runBackupWithOffHostSync({
-    runBackupImpl  = runBackup,
-    withLeaseImpl  = null,
-    backupRoot     = null,
-    syncConfig     = undefined
+    runBackupImpl          = runBackup,
+    withLeaseImpl          = null,
+    backupRoot             = null,
+    syncConfig             = undefined,
+    runOffHostSyncImpl     = runOffHostSync,
+    offHostBackupRequired  = undefined
 } = {}) {
     // The sync + BOTH receipts live INSIDE the self-acquired lease: success receipts and the
     // truthful not-run failure receipt are persisted before the lease releases.
@@ -705,7 +757,13 @@ export async function runBackupWithOffHostSync({
         const
             validation  = validateOffHostSyncConfig(syncConfig === undefined ? AiConfig.maintenance.backup.offHostSync : syncConfig),
             allowlist   = validation.value?.envAllowlist ?? [],
-            receiptPath = path.join(backupRoot ?? AiConfig.backupPath, 'last-backup-receipt.json');
+            receiptPath = path.join(backupRoot ?? AiConfig.backupPath, 'last-backup-receipt.json'),
+            required    = offHostBackupRequired === undefined
+                ? resolveCloudOnlyDefault(
+                    AiConfig.orchestrator.cloudOnly.offHostBackupRequired,
+                    AiConfig.orchestrator.deploymentMode
+                )
+                : offHostBackupRequired;
 
         let result, backupError = null;
 
@@ -747,10 +805,12 @@ export async function runBackupWithOffHostSync({
 
         if (validation.error) {
             syncStatus = 'validation-failed';
-            console.warn(`[Backup] offHostSync validation failed: ${validation.error} — skipping the off-host sync, the local bundle is unaffected.`);
+            console.warn(required
+                ? `[Backup] required offHostSync validation failed (${validation.errorCode}).`
+                : `[Backup] offHostSync validation failed: ${validation.error} — skipping the off-host sync, the local bundle is unaffected.`);
         } else if (validation.enabled) {
             try {
-                syncOutcome = await runOffHostSync({bundleDir: bundleRoot, bundleName, config: validation.value})
+                syncOutcome = await runOffHostSyncImpl({bundleDir: bundleRoot, bundleName, config: validation.value})
             } catch (syncError) {
                 // An unexpected spawn/config error is a SYNC outcome — the completed local bundle
                 // never becomes backup.status: 'failed' because the hook broke.
@@ -767,7 +827,9 @@ export async function runBackupWithOffHostSync({
             }
 
             if (syncOutcome.status !== 'success') {
-                console.warn(`[Backup] offHostSync ${syncOutcome.status} (terminatedVia=${syncOutcome.terminatedVia}): ${syncOutcome.stderrTail}`);
+                console.warn(required
+                    ? `[Backup] required offHostSync ${syncOutcome.status}.`
+                    : `[Backup] offHostSync ${syncOutcome.status} (terminatedVia=${syncOutcome.terminatedVia}): ${syncOutcome.stderrTail}`);
             }
         }
 
@@ -789,6 +851,12 @@ export async function runBackupWithOffHostSync({
         } catch (receiptError) {
             // A receipt write failure degrades observability, never the successful backup's truth.
             console.warn(`[Backup] failed to write the receipt after a successful backup: ${receiptError.message}`)
+        }
+
+        const observedSyncStatus = syncOutcome?.status ?? syncStatus;
+
+        if (required && observedSyncStatus !== 'success') {
+            throw createRequiredOffHostBackupError(observedSyncStatus)
         }
 
         return result
@@ -822,7 +890,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
             process.exit(0);
         })
         .catch(error => {
-            console.error('❌ Backup failed:', error);
+            reportBackupTerminalFailure(error);
             process.exit(1);
         });
 }

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -448,13 +448,19 @@ test.describe('owner boundary + overlay order (source contracts)', () => {
         const source         = readFileSync(new URL('../../../../../../ai/scripts/maintenance/backup.mjs', import.meta.url), 'utf8');
 
         // The exported primitive's body never names the sync/receipt machinery
-        const runBackupBody = source.slice(source.indexOf('export async function runBackup({'), source.indexOf('export async function runBackupWithOffHostSync'));
+        const
+            wrapperStart    = source.indexOf('export async function runBackupWithOffHostSync'),
+            wrapperDocStart = source.lastIndexOf('/**', wrapperStart),
+            runBackupBody   = source.slice(source.indexOf('export async function runBackup({'), wrapperDocStart);
         expect(runBackupBody).not.toContain('runOffHostSync');
         expect(runBackupBody).not.toContain('writeBackupReceipt');
 
         // Overlay-load-first: the CLI footer loads the top-level overlay BEFORE the wrapper runs
         const footer = source.slice(source.indexOf("if (import.meta.url === `file://"));
         expect(footer.indexOf('await loadTopLevelAiConfig()')).toBeLessThan(footer.indexOf('runBackupWithOffHostSync()'));
+        expect(footer).toContain('.catch(error => {');
+        expect(footer).toContain('reportBackupTerminalFailure(error);');
+        expect(footer).toContain('process.exit(1)');
 
         // Bundle root + retention resolve from the AiConfig leaf, never the module constant
         expect(source).toContain('path.join(AiConfig.backupPath, `backup-${timestamp}`)');
@@ -474,15 +480,19 @@ test.describe('wrapper lease/truth semantics (source contracts + projection shap
         const leaseBody = wrapperBody.slice(0, wrapperBody.indexOf("owner: 'backup'"));
         expect(leaseBody).toContain('(withLeaseImpl ?? withHeavyMaintenanceLease)(async () =>');
         expect(leaseBody).toContain("syncStatus       : 'not-run-backup-failed'");
-        expect(leaseBody).toContain('runOffHostSync');
+        const syncCall = 'syncOutcome = await runOffHostSyncImpl';
+        expect(leaseBody).toContain(syncCall);
         expect(leaseBody).toContain('writeBackupReceipt');
+        expect(leaseBody).toContain('resolveCloudOnlyDefault(');
+        expect(leaseBody).toContain('AiConfig.orchestrator.cloudOnly.offHostBackupRequired');
+        expect(leaseBody).toContain('AiConfig.orchestrator.deploymentMode');
 
         // no receipt write happens outside the lease call
         const afterLease = wrapperBody.slice(wrapperBody.indexOf("owner: 'backup'"));
         expect(afterLease).not.toContain('writeBackupReceipt({');
 
         // backup.durationMs measures runBackup only, never sync time
-        expect(leaseBody.indexOf('backupStartedAt')).toBeLessThan(leaseBody.indexOf('runOffHostSync'));
+        expect(leaseBody.indexOf('backupStartedAt')).toBeLessThan(leaseBody.indexOf(syncCall));
         expect(leaseBody).toContain('backupDurationMs');
 
         // unexpected sync errors become a sync outcome, never a backup failure
@@ -532,14 +542,26 @@ test.describe('wrapper + projection behavioral witnesses', () => {
 
     const completedLease = result => async fn => ({status: 'completed', result: await fn()});
 
+    const fakeSyncOutcome = status => ({
+        completionScope: 'direct-child',
+        descendants    : 'unknown',
+        durationMs     : 1,
+        exitCode       : status === 'success' ? 0 : 3,
+        signal         : null,
+        status,
+        stderrTail     : 'credential-canary /private/secret/cloud-target',
+        terminatedVia  : 'exit'
+    });
+
     test('success path: receipt carries provenance, sync outcome, and a local-backup-scoped duration', async () => {
         const root = makeTmp();
         try {
             const {runBackupWithOffHostSync} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
             const result                     = await runBackupWithOffHostSync({
-                runBackupImpl: async () => fakeBundle(root),
-                withLeaseImpl: completedLease(),
-                backupRoot   : root
+                runBackupImpl        : async () => fakeBundle(root),
+                withLeaseImpl        : completedLease(),
+                backupRoot           : root,
+                offHostBackupRequired: false
             });
 
             expect(result.result.bundleRoot).toContain('backup-2026-07-22');
@@ -578,24 +600,79 @@ test.describe('wrapper + projection behavioral witnesses', () => {
         }
     });
 
-    test('validation path: a malformed subtree yields the validation-failed receipt and never launches a child', async () => {
-        const root = makeTmp();
-        try {
-            const {runBackupWithOffHostSync} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+    test('required/optional terminal matrix preserves the receipt before deciding the operation', async () => {
+        const {
+            REQUIRED_OFFHOST_BACKUP_ERROR_CODE,
+            reportBackupTerminalFailure,
+            runBackupWithOffHostSync
+        } = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
 
-            await runBackupWithOffHostSync({
-                runBackupImpl: async () => fakeBundle(root),
-                withLeaseImpl: completedLease(),
-                backupRoot   : root,
-                syncConfig   : {command: 'rsync', timeoutMs: 5} // out-of-bounds: validation failure
-            });
+        const cases = [
+            {status: 'disabled',          syncConfig: {command: ''}},
+            {status: 'validation-failed', syncConfig: {command: 'rsync', argv: ['--token=credential-canary{bad}']}},
+            {status: 'failed',            syncConfig: VALID_CONFIG},
+            {status: 'timeout',           syncConfig: VALID_CONFIG},
+            {status: 'success',           syncConfig: VALID_CONFIG}
+        ];
 
-            const read = await readBackupReceipt({filePath: path.join(root, 'last-backup-receipt.json')});
-            expect(read.status).toBe('ok');
-            expect(read.receipt.backup.status).toBe('success'); // the bundle completed — only the sync was refused
-            expect(read.receipt.offHostSync.status).toBe('validation-failed');
-        } finally {
-            rmSync(root, {force: true, recursive: true})
+        for (const offHostBackupRequired of [false, true]) {
+            for (const {status, syncConfig} of cases) {
+                const root = makeTmp();
+
+                try {
+                    const
+                        warnings     = [],
+                        originalWarn = console.warn;
+
+                    console.warn = (...args) => warnings.push(args.map(String).join(' '));
+
+                    const run = runBackupWithOffHostSync({
+                        runBackupImpl     : async () => fakeBundle(root),
+                        withLeaseImpl     : completedLease(),
+                        backupRoot        : root,
+                        syncConfig,
+                        runOffHostSyncImpl: async () => fakeSyncOutcome(status),
+                        offHostBackupRequired
+                    }).finally(() => {
+                        console.warn = originalWarn
+                    });
+
+                    if (offHostBackupRequired && status !== 'success') {
+                        const error = await run.then(() => null, value => value);
+
+                        expect(error).toBeInstanceOf(Error);
+                        expect(error).toMatchObject({
+                            code             : REQUIRED_OFFHOST_BACKUP_ERROR_CODE,
+                            message          : expect.not.stringContaining('credential-canary'),
+                            offHostSyncStatus: status
+                        });
+                        expect(warnings.join('\n')).not.toContain('credential-canary');
+                        expect(warnings.join('\n')).not.toContain('/private/secret/cloud-target');
+
+                        const terminal = [];
+                        reportBackupTerminalFailure(error, {error: (...args) => terminal.push(args.map(String).join(' '))});
+
+                        expect(terminal).toEqual([
+                            `❌ Backup failed: ${REQUIRED_OFFHOST_BACKUP_ERROR_CODE} (status=${status}).`
+                        ]);
+                        expect(terminal.join('\n')).not.toContain('credential-canary');
+                        expect(terminal.join('\n')).not.toContain('/private/secret/cloud-target');
+                    } else {
+                        await expect(run).resolves.toMatchObject({status: 'completed'});
+
+                        if (!offHostBackupRequired && ['validation-failed', 'failed', 'timeout'].includes(status)) {
+                            expect(warnings).toHaveLength(1)
+                        }
+                    }
+
+                    const read = await readBackupReceipt({filePath: path.join(root, 'last-backup-receipt.json')});
+                    expect(read.status).toBe('ok');
+                    expect(read.receipt.backup.status).toBe('success');
+                    expect(read.receipt.offHostSync.status).toBe(status)
+                } finally {
+                    rmSync(root, {force: true, recursive: true})
+                }
+            }
         }
     });
 


### PR DESCRIPTION
Resolves #16199

The lease-owning backup wrapper now connects the deployment's existing off-host requirement to the operation terminal without falsifying local-bundle truth. It reuses the canonical cloud-only tri-state resolver, persists the same exact local/off-host receipt, and only then rejects required runs whose observed sync status is not `success`. Optional deployments retain the existing warning plus successful local-bundle terminal.

Evidence: L2 (required/optional × five-status executable matrix, canonical-resolver source witness, CLI exit-path witness, and credential/path canary capture across required warning + terminal output) → L2 required (the wrapper boundary, truthful receipt, and status-only terminal are fully exercised without running a destructive live backup). Residual: the real cloud seat still needs an operator-owned configured off-host target and post-merge live receipt.

Related: #16167

Related: #15641

Related: #16055

Related: #16197

## Deltas from ticket

None.

## Test Evidence

- Backup terminal + durability posture: `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/deploymentDurabilityPosture.spec.mjs` — 60 passed at `fa18fd56f8`.
- Full staged-file hook suite: whitespace, shorthand, JSDoc, ticket archaeology, block alignment, parse, AiConfig mutation, and derived-domain checks — passed.
- JSDoc type integrity: `node ./buildScripts/util/check-jsdoc-types.mjs` — 1,917 files scanned, 0 unparseable type expressions.
- Restoration preflight: `npm run agent-preflight -- --no-fix --change-class restoration ...` — all requested gates passed; one unrelated stale Tier-1 AiConfig overlay warning.
- Patch hygiene: `git show --check HEAD` — passed.

## Post-Merge Validation

- [ ] Configure and prove a real off-host command on the canonical seat before the data-plane cutover.
- [ ] Run one required backup and confirm the durable receipt reports `offHostSync.status: success`.
- [ ] Falsifier: disable the hook on a required test profile and confirm the receipt retains local `backup.status: success` while the CLI exits non-zero.

## Evolution

Vega's migration-sequencing falsifier exposed two separately correct contracts that did not compose: #15641 preserved optional off-host outcome truth, while #16055 made a cloud durability requirement observable. A pre-publication falsifier then caught required-mode diagnostics crossing the stderr boundary; the final patch preserves detailed optional diagnostics while required warning/terminal output carries only stable code/status. This PR adds no scheduler, process-management, config, or receipt-schema mechanism.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session b1ebc46a-5a83-496c-aa8b-385af785e9cb.
