### PR TITLE
feat(ai): surface stalled WAL drain health (#16305)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.mjs
+++ b/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.mjs
@@ -1,4 +1,4 @@
-import {readPendingWalRecords} from '../../../services/memory-core/helpers/memoryWalStore.mjs';
+import {classifyMemoryWalDrain, readPendingWalRecords} from '../../../services/memory-core/helpers/memoryWalStore.mjs';
 
 /**
  * @summary Read-only liveness watchdog for the embed-drain WAL backlog.
@@ -103,7 +103,12 @@ export async function getEmbedDrainPendingAge({walDir, now, readPending = readPe
  */
 export function evaluateStallAlarm({oldestAgeMs, pendingCount, thresholdMs, alarmState} = {}) {
     const alreadyAlarmed = !!alarmState?.alarmed;
-    const stalled        = thresholdMs > 0 && pendingCount > 0 && oldestAgeMs > thresholdMs;
+    const stalled        = classifyMemoryWalDrain({
+        observable        : true,
+        pendingDrainDepth : pendingCount,
+        oldestPendingAgeMs: oldestAgeMs,
+        stallThresholdMs  : thresholdMs
+    }) === 'stalled';
 
     if (!stalled) {
         // Healthy check: clear the latch so a future stall re-alarms.

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2827,6 +2827,15 @@ components:
               type: boolean
               description: "Whether the backlog could be measured. False means the WAL read failed; the sibling fields are then null rather than a reassuring zero."
               example: true
+            state:
+              type: string
+              enum: [caught-up, pending, stalled, unobservable]
+              description: "Shared embed-drain classification. A pending backlog becomes stalled only when its oldest measurable record strictly exceeds stallThresholdMs; an unreadable backlog is unobservable, never caught-up."
+              example: pending
+            stallThresholdMs:
+              type: number
+              description: "Configured oldest-pending-age threshold used by both this classification and the orchestrator watchdog. Values <= 0 disable stall classification."
+              example: 21600000
             pendingDrainDepth:
               type: integer
               nullable: true
@@ -2842,7 +2851,7 @@ components:
               nullable: true
               description: "True only when the backlog is empty. Null when not observable — never inferred from an unreadable WAL."
               example: true
-          required: [observable, pendingDrainDepth, oldestPendingAgeMs, allWritesSemanticallyQueryable]
+          required: [observable, state, stallThresholdMs, pendingDrainDepth, oldestPendingAgeMs, allWritesSemanticallyQueryable]
         plane:
           type: object
           description: "OBSERVED plane identity — the id/dataRoot THIS process resolved, read from the same per-server config the boot assertion verified (the deployment manifest's observed column). Always present."

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -177,6 +177,47 @@ const explorePullRequestHistoryOp = args => PullRequestHistoryService.explorePul
     now: new Date()
 });
 
+const ALL_FEATURES_OPERATIONAL_DETAIL = 'All features are operational';
+
+/**
+ * @summary Reconciles the base Memory Core health verdict with its measured WAL-drain state.
+ *
+ * A fresh asynchronous backlog is expected and leaves the base verdict unchanged. Once the shared
+ * drain classifier reports `stalled`, the composed response cannot still claim every feature is
+ * operational: healthy/degraded becomes degraded, an existing unhealthy verdict wins, and the
+ * reason names the measured depth and age. This projection is diagnostic-only and never repairs or
+ * mutates the WAL.
+ *
+ * @param {Object} options
+ * @param {Object} options.health Base HealthService response.
+ * @param {Object} options.memoryWalDrain Measured MemoryService drain response.
+ * @param {Object} options.plane Observed Memory Core plane identity.
+ * @returns {Object}
+ */
+export function composeMemoryCoreHealthcheck({health, memoryWalDrain, plane}) {
+    const response = {...health, memoryWalDrain, plane};
+
+    if (memoryWalDrain.state !== 'stalled') {
+        return response
+    }
+
+    const details = Array.isArray(health.details)
+        ? health.details.filter(detail => detail !== ALL_FEATURES_OPERATIONAL_DETAIL)
+        : [];
+
+    details.push(
+        `Memory WAL embed drain is stalled: ${memoryWalDrain.pendingDrainDepth} pending records; ` +
+        `oldest pending age ${memoryWalDrain.oldestPendingAgeMs} ms exceeds the ` +
+        `${memoryWalDrain.stallThresholdMs} ms threshold.`
+    );
+
+    return {
+        ...response,
+        status: health.status === 'unhealthy' ? 'unhealthy' : 'degraded',
+        details
+    }
+}
+
 const serviceMapping = {
     add_memory           : MemoryService          .addMemory               .bind(MemoryService),
     get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
@@ -202,8 +243,8 @@ const serviceMapping = {
     // slot on something an existing read already answers. Without it the `add_memory` disclosure
     // would only relocate the uncertainty: a caller told "queryability is deferred" needs somewhere
     // to CONFIRM visibility rather than a caveat and no instrument.
-    healthcheck                 : async args => ({
-        ...await HealthService.healthcheck(args),
+    healthcheck                 : async args => composeMemoryCoreHealthcheck({
+        health        : await HealthService.healthcheck(args),
         memoryWalDrain: await MemoryService.describeDrainState(),
         plane         : {id: mcConfig.plane.id, dataRoot: mcConfig.plane.dataRoot}
     }),

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1,19 +1,29 @@
-import Base                                                                                                                                              from '../../../src/core/Base.mjs';
-import StorageRouter                                                                                                                                     from './managers/StorageRouter.mjs';
-import crypto                                                                                                                                            from 'crypto';
-import GraphService                                                                                                                                      from './GraphService.mjs';
-import logger                                                                                                                                            from '../../mcp/server/memory-core/logger.mjs';
-import SessionService                                                                                                                                    from './SessionService.mjs';
-import TurnPresenceService                                                                                                                               from './TurnPresenceService.mjs';
-import {withTimeout}                                                                                                                                     from './helpers/withTimeout.mjs';
-import {appendWalGraphProjectionMarker, appendWalMemory, getMissingMemoryWalLeaves, pruneReconciledWalSegments, readPendingWalRecords, readWalMarkedIds} from './helpers/memoryWalStore.mjs';
-import {composeTurnDocumentText, resolveTurnDocumentForRead}                                                                                             from './helpers/turnDocumentText.mjs';
-import {isCollectionQuarantined}                                                                                                                         from './helpers/quarantineStore.mjs';
-import {buildChatModel}                                                                                                                                  from '../../provider/buildChatModel.mjs';
-import aiConfig                                                                                                                                          from '../../mcp/server/memory-core/config.mjs';
-import RequestContextService, {SHARED_USER_ID, normalizeUserId}                                                                                          from '../../mcp/server/shared/services/RequestContextService.mjs';
-import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER}                                                                                                       from '../../graph/identityRoots.mjs';
-import {normalizeAgentIdentityNodeId}                                                                                                                    from '../../graph/normalizeAgentIdentityNodeId.mjs';
+import Base                from '../../../src/core/Base.mjs';
+import StorageRouter       from './managers/StorageRouter.mjs';
+import crypto              from 'crypto';
+import GraphService        from './GraphService.mjs';
+import logger              from '../../mcp/server/memory-core/logger.mjs';
+import SessionService      from './SessionService.mjs';
+import TurnPresenceService from './TurnPresenceService.mjs';
+import {withTimeout}       from './helpers/withTimeout.mjs';
+
+import {
+    appendWalGraphProjectionMarker,
+    appendWalMemory,
+    classifyMemoryWalDrain,
+    getMissingMemoryWalLeaves,
+    pruneReconciledWalSegments,
+    readPendingWalRecords,
+    readWalMarkedIds
+} from './helpers/memoryWalStore.mjs';
+
+import {composeTurnDocumentText, resolveTurnDocumentForRead}    from './helpers/turnDocumentText.mjs';
+import {isCollectionQuarantined}                                from './helpers/quarantineStore.mjs';
+import {buildChatModel}                                         from '../../provider/buildChatModel.mjs';
+import aiConfig                                                 from '../../mcp/server/memory-core/config.mjs';
+import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER}              from '../../graph/identityRoots.mjs';
+import {normalizeAgentIdentityNodeId}                           from '../../graph/normalizeAgentIdentityNodeId.mjs';
 
 import {CONCEPT_EXPANSION_EDGE_TYPES, MEMORY_TERMINAL_EDGE_TYPES, enrichWithConceptWalk} from '../graph/conceptAnchoredRetrieval.mjs';
 import {buildMemoryResolveCandidate}                                                     from './conceptWalkMemoryGate.mjs';
@@ -591,7 +601,9 @@ class MemoryService extends Base {
      * @returns {Promise<Object>}
      */
     async describeDrainState() {
-        const walDir = aiConfig.memoryWal.dir;
+        const
+            stallThresholdMs = aiConfig.memoryWal.embedDrainStallThresholdMs,
+            walDir           = aiConfig.memoryWal.dir;
 
         try {
             const pending = await readPendingWalRecords({dir: walDir}),
@@ -602,12 +614,20 @@ class MemoryService extends Base {
                           return at !== null && (min === null || at < min) ? at : min
                       },
                       null
-                  );
+                  ),
+                  oldestPendingAgeMs = oldest === null ? null : Math.max(0, Date.now() - oldest);
 
             return {
-                observable        : true,
+                observable: true,
+                state     : classifyMemoryWalDrain({
+                    observable       : true,
+                    pendingDrainDepth: pending.length,
+                    oldestPendingAgeMs,
+                    stallThresholdMs
+                }),
+                stallThresholdMs,
                 pendingDrainDepth : pending.length,
-                oldestPendingAgeMs: oldest === null ? null : Math.max(0, Date.now() - oldest),
+                oldestPendingAgeMs,
                 // Zero pending is the ONLY state that means every accepted write is SEMANTICALLY
                 // queryable, and it is stated positively so a caller does not have to infer it from an
                 // absent field. Named for the axis: recency recall never waits on this backlog, so an
@@ -622,6 +642,8 @@ class MemoryService extends Base {
             // one layer up: a caller trusting a number that means "unknown".
             return {
                 observable                    : false,
+                state                         : classifyMemoryWalDrain({observable: false}),
+                stallThresholdMs,
                 pendingDrainDepth             : null,
                 oldestPendingAgeMs            : null,
                 allWritesSemanticallyQueryable: null

--- a/ai/services/memory-core/helpers/memoryWalStore.mjs
+++ b/ai/services/memory-core/helpers/memoryWalStore.mjs
@@ -37,6 +37,46 @@ import {withAppendLock}                    from './walAppendLock.mjs';
 const SEGMENT_RE = /^wal-(\d{4}-\d{2}-\d{2})\.jsonl$/;
 
 /**
+ * @summary Classifies the observable embed-drain backlog using the shared stall threshold.
+ *
+ * This is the single state definition consumed by both the orchestrator watchdog and the Memory
+ * Core health envelope. Keeping the threshold comparison here prevents a green MCP healthcheck and
+ * a failed watchdog from describing the same backlog differently. A read failure is explicit
+ * `unobservable`, never a reassuring `caught-up`; a non-empty backlog only becomes `stalled` after
+ * its oldest measurable record strictly exceeds the configured threshold.
+ *
+ * @param {Object} options
+ * @param {Boolean} options.observable Whether the WAL backlog was measured successfully.
+ * @param {Number|null} options.pendingDrainDepth Count of records awaiting an embed marker.
+ * @param {Number|null} options.oldestPendingAgeMs Age of the oldest pending record.
+ * @param {Number} options.stallThresholdMs Configured stall threshold; `<= 0` disables stall classification.
+ * @returns {'caught-up'|'pending'|'stalled'|'unobservable'}
+ */
+export function classifyMemoryWalDrain({
+    observable,
+    pendingDrainDepth,
+    oldestPendingAgeMs,
+    stallThresholdMs
+} = {}) {
+    if (observable !== true || !Number.isInteger(pendingDrainDepth) || pendingDrainDepth < 0) {
+        return 'unobservable'
+    }
+
+    if (pendingDrainDepth === 0) {
+        return 'caught-up'
+    }
+
+    if (
+        Number.isFinite(stallThresholdMs) && stallThresholdMs > 0 &&
+        Number.isFinite(oldestPendingAgeMs) && oldestPendingAgeMs > stallThresholdMs
+    ) {
+        return 'stalled'
+    }
+
+    return 'pending'
+}
+
+/**
  * @summary Names the `memoryWal` config leaves missing from a config slice.
  *
  * The stale-overlay guard: gitignored `config.mjs` files are MATERIALIZED copies of

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
@@ -3,7 +3,11 @@ import {mkdtemp, rm}  from 'fs/promises';
 import os             from 'os';
 import path           from 'path';
 
-import {appendWalEmbedMarker, appendWalMemory} from '../../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
+import {
+    appendWalEmbedMarker,
+    appendWalMemory,
+    classifyMemoryWalDrain
+} from '../../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
 import {
     evaluateStallAlarm,
     getDueTask,
@@ -37,6 +41,34 @@ const record = (id, timestampMs) => ({
     timestamp: timestampMs,
     metadata : {prompt: `p-${id}`, response: `r-${id}`, thought: `t-${id}`},
     document : `doc-${id}`
+});
+
+test.describe('memoryWalStore — classifyMemoryWalDrain shared state (#16305)', () => {
+    const thresholdMs = 6 * HOUR_MS;
+
+    test('distinguishes caught-up, expected pending, and threshold-exceeding stalled states', () => {
+        expect(classifyMemoryWalDrain({
+            observable: true, pendingDrainDepth: 0, oldestPendingAgeMs: null, stallThresholdMs: thresholdMs
+        })).toBe('caught-up');
+
+        expect(classifyMemoryWalDrain({
+            observable: true, pendingDrainDepth: 3, oldestPendingAgeMs: thresholdMs, stallThresholdMs: thresholdMs
+        })).toBe('pending');
+
+        expect(classifyMemoryWalDrain({
+            observable: true, pendingDrainDepth: 3, oldestPendingAgeMs: thresholdMs + 1, stallThresholdMs: thresholdMs
+        })).toBe('stalled');
+    });
+
+    test('keeps an unreadable backlog unobservable and a disabled threshold pending', () => {
+        expect(classifyMemoryWalDrain({
+            observable: false, pendingDrainDepth: 0, oldestPendingAgeMs: null, stallThresholdMs: thresholdMs
+        })).toBe('unobservable');
+
+        expect(classifyMemoryWalDrain({
+            observable: true, pendingDrainDepth: 1, oldestPendingAgeMs: 99 * HOUR_MS, stallThresholdMs: 0
+        })).toBe('pending');
+    });
 });
 
 test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — getEmbedDrainPendingAge (#13551)', () => {
@@ -92,13 +124,13 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — getEmbedDr
 
     test('(f) a thrown error in the WAL read degrades to a zero-backlog reading (never throws)', async () => {
         const throwingReader = async () => { throw new Error('simulated WAL read fault'); };
-        const result = await getEmbedDrainPendingAge({walDir, now: Date.now(), readPending: throwingReader});
+        const result         = await getEmbedDrainPendingAge({walDir, now: Date.now(), readPending: throwingReader});
         // Fails SOFT: a read fault must look like "no backlog" (→ no alarm), never a stall or a throw.
         expect(result).toEqual({oldestAgeMs: 0, pendingCount: 0, oldestTimestamp: null});
     });
 
     test('a malformed record (no finite timestamp) is still counted but never anchors the age', async () => {
-        const now = Date.UTC(2026, 5, 3, 12);
+        const now    = Date.UTC(2026, 5, 3, 12);
         const reader = async () => [
             {id: 'good', timestamp: now - 2 * HOUR_MS},
             {id: 'bad',  timestamp: 'not-a-number'}
@@ -160,6 +192,13 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — evaluateSt
         expect(r.stalled).toBe(true);
         expect(r.shouldAlarm).toBe(true);
         expect(r.nextAlarmState.alarmed).toBe(true);
+    });
+
+    test('exactly at the shared threshold is pending, not stalled', () => {
+        const r = evaluateStallAlarm({oldestAgeMs: THRESHOLD, pendingCount: 5, thresholdMs: THRESHOLD, alarmState: null});
+
+        expect(r.stalled).toBe(false);
+        expect(r.shouldAlarm).toBe(false);
     });
 
     test('above threshold while already latched → stalled but NO re-alarm', () => {
@@ -277,9 +316,9 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
             {dir: walDir, planeId: 'test-memory-plane'}
         ); // 8h > 6h threshold
 
-        const outcomes = [];
-        const alarmCalls = [];
-        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const outcomes         = [];
+        const alarmCalls       = [];
+        const dispatcher       = async payload => { alarmCalls.push(payload); };
         const taskStateService = makeTaskStateService();
 
         await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime: makeRuntime()});
@@ -305,9 +344,9 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
             {dir: walDir, planeId: 'test-memory-plane'}
         ); // 1h < 6h threshold
 
-        const outcomes = [];
-        const alarmCalls = [];
-        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const outcomes         = [];
+        const alarmCalls       = [];
+        const dispatcher       = async payload => { alarmCalls.push(payload); };
         const taskStateService = makeTaskStateService();
 
         await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime: makeRuntime()});
@@ -325,11 +364,11 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
             {dir: walDir, planeId: 'test-memory-plane'}
         );
 
-        const outcomes = [];
-        const alarmCalls = [];
-        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const outcomes         = [];
+        const alarmCalls       = [];
+        const dispatcher       = async payload => { alarmCalls.push(payload); };
         const taskStateService = makeTaskStateService();
-        const runtime = makeRuntime();
+        const runtime          = makeRuntime();
 
         // Two consecutive stalled checks → ONE alarm (one-shot latch).
         await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime});
@@ -360,9 +399,9 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
             {dir: walDir, planeId: 'test-memory-plane'}
         );
 
-        const outcomes = [];
-        const alarmCalls = [];
-        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const outcomes         = [];
+        const alarmCalls       = [];
+        const dispatcher       = async payload => { alarmCalls.push(payload); };
         const taskStateService = makeTaskStateService();
 
         await runWatchdogOnce({
@@ -382,8 +421,8 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
             {dir: walDir, planeId: 'test-memory-plane'}
         );
 
-        const alarmCalls = [];
-        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const alarmCalls       = [];
+        const dispatcher       = async payload => { alarmCalls.push(payload); };
         const taskStateService = makeTaskStateService();
 
         const services = {

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -34,8 +34,9 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
 
         const ToolServiceModule = await import('../../../../../../../ai/mcp/server/memory-core/toolService.mjs');
         toolService = {
-            listTools              : ToolServiceModule.listTools,
-            readLaneLandscapeConfig: ToolServiceModule.readLaneLandscapeConfig
+            composeMemoryCoreHealthcheck: ToolServiceModule.composeMemoryCoreHealthcheck,
+            listTools                   : ToolServiceModule.listTools,
+            readLaneLandscapeConfig     : ToolServiceModule.readLaneLandscapeConfig
         };
     });
 
@@ -207,6 +208,8 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
 
         expect(declared).toBeTruthy();
         expect(declared.properties.observable.type).toBe('boolean');
+        expect(declared.properties.state.enum).toEqual(['caught-up', 'pending', 'stalled', 'unobservable']);
+        expect(declared.properties.stallThresholdMs.type).toBe('number');
         expect(declared.properties.pendingDrainDepth.type).toBe('integer');
         expect(declared.properties.allWritesSemanticallyQueryable.type).toBe('boolean');
 
@@ -232,6 +235,65 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         const unproduced = Object.keys(declared.properties).filter(key => !(key in produced));
 
         expect(unproduced).toEqual([]);
+    });
+
+    test('healthcheck composition degrades only a stalled drain and preserves stronger verdicts (#16305)', () => {
+        const plane        = {id: 'test-plane', dataRoot: '/test-data'};
+        const pendingDrain = {
+            observable                    : true,
+            state                         : 'pending',
+            stallThresholdMs              : 6 * 60 * 60 * 1000,
+            pendingDrainDepth             : 2,
+            oldestPendingAgeMs            : 60 * 1000,
+            allWritesSemanticallyQueryable: false
+        };
+        const baseHealth = {
+            status : 'healthy',
+            details: ['Connected to ChromaDB', 'All features are operational']
+        };
+
+        const pending = toolService.composeMemoryCoreHealthcheck({health: baseHealth, memoryWalDrain: pendingDrain, plane});
+
+        expect(pending.status).toBe('healthy');
+        expect(pending.details).toContain('All features are operational');
+
+        const stalledDrain = {
+            ...pendingDrain,
+            state             : 'stalled',
+            pendingDrainDepth : 29,
+            oldestPendingAgeMs: pendingDrain.stallThresholdMs + 1
+        };
+        const stalled = toolService.composeMemoryCoreHealthcheck({health: baseHealth, memoryWalDrain: stalledDrain, plane});
+
+        expect(stalled.status).toBe('degraded');
+        expect(stalled.details).toContain('Connected to ChromaDB');
+        expect(stalled.details).not.toContain('All features are operational');
+        expect(stalled.details.at(-1)).toContain('29 pending records');
+        expect(stalled.details.at(-1)).toContain(`${stalledDrain.oldestPendingAgeMs} ms`);
+
+        const unhealthy = toolService.composeMemoryCoreHealthcheck({
+            health        : {...baseHealth, status: 'unhealthy'},
+            memoryWalDrain: stalledDrain,
+            plane
+        });
+
+        expect(unhealthy.status).toBe('unhealthy');
+
+        const unobservable = toolService.composeMemoryCoreHealthcheck({
+            health        : {...baseHealth, status: 'unhealthy'},
+            memoryWalDrain: {
+                ...pendingDrain,
+                observable                    : false,
+                state                         : 'unobservable',
+                pendingDrainDepth             : null,
+                oldestPendingAgeMs            : null,
+                allWritesSemanticallyQueryable: null
+            },
+            plane
+        });
+
+        expect(unobservable.status).toBe('unhealthy');
+        expect(unobservable.memoryWalDrain.state).toBe('unobservable');
     });
 
     test('healthcheck dispatch passes diagnostic options as one object (#13460)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -194,6 +194,8 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         const drain = await MemoryService.describeDrainState();
 
         expect(drain.observable).toBe(true);
+        expect(drain.state).toBe('pending');
+        expect(drain.stallThresholdMs).toBeGreaterThan(0);
         expect(drain.pendingDrainDepth).toBeGreaterThan(0);
         expect(drain.allWritesSemanticallyQueryable).toBe(false);
     });


### PR DESCRIPTION
Resolves #16305

Memory Core now classifies its embed-drain backlog through one shared `caught-up` / `pending` / `stalled` / `unobservable` rule used by both the existing watchdog and the MCP health surface. A stalled drain degrades the composed verdict, preserves an existing `unhealthy` result, removes the contradictory all-features claim, and reports the measured count and age; expected pending work remains healthy.

Evidence: L2 (production composition, real temp-WAL boundaries, and real OpenAPI/producer cross-check) → L2 required (all #16305 ACs are deterministic service contracts). No residuals.

## Deltas from ticket

None substantive. Required preflight formatting aligned declarations in the already-touched watchdog spec without changing behavior.

## Test Evidence

- WAL classifier, watchdog reuse, producer/schema parity, and health composition: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs` — 51 passed at `1e96c3634c`.
- Full unit safety net: `npm run test-unit` — 10,709 passed; 22 unrelated host/fixture failures from unavailable `ps`/`mktemp`, an ignored backup scanned by the retired-primitive guard, and one model-backed timing case. No #16305 owning test failed; this is not presented as a green full-suite receipt.
- Commit gates: whitespace, shorthand, AiConfig mutation, JSDoc types, derived-domain, ticket archaeology, block alignment, and parse checks passed.

## Post-Merge Validation

- [ ] After deployment, confirm `healthcheck.memoryWalDrain` exposes `state` and `stallThresholdMs` on the live plane.
- [ ] At the next genuine threshold crossing, confirm the live top-level verdict is at least `degraded` and omits `All features are operational`.

Related: #13551  
Related: #16299  
Related: D#15758

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 202ddc70-2892-4cce-b06c-bb49492b4ad4.
