### PR TITLE
fix(stop-hook): catch "unless you'd rather" in the deference detector (#16325)

### DIFF
--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -23,6 +23,10 @@ export const DEFERENCE_PHRASES = [
     'do you want me',
     'Your steer on',
     "if you'd rather",
+    // Composition of the two neighbours above; listed separately because neither matches it. Catches the
+    // lane-handback shape ("that is next unless you'd rather I took something else") - offering back a
+    // lane the agent already owns, which §swarm_topology_anchor assigns to the agent, not the operator.
+    "unless you'd rather",
     'or steer me elsewhere',
     'your call',
     'your move'

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -15,12 +15,31 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase('So - which do you want me driving next?')).toBe('do you want me');
     });
 
+    test("matches the operator-flagged lane-handback slip (#16325)", () => {
+        // The list already carried "if you'd rather" and "unless you want me", so this composition read
+        // as covered while returning null - on the autonomous path too, not just under the operator carve.
+        expect(matchDeferencePhrase("That's next unless you'd rather I take something else."))
+            .toBe("unless you'd rather");
+
+        // The negative control that keeps the addition honest: a decisive authority-boundary statement
+        // is not deference, and must stay silent.
+        expect(matchDeferencePhrase('Next: #16208. The merge is yours per critical_gates 1.')).toBeNull();
+
+        // The near-miss guard that already existed for "unless you ..." must survive.
+        expect(matchDeferencePhrase('The test fails unless you mock the system clock.')).toBeNull();
+
+        // Reporting the phrase is not using it - this ticket's own body does exactly that.
+        expect(matchDeferencePhrase("The phrase unless you'd rather is part of the deference register."))
+            .toBeNull();
+    });
+
     test('matches each tight phrase case-insensitively', () => {
         expect(matchDeferencePhrase('WOULD YOU LIKE ME TO open the PR?')).toBe('would you like me to');
         expect(matchDeferencePhrase('I can take it unless you want me elsewhere.')).toBe('unless you want me');
         expect(matchDeferencePhrase('Want me to start the refactor?')).toBe('want me to');
         expect(matchDeferencePhrase('Your steer on the next lane.')).toBe('Your steer on');
         expect(matchDeferencePhrase("IF YOU'D RATHER, I can leave this parked.")).toBe("if you'd rather");
+        expect(matchDeferencePhrase("I can take it UNLESS YOU'D RATHER I picked another.")).toBe("unless you'd rather");
         expect(matchDeferencePhrase('I can do this, or steer me elsewhere.')).toBe('or steer me elsewhere');
         expect(matchDeferencePhrase('Your call on the branch cut.')).toBe('your call');
         expect(matchDeferencePhrase('Your move.')).toBe('your move');
@@ -91,6 +110,7 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(DEFERENCE_PHRASES).toContain('do you want me');
         expect(DEFERENCE_PHRASES).toContain('Your steer on');
         expect(DEFERENCE_PHRASES).toContain("if you'd rather");
+        expect(DEFERENCE_PHRASES).toContain("unless you'd rather");
         expect(DEFERENCE_PHRASES).toContain('or steer me elsewhere');
         expect(DEFERENCE_REMINDER).toContain('helpful assistant');
         expect(reminder).toContain('equal peer');

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -292,6 +292,30 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — #14440 mid-chain operat
         expect(context.midChainOperator).toBe(false);
     });
 
+    test('the lane-handback phrase blocks autonomously but stays carved in live dialogue (#16325 boundary)', () => {
+        // The registry entry and the operator-dialogue carve are TWO independent gates, and both were
+        // shut when this phrase was first observed. Proving the registry missed it says nothing about
+        // the carve; this crosses classifyPromptingContext into the decision so the reachable boundary
+        // is executable rather than asserted in prose.
+        const slip = "That's next unless you'd rather I take something else.";
+
+        const autonomous = classifyPromptingContext({
+            stopHookActive: false,
+            promptingText : '[WAKE][priority:high] 1 events for @neo-opus-vega'
+        });
+        expect(autonomous.operatorInLoop).toBe(false);
+        expect(decideDeferenceStopHookAction(slip, autonomous)).not.toBeNull();
+
+        const liveDialogue = classifyPromptingContext({
+            stopHookActive: false,
+            promptingText : 'please check messages, choose your lanes'
+        });
+        expect(liveDialogue.operatorInLoop).toBe(true);
+        // Deliberately pinned as the CURRENT boundary, not as desired behavior: the live-dialogue case
+        // that motivated the phrase is still uncaught, and ownership of that carve is a separate lane.
+        expect(decideDeferenceStopHookAction(slip, liveDialogue)).toBeNull();
+    });
+
     test('chained + attested + synthetic / handoff / empty candidates all fail closed', () => {
         for (const promptingText of [
             '<hook_prompt hook_run_id="stop:2">reminder</hook_prompt>',


### PR DESCRIPTION
Resolves #16325

Adds `unless you'd rather` to the Stop-hook deference registry — a phrase sitting in the gap between two entries it already had (`if you'd rather`, `unless you want me`), so the composition read as covered while returning `null`. **This closes the autonomous-turn half only.** The live-operator-dialogue case that motivated it is blocked by a second, independent gate and remains open in #16338.

Evidence: L2 (unit + production-decision-path spec at exact head — both the matcher and the `classifyPromptingContext` gate are exercised in-sandbox) → L4 required (the block actually firing in a real harness Stop-hook turn is operator-gated and unreachable from here). Residual: the live-dialogue path stays uncaught by design [#16338]; real-hook firing in `## Post-Merge Validation`.

## Deltas from ticket

**Cycle-1 correction, and it inverts my original causal claim.** The first version of this body asserted *"the carve was never reached."* @neo-gpt-emmy falsified it and she is right. I reproduced her probe before accepting it:

```
ordinary human prompt  → operatorInLoop=true   → decideDeferenceStopHookAction = null
[WAKE] autonomous      → operatorInLoop=false  → decideDeferenceStopHookAction = "would-block"
```

**Two gates were shut independently.** I measured `matchDeferencePhrase` — the inner matcher — and drew a conclusion about `detectDeferencePhrase`, the gated consumer. Proving the registry gate was closed says nothing about whether the carve gate was open. It was also closed, and it is the one that blocks the reported incident.

The irony worth recording: my *original* theory (the `operatorInLoop` carve blocks the live case) was correct, and I discarded it on a measurement that answered a different question — then wrote that discarding as the PR's headline discipline. The registry gap is real and worth fixing; it just is not the reason the operator's turn went uncaught.

`#16325` now carries the corrected diagnosis with the original claim retained rather than silently edited, and is re-scoped to autonomous-only. #16338 is filed **unclaimed** and owns the still-open question — including the honest null hypothesis that the carve should stay exactly as it is, since the operator caught this himself in one turn.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/hooks/ --workers=1
  237 passed (10.4s)
```

Directory-scoped on purpose: `stopHookDecision.mjs` imports the changed module and the hook adapters consume that in turn, so the importer specs are the ones that could regress.

New in cycle 1 — the production-path control that was missing, crossing `classifyPromptingContext` into `decideDeferenceStopHookAction`:

| context | `operatorInLoop` | decision | pinned as |
|---|---|---|---|
| `[WAKE]` autonomous | `false` | blocks | intended behavior |
| ordinary human prompt | `true` | `null` | **observed** boundary, not desired — #16338 owns it |

Matcher-level controls (unchanged from cycle 0):

| input | before | after |
|---|---|---|
| `That's next unless you'd rather I take something else.` | `null` — miss | `unless you'd rather` |
| `Next: #16208. The merge is yours per critical_gates 1.` (Tier-4 control) | `null` | `null` |
| `The test fails unless you mock the system clock.` (near-miss guard) | `null` | `null` |
| `The phrase unless you'd rather is part of the deference register.` (mention carve) | — | `null` |

Surfaces touched: `ai/scripts/lifecycle/deferencePhraseMatch.mjs` — `deferencePhraseMatch.spec.mjs` + `stopHookDecision.spec.mjs`, plus the adapter specs, all green.

## Post-Merge Validation

- [ ] The entry fires in a real harness Stop-hook turn-terminal (the L4 step unreachable in-sandbox) without firing on ordinary authority-boundary or Tier-4 phrasing over a normal working day.
- [ ] No observed increase in false blocks across the `osascript` seats that run the Claude hook.
- [ ] #16338 reaches a recorded decision — including "leave the carve as-is" — so the live-dialogue miss is closed deliberately rather than forgotten.

## Commits

- `7d6497699e` — the phrase entry plus its regression spec and negative controls.
- `ad23a51f83` — the production-path boundary spec across the context gate (cycle-1 Required Action).

## Evolution

Two pivots, both from measurement rather than argument. Cycle 0: from *"the `operatorInLoop` carve is scoped on the wrong axis"* to *"the phrase is absent from the list"* — collapsing a would-be refactor into one entry. Cycle 1: Emmy's falsifier showed that first pivot over-corrected — the carve **is** what blocks the live case, and both gates were shut. The stable version is that the two causes are independent, this PR owns one, and #16338 owns the other.

Authored by Vega (Claude Opus 5, Claude Code). Session eb230051-9e42-4e6b-b540-112a79accc3a.
