### PR TITLE
feat(ai): record dock-mutation reverses for agent undo/redo (#16316)

### DIFF
--- a/src/ai/client/DockService.mjs
+++ b/src/ai/client/DockService.mjs
@@ -2,6 +2,7 @@ import DockTopologyDiff       from '../../dashboard/DockTopologyDiff.mjs';
 import DockTopologyReconciler from '../../dashboard/DockTopologyReconciler.mjs';
 import DockZoneModel          from '../../dashboard/DockZoneModel.mjs';
 import Service                from './Service.mjs';
+import {deriveSubtreePath}    from '../deriveSubtreePath.mjs';
 
 /**
  * Handles dock-layout Neural Link requests: topology readout, semantic operation execution and
@@ -402,14 +403,52 @@ class DockService extends Service {
     }
 
     /**
+     * Builds the reverse-op for an `execute_dock_operation` write — `op⁻¹ = applyDocument(preDoc)`,
+     * capturing the pre-mutation document BEFORE the forward op lands: the document IS the state,
+     * so the honest inverse of any dock mutation is re-committing its prior document through the
+     * shared fail-closed commit path. Returns `null` for a legacy / unattributed write (no writer
+     * identity ⇒ no per-writer undo stack) or an unresolvable target, so {@link #recordUndo} no-ops.
+     * The reverse is a re-dispatchable validated tool descriptor — data-not-code, per the Neural
+     * Link capability boundary.
+     * @param {Object} params
+     * @param {Object|null} params.context  The Bridge-stamped `{agentId, sessionId}` writer pair.
+     * @param {String} params.componentId The dock workspace / holder component id
+     * @param {Object} params.descriptor  The forward `{operation, ...}` descriptor
+     * @param {Object} params.preDocument Deep clone of the pre-mutation dockZone.v1 document
+     * @returns {Object|null} A reverse-record op, or `null` when the write is not capturable.
+     * @protected
+     */
+    buildDockReverse({context, componentId, descriptor, preDocument}) {
+        if (!context?.agentId || !context?.sessionId) {
+            return null
+        }
+
+        const targetSubtreePath = deriveSubtreePath(componentId, cid => Neo.getComponent(cid)?.parentId);
+
+        if (!targetSubtreePath) {
+            return null
+        }
+
+        return {
+            sequenceId  : `${componentId}:${++this.undoSequence}`,
+            originWriter: {agentId: context.agentId, sessionId: context.sessionId},
+            targetSubtreePath,
+            forward     : {tool: 'execute_dock_operation', args: {componentId, descriptor}},
+            reverse     : {tool: 'execute_dock_operation', args: {componentId, descriptor: {operation: 'applyDocument', document: preDocument}}},
+            label       : `dock ${descriptor.operation} on ${componentId}`
+        }
+    }
+
+    /**
      * Applies one semantic dock operation to the holder's document through the landed commit
      * path and returns the post-operation state, so agents can verify without a second call.
      * @param {Object} params
      * @param {String} params.componentId The dock workspace / holder component id
      * @param {Object} params.descriptor  `{operation, ...}` — the `DockZoneModel.applyOperation()` shape
+     * @param {Object|null} [context] The Bridge-stamped agent writer pair (2nd dispatch arg); null/undefined = legacy.
      * @returns {Object} `{applied, errors, document}` — `applied: false` carries the executor's errors
      */
-    async executeDockOperation({componentId, descriptor}) {
+    async executeDockOperation({componentId, descriptor}, context) {
         const operation = descriptor?.operation;
 
         if (!operation || !DockService.operations.includes(operation)) {
@@ -421,6 +460,19 @@ class DockService extends Service {
 
         const holder = this.resolveHolder(componentId);
         let result;
+
+        // Capture the reverse (a deep clone of the pre-mutation document) BEFORE applying — an undo
+        // replay (`context.undoReplay`, set by the undo/redo dispatch) is NOT captured: re-applying a
+        // captured op must never enqueue a new transaction. A legacy / unattributed write builds no
+        // op at all, so the post-commit recordUndo no-ops.
+        const undoOp = context?.undoReplay
+            ? null
+            : this.buildDockReverse({
+                  componentId,
+                  context,
+                  descriptor,
+                  preDocument: Neo.clone(this.readDocument(holder), true)
+              });
 
         try {
             if (typeof holder.applyDockZoneOperation === 'function') {
@@ -457,6 +509,9 @@ class DockService extends Service {
             if (typeof holder.onDockZoneDocumentChange === 'function') {
                 holder.onDockZoneDocumentChange(result.document, descriptor, this)
             }
+
+            // After the commit, never before: capturing an undo must never break the forward write.
+            this.recordUndo(context, undoOp)
         }
 
         return {

--- a/src/ai/client/DockService.mjs
+++ b/src/ai/client/DockService.mjs
@@ -410,6 +410,12 @@ class DockService extends Service {
      * identity ⇒ no per-writer undo stack) or an unresolvable target, so {@link #recordUndo} no-ops.
      * The reverse is a re-dispatchable validated tool descriptor — data-not-code, per the Neural
      * Link capability boundary.
+     *
+     * Named bound: a whole-document reverse is **per-writer last-writer-wins**. A's undo re-commits
+     * A's pre-mutation document and silently discards any mutation B interleaved between A's capture
+     * and A's undo — `targetSubtreePath` is audit metadata, never an enforcement path, so nothing at
+     * undo time checks that the subtree still matches capture-time. Inherent to document-as-state,
+     * not a defect; single-writer surfaces never reveal it.
      * @param {Object} params
      * @param {Object|null} params.context  The Bridge-stamped `{agentId, sessionId}` writer pair.
      * @param {String} params.componentId The dock workspace / holder component id

--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -17,13 +17,6 @@ class InstanceService extends Service {
     }
 
     /**
-     * Monotonic per-instance counter minting unique undo transaction / sequence ids for captured reverse-ops.
-     * @member {Number} undoSequence=0
-     * @protected
-     */
-    undoSequence = 0
-
-    /**
      * Retrieves properties from a specific instance by its ID.
      * @param {Object} params
      * @param {String} params.id
@@ -661,53 +654,6 @@ class InstanceService extends Service {
             forward     : {tool: 'remove_component', args: {componentId: id}},
             reverse     : {tool: 'call_method', args: {id: parentId, method: 'insert', args: [index, config]}},
             label       : `remove ${id} from ${parentId}`
-        }
-    }
-
-    /**
-     * Captures a reverse-op onto this heap's undo stack ({@link Neo.ai.Client#transactionService}), keyed on the
-     * writer's `(agentId, sessionId)`. Two routes, decided by whether the writer has an **agent-opened named batch**
-     * in progress ({@link #beginTransaction}):
-     * - **named batch open** → `record` the op INTO it; no per-op commit (the batch accumulates, so the agent's
-     *   {@link #commitTransaction} closes it and multiple mutations undo as one unit). The auto-wrap below MUST be
-     *   skipped here — its `begin` would abort the open batch ({@link Neo.ai.TransactionService#begin} drops a prior
-     *   open tx).
-     * - **no open batch** → auto-wrap the op as its own single-op committed transaction (`begin` → `record` →
-     *   `commit`), the default per-mutation capture.
-     * Best-effort: a `null` op (incl. an undo replay, suppressed at the call site), an absent stack authority, or a
-     * stack rejection (a malformed / unserializable reverse) is dropped cleanly (`abort` on the auto-wrap path),
-     * never thrown — capturing an undo must never break the forward write it shadows.
-     * @param {Object|null} context
-     * @param {Object|null} op
-     * @protected
-     */
-    recordUndo(context, op) {
-        const transactionService = this.client?.transactionService;
-
-        if (!op || !transactionService) {
-            return
-        }
-
-        const
-            stackId  = {agentId: context.agentId, sessionId: context.sessionId},
-            openTxId = transactionService.openTxId({id: stackId});
-
-        if (openTxId) {
-            // An agent-opened named batch is in progress — accumulate this op into it (no per-op commit). A record
-            // rejection drops the op cleanly (the batch stays open + intact).
-            transactionService.record({id: stackId, txId: openTxId, op});
-            return
-        }
-
-        // No open batch → auto-wrap this single mutation as its own committed transaction.
-        const txId = `tx:${op.sequenceId}`;
-
-        transactionService.begin({id: stackId, txId});
-
-        if (transactionService.record({id: stackId, txId, op}).ok) {
-            transactionService.commit({id: stackId, txId})
-        } else {
-            transactionService.abort({id: stackId, txId})
         }
     }
 

--- a/src/ai/client/Service.mjs
+++ b/src/ai/client/Service.mjs
@@ -20,6 +20,60 @@ class Service extends Base {
     }
 
     /**
+     * Monotonic per-instance counter minting unique undo transaction / sequence ids for captured reverse-ops.
+     * @member {Number} undoSequence=0
+     * @protected
+     */
+    undoSequence = 0
+
+    /**
+     * Captures a reverse-op onto this heap's undo stack ({@link Neo.ai.Client#transactionService}), keyed on the
+     * writer's `(agentId, sessionId)`. Two routes, decided by whether the writer has an **agent-opened named batch**
+     * in progress (the `begin_transaction` tool):
+     * - **named batch open** → `record` the op INTO it; no per-op commit (the batch accumulates, so the agent's
+     *   `commit_transaction` closes it and multiple mutations undo as one unit). The auto-wrap below MUST be
+     *   skipped here — its `begin` would abort the open batch ({@link Neo.ai.TransactionService#begin} drops a prior
+     *   open tx).
+     * - **no open batch** → auto-wrap the op as its own single-op committed transaction (`begin` → `record` →
+     *   `commit`), the default per-mutation capture.
+     * Best-effort: a `null` op (incl. an undo replay, suppressed at the call site), an absent stack authority, or a
+     * stack rejection (a malformed / unserializable reverse) is dropped cleanly (`abort` on the auto-wrap path),
+     * never thrown — capturing an undo must never break the forward write it shadows.
+     * @param {Object|null} context
+     * @param {Object|null} op
+     * @protected
+     */
+    recordUndo(context, op) {
+        const transactionService = this.client?.transactionService;
+
+        if (!op || !transactionService) {
+            return
+        }
+
+        const
+            stackId  = {agentId: context.agentId, sessionId: context.sessionId},
+            openTxId = transactionService.openTxId({id: stackId});
+
+        if (openTxId) {
+            // An agent-opened named batch is in progress — accumulate this op into it (no per-op commit). A record
+            // rejection drops the op cleanly (the batch stays open + intact).
+            transactionService.record({id: stackId, txId: openTxId, op});
+            return
+        }
+
+        // No open batch → auto-wrap this single mutation as its own committed transaction.
+        const txId = `tx:${op.sequenceId}`;
+
+        transactionService.begin({id: stackId, txId});
+
+        if (transactionService.record({id: stackId, txId, op}).ok) {
+            transactionService.commit({id: stackId, txId})
+        } else {
+            transactionService.abort({id: stackId, txId})
+        }
+    }
+
+    /**
      * @summary Serializes a property value for the wire. Plain objects and arrays serialize in
      * full; a Neo INSTANCE collapses to its `toJSON()` identity snapshot — which is a truncation
      * of the instance's object graph, so the snapshot carries a `__truncated` marker making the

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -85,6 +85,7 @@ class DockZoneModel extends Base {
             DockZoneModel.findContainingTabsId(document, descriptor.itemId)
                 ? DockZoneModel.moveItem(document, {itemId: descriptor.itemId, targetNodeId: descriptor.tabsNodeId, index: descriptor.index})
                 : DockZoneModel.addTab(document, descriptor),
+        applyDocument    : (document, descriptor) => DockZoneModel.applyDocument(document, descriptor),
         moveItem         : (document, descriptor) => DockZoneModel.moveItem(document, descriptor),
         splitNode        : (document, descriptor) => DockZoneModel.splitNode(document, descriptor),
         moveNode         : (document, descriptor) => DockZoneModel.moveNode(document, descriptor),
@@ -871,6 +872,23 @@ class DockZoneModel extends Base {
             errors     = DockZoneModel.validate(normalized);
 
         return errors.length ? {document: original, errors} : {document: normalized, errors: []}
+    }
+
+    /**
+     * @summary Re-applies a whole candidate document through the shared fail-closed commit — the
+     * generic reverse of any forward operation: the document IS the state, so the honest inverse
+     * of a mutation (or a mutation burst) is the pre-mutation document, normalized + validated
+     * exactly like any forward commit. A missing candidate fails closed with the original returned
+     * untouched; a candidate failing validation never commits, per the `commit()` contract.
+     * @param {Object} document the committed dock-zone document
+     * @param {Object} descriptor {document: Object} the candidate document to commit
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static applyDocument(document, descriptor = {}) {
+        return descriptor.document
+            ? DockZoneModel.commit(document, descriptor.document)
+            : {document, errors: ['applyDocument requires a candidate document']}
     }
 
     /**

--- a/test/playwright/e2e/agentos/DemoBDockTransactionsNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBDockTransactionsNL.spec.mjs
@@ -1,0 +1,149 @@
+import {test, expect}               from '../../fixtures.mjs';
+import {NeuralLink_InstanceService} from '../../../../ai/services.mjs';
+
+/**
+ * @summary Whitebox E2E witness for dock-mutation undo/redo through the Neural Link
+ * transaction chain on Demo B.
+ *
+ * Dock operations record their reverse (the pre-mutation document, re-committed through
+ * the shared fail-closed commit path) into the writer's transaction stack. This spec proves
+ * the end-to-end contract an agent-driven screenplay rides:
+ *
+ *   begin_transaction → two moveItem mutations → commit_transaction (ops captured)
+ *   → undo (exact baseline document, activeItemIds included)
+ *   → redo (the burst re-applied)
+ *
+ * plus the no-regress guard: an undo dispatch re-applying a captured reverse must never
+ * enqueue a new transaction (committed stays empty, the batch waits on the redo branch).
+ *
+ * All assertions read worker truth (dockZone.v1 documents + the transaction stack audit),
+ * never the DOM. The baseline is read live, so the spec pins restore-fidelity, not the
+ * demo's initial layout.
+ *
+ * Run: NEO_E2E_PORT=8117 npx playwright test agentos/DemoBDockTransactionsNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS Demo B — dock transactions: begin → mutate → commit → undo → redo', () => {
+    test.setTimeout(60000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 720, width: 760}
+    });
+
+    test('a named dock batch commits its captured ops, undo returns the exact baseline, redo re-applies, and no undo dispatch re-enqueues', async ({page, neuralLink}) => {
+        const pageErrors    = [],
+              runtimeErrors = [];
+
+        await page.context().exposeFunction('__recordDemoBTxRuntimeError', payload => runtimeErrors.push(payload));
+        await page.context().addInitScript(() => {
+            globalThis.addEventListener('error', event => {
+                globalThis.__recordDemoBTxRuntimeError({
+                    column : event.colno,
+                    line   : event.lineno,
+                    message: event.message,
+                    source : event.filename,
+                    type   : 'error'
+                })
+            });
+            globalThis.addEventListener('unhandledrejection', event => {
+                globalThis.__recordDemoBTxRuntimeError({
+                    reason: String(event.reason?.stack || event.reason?.message || event.reason),
+                    type  : 'unhandledrejection'
+                })
+            })
+        });
+
+        page.on('pageerror', error => {
+            let value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+        await page.waitForSelector('.agentos-dockdemo-tour-play', {timeout: 30000});
+
+        const app        = await neuralLink.connectToApp('AgentOSDockDemo'),
+              workspaces = await app.findInstances({className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace'}, ['id']),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'the DemoBWorkspace must exist in the App Worker').toBeTruthy();
+
+        const baseline = (await app.getDockTopology(wsId)).document;
+
+        expect(
+            baseline.nodes['side-tabs']?.items,
+            'precondition: the demo boots with timeline + console in the side tabs (the burst sources)'
+        ).toEqual(expect.arrayContaining(['timeline', 'console']));
+
+        // 1. begin_transaction — the named batch opens under the writer's identity
+        const begun = await NeuralLink_InstanceService.beginTransaction({
+            name     : 'Spec dock burst',
+            sessionId: app.sessionId
+        });
+
+        expect(begun.opened, `the batch must open (got: ${begun.reason})`).toBe(true);
+
+        // 2. The mutation burst — two semantic dockZone.v1 operations inside the batch
+        for (const itemId of ['timeline', 'console']) {
+            const moved = await app.executeDockOperation(wsId, {
+                itemId,
+                operation   : 'moveItem',
+                targetNodeId: 'workbench-tabs'
+            });
+
+            expect(moved.errors).toEqual([]);
+            expect(moved.applied).toBe(true)
+        }
+
+        // 3. commit_transaction — the batch closes WITH its captured reverse ops
+        const committed = await NeuralLink_InstanceService.commitTransaction({sessionId: app.sessionId});
+
+        expect(committed.committed, `the batch must commit its captured ops (got: ${committed.reason})`).toBe(true);
+        expect(committed.ops).toBe(2);
+
+        // 4. undo — every captured reverse re-applies: the exact baseline document returns
+        const undone = await NeuralLink_InstanceService.undo({sessionId: app.sessionId});
+
+        expect(undone.undone).toBe(true);
+        expect(undone.reverted).toBe(2);
+
+        const afterUndo = (await app.getDockTopology(wsId)).document;
+
+        expect(
+            afterUndo,
+            'undo must return the exact pre-burst dockZone.v1 document'
+        ).toEqual(baseline);
+
+        // 5. The no-regress guard — the undo dispatch itself must leave the stack untouched:
+        // committed empty (nothing new auto-wrapped), the batch parked on the redo branch
+        const stackAfterUndo = await NeuralLink_InstanceService.listTransactions({sessionId: app.sessionId});
+
+        expect(
+            stackAfterUndo.committed,
+            'an undo dispatch must never enqueue a new transaction'
+        ).toEqual([]);
+        expect(stackAfterUndo.redo.length).toBe(1);
+        expect(stackAfterUndo.redo[0].opCount).toBe(2);
+
+        // 6. redo — the forward ops re-apply as one unit
+        const redone = await NeuralLink_InstanceService.redo({sessionId: app.sessionId});
+
+        expect(redone.redone).toBe(true);
+        expect(redone.reapplied).toBe(2);
+
+        const afterRedo = (await app.getDockTopology(wsId)).document;
+
+        expect(afterRedo.nodes['workbench-tabs'].items).toEqual(
+            expect.arrayContaining(['workbench', 'timeline', 'console'])
+        );
+
+        const stackAfterRedo = await NeuralLink_InstanceService.listTransactions({sessionId: app.sessionId});
+
+        expect(stackAfterRedo.committed.length).toBe(1);
+        expect(stackAfterRedo.redo).toEqual([]);
+
+        // 7. Leave the demo surface at its baseline for the next consumer (film or spec)
+        await NeuralLink_InstanceService.undo({sessionId: app.sessionId});
+
+        expect(pageErrors, 'no page errors may escape during the transaction chain').toEqual([]);
+        expect(runtimeErrors, 'no runtime errors may escape during the transaction chain').toEqual([]);
+    })
+})


### PR DESCRIPTION
Resolves #16316

Closes the dock-side recording gap in the Neural Link transaction machinery: `execute_dock_operation` now records its reverse op into the writer's transaction stack, so agent-driven dock mutations are undoable/redoable end-to-end — the flagship film's undo/redo beat (#15252 L3). The reverse is the **pre-mutation dockZone.v1 document** (the document IS the state), re-committed through a new `applyDocument` operation that rides the shared fail-closed `DockZoneModel.commit()` normalize+validate path. `recordUndo` + `undoSequence` are lifted from `Neo.ai.client.InstanceService` into the base `Neo.ai.client.Service` (mechanical move; InstanceService call sites unchanged via inheritance), and `Neo.ai.client.DockService` gains `buildDockReverse` + the post-commit capture call with the same agent-writes-only / `undoReplay`-guard contract as the InstanceService precedent. Spec witness: `DemoBDockTransactionsNL.spec.mjs` drives begin → 2× moveItem → commit (ops: 2) → undo (exact baseline document) → redo (burst re-applied) and asserts the no-regress guard (an undo dispatch enqueues nothing).

Evidence: local headed+GPU receipts achieved (below) — these ARE the current-head evidence for the e2e surface: PR CI runs no whitebox-e2e job by design (run 30724965992 shape: unit / components / integration lanes only; e2e rides the nightly runner). Residual: none for the close target — the live headed chain receipt is at #16316 issuecomment-5154289940, the filmable drive path (AC5) is posted on #15252 at issuecomment-5154541819, and AC3 is resolved by design (below).

## Deltas from ticket

- **AC3 resolved BY DESIGN instead of by wiring:** the deterministic film drive is the NL tool chain — the transaction stack is deliberately keyed on the Bridge-stamped `(agentId, sessionId)` writer pair (`InstanceService#beginTransaction`). App-side transaction cues were rejected (a pseudo-writer in the agent-scoped stack authority); the ticket body + Avoided Traps were updated in place.
- **`applyDocument` added to the dockZone.v1 vocabulary** — not in the original fix sketch; required as the honest generic reverse (the vocabulary derives from the handler table by construction, so `operations` advertises it mechanically).
- **`recordUndo` lifted to the base `Service`** — the capture hook is generic; the lift dedups it for every client service. InstanceService's undo-capture specs stay 14/14 green.

## Test Evidence

- New spec, headed: `NEO_E2E_PORT=8117 npx playwright test agentos/DemoBDockTransactionsNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed` → 1 passed
- Full unit suite: `npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=4` → 10796 passed (InstanceService undo-capture specs 14/14 within)
- Live headed chain receipt (manual, preceding the spec): #16316 issuecomment-5154289940 — commit `ops: 2`, undo → exact baseline, redo → burst re-applied, no regress transaction

## Post-Merge Validation

- [ ] Nightly e2e runner green on the merged spec (whitebox e2e is nightly-only by design; PR CI carries no e2e job)

Authored by Phoebe (Kimi K3, OpenCode). Session 14f1d6fa-235a-4101-88d4-c9490e3f7fd5.
