### PR TITLE
feat(ai): cross-store MC vector rebuild with fate-stamped receipts and bounded embed retry

### DIFF
--- a/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.mjs
+++ b/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.mjs
@@ -45,29 +45,46 @@ export async function readAllIds(collection, pageSize = 2000) {
 /**
  * @summary Builds the embed function: token-budget truncation + batched calls to an
  * OpenAI-compatible /v1/embeddings endpoint using the canonical model identifier.
+ *
+ * Keeps `concurrency` requests in flight. A serial server just queues them at no cost, while
+ * any server-side parallelism added mid-run (more slots, a second instance) is exploited
+ * immediately — the resume-safe runner never needs a restart to pick up provider firepower.
  * @param {Object}  options
  * @param {String}  options.url        Embeddings endpoint
  * @param {String}  options.model      Model identifier (the one the servers use)
  * @param {Number}  [options.batch=8]  Inputs per request
+ * @param {Number}  [options.concurrency=6] Requests in flight
  * @param {Function} [options.fetchImpl=fetch]
  * @returns {Function} `(documents: String[]) => Promise<Number[][]>`
  */
-export function createEmbedFn({url, model, batch = 8, fetchImpl = fetch}) {
+export function createEmbedFn({url, model, batch = 8, concurrency = 6, fetchImpl = fetch}) {
     return async documents => {
-        const out = [];
+        const chunks = [];
         for (let i = 0; i < documents.length; i += batch) {
-            const input = documents.slice(i, i + batch).map(doc => truncateToEmbedTokenBudget(doc));
-            const res   = await fetchImpl(url, {
-                method : 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body   : JSON.stringify({model, input})
-            });
-            if (!res.ok) throw new Error(`embed HTTP ${res.status}`);
-            const json = await res.json();
-            // The API may return items out of order; index is authoritative.
-            const sorted = [...json.data].sort((a, b) => a.index - b.index);
-            out.push(...sorted.map(item => item.embedding));
+            chunks.push({at: i, docs: documents.slice(i, i + batch)});
         }
+
+        const out  = new Array(documents.length);
+        let   next = 0;
+
+        const worker = async () => {
+            while (next < chunks.length) {
+                const {at, docs} = chunks[next++];
+                const input      = docs.map(doc => truncateToEmbedTokenBudget(doc));
+                const res        = await fetchImpl(url, {
+                    method : 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body   : JSON.stringify({model, input})
+                });
+                if (!res.ok) throw new Error(`embed HTTP ${res.status}`);
+                const json = await res.json();
+                // The API may return items out of order; index is authoritative.
+                const sorted = [...json.data].sort((a, b) => a.index - b.index);
+                sorted.forEach((item, j) => { out[at + j] = item.embedding });
+            }
+        };
+
+        await Promise.all(Array.from({length: Math.min(concurrency, chunks.length) || 1}, worker));
         return out;
     };
 }
@@ -159,6 +176,7 @@ if (isDirectRun) {
         .option('--embed-url <url>', 'OpenAI-compatible embeddings endpoint', 'http://127.0.0.1:1234/v1/embeddings')
         .option('--embed-model <id>', 'embedding model identifier', 'text-embedding-qwen3-embedding-8b')
         .option('--embed-batch <n>', 'inputs per embed request', v => parseInt(v, 10), 8)
+        .option('--embed-concurrency <n>', 'embed requests in flight', v => parseInt(v, 10), 6)
         .option('--get-batch <n>', 'source read chunk size', v => parseInt(v, 10), 500)
         .option('--limit <n>', 'pilot mode: first N ids per collection', v => parseInt(v, 10), 0)
         .option('--dry-run', 'count and plan only', false)
@@ -175,7 +193,7 @@ if (isDirectRun) {
         sourceClient: new ChromaClient({path: opts.sourceUrl}),
         targetClient: new ChromaClient({path: opts.targetUrl}),
         collections : opts.collections.split(',').map(s => s.trim()).filter(Boolean),
-        embedFn     : createEmbedFn({url: opts.embedUrl, model: opts.embedModel, batch: opts.embedBatch}),
+        embedFn     : createEmbedFn({url: opts.embedUrl, model: opts.embedModel, batch: opts.embedBatch, concurrency: opts.embedConcurrency}),
         getBatch    : opts.getBatch,
         limit       : opts.limit,
         dryRun      : Boolean(opts.dryRun)

--- a/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.mjs
+++ b/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.mjs
@@ -1,0 +1,186 @@
+/**
+ * Memory Core vector-store rebuild — full re-embed from an old store into a FRESH one.
+ *
+ * Cross-store, one-shot, operator-run: reads ids + documents + metadatas from the SOURCE
+ * Chroma (stored vectors are deliberately ignored — a version-incompatible index cannot be
+ * trusted and the rebuild targets one uniform embedding model), re-embeds every document
+ * against the canonical embedding endpoint, and streams the batches into the TARGET store.
+ *
+ * Composes `extractMemoryCoreCollectionData` in its degenerate case (`missingVectorIds = allIds`):
+ * that module owns batching, resume (`skipIds`), fail-loud `unrecoverable` reporting, and
+ * progress. This script owns clients, the collection loop, the embed function, and receipts.
+ *
+ * Deliberately NOT integrated: AiConfig (both stores are named explicitly via argv — a rebuild
+ * must never inherit an ambient URL and hit the wrong store) and the heavy-maintenance lease
+ * (source access is read-only; the target is a pre-resident fresh store with no competing
+ * scheduler).
+ *
+ * STDOUT carries exactly one structured receipt JSON; progress goes to STDERR.
+ *
+ * @module Neo.ai.scripts.maintenance.rebuildMemoryCoreVectorStore
+ */
+
+import {program}                                                     from 'commander';
+import {ChromaClient}                                                from 'chromadb';
+import {fileURLToPath}                                               from 'url';
+import {extractMemoryCoreCollectionData, truncateToEmbedTokenBudget} from './repairMemoryCoreStoredEmbeddings.mjs';
+
+/**
+ * @summary Reads every id of a collection, paginated.
+ * @param {Object} collection Chroma collection handle
+ * @param {Number} [pageSize=2000]
+ * @returns {Promise<String[]>}
+ */
+export async function readAllIds(collection, pageSize = 2000) {
+    const ids = [];
+    for (let offset = 0; ; offset += pageSize) {
+        const page = await collection.get({limit: pageSize, offset, include: []});
+        const got  = page.ids || [];
+        ids.push(...got);
+        if (got.length < pageSize) break;
+    }
+    return ids;
+}
+
+/**
+ * @summary Builds the embed function: token-budget truncation + batched calls to an
+ * OpenAI-compatible /v1/embeddings endpoint using the canonical model identifier.
+ * @param {Object}  options
+ * @param {String}  options.url        Embeddings endpoint
+ * @param {String}  options.model      Model identifier (the one the servers use)
+ * @param {Number}  [options.batch=8]  Inputs per request
+ * @param {Function} [options.fetchImpl=fetch]
+ * @returns {Function} `(documents: String[]) => Promise<Number[][]>`
+ */
+export function createEmbedFn({url, model, batch = 8, fetchImpl = fetch}) {
+    return async documents => {
+        const out = [];
+        for (let i = 0; i < documents.length; i += batch) {
+            const input = documents.slice(i, i + batch).map(doc => truncateToEmbedTokenBudget(doc));
+            const res   = await fetchImpl(url, {
+                method : 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body   : JSON.stringify({model, input})
+            });
+            if (!res.ok) throw new Error(`embed HTTP ${res.status}`);
+            const json = await res.json();
+            // The API may return items out of order; index is authoritative.
+            const sorted = [...json.data].sort((a, b) => a.index - b.index);
+            out.push(...sorted.map(item => item.embedding));
+        }
+        return out;
+    };
+}
+
+/**
+ * @summary Rebuilds the named collections from source into target with a full re-embed.
+ *
+ * Resumable: ids already present in the target are skipped, so a crashed run continues
+ * where it stopped. The receipt is fail-loud — every unrecoverable row is listed, and
+ * `ok` is false unless targetAfter + unrecoverable === source for every collection.
+ *
+ * @param {Object}   options
+ * @param {Object}   options.sourceClient  ChromaClient (or compatible) for the OLD store
+ * @param {Object}   options.targetClient  ChromaClient (or compatible) for the FRESH store
+ * @param {String[]} options.collections   Collection names to rebuild
+ * @param {Function} options.embedFn       `(documents) => embeddings`
+ * @param {Number}   [options.getBatch=500]  Source read / re-embed chunk size
+ * @param {Number}   [options.limit=0]       Pilot mode: only the first N ids per collection
+ * @param {Boolean}  [options.dryRun=false]  Count and plan only; no embeds, no writes
+ * @param {Function} [options.log=console.error]
+ * @returns {Promise<Object>} `{ok, collections: [{name, source, targetBefore, targetAfter, reEmbedded, resumedExisting, unrecoverable}]}`
+ */
+export async function rebuildCollections({sourceClient, targetClient, collections, embedFn, getBatch = 500, limit = 0, dryRun = false, log = console.error}) {
+    const receipt = {ok: true, collections: []};
+
+    for (const name of collections) {
+        const sourceCol = await sourceClient.getCollection({name});
+        let   allIds    = await readAllIds(sourceCol);
+        const source    = allIds.length;
+
+        if (limit > 0) allIds = allIds.slice(0, limit);
+
+        const targetCol    = await targetClient.getOrCreateCollection({name});
+        const skipIds      = await readAllIds(targetCol);
+        const targetBefore = skipIds.length;
+        const entry        = {name, source, planned: allIds.length, targetBefore};
+
+        log(`[rebuild] ${name}: source=${source} planned=${allIds.length} targetBefore=${targetBefore}${dryRun ? ' (dry-run)' : ''}`);
+
+        if (dryRun) {
+            receipt.collections.push({...entry, dryRun: true});
+            continue;
+        }
+
+        const result = await extractMemoryCoreCollectionData({
+            collection      : sourceCol,
+            allIds,
+            missingVectorIds: allIds,
+            embedFn,
+            batchSize       : getBatch,
+            skipIds,
+            collectData     : false,
+            onDataBatch     : async batch => {
+                await targetCol.add({ids: batch.ids, embeddings: batch.embeddings, documents: batch.documents, metadatas: batch.metadatas});
+            },
+            onProgress: ({phase, percent}) => log(`[rebuild] ${name}: ${phase} ${percent}%`)
+        });
+
+        const targetAfter = (await readAllIds(targetCol)).length;
+        const done        = {
+            ...entry,
+            targetAfter,
+            reEmbedded     : result.counts.reEmbedded,
+            resumedExisting: result.counts.resumedExisting ?? 0,
+            unrecoverable  : result.unrecoverable ?? []
+        };
+
+        // Fail-loud reconciliation: every planned id is in the target or named unrecoverable.
+        if (targetAfter + done.unrecoverable.length < entry.planned) {
+            receipt.ok = false;
+            done.error = 'reconciliation-shortfall';
+        }
+        if (done.unrecoverable.length > 0) receipt.ok = false;
+
+        receipt.collections.push(done);
+        log(`[rebuild] ${name}: done targetAfter=${targetAfter} reEmbedded=${done.reEmbedded} unrecoverable=${done.unrecoverable.length}`);
+    }
+
+    return receipt;
+}
+
+const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isDirectRun) {
+    program
+        .requiredOption('--source-url <url>', 'OLD store Chroma URL (read-only source)')
+        .requiredOption('--target-url <url>', 'FRESH store Chroma URL (rebuild target)')
+        .requiredOption('--collections <csv>', 'comma-separated collection names')
+        .option('--embed-url <url>', 'OpenAI-compatible embeddings endpoint', 'http://127.0.0.1:1234/v1/embeddings')
+        .option('--embed-model <id>', 'embedding model identifier', 'text-embedding-qwen3-embedding-8b')
+        .option('--embed-batch <n>', 'inputs per embed request', v => parseInt(v, 10), 8)
+        .option('--get-batch <n>', 'source read chunk size', v => parseInt(v, 10), 500)
+        .option('--limit <n>', 'pilot mode: first N ids per collection', v => parseInt(v, 10), 0)
+        .option('--dry-run', 'count and plan only', false)
+        .parse();
+
+    const opts = program.opts();
+
+    if (opts.sourceUrl === opts.targetUrl) {
+        console.error('[rebuild] FATAL: --source-url and --target-url must differ (fail-closed).');
+        process.exit(1);
+    }
+
+    const receipt = await rebuildCollections({
+        sourceClient: new ChromaClient({path: opts.sourceUrl}),
+        targetClient: new ChromaClient({path: opts.targetUrl}),
+        collections : opts.collections.split(',').map(s => s.trim()).filter(Boolean),
+        embedFn     : createEmbedFn({url: opts.embedUrl, model: opts.embedModel, batch: opts.embedBatch}),
+        getBatch    : opts.getBatch,
+        limit       : opts.limit,
+        dryRun      : Boolean(opts.dryRun)
+    });
+
+    console.log(JSON.stringify(receipt, null, 2));
+    process.exit(receipt.ok ? 0 : 1);
+}

--- a/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.mjs
+++ b/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.mjs
@@ -7,8 +7,10 @@
  * against the canonical embedding endpoint, and streams the batches into the TARGET store.
  *
  * Composes `extractMemoryCoreCollectionData` in its degenerate case (`missingVectorIds = allIds`):
- * that module owns batching, resume (`skipIds`), fail-loud `unrecoverable` reporting, and
- * progress. This script owns clients, the collection loop, the embed function, and receipts.
+ * that module owns batching, resume (`skipIds`), bounded embed retry, fail-loud fate-stamped
+ * failure entries, and progress. This script owns clients, the collection loop, the embed
+ * function, and receipts — per-reason receipt rows (`{reason, count, retryable, sampleIds}`)
+ * rather than per-row dumps, since resume-by-diff makes full id lists redundant.
  *
  * Deliberately NOT integrated: AiConfig (both stores are named explicitly via argv — a rebuild
  * must never inherit an ambient URL and hit the wrong store) and the heavy-maintenance lease
@@ -90,11 +92,43 @@ export function createEmbedFn({url, model, batch = 8, concurrency = 6, fetchImpl
 }
 
 /**
+ * @summary Groups per-row failure entries into per-reason receipts.
+ *
+ * The binary verdict an operator needs ("resume, or repair the source?") is a projection of
+ * these rows, not a separate schema field: new reason codes become new array entries, and
+ * reconciliation stays a single sum over `count`.
+ *
+ * @param {Object[]} entries Structured extractor entries (`{id, reason, retryable, message?}`)
+ * @param {Number}   [sampleCap=10] Ids retained per reason — enough to eyeball, never a dump
+ * @returns {Object[]} `[{reason, count, retryable, sampleIds}]`, largest count first
+ */
+export function groupFailureReceipts(entries, sampleCap = 10) {
+    const byReason = new Map();
+
+    for (const entry of entries) {
+        let row = byReason.get(entry.reason);
+
+        if (!row) {
+            row = {reason: entry.reason, count: 0, retryable: entry.retryable === true, sampleIds: []};
+            byReason.set(entry.reason, row);
+        }
+
+        row.count++;
+
+        if (row.sampleIds.length < sampleCap) {
+            row.sampleIds.push(entry.id);
+        }
+    }
+
+    return [...byReason.values()].sort((a, b) => b.count - a.count);
+}
+
+/**
  * @summary Rebuilds the named collections from source into target with a full re-embed.
  *
  * Resumable: ids already present in the target are skipped, so a crashed run continues
- * where it stopped. The receipt is fail-loud — every unrecoverable row is listed, and
- * `ok` is false unless targetAfter + unrecoverable === source for every collection.
+ * where it stopped. The receipt is fail-loud — failures surface as per-reason receipts,
+ * and `ok` is false unless targetAfter covers every planned id with zero failures.
  *
  * @param {Object}   options
  * @param {Object}   options.sourceClient  ChromaClient (or compatible) for the OLD store
@@ -104,10 +138,11 @@ export function createEmbedFn({url, model, batch = 8, concurrency = 6, fetchImpl
  * @param {Number}   [options.getBatch=500]  Source read / re-embed chunk size
  * @param {Number}   [options.limit=0]       Pilot mode: only the first N ids per collection
  * @param {Boolean}  [options.dryRun=false]  Count and plan only; no embeds, no writes
+ * @param {Object}   [options.embedRetry]    Bounded-retry forwarding (`{attempts, backoffMs, wait}`)
  * @param {Function} [options.log=console.error]
- * @returns {Promise<Object>} `{ok, collections: [{name, source, targetBefore, targetAfter, reEmbedded, resumedExisting, unrecoverable}]}`
+ * @returns {Promise<Object>} `{ok, collections: [{name, source, targetBefore, targetAfter, reEmbedded, resumedExisting, failed}]}`
  */
-export async function rebuildCollections({sourceClient, targetClient, collections, embedFn, getBatch = 500, limit = 0, dryRun = false, log = console.error}) {
+export async function rebuildCollections({sourceClient, targetClient, collections, embedFn, getBatch = 500, limit = 0, dryRun = false, embedRetry, log = console.error}) {
     const receipt = {ok: true, collections: []};
 
     for (const name of collections) {
@@ -137,6 +172,7 @@ export async function rebuildCollections({sourceClient, targetClient, collection
             batchSize       : getBatch,
             skipIds,
             collectData     : false,
+            embedRetry,
             onDataBatch     : async batch => {
                 await targetCol.add({ids: batch.ids, embeddings: batch.embeddings, documents: batch.documents, metadatas: batch.metadatas});
             },
@@ -149,18 +185,20 @@ export async function rebuildCollections({sourceClient, targetClient, collection
             targetAfter,
             reEmbedded     : result.counts.reEmbedded,
             resumedExisting: result.counts.resumedExisting ?? 0,
-            unrecoverable  : result.unrecoverable ?? []
+            failed         : groupFailureReceipts(result.unrecoverable ?? [])
         };
+        const failedCount = done.failed.reduce((sum, row) => sum + row.count, 0);
+        const resumable   = done.failed.filter(row => row.retryable).reduce((sum, row) => sum + row.count, 0);
 
-        // Fail-loud reconciliation: every planned id is in the target or named unrecoverable.
-        if (targetAfter + done.unrecoverable.length < entry.planned) {
+        // Fail-loud reconciliation: every planned id is in the target or accounted for by a receipt.
+        if (targetAfter + failedCount < entry.planned) {
             receipt.ok = false;
             done.error = 'reconciliation-shortfall';
         }
-        if (done.unrecoverable.length > 0) receipt.ok = false;
+        if (failedCount > 0) receipt.ok = false;
 
         receipt.collections.push(done);
-        log(`[rebuild] ${name}: done targetAfter=${targetAfter} reEmbedded=${done.reEmbedded} unrecoverable=${done.unrecoverable.length}`);
+        log(`[rebuild] ${name}: done targetAfter=${targetAfter} reEmbedded=${done.reEmbedded} failed=${failedCount} (${resumable} resumable, ${failedCount - resumable} terminal)`);
     }
 
     return receipt;
@@ -177,6 +215,8 @@ if (isDirectRun) {
         .option('--embed-model <id>', 'embedding model identifier', 'text-embedding-qwen3-embedding-8b')
         .option('--embed-batch <n>', 'inputs per embed request', v => parseInt(v, 10), 8)
         .option('--embed-concurrency <n>', 'embed requests in flight', v => parseInt(v, 10), 6)
+        .option('--embed-attempts <n>', 'embed attempts per range before splitting/recording', v => parseInt(v, 10), 3)
+        .option('--embed-backoff <ms>', 'base backoff between embed attempts, doubling per attempt', v => parseInt(v, 10), 1000)
         .option('--get-batch <n>', 'source read chunk size', v => parseInt(v, 10), 500)
         .option('--limit <n>', 'pilot mode: first N ids per collection', v => parseInt(v, 10), 0)
         .option('--dry-run', 'count and plan only', false)
@@ -196,7 +236,8 @@ if (isDirectRun) {
         embedFn     : createEmbedFn({url: opts.embedUrl, model: opts.embedModel, batch: opts.embedBatch, concurrency: opts.embedConcurrency}),
         getBatch    : opts.getBatch,
         limit       : opts.limit,
-        dryRun      : Boolean(opts.dryRun)
+        dryRun      : Boolean(opts.dryRun),
+        embedRetry  : {attempts: opts.embedAttempts, backoffMs: opts.embedBackoff}
     });
 
     console.log(JSON.stringify(receipt, null, 2));

--- a/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
+++ b/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
@@ -12,8 +12,9 @@
  * rows from their DOCUMENTS (which still materialize — only the embedding fetch fails). Recovered batches
  * can either be retained in a merged `{ids, embeddings, documents, metadatas}` buffer or streamed into a
  * resumable shadow collection. A missing-vector row with no recoverable document/embedding is reported as
- * a structured `unrecoverable` entry (`{id, reason, message?}`; counts surfaced, never silently dropped —
- * the fail-loud discipline).
+ * a structured `unrecoverable` entry (`{id, reason, retryable, message?}`; counts surfaced, never silently
+ * dropped — the fail-loud discipline). `retryable` is the classifier-stamped fate: `true` for transient
+ * provider failures a later pass can fix, `false` for content problems no retry can recover.
  *
  * The live shadow run + canonical promotion is operator/env-gated (out of scope without
  * explicit authorization); this module is the pure extraction logic, unit-tested against mocked Chroma.
@@ -44,6 +45,8 @@ import {resolveTurnDocumentForRead} from '../../services/memory-core/helpers/tur
  * @param {Function}   [options.onDataBatch] Optional async sink for each recovered batch.
  * @param {Function}   [options.onProgress] Optional callback receiving 10%-bucket progress events:
  *                                           `{phase, percent, processed, total, counts}`.
+ * @param {Object}     [options.embedRetry] Bounded-retry forwarding for the re-embed leg
+ *                                           (`{attempts, backoffMs, wait}` — see `embedRecoverableDocuments`).
  * @returns {Promise<Object>} Extraction result with data buffers, structured unrecoverable entries,
  *   an ids-only `unrecoverableIds` projection, and repair counts.
  */
@@ -56,7 +59,8 @@ export async function extractMemoryCoreCollectionData({
     skipIds = [],
     collectData = true,
     onDataBatch,
-    onProgress
+    onProgress,
+    embedRetry
 } = {}) {
     if (typeof embedFn !== 'function') {
         throw new Error('extractMemoryCoreCollectionData: embedFn (documents -> embeddings) is required');
@@ -163,7 +167,7 @@ export async function extractMemoryCoreCollectionData({
         }
 
         if (reEmbedDocs.length > 0) {
-            const {embeddings, failedIndexes, failures} = await embedRecoverableDocuments({embedFn, ids: reEmbedIds, documents: reEmbedDocs});
+            const {embeddings, failedIndexes, failures} = await embedRecoverableDocuments({embedFn, ids: reEmbedIds, documents: reEmbedDocs, ...embedRetry});
             const batchData                             = {ids: [], embeddings: [], documents: [], metadatas: []};
 
             for (const failure of failures) {
@@ -220,15 +224,33 @@ function recordUnrecoverable({unrecoverable, counts, id, reason, message} = {}) 
 }
 
 /**
+ * Reason→fate map, owned by the classifier alongside reason assignment. `true` marks failures a
+ * later pass can fix (transient provider trouble — the row's content is intact); `false` marks
+ * content problems no retry can recover (the remedy is source-side repair or explicit acceptance).
+ * Consumers read the stamped `retryable` flag and never re-derive fate from reason strings — a
+ * second mapping would drift. Unknown reasons default to `false`: never promise a resume will fix
+ * what the classifier cannot vouch for.
+ * @type {Object}
+ */
+const RETRYABLE_BY_REASON = {
+    'document-empty'            : false,
+    'document-invalid'          : false,
+    'document-missing'          : false,
+    'embedding-provider-error'  : true,
+    'embedding-result-malformed': true,
+    'metadata-row-missing'      : false
+};
+
+/**
  * @summary Creates the structured unrecoverable row shape consumed by defrag diagnostics.
  * @param {Object} options
  * @param {String} options.id Row id.
  * @param {String} options.reason Stable reason code.
  * @param {String} [options.message] Operator-readable reason detail.
- * @returns {Object} Structured unrecoverable row entry.
+ * @returns {Object} Structured unrecoverable row entry, fate-stamped via `retryable`.
  */
 function createUnrecoverableEntry({id, reason, message} = {}) {
-    const entry = {id, reason};
+    const entry = {id, reason, retryable: RETRYABLE_BY_REASON[reason] ?? false};
 
     if (message) {
         entry.message = message;
@@ -268,17 +290,31 @@ function getDocumentProblem(document) {
 }
 
 /**
- * @summary Embeds a batch; on failure, binary-splits to isolate the failing document(s) and re-batches the survivors.
+ * @summary Embeds a batch; on failure, retries the intact range with backoff, then binary-splits to
+ * isolate the failing document(s) and re-batches the survivors.
  * @param {Object} options
  * @param {Function} options.embedFn Embedding function.
  * @param {String[]} options.ids Row ids paired with `documents`.
  * @param {String[]} options.documents Documents to embed.
+ * @param {Number}   [options.attempts=1] Embed attempts per range before splitting/recording. `1`
+ *                                        preserves the historical no-retry behavior; bulk callers
+ *                                        facing transient provider saturation should raise it.
+ * @param {Number}   [options.backoffMs=1000] Base backoff between attempts, doubling per attempt.
+ * @param {Function} [options.wait] `ms => Promise` — injectable for tests; defaults to setTimeout.
  * @returns {Promise<{embeddings: Number[][], failedIndexes: Set<Number>,
  *                    failures: Array<{index: Number, reason: String, message: String}>}>}
  */
-export async function embedRecoverableDocuments({embedFn, ids, documents} = {}) {
-    const embeddings = new Array(documents.length);
-    const failures   = [];
+export async function embedRecoverableDocuments({
+    embedFn,
+    ids,
+    documents,
+    attempts  = 1,
+    backoffMs = 1000,
+    wait      = ms => new Promise(resolve => setTimeout(resolve, ms))
+} = {}) {
+    const embeddings  = new Array(documents.length);
+    const failures    = [];
+    const maxAttempts = Math.max(1, attempts);
 
     // Embed the widest range that succeeds as a single batch; on failure, binary-split to isolate
     // the failing document(s) and RE-BATCH the survivors — rather than degrading the whole batch to
@@ -298,30 +334,46 @@ export async function embedRecoverableDocuments({embedFn, ids, documents} = {}) 
             return;
         }
 
-        try {
-            const vectors = await embedFn(slice);
+        // Retry the INTACT range before any split: the dominant bulk failure mode is transient
+        // provider saturation, which fails whole batches regardless of content — splitting those
+        // multiplies calls against an already-struggling provider, while backoff gives it room to
+        // drain. A deterministic bad document still fails every attempt and falls through below.
+        let lastError = null;
 
-            if (!Array.isArray(vectors) || vectors.length !== slice.length) {
-                throw createEmbeddingResultError(`embedFn returned ${Array.isArray(vectors) ? vectors.length : 'non-array'} embeddings for ${slice.length} documents`);
-            }
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                const vectors = await embedFn(slice);
 
-            for (let i = 0; i < slice.length; i++) {
-                embeddings[start + i] = vectors[i];
-            }
-        } catch (error) {
-            if (slice.length === 1) {
-                failures.push({
-                    index  : start,
-                    reason : getEmbeddingFailureReason(error),
-                    message: error?.message || String(error)
-                });
+                if (!Array.isArray(vectors) || vectors.length !== slice.length) {
+                    throw createEmbeddingResultError(`embedFn returned ${Array.isArray(vectors) ? vectors.length : 'non-array'} embeddings for ${slice.length} documents`);
+                }
+
+                for (let i = 0; i < slice.length; i++) {
+                    embeddings[start + i] = vectors[i];
+                }
+
                 return;
-            }
+            } catch (error) {
+                lastError = error;
 
-            const mid = start + Math.floor(slice.length / 2);
-            await embedRange(start, mid);
-            await embedRange(mid, end);
+                if (attempt < maxAttempts) {
+                    await wait(backoffMs * 2 ** (attempt - 1));
+                }
+            }
         }
+
+        if (slice.length === 1) {
+            failures.push({
+                index  : start,
+                reason : getEmbeddingFailureReason(lastError),
+                message: lastError?.message || String(lastError)
+            });
+            return;
+        }
+
+        const mid = start + Math.floor(slice.length / 2);
+        await embedRange(start, mid);
+        await embedRange(mid, end);
     }
 }
 

--- a/test/playwright/unit/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.spec.mjs
@@ -10,6 +10,7 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import {
     createEmbedFn,
+    groupFailureReceipts,
     readAllIds,
     rebuildCollections
 } from '../../../../../../ai/scripts/maintenance/rebuildMemoryCoreVectorStore.mjs';
@@ -73,7 +74,7 @@ test.describe('Neo.ai.scripts.maintenance.rebuildMemoryCoreVectorStore', () => {
 
         expect(receipt.ok).toBe(true);
         expect(receipt.collections[0]).toMatchObject({name: 'mem', source: 12, planned: 12, targetBefore: 0, targetAfter: 12, reEmbedded: 12});
-        expect(receipt.collections[0].unrecoverable).toEqual([]);
+        expect(receipt.collections[0].failed).toEqual([]);
         // Embeddings actually landed on the target rows (not merely accepted).
         expect(Object.values(target.mem.rows).every(row => Array.isArray(row.embedding))).toBe(true);
     });
@@ -94,21 +95,60 @@ test.describe('Neo.ai.scripts.maintenance.rebuildMemoryCoreVectorStore', () => {
         expect(receipt.collections[0]).toMatchObject({targetBefore: 4, targetAfter: 10, reEmbedded: 6, resumedExisting: 4});
     });
 
-    test('unrecoverable rows are listed fail-loud and flip ok to false', async () => {
+    test('failed rows surface as per-reason receipts, flip ok to false, and the done-line carries the fate rollup', async () => {
         const rows = sourceRows(6);
-        rows['id-3'].document = null; // no document, non-turn metadata -> unrecoverable
+        rows['id-3'].document = null; // no document, non-turn metadata -> terminal content problem
 
+        const lines   = [];
         const receipt = await rebuildCollections({
             sourceClient: makeClient({mem: makeCollection(rows)}),
             targetClient: makeClient({}),
             collections : ['mem'],
             embedFn     : fakeEmbedFn,
-            log         : () => {}
+            log         : line => lines.push(line)
         });
 
         expect(receipt.ok).toBe(false);
-        expect(receipt.collections[0].unrecoverable.map(u => u.id)).toEqual(['id-3']);
+        // Per-reason receipt row, not a per-row dump: fate stamped, samples capped.
+        expect(receipt.collections[0].failed).toEqual([
+            {reason: 'document-missing', count: 1, retryable: false, sampleIds: ['id-3']}
+        ]);
         expect(receipt.collections[0].targetAfter).toBe(5);
+        expect(lines.at(-1)).toContain('failed=1 (0 resumable, 1 terminal)');
+    });
+
+    test('a transient embed outage is absorbed by bounded retry — no failed receipts', async () => {
+        let   failuresLeft = 1;
+        const embedFn      = async docs => {
+            if (failuresLeft-- > 0) throw new Error('queue timeout');
+            return docs.map((_, i) => [i]);
+        };
+
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(4))}),
+            targetClient: makeClient({}),
+            collections : ['mem'],
+            embedFn,
+            embedRetry  : {attempts: 2, wait: async () => {}},
+            log         : () => {}
+        });
+
+        expect(receipt.ok).toBe(true);
+        expect(receipt.collections[0]).toMatchObject({targetAfter: 4, reEmbedded: 4, failed: []});
+    });
+
+    test('groupFailureReceipts groups by reason, caps samples, and sorts largest first', () => {
+        const entries = [
+            ...Array.from({length: 12}, (_, i) => ({id: `e-${i}`, reason: 'embedding-provider-error', retryable: true})),
+            {id: 'd-0', reason: 'document-empty', retryable: false},
+            {id: 'd-1', reason: 'document-empty', retryable: false}
+        ];
+
+        expect(groupFailureReceipts(entries, 3)).toEqual([
+            {reason: 'embedding-provider-error', count: 12, retryable: true,  sampleIds: ['e-0', 'e-1', 'e-2']},
+            {reason: 'document-empty',           count: 2,  retryable: false, sampleIds: ['d-0', 'd-1']}
+        ]);
+        expect(groupFailureReceipts([])).toEqual([]);
     });
 
     test('pilot --limit slices the planned set without touching the rest', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.spec.mjs
@@ -163,7 +163,25 @@ test.describe('Neo.ai.scripts.maintenance.rebuildMemoryCoreVectorStore', () => {
         const embedFn = createEmbedFn({url: 'http://x', model: 'm', batch: 2, fetchImpl});
         const vecs    = await embedFn(['a', 'b', 'c']);
 
-        expect(calls).toEqual([2, 1]);
+        // Chunks fire concurrently, so call order is not deterministic — the multiset is.
+        expect(calls.sort()).toEqual([1, 2]);
         expect(vecs).toEqual([[0], [1], [0]]);
+    });
+
+    test('createEmbedFn keeps chunk placement correct under concurrency with unequal latencies', async () => {
+        const fetchImpl = async (url, {body}) => {
+            const {input} = JSON.parse(body);
+            // First chunk (contains 'a0') resolves SLOWER than later chunks — placement must
+            // come from chunk offsets, never from completion order.
+            await new Promise(resolve => setTimeout(resolve, input[0] === 'a0' ? 30 : 1));
+            return {
+                ok  : true,
+                json: async () => ({data: input.map((doc, i) => ({index: i, embedding: [Number(doc.slice(1))]}))})
+            };
+        };
+        const embedFn = createEmbedFn({url: 'http://x', model: 'm', batch: 2, concurrency: 3, fetchImpl});
+        const vecs    = await embedFn(['a0', 'a1', 'a2', 'a3', 'a4']);
+
+        expect(vecs).toEqual([[0], [1], [2], [3], [4]]);
     });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.spec.mjs
@@ -1,0 +1,169 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'RebuildMcVectorStoreTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    createEmbedFn,
+    readAllIds,
+    rebuildCollections
+} from '../../../../../../ai/scripts/maintenance/rebuildMemoryCoreVectorStore.mjs';
+
+/**
+ * Mock Chroma collection over `rows` ({id: {document, metadata}}). Supports BOTH get shapes the
+ * runner exercises: ids-based (extraction) and limit/offset paging (readAllIds). `add` appends
+ * into `rows` so resume + targetAfter reconciliation run against real mutation.
+ */
+function makeCollection(rows = {}) {
+    const col = {
+        rows,
+        addCalls: [],
+        get     : async ({ids, limit, offset = 0, include = []}) => {
+            const pick = ids ?? Object.keys(rows).slice(offset, limit ? offset + limit : undefined);
+            const out  = {ids: []};
+            if (include.includes('documents'))  out.documents  = [];
+            if (include.includes('metadatas'))  out.metadatas  = [];
+            for (const id of pick) {
+                const row = rows[id];
+                if (!row) continue;
+                out.ids.push(id);
+                if (out.documents)  out.documents.push(row.document ?? null);
+                if (out.metadatas)  out.metadatas.push(row.metadata ?? {});
+            }
+            return out;
+        },
+        add: async ({ids, embeddings, documents, metadatas}) => {
+            col.addCalls.push({ids, embeddings});
+            ids.forEach((id, i) => { rows[id] = {document: documents[i], metadata: metadatas[i], embedding: embeddings[i]} });
+        }
+    };
+    return col;
+}
+
+const makeClient = cols => ({
+    getCollection        : async ({name}) => { if (!cols[name]) throw new Error(`no collection ${name}`); return cols[name] },
+    getOrCreateCollection: async ({name}) => (cols[name] ??= makeCollection())
+});
+
+const sourceRows = n => Object.fromEntries(
+    Array.from({length: n}, (_, i) => [`id-${i}`, {document: `doc ${i}`, metadata: {type: 'memory'}}])
+);
+
+// Deterministic fake embedder: one vector per document, first component encodes order.
+const fakeEmbedFn = async docs => docs.map((_, i) => [i, 0.5]);
+
+test.describe('Neo.ai.scripts.maintenance.rebuildMemoryCoreVectorStore', () => {
+
+    test('full rebuild re-embeds every source document into the fresh target', async () => {
+        const source  = {mem: makeCollection(sourceRows(12))};
+        const target  = {};
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient(source),
+            targetClient: makeClient(target),
+            collections : ['mem'],
+            embedFn     : fakeEmbedFn,
+            getBatch    : 5,
+            log         : () => {}
+        });
+
+        expect(receipt.ok).toBe(true);
+        expect(receipt.collections[0]).toMatchObject({name: 'mem', source: 12, planned: 12, targetBefore: 0, targetAfter: 12, reEmbedded: 12});
+        expect(receipt.collections[0].unrecoverable).toEqual([]);
+        // Embeddings actually landed on the target rows (not merely accepted).
+        expect(Object.values(target.mem.rows).every(row => Array.isArray(row.embedding))).toBe(true);
+    });
+
+    test('resume: ids already in the target are skipped, not re-embedded', async () => {
+        const source = {mem: makeCollection(sourceRows(10))};
+        const target = {mem: makeCollection(sourceRows(4))}; // id-0..id-3 already present
+
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient(source),
+            targetClient: makeClient(target),
+            collections : ['mem'],
+            embedFn     : fakeEmbedFn,
+            log         : () => {}
+        });
+
+        expect(receipt.ok).toBe(true);
+        expect(receipt.collections[0]).toMatchObject({targetBefore: 4, targetAfter: 10, reEmbedded: 6, resumedExisting: 4});
+    });
+
+    test('unrecoverable rows are listed fail-loud and flip ok to false', async () => {
+        const rows = sourceRows(6);
+        rows['id-3'].document = null; // no document, non-turn metadata -> unrecoverable
+
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(rows)}),
+            targetClient: makeClient({}),
+            collections : ['mem'],
+            embedFn     : fakeEmbedFn,
+            log         : () => {}
+        });
+
+        expect(receipt.ok).toBe(false);
+        expect(receipt.collections[0].unrecoverable.map(u => u.id)).toEqual(['id-3']);
+        expect(receipt.collections[0].targetAfter).toBe(5);
+    });
+
+    test('pilot --limit slices the planned set without touching the rest', async () => {
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(20))}),
+            targetClient: makeClient({}),
+            collections : ['mem'],
+            embedFn     : fakeEmbedFn,
+            limit       : 5,
+            log         : () => {}
+        });
+
+        expect(receipt.collections[0]).toMatchObject({source: 20, planned: 5, targetAfter: 5});
+        expect(receipt.ok).toBe(true);
+    });
+
+    test('dry-run counts and writes nothing', async () => {
+        const target  = {};
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(7))}),
+            targetClient: makeClient(target),
+            collections : ['mem'],
+            embedFn     : async () => { throw new Error('must not embed on dry-run') },
+            dryRun      : true,
+            log         : () => {}
+        });
+
+        expect(receipt.ok).toBe(true);
+        expect(receipt.collections[0]).toMatchObject({source: 7, dryRun: true});
+        expect(target.mem.addCalls).toEqual([]);
+    });
+
+    test('readAllIds paginates past one page', async () => {
+        const ids = await readAllIds(makeCollection(sourceRows(7)), 3);
+        expect(ids).toHaveLength(7);
+        expect(ids[6]).toBe('id-6');
+    });
+
+    test('createEmbedFn batches requests and restores index order', async () => {
+        const calls     = [];
+        const fetchImpl = async (url, {body}) => {
+            const {input} = JSON.parse(body);
+            calls.push(input.length);
+            return {
+                ok  : true,
+                json: async () => ({
+                    // Deliberately out of order: index must be authoritative.
+                    data: input.map((_, i) => ({index: i, embedding: [i]})).reverse()
+                })
+            };
+        };
+        const embedFn = createEmbedFn({url: 'http://x', model: 'm', batch: 2, fetchImpl});
+        const vecs    = await embedFn(['a', 'b', 'c']);
+
+        expect(calls).toEqual([2, 1]);
+        expect(vecs).toEqual([[0], [1], [0]]);
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
@@ -125,8 +125,8 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         });
 
         expect(result.unrecoverable).toEqual([
-            {id: 'empty', reason: 'document-empty', message: 'document field was empty'},
-            {id: 'missing', reason: 'document-missing', message: 'document field was missing from the Chroma metadata read'}
+            {id: 'empty', reason: 'document-empty', retryable: false, message: 'document field was empty'},
+            {id: 'missing', reason: 'document-missing', retryable: false, message: 'document field was missing from the Chroma metadata read'}
         ]);
         expect(result.unrecoverableIds).toEqual(['empty', 'missing']);
         expect(result.counts).toEqual({total: 3, intact: 0, reEmbedded: 1, unrecoverable: 2});
@@ -172,9 +172,10 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         });
 
         expect(result.unrecoverable).toEqual([{
-            id     : 'gone',
-            reason : 'metadata-row-missing',
-            message: 'id was absent from the Chroma documents/metadatas read'
+            id       : 'gone',
+            reason   : 'metadata-row-missing',
+            retryable: false,
+            message  : 'id was absent from the Chroma documents/metadatas read'
         }]);
         expect(result.unrecoverableIds).toEqual(['gone']);
         expect(result.counts.reEmbedded).toBe(1);
@@ -213,10 +214,12 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
             ['too-large'],
             ['small-2']
         ]);
+        // A provider failure is fate-stamped retryable — a later pass can fix it (unlike document-*).
         expect(result.unrecoverable).toEqual([{
-            id     : 'overcap',
-            reason : 'embedding-provider-error',
-            message: 'context overflow'
+            id       : 'overcap',
+            reason   : 'embedding-provider-error',
+            retryable: true,
+            message  : 'context overflow'
         }]);
         expect(result.unrecoverableIds).toEqual(['overcap']);
         expect(result.data.ids).toEqual(['ok', 'ok2']);
@@ -268,9 +271,10 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         });
 
         expect(result.unrecoverable).toEqual([{
-            id     : 'm',
-            reason : 'embedding-result-malformed',
-            message: 'embedFn returned 0 embeddings for 1 documents'
+            id       : 'm',
+            reason   : 'embedding-result-malformed',
+            retryable: true,
+            message  : 'embedFn returned 0 embeddings for 1 documents'
         }]);
         expect(result.unrecoverableIds).toEqual(['m']);
         expect(result.counts).toEqual({total: 1, intact: 0, reEmbedded: 0, unrecoverable: 1});
@@ -325,6 +329,67 @@ test.describe('embedRecoverableDocuments — binary-split isolate-then-rebatch (
         expect([...failedIndexes]).toEqual([]);
         expect(embeddings).toEqual([[3], [3], [3]]);
         expect(calls).toBe(1);
+    });
+
+    test('a transient whole-batch failure is retried at FULL width — recovered without any split', async () => {
+        const widths   = [];
+        const backoffs = [];
+        let   fails    = 1;
+        const embedFn  = async batch => {
+            widths.push(batch.length);
+            if (fails-- > 0) throw new Error('queue timeout');
+            return batch.map(() => [9]);
+        };
+
+        const {failedIndexes} = await embedRecoverableDocuments({
+            embedFn,
+            ids      : ['a', 'b', 'c', 'd'],
+            documents: ['a', 'b', 'c', 'd'],
+            attempts : 3,
+            wait     : async ms => { backoffs.push(ms) }
+        });
+
+        // The saturation regression this exists for: the intact range retried at width 4 —
+        // splitting the transient failure would have multiplied calls against a struggling provider.
+        expect(widths).toEqual([4, 4]);
+        expect([...failedIndexes]).toEqual([]);
+        expect(backoffs).toEqual([1000]);
+    });
+
+    test('attempts exhaust with doubling backoff before a single doc records its failure', async () => {
+        const backoffs = [];
+        let   calls    = 0;
+        const embedFn  = async () => { calls++; throw new Error('still saturated'); };
+
+        const {failures} = await embedRecoverableDocuments({
+            embedFn,
+            ids      : ['only'],
+            documents: ['only'],
+            attempts : 3,
+            backoffMs: 500,
+            wait     : async ms => { backoffs.push(ms) }
+        });
+
+        expect(calls).toBe(3);
+        expect(backoffs).toEqual([500, 1000]);
+        expect(failures).toEqual([{index: 0, reason: 'embedding-provider-error', message: 'still saturated'}]);
+    });
+
+    test('default attempts=1 preserves the historical no-retry contract (split immediately)', async () => {
+        const widths  = [];
+        const embedFn = async batch => {
+            widths.push(batch.length);
+            if (batch.length > 1) throw new Error('fails at full width');
+            return batch.map(() => [1]);
+        };
+
+        const {failedIndexes} = await embedRecoverableDocuments({
+            embedFn, ids: ['a', 'b'], documents: ['a', 'b']
+        });
+
+        // One full-width attempt, then straight to the split — no retry, no wait.
+        expect(widths).toEqual([2, 1, 1]);
+        expect([...failedIndexes]).toEqual([]);
     });
 });
 


### PR DESCRIPTION
Resolves #16208
Resolves #16227

## What

The cross-store Memory Core vector rebuild: reads ids + documents + metadatas from the OLD Chroma store, re-embeds every document against the canonical embedding endpoint (stored vectors are deliberately ignored — a version-incompatible index cannot be trusted), and streams batches into a FRESH target store. Resume-safe by construction: ids already in the target are skipped, so a crashed or partial run continues where it stopped and a re-run retries exactly the missing rows.

The `#16227` layer hardens the failure story the first live run exposed (memory leg: 7,562 of 31,202 rows reported "unrecoverable" — verified in-session to be per-pass transient embed failures, not content loss):

- **Fate-stamped entries**: every failure entry carries classifier-stamped `retryable` (`embedding-*` → true, `document-*`/`metadata-row-missing` → false, unknown → false, fail-closed). The reason→fate map lives beside reason assignment; consumers never pattern-match reason strings.
- **Bounded embed retry**: `embedRecoverableDocuments` retries the intact range with doubling backoff before binary-split descent — splitting a transient whole-batch failure multiplies calls against an already-saturated provider. Default `attempts = 1` preserves the historical contract (the production heal path `reEmbedMissingHeal` and `defragChromaDB` see zero behavior change); the rebuild CLI opts in via `--embed-attempts 3` / `--embed-backoff 1000`.
- **Per-reason receipts**: the runner receipt replaces the flat per-row dump (~750KB at 7.5k rows) with `failed: [{reason, count, retryable, sampleIds}]` (samples capped at 10), reconciliation as a single sum, and a done-line rollup `failed=N (X resumable, Y terminal)` — the line that makes a number like 7,562 self-explaining.

Deliberately NOT integrated: AiConfig (both stores are named explicitly via argv — a rebuild must never inherit an ambient URL and hit the wrong store) and the heavy-maintenance lease (source access is read-only; the target is a fresh store with no competing scheduler).

## Test Evidence

Evidence: 51/51 affected unit specs green locally (`--workers=1`), covering all four importers of the changed modules:

- `rebuildMemoryCoreVectorStore.spec.mjs` — full rebuild, resume-skip, pilot `--limit`, dry-run, paginated id reads, embed batching/order under concurrency, per-reason receipts + fate rollup line, transient-outage-absorbed-by-retry, `groupFailureReceipts` grouping/cap/sort.
- `repairMemoryCoreStoredEmbeddings.spec.mjs` — retryable stamping on all reason codes, full-width retry with no split (widths `[4,4]`), attempt exhaustion with doubling backoffs (`[500,1000]`), default-1 historical contract (widths `[2,1,1]`), plus the pre-existing extraction/split/truncation suite.
- `reEmbedMissingHeal.spec.mjs` + `CorruptionRecoveryGate.spec.mjs` — external consumers unchanged and green (additive-safety witness).

Live-run evidence (pre-`#16227` code, this branch's runner): memory leg source=31,202 → reEmbedded=23,040, targetAfter=23,689, with the 7,562 residue diff-verified as 400/400-sampled rows carrying full documents — the transient class this PR's retry + receipts address.

## Post-Merge Validation

- The active run (sessions/temporal/graph legs) completes → a resume sweep from this head retries the 7,562 memory-leg rows at gentler concurrency and exercises the new receipts + retry on real data; the reconciliation receipt (per-reason rollup, before/after counts) lands on #16208.
- Cutover blessing for the fresh store stays gated on that reconciliation receipt.

## Deltas

- Ticket `#16227` sketched "default 3" for retry attempts; the helper defaults to `attempts = 1` (historical contract — zero silent change for the production heal consumer) and the runner CLI carries the 3. The ticket's contract ledger anticipated exactly this fallback (`attempts: 1` reproduces current behavior).
- PR opened ahead of the run boundary per operator direction (CI runs while the embed legs grind); the live resume-sweep receipt follows as a PR/ticket comment instead of pre-open evidence.

Authored by @neo-opus-vega
Origin Session ID: 5814af6b-fe4e-41ba-819f-e1aeb5558643
