### PR TITLE
feat(ai): register neomjs/neo as the N=1 KB tenant — config tier + dual mounts (#16278)

### DIFF
--- a/ai/deploy/docker-compose.local-agent-os.yml
+++ b/ai/deploy/docker-compose.local-agent-os.yml
@@ -33,6 +33,11 @@ services:
       <<: [*local-auth, *local-provider]
     secrets:
       - mcp-auth-token
+    # N=1 tenant bootstrap: query-time tenant-config resolution reads
+    # <neoRootDir>/kb-config.yaml (tier 2, fail-soft). Compose appends override
+    # volume lists to the base service's, so this adds to the base mounts.
+    volumes:
+      - ./kb-config.yaml:/app/kb-config.yaml:ro
     healthcheck:
       test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3000", "--expected-plane-id", "neo-local-canonical", "--expected-plane-data-root", "/app/.neo-ai-data"]
 
@@ -55,6 +60,12 @@ services:
       # container. Monitor only the Compose services it actually starts.
       NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES: &local-runtime-services chroma,kb-server,mc-server,orchestrator
       NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES: *local-runtime-services
+    # N=1 tenant bootstrap: the pull-mode sync's tiered resolver reads
+    # <neoRootDir>/kb-config.yaml. This mount is load-bearing — without it the
+    # orchestrator silently falls back to the aiConfig default tier (the trap the
+    # base compose comment names). Appends to the base service's volume list.
+    volumes:
+      - ./kb-config.yaml:/app/kb-config.yaml:ro
 
   ingress:
     restart: unless-stopped

--- a/ai/deploy/kb-config.yaml
+++ b/ai/deploy/kb-config.yaml
@@ -1,0 +1,17 @@
+# N=1 tenant bootstrap: registers neomjs/neo as its own pull-mode KB tenant, so the containerized
+# plane ingests the repo (docs, src, and the hourly datasync artifacts under resources/content/)
+# and `ask_knowledge_base` answers from the current head instead of the last restore snapshot.
+#
+# Read fail-soft from `<neoRootDir>/kb-config.yaml` — tier 2 of the tenant-config resolution
+# (KnowledgeBaseTenantConfig graph node → THIS file → aiConfig defaults). Both the orchestrator
+# (pull-mode sync) and kb-server (query-time resolution) must mount it read-only; the orchestrator
+# mount is load-bearing — without it the sync silently falls back to the aiConfig default tier.
+#
+# Whole-tree ingestion is the accepted contract for this entry (the graduated zero-code PMV);
+# a per-tenant include-manifest is a separate contract lane on the multi-tenant epic. Mirror root
+# and sync cadence deliberately ride their defaults (`tenantRepoMirrorRoot`, the 30-minute
+# cadence floor) — per-entry overrides exist (`mirrorRoot`, `cadenceMs`) but are not opted into.
+tenantRepos:
+  - tenantId: neo-shared
+    cloneUrl: https://github.com/neomjs/neo.git
+    branch: dev

--- a/ai/deploy/kb-config.yaml
+++ b/ai/deploy/kb-config.yaml
@@ -3,15 +3,21 @@
 # and `ask_knowledge_base` answers from the current head instead of the last restore snapshot.
 #
 # Read fail-soft from `<neoRootDir>/kb-config.yaml` — tier 2 of the tenant-config resolution
-# (KnowledgeBaseTenantConfig graph node → THIS file → aiConfig defaults). Both the orchestrator
-# (pull-mode sync) and kb-server (query-time resolution) must mount it read-only; the orchestrator
-# mount is load-bearing — without it the sync silently falls back to the aiConfig default tier.
+# (KnowledgeBaseTenantConfig graph node → THIS file → aiConfig defaults). The document root is a
+# `tenants` map keyed by tenantId; entries normalize through the tenant-repo access contract,
+# which REQUIRES `credentialRef` (`none` = public clone, no credential material) and keys repo
+# identity as `tenantId/repoSlug`. Both the orchestrator (pull-mode sync) and kb-server
+# (query-time resolution) must mount this file read-only; the orchestrator mount is load-bearing —
+# without it the sync silently falls back to the aiConfig default tier.
 #
 # Whole-tree ingestion is the accepted contract for this entry (the graduated zero-code PMV);
 # a per-tenant include-manifest is a separate contract lane on the multi-tenant epic. Mirror root
-# and sync cadence deliberately ride their defaults (`tenantRepoMirrorRoot`, the 30-minute
-# cadence floor) — per-entry overrides exist (`mirrorRoot`, `cadenceMs`) but are not opted into.
-tenantRepos:
-  - tenantId: neo-shared
-    cloneUrl: https://github.com/neomjs/neo.git
-    branch: dev
+# and sync cadence deliberately ride their defaults (`tenantRepoMirrorRoot`, the cadence floor).
+tenants:
+  neo-shared:
+    tenantRepos:
+      - tenantId: neo-shared
+        repoSlug     : neo
+        cloneUrl     : https://github.com/neomjs/neo.git
+        credentialRef: none
+        branchRef    : dev

--- a/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
+++ b/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
@@ -1,0 +1,99 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : 'KbTenantBootstrapContractTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import fs             from 'node:fs';
+import path           from 'node:path';
+import process        from 'node:process';
+import {load}         from 'js-yaml';
+
+// Compose's `!override` merge tag (used by the overlay's ingress section, which this spec never
+// asserts) is not YAML-core; strip the tag token so the values parse as their plain shapes and
+// the document stays structurally readable. Assertions below run on the parsed model only.
+const yamlLoad = (source, {compose = false} = {}) => load(compose ? source.replace(/!override/g, '') : source);
+
+/**
+ * Guards the tracked N=1 tenant bootstrap (`ai/deploy/kb-config.yaml`) through the PRODUCTION
+ * read and normalization paths — not a schema the test invents.
+ *
+ * The deployment mounts this file at `<neoRootDir>/kb-config.yaml`, where the tenant-config
+ * resolver's tier-2 bootstrap reads it FAIL-SOFT: a malformed document resolves to `null` and the
+ * pull sync silently falls back to the aiConfig default tier (zero tenants). That silent-fallback
+ * shape is exactly why these assertions run the real reader and the real entry normalizer against
+ * the tracked bytes — a field-name drift fails here, loudly, instead of at a live boot.
+ */
+
+const
+    repoRoot     = path.resolve(process.cwd()),
+    bootstrapRel = 'ai/deploy/kb-config.yaml',
+    overlayRel   = 'ai/deploy/docker-compose.local-agent-os.yml',
+    MOUNT_ENTRY  = './kb-config.yaml:/app/kb-config.yaml:ro';
+
+test.describe('ai/deploy/kb-config.yaml — N=1 tenant bootstrap contract', () => {
+    let IngestionService, normalizeTenantRepoEntry;
+
+    test.beforeAll(async () => {
+        IngestionService         = (await import('../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
+        normalizeTenantRepoEntry = (await import('../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs')).normalizeTenantRepoEntry
+    });
+
+    test('the tracked deployment file loads through the production bootstrap reader', () => {
+        const tracked = fs.readFileSync(path.join(repoRoot, bootstrapRel), 'utf8');
+
+        const result = IngestionService.readKbConfigBootstrapResult({
+            fileSystem: {
+                readFileSync() {
+                    return tracked
+                }
+            }
+        });
+
+        expect(result.status).toBe('loaded');
+        expect(result.tenantCount).toBe(1);
+        expect(Object.keys(result.document.tenants)).toEqual(['neo-shared'])
+    });
+
+    test('the neo entry normalizes through the production contract to exactly one neo-shared/neo repo', () => {
+        const
+            document = yamlLoad(fs.readFileSync(path.join(repoRoot, bootstrapRel), 'utf8')),
+            repos    = document.tenants['neo-shared'].tenantRepos;
+
+        expect(repos).toHaveLength(1);
+
+        const normalized = normalizeTenantRepoEntry(repos[0]);
+
+        expect(normalized.tenantId).toBe('neo-shared');
+        expect(normalized.repoSlug).toBe('neo');
+        expect(normalized.cloneUrl).toBe('https://github.com/neomjs/neo.git');
+        expect(normalized.credentialRef).toBe('none');
+        expect(normalized.branchRef).toBe('dev')
+    });
+
+    test('exactly the two consuming services mount the bootstrap read-only in the local-agent-os overlay', () => {
+        const overlay = yamlLoad(fs.readFileSync(path.join(repoRoot, overlayRel), 'utf8'), {compose: true});
+
+        const mountingServices = Object.entries(overlay.services)
+            .filter(([, service]) => (service.volumes || []).includes(MOUNT_ENTRY))
+            .map(([name]) => name)
+            .sort();
+
+        // Pinned both ways: a service dropping the mount fails (silent tier-fallback trap),
+        // and a THIRD mounter fails too — new bootstrap consumers are a design change to review,
+        // not a drift for this spec to follow.
+        expect(mountingServices).toEqual(['kb-server', 'orchestrator'])
+    });
+});


### PR DESCRIPTION
Resolves #16278

## What

The zero-code build of the graduated N=1 slice (D#15605 body fold 5; quorum: Iris `[AUTHOR_SIGNAL]` + Emmy `[GRADUATION_APPROVED]`): the containerized plane gets its first ingestion feed by registering neomjs/neo as its own pull-mode KB tenant.

- **`ai/deploy/kb-config.yaml`** (new, tracked — no secrets): the production shape — a `tenants` map with one `tenants.neo-shared.tenantRepos` entry carrying `tenantId: neo-shared`, `repoSlug: neo`, `cloneUrl: https://github.com/neomjs/neo.git`, `credentialRef: none` (required by the access contract; `none` = public clone), `branchRef: dev`. Mirror root and cadence deliberately ride their defaults; whole-tree ingestion is the accepted contract per the graduated PMV (the include-manifest is a separate epic lane). Placement settled per the tiered resolver: tier 2 reads `<neoRootDir>/kb-config.yaml` fail-soft (graph node → this file → aiConfig defaults), and the deploy dir is where the overlay's relative mount resolves.
- **`test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs`** (new, test-only — no production code): guards the tracked bytes through the PRODUCTION paths — `readKbConfigBootstrapResult({fileSystem})` injected with the tracked file (`status: loaded`, `tenantCount: 1`), `normalizeTenantRepoEntry` asserting exactly one normalized neo-shared/neo repo with `credentialRef: none` + `branchRef: dev`, and the mount roster pinned both ways (derived-from-artifact set === exactly `[kb-server, orchestrator]` — a dropped mount fails, and so does an unreviewed third mounter).
- **Both read-only mounts** in `docker-compose.local-agent-os.yml` (kb-server + orchestrator): the orchestrator mount is load-bearing — without it the pull sync silently falls back to the aiConfig default tier, the exact trap the base compose comment names.

The pull lane is the additive complement — `kbSync` is never re-pointed at tenant content per the lane-classification separation invariant (verified in the sync service's contract JSDoc).

## Test Evidence

Evidence: L2 (config-contract) → L4 required (first sanctioned sync receipts on the live plane). Residual: #16278 ACs 1–5 — the resolver listing the tenant on boot, the identity-classified pre/post ID-set reconciliation receipt (zero same-identity duplication against the restored 61,206), the recurring checkpoint naming its delta commit, and the post-07-30-only cited `ask` known-hit — all land on #16278 after the kb-server + orchestrator recreate adopts the mounts.

- `kb-config.yaml` parses (js-yaml).
- Merged compose render (`docker compose --profile cloud -f docker-compose.yml -f docker-compose.local-agent-os.yml config`): **both** services carry `target: /app/kb-config.yaml` read-only (2/2) — the override volume list APPENDS to the base lists, verified in the rendered model, not assumed.

## Post-Merge Validation

- [ ] Recreate kb-server + orchestrator only (chroma untouched; MC/KB bounce = brief A2A blip, broadcast first) — the mounts adopt.
- [ ] AC 1: the tiered resolver lists the neo tenant on boot (a field-name miss fails here, by design).
- [ ] First sanctioned sync → the identity-classified reconciliation receipt on #16278.
- [ ] Recurring checkpoint + the post-07-30 `ask` known-hit → #16278.

## Deltas

- The RC1 repair added a test-only contract spec (above) — zero PRODUCTION code, keeping the PMV honestly zero-code; the deliberate config-shape delta from the ticket's original sketch (flat root + `branch`) to the production contract (`tenants` map + `repoSlug`/`credentialRef`/`branchRef`) is recorded in the ticket's backfilled Contract Ledger. Any code gap the sync surfaces (the known adjacent is #16224's suppression-retry class) files as its own leaf citing the graduation.

Authored by @neo-opus-vega
Origin Session ID: 1021960a-ad70-4ea9-ba96-c0f5b4bb553d
