### PR TITLE
refactor(fleet): point both provisioning templates at the container-plane ingress (#16205)

### DIFF
--- a/.claude/claude_desktop_config.example.json
+++ b/.claude/claude_desktop_config.example.json
@@ -1,14 +1,19 @@
 {
-  "_comment": "Claude DESKTOP (GUI) example for a LOCAL-FIRST Neo setup. Copy the `mcpServers` block into ~/Library/Application Support/Claude/claude_desktop_config.json (macOS) or %APPDATA%/Claude/claude_desktop_config.json (Windows), then replace every <PLACEHOLDER>. Claude Desktop and Claude Code do NOT share this file — Claude Code (CLI) reads a repo-root .mcp.json (see .github/AI_QUICK_START.md §5). SECRETS (GH_TOKEN and any optional cloud provider keys) live in the .env file loaded via --env-file — never inline here. NEO_OPENAI_COMPATIBLE_HOST points at your local inference endpoint (e.g. LM Studio on 127.0.0.1:1234), so NO cloud API key is required. NEO_AGENT_IDENTITY (your GitHub login — binds the A2A mailbox) goes in the memory-core env block only. On Apple Silicon prepend /opt/homebrew/bin to PATH (GUI launches strip it). Fully quit (Cmd-Q) and relaunch after any edit.",
+  "_comment": "Claude DESKTOP (GUI) example for a Neo setup. Copy the `mcpServers` block into ~/Library/Application Support/Claude/claude_desktop_config.json (macOS) or %APPDATA%/Claude/claude_desktop_config.json (Windows), then replace every <PLACEHOLDER>. Claude Desktop and Claude Code do NOT share this file — Claude Code (CLI) reads a repo-root .mcp.json (see .github/AI_QUICK_START.md §5). SECRETS (NEO_MCP_REMOTE_TOKEN, GH_TOKEN, any optional cloud provider keys) live in the .env file loaded via --env-file — never inline here. NEO_OPENAI_COMPATIBLE_HOST points at your local inference endpoint (e.g. LM Studio on 127.0.0.1:1234), so NO cloud API key is required. On Apple Silicon prepend /opt/homebrew/bin to PATH (GUI launches strip it). Fully quit (Cmd-Q) and relaunch after any edit.",
+  "_comment_remote": "Memory Core and Knowledge Base run in the container plane and are reached through its loopback ingress. Claude Desktop has NO native remote-MCP entry, so both go through Neo's own stdio-to-Streamable-HTTP bridge (ai/mcp/client/stdioToStreamableHttp.mjs) — the same reviewed entrypoint Fleet-managed Claude Desktop residents invoke. Do not substitute a third-party proxy: the bridge deliberately has no OAuth, browser-callback, SSE-fallback, cache, or package-download surface. github-workflow and neural-link stay stdio; they are not part of the plane.",
+  "_comment_bearer": "THE BEARER REACHES THE BRIDGE VIA --env-file, AND THAT IS DELIBERATE. `--token-env` names a slot the bridge reads from its OWN process environment; the value never enters argv or this file. A GUI app is launched by launchd, which does not inherit shell exports, so a NEO_MCP_REMOTE_TOKEN exported in your shell profile would NOT reach it — a seat that reads correct and never authenticates. Passing --env-file to node loads the repo .env into the bridge process before the script runs, which sidesteps launchd entirely. Keep --env-file first in args. NEO_MCP_REMOTE_TOKEN is the one slot for this plane, shared with the Fleet seat generators (src/ai/fleet/mcpServers.mjs); a repository credential is a different authority and may never be substituted for it. On the remote transport the bearer also binds your agent identity, so NEO_AGENT_IDENTITY is no longer set for these two servers.",
   "mcpServers": {
     "neo-mjs-knowledge-base": {
       "command": "<YOUR_NODE_PATH>",
       "args": [
         "--env-file=<YOUR_NEO_REPO_PATH>/.env",
-        "<YOUR_NEO_REPO_PATH>/ai/mcp/server/knowledge-base/mcp-server.mjs"
+        "<YOUR_NEO_REPO_PATH>/ai/mcp/client/stdioToStreamableHttp.mjs",
+        "--url",
+        "http://127.0.0.1:3102/kb/mcp",
+        "--token-env",
+        "NEO_MCP_REMOTE_TOKEN"
       ],
       "env": {
-        "NEO_OPENAI_COMPATIBLE_HOST": "http://127.0.0.1:1234",
         "PATH": "/opt/homebrew/bin:<YOUR_NEO_REPO_PATH>/node_modules/.bin:/usr/local/bin:/usr/bin:/bin",
         "HOME": "<YOUR_HOME>"
       }
@@ -17,11 +22,13 @@
       "command": "<YOUR_NODE_PATH>",
       "args": [
         "--env-file=<YOUR_NEO_REPO_PATH>/.env",
-        "<YOUR_NEO_REPO_PATH>/ai/mcp/server/memory-core/mcp-server.mjs"
+        "<YOUR_NEO_REPO_PATH>/ai/mcp/client/stdioToStreamableHttp.mjs",
+        "--url",
+        "http://127.0.0.1:3102/mc/mcp",
+        "--token-env",
+        "NEO_MCP_REMOTE_TOKEN"
       ],
       "env": {
-        "NEO_AGENT_IDENTITY": "<YOUR_GITHUB_LOGIN>",
-        "NEO_OPENAI_COMPATIBLE_HOST": "http://127.0.0.1:1234",
         "PATH": "/opt/homebrew/bin:<YOUR_NEO_REPO_PATH>/node_modules/.bin:/usr/local/bin:/usr/bin:/bin",
         "HOME": "<YOUR_HOME>"
       }

--- a/.codex/config.template.toml
+++ b/.codex/config.template.toml
@@ -24,9 +24,10 @@ model_context_window = 1000000
 model_auto_compact_token_limit = 850000
 model_max_output_tokens = 128000
 
-# Neo's Memory Core and Knowledge Base MCP servers talk to local Chroma and
-# embedding services over loopback. Keep those services bound to localhost; this
-# flag only lets Codex sandboxed commands reach them from trusted checkouts.
+# Memory Core and Knowledge Base are reached over the container-plane ingress on
+# loopback, and Chroma plus the embedding services sit behind it. Keep every one of
+# them bound to localhost; this flag only lets Codex sandboxed commands reach them
+# from trusted checkouts.
 [sandbox_workspace_write]
 network_access = true
 
@@ -38,45 +39,36 @@ startup_timeout_sec = 30
 tool_timeout_sec = 120
 enabled = true
 
-# Remote Gemini credentials are intentionally opt-in for local Codex MCP
-# servers. Add GEMINI_API_KEY only to the specific ignored .codex/config.toml
-# server env_vars that is explicitly testing remote Gemini, then restart the
-# harness so already-running MCP children drop any old environment.
+# Memory Core and Knowledge Base run inside the container plane and are reached
+# through its loopback ingress. Codex speaks remote MCP natively, so these two
+# tables carry `url` + `bearer_token_env_var` and no command, args, or env_vars.
+# Server-side configuration (embedding provider, Chroma, inference host) belongs
+# to the containers now, not to this file.
+#
+# THE BEARER IS RESOLVED IN THE HARNESS PROCESS ENVIRONMENT.
+# `bearer_token_env_var` names a slot Codex reads from its OWN environment at MCP
+# startup; the value never appears here. The retired stdio shape did not need this
+# — each server loaded the repo `.env` itself — so a seat that provisions cleanly
+# can still fail to authenticate if NEO_MCP_REMOTE_TOKEN is absent from the shell
+# that launched Codex. Export it from your shell profile before starting the
+# harness, and verify with `printenv NEO_MCP_REMOTE_TOKEN` in that same shell.
+# A GUI-launched harness inherits its environment from launchd rather than from a
+# shell, so this mechanism does not carry there; see
+# .claude/claude_desktop_config.example.json for the form that does.
+#
+# NEO_MCP_REMOTE_TOKEN is the one slot for this plane, shared with the Fleet seat
+# generators (src/ai/fleet/mcpServers.mjs). A repository credential is a different
+# authority and may never be substituted for it.
 [mcp_servers."neo-mjs-knowledge-base"]
-command = "npm"
-args = ["run", "--silent", "ai:mcp-server-knowledge-base"]
-env_vars = [
-    "NEO_AGENT_IDENTITY",
-    "NEO_CHROMA_EMBEDDING_PROVIDER",
-    "NEO_CHROMA_UNIFIED",
-    "NEO_EMBEDDING_PROVIDER",
-    "NEO_KB_ASK_API_KEY",
-    "NEO_KB_AUTO_START_DATABASE",
-    "NEO_OPENAI_COMPATIBLE_API_KEY",
-    "NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL",
-    "NEO_OPENAI_COMPATIBLE_HOST",
-    "NEO_OPENAI_COMPATIBLE_MODEL"
-]
+url = "http://127.0.0.1:3102/kb/mcp"
+bearer_token_env_var = "NEO_MCP_REMOTE_TOKEN"
 startup_timeout_sec = 30
 tool_timeout_sec = 120
 enabled = true
 
 [mcp_servers."neo-mjs-memory-core"]
-command = "npm"
-args = ["run", "--silent", "ai:mcp-server-memory-core"]
-env_vars = [
-    "NEO_AGENT_IDENTITY",
-    "NEO_CHROMA_EMBEDDING_PROVIDER",
-    "NEO_CHROMA_UNIFIED",
-    "NEO_EMBEDDING_PROVIDER",
-    "NEO_MEM_AUTO_START_DATABASE",
-    "NEO_MEM_AUTO_START_INFERENCE",
-    "NEO_MODEL_PROVIDER",
-    "NEO_OPENAI_COMPATIBLE_API_KEY",
-    "NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL",
-    "NEO_OPENAI_COMPATIBLE_HOST",
-    "NEO_OPENAI_COMPATIBLE_MODEL"
-]
+url = "http://127.0.0.1:3102/mc/mcp"
+bearer_token_env_var = "NEO_MCP_REMOTE_TOKEN"
 startup_timeout_sec = 30
 tool_timeout_sec = 120
 enabled = true

--- a/test/playwright/unit/ai/scripts/diagnostics/bootstrapCodexSandbox.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/bootstrapCodexSandbox.spec.mjs
@@ -23,49 +23,6 @@ function listProbeArtifacts(root) {
 }
 
 /**
- * @summary Reads the tracked Codex config template for static MCP policy guards.
- * @returns {String}
- */
-function readCodexConfigTemplate() {
-    return fs.readFileSync(
-        new URL('../../../../../../.codex/config.template.toml', import.meta.url),
-        'utf8'
-    );
-}
-
-/**
- * @summary Extracts one MCP server TOML block from the Codex config template.
- * @param {String} config
- * @param {String} serverName
- * @returns {String}
- */
-function getMcpServerBlock(config, serverName) {
-    const header = `[mcp_servers."${serverName}"]`;
-    const start  = config.indexOf(header);
-
-    expect(start).toBeGreaterThan(-1);
-
-    const remaining = config.slice(start + header.length);
-    const nextBlock = remaining.search(/\n\[/);
-    const end       = nextBlock === -1 ? config.length : start + header.length + nextBlock;
-
-    return config.slice(start, end);
-}
-
-/**
- * @summary Extracts the env_vars array body from a single MCP server block.
- * @param {String} serverBlock
- * @returns {String}
- */
-function getEnvVarsBlock(serverBlock) {
-    const match = serverBlock.match(/env_vars\s*=\s*\[([\s\S]*?)\]/);
-
-    expect(match).not.toBeNull();
-
-    return match[1];
-}
-
-/**
  * @summary Coverage for the Codex Desktop SQLite sandbox diagnostic.
  *
  * The tests keep all file writes in OS temp dirs and inject the failure-path
@@ -171,22 +128,5 @@ test.describe('bootstrapCodexSandbox diagnostic (#10714)', () => {
         expect(paths.physicalDir).toBe(paths.logicalDir);
         expect(paths.symlinkTarget).toBeNull();
         expect(paths.fileName).toBe('codex-sandbox-probe-paths.sqlite');
-    });
-});
-
-test.describe('Codex MCP config template (#12744)', () => {
-    test('keeps remote Gemini credentials opt-in for local KB and Memory Core servers', () => {
-        const config = readCodexConfigTemplate();
-
-        expect(config).toContain('Remote Gemini credentials are intentionally opt-in');
-
-        for (const serverName of ['neo-mjs-knowledge-base', 'neo-mjs-memory-core']) {
-            const serverBlock = getMcpServerBlock(config, serverName);
-            const envVars     = getEnvVarsBlock(serverBlock);
-
-            expect(envVars).not.toContain('"GEMINI_API_KEY"');
-            expect(envVars).toContain('"NEO_OPENAI_COMPATIBLE_HOST"');
-            expect(envVars).toContain('"NEO_OPENAI_COMPATIBLE_MODEL"');
-        }
     });
 });

--- a/test/playwright/unit/ai/services/fleet/provisioningTemplates.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/provisioningTemplates.spec.mjs
@@ -1,0 +1,145 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+
+import {REMOTE_MCP_CREDENTIAL_ENV_VAR} from '../../../../../../src/ai/fleet/mcpServers.mjs';
+
+const
+    BRIDGE_ENTRYPOINT = 'ai/mcp/client/stdioToStreamableHttp.mjs',
+    PLANE_SERVERS     = ['neo-mjs-memory-core', 'neo-mjs-knowledge-base'],
+    STDIO_SERVERS     = ['neo-mjs-github-workflow', 'neo-mjs-neural-link'],
+    SUFFIXES          = {'neo-mjs-memory-core': '/mc/mcp', 'neo-mjs-knowledge-base': '/kb/mcp'};
+
+/** @summary Read one repo-root file as UTF-8. */
+function readRepoFile(relativePath) {
+    return fs.readFileSync(new URL(`../../../../../../${relativePath}`, import.meta.url), 'utf8')
+}
+
+/**
+ * @summary The host port the container plane actually publishes, read from the Compose file rather
+ * than restated here. A template pinned to a port Compose no longer binds is the silent-provisioning
+ * failure this whole guard exists to catch. Scoped to the `ingress` service: several services publish
+ * on loopback, and the first one in the file is Chroma.
+ * @returns {String}
+ */
+function publishedIngressPort() {
+    const
+        compose = readRepoFile('ai/deploy/docker-compose.local-agent-os.yml'),
+        block   = compose.split(/^ {2}(?=\S)/m).find(section => section.startsWith('ingress:'));
+
+    expect(block, 'Compose no longer declares an ingress service').toBeTruthy();
+
+    const match = block.match(/"127\.0\.0\.1:(\d+):\d+"/);
+
+    expect(match, 'the ingress service no longer publishes a loopback host port').not.toBeNull();
+
+    return match[1]
+}
+
+/**
+ * @summary Extract one Codex MCP table: the header plus its contiguous key/value lines. Stops at a
+ * blank line, a comment, or the next table, so neighbouring prose cannot be read as table content.
+ * @param {String} source
+ * @param {String} serverName
+ * @returns {String}
+ */
+function codexTable(source, serverName) {
+    const
+        header = `[mcp_servers."${serverName}"]`,
+        start  = source.indexOf(header);
+
+    expect(start, `${serverName} table is absent`).toBeGreaterThan(-1);
+
+    const lines = [];
+
+    for (const line of source.slice(start + header.length).split('\n').slice(1)) {
+        if (!line.trim() || line.startsWith('#') || line.startsWith('[')) break;
+        lines.push(line)
+    }
+
+    return lines.join('\n')
+}
+
+/**
+ * @summary Both hand-maintained provisioning templates against the surfaces that own their shape.
+ *
+ * The Fleet seat generators emit the remote form from code and cannot drift; these two files are
+ * maintained by hand and can. Every assertion here is anchored to a live authority — the credential
+ * slot to `src/ai/fleet/mcpServers.mjs`, the port to the Compose binding, the Claude Desktop bridge
+ * to the entrypoint on disk — so a template that goes stale fails here rather than at a resident's
+ * first tool call.
+ */
+test.describe('Provisioning templates (#16205)', () => {
+    test('both templates name the one Fleet credential slot', () => {
+        for (const relativePath of ['.codex/config.template.toml', '.claude/claude_desktop_config.example.json']) {
+            expect(readRepoFile(relativePath), `${relativePath} drifted from the Fleet credential slot`)
+                .toContain(REMOTE_MCP_CREDENTIAL_ENV_VAR)
+        }
+    });
+
+    test('neither template carries a literal credential', () => {
+        for (const relativePath of ['.codex/config.template.toml', '.claude/claude_desktop_config.example.json']) {
+            const source = readRepoFile(relativePath);
+
+            // The slot may appear only as a bare name: never assigned a value, never inlined after `Bearer `.
+            expect(source, `${relativePath} assigns the credential slot a value`)
+                .not.toMatch(new RegExp(`${REMOTE_MCP_CREDENTIAL_ENV_VAR}\\s*[=:]\\s*["']?\\S`));
+            expect(source, `${relativePath} inlines a bearer value`).not.toMatch(/Bearer\s+(?!\$)\S/)
+        }
+    });
+
+    test('the Codex template carries the native remote form for both plane servers', () => {
+        const
+            source = readRepoFile('.codex/config.template.toml'),
+            port   = publishedIngressPort();
+
+        for (const serverName of PLANE_SERVERS) {
+            const table = codexTable(source, serverName);
+
+            expect(table).toContain(`url = "http://127.0.0.1:${port}${SUFFIXES[serverName]}"`);
+            expect(table).toContain(`bearer_token_env_var = "${REMOTE_MCP_CREDENTIAL_ENV_VAR}"`);
+
+            // A remote table that kept any stdio key would launch a local server that no longer exists.
+            for (const retired of ['command', 'args', 'env_vars']) {
+                expect(table, `${serverName} kept the retired stdio key '${retired}'`)
+                    .not.toMatch(new RegExp(`^${retired}\\s*=`, 'm'))
+            }
+        }
+
+        // Positive control: the same extraction proves the stdio shape is still present and matchable,
+        // so a passing assertion above cannot be a zero-match on a broken pattern.
+        for (const serverName of STDIO_SERVERS) {
+            expect(codexTable(source, serverName), `${serverName} should still be stdio`).toMatch(/^command\s*=/m)
+        }
+    });
+
+    test('the Claude Desktop template bridges both plane servers through Neo\'s own entrypoint', () => {
+        const
+            servers = JSON.parse(readRepoFile('.claude/claude_desktop_config.example.json')).mcpServers,
+            port    = publishedIngressPort();
+
+        for (const serverName of PLANE_SERVERS) {
+            const {args} = servers[serverName];
+
+            // `--env-file` must stay first: it is a Node option, and Node only applies it ahead of the
+            // script path. Behind the script path it becomes a script argument and the bearer never loads.
+            expect(args[0], `${serverName} lost the leading --env-file`).toMatch(/^--env-file=/);
+            expect(args[1], `${serverName} does not invoke Neo's bridge`).toContain(BRIDGE_ENTRYPOINT);
+            expect(args).toContain(`http://127.0.0.1:${port}${SUFFIXES[serverName]}`);
+            expect(args[args.indexOf('--token-env') + 1]).toBe(REMOTE_MCP_CREDENTIAL_ENV_VAR);
+
+            // A third-party proxy would reintroduce the OAuth, cache, and package-download surface the
+            // reviewed bridge deliberately has none of.
+            expect(args.join(' '), `${serverName} routes through a third-party proxy`).not.toMatch(/mcp-remote|npx/)
+        }
+
+        // Positive control: the servers that are not on the plane still run their local stdio entrypoints.
+        for (const serverName of STDIO_SERVERS) {
+            expect(servers[serverName].args.join(' '), `${serverName} should still be stdio`)
+                .toContain('mcp-server.mjs')
+        }
+    });
+
+    test('the bridge the Claude Desktop template names exists in this checkout', () => {
+        expect(fs.existsSync(new URL(`../../../../../../${BRIDGE_ENTRYPOINT}`, import.meta.url))).toBe(true)
+    })
+});


### PR DESCRIPTION
Resolves #16205

Related: #16167

Both hand-maintained provisioning templates now emit the container-plane shape, so a seat provisioned today lands on the transport that actually exists. Codex takes the native remote form; Claude Desktop takes Neo's own stdio-to-Streamable-HTTP bridge, because it has no native remote MCP entry. The token-slot divergence the flip introduced is closed by a drift spec that anchors every assertion to the surface that owns it rather than restating a constant — the credential slot to `src/ai/fleet/mcpServers.mjs`, the host port to the Compose ingress binding, the bridge to the entrypoint on disk.

The landing gate is satisfied: #16167 §5's routed healthchecks passed, receipt at https://github.com/neomjs/neo/issues/16167#issuecomment-5148306939 — both `/mc/mcp` and `/kb/mcp` answering in ~2ms with an unauthenticated control. Re-confirmed live while preparing this PR (401 / 401, 2.9ms / 2.2ms).

Evidence: L3 (the template's exact argv drives a real bridge process against the live ingress on this host; the seven-mutation falsification sweep below) → L2 required (every close-target AC is a static template property plus a drift test). Residual: the authenticated `200` leg is unproven — reaching it requires handling a live bearer, which I do not do; it moves to Post-Merge Validation.

## Deltas from ticket

Three corrections, each falsified against the surface that owns the decision rather than accepted from the ticket prose.

- **The `mcp-remote` prescription is wrong; Neo ships its own bridge.** Step 2 prescribes the third-party `mcp-remote` proxy for Claude Desktop. `src/ai/fleet/mcpServers.mjs:24-28` — the single Fleet MCP authority — names Neo's `ai/mcp/client/stdioToStreamableHttp.mjs` for `claude-desktop` instead; `prepareManagedAgentWorkspace.mjs:663-689` emits exactly that shape for managed seats; `FleetLifecycleService.mjs:1349` refuses a `claude-desktop` seat that does not expose it. Adopting `mcp-remote` for the hand-provisioned path would recreate the generated-vs-hand divergence step 3 exists to prevent, and would add the OAuth, cache, and package-download surface `learn/agentos/cloud-deployment/ClientAuthentication.md:180-183` states the bridge deliberately has none of. The template uses Neo's bridge, and the spec fails if a third-party proxy ever replaces it.

- **The `.tools.*` AC has no referent.** "preserving each server's `.tools.*` approval subsections" preserves nothing: there are zero `tools` occurrences in `.codex/config.template.toml` and zero `mcp_servers."x".` sub-tables in any tracked file. Confirmed with a working positive control — `mcp_servers` matches 4x in that same file, so the absence is the file's, not the pattern's. Recording it as vacuously satisfied rather than quietly ticking it. (Latent, out of scope: `codexMcpServerName` matches only an exact `mcp_servers."<name>"` header, so a `.tools.*` sub-table added later would survive `stripManagedMcpTables` and orphan itself beside Fleet's regenerated table.)

- **The Codex template is a live Fleet input, not only an example.** `prepareCodexArtifacts` reads `<mainCheckout>/.codex/config.template.toml` and renders managed seat config from it, with `stripManagedMcpTables` discarding every `neo-mjs-*` table before regenerating from the live plan. So these MC/KB edits are inert for Fleet-managed seats and load-bearing only for hand-provisioned ones. What had to survive is the non-MCP scaffolding — `project_doc_max_bytes`, `[sandbox_workspace_write]`, and the `[features]` marker `renderCodexProjectConfig` keys its insertion off. Verified byte-identical for both untouched servers, with the two changed servers as the control.

**Design decision the ticket could not anticipate.** Credit to @neo-kimi-phoebe, whose finding this rests on: stdio entries never needed the bearer in the harness process environment because they passed `--env-file` to node themselves, while the streamable-http remotes resolve their token slot in the *harness* process env — and launchd bypasses shells, so a GUI-launched Claude Desktop never sees a shell export. A template instructing operators to export the variable would produce a seat that reads correct, launches, and never authenticates: the ticket's own "silently non-functional Claude seat" trap. Resolution: pass `--env-file` to node ahead of the bridge script, which is the mechanism this file already documents for its stdio entries. Node consumes the flag itself, so argv reaches the bridge clean and the slot is populated before the script runs — no `launchctl setenv`, no literal token anywhere. `--env-file` position is asserted, because behind the script path it silently degrades into an ordinary script argument.

**Retired guard.** `bootstrapCodexSandbox.spec.mjs`'s `Codex MCP config template (#12744)` block asserted that KB and Memory Core keep `NEO_OPENAI_COMPATIBLE_*` in their `env_vars` and hold remote Gemini credentials opt-in. Its premise — that both are local stdio servers — no longer holds; that configuration belongs to the containers now. Ran it RED against the new template before removing it, rather than deleting a test that was merely in the way. Its three helpers had no other caller and went with it, leaving that spec 60 lines lighter.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  provisioningTemplates bootstrapCodexSandbox prepareManagedAgentWorkspace \
  FleetLifecycleService StdioToStreamableHttp generateKimiSeatConfig generateOpenCodeSeatConfig
  146 passed (4.2s)
```

Per surface touched:

- `.codex/config.template.toml`, `.claude/claude_desktop_config.example.json` — `test/playwright/unit/ai/services/fleet/provisioningTemplates.spec.mjs`, 5 specs, new.
- `ai/mcp/client/stdioToStreamableHttp.mjs` — **not modified**; existing `StdioToStreamableHttp.spec.mjs` still covers it, and the new spec asserts the entrypoint the template names exists in the checkout, so moving the bridge fails here.
- `ai/services/fleet/prepareManagedAgentWorkspace.mjs`, `FleetLifecycleService.mjs` — **not modified**; their specs are in the run above because they consume the Codex template and the credential slot.

**Green is not the evidence — these are.** Every assertion was mutation-tested against the failure mode it exists to catch, each mutation applied to a committed tree and reverted:

| Mutation | Result |
|---|---|
| Codex slot drifts to `GH_TOKEN` | RED |
| Claude Desktop slot drifts to `GH_TOKEN` | RED |
| Codex MC table keeps a stdio `command` | RED |
| `--env-file` moved behind the script path | RED |
| Claude Desktop swaps in third-party `mcp-remote` | RED |
| Compose ingress host port changes | RED |
| A literal bearer is inlined | RED |

Live probe, outside CI (L3) — the template's exact argv, with a deliberately bogus bearer:

- with `--env-file`: bridge starts, connects, and reports `Neo MCP bridge transport failed.` — it passed its own bearer-present gate and reached the ingress, which refused the bogus token.
- without `--env-file` (the launchd failure mode): bridge refuses to start with `Bridge bearer environment slot is missing or empty.`

Two distinguishable messages, so the probe can fail the way the claim can be wrong.

## Post-Merge Validation

- [ ] Provision one fresh Claude Desktop seat from the template with a real bearer in the repo `.env` and confirm an authenticated `initialize` returns `200` — the one leg this PR cannot reach without handling a credential.
- [ ] Provision one fresh Codex seat and confirm it resolves `NEO_MCP_REMOTE_TOKEN` from the shell that launched it; Codex is CLI-launched, so the `.zshenv` path applies there and the bridge path does not.
- [ ] Confirm on a non-darwin host: the `PATH` block in the Claude Desktop example is macOS-shaped (`/opt/homebrew/bin`) and unchanged by this PR, but it is now the only remaining machine-specific value in the two plane entries.

## Commits

- `ce1a9928fb` — both templates, the drift spec, and the retired #12744 guard.

## Evolution

Started from the ticket's two prescribed edits and expected a shape swap. The prior-art sweep of the Fleet authority inverted the Claude Desktop half — Neo already ships the bridge the ticket proposed importing — and reading `prepareCodexArtifacts` reframed the Codex half from "an example file" to "a live generator input whose non-MCP scaffolding is load-bearing". Both changes came from reading the consuming code rather than the ticket prose.

Authored by Ada (Claude Opus 5, Claude Code). Session 56105163-6e66-44b6-8c6f-9e81bc1be08c.
