### PR TITLE
fix(memory-core): persist hydrated broadcast receipts (#15825)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -287,7 +287,7 @@ function getRecordProperties(record) {
 
 function setRecordProperties(record, properties) {
     if (record?.isRecord) {
-        record.set('properties', properties);
+        record.set({properties});
     } else if (record) {
         record.properties = properties;
     }

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.ReceiptDurability.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.ReceiptDurability.spec.mjs
@@ -189,6 +189,23 @@ test.describe('MailboxService — receipt durability cannot outrun the durable w
         expect(propertiesOf(readReceiptFromStorage(messageId, RECIPIENT)).readAt).toBe(receipt.readAt);
     });
 
+    test('a hydrated broadcast carrier persists its read state to storage', async () => {
+        // Wake-subscription evaluation resolves delivery edges through Store#get(), which turns
+        // their raw graph rows into Neo records before mark_read sees them. Exercise that live
+        // representation explicitly: the raw-object setter path alone cannot prove this branch.
+        const messageId = await sendBroadcast('durability: hydrated broadcast carrier');
+        const stored    = readReceiptFromStorage(messageId, RECIPIENT);
+        const edgeId    = stored?.id ?? stored?.data?.id;
+        const hydrated  = GraphService.db.edges.get(edgeId);
+
+        expect(hydrated?.isRecord).toBe(true);
+
+        const receipt = await asRecipient(() => MailboxService.markRead({messageId}));
+
+        expect(receipt.status).toBe('read');
+        expect(propertiesOf(readReceiptFromStorage(messageId, RECIPIENT)).readAt).toBe(receipt.readAt);
+    });
+
     test('with NO storage the receipt degrades honestly instead of asserting persistence', async () => {
         // The one state where the write genuinely cannot run. Previously indistinguishable from
         // success; now the caller is told, so a false ack is impossible rather than merely unlikely.


### PR DESCRIPTION
Resolves #15825

Broadcast `mark_read` and `archive_message` now persist when the recipient `DELIVERED_TO` carrier has been hydrated into a Neo record. The record branch used the unsupported two-argument setter shape, so storage rewrote the unchanged `readAt: null` carrier while reporting success; it now uses the record API's object shape.

Evidence: L2 (RED/GREEN SQLite carrier readback on a hydrated `EdgeModel`) → L2 required (the fix control must read from storage, not the in-memory cache). No residuals.

## Deltas from ticket

- The live trigger is wake-subscription evaluation hydrating delivery edges through `Store#get()` before mailbox receipt mutation.
- The existing raw-object tests remain intact; the new control forces the production record representation and proves the exact storage row changes.
- No receipt schema, MCP surface, or wake-receiver behavior changes.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.ReceiptDurability.spec.mjs` — RED with SQLite `readAt: null` before the fix; GREEN, 12/12 after it.
- Receipt durability + carrier classifier/probe + graph-replace preservation matrix — 39/39 passed.
- `npm run agent-preflight -- --change-class restoration --commit-subject "fix(memory-core): persist hydrated broadcast receipts (#15825)" ...` — passed.
- Directly touched surface: Memory Core mailbox receipt persistence — storage-backed unit coverage above.

## Post-Merge Validation

- [ ] After the updated Memory Core image is deployed, mark one broadcast read and confirm `inspect_deployment.mailboxReadState` reports the recipient carrier as `read`.
- [ ] Confirm a subsequent one-message wake does not re-count the already-read broadcast backlog.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fb600-58b9-7fa2-86a7-5a15e1ccf659.
