### PR TITLE
fix(github-workflow): report the reviewer GitHub seated, not the one requested (#16394)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -979,6 +979,8 @@ paths:
         **Action: 'remove'** — `DELETE`s the review requests.
 
         At least one of `reviewers` or `team_reviewers` is required. A leading `@` on a login is stripped. Errors surface as `GH_API_ERROR` carrying the REST `requested_reviewers` response (repo-scope semantics), not a `gh` CLI exit code.
+
+        **The result reports the effect, not the request.** GitHub accepts an unknown login on this endpoint, returns 200, and seats nobody — so a 200 is not evidence a reviewer was assigned. Every requested login is checked against the reviewer state in GitHub's own response: unseated logins fail with `REVIEWER_NOT_SEATED` (naming each under `unseated`) instead of reporting partial success, and `verifiedReviewers` / `verifiedTeamReviewers` are always derived from that response rather than echoed from the arguments. Trust those fields, not the request you sent.
       tags: [PullRequests]
       parameters:
         - name: pr_number
@@ -1015,13 +1017,19 @@ paths:
                   example: ["maintainers"]
       responses:
         '200':
-          description: Reviewer-requests updated successfully.
+          description: Reviewer-requests updated AND verified — every requested login was confirmed seated (or, for `remove`, confirmed absent) in GitHub's returned reviewer state.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                $ref: '#/components/schemas/ManagePrReviewersResponse'
         '400':
           description: Invalid arguments (bad action OR missing both reviewers and team_reviewers).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: The call succeeded at the HTTP layer but the effect did not happen — `REVIEWER_NOT_SEATED` (GitHub returned 200 without seating a requested login, typically a nonexistent or non-collaborator account; the response names each one under `unseated`) or `REVIEWER_STATE_UNVERIFIABLE` (the response did not carry the reviewer arrays, so the outcome is unknown). Never reported as success.
           content:
             application/json:
               schema:
@@ -2136,6 +2144,30 @@ components:
           type: string
           description: "`git rev-parse HEAD` read back from `repoPath` after checkout."
           example: "0123456789abcdef0123456789abcdef01234567"
+
+    ManagePrReviewersResponse:
+      type: object
+      description: Verifiable result for `manage_pr_reviewers`. The reviewer lists are read out of GitHub's `requested_reviewers` response, NOT echoed from the request — GitHub accepts an unknown login, returns 200, and seats nobody, so a success message built from the arguments would report a reviewer that does not exist. A requested login that was not seated fails with `REVIEWER_NOT_SEATED` rather than reporting partial success.
+      properties:
+        message:
+          type: string
+          example: "Successfully requested reviewers on PR #123: neo-gpt (verified against the returned reviewer state)"
+        pr_number:
+          type: integer
+          description: The pull request the reviewer state was verified on.
+          example: 123
+        verifiedReviewers:
+          type: array
+          items:
+            type: string
+          description: User logins actually seated as requested reviewers, read back from GitHub's response after the mutation.
+          example: ["neo-gpt"]
+        verifiedTeamReviewers:
+          type: array
+          items:
+            type: string
+          description: Team slugs actually seated as requested reviewers, read back from GitHub's response after the mutation.
+          example: []
 
     CommentResponse:
       type: object

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -980,7 +980,7 @@ paths:
 
         At least one of `reviewers` or `team_reviewers` is required. A leading `@` on a login is stripped. Errors surface as `GH_API_ERROR` carrying the REST `requested_reviewers` response (repo-scope semantics), not a `gh` CLI exit code.
 
-        **The result reports the effect, not the request.** GitHub accepts an unknown login on this endpoint, returns 200, and seats nobody — so a 200 is not evidence a reviewer was assigned. Every requested login is checked against the reviewer state in GitHub's own response: unseated logins fail with `REVIEWER_NOT_SEATED` (naming each under `unseated`) instead of reporting partial success, and `verifiedReviewers` / `verifiedTeamReviewers` are always derived from that response rather than echoed from the arguments. Trust those fields, not the request you sent.
+        **The result reports the effect, not the request.** GitHub accepts an unknown login on this endpoint and seats nobody — so a successful mutation response is not evidence a reviewer was assigned (measured: that call answered 200 with the full PR object). Every requested login is checked against the reviewer state in GitHub's own response: a login `add` did not seat fails with `REVIEWER_NOT_SEATED`, a login `remove` left in place fails with `REVIEWER_STILL_REQUESTED`, both naming each target under `unseated` rather than reporting partial success. `verifiedReviewers` / `verifiedTeamReviewers` are always derived from that response, never echoed from the arguments. Trust those fields, not the request you sent.
       tags: [PullRequests]
       parameters:
         - name: pr_number
@@ -1029,11 +1029,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '422':
-          description: The call succeeded at the HTTP layer but the effect did not happen — `REVIEWER_NOT_SEATED` (GitHub returned 200 without seating a requested login, typically a nonexistent or non-collaborator account; the response names each one under `unseated`) or `REVIEWER_STATE_UNVERIFIABLE` (the response did not carry the reviewer arrays, so the outcome is unknown). Never reported as success.
+          description: The call succeeded at the HTTP layer but the effect did not happen — `REVIEWER_NOT_SEATED` (an `add` GitHub answered successfully without seating a requested login, typically a nonexistent or non-collaborator account), `REVIEWER_STILL_REQUESTED` (a `remove` whose target is still listed as a requested reviewer — the seat is NOT free), or `REVIEWER_STATE_UNVERIFIABLE` (the response did not carry the reviewer arrays, so the outcome is unknown). Never reported as success.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ManagePrReviewersErrorResponse'
         '500':
           description: REST `requested_reviewers` call failed (`GH_API_ERROR` — typically a repo-scope/permission or network error).
           content:
@@ -2147,7 +2147,18 @@ components:
 
     ManagePrReviewersResponse:
       type: object
-      description: Verifiable result for `manage_pr_reviewers`. The reviewer lists are read out of GitHub's `requested_reviewers` response, NOT echoed from the request — GitHub accepts an unknown login, returns 200, and seats nobody, so a success message built from the arguments would report a reviewer that does not exist. A requested login that was not seated fails with `REVIEWER_NOT_SEATED` rather than reporting partial success.
+      description: |
+        Verifiable result for `manage_pr_reviewers`. The reviewer lists are read out of GitHub's
+        `requested_reviewers` response, NOT echoed from the request — GitHub accepts an unknown login and
+        seats nobody (measured: that call answered 200 with the full PR object), so a success message built
+        from the arguments would report a reviewer that does not exist. A requested change GitHub did not
+        apply fails with `REVIEWER_NOT_SEATED` / `REVIEWER_STILL_REQUESTED` rather than reporting partial
+        success.
+
+        Every field is required: a success payload missing the verification fields is exactly the defect
+        this response type exists to make impossible, and without a `required` list an empty object
+        satisfies the declared contract.
+      required: [message, pr_number, verifiedReviewers, verifiedTeamReviewers]
       properties:
         message:
           type: string
@@ -2167,6 +2178,60 @@ components:
           items:
             type: string
           description: Team slugs actually seated as requested reviewers, read back from GitHub's response after the mutation.
+          example: []
+
+    ManagePrReviewersErrorResponse:
+      type: object
+      description: |
+        Structured failure for `manage_pr_reviewers` when GitHub answered successfully but the requested
+        reviewer change did not take effect. Distinct from the generic `ErrorResponse` because the caller
+        needs the observed state to act: which targets did not move (`unseated`) and who GitHub currently
+        reports as seated (`verifiedReviewers` / `verifiedTeamReviewers`).
+
+        `code` carries the direction that failed, and the two directions describe OPPOSITE observed states:
+        `REVIEWER_NOT_SEATED` means an `add` target is ABSENT from the returned reviewer state, while
+        `REVIEWER_STILL_REQUESTED` means a `remove` target is still PRESENT — so its seat is not free, and
+        remediation aimed at a nonexistent login would be wrong.
+
+        `unseated` and the verified arrays are documented but NOT required, because
+        `REVIEWER_STATE_UNVERIFIABLE` is the case where the response carried no reviewer arrays at all.
+        Requiring them there would force this schema to publish empty arrays, which read as "GitHub reports
+        nobody seated" — a definite claim about the exact state that is unknown. Only the four fields that
+        every failure can honestly supply are required.
+      required: [error, message, code, pr_number]
+      properties:
+        error:
+          type: string
+          example: "Reviewer still requested"
+        message:
+          type: string
+          example: "neo-gpt remain requested reviewers on PR #123: the removal was not applied."
+        code:
+          type: string
+          enum: [REVIEWER_NOT_SEATED, REVIEWER_STILL_REQUESTED, REVIEWER_STATE_UNVERIFIABLE]
+          description: Which postcondition failed. `REVIEWER_NOT_SEATED` — an `add` target is absent. `REVIEWER_STILL_REQUESTED` — a `remove` target is still present. `REVIEWER_STATE_UNVERIFIABLE` — the response carried no reviewer arrays, so the outcome is unknown.
+          example: "REVIEWER_STILL_REQUESTED"
+        pr_number:
+          type: integer
+          description: The pull request whose reviewer state was read.
+          example: 123
+        unseated:
+          type: array
+          items:
+            type: string
+          description: Targets whose requested change was not applied — absent after `add`, still present after `remove`. Omitted on `REVIEWER_STATE_UNVERIFIABLE`, where no per-target verdict could be reached.
+          example: ["neo-gpt"]
+        verifiedReviewers:
+          type: array
+          items:
+            type: string
+          description: User logins GitHub reports as seated right now — the same meaning as on the success path. Omitted on `REVIEWER_STATE_UNVERIFIABLE`.
+          example: ["neo-gpt"]
+        verifiedTeamReviewers:
+          type: array
+          items:
+            type: string
+          description: Team slugs GitHub reports as seated right now. Omitted on `REVIEWER_STATE_UNVERIFIABLE`.
           example: []
 
     CommentResponse:

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -103,6 +103,45 @@ function normalizeRequestedReviewer(node) {
 }
 
 /**
+ * @summary Reads the reviewer state GitHub actually seated out of a `requested_reviewers` REST response.
+ *
+ * The `POST`/`DELETE` `requested_reviewers` endpoints answer with the full pull-request object, whose
+ * `requested_reviewers` / `requested_teams` arrays are the post-mutation truth. That makes the response
+ * itself the verification channel — no follow-up read is needed, and none should be added: a second call
+ * would open a window in which a concurrent change could make the read disagree with what this call did.
+ *
+ * Logins are lower-cased because GitHub treats them case-insensitively (a caller passing `Neo-GPT` is
+ * seated as `neo-gpt`); comparing raw would report a seated reviewer as missing.
+ *
+ * @param {string} stdout Raw `gh api` stdout for the mutation.
+ * @returns {{users: Set<string>, teams: Set<string>}|null} Seated logins/slugs, or `null` when the payload
+ * does not carry the expected shape — an unverifiable result the caller must surface as a failure rather
+ * than degrade into an echo of its own request.
+ */
+function parseSeatedReviewerState(stdout) {
+    let parsed;
+
+    try {
+        parsed = JSON.parse(stdout);
+    } catch (error) {
+        return null;
+    }
+
+    const {requested_reviewers: users, requested_teams: teams} = parsed || {};
+
+    // Both arrays must be present. A payload missing them proves nothing about who is seated, and
+    // treating "absent" as "empty" would silently resurrect the false-success this guard exists to stop.
+    if (!Array.isArray(users) || !Array.isArray(teams)) {
+        return null;
+    }
+
+    return {
+        users: new Set(users.map(user => user?.login?.toLowerCase()).filter(Boolean)),
+        teams: new Set(teams.map(team => team?.slug?.toLowerCase()).filter(Boolean))
+    };
+}
+
+/**
  * @summary Projects one PR board row with explicit nulls when GitHub does not prove a freshness field.
  * @param {Object} pullRequest GitHub pull-request node from the list query.
  * @returns {Object}
@@ -2668,6 +2707,11 @@ class PullRequestService extends Base {
     /**
      * @summary Unified add/remove of GitHub PR reviewer-requests via the REST `requested_reviewers` endpoint.
      *
+     * Verifies the **effect**: the endpoint's own 200 body carries the resulting `requested_reviewers` /
+     * `requested_teams`, and the verdict is read from there. GitHub accepts a login that does not exist,
+     * returns 200, and seats nobody, so neither the exit code nor the absence of an exception proves a
+     * reviewer was assigned. Mirrors `IssueService.assignIssue`'s `verifiedAssignees` post-verify.
+     *
      * Sibling to `IssueService.manageIssueAssignees` for PR reviewer invitations — closes the
      * **invitation layer** of the cross-family review mandate (`pull-request §6.1`). The mandate
      * itself is the validation layer (Approved-status before merge); this tool is the active
@@ -2685,7 +2729,10 @@ class PullRequestService extends Base {
      * @param {string[]}  [options.reviewers]        Array of GitHub user logins to add or remove as reviewers.
      * @param {string[]}  [options.team_reviewers]   Array of bare team slugs (no owner prefix — the REST endpoint takes slugs directly).
      * @param {string}    options.action             Either `'add'` or `'remove'`.
-     * @returns {Promise<object>} Success message + reviewer payload on success, or structured error.
+     * @returns {Promise<object>} On success, a message plus `verifiedReviewers` / `verifiedTeamReviewers`
+     * read out of GitHub's response — never echoed from the arguments. A requested login that GitHub did
+     * not seat returns `REVIEWER_NOT_SEATED` (with `unseated`), and a response that cannot be verified
+     * returns `REVIEWER_STATE_UNVERIFIABLE`; both are failures, not partial successes.
      *
      * @see pull-request-workflow.md §6.1 (cross-family mandate — invitation layer cross-reference)
      */
@@ -2726,14 +2773,54 @@ class PullRequestService extends Base {
             const command = `gh api repos/${aiConfig.owner}/${aiConfig.repo}/pulls/${pr_number}/requested_reviewers -X ${method} ${allFlags}`;
             logger.info(`Attempting to ${action} reviewers on PR #${pr_number} via REST: ${allTargets.join(', ')}`);
 
-            await execFn(command, {cwd: aiConfig.projectRoot});
+            const {stdout} = await execFn(command, {cwd: aiConfig.projectRoot}) || {};
+
+            // Report the EFFECT, not the request. GitHub answers this endpoint with 200 and the
+            // full PR object even when it seated nobody: an unknown login is accepted and silently dropped,
+            // so `gh` exits 0 and there is no error for the catch below to see. Echoing `reviewerList` back
+            // as success told callers a reviewer was assigned when none was, and the PR then sat unreviewed
+            // with no failure signal anywhere. The 200 body already carries the resulting state, so the
+            // verdict comes from what GitHub returned — never from what we asked for.
+            const seated = parseSeatedReviewerState(stdout);
+
+            if (!seated) {
+                logger.error(`Unverifiable requested_reviewers response on PR #${pr_number}`);
+                return {
+                    error  : 'Reviewer state unverifiable',
+                    message: `Cannot confirm reviewer state on PR #${pr_number}: the requested_reviewers response did not carry the expected 'requested_reviewers'/'requested_teams' arrays, so whether ${allTargets.join(', ')} ${action === 'add' ? 'was seated' : 'was removed'} is unknown. Re-read the PR before trusting any reviewer assumption.`,
+                    code   : 'REVIEWER_STATE_UNVERIFIABLE',
+                    pr_number
+                };
+            }
+
+            // `add` demands presence, `remove` demands absence — the same read-back, inverted.
+            const wanted        = action === 'add';
+            const unseatedUsers = reviewerList    .filter(login => seated.users.has(login.toLowerCase()) !== wanted);
+            const unseatedTeams = teamReviewerList.filter(slug  => seated.teams.has(slug .toLowerCase()) !== wanted);
+            const unseated      = [...unseatedUsers, ...unseatedTeams];
+
+            if (unseated.length > 0) {
+                const failedVerb = wanted ? 'were not seated as reviewers on' : 'remain requested reviewers on';
+                logger.error(`REVIEWER_NOT_SEATED on PR #${pr_number}: ${unseated.join(', ')}`);
+                return {
+                    error  : 'Reviewer not seated',
+                    message: `${unseated.join(', ')} ${failedVerb} PR #${pr_number}. GitHub accepted the request (HTTP 200) but the returned reviewer state does not include the change — the usual cause is a login that does not exist or is not a collaborator. Verify the login against the roster in ai/graph/identityRoots.mjs.`,
+                    code   : 'REVIEWER_NOT_SEATED',
+                    pr_number,
+                    unseated,
+                    // Same meaning as on the success path: who GitHub reports as seated right now.
+                    verifiedReviewers    : [...seated.users],
+                    verifiedTeamReviewers: [...seated.teams]
+                };
+            }
 
             const verb = action === 'add' ? 'requested' : 'removed';
             return {
-                message       : `Successfully ${verb} reviewers on PR #${pr_number}: ${allTargets.join(', ')}`,
+                message              : `Successfully ${verb} reviewers on PR #${pr_number}: ${allTargets.join(', ')} (verified against the returned reviewer state)`,
                 pr_number,
-                reviewers     : reviewerList,
-                team_reviewers: teamReviewerList
+                // Derived from GitHub's response, not from the caller's arguments — that is the whole point.
+                verifiedReviewers    : [...seated.users],
+                verifiedTeamReviewers: [...seated.teams]
             };
         } catch (error) {
             logger.error(`Error managing reviewers on PR #${pr_number}:`, error);

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -2707,10 +2707,11 @@ class PullRequestService extends Base {
     /**
      * @summary Unified add/remove of GitHub PR reviewer-requests via the REST `requested_reviewers` endpoint.
      *
-     * Verifies the **effect**: the endpoint's own 200 body carries the resulting `requested_reviewers` /
-     * `requested_teams`, and the verdict is read from there. GitHub accepts a login that does not exist,
-     * returns 200, and seats nobody, so neither the exit code nor the absence of an exception proves a
-     * reviewer was assigned. Mirrors `IssueService.assignIssue`'s `verifiedAssignees` post-verify.
+     * Verifies the **effect**: the endpoint's own success body carries the resulting `requested_reviewers` /
+     * `requested_teams`, and the verdict is read from there. Measured against the live API, GitHub accepts
+     * a login that does not exist, answers 200, and seats nobody — so neither the exit code nor the absence
+     * of an exception proves a reviewer was assigned. Mirrors `IssueService.assignIssue`'s `verifiedAssignees`
+     * post-verify.
      *
      * Sibling to `IssueService.manageIssueAssignees` for PR reviewer invitations — closes the
      * **invitation layer** of the cross-family review mandate (`pull-request §6.1`). The mandate
@@ -2731,8 +2732,9 @@ class PullRequestService extends Base {
      * @param {string}    options.action             Either `'add'` or `'remove'`.
      * @returns {Promise<object>} On success, a message plus `verifiedReviewers` / `verifiedTeamReviewers`
      * read out of GitHub's response — never echoed from the arguments. A requested login that GitHub did
-     * not seat returns `REVIEWER_NOT_SEATED` (with `unseated`), and a response that cannot be verified
-     * returns `REVIEWER_STATE_UNVERIFIABLE`; both are failures, not partial successes.
+     * not seat returns `REVIEWER_NOT_SEATED`, a `remove` whose target is still listed returns
+     * `REVIEWER_STILL_REQUESTED` (both naming the targets under `unseated`), and a response that cannot be
+     * verified returns `REVIEWER_STATE_UNVERIFIABLE`. All three are failures, not partial successes.
      *
      * @see pull-request-workflow.md §6.1 (cross-family mandate — invitation layer cross-reference)
      */
@@ -2775,12 +2777,14 @@ class PullRequestService extends Base {
 
             const {stdout} = await execFn(command, {cwd: aiConfig.projectRoot}) || {};
 
-            // Report the EFFECT, not the request. GitHub answers this endpoint with 200 and the
-            // full PR object even when it seated nobody: an unknown login is accepted and silently dropped,
-            // so `gh` exits 0 and there is no error for the catch below to see. Echoing `reviewerList` back
-            // as success told callers a reviewer was assigned when none was, and the PR then sat unreviewed
-            // with no failure signal anywhere. The 200 body already carries the resulting state, so the
-            // verdict comes from what GitHub returned — never from what we asked for.
+            // Report the EFFECT, not the request. Measured directly against the live API: an unknown login
+            // is accepted and silently dropped, and that call answered 200 with the full PR object having
+            // seated nobody — so `gh` exits 0 and there is no error for the catch below to see. (200 there
+            // is the observed unknown-login receipt, not the endpoint's general contract; GitHub documents
+            // add as 201 and remove as 200. The verdict does not read the status either way.) Echoing
+            // `reviewerList` back as success told callers a reviewer was assigned when none was, and the PR
+            // then sat unreviewed with no failure signal anywhere. The success body already carries the
+            // resulting state, so the verdict comes from what GitHub returned — never from what we asked for.
             const seated = parseSeatedReviewerState(stdout);
 
             if (!seated) {
@@ -2800,13 +2804,37 @@ class PullRequestService extends Base {
             const unseated      = [...unseatedUsers, ...unseatedTeams];
 
             if (unseated.length > 0) {
-                const failedVerb = wanted ? 'were not seated as reviewers on' : 'remain requested reviewers on';
-                logger.error(`REVIEWER_NOT_SEATED on PR #${pr_number}: ${unseated.join(', ')}`);
+                // The two actions fail into OPPOSITE observed states, so they cannot share one envelope.
+                // A failed `remove` means the target is STILL a requested reviewer — telling that caller
+                // "reviewer not seated" and pointing them at the roster describes the inverse of what
+                // GitHub just returned, and sends them to look for a nonexistent login when the login
+                // demonstrably exists and holds the seat. Each action names its own postcondition.
+                const failure = wanted
+                    ? {
+                        error  : 'Reviewer not seated',
+                        code   : 'REVIEWER_NOT_SEATED',
+                        message: `${unseated.join(', ')} were not seated as reviewers on PR #${pr_number}. ` +
+                            `GitHub returned a successful mutation response, but the returned reviewer state ` +
+                            `does not include them — the usual cause is a login that does not exist or is not ` +
+                            `a collaborator. Verify the login against the roster in ai/graph/identityRoots.mjs.`
+                    }
+                    : {
+                        error  : 'Reviewer still requested',
+                        code   : 'REVIEWER_STILL_REQUESTED',
+                        message: `${unseated.join(', ')} remain requested reviewers on PR #${pr_number}: the ` +
+                            `removal was not applied. GitHub returned a successful mutation response, but the ` +
+                            `returned reviewer state still lists them, so the seat is NOT free. Re-read the ` +
+                            `PR's reviewer state before assigning it to anyone else.`
+                    };
+
+                logger.error(`${failure.code} on PR #${pr_number}: ${unseated.join(', ')}`);
+
                 return {
-                    error  : 'Reviewer not seated',
-                    message: `${unseated.join(', ')} ${failedVerb} PR #${pr_number}. GitHub accepted the request (HTTP 200) but the returned reviewer state does not include the change — the usual cause is a login that does not exist or is not a collaborator. Verify the login against the roster in ai/graph/identityRoots.mjs.`,
-                    code   : 'REVIEWER_NOT_SEATED',
+                    ...failure,
                     pr_number,
+                    // Targets whose requested change was not applied: absent after `add`, present after
+                    // `remove`. The name reads add-shaped; the meaning is action-relative, and `code` is
+                    // the field that says which direction failed.
                     unseated,
                     // Same meaning as on the success path: who GitHub reports as seated right now.
                     verifiedReviewers    : [...seated.users],

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -123,7 +123,7 @@ function parseSeatedReviewerState(stdout) {
 
     try {
         parsed = JSON.parse(stdout);
-    } catch (error) {
+    } catch {
         return null;
     }
 

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestServiceReviewers.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestServiceReviewers.spec.mjs
@@ -6,11 +6,35 @@ import * as core      from '../../../../../../src/core/_export.mjs';
  * @summary Coverage for `PullRequestService.managePrReviewers` — verifies it builds the REST
  * `requested_reviewers` command (needs only the `repo` scope) rather than the prior
  * `gh pr edit --add/remove-reviewer` path (which resolves logins via GraphQL → requires `read:org`,
- * a scope agent tokens routinely lack, so it failed for every agent on that credential class).
+ * a scope agent tokens routinely lack, so it failed for every agent on that credential class), AND
+ * that it reports the **effect** rather than the request.
  *
  * The method exposes an `execFn` injection seam (default `execAsync`), so the command is captured
  * here without shelling out — mirroring the `buildCheckoutPullRequest` test-seam pattern.
+ *
+ * The effect-verification cases exist because a false-success shipped past a suite that asserted only
+ * the command string: `manage_pr_reviewers` echoed its own arguments back as success, so requesting a
+ * nonexistent login reported "Successfully requested" while the PR kept zero reviewers.
+ * Measured against the live API, GitHub accepts an unknown login, answers 200 with the full PR
+ * object, and seats nobody — the exit code and the absence of an exception prove nothing. Fixtures
+ * below therefore mirror the real 200 payload; a bare `{}` stub would reproduce the blind spot.
  */
+
+/**
+ * @summary Builds a `requested_reviewers` REST response in GitHub's real shape.
+ * @param {String[]} [users=[]] Logins GitHub reports as seated.
+ * @param {String[]} [teams=[]] Team slugs GitHub reports as seated.
+ * @returns {Object} An `execFn`-shaped result whose `stdout` is the JSON payload.
+ */
+function reviewerResponse(users = [], teams = []) {
+    return {stdout: JSON.stringify({
+        number            : 42,
+        // The endpoint answers with the whole PR object; these two arrays are the post-mutation truth.
+        requested_reviewers: users.map((login, id) => ({login, id, type: 'User'})),
+        requested_teams    : teams.map((slug,  id) => ({slug,  id, name: slug}))
+    })};
+}
+
 test.describe('PullRequestService.managePrReviewers — REST requested_reviewers', () => {
     let PullRequestService;
 
@@ -22,7 +46,7 @@ test.describe('PullRequestService.managePrReviewers — REST requested_reviewers
         let captured;
         const res = await PullRequestService.managePrReviewers(
             {pr_number: 42, reviewers: ['@neo-gpt'], action: 'add'},
-            {execFn: async cmd => { captured = cmd; return {stdout: '{}'}; }}
+            {execFn: async cmd => { captured = cmd; return reviewerResponse(['neo-gpt']); }}
         );
 
         expect(captured).toContain('pulls/42/requested_reviewers -X POST');
@@ -36,7 +60,7 @@ test.describe('PullRequestService.managePrReviewers — REST requested_reviewers
         let captured;
         await PullRequestService.managePrReviewers(
             {pr_number: 7, team_reviewers: ['core'], action: 'remove'},
-            {execFn: async cmd => { captured = cmd; return {stdout: '{}'}; }}
+            {execFn: async cmd => { captured = cmd; return reviewerResponse(); }}
         );
 
         expect(captured).toContain('pulls/7/requested_reviewers -X DELETE');
@@ -47,5 +71,110 @@ test.describe('PullRequestService.managePrReviewers — REST requested_reviewers
     test('guards: unknown action + empty reviewer set', async () => {
         expect((await PullRequestService.managePrReviewers({pr_number: 1, action: 'nope', reviewers: ['x']})).code).toBe('INVALID_ARGUMENTS');
         expect((await PullRequestService.managePrReviewers({pr_number: 1, action: 'add'})).code).toBe('MISSING_ARGUMENTS');
+    });
+
+    test('a nonexistent login must NOT report success (#16394)', async () => {
+        // The live reproduction: GitHub returns 200 with an empty reviewer set, `gh` exits 0.
+        const res = await PullRequestService.managePrReviewers(
+            {pr_number: 16385, reviewers: ['neo-gpt-euclid'], action: 'add'},
+            {execFn: async () => reviewerResponse()}
+        );
+
+        expect(res.code).toBe('REVIEWER_NOT_SEATED');
+        expect(res.error).toBeTruthy();
+        expect(res.unseated).toEqual(['neo-gpt-euclid']);
+        expect(res.message).toContain('neo-gpt-euclid');
+        // The exact regression: the old code returned this string for the same response.
+        expect(res.message).not.toContain('Successfully');
+    });
+
+    test('partial seating fails and names only the login that was not seated', async () => {
+        const res = await PullRequestService.managePrReviewers(
+            {pr_number: 99, reviewers: ['neo-gpt', 'neo-gpt-euclid'], action: 'add'},
+            {execFn: async () => reviewerResponse(['neo-gpt'])}
+        );
+
+        expect(res.code).toBe('REVIEWER_NOT_SEATED');
+        expect(res.unseated).toEqual(['neo-gpt-euclid']);
+        expect(res.unseated).not.toContain('neo-gpt');
+        expect(res.verifiedReviewers).toEqual(['neo-gpt']);
+    });
+
+    test('an unseated team reviewer fails the same way', async () => {
+        const res = await PullRequestService.managePrReviewers(
+            {pr_number: 99, team_reviewers: ['ghost-team'], action: 'add'},
+            {execFn: async () => reviewerResponse([], [])}
+        );
+
+        expect(res.code).toBe('REVIEWER_NOT_SEATED');
+        expect(res.unseated).toEqual(['ghost-team']);
+    });
+
+    test('verifiedReviewers comes from the response, never echoed from the arguments', async () => {
+        // The falsifier for an echo: GitHub reports a reviewer that was never requested here
+        // (seated by an earlier call). An implementation echoing its input cannot produce it.
+        const res = await PullRequestService.managePrReviewers(
+            {pr_number: 42, reviewers: ['neo-gpt'], team_reviewers: ['core'], action: 'add'},
+            {execFn: async () => reviewerResponse(['neo-gpt', 'neo-opus-grace'], ['core'])}
+        );
+
+        expect(res.code).toBeUndefined();
+        expect(res.verifiedReviewers).toContain('neo-opus-grace');
+        expect(res.verifiedReviewers).toContain('neo-gpt');
+        expect(res.verifiedTeamReviewers).toEqual(['core']);
+        expect(res.message).toContain('Successfully');
+    });
+
+    test('login comparison is case-insensitive (GitHub seats logins case-folded)', async () => {
+        const res = await PullRequestService.managePrReviewers(
+            {pr_number: 42, reviewers: ['@Neo-GPT'], action: 'add'},
+            {execFn: async () => reviewerResponse(['neo-gpt'])}
+        );
+
+        // A case-sensitive compare would report a genuinely seated reviewer as unseated.
+        expect(res.code).toBeUndefined();
+        expect(res.message).toContain('Successfully');
+    });
+
+    test('remove verifies ABSENCE — a reviewer still present is a failure', async () => {
+        const res = await PullRequestService.managePrReviewers(
+            {pr_number: 42, reviewers: ['neo-gpt'], action: 'remove'},
+            {execFn: async () => reviewerResponse(['neo-gpt'])}   // still there → removal did not happen
+        );
+
+        expect(res.code).toBe('REVIEWER_NOT_SEATED');
+        expect(res.unseated).toEqual(['neo-gpt']);
+        expect(res.message).not.toContain('Successfully');
+    });
+
+    test('remove succeeds when the reviewer is gone from the returned state', async () => {
+        const res = await PullRequestService.managePrReviewers(
+            {pr_number: 42, reviewers: ['neo-gpt'], action: 'remove'},
+            {execFn: async () => reviewerResponse(['neo-opus-grace'])}
+        );
+
+        expect(res.code).toBeUndefined();
+        expect(res.message).toContain('removed');
+        expect(res.verifiedReviewers).toEqual(['neo-opus-grace']);
+    });
+
+    test('an unverifiable response is a failure, not a success', async () => {
+        // Missing arrays: proves nothing about who is seated. Treating absent as empty would
+        // resurrect the false-success — and `{}` was the old fixture, so this pins it directly.
+        const missing = await PullRequestService.managePrReviewers(
+            {pr_number: 42, reviewers: ['neo-gpt'], action: 'add'},
+            {execFn: async () => ({stdout: '{}'})}
+        );
+
+        expect(missing.code).toBe('REVIEWER_STATE_UNVERIFIABLE');
+        expect(missing.message).not.toContain('Successfully');
+
+        const unparseable = await PullRequestService.managePrReviewers(
+            {pr_number: 42, reviewers: ['neo-gpt'], action: 'add'},
+            {execFn: async () => ({stdout: 'not json'})}
+        );
+
+        expect(unparseable.code).toBe('REVIEWER_STATE_UNVERIFIABLE');
+        expect(unparseable.message).not.toContain('Successfully');
     });
 });

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestServiceReviewers.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestServiceReviewers.spec.mjs
@@ -1,6 +1,12 @@
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import * as yaml       from 'js-yaml';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
 
 /**
  * @summary Coverage for `PullRequestService.managePrReviewers` — verifies it builds the REST
@@ -142,9 +148,47 @@ test.describe('PullRequestService.managePrReviewers — REST requested_reviewers
             {execFn: async () => reviewerResponse(['neo-gpt'])}   // still there → removal did not happen
         );
 
-        expect(res.code).toBe('REVIEWER_NOT_SEATED');
+        expect(res.code).toBe('REVIEWER_STILL_REQUESTED');
         expect(res.unseated).toEqual(['neo-gpt']);
         expect(res.message).not.toContain('Successfully');
+    });
+
+    test('a failed remove describes the state GitHub returned, not the inverse', async () => {
+        // The two actions fail into opposite observed states. A shared add-shaped envelope told the
+        // caller of a failed REMOVE that the reviewer was "not seated" and sent them to check the
+        // roster for a nonexistent login — while GitHub had just reported that exact login holding
+        // the seat. Every assertion here is about the caller being routed at the real state.
+        const removeFailed = await PullRequestService.managePrReviewers(
+            {pr_number: 42, reviewers: ['neo-gpt'], action: 'remove'},
+            {execFn: async () => reviewerResponse(['neo-gpt'])}
+        );
+
+        expect(removeFailed.error).toBe('Reviewer still requested');
+        expect(removeFailed.message).toContain('remain requested reviewers');
+        // The inverted claim and the remediation it implies — the actual defect, pinned by name.
+        expect(removeFailed.error)  .not.toContain('not seated');
+        expect(removeFailed.message).not.toContain('not seated');
+        expect(removeFailed.message).not.toContain('identityRoots');
+        expect(removeFailed.message).not.toContain('does not exist');
+        // The seat is occupied; the caller must not read this as "free".
+        expect(removeFailed.verifiedReviewers).toEqual(['neo-gpt']);
+
+        // Positive control on the same axis: the add path must KEEP the roster remediation, or this
+        // could have been "fixed" by deleting the guidance from both branches.
+        const addFailed = await PullRequestService.managePrReviewers(
+            {pr_number: 42, reviewers: ['neo-gpt-euclid'], action: 'add'},
+            {execFn: async () => reviewerResponse([])}
+        );
+
+        expect(addFailed.code)   .toBe('REVIEWER_NOT_SEATED');
+        expect(addFailed.error)  .toBe('Reviewer not seated');
+        expect(addFailed.message).toContain('were not seated');
+        expect(addFailed.message).toContain('identityRoots');
+
+        // Neither envelope may state a status as the endpoint's general contract; the measured 200
+        // belongs to the unknown-login receipt, and GitHub documents add as 201 / remove as 200.
+        expect(removeFailed.message).not.toContain('HTTP 200');
+        expect(addFailed   .message).not.toContain('HTTP 200');
     });
 
     test('remove succeeds when the reviewer is gone from the returned state', async () => {
@@ -176,5 +220,51 @@ test.describe('PullRequestService.managePrReviewers — REST requested_reviewers
 
         expect(unparseable.code).toBe('REVIEWER_STATE_UNVERIFIABLE');
         expect(unparseable.message).not.toContain('Successfully');
+    });
+
+    test('the OpenAPI contract publishes what the runtime promises', async () => {
+        // A tool description that promises verification fields is prose; the generated MCP contract is
+        // what a client can actually discover. Before this, `ManagePrReviewersResponse` had no `required`
+        // list — so `{}` satisfied the declared success schema — and the 422 pointed at the generic
+        // `ErrorResponse`, which carries none of `pr_number` / `unseated` / the verified arrays.
+        const doc     = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/github-workflow/openapi.yaml'), 'utf8')),
+              schemas = doc.components.schemas,
+              op      = Object.values(doc.paths).flatMap(p => Object.values(p)).find(o => o?.operationId === 'manage_pr_reviewers');
+
+        expect(op, 'manage_pr_reviewers operation must exist').toBeTruthy();
+
+        const okRef  = op.responses['200'].content['application/json'].schema.$ref,
+              errRef = op.responses['422'].content['application/json'].schema.$ref;
+
+        expect(okRef) .toBe('#/components/schemas/ManagePrReviewersResponse');
+        expect(errRef).toBe('#/components/schemas/ManagePrReviewersErrorResponse');
+
+        // Success: every verification field is REQUIRED, so an empty object no longer validates.
+        expect(schemas.ManagePrReviewersResponse.required)
+            .toEqual(expect.arrayContaining(['message', 'pr_number', 'verifiedReviewers', 'verifiedTeamReviewers']));
+
+        // Failure: the structured fields are discoverable from the schema, not only from prose.
+        const errSchema = schemas.ManagePrReviewersErrorResponse;
+
+        expect(Object.keys(errSchema.properties))
+            .toEqual(expect.arrayContaining(['code', 'pr_number', 'unseated', 'verifiedReviewers', 'verifiedTeamReviewers']));
+        expect(errSchema.required).toEqual(expect.arrayContaining(['error', 'message', 'code', 'pr_number']));
+        // `unseated` and the verified arrays are deliberately NOT required: on
+        // REVIEWER_STATE_UNVERIFIABLE the response carried no reviewer arrays, and publishing empty
+        // ones would assert "GitHub reports nobody seated" — a definite claim about the unknown.
+        expect(errSchema.required).not.toContain('unseated');
+
+        // The lock that keeps this from rotting: every failure code the METHOD can return must appear
+        // in the enum. A fourth code added to the service without a schema update fails here.
+        const source  = fs.readFileSync(path.join(repoRoot, 'ai/services/github-workflow/PullRequestService.mjs'), 'utf8'),
+              start   = source.indexOf('async managePrReviewers('),
+              body    = source.slice(start, source.indexOf('\n    async ', start + 1) + 1 || undefined),
+              runtime = [...new Set(body.match(/'(REVIEWER_[A-Z_]+)'/g) || [])].map(m => m.slice(1, -1));
+
+        // Positive control: the slice must actually contain the method, or an empty `runtime` would
+        // make the arrayContaining below pass while checking nothing.
+        expect(start).toBeGreaterThan(-1);
+        expect(runtime.length).toBeGreaterThanOrEqual(3);
+        expect(errSchema.properties.code.enum).toEqual(expect.arrayContaining(runtime));
     });
 });


### PR DESCRIPTION
Resolves #16394

`manage_pr_reviewers` now reports what GitHub actually did. It previously built its success message from its own arguments and discarded the API response, so requesting the nonexistent `neo-gpt-euclid` returned `Successfully requested reviewers on PR #16385: neo-gpt-euclid` while the PR kept zero reviewers — an agent trusting that string believes review is arranged and moves on, and the PR sits unreviewed with no failure signal anywhere.

Evidence: L4 (live API measured directly against `neomjs/neo` + full unit suite at the exact head) → L4 required (every close-target AC is unit-verifiable through the existing `execFn` seam plus the live-API mechanism claim, both reached here). Residual: none.

## Deltas from ticket

Two substantive deltas, both surfaced by measurement rather than assumed:

**1. No read-back call — the mutation's own response is the verification channel.** The ticket (and the originating report) prescribed a follow-up read of `reviewRequests` after mutating. Measuring the endpoint showed that unnecessary: `POST`/`DELETE /pulls/{n}/requested_reviewers` answers **200 with the full PR object**, whose `requested_reviewers` / `requested_teams` arrays are the post-mutation truth. The service was already receiving that payload and throwing it away. Parsing what we were handed is strictly better than a second call — no extra round-trip, and no window in which a concurrent change makes the read disagree with what this call did. The ticket's Avoided Traps section records this.

**2. One AC was mis-specified and has been amended, with the reasoning recorded on the ticket** ([comment](https://github.com/neomjs/neo/issues/16394#issuecomment-5159903007)). It originally read *"No success path interpolates `reviewerList`/`teamReviewerList` into the returned `message`."* That is unsatisfiable on the `remove` path: a successfully removed reviewer is **absent** from the response by definition, so nothing but the request can supply its name. The AC conflated message text with the actual echo hazard, which lives in the machine-readable fields — and those are unchanged and pinned by test. Flagging it here rather than leaving a silent body/PR mismatch for review to trip over.

The measured mechanism, for the record — the report inferred that GitHub silently ignores unknown logins, and that inference held up, but three different causes were consistent with the symptom (swallowed non-zero exit, broken `-f 'reviewers[]='` shell quoting, silently-accepted request) and only the third survived:

| Probe | Result |
|---|---|
| `gh api users/neo-gpt-euclid` | HTTP 404 — no such account |
| `gh` exit code on the POST | **0** |
| GitHub HTTP status | **200**, full PR object |
| `requested_reviewers` in that same body | **`[]`** |
| `gh pr view 16385 --json reviewRequests` after | `[]` |

So neither the exit code nor the absence of an exception ever proved anything, and the `try/catch` had nothing to catch.

**3. Both failure directions carry their own envelope, and the OpenAPI contract publishes the promise** (review round 1, `@neo-gpt-emmy` — [review](https://github.com/neomjs/neo/pull/16396#pullrequestreview-4839562013)). Two defects sat on top of a correct effect gate.

The failure envelope described the **inverse** of the observed state. `add` and `remove` fail into opposite conditions and shared one add-shaped envelope, so a failed `remove` — where GitHub had just reported that login still holding the seat — answered `Reviewer not seated` / `REVIEWER_NOT_SEATED` and told the caller to check the roster for a login that demonstrably exists. Only the first clause of the message was action-aware; every field a caller acts on was not. A failed `remove` is now `REVIEWER_STILL_REQUESTED` / `Reviewer still requested`, states the removal was not applied and the seat is **not** free, and routes to re-reading the reviewer state.

And the generated contract did not publish what this body promised: `ManagePrReviewersResponse` had no `required` list (so `{}` satisfied the declared success schema) and `'422'` pointed at the generic `ErrorResponse`, which carries no `pr_number`, no `unseated`, and no verified arrays. The structured failure was reachable only by reading prose.

**One deliberate narrowing of that review's ask, stated rather than quietly delivered:** `unseated` and the verified arrays are documented on the 422 schema but **not** required. `REVIEWER_STATE_UNVERIFIABLE` is precisely the case where the response carried no reviewer arrays, so requiring them would force the schema to publish empty ones — which read as *"GitHub reports nobody seated"*, a definite claim about the exact state that is unknown. Only the four fields every failure can honestly supply are required.

**What changed:** `parseSeatedReviewerState` reads the seated state out of the response; `add` demands presence and `remove` demands absence, case-folded because GitHub seats logins case-insensitively. An `add` GitHub did not seat fails with `REVIEWER_NOT_SEATED`; a `remove` whose target is still listed fails with `REVIEWER_STILL_REQUESTED`; an unreadable payload fails with `REVIEWER_STATE_UNVERIFIABLE` rather than degrading back to the echo. `verifiedReviewers` / `verifiedTeamReviewers` are derived from the response on every path. This mirrors `IssueService.assignIssue`'s `verifiedAssignees` post-verify — the sibling this method's own JSDoc already named.

**On status provenance:** the measured **200** belongs to the unknown-login receipt and is labelled as such wherever it appears. GitHub documents the normal `POST` add as **201** and `DELETE` remove as **200**, and the verdict never reads the status either way — it reads the reviewer arrays.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback | Docs |
|---|---|---|---|---|
| `manage_pr_reviewers` result | This PR | Adds `verifiedReviewers` / `verifiedTeamReviewers`; unapplied change → error | None — the echo was the defect and is removed | `openapi.yaml` `ManagePrReviewersResponse` |
| `REVIEWER_NOT_SEATED` | New | An `add` target is **absent** from the returned state; names each under `unseated` | n/a | `openapi.yaml` `'422'` |
| `REVIEWER_STILL_REQUESTED` | New (review round 1) | A `remove` target is still **present** — the seat is not free | n/a | `openapi.yaml` `'422'` |
| `REVIEWER_STATE_UNVERIFIABLE` | New | Unparseable/missing arrays → failure, never success | n/a | `openapi.yaml` `'422'` |
| `SuccessResponse` → `ManagePrReviewersResponse` | `CheckoutPullRequestResponse` precedent | Dedicated verifiable-result schema; all four fields `required` | Generic `SuccessResponse` still serves other ops | `openapi.yaml` |
| `ErrorResponse` → `ManagePrReviewersErrorResponse` | New (review round 1) | 422 exposes `code` (enumerated), `pr_number`, `unseated`, verified arrays | Generic `ErrorResponse` still serves 400/500 | `openapi.yaml` |

**Caller-visible break (intended):** a request naming a login GitHub will not seat now returns an error where it previously returned success. That is the fix. Callers reading `result.reviewers` / `result.team_reviewers` must move to `verifiedReviewers` / `verifiedTeamReviewers`; the old fields were echoes of the request and carried no information the caller did not already have. No in-repo caller reads them — `manage_pr_reviewers` is invoked through the MCP boundary, and `grep` finds no consumer of those two response fields.

## Test Evidence

`ai/services/github-workflow` + MCP OpenAPI compliance, at the exact head:

```
npm run test-unit -- test/playwright/unit/ai/services/github-workflow/ test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
→ 651 passed (10.0s)          # at cde1bffe65; 649 at e5aa2b3a6c, +2 from round 1
```

**The tests are proven RED without the fix.** Green-with-the-fix would prove only that the assertions run. Stashing the service change and re-running the spec against the pre-fix implementation fails 7 of 11:

```
remove verifies ABSENCE — a reviewer still present is a failure
an unverifiable response is a failure, not a success
partial seating fails and names only the login that was not seated
verifiedReviewers comes from the response, never echoed from the arguments
a nonexistent login must NOT report success
remove succeeds when the reviewer is gone from the returned state
an unseated team reviewer fails the same way
→ 7 failed, 6 passed
```

The one effect-test that does *not* go red is `login comparison is case-insensitive`: pre-fix, every call returned success, so it passes trivially. It guards a regression this PR could introduce, not the original defect — stating that rather than counting it as witness coverage.

The three pre-existing tests asserted only the command string and fed `{stdout: '{}'}`, a payload GitHub never returns. That stub is why the defect shipped past a green suite, so their fixtures now carry the real response shape; their command-shape assertions are untouched. The `{}` case survives as an explicit `REVIEWER_STATE_UNVERIFIABLE` test.

**Round 1 added two assertions, both RED-verified against `e5aa2b3a6c`:**

```
remove verifies ABSENCE — a reviewer still present is a failure
  Expected: "REVIEWER_STILL_REQUESTED"   Received: "REVIEWER_NOT_SEATED"
a failed remove describes the state GitHub returned, not the inverse
  Expected: "Reviewer still requested"   Received: "Reviewer not seated"
the OpenAPI contract publishes what the runtime promises
  Expected: "#/components/schemas/ManagePrReviewersErrorResponse"
  Received: "#/components/schemas/ErrorResponse"
→ 3 failed, 12 passed
```

The schema test stops at the first `$ref` assertion, so its other two claims were probed separately against the same reverted tree rather than asserted on faith:

```
PRE-FIX success required : undefined
PRE-FIX {} validates?    : YES — empty object satisfies the declared success schema
PRE-FIX error schema     : ABSENT
```

Two controls, because either test could have been satisfied the wrong way. The envelope test carries a **positive control that the `add` path KEEPS the roster remediation** — without it, deleting the guidance from both branches would pass. The schema test asserts its extracted source slice is non-empty before checking enum containment, since an empty extraction makes `arrayContaining` vacuous; and it locks the enum against the **method's own source**, so a fourth runtime code added without a contract update fails here instead of shipping undocumented.

No caller migration is needed for the renamed code: `REVIEWER_NOT_SEATED` has zero hits on `origin/dev`, so both codes are introduced by this PR and nothing outside it can depend on the old spelling.

Non-CI lint gates run locally: `agent-preflight --change-class restoration` (passed), `check-ticket-archaeology` (initially failed on three `#16394` refs in durable comments — refs removed, they belong in the commit/PR, not in comments that rot when the ticket closes), `check-block-alignment --staged` (exit 0 — the round-1 import block was hand-aligned, not `--fix`ed, which has corrupted destructuring before), `node --check` on the committed blobs.

One instrument note from round 1: the first draft of the 422 schema description broke the YAML (`measured: that call…` — a `: ` inside an unquoted plain scalar), which surfaced as **12 unrelated compliance failures** rather than one. A parse break in a shared contract file fails everything that loads it, so the single root cause looked like a broad regression; converted to a block scalar.

## Post-Merge Validation

- [ ] Call `manage_pr_reviewers` through the live MCP surface with a nonexistent login and confirm `REVIEWER_NOT_SEATED` rather than a success string.
- [ ] Confirm a normal cross-family reviewer request still succeeds through the MCP surface and returns `verifiedReviewers`.
- [ ] Confirm a `remove` targeting a login GitHub leaves seated returns `REVIEWER_STILL_REQUESTED` — the seat-not-free direction, which no unit fixture can prove GitHub actually produces.

Both are end-to-end confirmations rather than open questions about whether the new fields survive the boundary: `guardGitHubWriteTools` wraps public write tools in `buildGitHubWriteIdentityGuard`, whose body is `await resolveGitHubIdentityAssertion(...); return delegate(...args)` — an identity gate and a pass-through, with no response reshaping. `verifiedReviewers` / `unseated` / the new codes reach callers unchanged.

## Commits

- `62870a0bf6` — report the effect rather than the request; contract + spec.
- `e5aa2b3a6c` — use optional catch binding in the parser, matching the in-repo idiom for a discarded `JSON.parse` error.
- `cde1bffe65` — round 1: action-accurate failure envelope (`REVIEWER_STILL_REQUESTED`), required success fields, dedicated 422 schema, status-neutral prose.

Rebased onto `dev` after `#16386` landed; no overlap with the files here.

---

Authored by Ada (Opus 5, Claude Code). Session: Memory Core session ID unavailable — the `neo-mjs-memory-core` and `neo-mjs-a2a` MCP surfaces were not reachable in this session, so no origin-session UUID exists to cite; recording that rather than inventing one. Two protocol steps degraded as a result and are declared here: the `ticket-create` §1a(ii) A2A in-flight claim sweep could not run (the live GitHub latest-20 sweep did, at `2026-08-02T19:00:19Z`, plus a re-check immediately before filing), and the §6.2 post-open A2A lifecycle notification is being handled by seating the reviewer request on GitHub directly instead of an `add_message` wake.


