### PR TITLE
feat(wake): admit OpenCode to the osascript delivery adapter (#16279)

### DIFF
--- a/ai/daemons/wake/localWakeAdapters.mjs
+++ b/ai/daemons/wake/localWakeAdapters.mjs
@@ -534,7 +534,7 @@ async function deliverOsascript({digest, effects, meta, record}) {
 
     const resolvedMeta = applyHarnessMetadataDefaults(meta);
     const appName      = resolvedMeta.appName;
-    if (!['Antigravity', 'Claude', 'Codex'].includes(appName)) return 'skipped';
+    if (!['Antigravity', 'Claude', 'Codex', 'OpenCode'].includes(appName)) return 'skipped';
     if (appName === 'Codex' && !resolvedMeta.focusSeedKey) return 'skipped';
 
     let   instancePid     = null;

--- a/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
@@ -361,4 +361,40 @@ test.describe.serial('ai/daemons/wake/localWakeAdapters', () => {
         // assertions above pass equally well against a route that never carried a key at all.
         expect(`leaked ${key}`).toContain(key);
     });
+
+    test('an OpenCode-named route dispatches through the generic osascript choreography', async () => {
+        let osascriptArgs;
+        const openCodeRecord = record('osascript', {
+            route: {
+                agentIdentity,
+                harnessTargetMetadata: {
+                    adapter        : 'osascript',
+                    appName        : 'OpenCode',
+                    addressType    : 'userDataDir',
+                    instanceAddress: '/seat/ai.opencode.desktop'
+                },
+                adapterConfig: {attemptTimeoutMs: 1000}
+            }
+        });
+
+        expect(await dispatchLocalWake(openCodeRecord, {
+            platform             : 'darwin',
+            resolveGuiInstancePid: async () => 5719,
+            spawnAsync           : async (command, args) => {
+                expect(command).toBe('osascript');
+                osascriptArgs = args;
+            }
+        })).toBe('delivered');
+
+        const script = osascriptArgs.join('\n');
+
+        // The generic Electron-safe path: activate, frontmost assert on the RESOLVED pid, clear and
+        // preserve the prompt, paste the payload, submit with Return, restore the user's draft.
+        expect(script).toContain('tell application "OpenCode" to activate');
+        expect(script).toContain('first process whose unix id is 5719');
+        expect(script).toContain('set the clipboard to wakePayload');
+        expect(script).toContain('key code 36');
+        // …and no Codex-only Esc prelude: the OpenCode route gets the generic submit, not a quirk.
+        expect(script).not.toContain('key code 53');
+    });
 });


### PR DESCRIPTION
Resolves #16279

Every OpenCode desktop seat can now receive wakes through the GUI path. The osascript adapter's `appName` allowlist gains `'OpenCode'` — the adapter's AppleScript is app-generic (activate → frontmost assert → clear-and-preserve prompt → paste payload → Return → restore the user's draft) and applies to OpenCode's Electron desktop unchanged, so the fix is one allowlist line plus a spec that pins the generic choreography for the new name.

Evidence: L1 (unit — the adapter's fake-effects harness asserts dispatch reaches the osascript spawn with the generic arg vector) → L1 required (#16279's ACs are dispatch-vs-skip properties, decidable in-process). Residual: the live end-to-end delivery on this machine is PMV (needs a receiver restart from merged dev; it currently runs pre-allowlist code).

## Deltas from ticket

None substantive. Two discoveries from the implementation worth recording:

- The desktop internal server does **not** accept env-provisioned credentials for its basic auth (every endpoint 401 with byte-equal spawn-env values, while an isolated `opencode serve` with the identical pair answers 200 — the env contract is real but scoped to standalone serve, and the desktop's internal server uses per-boot generated credentials only the app process knows). The osascript path needs no credentials at all, which is why it is the right delivery surface for desktop seats.
- The wake-envelope plugin (the opencode-server adapter's dependency) has never been observed arming — a marker `console.log` at file top is never evaluated in any tested configuration. That upstream question no longer blocks delivery: this PR's path has no plugin dependency.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
  17 passed (4.4s)
npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/wake/
  250 passed (1.1m)
npx playwright test -c test/playwright/playwright.config.unit.mjs
  10691 passed, 5 skipped, 3 failed
```

The 3 full-suite failures are the named load-flakes in untouched memory-core files (SessionSummarization ×2, TextEmbeddingService — all isolated-green; same family documented across today's runs). Per directly touched surface:

- `localWakeAdapters.mjs` — new spec: an OpenCode-named route with a `userDataDir` tuple dispatches through the generic choreography (activate line, instance-frontmost on the resolved pid, payload clipboard set, `key code 36` Return) and gets **no** Codex-only Esc prelude; the existing three app names stay as positive controls.
- Pre-commit hooks: whitespace, shorthand, aiconfig-test-mutation, derived-domain, jsdoc-types, ticket-archaeology, block-alignment, parse — all green.

## Post-Merge Validation

- [ ] Receiver restart from merged dev, then republish @neo-kimi-phoebe's route with `adapter: 'osascript', appName: 'OpenCode', addressType: 'userDataDir', instanceAddress: <seat data dir>` — and a high-priority non-suppressed DM flips the receiver record to `delivered` with the wake visible in the OpenCode desktop.
- [ ] If the Electron prompt is not focused by the generic choreography, the quirk lands as a named follow-up (never preemptively).

## Commits

- `d11e982b29` — the allowlist line + the OpenCode dispatch spec

Authored by Phoebe (Kimi k3, OpenCode). Session a9c25413-6846-4dee-a4e7-513e7600e0af.