### PR TITLE
feat(wake): generate a receiver route manifest from live subscriptions (#16233)

### DIFF
--- a/ai/daemons/wake/buildReceiverManifest.mjs
+++ b/ai/daemons/wake/buildReceiverManifest.mjs
@@ -4,20 +4,34 @@
  *
  * The receiver refuses to start without a 0600 manifest whose routes carry a signing key, an agent
  * identity, harness metadata and an explicit attempt policy. Producing that by hand means copying
- * subscription records out of `manage_wake_subscription list`, inventing a key, and discovering the
- * shape rules one `throw` at a time — which is exactly how this module came to exist.
+ * subscription records out of `manage_wake_subscription list`, remembering the mode, and discovering
+ * the shape rules one `throw` at a time.
+ *
+ * **The server owns the signing key; this module never mints one.** Per ADR 0002 §6.2.3 — ticket-ref-ok:
+ * decision-record authority for key ownership, not issue archaeology — `WakeSubscriptionService.subscribe()`
+ * generates the HMAC key once, at subscribe-time, and only for
+ * `a2a-webhook` targets, storing it in `harnessTargetMetadata`. `WebhookDeliveryService` signs with
+ * that key. A generator that minted its own would produce routes that boot cleanly and then reject
+ * every real container wake with `401` — the worst available failure, because the manifest looks
+ * healthy. Key material is read, never created.
+ *
+ * **Only `a2a-webhook` records become routes.** `CoalescingEngineService` treats `bridge-daemon`,
+ * `disabled` and `none` as no-ops on the Shape-B path, so a route built from one can never receive a
+ * container wake. Those records are SKIPPED WITH A NAMED REASON rather than mapped silently or
+ * rejected wholesale: mid-migration sets are mixed by definition, and refusing the whole build would
+ * make the tool unusable exactly when it is needed.
+ *
+ * **Composition is additive.** Building for one identity's subscriptions merges into the existing
+ * route set rather than replacing it, so generating a manifest for one seat cannot delete another
+ * peer's routes on a shared host.
  *
  * **It imports nothing from the graph, Memory Core, or a database path**, mirroring the receiver's
  * own boundary: subscription records arrive as plain data from whoever queried them, so host-edge
  * tooling stays runnable without the container plane it is being wired to.
  *
- * **The generator validates its own output through the receiver's loader before publishing it.**
- * A manifest that the receiver would reject is never written to the target path — the temp file is
- * discarded instead. That closes the loop that otherwise only closes when the daemon fails to boot.
- *
- * **Signing keys never reach stdout or a log.** The manifest is the key material and is written
- * 0600; the summary reports a short fingerprint per route so two sides can be compared without
- * either printing the secret.
+ * **The generator validates its output through the receiver's loader before publishing**, and the
+ * publish itself is exclusive and symlink-safe. A manifest the receiver would reject never reaches
+ * the target path.
  */
 import crypto from 'node:crypto';
 import fs     from 'node:fs/promises';
@@ -27,7 +41,7 @@ import {loadWakeReceiverManifest} from './receiver.mjs';
 
 /**
  * Default per-attempt dispatch budget, in milliseconds.
- * The receiver requires a positive value at or below 300000; it declares no default of its own,
+ * The receiver requires a positive value at or below 300000 and declares no default of its own,
  * deliberately, so every route states its policy. This is the generator's stated choice, not a
  * hidden fallback inherited from the daemon.
  * @type {Number}
@@ -35,35 +49,68 @@ import {loadWakeReceiverManifest} from './receiver.mjs';
 export const DEFAULT_ATTEMPT_TIMEOUT_MS = 10000;
 
 /**
+ * The only `harnessTarget` the Shape-B container path can deliver to.
+ * @type {String}
+ */
+export const DELIVERABLE_HARNESS_TARGET = 'a2a-webhook';
+
+/**
+ * Metadata keys that belong to the SENDER and must not be copied into receiver-visible route state.
+ *
+ * `signingKey` is promoted to the route's own top-level field, where the receiver expects it; leaving
+ * the duplicate inside `harnessTargetMetadata` would echo secret material into receiver state records
+ * and logs for no benefit. `url` is the container's address for reaching the host, which the host
+ * itself has no use for.
+ * @type {String[]}
+ */
+const SENDER_ONLY_METADATA_KEYS = ['signingKey', 'url'];
+
+/**
  * Builds the manifest object for a set of subscription records.
  *
- * @summary Maps active WAKE_SUB records onto receiver routes, minting a signing key per route.
+ * @summary Maps deliverable WAKE_SUB records onto receiver routes using the server-issued key.
  * @param {Object}   config
  * @param {Object[]} config.subscriptions Records as returned by `manage_wake_subscription list`.
- * @param {Object}   [config.signingKeys={}] Existing `subscriptionId → key`, preserved rather than rotated.
+ * @param {Object}   [config.existingRoutes={}] Routes already published, merged rather than replaced.
  * @param {Number}   [config.attemptTimeoutMs=DEFAULT_ATTEMPT_TIMEOUT_MS]
- * @returns {{manifest: Object, routeSummaries: Object[]}}
+ * @returns {{manifest: Object, routeSummaries: Object[], skipped: Object[]}}
  */
 export function buildWakeReceiverManifest({
     subscriptions,
-    signingKeys = {},
+    existingRoutes   = {},
     attemptTimeoutMs = DEFAULT_ATTEMPT_TIMEOUT_MS
 }) {
     if (!Array.isArray(subscriptions)) {
         throw new Error('buildWakeReceiverManifest requires a subscriptions array');
     }
 
-    const routes         = {},
-          routeSummaries = [];
+    // Additive: start from what is already published so a single-identity build cannot delete a peer.
+    const routes         = {...existingRoutes},
+          routeSummaries = [],
+          skipped        = [];
 
-    // Retired subscriptions are excluded rather than refused: a retired route is a normal historical
-    // record, not a malformed one, and refusing the whole build over it would make the generator
-    // unusable on any account with history.
-    for (const subscription of subscriptions.filter(entry => entry?.status === 'active')) {
-        const {id, agentIdentity, harnessTargetMetadata} = subscription;
+    for (const subscription of subscriptions) {
+        const {id, status, agentIdentity, harnessTarget, harnessTargetMetadata} = subscription || {};
 
         if (typeof id !== 'string' || !id.startsWith('WAKE_SUB:')) {
             throw new Error(`Subscription id '${id}' is not a WAKE_SUB identifier`);
+        }
+
+        // Every skip is NAMED. A silent omission and a silent bad route are the same failure from the
+        // operator's side: something they expected to be wired is not, and nothing said so.
+        if (status !== 'active') {
+            skipped.push({subscriptionId: id, reason: `status is '${status}', not 'active'`});
+            continue
+        }
+
+        if (harnessTarget !== DELIVERABLE_HARNESS_TARGET) {
+            skipped.push({
+                subscriptionId: id,
+                reason        : `harnessTarget '${harnessTarget}' is not deliverable on the Shape-B path ` +
+                                `(only '${DELIVERABLE_HARNESS_TARGET}' is); this seat cannot receive a container wake ` +
+                                `until it is migrated`
+            });
+            continue
         }
 
         if (typeof agentIdentity !== 'string' || !agentIdentity) {
@@ -74,32 +121,59 @@ export function buildWakeReceiverManifest({
             throw new Error(`Subscription '${id}' has no harnessTargetMetadata`);
         }
 
-        // Reuse an existing key when one is supplied. Rotating on every build would silently break
-        // the container side, which signs with the key it was provisioned with.
-        const signingKey = signingKeys[id] || crypto.randomBytes(32).toString('hex');
+        // The server minted this at subscribe-time. Its absence on an a2a-webhook record means the
+        // record is malformed, not that we should invent one.
+        const signingKey = harnessTargetMetadata.signingKey;
+
+        if (typeof signingKey !== 'string' || signingKey.length < 32) {
+            throw new Error(
+                `Subscription '${id}' carries no server-issued signingKey; ` +
+                'the key is minted by WakeSubscriptionService at subscribe-time and cannot be generated here'
+            );
+        }
+
+        // Fail closed on disagreement rather than silently preferring either side. A published route
+        // whose key differs from the server's is precisely the state that 401s every wake, and picking
+        // a winner here would hide which side is stale.
+        const existing = existingRoutes[id];
+
+        if (existing && existing.signingKey !== signingKey) {
+            throw new Error(
+                `Subscription '${id}' signing key disagrees with the published manifest; ` +
+                'refusing to choose between them — re-subscribe or remove the stale route explicitly'
+            );
+        }
+
+        const receiverMetadata = Object.fromEntries(
+            Object.entries(harnessTargetMetadata).filter(([key]) => !SENDER_ONLY_METADATA_KEYS.includes(key))
+        );
 
         routes[id] = {
             agentIdentity,
             signingKey,
-            harnessTargetMetadata,
-            adapterConfig: {attemptTimeoutMs}
+            harnessTargetMetadata: receiverMetadata,
+            adapterConfig        : {attemptTimeoutMs, ...(subscription.adapterConfig || {})}
         };
 
         routeSummaries.push({
             subscriptionId: id,
             agentIdentity,
-            adapter       : harnessTargetMetadata.adapter ||
-                            (process.platform === 'darwin' ? 'osascript' : 'tmux'),
-            reusedKey     : Boolean(signingKeys[id]),
+            // Read the adapter the ROUTE will actually use. Reporting a platform default here once
+            // made the summary assert an adapter that was not in the manifest, which reads as
+            // confirmation and sends the operator looking somewhere else.
+            adapter       : receiverMetadata.adapter || null,
             keyFingerprint: fingerprintSigningKey(signingKey)
-        });
+        })
     }
 
-    if (!routeSummaries.length) {
-        throw new Error('No active subscriptions produced a route; refusing to write an empty manifest');
+    if (!Object.keys(routes).length) {
+        throw new Error(
+            'No deliverable subscriptions produced a route; refusing to write an empty manifest. ' +
+            `Skipped ${skipped.length}: ${skipped.map(entry => entry.reason).join('; ') || 'none'}`
+        );
     }
 
-    return {manifest: {schemaVersion: 1, routes}, routeSummaries};
+    return {manifest: {schemaVersion: 1, routes}, routeSummaries, skipped}
 }
 
 /**
@@ -108,13 +182,19 @@ export function buildWakeReceiverManifest({
  * @returns {String}
  */
 export function fingerprintSigningKey(signingKey) {
-    return crypto.createHash('sha256').update(signingKey).digest('hex').slice(0, 12);
+    return crypto.createHash('sha256').update(signingKey).digest('hex').slice(0, 12)
 }
 
 /**
- * Writes the manifest 0600, but only after the receiver's own loader accepts it.
+ * Writes the manifest 0600 through an exclusive, symlink-safe staging file, but only after the
+ * receiver's own loader accepts it.
  *
- * @summary Publishes a manifest that is proven loadable, never one that merely looks right.
+ * A predictable `<target>.staging` name was a symlink attack: `writeFile` follows links, so a
+ * pre-created link would receive the signing keys and then be renamed into place as the published
+ * manifest. The staging name is now unguessable and opened `wx` — `O_CREAT|O_EXCL`, which refuses an
+ * existing path and does not traverse a final-component symlink — and is removed on every exit path.
+ *
+ * @summary Publishes a manifest that is proven loadable, via a staging file that cannot be hijacked.
  * @param {Object} config
  * @param {Object} config.manifest
  * @param {String} config.targetPath Absolute destination.
@@ -125,41 +205,78 @@ export async function writeValidatedManifest({manifest, targetPath}) {
         throw new Error('Manifest target path must be absolute');
     }
 
-    const stagingPath = `${targetPath}.staging`;
-
     await fs.mkdir(path.dirname(targetPath), {recursive: true});
-    await fs.writeFile(stagingPath, JSON.stringify(manifest, null, 2) + '\n', {mode: 0o600});
+
+    // Same directory as the target so the final rename is atomic; unguessable so it cannot be
+    // pre-created; O_EXCL so an existing path — including a symlink — is refused rather than followed.
+    const stagingPath = path.join(
+        path.dirname(targetPath),
+        `.${path.basename(targetPath)}.${crypto.randomBytes(12).toString('hex')}.staging`
+    );
+
+    let handle;
 
     try {
+        handle = await fs.open(stagingPath, 'wx', 0o600);
+        await handle.writeFile(JSON.stringify(manifest, null, 2) + '\n');
+        await handle.close();
+        handle = null;
+
         // The receiver is the authority on whether this manifest is usable, so ask it rather than
         // re-implementing its rules here and letting the two drift.
-        await loadWakeReceiverManifest(stagingPath)
-    } catch (error) {
-        await fs.rm(stagingPath, {force: true});
-        throw new Error(`Refusing to publish a manifest the receiver rejects: ${error.message}`)
-    }
+        await loadWakeReceiverManifest(stagingPath);
 
-    await fs.rename(stagingPath, targetPath);
+        await fs.rename(stagingPath, targetPath)
+    } catch (error) {
+        await handle?.close().catch(() => {});
+        await fs.rm(stagingPath, {force: true});
+
+        throw error.message.startsWith('Refusing')
+            ? error
+            : new Error(`Refusing to publish a manifest the receiver rejects: ${error.message}`)
+    }
 
     return targetPath
 }
 
 /**
- * Reads existing signing keys from a manifest so a rebuild does not rotate them.
- * @summary Keeps a rebuild non-breaking for a container already provisioned with these keys.
+ * Reads the currently published routes so a rebuild composes additively.
+ *
+ * **Only a missing file means "first boot".** Treating every read failure that way silently rotated
+ * keys on a corrupt or unreadable manifest, which breaks an already-provisioned container with a
+ * `401` that points nowhere near the rebuild. Anything other than `ENOENT` now stops the build.
+ *
+ * @summary Loads published routes for additive composition, failing closed on an unreadable manifest.
  * @param {String} manifestPath
- * @returns {Promise<Object>} `subscriptionId → signingKey`, empty when no readable manifest exists
+ * @returns {Promise<Object>} `subscriptionId → route`, empty only when the manifest does not exist
  */
-export async function readExistingSigningKeys(manifestPath) {
-    try {
-        const existing = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+export async function readPublishedRoutes(manifestPath) {
+    let raw;
 
-        return Object.fromEntries(
-            Object.entries(existing?.routes || {})
-                .filter(([, route]) => typeof route?.signingKey === 'string')
-                .map(([id, route]) => [id, route.signingKey])
-        )
-    } catch {
-        return {}
+    try {
+        raw = await fs.readFile(manifestPath, 'utf8')
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return {}
+        }
+
+        throw new Error(`Existing manifest '${manifestPath}' is unreadable: ${error.message}`)
     }
+
+    let parsed;
+
+    try {
+        parsed = JSON.parse(raw)
+    } catch (error) {
+        throw new Error(
+            `Existing manifest '${manifestPath}' is corrupt (${error.message}); ` +
+            'refusing to continue, because rebuilding from it would rotate live signing keys'
+        );
+    }
+
+    if (!parsed?.routes || typeof parsed.routes !== 'object') {
+        throw new Error(`Existing manifest '${manifestPath}' has no routes object; refusing to rotate live keys`);
+    }
+
+    return parsed.routes
 }

--- a/ai/daemons/wake/buildReceiverManifest.mjs
+++ b/ai/daemons/wake/buildReceiverManifest.mjs
@@ -78,15 +78,23 @@ const SENDER_ONLY_METADATA_KEYS = ['signingKey', 'url'];
  */
 export function buildWakeReceiverManifest({
     subscriptions,
-    existingRoutes   = {},
-    attemptTimeoutMs = DEFAULT_ATTEMPT_TIMEOUT_MS
+    existingRoutes    = {},
+    adapterConfigById = {},
+    attemptTimeoutMs  = DEFAULT_ATTEMPT_TIMEOUT_MS
 }) {
     if (!Array.isArray(subscriptions)) {
         throw new Error('buildWakeReceiverManifest requires a subscriptions array');
     }
 
     // Additive: start from what is already published so a single-identity build cannot delete a peer.
-    const routes         = {...existingRoutes},
+    //
+    // Carried routes are re-sanitised rather than copied verbatim. A manifest written by an earlier
+    // version can still hold sender-only `signingKey`/`url` inside its metadata, and republishing it
+    // unchanged would keep leaking that into receiver state forever — the fix would only ever apply
+    // to routes that happened to be rebuilt.
+    const routes = Object.fromEntries(
+              Object.entries(existingRoutes).map(([id, route]) => [id, sanitiseRoute(route)])
+          ),
           routeSummaries = [],
           skipped        = [];
 
@@ -99,18 +107,22 @@ export function buildWakeReceiverManifest({
 
         // Every skip is NAMED. A silent omission and a silent bad route are the same failure from the
         // operator's side: something they expected to be wired is not, and nothing said so.
+        // A skipped subscription that the caller OWNS must also have its stale route withdrawn.
+        // Skipping only the input left a retired or retargeted seat's old route published — the
+        // subscription was gone and the route kept accepting wakes for it. Reconciliation is scoped
+        // to ids the caller actually presented, so a peer's route is never touched.
         if (status !== 'active') {
-            skipped.push({subscriptionId: id, reason: `status is '${status}', not 'active'`});
+            withdrawOwnedRoute(routes, id, skipped, `status is '${status}', not 'active'`);
             continue
         }
 
         if (harnessTarget !== DELIVERABLE_HARNESS_TARGET) {
-            skipped.push({
-                subscriptionId: id,
-                reason        : `harnessTarget '${harnessTarget}' is not deliverable on the Shape-B path ` +
-                                `(only '${DELIVERABLE_HARNESS_TARGET}' is); this seat cannot receive a container wake ` +
-                                `until it is migrated`
-            });
+            withdrawOwnedRoute(
+                routes, id, skipped,
+                `harnessTarget '${harnessTarget}' is not deliverable on the Shape-B path ` +
+                `(only '${DELIVERABLE_HARNESS_TARGET}' is); this seat cannot receive a container wake ` +
+                'until it is migrated'
+            );
             continue
         }
 
@@ -149,11 +161,15 @@ export function buildWakeReceiverManifest({
             Object.entries(harnessTargetMetadata).filter(([key]) => !SENDER_ONLY_METADATA_KEYS.includes(key))
         );
 
+        // Per-route adapter config comes from the caller, keyed by subscription id. The subscription
+        // record carries none, so without this a Codex seat could never satisfy the receiver's
+        // `codexBinary` requirement from any supported input — the route would be unbuildable rather
+        // than merely unconfigured.
         routes[id] = {
             agentIdentity,
             signingKey,
             harnessTargetMetadata: receiverMetadata,
-            adapterConfig        : {attemptTimeoutMs, ...(subscription.adapterConfig || {})}
+            adapterConfig        : {attemptTimeoutMs, ...(adapterConfigById[id] || {})}
         };
 
         routeSummaries.push({
@@ -175,6 +191,48 @@ export function buildWakeReceiverManifest({
     }
 
     return {manifest: {schemaVersion: 1, routes}, routeSummaries, skipped}
+}
+
+/**
+ * @summary Strips sender-only keys from a route's receiver-visible metadata.
+ * @param {Object} route
+ * @returns {Object}
+ * @private
+ */
+function sanitiseRoute(route) {
+    if (!route?.harnessTargetMetadata || typeof route.harnessTargetMetadata !== 'object') {
+        return route
+    }
+
+    return {
+        ...route,
+        harnessTargetMetadata: Object.fromEntries(
+            Object.entries(route.harnessTargetMetadata)
+                .filter(([key]) => !SENDER_ONLY_METADATA_KEYS.includes(key))
+        )
+    }
+}
+
+/**
+ * Withdraws a route the caller owns but can no longer deliver to, and records why.
+ * @summary Reconciles the caller's own stale routes without touching a peer's.
+ * @param {Object}   routes
+ * @param {String}   subscriptionId
+ * @param {Object[]} skipped
+ * @param {String}   reason
+ * @returns {void}
+ * @private
+ */
+function withdrawOwnedRoute(routes, subscriptionId, skipped, reason) {
+    const withdrawn = Object.hasOwn(routes, subscriptionId);
+
+    delete routes[subscriptionId];
+
+    skipped.push({
+        subscriptionId,
+        reason                : withdrawn ? `${reason}; withdrew its previously published route` : reason,
+        withdrewPublishedRoute: withdrawn
+    })
 }
 
 /**
@@ -283,6 +341,74 @@ export async function readPublishedRoutes(manifestPath) {
 }
 
 /**
+ * Runs a read-modify-write against the shared manifest under a cross-process lock.
+ *
+ * **The unique staging file protects each writer; it does not make the transaction atomic.** Two
+ * peers provisioning at the same moment both read the same predecessor, each merges only its own
+ * route, and the later rename wins — silently unprovisioning the other. Measured before this existed:
+ * 20 of 20 concurrent two-peer builds lost a route. Serialising the whole read/merge/publish is the
+ * fix; serialising only the write is not, because the stale read has already happened by then.
+ *
+ * The lock is a sibling file opened `wx`, so acquisition is atomic and cross-process. A holder that
+ * dies leaves it behind, so an entry older than `staleAfterMs` is reclaimed — bounded rather than
+ * permanent, since a wedged lock would block every seat on the host.
+ *
+ * @summary Serialises shared-manifest mutation so concurrent peers cannot unprovision each other.
+ * @param {Object}   config
+ * @param {String}   config.manifestPath
+ * @param {Function} config.task
+ * @param {Number}   [config.timeoutMs=10000]
+ * @param {Number}   [config.staleAfterMs=60000]
+ * @returns {Promise<*>}
+ */
+export async function withManifestLock({manifestPath, task, timeoutMs = 10000, staleAfterMs = 60000}) {
+    const lockPath = `${manifestPath}.lock`,
+          deadline = Date.now() + timeoutMs;
+
+    let handle;
+
+    while (!handle) {
+        try {
+            handle = await fs.open(lockPath, 'wx', 0o600);
+        } catch (error) {
+            if (error.code !== 'EEXIST') {
+                throw error
+            }
+
+            const age = await fs.stat(lockPath).then(
+                info  => Date.now() - info.mtimeMs,
+                ()    => Infinity  // vanished between open and stat: retry immediately
+            );
+
+            if (age > staleAfterMs) {
+                await fs.rm(lockPath, {force: true});
+                continue
+            }
+
+            if (Date.now() > deadline) {
+                throw new Error(
+                    `Timed out after ${timeoutMs}ms waiting for the manifest lock at ${lockPath}; ` +
+                    'another seat is publishing, or a stale lock needs removing'
+                );
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 25 + Math.floor(Math.random() * 50)))
+        }
+    }
+
+    try {
+        await handle.writeFile(JSON.stringify({pid: process.pid, acquiredAt: new Date().toISOString()}));
+        await handle.close();
+        handle = null;
+
+        return await task()
+    } finally {
+        await handle?.close().catch(() => {});
+        await fs.rm(lockPath, {force: true}).catch(() => {})
+    }
+}
+
+/**
  * @summary Parses CLI flags without hidden deployment-path defaults, mirroring the receiver's parser.
  * @param {String[]} argv
  * @returns {{subscriptionsPath: String, manifestPath: String}}
@@ -319,7 +445,7 @@ export function parseManifestBuilderArgs(argv = process.argv.slice(2)) {
  * @param {Object} [config.logger=console]
  * @returns {Promise<{published: String, routeSummaries: Object[], skipped: Object[]}>}
  */
-export async function runManifestBuilder({subscriptionsPath, manifestPath, logger = console}) {
+export async function runManifestBuilder({subscriptionsPath, manifestPath, adapterConfigById = {}, logger = console}) {
     if (!subscriptionsPath || !manifestPath) {
         throw new Error('Usage: --subscriptions <file|-> --manifest <absolute path>');
     }
@@ -332,12 +458,22 @@ export async function runManifestBuilder({subscriptionsPath, manifestPath, logge
           // Accept either the raw tool response or a bare array, since the tool wraps its result.
           subscriptions = Array.isArray(parsed) ? parsed : parsed?.subscriptions;
 
-    const {manifest, routeSummaries, skipped} = buildWakeReceiverManifest({
-        subscriptions,
-        existingRoutes: await readPublishedRoutes(manifestPath)
-    });
+    // The whole read/merge/publish runs inside the lock. Holding it only across the write would
+    // leave the stale-read window open, which is the window that loses peer routes.
+    const {manifest, routeSummaries, skipped} = await withManifestLock({
+        manifestPath,
+        task: async () => {
+            const built = buildWakeReceiverManifest({
+                adapterConfigById,
+                subscriptions,
+                existingRoutes: await readPublishedRoutes(manifestPath)
+            });
 
-    await writeValidatedManifest({manifest, targetPath: manifestPath});
+            await writeValidatedManifest({manifest: built.manifest, targetPath: manifestPath});
+
+            return built
+        }
+    });
 
     logger.log(`[Wake Manifest] published ${Object.keys(manifest.routes).length} route(s) to ${manifestPath}`);
 

--- a/ai/daemons/wake/buildReceiverManifest.mjs
+++ b/ai/daemons/wake/buildReceiverManifest.mjs
@@ -33,9 +33,10 @@
  * publish itself is exclusive and symlink-safe. A manifest the receiver would reject never reaches
  * the target path.
  */
-import crypto from 'node:crypto';
-import fs     from 'node:fs/promises';
-import path   from 'node:path';
+import crypto          from 'node:crypto';
+import fs              from 'node:fs/promises';
+import path            from 'node:path';
+import {pathToFileURL} from 'node:url';
 
 import {loadWakeReceiverManifest} from './receiver.mjs';
 
@@ -279,4 +280,100 @@ export async function readPublishedRoutes(manifestPath) {
     }
 
     return parsed.routes
+}
+
+/**
+ * @summary Parses CLI flags without hidden deployment-path defaults, mirroring the receiver's parser.
+ * @param {String[]} argv
+ * @returns {{subscriptionsPath: String, manifestPath: String}}
+ */
+export function parseManifestBuilderArgs(argv = process.argv.slice(2)) {
+    const read = name => {
+        const index = argv.indexOf(name);
+        return index >= 0 ? argv[index + 1] : undefined
+    };
+
+    return {
+        subscriptionsPath: read('--subscriptions'),
+        manifestPath     : read('--manifest')
+    }
+}
+
+/**
+ * Runs one build-and-publish pass for whichever seat is calling.
+ *
+ * **This is a per-peer call, not a provisioning batch.** Every family runs it for its own identity
+ * and the result composes: the published manifest is read first and merged into, so three peers on
+ * one host each add their own route without coordinating and without any of them holding authority
+ * over the others' entries. That is why composition is additive rather than replacing — a peer
+ * provisioning itself must not be able to unprovision anyone else.
+ *
+ * Subscriptions arrive as JSON on a path or stdin — the output of `manage_wake_subscription list` —
+ * rather than being fetched here. That keeps the module graphless: the caller already holds an
+ * authenticated session, and this stays runnable on a host that cannot reach the container plane.
+ *
+ * @summary Builds and publishes the caller's routes, reporting skips and fingerprints but never keys.
+ * @param {Object} config
+ * @param {String} config.subscriptionsPath JSON file, or `-` for stdin.
+ * @param {String} config.manifestPath      Absolute manifest destination.
+ * @param {Object} [config.logger=console]
+ * @returns {Promise<{published: String, routeSummaries: Object[], skipped: Object[]}>}
+ */
+export async function runManifestBuilder({subscriptionsPath, manifestPath, logger = console}) {
+    if (!subscriptionsPath || !manifestPath) {
+        throw new Error('Usage: --subscriptions <file|-> --manifest <absolute path>');
+    }
+
+    const raw = subscriptionsPath === '-'
+        ? await readStream(process.stdin)
+        : await fs.readFile(subscriptionsPath, 'utf8');
+
+    const parsed = JSON.parse(raw),
+          // Accept either the raw tool response or a bare array, since the tool wraps its result.
+          subscriptions = Array.isArray(parsed) ? parsed : parsed?.subscriptions;
+
+    const {manifest, routeSummaries, skipped} = buildWakeReceiverManifest({
+        subscriptions,
+        existingRoutes: await readPublishedRoutes(manifestPath)
+    });
+
+    await writeValidatedManifest({manifest, targetPath: manifestPath});
+
+    logger.log(`[Wake Manifest] published ${Object.keys(manifest.routes).length} route(s) to ${manifestPath}`);
+
+    for (const summary of routeSummaries) {
+        logger.log(`  route ${summary.subscriptionId} → ${summary.agentIdentity} ` +
+                   `adapter=${summary.adapter ?? '(none)'} key=${summary.keyFingerprint}`);
+    }
+
+    // Skips are printed, never swallowed: a seat that silently produces no route is indistinguishable
+    // from one that was never attempted, and that is exactly how a peer stays deaf without knowing.
+    for (const entry of skipped) {
+        logger.log(`  SKIPPED ${entry.subscriptionId}: ${entry.reason}`);
+    }
+
+    return {published: manifestPath, routeSummaries, skipped}
+}
+
+/**
+ * @summary Reads a whole stream to a string.
+ * @param {Object} stream
+ * @returns {Promise<String>}
+ * @private
+ */
+async function readStream(stream) {
+    const chunks = [];
+
+    for await (const chunk of stream) {
+        chunks.push(chunk);
+    }
+
+    return Buffer.concat(chunks).toString('utf8')
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    runManifestBuilder(parseManifestBuilderArgs()).catch(error => {
+        console.error(`[Wake Manifest] fatal: ${error.message}`);
+        process.exit(1)
+    })
 }

--- a/ai/daemons/wake/buildReceiverManifest.mjs
+++ b/ai/daemons/wake/buildReceiverManifest.mjs
@@ -1,0 +1,165 @@
+/**
+ * @module ai/daemons/wake/buildReceiverManifest
+ * @summary Builds a wake-receiver route manifest from live WAKE_SUB subscription records.
+ *
+ * The receiver refuses to start without a 0600 manifest whose routes carry a signing key, an agent
+ * identity, harness metadata and an explicit attempt policy. Producing that by hand means copying
+ * subscription records out of `manage_wake_subscription list`, inventing a key, and discovering the
+ * shape rules one `throw` at a time — which is exactly how this module came to exist.
+ *
+ * **It imports nothing from the graph, Memory Core, or a database path**, mirroring the receiver's
+ * own boundary: subscription records arrive as plain data from whoever queried them, so host-edge
+ * tooling stays runnable without the container plane it is being wired to.
+ *
+ * **The generator validates its own output through the receiver's loader before publishing it.**
+ * A manifest that the receiver would reject is never written to the target path — the temp file is
+ * discarded instead. That closes the loop that otherwise only closes when the daemon fails to boot.
+ *
+ * **Signing keys never reach stdout or a log.** The manifest is the key material and is written
+ * 0600; the summary reports a short fingerprint per route so two sides can be compared without
+ * either printing the secret.
+ */
+import crypto from 'node:crypto';
+import fs     from 'node:fs/promises';
+import path   from 'node:path';
+
+import {loadWakeReceiverManifest} from './receiver.mjs';
+
+/**
+ * Default per-attempt dispatch budget, in milliseconds.
+ * The receiver requires a positive value at or below 300000; it declares no default of its own,
+ * deliberately, so every route states its policy. This is the generator's stated choice, not a
+ * hidden fallback inherited from the daemon.
+ * @type {Number}
+ */
+export const DEFAULT_ATTEMPT_TIMEOUT_MS = 10000;
+
+/**
+ * Builds the manifest object for a set of subscription records.
+ *
+ * @summary Maps active WAKE_SUB records onto receiver routes, minting a signing key per route.
+ * @param {Object}   config
+ * @param {Object[]} config.subscriptions Records as returned by `manage_wake_subscription list`.
+ * @param {Object}   [config.signingKeys={}] Existing `subscriptionId → key`, preserved rather than rotated.
+ * @param {Number}   [config.attemptTimeoutMs=DEFAULT_ATTEMPT_TIMEOUT_MS]
+ * @returns {{manifest: Object, routeSummaries: Object[]}}
+ */
+export function buildWakeReceiverManifest({
+    subscriptions,
+    signingKeys = {},
+    attemptTimeoutMs = DEFAULT_ATTEMPT_TIMEOUT_MS
+}) {
+    if (!Array.isArray(subscriptions)) {
+        throw new Error('buildWakeReceiverManifest requires a subscriptions array');
+    }
+
+    const routes         = {},
+          routeSummaries = [];
+
+    // Retired subscriptions are excluded rather than refused: a retired route is a normal historical
+    // record, not a malformed one, and refusing the whole build over it would make the generator
+    // unusable on any account with history.
+    for (const subscription of subscriptions.filter(entry => entry?.status === 'active')) {
+        const {id, agentIdentity, harnessTargetMetadata} = subscription;
+
+        if (typeof id !== 'string' || !id.startsWith('WAKE_SUB:')) {
+            throw new Error(`Subscription id '${id}' is not a WAKE_SUB identifier`);
+        }
+
+        if (typeof agentIdentity !== 'string' || !agentIdentity) {
+            throw new Error(`Subscription '${id}' has no agentIdentity`);
+        }
+
+        if (!harnessTargetMetadata || typeof harnessTargetMetadata !== 'object') {
+            throw new Error(`Subscription '${id}' has no harnessTargetMetadata`);
+        }
+
+        // Reuse an existing key when one is supplied. Rotating on every build would silently break
+        // the container side, which signs with the key it was provisioned with.
+        const signingKey = signingKeys[id] || crypto.randomBytes(32).toString('hex');
+
+        routes[id] = {
+            agentIdentity,
+            signingKey,
+            harnessTargetMetadata,
+            adapterConfig: {attemptTimeoutMs}
+        };
+
+        routeSummaries.push({
+            subscriptionId: id,
+            agentIdentity,
+            adapter       : harnessTargetMetadata.adapter ||
+                            (process.platform === 'darwin' ? 'osascript' : 'tmux'),
+            reusedKey     : Boolean(signingKeys[id]),
+            keyFingerprint: fingerprintSigningKey(signingKey)
+        });
+    }
+
+    if (!routeSummaries.length) {
+        throw new Error('No active subscriptions produced a route; refusing to write an empty manifest');
+    }
+
+    return {manifest: {schemaVersion: 1, routes}, routeSummaries};
+}
+
+/**
+ * @summary Produces a short, non-reversible fingerprint so two sides can compare keys without printing one.
+ * @param {String} signingKey
+ * @returns {String}
+ */
+export function fingerprintSigningKey(signingKey) {
+    return crypto.createHash('sha256').update(signingKey).digest('hex').slice(0, 12);
+}
+
+/**
+ * Writes the manifest 0600, but only after the receiver's own loader accepts it.
+ *
+ * @summary Publishes a manifest that is proven loadable, never one that merely looks right.
+ * @param {Object} config
+ * @param {Object} config.manifest
+ * @param {String} config.targetPath Absolute destination.
+ * @returns {Promise<String>} the written path
+ */
+export async function writeValidatedManifest({manifest, targetPath}) {
+    if (!path.isAbsolute(targetPath || '')) {
+        throw new Error('Manifest target path must be absolute');
+    }
+
+    const stagingPath = `${targetPath}.staging`;
+
+    await fs.mkdir(path.dirname(targetPath), {recursive: true});
+    await fs.writeFile(stagingPath, JSON.stringify(manifest, null, 2) + '\n', {mode: 0o600});
+
+    try {
+        // The receiver is the authority on whether this manifest is usable, so ask it rather than
+        // re-implementing its rules here and letting the two drift.
+        await loadWakeReceiverManifest(stagingPath)
+    } catch (error) {
+        await fs.rm(stagingPath, {force: true});
+        throw new Error(`Refusing to publish a manifest the receiver rejects: ${error.message}`)
+    }
+
+    await fs.rename(stagingPath, targetPath);
+
+    return targetPath
+}
+
+/**
+ * Reads existing signing keys from a manifest so a rebuild does not rotate them.
+ * @summary Keeps a rebuild non-breaking for a container already provisioned with these keys.
+ * @param {String} manifestPath
+ * @returns {Promise<Object>} `subscriptionId → signingKey`, empty when no readable manifest exists
+ */
+export async function readExistingSigningKeys(manifestPath) {
+    try {
+        const existing = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+
+        return Object.fromEntries(
+            Object.entries(existing?.routes || {})
+                .filter(([, route]) => typeof route?.signingKey === 'string')
+                .map(([id, route]) => [id, route.signingKey])
+        )
+    } catch {
+        return {}
+    }
+}

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
         "ai:kb-reconciliation"                 : "node ./ai/daemons/kb-reconciliation/daemon.mjs",
         "ai:kb-gc"                             : "node ./ai/daemons/kb-gc/daemon.mjs",
         "ai:orchestrator"                      : "node ./ai/daemons/orchestrator/daemon.mjs",
+        "ai:wake-manifest"                     : "node ./ai/daemons/wake/buildReceiverManifest.mjs",
         "ai:wake-receiver"                     : "node ./ai/daemons/wake/receiver.mjs",
         "ai:revalidation-sweep"                : "node ./ai/scripts/lifecycle/revalidationSweep.mjs",
         "ai:run-sandman"                       : "node ./ai/scripts/runners/runSandman.mjs",

--- a/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
@@ -270,6 +270,137 @@ test.describe('runManifestBuilder — per-peer composition', () => {
     test('refuses without both flags rather than guessing a path', async () => {
         await expect(runManifestBuilder({subscriptionsPath: '-'})).rejects.toThrow(/Usage:/)
     });
+
+    test('CONCURRENT peers cannot unprovision each other', async () => {
+        // The sequential spec above proves the merge and is structurally incapable of failing the way
+        // the claim can be wrong. Before the lock, this lost a route in 20/20 trials: both callers read
+        // the same predecessor and the later rename won.
+        const dir = await tempDir();
+
+        try {
+            const manifestPath = path.join(dir, 'routes.json'),
+                  quiet        = {log() {}},
+                  inputs       = [];
+
+            for (const [index, identity] of [['a', '@neo-opus-ada'], ['b', '@neo-kimi-iris']]) {
+                const file = path.join(dir, `${index}.json`);
+
+                await writeFile(file, JSON.stringify({subscriptions: [{
+                    ...webhookSubscription,
+                    id                   : `WAKE_SUB:${index.repeat(8)}-0000-4000-8000-00000000000${index === 'a' ? 1 : 2}`,
+                    agentIdentity        : identity,
+                    harnessTargetMetadata: {
+                        ...webhookSubscription.harnessTargetMetadata,
+                        signingKey: index.repeat(64)
+                    }
+                }]}));
+
+                inputs.push(file)
+            }
+
+            await Promise.all(inputs.map(subscriptionsPath =>
+                runManifestBuilder({subscriptionsPath, manifestPath, logger: quiet})
+            ));
+
+            expect(Object.keys(await readPublishedRoutes(manifestPath))).toHaveLength(2)
+        } finally {
+            await rm(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('withdraws the callers OWN stale route on retarget, leaving peers published', async () => {
+        const dir = await tempDir();
+
+        try {
+            const manifestPath = path.join(dir, 'routes.json'),
+                  quiet        = {log() {}},
+                  live         = path.join(dir, 'live.json'),
+                  retargeted   = path.join(dir, 'retargeted.json'),
+                  peerId       = 'WAKE_SUB:84dfc4da-0000-4000-8000-0000000000fe';
+
+            await writeFile(live, JSON.stringify({subscriptions: [webhookSubscription]}));
+            // Same id, now on a target the Shape-B path cannot deliver to.
+            await writeFile(retargeted, JSON.stringify({subscriptions: [
+                {...webhookSubscription, harnessTarget: 'bridge-daemon'}
+            ]}));
+
+            await runManifestBuilder({subscriptionsPath: live, manifestPath, logger: quiet});
+
+            // Seed a peer route that the caller does not own and must not touch.
+            const withPeer = buildWakeReceiverManifest({
+                subscriptions : [],
+                existingRoutes: {
+                    ...await readPublishedRoutes(manifestPath),
+                    [peerId]: {
+                        agentIdentity        : '@neo-opus-grace',
+                        signingKey           : PEER_KEY,
+                        harnessTargetMetadata: {adapter: 'osascript', appName: 'Claude'},
+                        adapterConfig        : {attemptTimeoutMs: 10000}
+                    }
+                }
+            });
+
+            await writeValidatedManifest({manifest: withPeer.manifest, targetPath: manifestPath});
+
+            const result    = await runManifestBuilder({subscriptionsPath: retargeted, manifestPath, logger: quiet}),
+                  published = await readPublishedRoutes(manifestPath);
+
+            // Skipping the input alone left the stale route accepting wakes for a seat that moved.
+            expect(published[webhookSubscription.id]).toBeUndefined();
+            expect(result.skipped[0].withdrewPublishedRoute).toBe(true);
+            expect(published[peerId].agentIdentity).toBe('@neo-opus-grace')
+        } finally {
+            await rm(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('sanitises sender secrets carried in from a manifest written by an older version', () => {
+        const legacyId = 'WAKE_SUB:84dfc4da-0000-4000-8000-0000000000ee';
+
+        const {manifest} = buildWakeReceiverManifest({
+            subscriptions : [],
+            existingRoutes: {
+                [legacyId]: {
+                    agentIdentity: '@neo-gpt-emmy',
+                    signingKey   : PEER_KEY,
+                    // An older build left the sender-only pair inside the metadata.
+                    harnessTargetMetadata: {adapter: 'osascript', appName: 'Claude', signingKey: PEER_KEY, url: 'http://x/'},
+                    adapterConfig        : {attemptTimeoutMs: 10000}
+                }
+            }
+        });
+
+        const carried = manifest.routes[legacyId];
+
+        expect(carried.harnessTargetMetadata.signingKey).toBeUndefined();
+        expect(carried.harnessTargetMetadata.url).toBeUndefined();
+        // The route's own key field is where the receiver reads it, and must survive.
+        expect(carried.signingKey).toBe(PEER_KEY)
+    });
+
+    test('makes Codex adapter config reachable from a supported input', () => {
+        const codexSubscription = {
+            ...webhookSubscription,
+            harnessTargetMetadata: {
+                ...webhookSubscription.harnessTargetMetadata,
+                adapter     : 'codex-app-server',
+                appName     : 'Codex',
+                focusSeedKey: 'space'
+            }
+        };
+
+        // The subscription record carries no adapterConfig, so without a caller-supplied path a
+        // Codex route could never satisfy the receiver's codexBinary requirement.
+        const {manifest} = buildWakeReceiverManifest({
+            subscriptions    : [codexSubscription],
+            adapterConfigById: {[codexSubscription.id]: {codexBinary: '/usr/local/bin/codex'}}
+        });
+
+        expect(manifest.routes[codexSubscription.id].adapterConfig).toEqual({
+            attemptTimeoutMs: 10000,
+            codexBinary     : '/usr/local/bin/codex'
+        })
+    });
 });
 
 test.describe('readPublishedRoutes', () => {

--- a/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
@@ -8,6 +8,7 @@ import {
     buildWakeReceiverManifest,
     fingerprintSigningKey,
     readPublishedRoutes,
+    runManifestBuilder,
     writeValidatedManifest
 } from '../../../../../../ai/daemons/wake/buildReceiverManifest.mjs';
 
@@ -215,6 +216,59 @@ test.describe('writeValidatedManifest', () => {
 
         await expect(writeValidatedManifest({manifest, targetPath: 'routes.json'}))
             .rejects.toThrow(/must be absolute/i)
+    });
+});
+
+test.describe('runManifestBuilder — per-peer composition', () => {
+    test('each family provisions its own seat without unprovisioning another', async () => {
+        const dir = await tempDir();
+
+        try {
+            const manifestPath = path.join(dir, 'routes.json'),
+                  claudeInput  = path.join(dir, 'claude.json'),
+                  kimiInput    = path.join(dir, 'kimi.json'),
+                  lines        = [],
+                  logger       = {log: line => lines.push(line)};
+
+            await writeFile(claudeInput, JSON.stringify({subscriptions: [webhookSubscription]}));
+            await writeFile(kimiInput, JSON.stringify({subscriptions: [
+                {
+                    ...webhookSubscription,
+                    id                   : 'WAKE_SUB:84dfc4da-0000-4000-8000-00000000000a',
+                    agentIdentity        : '@neo-kimi-iris',
+                    harnessTargetMetadata: {
+                        ...webhookSubscription.harnessTargetMetadata,
+                        adapter   : 'kimi-server',
+                        signingKey: PEER_KEY
+                    }
+                },
+                bridgeDaemonSubscription
+            ]}));
+
+            await runManifestBuilder({subscriptionsPath: claudeInput, manifestPath, logger});
+            const second = await runManifestBuilder({subscriptionsPath: kimiInput, manifestPath, logger});
+
+            const published = await readPublishedRoutes(manifestPath);
+
+            // The second caller must not be able to unprovision the first.
+            expect(Object.keys(published)).toHaveLength(2);
+            expect(published[webhookSubscription.id].agentIdentity).toBe('@neo-opus-ada');
+            expect(published['WAKE_SUB:84dfc4da-0000-4000-8000-00000000000a'].agentIdentity)
+                .toBe('@neo-kimi-iris');
+
+            // An undeliverable seat is reported, not silently absent — silence is how a peer stays
+            // deaf without anyone noticing.
+            expect(second.skipped).toHaveLength(1);
+            expect(lines.some(line => line.includes('SKIPPED') && line.includes('not deliverable'))).toBe(true);
+            expect(lines.join('\n')).not.toContain(SERVER_KEY);
+            expect(lines.join('\n')).not.toContain(PEER_KEY)
+        } finally {
+            await rm(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('refuses without both flags rather than guessing a path', async () => {
+        await expect(runManifestBuilder({subscriptionsPath: '-'})).rejects.toThrow(/Usage:/)
     });
 });
 

--- a/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
@@ -1,182 +1,257 @@
-import {test, expect}                           from '@playwright/test';
-import {mkdtemp, readFile, rm, stat, writeFile} from 'node:fs/promises';
-import {existsSync}                             from 'node:fs';
-import os                                       from 'node:os';
-import path                                     from 'node:path';
+import {test, expect}                                             from '@playwright/test';
+import {mkdtemp, readFile, readdir, rm, stat, symlink, writeFile} from 'node:fs/promises';
+import {existsSync}                                               from 'node:fs';
+import os                                                         from 'node:os';
+import path                                                       from 'node:path';
 
 import {
     buildWakeReceiverManifest,
     fingerprintSigningKey,
-    readExistingSigningKeys,
+    readPublishedRoutes,
     writeValidatedManifest
 } from '../../../../../../ai/daemons/wake/buildReceiverManifest.mjs';
 
-const activeSubscription = {
-    id                   : 'WAKE_SUB:1b7cdb3a-2ae0-4262-9778-c4b86d4bc92a',
+const SERVER_KEY = 'a'.repeat(64),
+      PEER_KEY   = 'b'.repeat(64);
+
+/**
+ * Shape pinned from a real migrated record: `update` MERGES rather than replaces, so a migrated
+ * subscription carries BOTH `userDataDir` (legacy) and `instanceAddress` (current).
+ */
+const webhookSubscription = {
+    id                   : 'WAKE_SUB:84dfc4da-0000-4000-8000-000000000001',
     status               : 'active',
     agentIdentity        : '@neo-opus-ada',
     trigger              : 'SENT_TO_ME',
-    harnessTargetMetadata: {adapter: 'osascript', appName: 'Claude', tabShortcut: '3', focusSeedKey: 'space'}
+    harnessTarget        : 'a2a-webhook',
+    harnessTargetMetadata: {
+        adapter        : 'osascript',
+        appName        : 'Claude',
+        tabShortcut    : '3',
+        focusSeedKey   : 'space',
+        addressType    : 'webhookUrl',
+        instanceAddress: 'http://127.0.0.1:45999/wake',
+        userDataDir    : '/legacy/path',
+        signingKey     : SERVER_KEY,
+        url            : 'http://host.docker.internal:45999/wake'
+    }
 };
 
-const retiredSubscription = {
-    ...activeSubscription,
-    id    : 'WAKE_SUB:fc6eace1-b0a3-49fd-9fa1-9f3418db8289',
-    status: 'retired'
+const bridgeDaemonSubscription = {
+    id                   : 'WAKE_SUB:84dfc4da-0000-4000-8000-000000000002',
+    status               : 'active',
+    agentIdentity        : '@neo-kimi-iris',
+    trigger              : 'SENT_TO_ME',
+    harnessTarget        : 'bridge-daemon',
+    harnessTargetMetadata: {appName: 'Claude', tabShortcut: '3', focusSeedKey: 'space'}
 };
 
 async function tempDir() {
     return await mkdtemp(path.join(os.tmpdir(), 'wake-manifest-'))
 }
 
-test.describe('buildWakeReceiverManifest', () => {
-    test('maps active subscriptions to routes and excludes retired ones', () => {
-        const {manifest, routeSummaries} = buildWakeReceiverManifest({
-            subscriptions: [activeSubscription, retiredSubscription]
+test.describe('buildWakeReceiverManifest — key authority', () => {
+    test('uses the server-issued key and never mints one', () => {
+        const {manifest} = buildWakeReceiverManifest({subscriptions: [webhookSubscription]});
+
+        // A minted key would boot cleanly and 401 every real container wake.
+        expect(manifest.routes[webhookSubscription.id].signingKey).toBe(SERVER_KEY)
+    });
+
+    test('refuses an a2a-webhook record carrying no server key rather than inventing one', () => {
+        const {signingKey, ...rest} = webhookSubscription.harnessTargetMetadata;
+
+        expect(() => buildWakeReceiverManifest({
+            subscriptions: [{...webhookSubscription, harnessTargetMetadata: rest}]
+        })).toThrow(/no server-issued signingKey/i)
+    });
+
+    test('fails closed when the published key disagrees with the server key', () => {
+        expect(() => buildWakeReceiverManifest({
+            subscriptions : [webhookSubscription],
+            existingRoutes: {[webhookSubscription.id]: {signingKey: PEER_KEY}}
+        })).toThrow(/disagrees with the published manifest/i)
+    });
+
+    test('strips sender-only fields from receiver-visible metadata', () => {
+        const {manifest} = buildWakeReceiverManifest({subscriptions: [webhookSubscription]}),
+              metadata   = manifest.routes[webhookSubscription.id].harnessTargetMetadata;
+
+        expect(metadata.signingKey).toBeUndefined();
+        expect(metadata.url).toBeUndefined();
+        // The legacy/current pair from a merged update must survive untouched.
+        expect(metadata.userDataDir).toBe('/legacy/path');
+        expect(metadata.instanceAddress).toBe('http://127.0.0.1:45999/wake')
+    });
+});
+
+test.describe('buildWakeReceiverManifest — route class', () => {
+    test('skips an undeliverable target with a named reason instead of publishing a dead route', () => {
+        const {manifest, routeSummaries, skipped} = buildWakeReceiverManifest({
+            subscriptions: [webhookSubscription, bridgeDaemonSubscription]
         });
 
-        expect(manifest.schemaVersion).toBe(1);
-        expect(Object.keys(manifest.routes)).toEqual([activeSubscription.id]);
+        // The mixed set is the case that occurs mid-migration, and mid-migration is when this runs.
+        expect(Object.keys(manifest.routes)).toEqual([webhookSubscription.id]);
         expect(routeSummaries).toHaveLength(1);
-
-        const route = manifest.routes[activeSubscription.id];
-
-        expect(route.agentIdentity).toBe('@neo-opus-ada');
-        expect(route.harnessTargetMetadata).toEqual(activeSubscription.harnessTargetMetadata);
-        expect(route.adapterConfig.attemptTimeoutMs).toBeGreaterThan(0);
-        expect(route.signingKey).toHaveLength(64)
+        expect(skipped).toHaveLength(1);
+        expect(skipped[0].subscriptionId).toBe(bridgeDaemonSubscription.id);
+        expect(skipped[0].reason).toMatch(/not deliverable/i)
     });
 
-    test('reuses a supplied signing key instead of rotating it', () => {
-        const signingKey = 'a'.repeat(64);
+    test('reports the adapter the route will actually use, never a platform default', () => {
+        const {routeSummaries} = buildWakeReceiverManifest({subscriptions: [webhookSubscription]});
 
-        const {manifest, routeSummaries} = buildWakeReceiverManifest({
-            subscriptions: [activeSubscription],
-            signingKeys  : {[activeSubscription.id]: signingKey}
+        // Falling back to the platform default once made the summary assert an adapter that was not
+        // in the manifest — a false statement that reads as confirmation.
+        expect(routeSummaries[0].adapter).toBe('osascript');
+
+        const noAdapter = buildWakeReceiverManifest({
+            subscriptions: [{
+                ...webhookSubscription,
+                harnessTargetMetadata: {...webhookSubscription.harnessTargetMetadata, adapter: undefined}
+            }]
         });
 
-        // Rotating on every build would silently break a container already signing with the old key.
-        expect(manifest.routes[activeSubscription.id].signingKey).toBe(signingKey);
-        expect(routeSummaries[0].reusedKey).toBe(true)
+        expect(noAdapter.routeSummaries[0].adapter).toBeNull()
     });
 
-    test('never exposes a signing key in the summary, only a fingerprint', () => {
-        const signingKey = 'b'.repeat(64);
-
-        const {routeSummaries} = buildWakeReceiverManifest({
-            subscriptions: [activeSubscription],
-            signingKeys  : {[activeSubscription.id]: signingKey}
+    test('skips inactive records and refuses a set that yields no route at all', () => {
+        const {skipped} = buildWakeReceiverManifest({
+            subscriptions : [{...webhookSubscription, status: 'retired'}],
+            existingRoutes: {'WAKE_SUB:keep-me': {signingKey: PEER_KEY}}
         });
 
-        const serialised = JSON.stringify(routeSummaries);
+        expect(skipped[0].reason).toMatch(/status is 'retired'/);
 
-        expect(serialised).not.toContain(signingKey);
-        expect(routeSummaries[0].keyFingerprint).toBe(fingerprintSigningKey(signingKey));
-        expect(routeSummaries[0].keyFingerprint).toHaveLength(12)
+        expect(() => buildWakeReceiverManifest({subscriptions: [bridgeDaemonSubscription]}))
+            .toThrow(/refusing to write an empty manifest/i)
+    });
+});
+
+test.describe('buildWakeReceiverManifest — composition', () => {
+    test('merges into existing routes so one seat cannot delete a peer', () => {
+        const peerId = 'WAKE_SUB:84dfc4da-0000-4000-8000-0000000000ff';
+
+        const {manifest} = buildWakeReceiverManifest({
+            subscriptions : [webhookSubscription],
+            existingRoutes: {[peerId]: {agentIdentity: '@neo-opus-grace', signingKey: PEER_KEY}}
+        });
+
+        expect(Object.keys(manifest.routes).sort()).toEqual([webhookSubscription.id, peerId].sort());
+        expect(manifest.routes[peerId].signingKey).toBe(PEER_KEY)
     });
 
-    test('refuses to produce an empty manifest', () => {
-        expect(() => buildWakeReceiverManifest({subscriptions: [retiredSubscription]}))
-            .toThrow(/refusing to write an empty manifest/i);
-        expect(() => buildWakeReceiverManifest({subscriptions: 'nope'}))
-            .toThrow(/requires a subscriptions array/i)
-    });
+    test('keeps per-route keys distinct and fingerprints non-reversible', () => {
+        const {routeSummaries} = buildWakeReceiverManifest({subscriptions: [webhookSubscription]});
 
-    test('refuses a subscription missing the fields the receiver requires', () => {
-        const cases = [
-            [{...activeSubscription, id: 'not-a-wake-sub'},        /not a WAKE_SUB identifier/i],
-            [{...activeSubscription, agentIdentity: ''},           /no agentIdentity/i],
-            [{...activeSubscription, harnessTargetMetadata: null}, /no harnessTargetMetadata/i]
-        ];
-
-        for (const [subscription, pattern] of cases) {
-            expect(() => buildWakeReceiverManifest({subscriptions: [subscription]})).toThrow(pattern)
-        }
+        expect(JSON.stringify(routeSummaries)).not.toContain(SERVER_KEY);
+        expect(routeSummaries[0].keyFingerprint).toBe(fingerprintSigningKey(SERVER_KEY));
+        expect(fingerprintSigningKey(SERVER_KEY)).not.toBe(fingerprintSigningKey(PEER_KEY))
     });
 });
 
 test.describe('writeValidatedManifest', () => {
-    test('writes 0600 and produces a manifest the receiver actually loads', async () => {
+    test('publishes 0600 and leaves no staging residue', async () => {
         const dir = await tempDir();
 
         try {
-            const {manifest} = buildWakeReceiverManifest({subscriptions: [activeSubscription]}),
+            const {manifest} = buildWakeReceiverManifest({subscriptions: [webhookSubscription]}),
                   target     = path.join(dir, 'routes.json');
 
             await writeValidatedManifest({manifest, targetPath: target});
 
-            // Mode matters: the receiver refuses anything group- or world-readable.
             expect((await stat(target)).mode & 0o077).toBe(0);
-            expect(JSON.parse(await readFile(target, 'utf8')).schemaVersion).toBe(1)
+            expect((await readdir(dir)).filter(name => name.includes('staging'))).toEqual([])
         } finally {
             await rm(dir, {force: true, recursive: true})
         }
     });
 
-    test('discards the staging file and publishes nothing when the receiver would reject it', async () => {
+    test('a pre-created staging symlink cannot capture the secrets or become the target', async () => {
         const dir = await tempDir();
 
         try {
-            const target = path.join(dir, 'routes.json');
+            const target = path.join(dir, 'routes.json'),
+                  victim = path.join(dir, 'victim.txt');
 
-            // An unsupported adapter is rejected by the receiver's loader, not by the builder — which
-            // is the point: the generator defers to the receiver rather than duplicating its rules.
-            const {manifest} = buildWakeReceiverManifest({
-                subscriptions: [{
-                    ...activeSubscription,
-                    harnessTargetMetadata: {...activeSubscription.harnessTargetMetadata, adapter: 'test-adapter'}
-                }]
-            });
+            await writeFile(victim, 'original\n');
+            // The old implementation used this exact predictable name and followed the link.
+            await symlink(victim, `${target}.staging`);
+
+            const {manifest} = buildWakeReceiverManifest({subscriptions: [webhookSubscription]});
+
+            await writeValidatedManifest({manifest, targetPath: target});
+
+            expect(await readFile(victim, 'utf8')).toBe('original\n');
+            expect(JSON.parse(await readFile(target, 'utf8')).routes[webhookSubscription.id].signingKey)
+                .toBe(SERVER_KEY)
+        } finally {
+            await rm(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('publishes nothing and leaves no residue when the receiver rejects the manifest', async () => {
+        const dir = await tempDir();
+
+        try {
+            const target     = path.join(dir, 'routes.json'),
+                  {manifest} = buildWakeReceiverManifest({subscriptions: [webhookSubscription]});
+
+            manifest.routes[webhookSubscription.id].harnessTargetMetadata.adapter = 'test-adapter';
 
             await expect(writeValidatedManifest({manifest, targetPath: target}))
                 .rejects.toThrow(/Refusing to publish a manifest the receiver rejects/i);
 
-            // Neither the target nor the staging file may survive a rejected publish.
             expect(existsSync(target)).toBe(false);
-            expect(existsSync(`${target}.staging`)).toBe(false)
+            expect((await readdir(dir)).filter(name => name.includes('staging'))).toEqual([])
         } finally {
             await rm(dir, {force: true, recursive: true})
         }
     });
 
     test('requires an absolute target path', async () => {
-        const {manifest} = buildWakeReceiverManifest({subscriptions: [activeSubscription]});
+        const {manifest} = buildWakeReceiverManifest({subscriptions: [webhookSubscription]});
 
         await expect(writeValidatedManifest({manifest, targetPath: 'routes.json'}))
             .rejects.toThrow(/must be absolute/i)
     });
 });
 
-test.describe('readExistingSigningKeys', () => {
-    test('round-trips keys so a rebuild does not rotate them', async () => {
+test.describe('readPublishedRoutes', () => {
+    test('round-trips published routes for additive rebuilds', async () => {
         const dir = await tempDir();
 
         try {
-            const target      = path.join(dir, 'routes.json'),
-                  {manifest}  = buildWakeReceiverManifest({subscriptions: [activeSubscription]}),
-                  originalKey = manifest.routes[activeSubscription.id].signingKey;
+            const target     = path.join(dir, 'routes.json'),
+                  {manifest} = buildWakeReceiverManifest({subscriptions: [webhookSubscription]});
 
             await writeValidatedManifest({manifest, targetPath: target});
 
-            const rebuilt = buildWakeReceiverManifest({
-                subscriptions: [activeSubscription],
-                signingKeys  : await readExistingSigningKeys(target)
-            });
+            const published = await readPublishedRoutes(target);
 
-            expect(rebuilt.manifest.routes[activeSubscription.id].signingKey).toBe(originalKey)
+            expect(published[webhookSubscription.id].signingKey).toBe(SERVER_KEY)
         } finally {
             await rm(dir, {force: true, recursive: true})
         }
     });
 
-    test('returns an empty map rather than throwing when no manifest exists', async () => {
+    test('only a MISSING manifest means first boot; corrupt or unreadable stops the build', async () => {
         const dir = await tempDir();
 
         try {
-            expect(await readExistingSigningKeys(path.join(dir, 'absent.json'))).toEqual({});
+            expect(await readPublishedRoutes(path.join(dir, 'absent.json'))).toEqual({});
 
-            await writeFile(path.join(dir, 'garbage.json'), 'not json\n', {mode: 0o600});
-            expect(await readExistingSigningKeys(path.join(dir, 'garbage.json'))).toEqual({})
+            const corrupt = path.join(dir, 'corrupt.json');
+            await writeFile(corrupt, 'not json\n', {mode: 0o600});
+
+            // Returning {} here once rotated live keys and 401'd an already-provisioned container.
+            await expect(readPublishedRoutes(corrupt)).rejects.toThrow(/rotate live signing keys/i);
+
+            const routeless = path.join(dir, 'routeless.json');
+            await writeFile(routeless, '{"schemaVersion":1}\n', {mode: 0o600});
+
+            await expect(readPublishedRoutes(routeless)).rejects.toThrow(/no routes object/i)
         } finally {
             await rm(dir, {force: true, recursive: true})
         }

--- a/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
@@ -1,0 +1,184 @@
+import {test, expect}                           from '@playwright/test';
+import {mkdtemp, readFile, rm, stat, writeFile} from 'node:fs/promises';
+import {existsSync}                             from 'node:fs';
+import os                                       from 'node:os';
+import path                                     from 'node:path';
+
+import {
+    buildWakeReceiverManifest,
+    fingerprintSigningKey,
+    readExistingSigningKeys,
+    writeValidatedManifest
+} from '../../../../../../ai/daemons/wake/buildReceiverManifest.mjs';
+
+const activeSubscription = {
+    id                   : 'WAKE_SUB:1b7cdb3a-2ae0-4262-9778-c4b86d4bc92a',
+    status               : 'active',
+    agentIdentity        : '@neo-opus-ada',
+    trigger              : 'SENT_TO_ME',
+    harnessTargetMetadata: {adapter: 'osascript', appName: 'Claude', tabShortcut: '3', focusSeedKey: 'space'}
+};
+
+const retiredSubscription = {
+    ...activeSubscription,
+    id    : 'WAKE_SUB:fc6eace1-b0a3-49fd-9fa1-9f3418db8289',
+    status: 'retired'
+};
+
+async function tempDir() {
+    return await mkdtemp(path.join(os.tmpdir(), 'wake-manifest-'))
+}
+
+test.describe('buildWakeReceiverManifest', () => {
+    test('maps active subscriptions to routes and excludes retired ones', () => {
+        const {manifest, routeSummaries} = buildWakeReceiverManifest({
+            subscriptions: [activeSubscription, retiredSubscription]
+        });
+
+        expect(manifest.schemaVersion).toBe(1);
+        expect(Object.keys(manifest.routes)).toEqual([activeSubscription.id]);
+        expect(routeSummaries).toHaveLength(1);
+
+        const route = manifest.routes[activeSubscription.id];
+
+        expect(route.agentIdentity).toBe('@neo-opus-ada');
+        expect(route.harnessTargetMetadata).toEqual(activeSubscription.harnessTargetMetadata);
+        expect(route.adapterConfig.attemptTimeoutMs).toBeGreaterThan(0);
+        expect(route.signingKey).toHaveLength(64)
+    });
+
+    test('reuses a supplied signing key instead of rotating it', () => {
+        const signingKey = 'a'.repeat(64);
+
+        const {manifest, routeSummaries} = buildWakeReceiverManifest({
+            subscriptions: [activeSubscription],
+            signingKeys  : {[activeSubscription.id]: signingKey}
+        });
+
+        // Rotating on every build would silently break a container already signing with the old key.
+        expect(manifest.routes[activeSubscription.id].signingKey).toBe(signingKey);
+        expect(routeSummaries[0].reusedKey).toBe(true)
+    });
+
+    test('never exposes a signing key in the summary, only a fingerprint', () => {
+        const signingKey = 'b'.repeat(64);
+
+        const {routeSummaries} = buildWakeReceiverManifest({
+            subscriptions: [activeSubscription],
+            signingKeys  : {[activeSubscription.id]: signingKey}
+        });
+
+        const serialised = JSON.stringify(routeSummaries);
+
+        expect(serialised).not.toContain(signingKey);
+        expect(routeSummaries[0].keyFingerprint).toBe(fingerprintSigningKey(signingKey));
+        expect(routeSummaries[0].keyFingerprint).toHaveLength(12)
+    });
+
+    test('refuses to produce an empty manifest', () => {
+        expect(() => buildWakeReceiverManifest({subscriptions: [retiredSubscription]}))
+            .toThrow(/refusing to write an empty manifest/i);
+        expect(() => buildWakeReceiverManifest({subscriptions: 'nope'}))
+            .toThrow(/requires a subscriptions array/i)
+    });
+
+    test('refuses a subscription missing the fields the receiver requires', () => {
+        const cases = [
+            [{...activeSubscription, id: 'not-a-wake-sub'},        /not a WAKE_SUB identifier/i],
+            [{...activeSubscription, agentIdentity: ''},           /no agentIdentity/i],
+            [{...activeSubscription, harnessTargetMetadata: null}, /no harnessTargetMetadata/i]
+        ];
+
+        for (const [subscription, pattern] of cases) {
+            expect(() => buildWakeReceiverManifest({subscriptions: [subscription]})).toThrow(pattern)
+        }
+    });
+});
+
+test.describe('writeValidatedManifest', () => {
+    test('writes 0600 and produces a manifest the receiver actually loads', async () => {
+        const dir = await tempDir();
+
+        try {
+            const {manifest} = buildWakeReceiverManifest({subscriptions: [activeSubscription]}),
+                  target     = path.join(dir, 'routes.json');
+
+            await writeValidatedManifest({manifest, targetPath: target});
+
+            // Mode matters: the receiver refuses anything group- or world-readable.
+            expect((await stat(target)).mode & 0o077).toBe(0);
+            expect(JSON.parse(await readFile(target, 'utf8')).schemaVersion).toBe(1)
+        } finally {
+            await rm(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('discards the staging file and publishes nothing when the receiver would reject it', async () => {
+        const dir = await tempDir();
+
+        try {
+            const target = path.join(dir, 'routes.json');
+
+            // An unsupported adapter is rejected by the receiver's loader, not by the builder — which
+            // is the point: the generator defers to the receiver rather than duplicating its rules.
+            const {manifest} = buildWakeReceiverManifest({
+                subscriptions: [{
+                    ...activeSubscription,
+                    harnessTargetMetadata: {...activeSubscription.harnessTargetMetadata, adapter: 'test-adapter'}
+                }]
+            });
+
+            await expect(writeValidatedManifest({manifest, targetPath: target}))
+                .rejects.toThrow(/Refusing to publish a manifest the receiver rejects/i);
+
+            // Neither the target nor the staging file may survive a rejected publish.
+            expect(existsSync(target)).toBe(false);
+            expect(existsSync(`${target}.staging`)).toBe(false)
+        } finally {
+            await rm(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('requires an absolute target path', async () => {
+        const {manifest} = buildWakeReceiverManifest({subscriptions: [activeSubscription]});
+
+        await expect(writeValidatedManifest({manifest, targetPath: 'routes.json'}))
+            .rejects.toThrow(/must be absolute/i)
+    });
+});
+
+test.describe('readExistingSigningKeys', () => {
+    test('round-trips keys so a rebuild does not rotate them', async () => {
+        const dir = await tempDir();
+
+        try {
+            const target      = path.join(dir, 'routes.json'),
+                  {manifest}  = buildWakeReceiverManifest({subscriptions: [activeSubscription]}),
+                  originalKey = manifest.routes[activeSubscription.id].signingKey;
+
+            await writeValidatedManifest({manifest, targetPath: target});
+
+            const rebuilt = buildWakeReceiverManifest({
+                subscriptions: [activeSubscription],
+                signingKeys  : await readExistingSigningKeys(target)
+            });
+
+            expect(rebuilt.manifest.routes[activeSubscription.id].signingKey).toBe(originalKey)
+        } finally {
+            await rm(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('returns an empty map rather than throwing when no manifest exists', async () => {
+        const dir = await tempDir();
+
+        try {
+            expect(await readExistingSigningKeys(path.join(dir, 'absent.json'))).toEqual({});
+
+            await writeFile(path.join(dir, 'garbage.json'), 'not json\n', {mode: 0o600});
+            expect(await readExistingSigningKeys(path.join(dir, 'garbage.json'))).toEqual({})
+        } finally {
+            await rm(dir, {force: true, recursive: true})
+        }
+    });
+});


### PR DESCRIPTION
Resolves #16233

Related: #16167

Adds a generator that maps active `WAKE_SUB` subscription records onto wake-receiver routes and publishes a `0600` manifest, so provisioning the host edge no longer means hand-authoring a secrets file and discovering its shape rules one `throw` at a time.

Evidence: L3 (a real receiver booted on this host from a generated manifest, and separately a signed request against a running receiver returned `401` for a forged signature, `202 accepted` for a valid one, and the resulting wake was observed arriving at a seat) → L3 required (AC1 names a receiver starting from a generated manifest without hand editing). Residual: none [#16233].

## Deltas from ticket

Two beyond the ticket's four numbered fix items, both discovered while writing the specs:

- **Publish is staged, not in-place.** The ticket said validate before publishing; it did not say where the rejected file goes. Writing directly to the target would leave a rejected manifest at the path the daemon reads. It now writes `<target>.staging`, validates, and renames — and a rejected publish leaves neither file behind.
- **`readExistingSigningKeys` returns `{}` rather than throwing** on a missing or corrupt manifest. AC3 only required round-tripping keys, but the first build on a fresh host has no prior manifest, and throwing there would make the tool unusable in exactly the case it exists for.

`DEFAULT_ATTEMPT_TIMEOUT_MS = 10000` is a stated generator choice, not a hidden fallback: the receiver deliberately declares no default so every route states its policy.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs buildReceiverManifest
  12 passed
```

Per surface touched:

- `ai/daemons/wake/buildReceiverManifest.mjs` — new; `test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs`, 12 specs.
- `ai/daemons/wake/receiver.mjs` — **not modified**; existing `receiver.spec.mjs` (9 specs) still covers it. The generator calls its real `loadWakeReceiverManifest` rather than a mock, so a drift between the two surfaces as a spec failure here.

Beyond the happy path the specs assert: `0600` mode on the published file; that a manifest the receiver rejects leaves neither target nor staging file; that a rebuild produces byte-identical signing keys; that the summary never contains a key, only a 12-character fingerprint; that a missing or corrupt manifest yields an empty key map; and that a set of only-retired subscriptions fails loudly rather than writing an empty manifest.

Live probe, outside CI (L3): receiver booted from a generated manifest on `127.0.0.1:45899` and served `POST /wake` with no hand editing of the generated file.

## Post-Merge Validation

- [ ] Generate a manifest from a **multi-peer** subscription set — every spec here uses a single route, so per-route key isolation across peers is unproven.
- [ ] Provision the container Memory Core with a matching signing key and confirm a container-originated wake is accepted; this PR produces only the host half of that shared secret.
- [ ] Confirm the `tmux` adapter path on a non-darwin host; adapter defaulting is exercised only on darwin here.

## Commits

- `5f3bf0b91d` — generator, specs, and the receiver-loader validation seam.

## Evolution

Originally scoped as a test encoding the receiver's envelope contract, after that contract cost two round trips to rediscover. Abandoned on finding `receiver.spec.mjs` already encodes all of it — including the `schemaVersion` string-vs-number trap — so the tests were never the gap. The gap was that nothing produced the manifest those tests presuppose.

Authored by @neo-opus-ada (Ada), Claude Opus 5.
