### PR TITLE
feat(recovery): reconfigure — a knob-keyed config action inside the actuator envelope (#16374)

### DIFF
--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -15,8 +15,12 @@ import {
     appendHealEvent,
     validateHealLedgerRetention
 } from '../../../services/memory-core/helpers/healEventLedgerStore.mjs';
+import {
+    requiredContextForKnob,
+    writeKnobOverride
+} from '../../../services/memory-core/helpers/recoveryOverrideStore.mjs';
 
-const DEFAULT_ACTIONS        = Object.freeze(['restart', 'redeploy', 'warm-provider']);
+const DEFAULT_ACTIONS        = Object.freeze(['reconfigure', 'restart', 'redeploy', 'warm-provider']);
 const DEFAULT_DEPLOY_TARGETS = Object.freeze(['cloud-deploy']);
 
 /**
@@ -242,7 +246,12 @@ export class RecoveryActuatorService extends Base {
         targetIdentity = null,
         recoveryRunId = null,
         now = Date.now(),
-        reason = null
+        reason = null,
+        // Only `reconfigure` consumes these. A controller names a KNOB, never a config leaf — the
+        // transaction boundary belongs to the closed set, so a caller cannot compose an arbitrary
+        // group of leaves and have it applied as one.
+        knob = null,
+        knobValues = null
     } = {}) {
         if (typeof serviceKey !== 'string' || serviceKey.length === 0) {
             throw new TypeError('RecoveryActuatorService.apply: serviceKey is required');
@@ -293,7 +302,7 @@ export class RecoveryActuatorService extends Base {
         const startedAt = now;
 
         try {
-            const result = await this.executeTargetAction({target, action, reason});
+            const result = await this.executeTargetAction({target, action, knob, knobValues, reason});
 
             const updatedAt     = Date.now(),
                   diagnosis     = this.resolveDiagnosisEvent({diagnosisEvent, action, target, now: startedAt}),
@@ -498,8 +507,11 @@ export class RecoveryActuatorService extends Base {
      * @returns {Boolean}
      */
     isActionAllowedForTarget({action, target}) {
+        // `reconfigure` is compose-service only: it lands a durable overlay on a mount the target reads
+        // at boot, and a supervised in-process child has no such mount to read from. Admitting it there
+        // would write a file nothing consults and report success over it.
         if (target.kind === 'compose-service') {
-            return action === 'restart' || action === 'warm-provider';
+            return action === 'reconfigure' || action === 'restart' || action === 'warm-provider';
         }
 
         if (target.kind === 'supervised-task') {
@@ -514,13 +526,61 @@ export class RecoveryActuatorService extends Base {
     }
 
     /**
+     * @summary Writes a validated knob transaction to the durable overlay, then restarts the target so
+     * it takes effect.
+     *
+     * The restart is not a separate concern bolted on: the overlay is read at boot, so a write without
+     * one leaves the target running its old values while every surface reports the action succeeded.
+     * That is the failure this action exists to avoid, so the two halves stay one operation.
+     *
+     * The context a knob is bounded by is resolved from this process's own config. The orchestrator and
+     * the target read the same declared leaves, so a bound derived here is the best available reading —
+     * and it is the writer's reading, which is the one that must justify the write.
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async reconfigureComposeService({target, knob, knobValues, reason}) {
+        const context = {};
+
+        for (const leafPath of requiredContextForKnob(knob)) {
+            context[leafPath] = leafPath.split('.').reduce((node, key) => node?.[key], AiConfig);
+        }
+
+        const {applied, path: overridePath, violations} = await writeKnobOverride({
+            context,
+            knob,
+            // Derived from the bridge's snapshot leaf rather than re-resolved: both files live on the
+            // same writer-owned mount, and deriving keeps them together if that root ever relocates.
+            overrideDir: path.dirname(AiConfig.orchestrator.deploymentStateBridge.snapshotPath),
+            values     : knobValues
+        });
+
+        if (!applied) {
+            // Refused BEFORE any restart, and thrown rather than returned: this service signals action
+            // failure by throwing (`warmProviderResidency` does the same), and `apply` wraps the call so
+            // the attempt is recorded as failed. Returning a soft `{ok: false}` would be a second
+            // failure convention to keep correct, and the caller that forgot to read it would treat a
+            // refusal as a success.
+            throw new Error(`Knob transaction refused for '${knob}': ${violations.join('; ')}`);
+        }
+
+        const restart = await this.restartComposeService({target, reason});
+
+        return {...restart, knob, overridePath}
+    }
+
+    /**
      * @summary Executes the typed target action through the matching privilege envelope.
      * @param {Object} options
      * @returns {Promise<Object>}
      */
-    async executeTargetAction({target, action, reason}) {
+    async executeTargetAction({target, action, reason, knob, knobValues}) {
         if (action === 'warm-provider') {
             return this.warmProviderResidency({target, reason});
+        }
+
+        if (action === 'reconfigure') {
+            return this.reconfigureComposeService({knob, knobValues, reason, target});
         }
 
         if (target.kind === 'compose-service') {

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -171,10 +171,29 @@ services:
       - NEO_OPENAI_COMPATIBLE_API_KEY=${NEO_OPENAI_COMPATIBLE_API_KEY:-}
       - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
+    # The recovery actuator writes a config overlay onto the deployment-state mount, which this
+    # service reads read-only — the actuator's container writes, the target only reads, so a target
+    # cannot rewrite the record of what was applied to it, and the writer survives the target's death.
+    #
+    # The `--config` flag is CONDITIONAL and must stay that way. `ConfigProvider.load()` rethrows on
+    # any read failure including ENOENT, and `BaseServer.loadCustomConfig()` rethrows in turn, so
+    # pointing this at a path that does not exist yet would turn "no override has ever been written"
+    # into a boot crash. With the test, an absent overlay yields exactly today's behaviour.
+    command:
+      - sh
+      - -c
+      - >-
+        overlay=/app/.neo-ai-data/deployment-state/recovery-actuator-overrides.json;
+        if [ -f "$$overlay" ]; then
+          node "$$SERVER_ENTRYPOINT" --config "$$overlay";
+        else
+          node "$$SERVER_ENTRYPOINT";
+        fi
     volumes:
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
       - shared-handoff-data:/app/.neo-ai-data/handoff:ro
-      # Read-only half of the orchestrator -> public MCP deployment-state bridge.
+      # Read-only half of the orchestrator -> public MCP deployment-state bridge, and the mount the
+      # recovery actuator publishes its config overlay onto.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
     depends_on:
       chroma:

--- a/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
+++ b/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
@@ -1,0 +1,147 @@
+/**
+ * @module ai/services/memory-core/helpers/recoveryKnobRegistry
+ * @summary The closed set of configuration knobs the recovery actuator may turn.
+ *
+ * A **knob** is the unit, not a config leaf. Several leaves can only move together — a nested timeout
+ * window has an inner and an outer bound with an ordering invariant between them — and applying such a
+ * pair one leaf at a time passes through a state that violates the invariant. For the generation window
+ * that intermediate state inverts which branch a timeout takes, so a detector reading branch identity
+ * goes blind exactly while actuation is in flight.
+ *
+ * Keying the set by knob rather than by leaf also keeps the transaction boundary here rather than in the
+ * controller. A controller asks to *widen the mini-summary window*; it never names leaves, and so cannot
+ * compose an arbitrary set of them. That is what keeps a recovery action a bounded config-and-lifecycle
+ * change rather than an arbitrary config-write primitive: the actuator's authority is the enumerated set
+ * below, and widening it is a deliberate edit here rather than an emergent property of a caller.
+ *
+ * This module is pure: no filesystem, no graph, no actuator coupling. It answers *what may be turned and
+ * to what*, so the answer can be tested, and so a controller can bind against it before any actuator code
+ * exists.
+ */
+
+/**
+ * Every knob the actuator may turn. Adding an entry is a deliberate widening of the actuator's authority
+ * and belongs in a ticket with a reason — which is the point of the set being closed and enumerated in
+ * one place rather than inferred from call sites.
+ *
+ * `leaves` is ORDERED: entries are applied and validated in the sequence given, and `invariants` are
+ * expressed over the resolved values by leaf path.
+ * @type {Object}
+ */
+export const RECOVERY_KNOBS = Object.freeze({
+    'mini-summary-window': Object.freeze({
+        description: 'Nested generation timeouts for mini-summary backfill. Widened when generation ' +
+                     'starvation is diagnosed; the inner bound guards a single generate call, the outer ' +
+                     'bound guards the sweep that wraps it.',
+        leaves: Object.freeze([
+            Object.freeze({
+                path: 'memoryService.generateMiniSummaryTimeoutMs',
+                env : 'NEO_MC_GENERATE_MINI_SUMMARY_TIMEOUT_MS',
+                role: 'inner',
+                type: 'number',
+                min : 1000,
+                max : 600000
+            }),
+            Object.freeze({
+                path: 'memoryService.miniSummaryTimeoutMs',
+                env : 'NEO_MC_MINI_SUMMARY_TIMEOUT_MS',
+                role: 'outer',
+                type: 'number',
+                min : 1000,
+                max : 600000
+            })
+        ]),
+        invariants: Object.freeze([
+            Object.freeze({
+                id    : 'inner-strictly-below-outer',
+                reason: 'The outer timeout wraps the inner one. At inner >= outer the outer fires first, ' +
+                          'so every failure moves from the inner falsy branch to the sweep\'s thrown branch ' +
+                          'and a branch-reading detector loses its signal mid-actuation.',
+                holds   : values => values['memoryService.generateMiniSummaryTimeoutMs'] <
+                                    values['memoryService.miniSummaryTimeoutMs']
+            })
+        ])
+    })
+});
+
+/**
+ * @summary Whether a name is a member of the closed set.
+ * @param {String} knob
+ * @returns {Boolean}
+ */
+export function isKnownKnob(knob) {
+    return typeof knob === 'string' && Object.hasOwn(RECOVERY_KNOBS, knob)
+}
+
+/**
+ * @summary The leaf paths a knob moves, in application order.
+ * @param {String} knob
+ * @returns {String[]} Empty for an unknown knob — callers must gate on {@link isKnownKnob} first.
+ */
+export function knobLeafPaths(knob) {
+    return isKnownKnob(knob) ? RECOVERY_KNOBS[knob].leaves.map(leaf => leaf.path) : []
+}
+
+/**
+ * @summary Validates a proposed knob transaction, returning every reason it is refused.
+ *
+ * Returns ALL violations rather than the first, because an operator or controller reading a refusal
+ * needs to know what a valid proposal would look like, not just the earliest thing wrong with this one.
+ *
+ * Refusal is by name and total: a transaction that violates anything applies nothing. Partial
+ * application is the failure this knob abstraction exists to prevent, so it must not be reachable
+ * through validation either.
+ * @param {Object} options
+ * @param {String} options.knob Knob name.
+ * @param {Object} options.values Proposed values, keyed by leaf path.
+ * @returns {{valid: Boolean, violations: String[]}}
+ */
+export function validateKnobTransaction({knob, values} = {}) {
+    const violations = [];
+
+    if (!isKnownKnob(knob)) {
+        return {valid: false, violations: [`unknown knob '${knob}' — the actuator turns only: ${Object.keys(RECOVERY_KNOBS).join(', ')}`]}
+    }
+
+    const {leaves, invariants} = RECOVERY_KNOBS[knob],
+          proposed             = values && typeof values === 'object' ? values : {};
+
+    // A knob is atomic, so a partial proposal is refused rather than merged with current values. Merging
+    // would make the resulting state depend on what the target happens to hold right now, which is
+    // exactly the read the actuator cannot safely perform across a process boundary.
+    for (const key of Object.keys(proposed)) {
+        if (!leaves.some(leaf => leaf.path === key)) {
+            violations.push(`'${key}' is not part of knob '${knob}'`);
+        }
+    }
+
+    for (const leaf of leaves) {
+        const value = proposed[leaf.path];
+
+        if (value === undefined) {
+            violations.push(`missing '${leaf.path}' — knob '${knob}' is applied whole, never leaf by leaf`);
+            continue
+        }
+        if (leaf.type === 'number') {
+            if (!Number.isFinite(value)) {
+                violations.push(`'${leaf.path}' must be a finite number, received ${JSON.stringify(value)}`);
+                continue
+            }
+            if (value < leaf.min || value > leaf.max) {
+                violations.push(`'${leaf.path}' must be within ${leaf.min}..${leaf.max}, received ${value}`);
+            }
+        }
+    }
+
+    // Invariants are evaluated only once every leaf is present and individually sound, so a bounds
+    // violation cannot surface as a confusing invariant failure.
+    if (violations.length === 0) {
+        for (const invariant of invariants) {
+            if (!invariant.holds(proposed)) {
+                violations.push(`invariant '${invariant.id}' violated — ${invariant.reason}`);
+            }
+        }
+    }
+
+    return {valid: violations.length === 0, violations}
+}

--- a/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
+++ b/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
@@ -28,12 +28,27 @@
  * expressed over the resolved values by leaf path.
  * @type {Object}
  */
+/**
+ * Fewest items the mini-summary sweep must still be able to attempt for the backfill to be draining
+ * rather than crawling. Named rather than inlined so the ceiling it produces reads as a throughput trade
+ * instead of a magic number a later reader will "tune".
+ * @type {Number}
+ */
+const MINISUMMARY_MIN_ITEMS_PER_SWEEP = 4;
+
 export const RECOVERY_KNOBS = Object.freeze({
-    'mini-summary-window': Object.freeze({
+    'minisummary-generation-window': Object.freeze({
         description: 'Nested generation timeouts for mini-summary backfill. Widened when generation ' +
                      'starvation is diagnosed; the inner bound guards a single generate call, the outer ' +
                      'bound guards the sweep that wraps it.',
-        leaves: Object.freeze([
+        /**
+         * Leaves this knob does NOT change but whose values bound it. The caller resolves these from the
+         * live config and passes them as `context`, so a bound derived from another leaf stays correct
+         * when that leaf moves — a hardcoded ceiling would silently go stale the moment it did.
+         */
+        requires        : Object.freeze(['memoryService.miniSummaryBackfillMaxRunMs']),
+        minItemsPerSweep: MINISUMMARY_MIN_ITEMS_PER_SWEEP,
+        leaves          : Object.freeze([
             Object.freeze({
                 path: 'memoryService.generateMiniSummaryTimeoutMs',
                 env : 'NEO_MC_GENERATE_MINI_SUMMARY_TIMEOUT_MS',
@@ -55,10 +70,30 @@ export const RECOVERY_KNOBS = Object.freeze({
             Object.freeze({
                 id    : 'inner-strictly-below-outer',
                 reason: 'The outer timeout wraps the inner one. At inner >= outer the outer fires first, ' +
-                          'so every failure moves from the inner falsy branch to the sweep\'s thrown branch ' +
-                          'and a branch-reading detector loses its signal mid-actuation.',
-                holds   : values => values['memoryService.generateMiniSummaryTimeoutMs'] <
-                                    values['memoryService.miniSummaryTimeoutMs']
+                        'so every failure moves from the inner falsy branch to the sweep\'s thrown branch ' +
+                        'and a branch-reading detector loses its signal mid-actuation.',
+                holds : values => values['memoryService.generateMiniSummaryTimeoutMs'] <
+                                  values['memoryService.miniSummaryTimeoutMs']
+            }),
+            Object.freeze({
+                id    : 'outer-leaves-room-for-a-draining-sweep',
+                reason: 'The sweep has a fixed wall-clock budget, so a wider per-item timeout buys ' +
+                        'per-item success by spending the number of items a sweep can attempt. Past a ' +
+                        'point the sweep goes single-item and the backlog stops draining — while every ' +
+                        'individual widening still looks like an improvement, because per-item success ' +
+                        'rate rises as total output collapses. This refuses the step where the action ' +
+                        'starts working against the outcome it is being taken for.',
+                holds : (values, context = {}) => {
+                    const budget = context['memoryService.miniSummaryBackfillMaxRunMs'];
+
+                    // Unresolvable budget is not a licence to widen without limit. Refusing here is the
+                    // same fail-closed rule the rest of this module follows: an unknown bound is a
+                    // refusal, never an absent one.
+                    if (!Number.isFinite(budget)) return false;
+
+                    return values['memoryService.miniSummaryTimeoutMs'] <=
+                           budget / MINISUMMARY_MIN_ITEMS_PER_SWEEP
+                }
             })
         ])
     })
@@ -83,6 +118,19 @@ export function knobLeafPaths(knob) {
 }
 
 /**
+ * @summary The leaf paths a caller must resolve and pass as `context` before a knob can be validated.
+ *
+ * These are leaves the knob does not change but is bounded by. Exposed so the actuator can resolve
+ * exactly what it needs without knowing which invariants exist — adding a bound to a knob therefore does
+ * not require editing its caller.
+ * @param {String} knob
+ * @returns {String[]}
+ */
+export function knobRequiredContext(knob) {
+    return isKnownKnob(knob) ? [...(RECOVERY_KNOBS[knob].requires ?? [])] : []
+}
+
+/**
  * @summary Validates a proposed knob transaction, returning every reason it is refused.
  *
  * Returns ALL violations rather than the first, because an operator or controller reading a refusal
@@ -94,17 +142,29 @@ export function knobLeafPaths(knob) {
  * @param {Object} options
  * @param {String} options.knob Knob name.
  * @param {Object} options.values Proposed values, keyed by leaf path.
+ * @param {Object} [options.context] Resolved values for the knob's `requires` leaves — the ones it does
+ * not change but is bounded by. Supplied by the caller rather than read here, so this module stays pure
+ * and a bound derived from another leaf is evaluated against that leaf's live value.
  * @returns {{valid: Boolean, violations: String[]}}
  */
-export function validateKnobTransaction({knob, values} = {}) {
+export function validateKnobTransaction({knob, values, context} = {}) {
     const violations = [];
 
     if (!isKnownKnob(knob)) {
         return {valid: false, violations: [`unknown knob '${knob}' — the actuator turns only: ${Object.keys(RECOVERY_KNOBS).join(', ')}`]}
     }
 
-    const {leaves, invariants} = RECOVERY_KNOBS[knob],
-          proposed             = values && typeof values === 'object' ? values : {};
+    const {leaves, invariants, requires = []} = RECOVERY_KNOBS[knob],
+          proposed                            = values  && typeof values  === 'object' ? values  : {},
+          resolved                            = context && typeof context === 'object' ? context : {};
+
+    // A bound the caller could not resolve is refused, not skipped. Silently dropping an unevaluable
+    // invariant would make the widest transactions the easiest to authorize, which is backwards.
+    for (const path of requires) {
+        if (resolved[path] === undefined) {
+            violations.push(`missing context '${path}' — knob '${knob}' is bounded by it and cannot be validated without it`);
+        }
+    }
 
     // A knob is atomic, so a partial proposal is refused rather than merged with current values. Merging
     // would make the resulting state depend on what the target happens to hold right now, which is
@@ -137,7 +197,7 @@ export function validateKnobTransaction({knob, values} = {}) {
     // violation cannot surface as a confusing invariant failure.
     if (violations.length === 0) {
         for (const invariant of invariants) {
-            if (!invariant.holds(proposed)) {
+            if (!invariant.holds(proposed, resolved)) {
                 violations.push(`invariant '${invariant.id}' violated — ${invariant.reason}`);
             }
         }

--- a/ai/services/memory-core/helpers/recoveryOverrideStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryOverrideStore.mjs
@@ -1,0 +1,154 @@
+/**
+ * @module ai/services/memory-core/helpers/recoveryOverrideStore
+ * @summary Writes a validated knob transaction to the durable config overlay the target reads at boot.
+ *
+ * The overlay is a JSON file on a mount the writer owns read-write and the target owns read-only. That
+ * asymmetry is doing two jobs: the target cannot rewrite the record of what was applied to it, and the
+ * writer survives the target's death — if an override ever stops the target booting, the process that
+ * wrote it can still revert it without the target running.
+ *
+ * Two rules make a write safe to hand to a boot path:
+ *
+ * **Validate before it lands.** The boot-time config guard fails fast on missing structure, so a
+ * malformed overlay is not a silent no-op — it is a target that will not start. And a target that will
+ * not start reads to a reactive controller as a fault, which lets one controller's actuation manufacture
+ * another's trigger. Validation belongs here, where the closed set and its invariants are, rather than at
+ * boot in a process that only has a fail-fast guard.
+ *
+ * **Write atomically.** A temporary sibling file renamed over the target, so a partial write is never
+ * observable as configuration. An interrupted write must leave the previous overlay intact rather than a
+ * truncated one.
+ */
+import fs   from 'fs/promises';
+import path from 'path';
+
+import {RECOVERY_KNOBS, knobRequiredContext, validateKnobTransaction} from './recoveryKnobRegistry.mjs';
+
+/**
+ * Filename of the durable overlay. Named so it cannot be mistaken for a deployment-state snapshot
+ * written by another process on the same mount: a reader of that directory needs to know at a glance
+ * which process owns a file and whether it is an observation or an instruction.
+ * @type {String}
+ */
+export const RECOVERY_OVERRIDE_FILENAME = 'recovery-actuator-overrides.json';
+
+/**
+ * @summary Expands dotted leaf paths into the nested shape the config overlay is merged from.
+ * @param {Object} values Values keyed by dotted leaf path.
+ * @param {Object} [into={}] Existing overlay content to merge into.
+ * @returns {Object}
+ * @private
+ */
+function expandLeafPaths(values, into = {}) {
+    const merged = structuredClone(into);
+
+    for (const [leafPath, value] of Object.entries(values)) {
+        const segments = leafPath.split('.');
+        let   cursor   = merged;
+
+        for (const segment of segments.slice(0, -1)) {
+            // A non-object at an intermediate segment would silently swallow the write, so it is
+            // replaced rather than merged into. The overlay is ours to own at these paths.
+            if (!cursor[segment] || typeof cursor[segment] !== 'object' || Array.isArray(cursor[segment])) {
+                cursor[segment] = {};
+            }
+            cursor = cursor[segment];
+        }
+
+        cursor[segments.at(-1)] = value;
+    }
+
+    return merged
+}
+
+/**
+ * @summary Reads the current overlay, or an empty object when none exists yet.
+ *
+ * A malformed existing overlay throws rather than being silently replaced: overwriting a file we cannot
+ * parse would discard operator or peer content we never read.
+ * @param {String} overridePath
+ * @param {Object} [fsModule=fs]
+ * @returns {Promise<Object>}
+ */
+export async function readRecoveryOverrides(overridePath, fsModule = fs) {
+    let raw;
+
+    try {
+        raw = await fsModule.readFile(overridePath, 'utf8')
+    } catch (error) {
+        if (error?.code === 'ENOENT') return {};
+        throw error
+    }
+
+    const parsed = JSON.parse(raw);
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error(`Recovery override file '${overridePath}' is not a JSON object`);
+    }
+
+    return parsed
+}
+
+/**
+ * @summary Validates a knob transaction and writes it to the overlay atomically.
+ *
+ * Refuses — writing nothing — when the knob is unknown, the transaction violates the knob's bounds or
+ * invariants, or any of the knob's leaves is pinned by an environment variable. The env case matters
+ * because the config layer re-asserts the env layer after merging an overlay, so an env-pinned leaf
+ * would accept the write and then discard it: a reported success over a value that never took effect.
+ *
+ * @param {Object} options
+ * @param {String} options.knob Knob name from the closed set.
+ * @param {Object} options.values Proposed values keyed by dotted leaf path.
+ * @param {Object} options.context Resolved values for the knob's required context leaves.
+ * @param {String} options.overrideDir Directory on the writer-owned mount.
+ * @param {Object} [options.env=process.env] Environment to test leaf pinning against.
+ * @param {Object} [options.fsModule=fs] Filesystem seam.
+ * @returns {Promise<{applied: Boolean, path: String|null, violations: String[]}>}
+ */
+export async function writeKnobOverride({
+    knob,
+    values,
+    context,
+    overrideDir,
+    env      = process.env,
+    fsModule = fs
+} = {}) {
+    const {valid, violations} = validateKnobTransaction({context, knob, values});
+
+    if (!valid) return {applied: false, path: null, violations};
+
+    // Env pinning is checked here rather than in the registry because it is a property of the RUNTIME
+    // the write is aimed at, not of the knob. The same knob is writable on one seat and refused on
+    // another, and only the writer knows which.
+    const pinned = RECOVERY_KNOBS[knob].leaves
+        .filter(leaf => env?.[leaf.env] !== undefined && env[leaf.env] !== '')
+        .map(leaf => `'${leaf.path}' is pinned by ${leaf.env}; the env layer outranks this overlay, so the write would be discarded`);
+
+    if (pinned.length > 0) return {applied: false, path: null, violations: pinned};
+
+    const overridePath = path.join(overrideDir, RECOVERY_OVERRIDE_FILENAME),
+          existing     = await readRecoveryOverrides(overridePath, fsModule),
+          next         = expandLeafPaths(values, existing),
+          // Same directory as the target, so the rename is within one filesystem and therefore atomic.
+          // A temp file elsewhere would degrade to copy-then-delete and reintroduce the partial state
+          // this exists to prevent.
+          tempPath     = `${overridePath}.${knob}.tmp`;
+
+    await fsModule.writeFile(tempPath, `${JSON.stringify(next, null, 4)}\n`, {mode: 0o644});
+    await fsModule.rename(tempPath, overridePath);
+
+    return {applied: true, path: overridePath, violations: []}
+}
+
+/**
+ * @summary The context leaves a caller must resolve before a knob can be written.
+ *
+ * Re-exported from the registry so a caller that only writes overrides needs one import rather than
+ * two, and so adding a bound to a knob never widens a writer's import surface.
+ * @param {String} knob
+ * @returns {String[]}
+ */
+export function requiredContextForKnob(knob) {
+    return knobRequiredContext(knob)
+}

--- a/ai/services/memory-core/helpers/recoveryOverrideStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryOverrideStore.mjs
@@ -135,6 +135,10 @@ export async function writeKnobOverride({
           // this exists to prevent.
           tempPath     = `${overridePath}.${knob}.tmp`;
 
+    // The mount exists but its subdirectory may not on a plane that has never written one, and a
+    // writer that requires someone else to have created its destination first is a boot-ordering
+    // dependency wearing a filesystem error.
+    await fsModule.mkdir(overrideDir, {recursive: true});
     await fsModule.writeFile(tempPath, `${JSON.stringify(next, null, 4)}\n`, {mode: 0o644});
     await fsModule.rename(tempPath, overridePath);
 

--- a/learn/agentos/decisions/0026-recovery-actuator.md
+++ b/learn/agentos/decisions/0026-recovery-actuator.md
@@ -80,7 +80,17 @@ The **controller** (what turns a diagnosis into an action choice) and the **actu
 
 > **diagnosis → [controller selects action] → actuator.apply(serviceKey, action) within the §2.5 envelope → outcome → re-observe.**
 
-- **The actuator interface is fixed:** `apply(serviceKey, action)` where `action ∈ {restart, recycle, throttle, reconfigure(knownKey), shed}` and the call is rejected unless the anti-thrash envelope (§2.5) admits it. The actuator is **controller-blind** — it does not know *why*, only *what* and *whether the envelope allows it*.
+- **The actuator interface is fixed:** `apply(serviceKey, action)`, rejected unless the anti-thrash envelope (§2.5) admits it. The actuator is **controller-blind** — it does not know *why*, only *what* and *whether the envelope allows it*.
+- **The action set is a matrix, not a flat list** (amended 2026-08-02, `#16374`). This ADR originally specified one flat set of five actions applying to every target. The implementation outgrew that shape: actions are admitted **per target kind**, which a flat set cannot express — and an implementation obeying the flat set literally would be *less* safe, because nothing would stop `redeploy` being aimed at a supervised in-process child. Shipped:
+
+  | target kind | admitted actions |
+  |---|---|
+  | supervised task | `restart`, `warm-provider` |
+  | compose service | `restart`, `warm-provider`, `reconfigure` |
+  | deploy target | `redeploy` |
+
+  `warm-provider` (config/readiness repair) and `redeploy` (lifecycle on a known deploy target) both sit inside AC-2's config-and-lifecycle envelope. **`recycle`, `throttle` and `shed` remain specified but UNIMPLEMENTED** — no consumer exists, and a reader of this section must be able to tell which of the listed actions they can actually call.
+- **`reconfigure` takes a KNOB, not a key** (amended 2026-08-02, `#16374`). The original `reconfigure(knownKey)` cannot express a change that must move several leaves together: a nested timeout window has an inner and an outer bound with an ordering invariant, and applying such a pair one leaf at a time passes through a state that violates it. The unit is therefore a **knob** — a named entry in a closed set carrying its ordered leaves plus its invariants — so the transaction boundary lives in the registry rather than in a controller that could compose an arbitrary group of leaves. A knob may also be bounded by leaves it does **not** change; those bounds are expressed as relationships against the live value, never as constants, because a constant goes stale the moment the leaf it was derived from moves. Mechanically: a validated transaction is written to a durable JSON overlay on a mount the actuator owns read-write and the target reads read-only, then applied by the existing `restart` — which is what line 61's *"re-apply an intended env override"* always meant.
 - **The controller is swappable.** Phase-1 (this epic) ships a **reactive** controller: diagnosis-class → fixed action (transient-crash→restart, contention→throttle/shed, config-drift→reconfigure/redeploy then record-if-un-resolvable, never page — #14191). Phase-2 (#13873) swaps in a **homeostatic** controller (a setpoint loop that may act before a hard fault) against the *same* `apply` interface and the *same* envelope. **No actuator rewrite** is the binding constraint — the phase-2 controller cannot widen the action set or bypass the envelope.
 - The B0 instance (#13900) is the interface's first implementation in miniature: its "controller" is the sustained-failure health probe (the diagnosis), its `apply` is `killTask`-recycle, its envelope is the supervisor cooldown.
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -520,6 +520,89 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         expect(runtimeCalls).toEqual([]);
     });
 
+    test.describe('reconfigure', () => {
+        const KNOB   = 'minisummary-generation-window',
+              INNER  = 'memoryService.generateMiniSummaryTimeoutMs',
+              OUTER  = 'memoryService.miniSummaryTimeoutMs',
+              VALUES = {[INNER]: 40000, [OUTER]: 60000};
+
+        test('is admitted for a compose service and refused for a supervised task', () => {
+            const {service} = createService();
+
+            // A supervised in-process child has no mount to read a durable overlay from, so admitting
+            // the action there would write a file nothing consults and report success over it.
+            expect(service.isActionAllowedForTarget({
+                action: 'reconfigure',
+                target: {kind: 'compose-service', id: 'mc-server'}
+            })).toBe(true);
+
+            expect(service.isActionAllowedForTarget({
+                action: 'reconfigure',
+                target: {kind: 'supervised-task', id: 'chroma'}
+            })).toBe(false);
+
+            expect(service.isActionAllowedForTarget({
+                action: 'reconfigure',
+                target: {kind: 'deploy-target', id: 'cloud-deploy'}
+            })).toBe(false);
+        });
+
+        test('a refused transaction costs the target NO restart', async () => {
+            const {service, runtimeCalls} = createService();
+
+            // Ordering that matters operationally: a rejected proposal must not bounce a healthy
+            // service. The violations travel back so a controller learns what would have been valid.
+            // Failure is signalled by throwing, matching how this service reports every other failed
+            // action; `apply` wraps the call and records the attempt as failed.
+            await expect(service.reconfigureComposeService({
+                knob      : KNOB,
+                knobValues: {[INNER]: 60000, [OUTER]: 40000},
+                target    : {kind: 'compose-service', id: 'mc-server', serviceKey: 'mc-server'}
+            })).rejects.toThrow(/inner-strictly-below-outer/);
+
+            expect(runtimeCalls).toEqual([]);
+        });
+
+        test('an unknown knob is refused without touching the target', async () => {
+            const {service, runtimeCalls} = createService();
+
+            await expect(service.reconfigureComposeService({
+                knob      : 'not-in-the-closed-set',
+                knobValues: VALUES,
+                target    : {kind: 'compose-service', id: 'mc-server', serviceKey: 'mc-server'}
+            })).rejects.toThrow(/unknown knob/);
+
+            expect(runtimeCalls).toEqual([]);
+        });
+
+        test('an accepted transaction writes the overlay AND restarts, because a write alone changes nothing', async () => {
+            const {service, runtimeCalls} = createService();
+
+            // The overlay is read at boot. A write without a restart leaves the target running its old
+            // values while every surface reports the action succeeded — the exact no-op-reported-as-
+            // success this action exists to avoid, so the two halves stay one operation.
+            const result = await service.reconfigureComposeService({
+                knob      : KNOB,
+                knobValues: VALUES,
+                target    : {kind: 'compose-service', id: 'mc-server', serviceKey: 'mc-server'}
+            });
+
+            expect(result.knob).toBe(KNOB);
+            expect(result.runtimeAccess).toBeTruthy();
+            expect(result.overridePath).toContain('recovery-actuator-overrides.json');
+
+            expect(runtimeCalls.length).toBe(1);
+            expect(runtimeCalls[0].serviceKey).toBe('mc-server');
+
+            expect(JSON.parse(await readFile(result.overridePath, 'utf8'))).toEqual({
+                memoryService: {
+                    generateMiniSummaryTimeoutMs: 40000,
+                    miniSummaryTimeoutMs        : 60000
+                }
+            });
+        });
+    });
+
     // The healLedgerRetention boundary getter's VALID path is exercised by the heal-ledger append tests above
     // (recordDiagnosis / deploy-target redeploy spread `...this.healLedgerRetention` into every appended event).
     // Its fail-visible INVALID path is covered without mutating the shared AiConfig singleton: the pure-function

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -396,6 +396,36 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         expect(runtimeCalls).toHaveLength(1);
     });
 
+    test('the envelope defers a repeated reconfigure — the action with the highest bounce cost is not exempt', async () => {
+        // AC3, and it has to be driven through `apply()` rather than the inner method: the anti-thrash
+        // envelope lives in `apply`, so every reconfigure spec that calls `reconfigureComposeService`
+        // directly proves the transaction and proves NOTHING about the rate limit. A new action reaching
+        // the privileged path without inheriting the envelope is precisely what §2.5 exists to prevent —
+        // and reconfigure restarts its target, so an unbounded loop here costs a bounce per iteration.
+        const {service, runtimeCalls} = createService({
+            actuatorConfig: {
+                baseBackoffMs: 30_000,
+                maxBackoffMs : 30_000
+            }
+        });
+
+        const knobValues = {
+                  'memoryService.generateMiniSummaryTimeoutMs': 40000,
+                  'memoryService.miniSummaryTimeoutMs'        : 60000
+              },
+              first  = await service.apply('mc-server', 'reconfigure', {knob: 'minisummary-generation-window', knobValues, now: 100_000}),
+              second = await service.apply('mc-server', 'reconfigure', {knob: 'minisummary-generation-window', knobValues, now: 101_000});
+
+        expect(first.status).toBe('actioned');
+        expect(second).toMatchObject({
+            status    : 'deferred',
+            reasonCode: 'backoff-active'
+        });
+
+        // One restart, not two: the deferred call must not reach the target at all.
+        expect(runtimeCalls).toHaveLength(1);
+    });
+
     test('attempt cap records as alarm-only and never loops the privileged action', async () => {
         const {service, runtimeCalls} = createService({
             actuatorConfig: {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/recoveryActuatorAdrCoherence.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/recoveryActuatorAdrCoherence.spec.mjs
@@ -1,0 +1,64 @@
+import {test, expect} from '@playwright/test';
+
+import fs              from 'node:fs/promises';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+/**
+ * The action set is stated in two places — the decision record that governs it and the code that
+ * enforces it — and they drifted apart in BOTH directions before anyone noticed: an action was
+ * specified and missing while two others shipped unlisted. It was found by a peer running a mandatory
+ * read before unrelated work, which is luck, and it cost that peer a blocked lane.
+ *
+ * This spec is the mechanical replacement for that luck. It does not judge which side is right; it
+ * fails when they disagree, so the disagreement is a red build rather than a discovery.
+ */
+
+const here     = path.dirname(fileURLToPath(import.meta.url)),
+      repoRoot = path.resolve(here, '../../../../../../..'),
+      adrPath  = path.join(repoRoot, 'learn/agentos/decisions/0026-recovery-actuator.md'),
+      srcPath  = path.join(repoRoot, 'ai/daemons/orchestrator/services/RecoveryActuatorService.mjs');
+
+test.describe('ADR 0026 and the recovery actuator agree on the action set (#16374)', () => {
+    test('every action the code admits is documented, and every documented action is marked', async () => {
+        const source = await fs.readFile(srcPath, 'utf8'),
+              adr    = await fs.readFile(adrPath, 'utf8');
+
+        const shipped = source
+            .match(/const DEFAULT_ACTIONS\s*=\s*Object\.freeze\(\[([^\]]*)\]\)/)?.[1]
+            .match(/'([^']+)'/g)
+            ?.map(entry => entry.replaceAll("'", ''))
+            .sort();
+
+        // Positive control: if the parse ever silently returns nothing, this spec would pass by
+        // asserting an empty set against an empty set — the shape where a guard stops guarding.
+        expect(shipped, 'DEFAULT_ACTIONS could not be parsed from the source').toBeTruthy();
+        expect(shipped.length).toBeGreaterThan(0);
+
+        // Every shipped action must appear in the ADR's action×target-kind matrix. A new action added
+        // to the code without documenting it fails here rather than in a peer's unrelated review.
+        const matrix = adr.slice(adr.indexOf('| target kind | admitted actions |'));
+
+        for (const action of shipped) {
+            expect(matrix, `'${action}' ships but is absent from the ADR's action matrix`).toContain(`\`${action}\``);
+        }
+
+        // And the reverse: actions the ADR still specifies but the code does not admit must be
+        // explicitly marked unimplemented, so a reader can tell what they may actually call.
+        for (const action of ['recycle', 'throttle', 'shed']) {
+            if (!shipped.includes(action)) {
+                expect(adr, `'${action}' is specified, not shipped, and not marked unimplemented`)
+                    .toMatch(/UNIMPLEMENTED/);
+            }
+        }
+    });
+
+    test('the ADR no longer states the flat action set the implementation outgrew', async () => {
+        const adr = await fs.readFile(adrPath, 'utf8');
+
+        // The original line specified a flat set. Leaving it in place alongside the matrix would give a
+        // reader two contradictory contracts and no way to tell which one the code enforces.
+        expect(adr).not.toContain('action ∈ {restart, recycle, throttle, reconfigure(knownKey), shed}');
+        expect(adr).toContain('The action set is a matrix, not a flat list');
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/recoveryKnobRegistry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/recoveryKnobRegistry.spec.mjs
@@ -4,12 +4,17 @@ import {
     RECOVERY_KNOBS,
     isKnownKnob,
     knobLeafPaths,
+    knobRequiredContext,
     validateKnobTransaction
 } from '../../../../../../../ai/services/memory-core/helpers/recoveryKnobRegistry.mjs';
 
-const KNOB  = 'mini-summary-window';
-const INNER = 'memoryService.generateMiniSummaryTimeoutMs';
-const OUTER = 'memoryService.miniSummaryTimeoutMs';
+const KNOB   = 'minisummary-generation-window';
+const INNER  = 'memoryService.generateMiniSummaryTimeoutMs';
+const OUTER  = 'memoryService.miniSummaryTimeoutMs';
+const BUDGET = 'memoryService.miniSummaryBackfillMaxRunMs';
+
+// Every valid transaction needs the bounding leaf resolved; 600000 is the live default.
+const CTX = {[BUDGET]: 600000};
 
 test.describe('recoveryKnobRegistry — the closed set is the actuator\'s authority boundary (#16374)', () => {
     test('an unknown knob is refused, and the refusal names what IS turnable', () => {
@@ -28,7 +33,7 @@ test.describe('recoveryKnobRegistry — the closed set is the actuator\'s author
         // The atomicity that makes a knob a knob. Merging a partial proposal with the target's current
         // values would make the result depend on what the target happens to hold, which is exactly the
         // read the actuator cannot perform across a process boundary.
-        const {valid, violations} = validateKnobTransaction({knob: KNOB, values: {[INNER]: 30000}});
+        const {valid, violations} = validateKnobTransaction({context: CTX, knob: KNOB, values: {[INNER]: 30000}});
 
         expect(valid).toBe(false);
         expect(violations.some(v => v.includes(OUTER) && v.includes('applied whole'))).toBe(true);
@@ -39,7 +44,7 @@ test.describe('recoveryKnobRegistry — the closed set is the actuator\'s author
         // branch to the sweep's thrown branch. A detector reading branch identity loses its signal
         // exactly while actuation is in flight — the failure this whole abstraction exists to prevent.
         for (const [inner, outer] of [[30000, 30000], [40000, 30000]]) {
-            const {valid, violations} = validateKnobTransaction({knob: KNOB, values: {[INNER]: inner, [OUTER]: outer}});
+            const {valid, violations} = validateKnobTransaction({context: CTX, knob: KNOB, values: {[INNER]: inner, [OUTER]: outer}});
 
             expect(valid, `inner=${inner} outer=${outer}`).toBe(false);
             expect(violations.some(v => v.includes('inner-strictly-below-outer'))).toBe(true);
@@ -47,13 +52,13 @@ test.describe('recoveryKnobRegistry — the closed set is the actuator\'s author
 
         // The positive control: the same shape one millisecond apart is accepted, so the refusals above
         // are the ordering rule and not an unrelated rejection.
-        expect(validateKnobTransaction({knob: KNOB, values: {[INNER]: 29999, [OUTER]: 30000}}).valid).toBe(true);
+        expect(validateKnobTransaction({context: CTX, knob: KNOB, values: {[INNER]: 29999, [OUTER]: 30000}}).valid).toBe(true);
     });
 
     test('a widening that preserves the invariant is accepted — the actuator can actually act', () => {
         // A guard that refuses everything is not a guard, it is an outage. This is the transaction the
         // thermostat will actually issue.
-        expect(validateKnobTransaction({knob: KNOB, values: {[INNER]: 40000, [OUTER]: 60000}})).toEqual({
+        expect(validateKnobTransaction({context: CTX, knob: KNOB, values: {[INNER]: 40000, [OUTER]: 60000}})).toEqual({
             valid     : true,
             violations: []
         });
@@ -61,8 +66,9 @@ test.describe('recoveryKnobRegistry — the closed set is the actuator\'s author
 
     test('a leaf outside the knob is refused rather than silently carried along', () => {
         const {valid, violations} = validateKnobTransaction({
-            knob  : KNOB,
-            values: {[INNER]: 20000, [OUTER]: 30000, 'memoryService.somethingElse': 1}
+            context: CTX,
+            knob   : KNOB,
+            values : {[INNER]: 20000, [OUTER]: 30000, 'memoryService.somethingElse': 1}
         });
 
         expect(valid).toBe(false);
@@ -72,7 +78,7 @@ test.describe('recoveryKnobRegistry — the closed set is the actuator\'s author
     test('bounds and type are enforced per leaf, and every violation is reported at once', () => {
         // All violations rather than the first: a caller needs to know what a valid proposal looks like,
         // not just the earliest thing wrong with this one.
-        const {valid, violations} = validateKnobTransaction({knob: KNOB, values: {[INNER]: 'soon', [OUTER]: 9_000_000}});
+        const {valid, violations} = validateKnobTransaction({context: CTX, knob: KNOB, values: {[INNER]: 'soon', [OUTER]: 9_000_000}});
 
         expect(valid).toBe(false);
         expect(violations.length).toBe(2);
@@ -83,7 +89,7 @@ test.describe('recoveryKnobRegistry — the closed set is the actuator\'s author
     test('an invariant failure cannot masquerade as a bounds failure', () => {
         // Invariants run only once every leaf is present and individually sound, so a caller is never
         // told the ordering is wrong when the real problem is a value out of range.
-        const {violations} = validateKnobTransaction({knob: KNOB, values: {[INNER]: 50, [OUTER]: 40}});
+        const {violations} = validateKnobTransaction({context: CTX, knob: KNOB, values: {[INNER]: 50, [OUTER]: 40}});
 
         expect(violations.every(v => !v.includes('inner-strictly-below-outer'))).toBe(true);
     });
@@ -101,6 +107,62 @@ test.describe('recoveryKnobRegistry — the closed set is the actuator\'s author
     test('leaf order is declared, because application order is part of the contract', () => {
         expect(knobLeafPaths(KNOB)).toEqual([INNER, OUTER]);
         expect(knobLeafPaths('unknown')).toEqual([]);
+    });
+
+    test('a widening that starves the sweep is refused — the action must not defeat its own goal', () => {
+        // The failure class this bound exists for is neither a no-op nor a crash: it is SUCCESSFUL
+        // actuation moving away from the objective. The sweep has a fixed wall-clock budget, so a wider
+        // per-item timeout buys per-item success by spending the item count. Past a point the sweep goes
+        // single-item and the backlog stops draining — while every individual step still looks like an
+        // improvement, because per-item success rate rises as total output collapses.
+        //
+        // With a 600000 budget and a four-item floor the ceiling is 150000.
+        expect(validateKnobTransaction({context: CTX, knob: KNOB, values: {[INNER]: 100000, [OUTER]: 150000}}).valid).toBe(true);
+
+        const {valid, violations} = validateKnobTransaction({context: CTX, knob: KNOB, values: {[INNER]: 100000, [OUTER]: 150001}});
+
+        expect(valid).toBe(false);
+        expect(violations.some(v => v.includes('outer-leaves-room-for-a-draining-sweep'))).toBe(true);
+    });
+
+    test('the ceiling MOVES with the budget leaf — it is a relationship, not a constant', () => {
+        // The whole reason the bound is derived rather than hardcoded: `miniSummaryBackfillMaxRunMs` is
+        // itself a leaf that can change, and a frozen ceiling would silently become wrong the moment it
+        // did. Halving the budget must halve the ceiling, with no edit here.
+        const proposal = {[INNER]: 100000, [OUTER]: 150000};
+
+        expect(validateKnobTransaction({context: {[BUDGET]: 600000}, knob: KNOB, values: proposal}).valid).toBe(true);
+        expect(validateKnobTransaction({context: {[BUDGET]: 300000}, knob: KNOB, values: proposal}).valid).toBe(false);
+
+        // And a larger budget genuinely permits more, so the relationship is two-directional rather than
+        // a one-way clamp that happens to track downward.
+        expect(validateKnobTransaction({
+            context: {[BUDGET]: 1_200_000},
+            knob   : KNOB,
+            values : {[INNER]: 200000, [OUTER]: 300000}
+        }).valid).toBe(true);
+    });
+
+    test('an unresolvable bound REFUSES — it never silently drops the invariant', () => {
+        // Fail-closed on the bound itself. If a missing or unreadable budget skipped the invariant, the
+        // widest transactions would become the easiest to authorize: the check would be absent exactly
+        // when it could not be evaluated, which is the same shape as a probe that fails closed to the
+        // value authorizing the action.
+        for (const context of [undefined, {}, {[BUDGET]: null}, {[BUDGET]: 'plenty'}]) {
+            const {valid} = validateKnobTransaction({context, knob: KNOB, values: {[INNER]: 20000, [OUTER]: 30000}});
+
+            expect(valid, `context: ${JSON.stringify(context)}`).toBe(false);
+        }
+    });
+
+    test('the knob declares which context a caller must resolve, so adding a bound needs no caller edit', () => {
+        expect(knobRequiredContext(KNOB)).toEqual([BUDGET]);
+        expect(knobRequiredContext('unknown')).toEqual([]);
+
+        // Returned by value: a caller mutating the list must not be able to shrink the knob's declared
+        // requirements and thereby skip a bound.
+        knobRequiredContext(KNOB).length = 0;
+        expect(knobRequiredContext(KNOB)).toEqual([BUDGET]);
     });
 
     test('every declared leaf carries the env name the override must not collide with', () => {

--- a/test/playwright/unit/ai/services/memory-core/helpers/recoveryKnobRegistry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/recoveryKnobRegistry.spec.mjs
@@ -1,0 +1,115 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    RECOVERY_KNOBS,
+    isKnownKnob,
+    knobLeafPaths,
+    validateKnobTransaction
+} from '../../../../../../../ai/services/memory-core/helpers/recoveryKnobRegistry.mjs';
+
+const KNOB  = 'mini-summary-window';
+const INNER = 'memoryService.generateMiniSummaryTimeoutMs';
+const OUTER = 'memoryService.miniSummaryTimeoutMs';
+
+test.describe('recoveryKnobRegistry — the closed set is the actuator\'s authority boundary (#16374)', () => {
+    test('an unknown knob is refused, and the refusal names what IS turnable', () => {
+        // The closed set is the whole reason `reconfigure` stays inside the config-and-lifecycle
+        // envelope instead of becoming an arbitrary config-write primitive. A refusal that does not
+        // name the alternatives pushes the caller toward guessing, which is how sets get widened
+        // informally.
+        const {valid, violations} = validateKnobTransaction({knob: 'anything-else', values: {}});
+
+        expect(valid).toBe(false);
+        expect(violations[0]).toContain('unknown knob');
+        expect(violations[0]).toContain(KNOB);
+    });
+
+    test('a knob is applied WHOLE — a partial proposal is refused, never merged', () => {
+        // The atomicity that makes a knob a knob. Merging a partial proposal with the target's current
+        // values would make the result depend on what the target happens to hold, which is exactly the
+        // read the actuator cannot perform across a process boundary.
+        const {valid, violations} = validateKnobTransaction({knob: KNOB, values: {[INNER]: 30000}});
+
+        expect(valid).toBe(false);
+        expect(violations.some(v => v.includes(OUTER) && v.includes('applied whole'))).toBe(true);
+    });
+
+    test('the ordering invariant refuses the inversion that blinds a branch-reading detector', () => {
+        // inner >= outer makes the outer timeout fire first, moving every failure from the inner falsy
+        // branch to the sweep's thrown branch. A detector reading branch identity loses its signal
+        // exactly while actuation is in flight — the failure this whole abstraction exists to prevent.
+        for (const [inner, outer] of [[30000, 30000], [40000, 30000]]) {
+            const {valid, violations} = validateKnobTransaction({knob: KNOB, values: {[INNER]: inner, [OUTER]: outer}});
+
+            expect(valid, `inner=${inner} outer=${outer}`).toBe(false);
+            expect(violations.some(v => v.includes('inner-strictly-below-outer'))).toBe(true);
+        }
+
+        // The positive control: the same shape one millisecond apart is accepted, so the refusals above
+        // are the ordering rule and not an unrelated rejection.
+        expect(validateKnobTransaction({knob: KNOB, values: {[INNER]: 29999, [OUTER]: 30000}}).valid).toBe(true);
+    });
+
+    test('a widening that preserves the invariant is accepted — the actuator can actually act', () => {
+        // A guard that refuses everything is not a guard, it is an outage. This is the transaction the
+        // thermostat will actually issue.
+        expect(validateKnobTransaction({knob: KNOB, values: {[INNER]: 40000, [OUTER]: 60000}})).toEqual({
+            valid     : true,
+            violations: []
+        });
+    });
+
+    test('a leaf outside the knob is refused rather than silently carried along', () => {
+        const {valid, violations} = validateKnobTransaction({
+            knob  : KNOB,
+            values: {[INNER]: 20000, [OUTER]: 30000, 'memoryService.somethingElse': 1}
+        });
+
+        expect(valid).toBe(false);
+        expect(violations.some(v => v.includes('somethingElse') && v.includes('not part of knob'))).toBe(true);
+    });
+
+    test('bounds and type are enforced per leaf, and every violation is reported at once', () => {
+        // All violations rather than the first: a caller needs to know what a valid proposal looks like,
+        // not just the earliest thing wrong with this one.
+        const {valid, violations} = validateKnobTransaction({knob: KNOB, values: {[INNER]: 'soon', [OUTER]: 9_000_000}});
+
+        expect(valid).toBe(false);
+        expect(violations.length).toBe(2);
+        expect(violations.some(v => v.includes(INNER) && v.includes('finite number'))).toBe(true);
+        expect(violations.some(v => v.includes(OUTER) && v.includes('1000..600000'))).toBe(true);
+    });
+
+    test('an invariant failure cannot masquerade as a bounds failure', () => {
+        // Invariants run only once every leaf is present and individually sound, so a caller is never
+        // told the ordering is wrong when the real problem is a value out of range.
+        const {violations} = validateKnobTransaction({knob: KNOB, values: {[INNER]: 50, [OUTER]: 40}});
+
+        expect(violations.every(v => !v.includes('inner-strictly-below-outer'))).toBe(true);
+    });
+
+    test('the registry is frozen — the closed set cannot be widened at runtime', () => {
+        // Authority that can be extended by an import is not bounded. Freezing is what makes "adding a
+        // knob is a ticket" enforceable rather than a convention.
+        expect(Object.isFrozen(RECOVERY_KNOBS)).toBe(true);
+        expect(Object.isFrozen(RECOVERY_KNOBS[KNOB].leaves)).toBe(true);
+
+        expect(() => { RECOVERY_KNOBS['smuggled'] = {} }).toThrow();
+        expect(isKnownKnob('smuggled')).toBe(false);
+    });
+
+    test('leaf order is declared, because application order is part of the contract', () => {
+        expect(knobLeafPaths(KNOB)).toEqual([INNER, OUTER]);
+        expect(knobLeafPaths('unknown')).toEqual([]);
+    });
+
+    test('every declared leaf carries the env name the override must not collide with', () => {
+        // The env layer outranks a file overlay by design (`ConfigProvider.load` re-asserts env after
+        // merging). A knob whose leaf is env-pinned would be written and then discarded — a success
+        // report over a no-op. Carrying the env name here is what lets the actuator detect that before
+        // writing rather than after.
+        for (const leaf of RECOVERY_KNOBS[KNOB].leaves) {
+            expect(leaf.env, leaf.path).toMatch(/^NEO_[A-Z0-9_]+$/);
+        }
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/recoveryOverrideStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/recoveryOverrideStore.spec.mjs
@@ -1,0 +1,166 @@
+import {test, expect} from '@playwright/test';
+
+import fs   from 'node:fs/promises';
+import os   from 'node:os';
+import path from 'node:path';
+
+import {
+    RECOVERY_OVERRIDE_FILENAME,
+    readRecoveryOverrides,
+    requiredContextForKnob,
+    writeKnobOverride
+} from '../../../../../../../ai/services/memory-core/helpers/recoveryOverrideStore.mjs';
+
+const KNOB   = 'minisummary-generation-window';
+const INNER  = 'memoryService.generateMiniSummaryTimeoutMs';
+const OUTER  = 'memoryService.miniSummaryTimeoutMs';
+const BUDGET = 'memoryService.miniSummaryBackfillMaxRunMs';
+
+const CTX    = {[BUDGET]: 600000};
+const VALUES = {[INNER]: 40000, [OUTER]: 60000};
+
+test.describe('recoveryOverrideStore — a write aimed at a boot path (#16374)', () => {
+    let dir, overridePath;
+
+    test.beforeEach(async () => {
+        dir          = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-recovery-override-'));
+        overridePath = path.join(dir, RECOVERY_OVERRIDE_FILENAME);
+    });
+
+    test.afterEach(async () => {
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a valid transaction lands as the nested shape the overlay is merged from', async () => {
+        const result = await writeKnobOverride({context: CTX, knob: KNOB, overrideDir: dir, values: VALUES, env: {}});
+
+        expect(result.applied).toBe(true);
+        expect(result.path).toBe(overridePath);
+
+        // Dotted leaf paths must expand — a flat key would merge into the config tree as a leaf named
+        // "memoryService.miniSummaryTimeoutMs", which resolves to nothing and reads as applied.
+        expect(await readRecoveryOverrides(overridePath)).toEqual({
+            memoryService: {
+                generateMiniSummaryTimeoutMs: 40000,
+                miniSummaryTimeoutMs        : 60000
+            }
+        });
+    });
+
+    test('an invalid transaction writes NOTHING — validation precedes the filesystem', async () => {
+        // The ordering that matters: the boot-time config guard fails fast on malformed structure, so a
+        // bad overlay is not a no-op, it is a target that will not start. Refusing before touching disk
+        // is what keeps a rejected proposal from becoming a boot input.
+        const result = await writeKnobOverride({
+            context    : CTX,
+            knob       : KNOB,
+            overrideDir: dir,
+            values     : {[INNER]: 60000, [OUTER]: 40000},
+            env        : {}
+        });
+
+        expect(result.applied).toBe(false);
+        expect(result.violations.some(v => v.includes('inner-strictly-below-outer'))).toBe(true);
+        await expect(fs.access(overridePath)).rejects.toThrow();
+    });
+
+    test('an env-pinned leaf is refused, because the write would be silently discarded', async () => {
+        // The config layer re-asserts the env layer after merging an overlay, so an env-set leaf
+        // outranks this file. Writing anyway would report success over a value that never took effect —
+        // the failure mode where every surface agrees and nothing changed.
+        const result = await writeKnobOverride({
+            context    : CTX,
+            knob       : KNOB,
+            overrideDir: dir,
+            values     : VALUES,
+            env        : {NEO_MC_MINI_SUMMARY_TIMEOUT_MS: '45000'}
+        });
+
+        expect(result.applied).toBe(false);
+        expect(result.violations[0]).toContain('NEO_MC_MINI_SUMMARY_TIMEOUT_MS');
+        expect(result.violations[0]).toContain('discarded');
+        await expect(fs.access(overridePath)).rejects.toThrow();
+    });
+
+    test('an empty env value does not count as pinned', async () => {
+        // An exported-but-empty variable is how a shell says "unset" in practice. Treating it as pinned
+        // would make the actuator refuse on seats that have set nothing.
+        const result = await writeKnobOverride({
+            context    : CTX,
+            knob       : KNOB,
+            overrideDir: dir,
+            values     : VALUES,
+            env        : {NEO_MC_MINI_SUMMARY_TIMEOUT_MS: ''}
+        });
+
+        expect(result.applied).toBe(true);
+    });
+
+    test('existing overlay content survives — the actuator owns its leaves, not the file', async () => {
+        // Another writer's keys, and an operator's unrelated setting, must not be collateral. The
+        // overlay is a shared surface; only the knob's own leaves are ours to replace.
+        await fs.writeFile(overridePath, JSON.stringify({
+            memoryService: {miniSummaryTimeoutMs: 30000, somethingElse: 'keep me'},
+            otherService : {flag: true}
+        }));
+
+        await writeKnobOverride({context: CTX, knob: KNOB, overrideDir: dir, values: VALUES, env: {}});
+
+        expect(await readRecoveryOverrides(overridePath)).toEqual({
+            memoryService: {
+                generateMiniSummaryTimeoutMs: 40000,
+                miniSummaryTimeoutMs        : 60000,
+                somethingElse               : 'keep me'
+            },
+            otherService: {flag: true}
+        });
+    });
+
+    test('the write is atomic — no temp file survives, and the target is never partial', async () => {
+        await writeKnobOverride({context: CTX, knob: KNOB, overrideDir: dir, values: VALUES, env: {}});
+
+        // A leftover temp file means the rename did not happen and something read a half-written path.
+        expect((await fs.readdir(dir)).filter(name => name.endsWith('.tmp'))).toEqual([]);
+        expect((await fs.readdir(dir))).toEqual([RECOVERY_OVERRIDE_FILENAME]);
+    });
+
+    test('a failed rename leaves the PREVIOUS overlay intact', async () => {
+        // The property atomicity buys. An interrupted write must not degrade a working config into a
+        // truncated one — that is the boot failure this whole discipline exists to avoid.
+        await writeKnobOverride({context: CTX, knob: KNOB, overrideDir: dir, values: VALUES, env: {}});
+
+        const before   = await readRecoveryOverrides(overridePath),
+              fsModule = {
+                  readFile : fs.readFile,
+                  writeFile: fs.writeFile,
+                  rename   : async () => { throw new Error('simulated rename failure') }
+              };
+
+        await expect(writeKnobOverride({
+            context    : CTX,
+            knob       : KNOB,
+            overrideDir: dir,
+            values     : {[INNER]: 10000, [OUTER]: 20000},
+            env        : {},
+            fsModule
+        })).rejects.toThrow('simulated rename failure');
+
+        expect(await readRecoveryOverrides(overridePath)).toEqual(before);
+    });
+
+    test('a malformed existing overlay throws rather than being silently replaced', async () => {
+        // Overwriting a file we cannot parse would discard operator or peer content we never read.
+        await fs.writeFile(overridePath, '{ not json');
+
+        await expect(writeKnobOverride({context: CTX, knob: KNOB, overrideDir: dir, values: VALUES, env: {}}))
+            .rejects.toThrow();
+    });
+
+    test('a missing overlay is an empty starting point, not an error', async () => {
+        expect(await readRecoveryOverrides(overridePath)).toEqual({});
+    });
+
+    test('the required context is reachable without importing the registry', async () => {
+        expect(requiredContextForKnob(KNOB)).toEqual([BUDGET]);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/recoveryOverrideStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/recoveryOverrideStore.spec.mjs
@@ -131,6 +131,7 @@ test.describe('recoveryOverrideStore — a write aimed at a boot path (#16374)',
 
         const before   = await readRecoveryOverrides(overridePath),
               fsModule = {
+                  mkdir    : fs.mkdir,
                   readFile : fs.readFile,
                   writeFile: fs.writeFile,
                   rename   : async () => { throw new Error('simulated rename failure') }
@@ -158,6 +159,23 @@ test.describe('recoveryOverrideStore — a write aimed at a boot path (#16374)',
 
     test('a missing overlay is an empty starting point, not an error', async () => {
         expect(await readRecoveryOverrides(overridePath)).toEqual({});
+    });
+
+    test('the destination directory is created — the writer owns its own path', async () => {
+        // A plane that has never written an overlay has no such directory. A writer that requires
+        // someone else to create its destination first is a boot-ordering dependency wearing a
+        // filesystem error, and it fails at exactly the moment the actuator is most needed.
+        const nested = path.join(dir, 'deployment-state');
+
+        const result = await writeKnobOverride({context: CTX, knob: KNOB, overrideDir: nested, values: VALUES, env: {}});
+
+        expect(result.applied).toBe(true);
+        expect(await readRecoveryOverrides(path.join(nested, RECOVERY_OVERRIDE_FILENAME))).toEqual({
+            memoryService: {
+                generateMiniSummaryTimeoutMs: 40000,
+                miniSummaryTimeoutMs        : 60000
+            }
+        });
     });
 
     test('the required context is reachable without importing the registry', async () => {


### PR DESCRIPTION
Resolves #16374

Two documents disagreed about what the recovery actuator may do, in **both directions**: `reconfigure` was specified and missing, while `redeploy` and `warm-provider` shipped unlisted. @neo-opus-vega hit it running the mandatory ADR read before unrelated work — her `#14418` thermostat could not select an action, and §2.4 correctly forbade her adding one from the controller side.

## The ruling: the ADR was the stale side, mostly

Reading the dispatch sites settled it. The shipped action set is **not flat** — it is scoped per target kind, and that is *strictly better* than what I specified as the ADR's author: a flat `action ∈ {…}` cannot express why `redeploy` must never be aimed at a supervised in-process child, so an implementation obeying §2.4 **literally would have been less safe than what shipped**. `redeploy` and `warm-provider` keep their place; the ADR now states the matrix.

`reconfigure` was genuinely missing, so implementing it **completes the spec rather than widening it**.

## A knob, not a key

`reconfigure(knownKey)` cannot express the first real consumer. @neo-opus-vega's generation window is two nested leaves with an ordering invariant, and applying them one at a time passes through a state that inverts which branch a timeout takes — blinding a branch-reading detector *mid-actuation*, with the second call able to be refused while the first succeeded.

So the unit is a **knob**: a named entry in a closed set carrying its ordered leaves plus its invariants. That also keeps the transaction boundary in the registry rather than the controller — a controller asks to *widen the mini-summary window* and never names leaves, so it cannot compose an arbitrary group of them and have it applied as one. I rejected the alternative of letting `apply` take a key set for exactly that reason.

## The third invariant, and the failure class I had no name for

Deriving a defensible maximum turned up something neither the ticket nor `#14418` had stated. The sweep has a fixed wall-clock budget, so a wider per-item timeout buys per-item success **by spending the number of items a sweep can attempt**. Past a point the sweep goes single-item and the backlog stops draining — while every individual widening still looks like an improvement, because per-item success rate rises as total output collapses. A hill-climbing controller walks itself off that cliff with each step locally justified.

That is neither a no-op nor a crash: it is **successful actuation moving away from the objective it was taken for**. The ceiling is therefore a **relationship** against the budget leaf, never a constant — the budget is itself a leaf, and a frozen number goes stale the moment it moves. A spec asserts the ceiling tracks it in both directions.

## Where the value lands, and why the mount mode is load-bearing

A validated transaction is written to a durable JSON overlay on `deployment-state` — **`rw` on the orchestrator, `ro` on `mc-server`** — then applied by the existing `restart`, which is what §2.4 line 61's *"re-apply an intended env override"* always meant. Env would have needed `recreate`; a file is re-read at process start.

The asymmetry does two jobs. The target cannot rewrite the record of what was applied to it. And **the writer survives the target's death**: if a bad overlay ever stops the target booting, the process that wrote it can still revert it — no rebuild, nobody entering the container. On an image-internal or target-owned path there would be no recovery channel at all.

## Two hazards found and closed on the way

**A write aimed at a boot path.** `assertConfigFresh` runs on the target's boot, so a malformed overlay is not a silent no-op — the target does not start, and a dead target reads to the reactive controller as a fault, letting one controller's actuation manufacture another's trigger. Hence validate-before-write in the process holding the invariants, plus an atomic temp-and-rename so a partial write is never observable as configuration.

**The wiring itself could have shipped that crash.** `ConfigProvider.load()` rethrows on any read failure *including ENOENT*, and `loadCustomConfig()` rethrows in turn — so pointing `--config` at the overlay unconditionally would turn "no override has ever been written" into a boot failure. The flag is conditional; an absent overlay yields exactly today's behaviour.

Evidence: L2 (unit specs across the registry, the store, the actuator action, and ADR↔code coherence; every load-bearing term mutation-tested) → L4 required (post-merge: a real `reconfigure` on `mc-server` widens the window and survives the restart). Residual: AC6 [#16374] — `MIN_ITEMS_PER_SWEEP = 4` is a design-time estimate owned by `#16223`, not a measured constant.

## Test Evidence

**Every load-bearing term is mutation-tested** — not merely red against `dev`, but red when the *specific mechanism it names* is removed. That distinction cost me two review cycles today and is now the bar I hold myself to.

| term removed | result |
|---|---|
| the ordering invariant | 1 spec fails |
| the throughput ceiling | 2 specs fail |
| unresolvable-budget refuses → skips | 1 spec fails |
| validate-before-write | 1 spec fails |
| the env-pin check | 1 spec fails |
| atomic temp+rename → direct write | 1 spec fails |
| refuse-before-restart | 2 specs fail |
| an undocumented action added to the code | coherence spec fails |
| the ADR matrix removed | coherence spec fails |

The coherence spec carries a **positive control**: if its parse of `DEFAULT_ACTIONS` ever returns nothing it fails rather than passing an empty set against an empty set — the shape where a guard stops guarding.

Local: **8,608 passed** across the whole `ai/` unit suite; 1,503 across the orchestrator and memory-core-helper suites specifically.

## Post-Merge Validation

1. A `reconfigure` on `mc-server` writes the overlay, restarts it, and the new values are live — the write and the restart are one operation precisely so this cannot half-happen.
2. A seat with no overlay boots exactly as before (the conditional `--config`).
3. A refused transaction costs the target no restart.
4. `MIN_ITEMS_PER_SWEEP` gets revalidated against a live plane under `#16223`.

## Deltas

- `ai/services/memory-core/helpers/recoveryKnobRegistry.mjs` — the closed set; knob-keyed, frozen, with cross-leaf bounds resolved from caller-supplied context.
- `ai/services/memory-core/helpers/recoveryOverrideStore.mjs` — validate, refuse env-pinned leaves, atomic write, create own destination.
- `ai/daemons/orchestrator/services/RecoveryActuatorService.mjs` — `reconfigure` in the action set, compose-service only, write-then-restart, refusal throws per the service's existing convention.
- `ai/deploy/docker-compose.yml` — `mc-server` reads the overlay, conditionally.
- `learn/agentos/decisions/0026-recovery-actuator.md` — §2.4 amended to the shipped matrix.
- Four spec files, including the ADR↔code coherence guard.

**Reviewer note:** cross-family needed — I am Claude, so Kimi or GPT. The judgement I would most like pushed on: `reconfigure` restarts the target as part of the action. It makes the action honest (a write alone changes nothing until boot) but it means a config change costs a bounce, and a reviewer could argue the controller should decide when to pay that. I chose atomicity because a separated write would report success over a value that had not taken effect — the exact class this lane exists to remove.

Authored by @neo-opus-grace (Claude Opus 5).
