### PR TITLE
feat(wake): an operator-reachable resume for a degraded route (#16253)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2447,7 +2447,7 @@ paths:
       operationId: manage_wake_subscription
       x-neo-tool-tier: extended
       x-pass-as-object: true
-      description: Subscribe / unsubscribe / update / list / resync agent wake-event subscriptions with trigger types (SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED), optional AND-conjunctive filters, and harness target routing.
+      description: Subscribe / unsubscribe / update / list / resync / resume agent wake-event subscriptions with trigger types (SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED), optional AND-conjunctive filters, and harness target routing.
       tags: [WakeSubscriptions]
       requestBody:
         required: true
@@ -2460,11 +2460,11 @@ paths:
               properties:
                 action:
                   type: string
-                  enum: [bootstrap, subscribe, unsubscribe, update, list, resync]
-                  description: Lifecycle action to perform on the subscription.
+                  enum: [bootstrap, subscribe, unsubscribe, update, list, resync, resume]
+                  description: "Lifecycle action to perform on the subscription. `resume` restores a route that was marked `status: degraded` after repeated delivery failures: it moves the persisted status back to `active` AND clears the in-flight markers in one step, which is what a restore requires - clearing only one half leaves the route skipped."
                 subscriptionId:
                   type: string
-                  description: Required for unsubscribe / update / resync; optional for list (single).
+                  description: Required for unsubscribe / update / resync / resume; optional for list (single).
                 trigger:
                   type: string
                   enum: [SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED]

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -8,6 +8,7 @@ import RequestContextService, {normalizeUserId}                                 
 import logger                                                                                   from '../../mcp/server/memory-core/logger.mjs';
 import CoalescingEngineService                                                                  from './CoalescingEngineService.mjs';
 import TurnPresenceService                                                                      from './TurnPresenceService.mjs';
+import WebhookDeliveryService                                                                   from './WebhookDeliveryService.mjs';
 import {HEARTBEAT_PULSE_ENTITY_PREFIX, HEARTBEAT_PULSE_ENTITY_TYPE, match, matchHeartbeatPulse} from './heartbeatPulseEvaluator.mjs';
 import {resolveResidentFamilyById}                                                              from '../graph/agentFamilyResolution.mjs';
 
@@ -337,7 +338,7 @@ class WakeSubscriptionService extends Base {
      * action-specific handlers per ADR 0002 §6.6. ticket-ref-ok: decision-record authority, not issue archaeology
      *
      * @param {Object} opts
-     * @param {String} opts.action One of 'subscribe' | 'unsubscribe' | 'update' | 'list' | 'resync'
+     * @param {String} opts.action One of 'subscribe' | 'unsubscribe' | 'update' | 'list' | 'resync' | 'resume'
      * @param {Object} [opts.rest] Action-specific parameters (see individual methods)
      * @returns {Promise<Object>}
      */
@@ -352,9 +353,10 @@ class WakeSubscriptionService extends Base {
             case 'update'     : return this.update     (rest);
             case 'list'       : return this.list       (rest);
             case 'resync'     : return this.resync     (rest);
+            case 'resume'     : return this.resume     (rest);
             default:
                 throw new Error(
-                    `Invalid action '${action}'. Must be one of: bootstrap, subscribe, unsubscribe, update, list, resync.`
+                    `Invalid action '${action}'. Must be one of: bootstrap, subscribe, unsubscribe, update, list, resync, resume.`
                 );
         }
     }
@@ -1049,6 +1051,53 @@ class WakeSubscriptionService extends Base {
         logger.info(`[WakeSubscription] unsubscribed ${subscriptionId} for ${caller}`);
 
         return {subscriptionId, status: 'removed'};
+    }
+
+    /**
+     * @summary Restores a degraded route to active — the operator-reachable resumption path.
+     *
+     * Degradation is deliberately terminal: a route whose endpoint refuses connections is marked
+     * `status: 'degraded'` and then never attempted again, which is what bounds the attempt count.
+     * Coming back is therefore an explicit operator act, never something the delivery path does on
+     * its own — a service that silently re-activates routes would restore the unbounded retry the
+     * bound exists to prevent.
+     *
+     * Resuming requires clearing BOTH truths the delivery skip reads: the durable
+     * `properties.status` on the node, and the in-flight process markers. Splitting them across two
+     * calls is a footgun — clearing only the in-memory half resumes nothing, because the next flush
+     * re-reads a `status` that still says `degraded`. This action performs both as one step so an
+     * operator never has to know that.
+     *
+     * @param {Object} opts
+     * @param {String} opts.subscriptionId
+     * @returns {Promise<Object>} `{subscriptionId, status: 'active', wasDegraded}`
+     */
+    async resume({subscriptionId} = {}) {
+        const caller = RequestContextService.getAgentIdentityNodeId();
+        if (!caller) throw RequestContextService.unboundIdentityError('resume');
+        if (!subscriptionId) throw new Error("Missing 'subscriptionId' parameter.");
+
+        const subscription = this._loadSubscription(subscriptionId);
+        if (!subscription) throw new Error(`Subscription not found: ${subscriptionId}`);
+        if (subscription.agentIdentity !== caller) {
+            throw new Error(`Permission denied: subscription ${subscriptionId} is owned by ${subscription.agentIdentity}, not ${caller}.`);
+        }
+
+        const wasDegraded = subscription.status === 'degraded';
+
+        // Durable half. `upsertNode` merges onto the stored properties, so this moves `status` only.
+        GraphService.upsertNode({id: subscriptionId, properties: {status: 'active'}});
+
+        // In-flight half: the process-local degraded marker plus the failure streak, so the route
+        // does not re-degrade on the very next failure from a stale count.
+        WebhookDeliveryService.clearDegraded(subscriptionId);
+
+        // The cache holds the pre-resume record; a stale read here would re-skip the route.
+        this.subscriptionCache.delete(subscriptionId);
+
+        logger.info(`[WakeSubscription] resumed ${subscriptionId} for ${caller} (wasDegraded: ${wasDegraded})`);
+
+        return {subscriptionId, status: 'active', wasDegraded};
     }
 
     /**

--- a/ai/services/memory-core/WebhookDeliveryService.mjs
+++ b/ai/services/memory-core/WebhookDeliveryService.mjs
@@ -212,12 +212,17 @@ class WebhookDeliveryService extends Base {
     }
 
     /**
-     * @summary The named resumption path out of the degraded state.
+     * @summary Clears the IN-MEMORY degraded markers only — the restorer must also move the node's
+     * persisted `properties.status` off `'degraded'`, or the route stays skipped.
      *
-     * Degradation is terminal by design — a degraded route is never probed again, which is what bounds the
-     * attempt count. Repair is therefore explicit: whoever restores the endpoint clears the marker, and the
-     * persisted `status` must be moved off `'degraded'` in the same operation for the route to survive a
-     * process restart.
+     * This is half of a two-phase contract, not a self-sufficient resumption. The delivery skip reads
+     * BOTH truths — the flush's fresh `properties.status` and this process-local set — so calling this
+     * alone resumes nothing: the next flush re-reads a status that still says degraded.
+     *
+     * Degradation is terminal by design (a degraded route is never probed again, which is what bounds the
+     * attempt count), so coming back is an explicit operator act rather than anything the delivery path
+     * does on its own. `WakeSubscriptionService.resume` is the operator-reachable action that performs
+     * both phases as one step; prefer it over calling this directly.
      * @param {String} subscriptionId
      */
     clearDegraded(subscriptionId) {

--- a/test/playwright/unit/ai/services/memory-core/WebhookDeliveryService.degradeDeadRoute.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WebhookDeliveryService.degradeDeadRoute.spec.mjs
@@ -68,6 +68,7 @@ function makeSubscriptionNode() {
         label     : 'WAKE_SUBSCRIPTION',
         properties: {
             userId               : '@neo-opus-grace',
+            agentIdentity        : '@neo-opus-grace',
             status               : 'active',
             harnessTarget        : 'a2a-webhook',
             harnessTargetMetadata: {
@@ -195,6 +196,135 @@ test.describe('WebhookDeliveryService — degrading a dead route from a backgrou
 
         expect(await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HYYY'})).toBe('delivered');
         expect(fetchCalls.length).toBe(1);
+    });
+});
+
+test.describe('WakeSubscriptionService.resume — the operator-reachable way back (#16253)', () => {
+    let GraphService, WakeSubscriptionService, WebhookDeliveryService, RequestContextService;
+    let originalDb, originalGetAgentIdentityNodeId, originalFetch;
+    let fetchCalls = [];
+
+    test.beforeAll(async () => {
+        GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        WakeSubscriptionService = (await import('../../../../../../ai/services/memory-core/WakeSubscriptionService.mjs')).default;
+        WebhookDeliveryService = (await import('../../../../../../ai/services/memory-core/WebhookDeliveryService.mjs')).default;
+        RequestContextService  = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+        originalFetch          = global.fetch;
+        originalGetAgentIdentityNodeId = RequestContextService.getAgentIdentityNodeId;
+    });
+
+    test.beforeEach(() => {
+        originalDb      = GraphService.db;
+        requester.value = null;
+        fetchCalls      = [];
+
+        // `resume` is an operator action, so it resolves its caller from the REQUEST context — unlike the
+        // background flush, which has none. That asymmetry is the point: degrading happens without a
+        // requester, restoring requires one.
+        RequestContextService.getAgentIdentityNodeId = () => '@neo-opus-grace';
+
+        WebhookDeliveryService.configure({attemptTimeoutSeconds: 1});
+        WebhookDeliveryService.consecutiveFailures.clear();
+        WebhookDeliveryService.degradedSubscriptions.clear();
+        WakeSubscriptionService.subscriptionCache.clear();
+
+        global.fetch = async (url, options) => {
+            fetchCalls.push({url, options});
+            return {ok: false, status: 400};
+        };
+    });
+
+    test.afterEach(() => {
+        GraphService.db = originalDb;
+        requester.value = null;
+        global.fetch    = originalFetch;
+        RequestContextService.getAgentIdentityNodeId = originalGetAgentIdentityNodeId;
+        WakeSubscriptionService.subscriptionCache.clear();
+    });
+
+    test('degrade then resume restores delivery end-to-end', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        // Degrade it for real, through the delivery path.
+        await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX'});
+        expect(subscriptionNode.properties.status).toBe('degraded');
+        expect(WebhookDeliveryService.degradedSubscriptions.has(subscriptionNode.id)).toBe(true);
+
+        const result = await WakeSubscriptionService.resume({subscriptionId: subscriptionNode.id});
+
+        expect(result).toEqual({subscriptionId: subscriptionNode.id, status: 'active', wasDegraded: true});
+
+        // BOTH truths clear — the durable one and the in-flight one.
+        expect(subscriptionNode.properties.status).toBe('active');
+        expect(WebhookDeliveryService.degradedSubscriptions.has(subscriptionNode.id)).toBe(false);
+
+        // And the route actually delivers again, which is the only claim that matters.
+        fetchCalls   = [];
+        global.fetch = async (url, options) => {
+            fetchCalls.push({url, options});
+            return {ok: true, status: 200};
+        };
+
+        expect(await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HYYY'})).toBe('delivered');
+        expect(fetchCalls.length).toBe(1);
+    });
+
+    test('clearDegraded ALONE does not resume — the two-phase contract is mandatory, not tribal', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX'});
+        expect(subscriptionNode.properties.status).toBe('degraded');
+
+        // The footgun, pinned: clearing only the in-memory half looks like a restore and is not one.
+        WebhookDeliveryService.clearDegraded(subscriptionNode.id);
+
+        fetchCalls = [];
+        expect(await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HYYY'})).toBe('skipped');
+        expect(fetchCalls.length).toBe(0);
+        expect(subscriptionNode.properties.status).toBe('degraded');
+    });
+
+    test('resume reports wasDegraded false for a route that was never degraded', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        const result = await WakeSubscriptionService.resume({subscriptionId: subscriptionNode.id});
+
+        expect(result.wasDegraded).toBe(false);
+        expect(subscriptionNode.properties.status).toBe('active');
+    });
+
+    test('resume refuses a subscription owned by someone else', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        RequestContextService.getAgentIdentityNodeId = () => '@neo-opus-ada';
+
+        // Restoring is an owner-scoped act. Without this, one seat could re-activate another seat's route.
+        await expect(WakeSubscriptionService.resume({subscriptionId: subscriptionNode.id}))
+            .rejects.toThrow(/Permission denied/);
+
+        expect(subscriptionNode.properties.status).toBe('active');
+    });
+
+    test('resume is reachable through the manage() tool dispatch', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX'});
+        expect(subscriptionNode.properties.status).toBe('degraded');
+
+        // The operator surface, not just the method — an action nothing can dispatch is not a path.
+        const result = await WakeSubscriptionService.manage({
+            action        : 'resume',
+            subscriptionId: subscriptionNode.id
+        });
+
+        expect(result.status).toBe('active');
+        expect(result.wasDegraded).toBe(true);
+        expect(subscriptionNode.properties.status).toBe('active');
     });
 });
 


### PR DESCRIPTION
Resolves #16253

The Approve+Follow-Up follow-up from @neo-kimi-iris's review of PR #16251 ([pullrequestreview-4834513251](https://github.com/neomjs/neo/pull/16251#pullrequestreview-4834513251)). Her finding was correct and I verified it independently before starting: `git grep clearDegraded` at the merge head hits only the method, its JSDoc link, and its spec.

That made the resumption path a **promise rather than a control** — which is precisely the shape of the defect #16246 fixed. I shipped a way back that nothing could walk. @neo-opus-ada's seat hit the full degrade chain the same morning and the restore needed a workaround.

## The problem

The delivery skip reads **two** truths (`WebhookDeliveryService.mjs:86`): the flush's fresh `properties.status`, and the process-local `degradedSubscriptions` set. Both must be clear for delivery to resume.

`clearDegraded` clears only the in-memory half, by design — its JSDoc assigned the persisted-status move to "whoever restores". But no caller implemented that assignment, which left two failure modes:

- **No production caller.** Restoring meant creating a new subscription with a fresh id, hand-editing `status` through a graph path, or restarting the process — and the restart does not even work, since it empties the in-memory set while leaving the persisted status degraded, so the route stays skipped.
- **The single-phase call is a footgun.** Calling `clearDegraded` alone *looks* like a restore and resumes nothing.

## The fix

`manage_wake_subscription` gains a `resume` action performing both halves as one step, so an operator never has to know about the two-phase contract:

```js
GraphService.upsertNode({id: subscriptionId, properties: {status: 'active'}});
WebhookDeliveryService.clearDegraded(subscriptionId);
this.subscriptionCache.delete(subscriptionId);
```

The cache invalidation is load-bearing: `_loadSubscription` caches by id, and a stale record would re-skip the route on the next flush.

Owner-scoped like `unsubscribe`/`update`, logs at INFO, and returns `wasDegraded` so restoring an already-active route is not silently indistinguishable from a real recovery.

**Rejected alternative — making `clearDegraded` move the persisted status itself.** It reads cleaner and it is wrong. The delivery service must not be able to re-activate routes on its own, or the bound that stops unbounded retry becomes reversible from inside the retry path. Re-activation stays an explicit operator act. This is the contract the review ratified, and the ticket reached the same conclusion independently.

Also addressed: `clearDegraded`'s JSDoc now leads with what it does *and does not* do (the review's inline nit — the old first line read as if the method were self-sufficient) and points at `resume` as the preferred caller.

## Deltas

| Surface | Before | After |
|---|---|---|
| Operator restore path | none — new subscription, hand-edit, or an ineffective restart | `manage_wake_subscription` action `resume` |
| `resume` semantics | — | both truths cleared atomically; owner-scoped; INFO log; returns `wasDegraded` |
| Tool action enum | `bootstrap \| subscribe \| unsubscribe \| update \| list \| resync` | `+ resume` |
| `clearDegraded` JSDoc | read as self-sufficient | leads with the two-phase contract, names `resume` |
| Re-activation from the delivery path | — | still impossible, deliberately |
| `clearDegraded` production callers | 0 | 1 |

## Test Evidence

Evidence: five new specs in `WebhookDeliveryService.degradeDeadRoute.spec.mjs`, all exercising the real `GraphService` read/write path rather than stubs.

- **End-to-end restore** — degrade through the real delivery path, `resume`, then assert both truths clear *and that the route actually delivers again*. The delivery assertion is the only claim that matters; the rest is bookkeeping.
- **The footgun, pinned** — `clearDegraded` alone leaves `status: 'degraded'` and the next delivery is still skipped with zero fetches. This is the test that keeps the two-phase requirement from being tribal knowledge.
- **Owner refusal** — a different identity gets `Permission denied` and the status is unchanged. Without it, one seat could re-activate another seat's route.
- **Never-degraded case** — `wasDegraded: false`, so a no-op restore is legible.
- **Reachable through `manage()`** — an action nothing can dispatch is not a path, which is the whole lesson of this ticket.

14/14 green in that file.

Wider regression check, run co-scheduled rather than in isolation: `memory-core/` + `daemons/wake/` gives **1625 passed, 3 failed**. The same suites on clean `dev` give **1620 passed, 3 failed**. The failures are provider-dependent (`SessionSummarization` against LM Studio, plus one varying third — `TextEmbeddingService` on clean dev, `QueryReRanker` on mine) and reproduce without my change. Baseline 3, mine 3, no regressions.

I ran the clean-`dev` comparison **co-scheduled** deliberately: the varying spec passed when run in isolation, and "safe alone" is not the same as "safe co-scheduled". The isolated run would have supported a weaker claim than the one made here.

## Post-Merge Validation

Deferred, and blocked by a standing team constraint rather than by choice: the quiesce-window plan-sync for #16208 says **no recreate and no hot-orchestrator restart** until both gates are green, and the running `mc-server` still carries pre-#16251 code. Once the window closes:

- Degrade a route, call `manage_wake_subscription` with `action: 'resume'`, confirm `list` reports `status` off `'degraded'` and the next message delivers.
- Confirm the INFO resume line appears in the mc-server log with the `wasDegraded` value.

## Notes for review

The same instrument disclosure as PR #16251 applies: Memory Core semantic recall is mid-restore (~23k of 30k), so the prior-art sweep returns noise rather than absence. Prior art here came from the review itself, the ticket, and direct source reads. @neo-kimi-iris independently recorded the same `[TOOLING_GAP]` in her review — worth noting that two of us hit it in one morning.

Authored by @neo-opus-grace (Claude Opus 5).
