### PR TITLE
fix(deploy): mount Chroma at its image-pinned /data persist path (#16208)

### DIFF
--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -113,10 +113,12 @@ x-provider-auth-env: &provider-auth-env
 services:
   chroma:
     image: chromadb/chroma:1.5.9
-    # One flat unified persist dir, identical local + cloud (ADR 0003 / Epic #12153).
-    # PERSIST_DIRECTORY is REQUIRED: the image persists to its WORKDIR-relative default
-    # (/chroma/chroma) and IGNORES a mount elsewhere, so the env must point at the same
-    # leaf as the mount or the daemon writes outside the persisted dir.
+    # One flat unified store, identical local + cloud (ADR 0003 / ADR 0017 §2.2 as amended).
+    # The volume MUST target /data: the 1.5.9 image's entrypoint runs `chroma run /config.yaml`,
+    # and that shipped config pins `persist_path: /data`. PERSIST_DIRECTORY is NOT read on that
+    # path — a mount anywhere else leaves the live store in the ephemeral container layer while
+    # the volume sits empty. The env stays declared on the same leaf so any image variant that
+    # does read it cannot re-split the store from the mount.
     #
     # PERSISTENT on the declared plane (was: tmpfs — which silently forked the vector
     # plane from the durable one). `engines.chroma.dataDirProd` is a declared Tier-1
@@ -142,9 +144,9 @@ services:
     # Asserted, not merely stated: see the parity-profile volume-scoping spec. A decision whose
     # correctness rests on a property nothing checks is the `toBe(10)` shape #15932 just retired.
     environment:
-      - PERSIST_DIRECTORY=/chroma/unified
+      - PERSIST_DIRECTORY=/data
     volumes:
-      - parity-chroma:/chroma/unified
+      - parity-chroma:/data
     healthcheck:
       test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
       interval: 10s

--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -1,14 +1,16 @@
 services:
   chroma:
     image: chromadb/chroma:1.5.9
-    # One flat unified persist dir, identical local + cloud (ADR 0003 / Epic #12153).
-    # PERSIST_DIRECTORY is REQUIRED: the image persists to its WORKDIR-relative default
-    # (/chroma/chroma) and IGNORES a mount elsewhere, so the env must point at the same
-    # leaf as the tmpfs mount or the daemon writes outside the tmpfs.
+    # One flat unified store (ADR 0003 / ADR 0017 §2.2 as amended). The tmpfs MUST target
+    # /data: the 1.5.9 image's entrypoint runs `chroma run /config.yaml`, and that shipped
+    # config pins `persist_path: /data`. PERSIST_DIRECTORY is NOT read on that path — a tmpfs
+    # anywhere else silently lands the store in the container's writable layer instead of the
+    # tmpfs this stack declares for speed + isolation. The env stays declared on the same leaf
+    # so any image variant that does read it cannot re-split the store from the mount.
     environment:
-      - PERSIST_DIRECTORY=/chroma/unified
+      - PERSIST_DIRECTORY=/data
     tmpfs:
-      - /chroma/unified
+      - /data
     # The published chromadb/chroma:1.5.9 image is a single 541MB compiled binary
     # at /usr/local/bin/chroma (built via docker-bake.hcl, not the GitHub Dockerfile).
     # It has NO python, NO python3, NO curl, NO wget — empirically verified via

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -23,15 +23,16 @@ name: "${NEO_DEPLOY_PROJECT_NAME:-neo-agent-os}"
 services:
   chroma:
     image: chromadb/chroma:1.5.9
-    # One flat unified persist dir, identical local + cloud (ADR 0003 / Epic #12153).
-    # PERSIST_DIRECTORY is REQUIRED, not optional: the chromadb/chroma:1.5.9 image persists
-    # to its WORKDIR-relative default (/chroma/chroma) and IGNORES a volume mounted elsewhere.
-    # Without this env the daemon would write to an ephemeral container layer while the named
-    # volume sat empty. The mount and the env MUST stay in lockstep on the same leaf.
+    # One flat unified store, identical local + cloud (ADR 0003 / ADR 0017 §2.2 as amended).
+    # The volume MUST target /data: the 1.5.9 image's entrypoint runs `chroma run /config.yaml`,
+    # and that shipped config pins `persist_path: /data`. PERSIST_DIRECTORY is NOT read on that
+    # path — a mount anywhere else leaves the live store in the ephemeral container layer while
+    # the named volume sits empty. The env stays declared on the same leaf so any image variant
+    # that does read it cannot re-split the store from the mount.
     environment:
-      - PERSIST_DIRECTORY=/chroma/unified
+      - PERSIST_DIRECTORY=/data
     volumes:
-      - chroma-data:/chroma/unified
+      - chroma-data:/data
     healthcheck:
       test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
       interval: 10s

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -104,7 +104,7 @@ The deployment's persistent state (`ai/deploy/docker-compose.yml`):
 | State | Mechanism | Lost when... |
 |---|---|---|
 | Memory Core graph + sessions — the **primary store** | `shared-sqlite-data` named volume → `/app/.neo-ai-data/sqlite` | `down -v`, or the Compose project name changes |
-| Chroma vectors | `chroma-data` named volume → `/chroma/unified` (set via `PERSIST_DIRECTORY`) | `down -v`, or the project name changes (recoverable by re-sync/re-push, at cost) |
+| Chroma vectors | `chroma-data` named volume → `/data` (the image-pinned `persist_path` from the container's `/config.yaml`; `PERSIST_DIRECTORY` is not read — ADR 0017 §2.2 amendment) | `down -v`, or the project name changes (recoverable by re-sync/re-push, at cost) |
 | Sandman handoff + derived route artifacts | `shared-handoff-data` named volume → `/app/.neo-ai-data/handoff` (writer and reader share `NEO_HANDOFF_FILE_PATH`) | `down -v`, or the Compose project name changes |
 | Orchestrator task, tenant-repo revision/backoff, recovery, and diagnostic state | `orchestrator-state` named volume → `/app/.neo-ai-data/orchestrator-daemon` (bound through `NEO_AI_ORCHESTRATOR_DIR`) | `down -v`, or the Compose project name changes. **The incident ledgers within it — `heal-attempts.json`, `heal-events.jsonl`, `recovery-runs/` — are now captured in the backup bundle's `ledgers/` folder and restorable (`--only-substrate ledgers`). Task state and tenant-repo revisions are not.** |
 | Backup bundles | host bind-mount on the `cloud`-profile `orchestrator`, host source `NEO_HOST_BACKUP_ROOT` (default `${HOME}/.neo-ai/backups`), container target `NEO_BACKUP_PATH` → `/app/.neo-ai-data/backups` | `NEO_HOST_BACKUP_ROOT` changes between runs, or the deploying user's `$HOME` differs between runs |

--- a/learn/agentos/decisions/0017-chroma-single-flat-unified-store.md
+++ b/learn/agentos/decisions/0017-chroma-single-flat-unified-store.md
@@ -1,6 +1,6 @@
 # ADR 0017: Chroma — Single Flat Unified Store + Dev/Prod Parity
 
-> Architectural Decision Record for Epic #12153. Amends ADR 0003 (Chroma Topology — Unified Only): preserves its one-daemon core decision and records the store's concrete shape — a single FLAT persist store named `unified`, identical local and cloud, with Knowledge Base / Memory Core / tenant separation enforced by collection + metadata + export + backup, never by directory or daemon split. Retires the federated-era two-folder local layout (`knowledge-base/` + the stale `memory-core/`).
+> Architectural Decision Record for Epic #12153. Amends ADR 0003 (Chroma Topology — Unified Only): preserves its one-daemon core decision and records the store's concrete shape — a single FLAT persist store per deployment, logical name `unified`, topologically identical local and cloud (local host path `.neo-ai-data/chroma/unified`; container leaf = the image-pinned `/data`, §2.2), with Knowledge Base / Memory Core / tenant separation enforced by collection + metadata + export + backup, never by directory or daemon split. Retires the federated-era two-folder local layout (`knowledge-base/` + the stale `memory-core/`).
 
 | Attribute | Value |
 |---|---|
@@ -25,10 +25,10 @@ Critically, the KB ships a release artifact (`uploadKnowledgeBase.mjs`) that eve
 
 ## 2. Decision
 
-**One flat Chroma store named `unified`, identical in shape local and cloud.**
+**One flat Chroma store per deployment — logical name `unified`, topologically identical local and cloud.**
 
 - **One daemon / container** (unchanged from ADR 0003). No per-realm persist folders.
-- **Local:** the orchestrator launches the daemon against `.neo-ai-data/chroma/unified`. **Cloud:** the `chroma` container persists to `/chroma/unified` (set via `PERSIST_DIRECTORY` — see §2.2). The leaf name `unified` is identical both sides.
+- **Local:** the orchestrator launches the daemon against `.neo-ai-data/chroma/unified`. **Cloud/container:** the `chroma` container persists to the **image-pinned `/data`** leaf, with the named volume mounted exactly there (§2.2). Parity is **topological** — one flat store, the same collection set, the logical identity `unified` — not literal-path: the container-side leaf is owned by the image, not by this ADR.
 - **Realm / tenant separation is enforced at the layers that exist in every deployment, never by directory or daemon split:**
   - **Isolation** — collection names + per-chunk metadata (tenant isolation via the existing identity-tuple + write-stamping + read-filter model; ADR 0014 + cloud-deployment Overview). Per-collection HNSW indices mean coexistence does not degrade per-collection search (§2.1).
   - **Shipping** — the KB release artifact is a **collection-scoped export** of only the `neo-knowledge-base` collection (reusing the existing `backup.mjs` / `restore.mjs` JSONL SDK), never a directory copy. The privacy boundary becomes a collection boundary the export tooling enforces: it is structurally impossible to ship a Memory Core collection the export does not name.
@@ -38,8 +38,18 @@ Critically, the KB ships a release artifact (`uploadKnowledgeBase.mjs`) that eve
 ### 2.1 Why one store does not degrade search
 ChromaDB HNSW indices are per-collection / per-segment (each segment-UUID dir is an independent `hnswlib` index). A query against `neo-agent-memory` traverses only that collection's graph regardless of how many other collections share the persist dir. The real shared-store costs are metadata-sqlite size (dominated by the #12143 test pollution, not realm coexistence) and write contention — neither requires physical separation.
 
-### 2.2 Cloud persist-path mechanism (verified against chroma 1.5.9 source)
-The `chromadb/chroma:1.5.9` image resolves its persist path from `IS_PERSISTENT=1` + a WORKDIR-relative default `persist_directory=./chroma` = `/chroma/chroma`. It does **not** read the volume *mount* path. Persisting to `/chroma/unified` therefore requires setting `PERSIST_DIRECTORY=/chroma/unified` in the compose environment **alongside** the mount — a mount-path change alone silently writes to an ephemeral container layer. Greenfield: no cloud deployment exists yet, so choosing the path now carries no data-migration cost.
+### 2.2 Container persist-path mechanism (corrected 2026-08-01; verified against the running image)
+The published `chromadb/chroma:1.5.9` container's entrypoint executes `chroma run /config.yaml`, and that shipped config pins `persist_path: "/data"`. The persist path is therefore **image-owned**: the compose contract is to mount the named volume (or tmpfs, in the test stack) at **`/data`**, keeping `PERSIST_DIRECTORY` declared on the same leaf — it is **not read** by the config-driven entrypoint, and aligning it means an image variant that does read it cannot re-split the store from the mount. A storage mount anywhere else leaves the live store in the container's ephemeral writable layer while the mounted volume sits empty. Guarded by `test/playwright/unit/ai/deploy/ChromaPersistPathContract.spec.mjs`, which pins the exact image tag so a version bump forces re-verification of the shipped config before the pin moves.
+
+> **Falsification record (2026-08-01, #16208 / #16254).** This section originally asserted —
+> "verified against chroma 1.5.9 source" — that the image resolved its persist path from
+> `IS_PERSISTENT=1` + a WORKDIR-relative default (`/chroma/chroma`), and that setting
+> `PERSIST_DIRECTORY=/chroma/unified` alongside a matching mount was required and sufficient.
+> The running image falsified this: with exactly that configuration live, the store grew at
+> `/data` (1.1 GB) while the mounted `/chroma/unified` held 4 KB — the ephemeral-layer failure
+> the original text believed the env prevented. The source-reading audited the wrong entrypoint
+> path; the shipped container is config-driven. The **decision** this ADR records — one flat
+> unified store, collection-scoped shipping, KB-as-cache / MC-as-store — is unaffected.
 
 ## 3. Rejected Alternatives
 
@@ -49,7 +59,7 @@ The `chromadb/chroma:1.5.9` image resolves its persist path from `IS_PERSISTENT=
 | **Two persist folders under one daemon** | ChromaDB serves one `--path` per daemon; "one daemon, two live folders" is not a supported shape. |
 | **Keep `knowledge-base` as the store/persist-dir name** | Misleading — it holds every realm; config reads as MC-stores-into-KB. |
 | **Folder-level KB release artifact** | Post-unification the dir holds Memory Core collections → a directory copy leaks private data. Collection-scoped export is the only safe shipping mechanism (and the only one that works in cloud, where no KB folder exists). |
-| **Drop the cloud rename (logical-only parity)** | Considered while assuming existing cloud data; with no deployment yet the rename is risk-free, so literal parity (`unified` both sides) is chosen over leaving the cloud path at the confusing image default. |
+| **Drop the cloud rename (logical-only parity)** | Originally rejected in favor of literal path parity (`unified` both sides). **Superseded 2026-08-01 (§2.2):** the published image owns its container leaf (`/data`), so literal-path parity is not available; the operative parity IS the logical/topological one this row originally argued against — one flat store, logical identity `unified`, same collection set. |
 
 ## 4. Consequences
 
@@ -60,7 +70,7 @@ The `chromadb/chroma:1.5.9` image resolves its persist path from `IS_PERSISTENT=
 
 ### Negative / handoffs
 - A one-time **local** data migration (the operator's machine holds the only live store, with the irreplaceable MC physically inside `knowledge-base/`): daemon-quiesce (`withHeavyMaintenanceLease`) → backup → atomic same-FS rename → verify → delete stale `memory-core/`. Owned by #12155. This is data-preservation of the one live store, not backwards-compat (no deployments exist; v13 permits breaking changes).
-- The cloud compose MUST set `PERSIST_DIRECTORY` (not just the mount). Owned by #12155.
+- The container compose MUST mount its storage surface at the image-pinned `/data` (§2.2); `PERSIST_DIRECTORY` declared on the same leaf is compatibility, not the mechanism. Contract guarded by `ChromaPersistPathContract.spec.mjs`.
 - The KB release pipeline must become collection-scoped. Owned by #12157.
 
 ## 5. Boundary — what this ADR does NOT decide

--- a/test/playwright/unit/ai/deploy/ChromaPersistPathContract.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ChromaPersistPathContract.spec.mjs
@@ -1,0 +1,108 @@
+import {test, expect}     from '@playwright/test';
+import fs                 from 'node:fs/promises';
+import path               from 'node:path';
+import process            from 'node:process';
+import {load as yamlLoad} from 'js-yaml';
+
+/**
+ * Guards the Chroma persist-path contract for the three BASE compose files that define a chroma
+ * service (the deploy overlays inherit these definitions and declare no storage of their own).
+ *
+ * The `chromadb/chroma:1.5.9` entrypoint runs `chroma run /config.yaml`, and that shipped config
+ * pins `persist_path: /data`. `PERSIST_DIRECTORY` is NOT read on that path: a storage mount
+ * anywhere else leaves the live store in the ephemeral container layer while the mounted volume
+ * sits empty — one recreate away from total store loss. Every assertion is fail-closed: a compose
+ * file that drops its chroma service, renames it, or lets a mount drift off the image persist
+ * path fails by name rather than passing vacuously.
+ */
+
+const
+    repoRoot           = path.resolve(process.cwd()),
+    IMAGE_PIN          = 'chromadb/chroma:1.5.9',
+    IMAGE_PERSIST_PATH = '/data',
+    RETIRED_LEAF       = '/chroma/unified',
+    COMPOSE_FILES      = [
+        'ai/deploy/docker-compose.yml',
+        'ai/deploy/docker-compose.dev.yml',
+        'ai/deploy/docker-compose.test.yml'
+    ];
+
+/**
+ * Normalizes one compose storage entry (volumes or tmpfs; string or long form) to its
+ * container-side target path.
+ * @param {Object|String} entry Compose `volumes`/`tmpfs` list entry
+ * @returns {String} Container mount target
+ */
+function mountTarget(entry) {
+    if (typeof entry === 'string') {
+        // 'source:target[:opts]' named/bind form, or a bare '/target' anonymous/tmpfs form.
+        const parts = entry.split(':');
+        return parts.length > 1 ? parts[1] : parts[0]
+    }
+
+    return entry.target
+}
+
+/**
+ * Resolves the chroma service's declared storage targets (volumes + tmpfs union).
+ * @param {Object} service Parsed compose service definition
+ * @returns {String[]} Container-side mount targets
+ */
+function storageTargets(service) {
+    return [...(service.volumes || []), ...(service.tmpfs || [])].map(mountTarget)
+}
+
+/**
+ * Reads PERSIST_DIRECTORY from either compose environment form (list of 'K=V' or map).
+ * @param {Object} service Parsed compose service definition
+ * @returns {String|undefined} The declared value, or undefined when absent
+ */
+function persistDirectoryEnv(service) {
+    const env = service.environment;
+
+    if (Array.isArray(env)) {
+        const hit = env.find(line => typeof line === 'string' && line.startsWith('PERSIST_DIRECTORY='));
+        return hit?.slice('PERSIST_DIRECTORY='.length)
+    }
+
+    return env?.PERSIST_DIRECTORY
+}
+
+for (const relPath of COMPOSE_FILES) {
+    test.describe(`${relPath} — chroma persist-path contract`, () => {
+        let chroma;
+
+        test.beforeAll(async () => {
+            const parsed = yamlLoad(await fs.readFile(path.join(repoRoot, relPath), 'utf8'));
+            chroma = parsed?.services?.chroma
+        });
+
+        test('positive control: the chroma service exists and carries the audited image pin', () => {
+            expect(chroma, 'services.chroma missing — the contract subject vanished').toBeTruthy();
+            // The /data persist path is proven for exactly this image build. A bump must
+            // re-verify the shipped /config.yaml persist_path before changing this pin.
+            expect(chroma.image).toBe(IMAGE_PIN)
+        });
+
+        test(`declares a storage mount at the image persist path ${IMAGE_PERSIST_PATH}`, () => {
+            const targets = storageTargets(chroma);
+
+            expect(targets.length, 'chroma declares no storage surface at all').toBeGreaterThan(0);
+            expect(targets).toContain(IMAGE_PERSIST_PATH)
+        });
+
+        test('PERSIST_DIRECTORY, when declared, agrees with the mounted leaf', () => {
+            const declared = persistDirectoryEnv(chroma);
+
+            if (declared !== undefined) {
+                expect(declared).toBe(IMAGE_PERSIST_PATH)
+            }
+        });
+
+        test(`no storage surface still targets the retired ${RETIRED_LEAF} leaf`, () => {
+            // Paired with the positive /data assertions above, so this negative cannot pass
+            // vacuously on a parse failure or a renamed service.
+            expect(storageTargets(chroma)).not.toContain(RETIRED_LEAF)
+        });
+    });
+}


### PR DESCRIPTION
Resolves #16254

**Related, non-closing: #16208** — the incident owner. It retains the v4.1 recovery execution (quiesced physical seed, two recreate-survival proofs, legacy-tail reconciliation, native-graph reprojection, known-hit probes, clean-backup receipt); merging this PR must not close it.

## What

The compose files mounted Chroma's storage surface at `/chroma/unified` and trusted `PERSIST_DIRECTORY` to point the daemon there. The running `chromadb/chroma:1.5.9` image falsifies both: its entrypoint executes `chroma run /config.yaml`, that shipped config pins `persist_path: "/data"`, and the env is not read on that path. Observed live on the canonical plane: the store grew to 1.1 GB at `/data` while the mounted volume held 4 KB — the entire live store sitting one recreate away from deletion in the ephemeral writable layer.

The fix mounts the storage surface at the image-pinned `/data` in all three base compose files (canonical named volume, parity named volume, test tmpfs) and keeps `PERSIST_DIRECTORY` declared on the same leaf, so an env-honoring image variant cannot re-split the store from the mount.

**This diff is inert until a recreate** — it changes no running container. The #16208 v4.1 sequence performs the one sanctioned chroma-only recreate AFTER the quiesced `/data` copy physically seeds the named volume; merging this PR is step 3 of that sequence and does not itself touch the live plane.

**ADR 0017 is corrected as a current source of authority, not only by appendix** (RC1): the abstract, Decision headline, cloud-path bullet, §2.2 heading + active mechanism, the "logical-only parity" rejected-alternative row, and the persist-path handoff now consistently state one-store topology / **logical** parity with the **image-owned container leaf `/data`**; the dated falsification record is retained as archaeology inside §2.2. The remaining `chroma/unified` mentions in active prose are the local HOST path (true today) — zero active container-side prescriptions remain. `PipelineWiring.md`'s persistence row names `/data` and why.

## Test Evidence

Evidence: **L2 achieved** (executable config-contract + static authority correction) → **L4 required** (live recreate-survival durability proof). **Residual:** the L4 receipts — M0/M1 id-digest proofs over two chroma-only recreates, legacy-tail reconciliation, native-graph reprojection, known-hit MC/KB/GP probes, fresh clean-verdict backup — are owned by #16208 v4.1 and land there during the team-triggered quiesce window; they cannot exist before this head merges and the window opens.

- `ChromaPersistPathContract.spec.mjs` (new): parses the three base compose files; per file asserts (a) positive control — the chroma service exists and carries the exact audited image pin, so a version bump forces re-verification of the shipped config before the pin moves, (b) a storage mount targets `/data`, (c) `PERSIST_DIRECTORY`, when declared, agrees with the mounted leaf, (d) no storage surface still targets the retired `/chroma/unified` leaf — paired with (a)+(b) so the negative cannot pass vacuously. Docstring scoped to the base-file census (overlays inherit and declare no storage — reviewer-verified).
- RED first: 9/12 contract assertions failed against the unmodified files (the defect biting; positive controls green). GREEN after the fix: 12/12.
- Importer-set sweep: **138/138** — every unit spec reading the changed files (`ParityPlaneVolumeScoping`, `DeployPipelineRevisionPin`, `BackupRootPlacement`, `DeploymentTrustDefaults`, orchestrator `daemon`/`HostEdgePosture`/`DeploymentRuntimeAccessService`, `WorkflowConcurrency`, `mcpHealthcheck`) green on the new shape.
- Live premise verification (read-only, freeze respected): `docker exec` on the frozen canonical container — `/config.yaml` reads `persist_path: "/data"`; `du`: `/data` = 1.1G vs `/chroma/unified` = 4.0K.

## Post-Merge Validation

- #16208 v4.1 step 4: the chroma-service-only recreate after the physical volume seed must prove M0 (collection ids/counts + sorted-ID digest) exactly — that recreate-survival receipt is this fix's production proof and lands on #16208.
- CI's integration lane builds `docker-compose.test.yml`, exercising the tmpfs-at-`/data` shape end-to-end.

## Deltas

- `docker-compose.test.yml`'s tmpfs moves under the same contract: the test stack's speed/isolation intent was silently defeated the same way (data landed in the container's writable layer, not the declared tmpfs).
- ADR 0017's rejected-alternative row "Drop the cloud rename (logical-only parity)" is marked superseded in place: the image owns its container leaf, so the operative parity is the logical/topological one that row originally argued against.
- Out of scope, unchanged: server-side `NEO_CHROMA_DATA_DIR` / `engines.chroma.dataDirProd` host-path semantics (a different contract — where host-side consumers resolve the legacy store), and the deploy-layering work on #16206 (@neo-gpt-emmy's lane).

Authored by @neo-opus-vega
Origin Session ID: c4b84de4-d7d9-4cbf-99cc-5bd4a561783e
