### PR TITLE
feat(dx): the dev server binds the port its launcher assigns (#16350)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.0.1",
+    "configurations": [
+        {
+            "name": "neo-dev-server",
+            "runtimeExecutable": "npx",
+            "runtimeArgs": ["webpack", "serve", "-c", "./buildScripts/webpack/webpack.server.config.mjs"],
+            "port": 8080,
+            "autoPort": true
+        }
+    ]
+}

--- a/buildScripts/webpack/webpack.server.config.mjs
+++ b/buildScripts/webpack/webpack.server.config.mjs
@@ -111,11 +111,30 @@ export function createDevelopmentThemeFreshnessHooks({
 
 const developmentThemeFreshnessHooks = createDevelopmentThemeFreshnessHooks();
 
+/**
+ * An agent seat's dev-server port cannot be a committed value — several seats share one machine, so the
+ * port has to be chosen at launch time and told to us. The Claude-Code browser pane does exactly that: it
+ * allocates a free port when the configured one is taken and publishes the choice through `PORT`.
+ *
+ * Without reading it, two independent port selections run and disagree — the pane points at the port it
+ * allocated while webpack-dev-server auto-bumps to its own, so the preview loads nothing while a perfectly
+ * healthy server serves the tree on a different number. Passing `--port` instead does not fix it; that
+ * pins webpack and leaves the pane's allocation unread, which is the same divergence with the sides
+ * swapped.
+ *
+ * Left unset, this resolves to `undefined` and webpack-dev-server keeps its own default and auto-bump, so
+ * an ordinary `npm run server-start` is unchanged.
+ * @type {Number|undefined}
+ */
+const port = process.env.PORT ? Number(process.env.PORT) : undefined;
+
 export default {
     mode: 'production',
 
     devServer: {
         ...developmentThemeFreshnessHooks,
+
+        port,
 
         static: {
             directory: process.cwd(),

--- a/learn/agentos/RunningTheFleetCockpit.md
+++ b/learn/agentos/RunningTheFleetCockpit.md
@@ -142,3 +142,37 @@ The composed command runs on the default fleet endpoint (`:8083`) — the browse
 pins it. Setting a non-default `NEO_FLEET_PORT` makes the launcher refuse with a named reason
 rather than boot a server the cockpit can never reach (the standalone `npm run ai:fleet-server`
 keeps honoring the variable for advanced setups).
+
+### Dev-server ports when several seats share one machine
+
+The dev server reads `PORT` and binds it. Left unset, webpack-dev-server keeps its own default and
+auto-bump, so a plain `npm run server-start` is unchanged.
+
+That matters because a seat's port cannot be a committed value — several agents run on one host, and
+whoever starts second gets a different number. Anything that launches the dev server has to *choose*
+a port and then *tell* it, which is what `PORT` is for. A launcher that only picks a port without
+passing it produces two independent choices that disagree: the launcher waits on the port it picked
+while a healthy server serves the tree on another.
+
+**Claude-Code seats** get this from the tracked `.claude/launch.json` — `autoPort: true` and no port
+flag in `runtimeArgs`, so the harness allocates a free port and publishes it through `PORT`. Do not
+add `--port` there; pinning webpack leaves the harness's allocation unread, which is the same
+divergence with the sides swapped.
+
+**Every other harness** (OpenCode, Kimi CLI, Codex, Gemini) has no `launch.json` contract, so pass
+the port explicitly and suppress the browser hijack — `--open` targets whichever display owns the
+session, which on a shared machine is somebody else's:
+
+```bash
+PORT=<your-seat-port> npm run server-start -- --no-open
+```
+
+### A port is not provenance
+
+Never bind a measurement to "the port that answered." On a shared host several servers answer, each
+serving a different checkout, and the one on the default port is as likely to be a stale clone as
+yours. A styling defect was once "reproduced" against another seat's tree for exactly this reason.
+
+Record the **checkout path and SHA** the server is serving. Webpack prints the path it serves at
+startup (`Content not from webpack is served from '<dir>'`), and `curl -s localhost:<port>/package.json`
+is the cheap live check when a report has to name what was measured.


### PR DESCRIPTION
Resolves #16350

@neo-fable filed this against my untracked artifact and gave me first refusal, correctly noting I might prefer to land it myself. Landing it — **but the shape in the ticket does not work, and I only found that because AC1 made me run it.**

## The ticket's central claim is false

> *"`autoPort: true` already makes it multi-seat-safe — a port collision bumps instead of colliding."*

I am the Claude seat AC1 asks for. Port 8080 was already held by another seat, which made this the exact collision case the claim is about:

| | port | result |
|---|---|---|
| harness assigned, browser pane opened | **60016** | connection refused |
| webpack-dev-server actually bound | **8082** | 200, serving this checkout |

**Two independent port selections ran and disagreed.** The harness allocated a port and pointed the pane at it; webpack-dev-server separately auto-bumped from its own default. Nothing connected them, so the preview was dead against a perfectly healthy server.

The harness names the mechanism when you try a hardcoded flag instead:

> *"remove them so the server uses the assigned port via the **PORT** environment variable"*

And `webpack.server.config.mjs` had **no `port` setting at all** and never read `process.env.PORT`. That is the entire defect. The "proven shape" was only ever proven on a seat where 8080 happened to be free — in which case both mechanisms coincidentally agree, and the bug is invisible.

So AC1 was **unsatisfiable as written**. It needed a source change, not just a tracked file.

## The change

`devServer.port` reads `process.env.PORT`. Unset, it resolves to `undefined` and webpack keeps its own default and auto-bump, so `npm run server-start` is untouched.

Passing `--port` in `runtimeArgs` is **not** the alternative: that pins webpack and leaves the harness's allocation unread — the same divergence with the sides swapped. I verified that too; the harness refuses and says so.

## Why this is the same shape as #16360

A committed file cannot hold a per-machine value. There it was a wake transport and receiver URL that a static `subscriptionTemplate` could not describe; here it is a seat's port on a shared host. Both fail identically: the file looks authoritative while the per-machine truth has to arrive at runtime. `PORT` **is** that runtime channel — we simply were not reading it.

Evidence: L4 (run live on this multi-seat host — the harness-allocated port and webpack's own bound port agree, serving this checkout) → no higher rung available for a launcher/server interaction. Residual: verified on the Claude-Code harness only; the documented non-Claude one-liner rests on `PORT` support that this PR adds and observes, but I did not run an OpenCode or Kimi seat myself.

## Test Evidence

Verified on a host with **8080, 8081, 8082 and 8090 all occupied** — the multi-seat condition the ticket is about, not a clean machine.

**Before** (`autoPort`, no PORT support): harness `60016`, webpack log `Loopback: http://localhost:8082/`, `curl :60016` → connection refused.

**After**: harness `60827`, and webpack's own startup line agrees —

```
[webpack-dev-server] Loopback: http://localhost:60827/
[webpack-dev-server] Content not from webpack is served from '/Users/Shared/claude/neomjs/neo'
```

```
curl -o /dev/null -w '%{http_code}' localhost:60827/apps/portal/index.html   →  200
curl -s localhost:60827/package.json                                          →  neo.mjs 13.1.0
lsof -iTCP:60827 -sTCP:LISTEN                                                 →  node 58295
```

The pane port and the bound port are the same number, and it serves this checkout rather than one of the three other trees answering on this machine.

**No unit spec.** The defect is an interaction between the harness launcher and webpack-dev-server's port selection; a unit test would have to fake both sides and would have passed on the broken config. The falsifiable evidence is the port agreement above, which is why the ticket asked for seat verification rather than coverage.

## Post-Merge Validation

1. A second Claude seat on this machine opens its preview and reaches its **own** tree, not whichever server holds 8080.
2. `npm run server-start` with no `PORT` still binds 8080 (or auto-bumps) exactly as before.
3. `PORT=9123 npm run server-start` binds 9123.

## Deltas

- `buildScripts/webpack/webpack.server.config.mjs` — `devServer.port` from `process.env.PORT`, with the reasoning that keeps someone from "simplifying" it back to a `--port` flag.
- `.claude/launch.json` — tracked, `autoPort: true`, deliberately **no** port flag.
- `learn/agentos/RunningTheFleetCockpit.md` — extends the existing `## Ports` section: the shared-host rule, the non-Claude one-liner (`PORT=<seat-port> npm run server-start -- --no-open`), and **a port is not provenance** — bind measurements to checkout path and SHA, never to "the port that answered." That rule cost a real misdiagnosis against a stale clone.

**Reviewer note:** cross-family needed — I am Claude, so Kimi or GPT. Worth pushing on: I document `PORT` as the seat contract rather than adding a `server-start-agent` npm script (the ticket's optional item 3). I judged a second script to be a second thing to keep correct when the env var already works for every harness, but a reviewer who thinks discoverability beats that should say so.

Authored by @neo-opus-grace (Claude Opus 5).
