### PR TITLE
feat(workstation): promote scene seven to the screenplay core (#16376)

### DIFF
--- a/apps/workstation/tour/fiveBeatFilm.mjs
+++ b/apps/workstation/tour/fiveBeatFilm.mjs
@@ -11,11 +11,10 @@
  *   are the working screenplay, and the final voice track re-times to the footage.
  *
  * Pacing: `targetSeconds` per scene is a budget, not a stopwatch — captured gestures own their
- * real duration and the cut re-paces around them. The non-conditional scenes sum to exactly 90s —
- * the envelope's `minSeconds` floor with ZERO slack, so a future core-scene budget cut must either
- * trade seconds between scenes or move the floor. The conditional scene lifts the total to 106s,
- * and captured gesture durations plus the edit-layer cut-in re-pace upward from there, inside the
- * 90–150s envelope.
+ * real duration and the cut re-paces around them. The scenes sum to exactly 106s inside the
+ * 90–150s envelope: the `minSeconds` floor no longer binds scene-for-scene — 16s of slack sit
+ * above it — so a budget edit trades seconds within the 106s sum or cuts toward the floor, and
+ * captured gesture durations plus the edit-layer cut-in re-pace upward from there.
  *
  * Claim discipline (revalidated against the current witnesses at authoring time):
  * - same-instance continuity   → `getPaneIdentity` equality asserts (scenes 3, 6, 8)
@@ -24,6 +23,10 @@
  * - atomic return + self-close → `phaseOrder` `documents-adopted → … → topology-exited` (scene 6)
  * - living-content continuity  → monotonic `feedSequence`, never reset (scenes 1, 8)
  * - preview determinism        → two-take beat-log equality + painted-dwell rect witnesses (scene 2)
+ * - perspective restore        → store-backed capture/list/restore with exact-baseline document
+ *   fidelity                     equality, fail-closed on unknown names (scene 7)
+ * - undo/redo round-trip       → dock-mutation transaction record, undo-to-exact-baseline and
+ *                                redo-re-applied witnesses on both demo surfaces (scene 7)
  * Narration makes NO cross-platform, default-selection, or portability claims, and carries no
  * competitive comparisons — captions inherit the spec's macOS-headed claim boundary.
  *
@@ -41,7 +44,8 @@
 /**
  * The flagship-film screenplay. Scene ids are stable anchors for the cut, the caption
  * renderer, and the take QA checklist; `conditional` scenes activate only when their wiring
- * ships and are skipped by consumers until then.
+ * ships and are skipped by consumers until then. The list currently carries none — the
+ * perspective and transaction wiring has landed, and the arrangements scene is core.
  * @type {Object}
  */
 export const fiveBeatFilmScript = Object.freeze({
@@ -91,7 +95,6 @@ export const fiveBeatFilmScript = Object.freeze({
         id           : 'film-perspectives-undo',
         title        : 'Arrangements are data; operations are transactions',
         targetSeconds: 16,
-        conditional  : 'activates when the workstation perspective + transaction wiring lands',
         narration    : 'Save this arrangement as a perspective. Tear the room apart — one click restores it, same instances, same living content. And every dock operation is a transaction: undo walks it back. Redo replays it.',
         beats        : ['capture perspective', 'disruptive rearrangement', 'restore: topology returns, instances persist', 'undo/redo round-trip on a dock mutation']
     }, {


### PR DESCRIPTION
Resolves #16376

Promotes `film-perspectives-undo` from conditional to core in the flagship screenplay: the `conditional` key is removed (scene id, narration, beats, and its 16s budget untouched), the header's pacing paragraph is restated for the new arithmetic (scenes sum to exactly 106s inside the 90–150s envelope; the 90s floor no longer binds scene-for-scene — 16s of slack sit above it — replacing the now-false zero-slack gating sentence), the scene-list contract records that the list currently carries no conditional scenes, and the claim-discipline block gains the two scene-7 claim→witness rows in behavioral text (store-backed capture/list/restore with exact-baseline document equality and fail-closed unknown-name handling; dock-mutation transaction record with undo-to-exact-baseline and redo-re-applied witnesses on both demo surfaces).

This is the exact activation edit the epic's R3⇄R2 reconciliation pre-declared, gated on the perspective-store merge — that gate opened when the store wiring landed and the R2 matrix's scene-7 cells flipped to provable-at-head.

Evidence: L1 (data + JSDoc prose in the narrative-authority file; no runtime surface exists to exercise) → L1 sufficient (the close-target ACs are text-accuracy and key-removal checks; the scene's BEHAVIORAL claims are witnessed by the already-merged NL specs this edit cites, not by this diff). Residual: none.

## Deltas from ticket

None substantive — the ticket's four prescribed touches shipped verbatim; the claim-row wording adds the fail-closed clause the perspective witness actually asserts, which is a precision gain inside the prescribed row.

## Test Evidence

- Consumer blast radius: `git grep -rn "fiveBeatFilm\|film-perspectives-undo" -- apps test` at head shows the file itself as the only hit — zero code consumers; the edit is narrative-authority data + prose.
- Scene-sum arithmetic: 12+14+14+10+16+14+16+10 = 106, matching the restated header exactly; envelope 90–150 unchanged.
- `npm run agent-preflight -- --change-class capability --commit-subject "feat(workstation): promote scene seven to the screenplay core (#16376)"` — all gates passed (including the ticket-archaeology guard over the touched comments and the parse check on the data file).
- Witness authorities cited by the new claim rows (merged, not part of this diff): the workstation perspective-chain NL spec (green headed + headless + an independent second-host repro receipted on its PR) and the dock-transaction witnesses on both demo surfaces plus the live workstation holder receipt on the R2 matrix.
- Direct spec coverage of this file: `None found` (by design — the screenplay is consumed by future tour/caption consumers; the witness authority for its claims lives in the NL specs named above).

## Post-Merge Validation

- [ ] The #15252 take-gate ledger's 106s-baseline line flips from "adds the store merge" to ACTIVE (ledger refresh comment).
- [ ] The eventual take's QA checklist consumes scene 7 as core (first take after readiness gates clear).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 45e84514-6c80-4239-97db-4551cc690137.
