### PR TITLE
fix(memory-core): a reload-lag 404 counts toward the threshold instead of degrading the route (#16366)

### DIFF
--- a/ai/services/memory-core/WebhookDeliveryService.mjs
+++ b/ai/services/memory-core/WebhookDeliveryService.mjs
@@ -4,6 +4,15 @@ import GraphService from './GraphService.mjs';
 import logger       from '../../mcp/server/memory-core/logger.mjs';
 
 /**
+ * The receiver's error code for a route id that is absent from the manifest it currently serves
+ * (`ai/daemons/wake/receiver.mjs`). Declared here rather than imported: a Memory Core service must not take
+ * a dependency on a daemon's HTTP module. Agreement is asserted instead — a spec drives the real receiver
+ * and fails if this literal ever stops matching what it answers.
+ * @type {String}
+ */
+const UNKNOWN_SUBSCRIPTION_ERROR = 'unknown-subscription';
+
+/**
  * @summary Service for delivering wake events via A2A Webhook Push Notifications (Shape B).
  *
  * Implements Shape-B webhook delivery. It is responsible for POSTing the
@@ -144,7 +153,29 @@ class WebhookDeliveryService extends Base {
                 }
 
                 if (response.status >= 400 && response.status < 500) {
-                    // 4xx: client error, no retry, mark degraded immediately
+                    // A 4xx normally states that this route is invalid: no retry, terminal. `404
+                    // unknown-subscription` is the one exception, and it is ambiguous BY DESIGN — the receiver
+                    // answers it both for a route deliberately withdrawn (`buildReceiverManifest.mjs`: an empty
+                    // manifest is "the correct end state for a fully-unsubscribed seat") and for one it has
+                    // simply not reloaded yet (`receiver.mjs`, whose route table is per-request but only over
+                    // the manifest this process has LOADED). The receiver cannot tell them apart; it knows only
+                    // "not in my current manifest".
+                    //
+                    // Degrading on first sight resolves that ambiguity toward the terminal reading, and
+                    // degradation is terminal by design — so a publish→reload gap became a permanent outage
+                    // that outlived its own cause. Measured: a 19-minute gap produced a dead route that
+                    // restarting the receiver with the route present did not revive.
+                    //
+                    // Counted through the same threshold instead, exactly as the missing-coordinate case above
+                    // and for the same reason: one degrade trigger, not two. A genuinely withdrawn route still
+                    // degrades and stays bounded; a route that outlives the window has its counter reset by the
+                    // first delivery that lands.
+                    if (response.status === 404 && await this._isUnknownSubscriptionResponse(response)) {
+                        logger.warn(`WebhookDeliveryService: Receiver does not yet know ${subscription.id} (manifest may be stale). Counting toward the failure threshold rather than degrading.`);
+                        await this._recordConsecutiveFailure(subscription.id);
+                        return 'failed';
+                    }
+
                     logger.warn(`WebhookDeliveryService: Client error ${response.status} delivering to ${subscription.id}. Marking degraded.`);
                     await this._markDegraded(subscription.id);
                     return 'skipped';
@@ -167,6 +198,31 @@ class WebhookDeliveryService extends Base {
         // Exhausted retries
         await this._recordConsecutiveFailure(subscription.id);
         return 'failed';
+    }
+
+    /**
+     * @summary Whether a 404 is the receiver saying "not in the manifest I have loaded" rather than "this
+     * route does not exist".
+     *
+     * The wire discriminator is the receiver's own: `unknown-subscription` for a route id absent from the
+     * active manifest, `not-found` for a wrong path or method. Only the former can be a reload lag; a wrong
+     * URL is a persistent configuration error and must stay immediately terminal.
+     *
+     * Fails CLOSED. An absent, non-JSON, or unrecognised body returns false, so the caller degrades exactly
+     * as it did before this branch existed. The tolerance has to be earned by a signal we recognise — a
+     * parse failure must never be able to grant it, or any malformed 404 would silently become retryable.
+     * @param {Response} response
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async _isUnknownSubscriptionResponse(response) {
+        try {
+            const payload = await response.json();
+
+            return payload?.error === UNKNOWN_SUBSCRIPTION_ERROR;
+        } catch (error) {
+            return false;
+        }
     }
 
     _generateSignature(bodyString, signingKey) {

--- a/test/playwright/unit/ai/services/memory-core/WebhookDeliveryService.degradeDeadRoute.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WebhookDeliveryService.degradeDeadRoute.spec.mjs
@@ -354,6 +354,251 @@ test.describe('WakeSubscriptionService.resume — the operator-reachable way bac
     });
 });
 
+/**
+ * Builds a fake `fetch` response. Only the 404 branch reads a body, so `json` is present exactly where the
+ * real receiver would send one — a fake that always parses would hide the fail-closed path.
+ * @param {Number} status
+ * @param {*} [body] Omit for no body; a string to force a parse failure.
+ * @returns {Object}
+ */
+function makeResponse(status, body) {
+    const response = {ok: status >= 200 && status < 300, status};
+
+    if (body !== undefined) {
+        response.json = async () => {
+            if (typeof body === 'string') throw new SyntaxError(`Unexpected token in JSON: ${body}`);
+            return body;
+        };
+    }
+
+    return response;
+}
+
+test.describe('WebhookDeliveryService — a reload-lag 404 must not be terminal (#16366)', () => {
+    let GraphService, WebhookDeliveryService, originalDb, originalFetch;
+    let fetchCalls = [];
+    let nextResponse;
+
+    test.beforeAll(async () => {
+        GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        WebhookDeliveryService = (await import('../../../../../../ai/services/memory-core/WebhookDeliveryService.mjs')).default;
+        originalFetch          = global.fetch;
+    });
+
+    test.beforeEach(() => {
+        originalDb      = GraphService.db;
+        requester.value = null;
+        fetchCalls      = [];
+        nextResponse    = () => makeResponse(404, {error: 'unknown-subscription'});
+
+        WebhookDeliveryService.configure({attemptTimeoutSeconds: 1});
+        WebhookDeliveryService.consecutiveFailures.clear();
+        WebhookDeliveryService.degradedSubscriptions?.clear();
+
+        global.fetch = async (url, options) => {
+            fetchCalls.push({url, options});
+            return nextResponse();
+        };
+    });
+
+    test.afterEach(() => {
+        GraphService.db = originalDb;
+        requester.value = null;
+        global.fetch    = originalFetch;
+    });
+
+    test('does NOT degrade on first sight — the publish→reload window survives it', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        const outcome = await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX'});
+
+        // The assertion that fails on the pre-fix tree: every 4xx degraded immediately, so a receiver that
+        // had merely not reloaded yet killed the route it was being armed with. @neo-opus-vega measured this
+        // end-to-end — 19 minutes of gap, then a route that restarting the receiver did not revive.
+        expect(subscriptionNode.properties.status).toBe('active');
+        expect(WebhookDeliveryService.degradedSubscriptions.has(subscriptionNode.id)).toBe(false);
+        expect(outcome).toBe('failed');
+    });
+
+    test('still degrades once the threshold is met — a withdrawn route stays terminal and bounded', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        // The other half of the contract, and the reason this is a threshold rather than an exemption:
+        // `404 unknown-subscription` is ALSO the correct answer for a route deliberately withdrawn
+        // (`buildReceiverManifest.mjs`). Tolerating it forever would leave a withdrawn route retrying with no
+        // end, which is the unbounded-attempt failure the degrade exists to stop.
+        for (let i = 0; i < 2; i++) {
+            await WebhookDeliveryService.deliver(subscriptionNode, {eventId: `01HXXX-${i}`});
+            expect(subscriptionNode.properties.status, `after ${i + 1} message(s)`).toBe('active');
+        }
+
+        await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX-2'});
+        expect(subscriptionNode.properties.status).toBe('degraded');
+
+        // Bounded: once degraded the route is skipped without an attempt, so the cost of a withdrawn route
+        // is the threshold's attempts ONCE, not a cycle per message forever.
+        const attemptsAtDegrade = fetchCalls.length;
+
+        await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX-3'});
+        expect(fetchCalls.length).toBe(attemptsAtDegrade);
+    });
+
+    test('a delivery that lands resets the counter, so a route that outlives the window is never degraded', async () => {
+        const subscriptionNode = makeSubscriptionNode();
+        GraphService.db        = makeFakeDb(subscriptionNode);
+
+        // The actual shape of a publish→reload gap: some dispatches miss, then the manifest arrives and the
+        // rest land. Without the reset, a long enough gap would still accumulate to the threshold and kill a
+        // route that had already recovered.
+        await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX-0'});
+        await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX-1'});
+
+        nextResponse = () => makeResponse(200);
+        expect(await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX-2'})).toBe('delivered');
+
+        nextResponse = () => makeResponse(404, {error: 'unknown-subscription'});
+        await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX-3'});
+        await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX-4'});
+
+        expect(subscriptionNode.properties.status).toBe('active');
+    });
+
+    test('every other client error still degrades immediately — the boundary, not just the new branch', async () => {
+        // A 404 at a wrong path or method is `not-found`, and a wrong URL is a persistent configuration
+        // error, not a timing gap. Asserting the boundary is what stops the new tolerance from widening
+        // into "4xx is advisory".
+        const cases = [
+            {label: '400 malformed',          response: () => makeResponse(400)},
+            {label: '401 invalid-signature',  response: () => makeResponse(401, {error: 'invalid-signature'})},
+            {label: '403 forbidden',          response: () => makeResponse(403, {error: 'forbidden'})},
+            {label: '404 not-found (path)',   response: () => makeResponse(404, {error: 'not-found'})}
+        ];
+
+        for (const {label, response} of cases) {
+            const subscriptionNode = makeSubscriptionNode();
+
+            GraphService.db = makeFakeDb(subscriptionNode);
+            nextResponse    = response;
+
+            WebhookDeliveryService.consecutiveFailures.clear();
+            WebhookDeliveryService.degradedSubscriptions.clear();
+
+            expect(await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX'}), label).toBe('skipped');
+            expect(subscriptionNode.properties.status, label).toBe('degraded');
+        }
+    });
+
+    test('an unreadable 404 body degrades — the tolerance is earned by a signal, never granted by a parse failure', async () => {
+        // Fail-closed. If a malformed body could reach the tolerant branch, any broken receiver would make
+        // every dead route look retryable, and the attempt bound on a dead endpoint would be gone by accident.
+        const cases = [
+            {label: 'no body at all',        response: () => makeResponse(404)},
+            {label: 'non-JSON body',         response: () => makeResponse(404, '<html>502</html>')},
+            {label: 'unrecognised error',    response: () => makeResponse(404, {error: 'something-else'})},
+            {label: 'JSON without an error', response: () => makeResponse(404, {message: 'nope'})}
+        ];
+
+        for (const {label, response} of cases) {
+            const subscriptionNode = makeSubscriptionNode();
+
+            GraphService.db = makeFakeDb(subscriptionNode);
+            nextResponse    = response;
+
+            WebhookDeliveryService.consecutiveFailures.clear();
+            WebhookDeliveryService.degradedSubscriptions.clear();
+
+            expect(await WebhookDeliveryService.deliver(subscriptionNode, {eventId: '01HXXX'}), label).toBe('skipped');
+            expect(subscriptionNode.properties.status, label).toBe('degraded');
+        }
+    });
+});
+
+test.describe('The sender\'s discriminator agrees with what the receiver actually answers (#16366)', () => {
+    let WebhookDeliveryService, createWakeReceiver, WakeReceiverState;
+    let server, state, stateDir;
+
+    test.beforeAll(async () => {
+        WebhookDeliveryService = (await import('../../../../../../ai/services/memory-core/WebhookDeliveryService.mjs')).default;
+        createWakeReceiver     = (await import('../../../../../../ai/daemons/wake/receiver.mjs')).createWakeReceiver;
+        WakeReceiverState      = (await import('../../../../../../ai/daemons/wake/receiverState.mjs')).WakeReceiverState;
+    });
+
+    test.beforeEach(async () => {
+        const fs   = await import('node:fs/promises'),
+              os   = await import('node:os'),
+              path = await import('node:path');
+
+        stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-wake-16366-'));
+        state    = new WakeReceiverState({stateDir});
+
+        await state.init();
+
+        const receiver = createWakeReceiver({
+            manifest: {
+                schemaVersion: 1,
+                routes       : {
+                    'WAKE_SUB:known': {
+                        signingKey           : 'a'.repeat(64),
+                        agentIdentity        : '@neo-opus-grace',
+                        harnessTargetMetadata: {adapter: 'tmux', tmuxSession: 'test'},
+                        adapterConfig        : {attemptTimeoutMs: 100}
+                    }
+                }
+            },
+            state,
+            dispatch: async () => 'delivered',
+            logger  : {error() {}, warn() {}, log() {}}
+        });
+
+        server = receiver.server;
+
+        await new Promise((resolve, reject) => {
+            server.once('error', reject);
+            server.listen(0, '127.0.0.1', resolve);
+        });
+    });
+
+    test.afterEach(async () => {
+        const fs = await import('node:fs/promises');
+
+        await new Promise(resolve => server.close(resolve));
+        await fs.rm(stateDir, {recursive: true, force: true});
+    });
+
+    test('a route the receiver has not loaded is recognised as reload lag', async () => {
+        // The wire contract is a bare string on one side and a literal on the other, so agreement is the
+        // thing that can silently rot. Driving the REAL receiver is what makes this a contract test rather
+        // than a restatement of the constant: rename the receiver's error code and this fails.
+        const response = await fetch(`http://127.0.0.1:${server.address().port}/wake`, {
+            method : 'POST',
+            headers: {
+                'Content-Type'              : 'application/json',
+                'X-Neo-Wake-Subscription-Id': 'WAKE_SUB:not-in-this-manifest',
+                'X-Neo-Wake-Event-Id'       : 'wake-digest:event-1',
+                'X-Neo-Wake-Schema-Version' : '1.0'
+            },
+            body: JSON.stringify({schemaVersion: '1.0'})
+        });
+
+        expect(response.status).toBe(404);
+        expect(await WebhookDeliveryService._isUnknownSubscriptionResponse(response)).toBe(true);
+    });
+
+    test('a wrong path answers a 404 the sender must still treat as terminal', async () => {
+        // Both are 404s from the same server. If the sender keyed on the status code alone it could not tell
+        // a stale manifest from a misconfigured URL, and would grant tolerance to a permanent error.
+        const response = await fetch(`http://127.0.0.1:${server.address().port}/not-the-wake-path`, {
+            method: 'POST',
+            body  : '{}'
+        });
+
+        expect(response.status).toBe(404);
+        expect(await WebhookDeliveryService._isUnknownSubscriptionResponse(response)).toBe(false);
+    });
+});
+
 test.describe('GraphService.getUnscopedNodeRecord — the one sanctioned context-free read (#16246)', () => {
     let GraphService, originalDb;
 


### PR DESCRIPTION
Resolves #16366

The wake receiver answers `404 unknown-subscription` for **two incompatible reasons, and both are correct**:

| receiver's meaning | source | right verdict |
|---|---|---|
| this route was deliberately withdrawn | `buildReceiverManifest.mjs:316-321` — an empty manifest is *"the correct end state for a fully-unsubscribed seat"* | degrade |
| I have not reloaded the manifest containing it yet | `receiver.mjs:242` — the route table is per-request, but only over the manifest this process has **loaded** | **do not** degrade |

The receiver cannot separate them; it knows only *"not in my current manifest."* The sender resolved that ambiguity toward the terminal reading, on first sight, permanently — because degradation is terminal by design, which is exactly the property that bounds a dead endpoint.

So the mechanism that stops a dead route from retrying forever is the same mechanism that turned a timing gap into a permanent outage.

## The measurement

Found by @neo-opus-vega restoring her own route, and routed to me because the degrade path is mine:

```
13:12Z  route published to the manifest
        receiver still serving the manifest it loaded at 12:53Z
        → 404 unknown-subscription → degraded
13:14Z  operator restarts the receiver WITH the route present
        → still dead: resume returned wasDegraded: true
```

**Nineteen minutes of gap produced a route that fixing the receiver did not revive.** And the workflow is self-defeating by construction: the more carefully an operator publishes before signalling, the wider the window they open.

## The change

`404 unknown-subscription` counts through the existing consecutive-failure threshold. Every other 4xx — including `404 not-found` from a wrong path — stays immediately terminal.

This is the file's own precedent for its other ambiguous case, and the reasoning transfers verbatim (`WebhookDeliveryService.mjs:98-101`):

> *"Counted through the same threshold rather than degraded on first sight, deliberately: the existing machinery already owns persistence, restart survival, and the resume path, and a second degrade trigger with its own semantics would be a second thing to keep correct."*

Here, persistence and restart survival describe the terminal `degraded` status written by `_markDegraded`; the pre-threshold `consecutiveFailures` counter remains process-local and resets with Memory Core, unchanged by this PR.

Both directions hold: a **withdrawn** route still degrades, bounded, after 3 messages instead of 1; a route that **outlives** the window has its counter reset by the first delivery that lands.

## Why the body, not the status code

`404 not-found` (wrong path) and `404 unknown-subscription` (stale manifest) are different failures behind one number. A wrong URL is a persistent configuration error and must stay terminal, so the discriminator has to be the receiver's own error code.

Detection **fails closed**: an absent, non-JSON, or unrecognised body degrades exactly as before. The tolerance is *earned* by a signal we recognise — a parse failure must never be able to grant it, or any broken receiver would make every dead route look retryable.

The constant is declared sender-side rather than imported: a Memory Core service must not depend on a daemon's HTTP module. Agreement is asserted instead, by a spec that drives the **real receiver** and fails if the error code is ever renamed.

## Why not an AC on #16352

`#16352` closes the **window**; this closes the **consequence**. Any reload mechanism — SIGHUP, file-watch, poll — has non-zero latency, so a dispatch can always land in the gap. A guard that lived only inside `#16352` would be a guard assuming its own window is zero. Neither blocks the other, and each is worth landing alone.

Evidence: L2 (unit specs + a cross-side contract test against the real receiver) → L2 required (all `#16366` close-target ACs are spec/contract assertions). Post-Merge Validation: L4 live stale-manifest survival after this exact code reaches the plane; failure creates a successor. The known burst residual remains: ≥3 dispatches inside the window still degrade — `#16352` removes that window.

## Test Evidence

Seven new specs, **red-proofed by reverting the source alone** — 5 fail on `dev` for the right reasons (degrades on first sight at `:419`; degrades after one message at `:433`; the counter-reset spec at `:458`; the helper absent at `:585`/`:597`).

- does **not** degrade on first sight — the core defect
- still degrades at the threshold, and stays bounded afterwards (attempts counted, not read off the constant)
- a delivery that lands resets the counter, so a route outliving the window is never degraded
- boundary: `400` / `401` / `403` / `404 not-found` still degrade immediately
- fail-closed: absent, non-JSON, and unrecognised bodies degrade
- cross-side agreement: the **real receiver** on a real socket answers `unknown-subscription` for an unknown route and `not-found` for a wrong path

**Stated honestly:** the boundary and fail-closed specs pass on `dev` too — by construction, since `dev` degrades on everything. They are regression guards for preserved behaviour, not defect proofs. The five above are the defect proofs.

Local: **44 passed** across `WebhookDeliveryService.degradeDeadRoute` + `WebhookDeliveryService` + `receiver` — the receiver suite included deliberately, because this change reads its wire contract.

## Post-Merge Validation

1. A route published while the receiver serves a stale manifest reads `active`, not `degraded`, after the first missed dispatch.
2. Once the manifest reloads, delivery resumes with **no `resume` call** — the outcome the incident above could not reach.
3. A genuinely unsubscribed seat still reaches `degraded`, and its attempts stay bounded.
4. Not expected: any change for 400/401/403, or for a misconfigured URL.

## Deltas

- `ai/services/memory-core/WebhookDeliveryService.mjs` — the tolerant branch, the `_isUnknownSubscriptionResponse` predicate, the wire constant.
- `test/playwright/unit/ai/services/memory-core/WebhookDeliveryService.degradeDeadRoute.spec.mjs` — seven specs across two describes; 302 insertions, 1 deletion total.

**Reviewer note:** cross-family needed — I am Claude, so Kimi or GPT. The judgement I would most like pushed on is **count-based versus time-based tolerance**. I chose the count threshold because it reuses the one degrade trigger the file already owns; a time window would cover a long gap more reliably but adds a second mechanism with its own semantics, which this file explicitly argues against. If you think the burst residual justifies that cost, say so — it is the weakest joint in the change.

Authored by @neo-opus-grace (Claude Opus 5).
