### PR TITLE
feat: fleet wake-state seams ride the containerized plane (#16347)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2447,7 +2447,7 @@ paths:
       operationId: manage_wake_subscription
       x-neo-tool-tier: extended
       x-pass-as-object: true
-      description: Subscribe / unsubscribe / update / list / resync / resume / rotate-key agent wake-event subscriptions with trigger types (SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED), optional AND-conjunctive filters, and harness target routing.
+      description: Subscribe / unsubscribe / update / list / resync / resume / rotate-key agent wake-event subscriptions with trigger types (SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED), optional AND-conjunctive filters, and harness target routing. `fleet-identities` is the fleet-telemetry read — the deduplicated identities holding an ACTIVE subscription, identities only, for any authenticated caller (the `who_is_online` disclosure class).
       tags: [WakeSubscriptions]
       requestBody:
         required: true
@@ -2460,7 +2460,7 @@ paths:
               properties:
                 action:
                   type: string
-                  enum: [bootstrap, subscribe, unsubscribe, update, list, resync, resume, rotate-key]
+                  enum: [bootstrap, subscribe, unsubscribe, update, list, resync, resume, rotate-key, fleet-identities]
                   description: "Lifecycle action to perform on the subscription. `resume` restores a route that was marked `status: degraded` after repeated delivery failures: it moves the persisted status back to `active` AND clears the in-flight markers in one step, which is what a restore requires - clearing only one half leaves the route skipped."
                 subscriptionId:
                   type: string

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -56,7 +56,7 @@ import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer,
         resolveFleetViewerClaim}                                          from './fleetLaunchContract.mjs';
 import {readMcpToolResultPayload}             from './mcpWireParsing.mjs';
 import {createPlaneMailboxClient}             from './planeMailboxClient.mjs';
-import {readActiveWakeSubscriptionIdentities} from './readActiveWakeSubscriptionIdentities.mjs';
+import {readActiveWakeSubscriptionIdentities} from '../memory-core/readActiveWakeSubscriptionIdentities.mjs';
 import {wireBootIdentityReadSource}           from './wireBootIdentityReadSource.mjs';
 import {wireFleetActivityReadSource}          from './wireFleetActivityReadSource.mjs';
 import {wireFleetCatchUpSource}               from './wireFleetCatchUpSource.mjs';

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -54,6 +54,7 @@ import FleetManager             from './FleetManager.mjs';
 import {startFleetBridgeServer} from './fleetBridgeServer.mjs';
 import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer,
         resolveFleetViewerClaim}                                          from './fleetLaunchContract.mjs';
+import {readMcpToolResultPayload}             from './mcpWireParsing.mjs';
 import {createPlaneMailboxClient}             from './planeMailboxClient.mjs';
 import {readActiveWakeSubscriptionIdentities} from './readActiveWakeSubscriptionIdentities.mjs';
 import {wireBootIdentityReadSource}           from './wireBootIdentityReadSource.mjs';
@@ -121,19 +122,56 @@ async function boot() {
     // the advisory-unknown fallback. Fail-soft — an absent dir leaves the seam honestly unwired.
     wireBootIdentityReadSource({dir: AiConfig.orchestrator.dataDir});
 
-    // Wire the wake-telltale producer sources (the S2 axis): the config-resolved daemon PID path +
-    // the trusted bulk subscription scan. This entrypoint is where config resolution belongs; the
-    // adapter itself never resolves it. Fail-soft by construction — a failing scan or an absent
-    // daemon degrades to honest per-row `unknown` inside the adapter, never a fabricated state.
+    // Wire the wake-telltale producer sources (the S2 axis). This entrypoint is where config
+    // resolution belongs; the adapter itself never resolves it. Fail-soft by construction — a
+    // failing scan or an absent source degrades to honest per-row `unknown` inside the adapter,
+    // never a fabricated state.
     //
-    // The `wakeDaemon` subtree is owned by the memory-core config, NOT Tier-1 `AiConfig` (which
-    // carries only the flat `wakeDaemonHeartbeatAlivePath` leaf) — so the daemon's own authority
-    // (`ai/daemons/wake/daemon.mjs`) is the one to mirror here.
-    FleetManager.wakeStateOptions = {
-        pidFilePath                     : path.join(memoryCoreConfig.wakeDaemon.dataDir, 'wake-daemon.pid'),
-        deliveryFailureFilePath         : path.join(memoryCoreConfig.wakeDaemon.dataDir, 'wake-delivery-failures.json'),
-        listActiveSubscriptionIdentities: readActiveWakeSubscriptionIdentities
-    };
+    // The axes follow the mailbox-seam plane decision: truth that moved with the hard cut is read
+    // where it now lives. In-process mode keeps the host truths (local daemon PID file + host
+    // graph scan). Plane mode reads subscription intent from the containerized plane through the
+    // proven client — the host graph holds only pre-cut relic rows there, and the retired local
+    // daemon's absent PID file would read as OBSERVED not-running, fabricating `suppressed` for
+    // every genuinely subscribed seat. The delivery axes stay honestly `unknown` in plane mode
+    // until the plane exposes a vouching surface: delivery runs container-side and behind the
+    // signed host receiver, and neither is observable from this process today.
+    if (planeClient) {
+        FleetManager.wakeStateOptions = {
+            listActiveSubscriptionIdentities: async () => {
+                const payload = readMcpToolResultPayload(
+                    await planeClient.callTool('manage_wake_subscription', {action: 'fleet-identities'})
+                );
+
+                if (!Array.isArray(payload?.identities)) {
+                    throw new Error('plane wake fleet-identities answer unreadable')
+                }
+
+                return payload.identities
+            },
+            resolveDeliveryLiveness: () => ({
+                alive : 'unknown',
+                reason: 'delivery-lane liveness is not exposed by the containerized plane yet'
+            }),
+            resolveTerminalDeliveryFailures: () => ({
+                state     : 'unknown',
+                reason    : 'terminal delivery receipts live with the containerized delivery authority; not exposed yet',
+                byIdentity: new Map()
+            })
+        };
+
+        console.log(`[fleet] wake-state seam bound to the containerized plane at ${planeBase} (subscription axis plane-side; delivery axes honest-unknown pending a plane vouching surface)`)
+    } else {
+        // The `wakeDaemon` subtree is owned by the memory-core config, NOT Tier-1 `AiConfig` (which
+        // carries only the flat `wakeDaemonHeartbeatAlivePath` leaf) — so the daemon's own authority
+        // (`ai/daemons/wake/daemon.mjs`) is the one to mirror here.
+        FleetManager.wakeStateOptions = {
+            pidFilePath                     : path.join(memoryCoreConfig.wakeDaemon.dataDir, 'wake-daemon.pid'),
+            deliveryFailureFilePath         : path.join(memoryCoreConfig.wakeDaemon.dataDir, 'wake-delivery-failures.json'),
+            listActiveSubscriptionIdentities: readActiveWakeSubscriptionIdentities
+        };
+
+        console.log('[fleet] wake-state seam stays host-local (host plane: daemon PID file + host graph subscription scan)')
+    }
 
     // Wire the composed activitySource onto FleetControlBridge. The memory-core mailbox + graph
     // singletons are imported lazily at this boot use site (mirroring readActiveWakeSubscriptionIdentities's

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -54,8 +54,8 @@ import FleetManager             from './FleetManager.mjs';
 import {startFleetBridgeServer} from './fleetBridgeServer.mjs';
 import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer,
         resolveFleetViewerClaim}                                          from './fleetLaunchContract.mjs';
-import {readMcpToolResultPayload}             from './mcpWireParsing.mjs';
 import {createPlaneMailboxClient}             from './planeMailboxClient.mjs';
+import {createPlaneWakeIdentitiesReader}      from './planeWakeIdentitiesReader.mjs';
 import {readActiveWakeSubscriptionIdentities} from '../memory-core/readActiveWakeSubscriptionIdentities.mjs';
 import {wireBootIdentityReadSource}           from './wireBootIdentityReadSource.mjs';
 import {wireFleetActivityReadSource}          from './wireFleetActivityReadSource.mjs';
@@ -137,17 +137,10 @@ async function boot() {
     // signed host receiver, and neither is observable from this process today.
     if (planeClient) {
         FleetManager.wakeStateOptions = {
-            listActiveSubscriptionIdentities: async () => {
-                const payload = readMcpToolResultPayload(
-                    await planeClient.callTool('manage_wake_subscription', {action: 'fleet-identities'})
-                );
-
-                if (!Array.isArray(payload?.identities)) {
-                    throw new Error('plane wake fleet-identities answer unreadable')
-                }
-
-                return payload.identities
-            },
+            // The proven client returns PARSED payloads (its mapToolResult owns envelope handling)
+            // — the reader consumes them directly; a second parse here would reject every healthy
+            // answer and silently blind the whole axis.
+            listActiveSubscriptionIdentities: createPlaneWakeIdentitiesReader(planeClient),
             resolveDeliveryLiveness: () => ({
                 alive : 'unknown',
                 reason: 'delivery-lane liveness is not exposed by the containerized plane yet'

--- a/ai/services/fleet/fleetWakeStateAdapter.mjs
+++ b/ai/services/fleet/fleetWakeStateAdapter.mjs
@@ -23,6 +23,15 @@ import path                from 'node:path'
  * default. The adapter itself never resolves configuration — config resolution belongs to process
  * entrypoints and this module is not one: the PID file path is injected by the composing
  * entrypoint; without it, liveness is honestly `unknown`.
+ *
+ * The delivery axes are RESOLVER-INJECTABLE at the same entrypoint boundary: a deployment whose
+ * delivery authority is not a host daemon (a containerized plane owning delivery, with its own
+ * vouching surface) injects `resolveDeliveryLiveness` / `resolveTerminalDeliveryFailures` instead
+ * of file paths that would measure a process which no longer exists — an absent retired daemon's
+ * PID file reads as OBSERVED not-running and would fabricate `suppressed` for every active
+ * subscription. Injected resolvers carry the exact same return contracts as the built-in sources
+ * and degrade identically: a throw or an out-of-contract answer becomes `unknown` with the reason
+ * preserved, never a fabricated state.
  */
 
 export const WAKE_STATES = Object.freeze(['on', 'off', 'suppressed', 'unknown'])
@@ -258,6 +267,14 @@ export function resolveAgentWakeState({subscriptionState, daemonAlive, deliveryF
  * @param {String|null} [options.deliveryFailureFilePath] Daemon-owned terminal receipt path. When
  *     omitted beside a configured PID path, defaults to `wake-delivery-failures.json` in that same
  *     injected directory; no config or env is resolved here.
+ * @param {Function|null} [options.resolveDeliveryLiveness] Axis-level replacement for the PID-file
+ *     liveness source: `() => {alive: Boolean|'unknown', reason: String|null}` (sync or async).
+ *     When provided, the PID-file path is not consulted for liveness — the entrypoint has named a
+ *     different delivery authority. Throw or out-of-contract ⇒ `alive: 'unknown'` with the reason.
+ * @param {Function|null} [options.resolveTerminalDeliveryFailures] Axis-level replacement for the
+ *     receipt-file source: `() => {state: 'observed'|'unknown', reason: String|null,
+ *     byIdentity: Map<String,Object[]>}` (sync or async). Same degradation contract as its file
+ *     sibling; rows must be pre-sorted newest-first per identity if order matters to the caller.
  * @param {Function} [options.readFile] Test seam for {@link resolveDaemonLiveness}.
  * @param {Function} [options.readDeliveryFailureFile] Test seam for terminal receipt reads.
  * @param {Function} [options.probeProcess] Test seam for {@link resolveDaemonLiveness}.
@@ -273,6 +290,8 @@ export async function readFleetWakeStateSnapshot({
     wakeIdentityFor = agent => `@${agent.githubUsername ?? agent.id}`,
     pidFilePath = null,
     deliveryFailureFilePath = null,
+    resolveDeliveryLiveness = null,
+    resolveTerminalDeliveryFailures = null,
     readFile,
     readDeliveryFailureFile,
     probeProcess,
@@ -298,17 +317,21 @@ export async function readFleetWakeStateSnapshot({
             resolveSubscriptionState = () => { throw new Error(reason || 'subscription scan failed') }
         }
     }
-    const liveness = resolveDaemonLiveness({
-        pidFilePath,
-        ...(readFile           && {readFile}),
-        ...(probeProcess       && {probeProcess}),
-        ...(readProcessCommand && {readProcessCommand})
-    })
-    const failures = readTerminalDeliveryFailures({
-        deliveryFailureFilePath: deliveryFailureFilePath ||
-            (pidFilePath ? path.join(path.dirname(pidFilePath), 'wake-delivery-failures.json') : null),
-        ...(readDeliveryFailureFile && {readDeliveryFailureFile})
-    })
+    const liveness = resolveDeliveryLiveness
+        ? await resolveInjectedLiveness(resolveDeliveryLiveness)
+        : resolveDaemonLiveness({
+            pidFilePath,
+            ...(readFile           && {readFile}),
+            ...(probeProcess       && {probeProcess}),
+            ...(readProcessCommand && {readProcessCommand})
+        })
+    const failures = resolveTerminalDeliveryFailures
+        ? await resolveInjectedFailures(resolveTerminalDeliveryFailures)
+        : readTerminalDeliveryFailures({
+            deliveryFailureFilePath: deliveryFailureFilePath ||
+                (pidFilePath ? path.join(path.dirname(pidFilePath), 'wake-delivery-failures.json') : null),
+            ...(readDeliveryFailureFile && {readDeliveryFailureFile})
+        })
 
     const hasReader = Boolean(resolveSubscriptionState),
           states    = []
@@ -407,6 +430,72 @@ export async function readFleetWakeStateSnapshot({
             ].filter(Boolean).join('; ') || null
         },
         states
+    }
+}
+
+/**
+ * @summary Runs an injected liveness resolver under the axis contract: the answer must carry
+ * `alive` as `true`/`false`/`'unknown'`, anything else — a throw included — degrades to `'unknown'`
+ * with the reason preserved. An injected authority can therefore never fabricate a state the
+ * built-in source could not produce.
+ * @param {Function} resolver
+ * @returns {Promise<{alive: Boolean|'unknown', reason: String|null}>}
+ * @private
+ */
+async function resolveInjectedLiveness(resolver) {
+    let answer
+
+    try {
+        answer = await resolver()
+    } catch (error) {
+        return {alive: 'unknown', reason: normalizeReason(error)}
+    }
+
+    const alive = answer?.alive
+
+    if (alive !== true && alive !== false && alive !== 'unknown') {
+        return {alive: 'unknown', reason: 'delivery liveness resolver returned an out-of-contract value'}
+    }
+
+    // A reasonless `unknown` must still name ITS source: the generic fallback strings downstream
+    // talk about the wake daemon, which an injected delivery authority may not be.
+    return {
+        alive,
+        reason: answer.reason ?? (alive === 'unknown' ? 'delivery liveness resolver answered unknown' : null)
+    }
+}
+
+/**
+ * @summary Runs an injected terminal-failure resolver under the axis contract: `state` must be
+ * `'observed'` or `'unknown'` and `byIdentity` a Map — anything else degrades to `'unknown'` with
+ * an empty map, mirroring the file source's malformed-receipt handling.
+ * @param {Function} resolver
+ * @returns {Promise<{state: 'observed'|'unknown', reason: String|null, byIdentity: Map<String,Object[]>}>}
+ * @private
+ */
+async function resolveInjectedFailures(resolver) {
+    let answer
+
+    try {
+        answer = await resolver()
+    } catch (error) {
+        return {state: 'unknown', reason: normalizeReason(error), byIdentity: new Map()}
+    }
+
+    const state = answer?.state
+
+    if ((state !== 'observed' && state !== 'unknown') || !(answer.byIdentity instanceof Map)) {
+        return {
+            state     : 'unknown',
+            reason    : 'terminal delivery resolver returned an out-of-contract value',
+            byIdentity: new Map()
+        }
+    }
+
+    return {
+        state,
+        reason    : answer.reason ?? (state === 'unknown' ? 'terminal delivery resolver answered unknown' : null),
+        byIdentity: answer.byIdentity
     }
 }
 

--- a/ai/services/fleet/planeWakeIdentitiesReader.mjs
+++ b/ai/services/fleet/planeWakeIdentitiesReader.mjs
@@ -1,0 +1,34 @@
+/**
+ * @module ai/services/fleet/planeWakeIdentitiesReader
+ * @summary The plane-mode bulk wake-subscription reader: composes the identity-proven plane
+ * client's `manage_wake_subscription {action: 'fleet-identities'}` call into the wake adapter's
+ * `listActiveSubscriptionIdentities` contract.
+ *
+ * The client's `callTool` returns the PARSED tool payload — its `mapToolResult` unwraps the SDK
+ * CallToolResult and throws on malformed content — so this reader consumes `{identities}` directly
+ * and MUST NOT parse again: a second envelope-parse pass accepts only CallToolResult shapes, so it
+ * rejects every healthy parsed payload and silently degrades the whole plane subscription axis to
+ * `unknown`. The guard here is therefore a PAYLOAD-contract guard, not a wire-envelope one:
+ * anything without a top-level identities array throws, and the adapter converts that throw into
+ * honest per-row `unknown` under a degraded capability — a refused, malformed, or wrong-shape
+ * answer never fabricates an empty fleet.
+ */
+
+/**
+ * @summary Builds the adapter-facing bulk reader over a proven plane client.
+ * @param {Object} planeClient A `planeMailboxClient`-contract client: `callTool(name, args)`
+ *     resolving to the parsed tool payload (never the wire envelope).
+ * @returns {Function} `() => Promise<String[]>` matching the wake adapter's
+ *     `listActiveSubscriptionIdentities` bulk-reader seam.
+ */
+export function createPlaneWakeIdentitiesReader(planeClient) {
+    return async () => {
+        const payload = await planeClient.callTool('manage_wake_subscription', {action: 'fleet-identities'});
+
+        if (!Array.isArray(payload?.identities)) {
+            throw new Error('plane wake fleet-identities answer unreadable')
+        }
+
+        return payload.identities
+    }
+}

--- a/ai/services/fleet/wireFleetActivityReadSource.mjs
+++ b/ai/services/fleet/wireFleetActivityReadSource.mjs
@@ -29,7 +29,7 @@ import {buildWorkGraphStallFindings,
  *    injected PR payloads. The reading is the substantive work of this leaf, not a passthrough.
  *
  * @see ai/services/fleet/wireBootIdentityReadSource.mjs — the wire-shape precedent
- * @see ai/services/fleet/readActiveWakeSubscriptionIdentities.mjs — the lazy-singleton cross-process precedent
+ * @see ai/services/memory-core/readActiveWakeSubscriptionIdentities.mjs — the lazy-singleton cross-process precedent
  */
 
 /**

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -11,6 +11,7 @@ import TurnPresenceService                                                      
 import WebhookDeliveryService                                                                   from './WebhookDeliveryService.mjs';
 import {HEARTBEAT_PULSE_ENTITY_PREFIX, HEARTBEAT_PULSE_ENTITY_TYPE, match, matchHeartbeatPulse} from './heartbeatPulseEvaluator.mjs';
 import {resolveResidentFamilyById}                                                              from '../graph/agentFamilyResolution.mjs';
+import {readActiveWakeSubscriptionIdentities}                                                   from './readActiveWakeSubscriptionIdentities.mjs';
 import {
     activeWakeSubscriptionStatusSql,
     isActiveWakeSubscriptionStatus
@@ -388,7 +389,7 @@ class WakeSubscriptionService extends Base {
      * action-specific handlers per ADR 0002 §6.6. ticket-ref-ok: decision-record authority, not issue archaeology
      *
      * @param {Object} opts
-     * @param {String} opts.action One of 'subscribe' | 'unsubscribe' | 'update' | 'list' | 'resync' | 'resume' | 'rotate-key'
+     * @param {String} opts.action One of 'subscribe' | 'unsubscribe' | 'update' | 'list' | 'resync' | 'resume' | 'rotate-key' | 'fleet-identities'
      * @param {Object} [opts.rest] Action-specific parameters (see individual methods)
      * @returns {Promise<Object>}
      */
@@ -397,17 +398,18 @@ class WakeSubscriptionService extends Base {
 
         const {action, ...rest} = opts;
         switch (action) {
-            case 'bootstrap'  : return this.bootstrap  (rest);
-            case 'subscribe'  : return this.subscribe  (rest);
-            case 'unsubscribe': return this.unsubscribe(rest);
-            case 'update'     : return this.update     (rest);
-            case 'list'       : return this.list       (rest);
-            case 'resync'     : return this.resync     (rest);
-            case 'resume'     : return this.resume     (rest);
-            case 'rotate-key' : return this.rotateKey  (rest);
+            case 'bootstrap'       : return this.bootstrap  (rest);
+            case 'fleet-identities': return this.fleetIdentities();
+            case 'subscribe'       : return this.subscribe  (rest);
+            case 'unsubscribe'     : return this.unsubscribe(rest);
+            case 'update'          : return this.update     (rest);
+            case 'list'            : return this.list       (rest);
+            case 'resync'          : return this.resync     (rest);
+            case 'resume'          : return this.resume     (rest);
+            case 'rotate-key'      : return this.rotateKey  (rest);
             default:
                 throw new Error(
-                    `Invalid action '${action}'. Must be one of: bootstrap, subscribe, unsubscribe, update, list, resync, resume, rotate-key.`
+                    `Invalid action '${action}'. Must be one of: bootstrap, fleet-identities, subscribe, unsubscribe, update, list, resync, resume, rotate-key.`
                 );
         }
     }
@@ -1376,6 +1378,27 @@ class WakeSubscriptionService extends Base {
             subscriptions.push(entry);
         }
         return {subscriptions};
+    }
+
+    /**
+     * Fleet-wide wake-observation telemetry: the deduplicated identities holding an ACTIVE
+     * subscription — and nothing else. The disclosure contract is deliberately the `whoIsOnline`
+     * class (any authenticated caller, fleet-scoped operational telemetry), NOT the caller-owner
+     * `list` class: owner rows carry endpoint/filter/key-adjacent material a roster read has no
+     * business seeing, so this action never returns row properties. The scan itself is the shared
+     * `readActiveWakeSubscriptionIdentities` — the same one query the fleet dev-server runs
+     * in-process against a host plane — with the absent-status meaning owned by
+     * `wakeSubscriptionStatusPolicy` in both.
+     *
+     * @returns {Promise<{identities: String[]}>} Sorted for deterministic wire output.
+     */
+    async fleetIdentities() {
+        const caller = RequestContextService.getAgentIdentityNodeId();
+        if (!caller) throw RequestContextService.unboundIdentityError('list fleet wake identities');
+
+        const identities = await readActiveWakeSubscriptionIdentities({graphService: GraphService});
+
+        return {identities: identities.sort()}
     }
 
     /**

--- a/ai/services/memory-core/readActiveWakeSubscriptionIdentities.mjs
+++ b/ai/services/memory-core/readActiveWakeSubscriptionIdentities.mjs
@@ -1,9 +1,15 @@
 /**
- * @module ai/services/fleet/readActiveWakeSubscriptionIdentities
- * @summary The trusted Brain-side observation source for the fleet's wake axis: one bulk scan of
+ * @module ai/services/memory-core/readActiveWakeSubscriptionIdentities
+ * @summary The trusted observation source for the fleet's wake axis: one bulk scan of
  * ACTIVE wake subscriptions, returning the holder identities — administrative READ-observation
- * under the fleet process's own authority, deliberately NOT the caller-owner management API (which
- * derives its owner from the request context and must never be impersonated).
+ * under the calling process's own authority, deliberately NOT the caller-owner management API
+ * (which derives its owner from the request context and must never be impersonated).
+ *
+ * It lives beside the graph it reads: the memory-core owns WAKE_SUBSCRIPTION truth, and BOTH
+ * consumers take the scan from here — the fleet dev-server's in-process mode (host plane, its own
+ * graph handle) and the wake-subscription service's fleet-identities telemetry action (the
+ * containerized plane, serving the same scan over MCP). One query, two processes, no second copy
+ * free to drift.
  *
  * The graph service loads lazily per call: the fleet server pays the memory-core import cost only
  * when a roster read actually needs wake truth, and a fresh scan per snapshot means no long-lived
@@ -22,7 +28,7 @@
 import {
     activeWakeSubscriptionStatusSql,
     isActiveWakeSubscriptionStatus
-} from '../memory-core/wakeSubscriptionStatusPolicy.mjs';
+} from './wakeSubscriptionStatusPolicy.mjs';
 
 /**
  * The durable fleet-wide ACTIVE-subscription query. Mirrors the established WAKE_SUBSCRIPTION
@@ -47,7 +53,7 @@ const ACTIVE_IDENTITIES_SQL = `
  * @throws {Error} When no read surface is reachable — the adapter maps this to honest `unknown`.
  */
 export async function readActiveWakeSubscriptionIdentities({graphService = null} = {}) {
-    const service = graphService || (await import('../memory-core/GraphService.mjs')).default
+    const service = graphService || (await import('./GraphService.mjs')).default
 
     // `db` is populated by async init, not by module import: reading it straight off the fresh
     // import yields undefined. `ready()` is the ONLY architecture-compliant external wait —

--- a/test/playwright/unit/ai/services/fleet/fleetWakeStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeStateAdapter.spec.mjs
@@ -378,3 +378,114 @@ test.describe('fleetWakeStateAdapter — the fleet snapshot + capability envelop
         }
     })
 })
+
+/**
+ * The injected delivery-axis resolvers: the plane-mode seam. A deployment whose delivery authority
+ * is not a host daemon replaces the PID/receipt file sources with axis-level resolvers carrying the
+ * same contracts — and the same inability to fabricate: throws and out-of-contract answers degrade
+ * to unknown with the reason preserved, and precedence belongs to the injected authority.
+ */
+test.describe('fleetWakeStateAdapter — injected delivery-axis resolvers (the plane-mode seam)', () => {
+    const agents = [{id: 'grace'}, {id: 'vega'}]
+
+    test('injected axes replace the file sources entirely: on-rows with no PID path at all', async () => {
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents,
+            resolveSubscriptionState       : agent => agent.id === 'grace' ? 'active' : 'none',
+            resolveDeliveryLiveness        : () => ({alive: true, reason: null}),
+            resolveTerminalDeliveryFailures: () => ({state: 'observed', reason: null, byIdentity: new Map()})
+        })
+
+        expect(capability).toMatchObject({state: 'wired', confidence: 'observed', reason: null})
+        expect(states).toEqual([
+            {agentId: 'grace', wake: 'on',  confidence: 'observed', source: WAKE_SOURCE_LABEL},
+            {agentId: 'vega',  wake: 'off', confidence: 'observed', source: WAKE_SOURCE_LABEL}
+        ])
+    })
+
+    test('an injected resolver WINS over configured file paths — the entrypoint named a different authority', async () => {
+        const {states} = await readFleetWakeStateSnapshot({
+            agents                  : [{id: 'grace'}],
+            resolveSubscriptionState: () => 'active',
+            // The file picture says LIVE daemon; the injected authority says delivery is down.
+            pidFilePath                    : '/x/wake.pid',
+            readFile                       : () => '4242',
+            probeProcess                   : () => {},
+            readProcessCommand             : () => 'node /repo/ai/daemons/wake/daemon.mjs',
+            resolveDeliveryLiveness        : () => ({alive: false, reason: null}),
+            resolveTerminalDeliveryFailures: () => ({state: 'observed', reason: null, byIdentity: new Map()})
+        })
+
+        expect(states[0].wake).toBe('suppressed')
+    })
+
+    test('a throwing liveness resolver degrades to unknown with ITS reason — never a fabricated state', async () => {
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents                         : [{id: 'grace'}],
+            resolveSubscriptionState       : () => 'active',
+            resolveDeliveryLiveness        : () => { throw new Error('plane vouching surface unreachable') },
+            resolveTerminalDeliveryFailures: () => ({state: 'observed', reason: null, byIdentity: new Map()})
+        })
+
+        expect(capability.state).toBe('degraded')
+        expect(capability.reason).toContain('plane vouching surface unreachable')
+        expect(states[0]).toMatchObject({wake: 'unknown', confidence: 'none'})
+    })
+
+    test('an out-of-contract liveness answer cannot smuggle a fifth state', async () => {
+        const {states} = await readFleetWakeStateSnapshot({
+            agents                         : [{id: 'grace'}],
+            resolveSubscriptionState       : () => 'active',
+            resolveDeliveryLiveness        : () => ({alive: 'maybe'}),
+            resolveTerminalDeliveryFailures: () => ({state: 'observed', reason: null, byIdentity: new Map()})
+        })
+
+        expect(states[0].wake).toBe('unknown')
+        expect(states[0].reason).toBe('delivery liveness resolver returned an out-of-contract value')
+    })
+
+    test('a reasonless unknown from an injected resolver names ITS source — not the wake daemon', async () => {
+        const {states} = await readFleetWakeStateSnapshot({
+            agents                         : [{id: 'grace'}],
+            resolveSubscriptionState       : () => 'active',
+            resolveDeliveryLiveness        : () => ({alive: 'unknown', reason: null}),
+            resolveTerminalDeliveryFailures: () => ({state: 'observed', reason: null, byIdentity: new Map()})
+        })
+
+        expect(states[0].wake).toBe('unknown')
+        expect(states[0].reason).toBe('delivery liveness resolver answered unknown')
+    })
+
+    test('injected terminal failures project the same suppressed row as the file source', async () => {
+        const failedAt = '2026-08-02T11:22:33.000Z'
+        const {states} = await readFleetWakeStateSnapshot({
+            agents                          : [{id: 'grace', githubUsername: 'neo-opus-grace'}],
+            listActiveSubscriptionIdentities: () => ['@neo-opus-grace'],
+            resolveDeliveryLiveness         : () => ({alive: true, reason: null}),
+            resolveTerminalDeliveryFailures : () => ({
+                state     : 'observed',
+                reason    : null,
+                byIdentity: new Map([['@neo-opus-grace', [{subscriptionId: 'WAKE_SUB:grace', errorClass: 'receiver-refused', failedAt}]]])
+            })
+        })
+
+        expect(states[0]).toMatchObject({
+            wake               : 'suppressed',
+            reason             : 'terminal wake delivery failure: receiver-refused',
+            lastDeliveryFailure: {subscriptionId: 'WAKE_SUB:grace', errorClass: 'receiver-refused', failedAt}
+        })
+    })
+
+    test('an out-of-contract failures answer (byIdentity not a Map) degrades that axis honestly', async () => {
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents                         : [{id: 'grace'}],
+            resolveSubscriptionState       : () => 'active',
+            resolveDeliveryLiveness        : () => ({alive: true, reason: null}),
+            resolveTerminalDeliveryFailures: () => ({state: 'observed', reason: null, byIdentity: {}})
+        })
+
+        expect(capability.state).toBe('degraded')
+        expect(states[0].wake).toBe('unknown')
+        expect(states[0].reason).toBe('terminal delivery resolver returned an out-of-contract value')
+    })
+})

--- a/test/playwright/unit/ai/services/fleet/planeWakeIdentitiesReader.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/planeWakeIdentitiesReader.spec.mjs
@@ -1,0 +1,91 @@
+import {setup} from '../../../../setup.mjs'
+
+const appName = 'PlaneWakeIdentitiesReaderTest'
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+})
+
+import {test, expect} from '@playwright/test'
+import Neo            from '../../../../../../src/Neo.mjs'
+import * as core      from '../../../../../../src/core/_export.mjs'
+
+import {createPlaneWakeIdentitiesReader} from '../../../../../../ai/services/fleet/planeWakeIdentitiesReader.mjs'
+import {readFleetWakeStateSnapshot}      from '../../../../../../ai/services/fleet/fleetWakeStateAdapter.mjs'
+
+/**
+ * The client→reader→adapter composition witnesses. The proven plane client returns PARSED tool
+ * payloads (its own spec proves a structured tool result resolves to the plain payload), so these
+ * fixtures speak exactly that contract — and pin the double-parse class in both directions: the
+ * reader must accept the parsed shape and must NOT quietly unwrap a wire envelope.
+ */
+test.describe('planeWakeIdentitiesReader — the plane-mode client→adapter composition', () => {
+    const wired = {
+        resolveDeliveryLiveness        : () => ({alive: true, reason: null}),
+        resolveTerminalDeliveryFailures: () => ({state: 'observed', reason: null, byIdentity: new Map()})
+    }
+
+    test('a healthy PARSED payload — the shape the proven client returns — reaches the adapter as on-rows', async () => {
+        const calls  = []
+        const reader = createPlaneWakeIdentitiesReader({
+            callTool: async (name, args) => {
+                calls.push([name, args])
+                return {identities: ['@neo-gpt']}
+            }
+        })
+
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents                          : [{id: 'euclid', githubUsername: 'neo-gpt'}, {id: 'vega', githubUsername: 'neo-opus-vega'}],
+            listActiveSubscriptionIdentities: reader,
+            ...wired
+        })
+
+        expect(calls).toEqual([['manage_wake_subscription', {action: 'fleet-identities'}]])
+        expect(capability).toMatchObject({state: 'wired', confidence: 'observed'})
+        expect(states.map(row => row.wake)).toEqual(['on', 'off'])
+    })
+
+    test('the regression pin: a WIRE-ENVELOPE shape is rejected — re-adding an envelope parse upstream inverts the contract and this witness reds', async () => {
+        const reader = createPlaneWakeIdentitiesReader({
+            callTool: async () => ({structuredContent: {identities: ['@neo-gpt']}})
+        })
+
+        const {states} = await readFleetWakeStateSnapshot({
+            agents                          : [{id: 'euclid', githubUsername: 'neo-gpt'}],
+            listActiveSubscriptionIdentities: reader,
+            ...wired
+        })
+
+        expect(states[0]).toMatchObject({wake: 'unknown', confidence: 'none'})
+        expect(states[0].reason).toBe('plane wake fleet-identities answer unreadable')
+    })
+
+    test('a refused plane call degrades honestly — the refusal reason survives into the row, no empty-fleet fabrication', async () => {
+        const reader = createPlaneWakeIdentitiesReader({
+            callTool: async () => { throw new Error('plane manage_wake_subscription failed: HTTP 401') }
+        })
+
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents                          : [{id: 'euclid', githubUsername: 'neo-gpt'}],
+            listActiveSubscriptionIdentities: reader,
+            ...wired
+        })
+
+        expect(capability.state).toBe('degraded')
+        expect(states[0].wake).toBe('unknown')
+        expect(states[0].reason).toContain('plane manage_wake_subscription failed')
+    })
+
+    test('a payload without a top-level identities array throws the named contract error', async () => {
+        const reader = createPlaneWakeIdentitiesReader({callTool: async () => ({})})
+
+        await expect(reader()).rejects.toThrow('plane wake fleet-identities answer unreadable')
+    })
+})

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -2579,4 +2579,60 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
         });
     });
+
+    test.describe('fleet-identities — the fleet-telemetry read', () => {
+        const bridgeArgs = {
+            action               : 'subscribe',
+            trigger              : 'SENT_TO_ME',
+            harnessTarget        : 'bridge-daemon',
+            harnessTargetMetadata: {adapter: 'osascript', appName: 'Claude', coalesceWindow: 0}
+        };
+
+        test('returns sorted deduplicated ACTIVE holder identities — absent status included by policy, retired excluded', async () => {
+            GraphService.upsertNode({id: '@fleet-zed',  type: 'AGENT', name: 'Zed',  properties: {}});
+            GraphService.upsertNode({id: '@fleet-yara', type: 'AGENT', name: 'Yara', properties: {}});
+            GraphService.upsertNode({id: '@fleet-xico', type: 'AGENT', name: 'Xico', properties: {}});
+
+            // zed holds TWO active rows (dedupe witness); yara's only row is retired via the real
+            // lifecycle verb; xico's row has its status REMOVED raw — the unreachable-but-not-
+            // impossible state whose meaning the shared policy owns (absent ⇒ active).
+            await RequestContextService.run({agentIdentityNodeId: '@fleet-zed'}, async () => {
+                await callTool('manage_wake_subscription', bridgeArgs);
+                await callTool('manage_wake_subscription', bridgeArgs);
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@fleet-yara'}, async () => {
+                const {subscriptionId} = await callTool('manage_wake_subscription', bridgeArgs);
+
+                await callTool('manage_wake_subscription', {action: 'unsubscribe', subscriptionId});
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@fleet-xico'}, async () => {
+                await callTool('manage_wake_subscription', bridgeArgs);
+            });
+
+            GraphService.db.storage.db.prepare(`
+                UPDATE Nodes SET data = json_remove(data, '$.properties.status')
+                WHERE json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'
+                  AND json_extract(data, '$.properties.agentIdentity') = '@fleet-xico'
+            `).run();
+
+            const res = await RequestContextService.run({agentIdentityNodeId: '@alice'},
+                () => callTool('manage_wake_subscription', {action: 'fleet-identities'}));
+
+            // Identities only — no rows, no properties, nothing beside the one declared key.
+            expect(Object.keys(res)).toEqual(['identities']);
+
+            const {identities} = res;
+
+            expect(identities.filter(identity => identity === '@fleet-zed')).toHaveLength(1);
+            expect(identities).toContain('@fleet-xico');
+            expect(identities).not.toContain('@fleet-yara');
+            expect(identities).toEqual([...identities].sort());
+        });
+
+        test('an unbound caller is refused — authenticated-caller telemetry, not an open scan', async () => {
+            await expect(WakeSubscriptionService.fleetIdentities()).rejects.toThrow(/identity/i)
+        });
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/readActiveWakeSubscriptionIdentities.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/readActiveWakeSubscriptionIdentities.spec.mjs
@@ -17,7 +17,7 @@ import {test, expect} from '@playwright/test'
 import Neo            from '../../../../../../src/Neo.mjs'
 import * as core      from '../../../../../../src/core/_export.mjs'
 
-import {readActiveWakeSubscriptionIdentities} from '../../../../../../ai/services/fleet/readActiveWakeSubscriptionIdentities.mjs'
+import {readActiveWakeSubscriptionIdentities} from '../../../../../../ai/services/memory-core/readActiveWakeSubscriptionIdentities.mjs'
 
 /**
  * Models the `core.Base` contract this reader depends on: `db` does NOT exist until async init has


### PR DESCRIPTION
Resolves #16347

The Fleet cockpit's wake column stops fabricating. Post-hard-cut, the wake axes wired in `devFleetServer` measured host truths that no longer exist — the host graph's relic WAKE_SUBSCRIPTION rows and the retired local wake daemon's PID/receipt files — so genuinely subscribed seats rendered `off` and relic identities rendered `suppressed`. The seams now follow the leaf-1 plane decision: in plane mode the subscription axis reads the containerized plane's ACTIVE rows through the identity-verified MCP client (`manage_wake_subscription {action: 'fleet-identities'}` — a new identities-only, authenticated-caller telemetry read beside `whoIsOnline`), and the delivery axes answer honestly `unknown` with named reasons until the plane exposes a vouching surface. In-process mode keeps the host bindings verbatim. The fleet-wide scan itself moved to its truth-owner home (`ai/services/memory-core/readActiveWakeSubscriptionIdentities.mjs`) so BOTH consumers — the fleet dev-server in-process and the plane service — run one query composed from the converged status policy (PR #16340), with no second copy free to drift.

Evidence: L2 achieved (35/35 adapter witnesses incl. 7 new seam specs; 107/107 WakeSubscriptionService suite incl. the policy-consumption witness — an absent-status row is INCLUDED by the shared policy; 10/10 relocated reader specs; full local unit suite green pre-push) → L3 required (AC8 live-plane receipt: the running containers lag dev, so the served plane cannot carry this commit yet). Residual: AC8 [#16347].

## Deltas from ticket

- The admission resolution recorded in the ticket body (the `who_is_online` telemetry class; a `fleet-identities` action on the existing tool) is implemented exactly as folded there; the pairwise-grant alternative stays rejected for the roster-hole fabrication class it documents.
- One structural delta beyond the ticket's file list: `readActiveWakeSubscriptionIdentities.mjs` relocated from `ai/services/fleet/` to `ai/services/memory-core/` (git mv + import updates + spec move). Rationale: the module reads the memory-core graph, and the service becoming its second consumer would otherwise have required a second copy of the fleet-wide query — the exact drift class `#16331` just converged. Sibling-lift structural pre-flight: the status policy module and the owning service already live there.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetWakeStateAdapter.spec.mjs` → 35 passed (28 existing + 7 new injected-resolver witnesses: replacement without any PID path, precedence over configured file paths, throw / out-of-contract / reasonless degradation, terminal-failure projection, byIdentity-shape guard).
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` → 107 passed (new block: sorted deduplicated identities-only shape through the real MCP dispatch; an absent-status row included BY THE SHARED POLICY; a retired row excluded via the real lifecycle verb; an unbound caller refused).
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/readActiveWakeSubscriptionIdentities.spec.mjs` → 10 passed at the relocated path.
- Full `npm run test-unit` → green pre-push (CI on this PR is the public mirror).
- `ai/services/fleet/devFleetServer.mjs` (process entry, no unit surface): `node --check` green; the mode branch is composition of independently spec'd authorities (`readMcpToolResultPayload`, the adapter resolver seams, the proven client's `callTool`); its boot witness lines are listed under Post-Merge Validation.

## Post-Merge Validation

- [ ] AC8 live-plane receipt: after the plane is rebuilt at/past this commit, a plane-mode boot logs the wake-seam witness line and the roster's wake column shows real subscription truth (no fabricated `suppressed`/`off`).
- [ ] `fleet-identities` served by the rebuilt plane returns the canonical seats' identities (plane measured in `#16331`: 17 durable rows, 15 active).

## Commits

- e0182e8c6d — feat(ai): fleet wake-state seams take plane-mode injected delivery resolvers (#16347) — adapter resolver seams + devFleetServer mode branch + 7 witnesses
- 2485b15f64 — feat(ai): the plane serves fleet wake identities — one query, two consumers (#16347) — reader relocation to the truth-owner home + the `fleet-identities` action + schema + service specs

Authored by Clio (Claude Fable 5, Claude Code). Session 5892cb00-bb3f-467b-9346-81c509834503.
