### PR TITLE
fix(wake): degrade a dead route from a background flush, onto the field its consumers read (#16246)

### DIFF
--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -901,6 +901,57 @@ class GraphService extends Base {
     }
 
     /**
+     * @summary The ONE sanctioned context-free node read, for background writers that run outside any request.
+     *
+     * Every RLS-scoped read ({@link GraphService#getNode}, {@link GraphService#getNodeRecord}) resolves its
+     * requester from the request-bound `RequestContextService`. A background timer — a coalescing flush, a
+     * delivery retry, a maintenance sweep — has no bound request, so `resolveRlsUserId` yields `null`, every
+     * branch of the visibility predicate evaluates false, and the read returns `null` for a node that plainly
+     * exists. The failure is silent and reads as absence: the caller concludes "no such node" and skips the
+     * work it was scheduled to do — a dead wake route that can never be marked degraded re-runs its failing
+     * delivery attempts on every subsequent message, forever.
+     *
+     * Consumers previously reached into `db.nodes.get` by hand to route around this, each with its own
+     * explanatory comment. This is that bypass, named once, so it is greppable and reviewable instead of
+     * arriving by copy-paste.
+     *
+     * **This is NOT an RLS bypass for request-scoped reads.** Calling it from a request path re-opens exactly
+     * the cross-requester cache leak the return-boundary re-check exists to prevent. That misuse is not
+     * mechanically preventable here, so it is made *visible*: a bound request context means the caller is on a
+     * request path and should be using `getNodeRecord`, and the accessor logs a warning naming the writer.
+     * @param {Object} data
+     * @param {String} data.id     Node id.
+     * @param {String} data.writer Name of the background writer, for the misuse warning and audit trails.
+     * @returns {Object|null} `{id, type, properties}`, or `null` only when the node genuinely does not exist.
+     */
+    getUnscopedNodeRecord({id, writer}) {
+        if (!writer) {
+            throw new Error('[GraphService] getUnscopedNodeRecord requires a `writer` name identifying the background writer.');
+        }
+
+        // Guarantee lazy-loading from SQLite triggers if not cached (mirrors the RLS-scoped reads).
+        this.db.getAdjacentNodes(id, 'both');
+
+        const node = this.db.nodes.get(id);
+        if (!node) {
+            return null;
+        }
+
+        // Misuse tripwire: a resolvable requester means a request IS bound, so this caller is on a request
+        // path and must use the RLS-scoped `getNodeRecord` instead. Warn rather than throw — a background
+        // task can legitimately be kicked off during a request — but never let the misuse be silent.
+        if (resolveRlsUserId(this.db.storage?.RequestContextService) !== null) {
+            logger.warn(`[GraphService] getUnscopedNodeRecord called by '${writer}' inside a bound request context; use getNodeRecord on request paths.`);
+        }
+
+        return {
+            id        : node.isRecord ? node.get('id') : node.id,
+            type      : node.isRecord ? node.get('label') : node.label,
+            properties: (node.isRecord ? node.get('properties') : node.properties) || {}
+        };
+    }
+
+    /**
      * @summary Lists full node records of one graph type through the same RLS boundary as single-node reads.
      *
      * This is the sanctioned enumeration companion to {@link GraphService#getNodeRecord}. It keeps

--- a/ai/services/memory-core/WebhookDeliveryService.mjs
+++ b/ai/services/memory-core/WebhookDeliveryService.mjs
@@ -36,6 +36,17 @@ class WebhookDeliveryService extends Base {
     consecutiveFailures = new Map();
 
     /**
+     * Subscription ids degraded during this process lifetime. This is what BOUNDS the attempt count: a
+     * degraded route is never attempted again, so a permanently dead endpoint costs the threshold's attempts
+     * once, not a full retry cycle on every message forever. The persisted
+     * `properties.status` is the durable half and survives restarts; this covers the window before the
+     * caller re-reads the node. {@link WebhookDeliveryService#clearDegraded} is the named resumption path.
+     * @member {Set} degradedSubscriptions
+     * @protected
+     */
+    degradedSubscriptions = new Set();
+
+    /**
      * Per-request timeout injected by the Memory Core entrypoint from
      * `AiConfig.orchestrator.wakeDispatch.attemptTimeoutSeconds`.
      * @member {Number|null}
@@ -66,6 +77,16 @@ class WebhookDeliveryService extends Base {
         const properties = subscription.properties || {};
         const url        = properties.harnessTargetMetadata?.url;
         const signingKey = properties.harnessTargetMetadata?.signingKey;
+
+        // A degraded route is dead until explicitly repaired, so it is not attempted at all. Without this the
+        // failure threshold only decides when to START logging: `_recordConsecutiveFailure` kept counting past
+        // it and re-fired the degrade on every subsequent message, each preceded by a full 4-attempt backoff
+        // cycle. The persisted status is authoritative across restarts; the in-memory set covers
+        // the window before the caller re-reads the node.
+        if (properties.status === 'degraded' || this.degradedSubscriptions.has(subscription.id)) {
+            logger.warn(`WebhookDeliveryService: Subscription ${subscription.id} is degraded; skipping delivery without an attempt.`);
+            return 'skipped';
+        }
 
         if (!url) {
             logger.error(`WebhookDeliveryService: Subscription ${subscription.id} is missing URL.`);
@@ -154,25 +175,54 @@ class WebhookDeliveryService extends Base {
 
     async _markDegraded(subscriptionId) {
         try {
-            // Updating the subscription's harnessTarget to 'degraded'
-            const subscriptionNode = GraphService.getNode({id: subscriptionId});
-            if (subscriptionNode) {
-                const properties = {
-                    ...(subscriptionNode.properties || {}),
-                    harnessTarget: 'degraded'
-                };
+            // Context-free read. This runs from a background delivery flush with no bound request, where an
+            // RLS-scoped read (`GraphService.getNode`) resolves a null requester, fails every visibility
+            // branch, and returns null for a node that plainly exists — the degrade was then skipped and the
+            // route stayed live forever.
+            const record = GraphService.getUnscopedNodeRecord({
+                id    : subscriptionId,
+                writer: 'WebhookDeliveryService._markDegraded'
+            });
 
-                GraphService.upsertNode({
-                    ...subscriptionNode,
-                    properties
-                });
-                logger.info(`WebhookDeliveryService: Subscription ${subscriptionId} marked as degraded.`);
-            } else {
-                logger.warn(`WebhookDeliveryService: Cannot degrade ${subscriptionId}, node not found in Graph.`);
+            if (!record) {
+                // ERROR, not WARN: a route that silently fails to change state is the condition that kept
+                // this invisible. The only signal was a WARN in a file nobody tails.
+                logger.error(`WebhookDeliveryService: Cannot degrade ${subscriptionId}, node not found in Graph.`);
+                return;
             }
+
+            // Degradation is a `status` value, never a `harnessTarget` value. `harnessTarget` is the ROUTING
+            // field, and its documented value space (`mcp-notifications | a2a-webhook | bridge-daemon |
+            // disabled | none`) has no `degraded` member. Both consumers of degradation read
+            // `properties.status`: the sunset check (`ai/scripts/lifecycle/checkSunsetted.mjs`) and the
+            // heartbeat push exclusion (`SwarmHeartbeatService`). Writing 'degraded' into `harnessTarget` left
+            // BOTH blind — the sunset check still classified the dead route as active and heartbeats kept
+            // being pushed at it — while corrupting routing into CoalescingEngineService's unknown-target
+            // drop branch. `upsertNode` merges onto the stored properties, so this touches `status` only.
+            GraphService.upsertNode({
+                id        : subscriptionId,
+                properties: {status: 'degraded'}
+            });
+
+            this.degradedSubscriptions.add(subscriptionId);
+            logger.info(`WebhookDeliveryService: Subscription ${subscriptionId} marked as degraded.`);
         } catch (error) {
             logger.error(`WebhookDeliveryService: Failed to mark subscription ${subscriptionId} degraded: ${error.message}`);
         }
+    }
+
+    /**
+     * @summary The named resumption path out of the degraded state.
+     *
+     * Degradation is terminal by design — a degraded route is never probed again, which is what bounds the
+     * attempt count. Repair is therefore explicit: whoever restores the endpoint clears the marker, and the
+     * persisted `status` must be moved off `'degraded'` in the same operation for the route to survive a
+     * process restart.
+     * @param {String} subscriptionId
+     */
+    clearDegraded(subscriptionId) {
+        this.degradedSubscriptions.delete(subscriptionId);
+        this.consecutiveFailures.delete(subscriptionId);
     }
 }
 

--- a/test/playwright/unit/ai/services/memory-core/WebhookDeliveryService.degradeDeadRoute.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WebhookDeliveryService.degradeDeadRoute.spec.mjs
@@ -1,0 +1,248 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'WebhookDeliveryServiceDegradeDeadRouteTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * A dead wake route that cannot be marked degraded re-runs the full delivery cycle on every subsequent
+ * message forever, with no surfaced signal.
+ *
+ * These specs deliberately do NOT stub `GraphService`. The sibling suite
+ * (`WebhookDeliveryService.spec.mjs`) replaces `getNode` / `upsertNode` with in-memory doubles that
+ * return a node WITH `properties` and never consult row-level security — which healed both halves of
+ * this defect in setup and is why it survived with coverage pointing straight at it. Here the real
+ * service runs against the real `GraphService` read/write path, with the requester left UNBOUND to
+ * reproduce a background flush.
+ *
+ * Every test below fails on the pre-fix tree, and fails for the right reason:
+ * - the degrade never lands, because the RLS-scoped read returns `null` for a node that exists;
+ * - and once it does land, it lands on `harnessTarget`, which no degradation consumer reads.
+ */
+
+// Mutable holder so one fake db can switch the "active requester" between calls. A background timer
+// binds no request, so `null` is the case under test — not an edge case, the normal flush condition.
+const requester = {value: null};
+
+/**
+ * Builds a fake `GraphService.db` holding one pre-warmed WAKE_SUBSCRIPTION node. `autoSave` is left
+ * unset so `upsertNode` mutates the in-memory node without reaching for SQLite, letting the specs
+ * assert against the node object itself.
+ * @param {Object} subscriptionNode
+ * @returns {Object}
+ */
+function makeFakeDb(subscriptionNode) {
+    const nodeMap = new Map([[subscriptionNode.id, subscriptionNode]]);
+
+    return {
+        getAdjacentNodes() {},
+        nodes  : nodeMap,
+        edges  : {getByIndex() { return [] }},
+        storage: {
+            RequestContextService: {
+                getAgentIdentityNodeId: () => requester.value
+            }
+        }
+    };
+}
+
+/**
+ * A WAKE_SUBSCRIPTION exactly as the migration writes it: owner-stamped, not shared, not team-visible —
+ * so every branch of the RLS predicate is false once the requester is absent.
+ * @returns {Object}
+ */
+function makeSubscriptionNode() {
+    return {
+        id        : 'WAKE_SUB:dead-route',
+        label     : 'WAKE_SUBSCRIPTION',
+        properties: {
+            userId               : '@neo-opus-grace',
+            status               : 'active',
+            harnessTarget        : 'a2a-webhook',
+            harnessTargetMetadata: {
+                url       : 'http://127.0.0.1:1/wake',
+                signingKey: 'test-signing-key'
+            }
+        }
+    };
+}
+
+test.describe('WebhookDeliveryService — degrading a dead route from a background flush (#16246)', () => {
+    let GraphService, WebhookDeliveryService, originalDb, originalFetch;
+    let fetchCalls = [];
+
+    test.beforeAll(async () => {
+        GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        WebhookDeliveryService = (await import('../../../../../../ai/services/memory-core/WebhookDeliveryService.mjs')).default;
+        originalFetch          = global.fetch;
+    });
+
+    test.beforeEach(() => {
+        originalDb      = GraphService.db;
+        requester.value = null;
+        fetchCalls      = [];
+
+        WebhookDeliveryService.configure({attemptTimeoutSeconds: 1});
+        WebhookDeliveryService.consecutiveFailures.clear();
+        WebhookDeliveryService.degradedSubscriptions?.clear();
+
+        global.fetch = async (url, options) => {
+            fetchCalls.push({url, options});
+            return {ok: false, status: 400};
+        };
+    });
+
+    test.afterEach(() => {
+        GraphService.db = originalDb;
+        requester.value = null;
+        global.fetch    = originalFetch;
+    });
+
+    test('marks a dead route degraded with NO bound request context', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        // Necessity probe (AC 2): the mechanism claims the flush has no resolvable requester. Assert that
+        // directly — if a requester IS bound here, the ticket's mechanism is wrong and the fix is misplaced.
+        expect(GraphService.db.storage.RequestContextService.getAgentIdentityNodeId()).toBe(null);
+
+        // Control: with no requester bound, the RLS-scoped read genuinely cannot see this node. This is the
+        // defect's cause, asserted rather than assumed — and it must stay true, because a fix that works by
+        // weakening RLS would open a cross-tenant read path to close a logging bug.
+        expect(GraphService.getNode({id: subscriptionNode.id})).toBe(null);
+        expect(GraphService.getNodeRecord({id: subscriptionNode.id})).toBe(null);
+
+        const outcome = await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX'});
+
+        expect(outcome).toBe('skipped');
+
+        // The assertion that fails on the pre-fix tree: the degrade was skipped entirely, so the route's
+        // state never changed and the next message repeated the whole sequence.
+        expect(subscriptionNode.properties.status).toBe('degraded');
+    });
+
+    test('degradation lands on `status`, the field its consumers actually read', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX'});
+
+        // `degraded` is a `status` value; `disabled` is a `harnessTarget` value. Both consumers of
+        // degradation read `properties.status`: the sunset check (`checkSunsetted.mjs` — which otherwise
+        // classifies this dead route as ACTIVE, since `status` is untouched and `harnessTarget` is not
+        // 'disabled') and the heartbeat push exclusion (`SwarmHeartbeatService`, whose SQL predicate is
+        // `$.properties.status != 'degraded'`). Writing into `harnessTarget` left both blind.
+        expect(subscriptionNode.properties.status).toBe('degraded');
+
+        // The routing field keeps its documented value space: mcp-notifications | a2a-webhook |
+        // bridge-daemon | disabled | none. 'degraded' was never a member, and only "worked" by falling
+        // through CoalescingEngineService's unknown-target branch, which drops the digest.
+        expect(subscriptionNode.properties.harnessTarget).toBe('a2a-webhook');
+
+        // The degrade must not disturb anything else — notably the delivery credentials, without which the
+        // route could never be repaired, and the owner stamp, whose loss would make the node null-owned and
+        // therefore readable by every tenant.
+        expect(subscriptionNode.properties.harnessTargetMetadata.url).toBe('http://127.0.0.1:1/wake');
+        expect(subscriptionNode.properties.harnessTargetMetadata.signingKey).toBe('test-signing-key');
+        expect(subscriptionNode.properties.userId).toBe('@neo-opus-grace');
+    });
+
+    test('delivery attempts against a permanently dead route are bounded across repeated messages', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        // Counted over N sends rather than read off the threshold constant: the constant was always 3, and
+        // the defect was that crossing it changed nothing, so every later message paid the full cycle again.
+        for (let i = 0; i < 6; i++) {
+            await WebhookDeliveryService.deliver(subscriptionNode, {eventId: `01HXXX-${i}`});
+        }
+
+        // A 4xx degrades immediately without retrying, so a bounded route costs exactly ONE attempt: the
+        // first. Pre-fix this is 6 — one per message, forever, and 4 apiece once the endpoint refuses the
+        // connection rather than answering 4xx.
+        expect(fetchCalls.length).toBe(1);
+        expect(subscriptionNode.properties.status).toBe('degraded');
+    });
+
+    test('a degraded route is skipped without an attempt, and clearDegraded is the way back', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+
+        subscriptionNode.properties.status = 'degraded';
+        GraphService.db                    = makeFakeDb(subscriptionNode);
+
+        expect(await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX'})).toBe('skipped');
+        expect(fetchCalls.length).toBe(0);
+
+        // Terminal by design, with a NAMED resumption path — the property that makes the bound safe to hold.
+        subscriptionNode.properties.status = 'active';
+        WebhookDeliveryService.clearDegraded(subscriptionNode.id);
+
+        global.fetch = async (url, options) => {
+            fetchCalls.push({url, options});
+            return {ok: true, status: 200};
+        };
+
+        expect(await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HYYY'})).toBe('delivered');
+        expect(fetchCalls.length).toBe(1);
+    });
+});
+
+test.describe('GraphService.getUnscopedNodeRecord — the one sanctioned context-free read (#16246)', () => {
+    let GraphService, originalDb;
+
+    test.beforeAll(async () => {
+        GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        originalDb      = GraphService.db;
+        requester.value = null;
+    });
+
+    test.afterEach(() => {
+        GraphService.db = originalDb;
+        requester.value = null;
+    });
+
+    test('returns an owner-stamped node that the RLS-scoped reads cannot see', () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        expect(GraphService.getNodeRecord({id: subscriptionNode.id})).toBe(null);
+
+        const record = GraphService.getUnscopedNodeRecord({
+            id    : subscriptionNode.id,
+            writer: 'spec'
+        });
+
+        expect(record.id).toBe(subscriptionNode.id);
+        expect(record.type).toBe('WAKE_SUBSCRIPTION');
+        expect(record.properties.userId).toBe('@neo-opus-grace');
+    });
+
+    test('returns null for a node that genuinely does not exist', () => {
+        GraphService.db = makeFakeDb(makeSubscriptionNode());
+
+        expect(GraphService.getUnscopedNodeRecord({id: 'WAKE_SUB:absent', writer: 'spec'})).toBe(null);
+    });
+
+    test('refuses a call that does not name its background writer', () => {
+        GraphService.db = makeFakeDb(makeSubscriptionNode());
+
+        // The `writer` name is what keeps this accessor greppable and auditable rather than an anonymous
+        // hole. Making it required means a copy-paste into a new call site cannot stay unattributed.
+        expect(() => GraphService.getUnscopedNodeRecord({id: 'WAKE_SUB:dead-route'}))
+            .toThrow(/requires a `writer` name/);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/WebhookDeliveryService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WebhookDeliveryService.spec.mjs
@@ -27,20 +27,22 @@ let GraphService;
 test.describe('WebhookDeliveryService', () => {
     let fetchCalls   = [];
     let updatedNodes = [];
-    let originalFetch, originalGetNode, originalUpsertNode;
+    let originalFetch, originalGetNode, originalUpsertNode, originalGetUnscopedNodeRecord;
 
     test.beforeAll(async () => {
-        WebhookDeliveryService = (await import('../../../../../../ai/services/memory-core/WebhookDeliveryService.mjs')).default;
-        GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
-        originalFetch          = global.fetch;
-        originalGetNode        = GraphService.getNode;
-        originalUpsertNode     = GraphService.upsertNode;
+        WebhookDeliveryService       = (await import('../../../../../../ai/services/memory-core/WebhookDeliveryService.mjs')).default;
+        GraphService                 = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        originalFetch                = global.fetch;
+        originalGetNode              = GraphService.getNode;
+        originalUpsertNode           = GraphService.upsertNode;
+        originalGetUnscopedNodeRecord = GraphService.getUnscopedNodeRecord;
     });
 
     test.afterAll(() => {
-        global.fetch            = originalFetch;
-        GraphService.getNode    = originalGetNode;
-        GraphService.upsertNode = originalUpsertNode;
+        global.fetch                       = originalFetch;
+        GraphService.getNode               = originalGetNode;
+        GraphService.upsertNode            = originalUpsertNode;
+        GraphService.getUnscopedNodeRecord = originalGetUnscopedNodeRecord;
     });
 
     test.beforeEach(() => {
@@ -75,6 +77,12 @@ test.describe('WebhookDeliveryService', () => {
             return null;
         };
 
+        // The degrade path reads through the context-free accessor, because it runs from a background
+        // flush where the RLS-scoped reads resolve no requester and return null. These doubles
+        // keep this suite's fast in-memory shape; the real read/write path — with RLS actually engaged
+        // and the requester unbound — is covered by WebhookDeliveryService.degradeDeadRoute.spec.mjs.
+        GraphService.getUnscopedNodeRecord = ({id}) => GraphService.getNode({id});
+
         GraphService.upsertNode = (node) => {
             if (node.id === 'WAKE_SUB:123') {
                 updatedNodes.push(node);
@@ -83,6 +91,7 @@ test.describe('WebhookDeliveryService', () => {
 
         // Reset the service state
         WebhookDeliveryService.consecutiveFailures.clear();
+        WebhookDeliveryService.degradedSubscriptions.clear();
         WebhookDeliveryService.configure({attemptTimeoutSeconds: 30});
     });
 
@@ -194,7 +203,9 @@ test.describe('WebhookDeliveryService', () => {
         test.expect(outcome).toBe('skipped');
         test.expect(fetchCalls.length).toBe(1); // No retries for 4xx
         test.expect(updatedNodes.length).toBe(1);
-        test.expect(updatedNodes[0].properties.harnessTarget).toBe('degraded');
+        // `status`, not `harnessTarget`: degradation and routing are separate fields with separate value
+        // spaces, and both consumers of degradation read `status`.
+        test.expect(updatedNodes[0].properties.status).toBe('degraded');
     });
 
     test('retries on 5xx response and degrades after 3 failures', async () => {
@@ -218,7 +229,7 @@ test.describe('WebhookDeliveryService', () => {
         global.setTimeout = originalSetTimeout;
 
         test.expect(fetchCalls.length).toBe(12); // 3 events * 4 attempts
-        test.expect(updatedNodes[0].properties.harnessTarget).toBe('degraded');
+        test.expect(updatedNodes[0].properties.status).toBe('degraded');
     });
 
     test('refuses unsigned Shape-B delivery without issuing a request', async () => {


### PR DESCRIPTION
Resolves #16246

A wake route whose endpoint refuses connections could never be marked degraded, so it re-ran the full delivery cycle on every subsequent message forever. The only signal was a WARN in a file inside the container that nothing tails.

Ada's filed mechanism is confirmed from source, not re-derived. Intake also turned up a **second, independent defect** that had to land with it: the degrade wrote to a field no degradation consumer reads. Fixing only the read produces a green PR that closes nothing observable.

## The two defects

**1 — The read could not see the node.**

`_markDegraded` resolved the subscription through the RLS-scoped `GraphService.getNode`, but it runs from a background delivery flush with no bound request. `resolveRlsUserId` yields `null`, every branch of `isRlsVisible` evaluates false, and the read returns `null` for a node that plainly exists. The failure reads as absence, so the degrade was skipped.

The within-run control in the ticket is what makes this airtight: in the same flush, the same process successfully read the same subscription — it had to, to resolve the `url` and `signingKey` it delivered against. One read succeeded and one returned nothing, milliseconds apart, on the same node. Existence was never the question.

Ada's competing hypothesis — the `@`-prefix vintage split in stored `userId` — stays falsified: `GraphService.mjs:41` normalizes the owner key before comparing. Not re-derived here.

**2 — The write targeted a field with no degradation consumer.**

`degraded` is a **`status`** value. `disabled` is a **`harnessTarget`** value. The state model is written down in production code at `ai/scripts/lifecycle/checkSunsetted.mjs:84-108`, which selects both fields and gives them separate value spaces; `checkSunsetted.spec.mjs:351` states it outright.

Trace a subscription that `_markDegraded` *successfully* wrote before this change — `harnessTarget: 'degraded'`, `status` untouched at `'active'`:

| Consumer | Predicate | Result |
|---|---|---|
| `checkSunsetted.mjs:101` | `(status ?? 'active') === 'active' && harnessTarget !== 'disabled'` | classifies the dead route **active** — the lifecycle check whose job is spotting a dead seat reports it healthy |
| `SwarmHeartbeatService.mjs:1095` | `COALESCE(json_extract(data, '$.properties.status'), 'active') != 'degraded'` | still `active`, so the dead route **keeps receiving heartbeat pushes** |

No reader anywhere compares `harnessTarget` to `'degraded'`. Positive control on that absence claim: `harnessTarget` readers do exist and grep finds them — twelve files across `ai/`, nine hits in `SwarmHeartbeatService` alone. So the value only ever "worked" by falling through `CoalescingEngineService`'s unknown-target branch, which drops the digest.

This picks ticket AC 5's second branch for us. Recording degradation outside `harnessTarget` is not the better of two designs — it is the already-documented contract the code violated.

## The fix

`GraphService.getUnscopedNodeRecord({id, writer})` — the one sanctioned context-free read, named once so it is greppable and reviewable instead of arriving by copy-paste. Three properties worth review attention:

- **`writer` is required and throws when absent.** A copy-paste into a new call site cannot stay unattributed.
- **A misuse tripwire.** Calling it from a request path re-opens exactly the cross-requester cache leak the return-boundary re-check exists to prevent. That is not mechanically preventable here, so it is made visible: a resolvable requester means a request *is* bound, and the accessor warns naming the writer. Warn rather than throw, because a background task can legitimately be kicked off during a request — but the misuse is never silent.
- **RLS is untouched.** `isRlsVisible`, `resolveRlsUserId`, `getNode` and `getNodeRecord` are unchanged. The security check was always correct; the caller was on the wrong side of it. A fix that worked by weakening RLS would open a cross-tenant read path to close a logging bug, and the new spec asserts the RLS-scoped reads still return `null` for this node so that stays true.

`_markDegraded` now reads through that accessor, writes `status: 'degraded'`, and logs at **ERROR** when it cannot degrade. `upsertNode` merges onto the stored properties, so the write touches `status` only — delivery credentials and the owner stamp are asserted intact.

Delivery attempts are bounded: a degraded route is skipped without an attempt, with `clearDegraded` as the named resumption path. Terminal-with-a-named-way-back is the same discipline `boundedRetryGate` encodes.

## Deltas

| Surface | Before | After |
|---|---|---|
| `_markDegraded` read | `GraphService.getNode` — RLS-scoped, returns `null` from a background flush | `GraphService.getUnscopedNodeRecord` — context-free, returns the node |
| Degrade write target | `properties.harnessTarget` — no consumer | `properties.status` — both consumers read it |
| `harnessTarget` value space | polluted with out-of-enum `degraded` | keeps `mcp-notifications \| a2a-webhook \| bridge-daemon \| disabled \| none` |
| Failed degrade log level | WARN, in an untailed file | ERROR |
| Attempts to a dead route over 6 messages | 6 | 1 |
| Degraded-route resumption | none | `clearDegraded` |
| RLS model | — | unchanged |

## Test Evidence

New spec `WebhookDeliveryService.degradeDeadRoute.spec.mjs` deliberately does **not** stub `GraphService`. The real service runs against the real read/write path with the requester left unbound, reproducing a background flush.

Evidence: red-proof run on the pre-fix tree — source changes stashed, spec retained. **7 failed, and every failure is for the right reason:**

```
Expected: "degraded"   Received: "active"     (status never changes — the degrade is skipped)
Expected: 1            Received: 6            (one attempt per message, forever)
Expected: 0            Received: 1            (a degraded route is still attempted)
TypeError: GraphService.getUnscopedNodeRecord is not a function
```

The `6` is the ticket's defect measured rather than inferred: six messages to a dead endpoint cost six delivery attempts, and nothing ever transitions.

Post-fix, the same file is 9/9 green, and 92/92 across the webhook suites plus the `GraphService`, `GraphService.TenantIsolation` and `nodeProjection` regression suites — the RLS coverage that would catch a weakened predicate.

The specs also carry the ticket's **necessity probe (AC 2)** as an assertion rather than a claim: the flush's resolved requester is asserted absent, and both RLS-scoped reads are asserted to return `null` for this node. If a requester were ever bound there, the mechanism would be wrong and these fail loudly instead of the fix silently sitting on a false premise.

Why the defect survived with coverage pointing at it: the pre-existing suite replaced `getNode`/`upsertNode` with doubles that returned a node **with** `properties` and never consulted RLS. That healed both halves in setup — exactly the trap the ticket named in Avoided Traps. Its two assertions moved from `harnessTarget` to `status`.

## Post-Merge Validation

- A wake subscription pointed at a refusing endpoint reaches `properties.status === 'degraded'`, read back off the node rather than off a log line.
- `checkSunsetted` reports that identity as `degraded`, not `active`.
- The `mc-server` log shows one delivery attempt for that route across several subsequent messages, not four per message.
- `list` via `manage_wake_subscription` never returns a `harnessTarget` outside the documented enum.

## Scope held

Deliberately **not** in this PR, with reasons:

- **The two `WakeSubscriptionService` hand-rolled bypasses** (`:854`, `:1373`). Ada cites them as precedent, and they are worth revisiting, but not here. `:854`'s stated reason — *"`getNode` filters out custom properties"* — is **stale**: `getNodeRecord` was added later and returns properties *with* RLS intact, so that site likely wants the RLS-scoped accessor, not this one, and the choice depends on whether it runs request-scoped. `:1373` must **not** move: it passes a raw node into the shared `match()` evaluator, and the wake daemon feeds that same evaluator raw nodes at `daemon.mjs:643` — changing one caller's shape is precisely the drift the comment there warns against. AC 7 asks for no **new** direct reach-ins, which this satisfies.
- **The bulk `db.nodes.items` iterations** in `ai/services/graph/*`. A different access pattern (enumeration, not single-node reads) and a much wider blast radius.
- **Provisioning a wake receiver** — #16233.

## Notes for review

`boundedRetryGate` was considered and does not drop in. It holds a **single** generation slot (`:78`) that `rotateIfNeeded` (`:87-98`) replaces on any key change, and a rotated generation "inherits nothing: clean streak, empty cache, no backoff." Webhook delivery fans out over N subscriptions, so one gate keyed by subscription id would rotate on every interleaved delivery and wipe the streak — the attempt budget would never accumulate. One gate *instance* per subscription would work and needs no primitive change, but the gate also coalesces demand and keeps only the newest, which is right for a probe and wrong for delivery where every message must go. That is a real design question for the primitive's owner rather than something to settle inside this lane; raised with @neo-kimi-iris. The bounded-attempt property here is achieved directly, and stays compatible with adopting the gate later.

**Instrument disclosure:** the `query_raw_memories` prior-art sweep on this topic returned noise (May heartbeat pings, February session-inits, nothing above 0.63 relevance). The Memory Core is mid-restore at roughly 23k of 30k memories, so a miss is not evidence of absence. Prior art was established with `git grep` / `git log` and direct source reads instead, and the one absence claim carries the positive control noted above.

Authored by @neo-opus-grace (Claude Opus 5).
