### PR TITLE
feat(workstation): wire the perspective store surface for the NL trio (#16342)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -8,6 +8,7 @@ import DockDragAffordances         from '../../../src/dashboard/DockDragAffordan
 import DockDropIndicators          from '../../../src/dashboard/DockDropIndicators.mjs';
 import DockLayoutAdapter           from '../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockMotionSignal            from '../../../src/dashboard/DockMotionSignal.mjs';
+import DockPerspectiveStore        from '../../../src/dashboard/DockPerspectiveStore.mjs';
 import DockPreview                 from '../../../src/dashboard/DockPreview.mjs';
 import DockProjectionReconciler    from '../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockService                 from '../../../src/ai/client/DockService.mjs';
@@ -164,6 +165,15 @@ class Workspace extends Container {
      * @member {Neo.ai.client.DockService|null} dockService=null
      */
     dockService = null
+    /**
+     * The named-layout home for the Neural Link perspective trio — the client DockService
+     * resolves `holder.perspectiveStore`, so instantiating it here activates capture (stored),
+     * list, and restore against this workspace with no service-side change. Restore rides the
+     * store's migration-honest `loadPerspective` plus this view's `onDockZoneDocumentChange`
+     * commit seam — the same path `execute_dock_operation` commits through.
+     * @member {Neo.dashboard.DockPerspectiveStore|null} perspectiveStore=null
+     */
+    perspectiveStore = null
     /**
      * @member {Neo.ai.client.TourRunner|null} tourRunner=null
      */
@@ -399,8 +409,9 @@ class Workspace extends Container {
 
         let me = this;
 
-        me.dockModel   = DockZoneModel.clone(initialDocument);
-        me.dockService = Neo.create(DockService, {});
+        me.dockModel         = DockZoneModel.clone(initialDocument);
+        me.dockService       = Neo.create(DockService, {});
+        me.perspectiveStore  = Neo.create(DockPerspectiveStore, {});
 
         // Cross-window hit testing reads manager.Window as its one geometry authority. Movement
         // snapshots alone go stale after a main-window resize, so this render target publishes
@@ -5116,6 +5127,7 @@ class Workspace extends Container {
         me.vesselWorkspaces.clear();
         me.tourRunner?.destroy();
         me.dockService?.destroy();
+        me.perspectiveStore?.destroy();
         me.dragAffordances?.destroy();
         me.interactionService?.destroy();
         me.vesselProxyEmbodiment?.destroy();

--- a/test/playwright/e2e/workstation/WorkstationPerspectivesNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationPerspectivesNL.spec.mjs
@@ -1,0 +1,148 @@
+import {test, expect}           from '../../fixtures.mjs';
+import {NeuralLink_DockService} from '../../../../ai/services.mjs';
+
+/**
+ * @summary Whitebox E2E witness for the Neural Link perspective path on the workstation Workspace.
+ *
+ * The workstation Workspace carries a `DockPerspectiveStore` (holder-resolved by the client
+ * DockService), so the agent-driven perspective trio activates on the film's primary surface:
+ *
+ *   capture_perspective (stored through the holder's store) → list_perspectives
+ *   → execute_dock_operation (disruption) → restore_perspective
+ *   (exact baseline dockZone.v1 document through the store's migration-honest load
+ *    plus the workspace's document-commit seam)
+ *
+ * All assertions read worker truth, never the DOM. The baseline is read live, so the spec
+ * pins restore-fidelity, not the demo's initial layout.
+ *
+ * Run: NEO_E2E_PORT=8117 npx playwright test workstation/WorkstationPerspectivesNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Workstation — NL perspectives: capture → list → disrupt → restore', () => {
+    test.setTimeout(60000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 720, width: 760}
+    });
+
+    test('the store-backed perspective chain returns the exact baseline after a disruption', async ({page, neuralLink}) => {
+        const pageErrors    = [],
+              runtimeErrors = [];
+
+        await page.context().exposeFunction('__recordWsPerspectiveRuntimeError', payload => runtimeErrors.push(payload));
+        await page.context().addInitScript(() => {
+            globalThis.addEventListener('error', event => {
+                globalThis.__recordWsPerspectiveRuntimeError({
+                    column : event.colno,
+                    line   : event.lineno,
+                    message: event.message,
+                    source : event.filename,
+                    type   : 'error'
+                })
+            });
+            globalThis.addEventListener('unhandledrejection', event => {
+                globalThis.__recordWsPerspectiveRuntimeError({
+                    reason: String(event.reason?.stack || event.reason?.message || event.reason),
+                    type  : 'unhandledrejection'
+                })
+            })
+        });
+
+        page.on('pageerror', error => {
+            let value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 30000});
+
+        const app        = await neuralLink.connectToApp('Workstation'),
+              workspaces = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'the workstation Workspace must exist in the App Worker').toBeTruthy();
+
+        const baseline = (await app.getDockTopology(wsId)).document;
+
+        expect(
+            baseline.nodes['bottom-tabs']?.items,
+            'precondition: the workspace boots with feed in the bottom tabs (the disruption source)'
+        ).toContain('feed');
+
+        // 1. capture_perspective — must land in the holder's store, not degrade to agent-held
+        const captured = await NeuralLink_DockService.capturePerspective({
+            captureScope   : 'window',
+            componentId    : wsId,
+            layoutId       : 'spec-ws-perspective',
+            perspectiveName: 'Spec WS Perspective',
+            sessionId      : app.sessionId,
+            title          : 'Spec witness baseline'
+        });
+
+        expect(captured.errors).toEqual([]);
+        expect(captured.captured).toBe(true);
+        expect(
+            captured.stored,
+            'capture must store through the workspace perspective store (stored:false would mean the holder store is absent)'
+        ).toBe(true);
+
+        // 2. list_perspectives — the store-backed read tier surfaces the capture
+        const listed = await NeuralLink_DockService.listPerspectives({
+            componentId: wsId,
+            sessionId  : app.sessionId
+        });
+
+        expect(listed.errors).toEqual([]);
+        expect(
+            listed.perspectives.some(p => p.layoutId === 'spec-ws-perspective' && p.perspectiveName === 'Spec WS Perspective'),
+            'list_perspectives must surface the just-captured layout'
+        ).toBe(true);
+
+        // 3. Disruption through the semantic dockZone.v1 path
+        const disrupted = await app.executeDockOperation(wsId, {
+            itemId      : 'feed',
+            operation   : 'moveItem',
+            targetNodeId: 'heavy-tabs'
+        });
+
+        expect(disrupted.errors).toEqual([]);
+        expect(disrupted.applied).toBe(true);
+        expect(
+            disrupted.document.nodes['bottom-tabs'].items,
+            'the disruption must be observable before restore (restore-fidelity is vacuous otherwise)'
+        ).not.toContain('feed');
+
+        // 4. restore_perspective — store load + the workspace commit seam returns the exact baseline
+        const restored = await NeuralLink_DockService.restorePerspective({
+            componentId: wsId,
+            name       : 'Spec WS Perspective',
+            sessionId  : app.sessionId
+        });
+
+        expect(restored.errors).toEqual([]);
+        expect(restored.switched).toBe(true);
+        expect(
+            restored.document,
+            'restore must return the exact pre-disruption dockZone.v1 document'
+        ).toEqual(baseline);
+
+        // 5. Fail-closed: an unknown name errors structurally and touches nothing
+        const failed = await NeuralLink_DockService.restorePerspective({
+            componentId: wsId,
+            name       : 'Spec WS Missing',
+            sessionId  : app.sessionId
+        });
+
+        expect(failed.switched).toBe(false);
+        expect(failed.errors.length, 'the fail-closed path must name its reason').toBeGreaterThan(0);
+
+        const untouched = (await app.getDockTopology(wsId)).document;
+
+        expect(
+            untouched,
+            'a failed restore must leave the live document byte-identical'
+        ).toEqual(baseline);
+
+        expect(pageErrors, 'no page errors may escape during the perspective chain').toEqual([]);
+        expect(runtimeErrors, 'no runtime errors may escape during the perspective chain').toEqual([]);
+    })
+})


### PR DESCRIPTION
Resolves #16342

Activates the Neural Link perspective trio on the film's primary surface: `apps/workstation/view/Workspace.mjs` gains a `DockPerspectiveStore` instance (4 lines + member JSDoc + teardown with the view). The Workspace already satisfied the holder contract (`applyDockZoneOperation` :568, `getDockZoneDocument` :702) and already owns the commit seam restore rides (`onDockZoneDocumentChange` :780), so the client DockService's store resolution (`:193` / `:222` / `:264`) activates capture (`stored: true`, was `stored: false`), list, and restore (was fail-closed) with zero service-side change. This is the scene-7 perspective cell of the flagship screenplay's conditional scene (`film-perspectives-undo`) — its undo/redo half is already provable (merged machinery, receipt on the ticket). Spec witness: `WorkstationPerspectivesNL.spec.mjs` (store-backed capture → list → disruption → exact-baseline restore → fail-closed no-mutation), green headed and headless.

Evidence: local headed+GPU receipts achieved (below) — these ARE the current-head evidence for the e2e surface: PR CI runs no whitebox-e2e job by design (e2e rides the nightly runner). Residual: none for the close target — the live headed chain receipt is at #16342 issuecomment-5158086626.

## Deltas from ticket

None substantive — the ticket's predicted minimal shape (instantiate the store, NL trio is the drive path, no switcher UI) is exactly what shipped; the receipt confirmed restore rides the Workspace's existing `onDockZoneDocumentChange` seam.

## Test Evidence

- New spec, headed: `NEO_E2E_PORT=8117 npx playwright test workstation/WorkstationPerspectivesNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed` → 1 passed; also green headless (stable across the current host flake window)
- Workstation unit dir: `npx playwright test unit/apps/workstation -c test/playwright/playwright.config.unit.mjs --workers=2` → 28 passed
- Full unit suite: `npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=4` → 10697 passed
- Live headed chain receipt (manual, preceding the spec): #16342 issuecomment-5158086626 — `stored: true`, list, disruption, exact 20-pane baseline restore
- e2e/workstation suite at this branch: no new failures introduced (3 pre-existing failures owned by #16341; FiveBeat scenes 4/5 show an intermittent host flake — stash-proven not caused by this change, evidence reported to the #16309-class owners)

## Post-Merge Validation

- [ ] Nightly e2e runner green on the merged spec (whitebox e2e is nightly-only by design; PR CI carries no e2e job)
- [ ] Scene-7 perspective cell flips on the #15252 R2 matrix (comment posted at merge)

Authored by Phoebe (Kimi K3, OpenCode). Session 1a7e3f91-8356-48bb-a353-9fd7da2647f5.
