### PR TITLE
feat(ai): probe orchestrator authority lease health (#16283)

### DIFF
--- a/ai/daemons/orchestrator/authorityLease.mjs
+++ b/ai/daemons/orchestrator/authorityLease.mjs
@@ -26,8 +26,10 @@
  * `container-plane` never contend for the same file.
  */
 
-import os                 from 'node:os';
-import {acquireFileLease} from '../shared/fileLease.mjs';
+import fs                                      from 'fs-extra';
+import os                                      from 'node:os';
+import path                                    from 'node:path';
+import {acquireFileLease, readFileLeaseHolder} from '../shared/fileLease.mjs';
 
 /**
  * Lease freshness window. The orchestrator polls every 3s, so 60s is 20 missed beats of margin —
@@ -43,6 +45,66 @@ export const AUTHORITY_LEASE_TTL_MS = 60_000;
  */
 export function authorityLeaseFilename(profile) {
     return `.authority-lease-${profile}`;
+}
+
+/**
+ * @summary Classifies one validated per-role authority-lease descriptor. The three states keep
+ * consumer semantics explicit: health accepts only `fresh`, while acquisition may reclaim only
+ * `stale`; `invalid` is unhealthy and unreclaimable.
+ *
+ * @param {Object} options
+ * @param {Object|null} options.holder Parsed file-lease descriptor.
+ * @param {String} options.profile Expected authority role.
+ * @param {Number} [options.ttlMs] Freshness window.
+ * @param {Number} [options.now] Current epoch milliseconds.
+ * @returns {'fresh'|'stale'|'invalid'}
+ */
+function classifyAuthorityLease({
+    holder,
+    profile,
+    ttlMs = AUTHORITY_LEASE_TTL_MS,
+    now   = Date.now()
+}) {
+    const age = now - Date.parse(holder?.lastPulse ?? holder?.startedAt);
+
+    if (holder?.profile !== profile || !Number.isFinite(age) || age < 0) return 'invalid';
+
+    return age < ttlMs ? 'fresh' : 'stale';
+}
+
+/**
+ * @summary Inspects the expected per-role authority lease without mutating it. Descriptor
+ * validation is delegated to the shared file-lease reader and freshness uses the same predicate
+ * as acquisition, so health probes cannot drift from ownership semantics.
+ *
+ * Missing, corrupt, invalid, wrong-role, future-dated, and stale leases all return `fresh: false`.
+ * Read failures are likewise fail-closed through the shared reader.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Lease directory.
+ * @param {String} options.profile Expected authority role.
+ * @param {Number} [options.ttlMs] Freshness window.
+ * @param {Number} [options.now] Current epoch milliseconds.
+ * @param {Object} [options.fs] Filesystem implementation (injected for specs).
+ * @returns {{fresh: Boolean, holder: Object|null, lockPath: String, status: 'fresh'|'stale'|'invalid'}}
+ */
+export function inspectAuthorityLease({
+    dir,
+    profile,
+    ttlMs     = AUTHORITY_LEASE_TTL_MS,
+    now       = Date.now(),
+    fs: fsImpl = fs
+} = {}) {
+    const lockPath = path.join(dir, authorityLeaseFilename(profile));
+    const holder   = readFileLeaseHolder(lockPath, fsImpl);
+    const status   = classifyAuthorityLease({holder, profile, ttlMs, now});
+
+    return {
+        fresh: status === 'fresh',
+        holder,
+        lockPath,
+        status
+    };
 }
 
 const REMEDIATION =
@@ -93,7 +155,9 @@ export function acquireAuthorityLease({
         // Authority state that cannot be judged is a REFUSAL, never a reclaim: a corrupt lease
         // might be a live cross-namespace holder mid-rotation, and guessing starts the duplicate.
         onCorrupt  : 'refuse',
+        // Only a canonically stale descriptor is reclaimable. Invalid/future/wrong-role state is
+        // unjudgeable authority and therefore stays held under the refuse-no-takeover contract.
         isHeldFresh: ({holder, now: at}) =>
-            (at - Date.parse(holder.lastPulse ?? holder.startedAt)) < ttlMs
+            classifyAuthorityLease({holder, profile, ttlMs, now: at}) !== 'stale'
     });
 }

--- a/ai/daemons/shared/fileLease.mjs
+++ b/ai/daemons/shared/fileLease.mjs
@@ -111,7 +111,7 @@ function defaultIsHeldFresh({holder}) {
  * @param {Object} fsImpl
  * @returns {Object|null}
  */
-function readHolder(lockPath, fsImpl) {
+export function readFileLeaseHolder(lockPath, fsImpl = fs) {
     try {
         const parsed = JSON.parse(fsImpl.readFileSync(lockPath, 'utf8'));
 
@@ -211,7 +211,7 @@ export function acquireFileLease({
                 }
 
                 try {
-                    const holder = readHolder(lockPath, fsImpl);
+                    const holder = readFileLeaseHolder(lockPath, fsImpl);
 
                     if (!holder) {
                         throw new FileLeaseLostError({lockPath, pid, reason: 'lease file missing or corrupt'});
@@ -253,7 +253,7 @@ export function acquireFileLease({
                 if (!guard) return; // contended — a stale leftover reclaims via the liveness strategy
 
                 try {
-                    const holder = readHolder(lockPath, fsImpl);
+                    const holder = readFileLeaseHolder(lockPath, fsImpl);
                     if (holder && holder.ownerToken === token && verifyLifecycleGuardOwnershipSync({ownerFilePath: guard.ownerFilePath, fsModule: fsImpl})) {
                         fsImpl.unlinkSync(lockPath);
                         log('INFO', `[file-lease] released by ${owner} pid ${pid} (${lockPath})`);
@@ -284,11 +284,11 @@ export function acquireFileLease({
             const guard = enterLifecycleGuardSync({leasePath: lockPath, fsModule: fsImpl});
 
             if (!guard) {
-                throw heldError({lockPath, holder: readHolder(lockPath, fsImpl), requester: {owner, pid}});
+                throw heldError({lockPath, holder: readFileLeaseHolder(lockPath, fsImpl), requester: {owner, pid}});
             }
 
             try {
-                const holder = readHolder(lockPath, fsImpl);
+                const holder = readFileLeaseHolder(lockPath, fsImpl);
 
                 if (holder && holder.ownerToken !== token && isHeldFresh({holder, now: now()})) {
                     throw heldError({lockPath, holder, requester: {owner, pid}});
@@ -314,5 +314,5 @@ export function acquireFileLease({
 
     // Both passes lost the wx race: another claimant re-claimed between our guarded unlink and
     // the retry — refuse rather than a third pass.
-    throw heldError({lockPath, holder: readHolder(lockPath, fsImpl), requester: {owner, pid}});
+    throw heldError({lockPath, holder: readFileLeaseHolder(lockPath, fsImpl), requester: {owner, pid}});
 }

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -309,13 +309,13 @@ services:
       - neo-mcp-network
     profiles:
       - cloud
-    # Liveness verified via TaskStateService's persistent state file (#11937).
-    # TaskStateService writes JSON state on every task lifecycle transition;
-    # mtime within 10 minutes (≫ swarm-heartbeat + summary cadences with safety
-    # margin) = orchestrator is alive and polling. 90s start_period covers the
-    # first-poll latency on cold container boot.
+    # Liveness follows the per-role authority lease, which the Orchestrator
+    # refreshes on every poll independently of task lifecycle transitions. A legitimate
+    # long-running child can leave orchestrator-state.json unchanged for more than ten
+    # minutes; task progress stays observable there without making Docker report daemon
+    # death. 90s start_period covers the first-poll latency on cold container boot.
     healthcheck:
-      test: ["CMD", "node", "--input-type=module", "-e", "await import('./src/Neo.mjs');await import('./src/core/_export.mjs');const{default:AiConfig}=await import('./ai/config.mjs');const fs=await import('node:fs');const f=AiConfig.orchestrator.dataDir+'/orchestrator-state.json';try{const m=fs.statSync(f).mtimeMs;process.exit(Date.now()-m<600000?0:1)}catch{process.exit(1)}"]
+      test: ["CMD", "node", "--input-type=module", "-e", "await import('./src/Neo.mjs');await import('./src/core/_export.mjs');const{default:AiConfig}=await import('./ai/config.mjs');const{inspectAuthorityLease}=await import('./ai/daemons/orchestrator/authorityLease.mjs');try{const{fresh}=inspectAuthorityLease({dir:AiConfig.orchestrator.dataDir,profile:AiConfig.orchestrator.authorityProfile});process.exit(fresh?0:1)}catch{process.exit(1)}"]
       interval: 60s
       timeout: 5s
       retries: 3

--- a/test/playwright/unit/ai/daemons/orchestrator/authorityLease.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/authorityLease.spec.mjs
@@ -8,7 +8,8 @@ import {Orchestrator}           from '../../../../../../ai/daemons/orchestrator/
 import {
     acquireAuthorityLease,
     AUTHORITY_LEASE_TTL_MS,
-    authorityLeaseFilename
+    authorityLeaseFilename,
+    inspectAuthorityLease
 } from '../../../../../../ai/daemons/orchestrator/authorityLease.mjs';
 import {FileLeaseHeldError} from '../../../../../../ai/daemons/shared/fileLease.mjs';
 
@@ -69,6 +70,41 @@ test.describe('#16230 — authorityLease specialization', () => {
         expect(written.lastPulse).toBe('2026-07-31T23:00:00.000Z');
 
         handle.release();
+    });
+
+    test('#16283: inspection shares validation, role, and TTL semantics with acquisition', () => {
+        const dir       = tmpDir();
+        const profile   = 'container-plane';
+        const leaseFile = path.join(dir, authorityLeaseFilename(profile));
+        const holder    = {
+            pid       : 7,
+            owner     : 'plane-daemon',
+            ownerToken: 'plane-token',
+            profile,
+            startedAt : new Date(T0).toISOString(),
+            lastPulse : new Date(T0).toISOString()
+        };
+
+        fs.writeJsonSync(leaseFile, holder);
+        expect(inspectAuthorityLease({dir, profile, now: T0 + TTL - 1})).toMatchObject({fresh: true, holder, status: 'fresh'});
+        expect(inspectAuthorityLease({dir, profile, now: T0 + TTL})).toMatchObject({fresh: false, holder, status: 'stale'});
+
+        fs.writeJsonSync(leaseFile, {...holder, profile: 'host-edge'});
+        expect(inspectAuthorityLease({dir, profile, now: T0})).toMatchObject({fresh: false, status: 'invalid'});
+        expect(() => acquireAuthorityLease({dir, profile, pid: 8, now: () => T0 + TTL})).toThrow(FileLeaseHeldError);
+
+        fs.writeJsonSync(leaseFile, {...holder, lastPulse: 'not-a-date'});
+        expect(inspectAuthorityLease({dir, profile, now: T0})).toMatchObject({fresh: false, holder: null, status: 'invalid'});
+
+        fs.writeJsonSync(leaseFile, {...holder, lastPulse: new Date(T0 + 1).toISOString()});
+        expect(inspectAuthorityLease({dir, profile, now: T0})).toMatchObject({fresh: false, status: 'invalid'});
+        expect(() => acquireAuthorityLease({dir, profile, pid: 8, now: () => T0})).toThrow(FileLeaseHeldError);
+
+        fs.writeFileSync(leaseFile, '{corrupt', 'utf8');
+        expect(inspectAuthorityLease({dir, profile, now: T0})).toMatchObject({fresh: false, holder: null, status: 'invalid'});
+
+        fs.rmSync(leaseFile);
+        expect(inspectAuthorityLease({dir, profile, now: T0})).toMatchObject({fresh: false, holder: null, status: 'invalid'});
     });
 
     test('the default holder identity is host-qualified, not a bare generic', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -14,6 +14,10 @@ import {
     requiresOrchestratorPlane
 } from '../../../../../../ai/daemons/orchestrator/daemon.mjs';
 import {
+    AUTHORITY_LEASE_TTL_MS,
+    authorityLeaseFilename
+} from '../../../../../../ai/daemons/orchestrator/authorityLease.mjs';
+import {
     buildOllamaServeEnv,
     getMaxOllamaContextLength,
     resolveOllamaHostPort,
@@ -355,34 +359,10 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(orchestrator.healthcheck.test.slice(0, 4)).toEqual(['CMD', 'node', '--input-type=module', '-e']);
         expect(healthcheckCmd).toContain("await import('./ai/config.mjs')");
         expect(healthcheckCmd).toContain('AiConfig.orchestrator.dataDir');
+        expect(healthcheckCmd).toContain('AiConfig.orchestrator.authorityProfile');
+        expect(healthcheckCmd).toContain('inspectAuthorityLease');
         expect(healthcheckCmd).not.toContain('process.env.NEO_AI_ORCHESTRATOR_DIR');
-
-        const probeDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-orchestrator-health-'));
-        const stateFile    = path.join(probeDataDir, 'orchestrator-state.json');
-        const probeEnv     = {...process.env, NEO_AI_ORCHESTRATOR_DIR: probeDataDir};
-        const probeArgs    = orchestrator.healthcheck.test.slice(2);
-
-        try {
-            fs.writeFileSync(stateFile, '{}');
-
-            expect(spawnSync('node', probeArgs, {
-                cwd     : process.cwd(),
-                encoding: 'utf8',
-                env     : probeEnv
-            }).status).toBe(0);
-
-            const staleAt = new Date(Date.now() - 11 * 60 * 1000);
-
-            fs.utimesSync(stateFile, staleAt, staleAt);
-
-            expect(spawnSync('node', probeArgs, {
-                cwd     : process.cwd(),
-                encoding: 'utf8',
-                env     : probeEnv
-            }).status).toBe(1);
-        } finally {
-            fs.rmSync(probeDataDir, {force: true, recursive: true});
-        }
+        expect(healthcheckCmd).not.toContain('orchestrator-state.json');
 
         for (const [serviceName, service] of Object.entries(compose.services)) {
             if (serviceName === 'orchestrator') continue;
@@ -398,6 +378,61 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
                 ),
                 `${serviceName} must not alias the orchestrator-owned source or target`
             ).toBe(false);
+        }
+    });
+
+    test('#16283: cloud health follows the authority lease, not task completion', () => {
+        const compose      = yaml.load(fs.readFileSync(path.resolve(process.cwd(), 'ai/deploy/docker-compose.yml'), 'utf8'));
+        const orchestrator = compose.services.orchestrator;
+        const probeDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-orchestrator-health-'));
+        const stateFile    = path.join(probeDataDir, 'orchestrator-state.json');
+        const leaseFile    = path.join(probeDataDir, authorityLeaseFilename('container-plane'));
+        const probeEnv     = {
+            ...process.env,
+            NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE: 'container-plane',
+            NEO_AI_ORCHESTRATOR_DIR              : probeDataDir
+        };
+        const probeArgs = orchestrator.healthcheck.test.slice(2);
+        const runProbe  = env => spawnSync('node', probeArgs, {
+            cwd     : process.cwd(),
+            encoding: 'utf8',
+            env     : {...probeEnv, ...env}
+        }).status;
+
+        try {
+            fs.writeFileSync(stateFile, JSON.stringify({summary: {running: true}}));
+
+            const staleTaskAt = new Date(Date.now() - 11 * 60 * 1000);
+            fs.utimesSync(stateFile, staleTaskAt, staleTaskAt);
+            fs.writeFileSync(leaseFile, JSON.stringify({
+                pid       : 7,
+                owner     : 'plane-daemon',
+                ownerToken: 'plane-token',
+                profile   : 'container-plane',
+                startedAt : new Date().toISOString(),
+                lastPulse : new Date().toISOString()
+            }));
+
+            expect(runProbe()).toBe(0);
+
+            const lease = JSON.parse(fs.readFileSync(leaseFile, 'utf8'));
+
+            fs.writeFileSync(leaseFile, JSON.stringify({
+                ...lease,
+                lastPulse: new Date(Date.now() - AUTHORITY_LEASE_TTL_MS - 1000).toISOString()
+            }));
+            expect(runProbe()).toBe(1);
+
+            fs.writeFileSync(leaseFile, '{corrupt');
+            expect(runProbe()).toBe(1);
+
+            fs.writeFileSync(leaseFile, JSON.stringify({...lease, profile: 'host-edge'}));
+            expect(runProbe()).toBe(1);
+
+            fs.rmSync(leaseFile);
+            expect(runProbe()).toBe(1);
+        } finally {
+            fs.rmSync(probeDataDir, {force: true, recursive: true});
         }
     });
 


### PR DESCRIPTION
Resolves #16283

Docker Orchestrator health now follows the existing per-role authority lease instead of using task-state file age as a proxy for daemon responsiveness. A canonical inspector shares descriptor validation, role matching, future-date rejection, and TTL interpretation with lease acquisition; task state remains a separate progress diagnostic.

Evidence: L2 (executable Compose probe against fresh/stale/corrupt/wrong-role/missing lease fixtures, 41 focused unit tests, and rendered Compose validation) → L3 required (AC6 live post-merge observation during one legitimate long child). Residual: AC6 [#16283].

## Deltas from ticket

- The health command does not hand-parse lease JSON. `inspectAuthorityLease()` owns the full fail-closed interpretation and reuses the shared file-lease descriptor reader.
- Future-dated leases explicitly fail health while remaining unreclaimable, alongside the ticket's missing, corrupt, wrong-role, and stale controls.

## Test Evidence

- Authority lease + Orchestrator Compose surfaces: `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs test/playwright/unit/ai/daemons/orchestrator/authorityLease.spec.mjs --reporter=line` — 41 passed.
- Shared file-lease surface: `npm run test-unit -- test/playwright/unit/ai/daemons/shared/fileLease.spec.mjs --reporter=line` — 19 passed.
- Compose surface: `docker compose -f ai/deploy/docker-compose.yml --profile cloud config --quiet` — passed.
- Repository gates: `npm run agent-preflight -- --change-class capability --commit-subject "feat(ai): probe orchestrator authority lease health (#16283)" <touched files>` and `git diff --check` — passed.
- Full unit suite: `npm run test-unit -- --reporter=dot` — 10,628 passed; 21 failed, 5 skipped, 39 did not run. Observed failures include the Docker-owned read-only `.neo-ai-data` plane and live backup artifacts. The three adjacent authority/host-edge failures were rerun independently and reproduced as `SQLITE_READONLY` before their tested guard; the #16283 focused paths remain green.

## Post-Merge Validation

- [ ] Deploy the merged revision, start one legitimate child exceeding the former ten-minute task-state threshold, and record Docker health plus authority-lease age while the child remains active.
- [ ] Confirm task state still exposes the running child independently of container liveness.
- [ ] Confirm a missing or expired expected-role lease still turns the deployed container unhealthy.

Aligned with ADR 0014 and ADR 0019; no new topology, authority class, config leaf, or heartbeat artifact.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fb600-58b9-7fa2-86a7-5a15e1ccf659.
