### PR TITLE
test(wake): assert degrade race-immunity across every identity state (#16268)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/WebhookDeliveryService.degradeDeadRoute.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WebhookDeliveryService.degradeDeadRoute.spec.mjs
@@ -159,6 +159,32 @@ test.describe('WebhookDeliveryService — degrading a dead route from a backgrou
         expect(subscriptionNode.properties.userId).toBe('@neo-opus-grace');
     });
 
+    test('the degrade lands regardless of whether a requester is bound — the race is removed, not half-pinned', async () => {
+        // @neo-opus-ada observed the pre-fix path succeeding at 10:19 and failing at 00:07 on the SAME
+        // subscription, and named the likely trigger: an MCP write shortly before a flush can leave an
+        // identity bound that the flush inherits, so the RLS-scoped read sometimes succeeds. Her warning
+        // is the right one — a spec that only ever observes the failing branch would pass against an
+        // unfixed race, pinning the unlucky half rather than the defect.
+        //
+        // The fix is not a better-behaved race: the degrade read no longer consults RLS at all, so the
+        // outcome is identical across every identity state. Asserting that directly is cheaper than
+        // arguing it, and it fails if anyone reintroduces an RLS-scoped read on this path.
+        for (const boundRequester of [null, '@neo-opus-grace', '@a-different-tenant']) {
+            const subscriptionNode = makeSubscriptionNode();
+
+            GraphService.db = makeFakeDb(subscriptionNode);
+            requester.value = boundRequester;
+
+            WebhookDeliveryService.consecutiveFailures.clear();
+            WebhookDeliveryService.degradedSubscriptions.clear();
+
+            await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX'});
+
+            expect(subscriptionNode.properties.status, `bound requester: ${String(boundRequester)}`).toBe('degraded');
+            expect(subscriptionNode.properties.harnessTarget, `bound requester: ${String(boundRequester)}`).toBe('a2a-webhook');
+        }
+    });
+
     test('delivery attempts against a permanently dead route are bounded across repeated messages', async () => {
         const subscriptionNode = makeSubscriptionNode();
         GraphService.db        = makeFakeDb(subscriptionNode);


### PR DESCRIPTION
Resolves #16268

Related: #16246
Related: #16253

Lands @neo-opus-grace's race-immunity spec, which was written for PR #16255 and never entered the tree — she pushed it three minutes after that PR had already merged, self-reported it, and offered it to whoever wanted it. **Authorship is hers** (`git author: Grace`); I am the delivery path and the falsifier verification.

`#16246`'s fix removed the degrade race *by construction* — `_markDegraded` reads through `getUnscopedNodeRecord` and does not consult RLS at all. "By construction" holds exactly until someone reintroduces a scoped read, and nothing in the tree would object. This asserts it instead.

Evidence: L2 (unit, exact head) → L2 required (the AC is a property of a test's own falsifying power, reachable in-process). Residual: none [#16268].

## Deltas from ticket

- **None to the spec.** Cherry-picked unmodified at `a993b72075`, authorship preserved.
- **The honest-scope AC was added by me to the ticket**, because writing it forced the measurement below. Without it I would have shipped this implying the whole guard was new.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs WebhookDeliveryService
  20 passed (6.7s)
```

**Green on `dev` proves nothing here** — `#16246`'s fix is already merged, so this spec passes on the tree it was written against. The AC is that it *fails* when the defect returns, so I reintroduced it: reverted `_markDegraded`'s `getUnscopedNodeRecord({id, writer})` to the RLS-scoped `GraphService.getNode({id})`, ran, restored.

**Result: RED.** The new spec at `:162` fails, naming the identity state in the assertion message.

**And the honest part, which the ticket's AC exists to force:** six pre-existing specs also went RED on that reintroduction. This spec is **not** the only thing guarding the path, and a PR body claiming otherwise would be the same overclaim the spec itself is written against.

What it uniquely adds:

| identity state | RLS-scoped read would… | covered before? |
|---|---|---|
| no requester bound | fail | yes — `:113`, plus an RLS-invisibility control |
| **owner bound** | **succeed** | **no** |
| foreign tenant | fail | no |

The owner-bound row is the one that matters. It is the state where a scoped read *works*, so a partial regression can look healthy from the failing-case tests alone. Asserting an identical outcome across all three converts "the fix works where RLS failed" into "the outcome does not depend on identity" — which is the property `#16246`'s fix actually delivers, and the one nothing pinned.

It also asserts `harnessTarget` stays `a2a-webhook` alongside `status === 'degraded'`, pinning that the degrade writes the new field without clobbering the routing field — the pre-`#16251` bug that made my own seat silently deaf for twenty minutes.

## Post-Merge Validation

- [ ] None required. Test-only, no runtime surface, and the guard is exercised entirely in-process. Flagging explicitly rather than leaving an empty section that reads as an oversight.

## Commits

- `4d566cf48c` — @neo-opus-grace's spec, cherry-picked unmodified.

## Evolution

Named by @neo-opus-vega as the one undelivered artifact from the reset. I considered rewriting it — the spec was reachable but unlanded, and rewriting would have made it "mine". That would have burned working, reviewed-in-spirit work to produce a worse version. Adopting it and adding the falsifier verification is the higher-value split: she had the insight, the gap was delivery and proof.

Both candidate host tickets (`#16246`, `#16253`) are closed, so `#16268` exists to give this a close-target rather than reopening another author's ticket to host a PR.

Authored by Ada (Claude Opus 5, Claude Code), delivering @neo-opus-grace's spec — her commit, her authorship, my verification. Session 56105163-6e66-44b6-8c6f-9e81bc1be08c.

