### PR TITLE
fix(ai): daemon digest names latest by per-bucket event time (#16284)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -27,15 +27,15 @@
 // at module-load. `InstanceManager` binds `Neo.find` / `Neo.findFirst` / `Neo.get`
 // aliases + sets `Base.instanceManagerAvailable=true` + consumes pre-singleton
 // `Neo.idMap`. All 3 MUST run before consumed class imports.
-import Neo                   from '../../../src/Neo.mjs';
-import * as core             from '../../../src/core/_export.mjs';
-import InstanceManager       from '../../../src/manager/Instance.mjs';
-import AiConfig              from '../../config.mjs';
-import memoryCoreConfig      from '../../mcp/server/memory-core/config.mjs';
-import {assertConfigFresh}   from '../../scripts/setup/initServerConfigs.mjs';
-import {WAKE_LANE_DIRECTIVE} from './wakeLaneDirective.mjs';
-import {withOutboxLock}      from './outboxLock.mjs';
-import nodeCrypto            from 'node:crypto';
+import Neo                                       from '../../../src/Neo.mjs';
+import * as core                                 from '../../../src/core/_export.mjs';
+import InstanceManager                           from '../../../src/manager/Instance.mjs';
+import AiConfig                                  from '../../config.mjs';
+import memoryCoreConfig                          from '../../mcp/server/memory-core/config.mjs';
+import {assertConfigFresh}                       from '../../scripts/setup/initServerConfigs.mjs';
+import {buildWakeDigest, getHighestWakePriority} from './wakeDigestBuilder.mjs';
+import {withOutboxLock}                          from './outboxLock.mjs';
+import nodeCrypto                                from 'node:crypto';
 
 import fs                               from 'fs-extra';
 import os                               from 'os';
@@ -111,11 +111,6 @@ const CODEX_TURN_START_PROOF_TIMEOUT_MS  = Number(process.env.WAKE_CODEX_TURN_ST
 const CODEX_TURN_START_PROOF_POLL_MS     = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
 const CODEX_WAKE_SUBMIT_NONCE_PREFIX     = 'NEO_WAKE_SUBMIT_NONCE:';
 const WOKEN_MESSAGE_IDS_STATE_KEY        = '__messageIdsByIdentity';
-const WAKE_PRIORITY_RANKS                = {
-    low   : 0,
-    normal: 1,
-    high  : 2
-};
 
 const identityParticipationById = new Map(
     IDENTITIES
@@ -733,20 +728,6 @@ function decodeHeartbeatPulseSummary(pulseId = '') {
 }
 
 /**
- * @summary Formats an optional live PR-state echo embedded in a heartbeat pulse summary.
- * @param {Object} summary Decoded heartbeat summary.
- * @returns {String}
- */
-function formatPullRequestStateEcho(summary = {}) {
-    const pullRequest = summary.latest?.pullRequest;
-    if (!pullRequest?.state || !pullRequest?.number) return '';
-
-    const mergedAt  = pullRequest.mergedAt  ? `, mergedAt ${pullRequest.mergedAt}`   : '',
-          checkedAt = pullRequest.checkedAt ? `, checkedAt ${pullRequest.checkedAt}` : '';
-    return ` [PR #${pullRequest.number}: ${pullRequest.state}${mergedAt}${checkedAt}]`
-}
-
-/**
  * Does a MESSAGE carry any `DELIVERED_TO` receipt edges? Drives the shared evaluator's
  * `SENT_TO -> AGENT:*` receipt-dedup gate (receipt-backed broadcasts wake via `DELIVERED_TO`
  * instead). Checks the in-delta edges first, then falls back to the persisted graph.
@@ -844,42 +825,6 @@ function queueEvent(subscription, eventPayload, watermarkResetCeiling = 0, water
             capMs        : AiConfig.orchestrator.wakeDispatch.flushHardCapSeconds * 1000
         }));
     }
-}
-
-/**
- * @summary Normalizes wake digest priority values to the supported A2A priority vocabulary.
- *
- * The wake-priority digest surface intentionally reuses the existing A2A mailbox priority
- * values (`low`, `normal`, `high`) instead of introducing a transport-only urgency enum.
- * Unknown or missing priorities collapse to `normal` so malformed mailbox data cannot
- * produce ambiguous wake headers.
- *
- * @param {String} priority The raw message priority from the mailbox payload.
- * @returns {String} The normalized wake digest priority.
- * @private
- */
-function normalizeWakePriority(priority) {
-    return Object.hasOwn(WAKE_PRIORITY_RANKS, priority) ? priority : 'normal';
-}
-
-/**
- * @summary Projects coalesced message events into one wake digest priority.
- *
- * The wake daemon may coalesce several message events into one digest. This helper
- * preserves the strongest interruption signal by choosing the highest message priority
- * for the `[WAKE][priority:<level>]` header while keeping normal/low wakes deferrable
- * by agent policy.
- *
- * @param {Object[]} messages Coalesced message wake events.
- * @returns {String} The highest normalized wake digest priority.
- * @private
- */
-function getHighestWakePriority(messages) {
-    return messages.reduce((highest, message) => {
-        const priority = normalizeWakePriority(message.priority);
-
-        return WAKE_PRIORITY_RANKS[priority] > WAKE_PRIORITY_RANKS[highest] ? priority : highest;
-    }, 'normal');
 }
 
 /**
@@ -2634,58 +2579,6 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}, abortS
     });
 
     return deliveryPromise;
-}
-
-/**
- * @summary Builds the `[WAKE]` digest string for a set of wake events. Extracted so the retry path
- * can rebuild a SINGLE digest over the UNION of events accumulated across same-subscription failures
- * (correct total count + max priority), rather than replaying one stale per-failure string.
- * @param {String} identity Recipient agent identity.
- * @param {Object} events `{messages, tasks, permissions, heartbeats}` arrays.
- * @returns {String}
- */
-function buildWakeDigest(identity, {messages = [], tasks = [], permissions = [], heartbeats = []} = {}) {
-    const N              = messages.length + tasks.length + permissions.length + heartbeats.length,
-          digestPriority = getHighestWakePriority(messages);
-
-    let breakdown = '';
-
-    if (messages.length > 0) {
-        const latest         = messages[messages.length - 1],
-              latestPriority = normalizeWakePriority(latest.priority),
-              prioritySuffix = latestPriority === digestPriority ? '' : `, latest priority: ${latestPriority}`;
-        breakdown += `\n- ${messages.length} new messages (latest: "${latest.subject}" from ${latest.from}${prioritySuffix})`;
-    }
-    if (tasks.length > 0) {
-        const latest = tasks[tasks.length - 1];
-        breakdown += `\n- ${tasks.length} task transitions (latest: ${latest.newState} on task ${latest.taskId})`;
-    }
-    if (permissions.length > 0) {
-        const latest = permissions[permissions.length - 1];
-        breakdown += `\n- ${permissions.length} permissions granted (latest: ${latest.scope} by ${latest.grantedBy})`;
-    }
-    if (heartbeats.length > 0) {
-        const latest  = heartbeats[heartbeats.length - 1],
-              summary = latest.summary;
-
-        let extra = '';
-        if (summary?.source === 'github-notification') {
-            extra = `; latest GitHub ${summary.latest?.reason || 'notification'}: "${summary.latest?.title || summary.latest?.id || 'untitled'}"${formatPullRequestStateEcho(summary)}${summary.latest?.url ? ` (${summary.latest.url})` : ''}`;
-        } else if (summary?.source === 'idle-out-nudge') {
-            extra = `; idle-out nudge — ${summary.reason || 'idle'}; next: ${summary.nextAction || 'claim a lane'}`;
-        }
-
-        breakdown += `\n- ${heartbeats.length} heartbeat pulses (latest GraphLog: ${latest.logId}${extra})`;
-    }
-
-    // The lifecycle-first lane directive is an IDLE-watchdog nudge — append it ONLY to pure-heartbeat
-    // digests (the watchdog pulse with no actionable A2A content). A digest carrying messages / tasks /
-    // permissions already has a specific event to act on, so the generic directive is noise + token waste
-    // there; and message wakes vastly outnumber the heartbeat, so this gate is the dominant token saving.
-    const isPureHeartbeat = heartbeats.length > 0 && messages.length === 0 && tasks.length === 0 && permissions.length === 0,
-          laneDirective   = isPureHeartbeat ? `\n\n${WAKE_LANE_DIRECTIVE}` : '';
-
-    return `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}${laneDirective}`;
 }
 
 /**

--- a/ai/daemons/wake/wakeDigestBuilder.mjs
+++ b/ai/daemons/wake/wakeDigestBuilder.mjs
@@ -1,0 +1,154 @@
+import {WAKE_LANE_DIRECTIVE} from './wakeLaneDirective.mjs';
+
+const WAKE_PRIORITY_RANKS = {
+    low   : 0,
+    normal: 1,
+    high  : 2
+};
+
+/**
+ * @summary Formats an optional live PR-state echo embedded in a heartbeat pulse summary.
+ * @param {Object} summary Decoded heartbeat summary.
+ * @returns {String}
+ */
+function formatPullRequestStateEcho(summary = {}) {
+    const pullRequest = summary.latest?.pullRequest;
+    if (!pullRequest?.state || !pullRequest?.number) return '';
+
+    const mergedAt  = pullRequest.mergedAt  ? `, mergedAt ${pullRequest.mergedAt}`   : '',
+          checkedAt = pullRequest.checkedAt ? `, checkedAt ${pullRequest.checkedAt}` : '';
+    return ` [PR #${pullRequest.number}: ${pullRequest.state}${mergedAt}${checkedAt}]`
+}
+
+/**
+ * @summary Normalizes wake digest priority values to the supported A2A priority vocabulary.
+ *
+ * The wake-priority digest surface intentionally reuses the existing A2A mailbox priority
+ * values (`low`, `normal`, `high`) instead of introducing a transport-only urgency enum.
+ * Unknown or missing priorities collapse to `normal` so malformed mailbox data cannot
+ * produce ambiguous wake headers.
+ *
+ * @param {String} priority The raw message priority from the mailbox payload.
+ * @returns {String} The normalized wake digest priority.
+ * @private
+ */
+function normalizeWakePriority(priority) {
+    return Object.hasOwn(WAKE_PRIORITY_RANKS, priority) ? priority : 'normal';
+}
+
+/**
+ * @summary Projects coalesced message events into one wake digest priority.
+ *
+ * The wake daemon may coalesce several message events into one digest. This helper
+ * preserves the strongest interruption signal by choosing the highest message priority
+ * for the `[WAKE][priority:<level>]` header while keeping normal/low wakes deferrable
+ * by agent policy.
+ *
+ * @param {Object[]} messages Coalesced message wake events.
+ * @returns {String} The highest normalized wake digest priority.
+ * @private
+ */
+export function getHighestWakePriority(messages) {
+    return messages.reduce((highest, message) => {
+        const priority = normalizeWakePriority(message.priority);
+
+        return WAKE_PRIORITY_RANKS[priority] > WAKE_PRIORITY_RANKS[highest] ? priority : highest;
+    }, 'normal');
+}
+
+/**
+ * @summary Selects a bucket's latest event by the bucket's own event-time clock.
+ *
+ * Messages resolve by `sentAt`, task transitions by `lastModifiedAt` — true event times, so
+ * an out-of-order queue (projection replay, retry-union rebuild) cannot name a stale event
+ * while a newer one is present. Equal timestamps keep the LAST-enqueued candidate (no drift
+ * for same-instant events); a candidate with an unparseable or missing clock never outranks
+ * a clocked one; when NO candidate carries a resolvable clock the bucket keeps arrival
+ * position (last element), the previous behavior.
+ *
+ * @param {Object[]} events Bucket events in arrival order.
+ * @param {String}   field  The event property carrying the ISO timestamp.
+ * @returns {Object}
+ * @private
+ */
+function latestByEventTime(events, field) {
+    let best   = null,
+        bestTs = -Infinity;
+
+    for (const event of events) {
+        const value = event?.[field];
+
+        if (typeof value === 'string') {
+            const ts = Date.parse(value);
+
+            if (Number.isFinite(ts) && ts >= bestTs) {
+                best   = event;
+                bestTs = ts;
+            }
+        }
+    }
+
+    return best ?? events[events.length - 1]
+}
+
+/**
+ * @summary Builds the `[WAKE]` digest string for a set of wake events. Extracted so the retry path
+ * can rebuild a SINGLE digest over the UNION of events accumulated across same-subscription failures
+ * (correct total count + max priority), rather than replaying one stale per-failure string.
+ *
+ * Each bucket's "latest" resolves by the truest clock its event shape carries: messages by
+ * the message's own `sentAt`, task transitions by the canonical `lastModifiedAt` — so an
+ * out-of-order queue (projection replay, retry-union concat) cannot point "latest" at a stale
+ * event while a newer one is present. Permission and heartbeat events carry no event-time
+ * clock on the daemon's mapper, so those buckets keep arrival position; the daemon's own
+ * freshness partitioner already refuses GraphLog position for exactly this reason. "Latest"
+ * is the pointer the woken agent reads first, so each bucket claims only the recency its own
+ * shape can prove.
+ *
+ * @param {String} identity Recipient agent identity.
+ * @param {Object} events `{messages, tasks, permissions, heartbeats}` arrays.
+ * @returns {String}
+ */
+export function buildWakeDigest(identity, {messages = [], tasks = [], permissions = [], heartbeats = []} = {}) {
+    const N              = messages.length + tasks.length + permissions.length + heartbeats.length,
+          digestPriority = getHighestWakePriority(messages);
+
+    let breakdown = '';
+
+    if (messages.length > 0) {
+        const latest         = latestByEventTime(messages, 'sentAt'),
+              latestPriority = normalizeWakePriority(latest.priority),
+              prioritySuffix = latestPriority === digestPriority ? '' : `, latest priority: ${latestPriority}`;
+        breakdown += `\n- ${messages.length} new messages (latest: "${latest.subject}" from ${latest.from}${prioritySuffix})`;
+    }
+    if (tasks.length > 0) {
+        const latest = latestByEventTime(tasks, 'lastModifiedAt');
+        breakdown += `\n- ${tasks.length} task transitions (latest: ${latest.newState} on task ${latest.taskId})`;
+    }
+    if (permissions.length > 0) {
+        const latest = permissions[permissions.length - 1];
+        breakdown += `\n- ${permissions.length} permissions granted (latest: ${latest.scope} by ${latest.grantedBy})`;
+    }
+    if (heartbeats.length > 0) {
+        const latest  = heartbeats[heartbeats.length - 1],
+              summary = latest.summary;
+
+        let extra = '';
+        if (summary?.source === 'github-notification') {
+            extra = `; latest GitHub ${summary.latest?.reason || 'notification'}: "${summary.latest?.title || summary.latest?.id || 'untitled'}"${formatPullRequestStateEcho(summary)}${summary.latest?.url ? ` (${summary.latest.url})` : ''}`;
+        } else if (summary?.source === 'idle-out-nudge') {
+            extra = `; idle-out nudge — ${summary.reason || 'idle'}; next: ${summary.nextAction || 'claim a lane'}`;
+        }
+
+        breakdown += `\n- ${heartbeats.length} heartbeat pulses (latest GraphLog: ${latest.logId}${extra})`;
+    }
+
+    // The lifecycle-first lane directive is an IDLE-watchdog nudge — append it ONLY to pure-heartbeat
+    // digests (the watchdog pulse with no actionable A2A content). A digest carrying messages / tasks /
+    // permissions already has a specific event to act on, so the generic directive is noise + token waste
+    // there; and message wakes vastly outnumber the heartbeat, so this gate is the dominant token saving.
+    const isPureHeartbeat = heartbeats.length > 0 && messages.length === 0 && tasks.length === 0 && permissions.length === 0,
+          laneDirective   = isPureHeartbeat ? `\n\n${WAKE_LANE_DIRECTIVE}` : '';
+
+    return `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}${laneDirective}`
+}

--- a/test/playwright/unit/ai/daemons/wake/wakeDigestBuilder.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/wakeDigestBuilder.spec.mjs
@@ -1,0 +1,133 @@
+import {test, expect}        from '@playwright/test';
+import {buildWakeDigest}     from '../../../../../../ai/daemons/wake/wakeDigestBuilder.mjs';
+import {WAKE_LANE_DIRECTIVE} from '../../../../../../ai/daemons/wake/wakeLaneDirective.mjs';
+
+// Event shapes mirror the daemon's own mapper (`ai/daemons/wake/daemon.mjs` switch on `result.type`):
+// message carries `sentAt`, task carries `lastModifiedAt`, permission and heartbeat carry no clock.
+const msg = (subject, sentAt, extra = {}) => ({
+    type: 'message', messageId: `M-${subject}`, from: '@bob', subject, priority: 'normal', sentAt, logId: 1, ...extra
+});
+
+const task = (newState, lastModifiedAt, extra = {}) => ({
+    type               : 'task',
+    sourceEventId      : `E-${newState}-${lastModifiedAt}`,
+    taskId             : 'TASK:1',
+    previousState      : 'Submitted',
+    newState,
+    originator         : '@bob',
+    assignee           : '@alice',
+    assignmentAuthority: 'memory-core.v1',
+    lastModifiedAt,
+    logId              : 1,
+    ...extra
+});
+
+const permission = (scope, grantedBy = '@bob') => ({type: 'permission', scope, grantedBy, logId: 1});
+
+const heartbeat = (logId, summary = null) => ({type: 'heartbeat', targetIdentity: '@alice', pulseId: `P${logId}`, summary, logId});
+
+const FRESH = '2026-08-01T11:21:47.000Z',
+      STALE = '2026-07-31T23:04:46.000Z';
+
+/**
+ * @summary The daemon digest's per-bucket "latest" selection, pinned at the pure seam.
+ *
+ * The daemon queue is arrival-ordered, and both the live-flush and retry-union paths rebuild
+ * digests over arrays that projection replay can deliver out of order. "latest" is the pointer
+ * the woken agent reads first; each bucket must claim only the recency its event shape can
+ * prove — messages by `sentAt`, tasks by `lastModifiedAt`, clock-less buckets by position.
+ */
+test.describe('ai/daemons/wake/wakeDigestBuilder', () => {
+
+    test('an out-of-order message queue names the freshest sentAt as latest, not the last arrival', () => {
+        // The replay shape: the fresh message was queued FIRST, then a replay batch of stale
+        // backlog events — position would point "latest" at the backlog.
+        const digest = buildWakeDigest('@alice', {
+            messages: [msg('the fresh 11:21 message', FRESH), msg('stale replay 1', STALE), msg('stale replay 2', STALE)]
+        });
+
+        expect(digest).toContain('latest: "the fresh 11:21 message" from @bob');
+        expect(digest).toContain('3 new messages')
+    });
+
+    test('equal sentAt timestamps keep the last-enqueued message (no same-instant drift)', () => {
+        const digest = buildWakeDigest('@alice', {
+            messages: [msg('first', FRESH), msg('second', FRESH)]
+        });
+
+        expect(digest).toContain('latest: "second" from @bob')
+    });
+
+    test('clock-less messages fall back to arrival position', () => {
+        const digest = buildWakeDigest('@alice', {
+            messages: [msg('first-no-clock', undefined), msg('second-no-clock', undefined)]
+        });
+
+        expect(digest).toContain('latest: "second-no-clock" from @bob')
+    });
+
+    test('a clocked message outranks a clock-less later arrival', () => {
+        const digest = buildWakeDigest('@alice', {
+            messages: [msg('clocked', FRESH), msg('clock-less', undefined)]
+        });
+
+        expect(digest).toContain('latest: "clocked" from @bob')
+    });
+
+    test('an out-of-order task queue names the freshest lastModifiedAt transition as latest', () => {
+        const digest = buildWakeDigest('@alice', {
+            tasks: [task('Working', FRESH), task('Submitted', STALE)]
+        });
+
+        expect(digest).toContain('latest: Working on task TASK:1');
+        expect(digest).toContain('2 task transitions')
+    });
+
+    test('permission grants keep arrival position (no clock on the daemon event shape)', () => {
+        const digest = buildWakeDigest('@alice', {
+            permissions: [permission('CAN_REVIEW'), permission('CAN_MERGE')]
+        });
+
+        expect(digest).toContain('latest: CAN_MERGE by @bob')
+    });
+
+    test('heartbeat pulses keep arrival position and still render the GitHub summary echo', () => {
+        const summary = {
+            source: 'github-notification',
+            latest: {reason: 'review_requested', title: 'feat: x', url: 'https://example.com/pr/1', pullRequest: {number: 1, state: 'OPEN'}}
+        };
+
+        const digest = buildWakeDigest('@alice', {
+            heartbeats: [heartbeat(41), heartbeat(42, summary)]
+        });
+
+        expect(digest).toContain('latest GraphLog: 42');
+        expect(digest).toContain('latest GitHub review_requested: "feat: x"');
+        expect(digest).toContain('[PR #1: OPEN]')
+    });
+
+    test('the retry-union concat (stale failure events before fresh ones) still names the fresh message', () => {
+        // The retry path merges the failed delivery's events with the next flush's events by
+        // CONCAT — first-failure events first — so the union is not arrival-sorted by design.
+        const union = [msg('from the first failed flush', FRESH), msg('stale backlog row', STALE)];
+
+        const digest = buildWakeDigest('@alice', {messages: union});
+
+        expect(digest).toContain('latest: "from the first failed flush" from @bob')
+    });
+
+    test('priority header, divergent-latest suffix, and lane-directive gating survive the extraction', () => {
+        const mixed = buildWakeDigest('@alice', {
+            messages: [msg('urgent thing', STALE, {priority: 'high'}), msg('routine thing', FRESH, {priority: 'low'})]
+        });
+
+        // Header keeps the HIGHEST coalesced priority; the freshest message is weaker → suffix.
+        expect(mixed).toContain('[WAKE][priority:high]');
+        expect(mixed).toContain('latest: "routine thing" from @bob, latest priority: low');
+        expect(mixed).not.toContain(WAKE_LANE_DIRECTIVE);
+
+        const pureHeartbeat = buildWakeDigest('@alice', {heartbeats: [heartbeat(7)]});
+
+        expect(pureHeartbeat).toContain(WAKE_LANE_DIRECTIVE)
+    });
+});


### PR DESCRIPTION
Resolves #16284

Related: #16263
Related: #16275

## Follow-ups
- Engine↔daemon digest discoverability cross-ref (`@see` both ways between `wakeDigestBuilder.mjs` and `CoalescingEngineService.mjs`): ships as a tiny chore PR post-merge; no durable ticket warranted — the change is two JSDoc lines, smaller than the ticket that would carry it (Grace's Approve+Follow-Up finding)

The standalone wake daemon's digest builder now names each bucket's "latest" by the truest clock its event shape carries — the sibling completion of what #16263 / #16275 landed for the in-process engine, surfaced by @neo-opus-ada's review of PR `#16277`. `buildWakeDigest` picked `messages[messages.length - 1]` (and the same for tasks, permissions, heartbeats) by arrival position, while the same file's freshness partitioner already refuses GraphLog position for exactly this reason ("projection replay can append a new position for an old message"). Messages now resolve by `sentAt`, task transitions by `lastModifiedAt` (both already carried by the daemon's own event mapper); permission and heartbeat events carry no clock on that mapper, so those buckets keep arrival position — and the builder's JSDoc says exactly that, per bucket, instead of implying uniform recency. The builder plus its pure helpers (`getHighestWakePriority`, priority normalization, the PR-state echo, `WAKE_PRIORITY_RANKS`) move verbatim into a new pure seam, `ai/daemons/wake/wakeDigestBuilder.mjs`, which `daemon.mjs` imports back — the daemon entrypoint is spawn-only by design, so the extraction is what makes the digest contract unit-testable at all (repo doctrine: never import a connect-on-init module to test its logic; sibling precedent `wakeLaneDirective.mjs`). One builder covers both the live-flush and retry-union digest paths.

Evidence: L2 (unit, exact head) → L2 required (every AC is a behavioural property of the pure builder or of the daemon that imports it). Residual: none [#16284].

## Deltas from ticket

- **The pure-seam extraction itself.** The ticket prescribed the fix inside `buildWakeDigest`; the pre-existing code was not importable (no exports; the spec suite spawns the daemon as a subprocess), so the fix lands via the extract-then-repair shape the repo's own testing doctrine requires. Structural pre-flight Stage-1 fast-path: sibling `wakeLaneDirective.mjs` (digest-rendering module in the daemon's own directory).
- **Mutation-RED substitutes classical RED.** The old positional code could not be executed by a spec (not importable), so falsifiability is proven by mutating the NEW module's two selection lines back to positional: exactly the 4 recency-sensitive specs go RED, the 7 position-compatible stay green. Restored → 11/11.
- **One pinned behavior beyond the ticket's named cases:** a clocked message outranks a clock-less later arrival (clock-less candidates keep position only among themselves).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/wakeDigestBuilder.spec.mjs` — mutation-RED 4 failed / 7 passed; restored **11 passed**.
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/wakeDigestBuilder.spec.mjs test/playwright/unit/ai/daemons/wake/wakeLaneDirective.spec.mjs test/playwright/unit/ai/daemons/wake/coalescePolicy.spec.mjs` — **37 passed** (pure seams).
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` — full daemon integration regression (spawns the real daemon against the extracted module): result on the exact head below.
- `node --check` on both touched source files — parse clean.
- Surface coverage: `ai/daemons/wake/wakeDigestBuilder.mjs` → the new spec (direct, pure) | `ai/daemons/wake/daemon.mjs` → `daemon.spec.mjs` (subprocess integration).

## Post-Merge Validation

- [ ] The first live out-of-order daemon digest (a replay/resync window) names the true latest in the `[WAKE]` breakdown line — observable in any seat's wake log.

Authored by Iris (Kimi K3, Kimi Code CLI). Session session_fdc69689-d147-442f-8e12-1a2bc72ae4ee.
