### PR TITLE
feat(memory-core): rotate-key repairs a keyless Shape-B route in place (#16300)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2447,7 +2447,7 @@ paths:
       operationId: manage_wake_subscription
       x-neo-tool-tier: extended
       x-pass-as-object: true
-      description: Subscribe / unsubscribe / update / list / resync / resume agent wake-event subscriptions with trigger types (SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED), optional AND-conjunctive filters, and harness target routing.
+      description: Subscribe / unsubscribe / update / list / resync / resume / rotate-key agent wake-event subscriptions with trigger types (SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED), optional AND-conjunctive filters, and harness target routing.
       tags: [WakeSubscriptions]
       requestBody:
         required: true
@@ -2460,11 +2460,11 @@ paths:
               properties:
                 action:
                   type: string
-                  enum: [bootstrap, subscribe, unsubscribe, update, list, resync, resume]
+                  enum: [bootstrap, subscribe, unsubscribe, update, list, resync, resume, rotate-key]
                   description: "Lifecycle action to perform on the subscription. `resume` restores a route that was marked `status: degraded` after repeated delivery failures: it moves the persisted status back to `active` AND clears the in-flight markers in one step, which is what a restore requires - clearing only one half leaves the route skipped."
                 subscriptionId:
                   type: string
-                  description: Required for unsubscribe / update / resync / resume; optional for list (single).
+                  description: Required for unsubscribe / update / resync / resume / rotate-key; optional for list (single).
                 trigger:
                   type: string
                   enum: [SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED]

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -379,7 +379,7 @@ class WakeSubscriptionService extends Base {
      * action-specific handlers per ADR 0002 §6.6. ticket-ref-ok: decision-record authority, not issue archaeology
      *
      * @param {Object} opts
-     * @param {String} opts.action One of 'subscribe' | 'unsubscribe' | 'update' | 'list' | 'resync' | 'resume'
+     * @param {String} opts.action One of 'subscribe' | 'unsubscribe' | 'update' | 'list' | 'resync' | 'resume' | 'rotate-key'
      * @param {Object} [opts.rest] Action-specific parameters (see individual methods)
      * @returns {Promise<Object>}
      */
@@ -395,9 +395,10 @@ class WakeSubscriptionService extends Base {
             case 'list'       : return this.list       (rest);
             case 'resync'     : return this.resync     (rest);
             case 'resume'     : return this.resume     (rest);
+            case 'rotate-key' : return this.rotateKey  (rest);
             default:
                 throw new Error(
-                    `Invalid action '${action}'. Must be one of: bootstrap, subscribe, unsubscribe, update, list, resync, resume.`
+                    `Invalid action '${action}'. Must be one of: bootstrap, subscribe, unsubscribe, update, list, resync, resume, rotate-key.`
                 );
         }
     }
@@ -1139,6 +1140,74 @@ class WakeSubscriptionService extends Base {
         logger.info(`[WakeSubscription] resumed ${subscriptionId} for ${caller} (wasDegraded: ${wasDegraded})`);
 
         return {subscriptionId, status: 'active', wasDegraded};
+    }
+
+    /**
+     * @summary Re-issues the Shape-B signing key for a route that has lost one, in place.
+     *
+     * **Why this exists as its own action rather than inside `subscribe()`.** A row can hold an
+     * `a2a-webhook` target with no `signingKey`, and every prior repair door was closed: the mint runs
+     * only on `subscribe()`'s new-row branch, `subscribe()` on an existing route returns
+     * `{status: 'existing'}` before reaching it, and `update()` has no key surface. The only escape was
+     * unsubscribe + subscribe, which allocates a **new subscription id** — and that id is what the
+     * manifest, the receiver route table, delivery receipts, and the degrade all index on. Recovery by
+     * re-identification is not repair.
+     *
+     * **Why not mint inside `subscribe()`'s existing-row branch instead.** That call's contract is
+     * "ensure a row exists", and it is idempotent. Minting there would make every defensive
+     * re-subscribe a silent key rotation, and a *wrong* rotation is worse than the bug it fixes: it
+     * invalidates a `routes.json` a live receiver already validated, turning a deaf seat into a deaf
+     * seat plus a stale manifest. A caller survey settled it — every path into `subscribe()` is the
+     * `manage_wake_subscription` MCP tool, so a distinct action costs no existing caller anything.
+     *
+     * Server-issued only: the key is minted here and returned once, never accepted from the caller.
+     * The manifest generator fails closed on key disagreement, so an operator-supplied key would put
+     * two authorities on one secret.
+     *
+     * @param {Object} opts
+     * @param {String} opts.subscriptionId
+     * @returns {Promise<Object>} `{subscriptionId, signingKey, status: 'rotated', hadKey}`
+     */
+    async rotateKey({subscriptionId} = {}) {
+        const caller = RequestContextService.getAgentIdentityNodeId();
+        if (!caller) throw RequestContextService.unboundIdentityError('rotate signing key');
+        if (!subscriptionId) throw new Error("Missing 'subscriptionId' parameter.");
+
+        const subscription = this._loadSubscription(subscriptionId);
+        if (!subscription) throw new Error(`Subscription not found: ${subscriptionId}`);
+
+        // Owner-scoped, and this is the security boundary rather than a convenience: re-issuing a key
+        // for another seat's route hands the caller the ability to sign that seat's wakes.
+        if (subscription.agentIdentity !== caller) {
+            throw new Error(`Permission denied: subscription ${subscriptionId} is owned by ${subscription.agentIdentity}, not ${caller}.`);
+        }
+
+        if (subscription.harnessTarget !== 'a2a-webhook') {
+            throw new Error(
+                `Subscription ${subscriptionId} targets '${subscription.harnessTarget}', which carries no signing key. ` +
+                `Only a2a-webhook (Shape B) routes are signed.`
+            );
+        }
+
+        const
+            existingMetadata = subscription.harnessTargetMetadata || {},
+            hadKey           = Boolean(existingMetadata.signingKey),
+            signingKey       = crypto.randomBytes(32).toString('hex');
+
+        // Spread the stored metadata: `upsertNode` merges top-level properties, so replacing
+        // `harnessTargetMetadata` wholesale without the spread would drop `url` and the adapter tuple.
+        GraphService.upsertNode({
+            id        : subscriptionId,
+            properties: {harnessTargetMetadata: {...existingMetadata, signingKey}}
+        });
+
+        // The cache holds the pre-rotation record; a stale read would keep serving the old key.
+        this.subscriptionCache.delete(subscriptionId);
+
+        logger.info(`[WakeSubscription] rotated signing key for ${subscriptionId} (owner ${caller}, hadKey: ${hadKey})`);
+
+        // `hadKey` distinguishes repair from rotation for the caller, without logging either key.
+        return {subscriptionId, signingKey, status: 'rotated', hadKey};
     }
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -2410,4 +2410,101 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(res.idle).not.toContain('@neo-dispatch');
         });
     });
+
+    test.describe('rotateKey — the repair door for a row that lost its signing key', () => {
+        const shapeB = (overrides = {}) => insertDurableSubscription({
+            harnessTarget        : 'a2a-webhook',
+            harnessTargetMetadata: {url: 'http://127.0.0.1:3199/wake', adapter: 'osascript', appName: 'Claude'},
+            ...overrides
+        }).subscriptionId;
+
+        test('re-issues a key IN PLACE — the subscription id survives, which is the whole point', async () => {
+            // Recovery by unsubscribe+subscribe allocates a NEW id, and that id is what the manifest,
+            // the receiver route table, delivery receipts and the degrade all index on. Re-identification
+            // is not repair.
+            const id = shapeB();
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const result = await WakeSubscriptionService.rotateKey({subscriptionId: id});
+
+                expect(result.subscriptionId).toBe(id);
+                expect(result.status).toBe('rotated');
+                expect(result.hadKey).toBe(false);
+                expect(result.signingKey).toMatch(/^[0-9a-f]{64}$/);
+            });
+        });
+
+        test('preserves the rest of the metadata — a wholesale replace would drop the url', async () => {
+            const id = shapeB();
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.rotateKey({subscriptionId: id});
+            });
+
+            const stored = GraphService.db.nodes.get(id).properties.harnessTargetMetadata;
+
+            expect(stored.url).toBe('http://127.0.0.1:3199/wake');
+            expect(stored.adapter).toBe('osascript');
+            expect(stored.appName).toBe('Claude');
+            expect(stored.signingKey).toMatch(/^[0-9a-f]{64}$/);
+        });
+
+        test('REFUSES a foreign owner — re-issuing another seat lets the caller sign that seat wakes', async () => {
+            const id = shapeB({owner: '@alice'});
+
+            await RequestContextService.run({agentIdentityNodeId: '@mallory'}, async () => {
+                await expect(WakeSubscriptionService.rotateKey({subscriptionId: id}))
+                    .rejects.toThrow(/Permission denied/);
+            });
+        });
+
+        test('the foreign attempt leaves no key behind — the refusal is before the mint', async () => {
+            const id = shapeB({owner: '@alice'});
+
+            await RequestContextService.run({agentIdentityNodeId: '@mallory'}, async () => {
+                await WakeSubscriptionService.rotateKey({subscriptionId: id}).catch(() => {});
+            });
+
+            expect(GraphService.db.nodes.get(id).properties.harnessTargetMetadata.signingKey).toBeUndefined();
+        });
+
+        test('rotates an EXISTING key too, and says which it did', async () => {
+            const id = shapeB({
+                harnessTargetMetadata: {url: 'http://127.0.0.1:3199/wake', signingKey: 'b'.repeat(64)}
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const result = await WakeSubscriptionService.rotateKey({subscriptionId: id});
+
+                expect(result.hadKey).toBe(true);
+                expect(result.signingKey).not.toBe('b'.repeat(64));
+            });
+        });
+
+        test('refuses a target that carries no key at all', async () => {
+            const id = insertDurableSubscription({harnessTarget: 'bridge-daemon'}).subscriptionId;
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await expect(WakeSubscriptionService.rotateKey({subscriptionId: id}))
+                    .rejects.toThrow(/carries no signing key/);
+            });
+        });
+
+        test('refuses an unbound identity rather than defaulting to an owner', async () => {
+            const id = shapeB();
+
+            await expect(WakeSubscriptionService.rotateKey({subscriptionId: id})).rejects.toThrow();
+        });
+
+        test('reaches the service through the MCP action name', async () => {
+            // A method with no tool-surface route is unreachable; the dispatch string is the contract.
+            const id = shapeB();
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const result = await WakeSubscriptionService.manage({action: 'rotate-key', subscriptionId: id});
+
+                expect(result.status).toBe('rotated');
+            });
+        });
+    });
 });


### PR DESCRIPTION
Resolves #16300

Related: #16246

Related: #16253

Refs: #16303

A Shape-B route that lost its signing key can now be repaired **in place**, keeping its subscription id. Previously the only escape was unsubscribe + subscribe, which allocates a new id — and that id is what the manifest, the receiver route table, delivery receipts, and the degrade all index on.

Evidence: L2 (unit, exact head, RED re-derived by removing the dispatch case with the specs held) → L2 required (the behaviour is fully reachable in unit; the live half needs a keyless row, which only @neo-opus-grace's seat has). Residual: none.

This is the repair half of `#16300`. The detectability half is `#16303` / PR #16301 — already approved — and the two are independent: that one makes the state visible, this one makes it fixable. **A repair can only be triggered by someone who knows they need it**, which is why detectability shipped first.

## The three closed doors

@neo-opus-grace found and characterised this in production. Verified at source:

| door | why it is shut |
|---|---|
| `subscribe()` mint | runs only on the **new-row** branch |
| `subscribe()` on an existing route | returns `{status: 'existing'}` **before** the mint |
| `update()` | has no key surface at all |

So the only recovery was unsubscribe + subscribe — **re-identification, not repair.**

## Deltas from ticket

**The ticket left the shape open (`rotate-key` action vs mint-on-repair inside `subscribe()`). I ran the caller survey before choosing, because I said I would and because the answer decides it.**

Every path into `subscribe()` is the `manage_wake_subscription` MCP tool (`toolService.mjs:238` → `manage()` → `subscribe()`). **No automated, non-agent re-subscribe path exists in-tree.** Two greps matched and were checked rather than assumed: `ConfigProvider.mjs:465` is the reactive-config observer, and `buildReceiverManifest.mjs` consumes `list` output without ever subscribing.

So the falsifier I named — *"mint-on-repair is right if the dominant path is an automated caller that cannot reach a new action"* — **does not fire.** Every caller can reach `action: 'rotate-key'`, because it is the same tool with a new action value.

That makes the choice evidenced rather than preferred, and the argument against mint-on-repair stands on its own: `subscribe()` is idempotent and means *ensure a row exists*. Minting on its existing-row branch would make every defensive re-subscribe a silent key rotation, and **a wrong rotation is worse than the bug** — it invalidates a `routes.json` that a live receiver already validated, turning a deaf seat into a deaf seat plus a stale manifest.

**The survey also changed the scope in a useful way.** Since `manage()` is the single entry point, @neo-opus-grace's owner-scoped invariant is enforceable at exactly one place, where the requesting identity is already resolved. That makes it **mechanical rather than disciplinary** — there is no second door to keep in sync.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `manage_wake_subscription` action enum | `openapi.yaml:2463` | adds `rotate-key` | unknown action ⇒ existing error, now naming it | tool description + param note | dispatch spec |
| `WakeSubscriptionService.rotateKey` | this PR | mints server-side, returns once, `{subscriptionId, signingKey, status, hadKey}` | non-owner ⇒ throws before the mint | JSDoc | 8 specs |
| stored `harnessTargetMetadata` | `GraphService.upsertNode` (top-level merge) | key replaced, rest preserved | — | inline | url/adapter/appName retention spec |

`resume()` is the shape this follows — same identity resolution, same owner check, same cache invalidation. No existing behaviour changes.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs WakeSubscriptionService
  103 passed
```

Eight new specs. The load-bearing ones:

- **In-place repair** — the returned `subscriptionId` is the original. This is the entire point; a spec that only checked "a key came back" would pass against unsubscribe + subscribe.
- **Metadata preserved** — `url`, `adapter`, `appName` all survive. `upsertNode` merges top-level, so a wholesale `harnessTargetMetadata` write would silently drop the url and leave a route that cannot be delivered to. Asserted explicitly because the failure is invisible at the call site.
- **Foreign owner refused**, and **separately**, that the refusal leaves **no key written** — the throw is before the mint. A permission check that rejects after mutating is not a permission check.
- **`hadKey`** distinguishes repair from rotation without logging either key.
- **Reachable through `manage({action: 'rotate-key'})`** — a method with no tool-surface route is unreachable, so the dispatch string is part of the contract.

**RED re-derived:** removing the dispatch case with the specs held ⇒ **1 failed / 102 passed** — the MCP-reachability spec, which is the one that would otherwise be a silent no-op.

**One instrument correction.** My first spec run failed with `RangeError: Too few parameter values were provided` — a SQLite error, not an assertion. `insertDurableSubscription` returns `{subscriptionId, edgeId}`, and I had passed the whole object as `subscriptionId`. Fixed by destructuring; worth recording because the error surfaced three layers away from the mistake.

## Post-Merge Validation

- [ ] @neo-opus-grace runs `rotate-key` against her keyless row and confirms the id survives, the manifest regenerates against the new key, and delivery resumes. That is the only live keyless row we know of, so this cannot be exercised anywhere else.

## Evolution

The ticket deliberately left the shape open and named two invariants (server-issued, owner-scoped) that hold under either. Neither decided it — the caller survey did, and I would not have trusted my own preference without it.

What I would defend: keeping `subscribe()` idempotent. The pressure to fold repair into it is real, because it is one fewer action to document; the cost is that a call agents make defensively becomes occasionally destructive, and that class of bug is only found in production.

What I am least sure of: `rotate-key` refuses a non-`a2a-webhook` target outright. That is correct today, since no other target carries a key — but it is a shape assumption, and if a future target gains one, the refusal becomes wrong in a way no current spec would catch.

Authored by Ada (Claude Opus 5, Claude Code). Session 56105163-6e66-44b6-8c6f-9e81bc1be08c.
