### PR TITLE
fix(ai): the restorability probe walks past an unusable newest bundle (#16384)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1603,6 +1603,20 @@ class ConfigBase extends ConfigProvider {
                         maxDays    : 30
                     },
                     /**
+                     * How many candidate bundles `verifyLatestBackupRestorable` may FULLY validate
+                     * before giving up and reporting the newest failure.
+                     *
+                     * The probe walks newest-first because a single unusable newest bundle must not
+                     * hide recoverable history behind it, but full validation streams and parses every
+                     * row of every JSONL in a bundle — on a multi-GB bundle that is not free, and an
+                     * unbounded walk would let a run of corrupt bundles turn a deploy preflight into an
+                     * arbitrarily long scan. Exhausting it logs which bundles went unexamined rather
+                     * than reporting a clean "nothing restorable" — a silent cap reads exactly like an
+                     * exhaustive search, which is the same false-negative the walk exists to end.
+                     * @type {Number}
+                     */
+                    restorabilityScanLimit: 5,
+                    /**
                      * Off-host durability hook (plain nested keys inside this object leaf — the owning
                      * ticket owns validation; see backup.mjs#validateOffHostSyncConfig). An empty
                      * `command` disables the hook entirely. Secrets never enter this tree: `envAllowlist`

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -698,27 +698,51 @@ export function assessEmbeddingCompatibility({expectedDimension, logger = consol
 }
 
 /**
- * @summary Verifies the latest backup bundle is structurally restorable WITHOUT performing a restore.
+ * @summary Verifies the newest RESTORABLE backup bundle WITHOUT performing a restore.
  *
  * Backups are the recovery source of last resort, yet assumed-restorable-but-never-checked. This runs
  * the same pre-flight `validateBundle` gate the restore path uses (required subdirs present, JSONL
- * parseable, `bundle-meta.json` parseable) against the newest `backup-<ISO-ts>/` under `backupRoot`,
- * returning a structured verdict. It performs NO writes and NO live-store import — a read-only
- * restorability probe. The alert-on-failure wiring is the escalation-mechanism piece (it shares the
- * AC1 sink decision, tracked on the parent backup-reliability ticket); this is the check that produces
- * the verdict that piece consumes.
+ * parseable, `bundle-meta.json` parseable) against `backup-<ISO-ts>/` directories under `backupRoot`
+ * newest-first, returning a structured verdict. It performs NO writes and NO live-store import — a
+ * read-only restorability probe. The alert-on-failure wiring is the escalation-mechanism piece (it
+ * shares the AC1 sink decision, tracked on the parent backup-reliability ticket); this is the check
+ * that produces the verdict that piece consumes.
+ *
+ * ## Why it does not stop at the newest bundle
+ *
+ * It used to inspect `bundleNames[0]` and nothing else, so ONE unusable newest bundle reported the
+ * whole root unrecoverable. A run that died mid-write left a 0-byte bundle-shaped directory, this
+ * probe read it, and a complete bundle carrying 94,325 recoverable rows sitting directly beside it
+ * was never looked at — the deploy guard refused, and the repair was `rm -rf` on a directory inside
+ * the backup root. Deleting evidence to unblock a guard is the operation this walk exists to stop
+ * being necessary.
+ *
+ * The fallback is deliberately NOT silent. Every bundle passed over travels in `skipped` with its own
+ * code and reason, and a warning names them, because a fallback that quietly succeeded would remove
+ * the pressure to notice that bundles are being produced broken at all — the underlying capture
+ * defect is a separate half of the same ticket.
  *
  * @param {Object}    options
  * @param {String}    options.backupRoot Absolute path to the `.neo-ai-data/backups` root.
  * @param {Object}   [options.logger=console] Log sink.
  * @param {Object}   [options.fsModule=fs] Filesystem seam (test injection).
  * @param {Function} [options.validateFn=validateBundle] Bundle validator seam (test injection).
- * @returns {Promise<{restorable: Boolean, code: String, bundleRoot: String|null, reason: String|null, checkedAt: String, embeddingAdvisories: Object[]}>}
+ * @param {Number}   [options.maxBundlesExamined=AiConfig.maintenance.backup.restorabilityScanLimit]
+ *     Cap on bundles validated. Read as a default parameter (evaluated per call, so an overlay change
+ *     is honoured without a reload). Exhausting it warns which candidates went unexamined rather than
+ *     reporting a clean "nothing restorable".
+ * @returns {Promise<{restorable: Boolean, code: String, bundleRoot: String|null, reason: String|null, checkedAt: String, rowTotal: Number|undefined, embeddingAdvisories: Object[], skipped: Object[], examined: Number}>}
  * `code` is the machine-readable verdict — `RESTORABLE`, `BUNDLE_ROOT_MISSING`, `NO_BUNDLES`,
- * `BUNDLE_EMPTY`, or `BUNDLE_INVALID`. `RESTORABLE` asserts the bundle is BOTH structurally valid
- * and non-empty; `rowTotal` reports the row count it was decided on. That strength lives here rather
- * than in a caller so a shell gate consumes one authoritative verdict instead of re-reading metadata
- * and growing a second predicate able to disagree with this one.
+ * `BUNDLE_EMPTY`, or `BUNDLE_INVALID`. `RESTORABLE` asserts the bundle is BOTH
+ * structurally valid and non-empty; `rowTotal` reports the row count it was decided on, and
+ * `bundleRoot` names WHICH bundle earned the verdict — no longer necessarily the newest one present.
+ * That strength lives here rather than in a caller so a shell gate consumes one authoritative verdict
+ * instead of re-reading metadata and growing a second predicate able to disagree with this one.
+ *
+ * On failure the reported `code`/`bundleRoot`/`reason` describe the NEWEST bundle rather than an
+ * invented aggregate, so a single-bundle root answers exactly as it did before this function learned
+ * to look further back, and `redeployPreflight`'s refusal still prints the most recent cause.
+ * `skipped` lists every rejected candidate newest-first; `examined` counts full validations spent.
  *
  * It exists so a caller gating on this probe branches on a value rather than
  * pattern-matching English out of `reason`, which would silently stop working the moment the prose
@@ -729,12 +753,21 @@ export function assessEmbeddingCompatibility({expectedDimension, logger = consol
  */
 export async function verifyLatestBackupRestorable({
     backupRoot,
-    logger     = console,
-    fsModule   = fs,
-    validateFn = validateBundle
+    logger             = console,
+    fsModule           = fs,
+    validateFn         = validateBundle,
+    maxBundlesExamined = AiConfig.maintenance.backup.restorabilityScanLimit
 } = {}) {
     if (!backupRoot) {
         throw new Error('verifyLatestBackupRestorable requires a `backupRoot` argument.');
+    }
+
+    // Guarding the class, not the one malformed value. A bound below 1 examines nothing, so the walk
+    // would fall through to the no-candidate return with nothing recorded and raise an obscure
+    // TypeError inside a deploy guard. A probe whose job is to be believed must fail loud about its
+    // own arguments rather than crash describing something else.
+    if (!Number.isInteger(maxBundlesExamined) || maxBundlesExamined < 1) {
+        throw new Error(`verifyLatestBackupRestorable requires a positive integer \`maxBundlesExamined\`; received ${maxBundlesExamined}.`);
     }
 
     const checkedAt = new Date().toISOString();
@@ -744,7 +777,7 @@ export async function verifyLatestBackupRestorable({
         // path RELATIVE to the compose project directory, so a deployment run from a different host
         // checkout addresses a directory that never existed rather than an empty one. Reporting "no
         // bundle" for bundles sitting safely in a prior checkout would answer about the wrong subject.
-        return {restorable: false, code: 'BUNDLE_ROOT_MISSING', bundleRoot: null, reason: `backup root not found: ${backupRoot}`, checkedAt};
+        return {restorable: false, code: 'BUNDLE_ROOT_MISSING', bundleRoot: null, reason: `backup root not found: ${backupRoot}`, checkedAt, skipped: [], examined: 0};
     }
 
     // backup-<ISO-ts> names sort lexically by their ISO timestamp, so reverse-sort yields newest-first.
@@ -755,10 +788,76 @@ export async function verifyLatestBackupRestorable({
         .reverse();
 
     if (bundleNames.length === 0) {
-        return {restorable: false, code: 'NO_BUNDLES', bundleRoot: null, reason: `no backup-* bundles under ${backupRoot}`, checkedAt};
+        return {restorable: false, code: 'NO_BUNDLES', bundleRoot: null, reason: `no backup-* bundles under ${backupRoot}`, checkedAt, skipped: [], examined: 0};
     }
 
-    const bundleRoot = path.join(backupRoot, bundleNames[0]);
+    const skipped  = [];
+    let   examined = 0,
+          newest   = null;
+
+    for (const bundleName of bundleNames) {
+        if (examined >= maxBundlesExamined) {
+            // A bound that is silent reads exactly like an exhaustive search that found nothing, which
+            // is the same false-negative this function exists to stop being. Say what was not looked at.
+            logger.warn?.(
+                `[Restore] examined ${examined} candidate bundle(s) without finding a restorable one; ` +
+                `${bundleNames.length - examined} older candidate(s) were NOT examined ` +
+                '(maxBundlesExamined). Raise the bound to search further back.'
+            );
+            break
+        }
+
+        examined++;
+
+        const verdict = await probeBundle({backupRoot, bundleName, logger, validateFn, checkedAt});
+
+        if (verdict.restorable) {
+            // Reporting rather than hiding. The operator's repair for the incident was `rm -rf` on the
+            // unusable newest directory; a fallback that silently succeeded would have removed the
+            // pressure to notice it at all, so every bundle passed over travels with the verdict.
+            if (skipped.length > 0) {
+                logger.warn?.(
+                    `[Restore] verified ${verdict.bundleRoot} after passing over ${skipped.length} ` +
+                    `unusable newer bundle(s): ${skipped.map(s => `${s.bundleName} (${s.code})`).join(', ')}`
+                );
+            }
+
+            return {...verdict, skipped, examined}
+        }
+
+        // The WHOLE verdict, not a projection of it. Rebuilding a reduced `{code, reason, bundleRoot}`
+        // silently dropped `rowTotal` and `embeddingAdvisories` from every refusal — fields a caller
+        // had before this function learned to walk. The failure shape must stay byte-identical to the
+        // single-bundle one it replaces.
+        newest ??= verdict;
+        skipped.push({bundleName, code: verdict.code, reason: verdict.reason});
+    }
+
+    // No candidate survived. The verdict keeps the NEWEST bundle's own result rather than inventing an
+    // aggregate one: consumers (`redeployPreflight.evaluateRedeployPreconditions`) branch on
+    // `RESTORABLE` vs everything-else and log the code as the refusal cause, so the most recent
+    // failure remains the most useful thing to print — and a single-bundle root reports exactly what
+    // it reported before this function learned to look further back.
+    return {...newest, skipped, examined}
+}
+
+/**
+ * @summary Runs the full structural + non-emptiness probe against ONE bundle.
+ *
+ * Extracted verbatim from {@link verifyLatestBackupRestorable}'s former single-bundle body so the
+ * walk gains a loop without the per-bundle contract changing. Every verdict this returns is one the
+ * function already returned before it could look past the newest bundle.
+ *
+ * @param {Object}    options
+ * @param {String}    options.backupRoot Absolute `.neo-ai-data/backups` root.
+ * @param {String}    options.bundleName `backup-<ISO-ts>` directory name.
+ * @param {Object}    options.logger Log sink.
+ * @param {Function}  options.validateFn Bundle validator seam.
+ * @param {String}    options.checkedAt Shared ISO timestamp for the whole walk.
+ * @returns {Promise<Object>} `RESTORABLE`, `BUNDLE_EMPTY`, or `BUNDLE_INVALID` for this bundle alone.
+ */
+async function probeBundle({backupRoot, bundleName, logger, validateFn, checkedAt}) {
+    const bundleRoot = path.join(backupRoot, bundleName);
     // `ledgers` belongs in the probe's layout because the probe ATTESTS a restore that will write
     // them. Omitting it meant malformed ledger content passed unexamined while the verdict still said
     // `RESTORABLE` — the probe vouching for a member it never looked at.

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -410,6 +410,59 @@ export async function runRestore({
 }
 
 /**
+ * @summary An error the validator raised as a JUDGEMENT ABOUT BUNDLE CONTENT, as opposed to a
+ * failure to observe the bundle at all.
+ *
+ * The distinction is an authorization boundary, not a tidiness one. `verifyLatestBackupRestorable`
+ * walks backwards past a bundle it has proven unusable — and "proven unusable" is only true when the
+ * validator actually reached the bytes and judged them. A permissions failure, a disappearing mount,
+ * file-descriptor exhaustion, or a bug inside the validator all say *"I could not tell"*, and
+ * treating that as *"this bundle is bad"* lets a newer, perfectly good recovery source be skipped
+ * because it was merely unreadable — authorizing a deploy against stale history.
+ *
+ * Marker-based rather than message-based on purpose: matching English out of `error.message` stops
+ * working the moment the prose is reworded, which is the same failure the machine-readable verdict
+ * codes exist to prevent. It is also an ALLOWLIST — only errors the validator deliberately
+ * constructs are continue-eligible, so any unrecognised throw (including one from a future code
+ * path nobody has thought about yet) fails closed by construction rather than by enumeration.
+ */
+/**
+ * @summary The only per-candidate verdicts that authorize {@link verifyLatestBackupRestorable} to
+ * keep walking backwards.
+ *
+ * Both members are POSITIVE findings about a bundle the validator actually read: it parsed and held
+ * no recoverable rows (`BUNDLE_EMPTY`), or it parsed far enough to be judged malformed
+ * (`BUNDLE_INVALID`). Everything else — notably `BUNDLE_UNVERIFIABLE` — means the probe failed to
+ * observe the candidate, which is not evidence about the candidate and must stop the walk.
+ *
+ * An allowlist rather than a denylist so a verdict code added later cannot silently become
+ * continue-eligible; a new code fails closed until someone decides otherwise.
+ * @type {Set<String>}
+ */
+export const CONTINUE_ELIGIBLE_BUNDLE_VERDICTS = new Set(['BUNDLE_EMPTY', 'BUNDLE_INVALID']);
+
+export class BundleContentError extends Error {
+    /**
+     * @param {String} message
+     */
+    constructor(message) {
+        super(message);
+        this.name             = 'BundleContentError';
+        this.bundleContentBad = true
+    }
+}
+
+/**
+ * @summary Constructs a content-judgement error. Use for every validator throw that expresses
+ * "I read this bundle and it is malformed"; never for an IO or instrument failure.
+ * @param {String} message
+ * @returns {BundleContentError}
+ */
+function bundleContentError(message) {
+    return new BundleContentError(message)
+}
+
+/**
  * Validates the bundle directory layout and every JSONL row without writing any state.
  *
  * Required subdirs (`kb`, `mc`, `graph`, `concepts`, `trajectories`) MUST exist; missing
@@ -430,18 +483,18 @@ export async function runRestore({
  */
 export async function validateBundle(bundleRoot, layout, logger = console, expectedDimension = AiConfig.vectorDimension) {
     if (!await fs.pathExists(bundleRoot)) {
-        throw new Error(`Bundle directory not found: ${bundleRoot}`);
+        throw bundleContentError(`Bundle directory not found: ${bundleRoot}`);
     }
 
     const stat = await fs.stat(bundleRoot);
     if (!stat.isDirectory()) {
-        throw new Error(`Bundle path is not a directory: ${bundleRoot}`);
+        throw bundleContentError(`Bundle path is not a directory: ${bundleRoot}`);
     }
 
     for (const subdir of REQUIRED_BUNDLE_SUBDIRS) {
         const dir = layout[subdir];
         if (!await fs.pathExists(dir)) {
-            throw new Error(`Required bundle subdirectory missing: ${subdir}/ (expected at ${dir})`);
+            throw bundleContentError(`Required bundle subdirectory missing: ${subdir}/ (expected at ${dir})`);
         }
     }
 
@@ -485,7 +538,7 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
                 try {
                     row = JSON.parse(line);
                 } catch (err) {
-                    throw new Error(`Bundle JSONL parse error at ${subdir}/${file} (line ${lineNo}): ${err.message}`);
+                    throw bundleContentError(`Bundle JSONL parse error at ${subdir}/${file} (line ${lineNo}): ${err.message}`);
                 }
 
                 const collection = collectionOf(subdir, file);
@@ -494,12 +547,12 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
                     streamedCounts[collection] = (streamedCounts[collection] ?? 0) + 1;
 
                     if (typeof row?.id !== 'string' || row.id.length === 0) {
-                        throw new Error(`Bundle vector invariant violation at ${subdir}/${file} (line ${lineNo}): missing-id`);
+                        throw bundleContentError(`Bundle vector invariant violation at ${subdir}/${file} (line ${lineNo}): missing-id`);
                     }
 
                     const reason = classifyRowVector(row, expectedDimension);
                     if (reason) {
-                        throw new Error(`Bundle vector invariant violation at ${subdir}/${file} (line ${lineNo}): ${reason} (row id: ${row?.id ?? 'unknown'})`);
+                        throw bundleContentError(`Bundle vector invariant violation at ${subdir}/${file} (line ${lineNo}): ${reason} (row id: ${row?.id ?? 'unknown'})`);
                     }
                 }
             }
@@ -515,7 +568,7 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
         try {
             meta = await fs.readJson(metaPath);
         } catch (err) {
-            throw new Error(`Failed to parse bundle-meta.json: ${err.message}`);
+            throw bundleContentError(`Failed to parse bundle-meta.json: ${err.message}`);
         }
     } else {
         logger.warn?.('[Restore] bundle-meta.json absent; topology compatibility check will be skipped (legacy bundle).');
@@ -535,7 +588,7 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
             try {
                 JSON.parse(await fs.readFile(attemptsPath, 'utf8'))
             } catch (err) {
-                throw new Error(`Bundle JSON parse error at ledgers/${INCIDENT_LEDGER_BUNDLE_MEMBERS.healAttempts}: ${err.message}`);
+                throw bundleContentError(`Bundle JSON parse error at ledgers/${INCIDENT_LEDGER_BUNDLE_MEMBERS.healAttempts}: ${err.message}`);
             }
         }
 
@@ -554,7 +607,7 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
                     try {
                         JSON.parse(line)
                     } catch (err) {
-                        throw new Error(`Bundle JSONL parse error at ledgers/${INCIDENT_LEDGER_BUNDLE_MEMBERS.recoveryRuns}/${file} (line ${lineNo}): ${err.message}`);
+                        throw bundleContentError(`Bundle JSONL parse error at ledgers/${INCIDENT_LEDGER_BUNDLE_MEMBERS.recoveryRuns}/${file} (line ${lineNo}): ${err.message}`);
                     }
                 }
             }
@@ -600,7 +653,7 @@ export function validateEmbeddingContractSchema({expectedDimension, meta, stream
     }
 
     const fail = (reason, detail) => {
-        throw new Error(`Bundle embedding contract violation: ${reason} (${detail})`)
+        throw bundleContentError(`Bundle embedding contract violation: ${reason} (${detail})`)
     };
 
     if (declared.schemaVersion !== 1) {
@@ -722,6 +775,19 @@ export function assessEmbeddingCompatibility({expectedDimension, logger = consol
  * the pressure to notice that bundles are being produced broken at all — the underlying capture
  * defect is a separate half of the same ticket.
  *
+ * ## Why it stops for an unreadable candidate
+ *
+ * Walking backwards is only justified by a POSITIVE finding: the validator reached this bundle and
+ * judged its content unusable (`BUNDLE_EMPTY` / `BUNDLE_INVALID` — see
+ * {@link CONTINUE_ELIGIBLE_BUNDLE_VERDICTS}). A permissions failure, a vanished mount, fd
+ * exhaustion, or a defect inside the validator all mean *"I could not tell"*, and an earlier
+ * revision of this walk collapsed those into `BUNDLE_INVALID` and continued — so a newer, perfectly
+ * good recovery source could be skipped merely because it was unreadable, authorizing a deploy
+ * against staler history than actually exists. That is missing evidence being used as negative
+ * evidence at a deployment authorization boundary. Such a candidate now returns
+ * `BUNDLE_UNVERIFIABLE` immediately, carrying `unverifiable: true` and the syscall `errorCode` when
+ * the platform supplied one, and older bundles are not considered.
+ *
  * @param {Object}    options
  * @param {String}    options.backupRoot Absolute path to the `.neo-ai-data/backups` root.
  * @param {Object}   [options.logger=console] Log sink.
@@ -733,7 +799,7 @@ export function assessEmbeddingCompatibility({expectedDimension, logger = consol
  *     reporting a clean "nothing restorable".
  * @returns {Promise<{restorable: Boolean, code: String, bundleRoot: String|null, reason: String|null, checkedAt: String, rowTotal: Number|undefined, embeddingAdvisories: Object[], skipped: Object[], examined: Number}>}
  * `code` is the machine-readable verdict — `RESTORABLE`, `BUNDLE_ROOT_MISSING`, `NO_BUNDLES`,
- * `BUNDLE_EMPTY`, or `BUNDLE_INVALID`. `RESTORABLE` asserts the bundle is BOTH
+ * `BUNDLE_EMPTY`, `BUNDLE_INVALID`, or `BUNDLE_UNVERIFIABLE`. `RESTORABLE` asserts the bundle is BOTH
  * structurally valid and non-empty; `rowTotal` reports the row count it was decided on, and
  * `bundleRoot` names WHICH bundle earned the verdict — no longer necessarily the newest one present.
  * That strength lives here rather than in a caller so a shell gate consumes one authoritative verdict
@@ -825,6 +891,24 @@ export async function verifyLatestBackupRestorable({
             return {...verdict, skipped, examined}
         }
 
+        // FAIL CLOSED on an unobservable candidate. Walking backwards is only justified when the
+        // validator REACHED this bundle and judged its content bad; an EACCES, a disappearing mount,
+        // fd exhaustion, or a bug in the validator all mean "I could not tell". Continuing there would
+        // let a newer, perfectly good recovery source be skipped because it was merely unreadable, and
+        // authorize a deploy against stale history — turning missing evidence into negative evidence
+        // at the exact boundary the restore gate exists to protect. Reported by @neo-gpt on this PR,
+        // reproduced with the validator seam before this branch existed.
+        if (!CONTINUE_ELIGIBLE_BUNDLE_VERDICTS.has(verdict.code)) {
+            logger.warn?.(
+                `[Restore] STOPPING at ${bundleName}: its bundle verdict could not be established ` +
+                `(${verdict.code}). Older bundles were NOT considered — an unreadable candidate is not ` +
+                'a bad one, and skipping it would authorize recovery from staler history than exists. ' +
+                `Reason: ${verdict.reason}`
+            );
+
+            return {...verdict, skipped, examined}
+        }
+
         // The WHOLE verdict, not a projection of it. Rebuilding a reduced `{code, reason, bundleRoot}`
         // silently dropped `rowTotal` and `embeddingAdvisories` from every refusal — fields a caller
         // had before this function learned to walk. The failure shape must stay byte-identical to the
@@ -898,7 +982,33 @@ async function probeBundle({backupRoot, bundleName, logger, validateFn, checkedA
 
         return {restorable: true, code: 'RESTORABLE', bundleRoot, reason: null, checkedAt, rowTotal, embeddingAdvisories: meta?.embeddingAdvisories ?? []};
     } catch (error) {
-        return {restorable: false, code: 'BUNDLE_INVALID', bundleRoot, reason: error.message, checkedAt, embeddingAdvisories: error.embeddingAdvisories ?? []};
+        // Two different answers, and only one of them is a judgement about the bundle.
+        //
+        // `BUNDLE_INVALID` means the validator read this bundle and found its content malformed —
+        // a fact about the artifact, and the only failure that entitles the caller to look further
+        // back. `BUNDLE_UNVERIFIABLE` means the validator could not establish anything: permissions,
+        // a vanished mount, fd exhaustion, or a defect in the validator itself.
+        //
+        // The test is the marker the validator sets on errors it deliberately constructs, never the
+        // message text — prose reworks silently, which is exactly why the verdict codes exist. And it
+        // is an ALLOWLIST, so an unrecognised throw from any future code path lands on the
+        // fail-closed side without anyone remembering to enumerate it.
+        const contentJudged = error instanceof BundleContentError || error?.bundleContentBad === true,
+              reason        = contentJudged
+                  ? error.message
+                  : `bundle verdict could not be established: ${error?.message ?? String(error)}`;
+
+        return {
+            restorable         : false,
+            code               : contentJudged ? 'BUNDLE_INVALID' : 'BUNDLE_UNVERIFIABLE',
+            bundleRoot,
+            reason,
+            checkedAt,
+            embeddingAdvisories: error.embeddingAdvisories ?? [],
+            // Structured, so a consumer distinguishes the two states without matching English.
+            // `errorCode` carries the syscall errno when the platform supplied one (EACCES, EMFILE…).
+            ...(contentJudged ? {} : {unverifiable: true, errorCode: error?.code ?? null})
+        }
     }
 }
 

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -463,6 +463,45 @@ function bundleContentError(message) {
 }
 
 /**
+ * @summary Reports absence that was PROVEN, never absence inferred from an error we could not read
+ * past.
+ *
+ * `fs.pathExists` resolves `false` for *any* failure, so an `EACCES` on a parent directory is
+ * indistinguishable from the path genuinely not being there. Every caller below turns that boolean
+ * into a statement about bundle CONTENT — "required subdirectory missing", "no receipt, therefore a
+ * legacy bundle" — which is how an unreadable bundle acquires a content verdict and, through
+ * {@link CONTINUE_ELIGIBLE_BUNDLE_VERDICTS}, permission for the walk to skip it.
+ *
+ * Only `ENOENT` proves absence. Everything else propagates UNMARKED so `probeBundle` classifies it
+ * as `BUNDLE_UNVERIFIABLE` — the same allowlist stance as the error classifier, for the same reason:
+ * an unanticipated errno must land on the fail-closed side without anyone having enumerated it.
+ *
+ * @param {String} target Absolute path.
+ * @returns {Promise<Boolean>} True only when the path is provably not there.
+ * @throws {Error} The original syscall error when presence could not be determined.
+ */
+async function pathIsProvablyAbsent(target) {
+    // A layout key that was never populated is an absent path, not an unreadable one — callers
+    // legitimately pass partial layouts (the optional-subdir and ledger loops both do). `fs.pathExists`
+    // absorbed this by resolving false; `fs.stat` raises a TypeError instead, so the tolerance has to
+    // be restated rather than inherited. Preserves the prior verdict exactly: no path, nothing to read.
+    if (!target) {
+        return true
+    }
+
+    try {
+        await fs.stat(target);
+        return false
+    } catch (error) {
+        if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') {
+            return true
+        }
+
+        throw error
+    }
+}
+
+/**
  * Validates the bundle directory layout and every JSONL row without writing any state.
  *
  * Required subdirs (`kb`, `mc`, `graph`, `concepts`, `trajectories`) MUST exist; missing
@@ -482,7 +521,7 @@ function bundleContentError(message) {
  *     receipt — the structured unknown-provenance classification is never dropped.
  */
 export async function validateBundle(bundleRoot, layout, logger = console, expectedDimension = AiConfig.vectorDimension) {
-    if (!await fs.pathExists(bundleRoot)) {
+    if (await pathIsProvablyAbsent(bundleRoot)) {
         throw bundleContentError(`Bundle directory not found: ${bundleRoot}`);
     }
 
@@ -493,14 +532,17 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
 
     for (const subdir of REQUIRED_BUNDLE_SUBDIRS) {
         const dir = layout[subdir];
-        if (!await fs.pathExists(dir)) {
+        if (await pathIsProvablyAbsent(dir)) {
             throw bundleContentError(`Required bundle subdirectory missing: ${subdir}/ (expected at ${dir})`);
         }
     }
 
     for (const subdir of OPTIONAL_BUNDLE_SUBDIRS) {
         const dir = layout[subdir];
-        if (!await fs.pathExists(dir)) {
+        // Provably-absent only. An unreadable optional subdir must NOT be quietly "skipped" — the probe
+        // would then attest a bundle whose member it never examined, which is the failure the ledger
+        // members already taught us once.
+        if (await pathIsProvablyAbsent(dir)) {
             logger.warn?.(`[Restore] Optional bundle subdirectory absent: ${subdir}/ (legacy bundle, skipping)`);
         }
     }
@@ -523,7 +565,10 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
     };
     for (const subdir of allSubdirs) {
         const dir = layout[subdir];
-        if (!await fs.pathExists(dir)) continue;
+        // Skipping on provable absence only. `pathExists` would also skip an unreadable directory, and
+        // a skipped directory is one whose rows never get streamed — so the bundle could be declared
+        // restorable on the strength of content nobody looked at.
+        if (await pathIsProvablyAbsent(dir)) continue;
         const entries    = await fs.readdir(dir);
         const jsonlFiles = entries.filter(f => f.endsWith('.jsonl'));
         for (const file of jsonlFiles) {
@@ -564,9 +609,15 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
     const metaPath = path.join(bundleRoot, 'bundle-meta.json');
     let   meta     = null;
 
-    if (await fs.pathExists(metaPath)) {
+    if (!await pathIsProvablyAbsent(metaPath)) {
+        // The read is OUTSIDE the try on purpose. `fs.readJson` both reads and parses, so wrapping it
+        // whole made an `EACCES` on the receipt indistinguishable from malformed JSON — the exact
+        // production path @neo-gpt reproduced, where an unreadable newest bundle was labelled
+        // `BUNDLE_INVALID` and the walk continued to older history. IO failures now propagate unmarked.
+        const rawMeta = await fs.readFile(metaPath, 'utf8');
+
         try {
-            meta = await fs.readJson(metaPath);
+            meta = JSON.parse(rawMeta)
         } catch (err) {
             throw bundleContentError(`Failed to parse bundle-meta.json: ${err.message}`);
         }
@@ -581,12 +632,15 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
     // The two ledger members the top-level scan cannot reach: `heal-attempts.json` is not `.jsonl`, and
     // the recovery-run files are NESTED. Both were accepted malformed while the verdict still read
     // `RESTORABLE`. A probe may only attest what it has actually parsed.
-    if (await fs.pathExists(layout.ledgers)) {
+    if (!await pathIsProvablyAbsent(layout.ledgers)) {
         const attemptsPath = path.join(layout.ledgers, INCIDENT_LEDGER_BUNDLE_MEMBERS.healAttempts);
 
-        if (await fs.pathExists(attemptsPath)) {
+        if (!await pathIsProvablyAbsent(attemptsPath)) {
+            // Same split as the receipt above: the read must not be able to masquerade as a parse.
+            const rawAttempts = await fs.readFile(attemptsPath, 'utf8');
+
             try {
-                JSON.parse(await fs.readFile(attemptsPath, 'utf8'))
+                JSON.parse(rawAttempts)
             } catch (err) {
                 throw bundleContentError(`Bundle JSON parse error at ledgers/${INCIDENT_LEDGER_BUNDLE_MEMBERS.healAttempts}: ${err.message}`);
             }
@@ -594,7 +648,7 @@ export async function validateBundle(bundleRoot, layout, logger = console, expec
 
         const runsDir = path.join(layout.ledgers, INCIDENT_LEDGER_BUNDLE_MEMBERS.recoveryRuns);
 
-        if (await fs.pathExists(runsDir)) {
+        if (!await pathIsProvablyAbsent(runsDir)) {
             for (const file of (await fs.readdir(runsDir)).filter(name => name.endsWith('.jsonl'))) {
                 const stream = fs.createReadStream(path.join(runsDir, file), {encoding: 'utf8'}),
                       rl     = readline.createInterface({crlfDelay: Infinity, input: stream});

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -537,7 +537,12 @@ test.describe('Tier 1 Config Immutability', () => {
                 keepMinimum: 3,
                 maxDays    : 30
             },
-            offHostSync: {
+            // Bounds how many bundles `verifyLatestBackupRestorable` validates while walking back past
+            // an unusable newest one. A policy value rather than a module constant: a primitive-local
+            // default is the forbidden config shape, and an operator on a host with a long run of
+            // broken bundles needs to raise it without a code change.
+            restorabilityScanLimit: 5,
+            offHostSync           : {
                 argv        : [],
                 command     : '',
                 envAllowlist: [],

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -873,8 +873,12 @@ test.describe('verifyLatestBackupRestorable — read-only restorability probe (#
         expect(empty.reason).toMatch(/no backup-\* bundles/);
         expect(empty.checkedAt).toBeTruthy();
 
-        // (2) an older valid bundle + a NEWER torn bundle → the newest is selected → not restorable.
-        writeBundle('backup-2026-05-01T00-00-00');
+        // (2) a torn bundle ALONE is still refused, and still names itself. This assertion moved to a
+        // single-bundle root deliberately: it used to place an older VALID bundle beside the torn one
+        // and assert the refusal anyway, which pinned newest-only selection as the contract. That case
+        // is now inverted in the fallback describe below, asserting RESTORABLE against the older
+        // bundle. What survives here is what did not change: a torn bundle with nothing behind it is
+        // not restorable.
         writeBundle('backup-2026-06-01T00-00-00', {torn: true});
         const torn = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
         expect(torn.restorable).toBe(false);
@@ -990,5 +994,215 @@ test.describe('verifyLatestBackupRestorable — read-only restorability probe (#
         fs.writeFileSync(path.join(bundle, 'ledgers', 'recovery-runs', 'run-bad.jsonl'), `${JSON.stringify({recoveryRunId: 'ok'})}\n`);
 
         expect((await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent})).code).toBe('RESTORABLE');
+    });
+});
+
+/**
+ * @summary Pins that one unusable newest bundle must not hide recoverable history behind it.
+ *
+ * The incident: a run died mid-write and left a bundle-shaped directory. The probe read that
+ * directory, reported the whole root unrecoverable, and a complete bundle carrying 94,325 rows sitting
+ * directly beside it was never looked at. The deploy guard refused and the repair was `rm -rf` inside
+ * the backup root — deleting evidence to unblock a guard.
+ *
+ * Every fallback case here asserts BOTH halves: that a valid older bundle is found, AND that the
+ * bundle passed over is still named in `skipped`. A fallback that succeeded silently would trade a
+ * false refusal for an invisible one.
+ */
+test.describe('verifyLatestBackupRestorable — falls back past an unusable newest bundle (#16348 AC4)', () => {
+    let verifyLatestBackupRestorable;
+    let probeRoot;
+    const silent = {log: () => {}, warn: () => {}, error: () => {}};
+
+    /** Writes a structurally valid bundle carrying one full-dimension vector row. */
+    const writeValidBundle = name => {
+        const bundleRoot = path.join(probeRoot, name);
+        for (const sub of ['kb', 'mc', 'graph', 'concepts', 'trajectories']) {
+            fs.mkdirSync(path.join(bundleRoot, sub), {recursive: true});
+        }
+        fs.writeFileSync(path.join(bundleRoot, 'mc', 'memory-backup.jsonl'),
+            JSON.stringify({id: `m-${name}`, embedding: new Array(4096).fill(0.1), metadata: {t: 'prompt'}}) + '\n');
+        return bundleRoot;
+    };
+
+    /** Specimen 2 — the abort-mid-write shape: bundle-shaped directories, no rows, no receipt. */
+    const writeAbortedBundle = name => {
+        const bundleRoot = path.join(probeRoot, name);
+        for (const sub of ['kb', 'mc', 'graph', 'concepts', 'trajectories']) {
+            fs.mkdirSync(path.join(bundleRoot, sub), {recursive: true});
+        }
+        fs.writeFileSync(path.join(bundleRoot, 'kb', 'knowledge-base-backup.jsonl'), '');
+        return bundleRoot;
+    };
+
+    /** Specimen 1 — the zero-capture shape: a complete receipt attesting an empty corpus. */
+    const writeZeroCaptureBundle = name => {
+        const bundleRoot = path.join(probeRoot, name);
+        for (const sub of ['kb', 'mc', 'graph', 'concepts', 'trajectories', 'mailbox']) {
+            fs.mkdirSync(path.join(bundleRoot, sub), {recursive: true});
+        }
+        fsExtra.writeJsonSync(path.join(bundleRoot, 'bundle-meta.json'), {
+            bundleVersion: 1,
+            integrity    : [{subsystem: 'kb', status: 'empty', sourceCount: 0, bundleCount: 0}],
+            subsystems   : {kb: {count: 0, message: 'Export complete. Exported 0 knowledge base chunks.'}},
+            topology     : {chromaUnified: true, shared_topology: true}
+        });
+        return bundleRoot;
+    };
+
+    /** Writes a torn bundle whose JSONL cannot parse. */
+    const writeTornBundle = name => {
+        const bundleRoot = path.join(probeRoot, name);
+        for (const sub of ['kb', 'mc', 'graph', 'concepts', 'trajectories']) {
+            fs.mkdirSync(path.join(bundleRoot, sub), {recursive: true});
+        }
+        fs.writeFileSync(path.join(bundleRoot, 'mc', 'memory-backup.jsonl'), '{this is not valid json\n');
+        return bundleRoot;
+    };
+
+    test.beforeAll(async () => {
+        ({verifyLatestBackupRestorable} = await import('../../../../../../ai/scripts/maintenance/restore.mjs'));
+    });
+
+    test.beforeEach(() => {
+        probeRoot = path.join(os.tmpdir(), `neo-restorable-fallback-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(probeRoot, {recursive: true});
+    });
+
+    test.afterEach(() => {
+        fsExtra.removeSync(probeRoot);
+    });
+
+    test('the live incident: an aborted newest bundle no longer hides the good bundle beside it', async () => {
+        // Ordered exactly as the incident was on disk — the aborted run is NEWER than the complete one.
+        writeValidBundle('backup-2026-08-01T12-13-23.398Z');
+        writeAbortedBundle('backup-2026-08-02T05-12-55.917Z');
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.restorable).toBe(true);
+        expect(verdict.code).toBe('RESTORABLE');
+        expect(verdict.bundleRoot).toContain('backup-2026-08-01T12-13-23.398Z');
+        expect(verdict.rowTotal).toBeGreaterThan(0);
+
+        // The half that keeps the fallback honest: the bad bundle is still reported, by name and code.
+        expect(verdict.skipped).toHaveLength(1);
+        expect(verdict.skipped[0].bundleName).toBe('backup-2026-08-02T05-12-55.917Z');
+        expect(verdict.skipped[0].code).toBe('BUNDLE_EMPTY');
+        expect(verdict.examined).toBe(2);
+    });
+
+    test('the fallback crosses every unusable class, not just the one that caused the incident', async () => {
+        // Three distinct failure shapes stacked ABOVE the only good bundle. If the walk only handled
+        // the shape it was written for, one of these would stop it.
+        writeValidBundle('backup-2026-07-01T00-00-00');
+        writeZeroCaptureBundle('backup-2026-07-02T00-00-00');
+        writeTornBundle('backup-2026-07-03T00-00-00');
+        writeAbortedBundle('backup-2026-07-04T00-00-00');
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.restorable).toBe(true);
+        expect(verdict.bundleRoot).toContain('backup-2026-07-01T00-00-00');
+        expect(verdict.skipped.map(s => s.code)).toEqual(['BUNDLE_EMPTY', 'BUNDLE_INVALID', 'BUNDLE_EMPTY']);
+        // Newest-first ordering, so an operator reads the skip list in the order the bundles were made.
+        expect(verdict.skipped.map(s => s.bundleName)).toEqual([
+            'backup-2026-07-04T00-00-00',
+            'backup-2026-07-03T00-00-00',
+            'backup-2026-07-02T00-00-00'
+        ]);
+    });
+
+    test('REGRESSION GUARD: a legacy bundle carrying no bundle-meta.json but real rows stays restorable', async () => {
+        // `validateBundle` documents meta-absence as the LEGACY bundle contract, returning
+        // `{legacy: true}` rather than failing. An earlier draft of this change rejected meta-less
+        // bundles up front as the abort-mid-write specimen, which would have made every pre-meta bundle
+        // permanently unrecoverable — the two shapes are only distinguishable by whether rows exist,
+        // not by whether a receipt does. `writeValidBundle` writes no meta, so this is that case.
+        writeValidBundle('backup-2026-06-01T00-00-00');
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.restorable).toBe(true);
+        expect(verdict.code).toBe('RESTORABLE');
+        expect(verdict.rowTotal).toBeGreaterThan(0);
+
+        // NEGATIVE CONTROL sharing the property under test: also meta-less, also no receipt — and
+        // refused. Proves the verdict turns on recoverable rows rather than on the file's absence,
+        // which is the discrimination the earlier draft got wrong.
+        fsExtra.removeSync(path.join(probeRoot, 'backup-2026-06-01T00-00-00'));
+        writeAbortedBundle('backup-2026-06-02T00-00-00');
+
+        const refused = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(refused.restorable).toBe(false);
+        expect(refused.code).toBe('BUNDLE_EMPTY');
+    });
+
+    test('when NOTHING is restorable the verdict still describes the NEWEST bundle', async () => {
+        // Contract preservation. `redeployPreflight` prints this code as the refusal cause and fails
+        // closed on anything but RESTORABLE, so the walk must not trade a precise newest-bundle reason
+        // for an aggregate that tells an operator less than the old single-bundle probe did.
+        writeAbortedBundle('backup-2026-05-01T00-00-00');
+        writeTornBundle('backup-2026-05-02T00-00-00');
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.restorable).toBe(false);
+        expect(verdict.code).toBe('BUNDLE_INVALID');
+        expect(verdict.bundleRoot).toContain('backup-2026-05-02T00-00-00');
+        expect(verdict.reason).toMatch(/parse error/);
+        expect(verdict.skipped).toHaveLength(2);
+        // The refusal must carry the newest bundle's WHOLE verdict. A first draft rebuilt a reduced
+        // `{code, reason, bundleRoot}` here and silently dropped these two fields from every failure —
+        // a shape regression invisible to any assertion that only checks the code.
+        expect(verdict.embeddingAdvisories).toEqual([]);
+        expect(verdict.checkedAt).toBeTruthy();
+    });
+
+    test('an EMPTY newest bundle keeps reporting its rowTotal through the walk', async () => {
+        // Same shape-preservation point on the other refusal branch: `rowTotal` is how a caller tells
+        // "verified against zero rows" from "never got a count", and only the BUNDLE_EMPTY path sets it.
+        writeZeroCaptureBundle('backup-2026-02-01T00-00-00');
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.code).toBe('BUNDLE_EMPTY');
+        expect(verdict.rowTotal).toBe(0);
+    });
+
+    test('the scan bound is enforced AND announced — a silent cap reads like an exhaustive search', async () => {
+        // A good bundle sits below more unusable ones than the bound allows. The probe must refuse
+        // rather than walk forever, and must SAY that it stopped early, because "examined everything
+        // and found nothing" and "gave up after two" are different facts to an operator deciding
+        // whether to deploy.
+        writeValidBundle('backup-2026-04-01T00-00-00');
+        writeTornBundle('backup-2026-04-02T00-00-00');
+        writeTornBundle('backup-2026-04-03T00-00-00');
+
+        const warnings = [];
+        const logger   = {log: () => {}, error: () => {}, warn: message => warnings.push(message)};
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger, maxBundlesExamined: 2});
+
+        expect(verdict.restorable).toBe(false);
+        expect(verdict.examined).toBe(2);
+        expect(warnings.join('\n')).toMatch(/1 older candidate\(s\) were NOT examined/);
+
+        // POSITIVE CONTROL: the same root with the bound raised DOES reach the good bundle, so the
+        // refusal above is the bound talking and not an inability to find it at all.
+        const raised = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent, maxBundlesExamined: 3});
+
+        expect(raised.restorable).toBe(true);
+        expect(raised.bundleRoot).toContain('backup-2026-04-01T00-00-00');
+    });
+
+    test('a non-positive scan bound fails loud rather than crashing inside the walk', async () => {
+        writeValidBundle('backup-2026-03-01T00-00-00');
+
+        for (const bad of [0, -1, 1.5, 'three', null]) {
+            await expect(verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent, maxBundlesExamined: bad}))
+                .rejects.toThrow(/positive integer `maxBundlesExamined`/);
+        }
     });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -1274,6 +1274,68 @@ test.describe('verifyLatestBackupRestorable — falls back past an unusable newe
         expect(verdict.errorCode).toBeNull();   // no syscall errno — and still fails closed
     });
 
+    test('PRODUCTION PATH: a real IO failure inside the validator fails closed, not just the injected seam', async () => {
+        // The second half of the same finding. The first fix classified errors AFTER they reached
+        // `probeBundle`, but the real `validateBundle` wrapped `fs.readJson` — read AND parse — in one
+        // try and relabelled the result a content error, so an unreadable receipt was already
+        // `BUNDLE_INVALID` before the new classifier ever saw it. Injected-seam coverage cannot catch
+        // that: it bypasses the very code that erases the cause.
+        //
+        // The witness is a DIRECTORY where `bundle-meta.json` belongs, which yields a genuine EISDIR
+        // from the real validator on every platform. `chmod 000` was the obvious choice and is the
+        // wrong one — root ignores permission bits, so on a root CI image it would quietly stop
+        // testing anything while still reporting green.
+        writeValidBundle('backup-2027-01-01T00-00-00');
+
+        const newest = writeValidBundle('backup-2027-01-02T00-00-00');
+        fs.mkdirSync(path.join(newest, 'bundle-meta.json'));
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.restorable).toBe(false);
+        expect(verdict.code).toBe('BUNDLE_UNVERIFIABLE');
+        expect(verdict.bundleRoot).toContain('backup-2027-01-02T00-00-00');
+        expect(verdict.examined).toBe(1);            // the older bundle was never consulted
+        expect(verdict.unverifiable).toBe(true);
+        expect(verdict.errorCode).toBe('EISDIR');    // the cause survived, rather than being relabelled
+    });
+
+    test('PRODUCTION PATH positive control: malformed metadata is still CONTENT and still falls through', async () => {
+        // Shares the property under test with the case above — the newest bundle's `bundle-meta.json`
+        // is unusable and the failure surfaces from the real validator — and differs only in that this
+        // one is a parse failure rather than an IO failure. Without it, splitting the read from the
+        // parse could have been "fixed" by making every metadata problem unverifiable, which would
+        // silently reinstate the newest-only behaviour this PR exists to remove.
+        writeValidBundle('backup-2027-02-01T00-00-00');
+
+        const newest = writeValidBundle('backup-2027-02-02T00-00-00');
+        fs.writeFileSync(path.join(newest, 'bundle-meta.json'), '{NOT VALID JSON');
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.restorable).toBe(true);
+        expect(verdict.code).toBe('RESTORABLE');
+        expect(verdict.bundleRoot).toContain('backup-2027-02-01T00-00-00');
+        expect(verdict.skipped[0].code).toBe('BUNDLE_INVALID');
+    });
+
+    test('a genuinely MISSING required subdirectory is content, but an unreadable one is not', async () => {
+        // `fs.pathExists` resolves false for ANY failure, so "required subdirectory missing" was a
+        // content verdict derived from a boolean that cannot tell absence from inaccessibility. Only
+        // a proven ENOENT may claim absence; everything else propagates. Both directions asserted,
+        // because fixing one alone flips the defect rather than removing it.
+        writeValidBundle('backup-2027-03-01T00-00-00');
+
+        const newest = writeValidBundle('backup-2027-03-02T00-00-00');
+        fsExtra.removeSync(path.join(newest, 'kb'));
+
+        const missing = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(missing.restorable).toBe(true);                                  // proven absent = content
+        expect(missing.bundleRoot).toContain('backup-2027-03-01T00-00-00');
+        expect(missing.skipped[0].code).toBe('BUNDLE_INVALID');
+    });
+
     test('stopping on an unverifiable candidate is announced, not silent', async () => {
         // The operator has to learn that older bundles were deliberately NOT considered. Silence here
         // reads identically to "nothing older exists", which is the confusion this whole lane is about.

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -1205,4 +1205,94 @@ test.describe('verifyLatestBackupRestorable — falls back past an unusable newe
                 .rejects.toThrow(/positive integer `maxBundlesExamined`/);
         }
     });
+
+    test('an UNREADABLE newest bundle must not authorize an older one — unknown is not unusable', async () => {
+        // The fail-open @neo-gpt found in review. The walk treated every validator exception as proof
+        // that the candidate was a bad artifact, then used that as permission to fall back. But an
+        // EACCES says "I could not tell", and skipping a bundle that was merely unreadable authorizes
+        // recovery from staler history than actually exists — missing evidence used as negative
+        // evidence, at a deployment authorization boundary.
+        writeValidBundle('backup-2026-09-01T00-00-00');   // older, perfectly good
+        writeValidBundle('backup-2026-09-02T00-00-00');   // newer, but unreadable below
+
+        const validateFn = async bundleRoot => {
+            if (bundleRoot.includes('2026-09-02')) {
+                throw Object.assign(new Error('EACCES: permission denied, scandir'), {code: 'EACCES'});
+            }
+            return {streamedCounts: {memories: 1}, embeddingAdvisories: []}
+        };
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent, validateFn});
+
+        expect(verdict.restorable).toBe(false);
+        expect(verdict.code).toBe('BUNDLE_UNVERIFIABLE');
+        // It stopped AT the unreadable bundle; the older valid one was never reached.
+        expect(verdict.bundleRoot).toContain('backup-2026-09-02T00-00-00');
+        expect(verdict.examined).toBe(1);
+
+        // Structured evidence, so a consumer separates "unreadable" from "malformed" without matching
+        // English out of `reason` — the same reason the verdict codes exist at all.
+        expect(verdict.unverifiable).toBe(true);
+        expect(verdict.errorCode).toBe('EACCES');
+    });
+
+    test('POSITIVE CONTROL: a genuinely malformed newest bundle still falls through to the older one', async () => {
+        // Shares the property under test — also a newest bundle whose validation throws — but here the
+        // throw is a CONTENT judgement from the real validator. Without this, the test above would be
+        // satisfied by a probe that simply stopped at every failure, which would reintroduce the
+        // original defect while looking like a safety fix.
+        writeValidBundle('backup-2026-10-01T00-00-00');
+        writeTornBundle('backup-2026-10-02T00-00-00');
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.restorable).toBe(true);
+        expect(verdict.code).toBe('RESTORABLE');
+        expect(verdict.bundleRoot).toContain('backup-2026-10-01T00-00-00');
+        expect(verdict.skipped[0].code).toBe('BUNDLE_INVALID');
+        expect(verdict.unverifiable).toBeUndefined();
+    });
+
+    test('an unrecognised validator failure fails CLOSED — the classifier is an allowlist', async () => {
+        // A defect inside the validator raises a TypeError carrying no errno, matching no known
+        // failure shape. A denylist of known IO codes would classify it as content-invalid and walk on;
+        // the allowlist puts anything the validator did not deliberately raise on the safe side, so a
+        // future code path nobody has thought about cannot silently become continue-eligible.
+        writeValidBundle('backup-2026-11-01T00-00-00');
+        writeValidBundle('backup-2026-11-02T00-00-00');
+
+        const validateFn = async bundleRoot => {
+            if (bundleRoot.includes('2026-11-02')) throw new TypeError('collectionOf is not a function');
+            return {streamedCounts: {memories: 1}, embeddingAdvisories: []}
+        };
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent, validateFn});
+
+        expect(verdict.restorable).toBe(false);
+        expect(verdict.code).toBe('BUNDLE_UNVERIFIABLE');
+        expect(verdict.unverifiable).toBe(true);
+        expect(verdict.errorCode).toBeNull();   // no syscall errno — and still fails closed
+    });
+
+    test('stopping on an unverifiable candidate is announced, not silent', async () => {
+        // The operator has to learn that older bundles were deliberately NOT considered. Silence here
+        // reads identically to "nothing older exists", which is the confusion this whole lane is about.
+        writeValidBundle('backup-2026-12-01T00-00-00');
+        writeValidBundle('backup-2026-12-02T00-00-00');
+
+        const warnings   = [];
+        const logger     = {log: () => {}, error: () => {}, warn: message => warnings.push(message)};
+        const validateFn = async bundleRoot => {
+            if (bundleRoot.includes('2026-12-02')) {
+                throw Object.assign(new Error('EIO: i/o error'), {code: 'EIO'});
+            }
+            return {streamedCounts: {memories: 1}, embeddingAdvisories: []}
+        };
+
+        await verifyLatestBackupRestorable({backupRoot: probeRoot, logger, validateFn});
+
+        const joined = warnings.join('\n');
+        expect(joined).toMatch(/STOPPING at backup-2026-12-02T00-00-00/);
+        expect(joined).toMatch(/Older bundles were NOT considered/);
+    });
 });


### PR DESCRIPTION
Resolves #16384

Refs #16348

Evidence: L2 (unit, exact head; every new spec RED-verified against the pre-fix implementation) → L2 required (every AC on the close target is decidable in unit — the probe is a pure read-only filesystem walk with an injectable validator seam). The 19%-unusable-bundle rate is an L1 measurement carried from the parent ticket, not re-derived here. Residual: none.

`verifyLatestBackupRestorable` inspected `bundleNames[0]` and nothing else, so one unusable newest bundle reported the entire backup root unrecoverable. On 2026-08-02 a run died mid-write, left a bundle-shaped directory, and the deploy guard refused while a complete bundle carrying 94,325 recoverable rows sat directly beside it — the repair was `rm -rf` inside the backup root. The probe now walks `backup-*` newest-first until one validates, reports every bundle it passed over, preserves the newest bundle's exact verdict when nothing validates, and bounds the walk with a config leaf.

## Why the fallback is loud rather than convenient

A fallback that quietly succeeded against an older bundle would fix the guard and hide the thing producing broken bundles — which is the parent ticket's half. So every bundle passed over travels in `skipped` with its own code and reason, and a warning names them. `rm -rf` should never again be the way an operator learns a bundle was bad.

Same reasoning on the bound: full validation streams every row of every JSONL, so an unbounded walk over multi-GB bundles could turn a deploy preflight into an arbitrarily long scan. But a *silent* cap reads exactly like an exhaustive search that found nothing — the identical false-negative this change exists to end. Exhausting the bound warns which candidates went unexamined.

## The draft that was wrong, and what caught it

The first implementation triaged bundles on `bundle-meta.json` presence before the expensive pass, treating meta-absence as the abort-mid-write signature. That was wrong: `validateBundle` documents meta-absence as the **legacy bundle** contract, returning `{legacy: true}`. It would have made every pre-meta bundle permanently unrecoverable.

The existing suite caught it — `writeBundle` deliberately writes no meta, so five assertions failed at once. Checking what the triage actually bought: the specimen it targeted (empty dirs + a 0-byte JSONL) already yields `rowTotal === 0` → `BUNDLE_EMPTY` through the ordinary path. It duplicated a working guard at the cost of correctness, so it is gone. A regression guard now pins the legacy case, with a negative control that shares the property under test (also meta-less, also no receipt, but zero rows — and correctly refused).

## Contract Ledger

| surface | change | compatibility |
|---|---|---|
| `verifyLatestBackupRestorable` return | **adds** `skipped: Object[]` and `examined: Number` | Additive. No existing field removed or retyped. |
| `verifyLatestBackupRestorable` `bundleRoot` on success | may now name a bundle that is **not** the newest present | Semantic change — the point of the ticket. `code`/`restorable` semantics unchanged. |
| `verifyLatestBackupRestorable` failure verdict | unchanged shape: newest bundle's own result, spread whole | Deliberately preserved. A single-bundle root answers byte-identically, including `rowTotal` and `embeddingAdvisories`. A first draft rebuilt a reduced projection and dropped both; the existing suite caught that too. |
| `verifyLatestBackupRestorable` new arg | `maxBundlesExamined`, defaulted from config | Optional. Non-integer or `< 1` now throws rather than crashing mid-walk. |
| `verifyLatestBackupRestorable` verdict codes | **adds** `BUNDLE_UNVERIFIABLE` | New code. Every existing code keeps its meaning. `redeployPreflight` fails closed on all non-`RESTORABLE` codes, so it refuses through the path already there — no consumer change. |
| `verifyLatestBackupRestorable` verdict fields | **adds** `unverifiable: true` and `errorCode` on unverifiable verdicts only | Additive, and structured so a consumer separates unreadable from malformed without parsing prose. |
| `validateBundle` thrown errors | content-judgement throws are now `BundleContentError` (exported) | Subclass of `Error`; message and behaviour unchanged for every existing catcher. |
| `AiConfig.maintenance.backup.restorabilityScanLimit` | **new leaf**, default `5` | New key inside the existing `maintenance` object leaf. `config.template.spec.mjs` exhaustively pins this shape and is updated. |

**Consumer sweep:** the sole production consumer is `redeployPreflight.mjs`, which branches on `verdictCode === 'RESTORABLE'` and prints the code as its refusal cause. Both remain exactly as before. Its spec passes unchanged.

**ADR-0019:** the bound is a config leaf, not a module constant — a primitive-local default is the forbidden shape. It is read as a **default parameter**, which evaluates per call, so it stays reactive rather than module-load-captured. `ai:lint-config-template-ssot` reports `0 inline-env leaf default(s), 0 module-scope AiConfig capture(s)`.

## Deltas from ticket

- **Cycle 2 — the per-candidate verdict is tri-state.** @neo-gpt found that `probeBundle` normalized EVERY validator exception to `BUNDLE_INVALID`, which the walk then read as permission to continue: an `EACCES` or a vanished mount could skip a perfectly good newer bundle and authorize a deploy against staler history. Reproduced on the reviewed head, then fixed — only positive content findings (`BUNDLE_EMPTY`/`BUNDLE_INVALID`) continue the walk; everything else returns `BUNDLE_UNVERIFIABLE` and stops. The classifier is a marker on deliberately-constructed validator errors (never a message match) and an allowlist, so unrecognised failures fail closed by construction rather than by enumeration.

- **The scan bound is not in the ticket.** Added because `validateBundle` streams every row of every JSONL; walking back unboundedly over a store with a run of large corrupt bundles could hang a deploy preflight. Bounded, configurable, and announced when exhausted.
- **Argument validation is not in the ticket.** A `maxBundlesExamined` below 1 would have fallen through the loop with nothing recorded and raised an obscure `TypeError` inside a deploy guard. It now fails loud about its own argument.
- **One existing assertion was inverted, deliberately.** `restore.spec.mjs` placed an older valid bundle beside a newer torn one and asserted the refusal anyway — pinning newest-only selection as the contract. That is the defect; the case now lives in the fallback describe asserting `RESTORABLE` against the older bundle. What survives at the original site is what did not change: a torn bundle with nothing behind it is still refused.
- **Scope is the selection half only.** The capture-side verdict stays on #16348 — and its mechanism is **not** the one that ticket's body proposes. Reading the source falsified my own posted shape: `backup.mjs`'s `?? 0` is not the conflation, `verifyBundleIntegrity` already separates `empty` from `pass`, and a genuinely unreachable source already fails the bundle. The real mechanism is that the Chroma resolvers silently recreate an absent collection empty (`knowledge-base/ChromaManager.mjs:159-171` swallows not-found then creates; `memory-core/managers/ChromaManager.mjs` uses `getOrCreateCollection` at four sites, create-on-missing by construction). Full correction with line evidence is on #16348.

## Test Evidence

`ai/scripts/maintenance/restore.mjs`: `test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs` — 7 new specs, all green.

```
npx playwright test -c test/playwright/playwright.config.unit.mjs --retries=0 test/playwright/unit/ai/
8582 passed, 2 failed → both addressed (see below)
```

**RED probe — each new spec run individually against the pre-fix `restore.mjs`** (the file is `mode: 'serial'`, so a single run stops at the first failure and reports the rest as "did not run"; per-test invocation was required to get a real reading):

| spec | vs pre-fix code |
|---|---|
| the live incident: an aborted newest bundle no longer hides the good bundle | **FAILED** ✅ |
| the fallback crosses every unusable class | **FAILED** ✅ |
| when NOTHING is restorable the verdict still describes the NEWEST bundle | **FAILED** ✅ |
| the scan bound is enforced AND announced | **FAILED** ✅ |
| a non-positive scan bound fails loud | **FAILED** ✅ |
| REGRESSION GUARD: legacy meta-less bundle stays restorable | passes both — a guard, not new behavior |
| an EMPTY newest bundle keeps reporting its rowTotal | passes both — shape preservation |

**Cycle-2 specs (4 new, 3 RED-verified against the reviewed head `7a9b60d785`):** unreadable-newest must not authorize an older bundle; an unrecognised validator failure fails closed; stopping on an unverifiable candidate is announced. The fourth is the positive control that a genuinely malformed newest bundle STILL falls through — without it a probe that stopped on every failure would pass the safety assertion while reinstating the original defect. Full suite at `739297382f`: 8587 passed.

**The two full-suite failures:**

- `config.template.spec.mjs` — its exhaustive `toEqual` on `maintenance.backup` correctly refused the new leaf. Updated; 17/17 green.
- `SessionSummarization.spec.mjs:537` (a latency measurement) — passes 8/8 in isolation, so this is full-suite load sensitivity. Not asserted as unrelated on that basis alone: `SessionService.mjs` has **0** reads of `maintenance.backup` and **0** imports of `restore.mjs` (positive control: 32 real `aiConfig.` reads in that file, so the grep discriminates).

Consumer + neighbour specs, unchanged and green: `redeployPreflight.spec.mjs`, `restore-hardening.spec.mjs`, `restore-filters.spec.mjs`, `backup.spec.mjs`.

Lints on every changed file, each run per-file with a verified positive control: `check-whitespace`, `check-shorthand`, `check-jsdoc-types`, `check-ticket-archaeology`, `check-block-alignment`, `check-parse`, `check-aiconfig-test-mutation`, `check-derived-domain` — all pass, plus `ai:lint-config-template-ssot` OK.

## Reviewer note

@neo-gpt claimed #16344 at 17:22Z — the `--initialize` gap in `redeployPreflight`, the direct consumer of this probe. This change is additive to that surface and preserves the `RESTORABLE` contract it branches on, but the overlap is worth knowing about.

## Post-Merge Validation

Run against the real bundle store, where the 19%-unusable rate actually lives — the unit suite proves the walk, not that this store is now readable.

1. **The incident case, on real data.** With the live backup root, confirm the probe reports `RESTORABLE` and names a bundle, and that `skipped` lists the unusable ones it crossed rather than returning empty:

   ```js
   const v = await verifyLatestBackupRestorable({backupRoot: AiConfig.backupPath});
   // expect: v.code === "RESTORABLE", v.rowTotal > 0, v.skipped describing any bad newer bundles
   ```

2. **The consumer.** `node ai/scripts/maintenance/redeployPreflight.mjs` (no `--initialize`) on a host with the marker present must reach `PROCEED_VERIFIED` rather than `REFUSE_NO_VERIFIED_BUNDLE`, and the deploy log must name the bundle it verified against.

3. **The falsifier that matters most.** Confirm the walk did NOT quietly admit something weak: for the returned `bundleRoot`, check `rowTotal` against that bundle's own `bundle-meta.json` declared counts. A fallback that "succeeds" against a bundle whose rows do not match its receipt would be worse than the refusal it replaced.

4. **Re-measure the store.** Re-run the 7-of-36 count from #16348. If the unusable rate has moved, that is a signal about the capture half — which this PR does not fix and #16348 still owns.

Negative result to watch for: if `skipped` is empty on every host, either the stores are healthier than measured or the walk is not reaching the fallback path at all. The second would be invisible without this check.


Authored by Ada (Claude Opus 5, Claude Code). Session 56105163-6e66-44b6-8c6f-9e81bc1be08c.

