### PR TITLE
test(deploy): guard ordinary project default (#16344)

### DIFF
--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -355,7 +355,7 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         }
     });
 
-    test('the survivability preflight refuses BEFORE Docker, even with a perfectly resolvable revision', async () => {
+    test('an ordinary redeploy keeps the default project and refuses BEFORE Docker without a bundle', async () => {
         // My change to this script broke the six positive-path tests here, and the honest repair is not
         // just to hand the fixture a declaration — it is to assert at this seam what the gate does.
         //
@@ -369,6 +369,10 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         expect(result.code).toBe(1);
         expect(result.output).toMatch(/REFUSING to proceed/);
         expect(result.output).toMatch(/REFUSE_NO_VERIFIED_BUNDLE/);
+        // An unset declaration is allowed on the non-destructive path and still resolves the
+        // reference deployment identity. Requiring the env var here would make the safety split
+        // costly enough to invite bypasses; sharing the initialize-path default would reopen it.
+        expect(result.output).toContain('[deploy] project:  neo-agent-os');
         // The resolvable revision is not what stopped it — the revision resolved fine.
         expect(result.output).toContain(FULL_SHA);
         // The load-bearing half: nothing touched containers.


### PR DESCRIPTION
Resolves #16344

Locks down the safe split between destructive initialization and ordinary redeploys. The existing survivability-preflight scenario now proves that omitting `NEO_DEPLOY_PROJECT_NAME` on an ordinary redeploy still resolves the canonical `neo-agent-os` project identity while refusal occurs before any Docker invocation when no verified bundle exists.

Evidence: L2 (mock-bin shell execution asserts default project resolution and zero Docker calls on the refused ordinary-redeploy path) → L2 required (the shell-guard regression contract). No residuals.

## Deltas from ticket

- The requested initialize-without-project failure and zero-Docker assertion already exist at the merged head from `d0fa4605a4`; this PR adds only the missing ordinary-redeploy default assertion.
- The assertion extends the existing survivability-preflight scenario instead of duplicating its fixture and Docker oracle.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs` — 21 passed.
- `npm run test-unit` — 10,991 passed, 5 skipped, 1 live-model summarization case failed in the aggregate run; its isolated rerun passed 3/3 with 19.7s observed model latency.
- `npm run agent-preflight -- --change-class zero-delta --commit-subject "test(deploy): guard ordinary project default (#16344)" test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs` — all requested gates passed.
- `git diff --check` — passed.

## Post-Merge Validation

- [ ] Unit CI remains green on the merged test contract.

Authored by Euclid (GPT-5.6, Codex Desktop). Session a8726a96-f327-4cb0-89cf-73bcd3d8901e.
