### PR TITLE
feat(draggable): suppress text selection across dock splitter drags (#16362)

### DIFF
--- a/resources/scss/src/Global.scss
+++ b/resources/scss/src/Global.scss
@@ -50,3 +50,11 @@ html, .neo-body-viewport {
 .neo-unselectable {
     user-select: none;
 }
+
+// Gesture-scoped selection guard: applied by the draggable Mouse sensor from mousedown on a
+// drag target until pointer release, so a drag across card content can never become a text
+// selection sweep (the native selection machinery otherwise claims the pre-threshold window).
+.neo-drag-active,
+.neo-drag-active * {
+    user-select: none !important;
+}

--- a/resources/scss/src/Global.scss
+++ b/resources/scss/src/Global.scss
@@ -52,8 +52,10 @@ html, .neo-body-viewport {
 }
 
 // Gesture-scoped selection guard: applied by the draggable Mouse sensor from mousedown on a
-// drag target until pointer release, so a drag across card content can never become a text
-// selection sweep (the native selection machinery otherwise claims the pre-threshold window).
+// drag target until the physical gesture ends — ordinary mouseup, or the gesture's own move
+// stream observing the primary button gone (an off-document release never reaches mouseup) —
+// so a drag across card content can never become a text selection sweep (the native selection
+// machinery otherwise claims the pre-threshold window).
 .neo-drag-active,
 .neo-drag-active * {
     user-select: none !important;

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -112,7 +112,27 @@
 
 .neo-dashboard-dock-splitter {
     flex-shrink: 0;
-    touch-action: none;
+    position     : relative;
+    touch-action : none;
+    z-index      : 2;
+
+    // The visible handle stays `size`-thin while its hit target expands past the rail:
+    // a near-handle miss used to fall through into a text-selection sweep across the
+    // adjacent cards. The pseudo-element is the hit surface only — pointer events on a
+    // ::before resolve to the originating element, so the drag contract is unchanged.
+    &::before {
+        content : '';
+        inset   : 0;
+        position: absolute;
+    }
+
+    &.neo-dashboard-dock-splitter-horizontal::before {
+        margin: 0 -4px;
+    }
+
+    &.neo-dashboard-dock-splitter-vertical::before {
+        margin: -4px 0;
+    }
 }
 
 // Opt-in only: `size` containment requires a host with definite inline and block extents.

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -353,6 +353,10 @@ class DragDrop extends Base {
     resetDragState() {
         let me = this;
 
+        // Defensive release of the sensor-side gesture selection guard (the Mouse sensor owns
+        // the mousedown→mouseup bracket; an off-document pointer release never reaches it).
+        document.body.classList.remove('neo-drag-active');
+
         DragDrop.prototype.promoteWindowDragParkRecovery.call(me);
 
         Object.assign(me, {

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -353,8 +353,11 @@ class DragDrop extends Base {
     resetDragState() {
         let me = this;
 
-        // Defensive release of the sensor-side gesture selection guard (the Mouse sensor owns
-        // the mousedown→mouseup bracket; an off-document pointer release never reaches it).
+        // Idempotent second release site for the sensor-side gesture selection guard — NOT an
+        // off-document-release fallback: resetDragState() is only reached downstream of the
+        // sensor's own `drag:end`. The Mouse sensor owns the physical mousedown→release bracket,
+        // including lost-release recovery on its own move stream; this line just keeps the two
+        // layers from drifting should that bracket's semantics ever change.
         // Guarded: bare test harnesses may stub `document` without a body/classList.
         document.body?.classList?.remove('neo-drag-active');
 

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -355,7 +355,8 @@ class DragDrop extends Base {
 
         // Defensive release of the sensor-side gesture selection guard (the Mouse sensor owns
         // the mousedown→mouseup bracket; an off-document pointer release never reaches it).
-        document.body.classList.remove('neo-drag-active');
+        // Guarded: bare test harnesses may stub `document` without a body/classList.
+        document.body?.classList?.remove('neo-drag-active');
 
         DragDrop.prototype.promoteWindowDragParkRecovery.call(me);
 

--- a/src/main/draggable/sensor/Mouse.mjs
+++ b/src/main/draggable/sensor/Mouse.mjs
@@ -108,6 +108,13 @@ class Mouse extends Base {
                     startEvent    : event
                 });
 
+                // Suppress text selection for the whole gesture from this point: the drag
+                // only officially starts past the delay+distance threshold, and the native
+                // selection machinery claims the pre-threshold window first — which is how a
+                // splitter drag comes to paint card text as a selection. The class releases
+                // in onMouseUp (and defensively in the DragDrop addon's resetDragState).
+                document.body.classList.add('neo-drag-active');
+
                 document.addEventListener('dragstart', preventDefault);
                 document.addEventListener('mousemove', me.onDistanceChange);
                 document.addEventListener('mouseup',   me.onMouseUp);
@@ -149,6 +156,8 @@ class Mouse extends Base {
             let me = this;
 
             clearTimeout(me.mouseDownTimeout);
+
+            document.body.classList.remove('neo-drag-active');
 
             document.removeEventListener('dragstart', preventDefault);
             document.removeEventListener('mousemove', me.onDistanceChange);

--- a/src/main/draggable/sensor/Mouse.mjs
+++ b/src/main/draggable/sensor/Mouse.mjs
@@ -72,6 +72,15 @@ class Mouse extends Base {
         let me = this;
 
         if (me.currentElement) {
+            // Lost-release recovery: the gesture's own move stream observes the primary button
+            // gone, so its mouseup happened off-document — terminate as the release never
+            // received. The delay-timeout re-entry passes a plain coords object with no
+            // `buttons` to inspect, so it skips this check by construction.
+            if (event.buttons !== undefined && (event.buttons & 1) === 0) {
+                me.endGesture(event);
+                return
+            }
+
             const {pageX, pageY}    = event,
                   timeElapsed       = Date.now() - me.mouseDownTime,
                   distanceTravelled = DomEvents.getDistance(me.startEvent.pageX, me.startEvent.pageY, pageX, pageY) || 0;
@@ -108,11 +117,14 @@ class Mouse extends Base {
                     startEvent    : event
                 });
 
-                // Suppress text selection for the whole gesture from this point: the drag
-                // only officially starts past the delay+distance threshold, and the native
+                // Suppress text selection for the whole physical gesture from this point: the
+                // drag only officially starts past the delay+distance threshold, and the native
                 // selection machinery claims the pre-threshold window first — which is how a
-                // splitter drag comes to paint card text as a selection. The class releases
-                // in onMouseUp (and defensively in the DragDrop addon's resetDragState).
+                // splitter drag comes to paint card text as a selection. The class brackets the
+                // PHYSICAL gesture, not the logical drag: Escape retires drag semantics, but the
+                // button is still down, so suppression must hold until release. Released in
+                // endGesture — on mouseup, or on the gesture's own move stream observing the
+                // primary button gone (an off-document release never reaches onMouseUp).
                 // Guarded: bare test harnesses may stub `document` without a body/classList.
                 document.body?.classList?.add('neo-drag-active');
 
@@ -133,6 +145,12 @@ class Mouse extends Base {
     onMouseMove(event) {
         let me = this;
 
+        // Same lost-release recovery for an engaged drag (see onDistanceChange).
+        if (event.buttons !== undefined && (event.buttons & 1) === 0) {
+            me.endGesture(event);
+            return
+        }
+
         if (me.dragging) {
             let element = me.currentElement,
                 target  = document.elementFromPoint(event.clientX, event.clientY);
@@ -150,45 +168,58 @@ class Mouse extends Base {
     }
 
     /**
+     * Tears the physical gesture bracket down: releases the document-level selection guard,
+     * detaches every gesture listener and, for an engaged drag, emits `drag:end` at the event's
+     * position. Called by `onMouseUp` for an ordinary release and by the move handlers when the
+     * primary button is observed gone — a release that happened off-document never reaches
+     * `onMouseUp`, so the gesture's own move stream is the independent terminal witness.
+     * @param {MouseEvent} event
+     * @protected
+     */
+    endGesture(event) {
+        let me = this;
+
+        clearTimeout(me.mouseDownTimeout);
+
+        document.body?.classList?.remove('neo-drag-active');
+
+        document.removeEventListener('dragstart', preventDefault);
+        document.removeEventListener('mousemove', me.onDistanceChange);
+        document.removeEventListener('mouseup',   me.onMouseUp);
+
+        if (me.dragging) {
+            let element = me.currentElement,
+                target  = document.elementFromPoint(event.clientX, event.clientY);
+
+            me.trigger(element, {
+                clientX      : event.clientX,
+                clientY      : event.clientY,
+                element,
+                originalEvent: event,
+                path         : me.startEvent.path || me.startEvent.composedPath(),
+                target,
+                type         : 'drag:end'
+            });
+
+            document.removeEventListener('contextmenu', preventDefault, true);
+            document.removeEventListener('mousemove',   me.onMouseMove);
+
+            Object.assign(me, {
+                currentElement: null,
+                dragging      : false,
+                startEvent    : null
+            })
+        }
+
+        me.dragging = false
+    }
+
+    /**
      * @param {MouseEvent} event
      */
     onMouseUp(event) {
         if (event.button === 0) {
-            let me = this;
-
-            clearTimeout(me.mouseDownTimeout);
-
-            document.body?.classList?.remove('neo-drag-active');
-
-            document.removeEventListener('dragstart', preventDefault);
-            document.removeEventListener('mousemove', me.onDistanceChange);
-            document.removeEventListener('mouseup',   me.onMouseUp);
-
-            if (me.dragging) {
-                let element = me.currentElement,
-                    target  = document.elementFromPoint(event.clientX, event.clientY);
-
-                me.trigger(element, {
-                    clientX      : event.clientX,
-                    clientY      : event.clientY,
-                    element,
-                    originalEvent: event,
-                    path         : me.startEvent.path || me.startEvent.composedPath(),
-                    target,
-                    type         : 'drag:end'
-                });
-
-                document.removeEventListener('contextmenu', preventDefault, true);
-                document.removeEventListener('mousemove',   me.onMouseMove);
-
-                Object.assign(me, {
-                    currentElement: null,
-                    dragging      : false,
-                    startEvent    : null
-                })
-            }
-
-            me.dragging = false
+            this.endGesture(event)
         }
     }
 

--- a/src/main/draggable/sensor/Mouse.mjs
+++ b/src/main/draggable/sensor/Mouse.mjs
@@ -113,7 +113,8 @@ class Mouse extends Base {
                 // selection machinery claims the pre-threshold window first — which is how a
                 // splitter drag comes to paint card text as a selection. The class releases
                 // in onMouseUp (and defensively in the DragDrop addon's resetDragState).
-                document.body.classList.add('neo-drag-active');
+                // Guarded: bare test harnesses may stub `document` without a body/classList.
+                document.body?.classList?.add('neo-drag-active');
 
                 document.addEventListener('dragstart', preventDefault);
                 document.addEventListener('mousemove', me.onDistanceChange);
@@ -157,7 +158,7 @@ class Mouse extends Base {
 
             clearTimeout(me.mouseDownTimeout);
 
-            document.body.classList.remove('neo-drag-active');
+            document.body?.classList?.remove('neo-drag-active');
 
             document.removeEventListener('dragstart', preventDefault);
             document.removeEventListener('mousemove', me.onDistanceChange);

--- a/test/playwright/e2e/workstation/WorkstationDragTextSelectionNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragTextSelectionNL.spec.mjs
@@ -1,15 +1,25 @@
 import {test, expect} from '../../fixtures.mjs';
 
 /**
- * @summary Whitebox E2E witness for text-selection suppression during dock splitter drags.
+ * @summary Whitebox E2E witness for text-selection suppression across dock splitter drags.
  *
  * A splitter drag is a mousedown + move gesture that crosses card content. Without a
  * gesture-scoped selection guard, the native selection machinery claims the pre-threshold
  * window before the drag officially starts — a near-handle miss or a fast sweep paints card
  * text as a selection. The guard under test: the draggable Mouse sensor applies a
- * document-level drag-active class from mousedown on a drag target until pointer release
- * (with a defensive release in the DragDrop addon's reset), and the dock splitter's hit
- * target expands past its thin visual rail so near-handle starts become drags, not sweeps.
+ * document-level drag-active class from mousedown on a drag target until the PHYSICAL gesture
+ * ends, and the dock splitter's hit target expands past its thin visual rail so near-handle
+ * starts become drags, not sweeps.
+ *
+ * Terminal contract (code/prose/test must agree):
+ * - Ordinary release: mouseup retires the class.
+ * - Escape-cancel retires the LOGICAL drag, but the physical bracket still owns suppression
+ *   while the button is down — releasing earlier would re-open the sweep window mid-gesture.
+ * - Lost release: a release off-document never reaches mouseup, so the gesture's own move
+ *   stream is the independent terminal witness — the first move reporting the primary button
+ *   gone terminates the gesture exactly as that release would have.
+ * The DragDrop addon's resetDragState() is an idempotent second release site reached only
+ * downstream of `drag:end`, never an off-document fallback.
  *
  * CDP page.mouse is REQUIRED for this witness: the app-side synthetic event path does not
  * create text selections at all (measured), so only the trusted-input path exercises the class.
@@ -23,48 +33,35 @@ test.describe('Workstation — text selection is suppressed during splitter drag
         viewport      : {height: 900, width: 1440}
     });
 
-    test('a splitter drag suppresses text selection mid-gesture and releases it fully afterward', async ({page, neuralLink}) => {
-        await page.goto('/apps/workstation/index.html');
-        await page.waitForSelector('.workstation-dock-host', {timeout: 30000});
-
-        const app            = await neuralLink.connectToApp('Workstation'),
-              windowId       = await page.evaluate(() => Neo.worker.Manager.windowId),
-              splitterResult = await app.queryVdom({cls: 'neo-dashboard-dock-splitter-horizontal'}),
+    async function getSplitterCenter(app) {
+        const splitterResult = await app.queryVdom({cls: 'neo-dashboard-dock-splitter-horizontal'}),
               splitterNode   = Array.isArray(splitterResult) ? splitterResult[0] : (splitterResult?.vdom ?? splitterResult),
-              splitterDomId  = splitterNode?.id,
-              [rect]         = await app.getDomRect(splitterDomId),
-              cx             = rect.x + rect.width / 2,
-              cy             = rect.y + rect.height / 2;
+              splitterDomId  = splitterNode?.id;
 
         expect(splitterDomId, 'the horizontal splitter must exist in the vdom').toBeTruthy();
 
-        // drag across the card surface: down on the splitter, sweep right over the heavy-tabs
-        // cards. CDP page.mouse is REQUIRED here — the app-side synthetic event path does not
-        // create text selections at all (measured: selection stays empty even without the fix),
-        // so only the trusted-input path can witness this defect class.
-        await page.mouse.move(cx, cy);
-        await page.mouse.down();
-        await page.mouse.move(cx + 40, cy, {steps: 4});
-        await page.mouse.move(cx + 120, cy + 30, {steps: 6});
+        const [rect] = await app.getDomRect(splitterDomId);
 
-        const midGesture = await page.evaluate(() => ({
+        return {cx: rect.x + rect.width / 2, cy: rect.y + rect.height / 2}
+    }
+
+    async function readGestureState(page) {
+        return page.evaluate(() => ({
             dragActiveCls: document.body.classList.contains('neo-drag-active'),
             selection    : document.getSelection().toString()
-        }));
+        }))
+    }
 
-        console.log('[selection-diag] mid-gesture state:', JSON.stringify(midGesture));
+    async function expectGuarded(page, phase) {
+        const state = await readGestureState(page);
 
-        expect(
-            midGesture.dragActiveCls,
-            'mid-gesture: the document must carry the drag-active suppression class'
-        ).toBe(true);
-        expect(
-            midGesture.selection,
-            'mid-gesture: a drag across card text must leave NO text selection'
-        ).toBe('');
+        console.log(`[selection-diag] ${phase}:`, JSON.stringify(state));
 
-        await page.mouse.up();
+        expect(state.dragActiveCls, `${phase}: the document must carry the drag-active suppression class`).toBe(true);
+        expect(state.selection,     `${phase}: a drag across card text must leave NO text selection`).toBe('')
+    }
 
+    async function assertSelectionRestored(page) {
         // Semantic settlement before the release control: the projection/FLIP lifecycle must
         // retire first — its transient state carries its own select guard, so "selection works
         // again" is only meaningful once the gesture's visual machinery has fully stood down.
@@ -110,8 +107,122 @@ test.describe('Workstation — text selection is suppressed during splitter drag
 
         console.log('[selection-diag] post-release state:', JSON.stringify(postRelease));
 
-        expect(postRelease.released, 'post-release: the suppression class must be removed').toBe(true);
+        expect(postRelease.released,   'post-release: the suppression class must be removed').toBe(true);
         expect(postRelease.selectable, 'post-release: ordinary text selection must work again').toBe(true)
+    }
+
+    test('a splitter drag suppresses text selection mid-gesture and releases it fully afterward', async ({page, neuralLink}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 30000});
+
+        const app      = await neuralLink.connectToApp('Workstation'),
+              {cx, cy} = await getSplitterCenter(app);
+
+        // Interference canary: in a headed run the virtual gesture shares the window with the
+        // physical input stack — a real OS-level move (buttons=0) interleaving with the virtual
+        // button-held gesture is a genuine lost-release terminal by design. The log makes any
+        // such environmental interference self-diagnosing instead of a mystery flake.
+        await page.evaluate(() => {
+            globalThis.__mmLog = [];
+            ['mousedown', 'mousemove', 'mouseup'].forEach(t =>
+                document.addEventListener(t, e => globalThis.__mmLog.push(`${t}:${e.buttons}`), true))
+        });
+
+        // drag across the card surface: down on the splitter, sweep right over the heavy-tabs
+        // cards. CDP page.mouse is REQUIRED here — the app-side synthetic event path does not
+        // create text selections at all (measured: selection stays empty even without the fix),
+        // so only the trusted-input path can witness this defect class.
+        await page.mouse.move(cx, cy);
+        await page.mouse.down();
+        await page.mouse.move(cx + 40, cy, {steps: 4});
+        await page.mouse.move(cx + 120, cy + 30, {steps: 6});
+
+        console.log('[selection-diag] event log:', JSON.stringify(await page.evaluate(() => globalThis.__mmLog)));
+
+        await expectGuarded(page, 'mid-gesture');
+
+        await page.mouse.up();
+
+        await assertSelectionRestored(page)
     })
 
+    test('Escape-cancel retires the logical drag while the physical bracket keeps suppression until release', async ({page, neuralLink}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 30000});
+
+        const app      = await neuralLink.connectToApp('Workstation'),
+              {cx, cy} = await getSplitterCenter(app);
+
+        await page.mouse.move(cx, cy);
+        await page.mouse.down();
+        await page.mouse.move(cx + 40, cy, {steps: 4});
+        await page.mouse.move(cx + 120, cy + 30, {steps: 6});
+
+        // The logical drag must be ENGAGED before Escape, or the gesture owner has no zone to cancel.
+        await expect.poll(
+            async () => page.evaluate(() => Neo.main.addon.DragDrop?.dragZoneId ?? null),
+            {message: 'the drag must be engaged (dragZoneId assigned) before the Escape terminal', timeout: 5000, intervals: [50]}
+        ).not.toBe(null);
+
+        await expectGuarded(page, 'mid-gesture');
+
+        await page.keyboard.press('Escape');
+
+        await expect.poll(
+            async () => page.evaluate(() => Neo.main.addon.DragDrop?.dragCancelled ?? false),
+            {message: 'Escape must mark the logical drag cancelled at the gesture owner', timeout: 5000, intervals: [50]}
+        ).toBe(true);
+
+        // Keep sweeping over card content with the button STILL down: the physical bracket owns
+        // suppression — retiring it at Escape would re-open the selection-sweep window mid-gesture.
+        await page.mouse.move(cx + 180, cy + 50, {steps: 3});
+
+        await expectGuarded(page, 'post-Escape, still holding');
+
+        await page.mouse.up();
+
+        await assertSelectionRestored(page)
+    })
+
+    test('a release lost off-document is recovered by the gesture\'s own move stream', async ({page, neuralLink}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 30000});
+
+        const app      = await neuralLink.connectToApp('Workstation'),
+              {cx, cy} = await getSplitterCenter(app),
+              cdp      = await page.context().newCDPSession(page);
+
+        await page.mouse.move(cx, cy);
+        await page.mouse.down();
+        await page.mouse.move(cx + 40, cy, {steps: 4});
+        await page.mouse.move(cx + 120, cy + 30, {steps: 6});
+
+        await expectGuarded(page, 'mid-gesture');
+
+        // The release happens off-document: no mouseReleased is ever dispatched. The next
+        // observed move reports the primary button gone — the sensor must treat it as the lost
+        // release and retire the guard exactly as that release would have.
+        await cdp.send('Input.dispatchMouseEvent', {
+            button : 'none',
+            buttons: 0,
+            type   : 'mouseMoved',
+            x      : Math.round(cx + 160),
+            y      : Math.round(cy + 40)
+        });
+
+        await expect.poll(
+            async () => page.evaluate(() => document.body.classList.contains('neo-drag-active')),
+            {message: 'the lost release must be recovered on the first observed move', timeout: 5000, intervals: [50]}
+        ).toBe(false);
+
+        // The full owner chain stood down: the addon reset its between-gestures baseline.
+        await expect.poll(
+            async () => page.evaluate(() => Neo.main.addon.DragDrop?.dragZoneId ?? null),
+            {message: 'the gesture owner must reset after the recovered drag:end', timeout: 5000, intervals: [50]}
+        ).toBe(null);
+
+        await cdp.detach();
+
+        await assertSelectionRestored(page)
+    })
 })

--- a/test/playwright/e2e/workstation/WorkstationDragTextSelectionNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDragTextSelectionNL.spec.mjs
@@ -1,0 +1,117 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E witness for text-selection suppression during dock splitter drags.
+ *
+ * A splitter drag is a mousedown + move gesture that crosses card content. Without a
+ * gesture-scoped selection guard, the native selection machinery claims the pre-threshold
+ * window before the drag officially starts — a near-handle miss or a fast sweep paints card
+ * text as a selection. The guard under test: the draggable Mouse sensor applies a
+ * document-level drag-active class from mousedown on a drag target until pointer release
+ * (with a defensive release in the DragDrop addon's reset), and the dock splitter's hit
+ * target expands past its thin visual rail so near-handle starts become drags, not sweeps.
+ *
+ * CDP page.mouse is REQUIRED for this witness: the app-side synthetic event path does not
+ * create text selections at all (measured), so only the trusted-input path exercises the class.
+ *
+ * Run: NEO_E2E_PORT=8117 npx playwright test workstation/WorkstationDragTextSelectionNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed
+ */
+test.describe('Workstation — text selection is suppressed during splitter drags', () => {
+    test.setTimeout(60000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 900, width: 1440}
+    });
+
+    test('a splitter drag suppresses text selection mid-gesture and releases it fully afterward', async ({page, neuralLink}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 30000});
+
+        const app            = await neuralLink.connectToApp('Workstation'),
+              windowId       = await page.evaluate(() => Neo.worker.Manager.windowId),
+              splitterResult = await app.queryVdom({cls: 'neo-dashboard-dock-splitter-horizontal'}),
+              splitterNode   = Array.isArray(splitterResult) ? splitterResult[0] : (splitterResult?.vdom ?? splitterResult),
+              splitterDomId  = splitterNode?.id,
+              [rect]         = await app.getDomRect(splitterDomId),
+              cx             = rect.x + rect.width / 2,
+              cy             = rect.y + rect.height / 2;
+
+        expect(splitterDomId, 'the horizontal splitter must exist in the vdom').toBeTruthy();
+
+        // drag across the card surface: down on the splitter, sweep right over the heavy-tabs
+        // cards. CDP page.mouse is REQUIRED here — the app-side synthetic event path does not
+        // create text selections at all (measured: selection stays empty even without the fix),
+        // so only the trusted-input path can witness this defect class.
+        await page.mouse.move(cx, cy);
+        await page.mouse.down();
+        await page.mouse.move(cx + 40, cy, {steps: 4});
+        await page.mouse.move(cx + 120, cy + 30, {steps: 6});
+
+        const midGesture = await page.evaluate(() => ({
+            dragActiveCls: document.body.classList.contains('neo-drag-active'),
+            selection    : document.getSelection().toString()
+        }));
+
+        console.log('[selection-diag] mid-gesture state:', JSON.stringify(midGesture));
+
+        expect(
+            midGesture.dragActiveCls,
+            'mid-gesture: the document must carry the drag-active suppression class'
+        ).toBe(true);
+        expect(
+            midGesture.selection,
+            'mid-gesture: a drag across card text must leave NO text selection'
+        ).toBe('');
+
+        await page.mouse.up();
+
+        // Semantic settlement before the release control: the projection/FLIP lifecycle must
+        // retire first — its transient state carries its own select guard, so "selection works
+        // again" is only meaningful once the gesture's visual machinery has fully stood down.
+        await expect.poll(
+            async () => page.locator('.neo-dashboard-dock-animating').count(),
+            {message: 'projection animation must settle before the release control', timeout: 8000, intervals: [100]}
+        ).toBe(0);
+        await expect.poll(
+            async () => page.locator('.neo-dock-flip-fixed-stage').count(),
+            {message: 'the FLIP staging frame must be fully retired before the release control', timeout: 8000, intervals: [100]}
+        ).toBe(0);
+
+        const postRelease = await page.evaluate(() => {
+            const released  = !document.body.classList.contains('neo-drag-active'),
+                  selection = document.getSelection();
+
+            selection.selectAllChildren(document.body);
+            const bodySelLen = selection.toString().length;
+
+            selection.removeAllRanges();
+
+            const card = [...document.querySelectorAll('.workstation-resident-card')]
+                .find(element => element.getClientRects().length > 0);
+
+            let cardSelLen = -1, cardUS = 'n/a';
+
+            if (card) {
+                cardUS = globalThis.getComputedStyle(card).userSelect;
+                selection.selectAllChildren(card);
+                cardSelLen = selection.toString().length;
+                selection.removeAllRanges()
+            }
+
+            return {
+                bodyClass : document.body.className,
+                bodySelLen,
+                cardSelLen,
+                cardUS,
+                released,
+                selectable: bodySelLen > 0
+            }
+        });
+
+        console.log('[selection-diag] post-release state:', JSON.stringify(postRelease));
+
+        expect(postRelease.released, 'post-release: the suppression class must be removed').toBe(true);
+        expect(postRelease.selectable, 'post-release: ordinary text selection must work again').toBe(true)
+    })
+
+})

--- a/test/playwright/unit/main/draggable/sensor/Mouse.spec.mjs
+++ b/test/playwright/unit/main/draggable/sensor/Mouse.spec.mjs
@@ -1,0 +1,212 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'MainMouseSensorTest'
+    },
+    mockLocalStorage: false,
+    mockMain        : false,
+    neoConfig       : {
+        unitTestMode: true
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+// The sensor module imports the eager DomEvents main-thread singleton. Install a native listener
+// surface before that dynamic import; EventTarget preserves real add/remove/dispatch semantics
+// while the spec drives trusted-shaped synthetic events through it. Each test gets a FRESH
+// document: attach() registers per-sensor listeners, and a stale surface would let one test's
+// sensor answer another test's mousedown.
+const originalDocument = globalThis.document,
+      originalWindow   = globalThis.window;
+
+let bodyClasses, documentRef;
+
+function installDocument() {
+    bodyClasses = new Set();
+    documentRef = new EventTarget();
+
+    documentRef.body = {
+        classList: {
+            add     : cls => bodyClasses.add(cls),
+            remove  : cls => bodyClasses.delete(cls),
+            contains: cls => bodyClasses.has(cls)
+        }
+    };
+    documentRef.documentElement  = {};
+    documentRef.elementFromPoint = () => null;
+
+    // sensor.Base.trigger() uses the legacy createEvent/initEvent pair: return a real Event
+    // (dispatchEvent demands one) whose read-only `type` is shadowed by an own getter.
+    documentRef.createEvent = () => {
+        let   type  = 'placeholder';
+        const event = new Event(type);
+
+        Object.defineProperty(event, 'type', {configurable: true, get: () => type});
+        event.initEvent = newType => { type = newType };
+
+        return event
+    };
+
+    globalThis.document = documentRef;
+
+    return documentRef
+}
+
+installDocument();
+globalThis.window = new EventTarget();
+
+const {default: Mouse} = await import('../../../../../../src/main/draggable/sensor/Mouse.mjs');
+
+// A drag target the sensor's path-inclusion probe accepts; isConnected: false routes the
+// sensor's custom-event dispatch to the document fallback (Base.trigger).
+const dragNode = {
+    classList  : {contains: cls => cls === 'neo-draggable'},
+    isConnected: false
+};
+
+function createSensor(overrides={}) {
+    const sensor = Object.create(Mouse.prototype);
+
+    Object.assign(sensor, {
+        currentElement   : null,
+        delay            : 0,
+        dragging         : false,
+        dragTargetClasses: ['neo-draggable', 'neo-resizable'],
+        minDistance      : 5,
+        mouseDownTime    : 0,
+        mouseDownTimeout : null,
+        pageX            : null,
+        pageY            : null,
+        startEvent       : null
+    }, overrides);
+
+    // Neo.bindMethods equivalent for a construct-less instance: listener identity must be
+    // stable across add/removeEventListener.
+    ['onDistanceChange', 'onMouseDown', 'onMouseMove', 'onMouseUp'].forEach(method => {
+        sensor[method] = sensor[method].bind(sensor)
+    });
+
+    return sensor
+}
+
+function mouseEvent(type, props) {
+    const event = new Event(type, {bubbles: true});
+
+    Object.assign(event, props);
+
+    return event
+}
+
+function mouseDown() {
+    return mouseEvent('mousedown', {
+        button : 0,
+        clientX: 10,
+        clientY: 10,
+        pageX  : 10,
+        pageY  : 10,
+        path   : [dragNode]
+    })
+}
+
+/**
+ * @summary Terminal contract of the gesture-scoped selection guard (`neo-drag-active`).
+ *
+ * The class brackets the PHYSICAL gesture, not the logical drag: the sensor adds it at
+ * mousedown on a drag target and endGesture() releases it — on an ordinary mouseup, or when
+ * the gesture's own move stream observes the primary button gone (a release that happened
+ * off-document never reaches onMouseUp, so the move stream is the independent terminal
+ * witness). The delay-timeout's coords-only re-entry carries no `buttons` and must never
+ * trigger the recovery.
+ */
+test.describe('Neo.main.draggable.sensor.Mouse — selection-guard terminal contract', () => {
+    test.beforeEach(() => {
+        installDocument()
+    });
+
+    test.afterAll(() => {
+        originalDocument === undefined ? delete globalThis.document : globalThis.document = originalDocument;
+        originalWindow   === undefined ? delete globalThis.window   : globalThis.window   = originalWindow
+    });
+
+    test('ordinary bracket: mousedown adds the guard, mouseup releases it', () => {
+        const sensor = createSensor();
+
+        Mouse.prototype.attach.call(sensor);
+
+        documentRef.dispatchEvent(mouseDown());
+        expect(bodyClasses.has('neo-drag-active')).toBe(true);
+
+        documentRef.dispatchEvent(mouseEvent('mouseup', {button: 0, clientX: 10, clientY: 10, pageX: 10, pageY: 10}));
+        expect(bodyClasses.has('neo-drag-active')).toBe(false);
+
+        sensor.detach()
+    });
+
+    test('pre-threshold lost release: a move reporting the primary button gone retires the guard', () => {
+        const sensor = createSensor();
+
+        Mouse.prototype.attach.call(sensor);
+
+        documentRef.dispatchEvent(mouseDown());
+        expect(bodyClasses.has('neo-drag-active')).toBe(true);
+
+        // The release happened off-document: no mouseup ever arrives, and the next observed
+        // move reports buttons=0. The sensor must treat it as the release never received.
+        documentRef.dispatchEvent(mouseEvent('mousemove', {buttons: 0, clientX: 30, clientY: 30, pageX: 30, pageY: 30}));
+
+        expect(bodyClasses.has('neo-drag-active')).toBe(false);
+        expect(sensor.dragging).toBe(false);
+
+        sensor.detach()
+    });
+
+    test('mid-drag lost release emits exactly one drag:end, retires the guard, and ignores a later mouseup', () => {
+        const ends   = [],
+              sensor = createSensor();
+
+        Mouse.prototype.attach.call(sensor);
+        documentRef.addEventListener('drag:end', event => ends.push(event.detail));
+
+        documentRef.dispatchEvent(mouseDown());
+        documentRef.dispatchEvent(mouseEvent('mousemove', {buttons: 1, clientX: 60, clientY: 60, pageX: 60, pageY: 60}));
+
+        expect(sensor.dragging).toBe(true);
+        expect(bodyClasses.has('neo-drag-active')).toBe(true);
+
+        documentRef.dispatchEvent(mouseEvent('mousemove', {buttons: 0, clientX: 80, clientY: 80, pageX: 80, pageY: 80}));
+
+        expect(bodyClasses.has('neo-drag-active')).toBe(false);
+        expect(sensor.dragging).toBe(false);
+        expect(sensor.currentElement).toBe(null);
+        expect(ends.length).toBe(1);
+        expect(ends[0].type).toBe('drag:end');
+
+        // endGesture detached every gesture listener: a trailing mouseup must not double-terminate.
+        documentRef.dispatchEvent(mouseEvent('mouseup', {button: 0, clientX: 80, clientY: 80, pageX: 80, pageY: 80}));
+        expect(ends.length).toBe(1);
+
+        sensor.detach()
+    });
+
+    test('the delay-timeout re-entry (coords only, no buttons) never triggers the lost-release recovery', () => {
+        const sensor = createSensor();
+
+        Mouse.prototype.attach.call(sensor);
+
+        documentRef.dispatchEvent(mouseDown());
+        expect(bodyClasses.has('neo-drag-active')).toBe(true);
+
+        // The exact shape the mouseDownTimeout callback passes: pageX/pageY and nothing else.
+        sensor.onDistanceChange({pageX: 12, pageY: 12});
+
+        expect(bodyClasses.has('neo-drag-active')).toBe(true);
+        expect(sensor.dragging).toBe(false);
+
+        clearTimeout(sensor.mouseDownTimeout);
+        sensor.detach()
+    })
+});


### PR DESCRIPTION
Resolves #16362

Splitter drags can no longer become text-selection sweeps across card content — the operator's observation ("dragging a splitter can select text inside cards, 'Priority Signals' specifically") decomposed into two mechanisms, and both are closed:

1. **The near-handle miss.** The dock splitter's visual handle is 6px thin; a start even 2px off it fell through into the adjacent cards and selected their text (pre-fix receipt: a sweep starting 2px right of the handle selected `"Priority Alert Observatory"`). The handle's **hit target now expands ±4px** past the visual rail via a hit-only `::before` (pointer events on a pseudo-element resolve to the originating element, so the drag contract is unchanged; the visual geometry is untouched — verified `width: 6` after).
2. **The pre-threshold selection window.** Even with the drag engaged, the native selection machinery claims the window before the Mouse sensor's delay+distance threshold fires `drag:start` (pre-fix receipt: a committed drag still showed `"\nPRIORITY SIGNALS\n07\n"` selected mid-gesture). The sensor now applies a document-level `neo-drag-active` class from `mousedown` on a drag target until the physical gesture ends — `user-select: none !important` scoped to it in `Global.scss`.

**Terminal contract — the class brackets the PHYSICAL gesture, not the logical drag:**

- **Ordinary release:** `mouseup` retires the class (shared `endGesture` teardown).
- **Escape-cancel:** retires the LOGICAL drag (`drag:cancel` at the gesture owner), but the physical bracket deliberately keeps suppression while the button is down — retiring at Escape would re-open the sweep window for the remainder of the physical gesture. The subsequent physical release retires the class; witness-bound.
- **Lost release:** a release that happens off-document never reaches `onMouseUp`, so the gesture's own move stream is the independent terminal witness — the first observed move reporting the primary button gone (`event.buttons`) terminates the gesture exactly as that release would have (class retired, `drag:end` emitted at the re-entry position, gesture owner reset). Named residual: a button released off-document with NO further mouse event ever observed leaves the class until the next observed event, which recovers it.
- The DragDrop addon's `resetDragState()` keeps an idempotent `classList.remove` as a second release site — reachable only downstream of the sensor's `drag:end`, never an off-document fallback. Code/prose/test agree.

Post-fix receipts: the +2px start **drags** (sizes commit `[0.6,0.4] → [0.724,0.276]`) with zero selection; mid-gesture the document carries the class and selection is empty; after settlement the class is gone and ordinary selection works (the release control rides the semantic FLIP/animating retirement predicates, not a fixed delay). Witness: `WorkstationDragTextSelectionNL.spec.mjs` — CDP `page.mouse` is required and documented: the app-side synthetic event path does not create text selections at all (measured), so only the trusted-input path exercises this defect class.

Evidence: L3 (headed Chromium before/after receipts + the green 3-test witness + drag-family regression suites + full unit suite) → L3 required (#16362's headed witness ACs). No residuals beyond the one named above.

## Deltas from ticket

- The ticket sketched a body-level drag-active class as the fix; the investigation showed that alone would not cover the near-handle miss (the dominant mechanism per the 2px receipt), so the hit-zone expansion joined it.
- AC2 ("releases fully on drag end AND on Escape-cancel") is bound with explicit semantics: Escape retires drag semantics while the physical bracket owns suppression until the button is observed released; after Escape + release the selection is empty and ordinary selection works again (witness test 2). The ticket's "any abort path" prescription is realized as the sensor-owned lost-release recovery — the addon's reset is only reachable downstream of `drag:end`, so it cannot own abort terminals.
- The investigation also falsified the "selection during a REAL drag is the problem" reading: during a fully-engaged drag the browser natively suppresses selection — the defect lives in the start boundary (miss + pre-threshold), which is where the fix sits.

## Test Evidence

- Witness, headed: `NEO_E2E_PORT=8117 npx playwright test workstation/WorkstationDragTextSelectionNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed` → **3 passed** (ordinary release; Escape-cancel bracket held through a post-Escape sweep, released at physical mouseup; lost release recovered on a CDP-dispatched `buttons=0` move with no `mouseReleased` ever sent, gesture owner reset observed)
- New unit spec `test/playwright/unit/main/draggable/sensor/Mouse.spec.mjs` → **4/4** (ordinary bracket; pre-threshold lost release; mid-drag lost release emits exactly one `drag:end` and ignores a trailing mouseup; the delay-timeout's coords-only re-entry never triggers recovery)
- Full unit suite at head: **10956 passed, zero failures** (5 conditional skips, 2 service-gated did-not-runs in memory-core summarization)
- Drag-family regression, headed: `WorkstationFiveBeatNL` 9/9 with the change
- Before/after receipts (headed, manual): miss-sweep at +2px selected `"Priority Alert Observatory"` pre-fix, selects nothing post-fix; drag commit verified both states; splitter visual `width: 6` unchanged, `::before` margins `-4px`
- `WorkstationGridRepaintNL` lives on the #16370 branch and does not exist here — the drag-family regression on this branch is FiveBeat + the witness

## Post-Merge Validation

- [ ] Nightly e2e runner green on the merged spec (whitebox e2e is nightly-only by design; PR CI carries no e2e job)

Authored by Phoebe (Kimi K3, OpenCode). Session 4a8185cb-635a-4657-9f1e-00511586bcde (origin) — terminal-contract cycle authored in the successor session at `e5277b105e`.
