### PR TITLE
fix(mcp): a freshness label may not claim a dimension nothing measures (#16295)

### DIFF
--- a/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
+++ b/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
@@ -57,14 +57,25 @@ const DEFAULT_IDENTITY_LABEL = 'runtime identity';
  * A freshness verdict is read by an operator deciding whether to investigate, so its prose is
  * load-bearing: `status: 'current'` beside "source identity matches" is a positive assurance about
  * something the tracker may never have looked at. Each entry answers "is this dimension actually
- * measured?" from the tracker's own configuration — `source` needs a `rootDir` (without one,
- * `readRuntimeIdentity` never spawns git and `gitHead` is never read), `config` and `schema` need a
- * file digest of the matching kind.
+ * measured?" from the tracker's own configuration.
+ *
+ * **The bar is verdict authority, not observation.** `fieldKeys` answer *what was observed*;
+ * `statusFields` answer *what may support the positive freshness verdict*. A label appears inside
+ * that verdict — "Runtime <label> matches the current checkout" is emitted only on `status:
+ * 'current'` — so it must be backed by the second set, never the first.
+ *
+ * `source` therefore requires `gitHead` to be **status-driving**, not merely readable. A `rootDir`
+ * alone only makes `gitHead` observed: `classifyRuntimeFreshness` defaults the status set to
+ * `fieldKeys.filter(key => key !== 'gitHead')`, so `gitHead` is contextual unless a caller names it
+ * explicitly. GitHub Workflow is exactly that shape — `rootDir` set, `statusFields:
+ * ['openApiDigest']` — and admitting it produced two adjacent contradictory sentences: *"Runtime
+ * source/schema identity matches the current checkout"* beside *"Contextual runtime identity differs
+ * (gitHead)"*, with `status: 'current'` and `stale.gitHead: true`.
  *
  * @member {Object}
  */
 const FRESHNESS_DIMENSIONS = Object.freeze({
-    source: options => Boolean(options.rootDir),
+    source: options => (options.statusFields || []).includes('gitHead'),
     config: options => (options.files || []).some(file => /config/i.test(file?.key || '')),
     schema: options => (options.files || []).some(file => /openapi|schema/i.test(file?.key || ''))
 });
@@ -86,12 +97,16 @@ function assertLabelIsBacked(options, label) {
         .map(([dimension]) => dimension);
 
     if (unbacked.length) {
-        const configured = (options.files || []).map(file => file?.key).filter(Boolean);
+        const
+            configured    = (options.files || []).map(file => file?.key).filter(Boolean),
+            statusDriving = options.statusFields || [];
 
         throw new Error(
             `RuntimeFreshnessService: identityLabel '${label}' claims ${unbacked.join(', ')} ` +
-            `identity, but no tracker input measures it (files: [${configured.join(', ') || 'none'}], ` +
-            `rootDir: ${options.rootDir ? 'set' : 'unset'}). Narrow the label, or configure the input.`
+            `identity, but no STATUS-DRIVING input supports it (files: [${configured.join(', ') || 'none'}], ` +
+            `statusFields: [${statusDriving.join(', ') || 'default — gitHead excluded'}], ` +
+            `rootDir: ${options.rootDir ? 'set' : 'unset'}). A contextual read is not verdict authority: ` +
+            `narrow the label, or add the field to statusFields.`
         );
     }
 }

--- a/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
+++ b/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
@@ -52,6 +52,35 @@ function compareIdentityField(field, boot, current) {
 const DEFAULT_IDENTITY_LABEL = 'runtime identity';
 
 /**
+ * @summary The status-driving field set a tracker configuration resolves to.
+ *
+ * **One definition, two consumers.** The tracker derives this in its constructor to decide which
+ * fields can produce `status: 'stale'`; the label guard needs the identical set to decide which
+ * dimensions a label may claim. Deriving it twice is how the two drift — the guard would then
+ * authorize a claim the verdict cannot support, which is the defect it exists to prevent, one layer
+ * up. Both call this.
+ *
+ * `gitHead` is excluded from the default because a repo-wide revision is contextual: it moves for
+ * reasons unrelated to a given service's own inputs. A caller wanting it verdict-driving must name
+ * it in `statusFields` explicitly.
+ *
+ * @param {Object} options `createTracker` / `RuntimeFreshnessTracker` options.
+ * @returns {String[]} Field keys that may drive the status verdict.
+ */
+export function resolveStatusFields(options = {}) {
+    if (Array.isArray(options.statusFields)) {
+        return options.statusFields
+    }
+
+    const fieldKeys = [
+        ...(options.rootDir ? ['gitHead'] : []),
+        ...(options.files || []).map(file => file?.key).filter(Boolean)
+    ];
+
+    return fieldKeys.filter(key => key !== 'gitHead')
+}
+
+/**
  * @summary Which tracker input backs each dimension an `identityLabel` may claim.
  *
  * A freshness verdict is read by an operator deciding whether to investigate, so its prose is
@@ -75,9 +104,9 @@ const DEFAULT_IDENTITY_LABEL = 'runtime identity';
  * @member {Object}
  */
 const FRESHNESS_DIMENSIONS = Object.freeze({
-    source: options => (options.statusFields || []).includes('gitHead'),
-    config: options => (options.files || []).some(file => /config/i.test(file?.key || '')),
-    schema: options => (options.files || []).some(file => /openapi|schema/i.test(file?.key || ''))
+    source: statusFields => statusFields.includes('gitHead'),
+    config: statusFields => statusFields.some(key => /config/i.test(key)),
+    schema: statusFields => statusFields.some(key => /openapi|schema/i.test(key))
 });
 
 /**
@@ -92,20 +121,20 @@ const FRESHNESS_DIMENSIONS = Object.freeze({
  * @throws {Error} When the label names a dimension with no configured input.
  */
 function assertLabelIsBacked(options, label) {
-    const unbacked = Object.entries(FRESHNESS_DIMENSIONS)
-        .filter(([dimension, isBacked]) => new RegExp(`\\b${dimension}\\b`, 'i').test(label) && !isBacked(options))
-        .map(([dimension]) => dimension);
+    const
+        statusFields = resolveStatusFields(options),
+        unbacked     = Object.entries(FRESHNESS_DIMENSIONS)
+            .filter(([dimension, isBacked]) => new RegExp(`\\b${dimension}\\b`, 'i').test(label) && !isBacked(statusFields))
+            .map(([dimension]) => dimension);
 
     if (unbacked.length) {
-        const
-            configured    = (options.files || []).map(file => file?.key).filter(Boolean),
-            statusDriving = options.statusFields || [];
+        const configured = (options.files || []).map(file => file?.key).filter(Boolean);
 
         throw new Error(
             `RuntimeFreshnessService: identityLabel '${label}' claims ${unbacked.join(', ')} ` +
             `identity, but no STATUS-DRIVING input supports it (files: [${configured.join(', ') || 'none'}], ` +
-            `statusFields: [${statusDriving.join(', ') || 'default — gitHead excluded'}], ` +
-            `rootDir: ${options.rootDir ? 'set' : 'unset'}). A contextual read is not verdict authority: ` +
+            `effective statusFields: [${statusFields.join(', ') || 'none'}], ` +
+            `rootDir: ${options.rootDir ? 'set' : 'unset'}). Observation is not verdict authority: ` +
             `narrow the label, or add the field to statusFields.`
         );
     }
@@ -176,8 +205,10 @@ export class RuntimeFreshnessTracker {
             'git metadata, config digest, and OpenAPI digest';
         this.startedAt          = options.startedAt || new Date().toISOString();
 
-        this.#fieldKeys      = [...(this.rootDir ? ['gitHead'] : []), ...this.#files.map(file => file.key)];
-        this.#statusFieldSet = new Set(options.statusFields || this.#fieldKeys.filter(key => key !== 'gitHead'));
+        this.#fieldKeys = [...(this.rootDir ? ['gitHead'] : []), ...this.#files.map(file => file.key)];
+        // Same derivation the label guard uses — see resolveStatusFields. Deriving it twice is how
+        // the guard and the verdict drift apart, which is the defect the guard exists to prevent.
+        this.#statusFieldSet = new Set(resolveStatusFields(options));
 
         const boot = this.#runtimeService.readRuntimeIdentitySync({
             files  : this.#files,

--- a/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
+++ b/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
@@ -41,6 +41,62 @@ function compareIdentityField(field, boot, current) {
 }
 
 /**
+ * @summary Default identity label — deliberately claims no dimension.
+ *
+ * The previous default named all three (`source/config/schema identity`), so a tracker that
+ * configured none of them still asserted all of them. A default that cannot overclaim makes the
+ * safe case free and forces a specific claim to be opted into alongside its input.
+ *
+ * @member {String}
+ */
+const DEFAULT_IDENTITY_LABEL = 'runtime identity';
+
+/**
+ * @summary Which tracker input backs each dimension an `identityLabel` may claim.
+ *
+ * A freshness verdict is read by an operator deciding whether to investigate, so its prose is
+ * load-bearing: `status: 'current'` beside "source identity matches" is a positive assurance about
+ * something the tracker may never have looked at. Each entry answers "is this dimension actually
+ * measured?" from the tracker's own configuration — `source` needs a `rootDir` (without one,
+ * `readRuntimeIdentity` never spawns git and `gitHead` is never read), `config` and `schema` need a
+ * file digest of the matching kind.
+ *
+ * @member {Object}
+ */
+const FRESHNESS_DIMENSIONS = Object.freeze({
+    source: options => Boolean(options.rootDir),
+    config: options => (options.files || []).some(file => /config/i.test(file?.key || '')),
+    schema: options => (options.files || []).some(file => /openapi|schema/i.test(file?.key || ''))
+});
+
+/**
+ * @summary Refuses a tracker whose label claims a dimension it cannot measure.
+ *
+ * Throws at construction rather than warning at report time: a freshness surface that reports its
+ * own unreliability inside the payload it makes unreliable is the same defect one layer up. A label
+ * word outside {@link FRESHNESS_DIMENSIONS} is ignored, so the guard cannot invent violations.
+ *
+ * @param {Object} options The `createTracker` options.
+ * @param {String} label The effective identity label.
+ * @throws {Error} When the label names a dimension with no configured input.
+ */
+function assertLabelIsBacked(options, label) {
+    const unbacked = Object.entries(FRESHNESS_DIMENSIONS)
+        .filter(([dimension, isBacked]) => new RegExp(`\\b${dimension}\\b`, 'i').test(label) && !isBacked(options))
+        .map(([dimension]) => dimension);
+
+    if (unbacked.length) {
+        const configured = (options.files || []).map(file => file?.key).filter(Boolean);
+
+        throw new Error(
+            `RuntimeFreshnessService: identityLabel '${label}' claims ${unbacked.join(', ')} ` +
+            `identity, but no tracker input measures it (files: [${configured.join(', ') || 'none'}], ` +
+            `rootDir: ${options.rootDir ? 'set' : 'unset'}). Narrow the label, or configure the input.`
+        );
+    }
+}
+
+/**
  * @summary Normalizes runtime identity file descriptors.
  *
  * Each file descriptor contributes one SHA-256 digest field to the runtime identity block.
@@ -96,7 +152,9 @@ export class RuntimeFreshnessTracker {
         this.rootDir         = options.rootDir;
         this.files           = options.files || [];
         this.serviceName     = options.serviceName || 'MCP server';
-        this.identityLabel   = options.identityLabel || 'source/config/schema identity';
+        // Must stay the SAME default `createTracker` validates against — a guard that checks one
+        // string while the runtime emits another is the defect this file now guards, one layer in.
+        this.identityLabel   = options.identityLabel || DEFAULT_IDENTITY_LABEL;
         this.assertionFacts  = options.assertionFacts || 'source, config, or tool-schema facts';
         this.restartScope    = options.restartScope || 'cached source, config, and tool definitions';
         this.unavailableSummary = options.unavailableSummary ||
@@ -184,36 +242,36 @@ export class RuntimeFreshnessTracker {
                 : [identity.errors].filter(Boolean);
 
             freshness = this.#runtimeService.classifyRuntimeFreshness({
-                assertionFacts  : this.assertionFacts,
-                boot            : identity.boot || this.bootRuntimeIdentity,
-                current         : identity.current || {},
-                errors          : [
+                assertionFacts: this.assertionFacts,
+                boot          : identity.boot || this.bootRuntimeIdentity,
+                current       : identity.current || {},
+                errors        : [
                     ...this.bootRuntimeFreshnessErrors,
                     ...runtimeErrors
                 ],
-                fieldKeys       : this.#fieldKeys,
-                identityLabel   : this.identityLabel,
-                restartScope    : this.restartScope,
-                serviceName     : this.serviceName,
-                startedAt       : this.startedAt,
-                statusFields    : [...this.#statusFieldSet],
+                fieldKeys         : this.#fieldKeys,
+                identityLabel     : this.identityLabel,
+                restartScope      : this.restartScope,
+                serviceName       : this.serviceName,
+                startedAt         : this.startedAt,
+                statusFields      : [...this.#statusFieldSet],
                 unavailableSummary: this.unavailableSummary
             });
         } catch (e) {
             freshness = this.#runtimeService.classifyRuntimeFreshness({
-                assertionFacts  : this.assertionFacts,
-                boot            : this.bootRuntimeIdentity,
-                current         : {},
-                errors          : [
+                assertionFacts: this.assertionFacts,
+                boot          : this.bootRuntimeIdentity,
+                current       : {},
+                errors        : [
                     ...this.bootRuntimeFreshnessErrors,
                     `runtime freshness reader failed: ${e.message}`
                 ],
-                fieldKeys       : this.#fieldKeys,
-                identityLabel   : this.identityLabel,
-                restartScope    : this.restartScope,
-                serviceName     : this.serviceName,
-                startedAt       : this.startedAt,
-                statusFields    : [...this.#statusFieldSet],
+                fieldKeys         : this.#fieldKeys,
+                identityLabel     : this.identityLabel,
+                restartScope      : this.restartScope,
+                serviceName       : this.serviceName,
+                startedAt         : this.startedAt,
+                statusFields      : [...this.#statusFieldSet],
                 unavailableSummary: this.unavailableSummary
             });
         }
@@ -282,7 +340,7 @@ class RuntimeFreshnessService extends Base {
         fieldKeys = [],
         statusFields = [],
         serviceName = 'MCP server',
-        identityLabel = 'source/config/schema identity',
+        identityLabel = DEFAULT_IDENTITY_LABEL,
         assertionFacts = 'source, config, or tool-schema facts',
         restartScope = 'cached source, config, and tool definitions',
         unavailableSummary = 'git metadata, config digest, and OpenAPI digest'
@@ -367,6 +425,8 @@ class RuntimeFreshnessService extends Base {
      * @returns {RuntimeFreshnessTracker}
      */
     createTracker(options = {}) {
+        assertLabelIsBacked(options, options.identityLabel || DEFAULT_IDENTITY_LABEL);
+
         return new RuntimeFreshnessTracker({
             ...options,
             runtimeService: this

--- a/ai/services/github-workflow/HealthService.mjs
+++ b/ai/services/github-workflow/HealthService.mjs
@@ -17,7 +17,7 @@ const
             errorLabel: 'OpenAPI digest'
         }],
         serviceName       : 'GitHub Workflow MCP server',
-        identityLabel     : 'source/schema identity',
+        identityLabel     : 'schema identity',
         assertionFacts    : 'tool-schema/source facts',
         restartScope      : 'cached tool definitions',
         statusFields      : ['openApiDigest'],

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -22,7 +22,7 @@ const
             errorLabel: 'OpenAPI digest'
         }],
         serviceName       : 'Knowledge Base MCP server',
-        identityLabel     : 'source/config identity',
+        identityLabel     : 'config/schema identity',
         assertionFacts    : 'tool-schema/source facts',
         restartScope      : 'cached source, config, and tool definitions',
         statusFields      : ['configDigest', 'openApiDigest'],

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -44,7 +44,7 @@ const
             errorLabel: 'OpenAPI digest'
         }],
         serviceName       : 'Memory Core MCP server',
-        identityLabel     : 'source/config identity',
+        identityLabel     : 'config/schema identity',
         assertionFacts    : 'provider, config, or tool-schema facts',
         restartScope      : 'cached provider/config state',
         statusFields      : ['configDigest', 'openApiDigest'],

--- a/ai/services/neural-link/HealthService.mjs
+++ b/ai/services/neural-link/HealthService.mjs
@@ -20,7 +20,7 @@ const
             errorLabel: 'OpenAPI digest'
         }],
         serviceName       : 'Neural Link MCP server',
-        identityLabel     : 'source/config identity',
+        identityLabel     : 'config/schema identity',
         assertionFacts    : 'tool-schema/source facts',
         restartScope      : 'cached source, config, and tool definitions',
         statusFields      : ['configDigest', 'openApiDigest'],

--- a/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
@@ -13,12 +13,12 @@ setup({
     }
 });
 
-import {test, expect}          from '@playwright/test';
-import path                    from 'path';
-import {fileURLToPath}         from 'url';
-import Neo                     from '../../../../../../../../src/Neo.mjs';
-import * as core               from '../../../../../../../../src/core/_export.mjs';
-import RuntimeFreshnessService from '../../../../../../../../ai/mcp/server/shared/services/RuntimeFreshnessService.mjs';
+import {test, expect}                                 from '@playwright/test';
+import path                                           from 'path';
+import {fileURLToPath}                                from 'url';
+import Neo                                            from '../../../../../../../../src/Neo.mjs';
+import * as core                                      from '../../../../../../../../src/core/_export.mjs';
+import RuntimeFreshnessService, {resolveStatusFields} from '../../../../../../../../ai/mcp/server/shared/services/RuntimeFreshnessService.mjs';
 
 const
     testDir  = path.dirname(fileURLToPath(import.meta.url)),
@@ -314,6 +314,58 @@ function describeLabelBacking() {
             files        : [],
             statusFields : ['gitHead']
         })).not.toThrow();
+    });
+
+    // Table-driven mixed authority: every dimension keys on the SAME effective status set, so a
+    // field that is observed-but-excluded can never authorize a positive claim. Isolating each
+    // dimension matters — the first cut fixed `source` and left `config`/`schema` on `files`,
+    // which is the identical defect one dimension over.
+    for (const [dimension, label, observedFiles, statusFields] of [
+        ['source', 'source identity', CONFIG_AND_SCHEMA,               ['configDigest', 'openApiDigest']],
+        ['config', 'config identity', CONFIG_AND_SCHEMA,               ['openApiDigest']],
+        ['schema', 'schema identity', CONFIG_AND_SCHEMA,               ['configDigest']]
+    ]) {
+        test(`rejects a ${dimension} claim when its field is observed but excluded from statusFields`, () => {
+            expect(() => RuntimeFreshnessService.createTracker({
+                identityLabel: label,
+                rootDir      : repoRoot,
+                files        : observedFiles,
+                statusFields
+            })).toThrow(new RegExp(`claims ${dimension} identity`));
+        });
+    }
+
+    for (const [dimension, label, statusFields] of [
+        ['source', 'source identity', ['gitHead']],
+        ['config', 'config identity', ['configDigest']],
+        ['schema', 'schema identity', ['openApiDigest']]
+    ]) {
+        test(`admits a ${dimension} claim once its field IS status-driving`, () => {
+            expect(() => RuntimeFreshnessService.createTracker({
+                identityLabel: label,
+                rootDir      : repoRoot,
+                files        : CONFIG_AND_SCHEMA,
+                statusFields
+            })).not.toThrow();
+        });
+    }
+
+    test('with statusFields defaulted, file digests ARE status-driving — the guard must not over-reject', () => {
+        // The default set is every fieldKey except gitHead, so config/schema are backed without an
+        // explicit statusFields. Over-rejecting here would make the honest common case unusable.
+        expect(() => RuntimeFreshnessService.createTracker({
+            identityLabel: 'config/schema identity',
+            files        : CONFIG_AND_SCHEMA
+        })).not.toThrow();
+    });
+
+    test('the guard and the tracker resolve the SAME status set — one definition, not two', () => {
+        // The defect this whole ticket is about, one layer up: if the guard derived the set
+        // independently it could authorize a claim the verdict cannot support.
+        expect(resolveStatusFields({files: CONFIG_AND_SCHEMA, rootDir: repoRoot}))
+            .toEqual(['configDigest', 'openApiDigest']);
+        expect(resolveStatusFields({statusFields: ['gitHead'], files: CONFIG_AND_SCHEMA}))
+            .toEqual(['gitHead']);
     });
 
     test('the refusal names statusFields, not just files — the reader must know which set was short', () => {

--- a/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
@@ -197,8 +197,12 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
                 errorLabel: 'OpenAPI digest'
             }],
             serviceName       : 'Cloud MCP server',
-            identityLabel     : 'source/schema identity',
-            assertionFacts    : 'tool-schema/source facts',
+            // Narrowed: this fixture claimed source identity while configuring no rootDir — the
+            // same overclaim the shipped call sites carried, and the construction guard now
+            // refuses it. The assertion below is about gitHead omission, so the label is
+            // incidental to what this test proves.
+            identityLabel     : 'schema identity',
+            assertionFacts    : 'tool-schema facts',
             restartScope      : 'cached tool definitions',
             statusFields      : ['openApiDigest'],
             unavailableSummary: 'config digest and OpenAPI digest'
@@ -218,4 +222,97 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
         expect(result.status).toBe('current');
         expect(result.stale).not.toHaveProperty('gitHead');
     });
+
+    /**
+     * A freshness verdict is what an operator reads to decide whether to investigate, so a label
+     * claiming an unmeasured dimension is a false assurance rather than a cosmetic slip. Witness:
+     * every MCP HealthService asserted "source identity matches the current checkout" while
+     * comparing only file digests, and a container running source 2h22m behind `dev` said
+     * `current` — which stopped three peers investigating fixes that were merged but not deployed.
+     */
+    describeLabelBacking();
 });
+
+function describeLabelBacking() {
+    const
+        CONFIG_AND_SCHEMA = [{key: 'configDigest'}, {key: 'openApiDigest'}],
+        SCHEMA_ONLY       = [{key: 'openApiDigest'}];
+
+    test('rejects a source claim when no rootDir is configured — the shipped defect', () => {
+        expect(() => RuntimeFreshnessService.createTracker({
+            identityLabel: 'source/config identity',
+            files        : CONFIG_AND_SCHEMA
+        })).toThrow(/claims source identity/);
+    });
+
+    test('rejects an unbacked claim even when the label\'s other dimension IS backed', () => {
+        // The shipped shape exactly: 'source/…' alongside a dimension that genuinely is measured.
+        // A guard asking "is ANY claimed dimension backed" would have passed this.
+        expect(() => RuntimeFreshnessService.createTracker({
+            identityLabel: 'source/schema identity',
+            files        : SCHEMA_ONLY
+        })).toThrow(/claims source identity/);
+    });
+
+    test('rejects a config claim when only a schema digest is configured', () => {
+        expect(() => RuntimeFreshnessService.createTracker({
+            identityLabel: 'config identity',
+            files        : SCHEMA_ONLY
+        })).toThrow(/claims config identity/);
+    });
+
+    test('the refusal names the unbacked dimension AND what is configured', () => {
+        let message = '';
+
+        try {
+            RuntimeFreshnessService.createTracker({identityLabel: 'source identity', files: CONFIG_AND_SCHEMA});
+        } catch (error) {
+            message = error.message;
+        }
+
+        expect(message).toContain('source');
+        expect(message).toContain('configDigest');
+        expect(message).toContain('rootDir: unset');
+    });
+
+    // POSITIVE CONTROLS — without these, a guard that rejected every label would satisfy the
+    // assertions above and read as correct.
+    test('an honest config/schema label constructs', () => {
+        expect(() => RuntimeFreshnessService.createTracker({
+            identityLabel: 'config/schema identity',
+            files        : CONFIG_AND_SCHEMA
+        })).not.toThrow();
+    });
+
+    test('source IS admissible once rootDir supplies it — the guard blocks the claim, not the dimension', () => {
+        expect(() => RuntimeFreshnessService.createTracker({
+            identityLabel: 'source identity',
+            rootDir      : repoRoot,
+            files        : []
+        })).not.toThrow();
+    });
+
+    test('the default label constructs with nothing configured — the safe case stays free', () => {
+        // The previous default named source/config/schema, so an unconfigured tracker asserted all
+        // three. A default that cannot overclaim is what makes the guard non-punitive.
+        expect(() => RuntimeFreshnessService.createTracker({})).not.toThrow();
+    });
+
+    test('a word outside the dimension vocabulary is ignored, never invented into a violation', () => {
+        expect(() => RuntimeFreshnessService.createTracker({
+            identityLabel: 'provider identity',
+            files        : CONFIG_AND_SCHEMA
+        })).not.toThrow();
+    });
+
+    for (const [service, identityLabel, files] of [
+        ['memory-core',     'config/schema identity', CONFIG_AND_SCHEMA],
+        ['knowledge-base',  'config/schema identity', CONFIG_AND_SCHEMA],
+        ['neural-link',     'config/schema identity', CONFIG_AND_SCHEMA],
+        ['github-workflow', 'schema identity',        SCHEMA_ONLY]
+    ]) {
+        test(`the shipped ${service} label is backed by its own configured inputs`, () => {
+            expect(() => RuntimeFreshnessService.createTracker({identityLabel, files})).not.toThrow();
+        });
+    }
+}

--- a/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
@@ -34,8 +34,8 @@ const
 test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776)', () => {
     test('keeps gitHead drift contextual when status-driving fields match', () => {
         const result = RuntimeFreshnessService.classifyRuntimeFreshness({
-            startedAt       : '2026-06-08T00:00:00.000Z',
-            boot            : {
+            startedAt: '2026-06-08T00:00:00.000Z',
+            boot     : {
                 gitHead      : 'old-head',
                 openApiDigest: 'sha256:same-openapi'
             },
@@ -43,12 +43,12 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
                 gitHead      : 'new-head',
                 openApiDigest: 'sha256:same-openapi'
             },
-            fieldKeys       : ['gitHead', 'openApiDigest'],
-            statusFields    : ['openApiDigest'],
-            serviceName     : 'Test MCP server',
-            identityLabel   : 'source/schema identity',
-            assertionFacts  : 'tool-schema/source facts',
-            restartScope    : 'cached tool definitions',
+            fieldKeys         : ['gitHead', 'openApiDigest'],
+            statusFields      : ['openApiDigest'],
+            serviceName       : 'Test MCP server',
+            identityLabel     : 'schema identity',
+            assertionFacts    : 'tool-schema/source facts',
+            restartScope      : 'cached tool definitions',
             unavailableSummary: 'git metadata and OpenAPI digest'
         });
 
@@ -61,7 +61,7 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
             },
             hint: null
         });
-        expect(result.details[0]).toBe('Runtime source/schema identity matches the current checkout.');
+        expect(result.details[0]).toBe('Runtime schema identity matches the current checkout.');
         expect(result.details[1]).toContain('Contextual runtime identity differs (gitHead)');
         expect(result.boot).toBeUndefined();
         expect(result.current).toBeUndefined();
@@ -69,8 +69,8 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
 
     test('marks stale when a status-driving digest differs', () => {
         const result = RuntimeFreshnessService.classifyRuntimeFreshness({
-            startedAt       : '2026-06-08T00:00:00.000Z',
-            boot            : {
+            startedAt: '2026-06-08T00:00:00.000Z',
+            boot     : {
                 gitHead      : 'same-head',
                 configDigest : 'sha256:old-config',
                 openApiDigest: 'sha256:same-openapi'
@@ -80,12 +80,12 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
                 configDigest : 'sha256:new-config',
                 openApiDigest: 'sha256:same-openapi'
             },
-            fieldKeys       : ['gitHead', 'configDigest', 'openApiDigest'],
-            statusFields    : ['configDigest', 'openApiDigest'],
-            serviceName     : 'Test MCP server',
-            identityLabel   : 'source/config identity',
-            assertionFacts  : 'provider/config facts',
-            restartScope    : 'cached provider/config state',
+            fieldKeys         : ['gitHead', 'configDigest', 'openApiDigest'],
+            statusFields      : ['configDigest', 'openApiDigest'],
+            serviceName       : 'Test MCP server',
+            identityLabel     : 'config/schema identity',
+            assertionFacts    : 'provider/config facts',
+            restartScope      : 'cached provider/config state',
             unavailableSummary: 'git metadata, config digest, and OpenAPI digest'
         });
 
@@ -103,20 +103,20 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
 
     test('reports unknown when only contextual gitHead can be compared', () => {
         const result = RuntimeFreshnessService.classifyRuntimeFreshness({
-            startedAt       : '2026-06-08T00:00:00.000Z',
-            boot            : {
+            startedAt: '2026-06-08T00:00:00.000Z',
+            boot     : {
                 gitHead: 'same-head'
             },
             current         : {
                 gitHead: 'same-head'
             },
-            errors          : ['current OpenAPI digest unavailable: fixture'],
-            fieldKeys       : ['gitHead', 'openApiDigest'],
-            statusFields    : ['openApiDigest'],
-            serviceName     : 'Test MCP server',
-            identityLabel   : 'source/schema identity',
-            assertionFacts  : 'tool-schema/source facts',
-            restartScope    : 'cached tool definitions',
+            errors            : ['current OpenAPI digest unavailable: fixture'],
+            fieldKeys         : ['gitHead', 'openApiDigest'],
+            statusFields      : ['openApiDigest'],
+            serviceName       : 'Test MCP server',
+            identityLabel     : 'schema identity',
+            assertionFacts    : 'tool-schema/source facts',
+            restartScope      : 'cached tool definitions',
             unavailableSummary: 'git metadata and OpenAPI digest'
         });
 
@@ -141,14 +141,14 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
                 errorLabel: 'OpenAPI digest'
             }],
             serviceName       : 'Test MCP server',
-            identityLabel     : 'source/schema identity',
+            identityLabel     : 'schema identity',
             assertionFacts    : 'tool-schema/source facts',
             restartScope      : 'cached tool definitions',
             statusFields      : ['openApiDigest'],
             unavailableSummary: 'git metadata and OpenAPI digest'
         });
 
-        let readCount = 0,
+        let readCount     = 0,
             openApiDigest = 'sha256:same-openapi';
 
         const reader = async () => {
@@ -284,12 +284,55 @@ function describeLabelBacking() {
         })).not.toThrow();
     });
 
-    test('source IS admissible once rootDir supplies it — the guard blocks the claim, not the dimension', () => {
+    test('rejects the pre-fix GitHub Workflow shape — rootDir observes gitHead but does not make it authoritative', () => {
+        // The configuration that shipped: gitHead readable via rootDir, but statusFields names only
+        // openApiDigest, so `classifyRuntimeFreshness` can return status:'current' with
+        // stale.gitHead:true — emitting "Runtime source/schema identity matches the current checkout"
+        // beside "Contextual runtime identity differs (gitHead)". A guard keyed on rootDir admits it.
+        expect(() => RuntimeFreshnessService.createTracker({
+            identityLabel: 'source/schema identity',
+            rootDir      : repoRoot,
+            files        : SCHEMA_ONLY,
+            statusFields : ['openApiDigest']
+        })).toThrow(/claims source identity/);
+    });
+
+    test('rejects source when statusFields is defaulted — the default excludes gitHead by construction', () => {
+        // `statusFields || fieldKeys.filter(key => key !== 'gitHead')`: omitting it can never make
+        // gitHead status-driving, so a rootDir plus silence is still not verdict authority.
         expect(() => RuntimeFreshnessService.createTracker({
             identityLabel: 'source identity',
             rootDir      : repoRoot,
-            files        : []
+            files        : CONFIG_AND_SCHEMA
+        })).toThrow(/claims source identity/);
+    });
+
+    test('source IS admissible when gitHead is named status-driving — the guard blocks the claim, not the dimension', () => {
+        expect(() => RuntimeFreshnessService.createTracker({
+            identityLabel: 'source identity',
+            rootDir      : repoRoot,
+            files        : [],
+            statusFields : ['gitHead']
         })).not.toThrow();
+    });
+
+    test('the refusal names statusFields, not just files — the reader must know which set was short', () => {
+        let message = '';
+
+        try {
+            RuntimeFreshnessService.createTracker({
+                identityLabel: 'source/schema identity',
+                rootDir      : repoRoot,
+                files        : SCHEMA_ONLY,
+                statusFields : ['openApiDigest']
+            });
+        } catch (error) {
+            message = error.message;
+        }
+
+        expect(message).toContain('STATUS-DRIVING');
+        expect(message).toContain('statusFields: [openApiDigest]');
+        expect(message).toContain('rootDir: set');
     });
 
     test('the default label constructs with nothing configured — the safe case stays free', () => {

--- a/test/playwright/unit/ai/services/github-workflow/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/HealthService.spec.mjs
@@ -51,7 +51,7 @@ test.describe.serial('Neo.ai.services.github-workflow.HealthService - runtimeFre
             },
             hint: null
         });
-        expect(result.details).toContain('Runtime source/schema identity matches the current checkout.');
+        expect(result.details).toContain('Runtime schema identity matches the current checkout.');
         expect(result.boot).toBeUndefined();
         expect(result.current).toBeUndefined();
     });

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -269,7 +269,7 @@ test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshn
             },
             hint: null
         });
-        expect(result.details).toContain('Runtime source/config identity matches the current checkout.');
+        expect(result.details).toContain('Runtime config/schema identity matches the current checkout.');
         expect(result.boot).toBeUndefined();
         expect(result.current).toBeUndefined();
     });

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -267,7 +267,7 @@ test.describe.serial('HealthService #12772 — runtimeFreshness', () => {
             },
             hint: null
         });
-        expect(result.details).toContain('Runtime source/config identity matches the current checkout.');
+        expect(result.details).toContain('Runtime config/schema identity matches the current checkout.');
         expect(result.boot).toBeUndefined();
         expect(result.current).toBeUndefined();
     });

--- a/test/playwright/unit/ai/services/neural-link/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/HealthService.spec.mjs
@@ -58,7 +58,7 @@ test.describe.serial('Neo.ai.services.neural-link.HealthService runtimeFreshness
             stale : {configDigest: false, openApiDigest: false},
             hint  : null
         });
-        expect(result.details).toContain('Runtime source/config identity matches the current checkout.');
+        expect(result.details).toContain('Runtime config/schema identity matches the current checkout.');
         expect(result.boot).toBeUndefined();
         expect(result.current).toBeUndefined();
     });


### PR DESCRIPTION
Resolves #16295

Related: #14477

Refs: #15825

A freshness verdict can no longer assert a dimension its tracker was never configured to measure. Three digest-only MCP HealthServices claimed source identity while measuring only file digests; GitHub Workflow also claimed source identity while observing `gitHead` only as contextual evidence, outside the fields that decide status. The claims are narrowed to what each verdict actually compares, and the class is refused at construction.

Evidence: L3 (live Memory Core healthcheck reproducing the false `current`, plus byte comparison of the loaded file against `dev`) → L2 required (close-target ACs are construction-time behaviour covered by the specs). Residual: none [#16295].

## Deltas from ticket

**One scope addition, found by the guard itself.** The ticket named four call sites. The guard rejected a fifth — a fixture inside `RuntimeFreshnessService.spec.mjs` carrying the same overclaim — and three more surfaced as assertions pinning the old wording. Eight instances, not four. The fixture's own assertion is about `gitHead` omission, so its label was incidental to what it proves; narrowing it does not weaken the test.

**One defect in my own first cut, found by sweeping my own work.** There are **two** defaults, not one: `classifyRuntimeFreshness`'s parameter default and `RuntimeFreshnessTracker`'s constructor fallback. I narrowed only the first, so `createTracker` would have validated the honest default while the runtime emitted the overclaiming one — the exact "guard checks one string, runtime uses another" shape this ticket is about, one layer in. Both now resolve to a single `DEFAULT_IDENTITY_LABEL`.

## The defect

```js
files        : [configDigest, openApiDigest]      // what it compares
statusFields : ['configDigest', 'openApiDigest']  // what decides status
identityLabel: 'source/config identity'           // what it CLAIMS
```

Three callers omit `rootDir`; GitHub Workflow supplies it, so `readRuntimeIdentity` observes `gitHead`, but that caller deliberately excludes `gitHead` from `statusFields`. In both shapes, the source-match claim was structurally incapable of being supported by the verdict: three never looked, and one treated the source observation as contextual only. Live:

```json
"runtimeFreshness": {"status": "current",
  "stale": {"configDigest": false, "openApiDigest": false},
  "details": ["Runtime source/config identity matches the current checkout."]}
```

against a container whose loaded source differed at the byte level:

```
container: record.set('properties', properties);
host(dev): record.set({properties});
```

`MailboxService.mjs:290` — PR #16272 merged `16:07:07Z`, container started `13:45:18.647Z`. **2h22m stale while reporting `current`.**

Found by **@neo-gpt** on the live plane; I reproduced it, then swept and found it was uniform across all four services rather than a Memory Core quirk.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback | Evidence |
|---|---|---|---|---|
| `runtimeFreshness.details` prose | `RuntimeFreshnessService` | names only measured dimensions | — | live healthcheck; 4 call-site specs |
| `createTracker` label validation | this PR | throws when a claim has no configured input | word outside the vocabulary ⇒ ignored | 4 throw specs + 5 positive controls |
| `DEFAULT_IDENTITY_LABEL` | this PR | claims nothing; both defaults share it | — | spec: `createTracker({})` constructs |

`status`, `stale`, and field names are untouched — no wire-format change.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs RuntimeFreshnessService HealthService
  139 passed
```

Twelve new tests folded into the existing `RuntimeFreshnessService.spec.mjs` rather than a new file — same module, same concern.

**Positive controls are the load-bearing half**, because a guard that rejected every label would satisfy every rejection assertion and read as correct:

| control | asserts |
|---|---|
| honest `config/schema` label | constructs |
| `source` with `gitHead` in `statusFields` | constructs — the guard admits the dimension only when it drives the verdict |
| `createTracker({})` | constructs — the safe case stays free |
| `provider identity` | constructs — an unknown word is ignored, not invented into a violation |
| four shipped labels | each constructs against its own configured inputs |

**Rejection specs** cover the exact mixed-authority GitHub Workflow shape (`rootDir` present, `gitHead` contextual, `openApiDigest` status-driving), the shipped digest-only shape (`source/…` alongside a dimension that *is* backed — a guard asking "is any claim backed" would have passed it), a config claim with only a schema digest, and the message naming both the unbacked dimension and what is configured.

**RED characterisation, honestly.** The four rejection specs fail against `dev` because the guard does not exist there — an absent-capability falsifier, the weaker class, and I would rather say so than imply otherwise. The strong evidence is the live receipt above plus the eight real instances the guard found in-tree, including one in a test fixture and one in my own first cut.

## Post-Merge Validation

- [ ] After the next rebuild, confirm the Memory Core healthcheck no longer asserts source identity. The false `current` cannot be observed as fixed until an image carrying this lands — that is D#15758's transaction, not this PR's.

## Evolution

The witness came from @neo-gpt; my contribution was reproducing it, widening it from one service to eight sites, and choosing where the fix belongs.

What I would defend: **throwing at construction rather than warning at report time.** A freshness surface that reports its own unreliability inside the payload it makes unreliable is the defect restated one layer up. Boot-time and loud is the only placement that cannot be ignored by the reader it is meant to protect.

What I would not defend as settled: the dimension vocabulary is three words matched by regex against free text. That is deliberately permissive — an unknown word passes — so it cannot block a legitimate label, but it also cannot catch a synonym. A stricter contract would replace the free-text label with a derived one; I chose not to, because the sibling `unavailableSummary` shows readable phrasing has value and I did not want to trade honesty for terseness. If a reviewer prefers derivation, that is a defensible different shape.

Authored by Ada (Claude Opus 5, Claude Code). Session 56105163-6e66-44b6-8c6f-9e81bc1be08c.
