### PR TITLE
chore(github): remove the dead bare-number tolerance from getPullRequestDiff (#16337)

### DIFF
--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -2124,7 +2124,7 @@ class PullRequestService extends Base {
 
     /**
      * Gets the diff for a specific pull request.
-     * @param {Object|number} options Either a PR number or an object with parameters
+     * @param {Object} options Parameters object
      * @param {number}  options.pr_number  The number of the pull request
      * @param {string}  [options.file]     Optional file path (or comma-separated paths) to filter diff
      * @param {string}  [options.sha]      Optional SHA to diff against instead of live PR head
@@ -2132,9 +2132,7 @@ class PullRequestService extends Base {
      * @returns {Promise<string|object>} A promise that resolves to the diff text, file list JSON, or a structured error.
      */
     async getPullRequestDiff(options) {
-        const { pr_number, file, sha, files_only } = typeof options === 'number' || typeof options === 'string'
-            ? { pr_number: parseInt(options, 10) }
-            : (options || {});
+        const { pr_number, file, sha, files_only } = options || {};
 
         const prNumber = parseInt(pr_number, 10);
 


### PR DESCRIPTION
Resolves #16337

The bare-number tolerance in `getPullRequestDiff` is gone. Its only producer was the MCP dispatcher's positional spread — the exact bug `#16330` just removed — and every in-repo caller passes an options object (seven spec call sites plus `sdk-manifest.md:75`, per the review-coordination census). The handler now takes the object contract directly; the JSDoc names it.

Two adjacent tolerance arms (`PullRequestService.mjs:1818`, `:2037`) belong to *other* methods and are deliberately untouched — `#16334`'s census owns their classification, per this ticket's Out of Scope.

Evidence: L2 (spec-suite receipts + call-site grep with positive control) — the surface is fully spec-reachable. Residual: none.

## Deltas from ticket

None substantive — the removal shipped exactly as ticketed (arm + JSDoc + zero-call-site verification).

## Test Evidence

- `PullRequestService.spec.mjs` + `toolService.spec.mjs` + `OpenApiValidatorCompliance.spec.mjs`: **173/173 green** at head (the merged base includes `#16330`'s guard-exception removal, verified `grep -c` 0 on the fresh ref).
- Call-site sweep: `getPullRequestDiff(` across `ai/ test/ docs/ resources/` — all seven live invocations pass objects; positive control: the same grep finds the archived `#10752` record documenting this arm as the compatibility seam (proving the pattern reaches historical bare-number producers).
- Behavior note: for well-formed callers nothing changes — the object path was already the sole live path post-`#16330`.

## Post-Merge Validation

- [ ] The next agent call with an options object resolves identically to pre-removal (behavioral continuity in production traffic).

Authored by Iris (Kimi K3, Kimi Code CLI). Session f91d8847-7722-4c4e-80d6-fa9f646a75e9.
