### PR TITLE
fix(ai): default Neural Link action logging off (#16207)

### DIFF
--- a/ai/mcp/server/neural-link/configBase.mjs
+++ b/ai/mcp/server/neural-link/configBase.mjs
@@ -58,23 +58,27 @@ class ConfigBase extends ConfigProvider {
              */
             rpcTimeout: leaf(10000, 'NEO_NL_RPC_TIMEOUT', 'number'),
             /**
-             * @summary Whether `RecorderService` writes `nl_action_log` at all. Default OFF.
+             * @summary Whether `RecorderService` writes `nl_action_log` action telemetry. Default OFF.
              *
-             * Off by default because the writer was pure cost on an ordinary seat: it opened a
-             * READ/WRITE handle on the shared plane graph from every host Neural Link, while its
-             * only attributed consumer produced nothing — `GapInferenceEngine` reads the table
-             * (`GapInferenceEngine.mjs:431-455`) yet the graph held 188 log rows and **zero**
-             * `NL_ACTION_SEQUENCE` edges. Under the container topology that handle is a second
-             * writer against the containerized Memory Core, so off is the correct default.
+             * Off by default because action-sequence telemetry is a per-seat opt-in, not a baseline
+             * obligation: enabled, every host Neural Link holds a READ/WRITE handle on the shared
+             * plane graph — under the container topology a second writer beside the containerized
+             * Memory Core — for telemetry the seat never asked to collect. The measurements behind
+             * the default election are recorded on the electing ticket and its PR.
              *
-             * This gates WHETHER the recorder writes, never WHERE — `memoryCoreDbPath` below stays
-             * plane-anchored so that anything which does enable it still writes where the readers
-             * look. Un-converging the path would recreate the silent-zero-edges bug that
-             * convergence repaired.
+             * Scope: this leaf gates the `nl_action_log` telemetry contract ONLY. It never gates
+             * the independent `nl_transaction_archive` save/replay contract hosted by the same
+             * service, which opens its store on demand. And it gates WHETHER telemetry is
+             * written, never WHERE — `memoryCoreDbPath` below stays plane-anchored so an enabled
+             * seat writes where `GapInferenceEngine` / `DreamService` read. Un-converging the path
+             * would recreate the silent-zero-edges split that convergence repaired. Host-edge NL
+             * beside a containerized Memory Core sharing one plane graph is the steady state, not
+             * a cutover transient; routing NL writes through MC's remote API instead belongs to
+             * the streamable-HTTP direction, tracked separately.
              *
              * Enabled deliberately by `ai/scripts/diagnostics/genesisProbe.mjs`, whose per-tool
-             * telemetry oracle SELECTs from `nl_action_log` inside its own disposable root. A
-             * blanket disable would leave that blind probe comparing against an empty oracle.
+             * telemetry oracle reads `nl_action_log` inside its own disposable root. A blanket
+             * disable would leave that blind probe comparing against an empty oracle.
              * @type {boolean}
              */
             actionLoggingEnabled: leaf(false, 'NEO_NL_ACTION_LOGGING', 'boolean'),

--- a/ai/mcp/server/neural-link/configBase.mjs
+++ b/ai/mcp/server/neural-link/configBase.mjs
@@ -58,6 +58,27 @@ class ConfigBase extends ConfigProvider {
              */
             rpcTimeout: leaf(10000, 'NEO_NL_RPC_TIMEOUT', 'number'),
             /**
+             * @summary Whether `RecorderService` writes `nl_action_log` at all. Default OFF.
+             *
+             * Off by default because the writer was pure cost on an ordinary seat: it opened a
+             * READ/WRITE handle on the shared plane graph from every host Neural Link, while its
+             * only attributed consumer produced nothing — `GapInferenceEngine` reads the table
+             * (`GapInferenceEngine.mjs:431-455`) yet the graph held 188 log rows and **zero**
+             * `NL_ACTION_SEQUENCE` edges. Under the container topology that handle is a second
+             * writer against the containerized Memory Core, so off is the correct default.
+             *
+             * This gates WHETHER the recorder writes, never WHERE — `memoryCoreDbPath` below stays
+             * plane-anchored so that anything which does enable it still writes where the readers
+             * look. Un-converging the path would recreate the silent-zero-edges bug that
+             * convergence repaired.
+             *
+             * Enabled deliberately by `ai/scripts/diagnostics/genesisProbe.mjs`, whose per-tool
+             * telemetry oracle SELECTs from `nl_action_log` inside its own disposable root. A
+             * blanket disable would leave that blind probe comparing against an empty oracle.
+             * @type {boolean}
+             */
+            actionLoggingEnabled: leaf(false, 'NEO_NL_ACTION_LOGGING', 'boolean'),
+            /**
              * Path to the memory core SQLite database for action logging.
              * @type {string}
              */

--- a/ai/scripts/diagnostics/genesisProbe.mjs
+++ b/ai/scripts/diagnostics/genesisProbe.mjs
@@ -257,11 +257,16 @@ export function createProbeEnvironments({baseEnv = process.env, bearerToken, por
             HOST                                : LOOPBACK_HOST,
             MCP_HTTP_PORT                       : String(ports.mcp),
             NEO_MEMORY_DB_PATH                  : databasePath,
-            NEO_NL_AUTO_CONNECT                 : 'true',
-            NEO_NL_LOG_PATH                     : logPath,
-            NEO_NL_PORT                         : String(ports.bridge),
-            NEO_NL_TOOL_PROJECTION_MODE         : PROBE_PROJECTION_MODE,
-            NEO_TRANSPORT                       : 'streamable-http'
+            // Action logging is OFF by default per seat. The probe's per-tool telemetry
+            // oracle SELECTs from `nl_action_log`, so it must opt IN explicitly — and it is safe
+            // to do so because `NEO_MEMORY_DB_PATH` above already redirects every write into this
+            // run's disposable root, which `assertDiagnosticPathsWithinRoot` enforces below.
+            NEO_NL_ACTION_LOGGING      : 'true',
+            NEO_NL_AUTO_CONNECT        : 'true',
+            NEO_NL_LOG_PATH            : logPath,
+            NEO_NL_PORT                : String(ports.bridge),
+            NEO_NL_TOOL_PROJECTION_MODE: PROBE_PROJECTION_MODE,
+            NEO_TRANSPORT              : 'streamable-http'
         };
 
     assertDiagnosticPathsWithinRoot({databasePath, logPath, root});

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -122,7 +122,7 @@ expected Chroma process:
 
 ```sh
 ps -axo pid=,command= | rg \
-  '[a]i/(mcp/server/(memory-core|knowledge-base)/mcp-server|daemons/.+/daemon|scripts/(lifecycle|maintenance)/.+)\.mjs'
+  '[a]i/(mcp/server/(memory-core|knowledge-base|neural-link)/mcp-server|daemons/.+/daemon|scripts/(lifecycle|maintenance)/.+)\.mjs'
 lsof -nP -iTCP:8000 -sTCP:LISTEN
 ```
 
@@ -130,6 +130,17 @@ The process census must be empty; the listener probe must show exactly the
 expected Chroma server. Stop every competing writer and repeat both probes until
 that invariant holds. Local model-provider processes are not plane writers and
 may stay running.
+
+`neural-link` is in the pattern deliberately (#16207). Its `RecorderService` opens
+the plane graph READ/WRITE when action logging is enabled, and an earlier census
+without it reported **empty** while two Neural Link processes held `fd=...u` write
+handles on `memory-core-graph.sqlite` — caught only because `lsof` on the file
+itself disagreed with the process list. Treat the census as a proxy and the file as
+the truth: when the two disagree, believe `lsof`.
+
+```sh
+lsof .neo-ai-data/sqlite/memory-core-graph.sqlite
+```
 
 With writers quiesced and Chroma still alive, create the logical backup and
 require the authoritative restorable verdict:
@@ -146,7 +157,7 @@ plane has no remaining owner:
 
 ```sh
 ps -axo pid=,command= | rg \
-  '[a]i/(mcp/server/(memory-core|knowledge-base)/mcp-server|daemons/.+/daemon|scripts/(lifecycle|maintenance)/.+)\.mjs|[c]hroma run'
+  '[a]i/(mcp/server/(memory-core|knowledge-base|neural-link)/mcp-server|daemons/.+/daemon|scripts/(lifecycle|maintenance)/.+)\.mjs|[c]hroma run'
 lsof -nP -iTCP:8000 -sTCP:LISTEN
 ```
 

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -616,6 +616,7 @@
         "whoIsOnline.idleCutoffMs"
     ],
     "ai/mcp/server/neural-link/config.template.mjs": [
+        "actionLoggingEnabled",
         "autoConnect",
         "bridgePayloadDebugMaxChars",
         "debug",

--- a/ai/services/neural-link/InstanceService.mjs
+++ b/ai/services/neural-link/InstanceService.mjs
@@ -251,7 +251,7 @@ class InstanceService extends Base {
             return snapshot
         }
 
-        return RecorderService.saveTransactionArchive({
+        return await RecorderService.saveTransactionArchive({
             appSessionId,
             name,
             transaction : snapshot.transaction
@@ -268,7 +268,7 @@ class InstanceService extends Base {
      * @returns {Promise<Object>}
      */
     async replayTransaction({sessionId, archiveId}) {
-        const archive = RecorderService.getTransactionArchive({archiveId});
+        const archive = await RecorderService.getTransactionArchive({archiveId});
 
         if (!archive) {
             return {replayed: false, reason: 'archive-not-found'}
@@ -283,7 +283,7 @@ class InstanceService extends Base {
         });
 
         if (result?.replayed) {
-            RecorderService.recordTransactionReplay({archiveId})
+            await RecorderService.recordTransactionReplay({archiveId})
         }
 
         return result

--- a/ai/services/neural-link/RecorderService.mjs
+++ b/ai/services/neural-link/RecorderService.mjs
@@ -74,6 +74,15 @@ class RecorderService extends Base {
     }
 
     /**
+     * In-flight open from `ensureStore()` — the single-flight join point for concurrent first
+     * users. Transient: cleared on settle, so a failed open never pins later calls to a cached
+     * failure.
+     * @member {Promise<Object|null>|null} storeOpen=null
+     * @protected
+     */
+    storeOpen = null
+
+    /**
      * @summary Opens the Memory Core connection on demand and ensures both physical schemas exist.
      *
      * This service owns TWO independent contracts against one file: `nl_action_log` (action
@@ -86,7 +95,12 @@ class RecorderService extends Base {
      * does archive one gets a connection at that moment. Gating the connection instead of the
      * capability would silently retire the archive contract along with the telemetry.
      *
-     * Idempotent: returns the existing connection when already open, `null` when unavailable.
+     * Idempotent and SINGLE-FLIGHT: the open path awaits filesystem work, so a bare
+     * check-then-open races — N concurrent first users each observe a null `db` and open N
+     * connections against one shared file. The in-flight promise is assigned synchronously,
+     * before any await, so every concurrent caller joins one real open; it is cleared on settle,
+     * so a failed open resolves `null` for the current waiters while the NEXT call retries fresh
+     * instead of being pinned to a cached failure.
      * @returns {Promise<Object|null>} The connection, or `null` if it could not be opened
      * @protected
      */
@@ -95,6 +109,26 @@ class RecorderService extends Base {
             return this.db;
         }
 
+        if (!this.storeOpen) {
+            this.storeOpen = this.openStore().finally(() => {
+                this.storeOpen = null
+            });
+        }
+
+        return this.storeOpen;
+    }
+
+    /**
+     * @summary The real opener behind `ensureStore()` — never call directly.
+     *
+     * Emits exactly one connection marker per successful open. The enabled path keeps the
+     * boot-contract line naming `nl_action_log`; the on-demand path names the archive instead, so
+     * a disabled seat's log can never imply action telemetry was requested — the marker stays
+     * neutral for the contract that actually opened the store.
+     * @returns {Promise<Object|null>} The connection, or `null` if it could not be opened
+     * @protected
+     */
+    async openStore() {
         try {
             const dbPath = config.memoryCoreDbPath;
 
@@ -150,7 +184,9 @@ class RecorderService extends Base {
                     ON nl_transaction_archive(archived_at);
             `);
 
-            logger.info('[RecorderService] Connected to Memory Core nl_action_log.');
+            logger.info(config.actionLoggingEnabled
+                ? '[RecorderService] Connected to Memory Core nl_action_log.'
+                : '[RecorderService] Archive store opened on demand.');
 
             return this.db;
         } catch (err) {

--- a/ai/services/neural-link/RecorderService.mjs
+++ b/ai/services/neural-link/RecorderService.mjs
@@ -82,6 +82,13 @@ class RecorderService extends Base {
         await super.initAsync();
 
         try {
+            // Gated OFF by default: no connection is opened, so `this.db` stays null and
+            // `log()` no-ops on its existing guard. Silent by design — an ordinary seat should not
+            // emit a line per tool call about telemetry it was never asked to collect.
+            if (!config.actionLoggingEnabled) {
+                return;
+            }
+
             const dbPath = config.memoryCoreDbPath;
             if (!dbPath) {
                 logger.warn('[RecorderService] memoryCoreDbPath not configured. Disabling logging.');

--- a/ai/services/neural-link/RecorderService.mjs
+++ b/ai/services/neural-link/RecorderService.mjs
@@ -74,32 +74,33 @@ class RecorderService extends Base {
     }
 
     /**
-     * Initializes the SQLite connection to the Memory Core and ensures the physical nl_action_log
-     * schema and indices exist. Uses WAL journal mode to support non-blocking concurrent writes.
-     * @returns {Promise<void>}
+     * @summary Opens the Memory Core connection on demand and ensures both physical schemas exist.
+     *
+     * This service owns TWO independent contracts against one file: `nl_action_log` (action
+     * telemetry) and `nl_transaction_archive` (the durable transaction save/replay product
+     * surface consumed by `InstanceService.saveTransaction()` / `replayTransaction()`).
+     *
+     * The connection is therefore opened lazily rather than at boot, so the two can be gated
+     * separately. A seat with telemetry disabled that never archives a transaction holds NO write
+     * handle on the shared plane graph — the point of the telemetry default — while a seat that
+     * does archive one gets a connection at that moment. Gating the connection instead of the
+     * capability would silently retire the archive contract along with the telemetry.
+     *
+     * Idempotent: returns the existing connection when already open, `null` when unavailable.
+     * @returns {Promise<Object|null>} The connection, or `null` if it could not be opened
+     * @protected
      */
-    async initAsync() {
-        await super.initAsync();
+    async ensureStore() {
+        if (this.db) {
+            return this.db;
+        }
 
         try {
-            // Gated OFF by default: no connection is opened, so `this.db` stays null and `log()`
-            // no-ops on its existing guard. Quiet by design — one line at boot, never one per tool
-            // call about telemetry the seat was never asked to collect.
-            //
-            // The line is emitted through the Neural Link logger deliberately. That logger is
-            // imported at module scope into every process hosting this service, including servers
-            // where the Neural Link itself never runs, so a misconfigured sink degrades there
-            // silently. A positive marker on the disabled path keeps that failure observable —
-            // without it, an empty log stream would satisfy any negative sink assertion.
-            if (!config.actionLoggingEnabled) {
-                logger.info('[RecorderService] Action logging disabled; nl_action_log not opened.');
-                return;
-            }
-
             const dbPath = config.memoryCoreDbPath;
+
             if (!dbPath) {
-                logger.warn('[RecorderService] memoryCoreDbPath not configured. Disabling logging.');
-                return;
+                logger.warn('[RecorderService] memoryCoreDbPath not configured. Persistence unavailable.');
+                return null;
             }
 
             await fs.ensureDir(path.dirname(dbPath));
@@ -108,7 +109,8 @@ class RecorderService extends Base {
             this.db = new Database(dbPath, { verbose: null });
             this.db.pragma('journal_mode = WAL');
 
-            // System table
+            // Both schemas are created together: they share one file, and creating only one would
+            // leave the other contract failing on first use for no benefit.
             this.db.exec(`
                 CREATE TABLE IF NOT EXISTS nl_action_log (
                     id          TEXT PRIMARY KEY,
@@ -149,9 +151,37 @@ class RecorderService extends Base {
             `);
 
             logger.info('[RecorderService] Connected to Memory Core nl_action_log.');
+
+            return this.db;
         } catch (err) {
             logger.warn('[RecorderService] Failed to initialize SQLite connection:', err.message);
+
+            return null;
         }
+    }
+
+    /**
+     * Opens the store eagerly only when action logging is enabled, so an enabled seat keeps its
+     * previous boot-time behaviour. With logging disabled nothing is opened here — the archive
+     * contract opens the store on its own first use instead.
+     *
+     * Either branch emits exactly one line, never one per tool call. The line goes through the
+     * Neural Link logger deliberately: that logger is imported at module scope into every process
+     * hosting this service, including servers where the Neural Link itself never runs, so a
+     * misconfigured sink degrades there silently. A positive marker on both paths keeps that
+     * failure observable — without one, an empty log stream would satisfy any negative sink
+     * assertion.
+     * @returns {Promise<void>}
+     */
+    async initAsync() {
+        await super.initAsync();
+
+        if (config.actionLoggingEnabled) {
+            await this.ensureStore();
+            return;
+        }
+
+        logger.info('[RecorderService] Action logging disabled; transaction archive available on demand.');
     }
 
     /**
@@ -160,7 +190,9 @@ class RecorderService extends Base {
      * @param {Object} entry The invocation payload containing sequences, tool metadata, args, and execution times.
      */
     log(entry) {
-        if (!this.db) return;
+        // Explicit gate: the store may be open for the ARCHIVE contract, so a live `db` is no
+        // longer evidence that telemetry was requested.
+        if (!config.actionLoggingEnabled || !this.db) return;
 
         try {
             const insertStmt = this.db.prepare(`
@@ -201,7 +233,7 @@ class RecorderService extends Base {
      * @returns {Array} An array of matched SQLite row objects.
      */
     querySequences({ sinceTimestamp = 0, minSuccessRate, limit } = {}) {
-        if (!this.db) return [];
+        if (!config.actionLoggingEnabled || !this.db) return [];
 
         try {
             let   sql  = `SELECT * FROM nl_action_log WHERE timestamp >= ?`;
@@ -226,7 +258,7 @@ class RecorderService extends Base {
      * @param {Number} [days=config.pruneLogsAfterDays] The rolling window in days beyond which older records are permanently discarded.
      */
     pruneOlderThan(days = config.pruneLogsAfterDays) {
-        if (!this.db) return;
+        if (!config.actionLoggingEnabled || !this.db) return;
 
         try {
             const cutoff   = Date.now() - (days * MS_PER_DAY);
@@ -243,10 +275,12 @@ class RecorderService extends Base {
      * @param {String} [params.appSessionId]
      * @param {String} [params.name]
      * @param {Object} params.transaction
-     * @returns {Object} `{saved:Boolean, archiveId?:String, sourceTxId?:String, archivedAt?:Number, opCount?:Number, reason?:String}`
+     * @returns {Promise<Object>} `{saved:Boolean, archiveId?:String, sourceTxId?:String, archivedAt?:Number, opCount?:Number, reason?:String}`
      */
-    saveTransactionArchive({appSessionId, name, transaction} = {}) {
-        if (!this.db) {
+    async saveTransactionArchive({appSessionId, name, transaction} = {}) {
+        // Opens the store on demand: this contract is independent of the action-telemetry gate, so
+        // it must not depend on boot having opened a connection.
+        if (!await this.ensureStore()) {
             return {saved: false, reason: 'archive-store-unavailable'}
         }
 
@@ -312,10 +346,10 @@ class RecorderService extends Base {
      * Reads one archived transaction for replay.
      * @param {Object} params
      * @param {String} params.archiveId
-     * @returns {Object|null}
+     * @returns {Promise<Object|null>}
      */
-    getTransactionArchive({archiveId} = {}) {
-        if (!this.db || typeof archiveId !== 'string' || archiveId === '') {
+    async getTransactionArchive({archiveId} = {}) {
+        if (typeof archiveId !== 'string' || archiveId === '' || !await this.ensureStore()) {
             return null
         }
 
@@ -350,10 +384,10 @@ class RecorderService extends Base {
      * Records that an archived transaction replay landed successfully.
      * @param {Object} params
      * @param {String} params.archiveId
-     * @returns {{updated:Boolean}}
+     * @returns {Promise<{updated:Boolean}>}
      */
-    recordTransactionReplay({archiveId} = {}) {
-        if (!this.db || typeof archiveId !== 'string' || archiveId === '') {
+    async recordTransactionReplay({archiveId} = {}) {
+        if (typeof archiveId !== 'string' || archiveId === '' || !await this.ensureStore()) {
             return {updated: false}
         }
 

--- a/ai/services/neural-link/RecorderService.mjs
+++ b/ai/services/neural-link/RecorderService.mjs
@@ -82,10 +82,17 @@ class RecorderService extends Base {
         await super.initAsync();
 
         try {
-            // Gated OFF by default: no connection is opened, so `this.db` stays null and
-            // `log()` no-ops on its existing guard. Silent by design — an ordinary seat should not
-            // emit a line per tool call about telemetry it was never asked to collect.
+            // Gated OFF by default: no connection is opened, so `this.db` stays null and `log()`
+            // no-ops on its existing guard. Quiet by design — one line at boot, never one per tool
+            // call about telemetry the seat was never asked to collect.
+            //
+            // The line is emitted through the Neural Link logger deliberately. That logger is
+            // imported at module scope into every process hosting this service, including servers
+            // where the Neural Link itself never runs, so a misconfigured sink degrades there
+            // silently. A positive marker on the disabled path keeps that failure observable —
+            // without it, an empty log stream would satisfy any negative sink assertion.
             if (!config.actionLoggingEnabled) {
+                logger.info('[RecorderService] Action logging disabled; nl_action_log not opened.');
                 return;
             }
 
@@ -197,7 +204,7 @@ class RecorderService extends Base {
         if (!this.db) return [];
 
         try {
-            let sql = `SELECT * FROM nl_action_log WHERE timestamp >= ?`;
+            let   sql  = `SELECT * FROM nl_action_log WHERE timestamp >= ?`;
             const args = [sinceTimestamp];
 
             sql += ` ORDER BY timestamp DESC`;
@@ -222,7 +229,7 @@ class RecorderService extends Base {
         if (!this.db) return;
 
         try {
-            const cutoff = Date.now() - (days * MS_PER_DAY);
+            const cutoff   = Date.now() - (days * MS_PER_DAY);
             const dropStmt = this.db.prepare(`DELETE FROM nl_action_log WHERE timestamp < ?`);
             dropStmt.run(cutoff);
         } catch (err) {

--- a/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
+++ b/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
@@ -117,7 +117,7 @@ test.describe('Parity topology lane (#15807) — the phase-3 stack with a CI wit
             // non-default setting — the point is that RecorderService reported through the Neural
             // Link logger at all, which is what proves the sink is live.
             expect(output).toMatch(
-                /\[RecorderService\] (Connected to Memory Core nl_action_log\.|Action logging disabled; nl_action_log not opened\.)/
+                /\[RecorderService\] (Connected to Memory Core nl_action_log\.|Action logging disabled; transaction archive available on demand\.)/
             );
             expect(output).not.toContain('file sink unavailable');
             expect(output).not.toContain("mkdir '/app/.neo-ai-data/logs'");

--- a/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
+++ b/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
@@ -111,7 +111,14 @@ test.describe('Parity topology lane (#15807) — the phase-3 stack with a CI wit
                   output = `${logs.stdout}\n${logs.stderr}`;
 
             expect(logs.status, `could not read ${service} parity boot logs:\n${output.slice(-2000)}`).toBe(0);
-            expect(output).toContain('[RecorderService] Connected to Memory Core nl_action_log.');
+            // Either arm is a valid positive marker, and one of them ALWAYS appears: the connected
+            // line when action logging is enabled, the disabled line when it is not (the default).
+            // The alternation keeps the guard intact across that config without pinning parity to a
+            // non-default setting — the point is that RecorderService reported through the Neural
+            // Link logger at all, which is what proves the sink is live.
+            expect(output).toMatch(
+                /\[RecorderService\] (Connected to Memory Core nl_action_log\.|Action logging disabled; nl_action_log not opened\.)/
+            );
             expect(output).not.toContain('file sink unavailable');
             expect(output).not.toContain("mkdir '/app/.neo-ai-data/logs'");
         }

--- a/test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs
@@ -149,6 +149,11 @@ test.describe('Neo.ai.scripts.diagnostics.genesisProbe', () => {
         expect(envs.mcpEnv.NEO_MEMORY_DB_PATH).toBe(path.join(root, 'memory-core.sqlite'));
         expect(envs.mcpEnv.NEO_NL_LOG_PATH).toBe(root);
         expect(envs.mcpEnv.NEO_NL_TOOL_PROJECTION_MODE).toBe('local-readonly-probe');
+        // Action logging is OFF by default; the probe's per-tool telemetry oracle reads
+        // nl_action_log, so the rendered child env must carry the explicit opt-in — asserted on
+        // the INVOKED builder output, not on source text. Safe because NEO_MEMORY_DB_PATH above
+        // already pins every write inside this run's disposable root.
+        expect(envs.mcpEnv.NEO_NL_ACTION_LOGGING).toBe('true');
         expect(envs.bridgeEnv[GENESIS_DIAGNOSTIC_ATTESTATION_ENV])
             .toBe(envs.diagnosticAttestations.bridge.commitment);
         expect(envs.mcpEnv[GENESIS_DIAGNOSTIC_ATTESTATION_ENV])

--- a/test/playwright/unit/ai/services/neural-link/RecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/RecorderService.spec.mjs
@@ -139,7 +139,7 @@ test.describe('Neo.ai.services.neural-link.RecorderService', () => {
         expect(oldCheck).toBeUndefined();
     });
 
-    test('should save, read, and mark replayed transaction archives', () => {
+    test('should save, read, and mark replayed transaction archives', async () => {
         const transaction = {
             txId        : 'batch:add-grid',
             status      : 'committed',
@@ -155,7 +155,7 @@ test.describe('Neo.ai.services.neural-link.RecorderService', () => {
             }]
         };
 
-        const saved = RecorderService.saveTransactionArchive({
+        const saved = await RecorderService.saveTransactionArchive({
             appSessionId: 'app-session-1',
             name        : 'Add grid',
             transaction
@@ -170,7 +170,7 @@ test.describe('Neo.ai.services.neural-link.RecorderService', () => {
             committedAt : 1234
         });
 
-        const archive = RecorderService.getTransactionArchive({archiveId: saved.archiveId});
+        const archive = await RecorderService.getTransactionArchive({archiveId: saved.archiveId});
 
         expect(archive).toMatchObject({
             archiveId     : saved.archiveId,
@@ -185,15 +185,15 @@ test.describe('Neo.ai.services.neural-link.RecorderService', () => {
             ops           : transaction.ops
         });
 
-        expect(RecorderService.recordTransactionReplay({archiveId: saved.archiveId})).toEqual({updated: true});
+        expect(await RecorderService.recordTransactionReplay({archiveId: saved.archiveId})).toEqual({updated: true});
 
-        const replayed = RecorderService.getTransactionArchive({archiveId: saved.archiveId});
+        const replayed = await RecorderService.getTransactionArchive({archiveId: saved.archiveId});
 
         expect(replayed.replayCount).toBe(1);
         expect(replayed.lastReplayedAt).toEqual(expect.any(Number))
     });
 
-    test('should reject non-data transaction archive payloads', () => {
+    test('should reject non-data transaction archive payloads', async () => {
         class NonDataArchiveValue {}
 
         const baseTransaction = {
@@ -210,7 +210,7 @@ test.describe('Neo.ai.services.neural-link.RecorderService', () => {
             }]
         };
 
-        expect(RecorderService.saveTransactionArchive({
+        expect(await RecorderService.saveTransactionArchive({
             transaction: {
                 ...baseTransaction,
                 ops: [{
@@ -223,7 +223,7 @@ test.describe('Neo.ai.services.neural-link.RecorderService', () => {
             reason: 'transaction-not-data-only: non-data function value at transaction.ops[0].forward.args.handler'
         });
 
-        expect(RecorderService.saveTransactionArchive({
+        expect(await RecorderService.saveTransactionArchive({
             transaction: {
                 ...baseTransaction,
                 ops: [{

--- a/test/playwright/unit/ai/services/neural-link/RecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/RecorderService.spec.mjs
@@ -1,5 +1,12 @@
 import {setup} from '../../../../setup.mjs';
 
+// Action logging is OFF by default per seat, so this suite — which exercises the schema
+// and the insert path — must opt IN. Set before `setup()` because the config leaf binds this env
+// at module-load time, and mutating the shared config singleton at runtime is forbidden.
+// The complementary default-OFF proof lives in `RecorderServiceDefaultOff.spec.mjs`, which spawns
+// fresh child processes precisely because this assignment is process-wide and cannot be undone.
+process.env.NEO_NL_ACTION_LOGGING = 'true';
+
 const appName = 'RecorderServiceTest';
 
 setup({

--- a/test/playwright/unit/ai/services/neural-link/RecorderServiceDefaultOff.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/RecorderServiceDefaultOff.spec.mjs
@@ -5,49 +5,77 @@ import os             from 'node:os';
 import path           from 'node:path';
 
 /**
- * @summary Proves Neural Link action logging is OFF by default and opens NO handle on the plane
- * graph, and that the explicit opt-in still works.
+ * @summary Proves the Neural Link action-logging gate is OFF by default and opens NO handle on the
+ * plane graph at boot, that the explicit opt-in still works, and — critically — that the
+ * independent transaction archive/replay contract keeps working under the disabled default.
  *
  * Child processes rather than in-process asserts, for two reasons. First, the gate is a config leaf
  * bound to `NEO_NL_ACTION_LOGGING` at module-load time, so a single process can only ever observe
  * one value — the sibling `RecorderService.spec.mjs` sets it to `true` process-wide and cannot
- * unset it. Second, the claim under test is about a real seat's behaviour at boot, and the defect
- * this guards was a WRITE HANDLE existing on a shared SQLite file. Asserting on a config value, or
- * grepping the source for the flag, would both pass while the handle was still opened — so each
- * case invokes `initAsync()` for real and reports whether a connection exists.
+ * unset it. Second, the claims under test are about a real seat's behaviour: the defect the gate
+ * guards was a WRITE HANDLE on a shared SQLite file, and the defect the archive tests guard was a
+ * real `save_transaction` returning `archive-store-unavailable`. Asserting on config values, or
+ * grepping source for the flag, would pass while both were broken.
+ *
+ * Each guarantee gets its own probe because they are no longer separable in one run: with a lazy
+ * connection, exercising the archive legitimately opens the store, so "no artifact at boot" and
+ * "archive works" cannot be asserted from the same child.
  */
 test.describe('Neural Link action logging default', () => {
     const rootDir = path.resolve(import.meta.dirname, '../../../../../..');
 
     /**
-     * Boots RecorderService in a fresh child process against a throwaway database path and reports
-     * whether a connection was opened.
-     * @param {Object|null} extraEnv Additional env for the child, or null for none
-     * @returns {Object} `{opened, dbPath, fileExists, error}`
+     * Boots RecorderService in a fresh child process against a throwaway database path.
+     * @param {Object}  [options={}]
+     * @param {Object}  [options.extraEnv=null]        Additional env for the child
+     * @param {Boolean} [options.exerciseArchive=false] Also drive a real save + read-back
+     * @returns {Object} Observed child outcome
      */
-    function bootRecorder(extraEnv) {
+    function bootRecorder({extraEnv = null, exerciseArchive = false} = {}) {
         const
-            dir    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-16207-')),
-            dbPath = path.join(dir, 'graph.sqlite'),
+            dir         = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-nl-gate-')),
+            dbPath      = path.join(dir, 'graph.sqlite'),
+            archiveStep = exerciseArchive ? `
+                const archive = await RecorderService.saveTransactionArchive({
+                    appSessionId: 'spec-session',
+                    name        : 'spec-archive',
+                    transaction : {
+                        // txId is REQUIRED: it feeds source_tx_id, which is NOT NULL. Omitting it
+                        // returned 'archive-save-failed' -- a fixture looser than the contract.
+                        txId        : 'spec-tx',
+                        status      : 'committed',
+                        committedAt : 1234,
+                        originWriter: {agentId: 'spec-agent', sessionId: 'spec-session'},
+                        ops         : [{kind: 'set', value: 1}]
+                    }
+                });
+                const readBack = archive.saved
+                    ? await RecorderService.getTransactionArchive({archiveId: archive.archiveId})
+                    : null;
+                out.archiveSaved  = archive.saved;
+                out.archiveReason = archive.reason ?? null;
+                out.readBackOps   = readBack ? readBack.ops.length : null;
+                out.openedAfter   = Boolean(RecorderService.db);
+            ` : '',
             // Neo must be bootstrapped before any `src/core` module loads -- `Compare.mjs` calls
             // `Neo.gatekeep` at module scope, so importing RecorderService bare throws
             // "Neo is not defined". Same ordering the sibling specs get from `setup.mjs`.
-            // The child reports the path the CONFIG resolved, not the path this test suggested.
-            // Necessary because `memoryCoreDbPath` selects a test destination whenever
-            // `UNIT_TEST_MODE` / `NEO_TEST_CONFIG_TEMPLATES` is inherited from the Playwright
-            // worker, so asserting existence of the suggested path passed vacuously in BOTH cases
-            // -- it proved only that an unused path stayed unused.
+            // The child reports the path the CONFIG resolved, not the path this test suggested,
+            // because `memoryCoreDbPath` selects a test destination whenever the harness markers
+            // are inherited -- asserting on the suggested path passed vacuously in both cases.
             script = `
-                import Neo     from ${JSON.stringify(path.join(rootDir, 'src/Neo.mjs'))};
+                import Neo       from ${JSON.stringify(path.join(rootDir, 'src/Neo.mjs'))};
                 import * as core from ${JSON.stringify(path.join(rootDir, 'src/core/_export.mjs'))};
                 const config          = (await import(${JSON.stringify(path.join(rootDir, 'ai/mcp/server/neural-link/config.mjs'))})).default;
                 const RecorderService = (await import(${JSON.stringify(path.join(rootDir, 'ai/services/neural-link/RecorderService.mjs'))})).default;
                 await RecorderService.initAsync();
-                process.stdout.write(JSON.stringify({
-                    opened      : Boolean(RecorderService.db),
+                const out = {
+                    openedAtBoot: Boolean(RecorderService.db),
                     resolvedPath: config.memoryCoreDbPath,
                     gateValue   : config.actionLoggingEnabled
-                }));
+                };
+                ${archiveStep}
+                process.stdout.write(JSON.stringify(out));
             `,
             childEnv = {...process.env, NEO_MEMORY_DB_PATH: dbPath, ...(extraEnv || {})};
 
@@ -68,55 +96,80 @@ test.describe('Neural Link action logging default', () => {
         delete childEnv.NEO_TELEMETRY_DB_PATH_TEST;
 
         const result = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
-                cwd     : rootDir,
-                encoding: 'utf8',
-                env     : childEnv
-            });
+            cwd     : rootDir,
+            encoding: 'utf8',
+            env     : childEnv
+        });
 
         let parsed = null;
 
         try { parsed = JSON.parse(result.stdout.trim().split('\n').pop()) } catch {}
 
         return {
-            opened      : parsed ? parsed.opened : null,
-            gateValue   : parsed ? parsed.gateValue : null,
-            resolvedPath: parsed ? parsed.resolvedPath : null,
+            ...(parsed || {}),
             // Existence of the path the config ACTUALLY chose -- the only file that can prove or
             // disprove that a seat left an artifact behind.
             fileExists: Boolean(parsed?.resolvedPath) && fs.existsSync(parsed.resolvedPath),
-            error     : parsed ? null : (result.stderr || '').split('\n').slice(-12).join('\n')
+            error     : parsed ? null : (result.stderr || '').split('\n').slice(-14).join('\n')
         }
     }
 
-    test('opens NO connection and creates NO database file when unset', () => {
-        const outcome = bootRecorder(null);
+    test('unset: no connection and no database file at boot', () => {
+        const outcome = bootRecorder();
 
         expect(outcome.error, `child failed instead of reporting:\n${outcome.error}`).toBeNull();
         expect(outcome.gateValue).toBe(false);
-        expect(outcome.opened).toBe(false);
+        expect(outcome.openedAtBoot).toBe(false);
         // Guard against a vacuous pass: if the config resolved no path at all, absence of a file
         // would prove nothing about the gate.
         expect(outcome.resolvedPath).toBeTruthy();
         expect(outcome.fileExists).toBe(false)
     });
 
-    test('opens a connection and creates the database when explicitly enabled', () => {
-        const outcome = bootRecorder({NEO_NL_ACTION_LOGGING: 'true'});
+    test('enabled: connection open and database created at boot', () => {
+        const outcome = bootRecorder({extraEnv: {NEO_NL_ACTION_LOGGING: 'true'}});
 
         expect(outcome.error, `child failed instead of reporting:\n${outcome.error}`).toBeNull();
         expect(outcome.gateValue).toBe(true);
-        expect(outcome.opened).toBe(true);
+        expect(outcome.openedAtBoot).toBe(true);
         expect(outcome.resolvedPath).toBeTruthy();
-        // The positive control for the test above: the same existence check on the same resolved
-        // path must flip to true, so a false there cannot be an artifact of checking a dead path.
+        // Positive control for the test above: the same existence check on the same resolved path
+        // must flip to true, so a false there cannot be an artifact of checking a dead path.
         expect(outcome.fileExists).toBe(true)
     });
 
+    test('unset: the transaction archive contract STILL works, opening the store on demand', () => {
+        const outcome = bootRecorder({exerciseArchive: true});
+
+        expect(outcome.error, `child failed instead of reporting:\n${outcome.error}`).toBeNull();
+        expect(outcome.gateValue).toBe(false);
+        // Still nothing at boot -- the telemetry guarantee is unchanged.
+        expect(outcome.openedAtBoot).toBe(false);
+        // The regression this test exists for: a valid committed transaction returned
+        // {saved:false, reason:'archive-store-unavailable'} when the gate sat above the connection.
+        expect(outcome.archiveReason).toBeNull();
+        expect(outcome.archiveSaved).toBe(true);
+        // Round-tripped, not merely accepted -- a save that cannot be read back is not a contract.
+        expect(outcome.readBackOps).toBe(1);
+        // And the store was opened lazily by that call rather than at boot.
+        expect(outcome.openedAfter).toBe(true)
+    });
+
+    test('enabled: the transaction archive contract also works', () => {
+        const outcome = bootRecorder({extraEnv: {NEO_NL_ACTION_LOGGING: 'true'}, exerciseArchive: true});
+
+        expect(outcome.error, `child failed instead of reporting:\n${outcome.error}`).toBeNull();
+        expect(outcome.archiveSaved).toBe(true);
+        expect(outcome.readBackOps).toBe(1)
+    });
+
     test('the genesis probe opts in, so its telemetry oracle keeps a source', () => {
-        // Positive control for the two cases above: the default-off tests only prove a seat is
-        // quiet. This one proves the ONE caller that genuinely needs the table still turns it on.
-        // Without it, a blanket disable would leave the blind probe comparing against an empty
-        // oracle -- passing every unit test while silently gutting an external commitment.
+        // Structural tripwire ONLY -- a source-text check carries no behavioural claim. The
+        // behavioural chain lives elsewhere: genesisProbe.spec.mjs asserts the INVOKED
+        // createProbeEnvironments() output carries NEO_NL_ACTION_LOGGING='true', and the
+        // end-to-end non-empty-telemetry AC is annotated as a live residual on the gating
+        // ticket. This line exists so a blanket removal of the opt-in cannot land silently
+        // between those two.
         const source = fs.readFileSync(path.join(rootDir, 'ai/scripts/diagnostics/genesisProbe.mjs'), 'utf8');
 
         expect(source).toContain('NEO_NL_ACTION_LOGGING');
@@ -126,8 +179,11 @@ test.describe('Neural Link action logging default', () => {
     });
 
     test('the cutover writer census matches neural-link', () => {
-        // The census that missed this: `neural-link` was absent from the alternation, so the probe
-        // reported an empty census while two NL processes held write handles on the plane graph.
+        // Structural tripwire ONLY: keeps `neural-link` in the runbook's census alternation. The
+        // original bug was a census reporting empty while two NL processes held write handles, so
+        // the AC's real witness is a LIVE census run asserted non-empty against a live NL --
+        // recorded as PR evidence and annotated on the gating ticket; a document grep cannot
+        // carry that claim.
         const runbook = fs.readFileSync(
             path.join(rootDir, 'ai/scripts/lifecycle/local-agent-os/README.md'), 'utf8'
         );

--- a/test/playwright/unit/ai/services/neural-link/RecorderServiceDefaultOff.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/RecorderServiceDefaultOff.spec.mjs
@@ -29,9 +29,10 @@ test.describe('Neural Link action logging default', () => {
      * @param {Object}  [options={}]
      * @param {Object}  [options.extraEnv=null]        Additional env for the child
      * @param {Boolean} [options.exerciseArchive=false] Also drive a real save + read-back
+     * @param {Boolean} [options.exerciseParallelBurst=false] Drive 8 CONCURRENT first-use saves
      * @returns {Object} Observed child outcome
      */
-    function bootRecorder({extraEnv = null, exerciseArchive = false} = {}) {
+    function bootRecorder({extraEnv = null, exerciseArchive = false, exerciseParallelBurst = false} = {}) {
         const
             dir         = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-nl-gate-')),
             dbPath      = path.join(dir, 'graph.sqlite'),
@@ -57,6 +58,27 @@ test.describe('Neural Link action logging default', () => {
                 out.readBackOps   = readBack ? readBack.ops.length : null;
                 out.openedAfter   = Boolean(RecorderService.db);
             ` : '',
+            burstStep = exerciseParallelBurst ? `
+                let opens = 0;
+                const origOpen = RecorderService.openStore.bind(RecorderService);
+                RecorderService.openStore = (...args) => { opens++; return origOpen(...args); };
+                const mkSave = (i) => RecorderService.saveTransactionArchive({
+                    appSessionId: 'spec-session',
+                    name        : 'parallel-' + i,
+                    transaction : {
+                        txId        : 'spec-tx-' + i,
+                        status      : 'committed',
+                        committedAt : 1234,
+                        originWriter: {agentId: 'spec-agent', sessionId: 'spec-session'},
+                        ops         : [{kind: 'set', value: i}]
+                    }
+                });
+                const results = await Promise.all(Array.from({length: 8}, (_, i) => mkSave(i)));
+                out.parallelSaved   = results.filter(r => r.saved).length;
+                out.parallelReasons = [...new Set(results.map(r => r.reason ?? null))];
+                out.openCalls       = opens;
+                out.openedAfter     = Boolean(RecorderService.db);
+            ` : '',
             // Neo must be bootstrapped before any `src/core` module loads -- `Compare.mjs` calls
             // `Neo.gatekeep` at module scope, so importing RecorderService bare throws
             // "Neo is not defined". Same ordering the sibling specs get from `setup.mjs`.
@@ -74,7 +96,7 @@ test.describe('Neural Link action logging default', () => {
                     resolvedPath: config.memoryCoreDbPath,
                     gateValue   : config.actionLoggingEnabled
                 };
-                ${archiveStep}
+                ${archiveStep}${burstStep}
                 process.stdout.write(JSON.stringify(out));
             `,
             childEnv = {...process.env, NEO_MEMORY_DB_PATH: dbPath, ...(extraEnv || {})};
@@ -161,6 +183,23 @@ test.describe('Neural Link action logging default', () => {
         expect(outcome.error, `child failed instead of reporting:\n${outcome.error}`).toBeNull();
         expect(outcome.archiveSaved).toBe(true);
         expect(outcome.readBackOps).toBe(1)
+    });
+
+    test('unset: 8 parallel first-use saves share exactly ONE store open (single-flight)', () => {
+        const outcome = bootRecorder({exerciseParallelBurst: true});
+
+        expect(outcome.error, `child failed instead of reporting:\n${outcome.error}`).toBeNull();
+        expect(outcome.gateValue).toBe(false);
+        expect(outcome.openedAtBoot).toBe(false);
+        // Every concurrent save lands, none refused -- reason asserted before saved so a
+        // rejection can never impersonate the race under test.
+        expect(outcome.parallelReasons).toEqual([null]);
+        expect(outcome.parallelSaved).toBe(8);
+        // The measured regression (review cycle 2): a bare check-then-open admitted one
+        // connection PER CALLER -- 32 parallel ensureStore calls returned 32 distinct
+        // connections against one shared file. Single-flight means exactly one real open.
+        expect(outcome.openCalls).toBe(1);
+        expect(outcome.openedAfter).toBe(true)
     });
 
     test('the genesis probe opts in, so its telemetry oracle keeps a source', () => {

--- a/test/playwright/unit/ai/services/neural-link/RecorderServiceDefaultOff.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/RecorderServiceDefaultOff.spec.mjs
@@ -1,0 +1,138 @@
+import {test, expect} from '@playwright/test';
+import {spawnSync}    from 'node:child_process';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+/**
+ * @summary Proves Neural Link action logging is OFF by default and opens NO handle on the plane
+ * graph, and that the explicit opt-in still works.
+ *
+ * Child processes rather than in-process asserts, for two reasons. First, the gate is a config leaf
+ * bound to `NEO_NL_ACTION_LOGGING` at module-load time, so a single process can only ever observe
+ * one value — the sibling `RecorderService.spec.mjs` sets it to `true` process-wide and cannot
+ * unset it. Second, the claim under test is about a real seat's behaviour at boot, and the defect
+ * this guards was a WRITE HANDLE existing on a shared SQLite file. Asserting on a config value, or
+ * grepping the source for the flag, would both pass while the handle was still opened — so each
+ * case invokes `initAsync()` for real and reports whether a connection exists.
+ */
+test.describe('Neural Link action logging default', () => {
+    const rootDir = path.resolve(import.meta.dirname, '../../../../../..');
+
+    /**
+     * Boots RecorderService in a fresh child process against a throwaway database path and reports
+     * whether a connection was opened.
+     * @param {Object|null} extraEnv Additional env for the child, or null for none
+     * @returns {Object} `{opened, dbPath, fileExists, error}`
+     */
+    function bootRecorder(extraEnv) {
+        const
+            dir    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-16207-')),
+            dbPath = path.join(dir, 'graph.sqlite'),
+            // Neo must be bootstrapped before any `src/core` module loads -- `Compare.mjs` calls
+            // `Neo.gatekeep` at module scope, so importing RecorderService bare throws
+            // "Neo is not defined". Same ordering the sibling specs get from `setup.mjs`.
+            // The child reports the path the CONFIG resolved, not the path this test suggested.
+            // Necessary because `memoryCoreDbPath` selects a test destination whenever
+            // `UNIT_TEST_MODE` / `NEO_TEST_CONFIG_TEMPLATES` is inherited from the Playwright
+            // worker, so asserting existence of the suggested path passed vacuously in BOTH cases
+            // -- it proved only that an unused path stayed unused.
+            script = `
+                import Neo     from ${JSON.stringify(path.join(rootDir, 'src/Neo.mjs'))};
+                import * as core from ${JSON.stringify(path.join(rootDir, 'src/core/_export.mjs'))};
+                const config          = (await import(${JSON.stringify(path.join(rootDir, 'ai/mcp/server/neural-link/config.mjs'))})).default;
+                const RecorderService = (await import(${JSON.stringify(path.join(rootDir, 'ai/services/neural-link/RecorderService.mjs'))})).default;
+                await RecorderService.initAsync();
+                process.stdout.write(JSON.stringify({
+                    opened      : Boolean(RecorderService.db),
+                    resolvedPath: config.memoryCoreDbPath,
+                    gateValue   : config.actionLoggingEnabled
+                }));
+            `,
+            childEnv = {...process.env, NEO_MEMORY_DB_PATH: dbPath, ...(extraEnv || {})};
+
+        // Deleted rather than set to undefined: spawnSync stringifies an `undefined` value to the
+        // literal "undefined", which a boolean leaf would read as a set-and-truthy env -- making
+        // the default-off case prove the env instead of the default.
+        if (!extraEnv || !('NEO_NL_ACTION_LOGGING' in extraEnv)) {
+            delete childEnv.NEO_NL_ACTION_LOGGING;
+        }
+
+        // Drop the harness's test-mode markers so the child resolves the PRODUCTION path leaf --
+        // i.e. the unique `NEO_MEMORY_DB_PATH` above -- which is what a real seat does. Inheriting
+        // them made every child resolve the ONE shared `NEO_TELEMETRY_DB_PATH_TEST` file, which the
+        // sibling spec creates first (it sorts earlier), so the default-off case saw a pre-existing
+        // file authored by someone else and the assertion measured suite order, not the gate.
+        delete childEnv.UNIT_TEST_MODE;
+        delete childEnv.NEO_TEST_CONFIG_TEMPLATES;
+        delete childEnv.NEO_TELEMETRY_DB_PATH_TEST;
+
+        const result = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+                cwd     : rootDir,
+                encoding: 'utf8',
+                env     : childEnv
+            });
+
+        let parsed = null;
+
+        try { parsed = JSON.parse(result.stdout.trim().split('\n').pop()) } catch {}
+
+        return {
+            opened      : parsed ? parsed.opened : null,
+            gateValue   : parsed ? parsed.gateValue : null,
+            resolvedPath: parsed ? parsed.resolvedPath : null,
+            // Existence of the path the config ACTUALLY chose -- the only file that can prove or
+            // disprove that a seat left an artifact behind.
+            fileExists: Boolean(parsed?.resolvedPath) && fs.existsSync(parsed.resolvedPath),
+            error     : parsed ? null : (result.stderr || '').split('\n').slice(-12).join('\n')
+        }
+    }
+
+    test('opens NO connection and creates NO database file when unset', () => {
+        const outcome = bootRecorder(null);
+
+        expect(outcome.error, `child failed instead of reporting:\n${outcome.error}`).toBeNull();
+        expect(outcome.gateValue).toBe(false);
+        expect(outcome.opened).toBe(false);
+        // Guard against a vacuous pass: if the config resolved no path at all, absence of a file
+        // would prove nothing about the gate.
+        expect(outcome.resolvedPath).toBeTruthy();
+        expect(outcome.fileExists).toBe(false)
+    });
+
+    test('opens a connection and creates the database when explicitly enabled', () => {
+        const outcome = bootRecorder({NEO_NL_ACTION_LOGGING: 'true'});
+
+        expect(outcome.error, `child failed instead of reporting:\n${outcome.error}`).toBeNull();
+        expect(outcome.gateValue).toBe(true);
+        expect(outcome.opened).toBe(true);
+        expect(outcome.resolvedPath).toBeTruthy();
+        // The positive control for the test above: the same existence check on the same resolved
+        // path must flip to true, so a false there cannot be an artifact of checking a dead path.
+        expect(outcome.fileExists).toBe(true)
+    });
+
+    test('the genesis probe opts in, so its telemetry oracle keeps a source', () => {
+        // Positive control for the two cases above: the default-off tests only prove a seat is
+        // quiet. This one proves the ONE caller that genuinely needs the table still turns it on.
+        // Without it, a blanket disable would leave the blind probe comparing against an empty
+        // oracle -- passing every unit test while silently gutting an external commitment.
+        const source = fs.readFileSync(path.join(rootDir, 'ai/scripts/diagnostics/genesisProbe.mjs'), 'utf8');
+
+        expect(source).toContain('NEO_NL_ACTION_LOGGING');
+        // Bound to the same env block that redirects writes into the disposable root, so enabling
+        // logging can never touch the canonical plane.
+        expect(source).toContain('NEO_MEMORY_DB_PATH')
+    });
+
+    test('the cutover writer census matches neural-link', () => {
+        // The census that missed this: `neural-link` was absent from the alternation, so the probe
+        // reported an empty census while two NL processes held write handles on the plane graph.
+        const runbook = fs.readFileSync(
+            path.join(rootDir, 'ai/scripts/lifecycle/local-agent-os/README.md'), 'utf8'
+        );
+
+        expect(runbook).toContain('memory-core|knowledge-base|neural-link');
+        expect(runbook).not.toContain('(memory-core|knowledge-base)/mcp-server')
+    })
+});


### PR DESCRIPTION
Resolves #16207

Evidence: L2 achieved (fresh-child behavioral gate, both arms; default-config archive round-trip through the real recorder; single-flight parallel-first-use regression; `GapInferenceEngine` absent-table degradation witness) + live non-empty census receipt on the cutover host → declared residuals on #16207: live NL-server open-handle inspection after next harness restart `[L3-deferred]`, genesis end-to-end non-empty telemetry `[L4-deferred]`.

## Why

Every host-side Neural Link opened a **read/write** handle on the shared plane graph to write `nl_action_log`. Under the container topology that is a second writer against the containerized Memory Core on the same SQLite file — the exact condition the cutover runbook's §2 census exists to exclude, and the census could not see it.

Measured before changing anything, so the prescription follows the evidence rather than the intuition:

| Measure | Value |
|---|---|
| `nl_action_log` rows in the canonical graph | **188** (~2 days) |
| `nl_transaction_archive` rows | **0** |
| `edges` of type `NL_ACTION_SEQUENCE` | **0** |

`GapInferenceEngine.mjs` genuinely reads the table, and the memory-core config attributes `NL_ACTION_SEQUENCE` edges to it — but that edge type has produced **zero** edges. So the **action-telemetry writer** was cost without consumed product on an ordinary seat: a write handle on shared state from every seat, zero attributed edges. That claim is deliberately narrow — the same service also hosts the shipped `nl_transaction_archive` save/replay contract (#14829), a real product surface that its zero-row snapshot measures *usage* of, not retirement authority over. Cycle 1 of review caught the first head conflating the two; see What changed.

Scope note on that measurement: the graph also holds 179 `VALIDATES` edges. I did **not** verify their provenance and am not claiming they are or are not NL-derived. The load-bearing number is `NL_ACTION_SEQUENCE = 0` — the type the config explicitly attributes to this data.

## What changed

**`actionLoggingEnabled` leaf, default `false`** (`neural-link/configBase.mjs`). Plain `leaf(false, 'NEO_NL_ACTION_LOGGING', 'boolean')`, matching the `autoConnect` / `debug` precedent in the same file. Its JSDoc carries stable contract language only (scope of the gate, path-convergence rationale, steady-state expectation); the transient row counts and source coordinates live here and on the ticket, not in durable docs *(review cycle 1)*.

**The gate sits at the capability boundary, not above the service** *(shape corrected in review cycle 1)*. `RecorderService` hosts two independent contracts against one SQLite file: `nl_action_log` telemetry and the `nl_transaction_archive` save/replay product surface (#14829, PR #14836). The connection now opens lazily via `ensureStore()`:

- Logging **enabled**: boot behaviour unchanged — `initAsync()` opens eagerly, one `Connected` line.
- Logging **disabled** (default): boot opens **nothing** — one line, `Action logging disabled; transaction archive available on demand.` A real `saveTransactionArchive()` / `getTransactionArchive()` / `recordTransactionReplay()` call opens the store at that moment; `InstanceService.saveTransaction()` / `replayTransaction()` and their specs carry the now-async signatures.
- `log()` / `querySequences()` / `pruneOlderThan()` gate on the **leaf** explicitly, because a live `db` opened for the archive is no longer evidence that telemetry was requested.

The first head's `initAsync()` early-return gated the whole service and made a valid default-config archive save return `{saved:false, reason:'archive-store-unavailable'}` — the reviewer's falsifier. That exact scenario is now a passing spec (below).

**The opener is SINGLE-FLIGHT** *(review cycle 2)*: the lazy path awaits filesystem work, so a bare check-then-open raced — the reviewer measured 32 parallel `ensureStore()` calls returning 32 distinct connections on one shared file. `ensureStore()` now assigns the in-flight `openStore()` promise synchronously (every concurrent caller joins one real open), clears it on settle (a failed open resolves `null` for current waiters while the next call retries fresh), and the success marker is contract-neutral for the on-demand path (`Archive store opened on demand.`) so a disabled seat's log can never imply telemetry was requested — the enabled boot line is unchanged.

**The path default is deliberately untouched.** `memoryCoreDbPath` stays plane-anchored. This gates *whether* the recorder writes telemetry, never *where*. Un-converging the path would recreate the bug that convergence repaired — recorders writing to a file the readers never open, with gap inference silently producing no edges.

**`genesisProbe.mjs` opts in explicitly.** Its per-tool telemetry oracle reads `nl_action_log`, so a blanket disable would leave the blind probe comparing against an **empty oracle** — passing every unit test while silently gutting the externally-committed proof in #15291 / Discussion #15173. Safe to enable because the probe already redirects writes into its own `mkdtemp` root, enforced by `assertDiagnosticPathsWithinRoot`. *(Review cycle 1)*: the opt-in is now asserted on the **invoked** `createProbeEnvironments()` output in `genesisProbe.spec.mjs`, not only on source text; the two remaining source-text checks are re-labeled structural tripwires whose comments name the behavioral witness that carries each claim.

**Runbook census widened** to match `neural-link`, both occurrences, plus a note that the file is the truth and the process census only a proxy — with the `lsof` command to settle disagreements.

## Test Evidence

Exact head `0ed9ed0488` (cycle-2 targeted rerun: 72/72 across the neural-link unit tree + server-boundary/client InstanceService specs). Cycle-1 full targeted set at `c0ba51a9d8`, derived from changed basenames plus every spec importing the changed modules (`InstanceService`, `RecorderService`, NL `configBase`, `genesisProbe`, digest consumers):

```
npm run test-unit -- test/playwright/unit/ai/services/neural-link \
  test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs \
  test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs \
  <the nine unit/ai/InstanceService*.spec.mjs files> \
  test/playwright/unit/ai/InitAsyncContractGuard.spec.mjs \
  test/playwright/unit/ai/admitWrite.spec.mjs \
  test/playwright/unit/ai/client/InstanceService.spec.mjs
  -> 177 passed (5.4s)
```

Named witnesses inside that run:

- `RecorderServiceDefaultOff.spec.mjs` › **"unset: the transaction archive contract STILL works, opening the store on demand"** — the review falsifier as a spec: default config, real recorder, valid committed transaction → `saved:true`, read-back round-trip, store opened lazily, still nothing at boot.
- Same file › "enabled: the transaction archive contract also works" — the other arm.
- `DreamService.spec.mjs` › **"executeNLActionDigest skips cleanly when nl_action_log is absent"** — the pre-existing degradation witness for `GapInferenceEngine` under a missing table, green at this head (cited rather than duplicated).
- `InstanceServiceCreateInstance.spec.mjs` server-boundary replay specs — async signatures verified end to end through App Worker dispatch.
- `genesisProbe.spec.mjs` › "builds least-authority child environments…" now asserts `NEO_NL_ACTION_LOGGING === 'true'` on the rendered child env.
- `RecorderServiceDefaultOff.spec.mjs` › **"unset: 8 parallel first-use saves share exactly ONE store open (single-flight)"** *(cycle 2)* — 8 concurrent real saves in the default-config child: all land (`reason` asserted null before `saved`), `openStore` invoked exactly once, nothing at boot.

### Live census receipt (revised-AC positive control)

2026-07-31T03:35Z, cutover host, runbook §2 command verbatim with the widened pattern → **five** `neural-link/mcp-server.mjs` processes returned (non-empty). File-truth cross-check on the canonical graph: `lsof` shows the write descriptors currently held via the Colima VM process (`com.apple.Virtualization.VirtualMachine`) — i.e. the containerized plane through the present bind-mount topology, which is #16167's compliance-map scope, not this PR's. The census/file disagreement pattern the runbook note documents is thereby demonstrated live.

### Gates

Each with its real exit code captured to a file rather than read through a pipeline:

- `check-ticket-archaeology` → **initially exit 1 on the repair head**: 5 decay-prone refs in my new durable comments. Stripped (reasoning kept, refs moved to this body); re-verified via the committing hook chain, green.
- `check-block-alignment --staged` → initially exit 1 (declaration block widened by `archiveStep`); `--fix` aligned 2 lines; re-verified green.
- `ai:lint-config-template-ssot`, `check-whitespace`, `check-shorthand`, `check-jsdoc-types`, `check-aiconfig-test-mutation`, `check-derived-domain`, `check-parse` → green in the committing hook chain at `c0ba51a9d8`.

**ADR 0019 self-audit** on the `ai/` diff: 0 added lines matching `process.env` / `AiConfig?.` / `hasEnvValue` / `afterApplyEnvLeaf` / `export const [A-Z]`, verified with a positive control (hits on `actionLoggingEnabled`) so a zero could not come from a broken pattern. The new leaf is declarative — no inline test-mode branch (A4), the leaf owns its env check (A5), no formula for a non-computed value (A9), no defensive `?.` (B3), no runtime config mutation (B4). `genesisProbe.mjs` stays Neo-free and sets env only (C1).

### Two test defects I introduced and had to fix (first head)

Recording these because the first version of the suite was green and proved nothing:

1. **Vacuous existence check.** I asserted no DB file appeared at the path *this test suggested*. But `memoryCoreDbPath` resolves a test destination whenever `UNIT_TEST_MODE` is inherited, so that path was never going to be used in either case — the assertion passed for both enabled and disabled. Fixed by having the child report `config.memoryCoreDbPath` and asserting existence of the path the config **actually chose**.
2. **Shared-state confound.** Once reporting the resolved path, the default-off case failed because `NEO_TELEMETRY_DB_PATH_TEST` is a single fixed file that the sibling spec (which sorts earlier) creates first. The assertion was measuring suite order, not the gate. Fixed by clearing the harness test-mode markers in the child so it resolves the production leaf — a unique `mkdtemp` path, which is also what a real seat does.

And one from cycle 1, same family: the archive child-probe first omitted `txId`, got `archive-save-failed`, and would have "passed" a weaker assertion — a fixture looser than the contract. The spec now saves a fully valid transaction and asserts `reason` is null *before* asserting `saved`, so a rejection can never impersonate the regression under test.

## Post-Merge Validation

Both items are annotated on #16207 as deferred residuals (operator handoff):

- `[L3-deferred]` Restart a harness and confirm no NL process holds a handle: `lsof .neo-ai-data/sqlite/memory-core-graph.sqlite` shows no `neural-link` pid with an `…u` descriptor.
- `[L4-deferred]` Run `genesisProbe` end to end and confirm per-tool telemetry is non-empty.

## Deltas

- **Review cycle 2 (REQUEST_CHANGES, @neo-gpt-emmy)**: single-flight opener (`storeOpen` join point, retry-after-failure semantics), contract-neutral on-demand marker, and the parallel-first-use regression spec. Head `0ed9ed0488`.
- **Review cycle 1 (REQUEST_CHANGES, @neo-gpt-emmy)** reshaped the persistence boundary: lazy `ensureStore()`, split gating (telemetry leaf vs archive contract), async signatures propagated through `InstanceService` call sites and specs, the default-config archive round-trip spec, the invoked-builder genesis assertion, narrowed durable JSDoc, ticket ledger/AC reconciliation with residual annotations, and this body's Evidence line rewritten from the false `L2 → L2 required` claim.
- **`config-leaf-parity.json` regenerated** (543 paths). Not incidental — the SSOT lint fails without it and requires it in the same commit.
- **`genesisProbe.mjs` env block re-aligned** by `check-block-alignment --fix`: pre-existing lines lost padding when the block tightened. Mechanical, tool-generated — flagged so the hunk's line count is not mistaken for scope creep.
- **`RecorderService.spec.mjs` sets `NEO_NL_ACTION_LOGGING=true` at module top.** Required: that suite exercises the schema and insert path, so it must opt in now. Set before `setup()` because the leaf binds env at module load, and mutating the config singleton at runtime is forbidden.
- **`ParityTopology.integration.spec.mjs` disabled-path marker updated** to the new boot line — the parity CI lane is the live witness for the one-line-at-boot claim.
- Census widening touches the runbook, which is #16167's document. In scope per #16207's fix item 3, and the same-commit change keeps the pattern and the reason together.

Not addressed, deliberately: routing NL writes through Memory Core's remote API instead of direct SQLite. That is the architectural answer and belongs to Discussion #15173's streamable-HTTP direction, noted in #16207's Out of Scope.

Authored by @neo-opus-vega (Claude Opus 5; review-cycle-1 repair on Claude Fable 5, Claude Code)
