### PR TITLE
feat: fleet stall telltales tell the truth (#16380)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -252,6 +252,20 @@ class ConfigBase extends ConfigProvider {
                  * @type {string}
                  */
                 planeBearer    : leaf('', 'NEO_FLEET_PLANE_BEARER', 'string'),
+                /**
+                 * Patience for ONE tenant-plane probe request (initialize, the initialized
+                 * notification, the identity proof) — a single declared bound replacing per-site
+                 * literals, env-relocatable. Calibrated from MEASURED plane latency, both modes:
+                 * healthy establish+prove answers in well under a second (measured 41-397ms,
+                 * 2026-08-02, post-rebuild), while the loaded-window receipts put `initialize`
+                 * at ~17s under WAL/embed load — the prior 10s literals read exactly those
+                 * healthy-but-loaded windows as degraded, a fabrication class, not caution.
+                 * 30s covers the measured loaded tail with margin while keeping boot-path
+                 * failure detection bounded; a wedged plane failing this probe after 30s is the
+                 * honest outcome, not the defect. Milliseconds.
+                 * @type {number}
+                 */
+                tenantProbeTimeoutMs: leaf(30000, 'NEO_FLEET_TENANT_PROBE_TIMEOUT_MS', 'number'),
                 harnessBinaries: {
                     /**
                      * The antigravity harness binary — the app-bundle MAIN binary (a directly

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -142,6 +142,7 @@
         "fleet.instanceRoot",
         "fleet.planeBase",
         "fleet.planeBearer",
+        "fleet.tenantProbeTimeoutMs",
         "geminiApiKey",
         "graphProvider",
         "knowledgeBase",

--- a/ai/services/fleet/FleetTenantService.mjs
+++ b/ai/services/fleet/FleetTenantService.mjs
@@ -7,6 +7,7 @@ import {
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/sdk/types.js';
 import Base                        from '../../../src/core/Base.mjs';
+import AiConfig                    from '../../config.mjs';
 import {resolveFleetCredentialKey} from './FleetRegistryService.mjs';
 import {
     normalizeAgentIdentity,
@@ -603,7 +604,7 @@ async function probeMcpIdentity({url, credential, sessionId, protocolVersion, ex
             method : 'tools/call',
             params : {name: 'list_permissions', arguments: {}}
         }),
-        signal: AbortSignal.timeout(10_000)
+        signal: AbortSignal.timeout(AiConfig.fleet.tenantProbeTimeoutMs)
     });
     const payload  = readMcpToolPayload(parseMcpEnvelope(await response.text()));
     const identity = normalizeAgentIdentity(payload?.identity);
@@ -644,7 +645,7 @@ async function notifyMcpInitialized({url, credential, sessionId, protocolVersion
             jsonrpc: '2.0',
             method : 'notifications/initialized'
         }),
-        signal: AbortSignal.timeout(10_000)
+        signal: AbortSignal.timeout(AiConfig.fleet.tenantProbeTimeoutMs)
     });
 
     await response.text();
@@ -682,7 +683,7 @@ async function initializeMcpResource({url, credential, expectedIdentity=null}) {
                 clientInfo     : {name: 'neo-fleet-readiness', version: '1'}
             }
         }),
-        signal: AbortSignal.timeout(10_000)
+        signal: AbortSignal.timeout(AiConfig.fleet.tenantProbeTimeoutMs)
     });
 
     const sessionId = response.headers.get('mcp-session-id');

--- a/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
+++ b/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
@@ -198,7 +198,10 @@ export function createIssueActivityEvents(issues = [], {capturedAt = new Date()}
  * that began yesterday is a yesterday event, however recently it was re-confirmed; the fresher
  * observation facts stay available in the payload. A finding carrying no temporal fact at all
  * degrades to the capture clock WITH the `rankAnchor` marker naming that degradation — never
- * silently.
+ * silently. One upstream bound the marker cannot see: the findings builder defaults an absent
+ * `waitingSince` to its own scan-time `observedAt` BEFORE the finding reaches this adapter, so
+ * such rows arrive indistinguishable from genuinely-anchored ones and read `rankAnchor: 'finding'`
+ * — the marker names locally-absent anchors only.
  * @param {Object[]} stallFindings Findings from `buildWorkGraphStallFindings`.
  * @param {Object} options
  * @param {Date|String} options.capturedAt Fallback timestamp.
@@ -224,6 +227,8 @@ export function createStallActivityEvents(stallFindings = [], {capturedAt = new 
                     evidenceRefs      : asArray(finding.evidenceRefs),
                     verificationSource: finding.verificationSource || null,
                     waitingSince      : finding.waitingSince || null,
+                    observedAt        : finding.observedAt || null,
+                    lastVerifiedAt    : finding.lastVerifiedAt || null,
                     rankAnchor        : anchoredAt ? 'finding' : 'capture-time-degraded',
                     subject           : normalizeSubject(finding.subject)
                 }

--- a/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
+++ b/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
@@ -190,6 +190,15 @@ export function createIssueActivityEvents(issues = [], {capturedAt = new Date()}
 
 /**
  * @summary Convert work-graph stall findings into cockpit activity events.
+ *
+ * The ranking timestamp rides the stall's own STABLE temporal fact — `waitingSince`, the moment
+ * the work stopped moving — never the scan clock: the findings builder re-stamps `observedAt`/
+ * `lastVerifiedAt` on every snapshot, so ranking by observation time re-floats every unchanged
+ * stall to the top of the merged feed on every poll, drowning genuinely fresh activity. A stall
+ * that began yesterday is a yesterday event, however recently it was re-confirmed; the fresher
+ * observation facts stay available in the payload. A finding carrying no temporal fact at all
+ * degrades to the capture clock WITH the `rankAnchor` marker naming that degradation — never
+ * silently.
  * @param {Object[]} stallFindings Findings from `buildWorkGraphStallFindings`.
  * @param {Object} options
  * @param {Date|String} options.capturedAt Fallback timestamp.
@@ -198,23 +207,28 @@ export function createIssueActivityEvents(issues = [], {capturedAt = new Date()}
 export function createStallActivityEvents(stallFindings = [], {capturedAt = new Date()} = {}) {
     return asArray(stallFindings)
         .filter(Boolean)
-        .map(finding => createFleetCockpitEvent({
-            type      : 'work-stall',
-            source    : FLEET_COCKPIT_SOURCES.graphStall,
-            agentId   : finding.subject?.owner || null,
-            confidence: finding.sourceFidelity === 'candidate' || finding.grade === 'candidate-stall' ? 'inferred' : 'observed',
-            occurredAt: toIsoString(finding.observedAt || finding.lastVerifiedAt || finding.waitingSince, capturedAt),
-            payload   : {
-                kind              : 'work-stall',
-                findingClass      : finding.findingClass || null,
-                grade             : finding.grade || null,
-                motionPredicate   : finding.motionPredicate || null,
-                evidenceRefs      : asArray(finding.evidenceRefs),
-                verificationSource: finding.verificationSource || null,
-                waitingSince      : finding.waitingSince || null,
-                subject           : normalizeSubject(finding.subject)
-            }
-        }))
+        .map(finding => {
+            const anchoredAt = finding.waitingSince || finding.observedAt || finding.lastVerifiedAt || null
+
+            return createFleetCockpitEvent({
+                type      : 'work-stall',
+                source    : FLEET_COCKPIT_SOURCES.graphStall,
+                agentId   : finding.subject?.owner || null,
+                confidence: finding.sourceFidelity === 'candidate' || finding.grade === 'candidate-stall' ? 'inferred' : 'observed',
+                occurredAt: toIsoString(anchoredAt, capturedAt),
+                payload   : {
+                    kind              : 'work-stall',
+                    findingClass      : finding.findingClass || null,
+                    grade             : finding.grade || null,
+                    motionPredicate   : finding.motionPredicate || null,
+                    evidenceRefs      : asArray(finding.evidenceRefs),
+                    verificationSource: finding.verificationSource || null,
+                    waitingSince      : finding.waitingSince || null,
+                    rankAnchor        : anchoredAt ? 'finding' : 'capture-time-degraded',
+                    subject           : normalizeSubject(finding.subject)
+                }
+            })
+        })
 }
 
 function createActivityCapability({capturedAt, confidence, reason = null, state}) {
@@ -330,7 +344,9 @@ function redactSecretText(text) {
 }
 
 function toIsoString(value, fallback = new Date()) {
-    const date = value instanceof Date ? value : new Date(value)
+    // null is MISSING, not a date: `new Date(null)` is the valid epoch, which would silently rank
+    // an anchorless event into 1970 instead of taking the declared fallback.
+    const date = value == null ? new Date(NaN) : (value instanceof Date ? value : new Date(value))
     if (!Number.isNaN(date.getTime())) return date.toISOString()
 
     const fallbackDate = fallback instanceof Date ? fallback : new Date(fallback)

--- a/apps/agentos/view/fleet/ActivityStream.mjs
+++ b/apps/agentos/view/fleet/ActivityStream.mjs
@@ -381,11 +381,46 @@ class ActivityStream extends Container {
      * @summary The row's human text — the event payload's summary/subject when present, else an agent +
      * type fallback so an un-summarized event still reads. `subject` is the live A2A/PR/lane adapter's
      * text field (fixtures carry `text`); both are honored so real feed events render meaningfully.
+     * The chain accepts STRINGS only: two payload vocabularies share the `subject` key — A2A rows
+     * carry the message subject (a string), work-stall rows carry the stall's subject ENTITY (an
+     * object) — and an object reaching a text node renders the literal `[object Object]`. Stall
+     * rows build their text from the entity instead; anything else shapeless takes the named
+     * agent+type fallback, never a raw object.
      * @param {Object} event
      * @returns {String}
      */
     eventText(event) {
-        return event?.payload?.text ?? event?.payload?.summary ?? event?.payload?.subject ?? `${event?.agentId ?? 'fleet'} · ${event?.type ?? 'event'}`
+        const
+            payload = event?.payload,
+            text    = [payload?.text, payload?.summary, payload?.subject]
+                .find(value => typeof value === 'string' && value !== '');
+
+        if (text) {
+            return text
+        }
+
+        if (payload?.kind === 'work-stall') {
+            return this.stallText(payload)
+        }
+
+        return `${event?.agentId ?? 'fleet'} · ${event?.type ?? 'event'}`
+    }
+
+    /**
+     * @summary The stall row's human text, from the finding's subject entity: reference (number or
+     * id) + title when present, else the finding class — a stall without a describable subject
+     * still reads as a stall, never as `[object Object]`.
+     * @param {Object} payload A `work-stall` event payload (`subject` per the PR/lane adapter).
+     * @returns {String}
+     */
+    stallText(payload) {
+        const
+            subject = payload?.subject,
+            ref     = subject?.number != null ? `#${subject.number}` : (subject?.id ?? null),
+            title   = typeof subject?.title === 'string' && subject.title !== '' ? subject.title : null,
+            detail  = [ref, title].filter(Boolean).join(' · ');
+
+        return detail ? `stalled · ${detail}` : `stalled · ${payload?.findingClass ?? 'work item'}`
     }
 }
 

--- a/test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs
@@ -241,3 +241,41 @@ test.describe('fleetPrLaneActivityAdapter - PR/lane activity mapping', () => {
         expect(approveThenDismiss.payload.humanGateState.changedRequested).toBe(false)
     })
 })
+
+/**
+ * The stall ranking timestamp rides the finding's STABLE temporal fact, never the scan clock —
+ * the findings builder re-stamps its observation fields every snapshot, and ranking by those
+ * re-floats every unchanged stall to the top of the merged feed on every poll.
+ */
+test.describe('createStallActivityEvents — stable rank time', () => {
+    const waitingSince = '2026-08-01T10:00:00.000Z'
+
+    test('an unchanged stall keeps its rank across snapshots: occurredAt is waitingSince, not the re-stamped observation', () => {
+        const base = {
+            findingClass: 'ownership-gap',
+            waitingSince,
+            subject     : {owner: '@grace', number: 16310, title: 'Nothing arms a wake route at boot'}
+        }
+
+        const [first]  = createStallActivityEvents([{...base, observedAt: '2026-08-02T16:00:00.000Z'}], {capturedAt: '2026-08-02T16:00:00.000Z'}),
+              [second] = createStallActivityEvents([{...base, observedAt: '2026-08-02T17:00:00.000Z'}], {capturedAt: '2026-08-02T17:00:00.000Z'})
+
+        expect(first.occurredAt).toBe(waitingSince)
+        expect(second.occurredAt).toBe(waitingSince)
+        expect(first.payload.rankAnchor).toBe('finding')
+    })
+
+    test('a fresh real event outranks a stale stall under the composer sort key', () => {
+        const [stall] = createStallActivityEvents([{waitingSince, subject: {owner: '@grace'}}], {capturedAt: '2026-08-02T17:00:00.000Z'})
+
+        expect('2026-08-02T16:59:00.000Z'.localeCompare(stall.occurredAt)).toBeGreaterThan(0)
+    })
+
+    test('a finding with no temporal fact degrades to capture time WITH the named marker — never silently', () => {
+        const capturedAt = '2026-08-02T17:00:00.000Z',
+              [event]    = createStallActivityEvents([{findingClass: 'x', subject: {owner: '@a'}}], {capturedAt})
+
+        expect(event.occurredAt).toBe(capturedAt)
+        expect(event.payload.rankAnchor).toBe('capture-time-degraded')
+    })
+})

--- a/test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs
@@ -263,6 +263,11 @@ test.describe('createStallActivityEvents — stable rank time', () => {
         expect(first.occurredAt).toBe(waitingSince)
         expect(second.occurredAt).toBe(waitingSince)
         expect(first.payload.rankAnchor).toBe('finding')
+
+        // The claim-vs-rank separation, pinned: the RANK ignores the re-stamped observation time,
+        // while the PAYLOAD carries it — a consumer can always see when the stall was last seen.
+        expect(first.payload.observedAt).toBe('2026-08-02T16:00:00.000Z')
+        expect(second.payload.observedAt).toBe('2026-08-02T17:00:00.000Z')
     })
 
     test('a fresh real event outranks a stale stall under the composer sort key', () => {

--- a/test/playwright/unit/apps/agentos/fleet/ActivityStream.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/ActivityStream.spec.mjs
@@ -1,0 +1,67 @@
+import {setup} from '../../../../setup.mjs'
+
+const appName = 'ActivityStreamTextTest'
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+})
+
+import {test, expect} from '@playwright/test'
+import Neo            from '../../../../../../src/Neo.mjs'
+import * as core      from '../../../../../../src/core/_export.mjs'
+
+import ActivityStream from '../../../../../../apps/agentos/view/fleet/ActivityStream.mjs'
+
+// Text-derivation logic only — exercised via prototype calls (no component lifecycle, no stores,
+// no timers): the methods read nothing off the instance beyond each other.
+const {eventText, stallText} = ActivityStream.prototype,
+      host                   = {stallText}
+
+test.describe('ActivityStream — row text derivation (two payload vocabularies, one string contract)', () => {
+    test('an A2A row keeps its string subject — the message-subject vocabulary is untouched', () => {
+        expect(eventText.call(host, {payload: {subject: 'PR #16368 approved'}})).toBe('PR #16368 approved')
+    })
+
+    test('a work-stall subject ENTITY renders the stall text — never [object Object]', () => {
+        const text = eventText.call(host, {
+            type   : 'work-stall',
+            agentId: '@neo-opus-grace',
+            payload: {
+                kind        : 'work-stall',
+                findingClass: 'ownership-gap',
+                subject     : {number: 16310, title: 'Nothing arms a wake route at boot'}
+            }
+        })
+
+        expect(text).toBe('stalled · #16310 · Nothing arms a wake route at boot')
+        expect(text).not.toContain('object Object')
+    })
+
+    test('a stall without a describable subject still reads as a stall via its finding class', () => {
+        expect(eventText.call(host, {type: 'work-stall', payload: {kind: 'work-stall', findingClass: 'ownership-gap', subject: {}}}))
+            .toBe('stalled · ownership-gap')
+
+        expect(eventText.call(host, {type: 'work-stall', payload: {kind: 'work-stall', subject: null}}))
+            .toBe('stalled · work item')
+    })
+
+    test('an id-anchored subject without a number still yields a reference', () => {
+        expect(stallText.call(host, {subject: {id: 'LANE:fm-week', title: null}})).toBe('stalled · LANE:fm-week')
+    })
+
+    test('a non-stall OBJECT subject degrades to the agent+type fallback — the string guard holds for every vocabulary', () => {
+        expect(eventText.call(host, {type: 'a2a', agentId: '@neo-gpt', payload: {subject: {weird: true}}}))
+            .toBe('@neo-gpt · a2a')
+    })
+
+    test('empty payloads keep the named fallback', () => {
+        expect(eventText.call(host, {})).toBe('fleet · event')
+    })
+})


### PR DESCRIPTION
Resolves #16380

The three receipt-observed stall-telltale defects from the Lane A leaf-1 sessions are repaired on one verification surface. **D1:** stall rows rendered the literal `[object Object]` — the root was a vocabulary collision, not the chip: two payload dialects share the `subject` key (A2A rows carry the message subject as a STRING, work-stall rows carry the stall's subject ENTITY), and `ActivityStream.eventText`'s fallback chain passed the object into a text node. The chain now accepts strings only, and stall rows build human text from the entity (`stalled · #16310 · Nothing arms a wake route at boot`) with a named fallback for shapeless payloads. **D2:** unchanged stalls re-floated to the top of the merged head-50 every poll because the findings builder re-stamps its observation fields per scan; the emitter now anchors `occurredAt` on the finding's STABLE fact (`waitingSince`), with `payload.rankAnchor` naming the degraded capture-time case — plus one latent-bug hardening the witness exposed: `toIsoString(null, fallback)` treated `null` as the VALID epoch date, silently ranking anchorless events into 1970 instead of taking the declared fallback. **D3:** the three hand-written `AbortSignal.timeout(10_000)` literals on the tenant plane probes became one ADR-0019-clean leaf (`fleet.tenantProbeTimeoutMs`, env `NEO_FLEET_TENANT_PROBE_TIMEOUT_MS`), calibrated from live measurement rather than hope.

Evidence: L2 achieved (41/41 scoped witnesses: 6 new ActivityStream text-derivation, 3 new stall-rank, composer suite untouched-green; full local unit suite green pre-push; D3 calibration measured through the production plane client) → L3 required (the cockpit receipt on a live loaded plane: readable stall chips, stable ranking, no false-degraded tenant rows). Residual: cockpit receipt [#16380].

## Deltas from ticket

- **D1's root moved one component over:** the ticket anchored `EventChip`/`kindRegistry`; the exact-source trace proved `EventChip` innocent (it renders `label ?? kindLabel(kind)`, both strings) — the object leak was `ActivityStream.eventText`'s `subject` fallback. Fixed at the true root; the chip is untouched.
- **D2 was subtler than "stamped with snapshot time":** the emitter already PREFERRED finding times — but the findings builder re-stamps `observedAt`/`lastVerifiedAt` every scan, so the preference order itself was the defect. The fix reorders the anchor chain to the stable fact and keeps the observation fields in the payload. The `toIsoString` null→epoch hardening was found by the new witness, not by inspection.
- **D3 calibration, measured live (2026-08-02, post-rebuild plane):** establish+prove ×3 = 41/110/326 ms healthy; `list_messages` ×3 = 21.2/21.6/23.6 s under the plane's normal embed load; the leaf-1 receipts put loaded-window `initialize` at ~17 s. Default 30_000 ms covers the measured loaded tail with margin while keeping boot-path failure detection bounded — the prior 10 s literals read exactly those healthy-but-loaded windows as degraded. Measurement receipts in the ticket thread's session record; the bound intentionally does NOT try to outwait a wedged plane (a 30 s probe refusal on a wedged plane is the honest outcome).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs test/playwright/unit/apps/agentos/fleet/ActivityStream.spec.mjs test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs` → 41 passed (13 + 6 new + 22; composer untouched and green against the re-anchored events).
- Full `npm run test-unit` → green pre-push (CI on this PR is the public mirror).
- `apps/agentos` fleet view surface: `ActivityStream.spec.mjs` (new, 6 witnesses — both payload vocabularies, entity/shapeless/id-anchored stall texts, the string guard, named fallbacks).
- `ai/services/fleet` adapter surface: `fleetPrLaneActivityAdapter.spec.mjs` +3 (stable rank across re-stamped snapshots, composer-sort-key comparison, capture-time-degraded marker).
- `FleetTenantService` probe surface: existing `FleetTenantService.spec.mjs` stays green (the leaf read replaces literals; no probe semantics changed); the leaf itself is guarded by the config-leaf parity lint.

## Post-Merge Validation

- [ ] Cockpit receipt on a live plane: stall chips render human text, unchanged stalls hold rank across polls with fresh events above them, and a loaded (not wedged) plane produces no false-degraded tenant rows under the 30 s bound.
- [ ] Plane rebuild at/past this commit carries the calibrated leaf (config parity green).

## Commits

- 5db93d7f47 — fix(ai): stall rows rank and read by their own facts (#16380) — D1 string-contract + stall text, D2 stable rank anchor + degraded marker, the toIsoString null hardening, 9 new witnesses
- be2e11f136 — feat(ai): one declared bound for the tenant plane probes (#16380) — the `fleet.tenantProbeTimeoutMs` leaf (calibrated 30 s) replacing three literals, read at the use sites; parity snapshot recorded in-commit

Authored by Clio (Claude Fable 5, Claude Code). Session 9286a9c0-91be-4143-9bd4-0395853d3d5b.
