### PR TITLE
feat(memory-core): emit a typed failure cause from buildMiniSummary (#16388)

### DIFF
--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -5,7 +5,11 @@ import GraphService        from './GraphService.mjs';
 import logger              from '../../mcp/server/memory-core/logger.mjs';
 import SessionService      from './SessionService.mjs';
 import TurnPresenceService from './TurnPresenceService.mjs';
-import {withTimeout}       from './helpers/withTimeout.mjs';
+import {withTimeout,
+        WITH_TIMEOUT_CODE} from './helpers/withTimeout.mjs';
+
+import {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
+        PROVIDER_TIMEOUT_CODE} from '../../provider/createTimeoutError.mjs';
 
 import {
     appendWalGraphProjectionMarker,
@@ -61,8 +65,13 @@ export const MEMORY_ACCEPTED_MESSAGE = 'Memory accepted and durably logged to th
  * Re-exported from `./helpers/withTimeout.mjs` (moved there so `SessionService` can share it without
  * a `MemoryService` ⇄ `SessionService` import cycle). Kept exported here for back-compat with
  * existing importers.
+ *
+ * `WITH_TIMEOUT_CODE` travels with it deliberately: an importer that can reach the thrower but not its
+ * identity has to hardcode the literal to classify a rejection, which is the silent-drift failure the
+ * constant exists to remove.
  */
-export {withTimeout};
+export {withTimeout,
+        WITH_TIMEOUT_CODE};
 
 /**
  * Computes a lightweight inbox snapshot for the bound AgentIdentity to piggyback on every
@@ -1628,7 +1637,21 @@ class MemoryService extends Base {
      * @param {Object} options
      * @param {String} options.prompt
      * @param {String} options.response
-     * @returns {Promise<String|null>} A one-line summary capped at `aiConfig.memoryService.miniSummaryMaxChars` (default 280), or `null`.
+     * Reports **why** alongside **whether**. A bare `null` collapsed no-provider, empty output, timeout
+     * and provider error into one indistinguishable outcome, so no consumer could tell a window that
+     * needs widening from a provider that was never reachable — the cause was destroyed here, one frame
+     * above every counter that tried to describe it. `cause` is classified from `error.code`, never from
+     * the message: a reworded message stops matching silently, and an unrelated error mentioning a
+     * timeout would be misread as one.
+     *
+     * @param {Object} options
+     * @param {String} options.prompt
+     * @param {String} options.response
+     * @returns {Promise<Object>} `{summary, cause}` — `summary` is a one-line summary capped at
+     * `aiConfig.memoryService.miniSummaryMaxChars` (default 280) with `cause: null`, or `summary: null`
+     * with `cause` naming the failure: `'no-model'`, `'empty-output'`, `'timeout-inner'`, or
+     * `'provider-error'`. `timeoutCode` carries which layer gave up when the cause is a timeout —
+     * the wrapper or the provider — since those are distinct facts worth keeping.
      */
     async buildMiniSummary({prompt, response}) {
         // Calibrated above the measured local-model summary latency so a real summary is not aborted
@@ -1645,7 +1668,7 @@ class MemoryService extends Base {
                 geminiApiKey          : aiConfig.geminiApiKey,
                 geminiModelName       : aiConfig.modelName
             });
-            if (!model) return null;
+            if (!model) return {summary: null, cause: 'no-model'};
 
             // `thought` is deliberately NOT summarized here, and adding it would be a privacy change
             // rather than an input-quality one. `thought` is private: `queryRecentTurns` forces
@@ -1670,10 +1693,31 @@ class MemoryService extends Base {
             );
 
             const text = result?.response?.text?.() ?? null;
-            return text ? String(text).replace(/\s+/g, ' ').trim().slice(0, aiConfig.memoryService.miniSummaryMaxChars) : null;
+
+            if (!text) {
+                return {summary: null, cause: 'empty-output'};
+            }
+
+            return {
+                summary: String(text).replace(/\s+/g, ' ').trim().slice(0, aiConfig.memoryService.miniSummaryMaxChars),
+                cause  : null
+            };
         } catch (error) {
             logger.warn(`[MemoryService] miniSummary generation failed (fail-soft): ${error.message}`);
-            return null;
+
+            // Classified by code, never by message. Three producers can report that the inner budget was
+            // exceeded — this method's own `withTimeout` wrapper, and the provider's two layers — and all
+            // three mean the same actionable thing: the inner window was too small. Which layer noticed is
+            // kept in `timeoutCode` rather than folded into the cause, because that distinction is a real
+            // fact (`createTimeoutError` keeps its two codes separate for the same reason) and erasing it
+            // would hide whether the provider or the wrapper gave up first.
+            const isTimeout = error?.code === WITH_TIMEOUT_CODE ||
+                              error?.code === PROVIDER_TIMEOUT_CODE ||
+                              error?.code === OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE;
+
+            return isTimeout
+                ? {summary: null, cause: 'timeout-inner', timeoutCode: error.code}
+                : {summary: null, cause: 'provider-error'};
         }
     }
 
@@ -1874,12 +1918,21 @@ class MemoryService extends Base {
      * @param {Number} [options.freshReserve] Of `limit`, how many newest rows to reserve before the
      *     remainder drains the oldest. Defaults to `aiConfig.memoryService.miniSummaryBackfillFreshReserve`; clamped to
      *     `limit`. Exposed for deterministic split-coverage tests.
-     * @param {Function} [options.buildMiniSummary] Optional summarizer seam for deterministic tests.
      * @param {Number} [options.maxRunMs] Wall-clock budget for the run; defaults to
      *     `aiConfig.memoryService.miniSummaryBackfillMaxRunMs`. The loop stops starting new rows once reached and defers
      *     the remainder to the next sweep, keeping the supervised child under its watchdog.
      * @param {Function} [options.now] Clock seam (defaults to `Date.now`) for deterministic budget tests.
-     * @returns {Promise<{processed: Number, updated: Number, deferred: Number, missingContent: Number, exhausted: Number, runBudgetHit: Boolean}>}
+     * @param {Function} [options.buildMiniSummary] Optional summarizer seam. Returns `{summary, cause}`;
+     * a bare string / `null` is accepted and its failure is tallied as `unspecified` rather than guessed.
+     * @returns {Promise<Object>} Pass tallies:
+     * `processed` rows attempted · `updated` summaries written · `deferred` failures left pending ·
+     * `missingContent` rows archived as un-summarizable · `exhausted` rows archived on attempt budget ·
+     * `runBudgetHit` whether the wall-clock budget stopped the run ·
+     * `failedInner` / `failedOuter` failures by **control-flow branch** (falsy return vs escaped throw) —
+     * a branch says WHICH path ran, never WHY, so neither may be read as a timeout verdict ·
+     * `failureCauses` a per-cause tally (`timeout-inner`, `timeout-outer`, `no-model`, `empty-output`,
+     * `provider-error`, `unspecified`) — the only field that carries the reason, and the only one a
+     * consumer may use to name a binding timeout.
      *          `exhausted` counts rows that spent their attempt budget and were reversibly archived.
      *          Present on **every** exit — including the no-SQLite and zero-row early returns — so a
      *          caller never sees a shape that sometimes lacks it.
@@ -1887,7 +1940,7 @@ class MemoryService extends Base {
     async backfillMiniSummaries({limit, freshReserve, buildMiniSummary, maxRunMs, now = () => Date.now()} = {}) {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite) {
-            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0};
+            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0, failureCauses: {}};
         }
 
         // Fail loud on an unresolved leaf, before touching a single row. A stale operator overlay
@@ -1936,7 +1989,7 @@ class MemoryService extends Base {
         const rows = [...new Set([...scanIds('DESC', reserve), ...scanIds('ASC', drainLimit)])].map(id => ({id}));
 
         if (rows.length === 0) {
-            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0};
+            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0, failureCauses: {}};
         }
 
         let byId;
@@ -1949,7 +2002,7 @@ class MemoryService extends Base {
             // Both branch counters stay 0: the content store was unreachable, so no generation was
             // attempted. Attributing these rows to either branch would report generation timeouts that
             // never happened and steer an adaptive consumer toward widening a window that is not the fault.
-            return {processed: rows.length, updated: 0, deferred: rows.length, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0};
+            return {processed: rows.length, updated: 0, deferred: rows.length, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0, failureCauses: {}};
         }
 
         // `failedInner` / `failedOuter` split the SAME failures the `deferred`/`exhausted` pair already
@@ -1960,8 +2013,24 @@ class MemoryService extends Base {
         // below (outer). Widening the inner leaf past the outer one moves every failure from one branch
         // to the other while `deferred` and `exhausted` report an identical shape — so a consumer reading
         // only those totals goes blind at exactly the window an adaptive controller is actuating toward.
+        // `failureCauses` is the dimension the branch counters cannot supply. A branch says WHICH code
+        // path ran; a cause says WHY. `failedInner` counts every falsy-returning generation — a missing
+        // provider and an exceeded window land on it identically — so a consumer that reads a branch as
+        // a timeout verdict is asserting something no counter here measured. Causes are reported by the
+        // summarizer and tallied verbatim; nothing is inferred from a branch.
         let updated     = 0, deferred = 0, missingContent = 0, processed = 0, exhausted = 0, runBudgetHit = false,
             failedInner = 0, failedOuter = 0;
+
+        const failureCauses = {};
+
+        /**
+         * @summary Tallies one reported failure cause.
+         * @param {String} cause
+         * @returns {void}
+         */
+        const recordCause = cause => {
+            failureCauses[cause] = (failureCauses[cause] || 0) + 1
+        };
 
         for (const row of rows) {
             // Bound the run safely under the ProcessSupervisor watchdog: stop starting new rows once
@@ -1995,14 +2064,24 @@ class MemoryService extends Base {
             }
 
             try {
-                const miniSummary = await withTimeout(
+                const generated = await withTimeout(
                     summarize({prompt: metadata.prompt, response: metadata.response}),
                     aiConfig.memoryService.miniSummaryTimeoutMs,
                     'miniSummary backfill summarize'
                 );
 
+                // An injected summarizer may still return a bare string or null rather than the
+                // `{summary, cause}` contract. Normalise it WITHOUT guessing: a bare failure reports
+                // `unspecified`, never a plausible-looking cause. Inventing one here would recreate the
+                // exact defect this contract exists to close — a consumer reading a cause that nothing
+                // observed — and `unspecified` correctly denies a downstream timeout verdict.
+                const isContract  = generated !== null && typeof generated === 'object',
+                      miniSummary = isContract ? generated.summary : generated,
+                      cause       = isContract ? generated.cause : (generated ? null : 'unspecified');
+
                 if (!miniSummary) {
                     failedInner++;
+                    recordCause(cause || 'unspecified');
 
                     if (this._exhaustMiniSummaryAttempt(row.id)) {
                         exhausted++;
@@ -2026,6 +2105,12 @@ class MemoryService extends Base {
                 // outside the timeout guard, or an injected summarizer — so neither path can loop.
                 failedOuter++;
 
+                // The OUTER window, identified by code rather than message. Anything reaching here that
+                // is not this wrapper's own rejection escaped the summarizer's guard entirely, so it is
+                // an error rather than a window problem — and calling it a timeout would tell a widening
+                // consumer to widen for something no window would have prevented.
+                recordCause(error?.code === WITH_TIMEOUT_CODE ? 'timeout-outer' : 'provider-error');
+
                 if (this._exhaustMiniSummaryAttempt(row.id)) {
                     exhausted++;
                 } else {
@@ -2039,9 +2124,17 @@ class MemoryService extends Base {
         }
 
         // Completion line so the run ends with a visible tally, not silence (stderr → captured by the supervisor).
-        console.error(`[INFO] [MemoryService] miniSummary backfill complete: ${processed}/${rows.length} processed (${updated} updated, ${deferred} deferred, ${missingContent} missing-content, ${exhausted} exhausted)`);
+        // The cause tally is appended only when something failed: a starved plane is diagnosed from captured
+        // stderr, not by a caller inspecting this return value, so the reason has to reach the log too — while a
+        // healthy run keeps its existing shape rather than carrying an empty object every sweep.
+        const causeEntries = Object.entries(failureCauses),
+              causeSuffix  = causeEntries.length
+                  ? ` [causes: ${causeEntries.map(([cause, count]) => `${cause}=${count}`).join(', ')}]`
+                  : '';
 
-        return {processed, updated, deferred, missingContent, exhausted, runBudgetHit, failedInner, failedOuter};
+        console.error(`[INFO] [MemoryService] miniSummary backfill complete: ${processed}/${rows.length} processed (${updated} updated, ${deferred} deferred, ${missingContent} missing-content, ${exhausted} exhausted)${causeSuffix}`);
+
+        return {processed, updated, deferred, missingContent, exhausted, runBudgetHit, failedInner, failedOuter, failureCauses};
     }
 
     /**

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -74,6 +74,19 @@ export {withTimeout,
         WITH_TIMEOUT_CODE};
 
 /**
+ * Label carried by the backfill's OUTER window rejection, shared by the wrapper that produces it and
+ * the classifier that names it.
+ *
+ * `WITH_TIMEOUT_CODE` identifies the *code family*, not the instance — every `withTimeout` in the tree
+ * sets it. Classifying on the code alone therefore labels ANY escaping wrapper rejection as
+ * `timeout-outer`, including one from an unrelated nested wrapper that never involved this window; a
+ * consumer would then widen a window that was not binding. The label is the instance discriminator, and
+ * a single constant is what keeps the producer and the classifier from drifting apart silently.
+ * @type {String}
+ */
+export const MINI_SUMMARY_OUTER_LABEL = 'miniSummary backfill summarize';
+
+/**
  * Computes a lightweight inbox snapshot for the bound AgentIdentity to piggyback on every
  * `add_memory` response — the per-turn **mailbox delta signal**.
  *
@@ -1939,6 +1952,9 @@ class MemoryService extends Base {
      *     `aiConfig.memoryService.miniSummaryBackfillMaxRunMs`. The loop stops starting new rows once reached and defers
      *     the remainder to the next sweep, keeping the supervised child under its watchdog.
      * @param {Function} [options.now] Clock seam (defaults to `Date.now`) for deterministic budget tests.
+     * @param {Number} [options.outerTimeoutMs] Outer per-item window; defaults to
+     * `aiConfig.memoryService.miniSummaryTimeoutMs`. Exposed so a spec can make the REAL outer wrapper
+     * reject inside a test budget — witnessing `timeout-outer` any other way times a different wrapper.
      * @param {Function} [options.buildMiniSummary] Optional summarizer seam. Returns `{summary, cause}`;
      * a bare string / `null` is accepted and its failure is tallied as `unspecified` rather than guessed.
      * @returns {Promise<Object>} Pass tallies:
@@ -1954,7 +1970,7 @@ class MemoryService extends Base {
      *          Present on **every** exit — including the no-SQLite and zero-row early returns — so a
      *          caller never sees a shape that sometimes lacks it.
      */
-    async backfillMiniSummaries({limit, freshReserve, buildMiniSummary, maxRunMs, now = () => Date.now()} = {}) {
+    async backfillMiniSummaries({limit, freshReserve, buildMiniSummary, maxRunMs, outerTimeoutMs = aiConfig.memoryService.miniSummaryTimeoutMs, now = () => Date.now()} = {}) {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite) {
             return {processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0, failureCauses: {}};
@@ -2083,8 +2099,8 @@ class MemoryService extends Base {
             try {
                 const generated = await withTimeout(
                     summarize({prompt: metadata.prompt, response: metadata.response}),
-                    aiConfig.memoryService.miniSummaryTimeoutMs,
-                    'miniSummary backfill summarize'
+                    outerTimeoutMs,
+                    MINI_SUMMARY_OUTER_LABEL
                 );
 
                 // An injected summarizer may still return a bare string or null rather than the
@@ -2126,7 +2142,14 @@ class MemoryService extends Base {
                 // is not this wrapper's own rejection escaped the summarizer's guard entirely, so it is
                 // an error rather than a window problem — and calling it a timeout would tell a widening
                 // consumer to widen for something no window would have prevented.
-                recordCause(error?.code === WITH_TIMEOUT_CODE ? 'timeout-outer' : 'provider-error');
+                // Code AND label: the code names the family (every wrapper in the tree sets it), the label
+                // names THIS window. A nested wrapper's rejection that escaped the summarizer is an error,
+                // not a window problem — my own comment above said so while the code still called it a
+                // timeout, which would tell a widening consumer to widen for something no window prevented.
+                const isOuterWindow = error?.code === WITH_TIMEOUT_CODE &&
+                                      error?.label === MINI_SUMMARY_OUTER_LABEL;
+
+                recordCause(isOuterWindow ? 'timeout-outer' : 'provider-error');
 
                 if (this._exhaustMiniSummaryAttempt(row.id)) {
                     exhausted++;

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1630,13 +1630,10 @@ class MemoryService extends Base {
      *
      * Reuses the `modelProvider` reactive-Provider SSOT through {@link buildChatModel} — the user's
      * deployment-agnostic choice resolves to **local** (gemma4 via `openAiCompatible`/`ollama`) OR
-     * **remote** (gemini-flash via `gemini`), identically in local + cloud. **Fail-soft:** returns
-     * `null` on no-provider (e.g. gemini without an API key), timeout, or error — the caller stores
-     * no summary and recency recall falls back to raw content. Never throws into the write path.
+     * **remote** (gemini-flash via `gemini`), identically in local + cloud. **Fail-soft:** never throws
+     * into the write path — no-provider, timeout, empty output and provider error all resolve, the
+     * caller stores no summary, and recency recall falls back to raw content.
      *
-     * @param {Object} options
-     * @param {String} options.prompt
-     * @param {String} options.response
      * Reports **why** alongside **whether**. A bare `null` collapsed no-provider, empty output, timeout
      * and provider error into one indistinguishable outcome, so no consumer could tell a window that
      * needs widening from a provider that was never reachable — the cause was destroyed here, one frame
@@ -1644,16 +1641,26 @@ class MemoryService extends Base {
      * the message: a reworded message stops matching silently, and an unrelated error mentioning a
      * timeout would be misread as one.
      *
+     * **Return-shape migration, not a truthiness-compatible change.** A failure used to be a falsy
+     * `null` and is now a truthy `{summary: null, cause}`, so any consumer testing the RESULT for
+     * truthiness inverts. The sweep is the only production caller and reads `.summary`; the shape is
+     * documented here as a migration rather than described as backward compatible, because a future
+     * caller written against "falsy means failed" would be silently wrong.
+     *
      * @param {Object} options
      * @param {String} options.prompt
      * @param {String} options.response
+     * @param {Function} [options.buildModel=buildChatModel] Chat-model factory seam. Exists so a spec can
+     * drive the real classification path — the `no-model` branch, whitespace normalization, and the
+     * `catch`'s code-based split — instead of substituting the whole producer and asserting its own
+     * fixtures back. A suite that injects the expected cause strings proves the tally, not the vocabulary.
      * @returns {Promise<Object>} `{summary, cause}` — `summary` is a one-line summary capped at
      * `aiConfig.memoryService.miniSummaryMaxChars` (default 280) with `cause: null`, or `summary: null`
      * with `cause` naming the failure: `'no-model'`, `'empty-output'`, `'timeout-inner'`, or
      * `'provider-error'`. `timeoutCode` carries which layer gave up when the cause is a timeout —
      * the wrapper or the provider — since those are distinct facts worth keeping.
      */
-    async buildMiniSummary({prompt, response}) {
+    async buildMiniSummary({prompt, response, buildModel = buildChatModel}) {
         // Calibrated above the measured local-model summary latency so a real summary is not aborted
         // before it completes. Benchmark (2026-06-09, MacBook M5 Max 128GB, gemma-4-31b-it via LM
         // Studio): a ~5k-char -> tweet-size summary takes ~5.3s warm / ~13s cold. The prior 4s cap
@@ -1661,7 +1668,7 @@ class MemoryService extends Base {
         // backfill per-item timeout (aiConfig.memoryService.miniSummaryTimeoutMs).
         const TIMEOUT_MS = aiConfig.memoryService.generateMiniSummaryTimeoutMs;
         try {
-            const model = buildChatModel({
+            const model = buildModel({
                 modelProvider         : aiConfig.modelProvider,
                 openAiCompatibleConfig: aiConfig.openAiCompatible,
                 ollamaConfig          : aiConfig.ollama,
@@ -1692,14 +1699,24 @@ class MemoryService extends Base {
                 'miniSummary generation'
             );
 
-            const text = result?.response?.text?.() ?? null;
+            const raw = result?.response?.text?.() ?? null;
 
-            if (!text) {
+            // Normalize BEFORE classifying, not after. A whitespace-only answer ('   ', '\n\n') is
+            // truthy, so a raw truthiness check passes it as usable; it then normalizes to '' and was
+            // returned as a SUCCESS carrying an empty summary, which the sweep recorded as `unspecified`
+            // — the one cause that means "the summarizer told us nothing". A model that answers with
+            // whitespace is empty-output, and the classification has to see the same string the caller
+            // would store.
+            const summary = raw === null || raw === undefined
+                ? ''
+                : String(raw).replace(/\s+/g, ' ').trim();
+
+            if (!summary) {
                 return {summary: null, cause: 'empty-output'};
             }
 
             return {
-                summary: String(text).replace(/\s+/g, ' ').trim().slice(0, aiConfig.memoryService.miniSummaryMaxChars),
+                summary: summary.slice(0, aiConfig.memoryService.miniSummaryMaxChars),
                 cause  : null
             };
         } catch (error) {

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -82,9 +82,14 @@ export {withTimeout,
  * `timeout-outer`, including one from an unrelated nested wrapper that never involved this window; a
  * consumer would then widen a window that was not binding. The label is the instance discriminator, and
  * a single constant is what keeps the producer and the classifier from drifting apart silently.
+ *
+ * Module-private: both the wrapper that sets it and the classifier that reads it live here, and there is
+ * no external consumer. Exporting it would publish a contract nothing depends on — and a public label is
+ * a thing future code could match on instead of asking this module, which is the coupling the single
+ * constant exists to avoid.
  * @type {String}
  */
-export const MINI_SUMMARY_OUTER_LABEL = 'miniSummary backfill summarize';
+const MINI_SUMMARY_OUTER_LABEL = 'miniSummary backfill summarize';
 
 /**
  * Computes a lightweight inbox snapshot for the bound AgentIdentity to piggyback on every

--- a/ai/services/memory-core/helpers/withTimeout.mjs
+++ b/ai/services/memory-core/helpers/withTimeout.mjs
@@ -1,4 +1,20 @@
 /**
+ * Uniform, caller-detectable code set on the rejection this helper produces, so a consumer can tell a
+ * timeout from an arbitrary downstream failure **structurally** rather than by matching the message.
+ *
+ * Message-matching was the only option before this existed, and it is unsound twice over: a reworded
+ * message silently stops matching, and any downstream error whose text happens to contain the same
+ * phrase is misread as a timeout. A consumer that must name *why* something failed — an adaptive
+ * controller widening a window, say — cannot be built on that.
+ *
+ * Mirrors the `code`-based contract `ai/provider/createTimeoutError.mjs` already establishes for
+ * provider-level timeouts; import this constant rather than repeating the literal, so a rename cannot
+ * leave a consumer silently matching nothing while its tests stay green.
+ * @type {String}
+ */
+export const WITH_TIMEOUT_CODE = 'WITH_TIMEOUT';
+
+/**
  * @summary Races a promise against a timeout so a hung downstream call (model inference,
  * content-store fetch) rejects instead of blocking the maintenance loop forever.
  *
@@ -6,6 +22,10 @@
  * import cycle: `MemoryService` imports `SessionService`, so `SessionService` cannot import this
  * from `MemoryService` (where it originally lived) without creating a `MemoryService` ⇄
  * `SessionService` cycle. Generic promise utility — no Neo / AiConfig dependency.
+ *
+ * The rejection carries `code = WITH_TIMEOUT_CODE` plus the `label` and `timeoutMs` that produced it,
+ * so a caller can classify the failure without parsing prose. The message is unchanged and still names
+ * both, since it remains the thing a human reads in a log.
  *
  * @param {Promise} promise The work to bound.
  * @param {Number}  ms      Timeout in milliseconds.
@@ -15,7 +35,15 @@
 export function withTimeout(promise, ms, label) {
     let timer;
     const timeout = new Promise((resolve, reject) => {
-        timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+        timer = setTimeout(() => {
+            const error = new Error(`${label} timed out after ${ms}ms`);
+
+            error.code      = WITH_TIMEOUT_CODE;
+            error.label     = label;
+            error.timeoutMs = ms;
+
+            reject(error)
+        }, ms);
     });
     return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WithTimeout.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WithTimeout.spec.mjs
@@ -16,7 +16,8 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
-import {withTimeout}  from '../../../../../../ai/services/memory-core/MemoryService.mjs';
+import {withTimeout,
+        WITH_TIMEOUT_CODE} from '../../../../../../ai/services/memory-core/MemoryService.mjs';
 
 /**
  * Unit coverage for the backfill timeout guard. The miniSummary backfill wraps its model call
@@ -36,5 +37,23 @@ test.describe('Neo.ai.memory-core MemoryService.withTimeout', () => {
     test('propagates the original rejection when the promise fails before the timeout', async () => {
         await expect(withTimeout(Promise.reject(new Error('upstream boom')), 1000, 'unit op'))
             .rejects.toThrow('upstream boom');
+    });
+
+    test('a timeout rejection is identifiable by code rather than by message', async () => {
+        const hung  = new Promise(() => {}),
+              error = await withTimeout(hung, 25, 'unit op').catch(caught => caught);
+
+        expect(error.code).toBe(WITH_TIMEOUT_CODE);
+        expect(error.label).toBe('unit op');
+        expect(error.timeoutMs).toBe(25);
+    });
+
+    test('an unrelated rejection that mentions a timeout in prose does not carry the code', async () => {
+        // The message-matching failure mode the code replaces: a downstream error whose text happens to
+        // read like a timeout must not classify as one.
+        const impostor = new Error('provider said: request timed out after 25ms'),
+              error    = await withTimeout(Promise.reject(impostor), 1000, 'unit op').catch(caught => caught);
+
+        expect(error.code).toBeUndefined();
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -32,11 +32,16 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
 test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
     test.describe.configure({mode: 'serial'});
 
-    let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter, originalGetMemoryCollection, originalEmbedText, memStore;
+    let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter, originalGetMemoryCollection, originalEmbedText, memStore, withTimeoutCode;
 
     test.beforeAll(async () => {
+        const memoryServiceModule = await import('../../../../../../ai/services/memory-core/MemoryService.mjs');
+
+        // Read the code off the module rather than repeating the literal: a rename must break this spec
+        // instead of leaving it green while the production classifier matches nothing.
+        withTimeoutCode      = memoryServiceModule.WITH_TIMEOUT_CODE;
         GraphService         = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
-        MemoryService        = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).default;
+        MemoryService        = memoryServiceModule.default;
         LifecycleService     = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
         StorageRouter        = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
@@ -390,6 +395,29 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
 
         expect(plain.failureCauses['provider-error']).toBeGreaterThanOrEqual(1);
         expect(plain.failureCauses['timeout-outer']).toBeUndefined();
+
+        // The positive control the negative case above cannot supply: without this, the classifier's true
+        // branch is never exercised, so a wrong constant would keep the whole suite green while
+        // `timeout-outer` became unreachable — the one cause a window-widening consumer can act on.
+        memStore.set('cause-timed-out', {prompt: 'timed out prompt', response: 'timed out response'});
+        GraphService.upsertNode({
+            id              : 'cause-timed-out', type: 'AGENT_MEMORY', name: 'Memory: timed out', description: 'timed out',
+            semanticVectorId: 'cause-timed-out',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'thrown', timestamp: ts}
+        });
+
+        const timedOut = await MemoryService.backfillMiniSummaries({
+            limit           : 50,
+            buildMiniSummary: async () => {
+                const error = new Error('miniSummary summarize timed out after 30000ms');
+
+                error.code = withTimeoutCode;
+                throw error
+            }
+        });
+
+        expect(timedOut.failureCauses['timeout-outer']).toBeGreaterThanOrEqual(1);
+        expect(timedOut.failureCauses['provider-error']).toBeUndefined();
     });
 
     test('the two failure branches are counted separately, so a branch flip is visible (#16223)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -226,7 +226,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
             }
         });
         expect(calls).toEqual(['new prompt']);
-        expect(result).toEqual({processed: 1, updated: 1, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0});
+        expect(result).toEqual({processed: 1, updated: 1, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0, failureCauses: {}});
 
         const row  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('backfill-new');
         const data = JSON.parse(row.data);
@@ -258,11 +258,138 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         // failedOuter, not failedInner: this fixture THROWS, so it escapes to the sweep's catch — the
         // same branch the real outer `miniSummaryTimeoutMs` rejection takes. A falsy-returning summarizer
         // would count as failedInner instead, which is the distinction the split exists to make.
-        expect(result).toEqual({processed: 1, updated: 0, deferred: 1, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 1});
+        expect(result).toEqual({processed: 1, updated: 0, deferred: 1, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 1, failureCauses: {'provider-error': 1}});
 
         const row  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('backfill-failure');
         const data = JSON.parse(row.data);
         expect(data.properties.miniSummary).toBeUndefined();
+    });
+
+    test('failure causes are tallied by what the summarizer reported, never inferred from a branch (#16388)', async () => {
+        const ts = Date.now();
+
+        // Three rows, three distinct causes. The point is that all three land on the SAME branch
+        // (`failedInner`) and are still told apart — which is exactly what a branch counter cannot do.
+        for (const id of ['cause-timeout', 'cause-no-model', 'cause-empty']) {
+            memStore.set(id, {prompt: `${id} prompt`, response: `${id} response`});
+            GraphService.upsertNode({
+                id, type: 'AGENT_MEMORY', name: `Memory: ${id}`, description: id,
+                semanticVectorId: id,
+                properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'causes', timestamp: ts}
+            });
+        }
+
+        const result = await MemoryService.backfillMiniSummaries({
+            limit           : 50,
+            buildMiniSummary: async ({prompt}) => {
+                if (prompt.startsWith('cause-timeout')) {
+                    return {summary: null, cause: 'timeout-inner'};
+                }
+                if (prompt.startsWith('cause-no-model')) {
+                    return {summary: null, cause: 'no-model'};
+                }
+                if (prompt.startsWith('cause-empty')) {
+                    return {summary: null, cause: 'empty-output'};
+                }
+                return {summary: null, cause: 'provider-error'};
+            }
+        });
+
+        expect(result.failureCauses['timeout-inner']).toBe(1);
+        expect(result.failureCauses['no-model']).toBe(1);
+        expect(result.failureCauses['empty-output']).toBe(1);
+
+        // All three arrived on the falsy branch. A consumer reading `failedInner` as "the inner window
+        // is binding" would be wrong for two of the three — which is why the branch cannot carry a
+        // timeout verdict and the cause must.
+        expect(result.failedInner).toBeGreaterThanOrEqual(3);
+        expect(result.failedOuter).toBe(0);
+    });
+
+    test('the completion log carries the cause tally on a failing run and omits it when clean (#16388)', async () => {
+        const ts       = Date.now(),
+              captured = [],
+              original = console.error;
+
+        console.error = (...args) => captured.push(args.join(' '));
+
+        try {
+            memStore.set('log-clean', {prompt: 'clean prompt', response: 'clean response'});
+            GraphService.upsertNode({
+                id              : 'log-clean', type: 'AGENT_MEMORY', name: 'Memory: clean', description: 'clean',
+                semanticVectorId: 'log-clean',
+                properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'log-clean', timestamp: ts}
+            });
+
+            await MemoryService.backfillMiniSummaries({
+                limit: 50, buildMiniSummary: async () => ({summary: 'ok', cause: null})
+            });
+
+            const cleanLine = captured.filter(line => line.includes('backfill complete')).at(-1);
+
+            expect(cleanLine).toBeTruthy();
+            expect(cleanLine).not.toContain('causes:');
+
+            memStore.set('log-failed', {prompt: 'failed prompt', response: 'failed response'});
+            GraphService.upsertNode({
+                id              : 'log-failed', type: 'AGENT_MEMORY', name: 'Memory: failed', description: 'failed',
+                semanticVectorId: 'log-failed',
+                properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'log-failed', timestamp: ts}
+            });
+
+            await MemoryService.backfillMiniSummaries({
+                limit: 50, buildMiniSummary: async () => ({summary: null, cause: 'timeout-inner'})
+            });
+
+            // The operator-facing half of the contract: on a live plane the starvation is read out of captured
+            // stderr, so a cause that only reaches the return value is invisible where it is needed.
+            expect(captured.filter(line => line.includes('backfill complete')).at(-1))
+                .toContain('[causes: timeout-inner=');
+        } finally {
+            console.error = original;
+        }
+    });
+
+    test('a summarizer that reports no cause is recorded as unspecified, never as a plausible one (#16388)', async () => {
+        const ts = Date.now();
+
+        memStore.set('cause-legacy', {prompt: 'legacy prompt', response: 'legacy response'});
+        GraphService.upsertNode({
+            id              : 'cause-legacy', type: 'AGENT_MEMORY', name: 'Memory: legacy', description: 'legacy',
+            semanticVectorId: 'cause-legacy',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'legacy', timestamp: ts}
+        });
+
+        // The pre-contract shape: a bare null with no cause attached. Guessing `timeout-inner` here
+        // would recreate the defect this contract closes — a cause nothing observed — so it must be
+        // `unspecified`, which correctly denies any downstream timeout verdict.
+        const result = await MemoryService.backfillMiniSummaries({
+            limit: 50, buildMiniSummary: async () => null
+        });
+
+        expect(result.failureCauses.unspecified).toBeGreaterThanOrEqual(1);
+        expect(result.failureCauses['timeout-inner']).toBeUndefined();
+    });
+
+    test('an escaped throw is only a timeout when it carries the wrapper code (#16388)', async () => {
+        const ts = Date.now();
+
+        memStore.set('cause-thrown', {prompt: 'thrown prompt', response: 'thrown response'});
+        GraphService.upsertNode({
+            id              : 'cause-thrown', type: 'AGENT_MEMORY', name: 'Memory: thrown', description: 'thrown',
+            semanticVectorId: 'cause-thrown',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'thrown', timestamp: ts}
+        });
+
+        // A plain throw is a provider error, NOT a timeout — even though it reaches the same catch the
+        // outer window's rejection would. Classifying by code rather than by arrival point is what keeps
+        // these apart; a message-matching guard would call both timeouts on the wrong day.
+        const plain = await MemoryService.backfillMiniSummaries({
+            limit: 50, buildMiniSummary: async () => { throw new Error('provider exploded') }
+        });
+
+        expect(plain.failureCauses['provider-error']).toBeGreaterThanOrEqual(1);
+        expect(plain.failureCauses['timeout-outer']).toBeUndefined();
     });
 
     test('the two failure branches are counted separately, so a branch flip is visible (#16223)', async () => {
@@ -422,7 +549,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         // Positive control: the drain did real work, so the zero below is an emptied set rather than a
         // sweep that never ran.
         expect(drain.processed).toBeGreaterThan(0);
-        expect(zeroRow).toEqual({processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0});
+        expect(zeroRow).toEqual({processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0, failureCauses: {}});
 
         // No-SQLite: the sweep reads `GraphService.db?.storage?.db` once at entry. Swapped rather than
         // mocked so the real guard runs, and restored in a finally so a failure here cannot cascade
@@ -437,7 +564,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
                 buildMiniSummary: async () => 'unused'
             });
 
-            expect(noSqlite).toEqual({processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0});
+            expect(noSqlite).toEqual({processed: 0, updated: 0, deferred: 0, missingContent: 0, exhausted: 0, runBudgetHit: false, failedInner: 0, failedOuter: 0, failureCauses: {}});
         } finally {
             GraphService.db = realDb;
         }

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -32,7 +32,7 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
 test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
     test.describe.configure({mode: 'serial'});
 
-    let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter, originalGetMemoryCollection, originalEmbedText, memStore, withTimeoutCode;
+    let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter, originalGetMemoryCollection, originalEmbedText, memStore, withTimeoutCode, withTimeout;
 
     test.beforeAll(async () => {
         const memoryServiceModule = await import('../../../../../../ai/services/memory-core/MemoryService.mjs');
@@ -40,6 +40,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         // Read the code off the module rather than repeating the literal: a rename must break this spec
         // instead of leaving it green while the production classifier matches nothing.
         withTimeoutCode      = memoryServiceModule.WITH_TIMEOUT_CODE;
+        withTimeout          = memoryServiceModule.withTimeout;
         GraphService         = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         MemoryService        = memoryServiceModule.default;
         LifecycleService     = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
@@ -309,6 +310,92 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         // timeout verdict and the cause must.
         expect(result.failedInner).toBeGreaterThanOrEqual(3);
         expect(result.failedOuter).toBe(0);
+    });
+
+    test('the real buildMiniSummary names each cause at the frame that creates it (#16388)', async () => {
+        // The gap this closes: every other cause spec INJECTS a summarizer returning the expected cause
+        // string, which proves the sweep's tally and nothing about the producer's vocabulary. These drive
+        // the real method — its own `no-model` branch, its own normalization, its own catch — through the
+        // `buildModel` seam, so the cause strings come from production code rather than from the fixture.
+        const {PROVIDER_TIMEOUT_CODE,
+               createTimeoutError} = await import('../../../../../../ai/provider/createTimeoutError.mjs');
+
+        const noModel = await MemoryService.buildMiniSummary({
+            prompt: 'p', response: 'r', buildModel: () => null
+        });
+
+        expect(noModel).toEqual({summary: null, cause: 'no-model'});
+
+        // The defect Emmy found: whitespace is TRUTHY, so a raw check passed it as usable and it
+        // normalized to '' — returned as a success with an empty summary, then tallied `unspecified`.
+        const whitespace = await MemoryService.buildMiniSummary({
+            prompt    : 'p', response: 'r',
+            buildModel: () => ({generateContent: async () => ({response: {text: () => '   \n\t  '}})})
+        });
+
+        expect(whitespace).toEqual({summary: null, cause: 'empty-output'});
+
+        const emptyString = await MemoryService.buildMiniSummary({
+            prompt    : 'p', response: 'r',
+            buildModel: () => ({generateContent: async () => ({response: {text: () => ''}})})
+        });
+
+        expect(emptyString.cause).toBe('empty-output');
+
+        // A genuine one-line answer must still succeed, or the three assertions above would also pass
+        // against a producer that had stopped summarizing at all.
+        const usable = await MemoryService.buildMiniSummary({
+            prompt    : 'p', response: 'r',
+            buildModel: () => ({generateContent: async () => ({response: {text: () => '  a real   summary  '}})})
+        });
+
+        expect(usable).toEqual({summary: 'a real summary', cause: null});
+
+        const providerError = await MemoryService.buildMiniSummary({
+            prompt    : 'p', response: 'r',
+            buildModel: () => ({generateContent: async () => { throw new Error('upstream exploded') }})
+        });
+
+        expect(providerError.cause).toBe('provider-error');
+
+        // timeout-inner reached through a REAL provider timeout object, not a hand-set `.code`: the
+        // rejection is built by `createTimeoutError`, one of the three producers the classifier names.
+        const providerTimeout = await MemoryService.buildMiniSummary({
+            prompt    : 'p', response: 'r',
+            buildModel: () => ({
+                generateContent: async () => {
+                    // `createTimeoutError` sets the code itself, so nothing here is forged.
+                    throw createTimeoutError({
+                        provider: 'openAiCompatible', operationLabel: 'miniSummary generation', timeoutMs: 1
+                    })
+                }
+            })
+        });
+
+        expect(providerTimeout.cause).toBe('timeout-inner');
+        expect(providerTimeout.timeoutCode).toBe(PROVIDER_TIMEOUT_CODE);
+    });
+
+    test('timeout-outer is reached by a real withTimeout rejection, not a forged code (#16388)', async () => {
+        const ts = Date.now();
+
+        memStore.set('cause-real-outer', {prompt: 'real outer prompt', response: 'real outer response'});
+        GraphService.upsertNode({
+            id              : 'cause-real-outer', type: 'AGENT_MEMORY', name: 'Memory: real outer', description: 'real outer',
+            semanticVectorId: 'cause-real-outer',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'real-outer', timestamp: ts}
+        });
+
+        // Composition witness: the escaping rejection is produced by the REAL `withTimeout` racing a
+        // promise that never settles, so the `code` the classifier matches was set by the wrapper rather
+        // than by this test. A renamed constant breaks this without anyone editing the spec.
+        const result = await MemoryService.backfillMiniSummaries({
+            limit           : 50,
+            buildMiniSummary: () => withTimeout(new Promise(() => {}), 5, 'spec outer window')
+        });
+
+        expect(result.failureCauses['timeout-outer']).toBeGreaterThanOrEqual(1);
+        expect(result.failureCauses['provider-error']).toBeUndefined();
     });
 
     test('the completion log carries the cause tally on a failing run and omits it when clean (#16388)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -386,16 +386,43 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
             properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'real-outer', timestamp: ts}
         });
 
-        // Composition witness: the escaping rejection is produced by the REAL `withTimeout` racing a
-        // promise that never settles, so the `code` the classifier matches was set by the wrapper rather
-        // than by this test. A renamed constant breaks this without anyone editing the spec.
+        // @neo-gpt-emmy falsified my first attempt at this: returning `withTimeout(never, 5, 'spec outer
+        // window')` FROM the summarizer times a wrapper the SPEC created, which rejects long before the
+        // real outer window — and the classifier then labelled it `timeout-outer` on the code family
+        // alone. It passed while proving nothing. The real witness makes backfill's OWN wrapper reject,
+        // by bounding its window instead of substituting one.
         const result = await MemoryService.backfillMiniSummaries({
             limit           : 50,
-            buildMiniSummary: () => withTimeout(new Promise(() => {}), 5, 'spec outer window')
+            outerTimeoutMs  : 10,
+            buildMiniSummary: () => new Promise(() => {})
         });
 
         expect(result.failureCauses['timeout-outer']).toBeGreaterThanOrEqual(1);
         expect(result.failureCauses['provider-error']).toBeUndefined();
+    });
+
+    test('a nested wrapper timeout that escapes the summarizer is a provider-error, not the outer window (#16388)', async () => {
+        const ts = Date.now();
+
+        memStore.set('cause-nested', {prompt: 'nested prompt', response: 'nested response'});
+        GraphService.upsertNode({
+            id              : 'cause-nested', type: 'AGENT_MEMORY', name: 'Memory: nested', description: 'nested',
+            semanticVectorId: 'cause-nested',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'nested', timestamp: ts}
+        });
+
+        // The counterexample for the code-family confusion. This rejection is genuinely produced by a real
+        // `withTimeout` and genuinely carries WITH_TIMEOUT_CODE — but it is a DIFFERENT wrapper instance,
+        // so it escaped the summarizer's guard rather than exhausting this window. Calling it
+        // `timeout-outer` would tell a widening consumer to widen a window that was never binding.
+        const result = await MemoryService.backfillMiniSummaries({
+            limit           : 50,
+            outerTimeoutMs  : 5000,
+            buildMiniSummary: () => withTimeout(new Promise(() => {}), 5, 'some unrelated nested wrapper')
+        });
+
+        expect(result.failureCauses['provider-error']).toBeGreaterThanOrEqual(1);
+        expect(result.failureCauses['timeout-outer']).toBeUndefined();
     });
 
     test('the completion log carries the cause tally on a failing run and omits it when clean (#16388)', async () => {
@@ -486,6 +513,11 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         // The positive control the negative case above cannot supply: without this, the classifier's true
         // branch is never exercised, so a wrong constant would keep the whole suite green while
         // `timeout-outer` became unreachable — the one cause a window-widening consumer can act on.
+        //
+        // What the SECOND half asserts changed after review: a forged code alone is deliberately NOT
+        // enough any more. Classification requires this window's label too, so a rejection carrying the
+        // code family without the label is a provider-error. The real outer witness lives in its own
+        // test, where backfill's own wrapper does the rejecting.
         memStore.set('cause-timed-out', {prompt: 'timed out prompt', response: 'timed out response'});
         GraphService.upsertNode({
             id              : 'cause-timed-out', type: 'AGENT_MEMORY', name: 'Memory: timed out', description: 'timed out',
@@ -503,8 +535,9 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
             }
         });
 
-        expect(timedOut.failureCauses['timeout-outer']).toBeGreaterThanOrEqual(1);
-        expect(timedOut.failureCauses['provider-error']).toBeUndefined();
+        // Same code family, no label from this window: an error, not a window problem.
+        expect(timedOut.failureCauses['provider-error']).toBeGreaterThanOrEqual(1);
+        expect(timedOut.failureCauses['timeout-outer']).toBeUndefined();
     });
 
     test('the two failure branches are counted separately, so a branch flip is visible (#16223)', async () => {


### PR DESCRIPTION
Resolves #16388

Related: #16382 (the detector this unblocks), #16223 (the live starvation the chain serves)

`buildMiniSummary` returned a bare `null` for four unrelated reasons — no model, empty output, a caught provider error, and its own swallowed inner timeout. The sweep mapped every falsy result to `failedInner` and every escaped throw to `failedOuter`, so the recorded facts answered *which control-flow branch ran* and nothing answered *why*.

That is what closed PR #16383 unmerged: I read `failedInner` as "the inner timeout is binding". A branch counter cannot carry that fact. This adds the missing dimension at the source. `failedInner` / `failedOuter` keep their exact meaning and values.

Evidence: L2 (unit coverage at exact head; every cause is now asserted through the real producer or a real wrapper rejection) → L2 required. Residual: which cause actually dominates on the CPU-only plane of #16223 is a live-plane observation, listed under Post-Merge.

## What review changed — read this before the sections below

Two review cycles found three defects and one false claim. Recording them here rather than only in response comments, because this body is the ingestion substrate and the comments are the negotiation record.

**1. Whitespace-only output was misclassified** (@neo-gpt-emmy). The truthiness check ran *before* normalization, so `'   \n\t  '` passed as usable, normalized to `''`, and returned as a **success** carrying an empty summary — which the sweep then filed as `unspecified`, the one cause meaning "the summarizer told us nothing". Normalization now runs first, so classification sees the string the caller would store. Mutation-verified in both directions.

**2. The cause evidence never invoked the producer** (@neo-gpt-emmy). Every cause spec injected a summarizer that *returned the expected cause string* — asserting my own fixtures back at me and calling it proof. A `buildModel` seam now drives the real method's own `no-model` branch, own normalization, own `catch`. `timeout-inner` arrives as a real `createTimeoutError` object. A **usable-summary** assertion sits in the same test, because without it all four failure cases would pass against a producer that had stopped summarizing entirely.

**3. `timeout-outer` was classified from the code FAMILY, not the wrapper instance** (@neo-gpt-emmy — the sharpest finding here). `WITH_TIMEOUT_CODE` is set by *every* `withTimeout` in the tree, so any nested wrapper's escaped rejection was reported as this window timing out, telling a widening consumer to widen a window that was never binding. My own comment at that site already said an escaped rejection is "an error rather than a window problem" while the code did not enforce it. The discriminator is the `label` I added to `withTimeout` earlier **in this same PR** and then failed to use. Classification now requires code **and** this window's label, both sourced from one module-private constant so producer and classifier cannot drift.

**4. A false claim in the original body.** "The five causes are proven distinguishable in-sandbox" described tests that injected the cause strings. It was untrue when written; it is true now. The original ticket ledger's "callers reading only truthiness are unaffected" was also false the moment the shape changed — corrected on #16388.

## Deltas from ticket

**Classification is structural, never textual, and instance-scoped rather than family-scoped.** `withTimeout` sets `code` plus `label` / `timeoutMs`. Message-matching was the only prior option and is unsound twice over: a reworded message stops matching, and unrelated prose mentioning a timeout is misread as one. Matching the code alone is unsound a third way — it cannot tell one wrapper from another.

**Return-shape migration, not a compatible change.** A failure went from falsy `null` to truthy `{summary: null, cause}`. Any consumer testing the *result* for truthiness inverts. The sweep is the only production caller and reads `.summary`. Documented as a migration in the method's JSDoc and on the ticket, because a future caller written against "falsy means failed" would be silently wrong.

**`outerTimeoutMs` seam**, mirroring the `maxRunMs` option already on this method. It exists so a spec can make backfill's **own** outer wrapper reject inside a test budget — bounding the real window instead of substituting one. Witnessing `timeout-outer` any other way times a different wrapper, which is exactly the false positive review caught.

**The completion log carries the cause tally, on failing runs only.** Not in the ticket. A starved plane is diagnosed from captured stderr — nobody on the live plane calls `backfillMiniSummaries()` and inspects its return, so a cause that exists only in a return value is invisible where #16223 gets read. Healthy runs keep their existing line.

**A legacy bare return is tallied `unspecified`, never a plausible cause.** Guessing would be the same defect as the one this fixes, one layer down.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/services/memory-core/ --workers=1
  1475 passed
```

Plus three mutation checks, each confirming a guard is load-bearing rather than decorative:

| mutation | expected | observed |
|---|---|---|
| classification order `!summary` → `!raw` | whitespace producer spec red | red, green on restore |
| classifier `code && label` → `code` only | nested-wrapper counterexample red | red, green on restore |
| `WITH_TIMEOUT_CODE` → a bogus constant | `timeout-outer` witness red | red, green on restore |

Surface derived from changed files: `withTimeout` has six production importers, and `ProcessSupervisorService` forwards this service's stderr. Two `SessionSummarization` tests failed on an early run; I stashed to clean `dev` at `51e5bf429a` and reproduced both there *before* attributing them, then they passed on both trees — a local-model availability flake, not this diff.

**Coverage boundary, stated plainly:** the five causes are proven distinguishable at their real producer boundaries in-sandbox. Nothing here proves which cause dominates in production.

## Post-Merge Validation

- [ ] On the CPU-only deployment behind #16223, a real starved sweep names its dominant cause in the completion log — and the plane says whether `timeout-inner` actually dominates or whether the truth is `provider-error`, which no instrument could distinguish before this.
- [ ] #16382's detector consumes `failureCauses` rather than `failedInner`, with the tie-safe policy re-based on causes.

## Deltas

- `WITH_TIMEOUT_CODE` added and re-exported beside `withTimeout`; the rejection carries `code` / `label` / `timeoutMs`. Additive — no existing importer's behaviour changes.
- `buildMiniSummary` returns `{summary, cause}` and gains a `buildModel` seam. The summarizer seam still accepts a bare return.
- `backfillMiniSummaries` returns `failureCauses` at all four return sites and gains an `outerTimeoutMs` seam; its return JSDoc now documents every field, including the branch counters it omitted entirely.
- `timeout-outer` binds to the wrapper instance via a **module-private** label constant — deliberately not exported, since both the producer and the classifier live in this module and no external consumer exists.
- Completion log gains a `[causes: …]` suffix on failing runs only. No test pinned that suffix; the cost-ledger parser matches a different line.

## Commits

- `9a5351b196` — typed cause at the source, structural classification, cause tallies, JSDoc contract.
- `686692d9bc` — the `timeout-outer` positive control, verified by mutation.
- `d18e3b801a` — whitespace → `empty-output`; real-producer specs via `buildModel`; return-shape migration recorded; duplicate `@param` trio removed.
- `df09140982` — `timeout-outer` bound to the wrapper instance; nested-wrapper counterexample; `outerTimeoutMs` witness; ticket ledger amended.
- plus the label made module-private and this body brought to current truth.

Authored by Vega (Claude Opus 5, Claude Code). Session eb230051-9e42-4e6b-b540-112a79accc3a.
