### PR TITLE
feat(ci): resolve package.json head content from the fork repo on fork PRs (#16289)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,8 +138,18 @@ jobs:
 
                 const depKindKeys = ['dependencies', 'devDependencies', 'overrides'];
 
-                const readDepKind = async ref => {
-                  const res     = await github.rest.repos.getContent({owner: context.repo.owner, repo: context.repo.repo, path: 'package.json', ref});
+                // Fork PRs: the head SHA exists only in the fork repo, so the head content read
+                // must follow the fork's coordinates — the base half stays on the PR target repo.
+                // Same-repo PRs and push events keep the single-repo path; an unreadable fork
+                // (deleted / private) throws below and keeps the fail-open stance.
+                const headRepo = eventName === 'pull_request' && context.payload.pull_request.head.repo?.fork === true
+                  ? {owner: context.payload.pull_request.head.repo.owner.login, repo: context.payload.pull_request.head.repo.name}
+                  : {owner: context.repo.owner, repo: context.repo.repo};
+
+                core.info(`package.json head content resolves from ${headRepo.owner}/${headRepo.repo}.`);
+
+                const readDepKind = async (ref, {owner, repo}) => {
+                  const res     = await github.rest.repos.getContent({owner, repo, path: 'package.json', ref});
                   const pkg     = JSON.parse(Buffer.from(res.data.content, 'base64').toString('utf8'));
                   const depKind = {};
 
@@ -154,7 +164,7 @@ jobs:
                   return depKind;
                 };
 
-                const [baseDepKind, headDepKind] = await Promise.all([readDepKind(baseRef), readDepKind(headRef)]),
+                const [baseDepKind, headDepKind] = await Promise.all([readDepKind(baseRef, {owner: context.repo.owner, repo: context.repo.repo}), readDepKind(headRef, headRepo)]),
                       relevant = JSON.stringify(baseDepKind) !== JSON.stringify(headDepKind);
 
                 core.info(`package.json dependency-kind change: ${relevant}`);

--- a/test/playwright/unit/ai/buildScripts/util/WorkflowScopeClassifier.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/WorkflowScopeClassifier.spec.mjs
@@ -16,18 +16,21 @@ const scopeScript = () =>
 
 // Runtime harness mirroring WorkflowConcurrency.spec.mjs: the scope step's inline script is
 // evaluated with mocked `github` / `context` / `core`, here additionally serving package.json
-// content at the base and head refs via repos.getContent.
+// content at the base and head refs via repos.getContent — keyed by repo for fork PRs, where the
+// head SHA exists only in the fork (a base-repo fetch of it correctly throws).
 const createRuntime = ({
     files           = ['package.json'],
     basePkg         = {dependencies: {leftpad: '1.0.0'}, scripts: {'build:all': 'a'}},
     headPkg         = {dependencies: {leftpad: '1.0.0'}, scripts: {'build:all': 'a', 'ai:new-script': 'b'}},
     headPkgRaw      = null,
     baseSha         = 'base-sha',
-    getContentError = null
+    getContentError = null,
+    forkOwner       = null,
+    forkUnreadable  = false
 } = {}) => {
     const outputs = new Map(),
           info    = [],
-          calls   = {getContent: 0, listFiles: 0, pullsGet: 0},
+          calls   = {getContent: 0, listFiles: 0, pullsGet: 0, contentCalls: []},
           core    = {
               info     : value => info.push(value),
               notice   : () => {},
@@ -51,10 +54,19 @@ const createRuntime = ({
                       }
                   },
                   repos: {
-                      getContent: async({ ref }) => {
+                      getContent: async({ owner, repo, ref }) => {
                           calls.getContent++;
+                          calls.contentCalls.push(`${owner}/${repo}@${ref}`);
                           if (getContentError) throw new Error(getContentError);
-                          const raw = ref === 'base-sha' ? JSON.stringify(basePkg) : (headPkgRaw ?? JSON.stringify(headPkg));
+                          if (ref === baseSha) {
+                              const raw = JSON.stringify(basePkg);
+                              return { data: { content: Buffer.from(raw).toString('base64') } };
+                          }
+                          // A fork head SHA is absent from the base repo; a deleted or private
+                          // fork refuses the read even at its own coordinates.
+                          if (forkOwner && owner !== forkOwner) throw new Error(`Not Found: ${ref}`);
+                          if (forkUnreadable) throw new Error(`Not Found: ${owner}/${repo}`);
+                          const raw = headPkgRaw ?? JSON.stringify(headPkg);
                           return { data: { content: Buffer.from(raw).toString('base64') } };
                       }
                   }
@@ -64,8 +76,10 @@ const createRuntime = ({
               eventName: 'pull_request',
               payload  : {
                   pull_request: {
-                      base  : { sha: baseSha },
-                      head  : { sha: 'head-sha' },
+                      base: { sha: baseSha },
+                      head: forkOwner
+                          ? { sha: 'head-sha', repo: { fork: true, name: 'neo', owner: { login: forkOwner } } }
+                          : { sha: 'head-sha' },
                       number: 16248
                   }
               },
@@ -185,6 +199,39 @@ test.describe('Tests scope classifier — package.json change-kind split', () =>
             run_integration: 'true',
             run_parity     : 'true',
             run_unit       : 'true'
+        });
+    });
+
+    test('a fork PR with a metadata-only package.json edit skips the suites — head content resolves from the fork', async () => {
+        // Fork heads exist only in the fork repo: the head-content read must follow
+        // `pull_request.head.repo`, or every fork PR fails open into full suites forever
+        // (the mock throws for a base-repo fetch of the fork SHA, exactly like the API).
+        const runtime = createRuntime({ forkOwner: 'contributor' });
+
+        await executeScript(scopeScript(), runtime);
+
+        expect(runtime.calls.getContent).toBe(2);
+        expect(runtime.calls.contentCalls).toEqual(['neomjs/neo@base-sha', 'contributor/neo@head-sha']);
+        expect(outputsOf(runtime)).toMatchObject({
+            run_components : 'false',
+            run_integration: 'false',
+            run_parity     : 'false',
+            run_unit       : 'true'
+        });
+        expect(runtime.info.join(' ')).toContain('contributor/neo'); // the resolved head repo stays legible in the log
+    });
+
+    test('a fork PR whose head repo is unreadable fails TOWARD running (deleted or private fork)', async () => {
+        // Same completeness rule as the same-repo fallbacks above: a skipped suite is a false
+        // negative; a wasted run costs minutes. Deleted forks also arrive as head.repo === null,
+        // which takes the same-repo path and fails open on the unknown-SHA fetch identically.
+        const runtime = createRuntime({ forkOwner: 'contributor', forkUnreadable: true });
+
+        await executeScript(scopeScript(), runtime);
+
+        expect(outputsOf(runtime)).toMatchObject({
+            run_components : 'true',
+            run_integration: 'true'
         });
     });
 });


### PR DESCRIPTION
Resolves #16289

Fork PRs can now take the CI scope classifier's optimized path: `packageJsonTouchesDependencies()` resolves the head `package.json` from the fork's repo coordinates when `pull_request.head.repo.fork === true` (the base half stays on the PR target repo), instead of fetching the fork-only head SHA from the base repo, throwing, and failing open into the full components + integration suites on every fork PR forever. The fail-open stance is unchanged — an unreadable fork (deleted/private), missing refs, and fetch/parse failures all still resolve `true` — and the classifier log now names the repo the head content resolved from. Origin: Grace's Approve+Follow-Up finding on PR `#16282`.

Evidence: L2 (harness behavioral contract + mutation-RED receipt, local) → L4 required (a real fork PR taking the optimized path — sandbox-unreachable from this seat). Residual: AC1/AC4 live-plane confirmation on the next external-contributor PR [#16289].

## Deltas from ticket

None substantive — the fix, the preserved fail-open stance, and the log-line legibility AC are exactly as ticketed. The spec factory gained repo-keyed `getContent` (a fork head SHA is correctly absent from the base-repo mock); existing test bodies are unmodified (AC3).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/WorkflowScopeClassifier.spec.mjs` — 11/11 pass at head (9 classifier specs + run teardown), including the two new fork variants.
- Mutation-RED receipt: with the workflow hunk stashed, the fork metadata-only spec fails (`run_components=true` via fail-open) while every other spec passes — the new spec discriminates the fix; the fallback specs are correctly insensitive to it.
- Touched surface (`.github/workflows/test.yml` scope step): `WorkflowScopeClassifier.spec.mjs` (extended here) + the sibling `WorkflowConcurrency.spec.mjs` harness (unaffected — different step, re-run locally green).

## Post-Merge Validation

- [ ] The next fork / external-contributor PR with a metadata-only `package.json` diff: the scope-step log names the fork repo and resolves `run_components=false` (AC1 + AC4 live); a deleted-fork PR still fails open (AC2 live).

Authored by Iris (Kimi K3, Kimi Code CLI). Session session_2f4d15f0-d626-4f16-9491-620b8b0bc9c2.
