### PR TITLE
fix(ai): pass the validated argument object on the two silently-truncating MCP operations (#16250)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -280,6 +280,7 @@ paths:
       summary: Get PR Diff
       operationId: get_pull_request_diff
       x-neo-tool-tier: read
+      x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
       description: |

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -72,6 +72,7 @@ paths:
       summary: Get Ingestion Progress
       operationId: get_ingestion_progress
       x-neo-tool-tier: extended
+      x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
       x-neo-tool-summary: Ingestion progress for THIS PROCESS only; pull-mode tenant lanes run elsewhere.

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -744,17 +744,7 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
             'get_mcp_tool_handbook': 'arrow handler takes the toolId positionally',
 
             // `getIssueById(issueNumber)` — genuinely positional, single argument.
-            'github-workflow:get_local_issue_by_id': 'handler signature is a single positional issueNumber',
-
-            // `getPullRequestDiff(options)` documents `{Object|number}` and re-wraps a bare number, so
-            // the positional call still resolves pr_number — but `file`, `sha` and `files_only` are
-            // dropped by arity. Listed to keep this guard green, NOT because the dispatch is right.
-            'github-workflow:get_pull_request_diff': 'tolerates a bare pr_number; the other three declared arguments never arrive',
-
-            // `getIngestionProgress({staleAfterMs = 60000} = {})` destructures, but the `= {}` default
-            // keeps it from throwing on a positional call: it falls back to 60000 and the caller's
-            // value never lands. Same category as the entry above.
-            'knowledge-base:get_ingestion_progress': 'destructures behind a `= {}` default; positional call degrades silently'
+            'github-workflow:get_local_issue_by_id': 'handler signature is a single positional issueNumber'
         };
 
         const offenders = [];


### PR DESCRIPTION
Resolves #16250

Both silent MCP degradations now fail visibly into the correct shape: the two operations dispatch `x-pass-as-object: true`, so the validated caller object reaches the handler intact instead of being spread positionally and silently truncated.

- **`knowledge-base.get_ingestion_progress`** (default-absorb): `{staleAfterMs: 5000}` was destructured off a bare `5000` and the `= 60000` default won — an operator narrowing the stall window got the default answer while believing they asked otherwise. Verified against the real `ToolService` + the real `openapi.yaml`: handler now receives `[{"staleAfterMs":5000}]`.
- **`github-workflow.get_pull_request_diff`** (arity-drop): one `options` parameter bound only the first of four declared arguments, so `file`, `sha`, and `files_only` never arrived — a narrowing request returned the *whole* diff, and `files_only: true` yielded full diff text. The handler (already written for `{Object|number}`) now receives all four. I observed this defect live on my own seat during review work: a two-file request returned three files — "more than requested reads as thoroughness," exactly the survival mode the ticket names.

The guard's exception list loses both entries (`OpenApiValidatorCompliance.spec.mjs`): every remaining `positionalHandlers` entry is now *correct* rather than tolerated — which also settles the `#16235` review residual (an exception with a reason but no anchor read as approved permanent debt; after this change there is nothing left to anchor).

Evidence: L2 (real-`ToolService` dispatch receipts for both operations + the compliance guard green) — the contract/dispatch surface is fully spec-reachable. Residual: none.

## Deltas from ticket

None substantive — the ticket's prescribed fix shipped verbatim (both annotations + guard cleanup). The live-observation receipt from my own seat is added as corroboration of defect B's in-the-wild behavior.

## Test Evidence

- Dispatch re-verification against the real `ToolService` with the real contracts (recording handlers):
  - A: `callTool('get_ingestion_progress', {staleAfterMs: 5000})` → handler received `[{"staleAfterMs":5000}]` ✓ (caller value lands)
  - B: `callTool('get_pull_request_diff', {pr_number: 42, file: 'src/Neo.mjs', files_only: true})` → handler received `[{"pr_number":42,"file":"src/Neo.mjs","files_only":true}]` ✓ (all four declared args arrive)
- `OpenApiValidatorCompliance.spec.mjs`: **48/48 green** — both exceptions removed; no new offenders surface; `x-pass-as-object` ops are correctly skipped by the positional-arity guard.

## Post-Merge Validation

- [ ] The next agent call to either operation with narrowing arguments returns the narrowed result (behavioral confirmation in production traffic).

Authored by Iris (Kimi K3, Kimi Code CLI). Session f91d8847-7722-4c4e-80d6-fa9f646a75e9.
