### PR TITLE
fix(memory-core): restore wake routes after restart (#16258)

### DIFF
--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -311,19 +311,60 @@ class WakeSubscriptionService extends Base {
     }
 
     /**
-     * Ensures all active Shape A (`mcp-notifications`) and Shape B (`a2a-webhook`)
-     * subscriptions are in cache.
+     * @summary Warms Shape A/B routes from durable SQLite before the live GraphLog cursor advances.
+     *
+     * A Memory Core restart begins with an empty graph/cache even though wake subscriptions remain
+     * durable. The pump therefore treats SQLite as the source of truth, refreshes push routes whose
+     * status or target changed, and removes cached push routes that no longer have a valid durable
+     * row. Isolated harnesses without raw SQLite retain the graph-resident fallback.
+     *
      * @protected
      */
     _warmPushSubscriptions() {
         const db = GraphService.db;
         if (!db) return;
+
+        const pushTargets = ['mcp-notifications', 'a2a-webhook'];
+        const sqlite      = db.storage?.db;
+
+        if (sqlite) {
+            const durableIds = new Set();
+            const rows       = sqlite.prepare(`
+                SELECT id, data FROM Nodes
+                WHERE json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'
+            `).all();
+
+            for (const row of rows) {
+                const parsed = this._parseDurableSubscriptionRow(row);
+                if (!parsed) continue;
+
+                const {id, node} = parsed;
+                const cached     = this.subscriptionCache.get(id);
+                const isPush     = pushTargets.includes(node.properties?.harnessTarget);
+                const wasPush    = pushTargets.includes(cached?.harnessTarget);
+
+                durableIds.add(id);
+
+                if (isPush || wasPush) {
+                    this._hydrateSubscriptionFromDurableNode(id, node);
+                }
+            }
+
+            for (const [id, cached] of this.subscriptionCache) {
+                if (pushTargets.includes(cached?.harnessTarget) && !durableIds.has(id)) {
+                    this.subscriptionCache.delete(id);
+                }
+            }
+
+            return;
+        }
+
         for (const node of db.nodes.items) {
             if (node.label !== 'WAKE_SUBSCRIPTION') continue;
             const props   = node.properties || {};
             const cached  = this.subscriptionCache.get(node.id);
-            const isPush  = ['mcp-notifications', 'a2a-webhook'].includes(props.harnessTarget);
-            const wasPush = ['mcp-notifications', 'a2a-webhook'].includes(cached?.harnessTarget);
+            const isPush  = pushTargets.includes(props.harnessTarget);
+            const wasPush = pushTargets.includes(cached?.harnessTarget);
 
             // Refresh active routes and invalidate a cached push route when webhook delivery
             // degraded or an operator changed/retired it since the previous pump.

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -1835,6 +1835,126 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(emittedEvents.length).toBe(1);
         });
 
+        test('dispatches the first event to a cache-cold durable mcp-notifications route after restart (#16258)', async () => {
+            CoalescingEngineService.addMcpServer(mockMcpServer);
+
+            const {subscriptionId} = insertDurableSubscription({
+                harnessTarget        : 'mcp-notifications',
+                harnessTargetMetadata: {}
+            });
+
+            expect(GraphService.db.nodes.get(subscriptionId) || null).toBeNull();
+            WakeSubscriptionService.subscriptionCache.clear();
+
+            GraphService.upsertNode({
+                id        : 'MSG:COLD-MCP-ROUTE',
+                type      : 'MESSAGE',
+                properties: {from: '@bob', subject: 'first post-restart event'}
+            });
+            GraphService.linkNodes('MSG:COLD-MCP-ROUTE', '@alice', 'SENT_TO', 1.0);
+            const expectedCursor = GraphService.db.storage.db
+                .prepare('SELECT MAX(log_id) as maxId FROM GraphLog')
+                .get().maxId;
+
+            await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
+
+            expect(WakeSubscriptionService.subscriptionCache.has(subscriptionId)).toBe(true);
+            expect(WakeSubscriptionService.liveCursor).toBe(expectedCursor);
+            expect(emittedEvents).toHaveLength(1);
+            expect(emittedEvents[0].params.payload.messageId).toBe('MSG:COLD-MCP-ROUTE');
+        });
+
+        test('dispatches the first event to a cache-cold durable a2a-webhook route after restart (#16258)', async () => {
+            const {subscriptionId} = insertDurableSubscription({
+                harnessTarget        : 'a2a-webhook',
+                harnessTargetMetadata: {
+                    url       : 'http://127.0.0.1:3199/wake',
+                    signingKey: 'test-signing-key'
+                }
+            });
+
+            expect(GraphService.db.nodes.get(subscriptionId) || null).toBeNull();
+            WakeSubscriptionService.subscriptionCache.clear();
+
+            GraphService.upsertNode({
+                id        : 'MSG:COLD-WEBHOOK-ROUTE',
+                type      : 'MESSAGE',
+                properties: {from: '@bob', subject: 'first post-restart webhook'}
+            });
+            GraphService.linkNodes('MSG:COLD-WEBHOOK-ROUTE', '@alice', 'SENT_TO', 1.0);
+
+            await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
+
+            expect(WakeSubscriptionService.subscriptionCache.has(subscriptionId)).toBe(true);
+            expect(webhookEvents).toHaveLength(1);
+            expect(webhookEvents[0].eventData.payload.sourceEventIds).toContain('MSG:COLD-WEBHOOK-ROUTE');
+        });
+
+        test('refreshes non-deliverable durable routes and removes deleted cached routes (#16258)', async () => {
+            const retired = insertDurableSubscription({
+                subscriptionId: 'WAKE_SUB:durable-retired',
+                harnessTarget : 'a2a-webhook',
+                status        : 'retired'
+            });
+            const disabled = insertDurableSubscription({
+                subscriptionId: 'WAKE_SUB:durable-disabled',
+                harnessTarget : 'disabled'
+            });
+            const degraded = insertDurableSubscription({
+                subscriptionId: 'WAKE_SUB:durable-degraded',
+                harnessTarget : 'a2a-webhook',
+                status        : 'degraded'
+            });
+            const deletedId = 'WAKE_SUB:deleted-route';
+
+            for (const id of [retired.subscriptionId, disabled.subscriptionId, degraded.subscriptionId, deletedId]) {
+                WakeSubscriptionService.subscriptionCache.set(id, {
+                    id,
+                    agentIdentity: '@alice',
+                    trigger      : 'SENT_TO_ME',
+                    harnessTarget: 'a2a-webhook',
+                    status       : 'active'
+                });
+            }
+
+            GraphService.upsertNode({id: 'MSG:NON-DELIVERABLE-ROUTES', type: 'MESSAGE', properties: {from: '@bob'}});
+            GraphService.linkNodes('MSG:NON-DELIVERABLE-ROUTES', '@alice', 'SENT_TO', 1.0);
+
+            await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
+
+            expect(WakeSubscriptionService.subscriptionCache.get(retired.subscriptionId).status).toBe('retired');
+            expect(WakeSubscriptionService.subscriptionCache.get(disabled.subscriptionId).harnessTarget).toBe('disabled');
+            expect(WakeSubscriptionService.subscriptionCache.get(degraded.subscriptionId).status).toBe('degraded');
+            expect(WakeSubscriptionService.subscriptionCache.has(deletedId)).toBe(false);
+            expect(webhookEvents).toEqual([]);
+        });
+
+        test('retains graph-resident warmup when raw SQLite is unavailable (#16258)', async () => {
+            let subscriptionId;
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                ({subscriptionId} = await WakeSubscriptionService.subscribe({
+                    trigger      : 'SENT_TO_ME',
+                    harnessTarget: 'mcp-notifications'
+                }));
+            });
+
+            WakeSubscriptionService.subscriptionCache.clear();
+
+            const storage = GraphService.db.storage;
+            const sqlite  = storage.db;
+            storage.db    = null;
+            try {
+                WakeSubscriptionService._warmPushSubscriptions();
+            } finally {
+                storage.db = sqlite;
+            }
+
+            expect(WakeSubscriptionService.subscriptionCache.has(subscriptionId)).toBe(true);
+        });
+
         test('dispatches a2a-webhook while skipping bridge-daemon and disabled targets', async () => {
             CoalescingEngineService.addMcpServer(mockMcpServer);
 
@@ -1878,7 +1998,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 type      : 'WAKE_SUBSCRIPTION',
                 properties: {
                     ...subscription.properties,
-                    harnessTarget: 'degraded'
+                    status: 'degraded'
                 }
             });
             GraphService.upsertNode({id: 'MSG:DEGRADED-WEBHOOK', type: 'MESSAGE', properties: {from: '@bob'}});
@@ -1887,7 +2007,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             await WakeSubscriptionService.pump();
             await CoalescingEngineService.flushAll();
 
-            expect(WakeSubscriptionService.subscriptionCache.get(subscriptionId).harnessTarget).toBe('degraded');
+            expect(WakeSubscriptionService.subscriptionCache.get(subscriptionId).status).toBe('degraded');
             expect(webhookEvents).toEqual([]);
         });
 


### PR DESCRIPTION
Resolves #16258

Memory Core now rebuilds Shape A/B push routes from durable SQLite before deciding that no routes exist or advancing the live GraphLog cursor. Durable rows refresh changed status and targets, missing rows evict stale push entries, and the graph scan remains the fallback only when raw SQLite is unavailable.

Evidence: L2 (run-scoped SQLite with stubbed MCP and webhook delivery sinks) → L4 required (post-merge Memory Core restart plus signed host-receiver receipt). Residual: AC6 [#16258].

## Deltas from ticket

The implementation follows the ticket shape. The adjacent degradation fixture was corrected to the current contract: `status: degraded` while `harnessTarget` remains `a2a-webhook`.

## Test Evidence

- Memory Core wake pump: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` — 94 passed.
- Full unit suite: `npm run test-unit` — 10,588 passed; 23 unrelated host-sandbox and checkout-data failures remained outside the touched files.
- Preflight: restoration classification, ticket archaeology, syntax, JSDoc, block alignment, and staged-file hooks passed.

## Post-Merge Validation

- [ ] Restart Memory Core without pre-warming subscriptions through `manage_wake_subscription list`.
- [ ] Send one high-priority self-message.
- [ ] Record the signed host receiver delivery and append the L4 receipt to #16258.

## Evolution

Independent pre-commit review caught an obsolete degradation fixture before handoff; the branch now tests the durable `status` contract instead of reviving the retired invalid-target failure mode.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session cef62056-42cc-4560-993c-d9f866e52a48.
