### PR TITLE
fix(ai): restore canonical local Compose target (#16206)

### DIFF
--- a/ai/deploy/docker-compose.local-agent-os.yml
+++ b/ai/deploy/docker-compose.local-agent-os.yml
@@ -51,6 +51,10 @@ services:
       <<: *local-provider
       # Keep Docker labels and constrained runtime lookup on one scalar.
       NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT: *local-project
+      # This profile uses host LM Studio, not the optional `local-model`
+      # container. Monitor only the Compose services it actually starts.
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES: &local-runtime-services chroma,kb-server,mc-server,orchestrator
+      NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES: *local-runtime-services
 
   ingress:
     restart: unless-stopped

--- a/ai/deploy/docker-compose.local-agent-os.yml
+++ b/ai/deploy/docker-compose.local-agent-os.yml
@@ -1,15 +1,11 @@
 # One-machine canonical Agent OS overlay (#16167).
 #
-# Apply after docker-compose.yml. The base owns the runtime topology; this file
-# only binds the existing local plane, adds loopback ingress, and selects the
-# loopback-only, provider-verified GitHub-PAT profile used by distinct residents.
+# Apply after docker-compose.yml. The base owns the runtime topology and Docker
+# volumes; this file pins the local project identity, adds loopback ingress, and
+# selects the provider-verified GitHub-PAT profile used by distinct residents.
+# The pre-Docker checkout plane is an import source, never the live target.
 
-x-local-plane-bind: &local-plane-bind
-  type: bind
-  source: ../../.neo-ai-data
-  target: /app/.neo-ai-data
-  bind:
-    create_host_path: false
+name: &local-project "${NEO_LOCAL_AGENT_OS_PROJECT_NAME:-neo-local-agent-os}"
 
 x-local-auth: &local-auth
   NEO_AUTH_MODE: github-pat
@@ -19,17 +15,15 @@ x-local-auth: &local-auth
   NEO_MCP_HEALTHCHECK_TOKEN_FILE: /run/secrets/mcp-auth-token
 
 x-local-provider: &local-provider
-  NEO_OPENAI_COMPATIBLE_HOST: ${NEO_LOCAL_AGENT_OS_PROVIDER_HOST:-http://host.docker.internal:11434}
+  NEO_MODEL_PROVIDER: openAiCompatible
+  NEO_EMBEDDING_PROVIDER: openAiCompatible
+  NEO_OPENAI_COMPATIBLE_HOST: ${NEO_LOCAL_AGENT_OS_PROVIDER_HOST:-http://host.docker.internal:1234}
+  NEO_OPENAI_COMPATIBLE_MODEL: ${NEO_LOCAL_AGENT_OS_MODEL:-google/gemma-4-26b-a4b}
+  NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: ${NEO_LOCAL_AGENT_OS_EMBEDDING_MODEL:-text-embedding-qwen3-embedding-8b}
 
 services:
   chroma:
     restart: unless-stopped
-    volumes: !override
-      - type: bind
-        source: ../../.neo-ai-data/chroma/unified
-        target: /chroma/unified
-        bind:
-          create_host_path: false
     ports:
       - "127.0.0.1:8000:8000"
 
@@ -37,8 +31,6 @@ services:
     restart: unless-stopped
     environment:
       <<: [*local-auth, *local-provider]
-    volumes: !override
-      - *local-plane-bind
     secrets:
       - mcp-auth-token
     healthcheck:
@@ -48,8 +40,6 @@ services:
     restart: unless-stopped
     environment:
       <<: [*local-auth, *local-provider]
-    volumes: !override
-      - *local-plane-bind
     secrets:
       - mcp-auth-token
     healthcheck:
@@ -59,16 +49,8 @@ services:
     restart: unless-stopped
     environment:
       <<: *local-provider
-      # The forward-only container role starts with its own cadence and never
-      # needs a reverse merge into the retired mixed host scheduler.
-      NEO_AI_ORCHESTRATOR_DIR: /app/.neo-ai-data/orchestrator-container-plane
-    volumes: !override
-      - *local-plane-bind
-      - type: bind
-        source: /var/run/docker.sock
-        target: /var/run/docker.sock
-        bind:
-          create_host_path: false
+      # Keep Docker labels and constrained runtime lookup on one scalar.
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT: *local-project
 
   ingress:
     restart: unless-stopped

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -85,6 +85,10 @@ services:
       - NEO_KB_ASK_MAX_RPM=${NEO_KB_ASK_MAX_RPM:-}
     volumes:
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
+      # Read-only half of the orchestrator -> public MCP deployment-state bridge.
+      # A dedicated volume keeps this graph-independent receipt visible without
+      # granting the KB container Docker/runtime authority.
+      - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
     depends_on:
       chroma:
         condition: service_healthy
@@ -169,6 +173,8 @@ services:
     volumes:
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
       - shared-handoff-data:/app/.neo-ai-data/handoff:ro
+      # Read-only half of the orchestrator -> public MCP deployment-state bridge.
+      - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
     depends_on:
       chroma:
         condition: service_healthy
@@ -240,6 +246,9 @@ services:
       # container recreate. This named volume is durability, not off-host backup.
       - orchestrator-state:/app/.neo-ai-data/orchestrator-daemon
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
+      # Sole writer for the graph-independent deployment-state bridge consumed
+      # read-only by KB/MC.
+      - shared-deployment-state-data:/app/.neo-ai-data/deployment-state
       - tenant-repo-mirrors:/app/.neo-ai-data/tenant-repos
       # The `golden-path` scheduler lane writes the handoff and its derived
       # route artifacts here; mc-server mounts the same directory read-side.
@@ -373,6 +382,7 @@ volumes:
   chroma-data:
   orchestrator-state:
   shared-sqlite-data:
+  shared-deployment-state-data:
   shared-handoff-data:
   tenant-repo-mirrors:
   caddy-data:

--- a/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
@@ -71,6 +71,11 @@ const mcpServices = Object.entries(compose.services ?? {})
     .filter(([, service]) => service?.build?.args?.TARGET_SERVER)
     .map(([name]) => name);
 
+/** Base-profile MCP servers, derived independently of the deployment-state mount asserted below. */
+const baseMcpServices = Object.entries(baseCompose.services ?? {})
+    .filter(([, service]) => service?.build?.args?.TARGET_SERVER)
+    .map(([name]) => name);
+
 /** Services binding the plane via the shared `<<: *plane-env` anchor — orthogonal to what they mount. */
 const planeEnvServices = Object.entries(compose.services ?? {})
     .filter(([, service]) => Object.keys(service?.environment ?? {}).includes('<<'))
@@ -382,8 +387,10 @@ test.describe('parity profile — volume scoping is the isolation mechanism', ()
 test.describe('data-plane profile election — base and integration-fixture dispositions', () => {
     test('canonical local hard cut is durable, multi-resident, and wake-only on the host', () => {
         const
-            overlaySource = fs.readFileSync(localOverlayPath, 'utf8'),
-            plistSource   = fs.readFileSync(localWakePlistPath, 'utf8');
+            overlaySource         = fs.readFileSync(localOverlayPath, 'utf8'),
+            plistSource           = fs.readFileSync(localWakePlistPath, 'utf8'),
+            deploymentStateTarget = '/app/.neo-ai-data/deployment-state',
+            deploymentStateVolume = 'shared-deployment-state-data';
 
         expect(overlaySource).not.toContain('NEO_LOCAL_AGENT_OS_DATA_ROOT');
         expect(overlaySource).toMatch(/^name:\s*&local-project\s/m);
@@ -411,6 +418,18 @@ test.describe('data-plane profile election — base and integration-fixture disp
         );
         expect(overlaySource.match(/restart: unless-stopped/g)).toHaveLength(5);
         expect(overlaySource).not.toMatch(/\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]+/);
+
+        expect(baseCompose.volumes).toHaveProperty(deploymentStateVolume);
+
+        expect(baseMcpServices.length, 'base Compose has no MCP consumers for the deployment-state bridge').toBeGreaterThan(0);
+
+        for (const service of baseMcpServices) {
+            expect(baseCompose.services[service].volumes)
+                .toContain(`${deploymentStateVolume}:${deploymentStateTarget}:ro`)
+        }
+
+        expect(baseCompose.services.orchestrator.volumes)
+            .toContain(`${deploymentStateVolume}:${deploymentStateTarget}`);
 
         expect(plistSource).toContain('<string>ai/daemons/wake/receiver.mjs</string>');
         expect(plistSource).toContain('<string>--manifest</string>');

--- a/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
@@ -397,6 +397,12 @@ test.describe('data-plane profile election — base and integration-fixture disp
         expect(overlaySource).toContain(
             'NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT: *local-project'
         );
+        expect(overlaySource).toMatch(
+            /NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES:\s*&local-runtime-services\s+chroma,kb-server,mc-server,orchestrator/
+        );
+        expect(overlaySource).toContain(
+            'NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES: *local-runtime-services'
+        );
         expect(overlaySource).not.toContain('source: ../../.neo-ai-data');
         expect(overlaySource).not.toContain('source: ../../.neo-ai-data/chroma/unified');
         expect(overlaySource).not.toContain('NEO_AI_ORCHESTRATOR_DIR');

--- a/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
@@ -386,8 +386,13 @@ test.describe('data-plane profile election — base and integration-fixture disp
             plistSource   = fs.readFileSync(localWakePlistPath, 'utf8');
 
         expect(overlaySource).not.toContain('NEO_LOCAL_AGENT_OS_DATA_ROOT');
-        expect(overlaySource).toContain('source: ../../.neo-ai-data');
-        expect(overlaySource).toContain('source: ../../.neo-ai-data/chroma/unified');
+        expect(overlaySource).toMatch(/^name:\s*&local-project\s/m);
+        expect(overlaySource).toContain(
+            'NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT: *local-project'
+        );
+        expect(overlaySource).not.toContain('source: ../../.neo-ai-data');
+        expect(overlaySource).not.toContain('source: ../../.neo-ai-data/chroma/unified');
+        expect(overlaySource).not.toContain('NEO_AI_ORCHESTRATOR_DIR');
         expect(overlaySource).toContain('NEO_AUTH_MODE: github-pat');
         expect(overlaySource).not.toContain('NEO_AUTH_AUTO_PROVISION_IDENTITY_SOURCES');
         expect(overlaySource).toContain('NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT: "false"');
@@ -396,7 +401,13 @@ test.describe('data-plane profile election — base and integration-fixture disp
         expect(overlaySource).toContain('file: ../../.neo-ai-secrets/mcp-auth-token');
         expect(overlaySource).not.toContain('environment: GH_TOKEN');
         expect(overlaySource).toContain(
-            'NEO_OPENAI_COMPATIBLE_HOST: ${NEO_LOCAL_AGENT_OS_PROVIDER_HOST:-http://host.docker.internal:11434}'
+            'NEO_OPENAI_COMPATIBLE_HOST: ${NEO_LOCAL_AGENT_OS_PROVIDER_HOST:-http://host.docker.internal:1234}'
+        );
+        expect(overlaySource).toContain(
+            'NEO_OPENAI_COMPATIBLE_MODEL: ${NEO_LOCAL_AGENT_OS_MODEL:-google/gemma-4-26b-a4b}'
+        );
+        expect(overlaySource).toContain(
+            'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: ${NEO_LOCAL_AGENT_OS_EMBEDDING_MODEL:-text-embedding-qwen3-embedding-8b}'
         );
         expect(overlaySource.match(/restart: unless-stopped/g)).toHaveLength(5);
         expect(overlaySource).not.toMatch(/\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]+/);

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -445,17 +445,19 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
         expect(orchestratorEnv.NEO_ORCHESTRATOR_MLX_ENABLED).toBeUndefined();
     });
 
-    test('local Agent OS overlay binds one physical plane and exposes only routed loopback MCP', () => {
+    test('local Agent OS overlay inherits the Docker-owned plane and exposes only routed loopback MCP', () => {
         const source = fs.readFileSync(
             new URL('../../../../../../ai/deploy/docker-compose.local-agent-os.yml', import.meta.url),
             'utf8'
         );
 
-        expect(source).toContain('source: ../../.neo-ai-data');
-        expect(source).toContain('source: ../../.neo-ai-data/chroma/unified');
+        expect(source).not.toContain('source: ../../.neo-ai-data');
+        expect(source).not.toContain('source: ../../.neo-ai-data/chroma/unified');
         expect(source).not.toContain('NEO_LOCAL_AGENT_OS_DATA_ROOT');
-        expect(source).toContain('target: /app/.neo-ai-data');
-        expect(source).toContain('NEO_AI_ORCHESTRATOR_DIR: /app/.neo-ai-data/orchestrator-container-plane');
+        expect(source).not.toMatch(/target:\s*\/app\/\.neo-ai-data(?:\/|$)/m);
+        expect(source).toMatch(/^name:\s*&local-project\s/m);
+        expect(source).toContain('NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT: *local-project');
+        expect(source).not.toContain('NEO_AI_ORCHESTRATOR_DIR');
         expect(source).not.toContain('NEO_AUTH_AUTO_PROVISION_IDENTITY_SOURCES');
         expect(source).toContain('NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT: "false"');
         expect(source).not.toContain('NEO_AUTH_PROVIDER_BOOTSTRAP_PAT');


### PR DESCRIPTION
Resolves neomjs/neo#16219

Related: neomjs/neo#16206, neomjs/neo-agent-brain#84

Restores the tracked local Agent OS composition as the clean Docker target: one project identity, Docker-owned volumes, a shared deployment-state bridge, and explicit host LM Studio settings. The pre-Docker checkout plane is an import source, never the live target.

## Deltas from ticket

This PR delivers the re-scoped Step 1 blocker. Compose fragment decomposition and the cutover runbook rewrite remain outside it.

## Test Evidence

Evidence: L4 — exact-head unit coverage plus a live tracked-Compose launch and routed MC/KB health verification.

- Focused Compose + healthcheck regression pair — 44 passed.
- Tracked base + local overlay launched as `neo-local-agent-os`; all five containers healthy.
- Routed MC + KB healthchecks served `neo-local-canonical` from `/app/.neo-ai-data`.
- Deployment snapshot: Chroma, KB, MC, orchestrator 4/4 available and healthy; zero lookup failures.
- Exact logical graph bundle: 292,159 records admitted, zero failures; no physical Chroma, scheduler state, locks, or daemon state copied.
- `git diff --check` — passed.

## Post-Merge Validation

- [x] Clean named-volume launch and service-discovery receipt.
- [x] Logical graph admission and post-restart routed healthchecks.
- [ ] neomjs/neo#16208 completes MC-first then KB re-embedding.
- [ ] neomjs/neo-agent-brain#84 records wake/resident/reboot receipts.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fb600-58b9-7fa2-86a7-5a15e1ccf659.
