### PR TITLE
feat(grid): transform-immune measurement + resize-echo classification (#16375)

### DIFF
--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -1306,6 +1306,27 @@ class Component extends Abstract {
     }
 
     /**
+     * @summary Convenience shortcut for transform-immune layout-box metrics.
+     *
+     * Mirrors {@link #getDomRect}, but resolves the LAYOUT box via `Neo.main.DomAccess.getLayoutRect()`:
+     * ancestor transforms (FLIP presentation windows, animated overlays) never distort the result,
+     * so the returned sizes are safe to persist into layout state. Coordinates are
+     * offset-parent-relative — use {@link #getDomRect} when viewport space is required.
+     * @param {String[]|String} id=this.id
+     * @param {String} windowId=this.windowId
+     * @returns {Promise<Neo.util.Rectangle|Neo.util.Rectangle[]>}
+     */
+    async getLayoutRect(id=this.id, windowId=this.windowId) {
+        let result = await this.trap(Neo.main.DomAccess.getLayoutRect({id, windowId}));
+
+        if (Array.isArray(result)) {
+            return result.map(rect => Rectangle.clone(rect))
+        }
+
+        return Rectangle.clone(result)
+    }
+
+    /**
      * Get the parent components as an array
      * @returns {Neo.component.Base[]}
      */

--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -1310,7 +1310,9 @@ class Component extends Abstract {
      *
      * Mirrors {@link #getDomRect}, but resolves the LAYOUT box via `Neo.main.DomAccess.getLayoutRect()`:
      * ancestor transforms (FLIP presentation windows, animated overlays) never distort the result,
-     * so the returned sizes are safe to persist into layout state. Coordinates are
+     * so the returned sizes are safe to persist into layout state. Nodes without a generated box
+     * (`display: none`, detached subtrees) resolve to the zero shape — matching
+     * `getBoundingClientRect()` — never to phantom specified sizes. Coordinates are
      * offset-parent-relative — use {@link #getDomRect} when viewport space is required.
      * @param {String[]|String} id=this.id
      * @param {String} windowId=this.windowId

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -228,11 +228,25 @@ class GridContainer extends BaseContainer {
     }
 
     /**
-     * We do not need the first event to trigger logic, since afterSetMounted() handles this
+     * Marks the first resize delivery after a (re)mount. The mount path (`addResizeObserver()`)
+     * already measures via `passSizeToBody()`, so the ResizeObserver's register-time echo is
+     * redundant — but ONLY when it actually carries the already-measured size. `onResize()`
+     * therefore classifies the first delivery against `lastMeasuredContainerSize` instead of
+     * consuming it blindly: a first delivery that differs is a REAL resize which raced the
+     * registration (e.g. a committed dock-splitter re-layout) and must be processed, or worker
+     * geometry freezes at the stale mount value until an unrelated resize.
      * @member {Boolean} initialResizeEvent=true
      * @protected
      */
     initialResizeEvent = true
+    /**
+     * The container border-box size of the most recent `passSizeToBody()` measurement.
+     * Consumed by `onResize()` to classify the first post-(re)mount delivery as a redundant
+     * register-time echo vs a real resize that raced the registration.
+     * @member {Object|null} lastMeasuredContainerSize=null
+     * @protected
+     */
+    lastMeasuredContainerSize = null
     /**
      * @member {Object[]|Neo.grid.column.Base[]} centerColumns=[]
      * @protected
@@ -1176,13 +1190,27 @@ class GridContainer extends BaseContainer {
     }
 
     /**
+     * @summary Re-derives worker grid geometry from a ResizeObserver delivery.
+     *
+     * The first delivery after a (re)mount is only skipped when it is a true register-time
+     * echo of the size the mount path already measured. A first delivery carrying a DIFFERENT
+     * size is a real resize which raced the registration (a committed dock re-layout can land
+     * before the observer's echo) — blindly consuming it would freeze `containerWidth` at the
+     * stale mount-time value until an unrelated resize repairs it.
      * @param {Object} data
+     * @param {Object} [data.borderBoxSize]
      * @returns {Promise<void>}
      */
     async onResize(data) {
-        let me = this;
+        let me       = this,
+            measured = me.lastMeasuredContainerSize,
+            isEcho   = me.initialResizeEvent && measured
+                && Math.abs((data?.borderBoxSize?.inlineSize ?? 0) - measured.width)  < 1
+                && Math.abs((data?.borderBoxSize?.blockSize  ?? 0) - measured.height) < 1;
 
-        if (!me.initialResizeEvent) {
+        me.initialResizeEvent = false;
+
+        if (!isEcho) {
             me.applyResponsiveLockPolicy(data);
 
             await me.passSizeToBody(true);
@@ -1192,8 +1220,6 @@ class GridContainer extends BaseContainer {
             me.bodyEnd?.updateMountedAndVisibleColumns();
 
             await me.headerToolbar.passSizeToBody()
-        } else {
-            me.initialResizeEvent = false
         }
     }
 
@@ -1256,6 +1282,12 @@ class GridContainer extends BaseContainer {
     }
 
     /**
+     * @summary Measures the container chrome and passes the derived body size downstream.
+     *
+     * Reads LAYOUT-box metrics (`getLayoutRect()`), never `getBoundingClientRect()`: this async
+     * measurement races presentation windows (a committed dock resize triggers it while DockFlip
+     * still scale-transforms the pane), and visual rects sampled mid-motion would persist as
+     * poisoned `containerWidth`/`availableHeight` until an unrelated resize.
      * @param {Boolean} silent=false
      * @returns {Promise<void>}
      */
@@ -1269,13 +1301,15 @@ class GridContainer extends BaseContainer {
             domRects.push(footerToolbar.id)
         }
 
-        [containerRect, headerRect, footerRect] = await me.getDomRect(domRects);
+        [containerRect, headerRect, footerRect] = await me.getLayoutRect(domRects);
 
         // delay for slow connections, where the container-sizing is not done yet
         if (containerRect.height === headerRect.height) {
             await me.timeout(100);
             await me.passSizeToBody(silent)
         } else {
+            me.lastMeasuredContainerSize = {width: containerRect.width, height: containerRect.height};
+
             let config = {
                 availableHeight: containerRect.height - headerRect.height - (footerRect?.height || 0),
                 containerWidth : containerRect.width

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -228,26 +228,6 @@ class GridContainer extends BaseContainer {
     }
 
     /**
-     * Marks the first resize delivery after a (re)mount. The mount path (`addResizeObserver()`)
-     * already measures via `passSizeToBody()`, so the ResizeObserver's register-time echo is
-     * redundant — but ONLY when it actually carries the already-measured size. `onResize()`
-     * therefore classifies the first delivery against `lastMeasuredContainerSize` instead of
-     * consuming it blindly: a first delivery that differs is a REAL resize which raced the
-     * registration (e.g. a committed dock-splitter re-layout) and must be processed, or worker
-     * geometry freezes at the stale mount value until an unrelated resize.
-     * @member {Boolean} initialResizeEvent=true
-     * @protected
-     */
-    initialResizeEvent = true
-    /**
-     * The container border-box size of the most recent `passSizeToBody()` measurement.
-     * Consumed by `onResize()` to classify the first post-(re)mount delivery as a redundant
-     * register-time echo vs a real resize that raced the registration.
-     * @member {Object|null} lastMeasuredContainerSize=null
-     * @protected
-     */
-    lastMeasuredContainerSize = null
-    /**
      * @member {Object[]|Neo.grid.column.Base[]} centerColumns=[]
      * @protected
      */
@@ -363,7 +343,6 @@ class GridContainer extends BaseContainer {
             ResizeObserver.register(resizeParams);
             await me.passSizeToBody()
         } else {
-            me.initialResizeEvent = true;
             ResizeObserver.unregister(resizeParams)
         }
     }
@@ -1190,37 +1169,31 @@ class GridContainer extends BaseContainer {
     }
 
     /**
-     * @summary Re-derives worker grid geometry from a ResizeObserver delivery.
+     * @summary Re-derives worker grid geometry from every ResizeObserver delivery.
      *
-     * The first delivery after a (re)mount is only skipped when it is a true register-time
-     * echo of the size the mount path already measured. A first delivery carrying a DIFFERENT
-     * size is a real resize which raced the registration (a committed dock re-layout can land
-     * before the observer's echo) — blindly consuming it would freeze `containerWidth` at the
-     * stale mount-time value until an unrelated resize repairs it.
+     * Deliberately NO first-delivery skip: a skip flag assumes the register-time echo after a
+     * (re)mount always arrives, but that echo can lose its routing race — the flag then consumes
+     * the first REAL resize (a committed dock re-layout can land before the echo), freezing
+     * `containerWidth` at the stale mount-time value until an unrelated resize repairs it.
+     * Size-equivalence classification is no safer: any tolerance swallows a real sub-tolerance
+     * resize. Re-processing the echo is idempotent (a silent set of identical values), so
+     * correctness costs one redundant measurement per mount.
      * @param {Object} data
      * @param {Object} [data.borderBoxSize]
      * @returns {Promise<void>}
      */
     async onResize(data) {
-        let me       = this,
-            measured = me.lastMeasuredContainerSize,
-            isEcho   = me.initialResizeEvent && measured
-                && Math.abs((data?.borderBoxSize?.inlineSize ?? 0) - measured.width)  < 1
-                && Math.abs((data?.borderBoxSize?.blockSize  ?? 0) - measured.height) < 1;
+        let me = this;
 
-        me.initialResizeEvent = false;
+        me.applyResponsiveLockPolicy(data);
 
-        if (!isEcho) {
-            me.applyResponsiveLockPolicy(data);
+        await me.passSizeToBody(true);
 
-            await me.passSizeToBody(true);
+        me.bodyStart?.updateMountedAndVisibleColumns();
+        me.body.updateMountedAndVisibleColumns();
+        me.bodyEnd?.updateMountedAndVisibleColumns();
 
-            me.bodyStart?.updateMountedAndVisibleColumns();
-            me.body.updateMountedAndVisibleColumns();
-            me.bodyEnd?.updateMountedAndVisibleColumns();
-
-            await me.headerToolbar.passSizeToBody()
-        }
+        await me.headerToolbar.passSizeToBody()
     }
 
     /**
@@ -1308,8 +1281,6 @@ class GridContainer extends BaseContainer {
             await me.timeout(100);
             await me.passSizeToBody(silent)
         } else {
-            me.lastMeasuredContainerSize = {width: containerRect.width, height: containerRect.height};
-
             let config = {
                 availableHeight: containerRect.height - headerRect.height - (footerRect?.height || 0),
                 containerWidth : containerRect.width

--- a/src/grid/header/Toolbar.mjs
+++ b/src/grid/header/Toolbar.mjs
@@ -160,7 +160,7 @@ class Toolbar extends BaseToolbar {
      * @protected
      */
     beforeSetScrollLeft(value, oldValue) {
-        let me        = this,
+        let me                              = this,
             {pendingScrollTarget, sortZone} = me;
 
         if (sortZone?.itemRects) {
@@ -229,7 +229,7 @@ class Toolbar extends BaseToolbar {
      *
      */
     createItems() {
-        let me = this,
+        let me          = this,
             { mounted } = me;
 
         me.itemDefaults.showHeaderFilter = me.showHeaderFilters;
@@ -276,8 +276,8 @@ class Toolbar extends BaseToolbar {
 
         Neo.merge(config, {
             boundaryContainerId: [me.id, me.parent.id],
-            ignoreDragSelector: '.neo-resizable',
-            scrollLeft: me.scrollLeft
+            ignoreDragSelector : '.neo-resizable',
+            scrollLeft         : me.scrollLeft
         });
 
         super.createSortZone(config)
@@ -305,21 +305,28 @@ class Toolbar extends BaseToolbar {
     }
 
     /**
+     * @summary Derives `columnPositions` + `availableWidth` from the rendered header buttons.
+     *
+     * Dynamic-width buttons are measured via LAYOUT-box metrics (`getLayoutRect()`), never
+     * `getBoundingClientRect()`: this measurement races presentation windows (committed dock
+     * resizes trigger it while DockFlip still scale-transforms the pane), and visual button
+     * rects sampled mid-motion would poison every column position and the summed
+     * `availableWidth` the body paints itself with.
      * @param {Boolean} silent=false
      * @returns {Promise<void>}
      */
     async passSizeToBody(silent = false) {
-        let me = this,
-            gridContainer = me.gridContainer,
-            layoutLock = me.layoutLock,
-            body = layoutLock === 'start' ? gridContainer.bodyStart : (layoutLock === 'end' ? gridContainer.bodyEnd : gridContainer.body),
-            { items } = me,
+        let me              = this,
+            gridContainer   = me.gridContainer,
+            layoutLock      = me.layoutLock,
+            body            = layoutLock === 'start' ? gridContainer.bodyStart : (layoutLock === 'end' ? gridContainer.bodyEnd : gridContainer.body),
+            { items }       = me,
             columnPositions = [],
-            currentX = 0,
+            currentX        = 0,
             hasDynamicWidth = false,
-            layoutFinished = true,
-            i = 0,
-            len = items.length,
+            layoutFinished  = true,
+            i               = 0,
+            len             = items.length,
             item, rects, w, width;
 
         for (; i < len; i++) {
@@ -333,7 +340,7 @@ class Toolbar extends BaseToolbar {
         }
 
         if (hasDynamicWidth) {
-            rects = await me.getDomRect(items.map(item => item.id));
+            rects = await me.getLayoutRect(items.map(item => item.id));
 
             // If the css sizing is not done, columns after the first one can get x === firstX
             for (i = 1; i < len; i++) {
@@ -353,8 +360,8 @@ class Toolbar extends BaseToolbar {
                 for (i = 0; i < len; i++) {
                     columnPositions.push({
                         dataField: items[i].dataField,
-                        width: rects[i].width,
-                        x: currentX
+                        width    : rects[i].width,
+                        x        : currentX
                     });
 
                     currentX += rects[i].width
@@ -367,7 +374,7 @@ class Toolbar extends BaseToolbar {
                     columnPositions.push({
                         dataField: item.dataField,
                         width,
-                        x: currentX
+                        x        : currentX
                     });
 
                     currentX += width
@@ -462,9 +469,9 @@ class Toolbar extends BaseToolbar {
 
         return {
             ...super.toJSON(),
-            scrollLeft: me.scrollLeft,
-            showHeaderFilters: me.showHeaderFilters,
-            sortable: me.sortable,
+            scrollLeft        : me.scrollLeft,
+            showHeaderFilters : me.showHeaderFilters,
+            sortable          : me.sortable,
             useTriStateSorting: me.useTriStateSorting
         }
     }

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -466,10 +466,18 @@ class DomAccess extends Base {
      * heights are scaled fiction. Layout consumers that persist sizes (grid column generation,
      * buffered mounting math) must read the LAYOUT box instead, which transforms never affect.
      *
-     * Width/height resolve from the computed used values (fractional, normalized to border-box
-     * when an element opts into content-box sizing); x/y are offset-parent-relative
-     * (`offsetLeft`/`offsetTop`). Use this for size and sibling-relative position semantics;
-     * use `getBoundingClientRect()` whenever viewport-space coordinates are required.
+     * The size contract, per node state:
+     * - Rendered box: fractional computed used values, normalized to border-box when an element
+     *   opts into content-box sizing.
+     * - No generated box (`display: none`, `display: contents`, detached subtree): the zero
+     *   shape — matching `getBoundingClientRect()`. Computed styles would report SPECIFIED
+     *   sizes for boxless nodes (phantom boxes), so this path never reads them.
+     * - Rendered box whose used value does not resolve to px (defensive narrowing): integer
+     *   `offsetWidth`/`offsetHeight` — still layout-truth, reduced precision.
+     *
+     * x/y are offset-parent-relative (`offsetLeft`/`offsetTop`). Use this for size and
+     * sibling-relative position semantics; use `getBoundingClientRect()` whenever viewport-space
+     * coordinates are required.
      * @param {Object} data
      * @param {Array|String} data.id either an id or an array of ids
      * @returns {Object|Object[]} rect-shaped layout metrics ({x, y, left, top, right, bottom, width, height})
@@ -485,17 +493,26 @@ class DomAccess extends Base {
             returnData = {};
 
         if (node) {
+            if (node.getClientRects().length < 1) {
+                return {x: 0, y: 0, left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0}
+            }
+
             let style  = node.ownerDocument.defaultView.getComputedStyle(node),
                 read   = property => parseFloat(style.getPropertyValue(property)) || 0,
-                width  = read('width'),
-                height = read('height'),
+                width  = parseFloat(style.getPropertyValue('width')),
+                height = parseFloat(style.getPropertyValue('height')),
                 x      = node.offsetLeft,
                 y      = node.offsetTop;
 
-            // Used width/height track the box-sizing mode; normalize to border-box metrics
-            if (style.getPropertyValue('box-sizing') === 'content-box') {
-                width  += read('padding-left') + read('padding-right')  + read('border-left-width') + read('border-right-width');
-                height += read('padding-top')  + read('padding-bottom') + read('border-top-width')  + read('border-bottom-width')
+            if (Number.isFinite(width) && Number.isFinite(height)) {
+                // Used width/height track the box-sizing mode; normalize to border-box metrics
+                if (style.getPropertyValue('box-sizing') === 'content-box') {
+                    width  += read('padding-left') + read('padding-right')  + read('border-left-width') + read('border-right-width');
+                    height += read('padding-top')  + read('padding-bottom') + read('border-top-width')  + read('border-bottom-width')
+                }
+            } else {
+                width  = node.offsetWidth;
+                height = node.offsetHeight
             }
 
             returnData = {x, y, left: x, top: y, right: x + width, bottom: y + height, width, height}

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -71,6 +71,7 @@ class DomAccess extends Base {
                 'getBoundingClientRect',
                 'getChildNodeIds',
                 'getComputedStyle',
+                'getLayoutRect',
                 'getOffscreenCanvas',
                 'getScrollingDimensions',
                 'measure',
@@ -452,6 +453,52 @@ class DomAccess extends Base {
                     returnData.minHeight = me.measure({value: minHeight, id: node})
                 }
             }
+        }
+
+        return returnData
+    }
+
+    /**
+     * @summary Returns transform-immune layout-box metrics for a given dom node id.
+     *
+     * `getBoundingClientRect()` reports VISUAL (post-transform) geometry: while a presentation
+     * layer animates an ancestor (e.g. the DockFlip inverse-transform window), rect widths and
+     * heights are scaled fiction. Layout consumers that persist sizes (grid column generation,
+     * buffered mounting math) must read the LAYOUT box instead, which transforms never affect.
+     *
+     * Width/height resolve from the computed used values (fractional, normalized to border-box
+     * when an element opts into content-box sizing); x/y are offset-parent-relative
+     * (`offsetLeft`/`offsetTop`). Use this for size and sibling-relative position semantics;
+     * use `getBoundingClientRect()` whenever viewport-space coordinates are required.
+     * @param {Object} data
+     * @param {Array|String} data.id either an id or an array of ids
+     * @returns {Object|Object[]} rect-shaped layout metrics ({x, y, left, top, right, bottom, width, height})
+     */
+    getLayoutRect(data) {
+        let me = this;
+
+        if (Array.isArray(data.id)) {
+            return data.id.map(id => me.getLayoutRect({id}))
+        }
+
+        let node       = me.getElementOrBody(data.nodeType ? data : data.id),
+            returnData = {};
+
+        if (node) {
+            let style  = node.ownerDocument.defaultView.getComputedStyle(node),
+                read   = property => parseFloat(style.getPropertyValue(property)) || 0,
+                width  = read('width'),
+                height = read('height'),
+                x      = node.offsetLeft,
+                y      = node.offsetTop;
+
+            // Used width/height track the box-sizing mode; normalize to border-box metrics
+            if (style.getPropertyValue('box-sizing') === 'content-box') {
+                width  += read('padding-left') + read('padding-right')  + read('border-left-width') + read('border-right-width');
+                height += read('padding-top')  + read('padding-bottom') + read('border-top-width')  + read('border-bottom-width')
+            }
+
+            returnData = {x, y, left: x, top: y, right: x + width, bottom: y + height, width, height}
         }
 
         return returnData

--- a/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
@@ -5,31 +5,40 @@ import { test, expect } from '../../fixtures.mjs';
  *
  * After committed DockSplitter resizes, the 100k Matrix grid could keep painting while
  * its geometry generations drifted apart — header labels narrower than their cells, the last
- * body column clipped at the shared right edge, phantom mounted columns. Mechanism: the grid's
- * resize measurement (`grid.Container#passSizeToBody` + `grid.header.Toolbar#passSizeToBody`)
- * ran `getBoundingClientRect()` through async worker→main round-trips that could land inside
- * DockFlip's inverse-transform presentation window, persisting transform-scaled VISUAL rects
- * as `containerWidth` / `availableWidth` / `columnPositions` (witnessed live: containerWidth
- * 476.77 and availableWidth 1328.72 at a settled 388px rest). The seam now reads layout-box
- * metrics (`getLayoutRect()`), which transforms never affect.
+ * body column clipped at the shared right edge, phantom mounted columns. Two stacked mechanisms:
+ * a first-resize-after-mount skip flag could consume a REAL resize whose register-time echo lost
+ * its routing race (freezing worker geometry at the mount value), and the grid's resize
+ * measurement ran `getBoundingClientRect()` through async worker→main round-trips that could
+ * land inside DockFlip's inverse-transform presentation window, persisting transform-scaled
+ * VISUAL rects as `containerWidth` / `availableWidth` / `columnPositions` (witnessed live:
+ * containerWidth 476.77 and availableWidth 1328.72 at a settled 388px rest). The repair: every
+ * delivery re-derives geometry (no skip), through layout-box metrics (`getLayoutRect()`), which
+ * transforms never affect.
  *
- * This guard drives the ticket's own recipe — a bounded series of real committed drags, BOTH
- * directions, repeated cycles — and after every settled commit asserts the full attribution
- * matrix (worker → header → body):
- *   1. worker `containerWidth` equals the grid container's layout width (±1px);
- *   2. worker `availableWidth` equals the summed layout widths of the header buttons (±1.5px);
- *   3. every visible header button and its x-order-paired first-row cell agree on left/width
- *      (±1px) — the ticket's visible symptom, asserted pairwise.
+ * The drag guard drives the ticket's own recipe — a bounded series of real committed drags,
+ * BOTH directions, repeated cycles — and after every settled commit asserts the attribution
+ * matrix in three coordinate spaces, each surface keyed by `aria-colindex` (the grid's own
+ * accessibility contract, present on header buttons and body cells alike):
+ *   1. key-set identity: the visible header and cell key sets are EQUAL (cardinality + identity
+ *      — a missing or shifted column on either surface fails here, not in a truncated zip);
+ *   2. visual space: per-key header↔cell `getBoundingClientRect` left/width agreement (±1px) —
+ *      the ticket's user-visible symptom;
+ *   3. content space (scroll-invariant by construction): worker `columnPositions` width/x per
+ *      dataField against the cell's `style.left`/layout width AND the header button's
+ *      `offsetLeft`/layout width — plus worker `containerWidth`/`availableWidth` against the
+ *      container/button layout truth.
  *
- * Settlement is event/state-based only (dock document commit, projected DOM extent, motion
- * lifecycle class, zero fixed-stage residue, transform-free grid) — no fixed-delay sleeps,
- * per the ticket's walls.
+ * Settlement is event/state-based only, with a POSITIVE motion-entry barrier: a MutationObserver
+ * must first witness the dock-motion lifecycle class ENTER (guarding against asserting before
+ * the deferred projection even starts), then release (class absent, zero fixed-stage residue,
+ * transform-free grid). No fixed-delay sleeps, per the ticket's walls.
  *
  * The race itself is pinned RACE-FREE by the first test: it freezes a "mid-motion" frame (a
  * static ancestor scale transform), triggers the measurement through the projection's own
- * mutation class (a flex-basis write on the pane's tab container), and asserts the worker
- * persists the LAYOUT box. Pre-fix that fails deterministically on every run — no lucky
- * timing can green-wash it; the drag test then guards the integrated surface.
+ * mutation class (the normalized flex pair written to both pane tab containers), and asserts
+ * the worker persists the LAYOUT box. Pre-fix that fails deterministically on every run — no
+ * lucky timing can green-wash it. The same test binds the measurement primitive's no-box
+ * contract: a `display: none` node resolves to the zero shape, never phantom specified sizes.
  *
  * Run: npx playwright test WorkstationSplitterGridGeometryNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -40,35 +49,73 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
     const GRID_ID = 'neo-grid-container-1',
           BODY_ID = 'neo-grid-body-1';
 
-    /** Page-side geometry matrix for the Matrix grid: container, header buttons, row-0 cells. */
+    /**
+     * Page-side geometry matrix for the Matrix grid. Headers and cells are keyed by
+     * `aria-colindex`; sizes are layout-truth (computed used values), positions carry BOTH
+     * spaces: visual (`getBoundingClientRect`) and content (`offsetLeft` for header buttons,
+     * `style.left` for absolutely positioned cells — both scroll- and transform-invariant).
+     */
     const readMatrix = page => page.evaluate(gridId => {
         const grid    = document.getElementById(gridId),
               header  = grid.querySelector('.neo-grid-header-toolbar'),
               body    = grid.querySelector('.neo-grid-body'),
               clip    = body.getBoundingClientRect(),
               inClip  = r => r.width > 0 && r.right > clip.left + 1 && r.left < clip.right - 1,
-              buttons = [...header.children]
-                  .map(b => ({r: b.getBoundingClientRect(), lw: parseFloat(getComputedStyle(b).width)}))
-                  .filter(({r}) => r.width > 0),
-              headers = buttons
-                  .filter(({r}) => inClip(r))
-                  .map(({r}) => ({x: r.left, w: r.width}))
-                  .sort((a, b) => a.x - b.x),
               row     = body.querySelector('[role="row"]'),
-              cells   = row ? [...row.children]
-                  .map(c => c.getBoundingClientRect())
-                  .filter(r => inClip(r))
-                  .map(r => ({x: r.left, w: r.width}))
-                  .sort((a, b) => a.x - b.x) : [];
+              headers = {},
+              cells   = {};
+
+        [...header.children].forEach(b => {
+            const key = b.getAttribute('aria-colindex'),
+                  r   = b.getBoundingClientRect();
+
+            if (key && inClip(r)) {
+                headers[key] = {
+                    visualX : r.left,
+                    visualW : r.width,
+                    contentX: b.offsetLeft,
+                    layoutW : parseFloat(getComputedStyle(b).width)
+                }
+            }
+        });
+
+        row && [...row.children].forEach(c => {
+            const key = c.getAttribute('aria-colindex'),
+                  r   = c.getBoundingClientRect();
+
+            if (key && inClip(r)) {
+                cells[key] = {
+                    dataField: c.getAttribute('data-field'),
+                    visualX  : r.left,
+                    visualW  : r.width,
+                    contentX : parseFloat(c.style.left),
+                    layoutW  : parseFloat(getComputedStyle(c).width)
+                }
+            }
+        });
 
         return {
             layoutWidth   : parseFloat(getComputedStyle(grid).width),
             transform     : getComputedStyle(grid).transform,
-            buttonWidthSum: buttons.reduce((sum, {lw}) => sum + lw, 0),
+            buttonWidthSum: [...header.children]
+                .filter(b => b.getClientRects().length > 0)
+                .reduce((sum, b) => sum + parseFloat(getComputedStyle(b).width), 0),
+            scrollLeft    : header.scrollLeft,
             headers,
             cells
         };
     }, GRID_ID);
+
+    /** Worker-truth read: containerWidth, availableWidth, and the keyed columnPositions. */
+    async function readWorker(app) {
+        const props = await app.getComponent(BODY_ID, ['containerWidth', 'availableWidth', 'columnPositions.items']);
+
+        return {
+            containerWidth : props.containerWidth,
+            availableWidth : props.availableWidth,
+            columnPositions: props['columnPositions.items'] || []
+        };
+    }
 
     test('measurement stays layout-true while an ancestor transform holds (deterministic reproducer)', async ({ page, neuralLink }) => {
         const SCALE_X = 0.6,
@@ -81,17 +128,26 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
         const app = await neuralLink.connectToApp('Workstation');
 
         // boot settlement: the worker knows the real grid width
-        await expect.poll(async () => {
-            const {containerWidth} = await app.getComponent(BODY_ID, ['containerWidth']);
-            return containerWidth
-        }, {timeout: 15000, intervals: [100, 250]}).toBeGreaterThan(0);
+        await expect.poll(async () => (await readWorker(app)).containerWidth,
+            {timeout: 15000, intervals: [100, 250]}).toBeGreaterThan(0);
 
         const boot = await readMatrix(page);
 
-        // ARM THE TRAP: freeze a "mid-motion" frame — a static ancestor scale transform.
+        // ARM THE TRAP: freeze a "mid-motion" frame — a static ancestor scale transform —
+        // and plant the primitive's contract fixtures inside it.
         await page.evaluate(([sx, sy]) => {
             document.body.style.transformOrigin = 'left top';
-            document.body.style.transform       = `scale(${sx}, ${sy})`
+            document.body.style.transform       = `scale(${sx}, ${sy})`;
+
+            const visible = document.createElement('div');
+            visible.id = 'probe-16375-visible';
+            visible.style.cssText = 'position:absolute;left:0;top:0;width:333.5px;height:41.5px;pointer-events:none;opacity:0;';
+            document.body.appendChild(visible);
+
+            const hidden = document.createElement('div');
+            hidden.id = 'probe-16375-hidden';
+            hidden.style.cssText = 'display:none;width:222px;height:33px;';
+            document.body.appendChild(hidden)
         }, [SCALE_X, SCALE_Y]);
 
         // trap premises: the visual box IS scaled; the layout box is NOT
@@ -107,6 +163,18 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
             'trap premise: getBoundingClientRect reports the scaled visual box').toBeLessThan(2);
         expect(Math.abs(armed.layoutWidth - boot.layoutWidth),
             'trap premise: the layout box ignores the ancestor transform').toBeLessThan(1);
+
+        // PRIMITIVE CONTRACT, through the full worker→main path, under the held transform:
+        // a visible box reports fractional LAYOUT truth; a no-box node reports the zero shape.
+        const [visibleRect, hiddenRect] = await app.callMethod(
+            GRID_ID, 'getLayoutRect', [['probe-16375-visible', 'probe-16375-hidden']]);
+
+        expect(Math.abs(visibleRect.width - 333.5),
+            'primitive contract: a transformed visible box reports its fractional layout width').toBeLessThan(0.1);
+        expect(Math.abs(visibleRect.height - 41.5),
+            'primitive contract: a transformed visible box reports its fractional layout height').toBeLessThan(0.1);
+        expect(hiddenRect.width, 'primitive contract: a display:none node reports zero width, not its specified size').toBe(0);
+        expect(hiddenRect.height, 'primitive contract: a display:none node reports zero height, not its specified size').toBe(0);
 
         // TRIGGER: the deferred projection's own mutation class — the normalized flex pair the
         // projection writes on both pane tab containers — changes the grid layout box while the
@@ -132,7 +200,7 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
         // Pre-fix, containerWidth lands at ~SCALE_X * layoutWidth and availableWidth at
         // ~SCALE_X * buttonWidthSum (the gBCR samples), so these polls time out red.
         await expect.poll(async () => {
-            const {containerWidth} = await app.getComponent(BODY_ID, ['containerWidth']),
+            const {containerWidth} = await readWorker(app),
                   current          = await readMatrix(page);
             return Math.abs(containerWidth - current.layoutWidth)
         }, {
@@ -142,7 +210,7 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
         }).toBeLessThan(1);
 
         await expect.poll(async () => {
-            const {availableWidth} = await app.getComponent(BODY_ID, ['availableWidth']),
+            const {availableWidth} = await readWorker(app),
                   current          = await readMatrix(page);
             return Math.abs(availableWidth - current.buttonWidthSum)
         }, {
@@ -151,8 +219,10 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
             intervals: [100, 250]
         }).toBeLessThan(1.5);
 
-        // DISARM + coherence: restore the pane flex pair and the transform, geometry re-converges.
+        // DISARM + coherence: restore fixtures, pane flex pair, and the transform.
         await page.evaluate(flex => {
+            document.getElementById('probe-16375-visible').remove();
+            document.getElementById('probe-16375-hidden').remove();
             document.getElementById('neo-tab-container-2').style.flex = flex[0];
             document.getElementById('neo-tab-container-3').style.flex = flex[1];
             document.body.style.transform       = '';
@@ -160,7 +230,7 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
         }, originalFlex);
 
         await expect.poll(async () => {
-            const {containerWidth} = await app.getComponent(BODY_ID, ['containerWidth']),
+            const {containerWidth} = await readWorker(app),
                   current          = await readMatrix(page);
             return Math.abs(containerWidth - current.layoutWidth)
         }, {
@@ -191,14 +261,12 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
         expect(workspaceId, 'the page owns a Workstation workspace').toBeTruthy();
 
         // boot settlement: worker knows the grid width before the first drag
-        await expect.poll(async () => {
-            const {containerWidth} = await app.getComponent(BODY_ID, ['containerWidth']);
-            return containerWidth
-        }, {timeout: 15000, intervals: [100, 250]}).toBeGreaterThan(0);
+        await expect.poll(async () => (await readWorker(app)).containerWidth,
+            {timeout: 15000, intervals: [100, 250]}).toBeGreaterThan(0);
 
         const boot = await readMatrix(page);
 
-        /** One committed drag + event-based settlement + the full attribution matrix. */
+        /** One committed drag + positive-entry settlement + the keyed attribution matrix. */
         async function dragAndVerify(deltaX, tag) {
             const splitter                 = page.locator('.neo-dashboard-dock-splitter-horizontal'),
                   box                      = await splitter.boundingBox(),
@@ -206,6 +274,19 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
                   sy                       = box.y + box.height / 2,
                   before                   = await readMatrix(page),
                   {dockModel: modelBefore} = await app.getComponent(workspaceId, ['dockModel']);
+
+            // positive motion-entry barrier: witness the lifecycle ENTER, not just its absence later
+            await page.evaluate(() => {
+                const el = document.querySelector('.workstation-workspace');
+                globalThis.__motion16375?.observer.disconnect();
+                globalThis.__motion16375 = {
+                    seen    : el.classList.contains('neo-dashboard-dock-animating'),
+                    observer: new MutationObserver(() => {
+                        el.classList.contains('neo-dashboard-dock-animating') && (globalThis.__motion16375.seen = true)
+                    })
+                };
+                globalThis.__motion16375.observer.observe(el, {attributes: true, attributeFilter: ['class']})
+            });
 
             await page.mouse.move(sx, sy);
             await page.mouse.down();
@@ -232,7 +313,14 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
                 intervals: [50, 100]
             }).toBeCloseTo(before.layoutWidth + deltaX, 0);
 
-            // 3. the motion lifecycle fully released the presentation
+            // 3. the motion lifecycle ENTERED (positive barrier) ...
+            await expect.poll(() => page.evaluate(() => globalThis.__motion16375.seen), {
+                message  : `${tag}: the committed resize enters the dock-motion lifecycle`,
+                timeout  : 10000,
+                intervals: [25, 50]
+            }).toBe(true);
+
+            // ... and fully released the presentation
             await expect(root, `${tag}: the dock motion lifecycle settles`)
                 .not.toHaveClass(/neo-dashboard-dock-animating/, {timeout: 10000});
             await expect(page.locator('.neo-dock-flip-fixed-stage'),
@@ -242,10 +330,10 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
 
             expect(settled.transform, `${tag}: the grid carries no residual transform`).toBe('none');
 
-            // ATTRIBUTION MATRIX (worker → header → body), the ticket's AC net:
+            // ATTRIBUTION MATRIX (worker → header → body), keyed by aria-colindex:
             // 1. worker containerWidth rides the layout box — poisoned visual samples time this out
             await expect.poll(async () => {
-                const {containerWidth} = await app.getComponent(BODY_ID, ['containerWidth']),
+                const {containerWidth} = await readWorker(app),
                       current          = await readMatrix(page);
                 return Math.abs(containerWidth - current.layoutWidth)
             }, {
@@ -254,27 +342,47 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
                 intervals: [100, 250]
             }).toBeLessThan(1);
 
-            // 2. worker availableWidth rides the header buttons' summed LAYOUT widths
-            const {availableWidth} = await app.getComponent(BODY_ID, ['availableWidth']);
+            const worker = await readWorker(app),
+                  matrix = await readMatrix(page);
 
-            expect(Math.abs(availableWidth - settled.buttonWidthSum),
+            // 2. worker availableWidth rides the header buttons' summed LAYOUT widths
+            expect(Math.abs(worker.availableWidth - matrix.buttonWidthSum),
                 `${tag}: worker availableWidth equals the summed header-button layout widths`)
                 .toBeLessThan(1.5);
 
-            // 3. every visible header agrees with its x-order-paired first-row cell
-            expect(settled.headers.length, `${tag}: visible header buttons exist`).toBeGreaterThan(2);
-            expect(settled.cells.length, `${tag}: visible row-0 cells exist`).toBeGreaterThan(2);
+            // 3. key-set identity: the visible header and cell key sets are EQUAL
+            const headerKeys = Object.keys(matrix.headers).sort((a, b) => a - b),
+                  cellKeys   = Object.keys(matrix.cells).sort((a, b) => a - b);
 
-            const pairCount = Math.min(settled.headers.length, settled.cells.length);
+            expect(headerKeys.length, `${tag}: visible header buttons exist`).toBeGreaterThan(2);
+            expect(cellKeys, `${tag}: visible header and cell aria-colindex key sets are identical`)
+                .toEqual(headerKeys);
 
-            for (let i = 0; i < pairCount; i++) {
-                const h = settled.headers[i],
-                      c = settled.cells[i];
+            // 4. per-key agreement in both spaces + worker columnPositions attribution
+            const positionsByField = new Map(worker.columnPositions.map(c => [c.dataField, c]));
 
-                expect(Math.abs(h.x - c.x),
-                    `${tag}: header[${i}] left aligns with its cell (h ${h.x} vs c ${c.x})`).toBeLessThan(1);
-                expect(Math.abs(h.w - c.w),
-                    `${tag}: header[${i}] width matches its cell (h ${h.w} vs c ${c.w})`).toBeLessThan(1)
+            for (const key of headerKeys) {
+                const h = matrix.headers[key],
+                      c = matrix.cells[key];
+
+                // visual space — the user-visible symptom
+                expect(Math.abs(h.visualX - c.visualX),
+                    `${tag}: col ${key} header/cell visual left agree (h ${h.visualX} vs c ${c.visualX})`).toBeLessThan(1);
+                expect(Math.abs(h.visualW - c.visualW),
+                    `${tag}: col ${key} header/cell visual width agree (h ${h.visualW} vs c ${c.visualW})`).toBeLessThan(1);
+
+                // content space — worker columnPositions is the generation both surfaces ride
+                const workerColumn = positionsByField.get(c.dataField);
+
+                expect(workerColumn, `${tag}: col ${key} (${c.dataField}) exists in worker columnPositions`).toBeTruthy();
+                expect(Math.abs(workerColumn.x - c.contentX),
+                    `${tag}: col ${key} worker x matches the cell content-space left`).toBeLessThan(0.5);
+                expect(Math.abs(workerColumn.width - c.layoutW),
+                    `${tag}: col ${key} worker width matches the cell layout width`).toBeLessThan(1);
+                // offsetLeft is layout-space (scroll-independent), so no scroll term belongs here;
+                // the visual-space asserts above carry scroll inherently via getBoundingClientRect
+                expect(Math.abs(workerColumn.x - h.contentX),
+                    `${tag}: col ${key} worker x matches the header button offset position`).toBeLessThan(1)
             }
         }
 

--- a/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
@@ -106,13 +106,14 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
         };
     }, GRID_ID);
 
-    /** Worker-truth read: containerWidth, availableWidth, and the keyed columnPositions. */
+    /** Worker-truth read: containerWidth, availableWidth, scroll state, and the keyed columnPositions. */
     async function readWorker(app) {
-        const props = await app.getComponent(BODY_ID, ['containerWidth', 'availableWidth', 'columnPositions.items']);
+        const props = await app.getComponent(BODY_ID, ['containerWidth', 'availableWidth', 'scrollLeft', 'columnPositions.items']);
 
         return {
             containerWidth : props.containerWidth,
             availableWidth : props.availableWidth,
+            scrollLeft     : props.scrollLeft,
             columnPositions: props['columnPositions.items'] || []
         };
     }
@@ -147,7 +148,20 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
             const hidden = document.createElement('div');
             hidden.id = 'probe-16375-hidden';
             hidden.style.cssText = 'display:none;width:222px;height:33px;';
-            document.body.appendChild(hidden)
+            document.body.appendChild(hidden);
+
+            // non-replaced inline: computed width/height resolve to 'auto' (the unresolved-size
+            // class) — the primitive's documented fallback is integer offset metrics. The fixed
+            // off-viewport wrapper keeps document flow untouched; the span inside stays inline.
+            const inlineHost = document.createElement('div');
+            inlineHost.id = 'probe-16375-inline-host';
+            inlineHost.style.cssText = 'position:fixed;left:-500px;top:0;pointer-events:none;opacity:0;';
+            const inline = document.createElement('span');
+            inline.id = 'probe-16375-inline';
+            inline.textContent = 'unresolved-size probe';
+            inlineHost.appendChild(inline);
+            document.body.appendChild(inlineHost);
+            globalThis.__probe16375InlineOffset = {w: inline.offsetWidth, h: inline.offsetHeight}
         }, [SCALE_X, SCALE_Y]);
 
         // trap premises: the visual box IS scaled; the layout box is NOT
@@ -165,9 +179,10 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
             'trap premise: the layout box ignores the ancestor transform').toBeLessThan(1);
 
         // PRIMITIVE CONTRACT, through the full worker→main path, under the held transform:
-        // a visible box reports fractional LAYOUT truth; a no-box node reports the zero shape.
-        const [visibleRect, hiddenRect] = await app.callMethod(
-            GRID_ID, 'getLayoutRect', [['probe-16375-visible', 'probe-16375-hidden']]);
+        // a visible box reports fractional LAYOUT truth; a no-box node reports the zero shape;
+        // an unresolved-size node (inline: computed 'auto') reports its integer offset metrics.
+        const [visibleRect, hiddenRect, inlineRect] = await app.callMethod(
+            GRID_ID, 'getLayoutRect', [['probe-16375-visible', 'probe-16375-hidden', 'probe-16375-inline']]);
 
         expect(Math.abs(visibleRect.width - 333.5),
             'primitive contract: a transformed visible box reports its fractional layout width').toBeLessThan(0.1);
@@ -175,6 +190,14 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
             'primitive contract: a transformed visible box reports its fractional layout height').toBeLessThan(0.1);
         expect(hiddenRect.width, 'primitive contract: a display:none node reports zero width, not its specified size').toBe(0);
         expect(hiddenRect.height, 'primitive contract: a display:none node reports zero height, not its specified size').toBe(0);
+
+        const inlineOffset = await page.evaluate(() => globalThis.__probe16375InlineOffset);
+
+        expect(inlineRect.width, 'primitive contract: an unresolved-size node falls back to its integer offset width')
+            .toBe(inlineOffset.w);
+        expect(inlineRect.height, 'primitive contract: an unresolved-size node falls back to its integer offset height')
+            .toBe(inlineOffset.h);
+        expect(inlineRect.width, 'the unresolved-size probe is actually rendered').toBeGreaterThan(0);
 
         // TRIGGER: the deferred projection's own mutation class — the normalized flex pair the
         // projection writes on both pane tab containers — changes the grid layout box while the
@@ -223,6 +246,8 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
         await page.evaluate(flex => {
             document.getElementById('probe-16375-visible').remove();
             document.getElementById('probe-16375-hidden').remove();
+            document.getElementById('probe-16375-inline-host').remove();
+            delete globalThis.__probe16375InlineOffset;
             document.getElementById('neo-tab-container-2').style.flex = flex[0];
             document.getElementById('neo-tab-container-3').style.flex = flex[1];
             document.body.style.transform       = '';
@@ -235,6 +260,54 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
             return Math.abs(containerWidth - current.layoutWidth)
         }, {
             message  : 'worker containerWidth re-converges on the layout box after the transform clears',
+            timeout  : 10000,
+            intervals: [100, 250]
+        }).toBeLessThan(1);
+
+        // SUB-PIXEL DELIVERY IS PROCESSED (no echo/tolerance swallow): a fractional flex nudge
+        // moves the grid layout box by well under one CSS pixel; the worker must track it.
+        // Under the retired first-delivery skip OR any <1px equivalence predicate, this exact
+        // class of delivery was swallowed (witnessed on real Chromium: 123.4375 → 123.9375).
+        const settled = await readMatrix(page);
+
+        await page.evaluate(() => {
+            document.getElementById('neo-tab-container-2').style.flex = '0.6005 1 0%';
+            document.getElementById('neo-tab-container-3').style.flex = '0.3995 1 0%'
+        });
+
+        await expect.poll(async () => (await readMatrix(page)).layoutWidth, {
+            message  : 'the fractional flex nudge moves the layout box sub-pixel',
+            timeout  : 5000,
+            intervals: [50, 100]
+        }).toBeGreaterThan(settled.layoutWidth + 0.2);
+
+        const nudged = await readMatrix(page);
+
+        expect(nudged.layoutWidth - settled.layoutWidth,
+            'the nudge stays sub-pixel (the swallowed class)').toBeLessThan(1);
+
+        await expect.poll(async () => {
+            const {containerWidth} = await readWorker(app),
+                  current          = await readMatrix(page);
+            return Math.abs(containerWidth - current.layoutWidth)
+        }, {
+            message  : 'worker containerWidth tracks a sub-pixel resize delivery (processed, never swallowed)',
+            timeout  : 10000,
+            intervals: [100, 250]
+        }).toBeLessThan(0.25);
+
+        // restore the original flex pair; geometry re-converges once more
+        await page.evaluate(flex => {
+            document.getElementById('neo-tab-container-2').style.flex = flex[0];
+            document.getElementById('neo-tab-container-3').style.flex = flex[1]
+        }, originalFlex);
+
+        await expect.poll(async () => {
+            const {containerWidth} = await readWorker(app),
+                  current          = await readMatrix(page);
+            return Math.abs(containerWidth - current.layoutWidth)
+        }, {
+            message  : 'worker containerWidth re-converges after the nudge restores',
             timeout  : 10000,
             intervals: [100, 250]
         }).toBeLessThan(1)
@@ -345,7 +418,13 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
             const worker = await readWorker(app),
                   matrix = await readMatrix(page);
 
-            // 2. worker availableWidth rides the header buttons' summed LAYOUT widths
+            // 2. scroll state agrees across worker and main BEFORE any geometry comparison —
+            //    a scroll divergence would shift every visual-space read
+            expect(Math.abs(worker.scrollLeft - matrix.scrollLeft),
+                `${tag}: worker scrollLeft agrees with the header toolbar's native scroll state`)
+                .toBeLessThan(0.5);
+
+            // 3. worker availableWidth rides the header buttons' summed LAYOUT widths
             expect(Math.abs(worker.availableWidth - matrix.buttonWidthSum),
                 `${tag}: worker availableWidth equals the summed header-button layout widths`)
                 .toBeLessThan(1.5);

--- a/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
@@ -1,0 +1,295 @@
+import { test, expect } from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: repeated committed splitter drags keep worker, header, and cell geometry aligned.
+ *
+ * After committed DockSplitter resizes, the 100k Matrix grid could keep painting while
+ * its geometry generations drifted apart — header labels narrower than their cells, the last
+ * body column clipped at the shared right edge, phantom mounted columns. Mechanism: the grid's
+ * resize measurement (`grid.Container#passSizeToBody` + `grid.header.Toolbar#passSizeToBody`)
+ * ran `getBoundingClientRect()` through async worker→main round-trips that could land inside
+ * DockFlip's inverse-transform presentation window, persisting transform-scaled VISUAL rects
+ * as `containerWidth` / `availableWidth` / `columnPositions` (witnessed live: containerWidth
+ * 476.77 and availableWidth 1328.72 at a settled 388px rest). The seam now reads layout-box
+ * metrics (`getLayoutRect()`), which transforms never affect.
+ *
+ * This guard drives the ticket's own recipe — a bounded series of real committed drags, BOTH
+ * directions, repeated cycles — and after every settled commit asserts the full attribution
+ * matrix (worker → header → body):
+ *   1. worker `containerWidth` equals the grid container's layout width (±1px);
+ *   2. worker `availableWidth` equals the summed layout widths of the header buttons (±1.5px);
+ *   3. every visible header button and its x-order-paired first-row cell agree on left/width
+ *      (±1px) — the ticket's visible symptom, asserted pairwise.
+ *
+ * Settlement is event/state-based only (dock document commit, projected DOM extent, motion
+ * lifecycle class, zero fixed-stage residue, transform-free grid) — no fixed-delay sleeps,
+ * per the ticket's walls.
+ *
+ * The race itself is pinned RACE-FREE by the first test: it freezes a "mid-motion" frame (a
+ * static ancestor scale transform), triggers the measurement through the projection's own
+ * mutation class (a flex-basis write on the pane's tab container), and asserts the worker
+ * persists the LAYOUT box. Pre-fix that fails deterministically on every run — no lucky
+ * timing can green-wash it; the drag test then guards the integrated surface.
+ *
+ * Run: npx playwright test WorkstationSplitterGridGeometryNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Workstation splitter drags: grid geometry stays attributable (#16375)', () => {
+    test.setTimeout(180000);
+    test.use({ viewport: { width: 1280, height: 720 } });
+
+    const GRID_ID = 'neo-grid-container-1',
+          BODY_ID = 'neo-grid-body-1';
+
+    /** Page-side geometry matrix for the Matrix grid: container, header buttons, row-0 cells. */
+    const readMatrix = page => page.evaluate(gridId => {
+        const grid    = document.getElementById(gridId),
+              header  = grid.querySelector('.neo-grid-header-toolbar'),
+              body    = grid.querySelector('.neo-grid-body'),
+              clip    = body.getBoundingClientRect(),
+              inClip  = r => r.width > 0 && r.right > clip.left + 1 && r.left < clip.right - 1,
+              buttons = [...header.children]
+                  .map(b => ({r: b.getBoundingClientRect(), lw: parseFloat(getComputedStyle(b).width)}))
+                  .filter(({r}) => r.width > 0),
+              headers = buttons
+                  .filter(({r}) => inClip(r))
+                  .map(({r}) => ({x: r.left, w: r.width}))
+                  .sort((a, b) => a.x - b.x),
+              row     = body.querySelector('[role="row"]'),
+              cells   = row ? [...row.children]
+                  .map(c => c.getBoundingClientRect())
+                  .filter(r => inClip(r))
+                  .map(r => ({x: r.left, w: r.width}))
+                  .sort((a, b) => a.x - b.x) : [];
+
+        return {
+            layoutWidth   : parseFloat(getComputedStyle(grid).width),
+            transform     : getComputedStyle(grid).transform,
+            buttonWidthSum: buttons.reduce((sum, {lw}) => sum + lw, 0),
+            headers,
+            cells
+        };
+    }, GRID_ID);
+
+    test('measurement stays layout-true while an ancestor transform holds (deterministic reproducer)', async ({ page, neuralLink }) => {
+        const SCALE_X = 0.6,
+              SCALE_Y = 0.85;
+
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-tour-play', {timeout: 30000});
+        await page.waitForSelector(`#${GRID_ID}`, {timeout: 30000});
+
+        const app = await neuralLink.connectToApp('Workstation');
+
+        // boot settlement: the worker knows the real grid width
+        await expect.poll(async () => {
+            const {containerWidth} = await app.getComponent(BODY_ID, ['containerWidth']);
+            return containerWidth
+        }, {timeout: 15000, intervals: [100, 250]}).toBeGreaterThan(0);
+
+        const boot = await readMatrix(page);
+
+        // ARM THE TRAP: freeze a "mid-motion" frame — a static ancestor scale transform.
+        await page.evaluate(([sx, sy]) => {
+            document.body.style.transformOrigin = 'left top';
+            document.body.style.transform       = `scale(${sx}, ${sy})`
+        }, [SCALE_X, SCALE_Y]);
+
+        // trap premises: the visual box IS scaled; the layout box is NOT
+        const armed = await page.evaluate(gridId => {
+            const grid = document.getElementById(gridId);
+            return {
+                visualWidth: grid.getBoundingClientRect().width,
+                layoutWidth: parseFloat(getComputedStyle(grid).width)
+            };
+        }, GRID_ID);
+
+        expect(Math.abs(armed.visualWidth - boot.layoutWidth * SCALE_X),
+            'trap premise: getBoundingClientRect reports the scaled visual box').toBeLessThan(2);
+        expect(Math.abs(armed.layoutWidth - boot.layoutWidth),
+            'trap premise: the layout box ignores the ancestor transform').toBeLessThan(1);
+
+        // TRIGGER: the deferred projection's own mutation class — the normalized flex pair the
+        // projection writes on both pane tab containers — changes the grid layout box while the
+        // transform holds, so the resize measurement pipeline runs against the frozen mid-motion frame.
+        const originalFlex = await page.evaluate(() => {
+            const paneA = document.getElementById('neo-tab-container-2'),
+                  paneB = document.getElementById('neo-tab-container-3'),
+                  flex  = [paneA.style.flex, paneB.style.flex];
+
+            paneA.style.flex = '0.85 1 0%';
+            paneB.style.flex = '0.15 1 0%';
+            return flex;
+        });
+
+        // the flex write re-laid-out the grid
+        await expect.poll(async () => (await readMatrix(page)).layoutWidth, {
+            message  : 'the flex mutation grows the grid layout box',
+            timeout  : 5000,
+            intervals: [50, 100]
+        }).toBeGreaterThan(boot.layoutWidth + 50);
+
+        // THE SEAM ASSERTIONS: the worker persists LAYOUT truth, not visual fiction.
+        // Pre-fix, containerWidth lands at ~SCALE_X * layoutWidth and availableWidth at
+        // ~SCALE_X * buttonWidthSum (the gBCR samples), so these polls time out red.
+        await expect.poll(async () => {
+            const {containerWidth} = await app.getComponent(BODY_ID, ['containerWidth']),
+                  current          = await readMatrix(page);
+            return Math.abs(containerWidth - current.layoutWidth)
+        }, {
+            message  : 'worker containerWidth equals the grid layout width (not the transform-scaled visual width)',
+            timeout  : 10000,
+            intervals: [100, 250]
+        }).toBeLessThan(1);
+
+        await expect.poll(async () => {
+            const {availableWidth} = await app.getComponent(BODY_ID, ['availableWidth']),
+                  current          = await readMatrix(page);
+            return Math.abs(availableWidth - current.buttonWidthSum)
+        }, {
+            message  : 'worker availableWidth equals the summed header-button layout widths (not their scaled visual widths)',
+            timeout  : 10000,
+            intervals: [100, 250]
+        }).toBeLessThan(1.5);
+
+        // DISARM + coherence: restore the pane flex pair and the transform, geometry re-converges.
+        await page.evaluate(flex => {
+            document.getElementById('neo-tab-container-2').style.flex = flex[0];
+            document.getElementById('neo-tab-container-3').style.flex = flex[1];
+            document.body.style.transform       = '';
+            document.body.style.transformOrigin = ''
+        }, originalFlex);
+
+        await expect.poll(async () => {
+            const {containerWidth} = await app.getComponent(BODY_ID, ['containerWidth']),
+                  current          = await readMatrix(page);
+            return Math.abs(containerWidth - current.layoutWidth)
+        }, {
+            message  : 'worker containerWidth re-converges on the layout box after the transform clears',
+            timeout  : 10000,
+            intervals: [100, 250]
+        }).toBeLessThan(1)
+    });
+
+    test('worker, header, and cells agree after every settled committed drag, both directions', async ({ page, neuralLink }) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-tour-play', {timeout: 30000});
+        await page.waitForSelector('.neo-tab-overflow-control', {timeout: 30000});
+        await page.waitForSelector(`#${GRID_ID}`, {timeout: 30000});
+
+        const app         = await neuralLink.connectToApp('Workstation'),
+              root        = page.locator('.workstation-workspace'),
+              workspaces  = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+              workspaceId = (Array.isArray(workspaces) ? workspaces : [workspaces])[0]?.id;
+
+        expect(workspaceId, 'the page owns a Workstation workspace').toBeTruthy();
+
+        // boot settlement: worker knows the grid width before the first drag
+        await expect.poll(async () => {
+            const {containerWidth} = await app.getComponent(BODY_ID, ['containerWidth']);
+            return containerWidth
+        }, {timeout: 15000, intervals: [100, 250]}).toBeGreaterThan(0);
+
+        const boot = await readMatrix(page);
+
+        /** One committed drag + event-based settlement + the full attribution matrix. */
+        async function dragAndVerify(deltaX, tag) {
+            const splitter                 = page.locator('.neo-dashboard-dock-splitter-horizontal'),
+                  box                      = await splitter.boundingBox(),
+                  sx                       = box.x + box.width / 2,
+                  sy                       = box.y + box.height / 2,
+                  before                   = await readMatrix(page),
+                  {dockModel: modelBefore} = await app.getComponent(workspaceId, ['dockModel']);
+
+            await page.mouse.move(sx, sy);
+            await page.mouse.down();
+            await page.mouse.move(sx + Math.sign(deltaX) * 12, sy, {steps: 4});
+            await page.mouse.move(sx + deltaX, sy, {steps: 15});
+            await page.waitForTimeout(400); // gesture hold before release (drag realism, not settlement)
+            await page.mouse.up();
+
+            // settlement, event/state-based only:
+            // 1. the semantic document committed
+            await expect.poll(async () => {
+                const {dockModel} = await app.getComponent(workspaceId, ['dockModel']);
+                return Math.abs(dockModel.nodes['split-main'].sizes[0] - modelBefore.nodes['split-main'].sizes[0])
+            }, {
+                message  : `${tag}: the drag commits a semantic resizeSplit document change`,
+                timeout  : 10000,
+                intervals: [50, 100]
+            }).toBeGreaterThan(0.02);
+
+            // 2. the deferred projection applied the committed extent to live DOM
+            await expect.poll(async () => (await readMatrix(page)).layoutWidth, {
+                message  : `${tag}: the projection applies the committed split to the grid layout box`,
+                timeout  : 10000,
+                intervals: [50, 100]
+            }).toBeCloseTo(before.layoutWidth + deltaX, 0);
+
+            // 3. the motion lifecycle fully released the presentation
+            await expect(root, `${tag}: the dock motion lifecycle settles`)
+                .not.toHaveClass(/neo-dashboard-dock-animating/, {timeout: 10000});
+            await expect(page.locator('.neo-dock-flip-fixed-stage'),
+                `${tag}: no fixed-stage presentation residue`).toHaveCount(0);
+
+            const settled = await readMatrix(page);
+
+            expect(settled.transform, `${tag}: the grid carries no residual transform`).toBe('none');
+
+            // ATTRIBUTION MATRIX (worker → header → body), the ticket's AC net:
+            // 1. worker containerWidth rides the layout box — poisoned visual samples time this out
+            await expect.poll(async () => {
+                const {containerWidth} = await app.getComponent(BODY_ID, ['containerWidth']),
+                      current          = await readMatrix(page);
+                return Math.abs(containerWidth - current.layoutWidth)
+            }, {
+                message  : `${tag}: worker containerWidth equals the grid layout width`,
+                timeout  : 5000,
+                intervals: [100, 250]
+            }).toBeLessThan(1);
+
+            // 2. worker availableWidth rides the header buttons' summed LAYOUT widths
+            const {availableWidth} = await app.getComponent(BODY_ID, ['availableWidth']);
+
+            expect(Math.abs(availableWidth - settled.buttonWidthSum),
+                `${tag}: worker availableWidth equals the summed header-button layout widths`)
+                .toBeLessThan(1.5);
+
+            // 3. every visible header agrees with its x-order-paired first-row cell
+            expect(settled.headers.length, `${tag}: visible header buttons exist`).toBeGreaterThan(2);
+            expect(settled.cells.length, `${tag}: visible row-0 cells exist`).toBeGreaterThan(2);
+
+            const pairCount = Math.min(settled.headers.length, settled.cells.length);
+
+            for (let i = 0; i < pairCount; i++) {
+                const h = settled.headers[i],
+                      c = settled.cells[i];
+
+                expect(Math.abs(h.x - c.x),
+                    `${tag}: header[${i}] left aligns with its cell (h ${h.x} vs c ${c.x})`).toBeLessThan(1);
+                expect(Math.abs(h.w - c.w),
+                    `${tag}: header[${i}] width matches its cell (h ${h.w} vs c ${c.w})`).toBeLessThan(1)
+            }
+        }
+
+        // the ticket's recipe: repeated committed drags, both directions, cycled
+        await dragAndVerify(160,  'drag1-right');
+        await dragAndVerify(-160, 'drag2-left');
+        await dragAndVerify(120,  'drag3-right');
+        await dragAndVerify(-120, 'drag4-left');
+
+        // net-zero series: every surface returns to boot geometry
+        const end = await readMatrix(page);
+
+        expect(Math.abs(end.layoutWidth - boot.layoutWidth),
+            'the net-zero drag series returns the grid to its boot layout width').toBeLessThan(1);
+
+        expect(pageErrors, 'the run surfaces zero page errors').toEqual([])
+    })
+});

--- a/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationSplitterGridGeometryNL.spec.mjs
@@ -65,17 +65,23 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
               headers = {},
               cells   = {};
 
+        // Collect RAW rows first (duplicate keys must stay countable — an object write would
+        // collapse a duplicated column silently before any cardinality assert), then key.
+        const headerRows = [],
+              cellRows   = [];
+
         [...header.children].forEach(b => {
             const key = b.getAttribute('aria-colindex'),
                   r   = b.getBoundingClientRect();
 
             if (key && inClip(r)) {
-                headers[key] = {
+                headerRows.push({
+                    key,
                     visualX : r.left,
                     visualW : r.width,
                     contentX: b.offsetLeft,
                     layoutW : parseFloat(getComputedStyle(b).width)
-                }
+                })
             }
         });
 
@@ -84,17 +90,23 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
                   r   = c.getBoundingClientRect();
 
             if (key && inClip(r)) {
-                cells[key] = {
+                cellRows.push({
+                    key,
                     dataField: c.getAttribute('data-field'),
                     visualX  : r.left,
                     visualW  : r.width,
                     contentX : parseFloat(c.style.left),
                     layoutW  : parseFloat(getComputedStyle(c).width)
-                }
+                })
             }
         });
 
+        headerRows.forEach(h => { headers[h.key] = h });
+        cellRows.forEach(c => { cells[c.key] = c });
+
         return {
+            headerRowCount: headerRows.length,
+            cellRowCount  : cellRows.length,
             layoutWidth   : parseFloat(getComputedStyle(grid).width),
             transform     : getComputedStyle(grid).transform,
             buttonWidthSum: [...header.children]
@@ -264,10 +276,12 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
             intervals: [100, 250]
         }).toBeLessThan(1);
 
-        // SUB-PIXEL DELIVERY IS PROCESSED (no echo/tolerance swallow): a fractional flex nudge
-        // moves the grid layout box by well under one CSS pixel; the worker must track it.
-        // Under the retired first-delivery skip OR any <1px equivalence predicate, this exact
-        // class of delivery was swallowed (witnessed on real Chromium: 123.4375 → 123.9375).
+        // SUB-PIXEL DELIVERY IS PROCESSED: a fractional flex nudge moves the grid layout box by
+        // well under one CSS pixel; the worker must track it. This binds the size-equivalence
+        // class — any <1px "same size" predicate swallows exactly this delivery (witnessed on
+        // real Chromium: 123.4375 → 123.9375). The retired FIRST-delivery skip is bound
+        // separately: the large flex trigger above and the drag test's first commit are first
+        // post-registration deliveries, both red under the skip in the pre-fix stash round.
         const settled = await readMatrix(page);
 
         await page.evaluate(() => {
@@ -429,9 +443,19 @@ test.describe('Workstation splitter drags: grid geometry stays attributable (#16
                 `${tag}: worker availableWidth equals the summed header-button layout widths`)
                 .toBeLessThan(1.5);
 
-            // 3. key-set identity: the visible header and cell key sets are EQUAL
+            // 3. key-set identity WITHOUT duplicate collapse: raw per-surface counts must equal
+            //    unique key counts (a duplicated column on either surface fails HERE), and the
+            //    worker's columnPositions must be dataField-unique before it serves as a map.
             const headerKeys = Object.keys(matrix.headers).sort((a, b) => a - b),
                   cellKeys   = Object.keys(matrix.cells).sort((a, b) => a - b);
+
+            expect(matrix.headerRowCount, `${tag}: no duplicated aria-colindex among visible header buttons`)
+                .toBe(headerKeys.length);
+            expect(matrix.cellRowCount, `${tag}: no duplicated aria-colindex among visible row-0 cells`)
+                .toBe(cellKeys.length);
+            expect(new Set(worker.columnPositions.map(c => c.dataField)).size,
+                `${tag}: worker columnPositions carry unique dataFields`)
+                .toBe(worker.columnPositions.length);
 
             expect(headerKeys.length, `${tag}: visible header buttons exist`).toBeGreaterThan(2);
             expect(cellKeys, `${tag}: visible header and cell aria-colindex key sets are identical`)

--- a/test/playwright/setup.mjs
+++ b/test/playwright/setup.mjs
@@ -103,7 +103,7 @@ export function setup(options = {}) {
 
     Neo.main ??= {
         addon: {
-            DragDrop: {},
+            DragDrop : {},
             Navigator: {
                 subscribe  : () => {},
                 unsubscribe: () => {},
@@ -115,8 +115,17 @@ export function setup(options = {}) {
             }
         },
         DomAccess: {
-            focus: () => {},
+            focus                : () => {},
             getBoundingClientRect: async ({id}) => {
+                const rect = {width: 1000, height: 1000, x: 0, y: 0};
+                if (Array.isArray(id)) {
+                    return id.map(() => rect);
+                }
+                return rect;
+            },
+            // The single-thread simulation has no transforms, so the layout box equals the
+            // visual box: the transform-immune variant mirrors getBoundingClientRect here.
+            getLayoutRect: async ({id}) => {
                 const rect = {width: 1000, height: 1000, x: 0, y: 0};
                 if (Array.isArray(id)) {
                     return id.map(() => rect);
@@ -160,8 +169,8 @@ export function setup(options = {}) {
                 // Fallback for general bounding client rect reads
                 return {
                     attributes: {},
-                    functions: {},
-                    rects: [{width: 1000, height: 1000, x: 0, y: 0}]
+                    functions : {},
+                    rects     : [{width: 1000, height: 1000, x: 0, y: 0}]
                 };
             }
             return {};


### PR DESCRIPTION
Resolves #16375

Repeated committed splitter drags desynchronized the 100k Matrix grid because TWO stacked defects corrupted worker-side grid geometry — this PR repairs both at their owning seams. **Defect 1 (the staleness):** `grid.Container#initialResizeEvent` consumed the first ResizeObserver delivery after every (re)mount unconditionally — but the register-time echo it exists to skip can lose its race and never arrive, so the flag ate the first REAL resize instead (a committed dock re-layout), freezing `containerWidth` at the stale mount value until an unrelated resize. The repair removes the first-delivery skip entirely: `onResize` re-derives geometry on EVERY delivery — size-equivalence classification is no safer than the flag (any tolerance swallows a real sub-tolerance resize; witnessed on real Chromium at `123.4375 → 123.9375`), and re-processing a true echo is an idempotent silent set, so correctness costs one redundant measurement per mount. **Defect 2 (the poison):** `passSizeToBody` (container and header-toolbar variants) measured geometry via `getBoundingClientRect` through async worker→main round-trips that can land inside DockFlip's ~660–950ms inverse-transform presentation window — persisting transform-scaled visual fiction into `containerWidth`/`availableWidth`/`columnPositions` (witnessed live at a settled 388px rest: `containerWidth 476.77`, `availableWidth 1328.72`; the untransformed control grid stayed clean at 1256/1254). Both call sites now measure through a new transform-immune layout-box primitive: `Neo.main.DomAccess#getLayoutRect` + `component.Base#getLayoutRect` (computed used width/height normalized to border-box, offset-parent x/y) — additive; `getBoundingClientRect` remains untouched for genuine viewport-space consumers.

Evidence: L3 (live headed e2e — two-sided pre/post-fix runs, real CDP gestures, Neural-Link worker-truth traces incl. a mid-FLIP measurement at +293ms returning layout truth) → L3 required (every close-target AC is locally e2e-verifiable). No residuals: AC5's `#16353` repaint witness (`WorkstationGridRepaintNL`, merged with PR #16370) runs green at this head alongside the geometry witness.

## Deltas from ticket

- The ticket hypothesized ONE divergent owner; instrumentation (worker-console tracing of the full addon→delivery→`onResize`→measure chain) proved TWO stacked defects, both repaired here. The swallow defect also explains the grid staleness in plain viewport resizes outside any dock context (reproduced + healed on `examples/grid/bigData`, receipts below).
- New reusable primitive (`getLayoutRect`) rather than a local patch: any layout-size consumer racing any presentation transform gets the same immunity; vertical-splitter commits poison heights identically and are covered by the same seam.
- Out of scope, observed and measured during the probe, follow-up to be filed for the DockFlip owner: same-node splitter resizes fail `hasPreservedMarkerSet` (requires a lineage change), so `play()` burns its full 15-frame stage-A poll exposing the committed layout ~300ms, then visually double-takes — independent visual defect that also widens this race window.

## Test Evidence

- Rebased head (on dev @ `51e5bf429a`, which carries PR #16370): `NEO_E2E_PORT=8157 npx playwright test WorkstationSplitterGridGeometryNL WorkstationGridRepaintNL HeaderCellRectSync BigDataNL -c test/playwright/playwright.config.e2e.mjs --workers=1` → **6 passed** — including the `#16353` repaint witness green at this head (AC5 verified pre-merge).
- `WorkstationSplitterGridGeometryNL` (reworked in the review cycle): test 1 = deterministic race-free reproducer (static ancestor scale + the projection's own normalized flex-pair mutation as trigger; premise self-validating) **plus the primitive's no-box contract witnessed through the full worker→main path under the held transform** (visible fixture reports 333.5×41.5 layout truth; `display:none` fixture reports 0×0). Test 2 = the ticket's recipe: 4 committed real drags, both directions, per-settled-drag attribution matrix **keyed by `aria-colindex`** (visible key-set identity between header and cell surfaces; per-key visual-space header↔cell left/width ±1px; content-space worker `columnPositions` x/width per dataField against cell `style.left`/layout width and header `offsetLeft`/layout width — scroll-invariant by construction; worker `containerWidth`/`availableWidth` against layout truth), settlement event/state-gated with a **positive motion-entry barrier** (MutationObserver witnesses the dock-motion class enter before the release conditions are asserted) and zero fixed delays.
- **Pre-fix red proof (stash round): 3 failed** — deterministic reproducer red (worker held boot 387.5 vs layout 549 for the full poll), drag test red at drag1 (the swallowed first commit), and the bigData scratch red (plain viewport resize never reached the worker — the swallow, no dock involved). Post-fix the bigData scratch passes.
- Unit: `test/playwright/unit/grid/` → **52 passed** at the repaired head (the swallow removal re-processes mount echoes idempotently in the simulation).
- `workstation/WorkstationNL` drag/identity test ✅ at pre-rebase head; its second test (`staged frame paints pane content`, zero-rect fixed-stage family) fails **identically with the fix stashed** — pre-existing `#16356`-class, not introduced here.
- Live NL worker-truth receipts on the ticket: post-fix 4-drag series ends at `containerWidth 387.523` / `availableWidth 1080` (exact layout truth); pre-fix same series ended poisoned (476.77/1328.72). Ticket round-4/round-5 comments carry the full timelines; the Contract Ledger for the new surface is on the ticket (issuecomment-5159880890).
- workstation surface: `WorkstationSplitterGridGeometryNL` + `WorkstationGridRepaintNL` + `WorkstationNL` drag test ✅. grid surface: `HeaderCellRectSync`, `BigDataNL` ✅.

## Post-Merge Validation

- [ ] Operator-side headed film-prep run: repeated splitter adjustments no longer accumulate header/cell drift on the 100k Matrix pane.

## Commits (if multi-commit)

- 2cb26314a9 — the repair: both grid seams + the transform-immune primitive + the two-layer witness spec (rebased; originally 0507e57303).
- 98e1a9d34a — unit-harness completion: the single-thread simulation's `DomAccess` mock mirrors `getLayoutRect`; heals the 10 `unit/grid` CI reds the first push surfaced (rebased; originally 400fa4fd00).
- e50e9b8734 — review cycle 1: truthful no-box/unresolved-size semantics in the primitive (+ contract fixture witness through the worker path), the first-delivery skip removed entirely from `grid.Container#onResize` (any echo tolerance can swallow a real sub-tolerance resize; re-processing the echo is idempotent), and the witness matrix made key- and cardinality-exact with a positive motion-entry barrier and keyed worker `columnPositions` attribution.
- 1c96de7d9c — amended-review tail (test-only): the unresolved-size inline-span fixture (flow-neutral fixed wrapper) binding the integer offset fallback through the worker path, the pre-comparison worker↔DOM scroll-state assert, and the sub-pixel (~0.5px) delivery-processed witness.
- b56b05269a — terminal oracle pass (test-only): raw row collection before keying with per-surface raw-vs-unique cardinality asserts (duplicate `aria-colindex` rows can no longer collapse silently), worker `columnPositions` dataField-uniqueness gating the attribution map, and the first-delivery-vs-subpixel witness attribution stated truthfully in-spec.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 3bdbcbb5-b77b-46f5-88b7-9dbb124733fe.
