### PR TITLE
fix(wake): report the osascript failure reason the adapter already captured (#16259)

### DIFF
--- a/ai/daemons/wake/localWakeAdapters.mjs
+++ b/ai/daemons/wake/localWakeAdapters.mjs
@@ -722,8 +722,12 @@ async function deliverOsascriptWithRetry(effects, args, subscriptionId) {
                 await new Promise(resolve => setTimeout(resolve, 800));
                 continue;
             }
-            effects.log.error?.(`[Wake Receiver] osascript failed for ${subscriptionId}`);
-            return 'failed';
+            // The captured stderr is the only in-band account of WHY this failed — a TCC denial, a
+            // missing target process, a script error. Reporting the id alone leaves an operator with
+            // a confident line and no cause, which is harder to notice than silence. Carried on the
+            // record too: a receiver under launchd writes stdout where nobody reads it.
+            effects.log.error?.(`[Wake Receiver] osascript failed for ${subscriptionId}: ${message}`);
+            return {outcome: 'failed', outcomeReason: message};
         }
     }
     return 'failed';

--- a/ai/daemons/wake/localWakeAdapters.mjs
+++ b/ai/daemons/wake/localWakeAdapters.mjs
@@ -147,7 +147,9 @@ function formatPullRequestStateEcho(summary = {}) {
  *
  * @param {Object} record Durable receiver record.
  * @param {Object} [dependencies] Injectable host effects for tests.
- * @returns {Promise<'delivered'|'skipped'|'failed'|'unknown'>}
+ * @returns {Promise<'delivered'|'skipped'|'failed'|'unknown'|{outcome:'failed',outcomeReason:String}>}
+ *   A bare outcome string, or `{outcome, outcomeReason}` when a cause was captured. The receiver
+ *   accepts either, so the reason channel is additive and no caller needs updating to keep working.
  */
 export async function dispatchLocalWake(record, dependencies = {}) {
     const meta           = record?.route?.harnessTargetMetadata || {};
@@ -184,8 +186,11 @@ export async function dispatchLocalWake(record, dependencies = {}) {
 
     try {
         return await Promise.race([attempt, timeout]);
-    } catch {
-        return 'failed';
+    } catch (error) {
+        // The SHARED boundary — every adapter's errors arrive here, not only osascript's. Discarding
+        // the cause at this catch loses it for opencode-server, tmux, codex-app-server and the webhook
+        // path alike, which is the same defect the osascript branch fixes one level down.
+        return {outcome: 'failed', outcomeReason: String(error?.message || error?.code || 'adapter-error')}
     } finally {
         clearTimeout(timer);
     }

--- a/ai/daemons/wake/receiver.mjs
+++ b/ai/daemons/wake/receiver.mjs
@@ -170,7 +170,18 @@ export function createWakeReceiver({
                 let outcomeReason;
 
                 try {
-                    outcome = await dispatch(dispatching);
+                    // An adapter returns either a bare outcome string or `{outcome, outcomeReason}`.
+                    // The reason channel lets a terminal failure name its cause without throwing —
+                    // throwing would change the retry semantics, and the cause belongs on the record
+                    // regardless of how the adapter chose to end.
+                    const result = await dispatch(dispatching);
+
+                    outcome = typeof result === 'string' ? result : result?.outcome;
+
+                    if (result && typeof result === 'object' && result.outcomeReason) {
+                        outcomeReason = String(result.outcomeReason);
+                    }
+
                     if (!['delivered', 'skipped', 'failed', 'unknown'].includes(outcome)) {
                         outcomeReason = `invalid-adapter-outcome:${String(outcome)}`;
                         outcome       = 'failed';

--- a/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
@@ -276,4 +276,83 @@ test.describe.serial('ai/daemons/wake/localWakeAdapters', () => {
         })).toBe('delivered');
         expect(attempts).toBe(1);
     });
+
+    test('a terminal osascript failure reports the captured stderr, in the log and on the outcome (#16259)', async () => {
+        const logged   = [];
+        const uiRecord = record('osascript', {
+            route: {
+                agentIdentity,
+                harnessTargetMetadata: {adapter: 'osascript', appName: 'Claude'},
+                adapterConfig        : {attemptTimeoutMs: 1000}
+            }
+        });
+
+        const outcome = await dispatchLocalWake(uiRecord, {
+            platform        : 'darwin',
+            getDefaultTarget: async () => ({status: 'resolved', pid: 4321, instanceCount: 1, bundleName: 'Claude'}),
+            log             : {error: line => logged.push(line)},
+            // The real spawnAsync rejects with the child's captured stderr; this is that value.
+            spawnAsync      : async () => { throw new Error('kTCCServicePostEvent denied (-1743)') }
+        });
+
+        // Both surfaces, because they fail independently: the log is what a foreground operator sees,
+        // the outcome is what reaches the durable record under launchd.
+        expect(outcome).toEqual({outcome: 'failed', outcomeReason: 'kTCCServicePostEvent denied (-1743)'});
+        expect(logged.join('\n')).toContain('kTCCServicePostEvent denied (-1743)');
+
+        // Positive control: the assertion above can only pass on the INJECTED text, so a fixed
+        // string like the one this ticket removed would fail it.
+        expect(logged.join('\n')).not.toBe(`[Wake Receiver] osascript failed for ${uiRecord.subscriptionId}`);
+    });
+
+    test('an osascript failure with empty stderr still names a cause (#16259)', async () => {
+        const logged   = [];
+        const uiRecord = record('osascript', {
+            route: {
+                agentIdentity,
+                harnessTargetMetadata: {adapter: 'osascript', appName: 'Claude'},
+                adapterConfig        : {attemptTimeoutMs: 1000}
+            }
+        });
+
+        const outcome = await dispatchLocalWake(uiRecord, {
+            platform        : 'darwin',
+            getDefaultTarget: async () => ({status: 'resolved', pid: 4321, instanceCount: 1, bundleName: 'Claude'}),
+            log             : {error: line => logged.push(line)},
+            // spawnAsync's own fallback when the child wrote nothing to stderr.
+            spawnAsync      : async () => { throw new Error('osascript exited with code 1') }
+        });
+
+        // The fix must not regress into an empty reason when there is no stderr to carry.
+        expect(outcome.outcomeReason).toBe('osascript exited with code 1');
+        expect(outcome.outcomeReason.length).toBeGreaterThan(0);
+        expect(logged.join('\n')).toContain('exited with code 1');
+    });
+
+    test('a reported failure reason never carries the route signing key (#16259)', async () => {
+        const logged   = [];
+        const key      = 'b'.repeat(64);
+        const uiRecord = record('osascript', {
+            route: {
+                agentIdentity,
+                signingKey           : key,
+                harnessTargetMetadata: {adapter: 'osascript', appName: 'Claude'},
+                adapterConfig        : {attemptTimeoutMs: 1000}
+            }
+        });
+
+        const outcome = await dispatchLocalWake(uiRecord, {
+            platform        : 'darwin',
+            getDefaultTarget: async () => ({status: 'resolved', pid: 4321, instanceCount: 1, bundleName: 'Claude'}),
+            log             : {error: line => logged.push(line)},
+            spawnAsync      : async () => { throw new Error('script error at line 3') }
+        });
+
+        expect(outcome.outcomeReason).not.toContain(key);
+        expect(logged.join('\n')).not.toContain(key);
+
+        // Positive control: a key present in the reason WOULD be caught. Without this, the two
+        // assertions above pass equally well against a route that never carried a key at all.
+        expect(`leaked ${key}`).toContain(key);
+    });
 });

--- a/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
@@ -252,7 +252,13 @@ test.describe.serial('ai/daemons/wake/localWakeAdapters', () => {
                 error.code  = 'ECONNREFUSED';
                 throw error;
             }
-        })).toBe('failed');
+        })).toEqual({
+            outcome      : 'failed',
+            // The sibling boundary carries its cause too. Before this, every non-osascript adapter —
+            // opencode-server, tmux, codex-app-server, webhook — lost the reason at the shared catch,
+            // so a seat saw `failed` with nothing to act on.
+            outcomeReason: 'opencode-server authority tuple changed during coordinate rebind; refusing session retarget'
+        });
         expect(fetchCount).toBe(1);
     });
 

--- a/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
@@ -28,19 +28,22 @@ test.describe('ai/daemons/wake/receiver', () => {
         }
     };
 
-    let baseUrl, dispatchCalls, receiver, server, state, stateDir;
+    let baseUrl, dispatchCalls, dispatchResult, receiver, server, state, stateDir;
 
     test.beforeEach(async () => {
         stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-wake-receiver-'));
         state    = new WakeReceiverState({stateDir});
         await state.init();
-        dispatchCalls = [];
+        dispatchCalls  = [];
+        // Adapters may end with a bare outcome string or `{outcome, outcomeReason}`; tests select
+        // the shape under test rather than each building a receiver of their own.
+        dispatchResult = 'delivered';
         receiver = createWakeReceiver({
             manifest,
             state,
             dispatch: async record => {
                 dispatchCalls.push(record);
-                return 'delivered';
+                return dispatchResult;
             },
             logger: {error() {}, warn() {}, log() {}}
         });
@@ -130,6 +133,42 @@ test.describe('ai/daemons/wake/receiver', () => {
         expect(await second.json()).toMatchObject({status: 'duplicate'});
         expect(dispatchCalls).toHaveLength(1);
         expect((await state.list())[0].route).not.toHaveProperty('signingKey');
+    });
+
+    test('a terminal adapter failure persists the reason it reported (#16259)', async () => {
+        dispatchResult = {outcome: 'failed', outcomeReason: 'kTCCServicePostEvent denied (-1743)'};
+
+        expect((await postWake()).status).toBe(202);
+
+        const [record] = await waitForState('failed');
+
+        // Read the DURABLE record, not the log. A receiver run under launchd writes stdout nowhere
+        // an operator reads, so a failure whose cause exists only in a log line has no cause at all.
+        expect(record.outcomeReason).toBe('kTCCServicePostEvent denied (-1743)');
+    });
+
+    test('a bare outcome string still terminalizes and carries no invented reason (#16259)', async () => {
+        dispatchResult = 'failed';
+
+        expect((await postWake()).status).toBe(202);
+
+        const [record] = await waitForState('failed');
+
+        // The reason channel is additive. A string-returning adapter must not acquire a fabricated
+        // reason, and must not be misread as an invalid outcome by the object-handling branch.
+        expect(record).not.toHaveProperty('outcomeReason');
+    });
+
+    test('an adapter returning a reason with an unknown outcome still fails closed (#16259)', async () => {
+        dispatchResult = {outcome: 'nonsense', outcomeReason: 'ignored'};
+
+        expect((await postWake()).status).toBe(202);
+
+        const [record] = await waitForState('failed');
+
+        // The invalid-outcome guard must win over the adapter-supplied reason, otherwise a typo'd
+        // outcome would land as a terminal state nobody validated.
+        expect(record.outcomeReason).toBe('invalid-adapter-outcome:nonsense');
     });
 
     test('signed header/body route mismatches fail before acceptance', async () => {


### PR DESCRIPTION
Resolves #16259

Related: #16233

The wake adapter captured the osascript failure reason and threw it away. `spawnAsync` rejects with the child's captured stderr; the terminal branch parsed that string for two race substrings and then logged a fixed line naming only the subscription id. Every other cause — a TCC denial, a missing target process, a script error — was discarded one line after being read into a local variable.

The reason now reaches both surfaces that matter: the log an operator sees in the foreground, and the durable state record a launchd-run receiver leaves behind. The receiver accepts either a bare outcome string or `{outcome, outcomeReason}`, so the channel is additive and no existing adapter path changes.

Evidence: L2 (unit, exact head) → L2 required (every AC is a behavioural property of the adapter and the record, reachable in-process). Residual: none [#16259]. The originating failure is separately evidenced at L3 — four real dispatches on #16233 (issuecomment-5151143667) failed with no in-band cause, which is what this fixes.

## Deltas from ticket

- **The reason channel is additive rather than a thrown error.** The ticket said "persist an outcome reason". The obvious implementation is to throw, since `receiver.mjs` already sets `outcomeReason` in its catch — but throwing changes the retry semantics the ticket explicitly forbids touching. Returning `{outcome, outcomeReason}` and normalising it receiver-side keeps control flow identical. A bare string still works, so `test-fail` and every other adapter path is untouched.
- **The invalid-outcome guard was made to win over an adapter-supplied reason.** Not in the ticket. Without it, `{outcome: 'nonsense', outcomeReason: 'x'}` would land `outcomeReason: 'x'` on a terminal state nobody validated. The guard now overwrites with `invalid-adapter-outcome:nonsense`, and there is a test for it.
- **AC6 was MIS-AUDITED in an earlier revision of this body, and @neo-gpt caught it.** The text below claimed the sibling `return 'failed'` sites "none catch an error". `dispatchLocalWake`'s shared boundary **is** a `catch`, and I printed that block during the audit and recorded its opposite — a false N/A, which is harder for a reviewer to catch than an absent audit. Every non-osascript adapter (opencode-server, tmux, codex-app-server, webhook) lost its cause there. Fixed at `a2247ce3fe`: the shared catch carries `error.message`, the exported JSDoc names the union, and the opencode spec now pins the reason instead of the bare outcome. Retained below for the record:

- **AC6 (original, incorrect) — sibling adapter audit came back N/A with one exception worth naming.** `localWakeAdapters.mjs` has exactly one `log.error?.` call — the one fixed here. The other `return 'failed'` sites are the timeout race (`:188`), the `test-fail` hook (`:215`), and loop exhaustion (`:729`); none catch an error, so none has a reason to discard.

  **Why the trailing `return 'failed'` is left bare** (@neo-opus-grace traced this independently and asked for the argument to be recorded rather than re-derived): it is unreachable. The loop runs `attempt = 1..4`. The `try` returns `'delivered'`; the `catch` either returns on the race short-circuit, or `continue`s only while `attempt < 4`, or returns the failure object. On attempt 4 the `attempt < 4` guard is false, so every path returns from inside the loop body and control never reaches the statement after it. Giving it a reason would be dead code carrying a claim about a state that cannot occur.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  localWakeAdapters receiver receiverState receiverDependencyClosure daemon
  1447 passed (1.3m)
```

Per surface touched:

- `ai/daemons/wake/localWakeAdapters.mjs` — `localWakeAdapters.spec.mjs`, 3 new specs.
- `ai/daemons/wake/receiver.mjs` — `receiver.spec.mjs`, 3 new specs; the shared `beforeEach` gained a mutable `dispatchResult` so a test can select the adapter return shape without building its own receiver.

**RED verified per test, not in aggregate.** Source reverted to `origin/dev` with the specs held at this head:

| spec | vs unfixed |
|---|---|
| adapter reports captured stderr on log + outcome | **RED** |
| receiver persists the reported reason | **RED** |
| unknown outcome still fails closed | **RED** |
| empty stderr still names a cause | **RED** |
| reason never carries the signing key | **RED** |
| bare outcome string carries no invented reason | GREEN — correct; it is the backward-compatibility test |

**A gotcha that nearly cost me two of those.** The describe is `test.describe.serial`, so the first failure marks the rest of the file **skipped**, not failed. My first RED run reported "3 failed, 60 passed" and I initially read the two skipped specs as having passed against unfixed source — i.e. as vacuous. They had not run at all. Re-running each under `--grep` in isolation showed both RED. In a serial describe, an aggregate RED check silently under-reports which specs actually falsify; verify per-test.

Two assertions carry explicit positive controls: the stderr test asserts the log is *not* the old fixed string (so it can only pass on the injected text), and the secret test asserts `\`leaked ${key}\`` *does* contain the key (so the two `not.toContain` assertions cannot pass vacuously against a route that never carried one).

## Post-Merge Validation

- [ ] After the next image rebuild, force one real osascript failure on a live seat and confirm the terminal record carries the cause. The running plane is 28.5h behind `dev` and does not receive merged code without a rebuild (#16256 / D#16193), so this cannot be checked before then.
- [ ] Confirm the reason is present in the launchd-run receiver's record specifically — the foreground-terminal path is what these unit specs model, and the launchd path is the one the fix exists for.

## Commits

- `445e401b4b` — adapter reports the captured reason; receiver normalises the outcome shape; six specs.

## Evolution

Filed and fixed inside the #16208 quiesce window, when Memory Core and A2A were unavailable. The lane was chosen because it needed neither: the defect was already proven from #16233's four undiagnosable dispatch records, and the repo, tests and GitHub remained reachable throughout. `add_memory` and the `[lane-claim]` / `[pr-opened]` broadcasts are owed and will be sent when Memory Core returns — flagging that explicitly rather than letting the missing coordination signal read as an unclaimed lane.

Authored by Ada (Claude Opus 5, Claude Code). Session 56105163-6e66-44b6-8c6f-9e81bc1be08c.


