### PR TITLE
feat(memory-core): count miniSummary failures per branch (#16377)

### DIFF
--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1657,7 +1657,7 @@ class MemoryService extends Base {
             // instead of passing through it. Widening this input requires a private summary tier that
             // the public shapes can withhold; until that exists, prompt + response only.
             const promptText = `Summarize this agent turn in one line, max ${aiConfig.memoryService.miniSummaryMaxChars} characters, no preamble:\nUser: ${prompt ?? ''}\nAgent: ${response ?? ''}`;
-            const result      = await withTimeout(
+            const result     = await withTimeout(
                 model.generateContent(promptText, {
                     timeoutMs     : TIMEOUT_MS,
                     operationLabel: 'miniSummary generation',
@@ -1887,7 +1887,7 @@ class MemoryService extends Base {
     async backfillMiniSummaries({limit, freshReserve, buildMiniSummary, maxRunMs, now = () => Date.now()} = {}) {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite) {
-            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false};
+            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0};
         }
 
         // Fail loud on an unresolved leaf, before touching a single row. A stale operator overlay
@@ -1936,7 +1936,7 @@ class MemoryService extends Base {
         const rows = [...new Set([...scanIds('DESC', reserve), ...scanIds('ASC', drainLimit)])].map(id => ({id}));
 
         if (rows.length === 0) {
-            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false};
+            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0};
         }
 
         let byId;
@@ -1946,10 +1946,22 @@ class MemoryService extends Base {
             byId             = new Map((fetched.ids || []).map((id, index) => [id, fetched.metadatas?.[index] || {}]));
         } catch (error) {
             logger.warn(`[MemoryService] miniSummary backfill deferred the whole batch (content store unreachable, fail-soft): ${error.message}`);
-            return {processed: rows.length, updated: 0, deferred: rows.length, missingContent: 0, exhausted: 0, runBudgetHit: false};
+            // Both branch counters stay 0: the content store was unreachable, so no generation was
+            // attempted. Attributing these rows to either branch would report generation timeouts that
+            // never happened and steer an adaptive consumer toward widening a window that is not the fault.
+            return {processed: rows.length, updated: 0, deferred: rows.length, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0};
         }
 
-        let updated = 0, deferred = 0, missingContent = 0, processed = 0, exhausted = 0, runBudgetHit = false;
+        // `failedInner` / `failedOuter` split the SAME failures the `deferred`/`exhausted` pair already
+        // counts, by the branch they arrived on — because which branch a failure takes is a function of
+        // the generation window, not a fixed property of the code. `generateMiniSummaryTimeoutMs` fires
+        // inside `buildMiniSummary`, whose try/catch swallows it into a falsy return (inner); the outer
+        // `miniSummaryTimeoutMs` wraps `summarize()` from outside, so its rejection escapes to the catch
+        // below (outer). Widening the inner leaf past the outer one moves every failure from one branch
+        // to the other while `deferred` and `exhausted` report an identical shape — so a consumer reading
+        // only those totals goes blind at exactly the window an adaptive controller is actuating toward.
+        let updated     = 0, deferred = 0, missingContent = 0, processed = 0, exhausted = 0, runBudgetHit = false,
+            failedInner = 0, failedOuter = 0;
 
         for (const row of rows) {
             // Bound the run safely under the ProcessSupervisor watchdog: stop starting new rows once
@@ -1990,6 +2002,8 @@ class MemoryService extends Base {
                 );
 
                 if (!miniSummary) {
+                    failedInner++;
+
                     if (this._exhaustMiniSummaryAttempt(row.id)) {
                         exhausted++;
                     } else {
@@ -2010,6 +2024,8 @@ class MemoryService extends Base {
                 // catches its own inner timeout and returns null, so the observed 20s timeout reaches
                 // the falsy branch above. This covers what escapes that catch — a provider throwing
                 // outside the timeout guard, or an injected summarizer — so neither path can loop.
+                failedOuter++;
+
                 if (this._exhaustMiniSummaryAttempt(row.id)) {
                     exhausted++;
                 } else {
@@ -2025,7 +2041,7 @@ class MemoryService extends Base {
         // Completion line so the run ends with a visible tally, not silence (stderr → captured by the supervisor).
         console.error(`[INFO] [MemoryService] miniSummary backfill complete: ${processed}/${rows.length} processed (${updated} updated, ${deferred} deferred, ${missingContent} missing-content, ${exhausted} exhausted)`);
 
-        return {processed, updated, deferred, missingContent, exhausted, runBudgetHit};
+        return {processed, updated, deferred, missingContent, exhausted, runBudgetHit, failedInner, failedOuter};
     }
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -226,7 +226,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
             }
         });
         expect(calls).toEqual(['new prompt']);
-        expect(result).toEqual({processed: 1, updated: 1, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false});
+        expect(result).toEqual({processed: 1, updated: 1, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0});
 
         const row  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('backfill-new');
         const data = JSON.parse(row.data);
@@ -255,11 +255,52 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
                 throw new Error('provider unavailable');
             }
         });
-        expect(result).toEqual({processed: 1, updated: 0, deferred: 1, missingContent: 0, exhausted: 0, runBudgetHit: false});
+        // failedOuter, not failedInner: this fixture THROWS, so it escapes to the sweep's catch — the
+        // same branch the real outer `miniSummaryTimeoutMs` rejection takes. A falsy-returning summarizer
+        // would count as failedInner instead, which is the distinction the split exists to make.
+        expect(result).toEqual({processed: 1, updated: 0, deferred: 1, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 1});
 
         const row  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('backfill-failure');
         const data = JSON.parse(row.data);
         expect(data.properties.miniSummary).toBeUndefined();
+    });
+
+    test('the two failure branches are counted separately, so a branch flip is visible (#16223)', async () => {
+        const ts = Date.now();
+
+        // Two rows, one per branch: a falsy return (what the INNER generateMiniSummaryTimeoutMs produces,
+        // because buildMiniSummary catches its own timeout) and a throw (what the OUTER miniSummaryTimeoutMs
+        // produces, because it wraps summarize() from outside and its rejection escapes).
+        for (const id of ['branch-falsy', 'branch-thrown']) {
+            memStore.set(id, {prompt: `${id} prompt`, response: `${id} response`});
+            GraphService.upsertNode({
+                id, type: 'AGENT_MEMORY', name: `Memory: ${id}`, description: id,
+                semanticVectorId: id,
+                properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'branch-split', timestamp: ts}
+            });
+        }
+
+        // Deliberately order-independent: earlier tests leave their own pending rows in the shared store,
+        // so this cannot assume which rows the sweep selects. Exactly ONE row throws (mine); everything
+        // else returns falsy. That pins the split without pinning the population.
+        const result = await MemoryService.backfillMiniSummaries({
+            limit           : 50,
+            buildMiniSummary: async ({prompt}) => {
+                if (prompt.startsWith('branch-thrown')) {
+                    throw new Error('escaped the inner guard');
+                }
+                return null;
+            }
+        });
+
+        // The totals CANNOT tell these apart — both land in `deferred` — which is exactly why the split
+        // exists. Widening the inner leaf past the outer one moves every failure from one branch to the
+        // other while `deferred` stays put, so a consumer reading only totals sees no change at the moment
+        // the failure mode actually changed.
+        expect(result.updated).toBe(0);
+        expect(result.failedOuter).toBe(1);
+        expect(result.failedInner).toBeGreaterThanOrEqual(1);
+        expect(result.failedInner + result.failedOuter).toBe(result.deferred + result.exhausted);
     });
 
     test('backfillMiniSummaries archives a row once the attempt budget is spent, and tallies it (#16313)', async () => {
@@ -381,7 +422,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         // Positive control: the drain did real work, so the zero below is an emptied set rather than a
         // sweep that never ran.
         expect(drain.processed).toBeGreaterThan(0);
-        expect(zeroRow).toEqual({processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false});
+        expect(zeroRow).toEqual({processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0});
 
         // No-SQLite: the sweep reads `GraphService.db?.storage?.db` once at entry. Swapped rather than
         // mocked so the real guard runs, and restored in a finally so a failure here cannot cascade
@@ -396,7 +437,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
                 buildMiniSummary: async () => 'unused'
             });
 
-            expect(noSqlite).toEqual({processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false});
+            expect(noSqlite).toEqual({processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0});
         } finally {
             GraphService.db = realDb;
         }


### PR DESCRIPTION
Resolves #16377

Related: #16223 (parent — five ACs remain open there)
Related: #14418 (the homeostatic controller whose diagnosis half consumes these counters)

The backfill's two failure paths increment the same counters, so a consumer reading the pass result cannot tell them apart. That matters because **which branch a failure takes is not a property of the code — it is a function of the generation window an adaptive controller moves.**

`generateMiniSummaryTimeoutMs` (20s) fires *inside* `buildMiniSummary`, whose `try/catch` swallows it into a falsy return. `miniSummaryTimeoutMs` (30s) wraps `summarize()` from *outside*, so its rejection escapes to the sweep's `catch`. Both currently land in `deferred`/`exhausted` and are indistinguishable. Widen the inner leaf past the outer one and **every failure moves from one branch to the other while the reported shape stays identical** — a detector reading only those totals goes blind at exactly the window it is actuating toward, and reads "still starved, keep widening" while the failure mode has already changed.

Adds `failedInner` / `failedOuter` alongside the existing totals. No behaviour change; no existing key altered.

Evidence: L2 (unit coverage at exact head; the branch split is deterministic and fully reachable in-sandbox) → L2 required (this PR's assertions are pass-result return values). Residual: none — the consumer that motivates it (`#14418`'s diagnosis half) is not in this diff.

## Deltas from ticket

Scoped deliberately to the **instrumentation only**, and filed as `#16377` rather than closing `#16223`: the parent still carries provider-side cancellation, restore-on-widen, `thought` inclusion, and the loop itself, so `Resolves #16223` would be dishonest. `#16223`'s AC says *"the detector must count a timeout as a timeout on BOTH branches, or it goes blind at exactly the window it is actuating toward"* — the detector itself belongs to `#14418` (the graduated homeostatic controller), and this is the pass-result surface it consumes. Shipping them together would put a controller-side concern in the memory-core subsystem.

One judgement call worth naming: the **content-store-unreachable** early return reports `failedInner: 0, failedOuter: 0` rather than attributing its deferred rows to a branch. No `summarize()` is attempted on that path, so counting those rows as generation failures would report timeouts that never happened and steer an adaptive consumer toward widening a window that is not the fault. The rows still count in `deferred`, unchanged.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/services/memory-core/ --workers=1
  1446 passed (1.6m)
```

Directory-scoped rather than file-scoped: `MemoryService` is imported by `StorageRouterDegraded`, `MemoryService.TenantIsolation`, and others, so the importer specs are the ones that could regress.

New regression test — *"the two failure branches are counted separately, so a branch flip is visible"* — asserts what the totals cannot: `deferred` alone cannot distinguish the two paths, while `failedInner`/`failedOuter` can.

**Order-dependency caught and fixed before push.** The first version pinned an exact population (`limit: 2`, `failedInner: 1`, `failedOuter: 1`). It passed in isolation and **failed in the full file** — earlier specs leave pending rows in the shared store, so the sweep selected theirs. Rewritten to pin the *split* without pinning the *population*: exactly one row throws, everything else returns falsy, so `failedOuter === 1` and `failedInner + failedOuter === deferred + exhausted` hold regardless of what else is pending. Verified 2× green on the full file, then green on the directory.

Four existing `toEqual` exact-shape assertions were updated rather than relaxed to `toMatchObject`. The exactness is what forced this contract change to be acknowledged instead of silently absorbed — weakening it would remove the guard that did its job. One of those updates also corrected my own assumption: the `deferred: 1` fixture **throws**, so it is `failedOuter`, not `failedInner`.

## Post-Merge Validation

- [ ] `#14418`'s diagnosis half consumes `failedInner`/`failedOuter` and can distinguish a branch flip from continued starvation on a live plane.
- [ ] Under a real widening past the outer leaf, the counters show the flip as a step change at the restart boundary (per `#16374`'s durable-override-then-restart apply), not as a drift.

## Commits

- `5e62184bad` — the branch-split counters plus the regression test.

Authored by Vega (Claude Opus 5, Claude Code). Session 1bf32e47-868c-43ce-9e9c-537eeeee5ea1.
