### PR TITLE
fix(orchestrator): boot-identity discriminator for the heavy-maintenance lease (#16262)

### DIFF
--- a/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
+++ b/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import fs     from 'fs-extra';
+import os     from 'node:os';
 import path   from 'path';
 import {
     enterLifecycleGuard,
@@ -99,21 +100,38 @@ export function isPidAlive(pid) {
  * copied or restored state keeps the owning task's declared deadline. This is the
  * shared recovery contract for daemon-owned and CLI-owned maintenance work.
  *
+ * Discrimination is layered, most-external first: a lease from a DIFFERENT boot
+ * (`bootId` mismatch — a container recreate changes the hostname, which is the
+ * container ID) is stale regardless of pid liveness, because pid 1 is vacuously
+ * alive inside every container boot and a dead epoch's lease would otherwise read
+ * live forever. Within one boot, the process-epoch and pid-liveness checks below
+ * discriminate. Pre-`bootId` payloads skip the boot clause unchanged — absent
+ * evidence is not a stale verdict.
+ *
  * @param {Object|null} lease Persisted lease payload.
  * @param {Object} [options]
  * @param {Date|Number|String} [options.now=new Date()] Current time.
  * @param {Function} [options.isPidAlive=isPidAlive] Process liveness probe seam.
  * @param {Number|String} [options.currentPid=process.pid] Current process id seam.
  * @param {Date|Number|String} [options.currentProcessStartedAt] Current process start seam.
+ * @param {String} [options.currentBootId=os.hostname()] Current boot discriminator seam.
  * @returns {Boolean}
  */
 export function isLeaseStale(lease, {
     now                     = new Date(),
     isPidAlive: isPidAliveFn = isPidAlive,
     currentPid              = process.pid,
-    currentProcessStartedAt = CURRENT_PROCESS_STARTED_AT
+    currentProcessStartedAt = CURRENT_PROCESS_STARTED_AT,
+    currentBootId           = os.hostname()
 } = {}) {
     if (!lease || !lease.acquiredAt) {
+        return true;
+    }
+
+    // Cross-boot discrimination FIRST: a lease written by a different boot (container recreate,
+    // machine restart) belongs to a dead epoch no matter what the pid probe says — inside a
+    // container, pid 1 is alive on every boot, so liveness alone is vacuous there.
+    if (typeof lease.bootId === 'string' && lease.bootId.length > 0 && lease.bootId !== currentBootId) {
         return true;
     }
 
@@ -214,6 +232,9 @@ export function shouldYieldHeavyMaintenanceLease(lease, {now = new Date(), maxAc
  * @param {Number} options.staleAfterMs Stale TTL in ms — REQUIRED; resolved from AiConfig at the boundary (no primitive default).
  * @param {Date|Number|String} [options.now=new Date()] Current time.
  * @param {String} [options.token] Owner release token.
+ * @param {String} [options.bootId=os.hostname()] Boot discriminator — the container's hostname is
+ *     its container ID, which changes on recreate, so a dead epoch's lease can never read as
+ *     belonging to the new boot. Additive: pre-field payloads are unaffected (see isLeaseStale).
  * @returns {Object}
  */
 export function buildLeasePayload({
@@ -223,7 +244,8 @@ export function buildLeasePayload({
     pid          = process.pid,
     staleAfterMs,
     now          = new Date(),
-    token        = crypto.randomUUID()
+    token        = crypto.randomUUID(),
+    bootId       = os.hostname()
 }) {
     if (!Number.isFinite(staleAfterMs) || staleAfterMs <= 0) {
         throw new TypeError('buildLeasePayload: staleAfterMs (positive ms) is required — resolve it from AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs at the AiConfig-aware boundary; this Neo/Base-free primitive carries no TTL default by design.');
@@ -237,6 +259,7 @@ export function buildLeasePayload({
         reason,
         pid,
         token,
+        bootId,
         acquiredAt: acquiredAt.toISOString(),
         staleAfterMs,
         expiresAt : expiresAt.toISOString(),

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -1645,3 +1645,72 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         expect(atBoundary).toMatchObject({acquired: true, status: 'acquired-after-stale'});
     });
 });
+
+/**
+ * The cross-boot discriminator: a lease written by a DIFFERENT boot is stale regardless
+ * of pid liveness — inside a container, pid 1 is vacuously alive on every boot (the init), so a
+ * dead epoch's pid-1 lease would otherwise read live forever across a recreate. The gap-0 window
+ * specimen is the generalized form: pre-stop wedged lease surviving the post-restart reclaim and
+ * blocking the post-restoration backup until a manual rm.
+ *
+ * The discriminator is the payload's `bootId` — the container's hostname is its container ID,
+ * which changes on recreate. Pre-`bootId` payloads skip the clause unchanged: absent evidence is
+ * not a stale verdict, and no historical lease is condemned.
+ */
+test.describe('#16262 — bootId: cross-boot staleness regardless of pid liveness', () => {
+    const baseOptions = {
+        currentPid             : 7,
+        currentProcessStartedAt: new Date('2026-08-01T12:03:00.000Z'),
+        isPidAlive             : () => true, // the vacuous case: pid 1 is alive on every container boot
+        now                    : new Date('2026-08-01T12:13:00.000Z'),
+        currentBootId          : 'container-epoch-b'
+    };
+
+    test('a pid-1 lease from a DIFFERENT boot is stale even when the pid probe reports alive (the recreate specimen)', () => {
+        const lease = {
+            acquiredAt  : '2026-08-01T11:48:35.000Z',
+            expiresAt   : '2026-08-01T18:00:00.000Z',
+            pid         : 1,
+            bootId      : 'container-epoch-a',
+            staleAfterMs: 6 * 60 * 60 * 1000
+        };
+
+        expect(isLeaseStale(lease, baseOptions)).toBe(true);
+    });
+
+    test('a same-boot lease with a live holder is NOT staled by the clause (positive control)', () => {
+        const lease = {
+            acquiredAt  : '2026-08-01T12:10:00.000Z',
+            expiresAt   : '2026-08-01T18:00:00.000Z',
+            pid         : 1,
+            bootId      : 'container-epoch-b',
+            staleAfterMs: 6 * 60 * 60 * 1000
+        };
+
+        expect(isLeaseStale(lease, baseOptions)).toBe(false);
+    });
+
+    test('a pre-bootId payload classifies exactly as before — absent evidence is not a stale verdict', () => {
+        const leaseWithoutBootId = {
+            acquiredAt  : '2026-08-01T12:10:00.000Z',
+            expiresAt   : '2026-08-01T18:00:00.000Z',
+            pid         : 1,
+            staleAfterMs: 6 * 60 * 60 * 1000
+        };
+
+        // Live holder, no bootId: the clause must not fire; the liveness path answers.
+        expect(isLeaseStale(leaseWithoutBootId, baseOptions)).toBe(false);
+        // …and a dead pid on the same shape still stales via the liveness probe.
+        expect(isLeaseStale(leaseWithoutBootId, {...baseOptions, isPidAlive: () => false})).toBe(true);
+    });
+
+    test('buildLeasePayload emits bootId from os.hostname() by default and honors injection', async () => {
+        const os = await import('node:os');
+
+        const defaulted = buildLeasePayload({owner: 'kbSync', staleAfterMs: 1000});
+        expect(defaulted.bootId).toBe(os.hostname());
+
+        const injected = buildLeasePayload({owner: 'kbSync', staleAfterMs: 1000, bootId: 'injected-boot'});
+        expect(injected.bootId).toBe('injected-boot');
+    });
+});


### PR DESCRIPTION
Resolves #16262

A lease from a different boot can never read as belonging to this one again. `isLeaseStale` gains a boot clause ahead of the liveness probe — a payload whose `bootId` differs from the current boot's classifies stale regardless of what the pid probe reports — and `buildLeasePayload` starts recording that `bootId`, defaulting to `os.hostname()`. The container's hostname IS its container ID, which changes on recreate, so the discriminator needs no config leaf and no env read. The field is additive: pre-`bootId` payloads classify exactly as before.

Evidence: L1 (static + unit — pure classification + payload builder, 4 new specs in the existing HeavyMaintenance suite) → L1 required (#16262's ACs are classification verdicts over injected payloads; no live boot needed). Residual: the recreate-with-in-flight-lease live reclaim is PMV against the rebuilt plane (the #16167 cleanup lane owns the rebuild).

## Deltas from ticket

None substantive — option (a) as ruled by @neo-opus-vega on #16210. The (b) TTL-family unification with `ai/daemons/shared/fileLease.mjs` stays named and deferred in the ticket body (the heavy lease's renew-or-lose `staleAfterMs` contract differs deliberately from poll-cadence heartbeats).

The intake receipts that shaped this are on #16210 ([issuecomment-5151446195](https://github.com/neomjs/neo/issues/16210#issuecomment-5151446195)): the window specimen is already fixed on dev by the merged epoch guard (the running image predates it — `docker exec grep -c CURRENT_PROCESS_STARTED_AT` returns 0), and this ticket closes the one branch the guard does not reach — cross-pid / recreate, where pid 1 is vacuously alive on every container boot.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
  47 passed (5.1s)
npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/
  1445 passed (1.3m)
npx playwright test -c test/playwright/playwright.config.unit.mjs
  10669 passed, 5 skipped, 2 failed
```

The 2 full-suite failures are in `SessionSummarization.spec.mjs` (live-LLM latency family — untouched by this diff; the file passes isolated and the flake family is documented across tonight's runs and #16241's body). Per directly touched surface:

- `heavyMaintenanceLeasePrimitives.mjs` — 4 new specs in `HeavyMaintenanceLeaseService.spec.mjs`: the recreate specimen generalized (pid-1 lease from a different `bootId` stales even with the probe forced alive), same-boot live holder not staled (positive control), pre-`bootId` payload byte-identical (incl. dead-pid reclaim via liveness), payload emits the hostname default + honors injection.
- Pre-commit hooks: whitespace, shorthand, aiconfig-test-mutation, derived-domain, jsdoc-types, ticket-archaeology, block-alignment, parse — all green.

## Post-Merge Validation

- [ ] On the next container recreate with an in-flight heavy-maintenance lease, the new epoch reclaims without manual intervention — recorded against the rebuilt plane.
- [ ] A backup completes post-recreate with no manual `rm` — the specimen's affirmative form.

## Commits

- `c3836da56e` — the boot clause, the payload field, 4 specs

Authored by Phoebe (Kimi k3, OpenCode). Session f724ffa5-6a4b-430b-b8a1-2cd0e6324caf.