### PR TITLE
fix(ai): read grantedAt + lastModifiedAt for digest latest (#16275)

### DIFF
--- a/ai/services/memory-core/CoalescingEngineService.mjs
+++ b/ai/services/memory-core/CoalescingEngineService.mjs
@@ -47,21 +47,29 @@ const WAKE_PRIORITY_RANKS = Object.freeze({
 /**
  * @summary Resolves an event's recency timestamp for digest `latest` selection.
  *
- * The payload's `sentAt` wins first (mailbox events carry the message's own send time, which is
- * the recency an agent reads the pointer by); the envelope's `emittedAt` is the fallback (numeric
- * epoch or ISO string). Returns `null` when nothing is resolvable — the caller then keeps the
- * previous last-write-wins behavior, so timestamp-less events are never re-ordered by guesswork.
+ * Payload-level event times win first, one wire-contract field per event type: `sentAt`
+ * (mailbox events carry the message's own send time — the recency an agent reads the
+ * pointer by), `grantedAt` (permission grants carry the delivery-time stamp minted in
+ * WakeSubscriptionService), `lastModifiedAt` (Task transitions carry the canonical
+ * transition clock). The envelope's `emittedAt` is the fallback (numeric
+ * epoch or ISO string). Returns `null` when nothing is resolvable — the caller then keeps
+ * the previous last-write-wins behavior, so timestamp-less events are never re-ordered
+ * by guesswork.
  * @param {Object} event Wake event envelope.
  * @returns {Number|null} Epoch ms, or null when no timestamp is resolvable.
  */
 function resolveEventTimestamp(event) {
-    const sentAt = event?.payload?.sentAt;
+    const payload = event?.payload;
 
-    if (typeof sentAt === 'string') {
-        const ts = Date.parse(sentAt);
+    for (const field of ['sentAt', 'grantedAt', 'lastModifiedAt']) {
+        const value = payload?.[field];
 
-        if (Number.isFinite(ts)) {
-            return ts
+        if (typeof value === 'string') {
+            const ts = Date.parse(value);
+
+            if (Number.isFinite(ts)) {
+                return ts
+            }
         }
     }
 
@@ -406,12 +414,16 @@ class CoalescingEngineService extends Base {
      * so Shape A and Shape B consumers can dispatch with the same shape they expect for
      * single events.
      *
-     * Each bucket's `latest` is chosen by RECENCY (max timestamp), never by iteration
-     * position: enqueue order is only arrival order when every event arrives live in
-     * sequence, and an out-of-order queue (replay batch, restart re-walk, multi-source
-     * evaluation) would otherwise point `latest` at a stale event while a newer one is
-     * present — the pointer agents use to decide whether a wake is worth acting on.
-     * Timestamp-less payloads fall back to last-write-wins, the previous behavior.
+     * Each bucket's `latest` resolves by the truest clock its payload carries:
+     * `sent_to_me` by the message's `sentAt`, `permission_granted` by the delivery-time
+     * `grantedAt`, `task_state_changed` by the transition clock `lastModifiedAt` — true
+     * event times, so an out-of-order queue (replay batch, restart re-walk, multi-source
+     * evaluation) cannot point `latest` at a stale event while a newer one is present.
+     * `heartbeat_pulse` carries no payload clock and resolves by the envelope's
+     * `emittedAt` (wrap/arrival time, which tracks position under in-order arrival);
+     * timestamp-less payloads keep last-write-wins. The pointer is what agents use to
+     * decide whether a wake is worth acting on, so each bucket claims only the recency
+     * its own wire contract can prove.
      *
      * @protected
      * @param {Object} subscription

--- a/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
@@ -416,6 +416,53 @@ test.describe('CoalescingEngineService', () => {
         expect(digest.payload.breakdown.sent_to_me.latest.subject).toBe('newer-payload')
     });
 
+    // -----------------------------------------------------------------------------
+    // Digest `latest` — wire-faithful per-bucket payload clocks
+    // -----------------------------------------------------------------------------
+
+    test('permission_granted resolves latest by payload.grantedAt, not position', () => {
+        // Wire shape per WakeSubscriptionService.mjs:1431-1433: {scope, grantedBy, grantedAt} — no sentAt.
+        const fresh = buildEnvelope('wake/permission_granted', {scope: 'CAN_REVIEW', grantedBy: '@bob', grantedAt: '2026-08-01T11:21:47.000Z'});
+        const stale = buildEnvelope('wake/permission_granted', {scope: 'CAN_MERGE',  grantedBy: '@bob', grantedAt: '2026-07-31T23:04:46.000Z'});
+
+        const digest = CoalescingEngineService._buildDigestEnvelope(buildSubscription(), [fresh, stale], Date.now() - 150000);
+
+        expect(digest.payload.breakdown.permission_granted.latest.scope).toBe('CAN_REVIEW')
+    });
+
+    test('task_state_changed resolves latest by payload.lastModifiedAt, not position', () => {
+        // Wire shape: the immutable typed-row payload carries the canonical transition clock.
+        const fresh = buildEnvelope('wake/task_state_changed', {taskId: 'T1', newState: 'Working',   lastModifiedAt: '2026-08-01T11:21:47.000Z'});
+        const stale = buildEnvelope('wake/task_state_changed', {taskId: 'T1', newState: 'Submitted', lastModifiedAt: '2026-07-31T23:04:46.000Z'});
+
+        const digest = CoalescingEngineService._buildDigestEnvelope(buildSubscription(), [fresh, stale], Date.now() - 150000);
+
+        expect(digest.payload.breakdown.task_state_changed.latest.newState).toBe('Working')
+    });
+
+    test('a payload clock beats a newer-position envelope emittedAt', () => {
+        // A replayed grant with a true delivery-time stamp must not lose to a fresh wrap of
+        // an older logical event: grantedAt (11:21) wins over the later emittedAt.
+        const stamped = buildEnvelope('wake/permission_granted', {scope: 'CAN_REVIEW', grantedBy: '@bob', grantedAt: '2026-08-01T11:21:47.000Z'});
+        stamped.emittedAt = '2026-07-31T23:04:46.000Z';
+        const wrappedFresh = buildEnvelope('wake/permission_granted', {scope: 'CAN_MERGE', grantedBy: '@bob', grantedAt: '2026-07-31T23:04:46.000Z'});
+
+        const digest = CoalescingEngineService._buildDigestEnvelope(buildSubscription(), [stamped, wrappedFresh], Date.now() - 150000);
+
+        expect(digest.payload.breakdown.permission_granted.latest.scope).toBe('CAN_REVIEW')
+    });
+
+    test('heartbeat_pulse carries no payload clock and resolves by envelope emittedAt', () => {
+        const newerWrapOlderPosition = buildEnvelope('wake/heartbeat_pulse', {targetIdentity: '@alice', pulseId: 'P-new'});
+        newerWrapOlderPosition.emittedAt = '2026-08-01T11:21:47.000Z';
+        const olderWrapNewerPosition = buildEnvelope('wake/heartbeat_pulse', {targetIdentity: '@alice', pulseId: 'P-old'});
+        olderWrapNewerPosition.emittedAt = '2026-07-31T23:04:46.000Z';
+
+        const digest = CoalescingEngineService._buildDigestEnvelope(buildSubscription(), [newerWrapOlderPosition, olderWrapNewerPosition], Date.now() - 150000);
+
+        expect(digest.payload.breakdown.heartbeat_pulse.latest.pulseId).toBe('P-new')
+    });
+
     test('all four breakdown buckets track recency, not position', () => {
         const events = [
             buildEnvelope('wake/sent_to_me',        {subject: 'fresh-stm',  sentAt: '2026-08-01T11:21:47.000Z'}),


### PR DESCRIPTION
Resolves #16275

Related: #16263
Related: #15106
Related: #15114

The digest `latest` resolver completed its recency contract. PR `#16265` made `resolveEventTimestamp()` read `payload.sentAt`, but two of the four buckets carry their own true event-time fields that stayed unread: `permission_granted.grantedAt` (the delivery-time stamp `WakeSubscriptionService.mjs:1431-1433` mints as a documented wire-contract field) and `task_state_changed.lastModifiedAt` (the canonical transition clock per #15106 / #15114). Under an out-of-order queue those two buckets silently fell back to envelope `emittedAt` — wrap time, i.e. position under in-order arrival — the stale-pointer class the original PR closed for `sent_to_me` only. The resolver now reads all three payload clocks (`sentAt` → `grantedAt` → `lastModifiedAt`) before the `emittedAt` fallback, and the `_buildDigestEnvelope` JSDoc states the per-bucket resolution truthfully instead of the unconditional "recency, never iteration position" overclaim @neo-opus-grace flagged post-merge.

Evidence: L2 (unit, exact head) → L2 required (every AC is a behavioural property of the resolver and the digest envelope, reachable in-process). Residual: none [#16275].

## Deltas from ticket

- One falsifier spec beyond the ticket's named cases: **a payload clock beats a newer-position envelope `emittedAt`** — a replayed grant with a true 11:21 `grantedAt` must not lose `latest` to a fresh wrap of an older logical event. This is the restart re-walk shape the ticket described, pinned directly.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs`

- RED before the fix (falsifier confirmation): 3 failed — `permission_granted resolves latest by payload.grantedAt`, `task_state_changed resolves latest by payload.lastModifiedAt`, `a payload clock beats a newer-position envelope emittedAt`; 29 passed. The fourth new spec (`heartbeat_pulse` resolves by envelope `emittedAt`) was green by design, pinning the unchanged fallback.
- GREEN after the fix: 32 passed (one intermediate run showed the known timing-sensitive refractory spec flaking at its 45ms threshold; immediate re-run 32/32 — unrelated to this change, which touches only `latest` selection).

Surface coverage: `ai/services/memory-core/CoalescingEngineService.mjs` → the spec above (exact head) | `test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs` → same run.

## Post-Merge Validation

- [ ] First live digest containing an out-of-order `permission_granted` or `task_state_changed` batch names the true latest by `grantedAt` / `lastModifiedAt` (observable in the receiver record `payload.breakdown`).

Authored by Iris (Kimi K3, Kimi Code CLI). Session session_fdc69689-d147-442f-8e12-1a2bc72ae4ee.
