### PR TITLE
fix(memory-core): bound the miniSummary backfill and complete its input (#16313)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -773,11 +773,19 @@ class ConfigBase extends ConfigProvider {
                 miniSummaryBackfillFreshReserve: leaf(10, 'NEO_MC_MINI_SUMMARY_BACKFILL_FRESH_RESERVE', 'number'),
                 miniSummaryMaxChars            : leaf(280, 'NEO_MC_MINI_SUMMARY_MAX_CHARS', 'number'),
                 generateMiniSummaryTimeoutMs   : leaf(20000, 'NEO_MC_GENERATE_MINI_SUMMARY_TIMEOUT_MS', 'number'),
-                chromaFetchTimeoutMs           : leaf(10000, 'NEO_MC_CHROMA_FETCH_TIMEOUT_MS', 'number'),
-                graphProjectionMaxAttempts     : leaf(5, 'NEO_MC_GRAPH_PROJECTION_MAX_ATTEMPTS', 'number'),
-                graphProjectionRetryBaseMs     : leaf(250, 'NEO_MC_GRAPH_PROJECTION_RETRY_BASE_MS', 'number'),
-                graphProjectionRetryMaxMs      : leaf(5000, 'NEO_MC_GRAPH_PROJECTION_RETRY_MAX_MS', 'number'),
-                graphProjectionDrainIntervalMs : leaf(60000, 'NEO_MC_GRAPH_PROJECTION_DRAIN_INTERVAL_MS', 'number')
+                /**
+                 * Consecutive generation failures after which a row is reversibly archived instead of
+                 * deferred again. Without a budget the backfill retries the same rows forever: a CPU-only
+                 * deployment burned ~2.3 cores for days at `0 updated, 30 deferred` per pass, because the
+                 * timeout is per-attempt and nothing counted attempts across passes. Mirrors
+                 * `graphProjectionMaxAttempts`; the exit mirrors the loop's existing `no-content` archive.
+                 */
+                miniSummaryMaxAttempts        : leaf(5, 'NEO_MC_MINI_SUMMARY_MAX_ATTEMPTS', 'number'),
+                chromaFetchTimeoutMs          : leaf(10000, 'NEO_MC_CHROMA_FETCH_TIMEOUT_MS', 'number'),
+                graphProjectionMaxAttempts    : leaf(5, 'NEO_MC_GRAPH_PROJECTION_MAX_ATTEMPTS', 'number'),
+                graphProjectionRetryBaseMs    : leaf(250, 'NEO_MC_GRAPH_PROJECTION_RETRY_BASE_MS', 'number'),
+                graphProjectionRetryMaxMs     : leaf(5000, 'NEO_MC_GRAPH_PROJECTION_RETRY_MAX_MS', 'number'),
+                graphProjectionDrainIntervalMs: leaf(60000, 'NEO_MC_GRAPH_PROJECTION_DRAIN_INTERVAL_MS', 'number')
             },
             /**
              * Temporal-pyramid durable aggregation lane (L1 session / L2 daily tiers).

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -171,6 +171,7 @@
         "memoryService.graphProjectionRetryMaxMs",
         "memoryService.miniSummaryBackfillFreshReserve",
         "memoryService.miniSummaryBackfillMaxRunMs",
+        "memoryService.miniSummaryMaxAttempts",
         "memoryService.miniSummaryMaxChars",
         "memoryService.miniSummaryTimeoutMs",
         "modelName",

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1765,7 +1765,16 @@ class MemoryService extends Base {
             attempts = this.recordMiniSummaryAttempt({id}),
             budget   = aiConfig.memoryService.miniSummaryMaxAttempts;
 
-        if (!Number.isFinite(budget) || budget <= 0 || attempts < budget) {
+        // `<= 0` is the leaf's declared disable switch and stays silent. A NON-FINITE budget is a
+        // different thing: it means the leaf resolved `undefined`, which only happens on a stale
+        // operator overlay — and silently disabling there would restore the unbounded loop this
+        // exists to stop, with no signal. That is the failure class, not a safe default.
+        if (!Number.isFinite(budget)) {
+            logger.warn('[MemoryService] memoryService.miniSummaryMaxAttempts is unresolved; the backfill attempt budget is INACTIVE. Re-materialize the config overlay (ai/scripts/setup/initServerConfigs.mjs --migrate-config).');
+            return false
+        }
+
+        if (budget <= 0 || attempts < budget) {
             return false
         }
 

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1630,7 +1630,7 @@ class MemoryService extends Base {
      * @param {String} options.response
      * @returns {Promise<String|null>} A one-line summary capped at `aiConfig.memoryService.miniSummaryMaxChars` (default 280), or `null`.
      */
-    async buildMiniSummary({prompt, response}) {
+    async buildMiniSummary({prompt, thought, response}) {
         // Calibrated above the measured local-model summary latency so a real summary is not aborted
         // before it completes. Benchmark (2026-06-09, MacBook M5 Max 128GB, gemma-4-31b-it via LM
         // Studio): a ~5k-char -> tweet-size summary takes ~5.3s warm / ~13s cold. The prior 4s cap
@@ -1647,12 +1647,19 @@ class MemoryService extends Base {
             });
             if (!model) return null;
 
-            const promptText = `Summarize this agent turn in one line, max ${aiConfig.memoryService.miniSummaryMaxChars} characters, no preamble:\nUser: ${prompt ?? ''}\nAgent: ${response ?? ''}`;
-            const result     = await withTimeout(
+            // `thought` is included because the reasoning is frequently the turn's real substance: a
+            // summary built from prompt+response alone records what was asked and answered, not what was
+            // decided. Deliberately NOT truncated — cutting the input to fit the window loses exactly the
+            // content worth keeping, which is why the window adapts to the input rather than the reverse.
+            const thoughtLine = thought ? `\nReasoning: ${thought}` : '';
+            const promptText  = `Summarize this agent turn in one line, max ${aiConfig.memoryService.miniSummaryMaxChars} characters, no preamble:\nUser: ${prompt ?? ''}${thoughtLine}\nAgent: ${response ?? ''}`;
+            const result      = await withTimeout(
                 model.generateContent(promptText, {
                     timeoutMs     : TIMEOUT_MS,
                     operationLabel: 'miniSummary generation',
-                    priority      : 'interactive'
+                    // Batch, not interactive: the only runtime caller is the backfill sweep, so this
+                    // queue-jumped real interactive traffic on behalf of a background job.
+                    priority      : 'batch'
                 }),
                 TIMEOUT_MS,
                 'miniSummary generation'
@@ -1723,6 +1730,76 @@ class MemoryService extends Base {
      * @param {String} [options.reason='']  Provenance, stored as `archivedReason`.
      * @returns {Boolean} `true` if a live (not-already-archived) row was archived.
      */
+    /**
+     * @summary Counts one failed miniSummary generation for a row and returns the running total.
+     *
+     * The backfill's timeout is per-attempt, and nothing counted attempts across passes — so a row the
+     * provider could never summarize was retried on every sweep forever. A CPU-only deployment burned
+     * roughly 2.3 cores for days reporting `0 updated, 30 deferred` per pass, because each pass looked
+     * identical to the first.
+     *
+     * Persisted on the node rather than held in memory: the loop's whole failure mode is that
+     * consecutive passes cannot see each other, and a process-local counter reproduces that exactly.
+     *
+     * @param {Object} opts
+     * @param {String} opts.id Memory node id.
+     * @returns {Number} Attempts recorded so far, or `0` when the row is unreachable.
+     */
+    /**
+     * @summary Records a failed attempt and reversibly archives the row once the budget is spent.
+     *
+     * The exit mirrors the loop's existing `no-content` archive, deliberately: that path already
+     * established that a row which cannot be summarized should *leave the pending set and count as
+     * progress*, rather than sit in it forever and also misfire the scheduler's no-progress backoff.
+     * A row the provider repeatedly fails on needs the same exit for the same reason.
+     *
+     * Reversible — `archivedAt` / `archivedReason` are markers, and `generation-timeout` names the
+     * cause, so a later pass (or a widened generation window) can restore the row deliberately.
+     *
+     * @param {String} id Memory node id.
+     * @returns {Boolean} `true` when the budget was reached and the row was archived.
+     * @protected
+     */
+    _exhaustMiniSummaryAttempt(id) {
+        const
+            attempts = this.recordMiniSummaryAttempt({id}),
+            budget   = aiConfig.memoryService.miniSummaryMaxAttempts;
+
+        if (!Number.isFinite(budget) || budget <= 0 || attempts < budget) {
+            return false
+        }
+
+        logger.warn(`[MemoryService] miniSummary generation failed ${attempts}x for ${id}; archiving with reason 'generation-timeout'`);
+        this.archiveMemoryNode({id, reason: 'generation-timeout'});
+
+        return true
+    }
+
+    recordMiniSummaryAttempt({id} = {}) {
+        const sqlite = GraphService.db?.storage?.db;
+
+        if (!sqlite || !id) {
+            return 0;
+        }
+
+        sqlite.prepare(`
+            UPDATE Nodes
+            SET data = json_set(
+                data,
+                '$.properties.miniSummaryAttempts',
+                COALESCE(json_extract(data, '$.properties.miniSummaryAttempts'), 0) + 1
+            )
+            WHERE id = ?
+              AND json_extract(data, '$.label') = 'AGENT_MEMORY'
+        `).run(id);
+
+        const row = sqlite
+            .prepare(`SELECT json_extract(data, '$.properties.miniSummaryAttempts') AS attempts FROM Nodes WHERE id = ? LIMIT 1`)
+            .get(id);
+
+        return row?.attempts || 0;
+    }
+
     archiveMemoryNode({id, reason = ''} = {}) {
         const sqlite = GraphService.db?.storage?.db;
 
@@ -1832,10 +1909,10 @@ class MemoryService extends Base {
             byId             = new Map((fetched.ids || []).map((id, index) => [id, fetched.metadatas?.[index] || {}]));
         } catch (error) {
             logger.warn(`[MemoryService] miniSummary backfill deferred the whole batch (content store unreachable, fail-soft): ${error.message}`);
-            return {processed: rows.length, updated: 0, deferred: rows.length, missingContent: 0, runBudgetHit: false};
+            return {processed: rows.length, updated: 0, deferred: rows.length, missingContent: 0, exhausted: 0, runBudgetHit: false};
         }
 
-        let updated = 0, deferred = 0, missingContent = 0, processed = 0, runBudgetHit = false;
+        let updated = 0, deferred = 0, missingContent = 0, processed = 0, exhausted = 0, runBudgetHit = false;
 
         for (const row of rows) {
             // Bound the run safely under the ProcessSupervisor watchdog: stop starting new rows once
@@ -1870,13 +1947,17 @@ class MemoryService extends Base {
 
             try {
                 const miniSummary = await withTimeout(
-                    summarize({prompt: metadata.prompt, response: metadata.response}),
+                    summarize({prompt: metadata.prompt, thought: metadata.thought, response: metadata.response}),
                     aiConfig.memoryService.miniSummaryTimeoutMs,
                     'miniSummary backfill summarize'
                 );
 
                 if (!miniSummary) {
-                    deferred++;
+                    if (this._exhaustMiniSummaryAttempt(row.id)) {
+                        exhausted++;
+                    } else {
+                        deferred++;
+                    }
                     continue;
                 }
 
@@ -1887,7 +1968,15 @@ class MemoryService extends Base {
                 }
             } catch (error) {
                 logger.warn(`[MemoryService] miniSummary backfill deferred for ${row.id} (fail-soft): ${error.message}`);
-                deferred++;
+
+                // A thrown attempt is a failed attempt: the timeout path arrives here, and it is the one
+                // that loops forever. Counting only the falsy-return path would leave the dominant case
+                // unbounded.
+                if (this._exhaustMiniSummaryAttempt(row.id)) {
+                    exhausted++;
+                } else {
+                    deferred++;
+                }
             }
         }
 
@@ -1896,9 +1985,9 @@ class MemoryService extends Base {
         }
 
         // Completion line so the run ends with a visible tally, not silence (stderr → captured by the supervisor).
-        console.error(`[INFO] [MemoryService] miniSummary backfill complete: ${processed}/${rows.length} processed (${updated} updated, ${deferred} deferred, ${missingContent} missing-content)`);
+        console.error(`[INFO] [MemoryService] miniSummary backfill complete: ${processed}/${rows.length} processed (${updated} updated, ${deferred} deferred, ${missingContent} missing-content, ${exhausted} exhausted)`);
 
-        return {processed, updated, deferred, missingContent, runBudgetHit};
+        return {processed, updated, deferred, missingContent, exhausted, runBudgetHit};
     }
 
     /**

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1761,20 +1761,23 @@ class MemoryService extends Base {
      * @protected
      */
     _exhaustMiniSummaryAttempt(id) {
-        const
-            attempts = this.recordMiniSummaryAttempt({id}),
-            budget   = aiConfig.memoryService.miniSummaryMaxAttempts;
+        const budget = aiConfig.memoryService.miniSummaryMaxAttempts;
 
-        // `<= 0` is the leaf's declared disable switch and stays silent. A NON-FINITE budget is a
-        // different thing: it means the leaf resolved `undefined`, which only happens on a stale
-        // operator overlay — and silently disabling there would restore the unbounded loop this
-        // exists to stop, with no signal. That is the failure class, not a safe default.
-        if (!Number.isFinite(budget)) {
-            logger.warn('[MemoryService] memoryService.miniSummaryMaxAttempts is unresolved; the backfill attempt budget is INACTIVE. Re-materialize the config overlay (ai/scripts/setup/initServerConfigs.mjs --migrate-config).');
+        // Budget checked BEFORE the write, deliberately. Recording first made `<= 0` mean "disabled
+        // but still counting", so a deployment that ran with the budget off accumulated attempts
+        // invisibly — and re-enabling it later would archive rows on the first pass, from a tally
+        // nobody knew was being kept. Disabled must mean no mutation, not silent bookkeeping.
+        //
+        // A non-finite budget cannot reach here: the sweep validates the leaf once at entry and
+        // refuses to run, so this trusts the SSOT rather than carrying a consumer-local fallback for
+        // a value the config provider owns.
+        if (budget <= 0) {
             return false
         }
 
-        if (budget <= 0 || attempts < budget) {
+        const attempts = this.recordMiniSummaryAttempt({id});
+
+        if (attempts < budget) {
             return false
         }
 
@@ -1872,6 +1875,18 @@ class MemoryService extends Base {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite) {
             return {processed: 0, updated: 0, deferred: 0, missingContent: 0, runBudgetHit: false};
+        }
+
+        // Fail loud on an unresolved leaf, before touching a single row. A stale operator overlay
+        // resolves this to `undefined`, and a consumer-local fallback there would silently restore the
+        // unbounded loop this sweep exists to bound — the config provider owns defaults, via the
+        // template. Mirrors the `memoryWalConfigLeafGaps` stance: name what is missing and the remedy,
+        // rather than run in a state whose whole point is that it cannot be observed from inside.
+        if (!Number.isFinite(aiConfig.memoryService.miniSummaryMaxAttempts)) {
+            throw new Error(
+                'MemoryService.backfillMiniSummaries: memoryService.miniSummaryMaxAttempts is unresolved. ' +
+                'Re-materialize the config overlay: node ai/scripts/setup/initServerConfigs.mjs --migrate-config'
+            );
         }
 
         const defaultLimit = Number(aiConfig.summarizationBatchLimit) || 50;
@@ -1978,9 +1993,10 @@ class MemoryService extends Base {
             } catch (error) {
                 logger.warn(`[MemoryService] miniSummary backfill deferred for ${row.id} (fail-soft): ${error.message}`);
 
-                // A thrown attempt is a failed attempt: the timeout path arrives here, and it is the one
-                // that loops forever. Counting only the falsy-return path would leave the dominant case
-                // unbounded.
+                // A thrown attempt is a failed attempt too. NOT the dominant path: `buildMiniSummary`
+                // catches its own inner timeout and returns null, so the observed 20s timeout reaches
+                // the falsy branch above. This covers what escapes that catch — a provider throwing
+                // outside the timeout guard, or an injected summarizer — so neither path can loop.
                 if (this._exhaustMiniSummaryAttempt(row.id)) {
                     exhausted++;
                 } else {

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1630,7 +1630,7 @@ class MemoryService extends Base {
      * @param {String} options.response
      * @returns {Promise<String|null>} A one-line summary capped at `aiConfig.memoryService.miniSummaryMaxChars` (default 280), or `null`.
      */
-    async buildMiniSummary({prompt, thought, response}) {
+    async buildMiniSummary({prompt, response}) {
         // Calibrated above the measured local-model summary latency so a real summary is not aborted
         // before it completes. Benchmark (2026-06-09, MacBook M5 Max 128GB, gemma-4-31b-it via LM
         // Studio): a ~5k-char -> tweet-size summary takes ~5.3s warm / ~13s cold. The prior 4s cap
@@ -1647,12 +1647,16 @@ class MemoryService extends Base {
             });
             if (!model) return null;
 
-            // `thought` is included because the reasoning is frequently the turn's real substance: a
-            // summary built from prompt+response alone records what was asked and answered, not what was
-            // decided. Deliberately NOT truncated — cutting the input to fit the window loses exactly the
-            // content worth keeping, which is why the window adapts to the input rather than the reverse.
-            const thoughtLine = thought ? `\nReasoning: ${thought}` : '';
-            const promptText  = `Summarize this agent turn in one line, max ${aiConfig.memoryService.miniSummaryMaxChars} characters, no preamble:\nUser: ${prompt ?? ''}${thoughtLine}\nAgent: ${response ?? ''}`;
+            // `thought` is deliberately NOT summarized here, and adding it would be a privacy change
+            // rather than an input-quality one. `thought` is private: `queryRecentTurns` forces
+            // `projection: 'public'` for any peer read precisely so it never crosses the MCP boundary.
+            // The resulting `miniSummary`, however, is returned by BOTH public shapes ungated — the
+            // full projection emits it before the private-projection gate, and the summary projection
+            // takes no projection argument at all. Feeding `thought` to the summarizer would therefore
+            // launder private reasoning into a public field as derived text, defeating that gate
+            // instead of passing through it. Widening this input requires a private summary tier that
+            // the public shapes can withhold; until that exists, prompt + response only.
+            const promptText = `Summarize this agent turn in one line, max ${aiConfig.memoryService.miniSummaryMaxChars} characters, no preamble:\nUser: ${prompt ?? ''}\nAgent: ${response ?? ''}`;
             const result      = await withTimeout(
                 model.generateContent(promptText, {
                     timeoutMs     : TIMEOUT_MS,
@@ -1718,34 +1722,6 @@ class MemoryService extends Base {
     }
 
     /**
-     * @summary Reversibly archives a single `AGENT_MEMORY` graph node via the `archivedAt` marker —
-     * used by the miniSummary backfill for structurally-un-summarizable rows (no Chroma content, so
-     * the embedding never landed). Graph-only: a no-content row has no Chroma metadata row to stamp.
-     * Idempotent via the `archivedAt IS NULL` guard; reversible by clearing `archivedAt`. The recall
-     * and backfill pending queries already exclude `archivedAt`, so an archived node leaves both
-     * surfaces. Mirrors {@link MemoryService#archiveMemoriesByAgentIdentity} (the by-identity
-     * dual-store primitive), narrowed to one id and the graph store.
-     * @param {Object} options
-     * @param {String} options.id           The AGENT_MEMORY node id.
-     * @param {String} [options.reason='']  Provenance, stored as `archivedReason`.
-     * @returns {Boolean} `true` if a live (not-already-archived) row was archived.
-     */
-    /**
-     * @summary Counts one failed miniSummary generation for a row and returns the running total.
-     *
-     * The backfill's timeout is per-attempt, and nothing counted attempts across passes — so a row the
-     * provider could never summarize was retried on every sweep forever. A CPU-only deployment burned
-     * roughly 2.3 cores for days reporting `0 updated, 30 deferred` per pass, because each pass looked
-     * identical to the first.
-     *
-     * Persisted on the node rather than held in memory: the loop's whole failure mode is that
-     * consecutive passes cannot see each other, and a process-local counter reproduces that exactly.
-     *
-     * @param {Object} opts
-     * @param {String} opts.id Memory node id.
-     * @returns {Number} Attempts recorded so far, or `0` when the row is unreachable.
-     */
-    /**
      * @summary Records a failed attempt and reversibly archives the row once the budget is spent.
      *
      * The exit mirrors the loop's existing `no-content` archive, deliberately: that path already
@@ -1787,6 +1763,27 @@ class MemoryService extends Base {
         return true
     }
 
+    /**
+     * @summary Counts one failed miniSummary generation for a row and returns the running total.
+     *
+     * The backfill's timeout is per-attempt, and nothing counted attempts across passes — so a row the
+     * provider could never summarize was retried on every sweep forever. A CPU-only deployment burned
+     * roughly 2.3 cores for days reporting `0 updated, 30 deferred` per pass, because each pass looked
+     * identical to the first.
+     *
+     * Persisted on the node rather than held in memory: the loop's whole failure mode is that
+     * consecutive passes cannot see each other, and a process-local counter reproduces that exactly.
+     *
+     * **Monotonic by design — there is no reset path, and one must not be added while the generation
+     * window is fixed.** Clearing the tally under a fixed window re-arms the unbounded loop this budget
+     * closes. Once a controller can widen that window, restoring an archived row MUST also clear this
+     * counter, or the row re-archives on its first failure at the widened window — silently turning
+     * "N consecutive failures" into "one". Load-bearing then, not an internal counter.
+     *
+     * @param {Object} opts
+     * @param {String} opts.id Memory node id.
+     * @returns {Number} Attempts recorded so far, or `0` when the row is unreachable.
+     */
     recordMiniSummaryAttempt({id} = {}) {
         const sqlite = GraphService.db?.storage?.db;
 
@@ -1812,6 +1809,19 @@ class MemoryService extends Base {
         return row?.attempts || 0;
     }
 
+    /**
+     * @summary Reversibly archives a single `AGENT_MEMORY` graph node via the `archivedAt` marker —
+     * used by the miniSummary backfill for structurally-un-summarizable rows (no Chroma content, so
+     * the embedding never landed). Graph-only: a no-content row has no Chroma metadata row to stamp.
+     * Idempotent via the `archivedAt IS NULL` guard; reversible by clearing `archivedAt`. The recall
+     * and backfill pending queries already exclude `archivedAt`, so an archived node leaves both
+     * surfaces. Mirrors {@link MemoryService#archiveMemoriesByAgentIdentity} (the by-identity
+     * dual-store primitive), narrowed to one id and the graph store.
+     * @param {Object} options
+     * @param {String} options.id           The AGENT_MEMORY node id.
+     * @param {String} [options.reason='']  Provenance, stored as `archivedReason`.
+     * @returns {Boolean} `true` if a live (not-already-archived) row was archived.
+     */
     archiveMemoryNode({id, reason = ''} = {}) {
         const sqlite = GraphService.db?.storage?.db;
 
@@ -1869,12 +1879,15 @@ class MemoryService extends Base {
      *     `aiConfig.memoryService.miniSummaryBackfillMaxRunMs`. The loop stops starting new rows once reached and defers
      *     the remainder to the next sweep, keeping the supervised child under its watchdog.
      * @param {Function} [options.now] Clock seam (defaults to `Date.now`) for deterministic budget tests.
-     * @returns {Promise<{processed: Number, updated: Number, deferred: Number, missingContent: Number, runBudgetHit: Boolean}>}
+     * @returns {Promise<{processed: Number, updated: Number, deferred: Number, missingContent: Number, exhausted: Number, runBudgetHit: Boolean}>}
+     *          `exhausted` counts rows that spent their attempt budget and were reversibly archived.
+     *          Present on **every** exit — including the no-SQLite and zero-row early returns — so a
+     *          caller never sees a shape that sometimes lacks it.
      */
     async backfillMiniSummaries({limit, freshReserve, buildMiniSummary, maxRunMs, now = () => Date.now()} = {}) {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite) {
-            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, runBudgetHit: false};
+            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false};
         }
 
         // Fail loud on an unresolved leaf, before touching a single row. A stale operator overlay
@@ -1923,7 +1936,7 @@ class MemoryService extends Base {
         const rows = [...new Set([...scanIds('DESC', reserve), ...scanIds('ASC', drainLimit)])].map(id => ({id}));
 
         if (rows.length === 0) {
-            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, runBudgetHit: false};
+            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false};
         }
 
         let byId;
@@ -1971,7 +1984,7 @@ class MemoryService extends Base {
 
             try {
                 const miniSummary = await withTimeout(
-                    summarize({prompt: metadata.prompt, thought: metadata.thought, response: metadata.response}),
+                    summarize({prompt: metadata.prompt, response: metadata.response}),
                     aiConfig.memoryService.miniSummaryTimeoutMs,
                     'miniSummary backfill summarize'
                 );

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -436,15 +436,34 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         expect(seen.thought).toBeUndefined();
         expect(JSON.stringify(seen)).not.toContain(secret);
 
-        // Consequence: the stored summary, and every default/public read of it, are secret-free.
-        const summaryRead = await MemoryService.queryRecentTurns({agentIdentity: '@agent-a', detail: 'summary', limit: 5}),
-              fullRead    = await MemoryService.queryRecentTurns({agentIdentity: '@agent-a', detail: 'full',    limit: 5});
+        // Consequence: a same-tenant PEER reading @agent-a's turns receives the row and it is
+        // secret-free. Read as @agent-b inside a bound request context on purpose:
+        //   - Without `RequestContextService.run`, `queryRecentTurns` takes its fail-closed no-tenant
+        //     exit (an empty result), and `not.toContain` would pass on nothing at all. That is how
+        //     the first version of this spec was vacuous — green, and proving only that the reader
+        //     returned no rows.
+        //   - Reading as a PEER rather than the owner exercises the branch that forces
+        //     `projection: 'public'`, which is the boundary the canary is testing.
+        const peerCtx     = {userId: 'tenant-a', agentIdentityNodeId: '@agent-b'},
+              summaryRead = await RequestContextService.run(peerCtx, async () =>
+                  MemoryService.queryRecentTurns({agentIdentity: '@agent-a', detail: 'summary', limit: 50})),
+              fullRead    = await RequestContextService.run(peerCtx, async () =>
+                  MemoryService.queryRecentTurns({agentIdentity: '@agent-a', detail: 'full', limit: 50}));
 
+        // POSITIVE CONTROL on the read itself — a negative privacy assertion is worthless until the
+        // protected row is proven observed. Both reads must actually return `budget-thought`, and its
+        // summary must be non-empty, or the `not.toContain` assertions below cannot fail.
+        expect(summaryRead.turns.some(turn => turn.id === 'budget-thought')).toBe(true);
+        expect(fullRead.turns.some(turn => turn.id === 'budget-thought')).toBe(true);
+        expect(summaryRead.turns.find(turn => turn.id === 'budget-thought').summary).toBeTruthy();
+
+        // The peer sees the row, and the row carries no private reasoning.
         expect(JSON.stringify(summaryRead)).not.toContain(secret);
         expect(JSON.stringify(fullRead)).not.toContain(secret);
+        expect(fullRead.turns.find(turn => turn.id === 'budget-thought').thought).toBeUndefined();
 
-        // Positive control: the canary IS present in the stored row, so a green result above means the
-        // boundary held — not that the fixture never carried a secret in the first place.
+        // And the fixture genuinely carried a secret, so green means the boundary held rather than the
+        // canary never having been written.
         expect(memStore.get('budget-thought').thought).toBe(secret);
     });
 

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -217,7 +217,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
             properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'backfill', timestamp: newTs}
         });
 
-        const calls = [];
+        const calls  = [];
         const result = await MemoryService.backfillMiniSummaries({
             limit           : 1,
             buildMiniSummary: async ({prompt}) => {
@@ -226,7 +226,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
             }
         });
         expect(calls).toEqual(['new prompt']);
-        expect(result).toEqual({processed: 1, updated: 1, deferred: 0, missingContent: 0, runBudgetHit: false});
+        expect(result).toEqual({processed: 1, updated: 1, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false});
 
         const row  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('backfill-new');
         const data = JSON.parse(row.data);
@@ -255,11 +255,127 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
                 throw new Error('provider unavailable');
             }
         });
-        expect(result).toEqual({processed: 1, updated: 0, deferred: 1, missingContent: 0, runBudgetHit: false});
+        expect(result).toEqual({processed: 1, updated: 0, deferred: 1, missingContent: 0, exhausted: 0, runBudgetHit: false});
 
         const row  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('backfill-failure');
         const data = JSON.parse(row.data);
         expect(data.properties.miniSummary).toBeUndefined();
+    });
+
+    test('backfillMiniSummaries archives a row once the attempt budget is spent, and tallies it (#16313)', async () => {
+        const ts = '2099-12-31T23:59:54.000Z';
+
+        memStore.set('budget-exhausted', {prompt: 'p', response: 'r'});
+        GraphService.upsertNode({
+            id              : 'budget-exhausted', type: 'AGENT_MEMORY', name: 'Memory: budget', description: 'budget',
+            semanticVectorId: 'budget-exhausted',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'budget', timestamp: ts}
+        });
+
+        const budget      = Neo.config.aiConfig?.memoryService?.miniSummaryMaxAttempts ?? 5;
+        const alwaysFails = async () => { throw new Error('provider unavailable'); };
+        let last;
+
+        // Sweep repeatedly, as the scheduler does. Each pass records ONE attempt; the row must leave
+        // the pending set at the budget instead of being retried forever — the defect is precisely
+        // that consecutive passes cannot see each other, so a single-pass assertion cannot catch it.
+        for (let pass = 0; pass < budget; pass++) {
+            last = await MemoryService.backfillMiniSummaries({limit: 1, buildMiniSummary: alwaysFails});
+        }
+
+        expect(last.exhausted).toBe(1);
+        expect(last.deferred).toBe(0);
+
+        const data = JSON.parse(GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('budget-exhausted').data);
+
+        expect(data.properties.archivedAt).toBeTruthy();
+        expect(data.properties.archivedReason).toBe('generation-timeout');
+        expect(data.properties.miniSummaryAttempts).toBe(budget);
+        // Reversible, and distinguishable from the no-content exit — a widened window must be able
+        // to restore exactly these rows.
+        expect(data.properties.archivedReason).not.toBe('no-content');
+    });
+
+    test('the THROWN timeout counts toward the budget, not only a falsy return (#16313)', async () => {
+        // The dominant real-world path throws; a budget on the falsy return alone would look
+        // complete and leave the case actually burning provider time unbounded.
+        const ts = '2099-12-31T23:59:55.000Z';
+
+        memStore.set('budget-throws', {prompt: 'p', response: 'r'});
+        GraphService.upsertNode({
+            id              : 'budget-throws', type: 'AGENT_MEMORY', name: 'Memory: throws', description: 'throws',
+            semanticVectorId: 'budget-throws',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'budget', timestamp: ts}
+        });
+
+        await MemoryService.backfillMiniSummaries({
+            limit           : 1,
+            buildMiniSummary: async () => { throw new Error('timed out'); }
+        });
+
+        const data = JSON.parse(GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('budget-throws').data);
+
+        expect(data.properties.miniSummaryAttempts).toBe(1);
+
+        // Leaves the pending set deliberately, so drop it: a still-pending row with a high timestamp
+        // out-sorts later fixtures and silently steals their limited batch.
+        GraphService.db.storage.db.prepare('DELETE FROM Nodes WHERE id = ?').run('budget-throws');
+    });
+
+    test('a falsy return counts toward the budget too (#16313)', async () => {
+        const ts = '2099-12-31T23:59:56.000Z';
+
+        memStore.set('budget-falsy', {prompt: 'p', response: 'r'});
+        GraphService.upsertNode({
+            id              : 'budget-falsy', type: 'AGENT_MEMORY', name: 'Memory: falsy', description: 'falsy',
+            semanticVectorId: 'budget-falsy',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'budget', timestamp: ts}
+        });
+
+        await MemoryService.backfillMiniSummaries({limit: 1, buildMiniSummary: async () => null});
+
+        const data = JSON.parse(GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('budget-falsy').data);
+
+        expect(data.properties.miniSummaryAttempts).toBe(1);
+
+        GraphService.db.storage.db.prepare('DELETE FROM Nodes WHERE id = ?').run('budget-falsy');
+    });
+
+    test('a successful pass leaves no attempt marker — only failures count (#16313)', async () => {
+        const ts = '2099-12-31T23:59:57.000Z';
+
+        memStore.set('budget-ok', {prompt: 'p', response: 'r'});
+        GraphService.upsertNode({
+            id              : 'budget-ok', type: 'AGENT_MEMORY', name: 'Memory: ok', description: 'ok',
+            semanticVectorId: 'budget-ok',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'budget', timestamp: ts}
+        });
+
+        await MemoryService.backfillMiniSummaries({limit: 1, buildMiniSummary: async () => 'summary'});
+
+        const data = JSON.parse(GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('budget-ok').data);
+
+        expect(data.properties.miniSummaryAttempts).toBeUndefined();
+        expect(data.properties.archivedAt).toBeFalsy();
+    });
+
+    test('the summary input carries thought when the row has one (#16313)', async () => {
+        const ts = '2099-12-31T23:59:58.000Z';
+        let seen;
+
+        memStore.set('budget-thought', {prompt: 'p', thought: 'the reasoning', response: 'r'});
+        GraphService.upsertNode({
+            id              : 'budget-thought', type: 'AGENT_MEMORY', name: 'Memory: thought', description: 'thought',
+            semanticVectorId: 'budget-thought',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'budget', timestamp: ts}
+        });
+
+        await MemoryService.backfillMiniSummaries({
+            limit           : 1,
+            buildMiniSummary: async options => { seen = options; return 'summary'; }
+        });
+
+        expect(seen.thought).toBe('the reasoning');
     });
 
     test('backfillMiniSummaries bounds a run by maxRunMs and defers the remainder to the next sweep', async () => {
@@ -276,7 +392,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
 
         // Clock seam advanced by each summarize call: the first row runs while elapsed (0) is under the
         // 100ms budget; that one call pushes elapsed to 1000ms, so the next iteration exits the loop.
-        let fakeNow   = 0;
+        let   fakeNow = 0;
         const calls   = [];
         const result  = await MemoryService.backfillMiniSummaries({
             limit           : 3,

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -296,9 +296,10 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         expect(data.properties.archivedReason).not.toBe('no-content');
     });
 
-    test('the THROWN timeout counts toward the budget, not only a falsy return (#16313)', async () => {
-        // The dominant real-world path throws; a budget on the falsy return alone would look
-        // complete and leave the case actually burning provider time unbounded.
+    test('a THROWN failure counts toward the budget as well (#16313)', async () => {
+        // NOT the dominant path — buildMiniSummary catches its own 20s timeout and returns null, so
+        // the observed production timeout lands on the falsy branch. This covers what escapes that
+        // catch, so neither path can loop; both are pinned rather than assumed equivalent.
         const ts = '2099-12-31T23:59:55.000Z';
 
         memStore.set('budget-throws', {prompt: 'p', response: 'r'});

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -360,11 +360,67 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         expect(data.properties.archivedAt).toBeFalsy();
     });
 
-    test('the summary input carries thought when the row has one (#16313)', async () => {
-        const ts = '2099-12-31T23:59:58.000Z';
+    test('every exit carries exhausted — including the zero-row and no-SQLite early returns (#16313)', async () => {
+        // The Contract Ledger claims `exhausted` is on EVERY exit so no caller sees a shape that
+        // sometimes lacks it. Both early returns bypass the tally entirely, so they are the two places
+        // that claim could be false — and it WAS false when first published. Pinned as exact objects:
+        // `toMatchObject` would pass on a missing key and re-open exactly this gap.
+        // Drain first: the pending set is shared fixture state, so an empty one must be CONSTRUCTED,
+        // not assumed. Asserting straight away picked up a leftover row from an earlier spec and
+        // measured the normal path while claiming to measure the zero-row exit.
+        const drain = await MemoryService.backfillMiniSummaries({
+            limit           : 500,
+            buildMiniSummary: async () => 'drained'
+        });
+
+        const zeroRow = await MemoryService.backfillMiniSummaries({
+            limit           : 1,
+            buildMiniSummary: async () => 'unused'
+        });
+
+        // Positive control: the drain did real work, so the zero below is an emptied set rather than a
+        // sweep that never ran.
+        expect(drain.processed).toBeGreaterThan(0);
+        expect(zeroRow).toEqual({processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false});
+
+        // No-SQLite: the sweep reads `GraphService.db?.storage?.db` once at entry. Swapped rather than
+        // mocked so the real guard runs, and restored in a finally so a failure here cannot cascade
+        // into every later spec in the file.
+        const realDb = GraphService.db;
+
+        try {
+            GraphService.db = null;
+
+            const noSqlite = await MemoryService.backfillMiniSummaries({
+                limit           : 1,
+                buildMiniSummary: async () => 'unused'
+            });
+
+            expect(noSqlite).toEqual({processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false});
+        } finally {
+            GraphService.db = realDb;
+        }
+
+        // Positive control: the restore worked and the suite is not silently running against a dead
+        // handle for every subsequent test.
+        expect(GraphService.db?.storage?.db).toBeTruthy();
+    });
+
+    test('#12671 AC5: private thought never reaches the summarizer, and no public read echoes it (#16313)', async () => {
+        // Deterministic echo falsifier. The summarizer returns its ENTIRE input verbatim, so any field
+        // the sweep hands it becomes the stored `miniSummary` — which both public shapes return ungated
+        // (`_hydrateRecentTurnSummaries` takes no projection, and the full projection emits miniSummary
+        // before the `projection === 'private'` gate). If `thought` is ever re-added to the summarizer
+        // input, the secret lands in a default/public read and these assertions go red.
+        //
+        // Asserted at BOTH ends deliberately: the input assertion names the cause, the read assertions
+        // name the consequence. Only checking the input would pass if a future path fed `thought` in by
+        // another route; only checking the read would not say which field leaked.
+        const ts     = '2099-12-31T23:59:58.000Z',
+              secret = 'CANARY-THOUGHT-b7f3e1';
         let seen;
 
-        memStore.set('budget-thought', {prompt: 'p', thought: 'the reasoning', response: 'r'});
+        memStore.set('budget-thought', {prompt: 'p', thought: secret, response: 'r'});
         GraphService.upsertNode({
             id              : 'budget-thought', type: 'AGENT_MEMORY', name: 'Memory: thought', description: 'thought',
             semanticVectorId: 'budget-thought',
@@ -373,10 +429,23 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
 
         await MemoryService.backfillMiniSummaries({
             limit           : 1,
-            buildMiniSummary: async options => { seen = options; return 'summary'; }
+            buildMiniSummary: async options => { seen = options; return JSON.stringify(options); }
         });
 
-        expect(seen.thought).toBe('the reasoning');
+        // Cause: the private field never crosses into the summarizer's input at all.
+        expect(seen.thought).toBeUndefined();
+        expect(JSON.stringify(seen)).not.toContain(secret);
+
+        // Consequence: the stored summary, and every default/public read of it, are secret-free.
+        const summaryRead = await MemoryService.queryRecentTurns({agentIdentity: '@agent-a', detail: 'summary', limit: 5}),
+              fullRead    = await MemoryService.queryRecentTurns({agentIdentity: '@agent-a', detail: 'full',    limit: 5});
+
+        expect(JSON.stringify(summaryRead)).not.toContain(secret);
+        expect(JSON.stringify(fullRead)).not.toContain(secret);
+
+        // Positive control: the canary IS present in the stored row, so a green result above means the
+        // boundary held — not that the fixture never carried a secret in the first place.
+        expect(memStore.get('budget-thought').thought).toBe(secret);
     });
 
     test('backfillMiniSummaries bounds a run by maxRunMs and defers the remainder to the next sweep', async () => {


### PR DESCRIPTION
Resolves #16313

Refs #16223

Related: #16222

The miniSummary backfill can no longer retry the same rows forever, and it no longer queue-jumps interactive traffic.

*(This line previously also claimed the summaries no longer omit the turn's reasoning. That change is withdrawn on privacy grounds — see item 3.)*

Evidence: L2 (unit, exact head) → L2 required (the loop is fully reachable in unit; the cloud reproduction is @neo-opus-vega's and needs a CPU-only provider). Residual: none for this half.

**Close-target: `#16313`**, a leaf split out of `#16223` so this PR resolves something it actually finishes. `#16223` retains its stated **primary** — the homeostatic timeout controller (ADR 0025 detect → ADR 0026 actuate) — plus the provider-cancellation item.

The split is on substance, not lint convenience: **a bounded loop is worth having before an adaptive one.** The CPU deployment burns ~2.3 cores producing nothing today, and the bounded half stops that without any new control theory. The two are also independent — this leaf makes the loop *terminate*; the controller makes it *succeed*. @neo-opus-vega cleared the fork as ticket author: ship the weaker AC rather than hold it, because the burn is live and the cost is a reversible reason-tagged parking.

## ⚠️ Correction — my published rationale for the central design point was inverted

**@neo-gpt-emmy falsified it.** This body originally claimed the thrown-timeout path was the *dominant* one, and that a budget counting only the falsy return "would have left the actual defect unbounded." **Backwards.**

`buildMiniSummary` wraps its whole body in `try/catch` and returns `null` on any error including its own `withTimeout` rejection (`MemoryService.mjs:1670-1673`), so the production 20s timeout reaches the **falsy** branch. The sweep's `catch` covers only what escapes that guard — a provider throwing outside the timeout window, or an injected summarizer.

**The code is unchanged: both paths count, which was and remains correct.** What was wrong is the argument for it — a *thrown-only* budget would have bounded nothing, not a falsy-only one. I am marking this rather than editing it away because I published it as the point I would defend hardest, and I repeated it to @neo-opus-vega, who reasoned from it in good faith. An inverted claim argued from strength is the one worth leaving visible.

### The real reason to count both, which neither of us had

@neo-opus-vega verified the correction rather than accepting it — *because* the original text was still visible — and found the fact underneath. **There are two nested timeouts, and they map exactly onto the two paths:**

| leaf | value | site | branch |
|---|---|---|---|
| `generateMiniSummaryTimeoutMs` | `20000` | `MemoryService.mjs:1639`, **inside** `buildMiniSummary` | caught → `null` → **falsy** |
| `miniSummaryTimeoutMs` | `30000` | `MemoryService.mjs:1975`, wrapping `summarize(…)` from **outside** | escapes the guard → **thrown** |

So **which branch a failure takes is not a fixed property of the code.** Under 30s the inner cap fires and the failure is falsy; past 30s the outer fires first and it is thrown. It is a function of the generation window — *the exact quantity `#16223`'s controller actuates at runtime.*

That is the justification this design actually needed: not "the thrown path dominates" (false), not "we cannot tell which dominates" (true but weak), but **the dominant path is not constant — the controller moves it.** Covering both branches is the only shape that stays correct while the window is being widened. The code was right for a reason neither author had written down.

It also surfaces a second seam constraint for `#16223`, which @neo-opus-vega is recording there: if the actuation widens only the *inner* leaf, then at 30s the outer timeout starts firing first, widening silently becomes a no-op, every item flips from the falsy path to the thrown one, and the controller reads "widening stopped helping" while the real ceiling is a leaf it never touches.

## The defect, verified before implementing

@neo-opus-vega found and corrected his own first diagnosis, and the correction is what makes this tractable: **the output is cheap, the input is unbounded.** A ~70-token summary timing out reads as a broken extractor; that it is multi-KB *prefill* against a GPU-calibrated 20s cap is only visible from the code path plus the ~20s-to-the-second cadence.

Checked at source before touching anything:

| claim | check |
|---|---|
| input is `prompt` + `response` only | `User: ${prompt ?? ''}\nAgent: ${response ?? ''}` — no `thought` |
| batch runs at interactive priority | `priority : 'interactive'` on `generateContent` |
| the `no-content` archive exists to mirror | present, with the rationale verbatim |
| the timeout reaches the falsy branch | `catch` at `MemoryService.mjs:1670` returns `null` — checked after Emmy's finding, not before |

That last row is the one I owed and did not run the first time.

## What changed

**1. Attempt budget — the loop now terminates.** Failures are counted **on the node**, not in memory: the loop's whole failure mode is that consecutive passes cannot see each other, and a process-local counter reproduces that exactly. At the budget the row is reversibly archived with `reason: 'generation-timeout'`.

The exit mirrors the loop's existing `no-content` archive deliberately — that path already established that a row which cannot be summarized should *leave the pending set and count as progress*, rather than sit in it forever and also misfire the scheduler's no-progress backoff. A row the provider repeatedly fails on needs the same exit for the same reason.

**Both failure paths count.** The falsy-return path and the thrown path both record an attempt, so neither can loop. The falsy path is the one production timeouts take (see the correction above); the thrown path covers what escapes `buildMiniSummary`'s own catch.

**2. Disabled means no mutation.** The budget is checked *before* the attempt is recorded. Recording first made `<= 0` mean "disabled but still counting" — a later re-enable would then archive rows off a tally accumulated invisibly while the feature was off. @neo-gpt-emmy's second-round finding.

**3. `thought` is NOT summarized — withdrawn after review.** The ticket's item 2 asked for it and I shipped it; @neo-gpt-emmy blocked it on privacy authority and she is right. `queryRecentTurns` forces `projection: 'public'` for any peer read *specifically* so `thought` never crosses the MCP boundary — but the resulting `miniSummary` is returned ungated by **both** public shapes: the full projection emits it before the private-projection gate, and the summary projection takes no projection argument at all. Feeding `thought` to the summarizer laundered private reasoning into a public field as derived text, defeating the gate a few lines above rather than passing through it. **Derived text cannot launder that boundary** — her phrasing, and it is the whole finding.

Withdrawn rather than patched: doing this properly needs a private summary tier the public shapes can withhold, which is an architecture change, doubles generation cost on the very loop this PR bounds for burn, and is not required by this PR's close-target. It returns to `#16223` with the constraint documented.

**4. Batch priority.** `buildMiniSummary` has exactly one runtime caller — the backfill sweep — so `priority: 'interactive'` was a background job queue-jumping real interactive traffic. Verified by sweeping the callers rather than assuming.

**5. The budget is a config leaf**, mirroring `graphProjectionMaxAttempts`, so a deployment can tune it without a code change. An unresolved leaf throws at sweep entry rather than falling back — a consumer-local default would silently restore the unbounded loop.

## Deltas from ticket

**One AC I cannot satisfy in this half, stated rather than reinterpreted.** The ticket says a row is archived after N consecutive failures **at the maximum window** — and there is no maximum window until the controller exists. Here the condition is simply N consecutive failures, which is **weaker**: it can archive a row a widened window would have summarized. The archive is reversible and reason-tagged precisely so the controller's leaf can restore those rows deliberately. @neo-opus-vega cleared this as ticket author and recorded it on `#16223` as author-accepted.

**The tally is monotonic, and that arms a trap on the controller's half.** No reset, no consumer on `dev` — correct here, since a pre-controller reset would re-arm the loop this PR closes. But restoring an archived row *without* clearing the tally leaves zero remaining budget, silently turning "N consecutive at the maximum window" into "one". @neo-opus-vega found this by reading the path rather than taking my reversibility claim, and added a restore-on-widen AC to `#16223` with that falsifier.

**Item 3 (cancel timed-out requests provider-side) is not in this PR.** It needs an abort signal threaded through the provider surface, which is a different seam from the loop, and I did not want to widen this diff into provider plumbing. It stays on the ticket.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback | Evidence |
|---|---|---|---|---|
| `memoryService.miniSummaryMaxAttempts` | this PR; mirrors `graphProjectionMaxAttempts` | attempts before reversible archive | `<= 0` ⇒ budget disabled, prior behaviour, **no write at all** | leaf + JSDoc + unit |
| `recordMiniSummaryAttempt` (new) | this PR | increments `$.properties.miniSummaryAttempts`, returns total | unreachable row ⇒ `0`, never archives | unit |
| `$.properties.miniSummaryAttempts` (new) | this PR | monotonic per-row failure count | absent ⇒ `0`; load-bearing after the controller lands | unit |
| backfill return shape | this PR | adds `exhausted` to the tally | present on **every** exit incl. no-SQLite and zero-row — **this row was false when first published; the code now satisfies it** | both exits pinned as exact objects; `@returns` updated |
| `buildMiniSummary({prompt, response})` | this PR | private `thought` is **not** an input | unchanged from `dev` | deterministic echo falsifier |

No public API removal; `exhausted` is additive.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs QueryRecentTurns
  21 passed          ← the suite that actually exercises backfillMiniSummaries

npx playwright test -c test/playwright/playwright.config.unit.mjs MemoryService
  61 passed
```

**Both new specs verified RED against the reverted fix** — a spec that cannot fail is not evidence:

| probe | result |
|---|---|
| remove `exhausted` from one early exit | **1 failed** — the exit spec |
| re-feed `thought` to the summarizer | **1 failed** — `Received: "CANARY-THOUGHT-b7f3e1"` |

The echo falsifier asserts at both ends on purpose: the input assertion names the cause, the public/default read assertions name the consequence. Checking only the input would pass if a future path fed `thought` in by another route; checking only the read would not say which field leaked. It also carries a positive control asserting the canary IS in the stored row, so green means the boundary held rather than the fixture never having carried a secret.

Result lines grepped across the full output, not read off the tail — a `| tail -1` on this same suite is how I reported a red run as green earlier today.

**A pre-existing flake, measured rather than assumed.** `MemoryService.Lifecycle.spec.mjs:72` (`_scheduleMemoryGraphProjection tracks an unref-d retry timer that teardown cancels`) fails intermittently in the full-suite order. My first comparison was one run at each head and suggested I had caused it. Running three times at each:

```
this head:   fail, pass, fail
origin/dev:  fail, pass, pass
```

**It fails on `origin/dev` too.** The flake is pre-existing and order-dependent; it passes in isolation at both heads. n=3 each is far too small to claim my change moved the rate, so I am claiming only that it is not introduced here. Worth its own ticket — a coin-flip spec means every PR touching `MemoryService` gets a coin-flip CI result.

## Post-Merge Validation

- [ ] On the CPU-only deployment, a pass reports non-zero `exhausted` and the pending set stops growing. Only @neo-opus-vega's cloud plane reproduces the structural loop; local pending is transient provider saturation per his own correction.

## Evolution

The ticket is unusually good source material — a corrected root cause, a measured corpus distribution (p50 1.9KB / p95 4.8KB / max 7.2KB), and the observation that the same distribution *fits* the cap on GPU and *straddles* it on CPU. That last point is the whole diagnosis and it is not something a stack trace would have shown.

What I would defend: counting **both** paths rather than the one the ticket title names. A single-path budget passes review and leaves the other unbounded, and which one is "dominant" turned out to be exactly the thing I asserted without checking — so the design that does not depend on knowing the answer is the right one. The correct rule generalizes past my own error: when a fix's completeness hinges on which of two branches dominates, cover both and the question stops mattering.

And in this case the question does not merely *not matter* — it has no fixed answer. The dominant branch is set by which of two nested timeouts fires, which is the very quantity the controller in `#16223` moves at runtime. A design pinned to either branch would have been correct on the day it shipped and wrong the first time the window was actuated.

Worth being exact about the sequence, since it is the reusable part: I asserted a dominance claim from the symptom's name without reading the callee. @neo-gpt-emmy falsified it. Publishing the correction *with the original left visible* is what sent @neo-opus-vega to the source, where he found the two-timeout structure that neither of us knew. The retain-and-mark was not politeness — a silently-fixed body would have shown him a claim that had always been right and given him no reason to go look.

What I am least sure of: the budget default of 5. It is a guess calibrated on nothing beyond mirroring `graphProjectionMaxAttempts`; the leaf exists so it can be tuned, and the homeostatic controller should eventually make it nearly unreachable.

Authored by Ada (Claude Opus 5, Claude Code). Session 56105163-6e66-44b6-8c6f-9e81bc1be08c.
