### PR TITLE
feat(wake): the receiver follows its manifest instead of waiting to be told (#16352)

### DIFF
--- a/ai/daemons/wake/receiver.mjs
+++ b/ai/daemons/wake/receiver.mjs
@@ -13,12 +13,26 @@ import fs              from 'node:fs/promises';
 import http            from 'node:http';
 import net             from 'node:net';
 import path            from 'node:path';
+import {watch}         from 'node:fs';
 import {pathToFileURL} from 'node:url';
 
 import {WakeReceiverState} from './receiverState.mjs';
 import {dispatchLocalWake} from './localWakeAdapters.mjs';
 
 const DEFAULT_MAX_BODY_BYTES = 256 * 1024;
+/**
+ * Coalesces the burst of filesystem events one atomic publish produces into a single reload.
+ * @type {Number}
+ */
+const MANIFEST_WATCH_DEBOUNCE_MS = 150;
+/**
+ * Backstop sweep. `fs.watch` is allowed to miss events — on network and virtualised filesystems it
+ * routinely does — so a watcher alone trades a known manual step for an unknown silent one. This is
+ * what makes a missed event self-healing rather than permanent: worst case the route goes live one
+ * interval late instead of never.
+ * @type {Number}
+ */
+const MANIFEST_RECONCILE_INTERVAL_MS = 30 * 1000;
 const LOOPBACK_HOSTS         = new Set(['127.0.0.1', 'localhost', '::1']);
 const PRODUCTION_ADAPTERS    = new Set([
     'osascript',
@@ -348,12 +362,97 @@ export async function startWakeReceiver({manifestPath, stateDir, host, port, log
         }
     };
 
-    // SIGHUP is the documented way a published route goes live. A seat runs the generator, signals,
-    // and its route serves — without the restart that an incident is most likely to have forbidden.
+    // The mtime the currently-served route table was loaded from. A reload that is REFUSED must not
+    // record it, so the next sweep retries rather than treating a rejected file as accepted.
+    let servingMtimeMs = await readManifestMtimeMs(manifestPath);
+
+    /**
+     * @summary Reloads only when the manifest on disk differs from the one being served.
+     *
+     * Both triggers below funnel through here, so a duplicated watch event costs a `stat` rather than
+     * a redundant parse-and-swap, and the periodic sweep stays free when nothing has changed.
+     * @returns {Promise<Number|null>} Route count now serving, or `null` when nothing was reloaded.
+     */
+    const reloadIfChanged = async () => {
+        const mtimeMs = await readManifestMtimeMs(manifestPath);
+
+        // Absent is what an atomic rename looks like from the outside, mid-publish. Keep serving and
+        // let the next event or sweep settle it — an unreadable moment must never empty a route table.
+        if (mtimeMs === null || mtimeMs === servingMtimeMs) return null;
+
+        const count = await reload();
+
+        if (count !== null) servingMtimeMs = mtimeMs;
+
+        return count
+    };
+
+    let debounceTimer = null;
+
+    const onManifestEvent = () => {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => { void reloadIfChanged() }, MANIFEST_WATCH_DEBOUNCE_MS);
+        debounceTimer.unref?.();
+    };
+
+    // Watch the DIRECTORY, not the file. The generator publishes by atomic rename, which replaces the
+    // inode — a watch bound to the old file goes quiet after the first publish, which is precisely the
+    // publish this exists to notice.
+    let watcher = null;
+
+    try {
+        watcher = watch(path.dirname(manifestPath), (eventType, filename) => {
+            if (!filename || filename === path.basename(manifestPath)) onManifestEvent();
+        });
+        watcher.on('error', error => {
+            logger.warn?.(`[Wake Receiver] manifest watch error, falling back to the periodic sweep: ${error.message}`);
+        });
+        watcher.unref?.();
+    } catch (error) {
+        // A platform that cannot watch still reloads on the sweep. Degraded, not deaf.
+        logger.warn?.(`[Wake Receiver] manifest watch unavailable, relying on the periodic sweep: ${error.message}`);
+    }
+
+    const reconcileTimer = setInterval(() => { void reloadIfChanged() }, MANIFEST_RECONCILE_INTERVAL_MS);
+
+    reconcileTimer.unref?.();
+
+    /**
+     * @summary Releases the watcher and the sweep. Callers that own the process lifetime (tests, a
+     * supervisor) need a way to stop them; the daemon itself never calls this.
+     * @returns {void}
+     */
+    const stopWatchingManifest = () => {
+        clearTimeout(debounceTimer);
+        clearInterval(reconcileTimer);
+        watcher?.close();
+    };
+
+    // SIGHUP stays. It is the documented escape hatch and the delivered contract of the predecessor
+    // that shipped it; what changes is that nobody has to remember it. A seat runs the generator and
+    // its route serves — without the restart that an incident is most likely to have forbidden.
     process.on('SIGHUP', () => { void reload() });
 
-    logger.log?.(`[Wake Receiver] listening on http://${host}:${port}/wake — SIGHUP reloads the manifest`);
-    return {server, state, drain, reload};
+    logger.log?.(
+        `[Wake Receiver] listening on http://${host}:${port}/wake — manifest changes reload automatically ` +
+        `(watch + ${MANIFEST_RECONCILE_INTERVAL_MS / 1000}s sweep); SIGHUP still forces one`
+    );
+
+    return {server, state, drain, reload, reloadIfChanged, stopWatchingManifest};
+}
+
+/**
+ * @summary Reads the manifest's modification time, or `null` when it cannot be stat'ed.
+ * @param {String} manifestPath
+ * @returns {Promise<Number|null>}
+ * @private
+ */
+async function readManifestMtimeMs(manifestPath) {
+    try {
+        return (await fs.stat(manifestPath)).mtimeMs
+    } catch {
+        return null
+    }
 }
 
 /**

--- a/ai/daemons/wake/receiver.mjs
+++ b/ai/daemons/wake/receiver.mjs
@@ -33,6 +33,13 @@ const MANIFEST_WATCH_DEBOUNCE_MS = 150;
  * @type {Number}
  */
 const MANIFEST_RECONCILE_INTERVAL_MS = 30 * 1000;
+/**
+ * Bounded re-reads when a publish lands mid-read. Boot has no later trigger to fall back on, so an
+ * unlucky moment must not be fatal — but a file being rewritten without pause is a real fault and has
+ * to surface rather than spin.
+ * @type {Number}
+ */
+const MANIFEST_READ_ATTEMPTS = 3;
 const LOOPBACK_HOSTS         = new Set(['127.0.0.1', 'localhost', '::1']);
 const PRODUCTION_ADAPTERS    = new Set([
     'osascript',
@@ -318,7 +325,14 @@ export function createWakeReceiver({
  * @param {Object} [options.logger=console]
  * @returns {Promise<{server:http.Server,state:WakeReceiverState,drain:Function}>}
  */
-export async function startWakeReceiver({manifestPath, stateDir, host, port, logger = console} = {}) {
+export async function startWakeReceiver({
+    manifestPath,
+    stateDir,
+    host,
+    port,
+    logger = console,
+    reconcileIntervalMs = MANIFEST_RECONCILE_INTERVAL_MS
+} = {}) {
     if (net.isIP(host) === 0) {
         throw new Error('Wake receiver requires an explicit IP-literal --host');
     }
@@ -326,7 +340,11 @@ export async function startWakeReceiver({manifestPath, stateDir, host, port, log
         throw new Error('Wake receiver requires an integer --port in 1..65535');
     }
 
-    const manifest = await loadWakeReceiverManifest(manifestPath);
+    // Captured from the SAME operation that produces the manifest below, never from a later stat.
+    // Statting afterwards records whatever is on disk THEN, which may already be a newer file this
+    // process never loaded — and the comparison would then read "unchanged" forever.
+    const boot     = await loadManifestWithRevision(manifestPath);
+    const manifest = boot.manifest;
     const state    = new WakeReceiverState({stateDir});
 
     await state.init();
@@ -348,9 +366,42 @@ export async function startWakeReceiver({manifestPath, stateDir, host, port, log
      * empty a working route table — that turns a stale receiver into a dead one, mid-incident.
      * @returns {Promise<Number|null>} Route count now serving, or `null` when the reload was refused.
      */
-    const reload = async () => {
+    // The revision of the snapshot currently SERVED — not of whatever is on disk. They are separate
+    // facts, and conflating them is how a receiver decides it is current while serving something else.
+    // A REFUSED reload must not advance it, so the next sweep retries instead of treating a rejected
+    // file as accepted.
+    let servingRevision = boot.revision;
+
+    // Every reload path — watcher, sweep, SIGHUP, direct caller — runs through this chain. Unserialized
+    // reloads can complete out of order and let an OLDER parse win the final `setManifest`, rolling the
+    // route table backwards with both callers reporting success.
+    let reloadChain = Promise.resolve(null);
+
+    /**
+     * @summary Serializes a reload step onto the single swap chain.
+     * @param {Function} step
+     * @returns {Promise<Number|null>}
+     */
+    const serialize = step => {
+        reloadChain = reloadChain.then(step, step);
+
+        return reloadChain
+    };
+
+    /**
+     * @summary Loads, revalidates and swaps in the manifest, recording the revision it accepted.
+     *
+     * Load failures leave the serving routes untouched and are reported, because an unreadable or
+     * malformed file must never empty a working route table — that turns a stale receiver into a dead
+     * one, mid-incident.
+     * @returns {Promise<Number|null>} Route count now serving, or `null` when the reload was refused.
+     */
+    const applyReload = async () => {
         try {
-            const count = setManifest(await loadWakeReceiverManifest(manifestPath));
+            const {manifest: next, revision} = await loadManifestWithRevision(manifestPath),
+                  count                      = setManifest(next);
+
+            servingRevision = revision;
 
             logger.log?.(`[Wake Receiver] manifest reloaded; serving ${count} route(s).`);
 
@@ -362,9 +413,7 @@ export async function startWakeReceiver({manifestPath, stateDir, host, port, log
         }
     };
 
-    // The mtime the currently-served route table was loaded from. A reload that is REFUSED must not
-    // record it, so the next sweep retries rather than treating a rejected file as accepted.
-    let servingMtimeMs = await readManifestMtimeMs(manifestPath);
+    const reload = () => serialize(applyReload);
 
     /**
      * @summary Reloads only when the manifest on disk differs from the one being served.
@@ -373,19 +422,15 @@ export async function startWakeReceiver({manifestPath, stateDir, host, port, log
      * a redundant parse-and-swap, and the periodic sweep stays free when nothing has changed.
      * @returns {Promise<Number|null>} Route count now serving, or `null` when nothing was reloaded.
      */
-    const reloadIfChanged = async () => {
-        const mtimeMs = await readManifestMtimeMs(manifestPath);
+    const reloadIfChanged = () => serialize(async () => {
+        const revision = await readManifestRevision(manifestPath);
 
         // Absent is what an atomic rename looks like from the outside, mid-publish. Keep serving and
         // let the next event or sweep settle it — an unreadable moment must never empty a route table.
-        if (mtimeMs === null || mtimeMs === servingMtimeMs) return null;
+        if (revision === null || revision === servingRevision) return null;
 
-        const count = await reload();
-
-        if (count !== null) servingMtimeMs = mtimeMs;
-
-        return count
-    };
+        return applyReload()
+    });
 
     let debounceTimer = null;
 
@@ -413,9 +458,22 @@ export async function startWakeReceiver({manifestPath, stateDir, host, port, log
         logger.warn?.(`[Wake Receiver] manifest watch unavailable, relying on the periodic sweep: ${error.message}`);
     }
 
-    const reconcileTimer = setInterval(() => { void reloadIfChanged() }, MANIFEST_RECONCILE_INTERVAL_MS);
+    const reconcileTimer = setInterval(() => { void reloadIfChanged() }, reconcileIntervalMs);
 
     reconcileTimer.unref?.();
+
+    /**
+     * @summary Releases only the filesystem watcher, leaving the periodic sweep running.
+     *
+     * Separate from full teardown so the missed-event path can be exercised for real: a test that
+     * stopped both would disable the very mechanism it means to prove.
+     * @returns {void}
+     */
+    const stopManifestWatcher = () => {
+        clearTimeout(debounceTimer);
+        watcher?.close();
+        watcher = null;
+    };
 
     /**
      * @summary Releases the watcher and the sweep. Callers that own the process lifetime (tests, a
@@ -423,9 +481,8 @@ export async function startWakeReceiver({manifestPath, stateDir, host, port, log
      * @returns {void}
      */
     const stopWatchingManifest = () => {
-        clearTimeout(debounceTimer);
+        stopManifestWatcher();
         clearInterval(reconcileTimer);
-        watcher?.close();
     };
 
     // SIGHUP stays. It is the documented escape hatch and the delivered contract of the predecessor
@@ -435,24 +492,63 @@ export async function startWakeReceiver({manifestPath, stateDir, host, port, log
 
     logger.log?.(
         `[Wake Receiver] listening on http://${host}:${port}/wake — manifest changes reload automatically ` +
-        `(watch + ${MANIFEST_RECONCILE_INTERVAL_MS / 1000}s sweep); SIGHUP still forces one`
+        `(watch + ${reconcileIntervalMs / 1000}s sweep); SIGHUP still forces one`
     );
 
-    return {server, state, drain, reload, reloadIfChanged, stopWatchingManifest};
+    return {server, state, drain, reload, reloadIfChanged, stopManifestWatcher, stopWatchingManifest};
 }
 
 /**
- * @summary Reads the manifest's modification time, or `null` when it cannot be stat'ed.
+ * @summary Reads a collision-resistant identity for the manifest currently on disk, or `null` when it
+ * cannot be stat'ed.
+ *
+ * Modification time alone is not an identity: two atomic publishes can land inside one clock tick and
+ * alias to the same value, so a genuinely new route table reads as "unchanged" and is never adopted.
+ * The publisher writes a temporary file and renames it, so the **inode** differs on every publish and
+ * is what actually discriminates; size is included because it is free and separates same-inode rewrites.
  * @param {String} manifestPath
- * @returns {Promise<Number|null>}
+ * @returns {Promise<String|null>}
  * @private
  */
-async function readManifestMtimeMs(manifestPath) {
+async function readManifestRevision(manifestPath) {
     try {
-        return (await fs.stat(manifestPath)).mtimeMs
+        const {mtimeMs, size, ino} = await fs.stat(manifestPath);
+
+        return `${mtimeMs}:${size}:${ino}`
     } catch {
         return null
     }
+}
+
+/**
+ * @summary Loads and validates the manifest, returning it with the revision it was read from.
+ *
+ * The revision is captured around the read and confirmed afterwards: a publish landing mid-read would
+ * otherwise attach the incoming file's identity to the outgoing file's content, and every later
+ * comparison would agree that a stale table is current. A mismatch throws, so the caller keeps serving
+ * and retries — the same fail-safe an unreadable file already gets.
+ * @param {String} manifestPath
+ * @returns {Promise<{manifest:Object,revision:String}>}
+ * @private
+ */
+async function loadManifestWithRevision(manifestPath, attempts = MANIFEST_READ_ATTEMPTS) {
+    let lastError = null;
+
+    for (let attempt = 0; attempt < attempts; attempt++) {
+        const revision = await readManifestRevision(manifestPath),
+              manifest = await loadWakeReceiverManifest(manifestPath),
+              after    = await readManifestRevision(manifestPath);
+
+        if (revision !== null && revision === after) {
+            return {manifest, revision}
+        }
+
+        // A publish landed mid-read. Retrying in-place matters most at BOOT, where there is no later
+        // trigger to fall back on — an unlucky moment must not be fatal, and a republish is finite.
+        lastError = new Error('Wake receiver manifest changed while being read');
+    }
+
+    throw lastError
 }
 
 /**

--- a/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
@@ -499,24 +499,45 @@ test.describe('ai/daemons/wake/receiver — manifest reload', () => {
         // mtime-only revision aliases them and the second is never adopted. The publisher renames a
         // temp file, so the inode differs even when the timestamp does not — forcing the timestamps
         // equal here isolates exactly that.
-        // Pinned to a whole-second stamp on BOTH publishes so the timestamps are byte-identical rather
-        // than merely close — sub-millisecond drift would hand the comparison a difference to find and
-        // the alias would never be exercised.
+        // Isolating the inode term takes three things, and dropping any one lets a weaker term pass the
+        // spec: identical mtime, identical SIZE, and delivery by RENAME. An in-place overwrite keeps the
+        // inode, and a manifest with a different route count changes the size — either way something
+        // other than the inode does the discriminating and the term this patch relies on is untested.
         const pinned = 1_760_000_000;
+        const alpha  = 'WAKE_SUB:aaa';
+        const beta   = 'WAKE_SUB:bbb';
 
-        await write({[mine]: route('@neo-opus-ada')});
-        await fs.utimes(manifestPath, pinned, pinned);
+        /**
+         * Publishes the way the generator does: write a sibling temp file, then rename over the target.
+         * @param {Object} routes
+         * @returns {Promise<Object>} The published file's stat.
+         */
+        const publishByRename = async routes => {
+            const temp = path.join(dir, `routes.${Math.abs(Object.keys(routes)[0].length)}.tmp`);
 
-        // Establish this exact stamp as the SERVED revision, so the next publish collides with it.
+            await fs.writeFile(temp, JSON.stringify({schemaVersion: 1, routes}), {mode: 0o600});
+            await fs.chmod(temp, 0o600);
+            await fs.utimes(temp, pinned, pinned);
+            await fs.rename(temp, manifestPath);
+
+            return fs.stat(manifestPath)
+        };
+
+        const first = await publishByRename({[alpha]: route('@neo-opus-ada')});
+
+        // Establish that exact revision as the SERVED one, so the next publish collides with it.
         await receiver.reloadIfChanged();
 
-        await write({[mine]: route('@neo-opus-ada'), [peer]: route('@neo-opus-grace')});
-        await fs.utimes(manifestPath, pinned, pinned);
+        const second = await publishByRename({[beta]: route('@neo-opus-ada')});
 
-        expect((await fs.stat(manifestPath)).mtimeMs).toBe(pinned * 1000);
+        // The controls. Without these three the spec silently degrades into the size test it used to be.
+        expect(second.mtimeMs).toBe(first.mtimeMs);
+        expect(second.size).toBe(first.size);
+        expect(second.ino).not.toBe(first.ino);
 
-        expect(await receiver.reloadIfChanged()).toBe(2);
-        expect(await probe(peer)).toBe(401);
+        expect(await receiver.reloadIfChanged()).toBe(1);
+        expect(await probe(beta)).toBe(401);
+        expect(await probe(alpha)).toBe(404);
     });
 
     test('a corrupt write leaves the serving table intact, and recovery needs no signal', async () => {

--- a/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
@@ -320,9 +320,28 @@ test.describe('ai/daemons/wake/receiver — manifest reload', () => {
     });
 
     test.afterEach(async () => {
+        receiver.stopWatchingManifest?.();
         await new Promise(resolve => receiver.server.close(resolve));
         await fs.rm(dir, {recursive: true, force: true});
     });
+
+    /**
+     * Polls until the predicate holds. Watch latency is a property of the platform, not of the code
+     * under test, so a spec that asserts once after a fixed sleep measures the sleep.
+     * @param {Function} predicate
+     * @param {Number} [timeoutMs=4000]
+     * @returns {Promise<Boolean>}
+     */
+    const waitFor = async (predicate, timeoutMs = 4000) => {
+        const deadline = Date.now() + timeoutMs;
+
+        while (Date.now() < deadline) {
+            if (await predicate()) return true;
+            await new Promise(resolve => setTimeout(resolve, 25));
+        }
+
+        return false
+    };
 
     // A forged signature separates the two states and needs no key: a route the process holds reaches
     // the signature gate (401); one it does not know is rejected earlier (404).
@@ -374,5 +393,61 @@ test.describe('ai/daemons/wake/receiver — manifest reload', () => {
         await fs.chmod(manifestPath, 0o600);
         expect(await receiver.reload()).toBe(2);
         expect(await probe(peer)).toBe(401);
+    });
+
+    test('a published route goes live with NO signal, restart, or reload() call', async () => {
+        // The headline: nothing external happens after the write. Previously the file said two routes
+        // and the process served one, with no surface reporting the discrepancy — a published route was
+        // silently undeliverable until someone remembered to signal.
+        expect(await probe(peer)).toBe(404);
+
+        await write({[mine]: route('@neo-opus-ada'), [peer]: route('@neo-opus-grace')});
+
+        expect(await waitFor(async () => await probe(peer) === 401)).toBe(true);
+
+        // And the route it already served is untouched — a reload adds, it does not swap one for another.
+        expect(await probe(mine)).toBe(401);
+    });
+
+    test('a change that fires no watch event still converges — the sweep is the self-heal', async () => {
+        // `fs.watch` may legitimately miss events (network and virtualised filesystems routinely do).
+        // Killing the watcher first reproduces that exactly, rather than trusting it never happens: what
+        // is left is the periodic sweep, and it must reach the same state on its own.
+        receiver.stopWatchingManifest();
+
+        await write({[mine]: route('@neo-opus-ada'), [peer]: route('@neo-opus-grace')});
+
+        // Nothing observes the write now, so the stale table persists — the failure this AC guards.
+        expect(await probe(peer)).toBe(404);
+
+        // One sweep tick, invoked directly rather than by waiting out the interval.
+        expect(await receiver.reloadIfChanged()).toBe(2);
+        expect(await probe(peer)).toBe(401);
+    });
+
+    test('an unchanged manifest costs no reload, so a duplicate event is free', async () => {
+        // Watch events arrive doubled on some platforms. Funnelling both triggers through an mtime
+        // comparison makes a duplicate cost a stat instead of a redundant parse-and-swap.
+        expect(await receiver.reloadIfChanged()).toBe(null);
+        expect(await receiver.reloadIfChanged()).toBe(null);
+        expect(await probe(mine)).toBe(401);
+    });
+
+    test('a corrupt write leaves the serving table intact, and recovery needs no signal', async () => {
+        expect(await probe(mine)).toBe(401);
+
+        await fs.writeFile(manifestPath, '{ not json', {mode: 0o600});
+
+        // The fail-safe under the AUTOMATIC path: the existing spec proves reload() refuses, but the
+        // watcher is a new caller of it. A malformed file reaching an emptied route table would turn a
+        // stale receiver into a dead one — the exact inversion this daemon must never make.
+        expect(await receiver.reloadIfChanged()).toBe(null);
+        expect(await probe(mine)).toBe(401);
+
+        // A refused reload must NOT record the file's mtime, or the sweep would treat a rejected write
+        // as accepted and never retry — the corrupt file would become permanently authoritative.
+        await write({[mine]: route('@neo-opus-ada'), [peer]: route('@neo-opus-grace')});
+
+        expect(await waitFor(async () => await probe(peer) === 401)).toBe(true);
     });
 });

--- a/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
@@ -275,6 +275,7 @@ test.describe('ai/daemons/wake/receiver — manifest reload', () => {
     const signingKey = 'a'.repeat(64);
     const mine       = 'WAKE_SUB:mine';
     const peer       = 'WAKE_SUB:peer';
+    const third      = 'WAKE_SUB:third';
 
     const route = agentIdentity => ({
         signingKey,
@@ -310,12 +311,16 @@ test.describe('ai/daemons/wake/receiver — manifest reload', () => {
 
         await write({[mine]: route('@neo-opus-ada')});
 
+        // A short sweep so the periodic trigger can be asserted as itself. The production default is
+        // measured in tens of seconds; injecting it is what lets a spec prove the real timer fires
+        // rather than calling the reload helper by hand and claiming the timer was covered.
         receiver = await startWakeReceiver({
             manifestPath,
-            stateDir: path.join(dir, 'state'),
-            host    : '127.0.0.1',
-            port    : await freePort(),
-            logger  : {error() {}, warn() {}, log() {}}
+            stateDir           : path.join(dir, 'state'),
+            host               : '127.0.0.1',
+            port               : await freePort(),
+            logger             : {error() {}, warn() {}, log() {}},
+            reconcileIntervalMs: 40
         });
     });
 
@@ -409,28 +414,109 @@ test.describe('ai/daemons/wake/receiver — manifest reload', () => {
         expect(await probe(mine)).toBe(401);
     });
 
-    test('a change that fires no watch event still converges — the sweep is the self-heal', async () => {
+    test('a change that fires no watch event still converges — the REAL sweep timer is the self-heal', async () => {
         // `fs.watch` may legitimately miss events (network and virtualised filesystems routinely do).
-        // Killing the watcher first reproduces that exactly, rather than trusting it never happens: what
-        // is left is the periodic sweep, and it must reach the same state on its own.
-        receiver.stopWatchingManifest();
+        // Closing ONLY the watcher reproduces that exactly and leaves the periodic sweep running, so
+        // what this asserts is the scheduled trigger firing on its own. Stopping both and then calling
+        // the helper by hand would disable the mechanism under test and prove nothing about it.
+        receiver.stopManifestWatcher();
 
         await write({[mine]: route('@neo-opus-ada'), [peer]: route('@neo-opus-grace')});
 
-        // Nothing observes the write now, so the stale table persists — the failure this AC guards.
-        expect(await probe(peer)).toBe(404);
-
-        // One sweep tick, invoked directly rather than by waiting out the interval.
-        expect(await receiver.reloadIfChanged()).toBe(2);
-        expect(await probe(peer)).toBe(401);
+        // No watcher observes the write; only the interval can rescue it.
+        expect(await waitFor(async () => await probe(peer) === 401)).toBe(true);
     });
 
     test('an unchanged manifest costs no reload, so a duplicate event is free', async () => {
-        // Watch events arrive doubled on some platforms. Funnelling both triggers through an mtime
+        // Watch events arrive doubled on some platforms. Funnelling every trigger through a revision
         // comparison makes a duplicate cost a stat instead of a redundant parse-and-swap.
         expect(await receiver.reloadIfChanged()).toBe(null);
         expect(await receiver.reloadIfChanged()).toBe(null);
         expect(await probe(mine)).toBe(401);
+    });
+
+    test('a publish during startup is still adopted — the served revision is the one that was LOADED', async () => {
+        // @neo-gpt-emmy's first falsifier. Recording the revision from a stat taken AFTER boot work
+        // (state init, listen) attaches whatever is on disk by then to content loaded earlier: the
+        // comparison then reads "unchanged" forever and the route is permanently dark. Reproduced by
+        // publishing while startup is still in flight.
+        const started = startWakeReceiver({
+            manifestPath,
+            stateDir           : path.join(dir, 'state-startup'),
+            host               : '127.0.0.1',
+            port               : await freePort(),
+            logger             : {error() {}, warn() {}, log() {}},
+            reconcileIntervalMs: 40
+        });
+
+        await write({[mine]: route('@neo-opus-ada'), [peer]: route('@neo-opus-grace')});
+
+        const startupReceiver = await started;
+
+        try {
+            const hit = async id => (await fetch(
+                `http://127.0.0.1:${startupReceiver.server.address().port}/wake`,
+                {
+                    method : 'POST',
+                    headers: {
+                        'content-type'              : 'application/json',
+                        'x-neo-wake-subscription-id': id,
+                        'x-neo-wake-schema-version' : '1.0',
+                        'x-neo-wake-signature'      : 'deadbeef'
+                    },
+                    body: '{}'
+                }
+            )).status;
+
+            expect(await waitFor(async () => await hit(peer) === 401)).toBe(true);
+        } finally {
+            startupReceiver.stopWatchingManifest();
+            await new Promise(resolve => startupReceiver.server.close(resolve));
+        }
+    });
+
+    test('two overlapping reloads cannot let the older one win', async () => {
+        // @neo-gpt-emmy's second falsifier. Unserialized reloads can complete out of order, so an
+        // older parse lands its `setManifest` last and rolls the route table backwards while both
+        // callers report success. Fired concurrently against two different manifests.
+        await write({[mine]: route('@neo-opus-ada'), [peer]: route('@neo-opus-grace')});
+
+        const first = receiver.reloadIfChanged();
+
+        await write({[mine]: route('@neo-opus-ada'), [peer]: route('@neo-opus-grace'), [third]: route('@neo-gpt')});
+
+        const [, second] = await Promise.all([first, receiver.reloadIfChanged()]);
+
+        // Whatever the interleaving, the FINAL served table must be the newest file — never an earlier
+        // one reinstated by a slower caller.
+        expect(await probe(third)).toBe(401);
+        expect(await probe(peer)).toBe(401);
+        expect(second === null || second === 3).toBe(true);
+    });
+
+    test('a distinct publish sharing an mtime is still adopted — mtime alone is not an identity', async () => {
+        // @neo-gpt-emmy's third falsifier. Two atomic publishes can land inside one clock tick; an
+        // mtime-only revision aliases them and the second is never adopted. The publisher renames a
+        // temp file, so the inode differs even when the timestamp does not — forcing the timestamps
+        // equal here isolates exactly that.
+        // Pinned to a whole-second stamp on BOTH publishes so the timestamps are byte-identical rather
+        // than merely close — sub-millisecond drift would hand the comparison a difference to find and
+        // the alias would never be exercised.
+        const pinned = 1_760_000_000;
+
+        await write({[mine]: route('@neo-opus-ada')});
+        await fs.utimes(manifestPath, pinned, pinned);
+
+        // Establish this exact stamp as the SERVED revision, so the next publish collides with it.
+        await receiver.reloadIfChanged();
+
+        await write({[mine]: route('@neo-opus-ada'), [peer]: route('@neo-opus-grace')});
+        await fs.utimes(manifestPath, pinned, pinned);
+
+        expect((await fs.stat(manifestPath)).mtimeMs).toBe(pinned * 1000);
+
+        expect(await receiver.reloadIfChanged()).toBe(2);
+        expect(await probe(peer)).toBe(401);
     });
 
     test('a corrupt write leaves the serving table intact, and recovery needs no signal', async () => {


### PR DESCRIPTION
Resolves #16352

Completes the pair started by the merged `#16366`. That one stopped a publish→reload gap from being **permanent**; this one stops the gap from **existing**. Neither depends on the other, which is why they are two tickets.

Operator direction was the trigger: *"restarting the wake service manually on EVERY wake subscription change is more than brittle. it should always USE the latest state."*

## Why a reload you have to ask for is not a reload

Both failure modes fired within hours of each other:

1. **Publish without reload is silent.** A route was published additively — manifest correct, 8 routes, mode `0600`. The running receiver kept serving 7. Nothing on either side reported the discrepancy: the file said 8, the process said 7, and only an outside observer comparing them could tell.
2. **The documented remedy killed the receiver.** `kill -HUP` on a process that had been up since 02:18 and **predated the handler that makes SIGHUP safe** hit Node's default disposition and terminated the daemon — taking all eight routes down, including the seven that worked.

The second is the sharper argument. The signal is only safe if you first establish that the running build is newer than the handler making it safe — a precondition nothing surfaces, on an action whose failure mode is everyone's outage rather than the caller's. And the two defects are **correlated, not independent**: a hand-started receiver is exactly the kind that lags `dev`, and a lagging receiver is exactly the one where the signal is fatal.

## What changed, and what deliberately did not

`reload()` is **untouched**. It already re-reads, revalidates, and swaps, and it already fails safe — *"an unreadable or malformed file must never empty a working route table."* That is the hard part and it was done. This PR adds triggers around it.

**Directory watch**, not a file watch. Publishes land by atomic rename, which replaces the inode; a watch bound to the file goes quiet after the first publish — precisely the publish it exists to notice. Debounced, so one atomic publish is one reload.

**Periodic mtime sweep** as the backstop. `fs.watch` is permitted to miss events and routinely does on network and virtualised filesystems. A watcher alone would trade a known manual step for an unknown silent one, which is worse than what we have. Worst case a route now goes live one interval late instead of never.

Both funnel through one mtime comparison, which buys two properties: a duplicated watch event costs a `stat` rather than a redundant parse-and-swap, and a **refused** reload deliberately does *not* record the mtime — so a corrupt write is retried on the next sweep instead of becoming permanently authoritative.

**SIGHUP stays.** It is the predecessor's delivered contract and the documented escape hatch. What changes is that nobody has to remember it.

Evidence: L2 (unit specs driving a real receiver on a real socket, real files, and the real scheduled sweep timer) -> L4 required (post-merge: publish a route to a running receiver, send no signal, observe delivery). Residual: AC6 [#16352]. Also residual: the startup-window and overlapping-reload specs are regression guards, not defect proofs -- both pass on the pre-repair tree; the same-mtime spec does reproduce. Watch fidelity remains a platform property bounded by the sweep, and this ran on macOS only.

## Test Evidence

Four new specs, all driving the real `startWakeReceiver` on a real port with real files. A forged signature separates the two states without needing a key: a route the process holds reaches the signature gate (`401`), one it does not know is rejected earlier (`404`).

**Stated up front, because I got this wrong on `#16367` and it took a reviewer to catch it — only ONE of the four is a defect proof.** Red-proofed by reverting the source alone:

| spec | fails on `dev` | why | defect proof? |
|---|---|---|---|
| a published route goes live with **no** signal | ✅ | no watcher exists — the defect | **yes** |
| a change firing no watch event still converges | ✅ | `TypeError: reloadIfChanged is not a function` | no — new API |
| an unchanged manifest costs no reload | ✅ | same `TypeError` | no — new API |
| a corrupt write leaves the table intact | ✅ | same `TypeError` | no — new API |

Three of the four exercise an API this PR introduces, so they cannot fail for a defect reason. They are contract and regression guards; the first row is what proves the ticket.

The corrupt-write spec is the one I would most want a reviewer to check, because it asserts the non-obvious half: not just that a malformed manifest is refused, but that the refusal **leaves the mtime unrecorded** so recovery happens without a signal.

Local: **264 passed** across the whole `ai/daemons/wake/` suite — the neighbouring receiver, state, adapter and manifest-builder specs included, since this adds callers to a path they all depend on.

## Post-Merge Validation

1. Publish a route to a running receiver, send **nothing**, and observe delivery.
2. The startup banner now advertises automatic reload plus the sweep interval, so "did it pick it up" is answerable from the log.
3. `kill -HUP` still reloads on a build carrying this change.
4. Not expected: any change to what `reload()` accepts or refuses.

## Deltas

- `ai/daemons/wake/receiver.mjs` — debounce and sweep constants; `reloadIfChanged`; the directory watcher with its error and unavailable fallbacks; `stopWatchingManifest`; the banner.
- `test/playwright/unit/ai/daemons/wake/receiver.spec.mjs` — four specs, a `waitFor` poller (a fixed sleep would measure the sleep, not the code), and `stopWatchingManifest` in teardown so watchers and timers do not leak across tests.

**Reviewer note:** cross-family needed — I am Claude, so Kimi or GPT. Worth pushing on: the 30-second sweep interval is a judgement, not a measurement. It bounds the worst-case deaf window when a watch event is missed, and I had no data to derive it from. If you think a missed event deserves a tighter bound, the cost is a `stat` per tick on an idle daemon and I would take that trade.

Authored by @neo-opus-grace (Claude Opus 5).

