### PR TITLE
feat(deploy): observe primary volume before initialize (#16344)

### DIFF
--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -29,8 +29,17 @@ COMPOSE_FILE="${NEO_DEPLOY_COMPOSE_FILE:-$SCRIPT_DIR/../../deploy/docker-compose
 
 # A stable project name pins named-volume identity across redeploys. Export the
 # same value consumed by docker-compose.yml for its top-level project name and
-# the orchestrator runtime-access target identity.
-PROJECT_NAME="${NEO_DEPLOY_PROJECT_NAME:-neo-agent-os}"
+# the orchestrator runtime-access target identity. Ordinary redeploys retain the
+# reference default; initialization cannot use it, because a defaulted selector
+# cannot prove that a differently named plane is absent.
+DECLARED_PROJECT_NAME="${NEO_DEPLOY_PROJECT_NAME:-}"
+PROJECT_NAME="${DECLARED_PROJECT_NAME:-neo-agent-os}"
+
+if [ "${NEO_DEPLOY_INITIALIZE:-0}" = "1" ] && [ -z "$DECLARED_PROJECT_NAME" ]; then
+    echo "[deploy] FATAL: NEO_DEPLOY_PROJECT_NAME must be explicitly declared when NEO_DEPLOY_INITIALIZE=1; --initialize will not use the ordinary redeploy default. Docker was NOT invoked." >&2
+    exit 1
+fi
+
 export NEO_DEPLOY_PROJECT_NAME="$PROJECT_NAME"
 
 # Profiles to deploy. Default: the full cloud stack + ingress. Override by
@@ -154,11 +163,14 @@ echo "[deploy] profiles: ${profile_args[*]}"
 #
 # On a GENUINE first install there is no bundle yet and nothing to protect, so pass --initialize:
 #
-#     NEO_DEPLOY_INITIALIZE=1 ai/examples/cloud-deployment/deploy-pipeline.sh
+#     NEO_DEPLOY_PROJECT_NAME=my-agent-os NEO_DEPLOY_INITIALIZE=1 \
+#         ai/examples/cloud-deployment/deploy-pipeline.sh
 #
-# That is an explicit declaration on purpose. A first deployment and a plane that was destroyed or
-# relocated both present as ABSENCE, and no heuristic separates them — so refusing on absence alone
+# Both values are explicit declarations on purpose. A first deployment and a plane that was destroyed
+# or relocated both present as ABSENCE, and no heuristic separates them — so refusing on absence alone
 # would block the first legitimate deploy, while proceeding on absence is how the incident happened.
+# The ordinary-redeploy project default cannot cross this branch: zero volumes under a defaulted label
+# says nothing about differently named planes on the same host.
 # The gate records a marker beside the bundles (on the bind-mount `down -v` does not touch), so a
 # later absence is informative rather than ambiguous. --initialize on an already-initialized host is
 # REFUSED: the escape hatch must not become the bypass.
@@ -173,7 +185,7 @@ PREFLIGHT="$SCRIPT_DIR/../../scripts/maintenance/redeployPreflight.mjs"
 
 echo "[deploy] running redeploy survivability preflight..."
 if [ "${NEO_DEPLOY_INITIALIZE:-0}" = "1" ]; then
-    node "$PREFLIGHT" --initialize --compose-project "$PROJECT_NAME"
+    node "$PREFLIGHT" --initialize --compose-project "$DECLARED_PROJECT_NAME"
 else
     node "$PREFLIGHT" --compose-project "$PROJECT_NAME"
 fi

--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -144,7 +144,8 @@ echo "[deploy] compose:  $COMPOSE_FILE"
 echo "[deploy] project:  $PROJECT_NAME"
 echo "[deploy] profiles: ${profile_args[*]}"
 
-# SURVIVABILITY GATE — runs BEFORE anything touches containers.
+# SURVIVABILITY GATE — runs BEFORE any container lifecycle mutation. On `--initialize` it may issue
+# a read-only Docker volume metadata query; it never starts, execs, recreates, or removes a container.
 #
 # Refuses unless a verified, non-empty, restorable pre-transition bundle exists. `up -d --build`
 # recreates containers, and a redeploy that crosses into an unrecoverable plane is exactly the
@@ -172,9 +173,9 @@ PREFLIGHT="$SCRIPT_DIR/../../scripts/maintenance/redeployPreflight.mjs"
 
 echo "[deploy] running redeploy survivability preflight..."
 if [ "${NEO_DEPLOY_INITIALIZE:-0}" = "1" ]; then
-    node "$PREFLIGHT" --initialize
+    node "$PREFLIGHT" --initialize --compose-project "$PROJECT_NAME"
 else
-    node "$PREFLIGHT"
+    node "$PREFLIGHT" --compose-project "$PROJECT_NAME"
 fi
 
 # Build + recreate containers, KEEPING named volumes and the backup bind-mount.

--- a/ai/scripts/maintenance/redeployPreflight.mjs
+++ b/ai/scripts/maintenance/redeployPreflight.mjs
@@ -1,5 +1,7 @@
 import fs              from 'fs-extra';
 import path            from 'path';
+import {execFile}      from 'node:child_process';
+import {promisify}     from 'node:util';
 import {fileURLToPath} from 'url';
 
 // Neo namespace bootstrap (entry-point invariant) — this is an operator-runnable driver, and the
@@ -14,7 +16,8 @@ import {verifyLatestBackupRestorable} from './restore.mjs';
 /**
  * @module ai/scripts/maintenance/redeployPreflight
  * @summary Refuses a container-affecting deploy unless a verified, non-empty, restorable
- * pre-transition bundle exists — or the operator has explicitly declared initialization.
+ * pre-transition bundle exists — or the operator has explicitly declared initialization and the
+ * Docker plane independently confirms that no primary-store volume exists.
  *
  * ## What this can and cannot protect
  *
@@ -31,19 +34,41 @@ import {verifyLatestBackupRestorable} from './restore.mjs';
  *
  * ## Why an explicit initialization mode rather than a heuristic
  *
- * A genuine first deployment and a plane that was destroyed or relocated **both present as
- * absence**. Nothing about "no bundle here" says which one it is, so keying the refusal on absence
- * alone would block the very first legitimate deploy. The operator therefore DECLARES
- * initialization, and a durable marker records that this host has deployed before.
+ * A genuine first deployment and a plane whose backup root was destroyed or relocated **both
+ * present as absence** on the host filesystem. Nothing about "no bundle here" says which one it is,
+ * so keying the refusal on that absence alone would either block the first legitimate deploy or
+ * fail open on an established plane. The operator therefore DECLARES initialization, while the
+ * preflight also observes the independently durable Compose primary-store volume.
  *
- * The marker lives beside the bundles on the host bind-mount, which is precisely the mount
- * `docker compose down -v` does not touch. That is the point: it has to survive the operation whose
- * aftermath it exists to describe. `verifyLatestBackupRestorable` only enumerates `backup-*`
- * directories, so a dotfile marker can never be mistaken for a bundle.
+ * The marker lives beside the bundles on the host bind-mount, which survives ordinary container
+ * recreation. The primary store lives in a Docker named volume, a separate durability domain. A
+ * read-only label query can therefore still prove prior plane state after the marker or entire
+ * backup root is lost, without starting or exec-ing a probe container. `verifyLatestBackupRestorable`
+ * only enumerates `backup-*` directories, so a dotfile marker can never be mistaken for a bundle.
  */
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname  = path.dirname(__filename);
+const __filename    = fileURLToPath(import.meta.url),
+      execFileAsync = promisify(execFile);
+
+const COMPOSE_PROJECT_LABEL = 'com.docker.compose.project';
+const COMPOSE_VOLUME_LABEL  = 'com.docker.compose.volume';
+
+/**
+ * Compose volume key that carries the Memory Core primary store.
+ * @type {String}
+ */
+export const PRIMARY_STORE_VOLUME_NAME = 'shared-sqlite-data';
+
+/**
+ * Tri-state result for the read-only Docker-plane observation. Only `ABSENT` can authorize a
+ * genuine first initialization; every unmeasurable or ambiguous result stays `UNKNOWN`.
+ * @type {Object}
+ */
+export const PRIMARY_VOLUME_STATE = Object.freeze({
+    ABSENT : 'absent',
+    PRESENT: 'present',
+    UNKNOWN: 'unknown'
+});
 
 /**
  * Marker filename. A dotfile beside the bundles: same surviving mount, invisible to bundle
@@ -64,7 +89,8 @@ export const REDEPLOY_PREFLIGHT_DECISION = Object.freeze({
     PROCEED_MARKER_RECOVERED  : 'PROCEED_MARKER_RECOVERED',
     PROCEED_VERIFIED          : 'PROCEED_VERIFIED',
     REFUSE_ALREADY_INITIALIZED: 'REFUSE_ALREADY_INITIALIZED',
-    REFUSE_NO_VERIFIED_BUNDLE : 'REFUSE_NO_VERIFIED_BUNDLE'
+    REFUSE_NO_VERIFIED_BUNDLE : 'REFUSE_NO_VERIFIED_BUNDLE',
+    REFUSE_PLANE_STATE_UNKNOWN: 'REFUSE_PLANE_STATE_UNKNOWN'
 });
 
 /**
@@ -77,32 +103,61 @@ export const REDEPLOY_PREFLIGHT_DECISION = Object.freeze({
  * @param {Object} options
  * @param {Boolean} options.markerPresent Whether this host has recorded a prior deployment.
  * @param {Boolean} options.initializeRequested Whether the operator passed the explicit flag.
+ * @param {String|null} [options.primaryVolumeState=null] Docker primary-volume observation.
  * @param {String} options.verdictCode A `verifyLatestBackupRestorable` code.
  * @returns {{decision: String, proceed: Boolean, writeMarker: Boolean, reason: String}}
  */
-export function evaluateRedeployPreconditions({markerPresent, initializeRequested, verdictCode}) {
+export function evaluateRedeployPreconditions({
+    markerPresent,
+    initializeRequested,
+    primaryVolumeState = null,
+    verdictCode
+}) {
     const restorable = verdictCode === 'RESTORABLE';
 
-    // Row 6 first. `--initialize` on a host that has already deployed is an operator mistake worth
-    // catching, never a licence to wipe — checking it before the restorable fast-path is what stops
-    // the escape hatch from becoming the bypass.
-    if (markerPresent && initializeRequested) {
-        return {
-            decision   : REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED,
-            proceed    : false,
-            writeMarker: false,
-            reason     : 'This host has deployed before, so --initialize cannot apply. Remove the flag to run an ordinary redeploy; if you intend to discard the existing plane, do that deliberately and separately.'
-        }
-    }
-
-    // Row 1 — declared first deployment. The one path that proceeds without a bundle, and it
-    // requires a human to have said so.
     if (initializeRequested) {
+        const priorEvidence = [];
+
+        if (markerPresent) {
+            priorEvidence.push('the initialization marker')
+        }
+        if (restorable) {
+            priorEvidence.push('a verified restorable bundle')
+        }
+        if (primaryVolumeState === PRIMARY_VOLUME_STATE.PRESENT) {
+            priorEvidence.push('the Compose-labeled primary-store volume')
+        }
+
+        // Destructive-path ordering is load-bearing: every proof of prior state must win BEFORE the
+        // initialization proceed branch. The old ordering consulted only the marker and ignored even
+        // a RESTORABLE bundle when the marker was missing.
+        if (priorEvidence.length > 0) {
+            return {
+                decision   : REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED,
+                proceed    : false,
+                writeMarker: false,
+                reason     : `--initialize cannot apply because prior deployment is proven by ${priorEvidence.join(', ')}. Remove the flag to run an ordinary redeploy; if you intend to discard the existing plane, do that deliberately and separately.`
+            }
+        }
+
+        // `absent` is the sole authorizing observation. Missing, malformed, ambiguous, and failed
+        // observations all remain unknown and fail closed under a distinct audit code.
+        if (primaryVolumeState !== PRIMARY_VOLUME_STATE.ABSENT) {
+            return {
+                decision   : REDEPLOY_PREFLIGHT_DECISION.REFUSE_PLANE_STATE_UNKNOWN,
+                proceed    : false,
+                writeMarker: false,
+                reason     : `--initialize requires proof that the Compose primary-store volume is absent; observed ${primaryVolumeState ?? 'no result'}. No plane mutation is authorized.`
+            }
+        }
+
+        // Declared first deployment: no marker, no restorable bundle, and the independent Docker
+        // plane observer positively measured that the primary-store volume does not exist.
         return {
             decision   : REDEPLOY_PREFLIGHT_DECISION.PROCEED_INITIALIZING,
             proceed    : true,
             writeMarker: true,
-            reason     : 'Initialization declared by the operator and no prior deployment is recorded on this host.'
+            reason     : 'Initialization declared by the operator; no marker or restorable bundle exists, and the Compose primary-store volume is absent.'
         }
     }
 
@@ -138,6 +193,122 @@ export function evaluateRedeployPreconditions({markerPresent, initializeRequeste
         reason     : markerPresent
             ? `This host has deployed before and has no usable pre-transition bundle (${verdictCode}). Proceeding could cross into an unrecoverable plane.`
             : `No prior deployment is recorded and no usable bundle exists (${verdictCode}). This is indistinguishable from a destroyed or relocated plane. If this is genuinely a first install, pass --initialize to say so.`
+    }
+}
+
+/**
+ * @summary Observes the Compose primary-store volume using read-only Docker metadata operations.
+ *
+ * The lookup first narrows by BOTH canonical Compose labels, then inspects the single match and
+ * verifies those labels exactly. Zero matches is a measured absence. Multiple matches, malformed
+ * labels, command failures, and missing project identity remain unknown and can never authorize
+ * initialization.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.composeProject] Expected Compose project label.
+ * @param {Function} [options.execFileFn=execFileAsync] Promise-based `execFile` seam.
+ * @returns {Promise<Object>} Tri-state observation with bounded audit metadata.
+ */
+export async function observePrimaryStoreVolume({composeProject, execFileFn = execFileAsync} = {}) {
+    const project = typeof composeProject === 'string' ? composeProject.trim() : '';
+
+    if (!project) {
+        return {
+            state : PRIMARY_VOLUME_STATE.UNKNOWN,
+            reason: 'compose-project-unavailable'
+        }
+    }
+
+    const commandOptions = {
+        encoding : 'utf8',
+        maxBuffer: 64 * 1024,
+        timeout  : 5000
+    };
+
+    try {
+        const listResult = await execFileFn('docker', [
+                  'volume',
+                  'ls',
+                  '--quiet',
+                  '--filter',
+                  `label=${COMPOSE_PROJECT_LABEL}=${project}`,
+                  '--filter',
+                  `label=${COMPOSE_VOLUME_LABEL}=${PRIMARY_STORE_VOLUME_NAME}`
+              ], commandOptions),
+              matches = String(listResult.stdout ?? '')
+                  .split(/\r?\n/)
+                  .map(item => item.trim())
+                  .filter(Boolean);
+
+        if (matches.length === 0) {
+            return {
+                matchCount: 0,
+                reason    : 'volume-not-found',
+                state     : PRIMARY_VOLUME_STATE.ABSENT
+            }
+        }
+
+        if (matches.length !== 1) {
+            return {
+                matchCount: matches.length,
+                reason    : 'volume-match-ambiguous',
+                state     : PRIMARY_VOLUME_STATE.UNKNOWN
+            }
+        }
+
+        const volumeName    = matches[0],
+              inspectResult = await execFileFn('docker', [
+                  'volume',
+                  'inspect',
+                  '--format',
+                  '{{json .Labels}}',
+                  volumeName
+              ], commandOptions);
+
+        let labels;
+
+        try {
+            labels = JSON.parse(String(inspectResult.stdout ?? '').trim())
+        } catch {
+            return {
+                matchCount: 1,
+                reason    : 'volume-labels-malformed',
+                state     : PRIMARY_VOLUME_STATE.UNKNOWN,
+                volumeName
+            }
+        }
+
+        if (!labels || Array.isArray(labels) || typeof labels !== 'object') {
+            return {
+                matchCount: 1,
+                reason    : 'volume-labels-malformed',
+                state     : PRIMARY_VOLUME_STATE.UNKNOWN,
+                volumeName
+            }
+        }
+
+        if (labels[COMPOSE_PROJECT_LABEL] !== project ||
+            labels[COMPOSE_VOLUME_LABEL] !== PRIMARY_STORE_VOLUME_NAME) {
+            return {
+                matchCount: 1,
+                reason    : 'volume-label-mismatch',
+                state     : PRIMARY_VOLUME_STATE.UNKNOWN,
+                volumeName
+            }
+        }
+
+        return {
+            matchCount: 1,
+            reason    : 'volume-labels-verified',
+            state     : PRIMARY_VOLUME_STATE.PRESENT,
+            volumeName
+        }
+    } catch (error) {
+        return {
+            errorCode: error && typeof error.code === 'string' ? error.code : null,
+            reason   : 'docker-volume-query-failed',
+            state    : PRIMARY_VOLUME_STATE.UNKNOWN
+        }
     }
 }
 
@@ -178,26 +349,34 @@ export async function writeInitializationMarker({backupRoot, decision, fsModule 
  *
  * @param {Object} [options]
  * @param {String} [options.backupRoot] Bundle root. Defaults to the resolved leaf.
+ * @param {String} [options.composeProject] Compose project used for the exact volume-label lookup.
  * @param {Boolean} [options.initializeRequested=false] Explicit initialization declaration.
  * @param {Object} [options.logger=console] Log sink.
  * @param {Function} [options.probeFn=verifyLatestBackupRestorable] Probe seam.
+ * @param {Function} [options.primaryVolumeProbeFn=observePrimaryStoreVolume] Docker observer seam.
  * @param {Object} [options.fsModule=fs] Filesystem seam.
  * @returns {Promise<Object>}
  */
 export async function runRedeployPreflight({
     backupRoot,
-    initializeRequested = false,
-    logger              = console,
-    probeFn             = verifyLatestBackupRestorable,
-    fsModule            = fs
+    composeProject,
+    initializeRequested  = false,
+    logger               = console,
+    probeFn              = verifyLatestBackupRestorable,
+    primaryVolumeProbeFn = observePrimaryStoreVolume,
+    fsModule             = fs
 } = {}) {
     const resolvedRoot  = backupRoot ?? AiConfig.backupPath,
           markerPresent = await readInitializationMarker({backupRoot: resolvedRoot, fsModule}),
           verdict       = await probeFn({backupRoot: resolvedRoot, logger}),
+          primaryVolume = initializeRequested
+              ? await primaryVolumeProbeFn({composeProject})
+              : {reason: 'not-required-for-ordinary-redeploy', state: null},
           outcome       = evaluateRedeployPreconditions({
               initializeRequested,
               markerPresent,
-              verdictCode: verdict.code
+              primaryVolumeState: primaryVolume.state,
+              verdictCode       : verdict.code
           });
 
     if (outcome.proceed && outcome.writeMarker) {
@@ -206,9 +385,15 @@ export async function runRedeployPreflight({
 
     return {
         ...outcome,
-        backupRoot: resolvedRoot,
-        bundleRoot: verdict.bundleRoot ?? null,
+        backupRoot             : resolvedRoot,
+        bundleRoot             : verdict.bundleRoot ?? null,
+        composeProject         : composeProject ?? null,
         markerPresent,
+        primaryVolumeErrorCode : primaryVolume.errorCode ?? null,
+        primaryVolumeMatchCount: primaryVolume.matchCount ?? null,
+        primaryVolumeName      : primaryVolume.volumeName ?? null,
+        primaryVolumeReason    : primaryVolume.reason,
+        primaryVolumeState     : primaryVolume.state,
         // The probe's own verdict travels with the decision so a deploy log records WHY, not just
         // whether. `rowTotal` is what `RESTORABLE` was decided on.
         verdictCode  : verdict.code,
@@ -218,13 +403,28 @@ export async function runRedeployPreflight({
 }
 
 /**
+ * @summary Reads a required value from a two-token CLI option.
+ * @param {String[]} argv CLI argument vector without the executable and script path.
+ * @param {String} option Option name, including its leading dashes.
+ * @returns {String|null}
+ */
+function readCliOption(argv, option) {
+    const index = argv.indexOf(option),
+          value = index === -1 ? null : argv[index + 1];
+
+    return typeof value === 'string' && value.length > 0 && !value.startsWith('--') ? value : null
+}
+
+/**
  * @summary CLI entrypoint. Exit 0 proceeds; exit 1 refuses.
  * @returns {Promise<void>}
  */
 async function main() {
-    const initializeRequested = process.argv.includes('--initialize'),
-          asJson              = process.argv.includes('--json'),
-          result              = await runRedeployPreflight({initializeRequested});
+    const args                = process.argv.slice(2),
+          initializeRequested = args.includes('--initialize'),
+          asJson              = args.includes('--json'),
+          composeProject      = readCliOption(args, '--compose-project'),
+          result              = await runRedeployPreflight({composeProject, initializeRequested});
 
     if (asJson) {
         console.log(JSON.stringify(result, null, 2));
@@ -232,10 +432,13 @@ async function main() {
         console.log(`[preflight] ${result.decision}`);
         console.log(`[preflight] ${result.reason}`);
         console.log(`[preflight] bundle root: ${result.backupRoot} (marker ${result.markerPresent ? 'present' : 'absent'}, probe ${result.verdictCode}${result.rowTotal === null ? '' : `, ${result.rowTotal} rows`})`);
+        if (result.primaryVolumeState !== null) {
+            console.log(`[preflight] primary volume: ${result.primaryVolumeState} (${result.primaryVolumeReason}${result.primaryVolumeName === null ? '' : `, ${result.primaryVolumeName}`})`);
+        }
     }
 
     if (!result.proceed) {
-        console.error('[preflight] REFUSING to proceed. Docker was NOT invoked.');
+        console.error('[preflight] REFUSING to proceed. A read-only Docker metadata query may have run; no container lifecycle mutation was invoked.');
         process.exit(1);
     }
 }
@@ -245,7 +448,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename
         // A preflight that cannot decide must REFUSE. Failing open here would make an unreadable
         // bundle root indistinguishable from a verified one, which is the whole defect inverted.
         console.error(`[preflight] FATAL: ${error.message}`);
-        console.error('[preflight] REFUSING to proceed. Docker was NOT invoked.');
+        console.error('[preflight] REFUSING to proceed. A read-only Docker metadata query may have run; no container lifecycle mutation was invoked.');
         process.exit(1);
     });
 }

--- a/ai/scripts/maintenance/redeployPreflight.mjs
+++ b/ai/scripts/maintenance/redeployPreflight.mjs
@@ -16,8 +16,9 @@ import {verifyLatestBackupRestorable} from './restore.mjs';
 /**
  * @module ai/scripts/maintenance/redeployPreflight
  * @summary Refuses a container-affecting deploy unless a verified, non-empty, restorable
- * pre-transition bundle exists — or the operator has explicitly declared initialization and the
- * Docker plane independently confirms that no primary-store volume exists.
+ * pre-transition bundle exists — or the operator has explicitly declared initialization plus its
+ * Compose project identity, and the Docker plane confirms that no primary-store volume exists for
+ * that declared project.
  *
  * ## What this can and cannot protect
  *
@@ -38,7 +39,9 @@ import {verifyLatestBackupRestorable} from './restore.mjs';
  * present as absence** on the host filesystem. Nothing about "no bundle here" says which one it is,
  * so keying the refusal on that absence alone would either block the first legitimate deploy or
  * fail open on an established plane. The operator therefore DECLARES initialization, while the
- * preflight also observes the independently durable Compose primary-store volume.
+ * preflight also observes the independently durable Compose primary-store volume. The project
+ * selector is part of that declaration: a defaulted or missing identity cannot authorize this path,
+ * because project-scoped absence is not plane-wide absence on a multi-project host.
  *
  * The marker lives beside the bundles on the host bind-mount, which survives ordinary container
  * recreation. The primary store lives in a Docker named volume, a separate durability domain. A
@@ -200,9 +203,9 @@ export function evaluateRedeployPreconditions({
  * @summary Observes the Compose primary-store volume using read-only Docker metadata operations.
  *
  * The lookup first narrows by BOTH canonical Compose labels, then inspects the single match and
- * verifies those labels exactly. Zero matches is a measured absence. Multiple matches, malformed
- * labels, command failures, and missing project identity remain unknown and can never authorize
- * initialization.
+ * verifies those labels exactly. Zero matches is a measured absence for the declared project.
+ * Multiple matches, malformed labels, command failures, and missing project identity remain unknown
+ * and can never authorize initialization.
  *
  * @param {Object} [options]
  * @param {String} [options.composeProject] Expected Compose project label.

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -120,9 +120,10 @@ async function createFakeBin(plainLines, peelLine = '') {
  *
  * @param {Object} fake The `createFakeBin` result.
  * @param {Boolean} declareInitialization
+ * @param {String} projectName Explicit deployment project identity; empty exercises the fail-closed path.
  * @returns {Object}
  */
-function preflightEnv(fake, declareInitialization) {
+function preflightEnv(fake, declareInitialization, projectName) {
     return {
         // INSIDE the per-test temp dir, never `fake.bin/..` — that resolved to `os.tmpdir()` itself, so
         // every test AND every run on the machine shared one backup root. The gate's own contract is
@@ -131,12 +132,18 @@ function preflightEnv(fake, declareInitialization) {
         //
         // It also made the suite non-idempotent in a way a single local run cannot show: the first run
         // passed because the marker did not exist yet, and created the state that failed the second.
-        NEO_BACKUP_PATH      : path.join(fake.bin, 'preflight-backups'),
-        NEO_DEPLOY_INITIALIZE: declareInitialization ? '1' : '0'
+        NEO_BACKUP_PATH        : path.join(fake.bin, 'preflight-backups'),
+        NEO_DEPLOY_INITIALIZE  : declareInitialization ? '1' : '0',
+        NEO_DEPLOY_PROJECT_NAME: projectName
     }
 }
 
-function runPipelineWithProbe(fake, selector, {declareInitialization = true, fetchFails = false, peelTo = ''} = {}) {
+function runPipelineWithProbe(fake, selector, {
+    declareInitialization = true,
+    fetchFails            = false,
+    peelTo                = '',
+    projectName           = declareInitialization ? 'neo-test-project' : ''
+} = {}) {
     // `spawnSync` rather than `execFileSync`, and NO shell. Both streams are needed on the SUCCESS
     // path too — the peel note is a stderr WARNING, and `execFileSync` discards stderr when the
     // command succeeds, so an assertion about it could never pass even when the script emits it
@@ -156,7 +163,7 @@ function runPipelineWithProbe(fake, selector, {declareInitialization = true, fet
             FAKE_PEEL_TO    : peelTo,
             NEO_REF         : selector,
             PATH            : `${fake.bin}:${process.env.PATH}`,
-            ...preflightEnv(fake, declareInitialization)
+            ...preflightEnv(fake, declareInitialization, projectName)
         },
         stdio: ['ignore', 'pipe', 'pipe']
     });
@@ -175,7 +182,10 @@ function runPipelineWithProbe(fake, selector, {declareInitialization = true, fet
  * @param {String} selector Value for `NEO_REF`.
  * @returns {Object} `{code, output}`.
  */
-function runPipeline(fake, selector, {declareInitialization = true} = {}) {
+function runPipeline(fake, selector, {
+    declareInitialization = true,
+    projectName           = declareInitialization ? 'neo-test-project' : ''
+} = {}) {
     try {
         const output = execFileSync('bash', [scriptPath], {
             cwd     : repoRoot,
@@ -186,7 +196,7 @@ function runPipeline(fake, selector, {declareInitialization = true} = {}) {
                 FAKE_LS_PLAIN: fake.plainLines,
                 NEO_REF      : selector,
                 PATH         : `${fake.bin}:${process.env.PATH}`,
-                ...preflightEnv(fake, declareInitialization)
+                ...preflightEnv(fake, declareInitialization, projectName)
             },
             stdio: ['ignore', 'pipe', 'pipe']
         });
@@ -362,6 +372,23 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         // The resolvable revision is not what stopped it — the revision resolved fine.
         expect(result.output).toContain(FULL_SHA);
         // The load-bearing half: nothing touched containers.
+        expect(await dockerInvocations(fake.dockerLog)).toBe(0)
+    });
+
+    test('declared initialization without a declared project identity fails before Docker', async () => {
+        // The pipeline's ordinary-redeploy default is not an initialization declaration. If this
+        // value is inferred, a truthful project-scoped absence can be misread as plane-wide absence
+        // while another Compose project still owns the populated primary volume.
+        const fake   = await createFakeBin(''),
+              result = runPipelineWithProbe(fake, FULL_SHA, {
+                  declareInitialization: true,
+                  peelTo               : FULL_SHA,
+                  projectName          : ''
+              });
+
+        expect(result.code).toBe(1);
+        expect(result.output).toContain('NEO_DEPLOY_PROJECT_NAME');
+        expect(result.output).toMatch(/explicitly declared.*--initialize/i);
         expect(await dockerInvocations(fake.dockerLog)).toBe(0)
     });
 

--- a/test/playwright/unit/ai/scripts/maintenance/redeployPreflight.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/redeployPreflight.spec.mjs
@@ -419,8 +419,10 @@ test.describe('redeploy preflight — wiring and marker durability (#16055 AC2)'
         expect(source).toMatch(/set -euo pipefail/);
         // And the escape hatch has to be reachable, or a genuine first install cannot deploy at all.
         expect(source).toMatch(/NEO_DEPLOY_INITIALIZE/);
-        // The initialization observer must use the SAME project identity Compose uses.
-        expect(source).toContain('--initialize --compose-project "$PROJECT_NAME"');
+        // The initialization observer must use the DECLARED identity, never the ordinary-redeploy
+        // default: a defaulted project-scoped absence cannot prove this host has no existing plane.
+        expect(source).toContain('--initialize --compose-project "$DECLARED_PROJECT_NAME"');
+        expect(source).toMatch(/NEO_DEPLOY_PROJECT_NAME must be explicitly declared/);
         // The contract permits metadata observation, but no container lifecycle mutation before the gate.
         expect(source).toMatch(/read-only Docker volume metadata query/);
     })

--- a/test/playwright/unit/ai/scripts/maintenance/redeployPreflight.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/redeployPreflight.spec.mjs
@@ -7,6 +7,9 @@ import path           from 'path';
 import {
     evaluateRedeployPreconditions,
     INITIALIZATION_MARKER_FILENAME,
+    observePrimaryStoreVolume,
+    PRIMARY_STORE_VOLUME_NAME,
+    PRIMARY_VOLUME_STATE,
     readInitializationMarker,
     REDEPLOY_PREFLIGHT_DECISION,
     runRedeployPreflight
@@ -30,6 +33,7 @@ test.describe('redeploy preflight — the truth table (#16055 AC2/AC3/AC4)', () 
             const declared = evaluateRedeployPreconditions({
                 initializeRequested: true,
                 markerPresent      : false,
+                primaryVolumeState : PRIMARY_VOLUME_STATE.ABSENT,
                 verdictCode
             });
 
@@ -104,11 +108,53 @@ test.describe('redeploy preflight — the truth table (#16055 AC2/AC3/AC4)', () 
             const outcome = evaluateRedeployPreconditions({
                 initializeRequested: true,
                 markerPresent      : true,
+                primaryVolumeState : PRIMARY_VOLUME_STATE.UNKNOWN,
                 verdictCode
             });
 
             expect(outcome.proceed).toBe(false);
             expect(outcome.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED);
+        }
+    });
+
+    test('--initialize refuses when a restorable bundle proves prior deployment without a marker', () => {
+        const outcome = evaluateRedeployPreconditions({
+            initializeRequested: true,
+            markerPresent      : false,
+            primaryVolumeState : PRIMARY_VOLUME_STATE.ABSENT,
+            verdictCode        : 'RESTORABLE'
+        });
+
+        expect(outcome.proceed).toBe(false);
+        expect(outcome.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED);
+        expect(outcome.reason).toContain('verified restorable bundle')
+    });
+
+    test('--initialize refuses when the independently durable primary-store volume exists', () => {
+        const outcome = evaluateRedeployPreconditions({
+            initializeRequested: true,
+            markerPresent      : false,
+            primaryVolumeState : PRIMARY_VOLUME_STATE.PRESENT,
+            verdictCode        : 'NO_BUNDLES'
+        });
+
+        expect(outcome.proceed).toBe(false);
+        expect(outcome.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED);
+        expect(outcome.reason).toContain('primary-store volume')
+    });
+
+    test('--initialize gives an unmeasurable plane its own refusal code', () => {
+        for (const primaryVolumeState of [null, PRIMARY_VOLUME_STATE.UNKNOWN, 'invalid-state']) {
+            const outcome = evaluateRedeployPreconditions({
+                initializeRequested: true,
+                markerPresent      : false,
+                primaryVolumeState,
+                verdictCode        : 'NO_BUNDLES'
+            });
+
+            expect(outcome.proceed).toBe(false);
+            expect(outcome.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_PLANE_STATE_UNKNOWN);
+            expect(outcome.writeMarker).toBe(false)
         }
     });
 
@@ -134,23 +180,147 @@ test.describe('redeploy preflight — the truth table (#16055 AC2/AC3/AC4)', () 
 
         for (const markerPresent of [true, false]) {
             for (const initializeRequested of [true, false]) {
-                for (const verdictCode of [...REFUSAL_CODES, 'RESTORABLE']) {
-                    const outcome = evaluateRedeployPreconditions({initializeRequested, markerPresent, verdictCode});
+                for (const primaryVolumeState of Object.values(PRIMARY_VOLUME_STATE)) {
+                    for (const verdictCode of [...REFUSAL_CODES, 'RESTORABLE']) {
+                        const outcome = evaluateRedeployPreconditions({
+                            initializeRequested,
+                            markerPresent,
+                            primaryVolumeState,
+                            verdictCode
+                        });
 
-                    expect(Object.values(REDEPLOY_PREFLIGHT_DECISION)).toContain(outcome.decision);
-                    expect(typeof outcome.proceed).toBe('boolean');
-                    // A refusal may never authorise a marker write: a refused deploy has to leave the
-                    // host exactly as it found it, or the next run reads a deployment that never was.
-                    if (!outcome.proceed) expect(outcome.writeMarker).toBe(false);
-                    decisions.add(outcome.decision);
+                        expect(Object.values(REDEPLOY_PREFLIGHT_DECISION)).toContain(outcome.decision);
+                        expect(typeof outcome.proceed).toBe('boolean');
+                        // A refusal may never authorise a marker write: a refused deploy has to leave the
+                        // host exactly as it found it, or the next run reads a deployment that never was.
+                        if (!outcome.proceed) expect(outcome.writeMarker).toBe(false);
+                        decisions.add(outcome.decision)
+                    }
                 }
             }
         }
 
-        // All five decisions reachable — otherwise the table has dead rows and the coverage above is
+        // All decisions reachable — otherwise the table has dead rows and the coverage above is
         // measuring less than it appears to.
         expect(decisions.size).toBe(Object.keys(REDEPLOY_PREFLIGHT_DECISION).length);
     });
+});
+
+test.describe('redeploy preflight — read-only Docker primary-volume observer (#16344)', () => {
+    test('zero exact-label matches is a measured absence', async () => {
+        const calls  = [],
+              result = await observePrimaryStoreVolume({
+                  composeProject: 'neo-agent-os',
+                  execFileFn(command, args) {
+                      calls.push({args, command});
+
+                      return Promise.resolve({stdout: ''})
+                  }
+              });
+
+        expect(result).toEqual({
+            matchCount: 0,
+            reason    : 'volume-not-found',
+            state     : PRIMARY_VOLUME_STATE.ABSENT
+        });
+        expect(calls).toHaveLength(1);
+        expect(calls[0].command).toBe('docker');
+        expect(calls[0].args).toContain(`label=com.docker.compose.project=neo-agent-os`);
+        expect(calls[0].args).toContain(`label=com.docker.compose.volume=${PRIMARY_STORE_VOLUME_NAME}`)
+    });
+
+    test('one match is present only after its exact Compose labels are verified', async () => {
+        const calls  = [],
+              result = await observePrimaryStoreVolume({
+                  composeProject: 'neo-agent-os',
+                  execFileFn(command, args) {
+                      calls.push({args, command});
+
+                      return Promise.resolve(args[1] === 'ls'
+                          ? {stdout: 'neo-agent-os_shared-sqlite-data\n'}
+                          : {stdout: JSON.stringify({
+                              'com.docker.compose.project': 'neo-agent-os',
+                              'com.docker.compose.volume' : PRIMARY_STORE_VOLUME_NAME
+                          })})
+                  }
+              });
+
+        expect(result).toEqual({
+            matchCount: 1,
+            reason    : 'volume-labels-verified',
+            state     : PRIMARY_VOLUME_STATE.PRESENT,
+            volumeName: 'neo-agent-os_shared-sqlite-data'
+        });
+        expect(calls).toHaveLength(2);
+        expect(calls[1].args.slice(0, 4)).toEqual(['volume', 'inspect', '--format', '{{json .Labels}}']);
+        // The observer is metadata-only: no container lifecycle or exec verb can appear.
+        const argv = calls.flatMap(call => call.args);
+
+        for (const forbidden of ['create', 'exec', 'remove', 'restart', 'run', 'start', 'stop']) {
+            expect(argv).not.toContain(forbidden)
+        }
+    });
+
+    test('multiple exact-label matches stay unknown and are never inspected heuristically', async () => {
+        const calls  = [],
+              result = await observePrimaryStoreVolume({
+                  composeProject: 'neo-agent-os',
+                  execFileFn(command, args) {
+                      calls.push({args, command});
+
+                      return Promise.resolve({stdout: 'first\nsecond\n'})
+                  }
+              });
+
+        expect(result).toEqual({
+            matchCount: 2,
+            reason    : 'volume-match-ambiguous',
+            state     : PRIMARY_VOLUME_STATE.UNKNOWN
+        });
+        expect(calls).toHaveLength(1)
+    });
+
+    test('malformed or mismatched labels stay unknown', async () => {
+        for (const inspectStdout of [
+            'not-json',
+            JSON.stringify({'com.docker.compose.project': 'foreign'}),
+            JSON.stringify({
+                'com.docker.compose.project': 'neo-agent-os',
+                'com.docker.compose.volume' : 'chroma-data'
+            })
+        ]) {
+            const result = await observePrimaryStoreVolume({
+                composeProject: 'neo-agent-os',
+                execFileFn(command, args) {
+                    return Promise.resolve(args[1] === 'ls'
+                        ? {stdout: 'candidate\n'}
+                        : {stdout: inspectStdout})
+                }
+            });
+
+            expect(result.state).toBe(PRIMARY_VOLUME_STATE.UNKNOWN);
+            expect(result.reason).toMatch(/volume-label/)
+        }
+    });
+
+    test('Docker/socket failure and missing project identity stay unknown', async () => {
+        const dockerError = Object.assign(new Error('socket unavailable'), {code: 'ECONNREFUSED'}),
+              failed      = await observePrimaryStoreVolume({
+                  composeProject: 'neo-agent-os',
+                  execFileFn    : async () => { throw dockerError }
+              }),
+              unscoped    = await observePrimaryStoreVolume();
+
+        expect(failed).toEqual({
+            errorCode: 'ECONNREFUSED',
+            reason   : 'docker-volume-query-failed',
+            state    : PRIMARY_VOLUME_STATE.UNKNOWN
+        });
+        expect(unscoped).toEqual({
+            reason: 'compose-project-unavailable',
+            state : PRIMARY_VOLUME_STATE.UNKNOWN
+        })
+    })
 });
 
 test.describe('redeploy preflight — wiring and marker durability (#16055 AC2)', () => {
@@ -165,31 +335,61 @@ test.describe('redeploy preflight — wiring and marker durability (#16055 AC2)'
     });
 
     test('a refused run writes NO marker, so a later absence stays informative', async () => {
+        let primaryProbeCalls = 0;
+
         const backupRoot = path.join(workRoot, 'backups'),
               result     = await runRedeployPreflight({
                   backupRoot,
-                  initializeRequested: false,
-                  logger             : silent,
-                  probeFn            : async () => ({code: 'NO_BUNDLES', reason: 'none', restorable: false})
+                  initializeRequested : false,
+                  logger              : silent,
+                  primaryVolumeProbeFn: async () => {
+                      primaryProbeCalls++;
+
+                      return {reason: 'unexpected', state: PRIMARY_VOLUME_STATE.PRESENT}
+                  },
+                  probeFn: async () => ({code: 'NO_BUNDLES', reason: 'none', restorable: false})
               });
 
         expect(result.proceed).toBe(false);
+        expect(primaryProbeCalls).toBe(0);
+        expect(result.primaryVolumeState).toBeNull();
         expect(await readInitializationMarker({backupRoot})).toBe(false);
     });
 
     test('an initializing run records the marker, and the SAME command then refuses', async () => {
-        const backupRoot = path.join(workRoot, 'backups'),
-              probeFn    = async () => ({code: 'NO_BUNDLES', reason: 'none', restorable: false});
+        const backupRoot           = path.join(workRoot, 'backups'),
+              composeProject       = 'neo-test',
+              primaryVolumeProbeFn = async () => ({
+                  matchCount: 0,
+                  reason    : 'volume-not-found',
+                  state     : PRIMARY_VOLUME_STATE.ABSENT
+              }),
+              probeFn              = async () => ({code: 'NO_BUNDLES', reason: 'none', restorable: false});
 
-        const first = await runRedeployPreflight({backupRoot, initializeRequested: true, logger: silent, probeFn});
+        const first = await runRedeployPreflight({
+            backupRoot,
+            composeProject,
+            initializeRequested: true,
+            logger             : silent,
+            primaryVolumeProbeFn,
+            probeFn
+        });
 
         expect(first.proceed).toBe(true);
+        expect(first.primaryVolumeState).toBe(PRIMARY_VOLUME_STATE.ABSENT);
         expect(await readInitializationMarker({backupRoot})).toBe(true);
 
         // Re-running the identical initialization command must now REFUSE. This is the property that
         // stops `--initialize` becoming a habit: it works exactly once per host, and a second use is
         // caught rather than silently repeating a wipe-authorising flag.
-        const second = await runRedeployPreflight({backupRoot, initializeRequested: true, logger: silent, probeFn});
+        const second = await runRedeployPreflight({
+            backupRoot,
+            composeProject,
+            initializeRequested: true,
+            logger             : silent,
+            primaryVolumeProbeFn,
+            probeFn
+        });
 
         expect(second.proceed).toBe(false);
         expect(second.decision).toBe(REDEPLOY_PREFLIGHT_DECISION.REFUSE_ALREADY_INITIALIZED);
@@ -219,5 +419,9 @@ test.describe('redeploy preflight — wiring and marker durability (#16055 AC2)'
         expect(source).toMatch(/set -euo pipefail/);
         // And the escape hatch has to be reachable, or a genuine first install cannot deploy at all.
         expect(source).toMatch(/NEO_DEPLOY_INITIALIZE/);
+        // The initialization observer must use the SAME project identity Compose uses.
+        expect(source).toContain('--initialize --compose-project "$PROJECT_NAME"');
+        // The contract permits metadata observation, but no container lifecycle mutation before the gate.
+        expect(source).toMatch(/read-only Docker volume metadata query/);
     })
 });


### PR DESCRIPTION
Resolves #16344

Related: #16055

`--initialize` now requires three independent observations to agree before it can authorize a first deployment: no initialization marker, no verified restorable bundle, and a measured absence of the exact Compose-labeled `shared-sqlite-data` volume. A marker, a restorable bundle, or the primary volume proves prior state and refuses initialization; Docker/socket failure, malformed labels, and ambiguous matches fail closed under `REFUSE_PLANE_STATE_UNKNOWN`. Ordinary redeploy behavior is unchanged and does not query Docker.

Evidence: L3 (real read-only Docker metadata probe plus a synthetic missing-backup-root refusal on a live local Compose plane) → L3 required (the close target's independent Docker-plane witness and lost-backup-root rehearsal). No residuals.

## Deltas from ticket

None substantive. The reference pipeline passes its already-canonical `NEO_DEPLOY_PROJECT_NAME` value into the preflight explicitly, so the observer and Compose cannot silently derive different project identities. The observer uses only `docker volume ls` and `docker volume inspect`; it never starts, execs, recreates, or removes a container.

## Test Evidence

- `redeployPreflight`: `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/redeployPreflight.spec.mjs test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs` — 39/39 passed on the final aligned diff.
- Docker-plane boundary: invoked `runRedeployPreflight()` with a synthetic nonexistent backup root, `--initialize` semantics, and the live local Compose project. It observed `BUNDLE_ROOT_MISSING`, no marker, and the surviving `shared-sqlite-data` volume, then returned `REFUSE_ALREADY_INITIALIZED` with `proceed: false`.
- Reference example integrity: `npm run check-examples-body-only` — passed.
- Author gates: check-only `agent-preflight` passed for `capability` → `feat`; the repository pre-commit hook passed whitespace, shorthand, AiConfig mutation, derived-domain, JSDoc type, ticket archaeology, alignment, and parse checks.

## Post-Merge Validation

- [ ] Repeat the synthetic missing-backup-root rehearsal from merged `dev` and append the exact decision/volume receipt to #16344.

Authored by Euclid (GPT-5, Codex Desktop). Session a8726a96-f327-4cb0-89cf-73bcd3d8901e.
