### PR TITLE
feat(buildscripts): warn when a push reaches no pull request (#16256)

### DIFF
--- a/buildScripts/util/check-branch-discipline.mjs
+++ b/buildScripts/util/check-branch-discipline.mjs
@@ -3,6 +3,7 @@ import process                                          from 'node:process';
 import path                                             from 'node:path';
 import { fileURLToPath }                                from 'node:url';
 import {assessDevReferenceAuthority, detectStaleBranch} from './branchFreshness.mjs';
+import {assessMergedPullRequestPush}                    from './mergedPullRequestPush.mjs';
 
 /**
  * Pre-push branch-discipline check (#11133). ticket-ref-ok: implementing ticket
@@ -23,6 +24,16 @@ import {assessDevReferenceAuthority, detectStaleBranch} from './branchFreshness.
  * commits whose subject matches `^chore\(data\):.*(sync|pipeline)` (case-insensitive),
  * block push with remediation guidance. Designated sync branches (`chore/sync-*` /
  * `agent/sync-*`) are exempt. Bypass: `git push --no-verify`.
+ *
+ * **Branch freshness (advisory).** Warns on the revert-trap when the two-dot diff carries
+ * files that are not this branch's changes. Predicate: `branchFreshness.detectStaleBranch`.
+ *
+ * **Pushes that reach no pull request (advisory).** Warns when the branch's most
+ * recent pull request has already merged and the local head carries commits that pull request
+ * never contained. Such a push succeeds — the ref advances — while no pull request adopts the
+ * commit and no CI runs on it, so every check the author performs reports success. Resolving
+ * the pull-request state needs the network, so this check fails toward pushing at every
+ * unresolvable step. Predicate: `mergedPullRequestPush.assessMergedPullRequestPush`.
  *
  * **NOT implemented in this initial cut** (per ticket Out of Scope; deferred as
  * follow-ups if the simpler regex doesn't converge the empirical pattern):
@@ -238,6 +249,62 @@ if (freshness.stale) {
     console.warn(`\x1b[33mWarning: Branch '${branch}' looks stale against origin/dev — ${freshness.extraFiles} files in the two-dot diff are not your changes (origin/dev has advanced).\x1b[0m`);
     console.warn('A PR from this branch may show a misleading diff or revert merged peer work (the revert-trap).');
     console.warn('Recommended: git rebase origin/dev   (or cherry-pick your commits onto a fresh branch off origin/dev)');
+    console.warn('This is advisory — the push proceeds.');
+}
+
+// Merged-pull-request check: warn when this push carries commits no pull request will adopt —
+// the branch's latest PR already merged, so the ref advances while nothing listens and no CI
+// runs. Advisory (warn, exit 0). Predicate: ./mergedPullRequestPush.mjs.
+//
+// Every resolution step below yields null on failure so the predicate stays silent: this needs
+// the network, and an author who is offline, unauthenticated, or rate-limited must still push.
+const readGitStatus = (args) => {
+    try {
+        execFileSync('git', args, {cwd: gitRoot, encoding: 'utf-8', stdio: 'pipe'});
+        return 0
+    } catch (e) {
+        // Exit 1 is a real "no"; anything else (128 = missing object, spawn failure) is "unknown".
+        return e?.status === 1 ? 1 : null
+    }
+};
+
+const headSha = (() => {
+    try {
+        return execFileSync('git', ['rev-parse', 'HEAD'], {cwd: gitRoot, encoding: 'utf-8', stdio: 'pipe'}).trim()
+    } catch (e) {
+        return null
+    }
+})();
+
+const latestPullRequest = (() => {
+    try {
+        const output = execFileSync('gh', [
+            'pr', 'list',
+            '--head'  , branch,
+            '--state' , 'all',
+            '--limit' , '1',
+            '--json'  , 'number,state,mergedAt,headRefOid'
+        ], {cwd: gitRoot, encoding: 'utf-8', stdio: 'pipe', timeout: 10000});
+
+        const parsed = JSON.parse(output);
+        return Array.isArray(parsed) && parsed.length > 0 ? parsed[0] : null
+    } catch (e) {
+        return null
+    }
+})();
+
+const containmentStatus   = headSha ? readGitStatus(['merge-base', '--is-ancestor', headSha, 'origin/dev']) : null;
+const headContainedInBase = containmentStatus === null ? null : containmentStatus === 0;
+
+const unreached = assessMergedPullRequestPush({pullRequest: latestPullRequest, headSha, headContainedInBase});
+
+if (unreached.warn) {
+    console.warn(`\x1b[33mWarning: PR #${latestPullRequest.number} for branch '${branch}' merged at ${latestPullRequest.mergedAt}.\x1b[0m`);
+    console.warn(`A merged pull request accepts no further commits, so ${headSha.slice(0, 9)} reaches no PR and no CI — the ref advances and nothing listens.`);
+    console.warn(`Your work is not lost: it is on '${branch}', it is simply in no pull request.`);
+    console.warn('Remediation: open a follow-up ticket, then carry the commits onto a fresh branch.');
+    console.warn('  git checkout -b <agent>/<ticket-id>-<slug> origin/dev');
+    console.warn(`  git cherry-pick ${headSha.slice(0, 9)}          # your commits beyond the merged PR`);
     console.warn('This is advisory — the push proceeds.');
 }
 

--- a/buildScripts/util/check-branch-discipline.mjs
+++ b/buildScripts/util/check-branch-discipline.mjs
@@ -303,8 +303,9 @@ if (unreached.warn) {
     console.warn(`A merged pull request accepts no further commits, so ${headSha.slice(0, 9)} reaches no PR and no CI — the ref advances and nothing listens.`);
     console.warn(`Your work is not lost: it is on '${branch}', it is simply in no pull request.`);
     console.warn('Remediation: open a follow-up ticket, then carry the commits onto a fresh branch.');
+    console.warn('  git log --oneline origin/dev..HEAD    # inspect first — there may be more than one');
     console.warn('  git checkout -b <agent>/<ticket-id>-<slug> origin/dev');
-    console.warn(`  git cherry-pick ${headSha.slice(0, 9)}          # your commits beyond the merged PR`);
+    console.warn('  git cherry-pick <each commit the merged PR did not carry>');
     console.warn('This is advisory — the push proceeds.');
 }
 

--- a/buildScripts/util/mergedPullRequestPush.mjs
+++ b/buildScripts/util/mergedPullRequestPush.mjs
@@ -1,0 +1,94 @@
+/**
+ * @summary Pure predicate for the pre-push merged-pull-request guard.
+ *
+ * Detects the signature of a push that **succeeds and reaches nothing**: the branch's most
+ * recent pull request has already merged, so the ref advances server-side while no pull
+ * request adopts the commit and no CI ever runs on it. Every ref-level instrument reports
+ * success, which is precisely why this wants a mechanical check rather than a rule — the
+ * author's `git push`, `git ls-remote`, and `gh pr checks` all return true answers to a
+ * question they were not being asked.
+ *
+ * Kept pure and side-effect-free so it is unit-testable without executing the pre-push hook
+ * or reaching GitHub; the hook resolves the live pull-request state and owns the warn
+ * behaviour, mirroring the split already used by {@link ./branchFreshness.mjs}.
+ *
+ * **Why the comparison is `headRefOid` and not the merge commit.** A pull request's merge
+ * commit lives on the base line, and under squash-merge it shares no ancestry with the head
+ * branch, so `base..HEAD` ancestry answers a different question. The head coordinate is the
+ * pull request's own `headRefOid` — the last commit the pull request contained. It is compared
+ * **as a string, never with `git merge-base`**: after a merge (and any subsequent rebase of the
+ * head branch) that object is frequently absent from the local clone, where `merge-base
+ * --is-ancestor` exits `128` — an error, not a truth value, and trivially misread as a `false`.
+ * Confirmed by replaying a real merged pull request whose head object no longer resolved in a
+ * fresh clone while its branch ref had advanced past it.
+ *
+ * **Fail toward pushing.** Every unresolvable input — no pull request, unreadable state, an
+ * unknown containment answer — yields `warn: false`. A false block would strand an author who
+ * is offline, unauthenticated, or rate-limited, and this guard has no block channel to begin
+ * with: the return shape cannot express one.
+ *
+ * @see #16256 — the ticket this module implements (ticket-ref-ok: implementing ticket)
+ * @see buildScripts/util/branchFreshness.mjs — the sibling pure predicate behind the
+ *      pre-push branch-staleness advisory, whose non-blocking stance this follows
+ * @see buildScripts/util/check-branch-discipline.mjs — the pre-push hook that supplies the
+ *      live coordinates and owns the console output
+ */
+
+/**
+ * @summary Decides whether a push carries commits that no pull request will adopt.
+ *
+ * Warns only when all three hold: the branch's most recent pull request is merged, the local
+ * head is not the commit that pull request merged, and the local head is demonstrably not yet
+ * contained in the base line. Anything else — including every unknown — stays silent, so the
+ * common path adds no noise and an advisory nobody reads is never created.
+ *
+ * @param {Object}        args
+ * @param {Object|null}  [args.pullRequest=null]         The branch's most recent pull request, or
+ *     `null` when the branch never had one or the lookup failed. Shape:
+ *     `{number: Number, state: String, mergedAt: String, headRefOid: String}`.
+ * @param {String|null}  [args.headSha=null]             Full local `HEAD` commit ID being pushed.
+ * @param {Boolean|null} [args.headContainedInBase=null] Whether every commit on this branch is
+ *     already contained in the base line. `true` ⇒ nothing can be lost, stay silent. `null` ⇒
+ *     the answer could not be computed, stay silent.
+ * @returns {{warn: Boolean, status: String}} `status` names the branch taken, so the hook and
+ *     its specs assert intent rather than a bare boolean.
+ */
+export function assessMergedPullRequestPush({
+    pullRequest = null,
+    headSha = null,
+    headContainedInBase = null
+}) {
+    if (!pullRequest || typeof pullRequest !== 'object') {
+        return {warn: false, status: 'no-pull-request'}
+    }
+
+    const state = typeof pullRequest.state === 'string' ? pullRequest.state.toUpperCase() : null;
+
+    if (!state) {
+        return {warn: false, status: 'pull-request-unresolved'}
+    }
+
+    if (state !== 'MERGED') {
+        return {warn: false, status: state === 'OPEN' ? 'pull-request-open' : 'pull-request-not-merged'}
+    }
+
+    const fullObjectIdPattern = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+
+    if (!fullObjectIdPattern.test(headSha || '') || !fullObjectIdPattern.test(pullRequest.headRefOid || '')) {
+        return {warn: false, status: 'coordinates-unresolved'}
+    }
+
+    if (headSha.toLowerCase() === pullRequest.headRefOid.toLowerCase()) {
+        return {warn: false, status: 'head-matches-merged-head'}
+    }
+
+    if (headContainedInBase === true) {
+        return {warn: false, status: 'head-contained-in-base'}
+    }
+
+    if (headContainedInBase !== false) {
+        return {warn: false, status: 'base-containment-unknown'}
+    }
+
+    return {warn: true, status: 'unreached-commits'}
+}

--- a/test/playwright/unit/ai/buildScripts/util/check-branch-discipline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-branch-discipline.spec.mjs
@@ -37,6 +37,11 @@ test.describe('check-branch-discipline.mjs (#11133)', () => {
             path.resolve(__dirname, '../../../../../../buildScripts/util/branchFreshness.mjs'),
             path.join(tempDir, 'buildScripts/util/branchFreshness.mjs')
         );
+        // …and ./mergedPullRequestPush.mjs, the merged-pull-request sibling predicate.
+        fs.copyFileSync(
+            path.resolve(__dirname, '../../../../../../buildScripts/util/mergedPullRequestPush.mjs'),
+            path.join(tempDir, 'buildScripts/util/mergedPullRequestPush.mjs')
+        );
     });
 
     test.afterEach(() => {
@@ -44,17 +49,40 @@ test.describe('check-branch-discipline.mjs (#11133)', () => {
         fs.rmSync(remoteDir, { recursive: true, force: true });
     });
 
-    const runScript = (cwd = tempDir) => {
+    const runScript = (cwd = tempDir, env = null) => {
         const result = spawnSync(process.execPath, [testScriptPath], {
             cwd,
             encoding: 'utf-8',
-            stdio   : 'pipe'
+            stdio   : 'pipe',
+            ...(env ? {env: {...process.env, ...env}} : {})
         });
 
         return {
             status: result.status,
             output: `${result.stdout || ''}${result.stderr || ''}`
         }
+    };
+
+    /**
+     * Puts a fake `gh` first on PATH so the merged-pull-request check is driven by a fixed
+     * payload instead of the live GitHub API. Returns the env overlay for `runScript`.
+     * @param {String|null} stdout JSON the stub prints; `null` makes the stub exit non-zero,
+     *     standing in for offline / unauthenticated / rate-limited.
+     */
+    const stubGh = (stdout) => {
+        const binDir = path.join(tempDir, 'stub-bin');
+        fs.mkdirSync(binDir, {recursive: true});
+
+        const ghPath = path.join(binDir, 'gh');
+        fs.writeFileSync(
+            ghPath,
+            stdout === null
+                ? '#!/bin/sh\nexit 1\n'
+                : `#!/bin/sh\ncat <<'NEO_STUB_EOF'\n${stdout}\nNEO_STUB_EOF\n`,
+            {mode: 0o755}
+        );
+
+        return {PATH: `${binDir}${path.delimiter}${process.env.PATH}`}
     };
 
     const blockFetchHeadWrites = () => {
@@ -256,5 +284,78 @@ test.describe('check-branch-discipline.mjs (#11133)', () => {
         expect(result.status).toBe(1);
         expect(result.output).toContain('remote refs/heads/dev coordinate is unavailable');
         expect(result.output).not.toContain('local ref is stale')
+    });
+
+    test.describe('pushes that reach no pull request (#16256)', () => {
+        const MERGED_HEAD = 'ddf522a6feb4abf9faf4ad49af110d2a3a5c96b7';
+
+        const mergedPrPayload = JSON.stringify([{
+            number    : 16255,
+            state     : 'MERGED',
+            mergedAt  : '2026-08-01T11:27:27Z',
+            headRefOid: MERGED_HEAD
+        }]);
+
+        test('warns — and still exits 0 — when the branch PR merged and the head carries unreached commits', () => {
+            execFileSync('git', ['checkout', '-b', 'agent/0000-merged-pr'], {cwd: tempDir, stdio: 'ignore'});
+            featureCommit('feat(test): a commit that will reach no PR');
+
+            const result = runScript(tempDir, stubGh(mergedPrPayload));
+
+            // Advisory: the whole point is that the push proceeds.
+            expect(result.status).toBe(0);
+            expect(result.output).toContain('PR #16255');
+            expect(result.output).toContain('2026-08-01T11:27:27Z');
+            expect(result.output).toContain('reaches no PR and no CI');
+            // The author's next question — answered in the same breath.
+            expect(result.output).toContain('Your work is not lost');
+            expect(result.output).toContain('origin/dev');
+            expect(result.output).toContain('advisory')
+        });
+
+        test('stays silent on an open pull request — no new noise on the common path', () => {
+            execFileSync('git', ['checkout', '-b', 'agent/0000-open-pr'], {cwd: tempDir, stdio: 'ignore'});
+            featureCommit();
+
+            const result = runScript(tempDir, stubGh(JSON.stringify([{
+                number    : 16264,
+                state     : 'OPEN',
+                mergedAt  : null,
+                headRefOid: MERGED_HEAD
+            }])));
+
+            expect(result.status).toBe(0);
+            expect(result.output).not.toContain('reaches no PR')
+        });
+
+        test('stays silent when the branch never had a pull request', () => {
+            execFileSync('git', ['checkout', '-b', 'agent/0000-no-pr'], {cwd: tempDir, stdio: 'ignore'});
+            featureCommit();
+
+            const result = runScript(tempDir, stubGh('[]'));
+
+            expect(result.status).toBe(0);
+            expect(result.output).not.toContain('reaches no PR')
+        });
+
+        test('fails toward pushing when gh cannot answer (offline / unauthenticated / rate-limited)', () => {
+            execFileSync('git', ['checkout', '-b', 'agent/0000-gh-down'], {cwd: tempDir, stdio: 'ignore'});
+            featureCommit();
+
+            const result = runScript(tempDir, stubGh(null));
+
+            expect(result.status).toBe(0);
+            expect(result.output).not.toContain('reaches no PR')
+        });
+
+        test('fails toward pushing when gh returns unparseable output', () => {
+            execFileSync('git', ['checkout', '-b', 'agent/0000-gh-garbage'], {cwd: tempDir, stdio: 'ignore'});
+            featureCommit();
+
+            const result = runScript(tempDir, stubGh('not json at all'));
+
+            expect(result.status).toBe(0);
+            expect(result.output).not.toContain('reaches no PR')
+        })
     })
 });

--- a/test/playwright/unit/ai/buildScripts/util/mergedPullRequestPush.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/mergedPullRequestPush.spec.mjs
@@ -1,0 +1,109 @@
+import { test, expect }              from '@playwright/test';
+import {assessMergedPullRequestPush} from '../../../../../../buildScripts/util/mergedPullRequestPush.mjs';
+
+/**
+ * Coordinates lifted from a real occurrence: a pull request merged at one head while its
+ * branch ref had already advanced past it, leaving the commits in between attached to no
+ * pull request and covered by no CI run.
+ */
+const
+    MERGED_HEAD   = 'ddf522a6feb4abf9faf4ad49af110d2a3a5c96b7',
+    ADVANCED_HEAD = 'a993b72075411b321d50908687e6445b44599156',
+    MERGE_COMMIT  = 'ad76ede9bfc8607314e98934e4ed2840629c23aa',
+    mergedPr      = {number: 16255, state: 'MERGED', mergedAt: '2026-08-01T11:27:27Z', headRefOid: MERGED_HEAD};
+
+test.describe('buildScripts/util/mergedPullRequestPush.assessMergedPullRequestPush (#16256)', () => {
+    test('warns on the incident signature — merged PR, head beyond it, not yet in the base line', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : mergedPr,
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: true, status: 'unreached-commits'});
+    });
+
+    test('stays silent when the branch never had a pull request', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : null,
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: false, status: 'no-pull-request'});
+    });
+
+    test('stays silent on an open pull request — the common path adds no noise', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : {...mergedPr, state: 'OPEN', mergedAt: null},
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: false, status: 'pull-request-open'});
+    });
+
+    test('stays silent on a closed-unmerged pull request — its branch can still be reopened', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : {...mergedPr, state: 'CLOSED', mergedAt: null},
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: false, status: 'pull-request-not-merged'});
+    });
+
+    test('stays silent when head is exactly what the pull request merged (a re-push of merged work)', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : mergedPr,
+            headSha            : MERGED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: false, status: 'head-matches-merged-head'});
+    });
+
+    test('compares the merged head case-insensitively rather than treating case as a divergence', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : {...mergedPr, headRefOid: MERGED_HEAD.toUpperCase()},
+            headSha            : MERGED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: false, status: 'head-matches-merged-head'});
+    });
+
+    test('stays silent when everything on the branch is already contained in the base line', () => {
+        expect(assessMergedPullRequestPush({
+            pullRequest        : mergedPr,
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: true
+        })).toEqual({warn: false, status: 'head-contained-in-base'});
+    });
+
+    test('does NOT key off the merge commit — under squash-merge it shares no ancestry with the head branch', () => {
+        // Passing the base-line merge commit as the pull request's head coordinate must not
+        // silence the guard: the incident head is still unreached work.
+        expect(assessMergedPullRequestPush({
+            pullRequest        : {...mergedPr, headRefOid: MERGE_COMMIT},
+            headSha            : ADVANCED_HEAD,
+            headContainedInBase: false
+        })).toEqual({warn: true, status: 'unreached-commits'});
+    });
+
+    test.describe('fail toward pushing — every unresolvable input stays silent', () => {
+        const unresolvable = [
+            ['pull-request state missing',      {pullRequest: {...mergedPr, state: undefined},    headSha: ADVANCED_HEAD, headContainedInBase: false}, 'pull-request-unresolved'],
+            ['pull-request state non-string',   {pullRequest: {...mergedPr, state: 7},            headSha: ADVANCED_HEAD, headContainedInBase: false}, 'pull-request-unresolved'],
+            ['local head unreadable',           {pullRequest: mergedPr,                          headSha: null,          headContainedInBase: false}, 'coordinates-unresolved'],
+            ['local head abbreviated',          {pullRequest: mergedPr,                          headSha: 'a993b72',     headContainedInBase: false}, 'coordinates-unresolved'],
+            ['merged head missing from the PR', {pullRequest: {...mergedPr, headRefOid: null},    headSha: ADVANCED_HEAD, headContainedInBase: false}, 'coordinates-unresolved'],
+            ['containment unknown (git errored)', {pullRequest: mergedPr,                        headSha: ADVANCED_HEAD, headContainedInBase: null},  'base-containment-unknown'],
+            ['pull request is not an object',   {pullRequest: 'MERGED',                          headSha: ADVANCED_HEAD, headContainedInBase: false}, 'no-pull-request']
+        ];
+
+        for (const [label, args, status] of unresolvable) {
+            test(`silent when ${label}`, () => {
+                expect(assessMergedPullRequestPush(args)).toEqual({warn: false, status});
+            });
+        }
+
+        test('the fallback cannot be flipped to blocking — the return shape has no block channel', () => {
+            // AC: a test that fails if the fallback is ever flipped to blocking. `warn` is the
+            // only actionable field the predicate can emit, so no input can request an exit.
+            for (const [, args] of unresolvable) {
+                const result = assessMergedPullRequestPush(args);
+                expect(Object.keys(result).sort()).toEqual(['status', 'warn']);
+                expect(result.warn).toBe(false);
+            }
+        });
+    });
+});


### PR DESCRIPTION
Resolves #16256

Related: #13652, #11133

A push to a branch whose pull request already merged now says so. The ref still advances, the push still succeeds, and the warning names the pull request, its merge time, the commit that will reach nothing, and the way out — because the author's next question is always "so where did my commit go?"

Evidence: L3 (the guard run on the originating incident's own branch against the live GitHub API, reproducing the exact warning) → L2 required (all close-target ACs are predicate and hook behaviour covered by the specs). Residual: none [#16256].

## Deltas from ticket

Three, one of which changes where the code lives. All were found by measuring the ticket's premises rather than implementing them.

**1. Placement: `check-branch-discipline.mjs`, not `agent-push.mjs`.** The ticket's Architectural Reality says `agent-push.mjs` "already emits advisory warnings at push time. It printed a branch-staleness advisory during this very incident." Measured:

```
console.* in buildScripts/util/agent-push.mjs               0
console.* in buildScripts/util/check-branch-discipline.mjs  35
agent-push referenced by .husky/pre-push                     0
check-branch-discipline referenced by .husky/pre-push        1
```

Positive control: `export function` matches 7 times in `agent-push.mjs`, so the file is being read and the zero is real. `agent-push.mjs` produces no output at all — it is a refspec-safety wrapper. The advisory came from `.husky/pre-push` → `check-branch-discipline.mjs`.

This is not pedantry about attribution. The pre-push hook runs on **every** `git push`; `agent-push` runs only when someone invokes `npm run agent-push`. The incident report opens with a plain `git push` returning `Everything up-to-date`, so a guard built in `agent-push.mjs` would have passed its own tests and been absent for the case that produced the ticket — which is the failure class this ticket is about. Recorded on the ticket at [issuecomment-5152025558](https://github.com/neomjs/neo/issues/16256#issuecomment-5152025558) with an offer to argue it rather than assume; no objection in the 100 minutes before implementation.

**2. The comparison coordinate is the pull request's `headRefOid`, compared as a string — not its merge commit.** The ticket prescribes warning when "the push would advance the ref beyond that PR's merge commit". Two problems, both measured against the real incident:

- Under squash-merge the merge commit lives on `dev` and shares no ancestry with the head branch, so it answers a different question.
- More decisively: **the pull request's head object is frequently absent from the local clone.** Replaying PR #16255 — `git cat-file -e ddf522a6fe^{commit}` fails, and `git merge-base --is-ancestor ddf522a6fe <branch>` exits **128**, an error, not a `false`.

That second point bit me inside this ticket: my first probe wrote `git merge-base --is-ancestor … && echo ancestor || echo "not ancestor"`, which collapsed exit 128 into the `false` arm and told me the opposite of the truth. The hook now distinguishes them explicitly — `e?.status === 1` is a real "no", anything else is "unknown" and stays silent. A guard that reads a missing object as a definite answer is exactly the bug class here.

**3. One AC added, one narrowed.** Added: a branch whose every commit is already contained in `origin/dev` stays silent — nothing can be lost, so a warning would be noise, and an advisory people learn to skip is worse than no advisory. This replaces the ticket's "does not advance past the merge commit" phrasing with something computable from objects the hook has already proven authoritative.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback | Evidence |
|---|---|---|---|---|
| `assessMergedPullRequestPush` (new, pure) | this PR | `{warn, status}` — warns only on merged-PR + head ≠ merged head + demonstrably not in base | every unknown ⇒ `warn: false` | 16 predicate specs |
| `check-branch-discipline.mjs` pre-push advisory | `.husky/pre-push`, existing staleness-advisory precedent | warn + exit 0 | `gh` failure / unparseable / missing ⇒ silent | 5 hook specs + live run |

No public API changes. The predicate's return shape has no block channel, so the non-blocking property is structural rather than guarded.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  mergedPullRequestPush check-branch-discipline branchFreshness
  45 passed (4.5s)
```

16 new predicate specs and 5 new hook specs; the 12 pre-existing `check-branch-discipline` specs still pass (they needed the new sibling module mirrored into their temp repo — without that, every one of them fails on the import, so they are a real integration check, not bystanders).

The hook specs put a stub `gh` first on `PATH`, so message content and exit code are asserted end-to-end rather than inferred from the predicate.

**Live receipt (L3).** The guard was run on the incident's own branch, with the real GitHub API and no stub:

```
$ git checkout -b ticket-16253 origin/ticket-16253
$ node buildScripts/util/check-branch-discipline.mjs
Warning: PR #16255 for branch 'ticket-16253' merged at 2026-08-01T11:27:27Z.
A merged pull request accepts no further commits, so a993b7207 reaches no PR and no CI — the ref advances and nothing listens.
Your work is not lost: it is on 'ticket-16253', it is simply in no pull request.
Remediation: open a follow-up ticket, then carry the commits onto a fresh branch.
  git log --oneline origin/dev..HEAD    # inspect first — there may be more than one
  git checkout -b <agent>/<ticket-id>-<slug> origin/dev
  git cherry-pick <each commit the merged PR did not carry>
This is advisory — the push proceeds.
EXIT CODE: 0
```

*(Re-run at `15f3c82bbe` after the review correction below, rather than left showing output the code no longer produces.)*

**Negative control, and it caught a probe error.** My first live attempt named the branch `probe-live-16253` and the guard stayed **silent** — correctly, because `gh pr list --head probe-live-16253` finds no pull request. The branch name is load-bearing input, so the silent run is the negative control: same repo, same commit, same code, no warning when the branch has no merged PR.

**RED characterisation, honestly.** The predicate specs are green-only by construction — the module is new, so there is no prior behaviour to differ from. The falsifier that carries real weight is the live run above plus its negative control, not a reverted line.

## Review corrections (@neo-kimi-iris)

Two nits, both taken. The second turned out to be a defect rather than polish.

1. **The spec count was wrong.** This body and the Contract Ledger claimed 18 predicate specs; the runtime count is **16**. She checked a falsifiable number rather than trusting it, which is the right instinct for exactly the kind of claim that decorates a PR body without anyone re-deriving it. Corrected above.

2. **The remediation assumed a single stranded commit.** It printed `git cherry-pick <headSha>` while its own comment read "your commits" — plural. With more than one commit past the merged PR, following it recovers the head and silently drops the rest: **a remedy that loses commits, inside a guard whose entire purpose is preventing lost commits.** Fixed at `15f3c82bbe`, and the live receipt above is re-run at that head.

The constraint behind the new wording, stated because "just compute the set" is the obvious objection: the stranded set is **not** mechanically computable here. After a squash merge every branch commit is absent from `dev` as an object, so `origin/dev..HEAD` over-reports; and the merged PR's own head object is frequently missing locally — the same exit-128 finding this PR is built on. So the guard now says *inspect first* and names the judgement, instead of emitting a precise-looking command that is not precise. That is the same discipline as the rest of the change: do not publish a claim wider than what you can measure.

## Post-Merge Validation

- [ ] Confirm the advisory fires for a peer who actually lands in the window, and that it does not fire on ordinary feature pushes. The common path is asserted by specs, but only fleet use shows whether the wording answers the question at the moment it is read.
- [ ] Watch the added latency. This introduces one `gh pr list` (10s timeout) into every push that has commits beyond `origin/dev`. It is skipped entirely when the branch is clean, but if it proves noticeable on slow links the next move is caching per branch head rather than removing the check.

## Evolution

The ticket was written by @neo-opus-grace immediately after losing a commit to this, and it is unusually good source material — the three-instrument table (`git push`, `git ls-remote`, `gh pr checks` all returning true answers to a question that was not being asked) is the whole diagnosis, and I did not improve on it.

What I would defend if challenged: the guard warns rather than blocks, even though blocking would have prevented the incident outright. The existing staleness advisory is non-blocking, and a hard block on unresolvable pull-request state would strand any author who is offline or rate-limited — a false block costs more than a false warning here, because the failure it prevents is recoverable and the failure it would cause is not.

What I am least sure of: whether `gh pr list --head` is the right resolution when a branch has had several pull requests. It takes the most recent, which is correct for the incident shape, but a branch reused across two tickets could resolve to a pull request the author is not thinking about. The warning names the number and the merge time, so a mismatch is visible rather than silent — but it is the seam I would look at first if this misfires.

Authored by Ada (Claude Opus 5, Claude Code). Session 56105163-6e66-44b6-8c6f-9e81bc1be08c.
