### PR TITLE
fix(memory-core): bootstrap derives the wake transport instead of reading a template that cannot hold one (#16360)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -95,7 +95,6 @@ export const IDENTITIES = [
             subscriptionTemplate: {
                 trigger              : 'SENT_TO_ME',
                 filters              : {priority: 'high'},
-                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {
                     appName     : 'Claude',
                     tabShortcut : '3',
@@ -174,7 +173,6 @@ export const IDENTITIES = [
             subscriptionTemplate: {
                 trigger              : 'SENT_TO_ME',
                 filters              : {priority: 'high'},
-                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {
                     appName     : 'Claude',
                     tabShortcut : '3',
@@ -292,7 +290,6 @@ export const IDENTITIES = [
             subscriptionTemplate: {
                 trigger              : 'SENT_TO_ME',
                 filters              : {priority: 'high'},
-                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {
                     // The macOS app is `Antigravity` (Google's IDE forked from Cursor;
                     // CFBundleName + CFBundleDisplayName: 'Antigravity'). Empirically verified
@@ -347,7 +344,6 @@ export const IDENTITIES = [
             subscriptionTemplate: {
                 trigger              : 'SENT_TO_ME',
                 filters              : {priority: 'high'},
-                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {
                     adapter     : 'osascript',
                     appName     : 'Codex',

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -9,6 +9,7 @@ import logger                                                                   
 import CoalescingEngineService                                                                  from './CoalescingEngineService.mjs';
 import TurnPresenceService                                                                      from './TurnPresenceService.mjs';
 import WebhookDeliveryService                                                                   from './WebhookDeliveryService.mjs';
+import {DELIVERABLE_HARNESS_TARGET}                                                             from '../../daemons/wake/buildReceiverManifest.mjs';
 import {HEARTBEAT_PULSE_ENTITY_PREFIX, HEARTBEAT_PULSE_ENTITY_TYPE, match, matchHeartbeatPulse} from './heartbeatPulseEvaluator.mjs';
 import {resolveResidentFamilyById}                                                              from '../graph/agentFamilyResolution.mjs';
 
@@ -445,12 +446,24 @@ class WakeSubscriptionService extends Base {
             ...(overrideMetadata || {})
         };
 
+        // The transport is DERIVED, never read from the template — and this is the whole reason
+        // bootstrap could not arm anyone. A committed template cannot describe a deliverable route,
+        // because the two things that make one deliverable are both un-committable: the signing key
+        // is minted server-side at subscribe-time (`subscribe()` below, a2a-webhook branch only),
+        // and the address is per-machine and arrives via the boot envelope as `overrideMetadata`.
+        // The four shipped templates still declared `bridge-daemon`, which `buildReceiverManifest`
+        // withdraws by design — so bootstrap faithfully minted rows the builder was built to reject
+        // and reported success. Deriving from the same constant the builder enforces is what makes
+        // the two agree. A template's legitimate content is policy (`trigger`, `filters`) plus GUI
+        // dispatch hints; never the transport.
+        const harnessTarget = DELIVERABLE_HARNESS_TARGET;
+
         // Bootstrap and public subscribe must share the same durable route-idempotency contract.
         const existing = this._findActiveSubscriptionByRoute({
             owner,
             trigger              : template.trigger,
             filters              : template.filters || {},
-            harnessTarget        : template.harnessTarget,
+            harnessTarget,
             harnessTargetMetadata: mergedMetadata
         });
 
@@ -465,11 +478,12 @@ class WakeSubscriptionService extends Base {
             return {subscriptionId: refreshed.id, harnessTarget: refreshed.harnessTarget, status: 'existing'};
         }
 
-        // Create new subscription from template.
+        // Create new subscription from template. `subscribe()` mints the signing key on this
+        // target's branch — the step the template can never perform for itself.
         const result = await this.subscribe({
             trigger              : template.trigger,
             filters              : template.filters || {},
-            harnessTarget        : template.harnessTarget,
+            harnessTarget,
             harnessTargetMetadata: mergedMetadata
         });
 

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -117,13 +117,12 @@ test.describe('ai/graph/identityRoots — same-app Claude wake routes', () => {
     const expectedTemplate = {
         trigger              : 'SENT_TO_ME',
         filters              : {priority: 'high'},
-        harnessTarget        : 'bridge-daemon',
         harnessTargetMetadata: {appName: 'Claude', tabShortcut: '3', focusSeedKey: 'space'}
     };
 
     // Identities that carry the static, machine-agnostic wake template.
     for (const id of ['@neo-opus-ada', '@neo-opus-vega']) {
-        test(`${id} defines the machine-agnostic bridge-daemon wake route`, () => {
+        test(`${id} defines policy and GUI hints only — never a transport`, () => {
             const entry = findIdentity(id);
             expect(entry, `${id} must be a registered AgentIdentity root`).toBeTruthy();
 
@@ -146,6 +145,28 @@ test.describe('ai/graph/identityRoots — same-app Claude wake routes', () => {
             expect(meta.addressType,     'addressType must not be committed').toBeUndefined();
         });
     }
+
+    test('NO identity template declares a transport — a committed one can never be deliverable', () => {
+        // The regression guard. Every template shipped `harnessTarget: 'bridge-daemon'`, which
+        // `buildReceiverManifest` withdraws by design — so `bootstrap()` minted rows the builder
+        // was built to reject, reported success, and left the seat reading `status: 'active'`
+        // while dark.
+        //
+        // Re-adding one cannot be made to work by choosing a better value, which is why this
+        // asserts ABSENCE rather than a correct target: the two things that make a route
+        // deliverable are both un-committable. The signing key is minted server-side at
+        // subscribe-time, and the address is per-machine and arrives via the boot envelope. A
+        // repository file can hold neither, so transport is derived at bootstrap from
+        // DELIVERABLE_HARNESS_TARGET — the same constant the manifest builder enforces.
+        const offenders = IDENTITIES
+            .filter(entry => entry.properties?.subscriptionTemplate?.harnessTarget !== undefined)
+            .map(entry => `${entry.id} → '${entry.properties.subscriptionTemplate.harnessTarget}'`);
+
+        expect(
+            offenders,
+            `subscriptionTemplate.harnessTarget is derived, never declared. Offending identities:\n${offenders.join('\n')}`
+        ).toEqual([]);
+    });
 
     // Self-registered-runtime identities carry NO static template: their wake route registers at
     // runtime from a distinct boot env. @neo-opus-grace uses a self-registered WAKE_SUBSCRIPTION;
@@ -254,7 +275,6 @@ test.describe('ai/graph/identityRoots — Codex wake route', () => {
         expect(entry.properties.subscriptionTemplate).toMatchObject({
             trigger              : 'SENT_TO_ME',
             filters              : {priority: 'high'},
-            harnessTarget        : 'bridge-daemon',
             harnessTargetMetadata: {
                 adapter     : 'osascript',
                 appName     : 'Codex',

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -234,6 +234,68 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
         });
 
+        test('a seat carrying a legacy transport gets a SECOND row, and the legacy one is never retired', async () => {
+            // The migration end-state, pinned because the mechanism is counter-intuitive and my PR
+            // body first described it wrongly. `_reconcileDuplicateSubscriptions` groups by canonical
+            // route key, and `_buildSubscriptionRouteKey` includes `harnessTarget` verbatim — so a
+            // stored `bridge-daemon` row and a derived `a2a-webhook` row are two singleton groups and
+            // neither is ever N-1'd. There is no self-heal. What neutralizes the legacy row is the
+            // manifest builder, which withdraws that target with a named reason; nothing retires it.
+            //
+            // Asserted rather than narrated so nobody can "fix" this back into a self-heal claim: the
+            // reconciler's route-key grouping is what protects legitimate multi-route seats, and
+            // blanket-retiring non-deliverable targets would destroy Shape C setups.
+            GraphService.upsertNode({
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger              : 'SENT_TO_ME',
+                        filters              : {},
+                        harnessTargetMetadata: {appName: 'Antigravity'}
+                    }
+                }
+            });
+
+            const legacy = insertDurableSubscription({
+                subscriptionId       : 'WAKE_SUB:legacy-uuid',
+                owner                : '@alice',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {appName: 'Antigravity'}
+            });
+
+            const readStatus = id => JSON.parse(
+                GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(id).data
+            ).properties.status;
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({
+                    action          : 'bootstrap',
+                    overrideMetadata: {url: BOOT_URL, adapter: 'osascript'}
+                });
+
+                // A second row is minted: the derived route tuple cannot match the stored one.
+                expect(res.status).toBe('created');
+                expect(res.subscriptionId).not.toBe(legacy.subscriptionId);
+                expect(res.harnessTarget).toBe('a2a-webhook');
+
+                // And the legacy row is STILL ACTIVE — not retired, on this boot or any later one.
+                // It stays visible as `active` on lifecycle surfaces while being unpublishable.
+                expect(readStatus(legacy.subscriptionId)).toBe('active');
+
+                // A second bootstrap changes nothing: reconcile still sees two singleton groups.
+                const again = await WakeSubscriptionService.manage({
+                    action          : 'bootstrap',
+                    overrideMetadata: {url: BOOT_URL, adapter: 'osascript'}
+                });
+
+                expect(again.subscriptionId).toBe(res.subscriptionId);
+                expect(readStatus(legacy.subscriptionId)).toBe('active');
+            });
+        });
+
         test('without a receiver URL it REFUSES by name instead of minting a dark row', async () => {
             // The behaviour change that matters most on a live plane, and it is a refusal rather
             // than an arming. Before, bootstrap read `bridge-daemon` off the template, minted a row
@@ -565,8 +627,9 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             // different creation times; only the newest route should remain active.
             // Seeded in the post-derivation shape so this test measures what it is named for —
             // duplicate reconciliation — rather than incidentally measuring route matching. A
-            // seat whose stored rows still carry the old transport is a different case, covered
-            // by the migration test below.
+            // seat whose stored rows still carry the old transport is a different case: those rows
+            // land in a different route group and are never reconciled, pinned by the legacy-transport
+            // bootstrap test above.
             const seededRoute = {harnessTarget: 'a2a-webhook', harnessTargetMetadata: {appName: 'Antigravity', url: BOOT_URL}};
 
             const older = insertDurableSubscription({

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -24,7 +24,12 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 // The setup regression is outside this spec's delivery contract.
 if (!Neo.get) Neo.get = () => null;
 
-import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+import RequestContextService       from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+import {buildWakeReceiverManifest} from '../../../../../../ai/daemons/wake/buildReceiverManifest.mjs';
+
+// The per-machine receiver address a real boot envelope supplies. No committed file can hold it,
+// which is why bootstrap derives the transport but must be GIVEN the address.
+const BOOT_URL = 'http://host.docker.internal:3199/wake';
 
 test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     test.describe.configure({mode: 'serial'});
@@ -107,8 +112,10 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         owner = '@alice',
         trigger = 'SENT_TO_ME',
         filters = {},
-        harnessTarget = 'bridge-daemon',
-        harnessTargetMetadata = {appName: 'Codex'},
+        // Defaults to the DERIVED shape, because that is what bootstrap now produces and what a
+        // post-migration plane stores. Specs that need the legacy transport pass it explicitly.
+        harnessTarget = 'a2a-webhook',
+        harnessTargetMetadata = {appName: 'Codex', url: BOOT_URL},
         status = 'active',
         createdAt = '2026-05-04T20:00:00.000Z',
         updatedAt = createdAt
@@ -181,8 +188,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     // -----------------------------------------------------------------------------
 
     test.describe('bootstrap', () => {
-        test('creates new subscription from identity template', async () => {
-            // Give Alice a template
+        test('creates new subscription from identity template, DERIVING the transport over a stale one', async () => {
+            // The template deliberately still declares `bridge-daemon`, because that is the live
+            // shape: cleaning the seed in `identityRoots.mjs` does not rewrite `subscriptionTemplate`
+            // on nodes already persisted in a graph. Deriving — rather than trusting a cleaned
+            // template — is what makes bootstrap arm a seat on a plane that already has the stale
+            // value stored. Reading the template would reproduce the original defect on every
+            // existing deployment while passing on a fresh one.
             GraphService.upsertNode({
                 id        : '@alice',
                 type      : 'AGENT',
@@ -198,15 +210,105 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
-                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+                // `overrideMetadata` is the boot envelope's channel. The receiver URL is per-machine
+                // and reaches bootstrap only this way — no committed file can hold it.
+                const res = await WakeSubscriptionService.manage({
+                    action          : 'bootstrap',
+                    overrideMetadata: {url: BOOT_URL, adapter: 'osascript'}
+                });
                 expect(res.status).toBe('created');
                 expect(res.subscriptionId).toMatch(/^WAKE_SUB:[0-9a-f-]{36}$/);
-                expect(res.harnessTarget).toBe('bridge-daemon');
+
+                // The whole point: NOT the template's 'bridge-daemon'. That target is withdrawn by
+                // `buildReceiverManifest`, so a row minted from it can never become a route.
+                expect(res.harnessTarget).toBe('a2a-webhook');
 
                 const node = GraphService.db.nodes.get(res.subscriptionId);
                 expect(node.properties.trigger).toBe('SENT_TO_ME');
                 expect(node.properties.filters.priority).toBe('high');
+                expect(node.properties.harnessTarget).toBe('a2a-webhook');
+                // GUI hints from the template survive — they are policy, not transport.
                 expect(node.properties.harnessTargetMetadata.appName).toBe('Antigravity');
+                // And the key the template could never carry is minted on this branch.
+                expect(node.properties.harnessTargetMetadata.signingKey).toMatch(/^[0-9a-f]{64}$/);
+            });
+        });
+
+        test('without a receiver URL it REFUSES by name instead of minting a dark row', async () => {
+            // The behaviour change that matters most on a live plane, and it is a refusal rather
+            // than an arming. Before, bootstrap read `bridge-daemon` off the template, minted a row
+            // the manifest builder withdraws by design, and returned `status: 'created'` — a silent
+            // false success that left the seat reading `active` while unreachable.
+            //
+            // Now the derived target reaches `subscribe()`'s Shape-B validation, which names the one
+            // input nothing supplies yet: the per-machine receiver URL. A named refusal the boot
+            // path logs beats a success that arms nobody — and it is why this ticket's remaining
+            // half is "where does the URL come from", not "why is the seat dark".
+            GraphService.upsertNode({
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger              : 'SENT_TO_ME',
+                        filters              : {priority: 'high'},
+                        harnessTargetMetadata: {appName: 'Claude', tabShortcut: '3', focusSeedKey: 'space'}
+                    }
+                }
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await expect(WakeSubscriptionService.manage({action: 'bootstrap'}))
+                    .rejects.toThrow(/requires harnessTargetMetadata\.url/);
+
+                // And it left nothing behind — a refusal that half-created a row would be worse
+                // than the silent success it replaces.
+                const owned = Object.values(GraphService.db.nodes.items || {})
+                    .filter(n => n.label === 'WAKE_SUBSCRIPTION' && n.properties?.agentIdentity === '@alice');
+                expect(owned).toEqual([]);
+            });
+        });
+
+        test('the bootstrapped row is one the manifest builder accepts — the two agree by construction', async () => {
+            // Cross-side agreement, asserted rather than assumed: bootstrap's output must be a row
+            // `buildWakeReceiverManifest` will publish. Before this, bootstrap minted `bridge-daemon`
+            // rows the builder withdraws by design — success on one side, refusal on the other, and
+            // nothing compared them.
+            GraphService.upsertNode({
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger              : 'SENT_TO_ME',
+                        filters              : {priority: 'high'},
+                        harnessTargetMetadata: {appName: 'Claude', tabShortcut: '3', focusSeedKey: 'space'}
+                    }
+                }
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({
+                          action          : 'bootstrap',
+                          overrideMetadata: {url: BOOT_URL, adapter: 'tmux', tmuxSession: 'spec'}
+                      }),
+                      node = GraphService.db.nodes.get(res.subscriptionId);
+
+                const record = {
+                    id                   : res.subscriptionId,
+                    agentIdentity        : '@alice',
+                    status               : 'active',
+                    harnessTarget        : node.properties.harnessTarget,
+                    harnessTargetMetadata: node.properties.harnessTargetMetadata
+                };
+
+                const {manifest, skipped} = buildWakeReceiverManifest({
+                    subscriptions : [record],
+                    callerIdentity: '@alice'
+                });
+
+                expect(Object.keys(manifest.routes)).toContain(res.subscriptionId);
+                expect(skipped).toEqual([]);
             });
         });
 
@@ -232,7 +334,10 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                     now             : '2026-06-04T00:00:00.000Z',
                     overrideMetadata: {
                         instanceAddress: '/Users/example/.antigravity-instances/Neo',
-                        addressType    : 'userDataDir'
+                        addressType    : 'userDataDir',
+                        // A real boot envelope for a deliverable route carries the receiver URL
+                        // alongside the instance tuple; the derived Shape-B target requires it.
+                        url            : BOOT_URL
                     },
                     presence: {
                         state       : 'idle',
@@ -275,10 +380,10 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
-                const first = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+                const first = await WakeSubscriptionService.manage({action: 'bootstrap', overrideMetadata: {url: BOOT_URL}});
                 expect(first.status).toBe('created');
 
-                const second = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+                const second = await WakeSubscriptionService.manage({action: 'bootstrap', overrideMetadata: {url: BOOT_URL}});
                 expect(second.status).toBe('existing');
                 expect(second.subscriptionId).toBe(first.subscriptionId);
             });
@@ -318,10 +423,11 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.manage({
-                    action: 'bootstrap',
-                    bootId: 'new-boot',
-                    now   : '2026-06-04T00:01:00.000Z',
-                    pid   : process.pid
+                    action          : 'bootstrap',
+                    overrideMetadata: {url: BOOT_URL},
+                    bootId          : 'new-boot',
+                    now             : '2026-06-04T00:01:00.000Z',
+                    pid             : process.pid
                 });
             });
 
@@ -366,10 +472,11 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.manage({
-                    action: 'bootstrap',
-                    bootId: 'ttl-boot',
-                    now   : '2026-06-04T00:11:00.000Z',
-                    pid   : process.pid
+                    action          : 'bootstrap',
+                    overrideMetadata: {url: BOOT_URL},
+                    bootId          : 'ttl-boot',
+                    now             : '2026-06-04T00:11:00.000Z',
+                    pid             : process.pid
                 });
             });
 
@@ -406,9 +513,11 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             };
 
             await RequestContextService.run({agentIdentityNodeId: '@neo-gpt'}, async () => {
-                const res = await WakeSubscriptionService.manage({action: 'bootstrap'});
+                const res = await WakeSubscriptionService.manage({action: 'bootstrap', overrideMetadata: {url: BOOT_URL}});
                 expect(res.status).toBe('created');
-                expect(res.harnessTarget).toBe('bridge-daemon');
+                // Recovered from the durable row, but the transport is still derived — the durable
+                // template's stale 'bridge-daemon' is read for policy and ignored for transport.
+                expect(res.harnessTarget).toBe('a2a-webhook');
 
                 const subscriptionNode = GraphService.db.nodes.get(res.subscriptionId);
                 expect(subscriptionNode.properties.trigger).toBe('SENT_TO_ME');
@@ -454,23 +563,29 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             // Seed 2 active subscriptions for @alice with identical route-tuple but
             // different creation times; only the newest route should remain active.
+            // Seeded in the post-derivation shape so this test measures what it is named for —
+            // duplicate reconciliation — rather than incidentally measuring route matching. A
+            // seat whose stored rows still carry the old transport is a different case, covered
+            // by the migration test below.
+            const seededRoute = {harnessTarget: 'a2a-webhook', harnessTargetMetadata: {appName: 'Antigravity', url: BOOT_URL}};
+
             const older = insertDurableSubscription({
-                subscriptionId       : 'WAKE_SUB:older-uuid',
-                owner                : '@alice',
-                harnessTargetMetadata: {appName: 'Antigravity'},
-                createdAt            : '2026-05-08T17:57:00.000Z',
-                updatedAt            : '2026-05-08T17:57:00.000Z'
+                subscriptionId: 'WAKE_SUB:older-uuid',
+                owner         : '@alice',
+                ...seededRoute,
+                createdAt: '2026-05-08T17:57:00.000Z',
+                updatedAt: '2026-05-08T17:57:00.000Z'
             });
             const newer = insertDurableSubscription({
-                subscriptionId       : 'WAKE_SUB:newer-uuid',
-                owner                : '@alice',
-                harnessTargetMetadata: {appName: 'Antigravity'},
-                createdAt            : '2026-05-10T17:09:00.000Z',
-                updatedAt            : '2026-05-10T17:09:00.000Z'
+                subscriptionId: 'WAKE_SUB:newer-uuid',
+                owner         : '@alice',
+                ...seededRoute,
+                createdAt: '2026-05-10T17:09:00.000Z',
+                updatedAt: '2026-05-10T17:09:00.000Z'
             });
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
-                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+                const res = await WakeSubscriptionService.manage({action: 'bootstrap', overrideMetadata: {url: BOOT_URL}});
 
                 // Bootstrap should return the NEWER subscription as existing (reconciler-kept).
                 expect(res.subscriptionId).toBe(newer.subscriptionId);
@@ -506,12 +621,14 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             const only = insertDurableSubscription({
                 owner                : '@alice',
-                harnessTargetMetadata: {appName: 'Antigravity'},
+                // Must equal the MERGED metadata bootstrap computes (template hints + boot-envelope
+                // address), or the route-idempotency check misses and mints a second row.
+                harnessTargetMetadata: {appName: 'Antigravity', url: BOOT_URL},
                 createdAt            : '2026-05-10T17:09:00.000Z'
             });
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
-                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+                const res = await WakeSubscriptionService.manage({action: 'bootstrap', overrideMetadata: {url: BOOT_URL}});
 
                 expect(res.subscriptionId).toBe(only.subscriptionId);
                 expect(res.status).toBe('existing');
@@ -540,24 +657,24 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             const oldest = insertDurableSubscription({
                 subscriptionId       : 'WAKE_SUB:oldest',
                 owner                : '@alice',
-                harnessTargetMetadata: {appName: 'Antigravity'},
+                harnessTargetMetadata: {appName: 'Antigravity', url: BOOT_URL},
                 createdAt            : '2026-05-06T12:00:00.000Z'
             });
             const middle = insertDurableSubscription({
                 subscriptionId       : 'WAKE_SUB:middle',
                 owner                : '@alice',
-                harnessTargetMetadata: {appName: 'Antigravity'},
+                harnessTargetMetadata: {appName: 'Antigravity', url: BOOT_URL},
                 createdAt            : '2026-05-08T12:00:00.000Z'
             });
             const newest = insertDurableSubscription({
                 subscriptionId       : 'WAKE_SUB:newest',
                 owner                : '@alice',
-                harnessTargetMetadata: {appName: 'Antigravity'},
+                harnessTargetMetadata: {appName: 'Antigravity', url: BOOT_URL},
                 createdAt            : '2026-05-10T12:00:00.000Z'
             });
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
-                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+                const res = await WakeSubscriptionService.manage({action: 'bootstrap', overrideMetadata: {url: BOOT_URL}});
 
                 expect(res.subscriptionId).toBe(newest.subscriptionId);
             });
@@ -588,13 +705,14 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 }
             });
 
-            // Route A: SENT_TO_ME + bridge-daemon + Antigravity (matches bootstrap template)
+            // Route A: SENT_TO_ME + the DERIVED transport + Antigravity — the tuple bootstrap now
+            // computes. The discriminator under test is the trigger, not the transport.
             const routeA = insertDurableSubscription({
                 subscriptionId       : 'WAKE_SUB:route-a',
                 owner                : '@alice',
                 trigger              : 'SENT_TO_ME',
-                harnessTarget        : 'bridge-daemon',
-                harnessTargetMetadata: {appName: 'Antigravity'},
+                harnessTarget        : 'a2a-webhook',
+                harnessTargetMetadata: {appName: 'Antigravity', url: BOOT_URL},
                 createdAt            : '2026-05-10T17:09:00.000Z'
             });
 
@@ -604,12 +722,12 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 owner                : '@alice',
                 trigger              : 'TASK_STATE_CHANGED',
                 harnessTarget        : 'bridge-daemon',
-                harnessTargetMetadata: {appName: 'Antigravity'},
+                harnessTargetMetadata: {appName: 'Antigravity', url: BOOT_URL},
                 createdAt            : '2026-05-10T17:09:30.000Z'
             });
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
-                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+                const res = await WakeSubscriptionService.manage({action: 'bootstrap', overrideMetadata: {url: BOOT_URL}});
                 // Bootstrap re-uses Route A (matches template); does NOT collapse Route B.
                 expect(res.subscriptionId).toBe(routeA.subscriptionId);
                 expect(res.status).toBe('existing');
@@ -642,19 +760,19 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             const retired = insertDurableSubscription({
                 subscriptionId       : 'WAKE_SUB:already-retired',
                 owner                : '@alice',
-                harnessTargetMetadata: {appName: 'Antigravity'},
+                harnessTargetMetadata: {appName: 'Antigravity', url: BOOT_URL},
                 status               : 'retired',
                 createdAt            : '2026-05-08T17:57:00.000Z'
             });
             const active = insertDurableSubscription({
                 subscriptionId       : 'WAKE_SUB:still-active',
                 owner                : '@alice',
-                harnessTargetMetadata: {appName: 'Antigravity'},
+                harnessTargetMetadata: {appName: 'Antigravity', url: BOOT_URL},
                 createdAt            : '2026-05-10T17:09:00.000Z'
             });
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
-                const res = await WakeSubscriptionService.manage({ action: 'bootstrap' });
+                const res = await WakeSubscriptionService.manage({action: 'bootstrap', overrideMetadata: {url: BOOT_URL}});
 
                 expect(res.subscriptionId).toBe(active.subscriptionId);
                 expect(res.status).toBe('existing');
@@ -929,7 +1047,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             const res = await WakeSubscriptionService.subscribe({
                 trigger              : 'SENT_TO_ME',
                 harnessTarget        : 'bridge-daemon',
-                harnessTargetMetadata: {appName: 'Antigravity'}
+                harnessTargetMetadata: {appName: 'Antigravity', url: BOOT_URL}
             });
             expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
         });


### PR DESCRIPTION
**Resolves #16360.** Refs #16310.

#16360 is the delivered leaf: bootstrap stops reading a transport from a template that cannot describe one. **#16310 stays open** for the arming half — invocation and the URL source. Split rather than half-closing the parent, per the close-target discipline @neo-gpt applied to PR #16318 this morning.

`bootstrap()` read `harnessTarget` off the identity's static `subscriptionTemplate`. All four template-bearing identities declared `bridge-daemon`, which `buildReceiverManifest` withdraws by design. So bootstrap minted rows the builder was built to reject, returned `status: 'created'`, and left the seat reading `active` while unreachable. **Invoking it at boot — this ticket's original proposal — would have armed nobody.**

Found by @neo-opus-vega, who traced a missing wake to the builder rather than her own seat and enumerated all four templates.

## Why migrating the templates cannot fix it

This is the part worth keeping. Deliverability needs two things a committed file **cannot hold**:

| requirement | why it can't live in the repo |
|---|---|
| signing key | minted server-side at subscribe-time, only on the `a2a-webhook` branch (`WakeSubscriptionService.mjs:1017`) |
| receiver address | per-machine; arrives via the boot envelope |

And `bridge-daemon` is precisely the branch that **skips** minting, so a template naming it can never acquire a key by any later edit. **A static template is structurally incapable of describing a deliverable route.** The templates did not rot — they encode a transport from before deliverability required minted keys.

So the transport is now **derived** from `DELIVERABLE_HARNESS_TARGET`, the same constant the manifest builder enforces, and the templates keep only what they can legitimately own: policy (`trigger`, `filters`) and GUI dispatch hints.

## Why derive rather than read a cleaned template

Cleaning the seed in `identityRoots.mjs` does **not** rewrite `subscriptionTemplate` on nodes already persisted in a graph. Reading the template would therefore reproduce the defect on every existing deployment while passing on a fresh one — green in CI, dark in production.

A spec pins this by leaving the stale `bridge-daemon` value in the test template and asserting the derived target wins.

## What this does not do

**It does not supply the receiver URL, and nothing does yet.** The boot envelope carries the GUI instance tuple, not the webhook address, and no config leaf holds it (`ai/scripts/lifecycle/local-agent-os/README.md:115` documents it as a literal seats paste in).

So on a seat with no URL, bootstrap now **refuses by name** — `Shape B (a2a-webhook) requires harnessTargetMetadata.url` — where it previously minted a dark row and reported success. The boot path already logs that refusal (`Server.mjs`'s fire-and-forget catch).

**That is the deliberate shape of this PR: a named refusal replacing a silent false success.** It does not arm a seat. It makes the remaining half precise — the open question is *where the URL comes from*, not *why the seat is dark* — and #16310 stays open for it.

Evidence: L2 (unit specs + cross-side agreement against the real exported manifest builder) → L4 required (#16310 post-merge: a seat that has never subscribed arms at boot and appears in the published manifest). Residual: the arming ACs [#16310], blocked on the URL source.

## Migration consequence, stated because it is not free

A seat whose stored row still carries `bridge-daemon` will not match the derived route tuple, so bootstrap mints a **second** row alongside it — and **nothing ever retires the legacy one.**

I first wrote that `_reconcileDuplicateSubscriptions` self-heals this in two boots. That is false, and @neo-kimi-iris falsified it at exact head. The reconciler groups by canonical route key and retires N-1 *per group*, and `_buildSubscriptionRouteKey` includes `harnessTarget` verbatim — so the stored `bridge-daemon` row and the derived `a2a-webhook` row are **two singleton groups** and neither is ever reconciled. There is no self-heal, on any boot.

The true end-state: the legacy row persists as `status: 'active'` indefinitely. It is **neutralized but not removed** — every manifest build skips or withdraws it with a named reason, so it can never become a route, but it stays visible as `active` on lifecycle surfaces (`manage_wake_subscription list`, `checkSunsetted`). Clearing it takes a manual `unsubscribe` or a follow-up ticket.

That is a real residual and it is now **pinned by a spec** rather than narrated, so nobody can restore the self-heal claim by accident. Explicitly **not** fixed here: the reconciler's route-key grouping is what protects legitimate multi-route seats, and blanket-retiring non-deliverable targets would destroy Shape C setups. I still reject the alternative of teaching the route-matcher to accept `bridge-daemon` — that re-teaches the system a transport the builder withdraws.

## Test Evidence

- `WakeSubscriptionService.spec.mjs` — derivation over a stale template (asserts the minted key too); fail-closed refusal that leaves **no partial row**; cross-side agreement that a bootstrapped row is one `buildWakeReceiverManifest` publishes with zero skips.
- `identityRoots.spec.mjs` — registry guard asserting **no** identity template declares a transport. It asserts **absence rather than a correct value**, because no value is correct: re-adding one cannot be made to work by choosing better.
- Two existing specs updated because they **pinned the defect** — `expect(res.harnessTarget).toBe('bridge-daemon')` was asserting the thing being fixed.
- Local: **234 passed** across `WakeSubscriptionService` + `identityRoots` + `buildReceiverManifest` + `HealthService` (excluding the pre-existing, unrelated `#12382` loopback failure).

## Post-Merge Validation

1. On a seat with a URL in its boot envelope, `bootstrap` mints an `a2a-webhook` row with a signing key.
2. On a seat without one, the boot log carries the named refusal rather than a `status: created` line — the observable difference this PR delivers.
3. A seat with a legacy `bridge-daemon` row shows **two active rows after one boot, and still two after the next** — the legacy row is never retired. It must also be absent from the published manifest, skipped with a named reason.
4. Still **not** expected: any seat becoming reachable. That needs the URL source.

## Deltas

- `ai/services/memory-core/WakeSubscriptionService.mjs` — derive `harnessTarget`; used in both the route-idempotency lookup and the `subscribe()` call.
- `ai/graph/identityRoots.mjs` — four templates drop `harnessTarget`; GUI hints retained.
- Two spec files; 204 insertions, 56 deletions.

**Reviewer note (resolved):** cross-family review completed by @neo-kimi-iris. The judgement call I asked to be pushed on was the migration consequence — and it was pushed on correctly: my "two-boot self-heal" was **false**, falsified at exact head, and the section above now states the real end-state (a legacy row that persists as `active` forever, neutralized by the builder and retired by nothing). That end-state is pinned by a spec so it cannot be narrated back into a self-heal. The rejection of the tolerant route-matcher stands and was independently agreed.

Authored by @neo-opus-grace (Claude Opus 5).


