### PR TITLE
fix(workstation): re-skin the dock auto-hide rails (#16336)

### DIFF
--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -95,12 +95,44 @@
         box-shadow    : 0 0 22px color-mix(in srgb, var(--workstation-signal) 12%, transparent);
         overflow      : hidden;
 
-        .neo-dashboard-dock-rail-tab {
+        // The stock theme floors every `.neo-button` at `min-width: var(--cmp-button-height)` (48px)
+        // through `:root .neo-theme-* .neo-button` — a (0,3,0) selector that TIES the shared rail
+        // override and wins on load order alone. On the 14px vertical rail that floor defeats the
+        // cross-axis stretch and pushes the rotated label span outside the clipped strip: the rail
+        // renders as an empty pill. The `.neo-button` compound lifts this layer to (0,4,0) so the
+        // tie stops being a load-order bet; with the floor released, the tab snaps to the strip and
+        // the label renders inside it.
+        .neo-button.neo-dashboard-dock-rail-tab {
             background: transparent;
             border    : 0;
-            color     : var(--workstation-ink);
+            box-shadow: none;
+            color     : var(--workstation-ink-dim);
             font-family: var(--workstation-font-mono);
+            min-width : 0;
+
+            &:hover {
+                background: color-mix(in srgb, var(--workstation-signal) 14%, transparent);
+                color     : var(--workstation-ink);
+            }
+
+            // The generic button skin re-colors these descendants through its own token layer,
+            // which resolves anti-theme against the workstation palette (black on the dark rail,
+            // white on the light one — inverted contrast in both themes). Inheriting pins them to
+            // the rail-tab ink above; same treatment the tourbar theme-button already needed.
+            .neo-button-glyph,
+            .neo-button-text {
+                color: inherit;
+            }
         }
+    }
+
+    // Horizontal rails read as an app-edge info line: give their labels the tourbar caption's
+    // breathing room instead of the shared strip's 1px inline padding. The vertical rails keep the
+    // slim shared padding — the physical 1px inline is what lets the rotated label fit the 14px
+    // strip at all.
+    .neo-dashboard-dock-edge-rail-top .neo-button.neo-dashboard-dock-rail-tab,
+    .neo-dashboard-dock-edge-rail-bottom .neo-button.neo-dashboard-dock-rail-tab {
+        padding: 4px 10px;
     }
 
 }

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -109,6 +109,8 @@
             color     : var(--workstation-ink-dim);
             font-family: var(--workstation-font-mono);
             min-width : 0;
+            transition: background var(--dock-transition-duration-fast) var(--dock-transition-easing),
+                        color var(--dock-transition-duration-fast) var(--dock-transition-easing);
 
             &:hover {
                 background: color-mix(in srgb, var(--workstation-signal) 14%, transparent);


### PR DESCRIPTION
Resolves #16336

Re-skins the workstation dock auto-hide rails: labels now render the workstation ink family in both themes, the horizontal rail labels gain the tourbar caption's breathing room, and the left vertical rail's label — previously clipped invisible ("the empty info bar") — renders inside the 14px strip. One file, app-scoped.

Root cause, measured live in both themes on the author tree at head: the stock theme floors every `.neo-button` at `min-width: var(--cmp-button-height)` (48px) via `:root .neo-theme-* .neo-button` — specificity (0,3,0), a dead TIE with the shared rail override `.neo-dashboard .neo-button.neo-dashboard-dock-rail-tab { min-width: 0 }`, decided purely by load order (themes load later). The 48px floor defeats the 14px rail's cross-axis stretch and pushes the rotated label span entirely outside the `overflow: hidden` strip. Separately, the generic button skin re-colors `.neo-button-text` anti-theme (black on the dark-green rail, white on the light-green one), and the shared 1px inline padding put the bottom label flush against the workspace edge. The fix lifts the workstation rail-tab layer to the `.neo-button` compound — (0,4,0), so the tie stops being a load-order bet — releasing the floor (`min-width: 0`), pinning descendants to the rail ink (`color: inherit`, the `FleetCockpit.scss:26-45` + tourbar `Workspace.scss:192-200` precedent pair), and scoping `padding: 4px 10px` to the horizontal rails only (the vertical strip needs the slim shared padding to fit its rotated label at all).

Evidence: L3 (headed live computed-style + screenshot receipts, both themes, author host at head) → L3 required (the close-target ACs demand per-theme live computed styles). Residual: the FleetCockpit no-regression AC is discharged by construction (see Test Evidence) with a belt-and-suspenders post-merge eyeball item.

## Deltas from ticket

- The ticket's suspect list for the clipped label named the FleetCockpit override properties first and the generic button height pin second; the measured culprit is the theme's `min-width` floor winning an equal-specificity load-order tie — the exact trap the shared `Container.scss:142-181` comment documents ("equal-specificity load-order ties are not a contract"). The fix therefore upgrades the selector tier instead of stacking more properties into the tie.
- Hover affordance added (signal-tint + ink lift): the rails are navigation, and the FleetCockpit precedent block ships the same quiet-nav idiom — two lines, same pattern, no new design language.

## Test Evidence

- Theme rebuild: `node ./buildScripts/build/themes.mjs -f -n -e dev -t all` → 640 files, clean.
- Live receipts (own checkout `/Users/Shared/fable/neomjs/neo`, `:8090`, branch head): **dark** — left label span computes `rgb(139, 151, 168)` (= `--workstation-ink-dim`) INSIDE the rail (span x 14 within rail 12→26; button width 48px → 12px after the floor release), bottom label padding `4px 10px`; **light** — spans compute `rgb(90, 107, 128)` on the light-green rails. Screenshots captured in both themes: "Dependency Graph Explorer" renders rotated + legible in the left rail; "Selection Inspector" reads correctly with its gap.
- FleetCockpit regression: discharged by construction — every added/changed selector is scoped under `.workstation-workspace` (or rail descendants inside it); the FM cockpit renders zero elements under that ancestor.
- Direct spec coverage of rail-label styling: `None found` (the workstation e2e suites own behavior witnesses, not skin asserts).
- `npm run agent-preflight -- --change-class restoration --commit-subject "fix(workstation): re-skin the dock auto-hide rails (#16336)"` → all gates passed.

## Post-Merge Validation

- [ ] FM fleet cockpit right-edge rail eyeball in both themes (by-construction safe; belt-and-suspenders).
- [ ] #15252 take-gate ledger: mark gate 1 cleared on the epic thread.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session cc037e9f-7577-4a11-968d-7a5fe3c8db8d.
