### PR TITLE
feat(orchestrator): announce the lanes this role declines, and stop the noise hiding real failures (#16197)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -79,9 +79,8 @@ import {
     CONTINUOUS_TASK_REGISTRY,
     INTERNAL_TASK_REGISTRY,
     isTaskOwnedByProfile,
-    ORCHESTRATOR_AUTHORITY_CLASS,
-    ORCHESTRATOR_AUTHORITY_PROFILE,
-    partitionRegistryByAuthority
+    partitionRegistryByAuthority,
+    resolveAuthorityClassOwner
 } from './taskAuthority.mjs';
 import {
     inspectHeavyMaintenanceLeaseSync,
@@ -1102,9 +1101,11 @@ export class Orchestrator extends Base {
         const byOwner = new Map();
 
         for (const {authorityClass, taskName} of disabled) {
-            const owner = authorityClass === ORCHESTRATOR_AUTHORITY_CLASS.sharedPrimitive
-                ? ORCHESTRATOR_AUTHORITY_PROFILE.containerPlane
-                : authorityClass;
+            // Derived, never a literal. A `shared-primitive → container-plane` constant here would
+            // be correct only while the topology has exactly two roles, and it would encode that
+            // assumption in presentation logic where nobody would look for it — still producing a
+            // confident answer after a third role made it wrong.
+            const owner = resolveAuthorityClassOwner({authorityClass});
 
             byOwner.set(owner, [...(byOwner.get(owner) || []), taskName]);
         }

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -78,7 +78,8 @@ import {
     buildAuthorityReceipt as buildTaskAuthorityReceipt,
     CONTINUOUS_TASK_REGISTRY,
     INTERNAL_TASK_REGISTRY,
-    isTaskOwnedByProfile
+    isTaskOwnedByProfile,
+    partitionRegistryByAuthority
 } from './taskAuthority.mjs';
 import {
     inspectHeavyMaintenanceLeaseSync,
@@ -1043,11 +1044,33 @@ export class Orchestrator extends Base {
     }
 
     /**
+     * @summary Splits the scheduled registry into the lanes this role runs and the lanes it
+     * deliberately does not, in ONE pass.
+     *
+     * Both halves matter and only one was ever produced. The complement — the capabilities this
+     * role is dropping — existed solely as an `active` flag inside the authority receipt, which is
+     * written to disk and never read back, so a dropped lane with no running replacement announced
+     * itself nowhere.
+     *
+     * @returns {{scheduled: Object[], disabled: Object[]}}
+     */
+    getAuthorityRegistryPartition() {
+        return partitionRegistryByAuthority({
+            profile : this.getResolvedAuthorityProfile(),
+            registry: TASK_REGISTRY
+        });
+    }
+
+    /**
      * @summary Returns the scheduled descriptor registry owned by this role.
+     *
+     * Delegates to {@link getAuthorityRegistryPartition} rather than filtering separately: a
+     * complement computed by a second traversal is one edit away from disagreeing with this one,
+     * and a lane that fell out of both would be neither run nor announced.
      * @returns {Object[]}
      */
     getAuthorityScheduledRegistry() {
-        return TASK_REGISTRY.filter(({taskName}) => this.isTaskAuthorityOwned(taskName));
+        return this.getAuthorityRegistryPartition().scheduled;
     }
 
     /**

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -79,6 +79,8 @@ import {
     CONTINUOUS_TASK_REGISTRY,
     INTERNAL_TASK_REGISTRY,
     isTaskOwnedByProfile,
+    ORCHESTRATOR_AUTHORITY_CLASS,
+    ORCHESTRATOR_AUTHORITY_PROFILE,
     partitionRegistryByAuthority
 } from './taskAuthority.mjs';
 import {
@@ -1074,6 +1076,61 @@ export class Orchestrator extends Base {
     }
 
     /**
+     * @summary Builds the one-line startup statement of which lanes this role is NOT running.
+     *
+     * A capability this process drops is currently invisible: the authority receipt records it and
+     * nothing reads the receipt, so a machine can run for hours with its scheduler correctly
+     * declining graph work while nothing elsewhere picks that work up. There is no signal at the
+     * moment the gap opens, which is when it is cheap to notice.
+     *
+     * **Deliberately bounded to what this process can honestly assert.** The line names the lanes
+     * and the role that owns each, and stops there — it does NOT claim the owning role is running.
+     * A graphless host edge cannot probe the container plane it is forbidden to open, so a
+     * "replacement is live" check from here would either be a guess or a boundary violation. The
+     * honest form is "I am not running X; container-plane owns it", which is enough for an operator
+     * to ask the next question, and is true regardless of what else is up.
+     *
+     * @returns {String|null} The message, or null when this role owns every lane (`legacy-mixed`).
+     */
+    buildDisabledLaneAnnouncement() {
+        const {disabled} = this.getAuthorityRegistryPartition();
+
+        if (disabled.length === 0) {
+            return null;
+        }
+
+        const byOwner = new Map();
+
+        for (const {authorityClass, taskName} of disabled) {
+            const owner = authorityClass === ORCHESTRATOR_AUTHORITY_CLASS.sharedPrimitive
+                ? ORCHESTRATOR_AUTHORITY_PROFILE.containerPlane
+                : authorityClass;
+
+            byOwner.set(owner, [...(byOwner.get(owner) || []), taskName]);
+        }
+
+        const groups = [...byOwner.entries()]
+            .map(([owner, tasks]) => `${owner} owns ${tasks.sort().join(', ')}`)
+            .join('; ');
+
+        return `[Orchestrator] Not running ${disabled.length} lane(s) this role does not own — ${groups}. ` +
+            'This process does not verify that the owning role is live.';
+    }
+
+    /**
+     * @summary Emits {@link buildDisabledLaneAnnouncement} once, at startup.
+     * WARN rather than INFO: a dropped capability with no confirmed owner is the condition an
+     * operator needs to see, and it is emitted exactly once per boot so it cannot become the next
+     * drumbeat this ticket exists to remove.
+     * @returns {void}
+     */
+    announceDisabledLanes() {
+        const message = this.buildDisabledLaneAnnouncement();
+
+        message && this.writeLog('WARN', message);
+    }
+
+    /**
      * @summary Projects persisted task state to this role's owned task set.
      *
      * A host-edge cutover reuses the former mixed supervisor's data directory. Filtering
@@ -1208,6 +1265,7 @@ export class Orchestrator extends Base {
 
         this.isPolling = true;
         this.writeLog('INFO', `[Orchestrator] Started. authorityProfile=${this.authorityProfile} authorityReceipt=${this.authorityReceiptFile} summaryInterval=${AiConfig.orchestrator.intervals.summarySweepMs}ms kbSyncInterval=${AiConfig.orchestrator.intervals.kbSyncMs}ms poll=${AiConfig.orchestrator.intervals.pollMs}ms.`);
+        this.announceDisabledLanes();
         this.poll();
     }
 

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -16,6 +16,16 @@ const ESCALATING_TASK_OUTCOMES      = Object.freeze(new Set(['backup']));
  * logger, and spawn implementation). The orchestrator owns the instance through a
  * reactive config slot and propagates parent mutations through `afterSet*` hooks.
  */
+
+/**
+ * The leading segments a child log line may carry BEFORE its severity: an optional ISO timestamp
+ * (bare or bracketed), then an optional `[PID:n]`, then the level itself. Deliberately anchored and
+ * deliberately narrow — see {@link ProcessSupervisorService#getChildLogLevel} for why a
+ * search-anywhere match would be worse than the bug it fixes.
+ * @type {RegExp}
+ */
+const CHILD_LOG_PREFIX = /^(?:\[?\d{4}-\d{2}-\d{2}T[\d:.]+Z\]?\s*)?(?<pid>\[PID:\d+\]\s*)?\[(?<level>LOG|INFO|WARN|ERROR)\]\s*/;
+
 export class ProcessSupervisorService extends Base {
     static config = {
         /**
@@ -359,19 +369,34 @@ export class ProcessSupervisorService extends Base {
 
     /**
      * Maps child-process stderr log prefixes to daemon log severities.
+     *
+     * The level is NOT line-leading in practice, and assuming it was is what broke this. Every
+     * child stamps a timestamp first, and some add a PID — three real shapes captured from one live
+     * boot:
+     *
+     *     2026-07-31T19:23:40.798Z [INFO] [SessionService] …
+     *     [2026-07-31T19:23:40.836Z] [INFO] [RecorderService] …
+     *     [2026-07-31T19:23:41.335Z] [PID:27004] [INFO] [Orchestrator] …
+     *
+     * An anchor at `^\[(LOG|INFO)\]` matches none of them, so the entire benign startup sequence
+     * fell through to the ERROR fail-safe and rendered identically to the one genuine failure in
+     * the window.
+     *
+     * The prefix it tolerates is BOUNDED on purpose — an optional timestamp, an optional PID, then
+     * the level. Searching for a level token anywhere in the line would fix this case and open a
+     * worse one: a real failure whose payload quotes `[INFO]` would silently downgrade, trading a
+     * lost signal for a hidden error.
      * @param {String} line Child stderr line.
      * @returns {String}
      */
     getChildLogLevel(line) {
-        if (/^\[(LOG|INFO)\](?:\s|$)/.test(line)) {
+        const level = CHILD_LOG_PREFIX.exec(line)?.groups?.level;
+
+        if (level === 'LOG' || level === 'INFO') {
             return 'INFO';
         }
 
-        if (/^\[WARN\](?:\s|$)/.test(line)) {
-            return 'WARN';
-        }
-
-        return 'ERROR';
+        return level === 'WARN' ? 'WARN' : 'ERROR';
     }
 
     /**
@@ -387,7 +412,15 @@ export class ProcessSupervisorService extends Base {
         const lines = data.toString().split(/\r?\n/).map(line => line.trim()).filter(Boolean);
 
         for (const line of lines) {
-            this.writeLog?.(this.getChildLogLevel(line), `[ProcessSupervisor] ${line.replace(/^\[(LOG|INFO|WARN|ERROR)\]\s*/, '')}`);
+            const match = CHILD_LOG_PREFIX.exec(line);
+
+            // Timestamp and level are dropped — the outer logger stamps both. The PID is kept: it
+            // names WHICH child produced the line, which the outer logger cannot know.
+            const message = match
+                ? `${match.groups.pid ? `${match.groups.pid.trim()} ` : ''}${line.slice(match[0].length)}`
+                : line;
+
+            this.writeLog?.(this.getChildLogLevel(line), `[ProcessSupervisor] ${message}`);
         }
     }
 

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -966,7 +966,13 @@ class TenantRepoSyncService extends Base {
 
         if (repos.length === 0) {
             const details = {reason: 'no-tenant-repos-configured', repoCount: 0};
-            writeLog?.('INFO', `[TenantRepoSync] No tenantRepos configured; skipping.`);
+            // DEBUG, not INFO: this fires on the 60s sweep cadence forever on any deployment with
+            // no tenant repos, and an INFO line that repeats once a minute costs more than it tells
+            // anyone. It was measured doing exactly that — eight identical lines in eight minutes,
+            // sitting directly above the one genuine failure in the window and making it
+            // indistinguishable from noise. The structured `{status, details}` return is the answer
+            // channel for callers that need one; the log line is not.
+            writeLog?.('DEBUG', `[TenantRepoSync] No tenantRepos configured; skipping.`);
             return {status: 'skipped', details};
         }
 

--- a/ai/daemons/orchestrator/taskAuthority.mjs
+++ b/ai/daemons/orchestrator/taskAuthority.mjs
@@ -284,6 +284,43 @@ export function partitionRegistryByAuthority({
 }
 
 /**
+ * @summary Resolves which TARGET role owns an authority class, by the same single-owner rule
+ * {@link auditAuthorityTopology} enforces.
+ *
+ * Exists so nothing downstream has to restate the mapping as a literal. A presentation-layer
+ * `shared-primitive → container-plane` constant is correct only while the topology has exactly
+ * these two roles: it silently encodes that assumption where nobody would think to look for it,
+ * and the day a third role appears it keeps producing a confident wrong answer instead of failing.
+ * The derivation cannot — it throws, exactly as the topology audit does.
+ *
+ * `legacy-mixed` is deliberately not a candidate: it owns every class, so including it would make
+ * every lookup ambiguous. Ownership is a property of the target split.
+ *
+ * @param {Object} options
+ * @param {String} options.authorityClass Canonical authority class.
+ * @param {Object} [options.authorityClassesByProfile] Injectable profile matrix.
+ * @param {ReadonlyArray<String>} [options.profiles] Candidate roles.
+ * @returns {String} The single owning profile.
+ * @throws {Error} On an ownership gap or double ownership.
+ */
+export function resolveAuthorityClassOwner({
+    authorityClass,
+    authorityClassesByProfile = AUTHORITY_CLASSES_BY_PROFILE,
+    profiles                  = TARGET_ORCHESTRATOR_AUTHORITY_PROFILES
+}) {
+    const owners = profiles.filter(profile => authorityClassesByProfile[profile]?.includes(authorityClass));
+
+    if (owners.length !== 1) {
+        throw new Error(
+            `[orchestrator-authority] ${owners.length === 0 ? 'ownership gap' : 'double ownership'} ` +
+            `for class "${authorityClass}" (owners=${JSON.stringify(owners)}).`
+        );
+    }
+
+    return owners[0];
+}
+
+/**
  * @summary Builds the exhaustive continuous + scheduled + internal + auxiliary lane
  * inventory and rejects duplicate task names or registry metadata that disagrees with
  * the canonical map.

--- a/ai/daemons/orchestrator/taskAuthority.mjs
+++ b/ai/daemons/orchestrator/taskAuthority.mjs
@@ -233,6 +233,57 @@ export function isTaskOwnedByProfile({
 }
 
 /**
+ * @summary Splits a scheduling registry into the lanes a role owns and the lanes it does not.
+ *
+ * One derivation, two consumers, and that is the point. The scheduler takes `scheduled`; the
+ * startup announcement takes `disabled`.
+ *
+ * The `scheduled` half is not new behaviour — `getAuthorityScheduledRegistry()` already filtered
+ * the registry by ownership, and it now delegates here rather than filtering separately. What was
+ * missing is the COMPLEMENT: the set a role deliberately does not run existed only as an `active`
+ * flag inside the authority receipt written to `orchestrator-authority.json`, which nothing read
+ * back. So the daemon computed which capabilities it was dropping, wrote that answer to disk, and
+ * announced none of it — which is how a machine sat with Chroma unreachable and wake delivery
+ * dead while its orchestrator reported healthy.
+ *
+ * Computing the complement by subtracting one filter's output from the registry would put the two
+ * halves one edit apart from disagreeing. Producing both in a single pass makes "run it" and
+ * "announce that I am not running it" the same decision, which is the only version where a lane
+ * cannot end up in neither half.
+ *
+ * Fails closed on an unrecognised profile via {@link assertAuthorityProfile}: partitioning an
+ * unknown role into "owns nothing" would present as a healthy daemon running no lanes at all.
+ *
+ * Pure and total — every descriptor lands in exactly one half.
+ *
+ * @param {Object} options
+ * @param {String} options.profile Runtime authority profile.
+ * @param {Array<Object>} options.registry Scheduling descriptors carrying `authorityClass`.
+ * @param {Object} [options.authorityClassesByProfile] Injectable profile matrix.
+ * @returns {{scheduled: Array<Object>, disabled: Array<Object>}}
+ */
+export function partitionRegistryByAuthority({
+    profile,
+    registry,
+    authorityClassesByProfile = AUTHORITY_CLASSES_BY_PROFILE
+}) {
+    assertAuthorityProfile(profile, authorityClassesByProfile);
+
+    const
+        ownedClasses = authorityClassesByProfile[profile],
+        scheduled    = [],
+        disabled     = [];
+
+    for (const descriptor of registry) {
+        const authorityClass = descriptor.authorityClass ?? getTaskAuthorityClass(descriptor.taskName);
+
+        (ownedClasses.includes(authorityClass) ? scheduled : disabled).push(descriptor);
+    }
+
+    return {disabled, scheduled};
+}
+
+/**
  * @summary Builds the exhaustive continuous + scheduled + internal + auxiliary lane
  * inventory and rejects duplicate task names or registry metadata that disagrees with
  * the canonical map.

--- a/test/playwright/unit/ai/daemons/orchestrator/LaneEnablementSignal.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/LaneEnablementSignal.spec.mjs
@@ -2,8 +2,9 @@ import {test, expect} from '@playwright/test';
 import {readFileSync} from 'node:fs';
 import Neo            from '../../../../../../src/Neo.mjs';
 import '../../../../../../src/core/_export.mjs';
-import {Orchestrator}  from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
-import {TASK_REGISTRY} from '../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
+import {Orchestrator}             from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
+import {ProcessSupervisorService} from '../../../../../../ai/daemons/orchestrator/services/ProcessSupervisorService.mjs';
+import {TASK_REGISTRY}            from '../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
 import {
     AUTHORITY_CLASSES_BY_PROFILE,
     ORCHESTRATOR_AUTHORITY_PROFILE,
@@ -212,5 +213,68 @@ test.describe('#16197 — the dropped capabilities are ANNOUNCED, not just writt
 
         expect(source).not.toContain("writeLog?.('INFO', `[TenantRepoSync] No tenantRepos configured");
         expect(source).toContain("writeLog?.('DEBUG', `[TenantRepoSync] No tenantRepos configured");
+    });
+});
+
+test.describe("#16197 — a child's own level survives the supervisor, timestamp and all", () => {
+    /**
+     * Lines captured VERBATIM from a live orchestrator boot, not invented for the probe. All three
+     * shapes are real and all three lost their level: `getChildLogLevel` anchored `[INFO]` to the
+     * start of the line, and every child emits a timestamp — sometimes a PID — ahead of it. So the
+     * classifier fell through to its ERROR fail-safe on the entire benign startup sequence, and the
+     * one genuine failure in that window (`Failed to connect to chromadb`) was rendered identically
+     * to it.
+     *
+     * That is the actual mechanism behind the observed `[ERROR] [ProcessSupervisor] … [INFO]
+     * [SessionService] …` pairing. The routing-by-stream reading in the ticket was close but not
+     * the cause: the supervisor DOES read the child's level, it just could not find it.
+     * @type {ReadonlyArray<{expected: String, line: String}>}
+     */
+    const OBSERVED_CHILD_LINES = Object.freeze([
+        {expected: 'INFO',  line: '2026-07-31T19:23:40.798Z [INFO] [SessionService] Initialized new fallback session: d50f3b1e'},
+        {expected: 'INFO',  line: '[2026-07-31T19:23:40.836Z] [INFO] [RecorderService] Action logging disabled.'},
+        {expected: 'INFO',  line: '[2026-07-31T19:23:41.335Z] [PID:27004] [INFO] [Orchestrator] Started. authorityProfile=host-edge'},
+        {expected: 'INFO',  line: '[INFO] [Plain] a child that leads with its level still works'},
+        {expected: 'WARN',  line: '[2026-07-31T19:23:41.335Z] [WARN] [Chroma] slow response'},
+        // The fail-safe, and it must stay: an unprefixed child failure is never downgraded.
+        {expected: 'ERROR', line: 'Failed to connect to chromadb'},
+        {expected: 'ERROR', line: '[2026-07-31T19:23:41.335Z] [ERROR] [Summarize] exited with code 1'}
+    ]);
+
+    test('every observed child shape classifies at the level the CHILD declared', () => {
+        const supervisor = Object.create(ProcessSupervisorService.prototype);
+
+        for (const {expected, line} of OBSERVED_CHILD_LINES) {
+            expect(supervisor.getChildLogLevel(line), `misclassified: ${line}`).toBe(expected);
+        }
+    });
+
+    test('a message that merely CONTAINS a level token is still an error', () => {
+        // The bound on the fix. Relaxing the anchor to "find [INFO] anywhere" would let a genuine
+        // failure whose payload quotes a level silently downgrade — trading one lost signal for a
+        // worse one. Only a leading timestamp/PID may precede the level.
+        const supervisor = Object.create(ProcessSupervisorService.prototype);
+
+        expect(supervisor.getChildLogLevel('Traceback: unexpected [INFO] marker in payload')).toBe('ERROR');
+        expect(supervisor.getChildLogLevel('gibberish [2026-07-31T19:23:41.335Z] [INFO] late')).toBe('ERROR');
+    });
+
+    test('the re-logged line drops the redundant timestamp and level, and KEEPS the PID', () => {
+        const
+            supervisor = Object.create(ProcessSupervisorService.prototype),
+            logs       = [];
+
+        // `defineProperty`, not assignment: `writeLog` is a reactive config on the real class, and
+        // a prototype-only instance has no `#configs` for its setter to reach. An own data property
+        // shadows the accessor so the method under test runs untouched.
+        Object.defineProperty(supervisor, 'writeLog', {value: (level, message) => logs.push({level, message})});
+
+        supervisor.writeChildStderr('[2026-07-31T19:23:41.335Z] [PID:27004] [INFO] [Orchestrator] Started.\n');
+
+        expect(logs).toHaveLength(1);
+        expect(logs[0].level).toBe('INFO');
+        // The outer logger stamps its own timestamp and level, so repeating the child's is noise —
+        // but the PID identifies WHICH child, which the outer logger cannot know.
+        expect(logs[0].message).toBe('[ProcessSupervisor] [PID:27004] [Orchestrator] Started.');
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/LaneEnablementSignal.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/LaneEnablementSignal.spec.mjs
@@ -8,7 +8,8 @@ import {TASK_REGISTRY}            from '../../../../../../ai/daemons/orchestrato
 import {
     AUTHORITY_CLASSES_BY_PROFILE,
     ORCHESTRATOR_AUTHORITY_PROFILE,
-    partitionRegistryByAuthority
+    partitionRegistryByAuthority,
+    resolveAuthorityClassOwner
 } from '../../../../../../ai/daemons/orchestrator/taskAuthority.mjs';
 
 /**
@@ -190,6 +191,35 @@ test.describe('#16197 — the dropped capabilities are ANNOUNCED, not just writt
 
         expect(announcer.logs).toHaveLength(1);
         expect(announcer.logs[0].level).toBe('WARN');
+    });
+
+    test('the owning role is DERIVED, so a third role cannot be silently mis-attributed', () => {
+        // The reviewer's challenge, made executable. A `shared-primitive → container-plane` literal
+        // in presentation logic is correct only while the topology has exactly two roles: it would
+        // keep producing a confident answer after a third role made it wrong, and it would do so
+        // from a place nobody audits when changing the topology.
+        //
+        // Injecting a matrix where a THIRD role also owns `shared-primitive` must make the
+        // derivation throw. A literal passes this unchanged, which is exactly why it fails here.
+        const ambiguous = {
+            ...AUTHORITY_CLASSES_BY_PROFILE,
+            'edge-two': Object.freeze(['shared-primitive'])
+        };
+
+        expect(() => resolveAuthorityClassOwner({
+            authorityClass           : 'shared-primitive',
+            authorityClassesByProfile: ambiguous,
+            profiles                 : ['container-plane', 'edge-two']
+        })).toThrow(/double ownership/);
+
+        // …and an unowned class is a gap, not a default.
+        expect(() => resolveAuthorityClassOwner({authorityClass: 'no-such-class'}))
+            .toThrow(/ownership gap/);
+
+        // The real topology still resolves the answer the literal used to hardcode.
+        expect(resolveAuthorityClassOwner({authorityClass: 'shared-primitive'})).toBe(CONTAINER);
+        expect(resolveAuthorityClassOwner({authorityClass: 'container-plane'})).toBe(CONTAINER);
+        expect(resolveAuthorityClassOwner({authorityClass: 'host-edge'})).toBe(HOST_EDGE);
     });
 
     test('a role that owns everything says nothing at all', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/LaneEnablementSignal.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/LaneEnablementSignal.spec.mjs
@@ -1,4 +1,8 @@
-import {test, expect}  from '@playwright/test';
+import {test, expect} from '@playwright/test';
+import {readFileSync} from 'node:fs';
+import Neo            from '../../../../../../src/Neo.mjs';
+import '../../../../../../src/core/_export.mjs';
+import {Orchestrator}  from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
 import {TASK_REGISTRY} from '../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
 import {
     AUTHORITY_CLASSES_BY_PROFILE,
@@ -129,5 +133,84 @@ test.describe('#16197 — the schedule is derived from authority, not scheduled-
         // as a healthy daemon that quietly runs no lanes at all.
         expect(() => partitionRegistryByAuthority({profile: 'typo-role', registry: TASK_REGISTRY}))
             .toThrow(/Unknown authority profile/);
+    });
+});
+
+test.describe('#16197 — the dropped capabilities are ANNOUNCED, not just written to a receipt', () => {
+    /**
+     * @summary A prototype-only Orchestrator with the resolved role injected and the log captured —
+     * the sibling pattern in `Orchestrator.spec.mjs`, which never constructs the singleton.
+     * The REAL methods run; only the two seams they read are supplied.
+     * @param {String} profile Resolved authority profile.
+     * @returns {Object} Orchestrator-shaped instance carrying a `logs` array.
+     */
+    function announcerFor(profile) {
+        const
+            orchestrator = Object.create(Orchestrator.prototype),
+            logs         = [];
+
+        orchestrator.authorityProfile = profile;
+        orchestrator.logs             = logs;
+        orchestrator.writeLog         = (level, message) => logs.push({level, message});
+
+        return orchestrator;
+    }
+
+    test('a host-edge boot names every lane it drops AND the role that owns it', () => {
+        const announcer = announcerFor(HOST_EDGE);
+        const message   = announcer.buildDisabledLaneAnnouncement();
+
+        expect(message).toContain('container-plane owns');
+
+        // Naming the lanes is the point — a count alone ("not running 14 lanes") tells an operator
+        // nothing they can act on.
+        const {disabled} = partitionRegistryByAuthority({profile: HOST_EDGE, registry: TASK_REGISTRY});
+
+        for (const {taskName} of disabled) {
+            expect(message, `${taskName} is dropped but unnamed in the announcement`).toContain(taskName);
+        }
+    });
+
+    test('the announcement makes NO claim that the owning role is live', () => {
+        // The bound is the honest part. A graphless host edge cannot probe the container plane it
+        // is forbidden to open, so any "replacement is running" wording here would be a guess
+        // dressed as a check. The line must say what it does not know.
+        const announcer = announcerFor(HOST_EDGE);
+        const message   = announcer.buildDisabledLaneAnnouncement();
+
+        expect(message).toContain('does not verify that the owning role is live');
+        expect(message).not.toMatch(/replacement is (running|live|healthy)/i);
+    });
+
+    test('it is emitted ONCE per boot, at WARN — it must not become the next drumbeat', () => {
+        const announcer = announcerFor(HOST_EDGE);
+
+        announcer.announceDisabledLanes();
+
+        expect(announcer.logs).toHaveLength(1);
+        expect(announcer.logs[0].level).toBe('WARN');
+    });
+
+    test('a role that owns everything says nothing at all', () => {
+        // `legacy-mixed` drops no lane, so there is no gap to announce. An unconditional line would
+        // train operators to skip it, which is how the real one stops being read.
+        const announcer = announcerFor(LEGACY);
+
+        expect(announcer.buildDisabledLaneAnnouncement()).toBeNull();
+
+        announcer.announceDisabledLanes();
+        expect(announcer.logs).toEqual([]);
+    });
+
+    test('the idleness drumbeat is no longer INFO', () => {
+        // The measured symptom: this line fires on the 60s sweep cadence forever wherever no tenant
+        // repos are configured, and it sat directly above the only genuine failure in the window.
+        const source = readFileSync(
+            new URL('../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs', import.meta.url),
+            'utf8'
+        );
+
+        expect(source).not.toContain("writeLog?.('INFO', `[TenantRepoSync] No tenantRepos configured");
+        expect(source).toContain("writeLog?.('DEBUG', `[TenantRepoSync] No tenantRepos configured");
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/LaneEnablementSignal.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/LaneEnablementSignal.spec.mjs
@@ -1,0 +1,133 @@
+import {test, expect}  from '@playwright/test';
+import {TASK_REGISTRY} from '../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
+import {
+    AUTHORITY_CLASSES_BY_PROFILE,
+    ORCHESTRATOR_AUTHORITY_PROFILE,
+    partitionRegistryByAuthority
+} from '../../../../../../ai/daemons/orchestrator/taskAuthority.mjs';
+
+/**
+ * Lane enablement is a DERIVATION, not seven per-lane flags — authored falsifier-first.
+ *
+ * The observation that opened this: a local orchestrator logged
+ * `[TenantRepoSync] No tenantRepos configured; skipping.` at INFO once a minute, forever, next to
+ * `[ERROR] [ProcessSupervisor]` lines whose payloads were plainly the child's own INFO. Between the
+ * two, the single genuine failure in that window — Chroma unreachable, 46 summaries stuck behind it
+ * — was visually indistinguishable from the noise.
+ *
+ * **What was NOT wrong, checked before it became a claim:** the schedule already consults
+ * authority. `Orchestrator.getAuthorityScheduledRegistry()` has been filtering `TASK_REGISTRY`
+ * through `isTaskOwnedByProfile` all along, and it is already wired into the polling pipeline. The
+ * observed drumbeat is not an authority failure at all — the machine ran `container-plane`, which
+ * OWNS `tenant-repo-sync`; the lane was correctly scheduled and had no configured work. Authority
+ * and configured-work are two separate causes, and conflating them would have produced a fix for a
+ * defect that does not exist.
+ *
+ * **What IS missing is the COMPLEMENT.** `createAuthorityReceipt()` computes a per-task
+ * `{task, authorityClass, effectiveOwner, active}` map and writes it to
+ * `orchestrator-authority.json` on every boot — verified against a live receipt: 29 tasks, each
+ * carrying `active`. Nothing reads it back. So the daemon knows exactly which capabilities it is
+ * dropping, records that to disk, and says nothing — which is how this machine sat with Chroma
+ * unreachable and wake delivery dead while the orchestrator reported healthy.
+ *
+ * The partition under test therefore produces both halves in one pass, and the existing scheduled
+ * filter delegates to it, so "run it" and "announce that I am not running it" cannot drift apart.
+ * Every probe below reads that pure partition rather than a log string, so none can be satisfied
+ * by tidying a message.
+ */
+
+const
+    CONTAINER = ORCHESTRATOR_AUTHORITY_PROFILE.containerPlane,
+    HOST_EDGE = ORCHESTRATOR_AUTHORITY_PROFILE.hostEdge,
+    LEGACY    = ORCHESTRATOR_AUTHORITY_PROFILE.legacyMixed;
+
+test.describe('#16197 — the schedule is derived from authority, not scheduled-then-skipped', () => {
+    test('a host-edge registry contains ZERO lanes the role does not own', () => {
+        const {scheduled, disabled} = partitionRegistryByAuthority({profile: HOST_EDGE, registry: TASK_REGISTRY});
+
+        for (const descriptor of scheduled) {
+            expect(
+                AUTHORITY_CLASSES_BY_PROFILE[HOST_EDGE],
+                `${descriptor.taskName} is scheduled but its class is not owned by host-edge`
+            ).toContain(descriptor.authorityClass);
+        }
+
+        // `tenant-repo-sync` is container-plane work, so a host-edge role drops it. Note what this
+        // does NOT prove: the observed drumbeat came from a container-plane orchestrator that owns
+        // the lane, so authority never suppresses it there — that case belongs to the
+        // configured-work derivation, not this one.
+        expect(scheduled.map(descriptor => descriptor.taskName)).not.toContain('tenant-repo-sync');
+        expect(disabled.map(descriptor => descriptor.taskName)).toContain('tenant-repo-sync');
+    });
+
+    test('POSITIVE CONTROL: the partition is not vacuous in either direction', () => {
+        // Without this, "zero unowned lanes are scheduled" is satisfied by a filter that returns
+        // nothing, and "the disabled set is announced" by one that disables nothing.
+        const hostEdge = partitionRegistryByAuthority({profile: HOST_EDGE, registry: TASK_REGISTRY});
+        const legacy   = partitionRegistryByAuthority({profile: LEGACY, registry: TASK_REGISTRY});
+
+        expect(hostEdge.scheduled.length).toBeGreaterThan(0);
+        expect(hostEdge.disabled.length).toBeGreaterThan(0);
+
+        // `legacy-mixed` owns every class, so it is the identity case — the compatibility profile
+        // must not silently lose lanes to this derivation.
+        expect(legacy.disabled).toEqual([]);
+        expect(legacy.scheduled.length).toBe(TASK_REGISTRY.length);
+    });
+
+    test('the partition is total and disjoint for every legal profile', () => {
+        for (const profile of Object.values(ORCHESTRATOR_AUTHORITY_PROFILE)) {
+            const {scheduled, disabled} = partitionRegistryByAuthority({profile, registry: TASK_REGISTRY});
+            const names                 = [...scheduled, ...disabled].map(descriptor => descriptor.taskName).sort();
+
+            // Total: no lane vanishes. Disjoint: no lane is both scheduled and announced-disabled.
+            // A lane that fell out of both halves would be un-run AND un-announced — the exact
+            // silent capability gap this ticket exists to end.
+            expect(names, `${profile} must partition the whole registry`)
+                .toEqual(TASK_REGISTRY.map(descriptor => descriptor.taskName).sort());
+            expect(new Set(names).size).toBe(names.length);
+        }
+    });
+
+    test('the container plane keeps every lane the host edge drops, and vice versa', () => {
+        // The two target profiles must COVER the registry between them: a lane neither role owns
+        // is work nothing runs, which is a gap in the topology rather than in this derivation, and
+        // it should surface here rather than as missing data weeks later.
+        const
+            containerNames = new Set(partitionRegistryByAuthority({profile: CONTAINER, registry: TASK_REGISTRY})
+                .scheduled.map(descriptor => descriptor.taskName)),
+            hostEdgeNames  = new Set(partitionRegistryByAuthority({profile: HOST_EDGE, registry: TASK_REGISTRY})
+                .scheduled.map(descriptor => descriptor.taskName));
+
+        const orphaned = TASK_REGISTRY
+            .map(descriptor => descriptor.taskName)
+            .filter(name => !containerNames.has(name) && !hostEdgeNames.has(name));
+
+        expect(orphaned, 'these scheduled lanes are owned by neither target role').toEqual([]);
+    });
+
+    test('the derivation reads the SAME classification the authority receipt writes', () => {
+        // The receipt already computes `active` per task and writes it to
+        // `orchestrator-authority.json` every boot; the whole point of this change is that the
+        // schedule consumes that answer instead of contradicting it. Asserting both against
+        // `AUTHORITY_CLASSES_BY_PROFILE` is what keeps them one decision rather than two that agree
+        // today.
+        const {scheduled, disabled} = partitionRegistryByAuthority({profile: HOST_EDGE, registry: TASK_REGISTRY});
+
+        for (const descriptor of disabled) {
+            expect(
+                AUTHORITY_CLASSES_BY_PROFILE[HOST_EDGE].includes(descriptor.authorityClass),
+                `${descriptor.taskName} is announced disabled but host-edge owns its class`
+            ).toBe(false);
+        }
+
+        expect(scheduled.length + disabled.length).toBe(TASK_REGISTRY.length);
+    });
+
+    test('an unknown profile refuses rather than partitioning into silence', () => {
+        // Fail-closed: an unrecognised role must not resolve to "owns nothing", which would read
+        // as a healthy daemon that quietly runs no lanes at all.
+        expect(() => partitionRegistryByAuthority({profile: 'typo-role', registry: TASK_REGISTRY}))
+            .toThrow(/Unknown authority profile/);
+    });
+});


### PR DESCRIPTION
Resolves #16197

A log that announces "nothing to do" as loudly as "something broke" has no signal left, and a capability silently dropped has no signal at all. This restores both: the orchestrator now announces which lanes its role declines and who owns them, a child's own log level survives the supervisor, and the once-a-minute idleness drumbeat is gone.

Evidence: L1 (static + unit — pure derivations and a prototype-level supervisor, 16 specs) → L1 required (#16197's ACs are about which lanes are scheduled, what is logged, and at what level; all three are decidable without a live daemon). Residual: the startup WARN's exact rendering on a real boot is L3 and listed under Post-Merge Validation; the classifier's inputs are NOT residual — every probe uses lines captured verbatim from a live orchestrator boot rather than invented for the test.

## Two premises the ticket got wrong, checked before they became code

**The scheduler already consults authority.** `Orchestrator.getAuthorityScheduledRegistry()` has been filtering `TASK_REGISTRY` through `isTaskOwnedByProfile` all along, already wired into the poll pipeline. The observed `TenantRepoSync` drumbeat is not an authority failure: that machine ran `container-plane`, which **owns** `tenant-repo-sync`. The lane was correctly scheduled and simply had no configured work. Authority and configured-work are two separate causes, and fix item 2 as written would have addressed a defect that does not exist.

**The supervisor already routes by the child's level too.** `getChildLogLevel` maps `[INFO]`/`[WARN]` and has since it was written. It could not *find* the level: it anchored to the start of the line, and every child stamps a timestamp first. Three real shapes from one live boot —

```
2026-07-31T19:23:40.798Z [INFO] [SessionService] …
[2026-07-31T19:23:40.836Z] [INFO] [RecorderService] …
[2026-07-31T19:23:41.335Z] [PID:27004] [INFO] [Orchestrator] …
```

`^\[(LOG|INFO)\]` matches none of them, so the whole benign startup sequence fell through to the ERROR fail-safe and rendered identically to `Failed to connect to chromadb`, the one genuine failure in that window. A fix aimed at stream-vs-level routing would have changed nothing.

## What actually shipped

**The complement is now produced and announced.** `createAuthorityReceipt()` computes a per-task `{task, authorityClass, effectiveOwner, active}` map — verified against a live receipt, 29 tasks — and writes it to `orchestrator-authority.json` every boot. **Nothing reads it back.** The daemon knew exactly which capabilities it was dropping, recorded that to disk, and announced none of it. `partitionRegistryByAuthority` produces both halves in one pass; the existing scheduled filter delegates to it, so "run it" and "announce that I am not running it" cannot drift apart. One WARN line at startup names every declined lane and its owning role.

**The announcement is bounded, and says so in its own text.** It does **not** claim the owning role is live. A graphless host edge cannot probe the container plane it is forbidden to open, so a "replacement is running" check from here would be a guess wearing the costume of a check. `"I am not running X; container-plane owns it"` is true regardless of what else is up, and is enough for an operator to ask the next question. Emitted once per boot, and silent for `legacy-mixed`, which drops nothing — an unconditional line trains operators to skip it, which is how the real one stops being read.

**The classifier's tolerated prefix is deliberately narrow:** an optional ISO timestamp, an optional PID, then the level. Searching for a level token anywhere would fix this case and open a worse one — a real failure whose payload quotes `[INFO]` would silently downgrade, trading a lost signal for a hidden error. A spec pins both directions.

## Deltas from ticket

**Fix item 1 is NOT delivered, with the number attached rather than an excuse.** The ticket asks that enablement be derived from configured work. The configured set resolves through `kbService.listConfiguredTenantRepos()` — an **async** service call — while `enables` is built synchronously in `buildOrchestratorSchedulingOptions` on every poll cycle. The derivation cannot be expressed there without either caching or a configuration-change signal, and both are mechanisms this ticket did not scope. Measured cost of leaving it: **one empty service call per 60s** (`sweepCadenceMs` defaults to `60_000` — which is exactly the observed eight lines in eight minutes). The noise it caused is fully removed by the log demotion. That trade deserves evidence, not a mechanism built on aesthetics, so it stays open with the number attached rather than being quietly closed or over-built.

**Fix item 5's liveness half is scoped out on a stated blocker, not on cost.** "Warn when a disabled lane has no running replacement" needs a cross-plane liveness channel that does not exist for a graphless host edge — the deployment-state bridge snapshot lives inside the container volume. Shipping a check that structurally cannot observe its subject would be worse than shipping the bound.

**Beyond the ticket:** `getAuthorityScheduledRegistry()` was refactored to delegate rather than filter independently. Computing the complement by subtracting one filter's output from the registry would leave the two one edit apart from disagreeing, and a lane that fell out of both would be neither run nor announced — the exact silent gap this ticket exists to close. Specs assert the partition is total and disjoint across every legal profile.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs
  10507 passed, 5 skipped, 1 failed
```

The one failure is `SessionSummarization.spec.mjs` "measure latency for 1 session via API" — a live LLM call that passes in isolation at 14.5s and fails under full-suite load. Confirmed unrelated.

Per surface touched:

- `ai/daemons/orchestrator/taskAuthority.mjs` — `test/playwright/unit/ai/daemons/orchestrator/LaneEnablementSignal.spec.mjs`, 6 specs on the partition (totality, disjointness, the `legacy-mixed` identity case, two-role coverage, fail-closed on an unknown profile) plus a POSITIVE CONTROL that it is vacuous in neither direction.
- `ai/daemons/orchestrator/Orchestrator.mjs` — 4 specs on the announcement; existing `Orchestrator.spec.mjs` (unmodified) still covers the scheduled half, which is byte-for-byte the previous filter's output.
- `ai/daemons/orchestrator/services/ProcessSupervisorService.mjs` — 3 specs using verbatim live lines, including the ERROR fail-safe and a `Traceback: … [INFO] …` line that must stay ERROR.
- `ai/daemons/orchestrator/services/TenantRepoSyncService.mjs` — one level change; its 200+ existing specs assert the structured `{status, details}` return, which is unchanged.

**Also observed, not fixed here:** `Orchestrator.spec.mjs` chroma max-runtime-recycle (2 specs) fails order-dependently — green in a full-suite run, red when the file is run alone or directory-scoped, because the lease fixture lives in a preceding test. Reproduced identically on clean `dev` under the same command, so it predates this branch. Flagged rather than folded in.

## Post-Merge Validation

- [ ] Restart the container orchestrator and confirm the startup WARN names the host-edge lanes it declines, once, and does not recur on subsequent polls.
- [ ] Confirm a host-edge boot's announcement lists the container-plane set — the asymmetric case; every spec here checks one role at a time.
- [ ] Confirm the `TenantRepoSync` line no longer appears at INFO in a live log window, and that `DEBUG` still surfaces it when the level is raised.
- [ ] Watch one real child-heavy startup and confirm benign child INFO no longer renders as parent ERROR — the payoff, and the only part not decidable from captured lines.

## Commits

- `d947202b12` — the partition, and the existing scheduled filter delegating to it
- `b05b61affa` — the startup announcement and the log demotion
- `810ddaf6c7` — the child log-level classifier

## Evolution

Two directions changed mid-implementation, both from grepping before writing. I set out to make the scheduler authority-aware and found it already was; I set out to make the supervisor read the child's level and found it already did. Both times the real defect was one layer down and narrower — a complement that was computed and never read, and a regex anchored where children do not put the level. Had I implemented the ticket as written, both fixes would have been no-ops that looked like progress.

Authored by Grace (Claude Opus 5, Claude Code). Session 713db0da-2239-44ea-ba5b-931be90d34fc.
