### PR TITLE
feat(ai): cause-classified vector rebuild with provenance and id-set receipts

### DIFF
--- a/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.mjs
+++ b/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.mjs
@@ -1,0 +1,399 @@
+/**
+ * Memory Core vector-store rebuild — re-embed into a fresh target with provenance-checked,
+ * id-set-reconciled, fail-loud receipts.
+ *
+ * Cross-store, operator-run: reads ids + documents + metadatas from the SOURCE Chroma collection
+ * (stored vectors are deliberately ignored — a version-incompatible index cannot be trusted and
+ * the rebuild targets one uniform embedding model), re-embeds every document against the named
+ * embeddings endpoint, and streams the batches into the TARGET collection.
+ *
+ * The SOURCE BOUNDARY is decided by the governing migration ticket, never here: this runner is a
+ * mechanism that the chosen source feeds. It composes `extractMemoryCoreCollectionData` in its
+ * degenerate case (`missingVectorIds = allIds`): that module owns batching, resume (`skipIds`),
+ * cause-classified bounded retry, and fate-stamped failure entries. This script owns clients,
+ * identity/provenance checks, the collection loop, the drained embed function, id-set
+ * reconciliation, and the receipt.
+ *
+ * Deliberately NOT integrated: AiConfig (both stores are named explicitly via argv — a rebuild
+ * must never inherit an ambient URL and hit the wrong store) and the heavy-maintenance lease
+ * (source access is read-only; the target is an operator-named store).
+ *
+ * STDOUT carries exactly one structured receipt JSON; progress goes to STDERR. Exit code is `0`
+ * only when every collection reconciled with zero failures.
+ *
+ * @module Neo.ai.scripts.maintenance.rebuildMemoryCoreVectorStore
+ */
+
+import {program}                         from 'commander';
+import {ChromaClient}                    from 'chromadb';
+import {fileURLToPath}                   from 'url';
+import {extractMemoryCoreCollectionData} from './repairMemoryCoreStoredEmbeddings.mjs';
+
+/**
+ * @summary Reads every id of a collection, paginated.
+ * @param {Object} collection Chroma collection handle
+ * @param {Number} [pageSize=2000]
+ * @returns {Promise<String[]>}
+ */
+export async function readAllIds(collection, pageSize = 2000) {
+    const ids = [];
+    for (let offset = 0; ; offset += pageSize) {
+        const page = await collection.get({limit: pageSize, offset, include: []});
+        const got  = page.ids || [];
+        ids.push(...got);
+        if (got.length < pageSize) break;
+    }
+    return ids;
+}
+
+/**
+ * @summary Builds the embed function: batched, concurrency-capped calls to an OpenAI-compatible
+ * `/v1/embeddings` endpoint that ALWAYS drain and ALWAYS validate.
+ *
+ * Two guarantees the failure engine upstream depends on:
+ *
+ * - **Drained**: workers never throw mid-pool. Every in-flight request settles before the call
+ *   resolves or rejects, so a retry round can never overlap orphaned requests from the previous
+ *   one — configured concurrency is a hard bound, not a hope. On any chunk failure the call
+ *   rejects AFTER the drain with the first failure as its cause (carrying `httpStatus` when the
+ *   provider answered), annotated with how many chunks failed.
+ * - **Validated**: the response must carry exactly one embedding per input at authoritative,
+ *   duplicate-free indexes. Sparse, duplicated, or wrong-shape results reject with the malformed
+ *   marker — this function never resolves with `undefined` holes.
+ *
+ * @param {Object}  options
+ * @param {String}  options.url        Embeddings endpoint
+ * @param {String}  options.model      Model identifier (the exact id the servers use)
+ * @param {Number}  [options.batch=8]  Inputs per request
+ * @param {Number}  [options.concurrency=6] Requests in flight
+ * @param {Function} [options.fetchImpl=fetch]
+ * @returns {Function} `(documents: String[]) => Promise<Number[][]>`
+ */
+export function createEmbedFn({url, model, batch = 8, concurrency = 6, fetchImpl = fetch}) {
+    return async documents => {
+        const chunks = [];
+        for (let i = 0; i < documents.length; i += batch) {
+            chunks.push({at: i, docs: documents.slice(i, i + batch)});
+        }
+
+        const out      = new Array(documents.length);
+        const failures = [];
+        let   next     = 0;
+
+        const worker = async () => {
+            while (next < chunks.length) {
+                const chunk = chunks[next++];
+
+                try {
+                    const res = await fetchImpl(url, {
+                        method : 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body   : JSON.stringify({model, input: chunk.docs})
+                    });
+
+                    if (!res.ok) {
+                        const error = new Error(`embed HTTP ${res.status}`);
+                        error.httpStatus = res.status;
+                        throw error;
+                    }
+
+                    const json = await res.json();
+                    const data = Array.isArray(json?.data) ? json.data : null;
+
+                    if (!data || data.length !== chunk.docs.length) {
+                        throw malformedError(`provider returned ${data ? data.length : 'no'} embeddings for ${chunk.docs.length} inputs`);
+                    }
+
+                    const seen = new Set();
+
+                    for (const item of data) {
+                        // The index is authoritative — but only when it is a real, in-range,
+                        // duplicate-free integer. Anything else is a malformed result, never a
+                        // silent hole.
+                        if (!Number.isInteger(item?.index) || item.index < 0 || item.index >= chunk.docs.length || seen.has(item.index)) {
+                            throw malformedError(`provider returned an invalid or duplicate embedding index (${item?.index})`);
+                        }
+                        seen.add(item.index);
+                        out[chunk.at + item.index] = item.embedding;
+                    }
+                } catch (error) {
+                    failures.push(error);
+                }
+            }
+        };
+
+        await Promise.all(Array.from({length: Math.min(concurrency, chunks.length) || 1}, worker));
+
+        if (failures.length > 0) {
+            // Rejection happens strictly AFTER the pool drained: the retry engine above may fire
+            // its next round immediately without ever exceeding the concurrency bound.
+            const primary = failures.find(failure => failure.httpStatus !== undefined) ?? failures[0];
+            primary.message = `${primary.message} (${failures.length}/${chunks.length} chunks failed, pool drained)`;
+            throw primary;
+        }
+
+        return out;
+    };
+}
+
+function malformedError(message) {
+    const error = new Error(message);
+    error.unrecoverableReason = 'embedding-result-malformed';
+    return error;
+}
+
+/**
+ * @summary Groups per-row failure entries into per-reason receipts.
+ *
+ * The binary verdict an operator needs ("resume, or repair configuration/source?") is a
+ * projection of these rows, not a separate schema field: new reason codes become new array
+ * entries, and reconciliation stays a single sum over `count`.
+ *
+ * @param {Object[]} entries Structured extractor entries (`{id, reason, retryable, message?}`)
+ * @param {Number}   [sampleCap=10] Ids retained per reason — enough to eyeball, never a dump
+ * @returns {Object[]} `[{reason, count, retryable, sampleIds}]`, largest count first
+ */
+export function groupFailureReceipts(entries, sampleCap = 10) {
+    const byReason = new Map();
+
+    for (const entry of entries) {
+        let row = byReason.get(entry.reason);
+
+        if (!row) {
+            row = {reason: entry.reason, count: 0, retryable: entry.retryable === true, sampleIds: []};
+            byReason.set(entry.reason, row);
+        }
+
+        row.count++;
+
+        if (row.sampleIds.length < sampleCap) {
+            row.sampleIds.push(entry.id);
+        }
+    }
+
+    return [...byReason.values()].sort((a, b) => b.count - a.count);
+}
+
+/**
+ * @summary Validates CLI options before any client is constructed. Pure — testable without a process.
+ * @param {Object} opts Parsed commander options.
+ * @returns {String[]} Human-readable errors; empty when valid.
+ */
+export function validateCliOptions(opts) {
+    const errors  = [];
+    const urlLike = value => /^https?:\/\//.test(value);
+
+    if (!urlLike(opts.sourceUrl ?? '')) errors.push(`--source-url must be an http(s) URL, got "${opts.sourceUrl}"`);
+    if (!urlLike(opts.targetUrl ?? '')) errors.push(`--target-url must be an http(s) URL, got "${opts.targetUrl}"`);
+    if (opts.sourceUrl && opts.sourceUrl === opts.targetUrl) errors.push('--source-url and --target-url must differ (fail-closed; identity is additionally verified per collection UUID)');
+    if (!urlLike(opts.embedUrl ?? '')) errors.push(`--embed-url must be an http(s) URL, got "${opts.embedUrl}"`);
+    if (!(opts.collections ?? '').split(',').map(s => s.trim()).filter(Boolean).length) errors.push('--collections must name at least one collection');
+
+    for (const [flag, min] of [['embedBatch', 1], ['embedConcurrency', 1], ['embedAttempts', 1], ['embedBackoff', 0], ['getBatch', 1], ['limit', 0], ['expectDims', 0]]) {
+        const value = opts[flag];
+        if (value !== undefined && (!Number.isInteger(value) || value < min)) {
+            errors.push(`--${flag.replace(/[A-Z]/g, c => '-' + c.toLowerCase())} must be an integer >= ${min}, got "${value}"`);
+        }
+    }
+
+    return errors;
+}
+
+/**
+ * @summary Rebuilds the named collections from source into target with a full re-embed,
+ * provenance checks, and id-set reconciliation.
+ *
+ * Resumable: planned ids already present in the target are skipped, so a crashed or partial run
+ * continues where it stopped and a re-run retries exactly the missing rows. Fail-loud: `ok` is
+ * true only when every planned id landed in the target (or the collection was refused before any
+ * work, which is `ok: false` by definition).
+ *
+ * Identity and provenance:
+ * - source and target resolving to the SAME collection UUID are refused — two spellings of one
+ *   host must never "reconcile" a no-op as success;
+ * - the receipt records endpoint URLs, both collection UUIDs, the embedding model, and the
+ *   expected dimension, so a later reader can tell WHAT was rebuilt against WHAT;
+ * - reconciliation is id-set based: `missingAfterRun` (planned ids in neither target nor the
+ *   failure list — must be zero even when counts happen to match) and `targetOnly` ids (present
+ *   in the target but not the source) are reported. Target-only ids do NOT fail the run: a live
+ *   plane legitimately receives new writes during a rebuild — they are observability, not error.
+ *
+ * @param {Object}   options
+ * @param {Object}   options.sourceClient  ChromaClient (or compatible) for the source store
+ * @param {Object}   options.targetClient  ChromaClient (or compatible) for the target store
+ * @param {String[]} options.collections   Collection names to rebuild
+ * @param {Function} options.embedFn       `(documents) => embeddings`
+ * @param {Object}   [options.provenance]  `{sourceUrl, targetUrl, model, expectedDimension}` for the receipt
+ * @param {Number}   [options.getBatch=500]  Source read / re-embed chunk size
+ * @param {Number}   [options.limit=0]       Pilot mode: only the first N ids per collection
+ * @param {Boolean}  [options.dryRun=false]  Count and plan only; performs NO write of any kind
+ * @param {Object}   [options.embedRetry]    Bounded-retry forwarding (`{attempts, backoffMs, wait}`)
+ * @param {Number}   [options.expectedDimension] Per-element dimension check forwarded to the extractor
+ * @param {Function} [options.log=console.error]
+ * @returns {Promise<Object>} `{ok, collections: [...]}` — see the per-collection shape in the receipt
+ */
+export async function rebuildCollections({
+    sourceClient,
+    targetClient,
+    collections,
+    embedFn,
+    provenance = {},
+    getBatch = 500,
+    limit = 0,
+    dryRun = false,
+    embedRetry,
+    expectedDimension,
+    log = console.error
+}) {
+    const receipt = {ok: true, dryRun, provenance: {...provenance, expectedDimension}, collections: []};
+
+    for (const name of collections) {
+        const sourceCol = await sourceClient.getCollection({name});
+
+        // Dry-run must not create anything: probe the target read-only and report absence
+        // instead of materializing an empty collection as a side effect of "counting".
+        let targetCol = null;
+
+        if (dryRun) {
+            try {
+                targetCol = await targetClient.getCollection({name});
+            } catch {
+                targetCol = null;
+            }
+        } else {
+            targetCol = await targetClient.getOrCreateCollection({name});
+        }
+
+        const entry = {
+            name,
+            sourceCollectionId: sourceCol.id ?? null,
+            targetCollectionId: targetCol?.id ?? null
+        };
+
+        // Semantic identity check: two DIFFERENT URLs can still resolve to one store (localhost
+        // vs 127.0.0.1 vs a LAN alias). Same collection UUID = same collection; a "rebuild" onto
+        // itself would skip everything and bless a no-op as success.
+        if (targetCol && sourceCol.id && sourceCol.id === targetCol.id) {
+            receipt.ok = false;
+            receipt.collections.push({...entry, error: 'source-and-target-are-the-same-collection', ok: false});
+            log(`[rebuild] ${name}: REFUSED — source and target resolve to the same collection (${sourceCol.id})`);
+            continue;
+        }
+
+        let   allIds = await readAllIds(sourceCol);
+        const source = allIds.length;
+
+        if (limit > 0) allIds = allIds.slice(0, limit);
+
+        const targetIds  = targetCol ? await readAllIds(targetCol) : [];
+        const sourceSet  = new Set(allIds);
+        const targetSet  = new Set(targetIds);
+        const skipIds    = allIds.filter(id => targetSet.has(id));
+        const targetOnly = targetIds.filter(id => !sourceSet.has(id));
+
+        Object.assign(entry, {
+            source,
+            planned     : allIds.length,
+            targetBefore: targetIds.length,
+            targetOnly  : {count: targetOnly.length, sampleIds: targetOnly.slice(0, 10)}
+        });
+
+        log(`[rebuild] ${name}: source=${source} planned=${allIds.length} targetBefore=${targetIds.length} targetOnly=${targetOnly.length}${dryRun ? ' (dry-run)' : ''}`);
+
+        if (dryRun) {
+            receipt.collections.push({...entry, wouldCreateTarget: !targetCol, resumedExisting: skipIds.length, ok: true});
+            continue;
+        }
+
+        const result = await extractMemoryCoreCollectionData({
+            collection      : sourceCol,
+            allIds,
+            missingVectorIds: allIds,
+            embedFn,
+            batchSize       : getBatch,
+            skipIds,
+            collectData     : false,
+            embedRetry,
+            expectedDimension,
+            onDataBatch     : async batch => {
+                await targetCol.add({ids: batch.ids, embeddings: batch.embeddings, documents: batch.documents, metadatas: batch.metadatas});
+            },
+            onProgress: ({phase, percent}) => log(`[rebuild] ${name}: ${phase} ${percent}%`)
+        });
+
+        // Id-set reconciliation: counts can lie (a contaminated target inflates them); only the
+        // set proves every planned id is accounted for — landed in the target or named failed.
+        const afterSet  = new Set(await readAllIds(targetCol));
+        const failedSet = new Set((result.unrecoverable ?? []).map(failure => failure.id));
+        const missing   = allIds.filter(id => !afterSet.has(id) && !failedSet.has(id));
+
+        const failed       = groupFailureReceipts(result.unrecoverable ?? []);
+        const failedCount  = failed.reduce((sum, row) => sum + row.count, 0);
+        const resumable    = failed.filter(row => row.retryable).reduce((sum, row) => sum + row.count, 0);
+        const stoppedEarly = Boolean(result.stoppedEarly);
+
+        const done = {
+            ...entry,
+            targetAfter    : afterSet.size,
+            reEmbedded     : result.counts.reEmbedded,
+            resumedExisting: result.counts.resumedExisting ?? 0,
+            failed,
+            stoppedEarly,
+            missingAfterRun: {count: missing.length, sampleIds: missing.slice(0, 10)},
+            ok             : missing.length === 0 && failedCount === 0
+        };
+
+        if (!done.ok) receipt.ok = false;
+
+        receipt.collections.push(done);
+        log(`[rebuild] ${name}: done targetAfter=${done.targetAfter} reEmbedded=${done.reEmbedded} failed=${failedCount} (${resumable} resumable, ${failedCount - resumable} terminal)${stoppedEarly ? ' STOPPED-EARLY' : ''} missing=${missing.length}`);
+    }
+
+    return receipt;
+}
+
+const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isDirectRun) {
+    program
+        .requiredOption('--source-url <url>', 'source store Chroma URL (read-only)')
+        .requiredOption('--target-url <url>', 'target store Chroma URL')
+        .requiredOption('--collections <csv>', 'comma-separated collection names')
+        .option('--embed-url <url>', 'OpenAI-compatible embeddings endpoint', 'http://127.0.0.1:1234/v1/embeddings')
+        .option('--embed-model <id>', 'embedding model identifier', 'text-embedding-qwen3-embedding-8b')
+        .option('--embed-batch <n>', 'inputs per embed request', v => parseInt(v, 10), 8)
+        .option('--embed-concurrency <n>', 'embed requests in flight', v => parseInt(v, 10), 6)
+        .option('--embed-attempts <n>', 'attempt budget per re-embed batch (transient failures retry whole-batch with backoff)', v => parseInt(v, 10), 3)
+        .option('--embed-backoff <ms>', 'base backoff between attempts, doubling per attempt', v => parseInt(v, 10), 1000)
+        .option('--expect-dims <n>', 'per-element vector dimension check (0 disables)', v => parseInt(v, 10), 4096)
+        .option('--get-batch <n>', 'source read chunk size', v => parseInt(v, 10), 500)
+        .option('--limit <n>', 'pilot mode: first N ids per collection', v => parseInt(v, 10), 0)
+        .option('--dry-run', 'count and plan only; performs no write of any kind', false)
+        .parse();
+
+    const opts   = program.opts();
+    const errors = validateCliOptions(opts);
+
+    if (errors.length > 0) {
+        for (const error of errors) console.error(`[rebuild] INVALID: ${error}`);
+        process.exit(2);
+    }
+
+    const expectedDimension = opts.expectDims > 0 ? opts.expectDims : undefined;
+
+    const receipt = await rebuildCollections({
+        sourceClient: new ChromaClient({path: opts.sourceUrl}),
+        targetClient: new ChromaClient({path: opts.targetUrl}),
+        collections : opts.collections.split(',').map(s => s.trim()).filter(Boolean),
+        embedFn     : createEmbedFn({url: opts.embedUrl, model: opts.embedModel, batch: opts.embedBatch, concurrency: opts.embedConcurrency}),
+        provenance  : {sourceUrl: opts.sourceUrl, targetUrl: opts.targetUrl, model: opts.embedModel},
+        getBatch    : opts.getBatch,
+        limit       : opts.limit,
+        dryRun      : Boolean(opts.dryRun),
+        embedRetry  : {attempts: opts.embedAttempts, backoffMs: opts.embedBackoff},
+        expectedDimension
+    });
+
+    console.log(JSON.stringify(receipt, null, 2));
+    process.exit(receipt.ok ? 0 : 1);
+}

--- a/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
+++ b/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
@@ -12,8 +12,9 @@
  * rows from their DOCUMENTS (which still materialize — only the embedding fetch fails). Recovered batches
  * can either be retained in a merged `{ids, embeddings, documents, metadatas}` buffer or streamed into a
  * resumable shadow collection. A missing-vector row with no recoverable document/embedding is reported as
- * a structured `unrecoverable` entry (`{id, reason, message?}`; counts surfaced, never silently dropped —
- * the fail-loud discipline).
+ * a structured `unrecoverable` entry (`{id, reason, retryable, message?}`; counts surfaced, never silently
+ * dropped — the fail-loud discipline). `retryable` is the classifier-stamped fate: `true` for transient
+ * provider failures a later pass can fix, `false` for content/config problems no retry can recover.
  *
  * The live shadow run + canonical promotion is operator/env-gated (out of scope without
  * explicit authorization); this module is the pure extraction logic, unit-tested against mocked Chroma.
@@ -44,6 +45,9 @@ import {resolveTurnDocumentForRead} from '../../services/memory-core/helpers/tur
  * @param {Function}   [options.onDataBatch] Optional async sink for each recovered batch.
  * @param {Function}   [options.onProgress] Optional callback receiving 10%-bucket progress events:
  *                                           `{phase, percent, processed, total, counts}`.
+ * @param {Object}     [options.embedRetry] Bounded-retry forwarding for the re-embed leg
+ *                                           (`{attempts, backoffMs, wait}` — see `embedRecoverableDocuments`).
+ * @param {Number}     [options.expectedDimension] Per-element vector dimension check for the re-embed leg.
  * @returns {Promise<Object>} Extraction result with data buffers, structured unrecoverable entries,
  *   an ids-only `unrecoverableIds` projection, and repair counts.
  */
@@ -56,7 +60,9 @@ export async function extractMemoryCoreCollectionData({
     skipIds = [],
     collectData = true,
     onDataBatch,
-    onProgress
+    onProgress,
+    embedRetry,
+    expectedDimension
 } = {}) {
     if (typeof embedFn !== 'function') {
         throw new Error('extractMemoryCoreCollectionData: embedFn (documents -> embeddings) is required');
@@ -115,6 +121,7 @@ export async function extractMemoryCoreCollectionData({
 
     // 2. Missing-vector rows — re-embed from documents (their stored embeddings cannot be fetched).
     const unrecoverable = [];
+    let   stoppedEarly  = false;
 
     for (let i = 0; i < missingIds.length; i += batchSize) {
         const batchIds = missingIds.slice(i, i + batchSize);
@@ -163,16 +170,19 @@ export async function extractMemoryCoreCollectionData({
         }
 
         if (reEmbedDocs.length > 0) {
-            const {embeddings, failedIndexes, failures} = await embedRecoverableDocuments({embedFn, ids: reEmbedIds, documents: reEmbedDocs});
-            const batchData                             = {ids: [], embeddings: [], documents: [], metadatas: []};
+            const {embeddings, failedIndexes, failures, stoppedEarly: batchStoppedEarly} = await embedRecoverableDocuments({embedFn, ids: reEmbedIds, documents: reEmbedDocs, ...embedRetry, expectedDimension});
+            const batchData                                                              = {ids: [], embeddings: [], documents: [], metadatas: []};
+
+            stoppedEarly ||= Boolean(batchStoppedEarly);
 
             for (const failure of failures) {
                 recordUnrecoverable({
                     unrecoverable,
                     counts,
-                    id     : reEmbedIds[failure.index],
-                    reason : failure.reason,
-                    message: failure.message
+                    id       : reEmbedIds[failure.index],
+                    reason   : failure.reason,
+                    retryable: failure.retryable,
+                    message  : failure.message
                 });
             }
 
@@ -200,9 +210,30 @@ export async function extractMemoryCoreCollectionData({
         data,
         unrecoverable,
         unrecoverableIds: unrecoverable.map(entry => entry.id),
+        stoppedEarly,
         counts
     };
 }
+
+/**
+ * Reason→fate map for reasons the classifier does not stamp inline (content problems and the
+ * static classes). `true` marks failures a later pass can fix; `false` marks problems no retry
+ * can recover. Consumers read the stamped `retryable` flag on each entry and never re-derive
+ * fate from reason strings — a second mapping would drift. Unknown reasons default to `false`:
+ * never promise a resume will fix what the classifier cannot vouch for.
+ * @type {Object}
+ */
+const RETRYABLE_BY_REASON = {
+    'document-empty'            : false,
+    'document-invalid'          : false,
+    'document-missing'          : false,
+    'embedding-config-terminal' : false,
+    'embedding-input-rejected'  : false,
+    'embedding-provider-error'  : true,
+    'embedding-result-malformed': true,
+    'embedding-unknown'         : false,
+    'metadata-row-missing'      : false
+};
 
 /**
  * @summary Records one unrecoverable row while keeping the fail-loud counter in sync.
@@ -211,11 +242,12 @@ export async function extractMemoryCoreCollectionData({
  * @param {Object} options.counts Mutable extraction counters.
  * @param {String} options.id Row id.
  * @param {String} options.reason Stable reason code.
+ * @param {Boolean} [options.retryable] Explicit fate from the failure classifier; falls back to the reason map.
  * @param {String} [options.message] Operator-readable reason detail.
  * @returns {void}
  */
-function recordUnrecoverable({unrecoverable, counts, id, reason, message} = {}) {
-    unrecoverable.push(createUnrecoverableEntry({id, reason, message}));
+function recordUnrecoverable({unrecoverable, counts, id, reason, retryable, message} = {}) {
+    unrecoverable.push(createUnrecoverableEntry({id, reason, retryable, message}));
     counts.unrecoverable++;
 }
 
@@ -224,11 +256,12 @@ function recordUnrecoverable({unrecoverable, counts, id, reason, message} = {}) 
  * @param {Object} options
  * @param {String} options.id Row id.
  * @param {String} options.reason Stable reason code.
+ * @param {Boolean} [options.retryable] Explicit fate; falls back to the reason map, then `false`.
  * @param {String} [options.message] Operator-readable reason detail.
- * @returns {Object} Structured unrecoverable row entry.
+ * @returns {Object} Structured unrecoverable row entry, fate-stamped via `retryable`.
  */
-function createUnrecoverableEntry({id, reason, message} = {}) {
-    const entry = {id, reason};
+function createUnrecoverableEntry({id, reason, retryable, message} = {}) {
+    const entry = {id, reason, retryable: retryable ?? RETRYABLE_BY_REASON[reason] ?? false};
 
     if (message) {
         entry.message = message;
@@ -268,59 +301,242 @@ function getDocumentProblem(document) {
 }
 
 /**
- * @summary Embeds a batch; on failure, binary-splits to isolate the failing document(s) and re-batches the survivors.
- * @param {Object} options
- * @param {Function} options.embedFn Embedding function.
+ * Network/transport error codes marking a failure provider-transient: the provider (or the path
+ * to it) is struggling, the documents are fine, and a later attempt can succeed. The
+ * connection-refused class is exactly what a provider outage throws.
+ * @type {Set<String>}
+ */
+const TRANSIENT_NETWORK_CODES = new Set([
+    'ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND', 'EAI_AGAIN',
+    'ETIMEDOUT', 'EPIPE',
+    'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT', 'UND_ERR_SOCKET'
+]);
+
+/**
+ * @summary Classifies one embed-call failure into a stable reason + fate + routing class.
+ *
+ * A fate bit is only as useful as its cause classifier: collapsing 401, 429, timeouts, and 5xx
+ * into one "provider error" recreates unrecoverable-ambiguity under a new label. The `routing`
+ * tells the retry engine WHAT to do; `reason` + `retryable` tell the receipt reader WHY it
+ * stopped and whether a later pass can fix it:
+ *
+ * - `transient` (retryable): 408/429/5xx, network/timeout codes, malformed provider results —
+ *   whole-batch retry with backoff can fix these; splitting them multiplies calls against a
+ *   struggling provider.
+ * - `config` (terminal): 401/403/404 — credential/route problems no retry or split can fix; the
+ *   engine stops immediately instead of burning budget against a misconfiguration.
+ * - `document` (terminal): remaining 4xx (400/413/422…) — the provider rejected INPUT; a single
+ *   split pass isolates the offending document(s) so the rest of the batch still recovers.
+ * - `unknown` (terminal): everything else — isolated like `document` (the historical
+ *   oversized-document class throws plain errors), but never retried across rounds. Unknown is
+ *   never optimistic.
+ *
+ * @param {Error} error Provider, transport, or shape error (may carry `httpStatus` / `code`).
+ * @returns {{reason: String, retryable: Boolean, routing: String}}
+ */
+export function classifyEmbedFailure(error) {
+    const status = error?.httpStatus;
+
+    if (status === 401 || status === 403 || status === 404) {
+        return {reason: 'embedding-config-terminal', retryable: false, routing: 'config'};
+    }
+
+    if (status === 408 || status === 429 || status >= 500) {
+        return {reason: 'embedding-provider-error', retryable: true, routing: 'transient'};
+    }
+
+    if (status >= 400) {
+        return {reason: 'embedding-input-rejected', retryable: false, routing: 'document'};
+    }
+
+    if (error?.unrecoverableReason === 'embedding-result-malformed') {
+        return {reason: 'embedding-result-malformed', retryable: true, routing: 'transient'};
+    }
+
+    if (TRANSIENT_NETWORK_CODES.has(error?.code) || TRANSIENT_NETWORK_CODES.has(error?.cause?.code) ||
+        error?.name === 'AbortError' || error?.name === 'TimeoutError') {
+        return {reason: 'embedding-provider-error', retryable: true, routing: 'transient'};
+    }
+
+    return {reason: 'embedding-unknown', retryable: false, routing: 'unknown'};
+}
+
+/**
+ * @summary Embeds a batch under ONE bounded attempt budget, routing failures by cause.
+ *
+ * The engine retires two historical failure modes at once: per-range retry budgets (which
+ * amplified a persistent outage multiplicatively down the split tree) and split-on-any-failure
+ * (which multiplied calls against an already-saturated provider). Routing instead:
+ *
+ * - **Transient failures retry the WHOLE remaining batch** with doubling backoff between rounds,
+ *   never splitting — a persistent outage costs exactly `attempts` embed calls, then stops with
+ *   `stoppedEarly: true` and every remaining document recorded retryable.
+ * - **Config failures (401/403/404) stop the whole operation immediately** — no further budget
+ *   is burned against a misconfiguration; every remaining document records terminal.
+ * - **Document/unknown failures get ONE split-isolation pass** (halving from the known-failed
+ *   set — the failed full-batch call is never repeated): survivors recover, offenders record
+ *   terminal at their exact index. Bounded at ~2n calls, once, with no retry inside the tree.
+ * - **Element validation**: every returned vector must be a non-empty numeric array (and match
+ *   `expectedDimension` when given). Sparse or wrong-shape results become per-document
+ *   retryable failures — never `undefined` vectors handed to the caller.
+ *
+ * @param {Object}   options
+ * @param {Function} options.embedFn Embedding function (`documents => vectors`; throws on failure).
  * @param {String[]} options.ids Row ids paired with `documents`.
  * @param {String[]} options.documents Documents to embed.
+ * @param {Number}   [options.attempts=1] Attempt budget for the WHOLE operation (`1` = the
+ *                                        historical single-pass contract).
+ * @param {Number}   [options.backoffMs=1000] Base backoff between rounds, doubling per round.
+ * @param {Function} [options.wait] `ms => Promise` — injectable for tests; defaults to setTimeout.
+ * @param {Number}   [options.expectedDimension] When set, every vector must have this length.
  * @returns {Promise<{embeddings: Number[][], failedIndexes: Set<Number>,
- *                    failures: Array<{index: Number, reason: String, message: String}>}>}
+ *                    failures: Array<{index: Number, reason: String, retryable: Boolean, message: String}>,
+ *                    stoppedEarly: Boolean, attemptsUsed: Number}>}
  */
-export async function embedRecoverableDocuments({embedFn, ids, documents} = {}) {
-    const embeddings = new Array(documents.length);
-    const failures   = [];
+export async function embedRecoverableDocuments({
+    embedFn,
+    ids,
+    documents,
+    attempts = 1,
+    backoffMs = 1000,
+    wait = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    expectedDimension
+} = {}) {
+    const embeddings  = new Array(documents.length);
+    const failures    = [];
+    const maxAttempts = Math.max(1, attempts);
 
-    // Embed the widest range that succeeds as a single batch; on failure, binary-split to isolate
-    // the failing document(s) and RE-BATCH the survivors — rather than degrading the whole batch to
-    // 1-by-1 single embeds, which forfeits the provider's batch parallelism on the failure path
-    // (the graph-recovery slowdown a single oversized doc caused). Failures stay attributed to their
-    // exact source index. Common case (few bad docs in a batch): O(log n) extra batch calls vs the
-    // old O(n) singles; pathological all-fail is bounded near ~2x calls — an acceptable trade for
-    // the far-more-common single-bad-apple path.
-    await embedRange(0, documents.length);
+    let stoppedEarly = false;
+    let attemptsUsed = 0;
+    let pending      = documents.map((_, index) => index);
 
-    return {embeddings, failedIndexes: new Set(failures.map(failure => failure.index)), failures};
+    const recordFailure = (index, {reason, retryable}, message) => {
+        failures.push({index, reason, retryable, message});
+    };
 
-    async function embedRange(start, end) {
-        const slice = documents.slice(start, end);
+    const elementProblem = vector => {
+        if (!Array.isArray(vector) || vector.length === 0 || typeof vector[0] !== 'number') {
+            return 'element is not a numeric vector';
+        }
+        if (expectedDimension && vector.length !== expectedDimension) {
+            return `element dimension ${vector.length}, expected ${expectedDimension}`;
+        }
+        return null;
+    };
 
-        if (slice.length === 0) {
+    for (let round = 1; round <= maxAttempts && pending.length > 0; round++) {
+        attemptsUsed = round;
+
+        try {
+            const docs    = pending.map(index => documents[index]);
+            const vectors = await embedFn(docs);
+
+            if (!Array.isArray(vectors) || vectors.length !== docs.length) {
+                throw createEmbeddingResultError(`embedFn returned ${Array.isArray(vectors) ? vectors.length : 'non-array'} embeddings for ${docs.length} documents`);
+            }
+
+            const malformed = [];
+
+            pending.forEach((origIndex, j) => {
+                const problem = elementProblem(vectors[j]);
+
+                if (problem) {
+                    malformed.push({origIndex, problem});
+                } else {
+                    embeddings[origIndex] = vectors[j];
+                }
+            });
+
+            if (malformed.length === 0) {
+                pending = [];
+                break;
+            }
+
+            // Malformed elements are provider-transient: retry them next round; at budget end
+            // they record retryable (a later pass can fix them) — never as silent undefineds.
+            pending = malformed.map(entry => entry.origIndex);
+
+            if (round === maxAttempts) {
+                stoppedEarly = true;
+                for (const {origIndex, problem} of malformed) {
+                    recordFailure(origIndex, {reason: 'embedding-result-malformed', retryable: true}, problem);
+                }
+                pending = [];
+            } else {
+                await wait(backoffMs * 2 ** (round - 1));
+            }
+        } catch (error) {
+            const classification = classifyEmbedFailure(error);
+
+            if (classification.routing === 'transient') {
+                if (round === maxAttempts) {
+                    stoppedEarly = true;
+                    for (const index of pending) {
+                        recordFailure(index, classification, error?.message || String(error));
+                    }
+                    pending = [];
+                } else {
+                    await wait(backoffMs * 2 ** (round - 1));
+                }
+                continue;
+            }
+
+            if (classification.routing === 'config') {
+                for (const index of pending) {
+                    recordFailure(index, classification, error?.message || String(error));
+                }
+                pending = [];
+                break;
+            }
+
+            // document / unknown routing: one bounded isolation pass from the known-failed set.
+            if (pending.length === 1) {
+                recordFailure(pending[0], classification, error?.message || String(error));
+            } else {
+                const mid = Math.floor(pending.length / 2);
+                await isolate(pending.slice(0, mid));
+                await isolate(pending.slice(mid));
+            }
+            pending = [];
+            break;
+        }
+    }
+
+    return {embeddings, failedIndexes: new Set(failures.map(failure => failure.index)), failures, stoppedEarly, attemptsUsed};
+
+    async function isolate(indexes) {
+        if (indexes.length === 0) {
             return;
         }
 
+        const docs = indexes.map(index => documents[index]);
+
         try {
-            const vectors = await embedFn(slice);
+            const vectors = await embedFn(docs);
 
-            if (!Array.isArray(vectors) || vectors.length !== slice.length) {
-                throw createEmbeddingResultError(`embedFn returned ${Array.isArray(vectors) ? vectors.length : 'non-array'} embeddings for ${slice.length} documents`);
+            if (!Array.isArray(vectors) || vectors.length !== docs.length) {
+                throw createEmbeddingResultError(`embedFn returned ${Array.isArray(vectors) ? vectors.length : 'non-array'} embeddings for ${docs.length} documents`);
             }
 
-            for (let i = 0; i < slice.length; i++) {
-                embeddings[start + i] = vectors[i];
-            }
+            indexes.forEach((origIndex, j) => {
+                const problem = elementProblem(vectors[j]);
+
+                if (problem) {
+                    recordFailure(origIndex, {reason: 'embedding-result-malformed', retryable: true}, problem);
+                } else {
+                    embeddings[origIndex] = vectors[j];
+                }
+            });
         } catch (error) {
-            if (slice.length === 1) {
-                failures.push({
-                    index  : start,
-                    reason : getEmbeddingFailureReason(error),
-                    message: error?.message || String(error)
-                });
+            if (indexes.length === 1) {
+                recordFailure(indexes[0], classifyEmbedFailure(error), error?.message || String(error));
                 return;
             }
 
-            const mid = start + Math.floor(slice.length / 2);
-            await embedRange(start, mid);
-            await embedRange(mid, end);
+            const mid = Math.floor(indexes.length / 2);
+
+            await isolate(indexes.slice(0, mid));
+            await isolate(indexes.slice(mid));
         }
     }
 }
@@ -336,15 +552,6 @@ function createEmbeddingResultError(message) {
     error.unrecoverableReason = 'embedding-result-malformed';
 
     return error
-}
-
-/**
- * @summary Maps a per-document embedding failure to a stable unrecoverable reason code.
- * @param {Error} error Provider or shape error.
- * @returns {String}
- */
-function getEmbeddingFailureReason(error) {
-    return error?.unrecoverableReason || 'embedding-provider-error'
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/rebuildMemoryCoreVectorStore.spec.mjs
@@ -1,0 +1,386 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'RebuildMcVectorStoreTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    createEmbedFn,
+    groupFailureReceipts,
+    readAllIds,
+    rebuildCollections,
+    validateCliOptions
+} from '../../../../../../ai/scripts/maintenance/rebuildMemoryCoreVectorStore.mjs';
+
+/**
+ * Falsifier-first suite: every test below encodes a reviewer-executable falsifier from the
+ * predecessor's terminal reviews — provider-fate truth, bounded pressure, drained concurrency,
+ * sparse-result rejection, semantic same-store refusal, id-set reconciliation, and true
+ * no-write dry-run — plus the salvaged happy-path/resume/grouping behaviors.
+ */
+
+/** Mock Chroma collection with a UUID; supports ids-based and limit/offset get plus add. */
+function makeCollection(rows = {}, id = `col-${Math.random().toString(36).slice(2, 8)}`) {
+    const col = {
+        id,
+        rows,
+        addCalls: [],
+        get     : async ({ids, limit, offset = 0, include = []}) => {
+            const pick = ids ?? Object.keys(rows).slice(offset, limit ? offset + limit : undefined);
+            const out  = {ids: []};
+            if (include.includes('documents'))  out.documents  = [];
+            if (include.includes('metadatas'))  out.metadatas  = [];
+            for (const rowId of pick) {
+                const row = rows[rowId];
+                if (!row) continue;
+                out.ids.push(rowId);
+                if (out.documents)  out.documents.push(row.document ?? null);
+                if (out.metadatas)  out.metadatas.push(row.metadata ?? {});
+            }
+            return out;
+        },
+        add: async ({ids, embeddings, documents, metadatas}) => {
+            col.addCalls.push({ids, embeddings});
+            for (const vector of embeddings) {
+                if (!Array.isArray(vector)) {
+                    throw new Error(`target received a non-vector embedding: ${vector}`);
+                }
+            }
+            ids.forEach((rowId, i) => { rows[rowId] = {document: documents[i], metadata: metadatas[i], embedding: embeddings[i]} });
+        }
+    };
+    return col;
+}
+
+const makeClient = cols => ({
+    getCollection        : async ({name}) => { if (!cols[name]) throw new Error(`no collection ${name}`); return cols[name] },
+    getOrCreateCollection: async ({name}) => (cols[name] ??= makeCollection())
+});
+
+/** Client whose every mutating surface throws — the dry-run witness. */
+const readOnlyClient = cols => ({
+    getCollection        : async ({name}) => { if (!cols[name]) throw new Error(`no collection ${name}`); return cols[name] },
+    getOrCreateCollection: async () => { throw new Error('dry-run must not create collections') }
+});
+
+const sourceRows = n => Object.fromEntries(
+    Array.from({length: n}, (_, i) => [`id-${i}`, {document: `doc ${i}`, metadata: {type: 'memory'}}])
+);
+
+const fakeEmbedFn = async docs => docs.map((_, i) => [i, 0.5]);
+
+const httpError = status => {
+    const error = new Error(`embed HTTP ${status}`);
+    error.httpStatus = status;
+    return error;
+};
+
+test.describe('Neo.ai.scripts.maintenance.rebuildMemoryCoreVectorStore', () => {
+
+    test('happy path: full rebuild re-embeds every source document into the fresh target, ok:true', async () => {
+        const target  = {};
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(12))}),
+            targetClient: makeClient(target),
+            collections : ['mem'],
+            embedFn     : fakeEmbedFn,
+            getBatch    : 5,
+            log         : () => {}
+        });
+
+        expect(receipt.ok).toBe(true);
+        expect(receipt.collections[0]).toMatchObject({
+            name  : 'mem', source: 12, planned: 12, targetBefore: 0, targetAfter: 12, reEmbedded: 12,
+            failed: [], stoppedEarly: false, missingAfterRun: {count: 0, sampleIds: []}
+        });
+        expect(Object.values(target.mem.rows).every(row => Array.isArray(row.embedding))).toBe(true);
+    });
+
+    test('FALSIFIER same-store: two URLs resolving to one collection UUID are REFUSED — no no-op blessing', async () => {
+        const shared  = makeCollection(sourceRows(5), 'uuid-same');
+        const embeds  = [];
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: shared}),
+            targetClient: makeClient({mem: shared}),
+            collections : ['mem'],
+            embedFn     : async docs => { embeds.push(docs); return fakeEmbedFn(docs) },
+            log         : () => {}
+        });
+
+        expect(receipt.ok).toBe(false);
+        expect(receipt.collections[0].error).toBe('source-and-target-are-the-same-collection');
+        expect(embeds).toEqual([]);
+        expect(shared.addCalls).toEqual([]);
+    });
+
+    test('FALSIFIER id-set reconciliation: matching COUNTS with wrong ids still fail — missing ids are named', async () => {
+        // Target pre-populated with 3 FOREIGN ids: counts alone would reconcile a lie.
+        const target = makeCollection({
+            'foreign-a': {document: 'x', metadata: {}, embedding: [1]},
+            'foreign-b': {document: 'x', metadata: {}, embedding: [1]},
+            'foreign-c': {document: 'x', metadata: {}, embedding: [1]}
+        }, 'uuid-target');
+        // The embedder fails EVERYTHING as unknown (terminal) so no planned id can land.
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(3), 'uuid-source')}),
+            targetClient: makeClient({mem: target}),
+            collections : ['mem'],
+            embedFn     : async () => { throw new Error('opaque provider explosion') },
+            log         : () => {}
+        });
+
+        const entry = receipt.collections[0];
+        expect(receipt.ok).toBe(false);
+        // Every planned id is accounted for AS A FAILURE (terminal unknown), none as landed.
+        expect(entry.failed).toEqual([
+            {reason: 'embedding-unknown', count: 3, retryable: false, sampleIds: ['id-0', 'id-1', 'id-2']}
+        ]);
+        expect(entry.missingAfterRun.count).toBe(0);
+        // The foreign population is REPORTED (observability) without failing the run by itself.
+        expect(entry.targetOnly).toMatchObject({count: 3});
+        expect(entry.targetOnly.sampleIds.sort()).toEqual(['foreign-a', 'foreign-b', 'foreign-c']);
+    });
+
+    test('live-plane writes during a rebuild (target-only ids) are reported, never an error', async () => {
+        const target  = makeCollection({'live-write-1': {document: 'new memory', metadata: {}, embedding: [9]}}, 'uuid-t');
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(4), 'uuid-s')}),
+            targetClient: makeClient({mem: target}),
+            collections : ['mem'],
+            embedFn     : fakeEmbedFn,
+            log         : () => {}
+        });
+
+        expect(receipt.ok).toBe(true);
+        expect(receipt.collections[0].targetOnly).toMatchObject({count: 1, sampleIds: ['live-write-1']});
+        expect(receipt.collections[0].targetAfter).toBe(5);
+    });
+
+    test('FALSIFIER dry-run: zero writes of any kind — a mutation-throwing client passes, absent target reported', async () => {
+        const embeds  = [];
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(7), 'uuid-s')}),
+            targetClient: readOnlyClient({}),
+            collections : ['mem'],
+            embedFn     : async docs => { embeds.push(docs); return fakeEmbedFn(docs) },
+            dryRun      : true,
+            log         : () => {}
+        });
+
+        expect(receipt.ok).toBe(true);
+        expect(receipt.collections[0]).toMatchObject({source: 7, planned: 7, wouldCreateTarget: true, ok: true});
+        expect(embeds).toEqual([]);
+    });
+
+    test('resume: planned ids already in the target are skipped, not re-embedded', async () => {
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(10), 'uuid-s')}),
+            targetClient: makeClient({mem: makeCollection(sourceRows(4), 'uuid-t')}),
+            collections : ['mem'],
+            embedFn     : fakeEmbedFn,
+            log         : () => {}
+        });
+
+        expect(receipt.ok).toBe(true);
+        expect(receipt.collections[0]).toMatchObject({targetBefore: 4, targetAfter: 10, reEmbedded: 6, resumedExisting: 4});
+    });
+
+    test('FALSIFIER provider fate: a persistent 401 stops WITHOUT burning the attempt budget and records terminal-config', async () => {
+        let   calls   = 0;
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(6), 'uuid-s')}),
+            targetClient: makeClient({}),
+            collections : ['mem'],
+            embedFn     : async () => { calls++; throw httpError(401) },
+            embedRetry  : {attempts: 3, wait: async () => {}},
+            log         : () => {}
+        });
+
+        const entry = receipt.collections[0];
+        expect(receipt.ok).toBe(false);
+        expect(calls).toBe(1);
+        expect(entry.failed).toEqual([
+            {reason: 'embedding-config-terminal', count: 6, retryable: false, sampleIds: ['id-0', 'id-1', 'id-2', 'id-3', 'id-4', 'id-5']}
+        ]);
+        expect(entry.stoppedEarly).toBe(false);
+    });
+
+    test('FALSIFIER bounded pressure: a persistent outage costs exactly `attempts` calls, then stops early as resumable', async () => {
+        let   calls    = 0;
+        const backoffs = [];
+        const receipt  = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(8), 'uuid-s')}),
+            targetClient: makeClient({}),
+            collections : ['mem'],
+            embedFn     : async () => { calls++; const e = new Error('fetch failed'); e.cause = {code: 'ECONNREFUSED'}; throw e },
+            embedRetry  : {attempts: 3, backoffMs: 500, wait: async ms => { backoffs.push(ms) }},
+            log         : () => {}
+        });
+
+        const entry = receipt.collections[0];
+        expect(receipt.ok).toBe(false);
+        // The predecessor amplified this to 45 calls via per-range budgets; the contract is 3.
+        expect(calls).toBe(3);
+        expect(backoffs).toEqual([500, 1000]);
+        expect(entry.stoppedEarly).toBe(true);
+        expect(entry.failed).toEqual([
+            {reason: 'embedding-provider-error', count: 8, retryable: true, sampleIds: ['id-0', 'id-1', 'id-2', 'id-3', 'id-4', 'id-5', 'id-6', 'id-7']}
+        ]);
+        // A follow-up resume run retries exactly these ids — witnessed by the resumable rollup.
+    });
+
+    test('transient outage that RECOVERS within the budget completes clean (attempt 2 succeeds)', async () => {
+        let   calls   = 0;
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(4), 'uuid-s')}),
+            targetClient: makeClient({}),
+            collections : ['mem'],
+            embedFn     : async docs => { if (++calls === 1) throw httpError(503); return fakeEmbedFn(docs) },
+            embedRetry  : {attempts: 3, wait: async () => {}},
+            log         : () => {}
+        });
+
+        expect(receipt.ok).toBe(true);
+        expect(calls).toBe(2);
+        expect(receipt.collections[0]).toMatchObject({targetAfter: 4, reEmbedded: 4, failed: [], stoppedEarly: false});
+    });
+
+    test('receipt provenance carries endpoints, collection UUIDs, model, and dimension', async () => {
+        const receipt = await rebuildCollections({
+            sourceClient     : makeClient({mem: makeCollection(sourceRows(2), 'uuid-src')}),
+            targetClient     : makeClient({mem: makeCollection({}, 'uuid-tgt')}),
+            collections      : ['mem'],
+            embedFn          : async docs => docs.map(() => new Array(8).fill(0.1)),
+            provenance       : {sourceUrl: 'http://a:8000', targetUrl: 'http://b:8000', model: 'test-embedder'},
+            expectedDimension: 8,
+            log              : () => {}
+        });
+
+        expect(receipt.provenance).toEqual({sourceUrl: 'http://a:8000', targetUrl: 'http://b:8000', model: 'test-embedder', expectedDimension: 8});
+        expect(receipt.collections[0]).toMatchObject({sourceCollectionId: 'uuid-src', targetCollectionId: 'uuid-tgt', ok: true});
+    });
+
+    test('groupFailureReceipts groups by reason, caps samples, and sorts largest first', () => {
+        const entries = [
+            ...Array.from({length: 12}, (_, i) => ({id: `e-${i}`, reason: 'embedding-provider-error', retryable: true})),
+            {id: 'd-0', reason: 'document-empty', retryable: false},
+            {id: 'd-1', reason: 'document-empty', retryable: false}
+        ];
+
+        expect(groupFailureReceipts(entries, 3)).toEqual([
+            {reason: 'embedding-provider-error', count: 12, retryable: true,  sampleIds: ['e-0', 'e-1', 'e-2']},
+            {reason: 'document-empty',           count: 2,  retryable: false, sampleIds: ['d-0', 'd-1']}
+        ]);
+        expect(groupFailureReceipts([])).toEqual([]);
+    });
+
+    test('readAllIds paginates past one page', async () => {
+        const ids = await readAllIds(makeCollection(sourceRows(7)), 3);
+        expect(ids).toHaveLength(7);
+        expect(ids[6]).toBe('id-6');
+    });
+
+    test('pilot --limit slices the planned set without touching the rest', async () => {
+        const receipt = await rebuildCollections({
+            sourceClient: makeClient({mem: makeCollection(sourceRows(20), 'uuid-s')}),
+            targetClient: makeClient({}),
+            collections : ['mem'],
+            embedFn     : fakeEmbedFn,
+            limit       : 5,
+            log         : () => {}
+        });
+
+        expect(receipt.collections[0]).toMatchObject({source: 20, planned: 5, targetAfter: 5, ok: true});
+        expect(receipt.ok).toBe(true);
+    });
+
+    test('FALSIFIER CLI validation: bad flags produce named errors, never a running process', () => {
+        const base = {sourceUrl: 'http://a:8000', targetUrl: 'http://b:8000', embedUrl: 'http://c:1234/v1/embeddings', collections: 'mem'};
+
+        expect(validateCliOptions(base)).toEqual([]);
+        expect(validateCliOptions({...base, targetUrl: 'http://a:8000'})[0]).toContain('must differ');
+        expect(validateCliOptions({...base, sourceUrl: 'not-a-url'})[0]).toContain('--source-url');
+        expect(validateCliOptions({...base, collections: ' , '})[0]).toContain('--collections');
+        expect(validateCliOptions({...base, embedAttempts: 0})[0]).toContain('--embed-attempts');
+        expect(validateCliOptions({...base, embedBatch: -1})[0]).toContain('--embed-batch');
+    });
+});
+
+test.describe('createEmbedFn — drained, validated provider pool', () => {
+
+    const okResponse = input => ({
+        ok  : true,
+        json: async () => ({data: input.map((_, i) => ({index: i, embedding: [i, 0.5]}))})
+    });
+
+    test('batches requests and places embeddings by authoritative index (out-of-order response)', async () => {
+        const calls     = [];
+        const fetchImpl = async (url, {body}) => {
+            const {input} = JSON.parse(body);
+            calls.push(input.length);
+            return {
+                ok  : true,
+                json: async () => ({data: input.map((_, i) => ({index: i, embedding: [i]})).reverse()})
+            };
+        };
+        const embedFn = createEmbedFn({url: 'http://x', model: 'm', batch: 2, fetchImpl});
+        const vecs    = await embedFn(['a', 'b', 'c']);
+
+        expect(calls.sort()).toEqual([1, 2]);
+        expect(vecs).toEqual([[0], [1], [0]]);
+    });
+
+    test('FALSIFIER sparse result: a response missing an index REJECTS as malformed — never an undefined hole', async () => {
+        const fetchImpl = async (url, {body}) => {
+            const {input} = JSON.parse(body);
+            return {ok: true, json: async () => ({data: input.slice(1).map((_, i) => ({index: i + 1, embedding: [1]}))})};
+        };
+        const embedFn = createEmbedFn({url: 'http://x', model: 'm', batch: 4, fetchImpl});
+
+        await expect(embedFn(['a', 'b'])).rejects.toMatchObject({unrecoverableReason: 'embedding-result-malformed'});
+    });
+
+    test('FALSIFIER duplicate index REJECTS as malformed', async () => {
+        const fetchImpl = async () => ({ok: true, json: async () => ({data: [{index: 0, embedding: [1]}, {index: 0, embedding: [2]}]})});
+        const embedFn   = createEmbedFn({url: 'http://x', model: 'm', batch: 4, fetchImpl});
+
+        await expect(embedFn(['a', 'b'])).rejects.toMatchObject({unrecoverableReason: 'embedding-result-malformed'});
+    });
+
+    test('FALSIFIER drain: a failing chunk NEVER aborts in-flight siblings — the pool settles before rejecting', async () => {
+        let   inFlight    = 0,
+              maxInFlight = 0,
+              resolved    = 0;
+        const fetchImpl = async (url, {body}) => {
+            const {input} = JSON.parse(body);
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            await new Promise(resolve => setTimeout(resolve, input[0] === 'poison' ? 1 : 15));
+            inFlight--;
+            if (input[0] === 'poison') {
+                return {ok: false, status: 503};
+            }
+            resolved++;
+            return okResponse(input);
+        };
+        const embedFn = createEmbedFn({url: 'http://x', model: 'm', batch: 1, concurrency: 4, fetchImpl});
+
+        // 'poison' fails FAST while three slow chunks are still in flight — the old fail-fast
+        // pool threw here and orphaned them; the drained pool waits for all four.
+        await expect(embedFn(['poison', 'slow-1', 'slow-2', 'slow-3'])).rejects.toMatchObject({httpStatus: 503});
+        expect(inFlight).toBe(0);
+        expect(resolved).toBe(3);
+        expect(maxInFlight).toBeLessThanOrEqual(4);
+    });
+
+    test('HTTP status is carried on the rejection (fate classification depends on it)', async () => {
+        const fetchImpl = async () => ({ok: false, status: 429});
+        const embedFn   = createEmbedFn({url: 'http://x', model: 'm', fetchImpl});
+
+        await expect(embedFn(['a'])).rejects.toMatchObject({httpStatus: 429});
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
@@ -9,6 +9,7 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import {
+    classifyEmbedFailure,
     embedRecoverableDocuments,
     extractMemoryCoreCollectionData,
     truncateToByteBudget,
@@ -125,8 +126,8 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         });
 
         expect(result.unrecoverable).toEqual([
-            {id: 'empty', reason: 'document-empty', message: 'document field was empty'},
-            {id: 'missing', reason: 'document-missing', message: 'document field was missing from the Chroma metadata read'}
+            {id: 'empty', reason: 'document-empty', retryable: false, message: 'document field was empty'},
+            {id: 'missing', reason: 'document-missing', retryable: false, message: 'document field was missing from the Chroma metadata read'}
         ]);
         expect(result.unrecoverableIds).toEqual(['empty', 'missing']);
         expect(result.counts).toEqual({total: 3, intact: 0, reEmbedded: 1, unrecoverable: 2});
@@ -172,9 +173,10 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         });
 
         expect(result.unrecoverable).toEqual([{
-            id     : 'gone',
-            reason : 'metadata-row-missing',
-            message: 'id was absent from the Chroma documents/metadatas read'
+            id       : 'gone',
+            reason   : 'metadata-row-missing',
+            retryable: false,
+            message  : 'id was absent from the Chroma documents/metadatas read'
         }]);
         expect(result.unrecoverableIds).toEqual(['gone']);
         expect(result.counts.reEmbedded).toBe(1);
@@ -213,10 +215,13 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
             ['too-large'],
             ['small-2']
         ]);
+        // A plain error with no HTTP status or network code is UNKNOWN — terminal, never
+        // optimistic (the v2 taxonomy; previously this collapsed into 'provider-error').
         expect(result.unrecoverable).toEqual([{
-            id     : 'overcap',
-            reason : 'embedding-provider-error',
-            message: 'context overflow'
+            id       : 'overcap',
+            reason   : 'embedding-unknown',
+            retryable: false,
+            message  : 'context overflow'
         }]);
         expect(result.unrecoverableIds).toEqual(['overcap']);
         expect(result.data.ids).toEqual(['ok', 'ok2']);
@@ -268,9 +273,10 @@ test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair ex
         });
 
         expect(result.unrecoverable).toEqual([{
-            id     : 'm',
-            reason : 'embedding-result-malformed',
-            message: 'embedFn returned 0 embeddings for 1 documents'
+            id       : 'm',
+            reason   : 'embedding-result-malformed',
+            retryable: true,
+            message  : 'embedFn returned 0 embeddings for 1 documents'
         }]);
         expect(result.unrecoverableIds).toEqual(['m']);
         expect(result.counts).toEqual({total: 1, intact: 0, reEmbedded: 0, unrecoverable: 1});
@@ -325,6 +331,165 @@ test.describe('embedRecoverableDocuments — binary-split isolate-then-rebatch (
         expect([...failedIndexes]).toEqual([]);
         expect(embeddings).toEqual([[3], [3], [3]]);
         expect(calls).toBe(1);
+    });
+});
+
+test.describe('classifyEmbedFailure — cause → reason/fate/routing', () => {
+
+    const withStatus = status => { const e = new Error(`embed HTTP ${status}`); e.httpStatus = status; return e };
+    const withCode   = code => { const e = new Error('fetch failed'); e.code = code; return e };
+
+    test('the classification table holds for every named class', () => {
+        for (const status of [401, 403, 404]) {
+            expect(classifyEmbedFailure(withStatus(status))).toEqual({reason: 'embedding-config-terminal', retryable: false, routing: 'config'});
+        }
+        for (const status of [408, 429, 500, 502, 503]) {
+            expect(classifyEmbedFailure(withStatus(status))).toEqual({reason: 'embedding-provider-error', retryable: true, routing: 'transient'});
+        }
+        for (const status of [400, 413, 422]) {
+            expect(classifyEmbedFailure(withStatus(status))).toEqual({reason: 'embedding-input-rejected', retryable: false, routing: 'document'});
+        }
+        for (const code of ['ECONNREFUSED', 'ETIMEDOUT', 'UND_ERR_HEADERS_TIMEOUT']) {
+            expect(classifyEmbedFailure(withCode(code)).routing).toBe('transient');
+        }
+
+        // undici wraps the network cause: `fetch failed` TypeError with cause.code.
+        const wrapped = new Error('fetch failed');
+        wrapped.cause = {code: 'ECONNREFUSED'};
+        expect(classifyEmbedFailure(wrapped).routing).toBe('transient');
+
+        const aborted = new Error('aborted');
+        aborted.name  = 'AbortError';
+        expect(classifyEmbedFailure(aborted).routing).toBe('transient');
+
+        const malformed = new Error('bad shape');
+        malformed.unrecoverableReason = 'embedding-result-malformed';
+        expect(classifyEmbedFailure(malformed)).toEqual({reason: 'embedding-result-malformed', retryable: true, routing: 'transient'});
+    });
+
+    test('unknown is never optimistic: a plain error is terminal', () => {
+        expect(classifyEmbedFailure(new Error('something odd'))).toEqual({reason: 'embedding-unknown', retryable: false, routing: 'unknown'});
+    });
+});
+
+test.describe('embedRecoverableDocuments — bounded, cause-routed retry engine', () => {
+
+    const connRefused = () => { const e = new Error('fetch failed'); e.cause = {code: 'ECONNREFUSED'}; return e };
+    const withStatus  = status => { const e = new Error(`embed HTTP ${status}`); e.httpStatus = status; return e };
+
+    test('FALSIFIER bounded pressure: persistent transient outage retries WHOLE batches — exact call ceiling, no split', async () => {
+        const widths                                 = [];
+        const backoffs                               = [];
+        const {failures, stoppedEarly, attemptsUsed} = await embedRecoverableDocuments({
+            embedFn  : async docs => { widths.push(docs.length); throw connRefused() },
+            ids      : ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+            documents: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+            attempts : 3,
+            backoffMs: 500,
+            wait     : async ms => { backoffs.push(ms) }
+        });
+
+        // The predecessor spent 45 calls here (per-range budgets down the split tree). The
+        // contract is one call per round: 3 attempts, full width every time, then stop.
+        expect(widths).toEqual([8, 8, 8]);
+        expect(backoffs).toEqual([500, 1000]);
+        expect(stoppedEarly).toBe(true);
+        expect(attemptsUsed).toBe(3);
+        expect(failures).toHaveLength(8);
+        expect(failures.every(failure => failure.reason === 'embedding-provider-error' && failure.retryable === true)).toBe(true);
+    });
+
+    test('FALSIFIER config fate: 401 stops the whole operation on call ONE — no budget burned, terminal records', async () => {
+        let   calls                    = 0;
+        const {failures, stoppedEarly} = await embedRecoverableDocuments({
+            embedFn  : async () => { calls++; throw withStatus(401) },
+            ids      : ['a', 'b'],
+            documents: ['a', 'b'],
+            attempts : 5,
+            wait     : async () => {}
+        });
+
+        expect(calls).toBe(1);
+        expect(stoppedEarly).toBe(false);
+        expect(failures).toEqual([
+            {index: 0, reason: 'embedding-config-terminal', retryable: false, message: 'embed HTTP 401'},
+            {index: 1, reason: 'embedding-config-terminal', retryable: false, message: 'embed HTTP 401'}
+        ]);
+    });
+
+    test('transient recovery inside the budget completes clean', async () => {
+        let   calls                                              = 0;
+        const {embeddings, failures, stoppedEarly, attemptsUsed} = await embedRecoverableDocuments({
+            embedFn  : async docs => { if (++calls === 1) throw withStatus(503); return docs.map(() => [7]) },
+            ids      : ['a', 'b'],
+            documents: ['a', 'b'],
+            attempts : 3,
+            wait     : async () => {}
+        });
+
+        expect(failures).toEqual([]);
+        expect(stoppedEarly).toBe(false);
+        expect(attemptsUsed).toBe(2);
+        expect(embeddings).toEqual([[7], [7]]);
+    });
+
+    test('document-class failure (413) gets ONE bounded isolation pass: survivors recover, offender records terminal', async () => {
+        const widths  = [];
+        const embedFn = async docs => {
+            widths.push(docs.length);
+            if (docs.includes('POISON')) throw withStatus(413);
+            return docs.map(() => [1]);
+        };
+
+        const {embeddings, failures} = await embedRecoverableDocuments({
+            embedFn,
+            ids      : ['a', 'b', 'c', 'd'],
+            documents: ['a', 'POISON', 'c', 'd'],
+            attempts : 3,
+            wait     : async () => {}
+        });
+
+        expect(failures).toEqual([
+            {index: 1, reason: 'embedding-input-rejected', retryable: false, message: 'embed HTTP 413'}
+        ]);
+        expect(embeddings[0]).toEqual([1]);
+        expect(embeddings[2]).toEqual([1]);
+        expect(embeddings[3]).toEqual([1]);
+        // One isolation pass from the KNOWN-failed set (depth-first halving): the failed full
+        // batch is never repeated, and no range inside the tree carries its own retry budget.
+        expect(widths).toEqual([4, 2, 1, 1, 2]);
+    });
+
+    test('expectedDimension: wrong-dimension elements retry as transient and record malformed at budget end — never delivered', async () => {
+        const {embeddings, failures, stoppedEarly} = await embedRecoverableDocuments({
+            embedFn          : async docs => docs.map(() => [1, 2]),
+            ids              : ['a'],
+            documents        : ['a'],
+            attempts         : 2,
+            expectedDimension: 4,
+            wait             : async () => {}
+        });
+
+        expect(embeddings[0]).toBeUndefined();
+        expect(stoppedEarly).toBe(true);
+        expect(failures).toEqual([
+            {index: 0, reason: 'embedding-result-malformed', retryable: true, message: 'element dimension 2, expected 4'}
+        ]);
+    });
+
+    test('a sparse element (undefined hole) is caught by validation, never returned as an embedding', async () => {
+        const {embeddings, failures} = await embedRecoverableDocuments({
+            embedFn  : async () => [[1], undefined],
+            ids      : ['a', 'b'],
+            documents: ['a', 'b'],
+            attempts : 1
+        });
+
+        expect(embeddings[0]).toEqual([1]);
+        expect(embeddings[1]).toBeUndefined();
+        expect(failures).toEqual([
+            {index: 1, reason: 'embedding-result-malformed', retryable: true, message: 'element is not a numeric vector'}
+        ]);
     });
 });
 


### PR DESCRIPTION
Resolves #16227

## What

The successor vector-rebuild runner, built falsifier-first: every executable falsifier from the predecessor's two terminal reviews was written as a failing spec before implementation, and the diff exists to make those specs pass. The predecessor PR is closed unmerged; its terminal review's salvage map is this PR's floor, carried forward deliberately.

**Cause-classified fate** (`classifyEmbedFailure`, shared extractor): a fate bit is only as useful as its cause classifier. Failures now carry `reason + retryable + routing`: 401/403/404 → `embedding-config-terminal` (no retry fixes credentials); 408/429/5xx and network/timeout codes (incl. undici `cause.code`) → `embedding-provider-error`, retryable; other 4xx → `embedding-input-rejected` (document class); malformed/sparse results → `embedding-result-malformed`, retryable; **unknown → terminal, never optimistic**. Every failure entry is fate-stamped; consumers never pattern-match reason strings.

**Bounded, cause-routed retry engine** (`embedRecoverableDocuments` v2): ONE attempt budget for the whole operation — transient failures retry the WHOLE remaining batch with doubling backoff (a persistent outage costs exactly `attempts` calls, then stops with `stoppedEarly: true` and resumable records); config failures stop everything on call one; document/unknown failures get ONE split-isolation pass from the known-failed set (the failed batch call is never repeated, no per-range budgets). The predecessor's 45-call amplification for 8 documents is now a spec asserting exactly 3.

**Drained, validated provider pool** (`createEmbedFn`): workers never throw mid-pool — every in-flight request settles before the call rejects (concurrency is a hard bound; witnessed by a falsifier that fails a fast chunk beside three slow ones), rejections carry `httpStatus`, and responses are index-validated (sparse, duplicate, or out-of-range indexes reject as malformed — this function never resolves with `undefined` holes; per-element dimension checks run in the extractor via `expectedDimension`).

**Provenance + id-set reconciliation** (`rebuildCollections`): source and target resolving to the same collection UUID are refused (two spellings of one host can no longer bless a no-op); the receipt records endpoints, both collection UUIDs, model, and dimension; reconciliation is id-set based — `missingAfterRun` must be zero (counts can lie; only the set proves the rebuild) and `targetOnly` ids are reported without failing the run (a live plane legitimately receives writes mid-rebuild).

**Operator CLI contract**: `validateCliOptions` (pure, spec'd) rejects malformed flags with named errors and exit 2; stderr carries progress, stdout exactly one receipt JSON, exit 0 only on `ok: true`; `--dry-run` performs **zero writes of any kind** — witnessed by a client mock whose every mutating surface throws.

**Source boundary**: decided by the migration ticket, never here — this runner is the mechanism the chosen source feeds (stated in the module doc; the ticket's composition rule).

## Test Evidence

Evidence: L2 — 65/65 locally (`--workers=1`) across the four suites importing the changed modules (runner spec, extractor spec, `reEmbedMissingHeal` + `CorruptionRecoveryGate` consumer suites, additive-safety witnessed); CI pending at head at submission. Falsifier→spec map:

| Terminal-review falsifier | Spec |
|---|---|
| 401 stamped retryable, status lost in grouping | provider-fate: 1 call, terminal-config, budget unburned |
| 45 calls / 8 docs, per-range budgets | bounded pressure: exactly 3 calls, backoffs [500, 1000], stoppedEarly |
| fail-fast pool overlaps retries | drain falsifier: fast failure beside 3 slow in-flight — all settle, then reject |
| sparse result → undefined vectors, zero receipts | embedFn rejects malformed; engine records per-doc; target mock throws on non-vector |
| same-store `ok:true, reEmbedded:0` | UUID identity refusal: zero embeds, zero writes |
| count-only reconciliation blesses foreign ids | id-set: 3 foreign ids + counts that "match" still reconcile honestly |
| dry-run `getOrCreateCollection` mutation | mutation-throwing client passes dry-run |
| `'context overflow'`-class plain errors (historical isolation) | unknown-routing: same 5-call isolation sequence, now terminal-stamped |

## Post-Merge Validation

- First sanctioned run executes under the migration ticket's source-boundary decision (graph+WAL replay or supported clone migration); its receipt (provenance block, per-reason rollup, id-set reconciliation) lands on that ticket.
- The two live failure populations from today's runs (7,562 saturation-era; 1,144 outage-era) are the intended first resume workload once the boundary is decided.

## Deltas

- Extractor failure entries gain `retryable` and two reason codes are renamed by the taxonomy (`embedding-unknown` for status-less plain errors; previously collapsed into `embedding-provider-error`) — consumer suites green; the historical single-bad-document isolation behavior is preserved call-for-call.
- `embedRecoverableDocuments` keeps its `attempts: 1` single-pass default (historical contract); the runner CLI opts in at `--embed-attempts 3`.

Authored by @neo-opus-vega
Origin Session ID: 5814af6b-fe4e-41ba-819f-e1aeb5558643
