### PR TITLE
test(ai): the handler-signature lint gate — the bug class fails at PR time now (#16343)

### DIFF
--- a/ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs
+++ b/ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs
@@ -98,6 +98,24 @@ export const SERVERS = [
  */
 const GENERIC_BAG_NAMES = new Set(['args', 'input', 'options', 'params', 'payload', 'query']);
 
+/**
+ * The classes that fail the gate: 2 (destructure-under-positional), 2M (annotation-mismatch),
+ * 3 (truncation). Suspects deliberately do NOT fail — they stay human-judged; a gate that cries
+ * on ambiguity trains contributors to dismiss it. Exported so the unit-suite gate
+ * (`test/playwright/unit/ai/mcp/validation/McpHandlerSignatureGate.spec.mjs`) and this CLI's
+ * `--fail-on-defects` share one predicate — never two copies that can drift.
+ * @type {Set<Number|String>}
+ */
+export const DEFECT_KLASSES = new Set([2, '2M', 3]);
+
+/**
+ * @param {Object} row a census row
+ * @returns {Boolean} true when the row's class is a gate-failing defect class
+ */
+export function isDefectRow(row) {
+    return DEFECT_KLASSES.has(row.klass);
+}
+
 // ------------------------------------------------------------------ contract side (runtime mirror)
 
 /**
@@ -118,6 +136,12 @@ export function resolveRef(doc, ref) {
  * `passAsObject` = `operation['x-pass-as-object'] === true`. Each arg also carries its declared
  * schema `type` (and `properties` keys for single-object args) so the classifier can tell a
  * nested-object destructure from a class-2 degrade.
+ *
+ * DRIFT POINTER (named in review): this function necessarily re-derives the argNames union that
+ * `ai/mcp/ToolService.mjs#initializeToolMapping` owns — a static tool cannot import the runtime's
+ * intermediate. If the runtime's derivation changes (new arg source, different extension name),
+ * change this mirror in the same PR or the census silently measures a dispatch that no longer
+ * exists.
  * @param {Object} doc parsed openapi.yaml
  * @returns {Object[]} `{operationId, args: [{name, type, properties}], passAsObject}` rows
  */
@@ -586,7 +610,7 @@ export function census(root) {
     const rows = SERVERS.flatMap(server => censusServer(root, server));
 
     const startingSet = rows.filter(r => !r.passAsObject && r.args.length > 0);
-    const defectSet   = rows.filter(r => r.klass === 2 || r.klass === '2M' || r.klass === 3);
+    const defectSet   = rows.filter(isDefectRow);
     const suspects    = rows.filter(r => r.klass === 'suspect');
     const unresolved  = rows.filter(r => r.klass === 'unresolved');
     const classOne    = rows.filter(r => r.klass === 1);
@@ -619,7 +643,7 @@ export function renderMarkdown(report, meta) {
     const {rows, totals} = report;
     const lines          = [];
 
-    const defectRows  = rows.filter(r => r.klass === 2 || r.klass === '2M' || r.klass === 3);
+    const defectRows  = rows.filter(isDefectRow);
     const suspectRows = rows.filter(r => r.klass === 'suspect');
     const unresRows   = rows.filter(r => r.klass === 'unresolved');
 

--- a/test/playwright/unit/ai/mcp/validation/McpHandlerSignatureGate.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/McpHandlerSignatureGate.spec.mjs
@@ -1,0 +1,133 @@
+import {test, expect}  from '@playwright/test';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {
+    census,
+    censusServer,
+    isDefectRow
+} from '../../../../../../ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs';
+
+/**
+ * @summary The lint gate for the silent-degradation bug class: any MCP operation whose handler
+ * signature mismatches its dispatch mode (class 2 destructure-under-positional, class 2M
+ * annotation-mismatch, class 3 truncation) fails this suite. The classifier, the taxonomy, and
+ * the resolver shapes are pinned in `test/playwright/unit/ai/scripts/diagnostics/`; this spec is
+ * the GATE — it runs the census over the live tree and asserts the verdict, so a future operation
+ * that re-introduces the class fails at PR time instead of being found by hand weeks later.
+ *
+ * Suspects do not fail the gate: ambiguity stays human-judged by design, and a gate that cries on
+ * "I cannot tell" trains contributors to dismiss it. Unresolvable bindings DO fail: a census that
+ * cannot see a handler is not a green census.
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../../../..');
+
+const formatRow = r => `${r.server}/${r.operationId} [class ${r.klass} · ${r.form}] ${r.detail} (${r.via})`;
+
+/**
+ * Builds a minimal MCP-server fixture (openapi.yaml + toolService.mjs + service module) in a tmp
+ * dir. The two bad shapes are the proven pair: a destructure-under-positional handler and a
+ * truncation handler — the gate that cannot trip on these has not been validated.
+ * @returns {{root: String, server: Object}}
+ */
+function buildDefectFixture() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'handler-gate-'));
+
+    fs.writeFileSync(path.join(root, 'openapi.yaml'), [
+        'openapi: 3.0.0',
+        'paths:',
+        '  /progress:',
+        '    get:',
+        '      operationId: get_progress',
+        '      parameters:',
+        '        - name: staleAfterMs',
+        '          schema: {type: integer}',
+        '  /diff:',
+        '    get:',
+        '      operationId: get_diff',
+        '      parameters:',
+        '        - {name: pr_number, schema: {type: integer}}',
+        '        - {name: file, schema: {type: string}}'
+    ].join('\n'));
+
+    fs.writeFileSync(path.join(root, 'toolService.mjs'), [
+        `import Svc from './Svc.mjs';`,
+        `const serviceMapping = {`,
+        `    get_progress: Svc.progress.bind(Svc),`,
+        `    get_diff    : Svc.diff.bind(Svc)`,
+        `};`
+    ].join('\n'));
+
+    fs.writeFileSync(path.join(root, 'Svc.mjs'), [
+        `class Svc {`,
+        `    progress({staleAfterMs = 60000} = {}) {}`,
+        `    diff(options) {}`,
+        `}`,
+        `export default Svc;`
+    ].join('\n'));
+
+    return {root, server: {id: 'fixture', openApi: 'openapi.yaml', toolService: 'toolService.mjs'}};
+}
+
+test.describe('MCP handler-signature gate', () => {
+    const report = census(repoRoot);
+
+    test('no operation silently degrades under its dispatch mode (defect set empty)', () => {
+        const failures = report.rows.filter(isDefectRow);
+
+        expect(
+            failures.map(formatRow).join('\n'),
+            'every listed operation binds garbage or drops arguments silently — annotate it (x-pass-as-object) or fix the handler signature, each in its own ticket'
+        ).toBe('');
+    });
+
+    test('every binding resolves — a census that cannot see is not green', () => {
+        const unseen = report.rows.filter(r => r.klass === 'unresolved');
+
+        expect(
+            unseen.map(formatRow).join('\n'),
+            'every listed operation resolved to no handler signature — extend the resolver, never waive the row'
+        ).toBe('');
+    });
+
+    test('the gate trips on both known-positive shapes (negative receipt)', () => {
+        const {root, server} = buildDefectFixture();
+        const defects        = censusServer(root, server).filter(isDefectRow);
+        const byOp           = Object.fromEntries(defects.map(r => [r.operationId, r.klass]));
+
+        expect(byOp).toEqual({get_progress: 2, get_diff: 3});
+    });
+
+    test('suspects never fail the gate — ambiguity stays human-judged', () => {
+        // The predicate contract: suspect rows are visible in the report, never in the defect set.
+        const {root, server} = (() => {
+            const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'handler-gate-suspect-'));
+
+            fs.writeFileSync(path.join(dir, 'openapi.yaml'), [
+                'openapi: 3.0.0',
+                'paths:',
+                '  /x:',
+                '    get:',
+                '      operationId: get_x',
+                '      parameters:',
+                '        - {name: staleAfterMs, schema: {type: integer}}'
+            ].join('\n'));
+            fs.writeFileSync(path.join(dir, 'toolService.mjs'), [
+                `const serviceMapping = {`,
+                `    get_x: args => args.staleAfterMs`,  // generic bag name under positional dispatch → suspect
+                `};`
+            ].join('\n'));
+
+            return {root: dir, server: {id: 'fixture', openApi: 'openapi.yaml', toolService: 'toolService.mjs'}};
+        })();
+
+        const rows = censusServer(root, server);
+
+        expect(rows[0].klass).toBe('suspect');
+        expect(rows.filter(isDefectRow)).toEqual([]);
+    });
+});


### PR DESCRIPTION
Resolves #16343

The lint gate #16343 asked for: `McpHandlerSignatureGate.spec.mjs` runs the merged census instrument (PR #16345) over the live tree inside the standard unit suite and fails when any operation's handler signature silently degrades under its dispatch mode — the bug class #16250 proved now fails at PR time instead of being found by hand weeks later. No new workflow surface: the existing unit config already runs in CI, so the gate inherits enforcement.

Four tests, mapping the ticket's ACs 1:1:

1. **Defect set empty** across all six servers — failing rows print as the failure message (server/operation, class, form, evidence, handler).
2. **Unresolved = 0** — a census that cannot see a binding is not green; the resolver must be extended, never the row waived.
3. **Negative receipt** — a fixture server carrying both known-positive shapes (destructure-under-positional → class 2, truncation → class 3) trips the gate predicate exactly.
4. **Suspects never fail** — a generic-bag-name fixture row classifies `suspect` and provably stays out of the defect set: ambiguity remains human-judged (the ticket's Out of Scope), so the gate never trains contributors to dismiss it.

Also folds in the review polish Grace named on PR #16345 (surfaced at #16343 issuecomment-5157840983): `DEFECT_KLASSES` / `isDefectRow` give the CLI's `--fail-on-defects` and this gate one shared predicate — never two copies that can drift — and `extractOperations` now carries the drift pointer back to `ToolService#initializeToolMapping`, whose derivation it mirrors.

Evidence: no runtime or sandbox-unreachable effects — a new spec plus a behavior-identical predicate extraction and comment in the instrument (census output verified unchanged after the refactor). Residual: none.

## Deltas from ticket

None substantive — the four ACs map to the four tests directly. Grace's two review notes (shared predicate; drift-pointer comment) are included as explicitly scoped on the ticket.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/validation/McpHandlerSignatureGate.spec.mjs test/playwright/unit/ai/scripts/diagnostics/mcpHandlerSignatureCensus.spec.mjs` → **28 passed** (4 gate + 24 instrument).
- `node ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs` → 159 operations, defect set 0 — output unchanged after the predicate extraction.
- `node ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs --fail-on-defects` → exit 0 on current dev.
- Gate fires in CI by construction: the spec lives in the unit suite the existing workflow runs.

## Post-Merge Validation

- [ ] The first dev CI run after merge executes `McpHandlerSignatureGate.spec.mjs` inside the unit shard (no separate workflow exists — the suite IS the enforcement).

Authored by Iris (Kimi K3, Kimi Code CLI). Session session_5c970912-b750-4835-ad51-fbb3d2bc4ebe.
