### PR TITLE
fix(build): admit the live zero-delta type vocabulary in agent-preflight (#16333)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -95,7 +95,8 @@ Classify the delivered delta in order; the first match wins:
    behavior/path. This wins even when a bug motivated the work.
 2. **`restoration` → `fix`** — adds no capability; corrects defined behavior.
 3. **`zero-delta` → `chore` / `test` / `docs` / `ci` / `build`** — changes neither
-   behavior nor capability.
+   behavior nor capability. The types are labels, not proof: the author's truthful
+   declaration stays the class authority.
 
 Ticket labels, filenames, and diff size do not decide the class. The author
 declares it; `agent-preflight` verifies the supplied subjects without inference.

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -94,7 +94,10 @@ Classify the delivered delta in order; the first match wins:
 1. **`capability` → `feat`** — adds reusable, operable, or separately testable
    behavior/path. This wins even when a bug motivated the work.
 2. **`restoration` → `fix`** — adds no capability; corrects defined behavior.
-3. **`zero-delta` → `chore`** — changes neither behavior nor capability.
+3. **`zero-delta` → `chore` / `test` / `docs` / `ci` / `build`** — changes neither
+   behavior nor capability; the type set is the repo's live zero-delta vocabulary
+   (a `test(...)` subject for a test-only delta declares `zero-delta`, never
+   `capability`).
 
 Ticket labels, filenames, and diff size do not decide the class. The author
 declares it; `agent-preflight` verifies the supplied subjects without inference.

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -95,9 +95,7 @@ Classify the delivered delta in order; the first match wins:
    behavior/path. This wins even when a bug motivated the work.
 2. **`restoration` → `fix`** — adds no capability; corrects defined behavior.
 3. **`zero-delta` → `chore` / `test` / `docs` / `ci` / `build`** — changes neither
-   behavior nor capability; the type set is the repo's live zero-delta vocabulary
-   (a `test(...)` subject for a test-only delta declares `zero-delta`, never
-   `capability`).
+   behavior nor capability.
 
 Ticket labels, filenames, and diff size do not decide the class. The author
 declares it; `agent-preflight` verifies the supplied subjects without inference.

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -35,10 +35,12 @@ const
 
 export {COMMIT_TICKET_PATTERN, DECLARED_TICKET_PATTERN};
 
-export const CHANGE_CLASS_TO_TYPE = Object.freeze({
-    capability  : 'feat',
-    restoration : 'fix',
-    'zero-delta': 'chore'
+export const CHANGE_CLASS_TO_TYPES = Object.freeze({
+    capability : ['feat'],
+    restoration: ['fix'],
+    // The repo's live zero-delta vocabulary: `chore` plus the conventional types history
+    // already merges for deltas that change neither runtime behavior nor capability.
+    'zero-delta': ['chore', 'test', 'docs', 'ci', 'build']
 });
 
 /**
@@ -127,7 +129,7 @@ export function filterMjsFiles(files) {
  * @param {String|null} [options.changeClass]
  * @param {String|null} [options.commitSubject]
  * @param {String|null} [options.prTitle]
- * @returns {{errors: String[], expectedType: String|null, skipped: Boolean, valid: Boolean}}
+ * @returns {{errors: String[], expectedTypes: String[]|null, skipped: Boolean, valid: Boolean}}
  */
 export function validateChangeClass({
     changeClass = null,
@@ -143,22 +145,22 @@ export function validateChangeClass({
 
     if (!hasInput) {
         return {
-            errors      : [],
-            expectedType: null,
-            skipped     : true,
-            valid       : true
+            errors       : [],
+            expectedTypes: null,
+            skipped      : true,
+            valid        : true
         }
     }
 
     const
-        errors       = [],
-        expectedType = Object.hasOwn(CHANGE_CLASS_TO_TYPE, changeClass)
-            ? CHANGE_CLASS_TO_TYPE[changeClass]
+        errors        = [],
+        expectedTypes = Object.hasOwn(CHANGE_CLASS_TO_TYPES, changeClass)
+            ? CHANGE_CLASS_TO_TYPES[changeClass]
             : null;
 
     if (!changeClass) {
         errors.push('`--change-class` is required when `--commit-subject` or `--pr-title` is provided.')
-    } else if (!expectedType) {
+    } else if (!expectedTypes) {
         errors.push(
             `Unknown change class \`${changeClass}\`; expected capability, restoration, or zero-delta.`
         )
@@ -168,19 +170,23 @@ export function validateChangeClass({
         errors.push('`--change-class` requires at least one `--commit-subject` or `--pr-title` to validate.')
     }
 
-    if (expectedType) {
+    if (expectedTypes) {
+        const requirement = expectedTypes.length === 1
+            ? `requires \`${expectedTypes[0]}\``
+            : `requires one of ${expectedTypes.map(type => `\`${type}\``).join(', ')}`;
+
         subjects.forEach(({label, value}) => {
             const match = value.match(CONVENTIONAL_TYPE_PATTERN);
 
             if (!match) {
                 errors.push(
                     `${label} is missing a valid Conventional Commit prefix; change class ` +
-                    `\`${changeClass}\` requires \`${expectedType}\`.`
+                    `\`${changeClass}\` ${requirement}.`
                 )
-            } else if (match[1] !== expectedType) {
+            } else if (!expectedTypes.includes(match[1])) {
                 errors.push(
                     `${label} declares \`${match[1]}\`, but change class \`${changeClass}\` ` +
-                    `requires \`${expectedType}\`.`
+                    `${requirement}.`
                 )
             }
         })
@@ -188,7 +194,7 @@ export function validateChangeClass({
 
     return {
         errors,
-        expectedType,
+        expectedTypes,
         skipped: false,
         valid  : errors.length === 0
     }
@@ -578,7 +584,7 @@ export function runAgentPreflight({
 
         writeLine(
             stdout,
-            `agent-preflight: declared ${options.changeClass} maps to ${changeClassResult.expectedType}; ` +
+            `agent-preflight: declared ${options.changeClass} maps to ${changeClassResult.expectedTypes.join(', ')}; ` +
             `${surfaceCount} intended subject${surfaceCount === 1 ? '' : 's'} matched.`
         )
     } else {

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -36,11 +36,15 @@ const
 export {COMMIT_TICKET_PATTERN, DECLARED_TICKET_PATTERN};
 
 export const CHANGE_CLASS_TO_TYPES = Object.freeze({
-    capability : ['feat'],
-    restoration: ['fix'],
-    // The repo's live zero-delta vocabulary: `chore` plus the conventional types history
-    // already merges for deltas that change neither runtime behavior nor capability.
-    'zero-delta': ['chore', 'test', 'docs', 'ci', 'build']
+    capability : Object.freeze(['feat']),
+    restoration: Object.freeze(['fix']),
+    // The repo's conventional zero-delta type labels. The gate maps the AUTHOR-DECLARED
+    // class to this allowed set — a prefix never proves the class; the author's truthful
+    // declaration remains the semantic authority. Evidence (14-day dev history): test 20,
+    // docs 22, chore 65, build 4; `ci` rides the same convention for CI-config deltas.
+    // Arrays are frozen and `validateChangeClass` returns an isolated copy: the policy is
+    // never mutable through the map or a returned observation.
+    'zero-delta': Object.freeze(['chore', 'test', 'docs', 'ci', 'build'])
 });
 
 /**
@@ -194,9 +198,11 @@ export function validateChangeClass({
 
     return {
         errors,
-        expectedTypes,
-        skipped: false,
-        valid  : errors.length === 0
+        // An observation, never a write capability: the copy isolates the caller from the
+        // frozen policy arrays, so mutating a result cannot change later validations.
+        expectedTypes: expectedTypes ? [...expectedTypes] : null,
+        skipped      : false,
+        valid        : errors.length === 0
     }
 }
 

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -2,6 +2,7 @@ import {test, expect} from '@playwright/test';
 import {readFileSync} from 'node:fs';
 import path           from 'node:path';
 import {
+    CHANGE_CLASS_TO_TYPES,
     COMMIT_TICKET_PATTERN,
     createProgram,
     DECLARED_TICKET_PATTERN,
@@ -544,6 +545,35 @@ test.describe('agent-preflight — ordered change classes (#16111)', () => {
         expect(overclaimed.errors[0]).toContain(
             'change class `zero-delta` requires one of `chore`, `test`, `docs`, `ci`, `build`.'
         )
+    });
+
+    test('the policy is not mutable through the exported map or a returned observation', () => {
+        // Every nested policy array is frozen — the shallow outer freeze is not the whole guard.
+        Object.values(CHANGE_CLASS_TO_TYPES).forEach(types => {
+            expect(Object.isFrozen(types)).toBe(true)
+        });
+        expect(() => { CHANGE_CLASS_TO_TYPES['zero-delta'].push('feat') }).toThrow(TypeError);
+
+        // Mutating one returned observation must not change a later validation's policy.
+        const first = validateChangeClass({
+            changeClass  : 'zero-delta',
+            commitSubject: 'feat(e2e): a capability mislabeled as zero-delta (#16333)'
+        });
+
+        expect(first.valid).toBe(false);
+
+        first.expectedTypes.push('feat');
+
+        const second = validateChangeClass({
+            changeClass  : 'zero-delta',
+            commitSubject: 'feat(e2e): a capability mislabeled as zero-delta (#16333)'
+        });
+
+        expect(
+            second.valid,
+            'mutating a prior result must never make a later zero-delta + feat validation pass'
+        ).toBe(false);
+        expect(second.expectedTypes).toEqual(['chore', 'test', 'docs', 'ci', 'build'])
     });
 
     test('rejects chore for a restoration delta', () => {

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.spec.mjs
@@ -473,10 +473,10 @@ test.describe('agent-preflight utility', () => {
 test.describe('agent-preflight — ordered change classes (#16111)', () => {
     test('remains backward compatible when no semantic inputs are supplied', () => {
         expect(validateChangeClass()).toEqual({
-            errors      : [],
-            expectedType: null,
-            skipped     : true,
-            valid       : true
+            errors       : [],
+            expectedTypes: null,
+            skipped      : true,
+            valid        : true
         })
     });
 
@@ -504,11 +504,46 @@ test.describe('agent-preflight — ordered change classes (#16111)', () => {
         });
 
         expect(result.valid).toBe(false);
-        expect(result.expectedType).toBe('feat');
+        expect(result.expectedTypes).toEqual(['feat']);
         expect(result.errors).toEqual([
             'commit subject declares `chore`, but change class `capability` requires `feat`.',
             'PR title declares `fix`, but change class `capability` requires `feat`.'
         ])
+    });
+
+    test('accepts the live zero-delta vocabulary (test, docs, ci, build) while capability and restoration stay strict', () => {
+        ['test', 'docs', 'ci', 'build', 'chore'].forEach(type => {
+            expect(validateChangeClass({
+                changeClass  : 'zero-delta',
+                commitSubject: `${type}(e2e): a delta with no runtime behavior (#16333)`
+            }).valid, `zero-delta must accept ${type}(...)`).toBe(true)
+        });
+
+        const mislabeled = validateChangeClass({
+            changeClass  : 'capability',
+            commitSubject: 'test(e2e): a delta that is really a capability (#16333)'
+        });
+
+        expect(mislabeled.valid).toBe(false);
+        expect(mislabeled.errors[0]).toContain('change class `capability` requires `feat`');
+
+        const strictRestore = validateChangeClass({
+            changeClass  : 'restoration',
+            commitSubject: 'test(e2e): a delta that is really a restoration (#16333)'
+        });
+
+        expect(strictRestore.valid).toBe(false);
+        expect(strictRestore.errors[0]).toContain('change class `restoration` requires `fix`');
+
+        const overclaimed = validateChangeClass({
+            changeClass  : 'zero-delta',
+            commitSubject: 'feat(e2e): a capability mislabeled as zero-delta (#16333)'
+        });
+
+        expect(overclaimed.valid).toBe(false);
+        expect(overclaimed.errors[0]).toContain(
+            'change class `zero-delta` requires one of `chore`, `test`, `docs`, `ci`, `build`.'
+        )
     });
 
     test('rejects chore for a restoration delta', () => {


### PR DESCRIPTION
Resolves #16333

The change-class gate now admits the repo's live zero-delta vocabulary as a **type set**: `zero-delta → chore / test / docs / ci / build`, while `capability → feat` and `restoration → fix` stay strict (the mislabeling risk `#16111`/`#10061` targeted). `CHANGE_CLASS_TO_TYPES` carries arrays; `validateChangeClass` returns `expectedTypes` and renders single-member requirements as ``requires `feat` `` vs multi-member as ``requires one of …``; the CLI success line prints the set; the workflow tells the same story. Before this, a `test(...)` subject — 8 merged in the last 14 days — had no valid class declaration and pushed disciplined authors onto the no-semantic-inputs escape, silently skipping the very gate the tool exists to enforce.

## Slot rationale (substrate mutation)

- **Modified:** `.agents/skills/pull-request/references/pull-request-workflow.md` §3.1 (the zero-delta bullet now names the type set + the "labels, not proof" framing) — disposition: **keep**; load/placement unchanged (conditionally loaded at PR time). The edit corrects the section's vocabulary to match the tool and the merged history; it adds no new rule surface.
- **Decision-tree application (`/turn-memory-pre-flight`):** Step 2 — the rule governs a specific lifecycle event (PR commit-type declaration) and already lives in the correct skill atlas; this is a modification of an existing section, not a placement. No router/manifest/harness change.
- **Mechanical load verification (run at `c3942c40aa`):** `.codex/hooks.json` → UserPromptSubmit runs `.codex/hooks/codex-context.mjs`; `codex-context.mjs:187` loads only `../CODEX.md`; `readlink .claude/CLAUDE.md` → `../AGENTS.md`. The edited file is in none of those turn-load paths — it loads exclusively via the pull-request SKILL.md's conditional pointer. Byte effect: 21879 → 21976 B, inside the 22000 `perFilePayloadBudget` (manifest lint green).

Evidence: local receipts achieved (below) — tooling surface with no runtime component; PR CI unit lane is the confirming gate. Residual: none.

## Deltas from ticket

- **Cycle-1 review repair (Euclid's RC):** the policy map's arrays are now frozen AND `validateChangeClass` returns an isolated copy — the shallow outer freeze plus shared-reference return had made the allowlist mutable through any returned observation (his exact-head probe: `expectedTypes.push('feat')` flipped a later `zero-delta + feat` to valid). Regression spec added: frozen arrays + cross-call mutation witness.
- **Framing correction (his rhetorical-drift point):** the types are **conventional labels, not proof** — the author's truthful declaration stays the class authority. Per-member evidence now named (14-day dev history: `test` 20, `docs` 22, `chore` 65, `build` 4, `ci` 0 — `ci` admitted by convention, not by count) in the map comment, the workflow line, and the ticket's new Contract Ledger.
- **Ticket body gained the Contract Ledger** the changed export/result/CLI contract required (successor to `#16111`'s scalar-era record).

## Test Evidence

- Preflight spec dir: `npx playwright test unit/ai/buildScripts -c test/playwright/playwright.config.unit.mjs --workers=2` → 443 passed (includes new zero-delta vocabulary acceptance, both strictness directions, and the `requires one of …` message shape)
- Full unit suite: `npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=4` → 10818 passed
- The exact #16319 friction case end-to-end: `npm run agent-preflight -- --change-class zero-delta --commit-subject "test(e2e): witness the NL perspective capture/list/restore path on Demo B (#16315)"` → `declared zero-delta maps to chore, test, docs, ci, build; 1 intended subject matched` / all gates passed

## Post-Merge Validation

- [ ] None — tooling-only surface; local + CI unit evidence is complete

Authored by Phoebe (Kimi K3, OpenCode). Session 1a7e3f91-8356-48bb-a353-9fd7da2647f5.
