### PR TITLE
fix(ai): isolate joined-waiter delivery copies in boundedRetryGate (#16243)

### DIFF
--- a/ai/services/shared/boundedRetryGate.mjs
+++ b/ai/services/shared/boundedRetryGate.mjs
@@ -24,7 +24,8 @@
  *    to the latest demand. A waiter therefore always receives the LATEST generation's truth,
  *    annotated by generation identity (`gate.genId` of the serving run vs `gate.demandedGenId`
  *    of the waiter's own demand; `gate.coalesced` marks the fold), never a superseded result
- *    presented as current.
+ *    presented as current. Every delivered result is an independent per-waiter deep copy —
+ *    joined callers cannot observe each other's mutations.
  * 3. **Draining.** A superseded flight's result is dropped (never cached into any other
  *    generation); the coalesced latest demand starts immediately after the active flight
  *    settles. Callers never hang and the latest generation always gets its own run.
@@ -148,22 +149,25 @@ export function createBoundedRetryGate({
     }
 
     /**
-     * @summary Per-waiter delivery: marks results served by a DIFFERENT generation than the one
-     * demanded (`coalesced: true` + the demanded generation identity), so a folded waiter can
-     * always tell which generation's truth it received versus which it asked for.
+     * @summary Per-waiter delivery: every waiter receives an INDEPENDENT deep copy of the serving
+     * run's result — one joined caller's mutation can never reach another joined caller's
+     * delivery. Marks results served by a DIFFERENT generation than the one demanded
+     * (`coalesced: true` + the demanded generation identity), so a folded waiter can always tell
+     * which generation's truth it received versus which it asked for.
      * @param {Object} annotated The serving run's annotated result.
      * @param {Object} waiter    `{key, genId, resolve}` — the demanded generation identity.
      */
     function fanout(annotated, waiter) {
-        waiter.resolve({
-            ...annotated,
-            gate: {
-                ...annotated.gate,
-                coalesced    : annotated.gate.genId !== waiter.genId,
-                demandedKey  : waiter.key,
-                demandedGenId: waiter.genId
-            }
-        });
+        const body = structuredClone(annotated); // per-waiter isolation; gate fields are scalars
+
+        body.gate = {
+            ...annotated.gate,
+            coalesced    : annotated.gate.genId !== waiter.genId,
+            demandedKey  : waiter.key,
+            demandedGenId: waiter.genId
+        };
+
+        waiter.resolve(body);
     }
 
     /**

--- a/test/playwright/unit/ai/services/shared/boundedRetryGate.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/boundedRetryGate.spec.mjs
@@ -414,6 +414,26 @@ test.describe('ai/services/shared/boundedRetryGate', () => {
         expect(snap2.cached.result.tags).toEqual(['a']);
     });
 
+    test('joined waiters receive independent delivery copies — one waiter\'s mutation cannot reach another', async () => {
+        const {gate} = makeGate({
+            runImpl: () => ({status: 'healthy', detail: {marker: 'pristine'}, tags: ['a']})
+        });
+
+        // Both waiters join the SAME flight — the exact joined-waiter probe shape.
+        const [a, b] = await Promise.all([gate.tick({key: 'A'}), gate.tick({key: 'A'})]);
+
+        a.detail.marker = 'mutated-by-A';
+        a.tags.push('b');
+
+        expect(b.detail.marker).toBe('pristine');
+        expect(b.tags).toEqual(['a']);
+
+        // …and the gate cache stays pristine too.
+        const snap = gate.snapshot();
+        expect(snap.cached.result.detail.marker).toBe('pristine');
+        expect(snap.cached.result.tags).toEqual(['a']);
+    });
+
     test('global single-flight holds across rotations and runNow churn (maxActive === 1)', async () => {
         let activeRuns = 0, maxActive = 0;
 


### PR DESCRIPTION
Resolves #16243

`fanout()` now deep-clones the annotated result per waiter before attaching the per-waiter gate fields — joined callers can no longer observe each other's mutations. A small mechanism change (per-waiter `structuredClone`) plus its guarantee JSDoc and the joined-waiter probe spec, discharging the A+FU follow-up from PR #16239's terminal review ahead of the #16223/#16224 adoption lanes this ticket blocks.

Evidence: L2 (unit suites at exact head `8ab4b7d5f7`) — no L3 residual: the change is caller-isolation semantics inside an already-merged primitive, fully exercisable in unit scope. AC1+AC2 proven by the new spec; AC3 (JSDoc guarantee) in-diff; AC4 = suites green below.

## Deltas from ticket

None substantive — the ticket prescribed per-waiter `structuredClone` in `fanout()`; that is exactly the delta. The rejected alternative (narrowing the JSDoc isolation claim) stays rejected.

## Test Evidence

- `test/playwright/unit/ai/services/shared/boundedRetryGate.spec.mjs` — new spec 'joined waiters receive independent delivery copies — one waiter's mutation cannot reach another' (two waiters joined on one flight; mutate A's nested object + array; B's copy and the gate cache stay pristine): shared tree green at exact head.
- `test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` — consumer regression: green; the canary path is semantically untouched.
- Focused run (shared tree + HealthService spec): **142/142** at exact head.
- Full memory-core + shared trees: **1425/1428** — the 3 failures are the known shifting load-flake set (retry-timer, latency-measure, ollama-timeout), all previously green in isolation and untouched by this diff.
- Pre-commit hooks green: whitespace, shorthand, aiconfig-test-mutation, jsdoc-types, derived-domain, ticket-archaeology, block-alignment, parse.
- Browser/e2e surfaces: `None found` (none touched).

## Post-Merge Validation

- [ ] Whoever takes an adoption lane (#16223 / #16224) lifts this ticket's `blockedBy` on GitHub as they start (the link is informational, not a merge gate).

Authored by Iris (Kimi K3, Kimi Code CLI). Session 05b5fdc9-1f2b-4b45-a2c9-4b64ed5f15cd.
