### PR TITLE
fix(workstation): publish the cross-window stack-return preview trio (#16309)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -993,13 +993,31 @@ class Workspace extends Container {
         if (me.isDestroyed) return null;
 
         return Neo.create(Participation, {
-            clearPreview         : () => me.clearCrossWindowPreview(workspaceId),
-            commitLocal          : operation => me.commitLocalWorkspaceOperation(workspaceId, operation),
-            commitTransfer       : data => me.commitCrossWindowTransfer(data),
-            getDocument          : () => me.getWorkspaceDocument(workspaceId),
-            getForeignDocument   : sourceWorkspaceId => me.getWorkspaceDocument(sourceWorkspaceId),
-            hitTest              : (localX, localY) => me.hitTestCrossWindowTarget(workspaceId, localX, localY),
-            previewFor           : data => me.renderCrossWindowPreview(workspaceId, data),
+            clearPreview      : () => me.clearCrossWindowPreview(workspaceId),
+            commitLocal       : operation => me.commitLocalWorkspaceOperation(workspaceId, operation),
+            commitTransfer    : data => me.commitCrossWindowTransfer(data),
+            getDocument       : () => me.getWorkspaceDocument(workspaceId),
+            getForeignDocument: sourceWorkspaceId => me.getWorkspaceDocument(sourceWorkspaceId),
+            hitTest           : (localX, localY) => me.hitTestCrossWindowTarget(workspaceId, localX, localY),
+            previewFor        : data => {
+                // Feed the local affordance tier from the remote hover frame: the indicator
+                // menu's only population path is this pipeline (its zone hit-test and the
+                // activeCandidate the gesture-ready contract reads), and the sort-zone event
+                // chain only fires for same-window drags. The promise is deliberately
+                // fire-and-forget (caught) — the readiness poll tolerates the async warm-up
+                // and a rejected measurement must never stall the gesture it annotates.
+                if (isMain) {
+                    Promise.resolve(me.dragAffordances?.onDragMove({
+                        clientX     : data?.localX,
+                        clientY     : data?.localY,
+                        groupNodeId : data?.draggedItem?.dockGroupNodeId ?? null,
+                        itemId      : data?.draggedItem?.dockItemId,
+                        sourceNodeId: data?.draggedItem?.dockSourceNodeId ?? data?.sourceNodeId
+                    })).catch(() => {});
+                }
+
+                return me.renderCrossWindowPreview(workspaceId, data)
+            },
             previewToOperation,
             promoteDragEmbodiment: data => me.vesselProxyEmbodiment.promote({
                 itemId        : data.draggedItem?.dockItemId,
@@ -1496,6 +1514,26 @@ class Workspace extends Container {
             sourceNodeId: data?.sourceNodeId,
             zones       : [zone]
         });
+
+        // Stored-home acquisition fallback: the window hit-test above already admitted the
+        // gesture, so a pointer that lands inside the window but outside every exact zone
+        // still acquires the stored-home semantic target — the preview (and its painting)
+        // binds the exact node rect, never the pointer's empty position. Real on-zone drags
+        // keep the full placement grammar (splits included); only the off-zone position
+        // resolves to the stored-home tab-into.
+        if (!preview && isMain) {
+            preview = producer.produce({
+                containerId: geometry.host.id,
+                groupNodeId,
+                itemId,
+                pointer    : {
+                    x: geometry.targetRect.x + geometry.targetRect.width  / 2,
+                    y: geometry.targetRect.y + geometry.targetRect.height / 2
+                },
+                sourceNodeId: data?.sourceNodeId,
+                zones       : [zone]
+            });
+        }
 
         if (geometry.renderer) {
             geometry.renderer.dockPreview = preview;
@@ -2028,7 +2066,7 @@ class Workspace extends Container {
             placeholders,
             preserveItemIds,
             retainTopology: operation === 'detachItem',
-            resolveItem: itemId => me.resolvePane(itemId, me.dockModel.items[itemId]),
+            resolveItem   : itemId => me.resolvePane(itemId, me.dockModel.items[itemId]),
             onProjectionStaged({plans}) {
                 const retainedTabBars = [...plans.values()]
                     .filter(plan => plan.tab)
@@ -4458,13 +4496,28 @@ class Workspace extends Container {
                 cursorDot = null
             }
 
+            // The film gesture aims at the semantic return target itself: the indicator
+            // menu's active candidate is selected geometrically, so the synthetic cursor
+            // hovers the stored-home tabs node (window center can lie outside it).
+            let storedHome   = me.tearOutPlacements[state.itemId]?.tabsNodeId,
+                returnNodeId = me.dockModel.nodes?.[storedHome]?.type === 'tabs'
+                    ? storedHome
+                    : Object.entries(me.dockModel.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],
+                returnHost   = me.dragAffordances?.host,
+                returnNode   = returnNodeId && returnHost?.down({dockNodeId: returnNodeId}),
+                [returnRect] = returnNode ? await returnHost.getDomRect([returnNode.id], me.windowId) : [];
+
             for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
                 targetWindow = WindowManager.get(me.windowId);
 
                 if (!targetWindow?.innerRect) break;
 
-                let targetClientX = Math.round(targetWindow.innerRect.width  / 2) + attempt % 2,
-                    targetClientY = Math.round(targetWindow.innerRect.height / 2),
+                let targetClientX = returnRect
+                        ? Math.round(returnRect.x + returnRect.width  / 2) + attempt % 2
+                        : Math.round(targetWindow.innerRect.width  / 2) + attempt % 2,
+                    targetClientY = returnRect
+                        ? Math.round(returnRect.y + returnRect.height / 2)
+                        : Math.round(targetWindow.innerRect.height / 2),
                     targetScreenX = Math.round(targetWindow.innerRect.x + targetClientX),
                     targetScreenY = Math.round(targetWindow.innerRect.y + targetClientY);
 

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1007,12 +1007,17 @@ class Workspace extends Container {
                 // fire-and-forget (caught) — the readiness poll tolerates the async warm-up
                 // and a rejected measurement must never stall the gesture it annotates.
                 if (isMain) {
+                    // writeRenderer: false — the semantic path (renderCrossWindowPreview)
+                    // owns this renderer for cross-window gestures and paints it
+                    // synchronously (incl. the stored-home fallback); this feed exists to
+                    // populate the indicator tier, and an async write here would race it.
                     Promise.resolve(me.dragAffordances?.onDragMove({
-                        clientX     : data?.localX,
-                        clientY     : data?.localY,
-                        groupNodeId : data?.draggedItem?.dockGroupNodeId ?? null,
-                        itemId      : data?.draggedItem?.dockItemId,
-                        sourceNodeId: data?.draggedItem?.dockSourceNodeId ?? data?.sourceNodeId
+                        clientX      : data?.localX,
+                        clientY      : data?.localY,
+                        groupNodeId  : data?.draggedItem?.dockGroupNodeId ?? null,
+                        itemId       : data?.draggedItem?.dockItemId,
+                        sourceNodeId : data?.draggedItem?.dockSourceNodeId ?? data?.sourceNodeId,
+                        writeRenderer: false
                     })).catch(() => {});
                 }
 

--- a/src/dashboard/DockDragAffordances.mjs
+++ b/src/dashboard/DockDragAffordances.mjs
@@ -185,9 +185,12 @@ class DockDragAffordances extends Base {
      * GLIDE); the pointer selects an indicator geometrically; the selected candidate's
      * preview — or the pointer-inference FALLBACK tier when no indicator is hovered — feeds
      * the renderer with its exact target region.
-     * @param {Object} data {clientX, clientY, itemId, sourceNodeId}
+     * @param {Object} data {clientX, clientY, itemId, groupNodeId, sourceNodeId} —
+     *     `groupNodeId` is optional; remote grouped (whole-stack) gestures pass it so the
+     *     indicator and fallback previews carry the SAME grouped previewId the cross-window
+     *     semantic path produces — the gesture-ready contract reads the trio's agreement.
      */
-    async onDragMove({clientX, clientY, itemId, sourceNodeId}) {
+    async onDragMove({clientX, clientY, itemId, groupNodeId = null, sourceNodeId}) {
         let me              = this,
             geometryPromise = me.ensureGeometry(),
             geometry        = await geometryPromise;
@@ -203,14 +206,14 @@ class DockDragAffordances extends Base {
         if (indicators) {
             if ((zone?.nodeId ?? null) !== (indicators.candidateSet?.zone?.nodeId ?? null)) {
                 indicators.candidateSet = zone
-                    ? producer.produceCandidates({pointer, zones: geometry.zones, itemId, sourceNodeId, root: geometry.root})
+                    ? producer.produceCandidates({pointer, zones: geometry.zones, itemId, groupNodeId, sourceNodeId, root: geometry.root})
                     : null
             }
         }
 
         let candidate   = indicators?.updatePointer(pointer) ?? null,
             dockPreview = candidate?.preview
-                ?? producer.produce({pointer, zones: geometry.zones, itemId, sourceNodeId});
+                ?? producer.produce({pointer, zones: geometry.zones, itemId, groupNodeId, sourceNodeId});
 
         if (preview) {
             preview.dockPreview = dockPreview;

--- a/src/dashboard/DockDragAffordances.mjs
+++ b/src/dashboard/DockDragAffordances.mjs
@@ -185,12 +185,16 @@ class DockDragAffordances extends Base {
      * GLIDE); the pointer selects an indicator geometrically; the selected candidate's
      * preview — or the pointer-inference FALLBACK tier when no indicator is hovered — feeds
      * the renderer with its exact target region.
-     * @param {Object} data {clientX, clientY, itemId, groupNodeId, sourceNodeId} —
+     * @param {Object} data {clientX, clientY, itemId, groupNodeId, sourceNodeId, writeRenderer} —
      *     `groupNodeId` is optional; remote grouped (whole-stack) gestures pass it so the
      *     indicator and fallback previews carry the SAME grouped previewId the cross-window
      *     semantic path produces — the gesture-ready contract reads the trio's agreement.
+     *     `writeRenderer` defaults to true; pass false when the caller owns the preview
+     *     renderer (the cross-window participation path, whose semantic preview writes the
+     *     same renderer synchronously) — the indicator menu + candidate selection still
+     *     update, but this async pipeline never clears or replaces a renderer it does not own.
      */
-    async onDragMove({clientX, clientY, itemId, groupNodeId = null, sourceNodeId}) {
+    async onDragMove({clientX, clientY, itemId, groupNodeId = null, sourceNodeId, writeRenderer = true}) {
         let me              = this,
             geometryPromise = me.ensureGeometry(),
             geometry        = await geometryPromise;
@@ -215,7 +219,7 @@ class DockDragAffordances extends Base {
             dockPreview = candidate?.preview
                 ?? producer.produce({pointer, zones: geometry.zones, itemId, groupNodeId, sourceNodeId});
 
-        if (preview) {
+        if (preview && writeRenderer) {
             preview.dockPreview = dockPreview;
 
             if (dockPreview) {

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -1149,6 +1149,76 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('the remote affordance feed never clears the semantic stored-home renderer after it settles (#16309)', async () => {
+        const
+            workspace         = Neo.create(Workspace, {}),
+            sourceWorkspaceId = Workspace.vesselWorkspaceId('queues'),
+            hostRect          = {x: 100, y: 80, width: 900, height: 600},
+            targetRect        = {x: 120, y: 120, width: 260, height: 260};
+
+        try {
+            await workspace.crossWindowParticipationPromise;
+
+            workspace.windowId = 'window-main';
+            workspace.vesselWorkspaces.set(sourceWorkspaceId, {itemId: 'queues'});
+            workspace.tearOutPlacements.queues = {index: 0, tabsNodeId: 'left-tabs'};
+
+            // The construct-time participation resolves before windowId exists in this
+            // harness — refresh it now that the window identity is set.
+            const participation = await workspace.refreshCrossWindowParticipation(Workspace.MAIN_WORKSPACE_ID);
+
+            const
+                host               = workspace.getReference('dock-host'),
+                renderer           = workspace.dragAffordances.preview,
+                WindowManager      = Neo.manager.Window,
+                originalGet        = WindowManager.get,
+                originalGetDomRect = host.getDomRect,
+                originalWindowId   = workspace.windowId;
+
+            try {
+                WindowManager.get = () => ({innerRect: {x: 0, y: 0, width: 1280, height: 720}});
+                host.getDomRect   = async () => [hostRect, targetRect];
+
+                await workspace.ensureCrossWindowPreviewGeometry(Workspace.MAIN_WORKSPACE_ID, 'left-tabs');
+
+                // Off-zone but window-admitted: inside the host rect, outside the exact node
+                // rect — the stored-home fallback must paint the grouped tab-into…
+                participation.target.onRemoteDragMove({
+                    draggedItem: {
+                        dockGroupNodeId      : 'workstation-vessel-tabs:queues',
+                        dockItemId           : 'queues',
+                        dockSourceWorkspaceId: sourceWorkspaceId
+                    },
+                    localX      : 700,
+                    localY      : 500,
+                    sourceNodeId: Workspace.vesselTabsNodeId('queues')
+                });
+
+                const semanticPreview = participation.target.currentPreview;
+
+                expect(semanticPreview?.previewId).toBe('preview:group:workstation-vessel-tabs:queues:left-tabs:tab-into');
+                expect(renderer.dockPreview?.previewId).toBe(semanticPreview.previewId);
+
+                // …and once the fire-and-forget affordance feed settles, its async tier
+                // must not clear or replace a renderer it does not own.
+                await new Promise(resolve => setTimeout(resolve, 0));
+                await new Promise(resolve => setTimeout(resolve, 0));
+                await new Promise(resolve => setTimeout(resolve, 0));
+
+                expect(renderer.dockPreview?.previewId).toBe(semanticPreview.previewId);
+                expect(participation.target.currentPreview?.previewId).toBe(renderer.dockPreview.previewId)
+            } finally {
+                WindowManager.get  = originalGet;
+                host.getDomRect    = originalGetDomRect;
+                workspace.windowId = originalWindowId;
+                workspace.vesselWorkspaces.delete(sourceWorkspaceId);
+                delete workspace.tearOutPlacements.queues
+            }
+        } finally {
+            workspace.destroy()
+        }
+    });
+
     test('pane identity remains readable after the catalog moves into a vessel workspace', () => {
         const workspace = Neo.create(Workspace, {});
 


### PR DESCRIPTION
Resolves #16309

The five-beat stack return publishes its full preview trio again: the two red scenes (4 reintegration, 5 signature) are green headless at dev head, isolated and in-suite, with the currently-green six untouched. The ticket's bisect recipe convicted `ef14085776` (#16134) as first-red (`c6ee7652f2` green → `ef14085776` red, six contemporary spec+app runs, posted on the ticket); the repair then surfaced two further contract gaps that the head's ready-contract exposes. The fix spans the Workstation app and the reusable dashboard-controller surface (`DockDragAffordances`) it composes.

Evidence: L3 (the failing leg reproduced byte-identically on this host, then driven green with receipts at every layer — bisect table, produce-gate numbers, and the final passing suite runs) → L4 achieved (reviewer exact-head headed witness: `NEO_E2E_PORT=8221 … --grep reintegration --headed --workers=1` → 1/1 at this head, @neo-gpt-emmy). Residual: none — AC6 is satisfied by the reviewer receipt.

## Root cause (AC1 — named with receipts, not inference)

Three layers, each receipted before the next was visible:

1. **Acquisition vs exact zone (`#16134`).** `DockPreviewProducer.produce()` gates on `hitTestZone` — the pointer must land inside a zone rect. `#16134` narrowed the preview zone from window dimensions to the exact tabs node (`right-top-tabs`: x 954–1268), while `executeStackReturnStep` drove the synthetic cursor to window center (640,400) — outside it. Probe receipt: `produce` input `{pointerX: 640, pointerY: 400}` vs `targetRect {x: 954, y: 110, w: 314, h: 460}` → null → `currentPreview` never sets → poll exhausts. Euclid's tier-2.5 ruling (A2A thread) convicted the same commit from the real-user side: exact-rect acquisition silently shrank the drop zone.
2. **The indicator tier had no cross-window population path.** The ready-contract's `indicators.activePreviewId` clause (arrived with `#16140`) requires the main workspace's indicator menu, whose only writer is `DockDragAffordances.onDragMove` — driven solely by a same-window `dockCrossZoneDragMove` fire gated on a local `startIndex`. Falsifier-swept: nothing in the coordinator, participation, or drag target drives it for remote gestures.
3. **Group identity.** The semantic preview is grouped (`preview:group:workstation-vessel-tabs:metrics:…`) while the local affordance pipeline emitted ungrouped ids (`preview:metrics:…`) — the trio could never agree for whole-stack gestures.

## The fix (the Workstation app + the reusable dashboard-controller surface it composes; the film spec is untouched per AC5)

- **`renderCrossWindowPreview` — stored-home acquisition fallback.** The whole-window hit-test already admits the gesture; when the pointer lands inside the window but outside every exact zone, a second `produce()` at the synthesized node-center point binds the stored-home target. On-zone drags keep the full placement grammar (splits included); painting stays glued to the exact rect. This is the real-user half of Euclid's ruling (off-tabs acquisition), and the ticket's H3 answer at the app seam.
- **`executeStackReturnStep` — the film gesture aims at the semantic return target.** The indicator menu's active candidate is selected geometrically (`updatePointer` is a rect hit-test), so the synthetic cursor now hovers the resolved stored-home tabs node (window-center fallback preserved). Deterministic witness per Euclid's note; no screenplay semantics changed.
- **Cross-window affordance feed.** The participation's `previewFor` hook feeds the main workspace's `dragAffordances.onDragMove` with the remote hover frame (fire-and-forget, caught — a rejected measurement can never stall the gesture it annotates). Restores the indicator tier for cross-window gestures: the failing snapshot went from `indicators: null` to `{candidateCount: 9, visible: true}` with a matching active id.
- **`DockDragAffordances.onDragMove` — optional `groupNodeId`** threaded into both producer calls, so indicator and fallback previews carry the same grouped `previewId` the semantic path emits. Additive and backward-compatible.

## Deltas from ticket

- The ticket left the fix "implementation-agnostic until the bisect lands"; the bisect plus Euclid's ruling shaped it. His literal `zones: [hostRect]` variant was tried and rejected with a receipt: at the film's node-center aim it resolves `split-*` kinds instead of the contract's `tab-into` (whole-window authority already lives in `hitTestCrossWindowTarget`'s gate — the fallback carries the acquisition semantics his ruling asks for).
- **Flagged, not built (Euclid's seam):** `DockDragAffordances.onDrop` has the same two gaps on the commit side — no stored-home fallback and no `groupNodeId` in its fallback `produce()`. The drop path is out of this ticket's contract (scene 4 commits through the indicator candidate, which now carries the grouped id); naming it here so it is not silently lost.
- `onDrop`'s indicator re-hit-test at release coordinates remains the commit gate it always was; nothing in this PR loosens it.

## Test Evidence

- Isolated `--grep reintegration`: failing receipt reproduced byte-identical pre-fix; **green** post-fix (three times — pre-cleanup, final tree, and the RC head with the renderer-ownership repair).
- **Full suite** `workstation/WorkstationFiveBeatNL`: **8 passed, 2 contracted skips, 0 failed** at the RC head — scenes 4+5 restored, the six green scenes unchanged.
- **`workstation/WorkstationDockPreviewSymmetryNL`** (`#16134`'s own exact-target witness, Euclid falsifier #4): **green**.
- Unit specs for touched surfaces: `apps/workstation/Workspace.spec.mjs` (incl. the new settlement regression: the remote affordance feed must not clear the semantic stored-home renderer after it settles — `target.currentPreview.previewId === renderer.dockPreview.previewId` for an off-zone grouped pointer), `dashboard/DockDragAffordances.spec.mjs`, `DockDropIndicators.spec.mjs`, `DockPreviewProducer.spec.mjs` — **58/58 green**.
- Reviewer falsifiers: headed exact-head `NEO_E2E_PORT=8221 … --headed --workers=1` → **1/1** (@neo-gpt-emmy, AC6); her pre-fix off-zone settlement spec → RED (the renderer cleared after the feed settled — the defect the `writeRenderer: false` mode repairs).
- Bisect table (6 runs, first-red pair) + probe receipts: on `#16309` (issuecomment-5153998088) and in review context.

## Post-Merge Validation

- [x] ~~AC6 headed witness~~ — achieved at this exact head via the reviewer's headed receipt (1/1, see Test Evidence).
- [ ] Euclid's remaining real-user falsifier on the commit side (drop at off-zone position acquires stored-home): tracked as the flagged `onDrop` seam above — file a linked follow-up if he confirms the shape.

Authored by Iris (Kimi K3, Kimi Code CLI) consuming Fable's bisect recipe + Euclid's tier-2.5 ruling — session f91d8847-7722-4c4e-80d6-fa9f646a75e9.

