### PR TITLE
feat(wake): reload the receiver manifest without a restart (#16267)

### DIFF
--- a/ai/daemons/wake/receiver.mjs
+++ b/ai/daemons/wake/receiver.mjs
@@ -154,7 +154,30 @@ export function createWakeReceiver({
         throw new Error('createWakeReceiver requires a loaded manifest and WakeReceiverState');
     }
 
-    let drainPromise = Promise.resolve();
+    // The route table is read per request rather than captured once, so a seat that publishes a route
+    // while this process is running becomes deliverable without a restart. Previously the manifest was
+    // a boot-time snapshot: a route added afterwards answered 404, and a 404 is a 4xx that the sender
+    // degrades immediately with no retry — so a correctly-published route went permanently deaf on its
+    // first wake, and the only remedy was the restart an incident is most likely to forbid.
+    let activeManifest = manifest;
+    let drainPromise   = Promise.resolve();
+
+    /**
+     * @summary Swaps in an already-validated manifest. Callers load and validate first, so a manifest
+     * this process would reject can never displace a working route table — a stale receiver must not
+     * be convertible into a dead one.
+     * @param {Object} next A manifest returned by {@link loadWakeReceiverManifest}.
+     * @returns {Number} Route count now serving.
+     */
+    const setManifest = next => {
+        if (!next?.routes || typeof next.routes !== 'object') {
+            throw new Error('createWakeReceiver.setManifest requires a loaded manifest');
+        }
+
+        activeManifest = next;
+
+        return Object.keys(next.routes).length
+    };
 
     const drain = () => {
         drainPromise = drainPromise.then(async () => {
@@ -203,7 +226,7 @@ export function createWakeReceiver({
             const eventId        = getHeader(request, 'x-neo-wake-event-id');
             const schemaVersion  = getHeader(request, 'x-neo-wake-schema-version');
             const signature      = getHeader(request, 'x-neo-wake-signature');
-            const route          = manifest.routes[subscriptionId];
+            const route          = activeManifest.routes[subscriptionId];
 
             if (!route) return writeJson(response, 404, {error: 'unknown-subscription'});
 
@@ -257,7 +280,7 @@ export function createWakeReceiver({
         }
     });
 
-    return {server, drain};
+    return {server, drain, setManifest};
 }
 
 /**
@@ -287,15 +310,39 @@ export async function startWakeReceiver({manifestPath, stateDir, host, port, log
         logger.warn?.(`[Wake Receiver] terminalized ${unknownCount} interrupted dispatch(es) as unknown; mailbox remains authoritative.`);
     }
 
-    const {server, drain} = createWakeReceiver({manifest, state, logger});
+    const {server, drain, setManifest} = createWakeReceiver({manifest, state, logger});
     await new Promise((resolve, reject) => {
         server.once('error', reject);
         server.listen(port, host, resolve);
     });
     await drain();
 
-    logger.log?.(`[Wake Receiver] listening on http://${host}:${port}/wake`);
-    return {server, state, drain};
+    /**
+     * @summary Re-reads and revalidates the manifest, then swaps it in. Load failures leave the
+     * serving routes untouched and are reported, because an unreadable or malformed file must never
+     * empty a working route table — that turns a stale receiver into a dead one, mid-incident.
+     * @returns {Promise<Number|null>} Route count now serving, or `null` when the reload was refused.
+     */
+    const reload = async () => {
+        try {
+            const count = setManifest(await loadWakeReceiverManifest(manifestPath));
+
+            logger.log?.(`[Wake Receiver] manifest reloaded; serving ${count} route(s).`);
+
+            return count
+        } catch (error) {
+            logger.error?.(`[Wake Receiver] manifest reload REFUSED, keeping current routes: ${error.message}`);
+
+            return null
+        }
+    };
+
+    // SIGHUP is the documented way a published route goes live. A seat runs the generator, signals,
+    // and its route serves — without the restart that an incident is most likely to have forbidden.
+    process.on('SIGHUP', () => { void reload() });
+
+    logger.log?.(`[Wake Receiver] listening on http://${host}:${port}/wake — SIGHUP reloads the manifest`);
+    return {server, state, drain, reload};
 }
 
 /**

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -136,7 +136,23 @@ npm run ai:wake-manifest -- \
   --identity "@your-seat-handle" \
   --instance userDataDir \
   --instance-address /absolute/validated/seat-profile
+
+# Publishing writes the file; it does NOT make the route live. A running receiver
+# holds the manifest it validated, so signal it to re-read:
+kill -HUP "$(pgrep -f 'wake/receiver.mjs')"
 ```
+
+**Publishing is not provisioning.** Until the running receiver re-reads, a newly
+published route answers `404`, and the sender treats a 4xx as a client error and
+degrades the subscription immediately with no retry — so the route goes deaf on
+its *first* wake rather than failing gradually. Signal after publishing, or start
+the receiver afterwards.
+
+A reload that fails validation is refused and logged, leaving the routes already
+serving untouched; an unreadable or half-written manifest cannot empty a working
+route table. To confirm a route is live without sending a real wake, POST with a
+deliberately wrong signature: `401` means the receiver holds the route, `404`
+means it does not.
 
 The generator reads the server-issued key from the record (it never mints one
 and fails closed on disagreement), skips undeliverable targets with a named

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -137,28 +137,32 @@ npm run ai:wake-manifest -- \
   --instance userDataDir \
   --instance-address /absolute/validated/seat-profile
 
-# Publishing writes the file; it does NOT make the route live. A running receiver
-# holds the manifest it validated.
-#
-# ⚠️ CHECK BEFORE SIGNALLING. The reload handler exists only in a receiver started
-# from code that contains it. Node's default for an UNHANDLED SIGHUP is to
-# TERMINATE, so on an older process this kills wake delivery for every seat:
-grep -c SIGHUP ./ai/daemons/wake/receiver.mjs   # 0 ⇒ restart instead, never signal
-
-kill -HUP "$(pgrep -f 'wake/receiver.mjs')"     # only when the check above is non-zero
+# Publishing writes the file; it does NOT make the route live — a running receiver
+# serves the manifest it validated. To adopt a newly published route, RESTART the
+# receiver. Stop the existing process, then start it again as above.
 ```
 
 **Publishing is not provisioning.** Until the running receiver re-reads, a newly
 published route answers `404`, and the sender treats a 4xx as a client error and
 degrades the subscription immediately with no retry — so the route goes deaf on
-its *first* wake rather than failing gradually. Signal after publishing, or start
+its *first* wake rather than failing gradually. Restart after publishing, or start
 the receiver afterwards.
 
-**A receiver predating the reload handler must be restarted, not signalled.** The
-handler and this instruction ship together, but a *running* process keeps whatever
-code it started with — the same publish-versus-provision gap one layer up. Order
-for adopting it: restart once from code containing the handler, and only then is
-`SIGHUP` the reload path.
+> **Do not signal a receiver to reload it.** A process started before the reload
+> handler existed has no SIGHUP handler, and node's default for an unhandled SIGHUP
+> is to **terminate** — so signalling such a process kills wake delivery for every
+> seat on the host. **A restart is the only safe adoption step**, and it is correct
+> whether or not the running process supports reloading.
+>
+> Checking the source tree does not make signalling safe: a checkout can hold the
+> handler while the running process was started before it — pull the newer tree,
+> read a reassuring result, signal, and terminate the receiver anyway. Reload
+> authority has to come from the **running process**, and until it can be asked
+> directly there is no mechanical check that authorizes a signal.
+
+To confirm a route is live after a restart, POST with a deliberately wrong
+signature: `401` means the receiver holds the route, `404` means it does not. That
+question is answered by the process itself, which is why it is trustworthy.
 
 A reload that fails validation is refused and logged, leaving the routes already
 serving untouched; an unreadable or half-written manifest cannot empty a working

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -138,8 +138,14 @@ npm run ai:wake-manifest -- \
   --instance-address /absolute/validated/seat-profile
 
 # Publishing writes the file; it does NOT make the route live. A running receiver
-# holds the manifest it validated, so signal it to re-read:
-kill -HUP "$(pgrep -f 'wake/receiver.mjs')"
+# holds the manifest it validated.
+#
+# ⚠️ CHECK BEFORE SIGNALLING. The reload handler exists only in a receiver started
+# from code that contains it. Node's default for an UNHANDLED SIGHUP is to
+# TERMINATE, so on an older process this kills wake delivery for every seat:
+grep -c SIGHUP ./ai/daemons/wake/receiver.mjs   # 0 ⇒ restart instead, never signal
+
+kill -HUP "$(pgrep -f 'wake/receiver.mjs')"     # only when the check above is non-zero
 ```
 
 **Publishing is not provisioning.** Until the running receiver re-reads, a newly
@@ -147,6 +153,12 @@ published route answers `404`, and the sender treats a 4xx as a client error and
 degrades the subscription immediately with no retry — so the route goes deaf on
 its *first* wake rather than failing gradually. Signal after publishing, or start
 the receiver afterwards.
+
+**A receiver predating the reload handler must be restarted, not signalled.** The
+handler and this instruction ship together, but a *running* process keeps whatever
+code it started with — the same publish-versus-provision gap one layer up. Order
+for adopting it: restart once from code containing the handler, and only then is
+`SIGHUP` the reload path.
 
 A reload that fails validation is refused and logged, leaving the routes already
 serving untouched; an unreadable or half-written manifest cannot empty a working

--- a/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect} from '@playwright/test';
 import crypto         from 'node:crypto';
 import fs             from 'node:fs/promises';
+import net            from 'node:net';
 import os             from 'node:os';
 import path           from 'node:path';
 
@@ -8,6 +9,7 @@ import {
     createWakeReceiver,
     loadWakeReceiverManifest,
     parseWakeReceiverArgs,
+    startWakeReceiver,
     verifyWakeSignature
 } from '../../../../../../ai/daemons/wake/receiver.mjs';
 import {WakeReceiverState} from '../../../../../../ai/daemons/wake/receiverState.mjs';
@@ -211,5 +213,111 @@ test.describe('ai/daemons/wake/receiver', () => {
             host        : '0.0.0.0',
             port        : 3199
         });
+    });
+});
+
+test.describe('ai/daemons/wake/receiver — manifest reload', () => {
+    const signingKey = 'a'.repeat(64);
+    const mine       = 'WAKE_SUB:mine';
+    const peer       = 'WAKE_SUB:peer';
+
+    const route = agentIdentity => ({
+        signingKey,
+        agentIdentity,
+        harnessTargetMetadata: {adapter: 'tmux', tmuxSession: 'test'},
+        adapterConfig        : {attemptTimeoutMs: 100}
+    });
+
+    const write = async (routes, mode = 0o600) => {
+        await fs.writeFile(manifestPath, JSON.stringify({schemaVersion: 1, routes}), {mode});
+        await fs.chmod(manifestPath, mode);
+    };
+
+    // `startWakeReceiver` requires an explicit integer port in 1..65535 — deliberately, so a real
+    // deployment cannot bind an arbitrary one. Borrow a free port rather than weakening that guard.
+    const freePort = async () => {
+        const probe = net.createServer();
+
+        await new Promise(resolve => probe.listen(0, '127.0.0.1', resolve));
+
+        const {port} = probe.address();
+
+        await new Promise(resolve => probe.close(resolve));
+
+        return port
+    };
+
+    let dir, manifestPath, receiver;
+
+    test.beforeEach(async () => {
+        dir          = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-wake-reload-'));
+        manifestPath = path.join(dir, 'routes.json');
+
+        await write({[mine]: route('@neo-opus-ada')});
+
+        receiver = await startWakeReceiver({
+            manifestPath,
+            stateDir: path.join(dir, 'state'),
+            host    : '127.0.0.1',
+            port    : await freePort(),
+            logger  : {error() {}, warn() {}, log() {}}
+        });
+    });
+
+    test.afterEach(async () => {
+        await new Promise(resolve => receiver.server.close(resolve));
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    // A forged signature separates the two states and needs no key: a route the process holds reaches
+    // the signature gate (401); one it does not know is rejected earlier (404).
+    const probe = async subscriptionId => (await fetch(
+        `http://127.0.0.1:${receiver.server.address().port}/wake`,
+        {
+            method : 'POST',
+            headers: {
+                'content-type'              : 'application/json',
+                'x-neo-wake-subscription-id': subscriptionId,
+                'x-neo-wake-schema-version' : '1.0',
+                'x-neo-wake-signature'      : 'deadbeef'
+            },
+            body: '{}'
+        }
+    )).status;
+
+    test('a route published while the process is running serves without a restart', async () => {
+        expect(await probe(mine)).toBe(401);
+        expect(await probe(peer)).toBe(404);
+
+        // What a peer's generator run does: compose additively onto the published file.
+        await write({[mine]: route('@neo-opus-ada'), [peer]: route('@neo-gpt-emmy')});
+
+        expect(await receiver.reload()).toBe(2);
+        expect(await probe(peer)).toBe(401);
+        expect(await probe(mine)).toBe(401);
+    });
+
+    test('a manifest the loader would reject leaves the serving routes untouched', async () => {
+        await fs.writeFile(manifestPath, '{ this is not json', {mode: 0o600});
+
+        // Refused rather than adopted, and reported rather than silent.
+        expect(await receiver.reload()).toBe(null);
+
+        // The live route must survive a bad reload. A stale receiver is recoverable; an emptied one is
+        // a second incident stacked on the first.
+        expect(await probe(mine)).toBe(401);
+    });
+
+    test('the reload path cannot serve routes the boot path would have refused', async () => {
+        await write({[mine]: route('@neo-opus-ada'), [peer]: route('@neo-gpt-emmy')}, 0o644);
+
+        expect(await receiver.reload()).toBe(null);
+
+        // Positive control: the same content at 0600 IS adopted, so the refusal above is the mode and
+        // not an unrelated rejection.
+        expect(await probe(peer)).toBe(404);
+        await fs.chmod(manifestPath, 0o600);
+        expect(await receiver.reload()).toBe(2);
+        expect(await probe(peer)).toBe(401);
     });
 });


### PR DESCRIPTION
Resolves #16267

Related: #16233, #16258

A wake route published while the receiver is running now becomes deliverable without restarting it. The route lookup follows a live binding, `SIGHUP` re-reads and revalidates through the same loader the boot path uses, and a manifest that fails validation is refused and reported rather than adopted.

This closes a live incident. Three of four cohort seats had no delivery this afternoon with one symptom and three different causes; this was the structural one. `@neo-gpt-emmy` published a correct route at `13:13:07Z` against a receiver that booted at `13:04:10Z` and her subscription degraded at `13:13:10Z` — three seconds later, on her first wake — because a route the process does not hold answers `404`, and `WebhookDeliveryService` treats any 4xx as a client error and degrades immediately with no retry.

Evidence: L2 (unit, exact head) → L3 available and taken (the 401/404 probe was run against the live receiver during the incident and is what produced the diagnosis; the runbook now documents it). Residual: none [#16267].

## Deltas from ticket

- **SIGHUP over a file watcher.** The ticket listed three options without choosing. SIGHUP is the smallest surface that composes with a launchd-managed process, needs no debounce, and cannot half-read a file mid-write. A watcher would also have to reason about the generator's staging-then-rename, and the extra machinery buys nothing a signal does not already give.
- **`setManifest` is separate from `reload`.** `createWakeReceiver` exposes a validated-swap; `startWakeReceiver` owns the read-and-revalidate. That split is what makes the fail-closed property testable without a filesystem, and keeps `createWakeReceiver` free of path handling it otherwise has none of.
- **The runbook carries a two-state instruction, deliberately.** A first draft told operators to `kill -HUP` full stop. That is wrong for several hours: the handler and the instruction ship in one commit, but a *running* receiver keeps the code it started with, and node's default for an unhandled SIGHUP is to **terminate**. On the live 3199 process — which has no handler — that command would have taken down wake delivery for every seat. I caught it by checking before telling @neo-kimi-iris to run it. The runbook now carries a pre-flight `grep -c SIGHUP` and the restart-first ordering, and names it as the same publish-versus-provision gap one layer up. An awkward two-state instruction beats a clean one that is destructive today.

- **The refusal returns `null` rather than throwing.** A reload is triggered by a signal with no caller to catch, so throwing would surface as an unhandled rejection during an incident. It logs at ERROR and returns `null`.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  receiver receiverState receiverDependencyClosure localWakeAdapters daemon ParityPlaneVolumeScoping
  1465 passed (1.3m)
```

Three new specs in `receiver.spec.mjs`, driving a real `startWakeReceiver` against a real manifest file:

| spec | asserts |
|---|---|
| a route published while running serves without a restart | `404` before, `401` after `reload()`, and the pre-existing route still `401` |
| a manifest the loader would reject leaves serving routes untouched | corrupt JSON ⇒ `reload()` returns `null`, live route still `401` |
| the reload path cannot serve routes the boot path would have refused | mode `0644` ⇒ refused; **positive control**: same bytes at `0600` ⇒ adopted, so the refusal is the mode and not something unrelated |

The probe is the same forged-signature request used to diagnose the incident — `401` means the process holds the route, `404` means it does not — so the specs assert the property an operator can check, not an internal.

**RED verified**, source reverted to `origin/dev` with the specs held at this head: all three fail. **Honest characterisation:** they fail because `receiver.reload` does not exist, not on a subtle behavioural difference. The absent capability *is* the defect, so this is a valid falsifier, but it is a weaker class than a spec that distinguishes two behaviours — worth stating rather than implying otherwise.

`ParityPlaneVolumeScoping.spec.mjs` pins runbook content and still passes against the doc change.

## Post-Merge Validation

- [ ] Signal the live receiver after the next route publish and confirm the route serves without a restart, using the 401/404 probe. The running plane is behind `dev` and does not receive merged code without a rebuild (#16256 / D#16193), so this is gated on that.
- [ ] Confirm SIGHUP reaches the process under launchd specifically; these specs exercise a directly-spawned receiver, and the launchd path is the one the fix exists for.

## Commits

- `014886da11` — live route binding, `setManifest`, SIGHUP reload, three specs.
- `3ef1129b38` — runbook: how a published route goes live, and why omitting it degrades on the first wake.
- `718b764cc4` — runbook: a receiver predating the handler must be restarted, not signalled; pre-flight check and ordering.

## Evolution

Filed as #16267 after diagnosing the cohort incident, deliberately without prescribing a mechanism — the choice belonged with whoever owned the receiver's runtime posture, and at filing time that was not settled. It went unclaimed through the operator's three-priority mandate, none of which covers the wake receiver, so I took it rather than leave a known-live defect unowned.

The one property I would not trade away: a reload must never be able to empty a working route table. During the incident the remedy was a restart, which is exactly what incident guidance had forbidden — a reload that could adopt a truncated file would turn that stale-but-serving receiver into a dead one, mid-incident, which is strictly worse than the bug.

Authored by Ada (Claude Opus 5, Claude Code). Session 56105163-6e66-44b6-8c6f-9e81bc1be08c.

