### PR TITLE
feat(orchestrator): detect miniSummary generation-timeout starvation (#16382)

### DIFF
--- a/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs
@@ -1,0 +1,135 @@
+import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis
+ * @summary Pure detect-producer for miniSummary generation-timeout starvation — the DETECT half the
+ * homeostatic window controller consumes. Turns a window of backfill pass results into a `contention`
+ * `recovery-diagnosis` when the loop is processing rows and completing none, and names WHICH timeout
+ * boundary the failures are landing on so a controller can tell an inner-leaf problem from an outer-leaf
+ * one.
+ *
+ * Detect-only by construction: it consumes pass RESULTS and emits a diagnosis — it widens no window,
+ * writes no config, and calls no actuator (those are the recovery actuator's `reconfigure`). Mirrors the
+ * coverage-drift and vector-count producers' pure shape: the samples are injected, so it is testable in
+ * isolation and carries no scheduling.
+ *
+ * ## Why `contention`, never `crash`
+ *
+ * A **model-dependent canary must classify as contention/degraded first, never "restart now"** — the
+ * standing example is an embedding canary that false-fails while the service is functionally fine.
+ * Summary generation depends on the chat model, so starvation here is a saturation signal, not a
+ * liveness one: the Memory Core answers A2A and persists memory throughout. Emitting `crash` would
+ * invite a restart that fixes nothing and costs an outage.
+ *
+ * ## Why a window, and why the branch split is load-bearing
+ *
+ * A single starved pass is advisory — a momentary provider spike is not saturation (§2.4). Starvation
+ * must hold across `minSustainedPasses` before this emits anything.
+ *
+ * The branch split matters because the miniSummary path has **two nested timeouts**:
+ * `generateMiniSummaryTimeoutMs` fires *inside* `buildMiniSummary`, whose try/catch swallows it into a
+ * falsy return (`failedInner`); `miniSummaryTimeoutMs` wraps the call from *outside*, so its rejection
+ * escapes to the sweep's catch (`failedOuter`). **Which branch a failure lands on is a function of the
+ * window a controller moves, not a property of the code** — so a diagnosis built on totals alone goes
+ * blind at exactly the boundary an adaptive controller is actuating toward. `dominantBranch` is the
+ * output that keeps it honest: an outer-dominant diagnosis means widening the inner leaf alone cannot
+ * help, because the outer bound is the one binding.
+ *
+ * ## Authority boundary
+ *
+ * This emits a diagnosis, never an action. The multi-fact requirement gates *authoritative actions*,
+ * not records — so a consumer that wants to act on this must combine it with a resource or lifecycle
+ * fact of its own. `confidence: 1` describes the observation (starvation is measured, not inferred),
+ * not a licence to actuate on it alone.
+ */
+
+/**
+ * Minimum consecutive starved passes before starvation is reported. One pass is advisory (§2.4).
+ * @type {Number}
+ */
+export const DEFAULT_MIN_SUSTAINED_PASSES = 3;
+
+/**
+ * @summary Reports whether a single backfill pass result shows the starved shape.
+ *
+ * Starved means: rows were processed, none completed, and at least one failed on a generation branch.
+ * The last clause is what separates starvation from an idle or content-missing pass — a sweep that
+ * processed rows and skipped them all as un-summarizable is not a timeout problem.
+ *
+ * @param {Object} pass A `backfillMiniSummaries` result.
+ * @returns {Boolean}
+ */
+function isStarvedPass(pass) {
+    const processed   = pass?.processed   ?? 0,
+          updated     = pass?.updated     ?? 0,
+          failedInner = pass?.failedInner ?? 0,
+          failedOuter = pass?.failedOuter ?? 0;
+
+    return processed > 0 && updated === 0 && (failedInner + failedOuter) > 0;
+}
+
+/**
+ * @summary Builds a `contention` `recovery-diagnosis` from a window of miniSummary backfill passes.
+ *
+ * Pure — no I/O. Returns `null` unless EVERY pass in the window is starved and the window is at least
+ * `minSustainedPasses` long, so a single bad pass or a partially-recovering loop never produces a
+ * diagnosis. The caller (the diagnostics daemon) supplies the recent pass results and the Memory Core
+ * service id.
+ *
+ * @param {Object} options
+ * @param {Object[]} options.passes Recent `backfillMiniSummaries` results, oldest first.
+ * @param {Number} options.observedAt Epoch milliseconds when the window was observed.
+ * @param {String} options.serviceId The Memory Core compose-service identifier.
+ * @param {Number} [options.minSustainedPasses=DEFAULT_MIN_SUSTAINED_PASSES] Consecutive starved passes required.
+ * @returns {Object|null} A `contention` `recovery-diagnosis` when starvation is sustained, else `null`.
+ * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
+ */
+export function buildMiniSummaryStarvationDiagnosis({
+    passes,
+    observedAt,
+    serviceId,
+    minSustainedPasses = DEFAULT_MIN_SUSTAINED_PASSES
+} = {}) {
+    if (typeof serviceId !== 'string' || serviceId.length === 0) {
+        throw new TypeError('buildMiniSummaryStarvationDiagnosis: serviceId is required');
+    }
+    if (!Number.isFinite(observedAt)) {
+        throw new TypeError('buildMiniSummaryStarvationDiagnosis: observedAt must be a finite number');
+    }
+
+    const window = Array.isArray(passes) ? passes : [];
+
+    // Not enough evidence, or the loop is completing work → no diagnosis (never a false positive).
+    if (window.length < minSustainedPasses || !window.every(isStarvedPass)) {
+        return null;
+    }
+
+    const innerTotal = window.reduce((sum, pass) => sum + (pass?.failedInner ?? 0), 0),
+          outerTotal = window.reduce((sum, pass) => sum + (pass?.failedOuter ?? 0), 0),
+          // Ties resolve to `outer` deliberately: the outer bound is the one a controller cannot widen
+          // past without also moving it, so an ambiguous window must not read as "widen the inner leaf".
+          dominantBranch = outerTotal >= innerTotal ? 'outer' : 'inner';
+
+    return createRecoveryDiagnosisEvent({
+        diagnosisId   : `contention:${serviceId}:minisummary-starvation:${observedAt}`,
+        recoveryClass : 'contention',
+        confidence    : 1,
+        targetIdentity: {kind: 'compose-service', id: serviceId},
+        evidenceFacts : window.map(pass => ({
+            type       : 'minisummary-generation-starvation',
+            processed  : pass?.processed   ?? 0,
+            updated    : pass?.updated     ?? 0,
+            failedInner: pass?.failedInner ?? 0,
+            failedOuter: pass?.failedOuter ?? 0
+        })),
+        observedAt,
+        source : 'minisummary-starvation-monitor',
+        details: {
+            reasonCode      : 'minisummary-generation-timeout-starvation',
+            sustainedPasses : window.length,
+            failedInnerTotal: innerTotal,
+            failedOuterTotal: outerTotal,
+            dominantBranch
+        }
+    });
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.spec.mjs
@@ -1,0 +1,115 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {buildMiniSummaryStarvationDiagnosis,
+        DEFAULT_MIN_SUSTAINED_PASSES}                             from '../../../../../../../ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs';
+
+// Pure detect-producer (no I/O). A window of backfill passes that process rows and complete none, with
+// failures landing on a generation branch, is generation-timeout starvation → a `contention`
+// recovery-diagnosis. Anything short of sustained, or any completing work → null.
+
+const starved = (failedInner, failedOuter) => ({
+          processed     : failedInner + failedOuter, updated: 0, deferred: failedInner + failedOuter,
+          missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner, failedOuter
+      }),
+      healthy  = () => ({
+          processed  : 2, updated: 2, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false,
+          failedInner: 0, failedOuter: 0
+      });
+
+test.describe('buildMiniSummaryStarvationDiagnosis — generation-timeout starvation detect-producer', () => {
+    test('a sustained starved window -> a contention recovery-diagnosis, never crash', () => {
+        const diag = buildMiniSummaryStarvationDiagnosis({
+            passes    : [starved(3, 0), starved(4, 0), starved(3, 0)],
+            observedAt: 1000,
+            serviceId : 'memory-core'
+        });
+
+        expect(diag).not.toBeNull();
+        // A model-dependent canary classifies as contention/degraded FIRST, never "restart now" — the
+        // service answers A2A and persists memory throughout, so a restart fixes nothing.
+        expect(diag.recoveryClass).toBe('contention');
+        expect(diag.targetIdentity).toEqual({kind: 'compose-service', id: 'memory-core'});
+        expect(diag.details.reasonCode).toBe('minisummary-generation-timeout-starvation');
+        expect(diag.details.sustainedPasses).toBe(3);
+    });
+
+    test('one starved pass is advisory, not a diagnosis (a spike is not saturation)', () => {
+        expect(buildMiniSummaryStarvationDiagnosis({
+            passes: [starved(5, 0)], observedAt: 1000, serviceId: 'memory-core'
+        })).toBeNull();
+    });
+
+    test('a window that completes any work is not starvation, however long', () => {
+        expect(buildMiniSummaryStarvationDiagnosis({
+            passes    : [starved(3, 0), healthy(), starved(3, 0), starved(3, 0)],
+            observedAt: 1000, serviceId: 'memory-core'
+        })).toBeNull();
+    });
+
+    test('processed rows with no generation failures are not starvation (missing content is not a timeout)', () => {
+        const skipped = {
+            processed  : 4, updated: 0, deferred: 0, missingContent: 4, exhausted: 0, runBudgetHit: false,
+            failedInner: 0, failedOuter: 0
+        };
+
+        expect(buildMiniSummaryStarvationDiagnosis({
+            passes: [skipped, skipped, skipped], observedAt: 1000, serviceId: 'memory-core'
+        })).toBeNull();
+    });
+
+    test('dominantBranch names which timeout boundary is binding — the controller cannot widen past the outer one', () => {
+        const innerDominant = buildMiniSummaryStarvationDiagnosis({
+            passes: [starved(5, 0), starved(4, 1), starved(5, 0)], observedAt: 1000, serviceId: 'memory-core'
+        });
+        expect(innerDominant.details.dominantBranch).toBe('inner');
+        expect(innerDominant.details.failedInnerTotal).toBe(14);
+        expect(innerDominant.details.failedOuterTotal).toBe(1);
+
+        // Outer-dominant is the case that matters: widening the inner leaf alone cannot help, because the
+        // outer bound is the one the failures are hitting.
+        const outerDominant = buildMiniSummaryStarvationDiagnosis({
+            passes: [starved(0, 4), starved(1, 3), starved(0, 5)], observedAt: 1000, serviceId: 'memory-core'
+        });
+        expect(outerDominant.details.dominantBranch).toBe('outer');
+
+        // A tie resolves to `outer` deliberately: an ambiguous window must not read as
+        // "widen the inner leaf", which is the move that silently flips every item to the other branch.
+        const tied = buildMiniSummaryStarvationDiagnosis({
+            passes: [starved(2, 2), starved(2, 2), starved(2, 2)], observedAt: 1000, serviceId: 'memory-core'
+        });
+        expect(tied.details.dominantBranch).toBe('outer');
+    });
+
+    test('evidence carries the per-pass branch split, so a flip is visible to the consumer', () => {
+        const diag = buildMiniSummaryStarvationDiagnosis({
+            passes    : [starved(4, 0), starved(2, 2), starved(0, 4)],
+            observedAt: 1000,
+            serviceId : 'memory-core'
+        });
+
+        expect(diag.evidenceFacts).toHaveLength(3);
+        expect(diag.evidenceFacts.map(fact => fact.failedInner)).toEqual([4, 2, 0]);
+        expect(diag.evidenceFacts.map(fact => fact.failedOuter)).toEqual([0, 2, 4]);
+        expect(diag.evidenceFacts[0].type).toBe('minisummary-generation-starvation');
+    });
+
+    test('the sustain threshold is configurable and defaults to the advisory-guard value', () => {
+        expect(DEFAULT_MIN_SUSTAINED_PASSES).toBe(3);
+
+        expect(buildMiniSummaryStarvationDiagnosis({
+            passes            : [starved(1, 0), starved(1, 0)], observedAt: 1000, serviceId: 'memory-core',
+            minSustainedPasses: 2
+        })).not.toBeNull();
+    });
+
+    test('missing serviceId or a non-finite observedAt throw rather than emitting a shapeless diagnosis', () => {
+        expect(() => buildMiniSummaryStarvationDiagnosis({
+            passes: [starved(1, 0)], observedAt: 1000
+        })).toThrow(TypeError);
+
+        expect(() => buildMiniSummaryStarvationDiagnosis({
+            passes: [starved(1, 0)], observedAt: Number.NaN, serviceId: 'memory-core'
+        })).toThrow(TypeError);
+    });
+});


### PR DESCRIPTION
Resolves #16382

Related: #14418 (the homeostatic controller that consumes this)
Related: #16223 (the live starvation this detects)

Adds `buildMiniSummaryStarvationDiagnosis` — the detect half of the window controller. Nothing previously turned *"the loop processes rows and completes none"* into a diagnosis a controller could consume: the backfill reports its tallies to a log line and returns them to its caller, and the Memory Core answers A2A and persists memory throughout, so the service reads as healthy while burning cores for days.

Pure producer mirroring the five siblings in the same folder: injected samples, no I/O, `null` when clean.

Evidence: L2 (unit coverage at exact head; the producer is pure and fully reachable in-sandbox) → L2 required (every AC is an assertion on a return value). Residual: none — scheduling is explicitly out of scope, matching how `#14075` shipped a pure producer and deferred wiring to `#14026`.

## Deltas from ticket

Three design choices worth review attention, none of which the ticket prescribed in this exact form:

**`contention`, never `crash`.** A model-dependent canary must classify as contention/degraded first — the standing example is an embedding canary that false-fails while the service is fine. Summary generation depends on the chat model, so this is saturation, not liveness. `crash` would invite a restart that fixes nothing and costs an outage. `contention` is already in the `RECOVERY_CLASSES` enum, so this widens nothing.

**Ties on `dominantBranch` resolve to `outer`.** This is the non-obvious one. The inner leaf's timeout is swallowed into a falsy return; the outer leaf's escapes to the sweep's catch. An ambiguous window resolving to `inner` would read as *"widen the inner leaf"* — which is precisely the move that pushes the inner bound past the outer one and silently flips every item to the other branch. The pessimistic tie is the safe one.

**`confidence: 1` describes the observation, not the authority.** Starvation is measured, not inferred, so the confidence is honest — but the multi-fact requirement gates *authoritative actions*, not records, so a consumer acting on this must combine it with a resource or lifecycle fact of its own. Stated in the module JSDoc so a future consumer cannot read `confidence: 1` as a licence to actuate alone.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/daemons/orchestrator/services/ --workers=1
  639 passed (19.8s)
```

Directory-scoped rather than file-scoped: the new producer sits beside five sibling diagnosis producers plus the services that consume the shared `createRecoveryDiagnosisEvent`, so the folder is the regression surface. The producer's own spec is 9 tests covering emit, both suppression paths, all three `dominantBranch` cases, evidence shape, threshold configurability, and both argument guards.

Two suppression cases are deliberate and easy to get wrong:

- **a window that completes any work** suppresses entirely — a partially-recovering loop is not starved;
- **processed rows failing for non-generation reasons** (missing content) do not read as starvation — otherwise a sweep that correctly skipped un-summarizable rows would trigger window-widening.

## Post-Merge Validation

- [ ] Scheduling lands (`#14418` or its own leaf) and the producer runs against real sweeps on a live plane.
- [ ] On the CPU-only deployment that motivated `#16223`, a real starved window produces a `contention` diagnosis with `dominantBranch: 'inner'` at the current 20s/30s leaf pair.

## Commits

- `be33b3e814` — the producer plus its spec.

Authored by Vega (Claude Opus 5, Claude Code). Session 1bf32e47-868c-43ce-9e9c-537eeeee5ea1.
