### PR TITLE
fix(orchestrator): declare the authority role, never inherit it (#16229)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -840,12 +840,31 @@ class ConfigBase extends ConfigProvider {
                  * `deploymentMode`: storage/deployment defaults cannot express which process owns
                  * host/session effects versus plane maintenance on the same machine.
                  *
-                 * `container-plane` is the canonical default. A machine-local Orchestrator
-                 * explicitly declares `host-edge`; `legacy-mixed` exists only for rollback to a
-                 * pre-cutover revision. Unknown values fail the preflight ownership audit.
-                 * @type {'legacy-mixed'|'host-edge'|'container-plane'}
+                 * **A role is declared, never inherited — there is deliberately no default.** Both
+                 * owners state their own role: the container profile declares `container-plane`,
+                 * a machine-local Orchestrator declares `host-edge`, and `legacy-mixed` exists only
+                 * for rollback to a pre-cutover revision. Unknown values fail the preflight
+                 * ownership audit.
+                 *
+                 * The empty default is the mechanism, not an oversight. A default cannot be correct
+                 * for both owners, and the previous `container-plane` default silently inverted at
+                 * the cutover: it described the container's reality, so a host process starting with
+                 * it claimed the role the container already owned — writing authority state and
+                 * running maintenance lanes against the wrong plane, with no error. Requiredness is
+                 * evaluated on the RESOLVED value (`ConfigProvider#validateRequiredEnv`), so any
+                 * non-empty default would make the `requiredFor` clause below unfireable.
+                 *
+                 * Environment detection was rejected as the alternative: `/.dockerenv` and cgroup
+                 * inspection infer an *environment*, while a declaration states an *intent* — two
+                 * orchestrators can share an environment, but they cannot share a declaration.
+                 * @type {''|'legacy-mixed'|'host-edge'|'container-plane'}
                  */
-                authorityProfile: leaf('container-plane', 'NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE', 'string'),
+                authorityProfile: leaf('', 'NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE', 'string', {
+                    requiredFor: [{
+                        entrypoints: ['orchestrator-daemon'],
+                        reason     : 'A role is declared, never inherited. Declare container-plane on the containerized Orchestrator (its Compose service sets it) or host-edge on a machine-local one (npm run ai:host-edge).'
+                    }]
+                }),
                 /**
                  * Filesystem root under which tenant-repo mirrors are stored. The
                  * `deriveTenantRepoMirrorPath` helper appends `tenant-repos/<tenant>/<repo>`,

--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -302,8 +302,13 @@ services:
         SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
     environment:
       <<: *plane-env
-      # AiConfig owns the cloud/container-plane posture and disabled local/model lanes.
-      # This profile declares only its relocated Chroma placement and Docker capability.
+      # AiConfig owns the cloud posture and the disabled local/model lanes; the ROLE is not
+      # inherited. The `authorityProfile` leaf carries no default, so every orchestrator declares
+      # its own — a default cannot be correct for both a container owner and a host-edge one, and
+      # the previous shared default let a host process silently claim this role. Without this line
+      # the daemon refuses at boot rather than starting with an unowned role.
+      NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE: container-plane
+      # This profile otherwise declares only its relocated Chroma placement and Docker capability.
       NEO_CHROMA_HOST: chroma
       # Runtime access is scoped to THIS plane's compose project — the same scalar the project
       # `name` and `NEO_PLANE_ID` resolve from, so a parity orchestrator can never address the

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -230,6 +230,13 @@ services:
       # in the writable layer. Without this line bundles would be written and then destroyed on
       # the next recreate. Paired with the host-source bind below; the two are separate contracts.
       - NEO_BACKUP_PATH=/app/.neo-ai-data/backups
+      # A role is declared, never inherited. The leaf carries no default (see `authorityProfile`
+      # in ai/configBase.mjs), so this line is REQUIRED — without it the daemon refuses at boot
+      # rather than inheriting a role. That refusal is the point: the previous default described
+      # this container's reality, so a host process starting bare claimed the role this service
+      # owns. Both owners now state their own: this one here, a machine-local one via
+      # `npm run ai:host-edge`.
+      - NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE=container-plane
       - NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED=true
       - NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT=${NEO_DEPLOY_PROJECT_NAME:-neo-agent-os}
       # `orchestrator` is in this list deliberately, and it is the reason the list needed changing.

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -20,6 +20,38 @@ Both host processes keep state under
 `~/Library/Application Support/Neo/AgentOS`, outside every checkout plane.
 `legacy-mixed` and Shape C are not part of this topology.
 
+## Start the host edge — terminal, any platform
+
+**The containerized stack alone has no wake delivery and no host-bound effects.** It comes up
+healthy and looks complete; the host edge is a second, separate process you start yourself. If you
+are trying the Agent OS in a fork and wondering why nudges never arrive, this section is why.
+
+Two commands, no installer, from the repository root:
+
+```sh
+npm run ai:host-edge        # graphless host-edge Orchestrator (host-bound effects)
+npm run ai:wake-receiver    # signed Shape-B wake receiver, host port 3199
+```
+
+Run them in their own terminals. Nothing here is macOS-specific — the launchd section below is
+**supervision only** (start-at-login, restart-on-crash), and everything in this file above it works
+on any platform Node runs on. On Linux or Windows, supervise these two commands with whatever your
+system already uses; there is no Neo-specific requirement.
+
+**Do not use `npm run ai:orchestrator` for this.** That entrypoint takes no role of its own, and the
+daemon now refuses to start without one:
+
+```
+[Orchestrator] Failed to start: Required deployment configuration is missing or invalid:
+  - NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE (orchestrator.authorityProfile): absent
+```
+
+A role is **declared, never inherited**. The container declares `container-plane` in its Compose
+service; `ai:host-edge` declares `host-edge`. The refusal exists because there is no default that
+could be correct for both: a shared default describes one owner's reality, so the other silently
+claims a role it does not own — writing authority state and running maintenance lanes against the
+wrong plane, with no error. Declaring is cheap; diagnosing a silent duplicate owner is not.
+
 ## Start the container plane
 
 Run from the repository root after provisioning `.env` and the mode-0600

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -33,10 +33,23 @@ npm run ai:host-edge        # graphless host-edge Orchestrator (host-bound effec
 npm run ai:wake-receiver    # signed Shape-B wake receiver, host port 3199
 ```
 
-Run them in their own terminals. Nothing here is macOS-specific — the launchd section below is
-**supervision only** (start-at-login, restart-on-crash), and everything in this file above it works
-on any platform Node runs on. On Linux or Windows, supervise these two commands with whatever your
-system already uses; there is no Neo-specific requirement.
+Run them in their own terminals. Neither command is macOS-specific; both work on any platform Node
+runs on. On Linux or Windows, supervise them with whatever your system already uses.
+
+> **What the terminal path gives you today, stated precisely.** It resolves the correct *role*, so
+> the process owns host-edge work and cannot claim the container's. It does **not** yet reproduce
+> the full lane posture: the launchd plist additionally pins the host-edge state directory and ~20
+> lane-enablement and provider values (`NEO_ORCHESTRATOR_KB_SYNC_ENABLED`, `…DEV_SERVER_ENABLED`,
+> the daemon toggles, the local provider host). Started bare, the orchestrator therefore takes
+> AiConfig defaults for those lanes and will run some the supervised install disables — and its
+> authority receipt lands in the checkout rather than under
+> `~/Library/Application Support/Neo/AgentOS`.
+>
+> So on macOS the supervised install below remains the complete path. The terminal path is correct
+> for the role and incomplete for the lane set, which is a known gap rather than a preference:
+> that configuration belongs in an AiConfig host-edge profile, not duplicated into a plist and an
+> npm script. Until it moves, prefer the install for a long-running host edge and the terminal for
+> a bounded run.
 
 **Do not use `npm run ai:orchestrator` for this.** That entrypoint takes no role of its own, and the
 daemon now refuses to start without one:

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -18,7 +18,6 @@
         },
         "forbiddenEnv": {
             "NEO_AI_DEPLOYMENT_MODE": "cloud is the canonical config posture",
-            "NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE": "container-plane is the canonical config authority",
             "NEO_AUTH_AUTO_PROVISION_IDENTITY_SOURCES": "derived from auth.mode unless a narrower deployment overlay opts out",
             "NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT": "derived from auth.mode unless a plural-resident deployment overlay opts out",
             "NEO_AUTO_DREAM": "retired MCP-server startup control; the orchestrator owns Dream",
@@ -44,8 +43,9 @@
         "census": {
             "profile": "ai/deploy/docker-compose.yml",
             "baselineUniqueKeys": 45,
-            "remainingUniqueKeys": 29,
+            "remainingUniqueKeys": 30,
             "requiredDeploymentInputs": [
+                "NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE",
                 "NEO_BACKUP_PATH",
                 "NEO_CHROMA_HOST",
                 "NEO_DEPLOY_HOSTNAME",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "ai:kb-alerting"                       : "node ./ai/daemons/kb-alerting/daemon.mjs",
         "ai:kb-reconciliation"                 : "node ./ai/daemons/kb-reconciliation/daemon.mjs",
         "ai:kb-gc"                             : "node ./ai/daemons/kb-gc/daemon.mjs",
+        "ai:host-edge"                         : "NEO_AI_DEPLOYMENT_MODE=local NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE=host-edge node ./ai/daemons/orchestrator/daemon.mjs",
         "ai:orchestrator"                      : "node ./ai/daemons/orchestrator/daemon.mjs",
         "ai:wake-receiver"                     : "node ./ai/daemons/wake/receiver.mjs",
         "ai:revalidation-sweep"                : "node ./ai/scripts/lifecycle/revalidationSweep.mjs",

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -184,6 +184,58 @@ test.describe('Tier 1 Config Immutability', () => {
         }
     });
 
+    // The orchestrator's role must be DECLARED by whoever starts it. These two tests are a pair,
+    // and the pairing is the point: requiredness is evaluated on the RESOLVED value, so a leaf
+    // carrying any non-empty default would make the requirement permanently unfireable — a guard
+    // that boots, runs, and certifies rather than protects. Asserting the refusal without also
+    // asserting the empty default would leave that hole open.
+    test('authorityProfile carries NO default, so the requirement can fire at all', () => {
+        expect(RootConfigBase.config.data.orchestrator.authorityProfile.default).toBe('');
+    });
+
+    test('an undeclared authorityProfile fails the orchestrator-daemon entrypoint closed', () => {
+        const
+            envName  = 'NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE',
+            original = process.env[envName];
+
+        delete process.env[envName];
+
+        const fresh = createIsolatedConfig();
+
+        try {
+            const
+                undeclared = fresh.validateRequiredEnv({entrypoint: 'orchestrator-daemon'}),
+                finding    = undeclared.findings.find(item => item.leafPath === 'orchestrator.authorityProfile');
+
+            expect(undeclared.ok).toBe(false);
+            expect(finding).toBeTruthy();
+            expect(finding.env).toBe(envName);
+            expect(finding.valueState).toBe('absent');
+            expect(finding.disposition).toBe('fail-closed');
+
+            // The message is the deliverable for whoever hits this, so assert it names the way out
+            // rather than only that something was rejected.
+            expect(finding.reason).toMatch(/declared, never inherited/);
+            expect(finding.reason).toContain('ai:host-edge');
+
+            // …and a declared role passes, so the guard discriminates instead of always refusing.
+            fresh.setEnvOverride(envName, 'container-plane');
+            expect(fresh.validateRequiredEnv({entrypoint: 'orchestrator-daemon'}).findings
+                .some(item => item.leafPath === 'orchestrator.authorityProfile')).toBe(false);
+
+            fresh.setEnvOverride(envName, 'host-edge');
+            expect(fresh.validateRequiredEnv({entrypoint: 'orchestrator-daemon'}).findings
+                .some(item => item.leafPath === 'orchestrator.authorityProfile')).toBe(false);
+        } finally {
+            if (original === undefined) {
+                delete process.env[envName];
+            } else {
+                process.env[envName] = original;
+            }
+            fresh.destroy();
+        }
+    });
+
     test('child configs validate inherited Tier-1 requiredness metadata (#13432)', () => {
         const
             envName          = 'NEO_UNIT_REQUIRED_ENV_VALIDATION_PARENT_URL',
@@ -375,7 +427,9 @@ test.describe('Tier 1 Config Immutability', () => {
 
     test('ships top-level deployment and maintenance policy defaults', async () => {
         expect(Config.orchestrator.deploymentMode).toBe(process.env.NEO_AI_DEPLOYMENT_MODE || 'cloud');
-        expect(Config.orchestrator.authorityProfile).toBe(process.env.NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE || 'container-plane');
+        // A role is declared, never inherited: no default, so an undeclared orchestrator refuses
+        // at boot instead of silently claiming the role another owner already holds.
+        expect(Config.orchestrator.authorityProfile).toBe(process.env.NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE || '');
         expect(Config.orchestrator.intervals).toMatchObject({
             pollMs                           : 3000,
             summarySweepMs                   : 10 * 60 * 1000,

--- a/test/playwright/unit/ai/configBase.spec.mjs
+++ b/test/playwright/unit/ai/configBase.spec.mjs
@@ -47,10 +47,10 @@ test.describe('ai/configBase — delta-only subclass overlays (overlay-drift roo
             expect(proxy.transport).toBe(process.env.NEO_TRANSPORT || 'stdio');
             expect(proxy.mcpHttpPort).toBe(Number(process.env.MCP_HTTP_PORT) || 3000);
             expect(ConfigBase.config.data.orchestrator.deploymentMode.default).toBe('cloud');
-            expect(ConfigBase.config.data.orchestrator.authorityProfile.default).toBe('container-plane');
+            expect(ConfigBase.config.data.orchestrator.authorityProfile.default).toBe('');
             expect(proxy.orchestrator.deploymentMode).toBe(process.env.NEO_AI_DEPLOYMENT_MODE || 'cloud');
             expect(proxy.orchestrator.authorityProfile)
-                .toBe(process.env.NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE || 'container-plane');
+                .toBe(process.env.NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE || '');
         } finally {
             instance.destroy();
         }

--- a/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
@@ -354,7 +354,7 @@ test.describe('parity profile — volume scoping is the isolation mechanism', ()
             .toBe(compose['x-plane-env'].NEO_PLANE_ID);
     });
 
-    test('the relocated dev profile places tenant mirrors and inherits container authority', () => {
+    test('the relocated dev profile places tenant mirrors and DECLARES container authority', () => {
         const
             planeEnvironment = compose['x-plane-env'],
             planeRoot        = planeEnvironment.NEO_PLANE_DATA_ROOT,
@@ -363,9 +363,12 @@ test.describe('parity profile — volume scoping is the isolation mechanism', ()
 
         expect(planeEnvironment.NEO_TENANT_REPO_MIRROR_ROOT).toBe(planeRoot);
         expect(orchestrator.environment['<<']).toBe(planeEnvironment);
-        expect(orchestrator.environment).not.toHaveProperty('NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE');
+
+        // The role is declared, never inherited. The leaf carries NO default, so this profile must
+        // name its own — without it the daemon refuses at boot rather than starting unowned.
+        expect(orchestrator.environment.NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE).toBe('container-plane');
         expect(configSource)
-            .toContain("authorityProfile: leaf('container-plane', 'NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE'")
+            .toContain("authorityProfile: leaf('', 'NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE'")
     });
 
     test('project identity and plane identity are ONE yaml scalar, not two expressions', () => {

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -361,7 +361,6 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
 
         for (const key of [
             'NEO_AI_DEPLOYMENT_MODE',
-            'NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE',
             'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED',
             'NEO_ORCHESTRATOR_KB_SYNC_ENABLED',
             'NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED',
@@ -373,6 +372,12 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
         ]) {
             expect(orchestratorEnv[key], `${key} duplicates an AiConfig default`).toBeUndefined();
         }
+
+        // The authority ROLE is the deliberate exception to "do not restate defaults": its leaf
+        // carries none, precisely because no single default is correct for both a container owner
+        // and a host-edge one. So this key must be PRESENT — its absence would make the daemon
+        // refuse at boot, and its presence is the declaration itself, not a duplicated default.
+        expect(orchestratorEnv.NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE).toBe('container-plane');
 
         // The cloud/container and local-model boundaries now belong to AiConfig. Compose must
         // also NOT pin the mailbox policy: doing so


### PR DESCRIPTION
Resolves #16229

The role that makes an Orchestrator a **host edge** lived only inside a macOS launchd plist. So `npm run ai:orchestrator` — still in `package.json`, still the first command a contributor finds — inherited the canonical `container-plane` default and claimed the role the container already owned.

Observed on the maintainer machine at 16:04Z, not theorised: it started cleanly, wrote an authority receipt and a first-write deployment snapshot into the **pre-cutover host plane**, began miniSummary backfill against the legacy graph, and contended for the shared inference provider. No error, no warning, durable state in a plane nobody watches.

**A role is now declared, never inherited.** The leaf carries no default and declares itself required at the `orchestrator-daemon` entrypoint. Both owners state their own: the canonical Compose service declares `container-plane`, `npm run ai:host-edge` declares `host-edge`.

### The empty default is the mechanism, not tidiness

Requiredness is evaluated on the **resolved value** (`ConfigProvider#validateRequiredEnv`), so any non-empty default leaves the requirement permanently unfireable — a guard that boots, runs, and certifies rather than protects. An earlier revision of this design kept the default and was wrong for exactly that reason; the two specs assert the pairing together so the hole cannot reopen.

**No new guard code.** `daemon.mjs:335` already called `validateRequiredEnv({entrypoint: 'orchestrator-daemon'})` before start, so this is a leaf declaration consumed by existing, tested machinery rather than a second requiredness mechanism beside the sanctioned one. The requirement names only `entrypoints`: the daemon passes neither mode nor consumerClaim, so naming a mode would have silently never matched.

**Environment detection was rejected.** `/.dockerenv` and cgroup inspection infer an *environment*; a declaration states an *intent*. Two orchestrators can share an environment — they cannot share a declaration.

Evidence: L2 (live refusal transcript from the real entrypoint, executable requiredness matrix, rendered-Compose declarations in both profiles, census lint) → L2 required (the entrypoint, both profiles, and the config contract are fully exercised without starting a second orchestrator against the live plane).

Related: #16167 (AC-7 host edge), #16230 (cross-process lease, deliberately out of scope), #16210

## Deltas from ticket

1. **Fix 3 became "refuse", not "guard or document".** The ticket left it open pending OQ1. @tobiu answered OQ1 empirically by running the command: it does **not** fail closed. Documentation was therefore off the table.
2. **The census carried a stale forbidden-env entry.** `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE` was denylisted as *"container-plane is the canonical config authority"* — true only while the default existed. Removed, and the key reclassified as a required deployment input, so the rule is lint-enforced rather than conventional.
3. **The dev profile needed the declaration too.** Not in the ticket. It never declared a role, so removing the default would have made its orchestrator refuse — and CI exercises it.

## Test Evidence

- **Live refusal at the real entrypoint** — `node ai/daemons/orchestrator/daemon.mjs` with the env unset:
  ```
  [Orchestrator] Failed to start: Required deployment configuration is missing or invalid:
    - NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE (orchestrator.authorityProfile): absent;
      needed for orchestrator-daemon/… — A role is declared, never inherited. Declare
      container-plane on the containerized Orchestrator (its Compose service sets it)
      or host-edge on a machine-local one (npm run ai:host-edge).
  ```
  It refuses **before** `Started.` — no authority receipt, no deployment snapshot, no maintenance lanes. That is the 16:04 incident structurally prevented.
- Config + deploy + healthcheck surfaces: `npm run test-unit -- test/playwright/unit/ai/deploy/ test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/configBase.spec.mjs` — **73 passed**.
- Full Brain suite before the spec updates: 8113 passed / 6 failed — 2 were the contract specs updated here; the remaining 4 are the provider-dependent set that reproduces on clean `dev` while the #16208 re-embed saturates the local endpoint. None touch config.
- Census lint: `node ai/scripts/lint/lint-config-template-ssot.mjs` — OK.

## Post-Merge Validation

- [ ] Rebuild the canonical stack and confirm the orchestrator starts with `authorityProfile=container-plane` from its Compose declaration.
- [ ] `npm run ai:host-edge` starts a host-edge Orchestrator in a terminal on this machine.
- [ ] **Falsifier:** with `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE` unset, `npm run ai:orchestrator` exits non-zero and writes no state to any plane.
- [ ] Ordering note for the operator: after merge, the container refuses to boot until its Compose carries the declaration. The canonical file is updated in this PR, so the exposure is the next `compose up`, not a lingering state.

## Evolution

The ticket's OQ1 asked whether a bare host start fails closed; I declined to run that probe against the live plane and @tobiu ran it, which turned Fix 3 from a documentation choice into a refusal. @neo-opus-vega's explicit-only-role shape came first and was correct; my "keep the default, `requiredFor` fires on the env" refinement was falsified against `ConfigProvider.mjs:246-249` and retracted before implementation — the mechanism checks the resolved value, so the default had to go. The one-pager leads with the terminal path because it works on every platform Node runs on; launchd is supervision only.

Authored by Grace (@neo-opus-grace, Anthropic Claude Opus 5). Session `59fd6dbb-fc01-482b-a778-bed01f16e699`. 🖖
