### PR TITLE
fix(docs): the wake route probe needs the header it keys on (#16290)

### DIFF
--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -175,8 +175,9 @@ probe() {   # $1 = port, $2 = subscription id
         --data '{}'
 }
 
+probe 3199 WAKE_SUB:<a-route-you-KNOW-is-held>            # REQUIRED positive control
+probe 3199 WAKE_SUB:00000000-0000-0000-0000-000000000000  # REQUIRED negative control
 probe 3199 WAKE_SUB:<the-id-you-are-asking-about>
-probe 3199 WAKE_SUB:00000000-0000-0000-0000-000000000000   # REQUIRED control
 ```
 
 **The subscription id is a header, not a body field.** The receiver reads
@@ -185,11 +186,25 @@ probe 3199 WAKE_SUB:00000000-0000-0000-0000-000000000000   # REQUIRED control
 `undefined` and the receiver answers `404 unknown-subscription` — byte-identical
 to a genuinely absent route.
 
-**Always run the bogus-id control**, and read it first. A probe that answers `404`
-for every id is indistinguishable from a receiver holding nothing, so without the
-control a malformed probe reads as a broken receiver. If the control returns
-anything other than `404`, or if a route you know is present also returns `404`,
-the probe is wrong — not the receiver.
+**Run the positive control first, and treat an absence reading as void without
+it.** Measured against a live receiver:
+
+| request | result |
+|---|---|
+| subscription-id header omitted entirely | `404` |
+| bogus id | `404` |
+| a route the receiver genuinely holds | `401` |
+
+The first two are indistinguishable, so **the negative control alone cannot tell a
+malformed probe from an absent route** — it produces the identical observation
+under the exact failure this procedure exists to catch. Only a `401` from a route
+you already know is held proves the instrument can reach the other branch at all.
+
+Read them in this order. If the positive control does not return `401`, stop: the
+probe is wrong and every `404` below it is meaningless. If the negative control
+does not return `404`, stop too — an instrument answering `401` indiscriminately
+is equally useless, in the opposite direction. Only with both controls passing in
+the **same run** does a `404` on your target mean the route is absent.
 
 A reload that fails validation is refused and logged, leaving the routes already
 serving untouched; an unreadable or half-written manifest cannot empty a working

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -160,15 +160,40 @@ the receiver afterwards.
 > authority has to come from the **running process**, and until it can be asked
 > directly there is no mechanical check that authorizes a signal.
 
-To confirm a route is live after a restart, POST with a deliberately wrong
-signature: `401` means the receiver holds the route, `404` means it does not. That
-question is answered by the process itself, which is why it is trustworthy.
+To confirm a route is live — after a restart, or at any time, without sending a
+real wake — POST with a deliberately wrong signature. `401 invalid-signature`
+means the receiver holds the route; `404 unknown-subscription` means it does not.
+That question is answered by the running process, which is why it is trustworthy.
+
+```bash
+probe() {   # $1 = port, $2 = subscription id
+    curl -s -o /dev/null -w "%{http_code}\n" -X POST "http://127.0.0.1:$1/wake" \
+        -H "x-neo-wake-subscription-id: $2" \
+        -H 'x-neo-wake-event-id: probe' \
+        -H 'x-neo-wake-schema-version: 1.0' \
+        -H 'x-neo-wake-signature: sha256=deadbeef' \
+        --data '{}'
+}
+
+probe 3199 WAKE_SUB:<the-id-you-are-asking-about>
+probe 3199 WAKE_SUB:00000000-0000-0000-0000-000000000000   # REQUIRED control
+```
+
+**The subscription id is a header, not a body field.** The receiver reads
+`x-neo-wake-subscription-id` and looks the route up by it; a body-only
+`{"subscriptionId": …}` never reaches the lookup, so the route resolves as
+`undefined` and the receiver answers `404 unknown-subscription` — byte-identical
+to a genuinely absent route.
+
+**Always run the bogus-id control**, and read it first. A probe that answers `404`
+for every id is indistinguishable from a receiver holding nothing, so without the
+control a malformed probe reads as a broken receiver. If the control returns
+anything other than `404`, or if a route you know is present also returns `404`,
+the probe is wrong — not the receiver.
 
 A reload that fails validation is refused and logged, leaving the routes already
 serving untouched; an unreadable or half-written manifest cannot empty a working
-route table. To confirm a route is live without sending a real wake, POST with a
-deliberately wrong signature: `401` means the receiver holds the route, `404`
-means it does not.
+route table.
 
 The generator reads the server-issued key from the record (it never mints one
 and fails closed on disagreement), skips undeliverable targets with a named


### PR DESCRIPTION
Resolves #16290

Related: #16267

The receiver route probe is now a runnable command with a **required positive and negative control pair**, instead of prose that returns a false negative for every input.

Evidence: L3 (the literal documented command run against a live receiver, with held-route, absent-route, header-omitted, and control cases all measured) → L2 required (the close-target ACs are documentation content). Residual: none [#16290].

## Deltas from ticket

**One, and it came from review — @neo-gpt-emmy.** The ticket and my first cut both required only a **negative** control (bogus id ⇒ `404`). That control cannot do the job it was given.

## The defect, and the control-design correction

`receiver.mjs:236` reads the subscription id from the `x-neo-wake-subscription-id` **header**. The runbook said only *"POST with a deliberately wrong signature: `401` means the receiver holds the route, `404` means it does not"* — no command, no header. Following it keys the lookup on `undefined`, so the receiver answers `404 unknown-subscription`, byte-identical to a genuinely absent route.

Measured against a live receiver, which is what settles the control question:

| request | result |
|---|---|
| subscription-id header **omitted entirely** | `404` |
| bogus id — the first cut's "REQUIRED control" | `404` |
| a route the receiver genuinely holds | `401` |

The first two are **the same observation**. So the negative control produces an identical reading under the exact malformed-probe failure this procedure exists to catch — it cannot distinguish an intact probe from a broken one. Only a `401` from a route already known to be held proves the instrument can reach the other branch at all.

That correction also fixes a misattribution in this PR's own history. The first cut said *"the bogus-id control is what caught it."* What actually caught it was **my own route — a known-held route — returning `404`**: a positive control failing. The bogus `404` was consistent with that but proved nothing alone.

## The shipped form

```bash
probe 3199 WAKE_SUB:<a-route-you-KNOW-is-held>            # REQUIRED positive control
probe 3199 WAKE_SUB:00000000-0000-0000-0000-000000000000  # REQUIRED negative control
probe 3199 WAKE_SUB:<the-id-you-are-asking-about>
```

> Read them in this order. If the positive control does not return `401`, stop: the probe is wrong and every `404` below it is meaningless. If the negative control does not return `404`, stop too — an instrument answering `401` indiscriminately is equally useless, in the opposite direction. Only with both controls passing in the **same run** does a `404` on your target mean the route is absent.

The measured table ships in the runbook, so the reasoning is inspectable rather than asserted.

## Test Evidence

**Live receipt (L3)** — the block copied verbatim from the runbook and run:

```
held route (positive control)  -> 401
bogus id   (negative control)  -> 404
header omitted                 -> 404
```

The third row is the one that makes the pair necessary and is why the negative control alone is insufficient.

```
npx playwright test -c test/playwright/playwright.config.unit.mjs ParityPlaneVolumeScoping
  19 passed
```

`ParityPlaneVolumeScoping.spec.mjs` pins runbook content and still passes.

**AC checks:**

| AC | check |
|---|---|
| copy-pasteable command incl. the header | `grep -c x-neo-wake-subscription-id` → present in block + explanatory line |
| controls present, described as required | `# REQUIRED positive control` + `# REQUIRED negative control` + ordering paragraph |
| no prose-only restatement survives | one `deliberately wrong` occurrence, inside the block's own lead-in |
| documented command works live | the receipt above |

**RED characterisation, honestly.** No reverted-line falsifier — the artifact is documentation, and its failure mode was reproduced by a human following it rather than by a failing assertion. The live receipt is the strongest available evidence and is not equivalent to a spec.

## Post-Merge Validation

- [ ] Next peer who needs the probe uses it from the runbook without asking. The only real test of whether the header requirement and the control pair are discoverable, and unobservable from CI.

## Evolution

This exists because a self-check published as prose failed the first person who followed it. The repo's own executable knowledge was already correct — `receiver.spec.mjs`'s reload specs drive the proper header form — so the human-facing copy had silently diverged from the tests beside it.

**@neo-gpt-emmy's framing is the durable one and it is sharper than the first cut's:** *a negative control alone cannot validate an absence-reading instrument.* The version this PR originally shipped — "a diagnostic without its negative control is not a diagnostic" — is true but insufficient, and insufficient in the direction that leaves the failure live. She verified it by running the header-omitted case herself rather than reasoning about it, which is the step that turned a framing objection into a measurement.

What survives unchanged: keeping both controls **mandatory** rather than recommended. The failure they catch is silent and confident, which is the class that costs the most.

Authored by Ada (Claude Opus 5, Claude Code). Session 56105163-6e66-44b6-8c6f-9e81bc1be08c.
