### PR TITLE
fix(memory-core): keep hydrated edge cache coherent (#16273)

### DIFF
--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -607,7 +607,7 @@ class GraphService extends Base {
                 if (ramEdge) {
                     if (ramEdge.isRecord) {
                         const newProps = { ...(ramEdge.get('properties') || {}), ...edgeProperties, weight: newWeight };
-                        ramEdge.set('properties', newProps);
+                        ramEdge.set({properties: newProps});
                     } else {
                         ramEdge.properties.weight = newWeight;
                         Object.assign(ramEdge.properties, edgeProperties);

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -140,6 +140,36 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(task2.weight).toBe(0.8);
     });
 
+    test('linkNodes keeps a hydrated existing-edge record coherent with SQLite on relink (#16273)', async () => {
+        await GraphService.upsertNode({id: 'RelinkSource', type: 'TEST_NODE'});
+        await GraphService.upsertNode({id: 'RelinkTarget', type: 'TEST_NODE'});
+        GraphService.linkNodes('RelinkSource', 'RelinkTarget', 'RELATES_TO', 1, {phase: 'initial'});
+
+        const selectEdge = GraphService.db.storage.db.prepare(`
+            SELECT id, data
+            FROM Edges
+            WHERE source = ?
+              AND target = ?
+              AND type = ?
+        `);
+        const initialRow = selectEdge.get('RelinkSource', 'RelinkTarget', 'RELATES_TO');
+        const cachedEdge = GraphService.db.edges.get(initialRow.id);
+
+        expect(cachedEdge.isRecord).toBe(true);
+        expect(cachedEdge.get('properties')).toMatchObject({phase: 'initial', weight: 1});
+
+        GraphService.linkNodes('RelinkSource', 'RelinkTarget', 'RELATES_TO', 2, {phase: 'updated'});
+
+        const storedProperties = JSON.parse(
+            selectEdge.get('RelinkSource', 'RelinkTarget', 'RELATES_TO').data
+        ).properties;
+
+        expect(storedProperties).toMatchObject({phase: 'updated'});
+        expect(storedProperties.weight).toBeCloseTo(1.2);
+        expect(GraphService.db.edges.get(initialRow.id)).toBe(cachedEdge);
+        expect(cachedEdge.get('properties')).toEqual(storedProperties);
+    });
+
     test('removeNodes rejects invalid node ids before Database.removeNode null path (#11698)', async () => {
         expect(() => GraphService.removeNodes([null])).toThrow(/invalid node id/);
         expect(() => GraphService.removeNodes(['ValidNode', undefined])).toThrow(/invalid node id/);


### PR DESCRIPTION
Resolves #16273

`GraphService.linkNodes()` now updates hydrated edge Records through the object-shaped setter, keeping the active RAM object identical to SQLite after a relink. The regression hydrates the edge first, changes its weight and metadata, then proves durable/cache parity without replacing the Record.

Evidence: L2 (real SQLite plus hydrated-Record unit regression) → L2 required (all close-target ACs are internal runtime behavior covered by the focused spec). No residuals.

## Deltas from ticket

None substantive.

## Test Evidence

- RED: focused regression failed with SQLite `{phase: "updated", weight: 1.2}` versus cached `{phase: "initial", weight: 1}`.
- GREEN: focused regression — 3/3 passed including Chroma setup/teardown.
- `GraphService.spec.mjs` — 51/51 passed.
- Full `npm run test-unit` — 10,624 passed; 24 unrelated host/sandbox failures outside the touched surface, 5 skipped, 39 did not run.
- Touched surface: GraphService relink/cache coherence — covered by the storage-backed regression above.

## Post-Merge Validation

- [ ] GitHub CI passes on the PR head.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fb600-58b9-7fa2-86a7-5a15e1ccf659.
