### PR TITLE
fix(agent-os): distinguish WAL drain boot epochs (#16298)

### DIFF
--- a/ai/daemons/embed/drainLock.mjs
+++ b/ai/daemons/embed/drainLock.mjs
@@ -8,12 +8,17 @@
  * daemon, the message drain wrapper, and the memory-core server's in-process loop consume it
  * unchanged.
  *
- * The drain lock keeps PID-liveness: its two mutually-exclusive hosts (the orchestrator-supervised
- * embed daemon and the in-process drain loop) are always SAME-namespace processes on one host, so
- * `process.kill(pid, 0)` is the correct probe here. Cross-namespace liveness (host vs Docker
- * container, where pid probes are blind) is the authority lease's TTL strategy — same core,
- * different injected `isHeldFresh`; see the core module's JSDoc.
+ * The drain lock combines boot identity with PID-liveness. Its two mutually-exclusive hosts (the
+ * orchestrator-supervised embed daemon and the in-process drain loop) are same-namespace processes
+ * within one boot, so `process.kill(pid, 0)` remains the live-holder probe there. The lock file can
+ * outlive a Docker container, however, and every replacement container starts its server as PID 1.
+ * `bootId` plus a legacy same-PID/process-start fallback distinguish that dead epoch before the PID
+ * probe. Cross-namespace liveness (host vs Docker container, where pid probes are blind) remains
+ * the authority lease's TTL strategy — same core, different injected `isHeldFresh`; see the core
+ * module's JSDoc.
  */
+
+import os from 'node:os';
 
 import {
     acquireFileLease,
@@ -31,6 +36,13 @@ const DEFAULT_REMEDIATION =
     'Disable one drain host for this deployment — the embed daemon OR memoryWal.inProcessDrain.';
 
 /**
+ * @summary Captures this Node process start once so a legacy lock from a previous container epoch
+ * cannot look live merely because both server processes use PID 1.
+ * @type {Number}
+ */
+const CURRENT_PROCESS_STARTED_AT = Date.now() - process.uptime() * 1000;
+
+/**
  * Default same-namespace liveness probe: ESRCH → dead (reclaimable), EPERM → alive (must not
  * displace).
  * @param {Number} pid
@@ -43,6 +55,41 @@ function defaultIsAlive(pid) {
     } catch (err) {
         return err.code === 'EPERM';
     }
+}
+
+/**
+ * @summary Classifies a persisted drain-lock holder within the current boot/process epoch.
+ * A different recorded boot is stale regardless of PID liveness. For pre-`bootId` descriptors,
+ * an equal PID whose lock predates this process is also stale; all other cases retain the existing
+ * same-namespace PID probe and therefore fail closed for a genuinely live different PID.
+ *
+ * @param {Object}   options
+ * @param {Object}   options.holder Persisted lock descriptor.
+ * @param {Number}   options.now Current clock value in epoch ms.
+ * @param {String}   options.bootId Current boot discriminator.
+ * @param {Number}   options.pid Current claimant PID.
+ * @param {Number}   options.currentProcessStartedAt Current process start in epoch ms.
+ * @param {Function} options.isAlive Same-namespace PID liveness probe.
+ * @returns {Boolean}
+ */
+function isDrainLockHolderFresh({holder, now, bootId, pid, currentProcessStartedAt, isAlive}) {
+    if (typeof holder.bootId === 'string' && holder.bootId.length > 0 && holder.bootId !== bootId) {
+        return false;
+    }
+
+    const holderStartedAt = Date.parse(holder.startedAt);
+
+    if (
+        holder.pid === pid &&
+        Number.isFinite(holderStartedAt) &&
+        Number.isFinite(currentProcessStartedAt) &&
+        now >= currentProcessStartedAt &&
+        holderStartedAt < currentProcessStartedAt
+    ) {
+        return false;
+    }
+
+    return isAlive(holder.pid);
 }
 
 /**
@@ -70,13 +117,15 @@ export class DrainLockHeldError extends Error {
 /**
  * @summary Atomically claims the drain lock for a WAL directory, enforcing single-host drain.
  * Specialization of {@link acquireFileLease} with the WAL filename, drain-specific refusal text,
- * and same-namespace pid-liveness.
+ * and boot/process-epoch-aware same-namespace PID-liveness.
  *
  * @param {Object}   options
  * @param {String}   options.dir       WAL directory (the resolved `memoryWal.dir` leaf).
  * @param {String}   options.owner     Host kind for diagnostics: `'daemon'` | `'in-process'`.
  * @param {Number}   [options.pid]     Owning pid (defaults to `process.pid`).
  * @param {Function} [options.now]     Clock (epoch ms) for `startedAt`. Defaults to `Date.now`.
+ * @param {String}   [options.bootId]  Boot discriminator. Defaults to `os.hostname()`.
+ * @param {Number}   [options.currentProcessStartedAt] Current process start in epoch ms.
  * @param {Object}   [options.fs]      Filesystem impl (injected for specs). Defaults to `fs-extra`.
  * @param {Function} [options.isAlive] Liveness probe `(pid) => boolean`. Defaults to a `process.kill` probe.
  * @param {Function} [options.log]     `(level, message)` sink. Defaults to a no-op.
@@ -90,6 +139,8 @@ export function acquireDrainLock({
     owner,
     pid        = process.pid,
     now        = Date.now,
+    bootId     = os.hostname(),
+    currentProcessStartedAt = CURRENT_PROCESS_STARTED_AT,
     fs: fsImpl,
     isAlive    = defaultIsAlive,
     log        = () => {},
@@ -98,13 +149,21 @@ export function acquireDrainLock({
 } = {}) {
     return acquireFileLease({
         dir,
-        filename       : DRAIN_LOCK_FILENAME,
+        filename   : DRAIN_LOCK_FILENAME,
         owner,
         pid,
         now,
-        fs             : fsImpl,
+        fields     : {bootId},
+        fs         : fsImpl,
         log,
-        isHeldFresh    : ({holder}) => isAlive(holder.pid),
+        isHeldFresh: ({holder, now: currentTime}) => isDrainLockHolderFresh({
+            holder,
+            now: currentTime,
+            bootId,
+            pid,
+            currentProcessStartedAt,
+            isAlive
+        }),
         createHeldError: ({lockPath, holder, requester}) =>
             new DrainLockHeldError({lockPath, holder, requester, lockLabel, remediation})
     });

--- a/ai/daemons/shared/fileLease.mjs
+++ b/ai/daemons/shared/fileLease.mjs
@@ -7,9 +7,10 @@
  *
  * One implementation serving two liveness domains:
  *
- *   - **Same-namespace** contenders (embed drain daemon vs in-process server loop): pid-liveness
- *     probe (`process.kill(pid, 0)`; ESRCH → dead/reclaimable, EPERM → alive/must not displace).
- *     See `ai/daemons/embed/drainLock.mjs`.
+ *   - **Same-namespace** contenders (embed drain daemon vs in-process server loop): boot identity
+ *     rejects persisted locks from a previous container epoch, then the pid-liveness probe
+ *     (`process.kill(pid, 0)`; ESRCH → dead/reclaimable, EPERM → alive/must not displace) governs
+ *     contenders within the current boot. See `ai/daemons/embed/drainLock.mjs`.
  *   - **Cross-namespace** contenders (host bare process vs Docker container): pid probes are
  *     BLIND — Docker Desktop runs containers in a VM, so a container's pid has no host-namespace
  *     existence and `kill(pid, 0)` reads a LIVE holder as dead, reclaiming its lease and starting

--- a/test/playwright/unit/ai/daemons/embed/drainLock.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainLock.spec.mjs
@@ -1,9 +1,9 @@
-import {test, expect}                  from '@playwright/test';
-import Neo                             from '../../../../../../src/Neo.mjs';
-import * as core                       from '../../../../../../src/core/_export.mjs';
+import {test, expect}                             from '@playwright/test';
+import Neo                                        from '../../../../../../src/Neo.mjs';
+import * as core                                  from '../../../../../../src/core/_export.mjs';
 import {mkdtemp, rm, readFile, writeFile, access} from 'fs/promises';
-import os                              from 'os';
-import path                            from 'path';
+import os                                         from 'os';
+import path                                       from 'path';
 
 import {
     acquireDrainLock,
@@ -19,7 +19,8 @@ import {
  *                     DrainLockHeldError and does NOT take over (holder descriptor unchanged).
  *   AC2 stale       — a dead holder's lock is reclaimed by the next host (daemon succession path).
  *   AC2 corrupt     — an unparseable lock never wedges the drain: it is reclaimed.
- *   AC2 same-pid    — our own leftover lock is reclaimed (no self-deadlock on pid reuse / restart).
+ *   AC2 boot epoch  — a previous container's PID-1 lock is reclaimed even though PID 1 is alive.
+ *   AC2 legacy pid  — a pre-bootId equal-PID lock predating this process is reclaimed.
  *   AC3 release     — release removes the lock iff it is still ours, is idempotent, and a displaced
  *                     host's late release never clobbers a successor's lock.
  *
@@ -49,7 +50,7 @@ test.describe('Neo.ai.daemons.embed.drainLock', () => {
         expect(handle.pid).toBe(4242);
 
         const holder = await holderNow();
-        expect(holder).toMatchObject({pid: 4242, owner: 'daemon'});
+        expect(holder).toMatchObject({pid: 4242, owner: 'daemon', bootId: os.hostname()});
         expect(holder.startedAt).toBe('1970-01-01T00:00:01.000Z');
     });
 
@@ -92,6 +93,75 @@ test.describe('Neo.ai.daemons.embed.drainLock', () => {
 
         expect(handle.pid).toBe(5555);
         expect((await holderNow()).pid).toBe(5555);
+    });
+
+    test('AC2: a previous container boot’s PID-1 lock is stale even though PID 1 is alive', async () => {
+        acquireDrainLock({
+            dir,
+            owner  : 'in-process',
+            pid    : 1,
+            bootId : 'container-epoch-a',
+            now    : () => 1000,
+            isAlive: alive
+        });
+
+        const handle = acquireDrainLock({
+            dir,
+            owner                  : 'in-process',
+            pid                    : 1,
+            bootId                 : 'container-epoch-b',
+            now                    : () => 3000,
+            currentProcessStartedAt: 2000,
+            isAlive                : alive
+        });
+
+        expect(handle.pid).toBe(1);
+        expect(await holderNow()).toMatchObject({pid: 1, bootId: 'container-epoch-b'});
+    });
+
+    test('AC2: a legacy equal-PID lock predating this process is reclaimed', async () => {
+        await writeFile(lockPath(), JSON.stringify({
+            pid       : 1,
+            owner     : 'in-process',
+            ownerToken: 'previous-process-token',
+            startedAt : '1970-01-01T00:00:01.000Z',
+            lastPulse : '1970-01-01T00:00:01.000Z'
+        }), 'utf8');
+
+        const handle = acquireDrainLock({
+            dir,
+            owner                  : 'in-process',
+            pid                    : 1,
+            bootId                 : 'container-epoch-b',
+            now                    : () => 3000,
+            currentProcessStartedAt: 2000,
+            isAlive                : alive
+        });
+
+        expect(handle.pid).toBe(1);
+        expect(await holderNow()).toMatchObject({pid: 1, bootId: 'container-epoch-b'});
+    });
+
+    test('AC2: a legacy different live PID remains held — absent boot identity is not stale evidence', async () => {
+        await writeFile(lockPath(), JSON.stringify({
+            pid       : 4242,
+            owner     : 'daemon',
+            ownerToken: 'live-holder-token',
+            startedAt : '1970-01-01T00:00:01.000Z',
+            lastPulse : '1970-01-01T00:00:01.000Z'
+        }), 'utf8');
+
+        expect(() => acquireDrainLock({
+            dir,
+            owner                  : 'in-process',
+            pid                    : 1,
+            bootId                 : 'container-epoch-b',
+            now                    : () => 3000,
+            currentProcessStartedAt: 2000,
+            isAlive                : alive
+        })).toThrow(DrainLockHeldError);
+
+        expect(await holderNow()).toMatchObject({pid: 4242, ownerToken: 'live-holder-token'});
     });
 
     test('AC2: equal numeric pids never self-deadlock — token identity governs, a dead probe still reclaims', async () => {

--- a/test/playwright/unit/ai/daemons/message/drainLock.spec.mjs
+++ b/test/playwright/unit/ai/daemons/message/drainLock.spec.mjs
@@ -59,4 +59,28 @@ test.describe('Neo.ai.daemons.message.drainLock', () => {
         expect(thrown.message).toContain('message daemon OR messageWal.inProcessDrain');
         expect((await holderNow()).pid).toBe(4242);
     });
+
+    test('reclaims the message WAL lock across container boot identity', async () => {
+        acquireMessageDrainLock({
+            dir,
+            owner  : 'in-process',
+            pid    : 1,
+            bootId : 'container-epoch-a',
+            now    : () => 1000,
+            isAlive: alive
+        });
+
+        const handle = acquireMessageDrainLock({
+            dir,
+            owner                  : 'in-process',
+            pid                    : 1,
+            bootId                 : 'container-epoch-b',
+            now                    : () => 3000,
+            currentProcessStartedAt: 2000,
+            isAlive                : alive
+        });
+
+        expect(handle.pid).toBe(1);
+        expect(await holderNow()).toMatchObject({pid: 1, bootId: 'container-epoch-b'});
+    });
 });


### PR DESCRIPTION
Resolves #16298

Memory Core now distinguishes a persisted WAL drain lock from a previous container boot before consulting PID liveness. New locks carry additive boot identity; the first fixed restart also recovers legacy PID-1 locks through the current process-start boundary. Same-boot live holders and legacy different live PIDs remain fail-closed. The message WAL wrapper inherits the same correction.

Evidence: L2 (real-filesystem unit coverage of boot/process-epoch reclaim and live-holder refusal) → L3 required (AC6 fixed-image restart and backlog-to-zero observation). Residual: AC6 [#16298].

## Deltas from ticket

None substantive. The shared file-lease contract note now names the composite boot-identity/PID-liveness strategy used by the existing drain-lock specialization.

## Test Evidence

- Memory WAL + shared lease core: `npm run test-unit -- test/playwright/unit/ai/daemons/embed/drainLock.spec.mjs test/playwright/unit/ai/daemons/message/drainLock.spec.mjs test/playwright/unit/ai/daemons/shared/fileLease.spec.mjs` — 32 passed.
- Message WAL wrapper: the same exact-head run proves inherited cross-boot reclaim and message-specific live-holder refusal.
- Repository staged validators: whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, AiConfig test mutation, and derived-domain checks passed.
- `npm run agent-preflight` — passed; only unrelated non-blocking stale-overlay warnings were reported.

## Post-Merge Validation

- [ ] Rebuild and deploy the Memory Core image containing this commit; do not manually delete either lock.
- [ ] Confirm both in-process drain loops acquire their locks at boot.
- [ ] Confirm the memory WAL backlog falls to zero and semantic queryability returns.
- [ ] Confirm post-restart message projection drains normally.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fb600-58b9-7fa2-86a7-5a15e1ccf659.
