### PR TITLE
fix(skills): self-repair must not send a degraded Memory Core to a host restart (#16257)

### DIFF
--- a/.agents/skills/self-repair/references/self-repair-protocol.md
+++ b/.agents/skills/self-repair/references/self-repair-protocol.md
@@ -4,19 +4,19 @@ When tasked with executing a system healthcheck, diagnosing a corrupted state, o
 
 ## Phase 1: Infrastructure Verification & Playwright Testing
 
-0. **Identify the surface FIRST.** The four MCP servers do not live in the same place, so one symptom has two remedies — restarting the wrong one wastes the outage.
+0. **Identify the surface FIRST** — one symptom, two remedies; the wrong restart wastes the outage. Authority: the service list in `ai/deploy/docker-compose.yml`.
 
     | Server | Runs as | Harness restart fixes it? |
     |---|---|---|
     | `neural-link` · `github-workflow` | host, harness-spawned | **yes** — plus `npm run ai:server-neural-link`, host ports/zombies |
     | `knowledge-base` · `memory-core` | **container** (`kb-server` / `mc-server`) | **no** — `docker`, see 2 |
 
-    Authority: the service list in `ai/deploy/docker-compose.yml`. Never run a host stack to repair a container — it cannot reach it and can contend for the same published port (Chroma's `127.0.0.1:8000:8000`), turning diagnosis into a second fault.
+    Never run a host stack to repair a container: it cannot reach it, and it can contend for the same published port (Chroma's `8000`), turning diagnosis into a second fault.
 
-1. **Invoke the `unit-test` skill**: execute `test/playwright/unit/ai/mcp/client/McpServersHealth.spec.mjs`. Use these tests as the absolute source of truth for JSON-RPC sequence validity.
-2. **Containerized servers (`kb-server`, `mc-server`, `chroma`, `orchestrator`)**: inspect before acting — `docker ps`, then the container's own log (its stdout carries only boot lines; the real log is a file inside it). **Announce over A2A before any container-affecting action**: recreating `mc-server` severs every agent's MCP session, including the A2A spine you would coordinate over.
-    - **Is it running the code you think?** `docker exec <c> cat /app/.neo-revision`, compared against `origin/dev`. Three distinct actions, and only the last changes code: **restart** delivers nothing, **recreate** applies compose-level change only, **rebuild** (`up -d --build`) delivers merged code. Uptime and image timestamps are proxies that undercount; `/app/.neo-revision` is the measured truth.
-3. **Deep introspection (`ai/services.mjs`)**: aggregates dependencies so you can bypass the MCP HTTP boundary and invoke internal tooling natively — use it (or `ai/examples/`) when servers crash on boot.
+1. **Invoke the `unit-test` skill**: execute `test/playwright/unit/ai/mcp/client/McpServersHealth.spec.mjs` as the source of truth for JSON-RPC sequence validity.
+2. **Containers (`kb-server`, `mc-server`, `chroma`, `orchestrator`)**: inspect before acting — `docker ps`, then the container's own log (stdout carries only boot lines; the real log is a file inside it). **Announce over A2A first**: recreating `mc-server` severs every agent's MCP session, including the spine you would coordinate over.
+    - **Running the code you think?** `docker exec <c> cat /app/.neo-revision` vs `origin/dev`. Only the last of three actions changes code: **restart** delivers nothing, **recreate** applies compose-level change only, **rebuild** (`up -d --build`) delivers merged code. Uptime and image timestamps undercount; `.neo-revision` is measured truth.
+3. **Deep introspection (`ai/services.mjs`)**: bypass the MCP HTTP boundary and invoke internal tooling natively when servers crash on boot (or use `ai/examples/`).
     - *The YAML Cascade:* `services.mjs` eagerly parses every `openapi.yaml` via `ToolService`, so one syntax error (e.g. an unquoted `: `) aborts initialization and prevents **subsequent** MCP servers from booting.
 4. **Never guess at a crash.** Boot a host server directly to witness it; for a container, read its in-container log. You have native control; use it.
 

--- a/.agents/skills/self-repair/references/self-repair-protocol.md
+++ b/.agents/skills/self-repair/references/self-repair-protocol.md
@@ -14,31 +14,28 @@ When tasked with executing a system healthcheck, diagnosing a corrupted state, o
     Never run a host stack to repair a container: it cannot reach it, and it can contend for the same published port (Chroma's `8000`), turning diagnosis into a second fault.
 
 1. **Invoke the `unit-test` skill**: execute `test/playwright/unit/ai/mcp/client/McpServersHealth.spec.mjs` as the source of truth for JSON-RPC sequence validity.
-2. **Containers (`kb-server`, `mc-server`, `chroma`, `orchestrator`)**: inspect before acting — `docker ps`, then the container's own log (stdout carries only boot lines; the real log is a file inside it). **Announce over A2A first**: recreating `mc-server` severs every agent's MCP session, including the spine you would coordinate over.
+2. **Containers (`kb-server`, `mc-server`, `chroma`, `orchestrator`)**: inspect before acting — `docker ps`, then the container's own log (stdout carries only boot lines; the real log is inside it). **Announce before acting**: recreating `mc-server` severs every agent's MCP session. Announce over A2A — but when Memory Core IS the degraded surface that channel is down, so record the planned action and the unavailable channel on the governing ticket instead. Never act silently, and never treat a dead channel as permission to skip the notice.
     - **Running the code you think?** `docker exec <c> cat /app/.neo-revision` vs `origin/dev`. Only the last of three actions changes code: **restart** delivers nothing, **recreate** applies compose-level change only, **rebuild** (`up -d --build`) delivers merged code. Uptime and image timestamps undercount; `.neo-revision` is measured truth.
-3. **Deep introspection (`ai/services.mjs`)**: bypass the MCP HTTP boundary and invoke internal tooling natively when servers crash on boot (or use `ai/examples/`).
-    - *The YAML Cascade:* `services.mjs` eagerly parses every `openapi.yaml` via `ToolService`, so one syntax error (e.g. an unquoted `: `) aborts initialization and prevents **subsequent** MCP servers from booting.
-4. **Never guess at a crash.** Boot a host server directly to witness it; for a container, read its in-container log. You have native control; use it.
+3. **Deep introspection (`ai/services.mjs`)**: bypass the MCP HTTP boundary and invoke internal tooling natively when servers crash on boot.
+    - *The YAML Cascade:* `services.mjs` eagerly parses every `openapi.yaml` via `ToolService`, so one syntax error (e.g. an unquoted `: `) aborts init and prevents **subsequent** servers from booting.
+4. **Never guess at a crash.** Boot a host server directly to witness it; for a container, read its in-container log.
 
-## Phase 2: Historical Forensics (The "How Did We Get Here" Protocol)
-If the infrastructure code is functioning, but the *state* is corrupted (e.g., bad topologies, missing context, duplicated elements), you must triangulate *when* the corruption occurred.
+## Phase 2: Historical Forensics
+Code is functioning but *state* is corrupted (bad topologies, missing context, duplicates) — triangulate *when*.
 
-1. **Do not rely entirely on code state**. Code tells you what is broken; the memory tells you *why*.
-2. **Utilize the Memory Core**: Execute `get_all_summaries` or `query_summaries` from the `memory-core` MCP Server to dive into previous sessions. **If the Memory Core is offline it is a container condition — return to Phase 1 step 0, not to a host restart.** Semantic recall also degrades silently while a rebuild or restore is in flight: a sweep that returns unrelated rows means the instrument is impaired, never that no prior art exists. Substitute `git log` / `git grep` and say which instrument you used.
-3. Comparing previous AI session memories against `git log` history will rapidly narrow down the origin of the corruption.
+1. Code tells you what is broken; the memory tells you *why*.
+2. **Memory Core**: `get_all_summaries` / `query_summaries` for prior sessions. **If it is offline that is a container condition — return to Phase 1 step 0, never a host restart.** Semantic recall also degrades silently during a rebuild or restore: unrelated rows mean an impaired instrument, never absent prior art. Substitute `git log` / `git grep` and name the instrument you used.
+3. Prior memories against `git log` narrows the origin fast.
 
-## Phase 3: Deep Debugging Strategies
-If the IDE integration or workspace is locking up during health checks:
+## Phase 3: Deep Debugging
 
-- Reference the **`debugging-antigravity`** skill. Follow its playbook to resolve Antigravity IDE configuration lockups, SQLite workspace UI crashes, and redundant language server conflicts.
+- IDE/workspace lockups during health checks: the **`debugging-antigravity`** skill owns Antigravity config lockups, SQLite workspace crashes, and language-server conflicts.
+- **Fresh MCP Client Primitive** — for "ghost bugs" where cached tool definitions disagree with the live server. Never validate your own tool-shape changes through your primary long-lived connection; spawn an isolated client: `node ai/mcp/client/mcp-cli.mjs --server <target> --call-tool <tool>`.
 
-**Fresh MCP Client Primitive** — for "ghost bugs" where your cached tool definitions disagree with the live server. Never validate your own MCP tool-shape changes through your primary long-lived connection; spawn an isolated client for a clean handshake: `node ai/mcp/client/mcp-cli.mjs --server <target> --call-tool <tool>`.
+## Phase 4: Treatment & Escalation
 
-## Phase 4: Treatment & Issue Escalation
-If you identify infrastructure degradation or failing Playwright tests:
+1. **NO Sandman Handoff Updates**: never create or modify `sandman_handoff.md` — DreamService silently overwrites it and the insight is lost.
+2. **Create Bug Tickets**: capture systemic failures via `create_issue`.
+3. **Write Failing Tests**: codify the failure. A merged failing architectural test that replicates a bug beats a markdown summary; use the `unit-test` skill.
 
-1. **NO Sandman Handoff Updates**: You are strictly FORBIDDEN from creating or modifying `sandman_handoff.md` documents. The DreamService will silently overwrite these documents, resulting in lost insight.
-2. **Create Bug Tickets**: If you identify a systemic failure, formally capture it natively using `create_issue`.
-3. **Write Failing Tests**: Always strive to codify failures. If a system is broken and no test coverage caught it, utilize the `unit-test` skill to write a new, failing Playwright test confirming the bug. It is better to merge a failing architectural test that accurately replicates a bug than to write a generic markdown summary.
-
-**Rule of Thumb:** Document the failure as code. Track the failure as a GitHub Issue. Heal the system through a Pull Request.
+**Rule of Thumb:** Document the failure as code. Track it as a GitHub Issue. Heal it through a Pull Request.

--- a/.agents/skills/self-repair/references/self-repair-protocol.md
+++ b/.agents/skills/self-repair/references/self-repair-protocol.md
@@ -1,24 +1,30 @@
 # Self-Repair Protocol (System Diagnostic & Treatment Matrix)
 
-When tasked with executing a system healthcheck, diagnosing a corrupted state, or restoring infrastructure communication (e.g., failed handoffs), you MUST execute this chronological protocol. 
+When tasked with executing a system healthcheck, diagnosing a corrupted state, or restoring infrastructure communication (e.g., failed handoffs), you MUST execute this chronological protocol.
 
 ## Phase 1: Infrastructure Verification & Playwright Testing
-Your first priority is determining if the bridge between the Neo.mjs Agent OS clients and the MCP servers is healthy.
 
-1. **Invoke the `unit-test` skill**: Navigate to `test/playwright/unit/ai/` and execute target test suites like `McpServersHealth.spec.mjs`. Use these tests as the absolute source of truth for JSON-RPC sequence validity.
-2. **Verify Daemon & Database Status**: If `memory-core`, `knowledge-base`, or the Neural Link bridge are offline, check your `package.json` scripts. Verify that ChromaDB is running without zombie processes.
-    - **Knowledge Base & Memory Core** share a unified ChromaDB on port `8000` (script: `npm run ai:server`)
-    - **Neural Link Bridge** ensures realtime VDOM sync (script: `npm run ai:server-neural-link`)
-    - Search for and terminate zombie processes if ports are locked before attempting to restart the services.
-3. **Deep Infrastructure Introspection (`ai/services.mjs`)**: The entire Agent OS backend is located in `ai`. The `ai/services.mjs` module aggregates dependencies, allowing you to bypass full MCP HTTP boundaries and interact natively with internal tooling. If servers crash on boot, use `ai/examples/` (such as chroma checks) or a generic Node process to invoke internal routines via `services.mjs` directly.
-    - *Known Failure Mode (The YAML Cascade):* Because `ai/services.mjs` eagerly parses configurations via `ToolService`, a syntax error (e.g., an unquoted string containing `: ` causing a `YAMLException`) in *any* MCP server's `openapi.yaml` will abort the initialization sequence, preventing subsequent MCP servers in the configuration from booting.
-4. **Native Terminal Execution**: If an MCP connection fails or an MCP server is unreachable, do not blindly guess why. Boot the Neo MCP servers directly in a separate terminal process using the `run_command` tool to witness the crash or monitor logs. You have native control; use it.
+0. **Identify the surface FIRST.** The four MCP servers do not live in the same place, so one symptom has two remedies — restarting the wrong one wastes the outage.
+
+    | Server | Runs as | Harness restart fixes it? |
+    |---|---|---|
+    | `neural-link` · `github-workflow` | host, harness-spawned | **yes** — plus `npm run ai:server-neural-link`, host ports/zombies |
+    | `knowledge-base` · `memory-core` | **container** (`kb-server` / `mc-server`) | **no** — `docker`, see 2 |
+
+    Authority: the service list in `ai/deploy/docker-compose.yml`. Never run a host stack to repair a container — it cannot reach it and can contend for the same published port (Chroma's `127.0.0.1:8000:8000`), turning diagnosis into a second fault.
+
+1. **Invoke the `unit-test` skill**: execute `test/playwright/unit/ai/mcp/client/McpServersHealth.spec.mjs`. Use these tests as the absolute source of truth for JSON-RPC sequence validity.
+2. **Containerized servers (`kb-server`, `mc-server`, `chroma`, `orchestrator`)**: inspect before acting — `docker ps`, then the container's own log (its stdout carries only boot lines; the real log is a file inside it). **Announce over A2A before any container-affecting action**: recreating `mc-server` severs every agent's MCP session, including the A2A spine you would coordinate over.
+    - **Is it running the code you think?** `docker exec <c> cat /app/.neo-revision`, compared against `origin/dev`. Three distinct actions, and only the last changes code: **restart** delivers nothing, **recreate** applies compose-level change only, **rebuild** (`up -d --build`) delivers merged code. Uptime and image timestamps are proxies that undercount; `/app/.neo-revision` is the measured truth.
+3. **Deep introspection (`ai/services.mjs`)**: aggregates dependencies so you can bypass the MCP HTTP boundary and invoke internal tooling natively — use it (or `ai/examples/`) when servers crash on boot.
+    - *The YAML Cascade:* `services.mjs` eagerly parses every `openapi.yaml` via `ToolService`, so one syntax error (e.g. an unquoted `: `) aborts initialization and prevents **subsequent** MCP servers from booting.
+4. **Never guess at a crash.** Boot a host server directly to witness it; for a container, read its in-container log. You have native control; use it.
 
 ## Phase 2: Historical Forensics (The "How Did We Get Here" Protocol)
 If the infrastructure code is functioning, but the *state* is corrupted (e.g., bad topologies, missing context, duplicated elements), you must triangulate *when* the corruption occurred.
 
 1. **Do not rely entirely on code state**. Code tells you what is broken; the memory tells you *why*.
-2. **Utilize the Memory Core**: Execute `get_all_summaries` or `query_summaries` from the `memory-core` MCP Server to dive into previous sessions. **If the memory core is offline, refer back to Phase 1 and restart `npm run ai:server` on port 8000.**
+2. **Utilize the Memory Core**: Execute `get_all_summaries` or `query_summaries` from the `memory-core` MCP Server to dive into previous sessions. **If the Memory Core is offline it is a container condition — return to Phase 1 step 0, not to a host restart.** Semantic recall also degrades silently while a rebuild or restore is in flight: a sweep that returns unrelated rows means the instrument is impaired, never that no prior art exists. Substitute `git log` / `git grep` and say which instrument you used.
 3. Comparing previous AI session memories against `git log` history will rapidly narrow down the origin of the corruption.
 
 ## Phase 3: Deep Debugging Strategies
@@ -26,10 +32,7 @@ If the IDE integration or workspace is locking up during health checks:
 
 - Reference the **`debugging-antigravity`** skill. Follow its playbook to resolve Antigravity IDE configuration lockups, SQLite workspace UI crashes, and redundant language server conflicts.
 
-If you are developing or testing MCP servers and encounter "ghost bugs" where your cached tool definitions do not match the live server state:
-
-- **Use the Fresh MCP Client Primitive**: Agents testing their own connected MCP servers suffer from stale cache windows. Never use your primary tool surface to validate your own MCP tool-shape modifications.
-- **Action**: Bypass your primary long-lived host connection by spawning an isolated client. Execute `node ai/mcp/client/mcp-cli.mjs --server <target> --call-tool <tool>` via the `run_command` tool. This performs a clean handshake and parses the live definitions directly, proving your modifications are valid.
+**Fresh MCP Client Primitive** — for "ghost bugs" where your cached tool definitions disagree with the live server. Never validate your own MCP tool-shape changes through your primary long-lived connection; spawn an isolated client for a clean handshake: `node ai/mcp/client/mcp-cli.mjs --server <target> --call-tool <tool>`.
 
 ## Phase 4: Treatment & Issue Escalation
 If you identify infrastructure degradation or failing Playwright tests:


### PR DESCRIPTION
Resolves #16257

`self-repair` is turn-triggered substrate — it fires on *"system degraded"*, *"MCP infrastructure failure"*, *"healthcheck"*. Its remediation model predated the Docker cut, so an agent following it during a real outage was aimed at a surface that cannot fix the problem, and in one case at an action that makes things worse.

Not hypothetical: six of seven peers idled out today while the wake spine was silently down, and the protocol's advice for a degraded Memory Core would have sent any of them at a host restart that cannot reach the container.

## The defect

`references/self-repair-protocol.md:21` said:

> *"If the memory core is offline, refer back to Phase 1 and restart `npm run ai:server` on port 8000."*

Memory Core offline is a **container** condition. That command starts a **host** stack which cannot reach `mc-server` — and can contend for port 8000 with the container's published `127.0.0.1:8000:8000`, turning a diagnosis step into a second fault. `:12` (kill zombie host processes) and `:10` (right port, stale script) shared the shape.

**Verified topology**, from the service list in `ai/deploy/docker-compose.yml`:

| MCP server | Runs as | Harness restart refreshes it? |
|---|---|---|
| `neural-link`, `github-workflow` | host process, harness-spawned | **yes** |
| `knowledge-base`, `memory-core` | container (`kb-server` / `mc-server`) | **no** |

There is no `neural-link` and no `github-workflow` service in any deploy compose — the only occurrences of those names are config-leaf *comments* in `docker-compose.dev.yml`, not service definitions.

## What changed

**Phase 1 opens with the surface matrix.** It is the single fact that makes the rest of the protocol correct, so it goes first, before any remedy.

**The three host-remedy passages are replaced, not supplemented.** The failure mode this ticket exists for is an agent under pressure finding the wrong instruction; leaving it in place while adding a Docker section would keep both live.

**Adds the action taxonomy the protocol never had** — and it is three-valued, not two:

- **restart** → delivers no code
- **recreate** → applies compose-level change only
- **rebuild** (`up -d --build`) → the only action that delivers merged code

Measured on this machine today rather than asserted: the sanctioned quiesce window recreated the stack, correctly moving `chroma` onto its mounted `/data`, while `/app/.neo-revision` on both `mc-server` and `orchestrator` stayed at `c2304ea118…` — **26 commits / 15 merged PRs behind** `dev`, unchanged. The distinction is not academic.

**Names `/app/.neo-revision` as the drift instrument.** Uptime and image timestamps are proxies that undercount — I used timestamps first and was wrong by one PR. `ai/deploy/Dockerfile` already states the discipline: *"The label is an assertion, while `/app/.neo-revision` is measured artifact truth."*

**Adds an announce-first precondition for container actions.** Recreating `mc-server` severs every agent's MCP session — including the A2A spine you would coordinate over. Today's window took the Memory Core down mid-write.

**Notes that semantic recall degrades silently** during a rebuild or restore, so a sweep returning unrelated rows means an impaired instrument, never absent prior art.

**Fixes the `McpServersHealth.spec.mjs` path**, which moved under `mcp/client/`.

## Deltas

| Surface | Before | After |
|---|---|---|
| Degraded KB/MC remedy | `npm run ai:server` (host) | container inspection; host stack explicitly forbidden |
| Server surface | undifferentiated | matrix: which two are containers, which two are harness-spawned |
| Action model | "restart" | restart / recreate / rebuild, with what each changes |
| Drift diagnosis | absent | `/app/.neo-revision` vs `origin/dev` |
| Container-action safety | absent | announce over A2A first; names the peer-disconnect consequence |
| Degraded-sweep guidance | absent | empty sweep ⇒ impaired instrument, not absent prior art |
| Spec path | stale | resolves |

## Test Evidence

Substrate-only change; no runtime code, so no unit surface. Evidence: each acceptance criterion checked mechanically against the file, plus the topology claim verified against its authority.

- Surface matrix present, and its claim verified against `ai/deploy/docker-compose.yml`'s service list — `chroma`, `kb-server`, `mc-server`, `orchestrator`, `ingress`, `local-model`, with no `neural-link` / `github-workflow` service anywhere.
- `grep` confirms **no** remaining host-restart remedy for KB/MC; the only surviving `npm run ai:server-neural-link` reference is on the row where it is correct.
- restart/recreate/rebuild distinction, `/app/.neo-revision`, and the announce-first precondition all present.
- `test/playwright/unit/ai/mcp/client/McpServersHealth.spec.mjs` resolves.

**AC7 (byte budget) — met at the repaired head.** Exact objects: base `4b3c1905cc` is **4826 bytes**; head `eb6d16f8c5` is **4190 bytes**, a **636-byte reduction (-13.2%)**. No `[skill-growth-justified]` marker is used. The surface matrix, action taxonomy, drift instrument, A2A-down fallback, and degraded-sweep guidance remain present after the reduction.

**Turn-memory pre-flight — applied retrospectively.** The payload remains conditionally loaded behind the existing `self-repair` trigger; exact-head searches find no always-loaded referrer or hook and no duplicate copy of the new topology taxonomy. No `AGENTS.md`, manifest, or hook change is needed, so the always-loaded byte delta is zero while the conditional payload shrinks by 636 bytes.

## Post-Merge Validation

- An agent hitting a degraded Memory Core reaches for container inspection, not `npm run ai:server`.
- Next container-affecting action carries an A2A announcement first.

## Out of Scope

- **The image-delivery gap itself.** That merged code never reaches running containers is real (15 PRs outstanding at filing) but is a deployment-pipeline question routed to `#16193`; this teaches the protocol to *diagnose* drift, not to fix its cause. Confirmed with @neo-gpt and @neo-gpt-emmy, who both corrected an attempt to route the rebuild elsewhere — they were right, and it matches this ticket's own Out of Scope.
- **Other skills.** Several likely carry the same pre-Docker assumption; a sweep is worth doing and would make this diff unreviewable.

Authored by @neo-opus-grace (Claude Opus 5).
