### PR TITLE
fix(workstation): serialize tour surface settlement (#16341)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -351,16 +351,18 @@ class Workspace extends Container {
      */
     cuePromise = Promise.resolve()
     /**
-     * Hosting-surface cue promises indexed by the runner's scene/step identity. `stepSettled`
-     * consumes each entry after runner-owned work succeeds; the map never becomes runner state.
+     * Hosting-surface cue promises indexed by the runner's scene/step identity. The injected
+     * `TourRunner.stepSettlement` callback awaits an entry before `stepSettled`; that event then
+     * consumes it for the independent progress-paint chain. The map never becomes runner state.
      * @member {Map<String,Promise>} cueSettlements
      * @protected
      */
     cueSettlements = new Map()
     /**
-     * Serialized, paint-confirmed tour progress. `TourRunner.stepSettled` proves runner-owned
-     * work only, so this local projection additionally waits for its cue and dock refresh before
-     * exposing progress to the viewer.
+     * Serialized, paint-confirmed tour progress. `TourRunner.stepSettled` arrives after this
+     * host's cue/refresh barrier, but events are observational and the next beat can start as soon
+     * as the listener returns. This local chain therefore re-awaits the keyed settlement before
+     * painting each pip in order; it never becomes part of runner execution.
      * @member {Promise} progressPromise
      * @protected
      */
@@ -419,10 +421,11 @@ class Workspace extends Container {
         Neo.main.addon.WindowPosition?.setConfigs({observeResize: true, windowId: me.windowId});
 
         me.tourRunner  = Neo.create(TourRunner, {
-            componentId: me.id,
-            dockService: me.dockService,
-            mode       : 'demo',
-            script     : workstationTourScript
+            componentId   : me.id,
+            dockService   : me.dockService,
+            mode          : 'demo',
+            script        : workstationTourScript,
+            stepSettlement: data => me.settleTourStep(data)
         });
 
         me.tourRunner.on({
@@ -840,9 +843,25 @@ class Workspace extends Container {
     }
 
     /**
-     * Projects one successful runner step only after the hosting surface's corresponding cue
-     * and dock refresh have also settled. The runner event deliberately does not claim either
-     * hosting-surface boundary.
+     * Settles the hosting surface for one runner step before the next screenplay beat may begin.
+     * @summary Prevents a following document operation from re-projecting the dock while the
+     * current surface cue still owns a live gesture, dwell, or paint boundary.
+     * @param {Object} data `TourRunner` settlement payload.
+     * @returns {Promise<void>}
+     */
+    async settleTourStep(data) {
+        let me            = this,
+            key           = `${data.sceneIndex}:${data.stepIndex}`,
+            cueSettlement = me.cueSettlements.get(key) || Promise.resolve();
+
+        await cueSettlement;
+        await me.refreshPromise
+    }
+
+    /**
+     * Projects one successful runner step after the injected host barrier has settled its cue and
+     * dock refresh. The listener remains observational: it serializes the independent pip paint
+     * without making event delivery an execution boundary for `TourRunner`.
      * @param {Object} data `TourRunner.stepSettled` payload.
      */
     onTourStepSettled(data) {
@@ -2420,14 +2439,34 @@ class Workspace extends Container {
             startedAt      = Date.now(),
             runnerResult   = await me.tourRunner.start();
 
-        await me.cuePromise;
-        await me.refreshPromise;
-        await me.progressPromise;
-        await me.setPipProgress(Workspace.totalBeats().length);
+        const
+            errors      = [...runnerResult.errors, ...me.cueErrors],
+            appendError = (label, result) => {
+                if (result.status === 'rejected') {
+                    const
+                        detail          = result.reason?.message || String(result.reason),
+                        alreadyRecorded = errors.some(error => error === detail || error.endsWith(`: ${detail}`));
+
+                    alreadyRecorded || errors.push(`${label} failed: ${detail}`)
+                }
+            },
+            settlements = await Promise.allSettled([
+                me.cuePromise,
+                me.refreshPromise,
+                me.progressPromise
+            ]);
+
+        ['surface cue settlement', 'dock refresh settlement', 'progress settlement']
+            .forEach((label, index) => appendError(label, settlements[index]));
+
+        const [finalProgress] = await Promise.allSettled([
+            me.setPipProgress(Workspace.totalBeats().length)
+        ]);
+
+        appendError('final progress paint', finalProgress);
 
         const
             elapsedMs    = Date.now() - startedAt,
-            errors       = [...runnerResult.errors, ...me.cueErrors],
             feedEndCount = feedStore.count,
             receipt      = {
                 completed  : runnerResult.completed && errors.length === 0,
@@ -3867,22 +3906,11 @@ class Workspace extends Container {
                 let indicators = me.dragAffordances.indicators,
                     candidate  = indicators.candidateSet.cross
                         .find(entry => entry.preview?.placement?.kind === dwell.placementKind),
-                    indicator  = candidate && indicators.items
-                        .find(item => item.candidateKey === `cross-${candidate.position}`),
-                    hostRect   = indicators.hostRect,
-                    left       = Number.parseFloat(indicator?.style?.left),
-                    top        = Number.parseFloat(indicator?.style?.top),
-                    width      = Number.parseFloat(indicator?.style?.width),
-                    height     = Number.parseFloat(indicator?.style?.height);
+                    indicatorPoint = candidate && indicators.getCandidateHitPoint(candidate.preview?.previewId);
 
-                if (!candidate || !hostRect || [left, top, width, height].some(value => !Number.isFinite(value))) {
-                    throw new Error(`indicator geometry is unavailable for '${dwell.placementKind}'`)
+                if (!candidate || !indicatorPoint) {
+                    throw new Error(`indicator hit geometry is unavailable for '${dwell.placementKind}'`)
                 }
-
-                let indicatorPoint = {
-                    x: Math.round(hostRect.x + left + width  / 2),
-                    y: Math.round(hostRect.y + top  + height / 2)
-                };
 
                 await walkTo(indicatorPoint);
 

--- a/src/ai/client/TourRunner.mjs
+++ b/src/ai/client/TourRunner.mjs
@@ -92,9 +92,13 @@ function validateCrossWindowResult(result) {
  *              with motion disabled would record a lie about the product).
  * - `spec`   — pause waits skipped entirely; assertions identical. The whitebox-e2e replay mode.
  *
+ * Hosting-surface cues and projection remain external to the replay log. A host that must prevent
+ * its asynchronous surface work from being overtaken can inject {@link #stepSettlement}; the runner
+ * awaits that opaque boundary after its own step succeeds and before the next beat starts.
+ *
  * Events (observable): `beat` (before each step — the tour bar's caption feed), `stepSettled`
- * (after one runner-owned step succeeds; hosting-surface cues/projection remain external), `scene`
- * (scene boundary), `error` (abort with structured failures), `complete` (full log).
+ * (after runner and optional host settlement), `scene` (scene boundary), `error` (abort with
+ * structured failures), `complete` (full log).
  * As with every object event, `Neo.core.Observable` adds the runner id as `source`.
  *
  * Script schema + fail-closed validator: `tourScript.mjs` (same directory) · dock documents:
@@ -178,6 +182,16 @@ class TourRunner extends Base {
          */
         reducedMotion: null,
         /**
+         * Optional host-owned settlement boundary. Called after runner-owned work succeeds and
+         * before `stepSettled` / the next beat, with the JSON-safe settlement payload. The runner
+         * neither interprets nor logs the returned value; it only awaits the promise so external
+         * cues and projections cannot be overtaken by a later document mutation. The callback may
+         * await only work already initiated by the current `beat`; awaiting `stepSettled`, `complete`,
+         * a progress boundary downstream of this callback, or a later beat creates a dependency cycle.
+         * @member {Function|null} stepSettlement=null
+         */
+        stepSettlement: null,
+        /**
          * The `neo.tour.script.v1` script to execute. Validated fail-closed at
          * {@link #start} time against the resolved operation vocabulary.
          * @member {Object|null} script=null
@@ -244,10 +258,10 @@ class TourRunner extends Base {
      */
     #preflight() {
         const
-            me                                 = this,
-            {crossWindowExecutor, dockService} = me,
-            crossWindowAvailable               = typeof crossWindowExecutor?.executeCrossWindowStep === 'function',
-            errors                             = [];
+            me                                                 = this,
+            {crossWindowExecutor, dockService, stepSettlement} = me,
+            crossWindowAvailable                               = typeof crossWindowExecutor?.executeCrossWindowStep === 'function',
+            errors                                             = [];
 
         if (typeof dockService?.executeDockOperation !== 'function' || typeof dockService?.getDockTopology !== 'function') {
             errors.push('dockService: required — inject Neo.ai.client.DockService (or a fixture exposing executeDockOperation + getDockTopology)')
@@ -255,6 +269,10 @@ class TourRunner extends Base {
 
         if (typeof me.componentId !== 'string' || me.componentId.length < 1) {
             errors.push('componentId: required — the dock-document holder component id (the execute_dock_operation target)')
+        }
+
+        if (stepSettlement !== null && typeof stepSettlement !== 'function') {
+            errors.push('stepSettlement: must be a Function or null')
         }
 
         if (me.mode === 'record' && me.reducedMotion !== false) {
@@ -340,9 +358,9 @@ class TourRunner extends Base {
      */
     async #run() {
         const
-            me                                              = this,
-            {componentId, crossWindowExecutor, dockService} = me,
-            {scenes}                                        = me.script;
+            me                                                              = this,
+            {componentId, crossWindowExecutor, dockService, stepSettlement} = me,
+            {scenes}                                                        = me.script;
 
         let sceneIndex = 0;
 
@@ -491,19 +509,33 @@ class TourRunner extends Base {
                     }
                 }
 
-                // This event owns ONLY runner settlement: the operation/assertion/pause succeeded
-                // and its deterministic log entry exists. Hosting surfaces combine it with their
-                // own cue and projection promises instead of making the runner await listeners.
-                const logLength = me.log.length;
+                // The explicit callback is the host's asynchronous settlement boundary. Events
+                // remain observational and are never awaited; the callback's return value never
+                // enters the deterministic replay log.
+                const
+                    logLength  = me.log.length,
+                    settlement = {
+                        completedCount: logLength,
+                        logLength,
+                        sceneId,
+                        sceneIndex,
+                        stepIndex,
+                        stepType      : step.type
+                };
 
-                me.fire('stepSettled', {
-                    completedCount: logLength,
-                    logLength,
-                    sceneId,
-                    sceneIndex,
-                    stepIndex,
-                    stepType      : step.type
-                });
+                if (stepSettlement) {
+                    try {
+                        await me.trap(Promise.resolve(stepSettlement({...settlement})))
+                    } catch (e) {
+                        if (e === Neo.isDestroyed) throw e;
+
+                        return me.#abort([
+                            `${sceneId}[${stepIndex}] host step settlement failed: ${e?.message || String(e)}`
+                        ])
+                    }
+                }
+
+                me.fire('stepSettled', settlement);
 
                 stepIndex++
             }

--- a/src/dashboard/DockDropIndicators.mjs
+++ b/src/dashboard/DockDropIndicators.mjs
@@ -232,6 +232,52 @@ class DockDropIndicators extends Container {
     }
 
     /**
+     * Finds the nearest integer pointer coordinate inside a candidate's rendered rect that
+     * resolves back to that candidate under the layer's live overlap precedence.
+     * @summary Lets programmatic pointer choreography target a visible part of an indicator instead
+     * of assuming its center is reachable when a higher root-edge chip overlaps it.
+     * @param {String|null} previewId
+     * @returns {{x: Number, y: Number}|null}
+     */
+    getCandidateHitPoint(previewId) {
+        let target = null;
+
+        for (let entry of this.#indicatorRects.values()) {
+            if (entry.candidate?.preview?.previewId === previewId) {
+                target = entry;
+                break
+            }
+        }
+
+        if (!target) return null;
+
+        let {height, width, x, y} = target.rect,
+            center                = {x: Math.round(x + width / 2), y: Math.round(y + height / 2)},
+            best                  = null,
+            bestDistance          = Infinity,
+            maxX                  = Math.floor(x + width),
+            maxY                  = Math.floor(y + height),
+            point, distance;
+
+        for (let pointY = Math.ceil(y); pointY <= maxY; pointY++) {
+            for (let pointX = Math.ceil(x); pointX <= maxX; pointX++) {
+                point = {x: pointX, y: pointY};
+
+                if (this.hitTest(point)?.preview?.previewId === previewId) {
+                    distance = (pointX - center.x) ** 2 + (pointY - center.y) ** 2;
+
+                    if (distance < bestDistance) {
+                        best         = point;
+                        bestDistance = distance
+                    }
+                }
+            }
+        }
+
+        return best
+    }
+
+    /**
      * @summary Pure viewport-space hit-test against the computed indicator rects.
      *
      * No DOM read: the layer positioned every indicator from rect inputs, so the same math

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -79,6 +79,13 @@ class DockTabSortZone extends TabHeaderSortZone {
          */
         dockWorkspaceId: null,
         /**
+         * Dock tab toolbars are parent-sized projection surfaces. Pinning their live width to the
+         * draggable button span would SHRINK a wide header during the gesture, causing Overflow to
+         * misclassify the dragged tab as space-hidden and create a phantom menu control.
+         * @member {Boolean} expandOwnerOnDrag=false
+         */
+        expandOwnerOnDrag: false,
+        /**
          * Slack in px around the source toolbar's REAL bounds inside which a release still counts
          * as a within-toolbar gesture (the base reorder applies). A release farther out than this
          * on any side is dock-gesture territory: the tracked reorder is voided so the cross-zone
@@ -142,11 +149,10 @@ class DockTabSortZone extends TabHeaderSortZone {
 
     /**
      * The source toolbar's PRISTINE viewport rect, measured once per gesture at
-     * {@link #onDragStart} — BEFORE the base runs: the base sort trims its in-memory `ownerRect`
-     * to the button span AND (via its inherited `expandOwnerOnDrag`) writes those trimmed
-     * dimensions onto the toolbar's live style, so neither the base rect nor any post-`super`
-     * measure is a release-decision surface. This pre-mutation snapshot is the real toolbar
-     * boundary {@link #releaseVoidsReorder} decides against.
+     * {@link #onDragStart} — BEFORE the base runs and trims its in-memory `ownerRect` to the
+     * draggable button span. Dock toolbars disable the base's live owner-width write, but the
+     * trimmed rect is still a sort-local surface rather than the real toolbar boundary
+     * {@link #releaseVoidsReorder} decides against.
      * @member {Object|null} dockSourceToolbarRect=null
      * @protected
      */
@@ -954,10 +960,8 @@ class DockTabSortZone extends TabHeaderSortZone {
 
         me.stackDragActive = false;
 
-        // The real toolbar boundary — measured BEFORE the base runs: the base drag-start (with
-        // its inherited `expandOwnerOnDrag`) WRITES the trimmed button-span dimensions onto the
-        // toolbar's live style, so any post-`super` measure reads the mutated box, not the
-        // toolbar's true extent. One pre-gesture measure, off the per-frame hot path.
+        // The real toolbar boundary — measured BEFORE the base trims its sort-local ownerRect to
+        // the draggable button span. One pre-gesture measure, off the per-frame hot path.
         me.dockSourceToolbarRect = await me.owner?.getDomRect() ?? null;
 
         await super.onDragStart(data);

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -1273,39 +1273,40 @@ test.describe('Workstation — dense living-data composition', () => {
                     .map(element => element.id);
 
             const state = globalThis.__workstationMonitor = {
-                activeTabEmptyMaxMs           : 0,
-                activeTabEmptySamples         : [],
-                blankSamples                  : [],
-                blankFrames                   : 0,
-                chromeAnimationLeakFrames     : 0,
-                chromeAnimationMaxTargets     : 0,
-                done                          : false,
-                flipSamples                   : 0,
+                activeTabEmptyMaxMs            : 0,
+                activeTabEmptySamples          : [],
+                blankSamples                   : [],
+                blankFrames                    : 0,
+                chromeAnimationLeakFrames      : 0,
+                chromeAnimationMaxTargets      : 0,
+                done                           : false,
+                flipSamples                    : 0,
                 initialContainerIds,
-                initialContainerMissingFrames : 0,
+                initialContainerMissingFrames  : 0,
                 initialHeaderIds,
-                initialHeaderMissingFrames    : 0,
-                midpointSeen                  : false,
-                missingBodyFrames             : 0,
-                novelContainerIds             : [],
-                novelHeaderIds                : [],
-                overflowControlCounts         : {},
-                overflowControlDuplicateFrames: 0,
-                palettes                      : [],
-                pipCounts                     : [initialPipCount],
-                pipRegressionFrames           : 0,
-                railMismatchFrames            : 0,
-                sampledFrames                 : 0,
-                securityCaptured              : false,
-                securityActiveHeaderMissFrames: 0,
-                securityBodyMissingFrames     : 0,
-                securityFullyClippedFrames    : 0,
-                securityFullyClippedSamples   : [],
-                securityMissingFrames         : 0,
-                securityPresenceTransitions   : [],
-                securityOverflowMutationFrames: 0,
-                securityReplacementFrames     : 0,
-                securityStageFramesByBurst    : []
+                initialHeaderMissingFrames     : 0,
+                midpointSeen                   : false,
+                missingBodyFrames              : 0,
+                novelContainerIds              : [],
+                novelHeaderIds                 : [],
+                overflowControlCounts          : {},
+                overflowControlDuplicateFrames : 0,
+                overflowControlDuplicateSamples: [],
+                palettes                       : [],
+                pipCounts                      : [initialPipCount],
+                pipRegressionFrames            : 0,
+                railMismatchFrames             : 0,
+                sampledFrames                  : 0,
+                securityCaptured               : false,
+                securityActiveHeaderMissFrames : 0,
+                securityBodyMissingFrames      : 0,
+                securityFullyClippedFrames     : 0,
+                securityFullyClippedSamples    : [],
+                securityMissingFrames          : 0,
+                securityPresenceTransitions    : [],
+                securityOverflowMutationFrames : 0,
+                securityReplacementFrames      : 0,
+                securityStageFramesByBurst     : []
             };
             const activeTabEmptySpans = {};
             let   securityNode        = null,
@@ -1328,8 +1329,9 @@ test.describe('Workstation — dense living-data composition', () => {
                       body         = document.querySelector('.workstation-scale-pane .neo-grid-body'),
                       railTabCount = [...document.querySelectorAll('.neo-dashboard-dock-rail-tab')]
                           .filter(isVisible).length,
-                      overflowControlCount = [...document.querySelectorAll('.neo-tab-overflow-control')]
-                          .filter(isVisible).length,
+                      overflowControls = [...document.querySelectorAll('.neo-tab-overflow-control')]
+                          .filter(isVisible),
+                      overflowControlCount = overflowControls.length,
                       currentSecurityNode = document.getElementById(identity.securityPaneId);
 
                 if (Boolean(currentSecurityNode) !== Boolean(state.securityPresent)) {
@@ -1426,7 +1428,47 @@ test.describe('Workstation — dense living-data composition', () => {
                 railTabCount === 2 || state.railMismatchFrames++;
                 state.overflowControlCounts[overflowControlCount]
                     = (state.overflowControlCounts[overflowControlCount] || 0) + 1;
-                overflowControlCount > 1 && state.overflowControlDuplicateFrames++;
+
+                if (overflowControlCount > 1) {
+                    state.overflowControlDuplicateFrames++;
+
+                    const sample = {
+                        caption: document.querySelector('.workstation-tour-caption')?.textContent?.trim() || '',
+                        owners : overflowControls.map(control => {
+                            const
+                                controlRect = control.getBoundingClientRect(),
+                                toolbar     = [...document.querySelectorAll('.neo-tab-header-toolbar')]
+                                    .filter(isVisible)
+                                    .map(element => {
+                                        const rect = element.getBoundingClientRect();
+
+                                        return {
+                                            distance: Math.hypot(
+                                                controlRect.right - rect.right,
+                                                controlRect.top + controlRect.height / 2 - (rect.top + rect.height / 2)
+                                            ),
+                                            element
+                                        }
+                                    })
+                                    .sort((a, b) => a.distance - b.distance)[0]?.element,
+                                container   = toolbar?.closest('.neo-tab-container');
+
+                            return {
+                                containerId: container?.id || null,
+                                controlId  : control.id || null,
+                                tabs       : [...toolbar?.querySelectorAll('.neo-tab-header-button') || []]
+                                    .filter(isVisible)
+                                    .map(element => element.textContent?.trim() || ''),
+                                toolbarId: toolbar?.id || null
+                            }
+                        }),
+                        pipCount: root?.querySelectorAll('.workstation-pip-done').length || 0
+                    };
+
+                    JSON.stringify(state.overflowControlDuplicateSamples.at(-1)) === JSON.stringify(sample)
+                        || state.overflowControlDuplicateSamples.length >= 20
+                        || state.overflowControlDuplicateSamples.push(sample)
+                }
 
                 if (currentSecurityNode) {
                     if (!securityNode) {
@@ -1668,7 +1710,8 @@ test.describe('Workstation — dense living-data composition', () => {
             .toBe(0);
         expect(monitor.railMismatchFrames, 'both real rails remain present through every sampled frame').toBe(0);
         expect(monitor.overflowControlDuplicateFrames,
-            `the projection never leaks duplicate overflow controls: ${JSON.stringify(monitor.overflowControlCounts)}`)
+            `the projection never leaks duplicate overflow controls: counts=${JSON.stringify(monitor.overflowControlCounts)} ` +
+            `samples=${JSON.stringify(monitor.overflowControlDuplicateSamples)}`)
             .toBe(0);
         expect(monitor.overflowControlCounts['1'], 'the real overflow state is observed').toBeGreaterThan(0);
         expect(monitor.securityCaptured, 'the overflow cue mounts Security before its structural move').toBe(true);

--- a/test/playwright/unit/ai/client/TourRunner.spec.mjs
+++ b/test/playwright/unit/ai/client/TourRunner.spec.mjs
@@ -424,6 +424,15 @@ test.describe.serial('Neo.ai.client.TourRunner', () => {
             expect(result.errors.join('\n')).toContain("unknown 'teleportItem'")
         });
 
+        test('a malformed host settlement boundary is refused before dispatch', async () => {
+            createRunner({stepSettlement: {}});
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain('stepSettlement: must be a Function or null')
+        });
+
         test('cross-window refuses an absent or incompatible executor before dispatch', async () => {
             createRunner({script: crossWindowScript()});
 
@@ -512,6 +521,103 @@ test.describe.serial('Neo.ai.client.TourRunner', () => {
 
             expect(result.completed).toBe(true);
             expect(events).toEqual(['wait:14', 'settled:pause:1'])
+        });
+
+        test('an injected host settlement blocks the next beat without changing the replay log', async () => {
+            let release, enteredResolve;
+            const
+                entered = new Promise(resolve => enteredResolve = resolve),
+                events  = [];
+
+            createRunner({
+                stepSettlement(data) {
+                    events.push(`host:${data.stepIndex}:${data.stepType}:log-${data.logLength}`);
+
+                    if (data.stepIndex === 0) {
+                        enteredResolve();
+                        data.stepIndex = 99;
+                        return new Promise(resolve => release = resolve)
+                    }
+                }
+            });
+            runner.on({
+                beat       : data => events.push(`beat:${data.stepIndex}`),
+                stepSettled: data => events.push(`settled:${data.stepIndex}`)
+            });
+
+            const running = runner.start();
+
+            await entered;
+
+            expect(events).toEqual(['beat:0', 'host:0:op:log-1']);
+            expect(runner.log).toHaveLength(1);
+
+            release();
+
+            const result = await running;
+
+            expect(result.completed).toBe(true);
+            expect(events.slice(0, 4)).toEqual([
+                'beat:0',
+                'host:0:op:log-1',
+                'settled:0',
+                'beat:1'
+            ]);
+            expect(events).not.toContain('settled:99');
+            expect(events.filter(event => event.startsWith('host:'))).toEqual([
+                'host:0:op:log-1',
+                'host:1:pause:log-2',
+                'host:2:op:log-3',
+                'host:3:topology-assert:log-4',
+                'host:4:op:log-5'
+            ]);
+            expect(result.log).toHaveLength(smokeScript().scenes[0].steps.length)
+        });
+
+        test('destroying the runner rejects a pending host settlement without a late step event', async () => {
+            let release, enteredResolve;
+            const
+                entered = new Promise(resolve => enteredResolve = resolve),
+                settled = [];
+
+            createRunner({
+                stepSettlement() {
+                    enteredResolve();
+                    return new Promise(resolve => release = resolve)
+                }
+            });
+            runner.on('stepSettled', data => settled.push(data));
+
+            const running = runner.start();
+
+            await entered;
+            runner.destroy();
+
+            expect(await running).toEqual({
+                completed: false,
+                errors   : ['TourRunner destroyed mid-tour'],
+                log      : [expect.objectContaining({stepIndex: 0, type: 'op'})]
+            });
+            expect(settled).toEqual([]);
+
+            release();
+            await Promise.resolve();
+
+            expect(settled).toEqual([])
+        });
+
+        test('a rejected host settlement aborts structurally without a successful step event', async () => {
+            const settled = [];
+
+            createRunner({stepSettlement: async () => { throw new Error('surface vanished') }});
+            runner.on('stepSettled', data => settled.push(data));
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain('host step settlement failed: surface vanished');
+            expect(result.log).toHaveLength(1);
+            expect(settled).toEqual([])
         });
 
         test('cross-window awaits one host dispatch before settlement and logs semantics only', async () => {

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -231,6 +231,52 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     });
 
+    test('startTour preserves the structured receipt when host refresh settlement rejects', async () => {
+        const
+            feedStore = {count: 25, maxRecords: 500},
+            failure   = new Error('projection vanished'),
+            captions  = [];
+
+        let host;
+
+        host = {
+            cueErrors           : [],
+            cuePromise          : Promise.resolve(),
+            cueReceipts         : [],
+            cueSettlements      : new Map(),
+            dockModel           : null,
+            feedBatchCount      : 7,
+            lastTourReceipt     : null,
+            progressPromise     : Promise.resolve(),
+            refreshPromise      : Promise.resolve(),
+            getStateProvider    : () => ({getStore: () => feedStore}),
+            refreshDockWorkspace: async () => {},
+            setPipProgress      : async () => {},
+            setTourCaption      : value => captions.push(value),
+            tourRunner          : {
+                running: false,
+                async start() {
+                    host.refreshPromise = Promise.reject(failure);
+
+                    return {
+                        completed: false,
+                        errors   : ['scene[0] host step settlement failed: projection vanished'],
+                        log      : [{sceneIndex: 0, stepIndex: 0, type: 'op'}]
+                    }
+                }
+            }
+        };
+
+        const receipt = await Workspace.prototype.startTour.call(host);
+
+        expect(receipt).toBe(host.lastTourReceipt);
+        expect(receipt.completed).toBe(false);
+        expect(receipt.errors).toEqual([
+            'scene[0] host step settlement failed: projection vanished'
+        ]);
+        expect(captions.at(-1)).toContain('Tour stopped')
+    });
+
     test('provider-owned stores and cached data panes survive split + return', async () => {
         const workspace = Neo.create(Workspace, {});
 

--- a/test/playwright/unit/dashboard/DockDropIndicators.spec.mjs
+++ b/test/playwright/unit/dashboard/DockDropIndicators.spec.mjs
@@ -139,6 +139,23 @@ test.describe('Neo.dashboard.DockDropIndicators (§06 — the indicator-overlay 
         expect(hit.edge).toBe('top')
     });
 
+    test('getCandidateHitPoint finds a reachable cross point when a higher chip covers its center', () => {
+        layer = Neo.create(DockDropIndicators, {hostRect: HOST_RECT});
+        layer.candidateSet = mkSet({zoneRect: {x: 400, y: 539, width: 200, height: 100}});
+
+        const previewId = 'preview:terminal:main-tabs:edge-bottom';
+
+        // The root-bottom chip owns the exact center by render-order precedence.
+        expect(layer.hitTest({x: 500, y: 627}).preview.previewId)
+            .toBe('preview:terminal:root:edge-bottom');
+
+        const point = layer.getCandidateHitPoint(previewId);
+
+        expect(point).not.toBeNull();
+        expect(layer.hitTest(point).preview.previewId).toBe(previewId);
+        expect(layer.getCandidateHitPoint('missing-preview')).toBeNull()
+    });
+
     test('updatePointer drives the active candidate: event fired, active cls tracked', () => {
         layer = Neo.create(DockDropIndicators, {hostRect: HOST_RECT});
         layer.candidateSet = mkSet();

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -22,6 +22,10 @@ import TabHeaderSortZone from '../../../../src/draggable/tab/header/toolbar/Sort
  * walk); the rendered consequence rides the visual harness.
  */
 test.describe('Neo.dashboard.DockTabSortZone', () => {
+    test('keeps the parent-sized dock toolbar extent during a drag', () => {
+        expect(DockTabSortZone.config.expandOwnerOnDrag).toBe(false)
+    });
+
     test.describe('getDragProxyConfig — the carried-scope embodiment contract', () => {
         // Mirrors the real workstation shape: the workspace theme-swaps an INNER root
         // (document.body keeps the boot theme), the dock host below it owns the language,
@@ -106,35 +110,33 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
      * `dockReleaseTolerance` config — pure over instance state, so the matrix drives it with
      * explicit rects for both orientations.
      */
-    test.describe('onDragStart — the snapshot precedes the base mutation (lifecycle order)', () => {
-        test('the toolbar rect is captured BEFORE the base writes span dimensions onto the live style', async () => {
-            // A toolbar WIDER than its button span — the exact shape where the base's
-            // expandOwnerOnDrag style-write shrinks the live box at drag start. The stub owner
-            // reports the wide rect only while that write has not happened: a post-`super`
-            // measure would read the span box, so the assertion proves the ORDER, not a value.
+    test.describe('onDragStart — the source-boundary snapshot precedes the base lifecycle', () => {
+        test('captures the real toolbar rect before delegating to the base drag start', async () => {
+            // A toolbar WIDER than its button span. DockTabSortZone disables the inherited live
+            // owner-width write, but release decisions still require the pre-base toolbar rect
+            // rather than the base's later span-trimmed sort geometry.
             // Prototype-driven like the carried-scope pins above — the method chain is the unit,
             // never a fully-constructed zone.
             const WIDE = {x: 100, y: 100, width: 600, height: 32};
             const SPAN = {x: 100, y: 100, width: 180, height: 32};
 
-            let styleWritten = false;
+            const calls = [];
 
             const owner = {
                 getDomRect(ids) {
-                    // the no-arg call is the subclass snapshot; array calls are the base batch
-                    if (ids === undefined) return Promise.resolve(styleWritten ? {...SPAN} : {...WIDE});
+                    calls.push(ids === undefined ? 'snapshot' : 'base-measure');
+
+                    if (ids === undefined) return Promise.resolve({...WIDE});
                     return Promise.resolve(ids.map(() => ({...SPAN})))
-                },
-                get style() { return {} },
-                set style(value) { styleWritten = true }
+                }
             };
 
-            // The base chain needs more scaffolding than this witness wants to carry — stub it
-            // to ONLY perform the mutation whose ordering is under test.
+            // The base chain needs more scaffolding than this witness wants to carry. Its stub
+            // records delegation and reads the snapshot so ordering remains the tested contract.
             const original = TabHeaderSortZone.prototype.onDragStart;
 
             TabHeaderSortZone.prototype.onDragStart = async function() {
-                this.owner.style = {width: '180px'} // the expandOwnerOnDrag write, distilled
+                calls.push('base-start')
             };
 
             const zone = {dockItemIds: ['audit'], dockWorkspaceId: null, dragComponent: null, owner, startIndex: 0};
@@ -142,8 +144,8 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
             try {
                 await DockTabSortZone.prototype.onDragStart.call(zone, {path: []});
 
-                expect(styleWritten, 'the base mutation ran').toBe(true);
-                expect(zone.dockSourceToolbarRect, 'the snapshot is the PRE-mutation toolbar extent').toEqual(WIDE);
+                expect(calls).toEqual(['snapshot', 'base-start']);
+                expect(zone.dockSourceToolbarRect, 'release truth is the pre-base toolbar extent').toEqual(WIDE);
             } finally {
                 TabHeaderSortZone.prototype.onDragStart = original
             }


### PR DESCRIPTION
Resolves #16341

Serializes each tour step with its host-owned cue and projection work, targets a reachable point of overlapping drop indicators, and keeps dock toolbars parent-sized during tab drags. The repaired tour now completes the original edge-bottom drop and overflow/identity checks instead of letting the following document operation erase an in-flight gesture.

Evidence: L3 (headed Chromium on the film host proves the repaired cross-zone path through the post-tour monitor boundary) → L3 required (live preview-surface behavior). Residual: independent roots moved to successors [#16356] [#16357] [#16358]; the separate grid hypothesis remains [#16353].

Related: #16353
Related: #16356
Related: #16357
Related: #16358

## Deltas from ticket

- Added an optional, fail-closed `TourRunner.stepSettlement` boundary without changing the deterministic replay log or making events awaitable.
- Moved programmatic pointer selection to `DockDropIndicators`' live hit-test authority, so an overlapping root-edge chip cannot steal the assumed center point.
- Disabled inherited owner-width expansion for dock tab toolbars, preventing a drag from manufacturing a phantom overflow control.
- Split the two popup failures and newly exposed fixed-stage blank frame into independent successors; no timing allowance or draft-state deadlock.

## Test Evidence

- `npm run test-unit -- TourRunner.spec DockDropIndicators.spec DockTabSortZone.spec apps/workstation/Workspace.spec.mjs` — 116/116 passed at `bb02fcc592`.
- `npm run agent-preflight -- --no-fix ...` plus `git diff --check` — passed.
- Headed `WorkstationNL.spec.mjs --grep "the real tour keeps density"` — original cross-zone receipt and later overflow/identity assertions passed; the row then failed only at #16356 with three zero-rect Security samples.
- Full `npm run test-unit` sandbox run — 10,847/10,915 passed; 24 failures were outside changed files, dominated by sandbox `EPERM` on Docker-owned runtime-data / macOS temp paths plus environment-dependent model tests. No full-suite-green claim.

## Post-Merge Validation

- [ ] Let CI rerun the complete unit matrix in its owned filesystem.
- [ ] After #16356 lands, capture the full headed Workstation row green without weakening its frame oracle.

## Evolution

The intake grouped three preview symptoms. Live falsification found a coherent first root—an unawaited host cue, an overlapped indicator center, and an inherited toolbar-width mutation—while the popup cases and later FLIP blank frame have different lifecycle owners. The ready PR therefore repairs the first root and preserves the remaining claims in fresh tickets.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fb600-58b9-7fa2-86a7-5a15e1ccf659.
