### PR TITLE
fix(ai): declare x-pass-as-object on the file-system MCP tools

### DIFF
--- a/ai/mcp/server/file-system/openapi.yaml
+++ b/ai/mcp/server/file-system/openapi.yaml
@@ -101,6 +101,7 @@ paths:
         the permitted workspace is rejected by the file-system service rather than silently
         rewritten.
       tags: [IO]
+      x-pass-as-object: true
       requestBody:
         required: true
         content:
@@ -129,6 +130,7 @@ paths:
       operationId: write_file
       description: Writes content to a specific file. Throws a 403 on directory escape attempts.
       tags: [IO]
+      x-pass-as-object: true
       requestBody:
         required: true
         content:
@@ -153,6 +155,7 @@ paths:
       operationId: list_directory
       description: Returns an array of file/folder names inside the given directory path.
       tags: [IO]
+      x-pass-as-object: true
       requestBody:
         required: true
         content:
@@ -174,6 +177,7 @@ paths:
       operationId: check_syntax
       description: Runs a native AST/syntax check against a file. Returns empty if valid, else returns the syntax error preventing execution.
       tags: [Execution]
+      x-pass-as-object: true
       requestBody:
         required: true
         content:
@@ -195,6 +199,7 @@ paths:
       operationId: run_playwright_test
       description: Runs the Playwright runner isolated to the requested spec file to test pass/fail conditions.
       tags: [Execution]
+      x-pass-as-object: true
       requestBody:
         required: true
         content:

--- a/test/playwright/unit/ai/mcp/server/file-system/toolServiceDispatch.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/file-system/toolServiceDispatch.spec.mjs
@@ -1,0 +1,156 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FileSystemToolServiceDispatchTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+// Bootstrap parity: importing toolService.mjs chains to Neo service classes that require
+// Neo.gatekeep. The setup() call only configures Neo; the augmentation happens via these imports,
+// and toolService.mjs itself is imported dynamically in beforeAll so it evaluates AFTER setup() —
+// mirrors McpServerListToolsSmoke.spec.mjs.
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import * as yaml       from 'js-yaml';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    repoRoot   = path.resolve(__dirname, '../../../../../../..'),
+    openApiDoc = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/file-system/openapi.yaml'), 'utf8')),
+
+    // `get_mcp_tool_handbook` is the one file-system tool whose handler is positional:
+    // `toolId => toolService.getToolHandbook(toolId)`, the identical arrow all six servers use. The
+    // cross-server form of this exception list lives beside the recurrence guard in
+    // test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs.
+    positionalTools = ['get_mcp_tool_handbook'];
+
+/**
+ * @summary Resolves the argument names ToolService derives for one operationId — the same union of
+ * `parameters` and request-body properties that `initializeToolMapping()` builds. An operation with
+ * no argument names dispatches identically either way, so only a non-empty result is interesting.
+ * @param {String} operationId The tool name.
+ * @returns {Object} `{argNames, operation}` for the matching operation.
+ */
+function getOperation(operationId) {
+    for (const pathItem of Object.values(openApiDoc.paths || {})) {
+        for (const operation of Object.values(pathItem || {})) {
+            if (operation?.operationId !== operationId) continue;
+
+            const argNames = (operation.parameters || []).map(parameter => parameter.name),
+                  schema   = operation.requestBody?.content?.['application/json']?.schema;
+
+            if (schema) {
+                // No file-system operation uses a $ref today. If one starts to, resolving it is the
+                // difference between this guard asserting and silently skipping, so it fails loudly
+                // instead — a quietly empty argument list is the shape of the defect being fixed.
+                expect(schema.$ref, `${operationId} uses a $ref request body; teach this helper to resolve it`).toBeUndefined();
+
+                argNames.push(...Object.keys(schema.properties || {}));
+            }
+
+            return {argNames, operation};
+        }
+    }
+
+    throw new Error(`operationId "${operationId}" is not declared in the file-system contract`);
+}
+
+/**
+ * @summary Coverage for the seam between the OpenAPI contract and the file-system handlers.
+ *
+ * `ToolService.callTool()` branches on `x-pass-as-object`: declared, the validated object goes to
+ * the handler whole; absent, the arguments are spread positionally. Every argument-taking
+ * `FileSystemService` handler destructures a single object, and the file-system contract declared
+ * the annotation on nothing — so every argument-taking tool of this server failed at call time from
+ * the day the server was added.
+ *
+ * Nothing caught it, and the reason is structural: `FileSystemPolicy.spec.mjs` substitutes
+ * `callTool` with a mock, and `FileSystemService.spec.mjs` calls the handlers directly with an
+ * object. Both contracts were green while the join between them was broken. These tests exercise
+ * the join, which is the only place the defect is observable.
+ */
+test.describe('ai/mcp/server/file-system — ToolService dispatch (#16231)', () => {
+    const tmpDir = path.join(repoRoot, 'tmp', `fs-dispatch-spec-${process.pid}`),
+          probe  = path.join(tmpDir, 'probe.mjs');
+
+    let callTool, listTools;
+
+    test.beforeAll(async () => {
+        ({callTool, listTools} = await import('../../../../../../../ai/mcp/server/file-system/services/toolService.mjs'));
+
+        await fs.ensureDir(tmpDir);
+        await fs.writeFile(probe, 'export const ok = 1;\n', 'utf-8');
+    });
+
+    test.afterAll(async () => {
+        await fs.remove(tmpDir).catch(() => {});
+    });
+
+    test('#16231 every argument-taking tool survives the real dispatch, not just a direct handler call', async () => {
+        // The assertions are on real return values rather than "did not throw", because the broken
+        // dispatch does not fail loudly: the handler receives a bare string, destructuring yields
+        // `absolutePath === undefined`, and the sandbox guard reports that as a 403. A tool that
+        // answers with the file's actual content cannot have been called that way.
+        expect(await callTool('read_file', {absolutePath: probe}))
+            .toEqual({content: 'export const ok = 1;\n'});
+
+        expect(await callTool('write_file', {absolutePath: path.join(tmpDir, 'written.txt'), content: 'ok\n'}))
+            .toBe('success');
+        expect(await fs.readFile(path.join(tmpDir, 'written.txt'), 'utf-8')).toBe('ok\n');
+
+        expect(await callTool('list_directory', {absolutePath: tmpDir}))
+            .toEqual(expect.arrayContaining([{name: 'probe.mjs', isDirectory: false, isFile: true}]));
+
+        expect(await callTool('check_syntax', {absolutePath: probe})).toBe('Syntax OK');
+    });
+
+    test('#16231 run_playwright_test reaches its OWN guard — the path arrived, it was simply out of bounds', async () => {
+        // Distinguishing which 403 comes back is the whole point. Under the broken dispatch this
+        // rejects from the sandbox guard because `absolutePath` is undefined; with the annotation in
+        // place it rejects from the directory guard, which can only be reached by a real path string.
+        // Asserting the second message therefore fails if the dispatch ever regresses.
+        await expect(callTool('run_playwright_test', {absolutePath: probe}))
+            .rejects.toThrow(/403 Forbidden: Can only execute Playwright specs/);
+    });
+
+    test('#16231 the two tools that must NOT be annotated keep working — the fix is per operation, not per file', async () => {
+        // `healthcheck` takes no arguments at all; `get_mcp_tool_handbook` takes its toolId
+        // positionally. Annotating the whole file would have broken the second one, so the contract
+        // has to stay per operation.
+        expect(await callTool('healthcheck', {})).toEqual({status: 'healthy'});
+        expect(await callTool('get_mcp_tool_handbook', {toolId: 'read_file'}))
+            .toMatchObject({toolId: 'read_file', found: true});
+    });
+
+    test('#16231 every tool this server LISTS is annotated — the contract cannot grow past this spec unnoticed', async () => {
+        // The dispatch tests above name the tools they call, so a seventh tool added later would
+        // inherit the same 0-annotation treatment unnoticed. This one reads `tools/list` instead, so
+        // the assertion widens with the surface rather than with this file.
+        const {tools} = await listTools();
+
+        expect(tools.length, 'file-system should expose tools at all').toBeGreaterThan(0);
+
+        for (const tool of tools) {
+            const {argNames, operation} = getOperation(tool.name);
+
+            if (argNames.length === 0)                continue;
+            if (positionalTools.includes(tool.name))  continue;
+
+            expect(operation['x-pass-as-object'], `file-system.${tool.name} handler takes an object but the contract does not say so`).toBe(true);
+        }
+    });
+});

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -726,6 +726,68 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(offenders, `x-handler ops missing x-pass-as-object (arg-shape mismatch):\n${offenders.join('\n')}`).toEqual([]);
     });
 
+    test('every server: an argument-taking operation carries x-pass-as-object unless its handler is positional (#16231)', () => {
+        // The guard above, generalized. That one covers neural-link x-handler ops; the same omission
+        // put every argument-taking file-system tool out of action from the day that server was
+        // created, because nothing asserted over the whole surface. The annotation is required for
+        // correctness, silent when absent, and undocumented, so each new server inherits the trap
+        // intact.
+        //
+        // gitlab-workflow is included here even though the module-level `servers` list omits it — the
+        // trap does not care which suites cover a server. Deduplicated so that adding it to `servers`
+        // later widens the shared list instead of scanning it twice here.
+        const allServers = [...new Set([...servers, 'gitlab-workflow'])].sort();
+
+        // Exceptions need a reason, because an unlisted one is exactly the defect this test catches.
+        const positionalHandlers = {
+            // `toolId => toolService.getToolHandbook(toolId)` — the identical arrow in all six servers.
+            'get_mcp_tool_handbook': 'arrow handler takes the toolId positionally',
+
+            // `getIssueById(issueNumber)` — genuinely positional, single argument.
+            'github-workflow:get_local_issue_by_id': 'handler signature is a single positional issueNumber',
+
+            // `getPullRequestDiff(options)` documents `{Object|number}` and re-wraps a bare number, so
+            // the positional call still resolves pr_number — but `file`, `sha` and `files_only` are
+            // dropped by arity. Listed to keep this guard green, NOT because the dispatch is right.
+            'github-workflow:get_pull_request_diff': 'tolerates a bare pr_number; the other three declared arguments never arrive',
+
+            // `getIngestionProgress({staleAfterMs = 60000} = {})` destructures, but the `= {}` default
+            // keeps it from throwing on a positional call: it falls back to 60000 and the caller's
+            // value never lands. Same category as the entry above.
+            'knowledge-base:get_ingestion_progress': 'destructures behind a `= {}` default; positional call degrades silently'
+        };
+
+        const offenders = [];
+
+        for (const server of allServers) {
+            const doc = yaml.load(fs.readFileSync(path.join(repoRoot, `ai/mcp/server/${server}/openapi.yaml`), 'utf8'));
+
+            for (const [operationId, op] of Object.entries(getOperationsById(doc))) {
+                // The same union ToolService.initializeToolMapping() builds. No argument names means the
+                // operation dispatches identically either way, so only a non-empty set is interesting.
+                const argNames = (op.parameters || []).map(parameter => parameter.name),
+                      schema   = op.requestBody?.content?.['application/json']?.schema;
+
+                if (schema) {
+                    const resolved = schema.$ref
+                        ? schema.$ref.replace(/^#\//, '').split('/').reduce((node, key) => node[key], doc)
+                        : schema;
+
+                    argNames.push(...Object.keys(resolved.properties || {}));
+                }
+
+                if (argNames.length === 0)                          continue;
+                if (op['x-pass-as-object'] === true)                continue;
+                if (positionalHandlers[operationId])                continue;
+                if (positionalHandlers[`${server}:${operationId}`]) continue;
+
+                offenders.push(`${server}.${operationId} (${argNames.join(', ')})`);
+            }
+        }
+
+        expect(offenders, `ops dispatch positionally with no positional handler recorded:\n${offenders.join('\n')}`).toEqual([]);
+    });
+
     test('neural-link inspect_store + list_stores output schemas (object `model` #13372; list_stores `{stores:[]}` envelope + `isLoaded` #10072)', () => {
         const doc     = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'), 'utf8')),
               opsById = getOperationsById(doc),


### PR DESCRIPTION
Resolves #16231

Five lines of YAML on the five file-system operations whose handler destructures a single object, plus the dispatch-level spec that was missing. `ToolService.callTool()` branches on `x-pass-as-object`: declared, the validated object reaches the handler whole; absent, the arguments are spread positionally. Every argument-taking `FileSystemService` handler destructures, the contract declared the annotation on nothing, and so `absolutePath` arrived as `undefined` from the day the server was added. `get_mcp_tool_handbook` is deliberately left unannotated — its handler takes the `toolId` positionally, so annotating the file wholesale would have broken it.

Evidence: L3 achieved (the real `toolService.callTool()` invoked against the real server surface, both dispatch branches, before and after the change; real child processes for `check_syntax`) → L3 required. The close-target's ACs are entirely observable inside CI, so the sandbox/achievable gap the ladder exists to track does not open here. Residual: none. The stdio-transport reading in #16231 was taken against the published 13.0.0 / 13.1.0 packages with a real MCP client; on `dev` I verified in-process only, which is why the stdio session is listed under Post-Merge Validation rather than claimed here.

Authored by novice-22, an external contributor. Claude Opus assisted with the diagnosis and the spec, per CONTRIBUTING §5; the analysis and the code are mine and my responsibility.

## Deltas from ticket

Three, all additive:

1. The ticket proposed the annotation on five operations. Building the cross-server case confirmed `get_mcp_tool_handbook` must stay unannotated in all six servers, so the spec pins that explicitly rather than leaving it implied.
2. The cross-server assertion is not a new file. `OpenApiValidatorCompliance.spec.mjs` already carries the neural-link `x-handler` recurrence guard from #14542, which is the same assertion narrowed to one server, so this generalizes that test in place rather than starting a parallel one somewhere else. `gitlab-workflow` is included even though the module-level `servers` list in that file omits it.
3. The same cross-server case surfaced two operations that are unannotated, do **not** crash, and still do not fully work. They are recorded with a reason instead of changed, since they are outside this ticket:
   - `knowledge-base.get_ingestion_progress` — `getIngestionProgress({staleAfterMs = 60000} = {})`. The `= {}` default keeps a positional call from throwing: destructuring a bare number yields `undefined`, the fallback 60000 wins, and the caller's `staleAfterMs` never lands.
   - `github-workflow.get_pull_request_diff` — `getPullRequestDiff(options)` documents `{Object|number}` and re-wraps a bare number, so `pr_number` still resolves. The other three declared parameters (`file`, `sha`, `files_only`) are dropped by arity, so a caller asking for one file's diff gets the whole diff.

   `github-workflow.get_local_issue_by_id` is genuinely positional (`getIssueById(issueNumber)`) and is listed as correct.

   Happy to file those two as their own ticket, or to fold them in here if you would rather they land together.

## Test Evidence

- `test/playwright/unit/ai/mcp/server/file-system/toolServiceDispatch.spec.mjs` — new, 4 tests, dispatch-level
- `test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — one test added beside the #14542 guard, cross-server

Existing coverage is green on both sides of the defect and blind to it: `FileSystemPolicy.spec.mjs` substitutes `callTool` with a mock, and `FileSystemService.spec.mjs` calls the handlers directly with an object. The seam between them is the only place the defect is observable, so the new spec calls the real `callTool` exported by the real `toolService.mjs`.

```
npx playwright test -c test/playwright/playwright.config.unit.mjs --project=unit-brain --no-deps \
    test/playwright/unit/ai/mcp/server/file-system/ test/playwright/unit/ai/mcp/validation/
→ 62 passed
```

(`--no-deps` because neither directory needs the Chroma setup the project declares.)

Reverting only the YAML to its `dev` state and rerunning the same command:

```
→ 4 failed, 58 passed
    toolServiceDispatch.spec.mjs — every argument-taking tool survives the real dispatch
    toolServiceDispatch.spec.mjs — run_playwright_test reaches its OWN guard
    toolServiceDispatch.spec.mjs — every tool this server LISTS is annotated
    OpenApiValidatorCompliance.spec.mjs — every server: an argument-taking operation carries x-pass-as-object
```

A standalone probe driving the same `toolService.callTool()` outside Playwright, before the change on `dev`:

```
tools/list -> healthcheck, get_mcp_tool_handbook, read_file, write_file,
              list_directory, check_syntax, run_playwright_test

OK    healthcheck            {"status":"healthy"}
OK    get_mcp_tool_handbook  {"toolId":"read_file","found":true,...}
FAIL  read_file              403 Forbidden: Canonical containment could not be established (ERR_INVALID_ARG_TYPE)
FAIL  write_file             (same)
FAIL  list_directory         (same)
FAIL  check_syntax           (same)
FAIL  run_playwright_test    (same)
```

After:

```
OK    read_file              {"content":"export const ok = 1;\n"}
OK    write_file             "success"
OK    list_directory         [{"name":"probe.mjs","isDirectory":false,"isFile":true},...]
OK    check_syntax           "Syntax OK"
OK    run_playwright_test    403 Forbidden: Can only execute Playwright specs within the test/playwright/ directory.
```

The last line is the intended outcome, not a failure: the probe file sits outside `test/playwright/`, so the tool's own directory guard answers. Reaching that guard requires a real path string, which is what makes it a regression assertion — under the broken dispatch the rejection comes from the sandbox guard instead, with a different message.

Worth one note for triage: on current `dev` the broken dispatch no longer surfaces as a raw `TypeError`. The fail-closed canonicalization guard classifies `ERR_INVALID_ARG_TYPE` as a **403 containment refusal**, so the symptom now reads as a path-permission problem rather than an argument-shape one.

Whole MCP tree, my branch against a pristine `dev` checkout in the same environment:

```
test/playwright/unit/ai/mcp/   (project unit-brain)

dev        493 passed, 11 failed
this PR    498 passed, 11 failed
```

The +5 are the tests this PR adds. The 11 failures are the same count, in the same two spec files, on both sides: `McpServersHealth.spec.mjs` and `DestructiveOperationGuard.spec.mjs`, neither of which this PR touches. I did not diagnose why they fail in my checkout, only that this branch does not change them.

Lints that trigger on the changed paths, all run locally:

- `ai/scripts/lint/lint-identity-vocabulary.mjs` (`ai/mcp/server/*/openapi.yaml`) → 6 surfaces, 0 violations
- `buildScripts/util/check-aiconfig-test-mutation.mjs` (`test/**/*.mjs`) → 1046 files, 0 new violations
- `buildScripts/util/check-ticket-archaeology.mjs` (`test/playwright/**/*.mjs`) → 0 violations
- `npm run ai:lint-mcp-test-locations` → OK

## Post-Merge Validation

- [ ] The five tools answer over a real stdio MCP client session, not just in-process dispatch
- [ ] An agent harness that mounts the file-system server can complete a read → check_syntax → write loop
- [ ] Decide whether the two argument-dropping operations named under Deltas become their own ticket

## Commits

- `fix(ai): declare x-pass-as-object on the file-system MCP tools (#16231)` — annotation, dispatch spec, and the #14542 guard generalized to every server
