### PR TITLE
feat(ai): guard the tenant-repo-sync starved-leaf ordering (#16312)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -187,3 +187,25 @@ export function detectStarvedTenantSync({repoStates = [], attemptedCount = 0, no
         }
     };
 }
+
+/**
+ * @summary Pure relationship check for the two tenant-repo-sync tuning leaves: the starved
+ * duration floor must EXCEED the backoff cap, or a lane in ordinary capped backoff crosses
+ * the floor and emits heal records for what is merely a transient outage — the false-positive
+ * shape the floor exists to prevent. `starvedAfterMs: 0` is the documented disable and is
+ * never inverted; a non-positive or unresolvable value cannot be judged and is not inverted.
+ *
+ * Deliberately independent of both predicates (`isRepoDue`, `detectStarvedTenantSync`): the
+ * relationship binds how the values are CONFIGURED, not how either computation uses them,
+ * so it belongs where the leaves resolve, never inside a pure computation.
+ *
+ * @param {Object} options
+ * @param {Number} options.backoffCapMs Failure-backoff ceiling (`tenantRepoSync.backoffCapMs`).
+ * @param {Number} options.starvedAfterMs Starved-lane duration floor (`tenantRepoSync.starvedAfterMs`).
+ * @returns {Boolean}
+ */
+export function isStarvedOrderInverted({backoffCapMs, starvedAfterMs}) {
+    return Number.isFinite(starvedAfterMs) && starvedAfterMs > 0
+        && Number.isFinite(backoffCapMs) && backoffCapMs > 0
+        && starvedAfterMs <= backoffCapMs
+}

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -15,7 +15,7 @@ import {
     TenantRepoAccessCode,
     TenantRepoAccessStatus
 } from '../../../services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
-import {detectStarvedTenantSync, isRepoDue} from '../scheduling/tenantRepoSync.mjs';
+import {detectStarvedTenantSync, isRepoDue, isStarvedOrderInverted} from '../scheduling/tenantRepoSync.mjs';
 import {
     KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
@@ -362,6 +362,15 @@ function assertFullMaterializationEffect(envelope, summary, priorState, material
  * @see https://github.com/neomjs/neo/issues/16045
  */
 class TenantRepoSyncService extends Base {
+    /**
+     * Latches the once-per-process inverted-leaf-order warning (runTask boundary): the
+     * first sweep emits it, later sweeps stay quiet. Deliberately not reactive — it is
+     * process-local latch state, not configuration.
+     * @member {Boolean} starvedOrderWarned=false
+     * @protected
+     */
+    starvedOrderWarned = false
+
     static config = {
         /**
          * @member {String} className='Neo.ai.daemons.services.TenantRepoSyncService'
@@ -746,6 +755,15 @@ class TenantRepoSyncService extends Base {
         leaseRenewalIntervalMs,
         seedBootstrap     = true
     } = {}) {
+        // One-time deployment sanity check on the two tuning leaves' RELATIONSHIP (never a
+        // throw — a noisy alert beats a dead lane): an inverted floor makes ordinary capped
+        // backoff emit heal records for transient outages. The checker stays out of the pure
+        // predicates; this boundary is where the resolved values meet.
+        if (!this.starvedOrderWarned && isStarvedOrderInverted({backoffCapMs, starvedAfterMs})) {
+            this.starvedOrderWarned = true;
+            writeLog?.('WARN', `[TenantRepoSync] tenantRepoSync.starvedAfterMs (${starvedAfterMs}) does not exceed backoffCapMs (${backoffCapMs}): a lane in ordinary capped backoff crosses the starved duration floor and emits heal records for a transient outage. Set starvedAfterMs above the cap, or 0 to disable the record.`);
+        }
+
         const state = taskStateService.getTaskState(taskName);
 
         if (state?.running) {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
@@ -4,7 +4,8 @@ import {
     computeDeterministicJitter,
     detectStarvedTenantSync,
     getDueTask,
-    isRepoDue
+    isRepoDue,
+    isStarvedOrderInverted
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 
 test.describe('tenantRepoSync trigger (#11790)', () => {
@@ -367,5 +368,28 @@ test.describe('detectStarvedTenantSync (#16224 AC2/AC3)', () => {
         const detection = detectStarvedTenantSync({repoStates: [], attemptedCount: 0, now: NOW, starvedAfterMs: 6 * H});
 
         expect(detection.starved).toBe(false);
+    });
+});
+
+test.describe('isStarvedOrderInverted (#16312)', () => {
+    test('the documented defaults are not inverted (6h floor > 2h cap)', () => {
+        expect(isStarvedOrderInverted({backoffCapMs: 2 * 60 * 60 * 1000, starvedAfterMs: 6 * 60 * 60 * 1000})).toBe(false);
+    });
+
+    test('a floor at or below the cap is inverted — the transient-outage false-positive shape', () => {
+        expect(isStarvedOrderInverted({backoffCapMs: 2 * 60 * 60 * 1000, starvedAfterMs: 60 * 60 * 1000})).toBe(true);
+        // Equality is inverted too: the floor must EXCEED the cap, or a repo at its very
+        // first capped retry already crosses it.
+        expect(isStarvedOrderInverted({backoffCapMs: 2 * 60 * 60 * 1000, starvedAfterMs: 2 * 60 * 60 * 1000})).toBe(true);
+    });
+
+    test('starvedAfterMs 0 (the documented disable) is never inverted', () => {
+        expect(isStarvedOrderInverted({backoffCapMs: 2 * 60 * 60 * 1000, starvedAfterMs: 0})).toBe(false);
+    });
+
+    test('unresolvable values cannot be judged and are not inverted', () => {
+        expect(isStarvedOrderInverted({backoffCapMs: 0,   starvedAfterMs: 1000})).toBe(false);
+        expect(isStarvedOrderInverted({backoffCapMs: NaN, starvedAfterMs: 1000})).toBe(false);
+        expect(isStarvedOrderInverted({backoffCapMs: 1000, starvedAfterMs: NaN})).toBe(false);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -3361,6 +3361,46 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             events = await readHealLedger({dir: ledgerDir});
             expect(events).toHaveLength(1);
         });
+
+        test('an inverted starved floor warns exactly once per process — and never throws (#16312)', async () => {
+            const
+                taskStateService = createInMemoryTaskStateService(),
+                logLines         = [],
+                options          = {
+                    reason                       : 'periodic',
+                    taskStateService,
+                    writeLog                     : (level, msg) => logLines.push({level, msg}),
+                    tenantReposConfig            : {tenantRepos: [buildStarvedRepo()]},
+                    gitMirror                    : makeFakeGitMirror(),
+                    knowledgeBaseIngestionService: makeFakeIngestionService(),
+                    revisionsFilePath            : revisionsFile,
+                    globalCadenceMs              : 60_000,
+                    jitterRatio                  : 0,
+                    backoffCapMs                 : 6 * 60 * 60 * 1000, // inverted: cap ABOVE the floor
+                    starvedAfterMs               : 2 * 60 * 60 * 1000,
+                    seedBootstrap                : false
+                },
+                originalLatch    = TenantRepoSyncService.starvedOrderWarned;
+
+            try {
+                TenantRepoSyncService.starvedOrderWarned = false;
+
+                await seedStarvedState(Date.now() - 30 * 60 * 1000);
+
+                const first    = await TenantRepoSyncService.runTask(options),
+                      second   = await TenantRepoSyncService.runTask(options),
+                      warnings = logLines.filter(l => l.level === 'WARN' && l.msg.includes('starvedAfterMs'));
+
+                // The lane runs regardless — a noisy alert beats a dead lane, never a throw.
+                expect(first.status).not.toBe('failed');
+                expect(second.status).not.toBe('failed');
+
+                expect(warnings).toHaveLength(1);
+                expect(warnings[0].msg).toContain('does not exceed backoffCapMs')
+            } finally {
+                TenantRepoSyncService.starvedOrderWarned = originalLatch
+            }
+        });
     });
 });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/tenantRepoSyncLeaves.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/tenantRepoSyncLeaves.spec.mjs
@@ -1,0 +1,31 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import RootConfigBase from '../../../../../../ai/configBase.mjs';
+
+// The canonical defaults' RELATIONSHIP is the guard: the starved duration floor
+// must exceed the backoff cap, or an inverted deployment emits starved-lane heal records
+// for what is merely a transient outage. Pinned as literals AND as the ordered pair so an
+// edit to either leaf fails loudly here instead of silently in production.
+test.describe('tenantRepoSync leaf defaults — the starved ordering pin (#16312)', () => {
+    let tier1Root;
+
+    test.beforeAll(() => {
+        tier1Root = Neo.create(RootConfigBase)
+    });
+
+    test.afterAll(() => {
+        tier1Root?.destroy()
+    });
+
+    test('the canonical defaults hold their documented values', () => {
+        const {backoffCapMs, starvedAfterMs} = tier1Root.data.orchestrator.tenantRepoSync;
+
+        expect(backoffCapMs).toBe(2 * 60 * 60 * 1000);
+        expect(starvedAfterMs).toBe(6 * 60 * 60 * 1000);
+    });
+
+    test('the starved duration floor exceeds the backoff cap', () => {
+        expect(tier1Root.data.orchestrator.tenantRepoSync.starvedAfterMs)
+            .toBeGreaterThan(tier1Root.data.orchestrator.tenantRepoSync.backoffCapMs);
+    });
+});


### PR DESCRIPTION
Resolves #16312

The two tenant-repo-sync tuning leaves now carry their ordering requirement mechanically instead of in prose. `starvedAfterMs` must exceed `backoffCapMs` — inverted, a lane in ordinary capped backoff crosses the starved duration floor and emits heal records for a transient outage (the false positive the floor exists to prevent). Three coordinated pieces, all shaped by the ticket's recorded traps:

- **`isStarvedOrderInverted`** (pure, sibling of the scheduling predicates): the relationship checker. `starvedAfterMs: 0` (the documented disable) is never inverted; unresolvable values cannot be judged and are not inverted; equality is inverted (the floor must *exceed* the cap). The predicates stay independent — the relationship is a deployment concern, so it lives where the values resolve, not inside either computation.
- **Resolve-time WARN, once per process** (`TenantRepoSyncService.runTask` boundary): an inverted deployment logs a WARN naming both values and the remedy (raise the floor above the cap, or 0 to disable). Never a throw — a noisy alert beats a dead lane. A process-local latch (`starvedOrderWarned`, deliberately not reactive) keeps it to one emission per process, not per sweep.
- **Defaults pin** (`tenantRepoSyncLeaves.spec.mjs`): the canonical defaults are asserted both as literals (6h floor, 2h cap) and as the ordered pair — an edit to either leaf fails loudly here instead of silently in production.

Evidence: L2 (pure checker matrix + service-harness WARN behavior + resolved-defaults pin) — the surfaces are all spec-reachable; no runtime ladder needed. Residual: none.

## Deltas from ticket

None substantive — the two dispositions posted on the ticket (spec pin + resolve-time WARN, shaped by the recorded traps) are exactly what shipped. The checker lives in `scheduling/tenantRepoSync.mjs` beside the predicates it deliberately does not touch; the WARN rides the existing `writeLog` channel the service already uses.

## Test Evidence

- `tenantRepoSync.spec.mjs` (scheduling): **34/34 green** — 4 new checker matrix tests (defaults clean, at/below-cap inverted, equality inverted, 0 exempt, unresolvable quiet).
- `TenantRepoSyncService.spec.mjs`: **91/91 green** — 1 new test: inverted leaves → exactly one WARN across two sweeps, lane never fails.
- `tenantRepoSyncLeaves.spec.mjs` (new): **2/2 green** — literal pin + relationship pin on the resolved canonical defaults.
- Full run of all three files: **127/127, zero failure lines.**

## Post-Merge Validation

- [ ] On the next inverted-by-env deployment (if any): exactly one WARN at the first sweep, no second emission, lane unaffected.

Authored by Iris (Kimi K3, Kimi Code CLI). Session f91d8847-7722-4c4e-80d6-fa9f646a75e9.
