### PR TITLE
fix(ai): compute digest latest by recency, not iteration position (#16263)

### DIFF
--- a/ai/services/memory-core/CoalescingEngineService.mjs
+++ b/ai/services/memory-core/CoalescingEngineService.mjs
@@ -43,6 +43,45 @@ const WAKE_PRIORITY_RANKS = Object.freeze({
  * @singleton
  * @see learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md §6.4
  */
+
+/**
+ * @summary Resolves an event's recency timestamp for digest `latest` selection.
+ *
+ * The payload's `sentAt` wins first (mailbox events carry the message's own send time, which is
+ * the recency an agent reads the pointer by); the envelope's `emittedAt` is the fallback (numeric
+ * epoch or ISO string). Returns `null` when nothing is resolvable — the caller then keeps the
+ * previous last-write-wins behavior, so timestamp-less events are never re-ordered by guesswork.
+ * @param {Object} event Wake event envelope.
+ * @returns {Number|null} Epoch ms, or null when no timestamp is resolvable.
+ */
+function resolveEventTimestamp(event) {
+    const sentAt = event?.payload?.sentAt;
+
+    if (typeof sentAt === 'string') {
+        const ts = Date.parse(sentAt);
+
+        if (Number.isFinite(ts)) {
+            return ts
+        }
+    }
+
+    const emitted = event?.emittedAt;
+
+    if (typeof emitted === 'number' && Number.isFinite(emitted)) {
+        return emitted
+    }
+
+    if (typeof emitted === 'string') {
+        const ts = Date.parse(emitted);
+
+        if (Number.isFinite(ts)) {
+            return ts
+        }
+    }
+
+    return null
+}
+
 class CoalescingEngineService extends Base {
     static config = {
         /**
@@ -367,6 +406,13 @@ class CoalescingEngineService extends Base {
      * so Shape A and Shape B consumers can dispatch with the same shape they expect for
      * single events.
      *
+     * Each bucket's `latest` is chosen by RECENCY (max timestamp), never by iteration
+     * position: enqueue order is only arrival order when every event arrives live in
+     * sequence, and an out-of-order queue (replay batch, restart re-walk, multi-source
+     * evaluation) would otherwise point `latest` at a stale event while a newer one is
+     * present — the pointer agents use to decide whether a wake is worth acting on.
+     * Timestamp-less payloads fall back to last-write-wins, the previous behavior.
+     *
      * @protected
      * @param {Object} subscription
      * @param {Object[]} events Queued event envelopes
@@ -375,41 +421,46 @@ class CoalescingEngineService extends Base {
      */
     _buildDigestEnvelope(subscription, events, firstQueuedAt) {
         const breakdown = {
-            sent_to_me        : {count: 0, latest: null, highestPriority: 'normal'},
-            task_state_changed: {count: 0, latest: null},
-            permission_granted: {count: 0, latest: null},
-            heartbeat_pulse   : {count: 0, latest: null}
+            sent_to_me        : {count: 0, latest: null, latestTs: null, highestPriority: 'normal'},
+            task_state_changed: {count: 0, latest: null, latestTs: null},
+            permission_granted: {count: 0, latest: null, latestTs: null},
+            heartbeat_pulse   : {count: 0, latest: null, latestTs: null}
+        };
+
+        const bucketOf = {
+            'wake/sent_to_me'        : 'sent_to_me',
+            'wake/task_state_changed': 'task_state_changed',
+            'wake/permission_granted': 'permission_granted',
+            'wake/heartbeat_pulse'   : 'heartbeat_pulse'
         };
 
         for (const evt of events) {
-            switch (evt.eventType) {
-                case 'wake/sent_to_me': {
-                    const priority = Object.hasOwn(WAKE_PRIORITY_RANKS, evt.payload?.priority)
-                        ? evt.payload.priority
-                        : 'normal';
+            const bucketKey = bucketOf[evt.eventType];
 
-                    breakdown.sent_to_me.count++;
-                    breakdown.sent_to_me.latest = evt.payload;
-                    if (
-                        WAKE_PRIORITY_RANKS[priority] >
-                        WAKE_PRIORITY_RANKS[breakdown.sent_to_me.highestPriority]
-                    ) {
-                        breakdown.sent_to_me.highestPriority = priority;
-                    }
-                    break;
+            if (!bucketKey) {
+                continue
+            }
+
+            const bucket = breakdown[bucketKey];
+
+            bucket.count++;
+
+            const ts = resolveEventTimestamp(evt);
+
+            // Recency wins over position; a timestamp-less candidate keeps last-write-wins.
+            if (bucket.latest === null || ts === null || ts >= bucket.latestTs) {
+                bucket.latest   = evt.payload;
+                bucket.latestTs = ts ?? bucket.latestTs;
+            }
+
+            if (bucketKey === 'sent_to_me') {
+                const priority = Object.hasOwn(WAKE_PRIORITY_RANKS, evt.payload?.priority)
+                    ? evt.payload.priority
+                    : 'normal';
+
+                if (WAKE_PRIORITY_RANKS[priority] > WAKE_PRIORITY_RANKS[bucket.highestPriority]) {
+                    bucket.highestPriority = priority;
                 }
-                case 'wake/task_state_changed':
-                    breakdown.task_state_changed.count++;
-                    breakdown.task_state_changed.latest = evt.payload;
-                    break;
-                case 'wake/permission_granted':
-                    breakdown.permission_granted.count++;
-                    breakdown.permission_granted.latest = evt.payload;
-                    break;
-                case 'wake/heartbeat_pulse':
-                    breakdown.heartbeat_pulse.count++;
-                    breakdown.heartbeat_pulse.latest = evt.payload;
-                    break;
             }
         }
 

--- a/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
@@ -336,4 +336,106 @@ test.describe('CoalescingEngineService', () => {
         expect(aDigest?.payload.totalEvents).toBe(2);
         expect(bDigest?.payload.totalEvents).toBe(1);
     });
+
+    // -----------------------------------------------------------------------------
+    // Digest `latest` — recency, never iteration position
+    // -----------------------------------------------------------------------------
+
+    test('an out-of-order queue names the NEWEST event as latest, not the last-iterated one', () => {
+        // The live enablement-day shape: the fresh message was enqueued FIRST, then a replay
+        // batch of stale backlog events — and last-write-wins pointed at the backlog.
+        const fresh = buildEnvelope('wake/sent_to_me', {
+            subject: 'the fresh 11:21 message',
+            sentAt : '2026-08-01T11:21:47.000Z'
+        });
+        const staleBatch = [1, 2, 3].map(n => buildEnvelope('wake/sent_to_me', {
+            subject: `stale backlog probe ${n}`,
+            sentAt : '2026-07-31T23:04:46.000Z'
+        }));
+
+        const digest = CoalescingEngineService._buildDigestEnvelope(
+            buildSubscription(),
+            [fresh, ...staleBatch],
+            Date.now() - 150000
+        );
+
+        expect(digest.payload.breakdown.sent_to_me.latest.subject).toBe('the fresh 11:21 message');
+        expect(digest.payload.breakdown.sent_to_me.count).toBe(4)
+    });
+
+    test('arrival-ordered queues behave exactly as before (recency matches iteration)', () => {
+        const stale = buildEnvelope('wake/sent_to_me', {subject: 'older', sentAt: '2026-07-31T23:04:46.000Z'});
+        const fresh = buildEnvelope('wake/sent_to_me', {subject: 'newer', sentAt: '2026-08-01T11:21:47.000Z'});
+
+        const digest = CoalescingEngineService._buildDigestEnvelope(buildSubscription(), [stale, fresh], Date.now() - 150000);
+
+        expect(digest.payload.breakdown.sent_to_me.latest.subject).toBe('newer')
+    });
+
+    test('equal timestamps keep the last-enqueued one (no drift for same-instant events)', () => {
+        const ts  = '2026-08-01T11:21:47.000Z',
+              one = buildEnvelope('wake/sent_to_me', {subject: 'first', sentAt: ts}),
+              two = buildEnvelope('wake/sent_to_me', {subject: 'second', sentAt: ts});
+
+        const digest = CoalescingEngineService._buildDigestEnvelope(buildSubscription(), [one, two], Date.now() - 150000);
+
+        expect(digest.payload.breakdown.sent_to_me.latest.subject).toBe('second')
+    });
+
+    test('timestamp-less payloads fall back to last-write-wins, never re-ordered by guesswork', () => {
+        const noTs = subject => {
+            const env = buildEnvelope('wake/sent_to_me', {subject});
+            delete env.emittedAt;
+            return env;
+        };
+
+        const first  = noTs('first-no-ts'),
+              second = noTs('second-no-ts');
+
+        const digest = CoalescingEngineService._buildDigestEnvelope(buildSubscription(), [first, second], Date.now() - 150000);
+
+        expect(digest.payload.breakdown.sent_to_me.latest.subject).toBe('second-no-ts')
+    });
+
+    test('the envelope emittedAt is the recency fallback when the payload carries no sentAt', () => {
+        const noSentAt = (subject, emittedAt) => {
+            const env = buildEnvelope('wake/sent_to_me', {subject});
+            env.emittedAt = emittedAt;
+            return env;
+        };
+
+        const newerPayloadOlderPosition = noSentAt('newer-payload', '2026-08-01T11:21:47.000Z');
+        const olderPayloadNewerPosition = noSentAt('older-payload', '2026-07-31T23:04:46.000Z');
+
+        const digest = CoalescingEngineService._buildDigestEnvelope(
+            buildSubscription(),
+            [newerPayloadOlderPosition, olderPayloadNewerPosition],
+            Date.now() - 150000
+        );
+
+        expect(digest.payload.breakdown.sent_to_me.latest.subject).toBe('newer-payload')
+    });
+
+    test('all four breakdown buckets track recency, not position', () => {
+        const events = [
+            buildEnvelope('wake/sent_to_me',        {subject: 'fresh-stm',  sentAt: '2026-08-01T11:21:47.000Z'}),
+            buildEnvelope('wake/task_state_changed', {subject: 'fresh-tsc',  sentAt: '2026-08-01T11:21:47.000Z'}),
+            buildEnvelope('wake/permission_granted', {subject: 'fresh-pg',   sentAt: '2026-08-01T11:21:47.000Z'}),
+            buildEnvelope('wake/heartbeat_pulse',    {subject: 'fresh-hbp',  sentAt: '2026-08-01T11:21:47.000Z'}),
+            buildEnvelope('wake/sent_to_me',        {subject: 'stale-stm',  sentAt: '2026-07-31T23:04:46.000Z'}),
+            buildEnvelope('wake/task_state_changed', {subject: 'stale-tsc',  sentAt: '2026-07-31T23:04:46.000Z'}),
+            buildEnvelope('wake/permission_granted', {subject: 'stale-pg',   sentAt: '2026-07-31T23:04:46.000Z'}),
+            buildEnvelope('wake/heartbeat_pulse',    {subject: 'stale-hbp',  sentAt: '2026-07-31T23:04:46.000Z'})
+        ];
+
+        const digest = CoalescingEngineService._buildDigestEnvelope(buildSubscription(), events, Date.now() - 150000),
+              b      = digest.payload.breakdown;
+
+        expect(b.sent_to_me.latest.subject).toBe('fresh-stm');
+        expect(b.task_state_changed.latest.subject).toBe('fresh-tsc');
+        expect(b.permission_granted.latest.subject).toBe('fresh-pg');
+        expect(b.heartbeat_pulse.latest.subject).toBe('fresh-hbp');
+        expect(b.sent_to_me.count).toBe(2);
+        expect(b.sent_to_me.highestPriority).toBe('normal')
+    });
 });


### PR DESCRIPTION
Resolves #16263

The wake digest's `latest` pointer is now computed by **recency** (max timestamp per breakdown bucket) instead of last-write-wins over iteration position. Enqueue order is only arrival order when every event arrives live in sequence — an out-of-order queue (replay batch, restart re-walk, multi-source evaluation) previously pointed `latest` at a stale event while a newer one sat in the same window, which is exactly what @neo-opus-ada's live receipt showed on her enablement day (a 12-hour-old self-probe named `latest` over a window containing an 11:21Z message). Timestamp-less payloads keep the previous last-write-wins behavior as a documented fallback.

## Deltas from ticket

None substantive — the ticket prescribed recency-by-timestamp uniformly across all four buckets with the two fallbacks (equal timestamps keep last-enqueued; timestamp-less keeps last-write-wins); that is exactly the delta. The loop's per-bucket switch became a bucket map plus one recency rule, so the rule can never drift between buckets again.

## Test Evidence

- `test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs` — 6 new specs: (a) **out-of-order queue names the newest event** (Ada's live shape as the fixture: fresh 11:21 message enqueued first, stale 23:04 batch after — `latest` = the fresh one); (b) arrival-ordered queues behave exactly as before; (c) equal timestamps keep last-enqueued; (d) timestamp-less payloads fall back to last-write-wins; (e) envelope `emittedAt` is the recency fallback when the payload has no `sentAt`; (f) all four buckets track recency. **28/28** at exact head (22 inherited green).
- Pre-commit hooks green (all eight gates).
- Browser/e2e surfaces: `None found` (none touched).

Evidence: L2 (unit suites at exact head `5d9488222c`) — no L3 residual: the pointer rule is fully exercisable in unit scope; the first live digest after merge on Ada's seat is an observation, not a gate.

## Post-Merge Validation

- [ ] The first digest on @neo-opus-ada's enabled seat names the genuinely newest message as `latest` (observation lands on #16167's wake thread).
- [ ] No seat reports a `latest` pointing at backlog once enabled — the enablement-day false-wake class this ticket exists to close.

Authored by Iris (Kimi K3, Kimi Code CLI). Session 05b5fdc9-1f2b-4b45-a2c9-4b64ed5f15cd.
