### PR TITLE
feat: fleet mailbox seams ride the containerized MC plane (#16324)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -234,6 +234,24 @@ class ConfigBase extends ConfigProvider {
                  * @type {string}
                  */
                 instanceRoot   : leaf(path.resolve(planeDataRootDefault, 'fleet/instances'), 'NEO_FLEET_INSTANCE_ROOT', 'string', {planeMember: true}),
+                /**
+                 * Canonical base of the containerized Agent OS plane the Fleet server's mailbox,
+                 * compose, and catch-up seams consume (`<base>/mc/mcp` is derived — the
+                 * connected-tenant resource contract). EMPTY means in-process binding: correct for machines without
+                 * the container stack; the dockerized canonical machine activates plane mode via
+                 * its operator overlay or env (e.g. `http://127.0.0.1:3102`). Not a plane member —
+                 * this is host-edge consumer config, not a data-root path.
+                 * @type {string}
+                 */
+                planeBase: leaf('', 'NEO_FLEET_PLANE_BASE', 'string'),
+                /**
+                 * Bearer credential for the plane's MCP resources. The plane resolves this to its
+                 * canonical subject, and the Fleet entry refuses plane mode unless that subject IS
+                 * the boot-resolved viewer (the single-viewer invariant). Empty is accepted
+                 * only by planes that admit tokenless callers; admission failure degrades honestly.
+                 * @type {string}
+                 */
+                planeBearer    : leaf('', 'NEO_FLEET_PLANE_BEARER', 'string'),
                 harnessBinaries: {
                     /**
                      * The antigravity harness binary — the app-bundle MAIN binary (a directly

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -140,6 +140,8 @@
         "fleet.harnessBinaries.kimiCode",
         "fleet.harnessBinaries.openCode",
         "fleet.instanceRoot",
+        "fleet.planeBase",
+        "fleet.planeBearer",
         "geminiApiKey",
         "graphProvider",
         "knowledgeBase",

--- a/ai/services/fleet/FleetTenantService.mjs
+++ b/ai/services/fleet/FleetTenantService.mjs
@@ -10,28 +10,14 @@ import Base                        from '../../../src/core/Base.mjs';
 import {resolveFleetCredentialKey} from './FleetRegistryService.mjs';
 import {
     normalizeAgentIdentity,
+    normalizeSecureMcpEndpoint,
     parseMcpEnvelope,
     readMcpToolPayload
 } from './mcpWireParsing.mjs';
 
-/**
- * Hosts for which plain `http:` is accepted. Deliberately an exact set rather than a range or a
- * pattern: this is the one exception to the TLS rule that protects the bearer, so it stays small
- * enough to audit at a glance. A developer running a tenant on a non-loopback address uses TLS.
- *
- * `[::1]` keeps its brackets: these are compared against `URL#hostname`, which returns the IPv6
- * literal bracketed. Un-bracketing it here would silently stop matching.
- */
-const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
-
-/**
- * @summary Canonical origin+path form (no trailing slash) so one endpoint maps to one tenant id.
- * @param {URL} url
- * @returns {String}
- */
-function canonicalize(url) {
-    return (url.origin + url.pathname).replace(/\/+$/, '');
-}
+// The loopback-http exception, URL-credential rejection, and canonical endpoint form live in
+// ./mcpWireParsing.mjs (`normalizeSecureMcpEndpoint`) — one endpoint-boundary policy shared with
+// the plane mailbox client.
 
 /**
  * @summary The CLOSED public vocabulary for a failed connect.
@@ -338,28 +324,10 @@ class FleetTenantService extends Base {
      * @protected
      */
     normalizeEndpoint(tenantUrl) {
-        if (typeof tenantUrl !== 'string' || tenantUrl.trim() === '') return null;
-
-        let url;
-
-        try {
-            url = new URL(tenantUrl.trim());
-        } catch {
-            return null;
-        }
-
-        // A URL-embedded secret would bypass the encrypted store — reject the shape outright.
-        if (url.username || url.password) return null;
-
         // The provider bearer rides to this endpoint as a header (see `probeTenantEndpoint`), so the
-        // endpoint's scheme decides whether the credential crosses the wire in cleartext. TLS is
-        // required for anything remote; `http:` survives only for loopback, where there is no
-        // network hop to intercept and a developer can run a tenant without a certificate.
-        if (url.protocol === 'https:') return canonicalize(url);
-
-        if (url.protocol === 'http:' && LOOPBACK_HOSTS.has(url.hostname)) return canonicalize(url);
-
-        return null;
+        // endpoint's scheme decides whether the credential crosses the wire in cleartext — the shared
+        // boundary policy enforces TLS-off-loopback and rejects URL-embedded secrets outright.
+        return normalizeSecureMcpEndpoint(tenantUrl);
     }
 
     /**

--- a/ai/services/fleet/FleetTenantService.mjs
+++ b/ai/services/fleet/FleetTenantService.mjs
@@ -8,6 +8,11 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import Base                        from '../../../src/core/Base.mjs';
 import {resolveFleetCredentialKey} from './FleetRegistryService.mjs';
+import {
+    normalizeAgentIdentity,
+    parseMcpEnvelope,
+    readMcpToolPayload
+} from './mcpWireParsing.mjs';
 
 /**
  * Hosts for which plain `http:` is accepted. Deliberately an exact set rather than a range or a
@@ -597,69 +602,8 @@ class FleetTenantService extends Base {
     }
 }
 
-/**
- * @summary Normalize a provider login / AgentIdentity node id to the canonical `@login` shape.
- * The provider response is remote-authored, so malformed values fail closed instead of crossing
- * into diagnostics.
- * @param {*} value
- * @returns {String|null}
- * @private
- */
-function normalizeAgentIdentity(value) {
-    if (typeof value !== 'string') return null;
-
-    const login = value.trim().replace(/^AGENT_IDENTITY:/, '').replace(/^@/, '');
-
-    return login && /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})$/.test(login) ? `@${login}` : null
-}
-
-/**
- * @summary Parse one JSON or SSE MCP response envelope without forwarding remote prose.
- * @param {String} text
- * @returns {Object|null}
- * @private
- */
-function parseMcpEnvelope(text) {
-    try {
-        return JSON.parse(text)
-    } catch {}
-
-    for (const line of String(text).split(/\r?\n/)) {
-        if (!line.startsWith('data:')) continue;
-
-        try {
-            return JSON.parse(line.slice(5).trim())
-        } catch {}
-    }
-
-    return null
-}
-
-/**
- * @summary Read the JSON payload of one MCP tool result. Only structured JSON or a JSON text item
- * is accepted; arbitrary remote text never becomes a diagnostic.
- * @param {Object|null} envelope
- * @returns {Object|null}
- * @private
- */
-function readMcpToolPayload(envelope) {
-    const result = envelope?.result;
-
-    if (!result || result.isError) return null;
-    if (result.structuredContent && typeof result.structuredContent === 'object') {
-        return result.structuredContent
-    }
-
-    const text = result.content?.find?.(item => item?.type === 'text')?.text;
-
-    if (typeof text !== 'string') return null;
-
-    try {
-        return JSON.parse(text)
-    } catch {
-        return null
-    }
-}
+// normalizeAgentIdentity / parseMcpEnvelope / readMcpToolPayload live in ./mcpWireParsing.mjs —
+// the fleet subsystem's one MCP-wire parsing authority, shared with planeMailboxClient.
 
 /**
  * @summary Ask Memory Core for the request-bound caller identity inside the initialized session.

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -21,6 +21,11 @@
  * 4. wires the mailbox-mirror source BEHIND the boundary: the adapter reads through the real
  *    `MailboxService.listMessages` under the per-request identity `RequestContextService` carries —
  *    admission is the Memory Core's decision, attributed to the transport-stamped viewer.
+ * 5. decides the mailbox-seam plane ONCE: a configured `fleet.planeBase` binds the
+ *    mailbox, compose, and catch-up seams to the containerized plane through an identity-verified
+ *    MCP client — the bearer's plane-side subject must BE the boot-resolved viewer, else startup
+ *    refuses plane mode fail-closed; an empty base keeps the in-process singletons. All-or-nothing
+ *    per boot, logged either way — the operator can always trust which plane the cockpit shows.
  *
  * Invocation: `node ai/services/fleet/devFleetServer.mjs` (or `npm run ai:fleet-server`). Loopback
  * only; the port is `NEO_FLEET_PORT` (default 8083) and must match the URL the App Worker's
@@ -44,6 +49,7 @@ import FleetControlBridge                                                 from '
 import FleetManager                                                       from './FleetManager.mjs';
 import {startFleetBridgeServer}                                           from './fleetBridgeServer.mjs';
 import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer} from './fleetLaunchContract.mjs';
+import {createPlaneMailboxClient}                                         from './planeMailboxClient.mjs';
 import {readActiveWakeSubscriptionIdentities}                             from './readActiveWakeSubscriptionIdentities.mjs';
 import {wireBootIdentityReadSource}                                       from './wireBootIdentityReadSource.mjs';
 import {wireFleetActivityReadSource}                                      from './wireFleetActivityReadSource.mjs';
@@ -70,6 +76,29 @@ async function boot() {
     // the advisory-unknown fallback. Fail-soft — an absent dir leaves the seam honestly unwired.
     wireBootIdentityReadSource({dir: AiConfig.orchestrator.dataDir});
 
+    // The mailbox-seam plane decision: resolved ONCE at boot, all-or-nothing, logged. The
+    // leaves resolve here at the use site (the AiConfig SSOT contract); the client itself reads no config. Fail-closed:
+    // a configured plane whose bearer resolves to any OTHER subject than the boot viewer would
+    // silently re-attribute every admission decision — refusal is the only honest outcome.
+    const planeBase   = AiConfig.fleet.planeBase.trim(),
+          planeClient = planeBase ? createPlaneMailboxClient({
+              baseUrl   : `${planeBase.replace(/\/+$/, '')}/mc/mcp`,
+              credential: AiConfig.fleet.planeBearer
+          }) : null;
+
+    if (planeClient) {
+        const admission = await planeClient.init({expectedIdentity: viewer.agentIdentityNodeId});
+
+        if (!admission.ok) {
+            console.error(`[fleet] plane mode refused (${planeBase}): ${admission.reason ?? `status ${admission.status}`} — fix fleet.planeBase / fleet.planeBearer, or empty the base for in-process mode.`);
+            process.exit(1)
+        }
+
+        console.log(`[fleet] mailbox/compose/catch-up seams bound to the containerized plane at ${planeBase} (viewer-verified: ${admission.identity})`)
+    } else {
+        console.log('[fleet] fleet.planeBase is empty — mailbox/compose/catch-up seams stay in-process (host plane).')
+    }
+
     // Wire the wake-telltale producer sources (the S2 axis): the config-resolved daemon PID path +
     // the trusted bulk subscription scan. This entrypoint is where config resolution belongs; the
     // adapter itself never resolves it. Fail-soft by construction — a failing scan or an absent
@@ -91,25 +120,42 @@ async function boot() {
     // the pulls reader fills the composer's last honest-empty slot so the PR/lane slot emits pr-activity
     // events (opens/reviews/merges) alongside issues + lane-claims + stall. Fail-soft: an unavailable
     // singleton leaves activitySource unwired.
-    Promise.all([
-        import('../memory-core/MailboxService.mjs'),
-        import('../memory-core/GraphService.mjs')
-    ]).then(([{default: MailboxService}, {default: GraphService}]) => {
+    if (planeClient) {
+        // Plane mode: both seams ride the verified client — no in-process memory-core spin-up at
+        // all (opening the host graph/mailbox is the split-brain read this mode exists to end).
+        // The PR/lane slot's OPTIONAL graphService is deliberately absent: its stall
+        // defer-disposition degrades per that slot's own fail-soft contract while issues/pulls
+        // keep reading the git-synced local trees (correctly host-local, ticket Out of Scope).
         wireFleetActivityReadSource({
             issuesDir   : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../resources/content/issues'),
             pullsDir    : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../resources/content/pulls'),
-            listMessages: MailboxService.listMessages.bind(MailboxService),
-            graphService: GraphService
+            listMessages: args => planeClient.listMessages(args)
         });
 
-        // The write-side sibling: the composeOperatorMessage verb's writer. Same lazy-singleton
-        // boundary discipline — the bound addMessage resolves the author + principal class from
-        // the request context the authenticated ingress stamped; the seam carries payload, never
-        // identity. Fail-soft: an unavailable singleton leaves the compose seam honestly unwired.
         wireOperatorComposeWriter({
-            addMessage: MailboxService.addMessage.bind(MailboxService)
+            addMessage: args => planeClient.addMessage(args)
         })
-    }).catch(error => console.warn('[fleet] activity source not wired:', error?.message ?? error));
+    } else {
+        Promise.all([
+            import('../memory-core/MailboxService.mjs'),
+            import('../memory-core/GraphService.mjs')
+        ]).then(([{default: MailboxService}, {default: GraphService}]) => {
+            wireFleetActivityReadSource({
+                issuesDir   : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../resources/content/issues'),
+                pullsDir    : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../resources/content/pulls'),
+                listMessages: MailboxService.listMessages.bind(MailboxService),
+                graphService: GraphService
+            });
+
+            // The write-side sibling: the composeOperatorMessage verb's writer. Same lazy-singleton
+            // boundary discipline — the bound addMessage resolves the author + principal class from
+            // the request context the authenticated ingress stamped; the seam carries payload, never
+            // identity. Fail-soft: an unavailable singleton leaves the compose seam honestly unwired.
+            wireOperatorComposeWriter({
+                addMessage: MailboxService.addMessage.bind(MailboxService)
+            })
+        }).catch(error => console.warn('[fleet] activity source not wired:', error?.message ?? error))
+    }
 
     // The mailbox mirror goes live ONLY behind the boundary: the adapter + MailboxService load
     // lazily (the established cross-process read pattern — pay the memory-core import when a pane
@@ -127,11 +173,13 @@ async function boot() {
     // notAuthority envelopes included) through a lazy import; no MCP code crosses into the Body.
     // The closure holds zero result cache. The source instance holds only per-viewer runtime anchors,
     // so a cockpit reload preserves them while this process lives and a service restart resets them.
-    const callHistoryOperation = async (name, args) => {
-        const {callTool} = await import('../../mcp/server/memory-core/toolService.mjs');
+    const callHistoryOperation = planeClient
+        ? (name, args) => planeClient.callTool(name, args)
+        : async (name, args) => {
+            const {callTool} = await import('../../mcp/server/memory-core/toolService.mjs');
 
-        return callTool(name, args)
-    };
+            return callTool(name, args)
+        };
 
     wireFleetCatchUpSource({
         exploreMemoryHistory     : args => callHistoryOperation('explore_memory_history', args),
@@ -141,10 +189,20 @@ async function boot() {
 
     FleetControlBridge.mailboxMirrorSource = {
         async readMailboxMirror(params = {}) {
-            const [{readFleetMailboxMirror}, {default: MailboxService}] = await Promise.all([
-                import('./fleetMailboxMirrorAdapter.mjs'),
-                import('../memory-core/MailboxService.mjs')
-            ]);
+            const {readFleetMailboxMirror} = await import('./fleetMailboxMirrorAdapter.mjs');
+
+            // Plane mode keeps the audit contract intact: the read executes as the plane bearer's
+            // subject, which init PROVED is the boot viewer — the same identity the ingress stamps
+            // on every request and resolveBoundIdentity reports. One identity, two witnesses.
+            if (planeClient) {
+                return readFleetMailboxMirror({
+                    listMessages        : args => planeClient.listMessages(args),
+                    resolveBoundIdentity: () => RequestContextService.getAgentIdentityNodeId(),
+                    ...params
+                })
+            }
+
+            const {default: MailboxService} = await import('../memory-core/MailboxService.mjs');
 
             return readFleetMailboxMirror({
                 mailboxService      : MailboxService,
@@ -165,6 +223,7 @@ async function boot() {
 
         const cleanShutdown = signal => {
             console.log(`[fleet] received ${signal}; stopping.`);
+            planeClient?.close();
             server.close(() => process.exit(0))
         };
 

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -12,9 +12,13 @@
  *    mode: the launcher holds the value in memory and hands the browser its half in-process; env is
  *    the in-memory channel, and a malformed value REFUSES startup rather than silently regenerating),
  *    else generates a fresh one. The bearer is never logged, persisted, or echoed by this process.
- * 2. resolves and BINDS the viewer — the stdio identity chain (`NEO_AGENT_IDENTITY` → gh CLI) must
- *    land on a seeded `AgentIdentity` graph node, or startup fails closed with a named remediation:
- *    every admitted request is stamped with this viewer, so serving without one is unattributable.
+ * 2. resolves and BINDS the viewer — the stdio identity chain (`NEO_AGENT_IDENTITY` → gh CLI)
+ *    produces the claim; its VERIFICATION authority depends on the mailbox-seam plane (step 5):
+ *    in-process mode verifies against a seeded host `AgentIdentity` graph node, while plane mode
+ *    verifies plane-side (the client's `list_permissions` proof binds the bearer's server-resolved
+ *    subject to the claim) and deliberately never opens host Memory Core — a missing or stale host
+ *    graph cannot veto a healthy configured plane. Either way startup fails closed with a named
+ *    remediation: every admitted request is stamped with this viewer.
  * 3. on an occupied port, probes the incumbent through its authenticated `/fleet/probe`: reuse only
  *    on "same token, same viewer"; anything else exits with the probe's named refusal — an unknown,
  *    stale, or wrong-viewer process is never silently adopted.
@@ -48,7 +52,8 @@ import RequestContextService                                              from '
 import FleetControlBridge                                                 from './FleetControlBridge.mjs';
 import FleetManager                                                       from './FleetManager.mjs';
 import {startFleetBridgeServer}                                           from './fleetBridgeServer.mjs';
-import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer} from './fleetLaunchContract.mjs';
+import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer,
+        resolveFleetViewerClaim}                                          from './fleetLaunchContract.mjs';
 import {createPlaneMailboxClient}                                         from './planeMailboxClient.mjs';
 import {readActiveWakeSubscriptionIdentities}                             from './readActiveWakeSubscriptionIdentities.mjs';
 import {wireBootIdentityReadSource}                                       from './wireBootIdentityReadSource.mjs';
@@ -67,37 +72,49 @@ const port = Number(process.env.NEO_FLEET_PORT) || 8083;
  */
 async function boot() {
     const bearerToken = resolveFleetBearer({suppliedToken: process.env.NEO_FLEET_BEARER}),
-          viewer      = await resolveFleetViewer(),
           origins     = (process.env.NEO_FLEET_COCKPIT_ORIGIN || 'http://localhost:8080,http://127.0.0.1:8080')
               .split(',').map(origin => origin.trim()).filter(Boolean);
 
-    // Wire the cross-process boot-identity reader BEFORE serving: getBootIdentity() then serves the
-    // orchestrator's advisory fact from the shared runtime-state dir (read at this use site), instead of
-    // the advisory-unknown fallback. Fail-soft — an absent dir leaves the seam honestly unwired.
-    wireBootIdentityReadSource({dir: AiConfig.orchestrator.dataDir});
-
-    // The mailbox-seam plane decision: resolved ONCE at boot, all-or-nothing, logged. The
-    // leaves resolve here at the use site (the AiConfig SSOT contract); the client itself reads no config. Fail-closed:
-    // a configured plane whose bearer resolves to any OTHER subject than the boot viewer would
-    // silently re-attribute every admission decision — refusal is the only honest outcome.
+    // The mailbox-seam plane decision: resolved ONCE at boot, BEFORE viewer binding, all-or-nothing,
+    // logged. The leaves resolve here at the use site (the AiConfig SSOT contract); the client itself
+    // reads no config. The decision also selects the viewer's VERIFICATION AUTHORITY:
+    //  - plane mode: the graphless identity claim (env/gh chain only) is verified by the PLANE —
+    //    the client's init proves the bearer's server-resolved subject IS the claim. Host Memory
+    //    Core is never opened, so a missing/stale host graph cannot veto a healthy plane. Fail-closed:
+    //    a bearer resolving to any OTHER subject would silently re-attribute every admission
+    //    decision — refusal is the only honest outcome.
+    //  - in-process mode: the existing host-graph verification (seeded AgentIdentity node).
     const planeBase   = AiConfig.fleet.planeBase.trim(),
           planeClient = planeBase ? createPlaneMailboxClient({
               baseUrl   : `${planeBase.replace(/\/+$/, '')}/mc/mcp`,
               credential: AiConfig.fleet.planeBearer
           }) : null;
 
+    let viewer;
+
     if (planeClient) {
+        viewer = await resolveFleetViewerClaim();
+
         const admission = await planeClient.init({expectedIdentity: viewer.agentIdentityNodeId});
 
         if (!admission.ok) {
-            console.error(`[fleet] plane mode refused (${planeBase}): ${admission.reason ?? `status ${admission.status}`} — fix fleet.planeBase / fleet.planeBearer, or empty the base for in-process mode.`);
+            console.error(`[fleet] plane mode refused (${planeBase}): ${admission.reason} — fix fleet.planeBase / fleet.planeBearer, or empty the base for in-process mode.`);
             process.exit(1)
         }
 
-        console.log(`[fleet] mailbox/compose/catch-up seams bound to the containerized plane at ${planeBase} (viewer-verified: ${admission.identity})`)
+        // The boot witness: name the verification authority explicitly so a capture/log always
+        // shows WHICH plane verified this viewer (and that the host graph was not consulted).
+        console.log(`[fleet] mailbox/compose/catch-up seams bound to the containerized plane at ${planeBase} (viewer ${admission.identity} verified plane-side; host graph not consulted)`)
     } else {
-        console.log('[fleet] fleet.planeBase is empty — mailbox/compose/catch-up seams stay in-process (host plane).')
+        viewer = await resolveFleetViewer();
+
+        console.log('[fleet] fleet.planeBase is empty — mailbox/compose/catch-up seams stay in-process (host plane; viewer verified against the host graph).')
     }
+
+    // Wire the cross-process boot-identity reader BEFORE serving: getBootIdentity() then serves the
+    // orchestrator's advisory fact from the shared runtime-state dir (read at this use site), instead of
+    // the advisory-unknown fallback. Fail-soft — an absent dir leaves the seam honestly unwired.
+    wireBootIdentityReadSource({dir: AiConfig.orchestrator.dataDir});
 
     // Wire the wake-telltale producer sources (the S2 axis): the config-resolved daemon PID path +
     // the trusted bulk subscription scan. This entrypoint is where config resolution belongs; the

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -238,9 +238,11 @@ async function boot() {
             runInContext  : (context, fn) => RequestContextService.run(context, fn)
         });
 
-        const cleanShutdown = signal => {
+        // AWAITED plane teardown before every exit: an un-awaited close races process death, which
+        // leaks the proven plane session (the server reaps it only on its own timeline).
+        const cleanShutdown = async signal => {
             console.log(`[fleet] received ${signal}; stopping.`);
-            planeClient?.close();
+            await planeClient?.close();
             server.close(() => process.exit(0))
         };
 
@@ -261,12 +263,16 @@ async function boot() {
             agentIdentityNodeId: viewer.agentIdentityNodeId
         });
 
+        // Both occupied-port exits close the proven plane session AWAITED — reuse and refusal alike
+        // would otherwise orphan it on the plane.
         if (probe.reusable) {
             console.log(`[fleet] healthy Fleet already listening on port ${port} (${probe.reason}; viewer: ${probe.viewer}, pid: ${probe.pid}) — reusing it.`);
+            await planeClient?.close();
             process.exit(0)
         }
 
         console.error(`[fleet] port ${port} is occupied and NOT reusable: ${probe.reason}`);
+        await planeClient?.close();
         process.exit(1)
     }
 }

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -111,6 +111,11 @@ async function boot() {
         console.log('[fleet] fleet.planeBase is empty — mailbox/compose/catch-up seams stay in-process (host plane; viewer verified against the host graph).')
     }
 
+    // From here on, EVERY exit — wiring throws included — closes the proven plane session awaited:
+    // the try below spans the whole post-admission life (wiring + serve + occupied-port handling),
+    // so the ALL-exits close guarantee is structural, not prose.
+    try {
+
     // Wire the cross-process boot-identity reader BEFORE serving: getBootIdentity() then serves the
     // orchestrator's advisory fact from the shared runtime-state dir (read at this use site), instead of
     // the advisory-unknown fallback. Fail-soft — an absent dir leaves the seam honestly unwired.
@@ -229,7 +234,6 @@ async function boot() {
         }
     };
 
-    try {
         const server = await startFleetBridgeServer({
             port,
             bearerToken,

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -43,25 +43,25 @@
 
 // Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate globalThis.Neo so
 // the fleet singletons' `Neo.setupClass` succeeds at module-load; `InstanceManager` binds the aliases.
-import Neo                                                                from '../../../src/Neo.mjs';
-import * as core                                                          from '../../../src/core/_export.mjs';
-import InstanceManager                                                    from '../../../src/manager/Instance.mjs';
-import AiConfig                                                           from '../../config.mjs';
-import memoryCoreConfig                                                   from '../../mcp/server/memory-core/config.mjs';
-import RequestContextService                                              from '../../mcp/server/shared/services/RequestContextService.mjs';
-import FleetControlBridge                                                 from './FleetControlBridge.mjs';
-import FleetManager                                                       from './FleetManager.mjs';
-import {startFleetBridgeServer}                                           from './fleetBridgeServer.mjs';
+import Neo                      from '../../../src/Neo.mjs';
+import * as core                from '../../../src/core/_export.mjs';
+import InstanceManager          from '../../../src/manager/Instance.mjs';
+import AiConfig                 from '../../config.mjs';
+import memoryCoreConfig         from '../../mcp/server/memory-core/config.mjs';
+import RequestContextService    from '../../mcp/server/shared/services/RequestContextService.mjs';
+import FleetControlBridge       from './FleetControlBridge.mjs';
+import FleetManager             from './FleetManager.mjs';
+import {startFleetBridgeServer} from './fleetBridgeServer.mjs';
 import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer,
         resolveFleetViewerClaim}                                          from './fleetLaunchContract.mjs';
-import {createPlaneMailboxClient}                                         from './planeMailboxClient.mjs';
-import {readActiveWakeSubscriptionIdentities}                             from './readActiveWakeSubscriptionIdentities.mjs';
-import {wireBootIdentityReadSource}                                       from './wireBootIdentityReadSource.mjs';
-import {wireFleetActivityReadSource}                                      from './wireFleetActivityReadSource.mjs';
-import {wireFleetCatchUpSource}                                           from './wireFleetCatchUpSource.mjs';
-import {wireOperatorComposeWriter}                                        from './wireOperatorComposeWriter.mjs';
-import path                                                               from 'node:path';
-import {fileURLToPath, pathToFileURL}                                     from 'node:url';
+import {createPlaneMailboxClient}             from './planeMailboxClient.mjs';
+import {readActiveWakeSubscriptionIdentities} from './readActiveWakeSubscriptionIdentities.mjs';
+import {wireBootIdentityReadSource}           from './wireBootIdentityReadSource.mjs';
+import {wireFleetActivityReadSource}          from './wireFleetActivityReadSource.mjs';
+import {wireFleetCatchUpSource}               from './wireFleetCatchUpSource.mjs';
+import {wireOperatorComposeWriter}            from './wireOperatorComposeWriter.mjs';
+import path                                   from 'node:path';
+import {fileURLToPath, pathToFileURL}         from 'node:url';
 
 const port = Number(process.env.NEO_FLEET_PORT) || 8083;
 
@@ -253,18 +253,29 @@ async function boot() {
         // process emits; the launcher that supplied (or will inject) it owns the hand-off.
         console.log(`[fleet] authenticated app<->fleet transport listening on http://127.0.0.1:${server.address().port}/fleet (viewer: ${viewer.agentIdentityNodeId}, bearer: ${process.env.NEO_FLEET_BEARER ? 'supplied' : 'generated'})`)
     } catch (error) {
-        if (error?.code !== 'EADDRINUSE') throw error;
+        // EVERY exit below this line closes the proven plane session AWAITED — startup failures,
+        // probe failures, reuse, and refusal alike would otherwise orphan it on the plane. The
+        // client's close() is a shared terminal barrier, so overlapping closers are safe.
+        if (error?.code !== 'EADDRINUSE') {
+            await planeClient?.close();
+            throw error
+        }
 
         // Occupied port: reuse-or-refuse through the incumbent's authenticated probe — never
         // silent adoption of a process we cannot verify.
-        const probe = await probeExistingFleetServer({
-            probeUrl           : `http://127.0.0.1:${port}/fleet/probe`,
-            bearerToken,
-            agentIdentityNodeId: viewer.agentIdentityNodeId
-        });
+        let probe;
 
-        // Both occupied-port exits close the proven plane session AWAITED — reuse and refusal alike
-        // would otherwise orphan it on the plane.
+        try {
+            probe = await probeExistingFleetServer({
+                probeUrl           : `http://127.0.0.1:${port}/fleet/probe`,
+                bearerToken,
+                agentIdentityNodeId: viewer.agentIdentityNodeId
+            })
+        } catch (probeError) {
+            await planeClient?.close();
+            throw probeError
+        }
+
         if (probe.reusable) {
             console.log(`[fleet] healthy Fleet already listening on port ${port} (${probe.reason}; viewer: ${probe.viewer}, pid: ${probe.pid}) — reusing it.`);
             await planeClient?.close();

--- a/ai/services/fleet/fleetLaunchContract.mjs
+++ b/ai/services/fleet/fleetLaunchContract.mjs
@@ -17,24 +17,23 @@ import {normalizeAgentIdentityNodeId}                 from '../../graph/normaliz
  */
 
 /**
- * @summary Resolves and BINDS the Fleet viewer at trusted server bootstrap — fail-closed.
+ * @summary Resolves the Fleet viewer's identity CLAIM — the graphless first half of viewer binding.
  *
- * Composition mirrors the memory-core stdio boot (identity chain → canonical node id → seeded
- * graph-node verification) with one deliberate inversion: where memory-core treats a missing
- * graph node as single-tenant fallthrough, Fleet REFUSES to serve. The viewer identity is what
- * every admitted request gets stamped with; serving without a bound one would make admission
- * facts unattributable.
+ * Runs only the identity chain (env-var → gh CLI) and canonical node-id derivation; it deliberately
+ * touches NO Memory Core surface. Plane-mode boot consumes this claim and lets the plane itself
+ * verify it (the plane-side `list_permissions` proof binds the bearer's server-resolved subject to
+ * this claim), so a missing or stale HOST graph can never veto a healthy configured plane. The
+ * in-process mode composes this claim with the host-graph verification via
+ * {@link resolveFleetViewer}.
  *
  * @param {Object}   [options]
  * @param {Function} [options.resolveIdentity] `() => Promise<{githubLogin, username, source}>` —
  *     defaults to the shared stdio resolver (env-var → gh CLI chain), lazily imported so tests
  *     inject without paying the Neo-class import.
- * @param {Function} [options.getGraphService] `() => Promise<{ready, getNode}>` — defaults to the
- *     memory-core GraphService, lazily imported per the established cross-process read pattern.
  * @returns {Promise<{userId: String, username: String, agentIdentityNodeId: String, source: String}>}
- * @throws {Error} Named, remediation-bearing refusals for the unresolved and unseeded cases.
+ * @throws {Error} The named, remediation-bearing refusal for the unresolved case.
  */
-export async function resolveFleetViewer({resolveIdentity = null, getGraphService = null} = {}) {
+export async function resolveFleetViewerClaim({resolveIdentity = null} = {}) {
     const resolve = resolveIdentity
         || (async () => (await import('../../mcp/server/shared/services/StdioIdentityResolver.mjs')).default.resolve());
 
@@ -48,7 +47,37 @@ export async function resolveFleetViewer({resolveIdentity = null, getGraphServic
         )
     }
 
-    const nodeId  = normalizeAgentIdentityNodeId(identity.githubLogin),
+    return {
+        userId             : identity.githubLogin,
+        username           : identity.username || identity.githubLogin,
+        agentIdentityNodeId: normalizeAgentIdentityNodeId(identity.githubLogin),
+        source             : identity.source
+    }
+}
+
+/**
+ * @summary Resolves and BINDS the Fleet viewer at trusted server bootstrap — fail-closed.
+ *
+ * Composition mirrors the memory-core stdio boot (identity chain → canonical node id → seeded
+ * graph-node verification) with one deliberate inversion: where memory-core treats a missing
+ * graph node as single-tenant fallthrough, Fleet REFUSES to serve. The viewer identity is what
+ * every admitted request gets stamped with; serving without a bound one would make admission
+ * facts unattributable.
+ *
+ * This is the IN-PROCESS mode binding: the {@link resolveFleetViewerClaim} claim verified against
+ * the host graph. Plane-mode boot uses the claim alone — its verification authority is the plane.
+ *
+ * @param {Object}   [options]
+ * @param {Function} [options.resolveIdentity] Forwarded to {@link resolveFleetViewerClaim}.
+ * @param {Function} [options.getGraphService] `() => Promise<{ready, getNode}>` — defaults to the
+ *     memory-core GraphService, lazily imported per the established cross-process read pattern.
+ * @returns {Promise<{userId: String, username: String, agentIdentityNodeId: String, source: String}>}
+ * @throws {Error} Named, remediation-bearing refusals for the unresolved and unseeded cases.
+ */
+export async function resolveFleetViewer({resolveIdentity = null, getGraphService = null} = {}) {
+    const claim = await resolveFleetViewerClaim({resolveIdentity});
+
+    const nodeId  = claim.agentIdentityNodeId,
           service = getGraphService
               ? await getGraphService()
               : (await import('../memory-core/GraphService.mjs')).default;
@@ -59,7 +88,7 @@ export async function resolveFleetViewer({resolveIdentity = null, getGraphServic
 
     if (node?.type !== 'AgentIdentity') {
         throw new Error(
-            `[fleet] startup refused: resolved viewer '${identity.githubLogin}' has no seeded ` +
+            `[fleet] startup refused: resolved viewer '${claim.userId}' has no seeded ` +
             `AgentIdentity node ${nodeId}. The handle is stale, renamed, or unseeded — fix ` +
             'NEO_AGENT_IDENTITY or seed it via seedAgentIdentities.mjs. Serving without a bound ' +
             'viewer would make admission unattributable, so the Fleet ingress fails closed.'
@@ -67,10 +96,8 @@ export async function resolveFleetViewer({resolveIdentity = null, getGraphServic
     }
 
     return {
-        userId             : identity.githubLogin,
-        username           : identity.username || identity.githubLogin,
-        agentIdentityNodeId: node.id,
-        source             : identity.source
+        ...claim,
+        agentIdentityNodeId: node.id
     }
 }
 

--- a/ai/services/fleet/mcpWireParsing.mjs
+++ b/ai/services/fleet/mcpWireParsing.mjs
@@ -1,0 +1,72 @@
+/**
+ * @module ai/services/fleet/mcpWireParsing
+ * @summary The fleet subsystem's ONE MCP-wire parsing authority — the pure envelope/payload/identity
+ * helpers shared by the tenant readiness probe (`FleetTenantService.initializeMcpResource`) and the
+ * plane mailbox client (`planeMailboxClient.mjs`).
+ *
+ * Extracted standalone (no Neo, no config, no service imports) for two reasons: per-module security
+ * copies are a known defect class (five redactors, three authors, zero complete copies), and a pure
+ * module keeps unit suites hermetic — consumers can be spec'd without dragging the tenant service's
+ * class-system import graph into the test process.
+ */
+
+/**
+ * @summary Normalize a provider login / AgentIdentity node id to the canonical `@login` shape.
+ * The provider response is remote-authored, so malformed values fail closed instead of crossing
+ * into diagnostics.
+ * @param {*} value
+ * @returns {String|null}
+ */
+export function normalizeAgentIdentity(value) {
+    if (typeof value !== 'string') return null;
+
+    const login = value.trim().replace(/^AGENT_IDENTITY:/, '').replace(/^@/, '');
+
+    return login && /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})$/.test(login) ? `@${login}` : null
+}
+
+/**
+ * @summary Parse one JSON or SSE MCP response envelope without forwarding remote prose.
+ * @param {String} text
+ * @returns {Object|null}
+ */
+export function parseMcpEnvelope(text) {
+    try {
+        return JSON.parse(text)
+    } catch {}
+
+    for (const line of String(text).split(/\r?\n/)) {
+        if (!line.startsWith('data:')) continue;
+
+        try {
+            return JSON.parse(line.slice(5).trim())
+        } catch {}
+    }
+
+    return null
+}
+
+/**
+ * @summary Read the JSON payload of one MCP tool result. Only structured JSON or a JSON text item
+ * is accepted; arbitrary remote text never becomes a diagnostic.
+ * @param {Object|null} envelope
+ * @returns {Object|null}
+ */
+export function readMcpToolPayload(envelope) {
+    const result = envelope?.result;
+
+    if (!result || result.isError) return null;
+    if (result.structuredContent && typeof result.structuredContent === 'object') {
+        return result.structuredContent
+    }
+
+    const text = result.content?.find?.(item => item?.type === 'text')?.text;
+
+    if (typeof text !== 'string') return null;
+
+    try {
+        return JSON.parse(text)
+    } catch {
+        return null
+    }
+}

--- a/ai/services/fleet/mcpWireParsing.mjs
+++ b/ai/services/fleet/mcpWireParsing.mjs
@@ -11,6 +11,56 @@
  */
 
 /**
+ * Hosts for which plain `http:` is accepted. Deliberately an exact set rather than a range or a
+ * pattern: this is the one exception to the TLS rule that protects the bearer, so it stays small
+ * enough to audit at a glance. `[::1]` keeps its brackets: compared against `URL#hostname`, which
+ * returns the IPv6 literal bracketed.
+ * @type {Set<String>}
+ */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+/**
+ * @summary Canonical origin+path form (no trailing slash) so one endpoint maps to one identity.
+ * @param {URL} url
+ * @returns {String}
+ * @private
+ */
+function canonicalize(url) {
+    return (url.origin + url.pathname).replace(/\/+$/, '');
+}
+
+/**
+ * @summary The shared endpoint-boundary policy for authenticated MCP consumption: http/https only,
+ * no credentials-in-URL (a URL-embedded secret would bypass the credential store and land in logs),
+ * and TLS required for anything remote — plain `http:` survives only for exact loopback hosts,
+ * where there is no network hop to intercept. Returns the canonical endpoint or `null`.
+ *
+ * One policy, two consumers: the tenant connect flow (`FleetTenantService.normalizeEndpoint`) and
+ * the plane mailbox client validate through this single definition.
+ * @param {*} candidateUrl
+ * @returns {String|null}
+ */
+export function normalizeSecureMcpEndpoint(candidateUrl) {
+    if (typeof candidateUrl !== 'string' || candidateUrl.trim() === '') return null;
+
+    let url;
+
+    try {
+        url = new URL(candidateUrl.trim());
+    } catch {
+        return null;
+    }
+
+    if (url.username || url.password) return null;
+
+    if (url.protocol === 'https:') return canonicalize(url);
+
+    if (url.protocol === 'http:' && LOOPBACK_HOSTS.has(url.hostname)) return canonicalize(url);
+
+    return null
+}
+
+/**
  * @summary Normalize a provider login / AgentIdentity node id to the canonical `@login` shape.
  * The provider response is remote-authored, so malformed values fail closed instead of crossing
  * into diagnostics.
@@ -49,12 +99,20 @@ export function parseMcpEnvelope(text) {
 /**
  * @summary Read the JSON payload of one MCP tool result. Only structured JSON or a JSON text item
  * is accepted; arbitrary remote text never becomes a diagnostic.
- * @param {Object|null} envelope
+ * @param {Object|null} envelope A JSON-RPC response envelope (`{result}`).
  * @returns {Object|null}
  */
 export function readMcpToolPayload(envelope) {
-    const result = envelope?.result;
+    return readMcpToolResultPayload(envelope?.result)
+}
 
+/**
+ * @summary The bare-result sibling of {@link readMcpToolPayload} for SDK-client callers, which
+ * receive the CallToolResult directly rather than a JSON-RPC envelope. Same acceptance rule.
+ * @param {Object|null} result
+ * @returns {Object|null}
+ */
+export function readMcpToolResultPayload(result) {
     if (!result || result.isError) return null;
     if (result.structuredContent && typeof result.structuredContent === 'object') {
         return result.structuredContent

--- a/ai/services/fleet/planeMailboxClient.mjs
+++ b/ai/services/fleet/planeMailboxClient.mjs
@@ -90,18 +90,33 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
         closing      = null; // the shared terminal close barrier every closer awaits
 
     /**
+     * Every teardown in flight, OBSERVABLE to the close barrier: a failing caller's candidate-local
+     * teardown runs outside the barrier's own awaits, and an unobservable one would let `close()`
+     * resolve — and a signal handler exit — while a stale-session DELETE is still pending.
+     * @type {Set<Promise>}
+     */
+    const pendingTeardowns = new Set();
+
+    /**
      * @summary Tear one session down, awaited and tolerant: the plane-side session DELETE
      * (`terminateSession`) then the transport close, each best-effort so a refusal exit can never
-     * leak a half-open session or mask the refusal itself.
+     * leak a half-open session or mask the refusal itself. Enrolled in {@link pendingTeardowns} so
+     * the close barrier drains EVERY in-flight teardown before it resolves, whoever started it.
      * @param {Object|null} candidate `{client, transport}`
      * @returns {Promise<void>}
      * @private
      */
-    async function teardown(candidate) {
-        if (!candidate) return;
+    function teardown(candidate) {
+        if (!candidate) return Promise.resolve();
 
-        try { await candidate.transport?.terminateSession?.() } catch { /* reaped or unreachable */ }
-        try { await candidate.client?.close?.() }               catch { /* already closed */ }
+        const work = (async () => {
+            try { await candidate.transport?.terminateSession?.() } catch { /* reaped or unreachable */ }
+            try { await candidate.client?.close?.() }               catch { /* already closed */ }
+        })().finally(() => pendingTeardowns.delete(work));
+
+        pendingTeardowns.add(work);
+
+        return work
     }
 
     /**
@@ -370,8 +385,16 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
 
                 session = null;
 
-                await teardown(held);
-                await teardown(late)
+                teardown(held);
+                teardown(late);
+
+                // Drain EVERY in-flight teardown — the barrier's own two above AND any
+                // candidate-local teardown a concurrently failing caller started before or during
+                // this close. A signal handler awaiting close() therefore never exits while a
+                // stale-session DELETE is still pending.
+                while (pendingTeardowns.size) {
+                    await Promise.allSettled([...pendingTeardowns])
+                }
             })();
 
             return closing

--- a/ai/services/fleet/planeMailboxClient.mjs
+++ b/ai/services/fleet/planeMailboxClient.mjs
@@ -85,7 +85,8 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
     });
 
     let session = null, // {client, transport, identity} once proven
-        expected = null;
+        expected     = null,
+        establishing = null; // the single-flight proof attempt every concurrent acquirer shares
 
     /**
      * @summary Tear one session down, awaited and tolerant: the plane-side session DELETE
@@ -152,6 +153,35 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
     }
 
     /**
+     * @summary SINGLE-FLIGHT proven-session acquisition: every concurrent acquirer (recovering
+     * callers, lazy re-establishment, init) shares ONE `connectProven` attempt — N failures never
+     * produce N parallel handshakes, so exactly one proven session exists afterwards and no proven
+     * session is orphaned by a later candidate overwriting the shared slot.
+     * @returns {Promise<Object>} The shared attempt's bounded `{ok, identity?, reason?}`.
+     * @private
+     */
+    function acquireProven() {
+        establishing ||= connectProven().finally(() => { establishing = null });
+
+        return establishing
+    }
+
+    /**
+     * @summary Positively identified session-invalid failure — the SDK's proven 404 class (the
+     * streamable-HTTP server answers 404 for a stale/unknown `mcp-session-id`). ONLY this class is
+     * replay-eligible: a timeout, network error, or 5xx is AMBIGUOUS — the server may have already
+     * committed the call — and an ambiguous mutating replay double-sends (MC assigns a fresh
+     * message id per `add_message` invocation, so a replay is a second durable message, never a
+     * dedupe).
+     * @param {*} error
+     * @returns {Boolean}
+     * @private
+     */
+    function isSessionInvalid(error) {
+        return error?.code === 404 || /\bHTTP 404\b/.test(error?.message ?? '')
+    }
+
+    /**
      * @summary Map one SDK CallToolResult into the in-process contract: tool errors throw their own
      * text, malformed payloads throw bounded, valid payloads return parsed.
      * @param {String} name
@@ -196,19 +226,25 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
 
             expected = next;
 
-            return connectProven()
+            return acquireProven()
         },
 
         /**
          * @summary Call one plane tool and return its parsed JSON payload. Throws like the
          * in-process services so the adapters' degraded/denied mapping applies unchanged.
          *
-         * Recovery contract: at most ONE proven reconnect per invocation. A transport-level failure
-         * mid-call triggers it with a single replay; a call arriving while no session is held (a
-         * previous recovery failed — the plane was down at that moment) SPENDS it up front on lazy
-         * re-establishment instead of staying bricked until re-init. Every reconnect must RE-PROVE
-         * the same identity before any request rides it; an unprovable or changed identity throws
-         * without replaying.
+         * Recovery contract, three rules with teeth:
+         * 1. **Replay only the proven session-invalid class** (the SDK's 404 on a stale
+         *    `mcp-session-id`), at most once per invocation. A timeout, network error, or 5xx is
+         *    AMBIGUOUS — the server may have committed the call — so it throws instead of
+         *    replaying: for `add_message` a replay would be a SECOND durable message, and the
+         *    honest answer for reads is the adapters' degraded state, not a maybe-doubled read.
+         * 2. **Acquisition is single-flight** ({@link acquireProven}): concurrent recovering
+         *    callers share one re-proof; a lazy re-establishment after an earlier failed recovery
+         *    rides the same gate, so the client never bricks and never races handshakes.
+         * 3. **Clearing is candidate-local**: a failing caller only clears/tears the session IT
+         *    rode, and only while that session is still current — a caller failing on an
+         *    already-replaced session must not destroy its successor.
          * @param {String} name Registered MC tool name (e.g. `list_messages`).
          * @param {Object} [args]
          * @returns {Promise<Object>}
@@ -219,7 +255,7 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
             let recovered = false;
 
             if (!session) {
-                const readmission = await connectProven();
+                const readmission = await acquireProven();
 
                 if (!readmission.ok) {
                     throw new Error(`plane ${name} failed: session lost and ${readmission.reason}`)
@@ -228,15 +264,24 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
                 recovered = true
             }
 
+            const mine = session;
+
             let result;
 
             try {
-                result = await session.client.callTool({name, arguments: args})
+                result = await mine.client.callTool({name, arguments: args})
             } catch (error) {
-                const lost = session;
+                // Candidate-local clear: only the still-current failed session is cleared and torn
+                // down; when a concurrent caller already replaced it, the successor stays untouched
+                // (the replacer's own failure path tore the shared predecessor exactly once).
+                if (session === mine) {
+                    session = null;
+                    await teardown(mine)
+                }
 
-                session = null;
-                await teardown(lost);
+                if (!isSessionInvalid(error)) {
+                    throw new Error(`plane ${name} failed: ${error?.name ?? 'call failure'} (ambiguous — not replayed)`)
+                }
 
                 if (recovered) {
                     // This invocation already spent its one reconnect — a second failure on a
@@ -244,13 +289,15 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
                     throw new Error(`plane ${name} failed: ${error?.name ?? 'call failure'} on a freshly established session`)
                 }
 
-                const readmission = await connectProven();
+                const readmission = await acquireProven();
 
                 if (!readmission.ok) {
                     throw new Error(`plane ${name} failed: session lost and ${readmission.reason}`)
                 }
 
-                result = await session.client.callTool({name, arguments: args})
+                const fresh = session;
+
+                result = await fresh.client.callTool({name, arguments: args})
             }
 
             return mapToolResult(name, result)
@@ -279,7 +326,9 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
          * is TERMINAL: it clears the held identity expectation, so later calls answer
          * "client not initialized" instead of lazily resurrecting a deliberately shut-down client
          * (lazy re-establishment is reserved for failed recoveries, where the intent to serve
-         * still stands).
+         * still stands). An acquisition in flight at close time cannot resurrect either: clearing
+         * `expected` first makes the in-flight proof land on its own mismatch path, which tears the
+         * candidate down without storing it.
          * @returns {Promise<void>}
          */
         async close() {

--- a/ai/services/fleet/planeMailboxClient.mjs
+++ b/ai/services/fleet/planeMailboxClient.mjs
@@ -86,7 +86,8 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
 
     let session = null, // {client, transport, identity} once proven
         expected     = null,
-        establishing = null; // the single-flight proof attempt every concurrent acquirer shares
+        establishing = null, // the single-flight proof attempt every concurrent acquirer shares
+        closing      = null; // the shared terminal close barrier every closer awaits
 
     /**
      * @summary Tear one session down, awaited and tolerant: the plane-side session DELETE
@@ -153,14 +154,20 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
     }
 
     /**
-     * @summary SINGLE-FLIGHT proven-session acquisition: every concurrent acquirer (recovering
-     * callers, lazy re-establishment, init) shares ONE `connectProven` attempt — N failures never
-     * produce N parallel handshakes, so exactly one proven session exists afterwards and no proven
-     * session is orphaned by a later candidate overwriting the shared slot.
-     * @returns {Promise<Object>} The shared attempt's bounded `{ok, identity?, reason?}`.
+     * @summary SINGLE-FLIGHT, GENERATION-SAFE proven-session acquisition: every concurrent acquirer
+     * (recovering callers, lazy re-establishment, init) shares ONE `connectProven` attempt — and an
+     * acquirer arriving while a proven session ALREADY exists rides it instead of starting a later
+     * proof. The two guards together kill both windows of the overwrite/orphan race: overlapping
+     * acquisitions share the latch, and post-completion acquisitions see the stored session — no
+     * generation-3 proof can ever overwrite and orphan generation 2. A closed client (no held
+     * expectation) refuses instead of reacquiring.
+     * @returns {Promise<Object>} Bounded `{ok, identity?, reason?}`.
      * @private
      */
     function acquireProven() {
+        if (!expected) return Promise.resolve({ok: false, reason: 'client closed'});
+        if (session)   return Promise.resolve({ok: true, identity: session.identity});
+
         establishing ||= connectProven().finally(() => { establishing = null });
 
         return establishing
@@ -221,9 +228,11 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
             }
 
             // Terminal-close any prior life FIRST — close() clears the expectation, so the new one
-            // is installed after it, never nulled by it.
+            // is installed after it, never nulled by it. Re-arming opens a NEW close epoch: the
+            // spent barrier is reset so a later close() tears THIS life down too.
             await this.close();
 
+            closing  = null;
             expected = next;
 
             return acquireProven()
@@ -289,13 +298,25 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
                     throw new Error(`plane ${name} failed: ${error?.name ?? 'call failure'} on a freshly established session`)
                 }
 
-                const readmission = await acquireProven();
+                // Generation-safe: a concurrent caller may already have proven the replacement —
+                // ride it. Only acquire when no current session exists (and acquireProven itself
+                // re-checks, so a still-later arrival cannot start an overwriting proof either).
+                let fresh = session;
 
-                if (!readmission.ok) {
-                    throw new Error(`plane ${name} failed: session lost and ${readmission.reason}`)
+                if (!fresh) {
+                    const readmission = await acquireProven();
+
+                    if (!readmission.ok) {
+                        throw new Error(`plane ${name} failed: session lost and ${readmission.reason}`)
+                    }
+
+                    fresh = session
                 }
 
-                const fresh = session;
+                if (!fresh) {
+                    // A terminal close raced the acquisition — closed beats replay.
+                    throw new Error(`plane ${name} failed: client closed during recovery`)
+                }
 
                 result = await fresh.client.callTool({name, arguments: args})
             }
@@ -322,22 +343,38 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
         },
 
         /**
-         * @summary Awaited, idempotent teardown for normal and refusal exits alike. Explicit close
-         * is TERMINAL: it clears the held identity expectation, so later calls answer
-         * "client not initialized" instead of lazily resurrecting a deliberately shut-down client
-         * (lazy re-establishment is reserved for failed recoveries, where the intent to serve
-         * still stands). An acquisition in flight at close time cannot resurrect either: clearing
-         * `expected` first makes the in-flight proof land on its own mismatch path, which tears the
-         * candidate down without storing it.
+         * @summary The SHARED TERMINAL close barrier. Every closer — explicit close, concurrent
+         * signal handlers, refusal exits — awaits the SAME promise, and that promise resolves only
+         * after (1) any in-flight establishment is fenced (awaited; with the expectation already
+         * cleared it lands on its own mismatch path and tears its candidate down — and a proof that
+         * beat the clear is captured late and torn here), and (2) the held session's teardown
+         * completed. Post-close reacquisition is refused at {@link acquireProven} (`client closed`),
+         * and later calls answer "client not initialized". `init` opens a new epoch by resetting
+         * the spent barrier after awaiting it.
          * @returns {Promise<void>}
          */
-        async close() {
-            const held = session;
+        close() {
+            closing ||= (async () => {
+                const held = session;
 
-            session  = null;
-            expected = null;
+                session  = null;
+                expected = null;
 
-            await teardown(held)
+                if (establishing) {
+                    try { await establishing } catch { /* refusal paths tear their own candidate */ }
+                }
+
+                // A proof that completed between the clear above and its own mismatch check may
+                // have stored — capture and tear it so no candidate survives the barrier.
+                const late = session;
+
+                session = null;
+
+                await teardown(held);
+                await teardown(late)
+            })();
+
+            return closing
         }
     }
 }

--- a/ai/services/fleet/planeMailboxClient.mjs
+++ b/ai/services/fleet/planeMailboxClient.mjs
@@ -1,279 +1,259 @@
-import {
-    InitializeResultSchema,
-    SUPPORTED_PROTOCOL_VERSIONS
-} from '@modelcontextprotocol/sdk/types.js';
+import {Client}                        from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {
     normalizeAgentIdentity,
-    parseMcpEnvelope,
-    readMcpToolPayload
+    normalizeSecureMcpEndpoint,
+    readMcpToolResultPayload
 } from './mcpWireParsing.mjs';
 
 /**
  * @module ai/services/fleet/planeMailboxClient
- * @summary Streamable-HTTP MCP client for the containerized Agent OS plane — the seam that lets the
- * Fleet server's mailbox, compose, and catch-up bindings ride `<base>/mc/mcp` instead of in-process
- * memory-core singletons (the post-hard-cut split-brain fix).
+ * @summary The containerized-plane MCP client the Fleet server binds its mailbox, compose, and
+ * catch-up seams to — the post-hard-cut split-brain fix, riding the OFFICIAL MCP SDK client and
+ * Streamable-HTTP transport rather than a hand-rolled protocol state machine: the SDK owns request
+ * ids (unique across in-flight calls), response correlation, protocol negotiation, and the
+ * initialized handshake, so concurrent consumers (the catch-up source issues two tool calls via
+ * `Promise.allSettled`) correlate safely by construction.
  *
- * **One living session, verified once.** Unlike the tenant readiness probe
- * (`FleetTenantService.initializeMcpResource`, which deliberately closes its session), this client
- * exists to SERVE: `init({expectedIdentity})` performs the authenticated handshake (`initialize` →
- * negotiated `protocolVersion` → `notifications/initialized`), proves the bearer's plane-side
- * subject via `list_permissions` (the same oracle `probeMcpIdentity` rides — "returns the canonical
- * identity it actually used"), and keeps the session open for the process lifetime. A session the
- * plane expires mid-life is re-established ONCE per call, transparently.
+ * **Endpoint boundary before any request.** Construction validates through the shared
+ * `normalizeSecureMcpEndpoint` policy (http/https only, no URL-embedded credentials, TLS required
+ * off-loopback) — the same single definition the tenant connect flow enforces. A rejected endpoint
+ * never emits a request.
  *
- * **The single-viewer invariant is init's job, not the caller's.** The Fleet server is
- * single-viewer by design (viewer resolved at boot, stamped per request).
- * Via a plane bearer, every call runs as the bearer's server-resolved subject, so plane mode is
- * only honest when that subject IS the boot-resolved viewer. `init` therefore REQUIRES
- * `expectedIdentity` and reports `{ok: false, reason: 'plane identity mismatch'}` on any other
- * subject — the entry refuses plane mode rather than silently re-attributing every admission
- * decision.
+ * **One living session, proven every time it is (re)established.** `init({expectedIdentity})`
+ * connects and proves the bearer's plane-side subject via `list_permissions` ("returns the
+ * canonical identity it actually used"). The Fleet server is single-viewer by design (viewer
+ * resolved at boot, stamped per request), so plane mode is only honest when that subject IS the
+ * boot viewer — any other subject refuses fail-closed. The SAME proof gates every recovery: a
+ * transport-level failure mid-call triggers exactly one reconnect, which must re-prove the SAME
+ * identity before the original call is replayed; a changed or unprovable identity throws WITHOUT
+ * replaying (a session replacement is a new trust decision, not a retry detail).
  *
- * **Error shape mirrors the in-process services.** The wire modules and adapters
- * (`fleetA2AActivityAdapter`, `fleetMailboxMirrorAdapter`, `wireFleetCatchUpSource`) already map a
- * THROWN read into their honest degraded/denied snapshots — so `callTool` throws on failure exactly
- * like the singletons do. Two bounded flavors, per the tenant service's no-remote-prose rule:
- * transport/protocol failures throw with status-only diagnostics; a tool-level `isError` result
- * throws the tool's own text — that text is OUR plane's service message (e.g. the
- * `CAN_READ_INBOX_OF` denial the mirror adapter classifies by contract), not arbitrary remote
- * prose, and suppressing it would break the admission-classification contract.
+ * **Error shape mirrors the in-process services.** The wire modules and adapters map a THROWN read
+ * into their honest degraded/denied snapshots — so `callTool` throws on failure exactly like the
+ * singletons do. Transport failures throw with bounded diagnostics; a tool-level `isError` result
+ * throws the tool's own text — that text is OUR plane's service message (e.g. the admission denial
+ * the mirror adapter classifies by contract), not arbitrary remote prose. Request timeout is the
+ * SDK protocol default (60s), which matches the measured local plane under embed/WAL load
+ * (initialize ~17s, list_messages ~25s observed 2026-08-02) while still bounding every call —
+ * an unbounded hang is the sender-eating failure mode the wake fabric taught the same night.
  *
  * Zero config reads: `baseUrl` + `credential` are injected by the boot entry, which resolves the
- * `AiConfig.fleet.planeBase` / `planeBearer` leaves at its use site per the AiConfig SSOT discipline.
+ * `AiConfig.fleet.planeBase` / `planeBearer` leaves at its use site per the AiConfig SSOT
+ * discipline.
  *
  * @see ai/services/fleet/devFleetServer.mjs — the consuming entry (binding decision + fallback)
- * @see ai/services/fleet/mcpWireParsing.mjs — the shared MCP-wire parsing authority
- * @see ai/services/fleet/FleetTenantService.mjs — the readiness-probe precedent this lifecycle mirrors
+ * @see ai/services/fleet/mcpWireParsing.mjs — the shared wire-parsing + endpoint-boundary authority
+ * @see test/playwright/integration/fixtures/mcpClient.mjs — the SDK client/transport precedent
  */
 
-const REQUESTED_PROTOCOL_VERSION = '2024-11-05';
-
 /**
- * Per-request abort bound. Generous by design: the local plane legitimately answers in the
- * 15-25s range under embed/WAL load (measured 2026-08-02), and the in-process bindings this
- * client replaces had no bound at all — but a bound must exist, because an unbounded hang is
- * the sender-eating failure mode the wake fabric just taught us about. 60s matches the MCP
- * client norm this seat itself runs under.
- * @type {Number}
- */
-const CALL_TIMEOUT_MS = 60_000;
-
-/**
- * @summary Build the fixed header set for one plane request.
- * @param {Object} options
- * @param {String} options.credential
- * @param {String|null} [options.sessionId]
- * @param {String|null} [options.protocolVersion]
- * @returns {Object}
- * @private
- */
-function planeHeaders({credential, sessionId = null, protocolVersion = null}) {
-    const headers = {
-        Accept        : 'application/json, text/event-stream',
-        'Content-Type': 'application/json'
-    };
-
-    if (credential)      headers.Authorization          = `Bearer ${credential}`;
-    if (protocolVersion) headers['mcp-protocol-version'] = protocolVersion;
-    if (sessionId)       headers['mcp-session-id']       = sessionId;
-
-    return headers
-}
-
-/**
- * @summary Create one plane mailbox client. Construction is passive — no request leaves before
- * `init()`.
+ * @summary Create one plane mailbox client. Construction validates the endpoint and is otherwise
+ * passive — no request leaves before `init()`.
  * @param {Object} options
  * @param {String} options.baseUrl Full MCP resource URL (`<planeBase>/mc/mcp`), derived by the
  *     entry per the connected-tenant resource contract.
- * @param {String} [options.credential] Plane bearer; empty is forwarded as-is (tokenless planes
- *     decide admission themselves, fail-closed).
- * @param {Function} [options.fetchImpl] Injection seam for tests; defaults to global `fetch`.
+ * @param {String} [options.credential] Plane bearer; empty omits the Authorization header
+ *     (tokenless planes decide admission themselves, fail-closed).
+ * @param {Function} [options.fetchImpl] Injection seam for tests — forwarded to the SDK transport's
+ *     custom-fetch option; defaults to global `fetch`.
+ * @param {Function} [options.createSession] Full session-factory override for tests:
+ *     `() => {client, transport}` with SDK-compatible shapes. Defaults to the real SDK pair.
  * @returns {Object} `{init, callTool, listMessages, addMessage, close}`
+ * @throws {Error} When the endpoint fails the shared secure-endpoint policy.
  */
-export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = fetch}) {
-    if (typeof baseUrl !== 'string' || !baseUrl.trim()) {
-        throw new Error('planeMailboxClient requires a non-empty baseUrl')
+export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = null, createSession = null}) {
+    const endpoint = normalizeSecureMcpEndpoint(baseUrl);
+
+    if (!endpoint) {
+        throw new Error(
+            'planeMailboxClient refused the endpoint: http/https only, no URL-embedded ' +
+            'credentials, and TLS is required for non-loopback hosts.'
+        )
     }
 
-    const url = baseUrl.trim();
+    const buildSession = createSession || (() => {
+        const headers = credential ? {Authorization: `Bearer ${credential}`} : {};
 
-    let session = null; // {sessionId, protocolVersion} once initialized
+        return {
+            transport: new StreamableHTTPClientTransport(new URL(endpoint), {
+                requestInit: {headers},
+                ...(fetchImpl ? {fetch: fetchImpl} : {})
+            }),
+            client: new Client({name: 'neo-fleet-plane-mailbox', version: '1'}, {capabilities: {}})
+        }
+    });
+
+    let session = null, // {client, transport, identity} once proven
+        expected = null;
 
     /**
-     * @summary Run the full handshake and hold the resulting session.
-     * @returns {Promise<Object>} Bounded `{ok, status, reason?}` — never remote prose.
+     * @summary Tear one session down, awaited and tolerant: the plane-side session DELETE
+     * (`terminateSession`) then the transport close, each best-effort so a refusal exit can never
+     * leak a half-open session or mask the refusal itself.
+     * @param {Object|null} candidate `{client, transport}`
+     * @returns {Promise<void>}
      * @private
      */
-    async function establishSession() {
-        const response = await fetchImpl(url, {
-            method : 'POST',
-            headers: planeHeaders({credential}),
-            body   : JSON.stringify({
-                jsonrpc: '2.0',
-                id     : 1,
-                method : 'initialize',
-                params : {
-                    protocolVersion: REQUESTED_PROTOCOL_VERSION,
-                    capabilities   : {},
-                    clientInfo     : {name: 'neo-fleet-plane-mailbox', version: '1'}
-                }
-            }),
-            signal: AbortSignal.timeout(CALL_TIMEOUT_MS)
-        });
+    async function teardown(candidate) {
+        if (!candidate) return;
 
-        const
-            sessionId       = response.headers.get('mcp-session-id'),
-            envelope        = parseMcpEnvelope(await response.text()),
-            parsedResult    = InitializeResultSchema.safeParse(envelope?.result),
-            result          = parsedResult.success ? parsedResult.data : null,
-            protocolVersion = result?.protocolVersion;
-
-        const initialized = response.ok &&
-            envelope?.jsonrpc === '2.0' &&
-            envelope?.id === 1 &&
-            result &&
-            SUPPORTED_PROTOCOL_VERSIONS.includes(protocolVersion);
-
-        if (!initialized) {
-            return {ok: false, status: response.status, reason: `plane MCP initialize failed (${response.status})`}
-        }
-
-        const notifyResponse = await fetchImpl(url, {
-            method : 'POST',
-            headers: planeHeaders({credential, sessionId, protocolVersion}),
-            body   : JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}),
-            signal : AbortSignal.timeout(CALL_TIMEOUT_MS)
-        });
-
-        await notifyResponse.text();
-
-        if (!notifyResponse.ok) {
-            return {ok: false, status: notifyResponse.status, reason: `plane MCP initialized-notification failed (${notifyResponse.status})`}
-        }
-
-        session = {sessionId, protocolVersion};
-
-        return {ok: true, status: response.status}
+        try { await candidate.transport?.terminateSession?.() } catch { /* reaped or unreachable */ }
+        try { await candidate.client?.close?.() }               catch { /* already closed */ }
     }
 
     /**
-     * @summary One raw `tools/call` round-trip on the held session. No re-establishment here —
-     * `callTool` owns the one-retry policy.
+     * @summary Establish + PROVE one session: SDK connect (initialize handshake included), then the
+     * `list_permissions` identity oracle against the held expectation. Any failure tears the
+     * candidate down and reports a bounded refusal — a session is only ever stored proven.
+     * @returns {Promise<Object>} Bounded `{ok, identity?, reason?}`.
+     * @private
+     */
+    async function connectProven() {
+        const candidate = buildSession();
+
+        try {
+            await candidate.client.connect(candidate.transport)
+        } catch (error) {
+            await teardown(candidate);
+
+            return {ok: false, reason: `plane unreachable (${error?.name ?? 'connect failure'})`}
+        }
+
+        let result;
+
+        try {
+            result = await candidate.client.callTool({name: 'list_permissions', arguments: {}})
+        } catch (error) {
+            await teardown(candidate);
+
+            return {ok: false, reason: `plane identity probe unreachable (${error?.name ?? 'call failure'})`}
+        }
+
+        const identity = normalizeAgentIdentity(readMcpToolResultPayload(result)?.identity);
+
+        if (!identity) {
+            await teardown(candidate);
+
+            return {ok: false, reason: 'plane identity probe returned no canonical identity'}
+        }
+
+        if (identity !== expected) {
+            // The one refusal that protects every admission decision downstream: a bearer resolving
+            // to a different subject would silently re-attribute the whole surface.
+            await teardown(candidate);
+
+            return {ok: false, reason: 'plane identity mismatch'}
+        }
+
+        session = {...candidate, identity};
+
+        return {ok: true, identity}
+    }
+
+    /**
+     * @summary Map one SDK CallToolResult into the in-process contract: tool errors throw their own
+     * text, malformed payloads throw bounded, valid payloads return parsed.
      * @param {String} name
-     * @param {Object} args
-     * @returns {Promise<Object>} `{response, envelope}`
+     * @param {Object} result
+     * @returns {Object}
      * @private
      */
-    async function rawToolCall(name, args) {
-        const response = await fetchImpl(url, {
-            method : 'POST',
-            headers: planeHeaders({credential, ...session}),
-            body   : JSON.stringify({
-                jsonrpc: '2.0',
-                id     : 2,
-                method : 'tools/call',
-                params : {name, arguments: args ?? {}}
-            }),
-            signal: AbortSignal.timeout(CALL_TIMEOUT_MS)
-        });
+    function mapToolResult(name, result) {
+        if (result?.isError) {
+            const text = result.content?.find?.(item => item?.type === 'text')?.text;
 
-        return {response, envelope: parseMcpEnvelope(await response.text())}
+            throw new Error(typeof text === 'string' && text ? text : `plane ${name} failed: tool error`)
+        }
+
+        const payload = readMcpToolResultPayload(result);
+
+        if (payload === null) {
+            throw new Error(`plane ${name} failed: malformed tool payload`)
+        }
+
+        return payload
     }
 
     return {
         /**
-         * @summary Handshake + single-viewer verification. REQUIRED before any tool call.
+         * @summary Connect + prove the single-viewer invariant. REQUIRED before any tool call.
          * @param {Object} options
          * @param {String} options.expectedIdentity Boot-resolved viewer the bearer's plane-side
          *     subject must equal (canonical `@login` form).
-         * @returns {Promise<Object>} Bounded `{ok, status, identity?, reason?}`.
+         * @returns {Promise<Object>} Bounded `{ok, identity?, reason?}`.
          */
         async init({expectedIdentity}) {
-            const expected = normalizeAgentIdentity(expectedIdentity);
+            const next = normalizeAgentIdentity(expectedIdentity);
 
-            if (!expected) {
-                return {ok: false, status: 0, reason: 'plane init requires a canonical expectedIdentity'}
+            if (!next) {
+                return {ok: false, reason: 'plane init requires a canonical expectedIdentity'}
             }
 
-            let handshake;
+            // Terminal-close any prior life FIRST — close() clears the expectation, so the new one
+            // is installed after it, never nulled by it.
+            await this.close();
 
-            try {
-                handshake = await establishSession()
-            } catch (error) {
-                return {ok: false, status: 0, reason: `plane unreachable (${error?.name ?? 'fetch failure'})`}
-            }
+            expected = next;
 
-            if (!handshake.ok) return handshake;
-
-            try {
-                const {response, envelope} = await rawToolCall('list_permissions', {});
-                const payload              = readMcpToolPayload(envelope);
-                const identity             = normalizeAgentIdentity(payload?.identity);
-
-                if (!response.ok || !identity) {
-                    return {ok: false, status: response.status, reason: `plane identity probe failed (${response.status})`}
-                }
-
-                if (identity !== expected) {
-                    // The one refusal that protects every admission decision downstream: a bearer
-                    // resolving to a different subject would silently re-attribute the whole surface.
-                    return {ok: false, status: response.status, reason: 'plane identity mismatch'}
-                }
-
-                return {ok: true, status: response.status, identity}
-            } catch (error) {
-                return {ok: false, status: 0, reason: `plane identity probe unreachable (${error?.name ?? 'fetch failure'})`}
-            }
+            return connectProven()
         },
 
         /**
          * @summary Call one plane tool and return its parsed JSON payload. Throws like the
          * in-process services so the adapters' degraded/denied mapping applies unchanged.
+         *
+         * Recovery contract: at most ONE proven reconnect per invocation. A transport-level failure
+         * mid-call triggers it with a single replay; a call arriving while no session is held (a
+         * previous recovery failed — the plane was down at that moment) SPENDS it up front on lazy
+         * re-establishment instead of staying bricked until re-init. Every reconnect must RE-PROVE
+         * the same identity before any request rides it; an unprovable or changed identity throws
+         * without replaying.
          * @param {String} name Registered MC tool name (e.g. `list_messages`).
          * @param {Object} [args]
          * @returns {Promise<Object>}
          */
         async callTool(name, args = {}) {
-            if (!session) throw new Error(`plane ${name} failed: client not initialized`);
+            if (!expected) throw new Error(`plane ${name} failed: client not initialized`);
 
-            let {response, envelope} = await rawToolCall(name, args);
+            let recovered = false;
 
-            // A plane restart invalidates the held session (404 per streamable-HTTP). One
-            // transparent re-handshake per call keeps a long-lived Fleet process honest without
-            // masking a genuinely down plane (the retry itself throws through on failure).
-            if (response.status === 404) {
-                const reestablished = await establishSession();
+            if (!session) {
+                const readmission = await connectProven();
 
-                if (!reestablished.ok) {
-                    throw new Error(`plane ${name} failed: session lost and ${reestablished.reason}`)
+                if (!readmission.ok) {
+                    throw new Error(`plane ${name} failed: session lost and ${readmission.reason}`)
                 }
 
-                ({response, envelope} = await rawToolCall(name, args))
+                recovered = true
             }
 
-            if (!response.ok) {
-                throw new Error(`plane ${name} failed: HTTP ${response.status}`)
+            let result;
+
+            try {
+                result = await session.client.callTool({name, arguments: args})
+            } catch (error) {
+                const lost = session;
+
+                session = null;
+                await teardown(lost);
+
+                if (recovered) {
+                    // This invocation already spent its one reconnect — a second failure on a
+                    // freshly proven session is the plane failing NOW, not a stale-session artifact.
+                    throw new Error(`plane ${name} failed: ${error?.name ?? 'call failure'} on a freshly established session`)
+                }
+
+                const readmission = await connectProven();
+
+                if (!readmission.ok) {
+                    throw new Error(`plane ${name} failed: session lost and ${readmission.reason}`)
+                }
+
+                result = await session.client.callTool({name, arguments: args})
             }
 
-            const result = envelope?.result;
-
-            if (result?.isError) {
-                // The tool's own text is OUR plane service's message (admission denials included) —
-                // the mirror adapter's ADMISSION_SCOPE classification contract depends on it.
-                const text = result.content?.find?.(item => item?.type === 'text')?.text;
-
-                throw new Error(typeof text === 'string' && text ? text : `plane ${name} failed: tool error`)
-            }
-
-            const payload = readMcpToolPayload(envelope);
-
-            if (payload === null) {
-                throw new Error(`plane ${name} failed: malformed tool payload`)
-            }
-
-            return payload
+            return mapToolResult(name, result)
         },
 
         /**
@@ -295,27 +275,20 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
         },
 
         /**
-         * @summary Best-effort session teardown for clean shutdown paths.
+         * @summary Awaited, idempotent teardown for normal and refusal exits alike. Explicit close
+         * is TERMINAL: it clears the held identity expectation, so later calls answer
+         * "client not initialized" instead of lazily resurrecting a deliberately shut-down client
+         * (lazy re-establishment is reserved for failed recoveries, where the intent to serve
+         * still stands).
          * @returns {Promise<void>}
          */
         async close() {
-            if (!session) return;
-
             const held = session;
 
-            session = null;
+            session  = null;
+            expected = null;
 
-            try {
-                const response = await fetchImpl(url, {
-                    method : 'DELETE',
-                    headers: planeHeaders({credential, ...held}),
-                    signal : AbortSignal.timeout(2_000)
-                });
-
-                await response.text()
-            } catch {
-                // Shutdown cleanup stays bounded best effort — the plane reaps expired sessions.
-            }
+            await teardown(held)
         }
     }
 }

--- a/ai/services/fleet/planeMailboxClient.mjs
+++ b/ai/services/fleet/planeMailboxClient.mjs
@@ -1,0 +1,321 @@
+import {
+    InitializeResultSchema,
+    SUPPORTED_PROTOCOL_VERSIONS
+} from '@modelcontextprotocol/sdk/types.js';
+import {
+    normalizeAgentIdentity,
+    parseMcpEnvelope,
+    readMcpToolPayload
+} from './mcpWireParsing.mjs';
+
+/**
+ * @module ai/services/fleet/planeMailboxClient
+ * @summary Streamable-HTTP MCP client for the containerized Agent OS plane — the seam that lets the
+ * Fleet server's mailbox, compose, and catch-up bindings ride `<base>/mc/mcp` instead of in-process
+ * memory-core singletons (the post-hard-cut split-brain fix).
+ *
+ * **One living session, verified once.** Unlike the tenant readiness probe
+ * (`FleetTenantService.initializeMcpResource`, which deliberately closes its session), this client
+ * exists to SERVE: `init({expectedIdentity})` performs the authenticated handshake (`initialize` →
+ * negotiated `protocolVersion` → `notifications/initialized`), proves the bearer's plane-side
+ * subject via `list_permissions` (the same oracle `probeMcpIdentity` rides — "returns the canonical
+ * identity it actually used"), and keeps the session open for the process lifetime. A session the
+ * plane expires mid-life is re-established ONCE per call, transparently.
+ *
+ * **The single-viewer invariant is init's job, not the caller's.** The Fleet server is
+ * single-viewer by design (viewer resolved at boot, stamped per request).
+ * Via a plane bearer, every call runs as the bearer's server-resolved subject, so plane mode is
+ * only honest when that subject IS the boot-resolved viewer. `init` therefore REQUIRES
+ * `expectedIdentity` and reports `{ok: false, reason: 'plane identity mismatch'}` on any other
+ * subject — the entry refuses plane mode rather than silently re-attributing every admission
+ * decision.
+ *
+ * **Error shape mirrors the in-process services.** The wire modules and adapters
+ * (`fleetA2AActivityAdapter`, `fleetMailboxMirrorAdapter`, `wireFleetCatchUpSource`) already map a
+ * THROWN read into their honest degraded/denied snapshots — so `callTool` throws on failure exactly
+ * like the singletons do. Two bounded flavors, per the tenant service's no-remote-prose rule:
+ * transport/protocol failures throw with status-only diagnostics; a tool-level `isError` result
+ * throws the tool's own text — that text is OUR plane's service message (e.g. the
+ * `CAN_READ_INBOX_OF` denial the mirror adapter classifies by contract), not arbitrary remote
+ * prose, and suppressing it would break the admission-classification contract.
+ *
+ * Zero config reads: `baseUrl` + `credential` are injected by the boot entry, which resolves the
+ * `AiConfig.fleet.planeBase` / `planeBearer` leaves at its use site per the AiConfig SSOT discipline.
+ *
+ * @see ai/services/fleet/devFleetServer.mjs — the consuming entry (binding decision + fallback)
+ * @see ai/services/fleet/mcpWireParsing.mjs — the shared MCP-wire parsing authority
+ * @see ai/services/fleet/FleetTenantService.mjs — the readiness-probe precedent this lifecycle mirrors
+ */
+
+const REQUESTED_PROTOCOL_VERSION = '2024-11-05';
+
+/**
+ * Per-request abort bound. Generous by design: the local plane legitimately answers in the
+ * 15-25s range under embed/WAL load (measured 2026-08-02), and the in-process bindings this
+ * client replaces had no bound at all — but a bound must exist, because an unbounded hang is
+ * the sender-eating failure mode the wake fabric just taught us about. 60s matches the MCP
+ * client norm this seat itself runs under.
+ * @type {Number}
+ */
+const CALL_TIMEOUT_MS = 60_000;
+
+/**
+ * @summary Build the fixed header set for one plane request.
+ * @param {Object} options
+ * @param {String} options.credential
+ * @param {String|null} [options.sessionId]
+ * @param {String|null} [options.protocolVersion]
+ * @returns {Object}
+ * @private
+ */
+function planeHeaders({credential, sessionId = null, protocolVersion = null}) {
+    const headers = {
+        Accept        : 'application/json, text/event-stream',
+        'Content-Type': 'application/json'
+    };
+
+    if (credential)      headers.Authorization          = `Bearer ${credential}`;
+    if (protocolVersion) headers['mcp-protocol-version'] = protocolVersion;
+    if (sessionId)       headers['mcp-session-id']       = sessionId;
+
+    return headers
+}
+
+/**
+ * @summary Create one plane mailbox client. Construction is passive — no request leaves before
+ * `init()`.
+ * @param {Object} options
+ * @param {String} options.baseUrl Full MCP resource URL (`<planeBase>/mc/mcp`), derived by the
+ *     entry per the connected-tenant resource contract.
+ * @param {String} [options.credential] Plane bearer; empty is forwarded as-is (tokenless planes
+ *     decide admission themselves, fail-closed).
+ * @param {Function} [options.fetchImpl] Injection seam for tests; defaults to global `fetch`.
+ * @returns {Object} `{init, callTool, listMessages, addMessage, close}`
+ */
+export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = fetch}) {
+    if (typeof baseUrl !== 'string' || !baseUrl.trim()) {
+        throw new Error('planeMailboxClient requires a non-empty baseUrl')
+    }
+
+    const url = baseUrl.trim();
+
+    let session = null; // {sessionId, protocolVersion} once initialized
+
+    /**
+     * @summary Run the full handshake and hold the resulting session.
+     * @returns {Promise<Object>} Bounded `{ok, status, reason?}` — never remote prose.
+     * @private
+     */
+    async function establishSession() {
+        const response = await fetchImpl(url, {
+            method : 'POST',
+            headers: planeHeaders({credential}),
+            body   : JSON.stringify({
+                jsonrpc: '2.0',
+                id     : 1,
+                method : 'initialize',
+                params : {
+                    protocolVersion: REQUESTED_PROTOCOL_VERSION,
+                    capabilities   : {},
+                    clientInfo     : {name: 'neo-fleet-plane-mailbox', version: '1'}
+                }
+            }),
+            signal: AbortSignal.timeout(CALL_TIMEOUT_MS)
+        });
+
+        const
+            sessionId       = response.headers.get('mcp-session-id'),
+            envelope        = parseMcpEnvelope(await response.text()),
+            parsedResult    = InitializeResultSchema.safeParse(envelope?.result),
+            result          = parsedResult.success ? parsedResult.data : null,
+            protocolVersion = result?.protocolVersion;
+
+        const initialized = response.ok &&
+            envelope?.jsonrpc === '2.0' &&
+            envelope?.id === 1 &&
+            result &&
+            SUPPORTED_PROTOCOL_VERSIONS.includes(protocolVersion);
+
+        if (!initialized) {
+            return {ok: false, status: response.status, reason: `plane MCP initialize failed (${response.status})`}
+        }
+
+        const notifyResponse = await fetchImpl(url, {
+            method : 'POST',
+            headers: planeHeaders({credential, sessionId, protocolVersion}),
+            body   : JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}),
+            signal : AbortSignal.timeout(CALL_TIMEOUT_MS)
+        });
+
+        await notifyResponse.text();
+
+        if (!notifyResponse.ok) {
+            return {ok: false, status: notifyResponse.status, reason: `plane MCP initialized-notification failed (${notifyResponse.status})`}
+        }
+
+        session = {sessionId, protocolVersion};
+
+        return {ok: true, status: response.status}
+    }
+
+    /**
+     * @summary One raw `tools/call` round-trip on the held session. No re-establishment here —
+     * `callTool` owns the one-retry policy.
+     * @param {String} name
+     * @param {Object} args
+     * @returns {Promise<Object>} `{response, envelope}`
+     * @private
+     */
+    async function rawToolCall(name, args) {
+        const response = await fetchImpl(url, {
+            method : 'POST',
+            headers: planeHeaders({credential, ...session}),
+            body   : JSON.stringify({
+                jsonrpc: '2.0',
+                id     : 2,
+                method : 'tools/call',
+                params : {name, arguments: args ?? {}}
+            }),
+            signal: AbortSignal.timeout(CALL_TIMEOUT_MS)
+        });
+
+        return {response, envelope: parseMcpEnvelope(await response.text())}
+    }
+
+    return {
+        /**
+         * @summary Handshake + single-viewer verification. REQUIRED before any tool call.
+         * @param {Object} options
+         * @param {String} options.expectedIdentity Boot-resolved viewer the bearer's plane-side
+         *     subject must equal (canonical `@login` form).
+         * @returns {Promise<Object>} Bounded `{ok, status, identity?, reason?}`.
+         */
+        async init({expectedIdentity}) {
+            const expected = normalizeAgentIdentity(expectedIdentity);
+
+            if (!expected) {
+                return {ok: false, status: 0, reason: 'plane init requires a canonical expectedIdentity'}
+            }
+
+            let handshake;
+
+            try {
+                handshake = await establishSession()
+            } catch (error) {
+                return {ok: false, status: 0, reason: `plane unreachable (${error?.name ?? 'fetch failure'})`}
+            }
+
+            if (!handshake.ok) return handshake;
+
+            try {
+                const {response, envelope} = await rawToolCall('list_permissions', {});
+                const payload              = readMcpToolPayload(envelope);
+                const identity             = normalizeAgentIdentity(payload?.identity);
+
+                if (!response.ok || !identity) {
+                    return {ok: false, status: response.status, reason: `plane identity probe failed (${response.status})`}
+                }
+
+                if (identity !== expected) {
+                    // The one refusal that protects every admission decision downstream: a bearer
+                    // resolving to a different subject would silently re-attribute the whole surface.
+                    return {ok: false, status: response.status, reason: 'plane identity mismatch'}
+                }
+
+                return {ok: true, status: response.status, identity}
+            } catch (error) {
+                return {ok: false, status: 0, reason: `plane identity probe unreachable (${error?.name ?? 'fetch failure'})`}
+            }
+        },
+
+        /**
+         * @summary Call one plane tool and return its parsed JSON payload. Throws like the
+         * in-process services so the adapters' degraded/denied mapping applies unchanged.
+         * @param {String} name Registered MC tool name (e.g. `list_messages`).
+         * @param {Object} [args]
+         * @returns {Promise<Object>}
+         */
+        async callTool(name, args = {}) {
+            if (!session) throw new Error(`plane ${name} failed: client not initialized`);
+
+            let {response, envelope} = await rawToolCall(name, args);
+
+            // A plane restart invalidates the held session (404 per streamable-HTTP). One
+            // transparent re-handshake per call keeps a long-lived Fleet process honest without
+            // masking a genuinely down plane (the retry itself throws through on failure).
+            if (response.status === 404) {
+                const reestablished = await establishSession();
+
+                if (!reestablished.ok) {
+                    throw new Error(`plane ${name} failed: session lost and ${reestablished.reason}`)
+                }
+
+                ({response, envelope} = await rawToolCall(name, args))
+            }
+
+            if (!response.ok) {
+                throw new Error(`plane ${name} failed: HTTP ${response.status}`)
+            }
+
+            const result = envelope?.result;
+
+            if (result?.isError) {
+                // The tool's own text is OUR plane service's message (admission denials included) —
+                // the mirror adapter's ADMISSION_SCOPE classification contract depends on it.
+                const text = result.content?.find?.(item => item?.type === 'text')?.text;
+
+                throw new Error(typeof text === 'string' && text ? text : `plane ${name} failed: tool error`)
+            }
+
+            const payload = readMcpToolPayload(envelope);
+
+            if (payload === null) {
+                throw new Error(`plane ${name} failed: malformed tool payload`)
+            }
+
+            return payload
+        },
+
+        /**
+         * @summary MailboxService-compatible `listMessages(args)`.
+         * @param {Object} [args]
+         * @returns {Promise<Object>}
+         */
+        listMessages(args = {}) {
+            return this.callTool('list_messages', args)
+        },
+
+        /**
+         * @summary MailboxService-compatible `addMessage(args)`.
+         * @param {Object} [args]
+         * @returns {Promise<Object>}
+         */
+        addMessage(args = {}) {
+            return this.callTool('add_message', args)
+        },
+
+        /**
+         * @summary Best-effort session teardown for clean shutdown paths.
+         * @returns {Promise<void>}
+         */
+        async close() {
+            if (!session) return;
+
+            const held = session;
+
+            session = null;
+
+            try {
+                const response = await fetchImpl(url, {
+                    method : 'DELETE',
+                    headers: planeHeaders({credential, ...held}),
+                    signal : AbortSignal.timeout(2_000)
+                });
+
+                await response.text()
+            } catch {
+                // Shutdown cleanup stays bounded best effort — the plane reaps expired sessions.
+            }
+        }
+    }
+}

--- a/test/playwright/unit/ai/fleetLaunchContract.spec.mjs
+++ b/test/playwright/unit/ai/fleetLaunchContract.spec.mjs
@@ -1,0 +1,74 @@
+import {test, expect} from '@playwright/test';
+
+import {resolveFleetViewer, resolveFleetViewerClaim} from '../../../../ai/services/fleet/fleetLaunchContract.mjs';
+
+/**
+ * @summary Unit coverage for the Fleet viewer-binding split: the graphless identity CLAIM
+ * (plane-mode boot) versus the host-graph-verified binding (in-process boot).
+ *
+ * The load-bearing witness here is the veto asymmetry: a broken or unseeded HOST graph must veto
+ * the in-process binding (fail-closed attribution) while remaining structurally UNABLE to veto the
+ * claim — plane mode's verification authority is the plane itself, so these cases prove a healthy
+ * configured plane cannot be vetoed by host Memory Core state.
+ */
+
+const IDENTITY = {githubLogin: 'neo-fable-clio', username: 'clio', source: 'env-var'};
+
+test.describe('fleetLaunchContract: resolveFleetViewerClaim (graphless half)', () => {
+    test('resolves the canonical claim shape from the identity chain alone', async () => {
+        const claim = await resolveFleetViewerClaim({resolveIdentity: async () => IDENTITY});
+
+        expect(claim).toEqual({
+            userId             : 'neo-fable-clio',
+            username           : 'clio',
+            agentIdentityNodeId: expect.stringContaining('neo-fable-clio'),
+            source             : 'env-var'
+        })
+    });
+
+    test('fails closed with the named remediation when no identity resolves', async () => {
+        await expect(resolveFleetViewerClaim({resolveIdentity: async () => null}))
+            .rejects.toThrow('no viewer identity resolved')
+    });
+
+    test('WITNESS: a host graph that would explode cannot veto the claim — no graph seam exists', async () => {
+        // The claim function has no graph parameter at all; this case pins that property by
+        // resolving successfully in an environment where any host-graph touch would throw loudly
+        // (the same injected identity that the veto case below uses against resolveFleetViewer).
+        const claim = await resolveFleetViewerClaim({resolveIdentity: async () => IDENTITY});
+
+        expect(claim.agentIdentityNodeId).toBeTruthy()
+    })
+});
+
+test.describe('fleetLaunchContract: resolveFleetViewer (in-process, host-graph-verified half)', () => {
+    test('verifies the claim against a seeded AgentIdentity node and returns its id', async () => {
+        const viewer = await resolveFleetViewer({
+            resolveIdentity: async () => IDENTITY,
+            getGraphService: async () => ({
+                ready  : async () => {},
+                getNode: async ({id}) => ({id, type: 'AgentIdentity'})
+            })
+        });
+
+        expect(viewer.userId).toBe('neo-fable-clio');
+        expect(viewer.agentIdentityNodeId).toContain('neo-fable-clio')
+    });
+
+    test('VETO half: a broken host graph refuses the in-process binding fail-closed', async () => {
+        await expect(resolveFleetViewer({
+            resolveIdentity: async () => IDENTITY,
+            getGraphService: async () => { throw new Error('host graph unavailable') }
+        })).rejects.toThrow('host graph unavailable')
+    });
+
+    test('VETO half: an unseeded node refuses with the named remediation', async () => {
+        await expect(resolveFleetViewer({
+            resolveIdentity: async () => IDENTITY,
+            getGraphService: async () => ({
+                ready  : async () => {},
+                getNode: async () => null
+            })
+        })).rejects.toThrow('no seeded AgentIdentity node')
+    })
+});

--- a/test/playwright/unit/ai/planeMailboxClient.spec.mjs
+++ b/test/playwright/unit/ai/planeMailboxClient.spec.mjs
@@ -3,224 +3,442 @@ import {test, expect} from '@playwright/test';
 import {createPlaneMailboxClient} from '../../../../ai/services/fleet/planeMailboxClient.mjs';
 
 /**
- * @summary Unit coverage for the plane mailbox client — the streamable-HTTP MCP client the
- * Fleet server binds its mailbox/compose/catch-up seams to in plane mode.
+ * @summary Unit coverage for the plane mailbox client — the SDK-backed streamable-HTTP MCP client
+ * the Fleet server binds its mailbox/compose/catch-up seams to in plane mode.
  *
- * Hermetic by construction: the module chain (client + mcpWireParsing + SDK type schemas) is pure,
- * so no Neo namespace, no setup(), and no network — every wire interaction rides the injected
- * `fetchImpl` seam with scripted responses.
+ * Hermetic by construction, but NOT mock-shallow: every case drives the REAL MCP SDK client and
+ * Streamable-HTTP transport through the transport's custom-fetch seam, so protocol negotiation,
+ * request-id allocation, and response correlation are the production code paths under scripted
+ * HTTP. The concurrent case pins the exact production call shape (the catch-up source's
+ * `Promise.allSettled` pair) that a serial script cannot see.
  */
 
-const BASE_URL = 'http://127.0.0.1:3102/mc/mcp';
-const IDENTITY = '@neo-fable-clio';
+const LOOPBACK_URL = 'http://127.0.0.1:3102/mc/mcp';
+const IDENTITY     = '@neo-fable-clio';
 
 /**
- * @summary One scripted Response-shaped object (the subset the client reads).
+ * @summary One Response-shaped object covering the subset the SDK transport reads.
  * @param {Object} options
  * @returns {Object}
  */
-function scriptedResponse({status = 200, sessionId = null, body = {}}) {
+function planeResponse({status = 200, contentType = 'application/json', sessionId = null, body = null}) {
+    const text = body === null ? '' : (typeof body === 'string' ? body : JSON.stringify(body));
+
     return {
-        ok     : status >= 200 && status < 300,
+        ok        : status >= 200 && status < 300,
         status,
-        headers: {get: name => (name === 'mcp-session-id' ? sessionId : null)},
-        text   : async () => (typeof body === 'string' ? body : JSON.stringify(body))
+        statusText: String(status),
+        headers   : {
+            get: name => {
+                const key = String(name).toLowerCase();
+
+                if (key === 'mcp-session-id') return sessionId;
+                if (key === 'content-type')   return body === null ? null : contentType;
+
+                return null
+            }
+        },
+        text: async () => text,
+        json: async () => JSON.parse(text)
     }
 }
 
 /**
- * @summary Scripted fetch: consumes one queued response per call and records every request for
- * sequence assertions. A queue underrun throws — an unexpected extra request is a test failure,
- * never a hang.
- * @param {Object[]} queue
- * @returns {Function} fetchImpl with a `.calls` recorder.
+ * @summary A scripted plane: a handler-based fetch implementation speaking the MCP streamable-HTTP
+ * dialect (initialize echo, session headers, tools/call correlation by echoed request id). Handlers
+ * make failure injection per-call precise; `calls` records every request for sequence assertions.
+ *
+ * @param {Object}   [options]
+ * @param {String[]} [options.identityBySession] `list_permissions` identity per session ordinal —
+ *     index 0 answers the first established session, index 1 the session after one reconnect, etc.
+ *     The last entry repeats for later sessions.
+ * @param {Function} [options.toolResponder] `({name, args, call, sessionOrdinal}) =>` one of
+ *     `{payload}`, `{textPayload}`, `{toolError}`, `{status}`, optionally `{delayMs}` — scripted
+ *     behavior for non-`list_permissions` tools.
+ * @param {Number}   [options.failInitializeTimes] Reject that many initialize attempts with 503
+ *     before succeeding.
+ * @returns {Object} `{fetchImpl, calls}`
  */
-function scriptedFetch(queue) {
+function scriptedPlane({identityBySession = [IDENTITY], toolResponder = null, failInitializeTimes = 0} = {}) {
     const calls = [];
 
-    const impl = async (url, options) => {
-        const parsedBody = options?.body ? JSON.parse(options.body) : null;
+    let sessions           = 0,
+        initializeFailures = failInitializeTimes;
 
-        calls.push({url, method: options?.method, headers: options?.headers ?? {}, body: parsedBody});
+    const fetchImpl = async (url, init = {}) => {
+        const method  = init.method || 'GET',
+              headers = new Headers(init.headers || {}),
+              rawBody = typeof init.body === 'string' ? init.body : null,
+              body    = rawBody ? JSON.parse(rawBody) : null;
 
-        const next = queue.shift();
+        const call = {
+            method,
+            url          : String(url),
+            authorization: headers.get('authorization'),
+            sessionHeader: headers.get('mcp-session-id'),
+            rpcMethod    : body?.method ?? null,
+            rpcId        : body?.id ?? null,
+            toolName     : body?.method === 'tools/call' ? body?.params?.name : null,
+            toolArgs     : body?.method === 'tools/call' ? body?.params?.arguments : null
+        };
 
-        if (!next)               throw new Error(`scriptedFetch queue underrun (call ${calls.length})`);
-        if (next.reject)         throw Object.assign(new Error('scripted network failure'), {name: next.reject});
+        calls.push(call);
 
-        return scriptedResponse(next)
+        if (method === 'GET')    return planeResponse({status: 405});
+        if (method === 'DELETE') return planeResponse({status: 200, body: {}});
+
+        if (body?.method === 'initialize') {
+            if (initializeFailures > 0) {
+                initializeFailures--;
+
+                return planeResponse({status: 503, body: 'unavailable'})
+            }
+
+            sessions++;
+
+            return planeResponse({
+                sessionId: `sess-${sessions}`,
+                body     : {jsonrpc: '2.0', id: body.id, result: {
+                    protocolVersion: body.params.protocolVersion,
+                    capabilities   : {tools: {}},
+                    serverInfo     : {name: 'scripted-plane', version: '1'}
+                }}
+            })
+        }
+
+        if (body?.method === 'notifications/initialized') {
+            return planeResponse({status: 202})
+        }
+
+        if (body?.method === 'tools/call') {
+            const sessionOrdinal = Math.max(0, sessions - 1);
+
+            if (call.toolName === 'list_permissions') {
+                const identity = identityBySession[Math.min(sessionOrdinal, identityBySession.length - 1)];
+
+                return planeResponse({body: {jsonrpc: '2.0', id: body.id, result: {
+                    content: [{type: 'text', text: JSON.stringify({identity})}]
+                }}})
+            }
+
+            const scripted = toolResponder
+                ? await toolResponder({name: call.toolName, args: call.toolArgs, call, sessionOrdinal})
+                : {payload: {}};
+
+            if (scripted.delayMs) await new Promise(resolve => setTimeout(resolve, scripted.delayMs));
+
+            if (scripted.status) return planeResponse({status: scripted.status, body: 'scripted failure'});
+
+            if (scripted.toolError) {
+                return planeResponse({body: {jsonrpc: '2.0', id: body.id, result: {
+                    isError: true,
+                    content: [{type: 'text', text: scripted.toolError}]
+                }}})
+            }
+
+            if (scripted.textPayload !== undefined) {
+                return planeResponse({body: {jsonrpc: '2.0', id: body.id, result: {
+                    content: [{type: 'text', text: scripted.textPayload}]
+                }}})
+            }
+
+            return planeResponse({body: {jsonrpc: '2.0', id: body.id, result: {
+                structuredContent: scripted.payload,
+                content          : [{type: 'text', text: JSON.stringify(scripted.payload)}]
+            }}})
+        }
+
+        return planeResponse({status: 400, body: 'unscripted request'})
     };
 
-    impl.calls = calls;
-
-    return impl
+    return {fetchImpl, calls}
 }
 
-/** @summary The standard happy-path handshake pair: initialize + initialized-notification. */
-function handshakeResponses({sessionId = 'sess-1'} = {}) {
-    return [
-        {status: 200, sessionId, body: {jsonrpc: '2.0', id: 1, result: {
-            protocolVersion: '2024-11-05',
-            capabilities   : {},
-            serverInfo     : {name: 'mc', version: '1'}
-        }}},
-        {status: 200}
-    ]
-}
-
-/** @summary One successful tools/call response carrying a JSON text payload. */
-function toolResponse(payload) {
-    return {status: 200, body: {jsonrpc: '2.0', id: 2, result: {
-        content: [{type: 'text', text: JSON.stringify(payload)}]
-    }}}
-}
-
-/** @summary Init a client through the scripted happy-path handshake + identity probe. */
-async function initializedClient({extraResponses = [], identity = IDENTITY} = {}) {
-    const fetchImpl = scriptedFetch([
-        ...handshakeResponses(),
-        toolResponse({identity}),
-        ...extraResponses
-    ]);
-
-    const client    = createPlaneMailboxClient({baseUrl: BASE_URL, credential: 'token-1', fetchImpl}),
+/** @summary Create + init one client against a scripted plane. */
+async function initializedClient(planeOptions = {}, clientOptions = {}) {
+    const plane  = scriptedPlane(planeOptions),
+          client = createPlaneMailboxClient({
+              baseUrl   : LOOPBACK_URL,
+              credential: 'token-1',
+              fetchImpl : plane.fetchImpl,
+              ...clientOptions
+          }),
           admission = await client.init({expectedIdentity: IDENTITY});
 
-    return {client, fetchImpl, admission}
+    return {client, plane, admission}
 }
 
-test.describe('planeMailboxClient: construction', () => {
-    test('refuses an empty baseUrl', () => {
-        expect(() => createPlaneMailboxClient({baseUrl: '  '})).toThrow('non-empty baseUrl')
+test.describe('planeMailboxClient: endpoint boundary (before any request)', () => {
+    test('rejects a non-loopback http endpoint — TLS required off-loopback', () => {
+        expect(() => createPlaneMailboxClient({baseUrl: 'http://fleet.example.com/mc/mcp'}))
+            .toThrow('TLS is required')
     });
 
-    test('callTool before init throws the uninitialized error, no request leaves', async () => {
-        const fetchImpl = scriptedFetch([]),
-              client    = createPlaneMailboxClient({baseUrl: BASE_URL, fetchImpl});
+    test('rejects URL-embedded credentials outright', () => {
+        expect(() => createPlaneMailboxClient({baseUrl: 'https://user:secret@fleet.example.com/mc/mcp'}))
+            .toThrow('URL-embedded')
+    });
 
-        await expect(client.callTool('list_messages')).rejects.toThrow('client not initialized');
-        expect(fetchImpl.calls).toHaveLength(0)
+    test('rejects a malformed endpoint', () => {
+        expect(() => createPlaneMailboxClient({baseUrl: 'not a url'})).toThrow('refused the endpoint')
+    });
+
+    test('accepts loopback http and any https, emitting no request at construction', () => {
+        const plane = scriptedPlane();
+
+        createPlaneMailboxClient({baseUrl: LOOPBACK_URL, fetchImpl: plane.fetchImpl});
+        createPlaneMailboxClient({baseUrl: 'https://fleet.example.com/mc/mcp', fetchImpl: plane.fetchImpl});
+
+        expect(plane.calls).toHaveLength(0)
     })
 });
 
-test.describe('planeMailboxClient: init (handshake + single-viewer invariant)', () => {
-    test('happy path: initialize → initialized → identity probe, session held', async () => {
-        const {admission, fetchImpl} = await initializedClient();
+test.describe('planeMailboxClient: init (SDK handshake + single-viewer proof)', () => {
+    test('happy path: SDK connect handshake, then list_permissions proves the viewer', async () => {
+        const {admission, plane} = await initializedClient();
 
-        expect(admission).toEqual({ok: true, status: 200, identity: IDENTITY});
+        expect(admission).toEqual({ok: true, identity: IDENTITY});
 
-        const [initCall, notifyCall, probeCall] = fetchImpl.calls;
+        const rpcMethods = plane.calls.filter(call => call.rpcMethod).map(call => call.rpcMethod);
 
-        expect(initCall.body.method).toBe('initialize');
-        expect(initCall.headers.Authorization).toBe('Bearer token-1');
-        expect(notifyCall.body.method).toBe('notifications/initialized');
-        expect(notifyCall.headers['mcp-session-id']).toBe('sess-1');
-        expect(probeCall.body.params.name).toBe('list_permissions')
+        expect(rpcMethods[0]).toBe('initialize');
+        expect(rpcMethods).toContain('notifications/initialized');
+        expect(plane.calls.at(-1).toolName).toBe('list_permissions');
+        expect(plane.calls[0].authorization).toBe('Bearer token-1')
     });
 
-    test('identity mismatch refuses plane mode with the bounded reason', async () => {
-        const {admission} = await initializedClient({identity: '@someone-else'});
+    test('identity mismatch refuses fail-closed AND tears the session down (awaited DELETE)', async () => {
+        const {admission, plane} = await initializedClient({identityBySession: ['@someone-else']});
 
-        expect(admission.ok).toBe(false);
-        expect(admission.reason).toBe('plane identity mismatch')
-    });
-
-    test('rejected initialize yields a bounded status reason, never remote prose', async () => {
-        const fetchImpl = scriptedFetch([{status: 401, body: 'go away, secret prose'}]),
-              client    = createPlaneMailboxClient({baseUrl: BASE_URL, fetchImpl}),
-              admission = await client.init({expectedIdentity: IDENTITY});
-
-        expect(admission).toEqual({ok: false, status: 401, reason: 'plane MCP initialize failed (401)'})
+        expect(admission).toEqual({ok: false, reason: 'plane identity mismatch'});
+        expect(plane.calls.some(call => call.method === 'DELETE')).toBe(true)
     });
 
     test('unreachable plane yields a bounded transport reason', async () => {
-        const fetchImpl = scriptedFetch([{reject: 'TimeoutError'}]),
-              client    = createPlaneMailboxClient({baseUrl: BASE_URL, fetchImpl}),
-              admission = await client.init({expectedIdentity: IDENTITY});
+        const client = createPlaneMailboxClient({
+            baseUrl  : LOOPBACK_URL,
+            fetchImpl: async () => { throw Object.assign(new Error('boom'), {name: 'TypeError'}) }
+        });
+
+        const admission = await client.init({expectedIdentity: IDENTITY});
 
         expect(admission.ok).toBe(false);
-        expect(admission.reason).toBe('plane unreachable (TimeoutError)')
+        expect(admission.reason).toMatch(/^plane unreachable \(/)
     });
 
     test('non-canonical expectedIdentity is refused before any request leaves', async () => {
-        const fetchImpl = scriptedFetch([]),
-              client    = createPlaneMailboxClient({baseUrl: BASE_URL, fetchImpl}),
-              admission = await client.init({expectedIdentity: '   '});
+        const plane  = scriptedPlane(),
+              client = createPlaneMailboxClient({baseUrl: LOOPBACK_URL, fetchImpl: plane.fetchImpl});
+
+        const admission = await client.init({expectedIdentity: '   '});
 
         expect(admission.ok).toBe(false);
-        expect(fetchImpl.calls).toHaveLength(0)
+        expect(plane.calls).toHaveLength(0)
     })
 });
 
 test.describe('planeMailboxClient: tool calls (error shape mirrors the in-process services)', () => {
+    test('callTool before init throws the uninitialized error, no request leaves', async () => {
+        const plane  = scriptedPlane(),
+              client = createPlaneMailboxClient({baseUrl: LOOPBACK_URL, fetchImpl: plane.fetchImpl});
+
+        await expect(client.callTool('list_messages')).rejects.toThrow('client not initialized');
+        expect(plane.calls).toHaveLength(0)
+    });
+
     test('listMessages maps to the list_messages tool and resolves the parsed payload', async () => {
-        const payload             = {messages: [{messageId: 'MESSAGE:1', subject: 'hi'}]},
-              {client, fetchImpl} = await initializedClient({extraResponses: [toolResponse(payload)]});
+        const payload = {messages: [{messageId: 'MESSAGE:1', subject: 'hi'}]};
+
+        const {client, plane} = await initializedClient({
+            toolResponder: ({name}) => (name === 'list_messages' ? {payload} : {payload: {}})
+        });
 
         await expect(client.listMessages({limit: 5})).resolves.toEqual(payload);
 
-        const call = fetchImpl.calls.at(-1);
+        const call = plane.calls.at(-1);
 
-        expect(call.body.params).toEqual({name: 'list_messages', arguments: {limit: 5}})
+        expect(call.toolName).toBe('list_messages');
+        expect(call.toolArgs).toEqual({limit: 5})
     });
 
-    test('addMessage maps to the add_message tool', async () => {
-        const {client, fetchImpl} = await initializedClient({extraResponses: [toolResponse({status: 'sent'})]});
+    test('addMessage maps to the add_message tool; text-only payloads parse too', async () => {
+        const {client, plane} = await initializedClient({
+            toolResponder: () => ({textPayload: JSON.stringify({status: 'sent'})})
+        });
 
         await expect(client.addMessage({to: '@peer', subject: 's', body: 'b'})).resolves.toEqual({status: 'sent'});
-        expect(fetchImpl.calls.at(-1).body.params.name).toBe('add_message')
+        expect(plane.calls.at(-1).toolName).toBe('add_message')
     });
 
     test('a tool-level isError result throws the tool text (the admission-classification contract)', async () => {
         const denial = 'Unauthorized: CAN_READ_INBOX_OF denied for @neo-fable-clio -> @peer';
 
-        const {client} = await initializedClient({extraResponses: [
-            {status: 200, body: {jsonrpc: '2.0', id: 2, result: {isError: true, content: [{type: 'text', text: denial}]}}}
-        ]});
+        const {client} = await initializedClient({toolResponder: () => ({toolError: denial})});
 
         await expect(client.callTool('list_messages', {to: '@peer'})).rejects.toThrow(denial)
     });
 
-    test('a transport failure throws a bounded status-only diagnostic', async () => {
-        const {client} = await initializedClient({extraResponses: [
-            {status: 500, body: 'stack trace prose the caller must never see'}
-        ]});
-
-        await expect(client.listMessages()).rejects.toThrow('plane list_messages failed: HTTP 500')
-    });
-
     test('a malformed tool payload throws bounded, never resolves null', async () => {
-        const {client} = await initializedClient({extraResponses: [
-            {status: 200, body: {jsonrpc: '2.0', id: 2, result: {content: [{type: 'text', text: 'not json'}]}}}
-        ]});
+        const {client} = await initializedClient({toolResponder: () => ({textPayload: 'not json'})});
 
         await expect(client.listMessages()).rejects.toThrow('plane list_messages failed: malformed tool payload')
+    })
+});
+
+test.describe('planeMailboxClient: concurrency (the production catch-up call shape)', () => {
+    test('two in-flight tool calls carry UNIQUE request ids and correlate to their own payloads', async () => {
+        const {client, plane} = await initializedClient({
+            toolResponder: ({name}) => ({
+                // Answer the FIRST tool slower than the second: correct correlation must survive
+                // out-of-order completion, which is exactly what a shared static id cannot do.
+                delayMs: name === 'explore_memory_history' ? 40 : 5,
+                payload: {tool: name}
+            })
+        });
+
+        const [memory, pulls] = await Promise.allSettled([
+            client.callTool('explore_memory_history',       {limit: 1}),
+            client.callTool('explore_pull_request_history', {limit: 1})
+        ]);
+
+        expect(memory.status).toBe('fulfilled');
+        expect(pulls.status).toBe('fulfilled');
+        expect(memory.value).toEqual({tool: 'explore_memory_history'});
+        expect(pulls.value).toEqual({tool: 'explore_pull_request_history'});
+
+        const inFlightIds = plane.calls
+            .filter(call => ['explore_memory_history', 'explore_pull_request_history'].includes(call.toolName))
+            .map(call => call.rpcId);
+
+        expect(inFlightIds).toHaveLength(2);
+        expect(new Set(inFlightIds).size).toBe(2)
+    })
+});
+
+test.describe('planeMailboxClient: session loss (one bounded recovery, identity re-proven)', () => {
+    test('a transport-level failure reconnects ONCE, re-proves the SAME identity, then replays', async () => {
+        let failed = false;
+
+        const {client, plane} = await initializedClient({
+            identityBySession: [IDENTITY, IDENTITY],
+            toolResponder    : ({name}) => {
+                if (name === 'list_messages' && !failed) {
+                    failed = true;
+
+                    return {status: 404}
+                }
+
+                return {payload: {recovered: true}}
+            }
+        });
+
+        await expect(client.listMessages()).resolves.toEqual({recovered: true});
+
+        // Sequence proof: failed call → teardown DELETE → fresh initialize → re-proof → replay.
+        const tail        = plane.calls.map(call => call.rpcMethod ?? call.method);
+        const failedIndex = plane.calls.findIndex(call => call.toolName === 'list_messages');
+
+        expect(tail.slice(failedIndex + 1)).toEqual(
+            expect.arrayContaining(['DELETE', 'initialize', 'notifications/initialized', 'tools/call'])
+        );
+        expect(plane.calls.filter(call => call.toolName === 'list_permissions')).toHaveLength(2);
+        expect(plane.calls.filter(call => call.toolName === 'list_messages')).toHaveLength(2)
     });
 
-    test('a lost session (404) re-establishes ONCE and retries the call transparently', async () => {
-        const payload = {messages: []};
+    test('a reconnect that proves a CHANGED identity rejects WITHOUT replaying the original tool', async () => {
+        const {client, plane} = await initializedClient({
+            identityBySession: [IDENTITY, '@rotated-subject'],
+            toolResponder    : () => ({status: 404})
+        });
 
-        const {client, fetchImpl} = await initializedClient({extraResponses: [
-            {status: 404},               // held session rejected → re-handshake expected
-            ...handshakeResponses({sessionId: 'sess-2'}),
-            toolResponse(payload)
-        ]});
+        await expect(client.listMessages())
+            .rejects.toThrow('plane list_messages failed: session lost and plane identity mismatch');
 
-        await expect(client.listMessages()).resolves.toEqual(payload);
-
-        // Sequence proof: probe(3) → failed call → initialize → initialized → retried call.
-        const methods = fetchImpl.calls.slice(3).map(call => call.body?.method ?? null);
-
-        expect(methods).toEqual(['tools/call', 'initialize', 'notifications/initialized', 'tools/call']);
-        expect(fetchImpl.calls.at(-1).headers['mcp-session-id']).toBe('sess-2')
+        expect(plane.calls.filter(call => call.toolName === 'list_messages')).toHaveLength(1);
+        expect(plane.calls.filter(call => call.toolName === 'list_permissions')).toHaveLength(2)
     });
 
-    test('a lost session with an unreachable plane throws through, not into a retry loop', async () => {
-        const {client} = await initializedClient({extraResponses: [
-            {status: 404},
-            {status: 503}
-        ]});
+    test('a reconnect against a dead plane throws through, not into a retry loop', async () => {
+        // The plane dies mid-life: the first initialize succeeds (healthy boot), every later
+        // initialize 503s, and tool calls 404 — so the single recovery attempt must fail loudly.
+        const plane = scriptedPlane({toolResponder: () => ({status: 404})});
 
-        await expect(client.listMessages()).rejects.toThrow('session lost and plane MCP initialize failed (503)')
+        let initializes = 0;
+
+        const fetchImpl = async (url, init = {}) => {
+            const body = typeof init.body === 'string' ? JSON.parse(init.body) : null;
+
+            if (body?.method === 'initialize' && ++initializes > 1) {
+                return planeResponse({status: 503, body: 'gone'})
+            }
+
+            return plane.fetchImpl(url, init)
+        };
+
+        const client    = createPlaneMailboxClient({baseUrl: LOOPBACK_URL, credential: 't', fetchImpl}),
+              admission = await client.init({expectedIdentity: IDENTITY});
+
+        expect(admission.ok).toBe(true);
+
+        await expect(client.listMessages())
+            .rejects.toThrow(/^plane list_messages failed: session lost and plane unreachable/);
+
+        expect(initializes).toBe(2)
+    })
+});
+
+test.describe('planeMailboxClient: post-failure liveness (the bricked-client regression)', () => {
+    test('a FAILED recovery does not brick the client — the next call lazily re-establishes with proof', async () => {
+        // Reproduces the live-receipt defect: call 1 loses its session AND its recovery fails
+        // (plane down); call 2 arrives later when the plane is back. The broken shape answered
+        // "client not initialized" forever; the contract is lazy proven re-establishment.
+        let initializes = 0,
+            planeDown   = false;
+
+        const plane = scriptedPlane({
+            identityBySession: [IDENTITY, IDENTITY, IDENTITY],
+            toolResponder    : ({name, sessionOrdinal}) =>
+                (name === 'list_messages' && sessionOrdinal === 0 ? {status: 404} : {payload: {alive: true}})
+        });
+
+        const fetchImpl = async (url, init = {}) => {
+            const body = typeof init.body === 'string' ? JSON.parse(init.body) : null;
+
+            if (body?.method === 'initialize') {
+                initializes++;
+
+                if (planeDown) return planeResponse({status: 503, body: 'down'})
+            }
+
+            return plane.fetchImpl(url, init)
+        };
+
+        const client = createPlaneMailboxClient({baseUrl: LOOPBACK_URL, credential: 't', fetchImpl});
+
+        expect((await client.init({expectedIdentity: IDENTITY})).ok).toBe(true);
+
+        // Call 1: session lost (404) and the recovery initialize finds the plane DOWN.
+        planeDown = true;
+        await expect(client.listMessages()).rejects.toThrow(/session lost and plane unreachable/);
+
+        // Call 2: the plane is back — the client must re-establish WITH identity proof and serve.
+        planeDown = false;
+        await expect(client.listMessages()).resolves.toEqual({alive: true});
+
+        expect(initializes).toBeGreaterThanOrEqual(3);
+        expect(plane.calls.filter(call => call.toolName === 'list_permissions').length).toBeGreaterThanOrEqual(2)
+    })
+});
+
+test.describe('planeMailboxClient: teardown', () => {
+    test('close() is awaited and idempotent — one DELETE, then no-ops', async () => {
+        const {client, plane} = await initializedClient();
+
+        await client.close();
+        await client.close();
+
+        expect(plane.calls.filter(call => call.method === 'DELETE')).toHaveLength(1);
+
+        await expect(client.callTool('list_messages')).rejects.toThrow('client not initialized')
     })
 });

--- a/test/playwright/unit/ai/planeMailboxClient.spec.mjs
+++ b/test/playwright/unit/ai/planeMailboxClient.spec.mjs
@@ -573,6 +573,54 @@ test.describe('planeMailboxClient: generation safety + the terminal close barrie
         await expect(client.callTool('list_messages')).rejects.toThrow('client not initialized')
     });
 
+    test('close during a FAILURE teardown waits for it: no exit while a stale-session DELETE pends', async () => {
+        // Reviewer-measured shape: a live call gets 404, clears the session, and enters a slow
+        // teardown; close() then saw session === null / establishing === null and resolved with the
+        // DELETE still pending ({closeResolvedBeforeInFlightDelete: true} on the broken build). The
+        // barrier must drain OBSERVABLE teardown ownership, whoever started the teardown.
+        const order = [];
+
+        let initializes = 0;
+
+        const plane = scriptedPlane({
+            deleteDelayMs: 40,
+            toolResponder: () => ({status: 404})
+        });
+
+        const fetchImpl = async (url, init = {}) => {
+            const body = typeof init.body === 'string' ? JSON.parse(init.body) : null;
+
+            // The recovery initialize finds the plane down — the failing call ends in its slow
+            // candidate-local teardown with nothing else to observe it but the barrier.
+            if (body?.method === 'initialize' && ++initializes > 1) {
+                return planeResponse({status: 503, body: 'down'})
+            }
+
+            const response = await plane.fetchImpl(url, init);
+
+            if (init.method === 'DELETE') order.push('delete-done');
+
+            return response
+        };
+
+        const client = createPlaneMailboxClient({baseUrl: LOOPBACK_URL, credential: 't', fetchImpl});
+
+        expect((await client.init({expectedIdentity: IDENTITY})).ok).toBe(true);
+
+        const failing = client.listMessages().catch(error => error);
+
+        // Let the 404 land and the slow teardown begin before closing.
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        await client.close();
+        order.push('close-resolved');
+
+        expect(order.indexOf('delete-done')).toBeGreaterThanOrEqual(0);
+        expect(order.indexOf('delete-done')).toBeLessThan(order.indexOf('close-resolved'));
+
+        expect((await failing) instanceof Error).toBe(true)
+    });
+
     test('concurrent closers share ONE terminal barrier: a single teardown sequence', async () => {
         const {client, plane} = await initializedClient();
 

--- a/test/playwright/unit/ai/planeMailboxClient.spec.mjs
+++ b/test/playwright/unit/ai/planeMailboxClient.spec.mjs
@@ -1,0 +1,226 @@
+import {test, expect} from '@playwright/test';
+
+import {createPlaneMailboxClient} from '../../../../ai/services/fleet/planeMailboxClient.mjs';
+
+/**
+ * @summary Unit coverage for the plane mailbox client — the streamable-HTTP MCP client the
+ * Fleet server binds its mailbox/compose/catch-up seams to in plane mode.
+ *
+ * Hermetic by construction: the module chain (client + mcpWireParsing + SDK type schemas) is pure,
+ * so no Neo namespace, no setup(), and no network — every wire interaction rides the injected
+ * `fetchImpl` seam with scripted responses.
+ */
+
+const BASE_URL = 'http://127.0.0.1:3102/mc/mcp';
+const IDENTITY = '@neo-fable-clio';
+
+/**
+ * @summary One scripted Response-shaped object (the subset the client reads).
+ * @param {Object} options
+ * @returns {Object}
+ */
+function scriptedResponse({status = 200, sessionId = null, body = {}}) {
+    return {
+        ok     : status >= 200 && status < 300,
+        status,
+        headers: {get: name => (name === 'mcp-session-id' ? sessionId : null)},
+        text   : async () => (typeof body === 'string' ? body : JSON.stringify(body))
+    }
+}
+
+/**
+ * @summary Scripted fetch: consumes one queued response per call and records every request for
+ * sequence assertions. A queue underrun throws — an unexpected extra request is a test failure,
+ * never a hang.
+ * @param {Object[]} queue
+ * @returns {Function} fetchImpl with a `.calls` recorder.
+ */
+function scriptedFetch(queue) {
+    const calls = [];
+
+    const impl = async (url, options) => {
+        const parsedBody = options?.body ? JSON.parse(options.body) : null;
+
+        calls.push({url, method: options?.method, headers: options?.headers ?? {}, body: parsedBody});
+
+        const next = queue.shift();
+
+        if (!next)               throw new Error(`scriptedFetch queue underrun (call ${calls.length})`);
+        if (next.reject)         throw Object.assign(new Error('scripted network failure'), {name: next.reject});
+
+        return scriptedResponse(next)
+    };
+
+    impl.calls = calls;
+
+    return impl
+}
+
+/** @summary The standard happy-path handshake pair: initialize + initialized-notification. */
+function handshakeResponses({sessionId = 'sess-1'} = {}) {
+    return [
+        {status: 200, sessionId, body: {jsonrpc: '2.0', id: 1, result: {
+            protocolVersion: '2024-11-05',
+            capabilities   : {},
+            serverInfo     : {name: 'mc', version: '1'}
+        }}},
+        {status: 200}
+    ]
+}
+
+/** @summary One successful tools/call response carrying a JSON text payload. */
+function toolResponse(payload) {
+    return {status: 200, body: {jsonrpc: '2.0', id: 2, result: {
+        content: [{type: 'text', text: JSON.stringify(payload)}]
+    }}}
+}
+
+/** @summary Init a client through the scripted happy-path handshake + identity probe. */
+async function initializedClient({extraResponses = [], identity = IDENTITY} = {}) {
+    const fetchImpl = scriptedFetch([
+        ...handshakeResponses(),
+        toolResponse({identity}),
+        ...extraResponses
+    ]);
+
+    const client    = createPlaneMailboxClient({baseUrl: BASE_URL, credential: 'token-1', fetchImpl}),
+          admission = await client.init({expectedIdentity: IDENTITY});
+
+    return {client, fetchImpl, admission}
+}
+
+test.describe('planeMailboxClient: construction', () => {
+    test('refuses an empty baseUrl', () => {
+        expect(() => createPlaneMailboxClient({baseUrl: '  '})).toThrow('non-empty baseUrl')
+    });
+
+    test('callTool before init throws the uninitialized error, no request leaves', async () => {
+        const fetchImpl = scriptedFetch([]),
+              client    = createPlaneMailboxClient({baseUrl: BASE_URL, fetchImpl});
+
+        await expect(client.callTool('list_messages')).rejects.toThrow('client not initialized');
+        expect(fetchImpl.calls).toHaveLength(0)
+    })
+});
+
+test.describe('planeMailboxClient: init (handshake + single-viewer invariant)', () => {
+    test('happy path: initialize → initialized → identity probe, session held', async () => {
+        const {admission, fetchImpl} = await initializedClient();
+
+        expect(admission).toEqual({ok: true, status: 200, identity: IDENTITY});
+
+        const [initCall, notifyCall, probeCall] = fetchImpl.calls;
+
+        expect(initCall.body.method).toBe('initialize');
+        expect(initCall.headers.Authorization).toBe('Bearer token-1');
+        expect(notifyCall.body.method).toBe('notifications/initialized');
+        expect(notifyCall.headers['mcp-session-id']).toBe('sess-1');
+        expect(probeCall.body.params.name).toBe('list_permissions')
+    });
+
+    test('identity mismatch refuses plane mode with the bounded reason', async () => {
+        const {admission} = await initializedClient({identity: '@someone-else'});
+
+        expect(admission.ok).toBe(false);
+        expect(admission.reason).toBe('plane identity mismatch')
+    });
+
+    test('rejected initialize yields a bounded status reason, never remote prose', async () => {
+        const fetchImpl = scriptedFetch([{status: 401, body: 'go away, secret prose'}]),
+              client    = createPlaneMailboxClient({baseUrl: BASE_URL, fetchImpl}),
+              admission = await client.init({expectedIdentity: IDENTITY});
+
+        expect(admission).toEqual({ok: false, status: 401, reason: 'plane MCP initialize failed (401)'})
+    });
+
+    test('unreachable plane yields a bounded transport reason', async () => {
+        const fetchImpl = scriptedFetch([{reject: 'TimeoutError'}]),
+              client    = createPlaneMailboxClient({baseUrl: BASE_URL, fetchImpl}),
+              admission = await client.init({expectedIdentity: IDENTITY});
+
+        expect(admission.ok).toBe(false);
+        expect(admission.reason).toBe('plane unreachable (TimeoutError)')
+    });
+
+    test('non-canonical expectedIdentity is refused before any request leaves', async () => {
+        const fetchImpl = scriptedFetch([]),
+              client    = createPlaneMailboxClient({baseUrl: BASE_URL, fetchImpl}),
+              admission = await client.init({expectedIdentity: '   '});
+
+        expect(admission.ok).toBe(false);
+        expect(fetchImpl.calls).toHaveLength(0)
+    })
+});
+
+test.describe('planeMailboxClient: tool calls (error shape mirrors the in-process services)', () => {
+    test('listMessages maps to the list_messages tool and resolves the parsed payload', async () => {
+        const payload             = {messages: [{messageId: 'MESSAGE:1', subject: 'hi'}]},
+              {client, fetchImpl} = await initializedClient({extraResponses: [toolResponse(payload)]});
+
+        await expect(client.listMessages({limit: 5})).resolves.toEqual(payload);
+
+        const call = fetchImpl.calls.at(-1);
+
+        expect(call.body.params).toEqual({name: 'list_messages', arguments: {limit: 5}})
+    });
+
+    test('addMessage maps to the add_message tool', async () => {
+        const {client, fetchImpl} = await initializedClient({extraResponses: [toolResponse({status: 'sent'})]});
+
+        await expect(client.addMessage({to: '@peer', subject: 's', body: 'b'})).resolves.toEqual({status: 'sent'});
+        expect(fetchImpl.calls.at(-1).body.params.name).toBe('add_message')
+    });
+
+    test('a tool-level isError result throws the tool text (the admission-classification contract)', async () => {
+        const denial = 'Unauthorized: CAN_READ_INBOX_OF denied for @neo-fable-clio -> @peer';
+
+        const {client} = await initializedClient({extraResponses: [
+            {status: 200, body: {jsonrpc: '2.0', id: 2, result: {isError: true, content: [{type: 'text', text: denial}]}}}
+        ]});
+
+        await expect(client.callTool('list_messages', {to: '@peer'})).rejects.toThrow(denial)
+    });
+
+    test('a transport failure throws a bounded status-only diagnostic', async () => {
+        const {client} = await initializedClient({extraResponses: [
+            {status: 500, body: 'stack trace prose the caller must never see'}
+        ]});
+
+        await expect(client.listMessages()).rejects.toThrow('plane list_messages failed: HTTP 500')
+    });
+
+    test('a malformed tool payload throws bounded, never resolves null', async () => {
+        const {client} = await initializedClient({extraResponses: [
+            {status: 200, body: {jsonrpc: '2.0', id: 2, result: {content: [{type: 'text', text: 'not json'}]}}}
+        ]});
+
+        await expect(client.listMessages()).rejects.toThrow('plane list_messages failed: malformed tool payload')
+    });
+
+    test('a lost session (404) re-establishes ONCE and retries the call transparently', async () => {
+        const payload = {messages: []};
+
+        const {client, fetchImpl} = await initializedClient({extraResponses: [
+            {status: 404},               // held session rejected → re-handshake expected
+            ...handshakeResponses({sessionId: 'sess-2'}),
+            toolResponse(payload)
+        ]});
+
+        await expect(client.listMessages()).resolves.toEqual(payload);
+
+        // Sequence proof: probe(3) → failed call → initialize → initialized → retried call.
+        const methods = fetchImpl.calls.slice(3).map(call => call.body?.method ?? null);
+
+        expect(methods).toEqual(['tools/call', 'initialize', 'notifications/initialized', 'tools/call']);
+        expect(fetchImpl.calls.at(-1).headers['mcp-session-id']).toBe('sess-2')
+    });
+
+    test('a lost session with an unreachable plane throws through, not into a retry loop', async () => {
+        const {client} = await initializedClient({extraResponses: [
+            {status: 404},
+            {status: 503}
+        ]});
+
+        await expect(client.listMessages()).rejects.toThrow('session lost and plane MCP initialize failed (503)')
+    })
+});

--- a/test/playwright/unit/ai/planeMailboxClient.spec.mjs
+++ b/test/playwright/unit/ai/planeMailboxClient.spec.mjs
@@ -315,7 +315,104 @@ test.describe('planeMailboxClient: concurrency (the production catch-up call sha
     })
 });
 
+test.describe('planeMailboxClient: replay boundary (proven session-invalid only)', () => {
+    test('an AMBIGUOUS mutating failure commits at most once: response lost AFTER commit → throw, no replay', async () => {
+        // Reviewer-reproduced shape (committedCopies: 2 on the broken build): the plane COMMITS the
+        // add_message, then the response is lost to a network error. Ambiguity must throw — a
+        // replay would be a SECOND durable message, since MC mints a fresh id per invocation.
+        let committedCopies = 0;
+
+        const plane = scriptedPlane({
+            toolResponder: ({name}) => {
+                if (name === 'add_message') {
+                    committedCopies++;
+
+                    throw Object.assign(new Error('socket closed mid-response'), {name: 'TypeError'})
+                }
+
+                return {payload: {}}
+            }
+        });
+
+        const client = createPlaneMailboxClient({baseUrl: LOOPBACK_URL, credential: 't', fetchImpl: plane.fetchImpl});
+
+        expect((await client.init({expectedIdentity: IDENTITY})).ok).toBe(true);
+
+        await expect(client.addMessage({to: '@peer', subject: 's', body: 'b'}))
+            .rejects.toThrow(/ambiguous — not replayed/);
+
+        expect(committedCopies).toBe(1);
+        expect(plane.calls.filter(call => call.toolName === 'add_message')).toHaveLength(1)
+    });
+
+    test('an ambiguous 5xx read failure throws without replay — the adapters own the degraded state', async () => {
+        const {client, plane} = await initializedClient({toolResponder: () => ({status: 503})});
+
+        await expect(client.listMessages()).rejects.toThrow(/ambiguous — not replayed/);
+        expect(plane.calls.filter(call => call.toolName === 'list_messages')).toHaveLength(1)
+    })
+});
+
 test.describe('planeMailboxClient: session loss (one bounded recovery, identity re-proven)', () => {
+    test('CONCURRENT callers after a FAILED recovery share ONE single-flight re-proof — no orphan session', async () => {
+        // Reviewer-named race: session === null after a failed recovery, then two production-shaped
+        // concurrent callers. Broken build: two parallel handshakes, the later candidate overwrites
+        // the shared slot, the earlier proven session is orphaned. Contract: ONE shared re-proof.
+        let initializeAttempts = 0,
+            firstToolFailed    = false;
+
+        const plane = scriptedPlane({
+            identityBySession: [IDENTITY, IDENTITY, IDENTITY],
+            toolResponder    : ({name}) => {
+                if (!firstToolFailed) {
+                    firstToolFailed = true;
+
+                    return {status: 404}
+                }
+
+                return {payload: {tool: name}}
+            }
+        });
+
+        const fetchImpl = async (url, init = {}) => {
+            const body = typeof init.body === 'string' ? JSON.parse(init.body) : null;
+
+            // Initialize #2 (the first recovery) fails — that failed recovery leaves session null.
+            if (body?.method === 'initialize' && ++initializeAttempts === 2) {
+                return planeResponse({status: 503, body: 'down'})
+            }
+
+            return plane.fetchImpl(url, init)
+        };
+
+        const client = createPlaneMailboxClient({baseUrl: LOOPBACK_URL, credential: 't', fetchImpl});
+
+        expect((await client.init({expectedIdentity: IDENTITY})).ok).toBe(true);
+
+        // Call 1: 404 → recovery initialize 503s → session stays null.
+        await expect(client.listMessages()).rejects.toThrow(/session lost and plane unreachable/);
+
+        // The production catch-up pair arrives concurrently against the null session.
+        const [memory, pulls] = await Promise.allSettled([
+            client.callTool('explore_memory_history',       {limit: 1}),
+            client.callTool('explore_pull_request_history', {limit: 1})
+        ]);
+
+        expect(memory.status).toBe('fulfilled');
+        expect(pulls.status).toBe('fulfilled');
+        expect(memory.value).toEqual({tool: 'explore_memory_history'});
+        expect(pulls.value).toEqual({tool: 'explore_pull_request_history'});
+
+        // Single-flight: exactly 3 initialize attempts total (boot, failed recovery, ONE shared
+        // re-proof) and exactly 2 identity proofs (boot + the shared re-proof).
+        expect(initializeAttempts).toBe(3);
+        expect(plane.calls.filter(call => call.toolName === 'list_permissions')).toHaveLength(2);
+
+        // No orphan: the only torn session is the boot session (one DELETE); the shared re-proof
+        // session is current, never overwritten by a second candidate.
+        expect(plane.calls.filter(call => call.method === 'DELETE')).toHaveLength(1)
+    });
+
     test('a transport-level failure reconnects ONCE, re-proves the SAME identity, then replays', async () => {
         let failed = false;
 

--- a/test/playwright/unit/ai/planeMailboxClient.spec.mjs
+++ b/test/playwright/unit/ai/planeMailboxClient.spec.mjs
@@ -59,7 +59,7 @@ function planeResponse({status = 200, contentType = 'application/json', sessionI
  *     before succeeding.
  * @returns {Object} `{fetchImpl, calls}`
  */
-function scriptedPlane({identityBySession = [IDENTITY], toolResponder = null, failInitializeTimes = 0} = {}) {
+function scriptedPlane({identityBySession = [IDENTITY], toolResponder = null, failInitializeTimes = 0, deleteDelayMs = 0} = {}) {
     const calls = [];
 
     let sessions           = 0,
@@ -84,8 +84,15 @@ function scriptedPlane({identityBySession = [IDENTITY], toolResponder = null, fa
 
         calls.push(call);
 
-        if (method === 'GET')    return planeResponse({status: 405});
-        if (method === 'DELETE') return planeResponse({status: 200, body: {}});
+        if (method === 'GET') return planeResponse({status: 405});
+
+        if (method === 'DELETE') {
+            // Slow teardown widens the window in which a concurrent caller's failure lands while a
+            // predecessor is still being torn down — the reviewer's asymmetric-teardown probe shape.
+            if (deleteDelayMs) await new Promise(resolve => setTimeout(resolve, deleteDelayMs));
+
+            return planeResponse({status: 200, body: {}})
+        }
 
         if (body?.method === 'initialize') {
             if (initializeFailures > 0) {
@@ -481,6 +488,97 @@ test.describe('planeMailboxClient: session loss (one bounded recovery, identity 
             .rejects.toThrow(/^plane list_messages failed: session lost and plane unreachable/);
 
         expect(initializes).toBe(2)
+    })
+});
+
+test.describe('planeMailboxClient: generation safety + the terminal close barrier', () => {
+    test('dual 404 from ONE live predecessor with slow teardown: the replacement is reused, never overwritten — every candidate closes', async () => {
+        // Reviewer-reproduced shape: two concurrent callers fail 404 on the SAME live session while
+        // the predecessor teardown is still in flight. Broken build: generations 2 AND 3 proven,
+        // generation 2 overwritten and left unclosed after explicit close. Contract: the later
+        // failure RIDES the current proven replacement.
+        const plane = scriptedPlane({
+            identityBySession: [IDENTITY, IDENTITY],
+            deleteDelayMs    : 30,
+            toolResponder    : ({name, sessionOrdinal}) => {
+                if (sessionOrdinal === 0) {
+                    // Both first-session calls fail 404, landing staggered so the second failure
+                    // arrives while the first caller's teardown/re-proof is in progress.
+                    return {status: 404, delayMs: name === 'explore_memory_history' ? 5 : 20}
+                }
+
+                return {payload: {tool: name}}
+            }
+        });
+
+        const client = createPlaneMailboxClient({baseUrl: LOOPBACK_URL, credential: 't', fetchImpl: plane.fetchImpl});
+
+        expect((await client.init({expectedIdentity: IDENTITY})).ok).toBe(true);
+
+        const [memory, pulls] = await Promise.allSettled([
+            client.callTool('explore_memory_history',       {limit: 1}),
+            client.callTool('explore_pull_request_history', {limit: 1})
+        ]);
+
+        expect(memory.status).toBe('fulfilled');
+        expect(pulls.status).toBe('fulfilled');
+        expect(memory.value).toEqual({tool: 'explore_memory_history'});
+        expect(pulls.value).toEqual({tool: 'explore_pull_request_history'});
+
+        // Generation safety: exactly TWO sessions ever proven (boot + ONE replacement) — no
+        // generation 3, and the identity oracle ran exactly twice.
+        const initializes = plane.calls.filter(call => call.rpcMethod === 'initialize');
+
+        expect(initializes).toHaveLength(2);
+        expect(plane.calls.filter(call => call.toolName === 'list_permissions')).toHaveLength(2);
+
+        // Every candidate closes: after the terminal close, both proven sessions carry a DELETE.
+        await client.close();
+
+        expect(plane.calls.filter(call => call.method === 'DELETE')).toHaveLength(2)
+    });
+
+    test('close during establishment FENCES the in-flight proof: candidate torn before close resolves, no resurrection', async () => {
+        const plane = scriptedPlane();
+
+        let initializeStarted;
+
+        const started   = new Promise(resolve => { initializeStarted = resolve });
+        const fetchImpl = async (url, init = {}) => {
+            const body = typeof init.body === 'string' ? JSON.parse(init.body) : null;
+
+            if (body?.method === 'initialize') {
+                initializeStarted();
+                await new Promise(resolve => setTimeout(resolve, 40))
+            }
+
+            return plane.fetchImpl(url, init)
+        };
+
+        const client = createPlaneMailboxClient({baseUrl: LOOPBACK_URL, credential: 't', fetchImpl});
+
+        const admissionPromise = client.init({expectedIdentity: IDENTITY});
+
+        await started;
+
+        await client.close();
+
+        // The barrier resolved only after the fenced proof settled and its candidate was torn.
+        expect(plane.calls.filter(call => call.method === 'DELETE').length).toBeGreaterThanOrEqual(1);
+
+        const admission = await admissionPromise;
+
+        expect(admission.ok).toBe(false);
+
+        await expect(client.callTool('list_messages')).rejects.toThrow('client not initialized')
+    });
+
+    test('concurrent closers share ONE terminal barrier: a single teardown sequence', async () => {
+        const {client, plane} = await initializedClient();
+
+        await Promise.all([client.close(), client.close(), client.close()]);
+
+        expect(plane.calls.filter(call => call.method === 'DELETE')).toHaveLength(1)
     })
 });
 


### PR DESCRIPTION
Resolves #16324

The Fleet server's four Memory-Core seams (activity `listMessages`, operator-compose `addMessage`, catch-up `callTool`, mailbox mirror) ride the containerized Agent OS plane through an SDK-backed streamable-HTTP MCP client, decided once at boot. Plane mode boots **graphless**: the viewer identity claim (env/gh chain) is verified by the plane itself (`list_permissions` proof binds the bearer's server-resolved subject to the claim), host Memory Core is never opened, and a missing/stale host graph structurally cannot veto a healthy plane. An empty `fleet.planeBase` keeps today's in-process bindings (host-graph-verified viewer), logged either way. Adapters, admission logic, and DTO shapes are untouched.

**Error containment contract (authoritative wording):** the plane client THROWS exactly like the in-process services (transport failures bounded; tool-level `isError` text passed through for the admission-classification contract); the ADAPTERS own the degraded/denied mapping. **Session lifecycle:** the official SDK owns request-id uniqueness and response correlation; proven-session acquisition is single-flight (concurrent recoverers share one re-proof; clearing is candidate-local); replay is gated to the positively identified session-invalid class (the SDK 404) — timeout/network/5xx ambiguity throws for every tool, so a mutating `add_message` can never double-send; every establishment re-proves the same viewer, and a changed identity rejects without replaying; `close()` is awaited on signal shutdown and both occupied-port exits.

Evidence: L3 achieved on the PROVEN FLEET PATHS (headed full-rows receipt at the durable receipt tree `receipt/16324-headed-receipt-tree` = `e3033cf6a8`; boot/roster/degrade receipts re-run at the cycle-2 head; sandbox ceiling L2 = real-SDK-stack scripted-dispatch specs) → L3 required (AC-5 [#16324]). Residual: none for the Fleet-path claims. Scope precision: receipt-tree → head is NOT whole-tree equivalent (the rebases carried unrelated dev advances — including foreign `test/playwright/unit/ai/` specs and a foreign `configBase` delta); the equivalence claim is scoped to the exact repair files — `git diff receipt/16324-headed-receipt-tree..HEAD -- ai/services/fleet/planeMailboxClient.mjs ai/services/fleet/devFleetServer.mjs test/playwright/unit/ai/planeMailboxClient.spec.mjs` is exactly the cycle-2/3 repair content, and `git log` over that range and those paths shows ONLY this PR's commits. The receipted read/render path is covered by the spec suite at every head.

## Deltas from ticket

- The per-call bound is the SDK protocol default (60s), not the drafted 10s: the local plane legitimately answers `initialize` ~17s / `list_messages` ~25s under embed/WAL load (measured), and this week the plane also ran windows where the heavy a2a read exceeds any sane bound (WAL drain dead 13.9h+, container rebuild pending per the plane-incident thread) — those windows now surface as precise named degrade reasons instead of fabricated data.
- The ADR-0019 lint caught a hidden-default config read on the first draft; shipped form reads the leaf plainly.
- In plane mode the PR/lane slot's OPTIONAL `graphService` is deliberately absent (host graph stays unopened); its stall defer-disposition degrades per that slot's own fail-soft contract.
- The headed receipt caught a defect no review could see statically: a FAILED recovery left the client bricked; fixed with single-flight lazy re-establishment (the live exposure was the mc-server being restarted mid-receipt).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/planeMailboxClient.spec.mjs` → **28/28** at head: endpoint boundary (4), SDK handshake + single-viewer proof (4), tool calls/error shapes (5), production-shape concurrency (unique ids + out-of-order correlation), replay boundary (ambiguous mutating commit-once witness — the reviewer-reproduced `committedCopies` shape — + ambiguous 5xx read), session loss (single-flight concurrent re-proof with no-orphan DELETE accounting; 404 reconnect re-proof + replay; changed-identity rejects without replay; dead-plane no-retry-loop), generation safety + the terminal close barrier (dual-404 + slow-teardown; close-during-establishment fencing; close-during-FAILURE-teardown — the gated-DELETE witness asserting the DELETE completes before close resolves; concurrent closers single-teardown), bricked-client regression, idempotent awaited close.
- `npm run test-unit -- test/playwright/unit/ai/fleetLaunchContract.spec.mjs` → **6/6**: claim shape, fail-closed unresolved, graph-cannot-veto witness; in-process verification + two veto halves.
- Full `test/playwright/unit/ai/` tree → 8464 passed at the cycle-1 head; 2 memory-core stragglers pass solo (load-flake on the WAL-wedged host, outside this diff). CI green 16/16 at every pushed head so far; current head CI running.
- Fleet surfaces, live receipts:
  - Boot fail-closed (bad bearer): named 401 refusal + exit 1. Boot verified (current head): `viewer @neo-fable-clio verified plane-side; host graph not consulted`. Boot fallback: explicit in-process log line.
  - Full-rows headed receipt (receipt tree, public ref): cockpit via `ViewportController.wireFleetBridge` (the e2e-harness injector) — roster `rosterWired: true` / `gridAdapterState: 'live'`; ActivityStream `streamAdapterState: 'live'` ("LIVE ACTIVITY · streaming"); operator mailbox pane rendering "A2A Mailbox · 1–50 · updated 54s ago" with real plane rows (the plane-incident broadcast six minutes old at read time; this PR's own review-action message; `admission: granted`, viewer-stamped, `hasMore` paging); compose surface with the wake-default-quiet toggle.
  - Current-head re-run (degraded-plane window): boot proof + roster live + operator identity resolved; the a2a read surfaced the NEW boundary honestly — `"a2a: plane list_messages failed: Error (ambiguous — not replayed)"` — no fabricated rows, no replay, lazy re-acquisition on later calls (the bricked-client fix observable in production).
  - Compose round-trip (cycle 1): bridge-composed message landed in the plane and was read back through an independent MCP client, `from` server-resolved.

## Post-Merge Validation

- [ ] Operator-principal compose: when the operator seat runs the cockpit with their own PAT, composed messages carry the operator's server-stamped identity + principal class (receipts here ran under an agent seat; same rails, different principal).
- [ ] Full-rows pane receipt on a healthy plane at the merged head (the current-head window coincided with the known WAL-dead container state; the degrade half is receipted live, the rows half at the public receipt tree).

## Commits

(shas as of the cycle-3 rebase)
- feat commit — the four-seam plane swap + client + wire-parsing extraction + leaves + parity snapshot.
- cycle-1 repair commit — SDK-backed client, graphless plane boot, shared endpoint policy, bricked-client fix (receipt tree `e3033cf6a8` carries this content pre-rebase).
- cycle-2 repair commit — single-flight proven acquisition, 404-only replay boundary, awaited exit close, two reviewer-shaped witnesses.
- cycle-3 repair commit — generation-safe recovery (current-replacement reuse; no overwriting third proof), the shared terminal close barrier (fences establishment, one promise for every closer, epoch reset on re-init), awaited close on non-`EADDRINUSE`/probe-failure exits, three reviewer-shaped witnesses (dual-404 + slow teardown / close-during-establishment / concurrent closers).
- `a6dd919c3e` (head) — teardown ownership OBSERVABLE to the close barrier (every teardown enrolls in a pending set close drains — an already-started failure-path DELETE is awaited before close resolves), the entry try spans all post-admission exits structurally, the gated-DELETE witness. Spec suite: 28 client + 6 contract = 34/34.

## Evolution

Cycle 1 shipped a hand-rolled protocol state machine lifted from the one-shot tenant probe; review falsified it for long-lived concurrent use (static request id) and the repair moved to the installed SDK pair, which also dissolved the correlation and lifecycle classes wholesale. Cycle 2 hardened recovery into single-flight/candidate-local acquisition and drew the replay boundary at proven session-invalidity — the ambiguous-mutating double-send the reviewer reproduced is now structurally impossible.

Authored by Clio (Claude Fable 5, Claude Code). Session 96ee8bfe-9dd2-4fd9-9532-304df7044dc6.
