### PR TITLE
chore(ai): cross-reference the per-bucket digest recency seams (#16292)

### DIFF
--- a/ai/daemons/wake/wakeDigestBuilder.mjs
+++ b/ai/daemons/wake/wakeDigestBuilder.mjs
@@ -105,6 +105,11 @@ function latestByEventTime(events, field) {
  * is the pointer the woken agent reads first, so each bucket claims only the recency its own
  * shape can prove.
  *
+ * @see CoalescingEngineService.resolveEventTimestamp (ai/services/memory-core/CoalescingEngineService.mjs) —
+ *      the engine-side sibling seam for per-bucket "latest" recency; structured digest envelope vs
+ *      this module's string digest. Deliberately separate implementations (Neo singleton vs spawn-only
+ *      daemon entrypoint) — repair one, check the other.
+ *
  * @param {String} identity Recipient agent identity.
  * @param {Object} events `{messages, tasks, permissions, heartbeats}` arrays.
  * @returns {String}

--- a/ai/services/memory-core/CoalescingEngineService.mjs
+++ b/ai/services/memory-core/CoalescingEngineService.mjs
@@ -55,6 +55,12 @@ const WAKE_PRIORITY_RANKS = Object.freeze({
  * epoch or ISO string). Returns `null` when nothing is resolvable — the caller then keeps
  * the previous last-write-wins behavior, so timestamp-less events are never re-ordered
  * by guesswork.
+ *
+ * @see buildWakeDigest (ai/daemons/wake/wakeDigestBuilder.mjs) — the daemon-side sibling seam for
+ *      per-bucket "latest" recency; string digest vs this service's structured digest envelope.
+ *      Deliberately separate implementations (spawn-only daemon entrypoint vs Neo singleton) —
+ *      repair one, check the other.
+ *
  * @param {Object} event Wake event envelope.
  * @returns {Number|null} Epoch ms, or null when no timestamp is resolvable.
  */


### PR DESCRIPTION
Resolves #16292

One `@see` line each way between the two deliberately-separate per-bucket digest recency seams: `wakeDigestBuilder.buildWakeDigest` (daemon, string digest) now names `CoalescingEngineService.resolveEventTimestamp` (engine, structured digest envelope) as its sibling — and vice versa — each carrying the shape difference and the "repair one, check the other" pointer. Comment-only; no code path or test surface touched. Origin: Grace's Approve+Follow-Up discoverability finding on PR `#16288`.

Evidence: L1 (static comment-only diff, mechanically verified) — no runtime/substrate/host effects to ladder. Residual: none.

§6.1 micro-change exception stated: chore class, 11 changed lines, comment-only with no runtime impact — cross-family review waiver eligible.

## Deltas from ticket

None substantive — the diff is exactly the ticket's "Fix" section (one `@see` line each way, shape note included both directions).

## Test Evidence

- Comment-only verified mechanically: 11 insertions across 2 files, every added line a JSDoc `*` line (grep-filtered `git diff` — zero non-comment delta).
- `npm run agent-preflight -- --change-class zero-delta --commit-subject "chore(ai): … (#16292)"` — all gates green at head (ticket archaeology, change-class, PR-body lint).
- Full suite runs in CI regardless: `ai/` is in the integration whitelist (ticket AC 3).
- Touched surfaces keep their existing coverage, unchanged by a comment-only diff: `#16284` shipped the mutation-RED-verified builder specs; `#16277` the engine seam.

## Post-Merge Validation

- [ ] None — docs-class chore. ACs 1–2 are verifiable in the diff itself; AC 3 is CI-green at head.

Authored by Iris (Kimi K3, Kimi Code CLI). Session session_2f4d15f0-d626-4f16-9491-620b8b0bc9c2.
