### PR TITLE
feat(wake): admit OpenCode at the route-declaration and registration gates (#16279)

### DIFF
--- a/ai/daemons/wake/receiver.mjs
+++ b/ai/daemons/wake/receiver.mjs
@@ -104,7 +104,7 @@ export async function loadWakeReceiverManifest(manifestPath) {
             }
         }
         if (adapter === 'osascript' && (
-            !['Antigravity', 'Claude', 'Codex'].includes(metadata.appName) ||
+            !['Antigravity', 'Claude', 'Codex', 'OpenCode'].includes(metadata.appName) ||
             (metadata.appName === 'Codex' && !metadata.focusSeedKey)
         )) {
             throw new Error(`Wake receiver route '${subscriptionId}' has incomplete osascript target metadata`);

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -104,7 +104,7 @@ class WakeSubscriptionService extends Base {
      *
      * @protected
      */
-    validAppNames = ['Antigravity', 'Claude', 'Codex']
+    validAppNames = ['Antigravity', 'Claude', 'Codex', 'OpenCode']
 
     /**
      * @member {String[]} validAdapters

--- a/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
@@ -219,6 +219,22 @@ test.describe('ai/daemons/wake/receiver', () => {
         await expect(loadWakeReceiverManifest(manifestPath)).rejects.toThrow('must be mode 0600');
     });
 
+    test('an OpenCode osascript route passes manifest validation (#16279)', async () => {
+        const manifestPath = path.join(stateDir, 'opencode-routes.json');
+        const valid        = structuredClone(manifest);
+
+        valid.routes[subscriptionId].harnessTargetMetadata = {
+            adapter        : 'osascript',
+            appName        : 'OpenCode',
+            addressType    : 'userDataDir',
+            instanceAddress: '/seat/ai.opencode.desktop'
+        };
+
+        await fs.writeFile(manifestPath, JSON.stringify(valid), {mode: 0o600});
+
+        expect(await loadWakeReceiverManifest(manifestPath)).toEqual(valid);
+    });
+
     test('rejects test adapters and incomplete production routes in a disk manifest', async () => {
         const manifestPath = path.join(stateDir, 'invalid-routes.json');
         const invalid      = structuredClone(manifest);

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -742,7 +742,19 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 trigger              : 'SENT_TO_ME',
                 harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'antigravity'}
-            })).rejects.toThrow("Invalid appName 'antigravity'. Must be one of: Antigravity, Claude, Codex");
+            })).rejects.toThrow("Invalid appName 'antigravity'. Must be one of: Antigravity, Claude, Codex, OpenCode");
+        });
+    });
+
+    test('subscribe accepts OpenCode as a canonical appName (#16279)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const result = await WakeSubscriptionService.subscribe({
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {appName: 'OpenCode'}
+            });
+
+            expect(result.subscriptionId ?? result.id ?? result.subscription?.id).toBeTruthy();
         });
     });
 


### PR DESCRIPTION
Resolves #16279

The route can now actually be declared. PR #16281 admitted OpenCode to the osascript dispatch adapter, but two further appName gates meant an OpenCode route could neither be registered nor loaded: the subscription service's `validAppNames` rejected it at subscribe/update time, and the receiver's manifest loader rejected it at validation. Found live by attempting the production flip on my own seat — the subscription update threw `Invalid appName 'OpenCode'`. Both lists now admit OpenCode.

Evidence: L1 (unit — loader + registration specs) → L1 required (validation outcomes are decidable in-process). Residual: the live flip + end-to-end delivery on this machine is PMV (route republish after this merge, receiver restart from merged dev).

## Deltas from ticket

The ticket's Contract Ledger is amended on the ticket ([issuecomment-5152895198](https://github.com/neomjs/neo/issues/16279#issuecomment-5152895198)) with all three validation surfaces, because AC-1's "a route with `appName: 'OpenCode'` dispatches" was never achievable while the route could not be declared — these rows are that AC's full contract:

| Surface | Change |
|---|---|
| dispatch allowlist (`localWakeAdapters.mjs`) | admitted in PR #16281 (merged) |
| manifest-loader osascript validation (`receiver.mjs`) | `OpenCode` added — this PR |
| `validAppNames` (`WakeSubscriptionService.mjs`) | `OpenCode` added — this PR |

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/wake/ test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
  344 passed (1.1m)
npx playwright test -c test/playwright/playwright.config.unit.mjs
  10676 passed, 5 skipped, 2 failed
```

The 2 full-suite failures are the named load-flakes in untouched memory-core files (SessionSummarization, TextEmbeddingService.retry — same family as today's earlier runs). Per directly touched surface:

- `receiver.mjs` — spec: an OpenCode osascript route (userDataDir tuple) passes `loadWakeReceiverManifest` at 0600.
- `WakeSubscriptionService.mjs` — spec: OpenCode appName accepted on subscribe; the non-canonical rejection message updated to list all four names (existing pin adjusted).
- Pre-commit hooks: whitespace, shorthand, aiconfig-test-mutation, derived-domain, jsdoc-types, ticket-archaeology, block-alignment, parse — all green.

## Post-Merge Validation

- [ ] Flip @neo-kimi-phoebe's subscription to `osascript`/`OpenCode` (now accepted), republish the route with the seat's userDataDir tuple, and restart the receiver from merged dev (operator-gated).
- [ ] A high-priority non-suppressed DM to @neo-kimi-phoebe delivers with the record flipping to `delivered` and the wake visible in the OpenCode desktop.

## Commits

- `bbde06f542` — both gates + both specs + the rejection-message update

Authored by Phoebe (Kimi k3, OpenCode). Session c8496441-e4ef-40a3-a67f-12d0c4874431.