### PR TITLE
feat: fleet cockpit memories view — viewer-scoped turn recall from the plane (#16398)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -107,6 +107,15 @@ class FleetControlBridge extends Base {
      */
     historySource = null
     /**
+     * Viewer-bound memories source — an injected collaborator exposing `readMemories(params)`:
+     * one page of an explicit target agent's recent turn memories through the single registered
+     * `query_recent_turns` operation. The source resolves the viewer from authenticated request
+     * context at each call and DERIVES the projection (private only for self); this bridge carries
+     * no viewer field and never simulates the plane's admission decision.
+     * @member {Object|null} memoriesSource=null
+     */
+    memoriesSource = null
+    /**
      * Per-agent mailbox-mirror **read-observe** source — an injected collaborator exposing
      * `readMailboxMirror({subjectAgentId, limit, offset})` that returns the S1 mirror snapshot
      * (`{capability, admission, rows, page}`). Same DI contract as {@link #activitySource}: the
@@ -480,6 +489,28 @@ class FleetControlBridge extends Base {
                 viewerState        : {lastSeen: null, lastVisitAt: null},
                 window             : null,
                 sources            : null
+            };
+    }
+
+    /**
+     * @summary READ-OBSERVE: read one page of an agent's recent turn memories for the
+     * authenticated viewer. The source envelope passes through untouched; an unwired source is
+     * named as unavailable rather than fabricated empty history.
+     * @param {Object} [params]
+     * @returns {Promise<Object>|Object}
+     */
+    fleetMemories(params = {}) {
+        return typeof this.memoriesSource?.readMemories === 'function'
+            ? this.memoriesSource.readMemories(params)
+            : {
+                capability: {state: 'unavailable', reason: 'fleet memories source not wired'},
+                viewer    : null,
+                target    : params.agentIdentity || null,
+                projection: null,
+                page      : {before: params.before ?? null, limit: null},
+                turns     : [],
+                count     : 0,
+                nextCursor: null
             };
     }
 

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -60,6 +60,7 @@ import {readActiveWakeSubscriptionIdentities} from '../memory-core/readActiveWak
 import {wireBootIdentityReadSource}           from './wireBootIdentityReadSource.mjs';
 import {wireFleetActivityReadSource}          from './wireFleetActivityReadSource.mjs';
 import {wireFleetCatchUpSource}               from './wireFleetCatchUpSource.mjs';
+import {wireFleetMemoriesSource}              from './wireFleetMemoriesSource.mjs';
 import {wireOperatorComposeWriter}            from './wireOperatorComposeWriter.mjs';
 import path                                   from 'node:path';
 import {fileURLToPath, pathToFileURL}         from 'node:url';
@@ -238,6 +239,15 @@ async function boot() {
         exploreMemoryHistory     : args => callHistoryOperation('explore_memory_history', args),
         explorePullRequestHistory: args => callHistoryOperation('explore_pull_request_history', args),
         resolveViewerIdentity    : () => RequestContextService.getAgentIdentityNodeId()
+    });
+
+    // The memories view rides the SAME operation boundary as the catch-up source: the single
+    // registered `query_recent_turns` op through the proven plane client (plane mode) or the lazy
+    // tool-service import (in-process mode). Zero new Memory Core surface — the plane's own
+    // admission (CAN_READ_MEMORIES_OF, tenant sharing policy) stays the only read authority.
+    wireFleetMemoriesSource({
+        queryRecentTurns     : args => callHistoryOperation('query_recent_turns', args),
+        resolveViewerIdentity: () => RequestContextService.getAgentIdentityNodeId()
     });
 
     FleetControlBridge.mailboxMirrorSource = {

--- a/ai/services/fleet/fleetMemoriesSource.mjs
+++ b/ai/services/fleet/fleetMemoriesSource.mjs
@@ -1,0 +1,187 @@
+/**
+ * @module ai/services/fleet/fleetMemoriesSource
+ * @summary Brain-side, viewer-bound source for the Fleet cockpit's memories view. It invokes the
+ * single injected `query_recent_turns` operation for one explicit target agent and passes the
+ * result through as a typed, fail-honest envelope. There is no Fleet synthesis, ranking, cache,
+ * durable state, or permission simulation on this path: the plane (or in-process Memory Core)
+ * remains the only read authority, and a denial or failure surfaces as an honest capability state,
+ * never a fabricated empty success.
+ */
+
+const
+    CANONICAL_IDENTITY = /^@[A-Za-z0-9][A-Za-z0-9._-]*$/,
+    MAX_LIMIT          = 50,
+    DEFAULT_LIMIT      = 20;
+
+/**
+ * @summary Coerce one supported time value to finite epoch milliseconds.
+ * @param {Date|String|Number} value
+ * @param {String} name
+ * @returns {Number}
+ * @private
+ */
+function toMs(value, name) {
+    const ms = value instanceof Date ? value.getTime() : typeof value === 'number' ? value : Date.parse(value);
+
+    if (!Number.isFinite(ms)) {
+        throw new TypeError(`fleet memories: ${name} must be a finite timestamp`)
+    }
+
+    return ms
+}
+
+/**
+ * @summary Validate the optional paging cursor. The cursor is the operation's own `nextCursor`
+ * shape (`{timestamp, id}`) passed back verbatim; this guard only rejects shapes that could never
+ * have come from a previous envelope.
+ * @param {Object|undefined} before
+ * @returns {Object|undefined}
+ * @private
+ */
+function validateBefore(before) {
+    if (before === undefined || before === null) {
+        return undefined
+    }
+
+    if (typeof before !== 'object' || Array.isArray(before) ||
+        (typeof before.timestamp !== 'string' && typeof before.id !== 'string')) {
+        throw new TypeError('fleet memories: before must be a cursor object carrying timestamp and/or id strings')
+    }
+
+    return before
+}
+
+/**
+ * @summary Validate the page size. Absent resolves to the default; anything outside the closed
+ * integer range is rejected rather than clamped, so a caller bug is visible instead of silently
+ * reshaped.
+ * @param {Number|undefined} limit
+ * @returns {Number}
+ * @private
+ */
+function validateLimit(limit) {
+    if (limit === undefined) {
+        return DEFAULT_LIMIT
+    }
+
+    if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+        throw new TypeError(`fleet memories: limit must be an integer between 1 and ${MAX_LIMIT}`)
+    }
+
+    return limit
+}
+
+/**
+ * @summary Create the process-lifetime Fleet memories source.
+ *
+ * The transport-stamped viewer is resolved at EACH call. The target agent is an explicit canonical
+ * `@identity` (defaulting to the viewer); the `@me` alias is rejected because aliases have no place
+ * at a trust boundary — the wire carries concrete identities only. The projection is DERIVED, never
+ * caller-chosen: `private` exactly when the target IS the viewer, `public` otherwise. The plane
+ * enforces its own admission (`CAN_READ_MEMORIES_OF`, tenant sharing policy) regardless; this
+ * source never pre-filters or predicts that decision.
+ *
+ * @param {Object} options
+ * @param {Function} options.queryRecentTurns Injected `query_recent_turns` operation returning the
+ *     parsed payload (`{count, turns, nextCursor}`).
+ * @param {Function} options.resolveViewerIdentity Returns the transport-stamped canonical @identity.
+ * @param {Function} [options.now] Clock returning a Date/epoch/ISO value.
+ * @returns {{readMemories: Function}}
+ */
+export function createFleetMemoriesSource({
+    queryRecentTurns,
+    resolveViewerIdentity,
+    now = () => new Date()
+} = {}) {
+    if (typeof queryRecentTurns !== 'function' || typeof resolveViewerIdentity !== 'function' ||
+        typeof now !== 'function') {
+        throw new TypeError('createFleetMemoriesSource: queryRecentTurns, resolveViewerIdentity, and now are required')
+    }
+
+    const resolveViewer = async () => {
+        const viewer = await resolveViewerIdentity();
+
+        if (typeof viewer !== 'string' || !CANONICAL_IDENTITY.test(viewer)) {
+            throw new Error('fleet memories: authenticated ingress did not bind a canonical viewer identity')
+        }
+
+        return viewer
+    };
+
+    return {
+        /**
+         * @summary Read one page of an agent's recent turn memories through the source-owned
+         * operation. Success passes the operation's rows through untouched under a `wired`
+         * capability; an operation failure or unrecognized payload becomes an honest
+         * `unavailable` envelope carrying zero rows.
+         * @param {Object} [params]
+         * @param {String} [params.agentIdentity] Canonical `@identity` target; defaults to the viewer.
+         * @param {Object} [params.before] The previous envelope's `nextCursor`, for paging back.
+         * @param {Number} [params.limit] Page size, 1..50.
+         * @returns {Promise<Object>}
+         */
+        async readMemories(params = {}) {
+            const viewer = await resolveViewer();
+
+            let target = params?.agentIdentity === undefined || params?.agentIdentity === null
+                ? viewer
+                : params.agentIdentity;
+
+            if (target === '@me') {
+                throw new TypeError('fleet memories: the @me alias is not admitted on this wire — name the concrete identity')
+            }
+
+            if (typeof target !== 'string' || !CANONICAL_IDENTITY.test(target)) {
+                throw new TypeError('fleet memories: agentIdentity must be a canonical @identity')
+            }
+
+            const
+                before     = validateBefore(params?.before),
+                limit      = validateLimit(params?.limit),
+                projection = target === viewer ? 'private' : 'public',
+                capturedAt = new Date(toMs(now(), 'now')).toISOString(),
+                page       = {before: before ?? null, limit},
+                shared     = {viewer, target, projection, page};
+
+            let result;
+
+            try {
+                result = await queryRecentTurns({
+                    agentIdentity: target,
+                    detail       : 'summary',
+                    limit,
+                    projection,
+                    ...(before ? {before} : {})
+                })
+            } catch (error) {
+                return {
+                    capability: {state: 'unavailable', reason: 'memories-read-failed', capturedAt},
+                    ...shared,
+                    turns     : [],
+                    count     : 0,
+                    nextCursor: null
+                }
+            }
+
+            if (!result || typeof result !== 'object' || !Array.isArray(result.turns)) {
+                return {
+                    capability: {state: 'unavailable', reason: 'memories-payload-unrecognized', capturedAt},
+                    ...shared,
+                    turns     : [],
+                    count     : 0,
+                    nextCursor: null
+                }
+            }
+
+            return {
+                capability: {state: 'wired', capturedAt},
+                ...shared,
+                turns     : result.turns,
+                count     : Number.isFinite(result.count) ? result.count : result.turns.length,
+                nextCursor: result.nextCursor ?? null
+            }
+        }
+    }
+}
+
+export default createFleetMemoriesSource;

--- a/ai/services/fleet/wireFleetMemoriesSource.mjs
+++ b/ai/services/fleet/wireFleetMemoriesSource.mjs
@@ -1,0 +1,41 @@
+import FleetControlBridge          from './FleetControlBridge.mjs';
+import {createFleetMemoriesSource} from './fleetMemoriesSource.mjs';
+
+/**
+ * @module ai/services/fleet/wireFleetMemoriesSource
+ * @summary Installs the viewer-bound memories source onto the Fleet control bridge at the
+ * authenticated server entry. The operation function and viewer resolver are injected at that
+ * use site; this wiring imports neither MCP tool service nor request context.
+ */
+
+/**
+ * @summary Wire one process-lifetime memories source.
+ * @param {Object} options
+ * @param {Function} options.queryRecentTurns
+ * @param {Function} options.resolveViewerIdentity
+ * @param {Function} [options.now]
+ * @param {Object} [options.bridge=FleetControlBridge]
+ * @param {Function} [options.createSource=createFleetMemoriesSource]
+ * @returns {Object|null}
+ */
+export function wireFleetMemoriesSource({
+    queryRecentTurns,
+    resolveViewerIdentity,
+    now,
+    bridge       = FleetControlBridge,
+    createSource = createFleetMemoriesSource
+} = {}) {
+    if (typeof queryRecentTurns !== 'function' || typeof resolveViewerIdentity !== 'function') {
+        return null
+    }
+
+    bridge.memoriesSource = createSource({
+        queryRecentTurns,
+        resolveViewerIdentity,
+        ...(now ? {now} : {})
+    });
+
+    return bridge.memoriesSource
+}
+
+export default wireFleetMemoriesSource;

--- a/apps/agentos/model/MemoryTurn.mjs
+++ b/apps/agentos/model/MemoryTurn.mjs
@@ -1,0 +1,50 @@
+import Model from '../../../src/data/Model.mjs';
+
+/**
+ * @class AgentOS.model.MemoryTurn
+ * @extends Neo.data.Model
+ *
+ * @summary One view-projection record in the Fleet memories pane: a single turn memory row as the
+ * `query_recent_turns` operation returned it. The model is intentionally thin — it stores
+ * projection input and never derives a second memory authority. The `summary` convert is the
+ * rendering guard for the vocabulary-collision class: a non-string summary becomes `null` and the
+ * pane names it honestly, instead of a coerced `[object Object]` row.
+ */
+class MemoryTurn extends Model {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.model.MemoryTurn'
+         * @protected
+         */
+        className: 'AgentOS.model.MemoryTurn',
+        /**
+         * @member {String} keyProperty='id'
+         * @reactive
+         */
+        keyProperty: 'id',
+        /**
+         * @member {Object[]} fields
+         */
+        fields: [{
+            name: 'id',
+            type: 'String'
+        }, {
+            name: 'sessionId',
+            type: 'String'
+        }, {
+            name: 'timestamp',
+            type: 'String'
+        }, {
+            name        : 'summary',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'summaryFallback',
+            type        : 'Boolean',
+            defaultValue: false
+        }]
+    }
+}
+
+export default Neo.setupClass(MemoryTurn);

--- a/apps/agentos/store/AgentMemories.mjs
+++ b/apps/agentos/store/AgentMemories.mjs
@@ -1,0 +1,31 @@
+import MemoryTurnModel from '../model/MemoryTurn.mjs';
+import Store           from '../../../src/data/Store.mjs';
+
+/**
+ * @class AgentOS.store.AgentMemories
+ * @extends Neo.data.Store
+ *
+ * @summary Pane-local projection store for one agent's recent turn memories. Each MemoriesPane
+ * owns its store and destroys it with the pane; memory history remains query-time on the plane and
+ * no record survives the view/process lifecycle.
+ */
+class AgentMemories extends Store {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.store.AgentMemories'
+         * @protected
+         */
+        className: 'AgentOS.store.AgentMemories',
+        /**
+         * @member {String} keyProperty='id'
+         */
+        keyProperty: 'id',
+        /**
+         * @member {Neo.data.Model} model=MemoryTurnModel
+         * @reactive
+         */
+        model: MemoryTurnModel
+    }
+}
+
+export default Neo.setupClass(AgentMemories);

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -15,6 +15,7 @@ import DockZoneModel               from '../../../../src/dashboard/DockZoneModel
 import FleetCockpitController      from './FleetCockpitController.mjs';
 import FleetGrid                   from './FleetGrid.mjs';
 import FleetRoster                 from '../../store/FleetRoster.mjs';
+import MemoriesPane                from './MemoriesPane.mjs';
 import OperatorMailbox             from './OperatorMailbox.mjs';
 import StateProvider               from '../../../../src/state/Provider.mjs';
 import cockpitDockDocument         from './cockpitDockDocument.mjs';
@@ -477,6 +478,16 @@ class FleetCockpit extends Container {
      * @member {Number} catchUpReadGeneration=0
      */
     catchUpReadGeneration = 0
+    /**
+     * Latest memories envelope, owner-held so rail re-projection rematerializes from current truth.
+     * @member {Object|null} memoriesSnapshot=null
+     */
+    memoriesSnapshot = null
+    /**
+     * Read-generation fence for {@link #loadMemories} — a slow older read never overwrites a newer one.
+     * @member {Number} memoriesReadGeneration=0
+     */
+    memoriesReadGeneration = 0
     /**
      * Detached-detail bookkeeping — `null` while the inspector is docked. While detached it holds
      * `{homeTabsNodeId, homeTabIndex, windowId, windowName, connectTimer}`: the tabs node + EXACT
@@ -1161,6 +1172,18 @@ class FleetCockpit extends Container {
                         liveSurfaceRequest : 'onCatchUpLiveSurfaceRequest'
                     },
                     reference: 'catch-up'
+                };
+            case 'memories':
+                // invoked per-agent turn recall: the pane renders the owner-held source envelope
+                // and fires intent; this cockpit owns the authenticated bridge. Agent choices
+                // derive from the same provider-owned roster as the cards — no second resident list.
+                return {
+                    module      : MemoriesPane,
+                    cls         : [marker],
+                    snapshot    : me.memoriesSnapshot,
+                    agentOptions: me.buildMemoriesAgentOptions(),
+                    listeners   : {memoriesRequest: 'onMemoriesRequest'},
+                    reference   : 'memories'
                 };
             default:
                 // perspectives arrives with its own leaf — an honest labelled placeholder, never a
@@ -2158,6 +2181,7 @@ class FleetCockpit extends Container {
             me.gridAdapterState = 'live';
             grid.adapterState   = 'live';
             me.getReference('catch-up')?.set({partitionOptions: me.buildCatchUpPartitionOptions()});
+            me.getReference('memories')?.set({agentOptions: me.buildMemoriesAgentOptions()});
             me.clearDegradedReason('grid')
         } catch (error) {
             // fenced: a slow failure must not overwrite a newer success (see the stream twin)
@@ -2207,6 +2231,24 @@ class FleetCockpit extends Container {
                 id       : `catch-up-${row.agentId}`,
                 label    : row.displayName || row.githubUsername,
                 partition: `@${row.githubUsername}`
+            }))
+    }
+
+    /**
+     * @summary Build the memories-pane agent choices from the live roster Store — canonical
+     * `@identity` targets for the viewer-bound `fleetMemories` read. Same provider-owned roster as
+     * the cards; the projection (private only for self) is derived server-side, never here.
+     * @returns {Object[]}
+     */
+    buildMemoriesAgentOptions() {
+        const rows = this.getReference('fleet-grid')?.store?.items ?? [];
+
+        return rows
+            .filter(row => row.githubUsername)
+            .map(row => ({
+                id           : `memories-${row.agentId}`,
+                label        : row.displayName || row.githubUsername,
+                agentIdentity: `@${row.githubUsername}`
             }))
     }
 
@@ -2284,6 +2326,50 @@ class FleetCockpit extends Container {
         }
 
         return outcome
+    }
+
+    /**
+     * @summary READ-OBSERVE: route one pane memories intent through the authenticated Fleet verb
+     * and write the returned source envelope back as owner state. Fail-closed: absence/throw
+     * becomes an explicit unavailable envelope, never an empty historical claim. Generation-fenced
+     * so a slow older read never overwrites a newer target's rows.
+     * @param {Object} [params] `{agentIdentity, before?, limit?}`
+     * @returns {Promise<Object>}
+     */
+    async loadMemories(params = {}) {
+        const me         = this,
+              pane       = me.getReference('memories'),
+              bridge     = globalThis.AgentOS?.fleet?.registryBridge,
+              generation = ++me.memoriesReadGeneration,
+              fallback   = reason => ({
+                  capability: {state: 'unavailable', reason},
+                  viewer    : null,
+                  target    : params.agentIdentity || null,
+                  projection: null,
+                  page      : {before: params.before ?? null, limit: null},
+                  turns     : [],
+                  count     : 0,
+                  nextCursor: null
+              });
+
+        let snapshot;
+
+        if (typeof bridge?.fleetMemories !== 'function') {
+            snapshot = fallback('fleet memories verb not wired')
+        } else {
+            try {
+                snapshot = await bridge.fleetMemories(params)
+            } catch (error) {
+                snapshot = fallback('fleet memories read failed')
+            }
+        }
+
+        if (generation === me.memoriesReadGeneration && !me.isDestroyed) {
+            me.memoriesSnapshot = snapshot;
+            pane && (pane.snapshot = snapshot)
+        }
+
+        return snapshot
     }
 
     /**

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -278,6 +278,17 @@ class FleetCockpitController extends Controller {
     }
 
     /**
+     * @summary Relay a MemoriesPane read intent to the cockpit-owned authenticated bridge.
+     * @param {Object} data `{agentIdentity, before?}`
+     * @returns {Promise<Object>}
+     */
+    onMemoriesRequest(data) {
+        const {source, ...params} = data;
+
+        return this.component.loadMemories(params)
+    }
+
+    /**
      * @summary Re-poll the roster once a lifecycle intent has genuinely changed runtime state.
      *
      * `loadRoster` is the ONLY path that maps live runtime truth onto the roster records, and the

--- a/apps/agentos/view/fleet/MemoriesPane.mjs
+++ b/apps/agentos/view/fleet/MemoriesPane.mjs
@@ -1,0 +1,334 @@
+import AgentMemories from '../../store/AgentMemories.mjs';
+import Button        from '../../../../src/button/Base.mjs';
+import Component     from '../../../../src/component/Base.mjs';
+import Container     from '../../../../src/container/Base.mjs';
+
+/**
+ * The invoked Fleet memories surface: what one agent remembers, turn by turn.
+ *
+ * @summary Renders one viewer-bound `fleetMemories` source envelope without synthesizing, ranking,
+ * merging, or caching it. The pane owns only a local projection Store of turn rows; it fires
+ * intent events for reads and the owning FleetCockpit holds the authenticated bridge. Choosing
+ * whose memories to read is an explicit act — the pane never auto-defaults to a roster agent, and
+ * the projection (private only for self) is derived server-side, never chosen here.
+ *
+ * Honest states are first-class: no-selection, unavailable (with the source's reason), an empty
+ * wired window, per-row fallback summaries, and the paging cursor all render explicitly. Appending
+ * happens only when the envelope's own `page.before` echo proves a continuation of the same
+ * target; any fresh read replaces the rows.
+ *
+ * @class AgentOS.view.fleet.MemoriesPane
+ * @extends Neo.container.Base
+ */
+class MemoriesPane extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.MemoriesPane'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.MemoriesPane',
+        /**
+         * @member {String} ntype='fm-memories-pane'
+         * @protected
+         */
+        ntype: 'fm-memories-pane',
+        /**
+         * @member {String[]} baseCls=['fm-memories-pane']
+         */
+        baseCls: ['fm-memories-pane'],
+        /**
+         * Selected target agent as canonical `@identity`, or null for the explicit
+         * "pick an agent" state.
+         * @member {String|null} activeAgent_=null
+         * @reactive
+         */
+        activeAgent_: null,
+        /**
+         * Agent choices supplied by the cockpit from its provider-owned roster.
+         * @member {Object[]} agentOptions_=[]
+         * @reactive
+         */
+        agentOptions_: [],
+        /**
+         * Latest memories envelope. `null` is unobserved, never empty.
+         * @member {Object|null} snapshot_=null
+         * @reactive
+         */
+        snapshot_: null,
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            ntype : 'container',
+            cls   : ['fm-memories-head'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                ntype: 'component',
+                cls  : ['fm-memories-title'],
+                flex : 1,
+                text : 'What they remember'
+            }, {
+                ntype: 'component',
+                cls  : ['fm-memories-authority'],
+                text : 'query-time · not authority'
+            }]
+        }, {
+            ntype    : 'container',
+            cls      : ['fm-memories-agents'],
+            flex     : 'none',
+            layout   : {ntype: 'hbox', align: 'center', wrap: 'wrap'},
+            reference: 'memories-agents'
+        }, {
+            ntype    : 'component',
+            cls      : ['fm-memories-meta'],
+            flex     : 'none',
+            reference: 'memories-meta',
+            text     : 'Memories not observed yet'
+        }, {
+            ntype    : 'container',
+            cls      : ['fm-memories-rows'],
+            flex     : 1,
+            layout   : {ntype: 'vbox', align: 'stretch'},
+            reference: 'memories-rows'
+        }, {
+            ntype : 'container',
+            cls   : ['fm-memories-actions'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                ntype: 'component',
+                flex : 1
+            }, {
+                module   : Button,
+                reference: 'memories-refresh',
+                text     : 'Refresh',
+                iconCls  : 'fa fa-rotate',
+                ui       : 'ghost',
+                hidden   : true,
+                handler  : 'up.onRefreshClick'
+            }, {
+                module   : Button,
+                reference: 'memories-more',
+                text     : 'Older turns',
+                iconCls  : 'fa fa-angles-down',
+                ui       : 'ghost',
+                hidden   : true,
+                handler  : 'up.onLoadMoreClick'
+            }]
+        }]
+    }
+
+    /** @member {AgentOS.store.AgentMemories|null} turnStore=null */
+    turnStore = null
+    /**
+     * The target whose rows the Store currently holds — the append guard: a `page.before`
+     * continuation appends only when the envelope's target matches this.
+     * @member {String|null} renderedTarget=null
+     */
+    renderedTarget = null
+
+    /**
+     * @summary Create the pane-local Store and render held owner state. No read fires here:
+     * choosing an agent is the explicit first act, so an auto-hidden pane construction never
+     * queries the plane on its own.
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+
+        this.turnStore = Neo.create(AgentMemories);
+        this.refreshAgents();
+        this.applySnapshot()
+    }
+
+    /** @param {...*} args */
+    destroy(...args) {
+        this.turnStore?.destroy();
+        this.turnStore = null;
+        super.destroy(...args)
+    }
+
+    /** @param {String|null} value @param {String|null} oldValue @returns {String|null} */
+    beforeSetActiveAgent(value, oldValue) {
+        return value === null || /^@[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value) ? value : oldValue ?? null
+    }
+
+    /** @param {String|null} value @param {String|null} oldValue */
+    afterSetActiveAgent(value, oldValue) {
+        this.isConstructed && this.refreshAgents()
+    }
+
+    /** @param {Object[]} value @param {Object[]} oldValue */
+    afterSetAgentOptions(value, oldValue) {
+        this.isConstructed && this.refreshAgents()
+    }
+
+    /** @param {Object|null} value @param {Object|null} oldValue */
+    afterSetSnapshot(value, oldValue) {
+        this.isConstructed && this.applySnapshot()
+    }
+
+    /** @param {String} agentIdentity */
+    onAgentClick(agentIdentity) {
+        if (agentIdentity === this.activeAgent) return;
+
+        this.activeAgent = agentIdentity;
+        this.fire('memoriesRequest', {agentIdentity})
+    }
+
+    /** @summary Re-read the newest page for the selected agent. */
+    onRefreshClick() {
+        this.activeAgent && this.fire('memoriesRequest', {agentIdentity: this.activeAgent})
+    }
+
+    /** @summary Page back through the envelope's own cursor. */
+    onLoadMoreClick() {
+        const cursor = this.snapshot?.nextCursor;
+
+        this.activeAgent && cursor && this.fire('memoriesRequest', {agentIdentity: this.activeAgent, before: cursor})
+    }
+
+    /**
+     * @summary Rebuild the agent chips from the roster-supplied options in source order.
+     */
+    refreshAgents() {
+        const target = this.getReference('memories-agents');
+
+        if (!target) return;
+
+        const options = (this.agentOptions || [])
+            .filter((option, index, all) => option?.agentIdentity && all.findIndex(item => item.agentIdentity === option.agentIdentity) === index);
+
+        target.removeAll(true);
+        target.add(options.map(option => ({
+            module : Button,
+            cls    : option.agentIdentity === this.activeAgent ? ['fm-memories-agent', 'is-active'] : ['fm-memories-agent'],
+            text   : option.label || option.agentIdentity,
+            ui     : 'ghost',
+            handler: () => this.onAgentClick(option.agentIdentity)
+        })))
+    }
+
+    /**
+     * @summary Project the latest envelope into Store rows and honest chrome. Replace is the
+     * default; append happens only for a same-target `page.before` continuation.
+     */
+    applySnapshot() {
+        const
+            me        = this,
+            snapshot  = me.snapshot,
+            metaEl    = me.getReference('memories-meta'),
+            moreEl    = me.getReference('memories-more'),
+            refreshEl = me.getReference('memories-refresh'),
+            wired     = snapshot?.capability?.state === 'wired';
+
+        if (metaEl) {
+            metaEl.text = !snapshot
+                ? (me.activeAgent ? 'Memories not observed yet' : 'Pick an agent to read their recent turns.')
+                : wired
+                    ? `${snapshot.target} · ${snapshot.projection} projection · captured ${me.formatStamp(snapshot.capability.capturedAt)}`
+                    : `Memories unavailable · ${snapshot.capability?.reason || 'unknown reason'}`
+        }
+
+        refreshEl && (refreshEl.hidden = !me.activeAgent);
+        moreEl    && (moreEl.hidden    = !(wired && snapshot.nextCursor));
+
+        if (!me.turnStore) return;
+
+        const append = wired && snapshot.page?.before && snapshot.target === me.renderedTarget;
+
+        if (!append) {
+            me.turnStore.clear()
+        }
+
+        if (wired) {
+            const fresh = snapshot.turns.filter(turn => turn?.id && !me.turnStore.get(turn.id));
+
+            fresh.length > 0 && me.turnStore.add(fresh);
+            me.renderedTarget = snapshot.target
+        } else {
+            me.renderedTarget = null
+        }
+
+        me.renderRows(snapshot, wired)
+    }
+
+    /**
+     * @summary Render the Store's rows (or the honest empty/unavailable state) into the rows zone.
+     * @param {Object|null} snapshot
+     * @param {Boolean} wired
+     */
+    renderRows(snapshot, wired) {
+        const target = this.getReference('memories-rows');
+
+        if (!target) return;
+
+        target.removeAll(true);
+
+        if (!snapshot) {
+            target.add({
+                module: Component,
+                cls   : ['fm-memories-empty'],
+                text  : this.activeAgent ? 'No read has been made yet.' : 'Memories render here once an agent is chosen.'
+            });
+            return
+        }
+
+        if (!wired) {
+            target.add({
+                module: Component,
+                cls   : ['fm-memories-empty'],
+                text  : 'The memories source did not answer. Nothing here claims to be history.'
+            });
+            return
+        }
+
+        if (this.turnStore.count === 0) {
+            target.add({module: Component, cls: ['fm-memories-empty'], text: 'No turn memories in this window.'});
+            return
+        }
+
+        target.add(this.turnStore.items.map(record => this.turnRowConfig(record)))
+    }
+
+    /**
+     * @summary Build one turn row from a Store record. The summary text renders as returned; a
+     * guarded-null summary and a fallback summary are both named rather than silently coerced.
+     * @param {Neo.data.Model} record
+     * @returns {Object}
+     */
+    turnRowConfig(record) {
+        const session = typeof record.sessionId === 'string' && record.sessionId ? record.sessionId.slice(0, 8) : 'unknown';
+
+        return {
+            module: Container,
+            cls   : ['fm-memories-turn'],
+            flex  : 'none',
+            layout: {ntype: 'vbox', align: 'stretch'},
+            items : [{
+                module: Component,
+                cls   : ['fm-memories-turn-meta'],
+                text  : `${this.formatStamp(record.timestamp)} · session ${session}${record.summaryFallback ? ' · fallback summary' : ''}`
+            }, {
+                module: Component,
+                cls   : ['fm-memories-turn-body'],
+                text  : record.summary ?? 'Summary unavailable for this turn.'
+            }]
+        }
+    }
+
+    /** @param {Date|String|Number|null} value @returns {String} */
+    formatStamp(value) {
+        const date = new Date(value);
+
+        return Number.isFinite(date.getTime()) ? date.toISOString().replace('T', ' ').slice(0, 16) + 'Z' : 'unknown time'
+    }
+}
+
+export default Neo.setupClass(MemoriesPane);

--- a/apps/agentos/view/fleet/cockpitDockDocument.mjs
+++ b/apps/agentos/view/fleet/cockpitDockDocument.mjs
@@ -34,6 +34,9 @@ export function cockpitDockDocument() {
             // invoked historical complement to the bounded Activity stream — source-owned Bird
             // Views, Fleet-owned runtime anchor, never ambient cockpit density
             catchUp     : {componentRef: 'catch-up',          title: 'Catch up',     kind: 'tool',      autoHidden: true},
+            // invoked per-agent turn recall — the memory complement to catch-up's window digests;
+            // viewer-bound plane reads, never ambient cockpit density
+            memories    : {componentRef: 'memories',          title: 'Memories',     kind: 'tool',      autoHidden: true},
             // the operator's own mailbox + compose surface — a secondary tool pane like
             // perspectives, so it rides the auto-hide rail and never crowds the split
             operator    : {componentRef: 'operator-mailbox',  title: 'Operator',     kind: 'tool',      autoHidden: true}
@@ -46,7 +49,7 @@ export function cockpitDockDocument() {
             'fleet-tabs'   : {type: 'tabs', items: ['fleet'],  activeItemId: 'fleet'},
             'stream-tabs'  : {type: 'tabs', items: ['stream'], activeItemId: 'stream'},
             // Secondary panes collapse to this edge's rail (§2.7): their item records carry `autoHidden`.
-            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives', 'defineAgent', 'catchUp', 'operator'], activeItemId: 'detail'}
+            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'operator'], activeItemId: 'detail'}
         }
     }
 }

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -11,9 +11,11 @@
  * `Object` / `Neo.core.Base` member, so a crafted `{method:'getManager'}` / `{method:'constructor'}`
  * request cannot reach a non-operation.
  *
- * `getBootIdentity`, `fleetActivity`, `fleetHistory`, `fleetRoster`, and `fleetMailboxMirror` are **read-observe**
- * verbs — the advisory boot-identity fact, the bounded fleet activity snapshot, the assembled roster
- * cockpit DTO, and one agent's mailbox mirror: they carry NO lifecycle-write / restart authority. The
+ * `getBootIdentity`, `fleetActivity`, `fleetHistory`, `fleetMemories`, `fleetRoster`, and `fleetMailboxMirror`
+ * are **read-observe** verbs — the advisory boot-identity fact, the bounded fleet activity snapshot,
+ * one viewer-bound catch-up window, one page of an agent's recent turn memories (projection derived
+ * server-side, private only for self), the assembled roster cockpit DTO, and one agent's mailbox
+ * mirror: they carry NO lifecycle-write / restart authority. The
  * R3 read-observe ÷ lifecycle-write seam keeps the daemon-core restart actuator physically OFF this
  * client wire — only advisory reads ride it.
  *
@@ -52,7 +54,7 @@
 export const FLEET_WIRE_METHODS = Object.freeze([
     'defineAgent', 'configureAgent', 'setRepo', 'setAvatar', 'listAgents', 'getAgent',
     'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus', 'fleetRuntimeStatus',
-    'getBootIdentity', 'fleetActivity', 'fleetHistory', 'fleetRoster', 'fleetMailboxMirror', 'connectTenant', 'listTenants',
+    'getBootIdentity', 'fleetActivity', 'fleetHistory', 'fleetMemories', 'fleetRoster', 'fleetMailboxMirror', 'connectTenant', 'listTenants',
     'composeOperatorMessage', 'markFleetCaughtUp', 'resolveViewerIdentity'
 ]);
 

--- a/test/playwright/e2e/agentos/FleetMemoriesNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetMemoriesNL.spec.mjs
@@ -1,0 +1,160 @@
+import {expect, test}                                            from '../../fixtures.mjs';
+import {authenticatedFleetOptions, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
+
+const
+    CAPTURED_AT = '2026-08-02T12:00:00.000Z',
+    CURSOR      = {timestamp: '2026-08-02T10:00:00.000Z', id: 'turn-1'};
+
+const rosterRows = [
+    {id: 'ada', githubUsername: 'neo-opus-ada', displayName: 'Ada', engineTag: 'fixture', family: 'claude'}
+];
+
+/**
+ * @summary One fixture envelope per page, exactly the `fleetMemories` source contract: the newest
+ * page carries two rows (one honest fallback summary) and a cursor; the `before` continuation
+ * carries the older row whose summary is a NON-STRING — the vocabulary-collision class the model
+ * boundary must name instead of coercing to `[object Object]`.
+ * @param {Object} params
+ * @returns {Object}
+ */
+function memoriesResult(params = {}) {
+    const
+        target = params.agentIdentity,
+        shared = {
+            viewer    : '@e2e-operator',
+            target,
+            projection: target === '@e2e-operator' ? 'private' : 'public'
+        };
+
+    if (params.before) {
+        return {
+            capability: {state: 'wired', capturedAt: CAPTURED_AT},
+            ...shared,
+            page : {before: params.before, limit: 20},
+            turns: [
+                {id: 'turn-0', sessionId: '36ea85e4-fcdc', timestamp: '2026-08-02T09:00:00.000Z', summary: {payload: 'not a string'}, summaryFallback: false}
+            ],
+            count     : 1,
+            nextCursor: null
+        }
+    }
+
+    return {
+        capability: {state: 'wired', capturedAt: CAPTURED_AT},
+        ...shared,
+        page : {before: null, limit: 20},
+        turns: [
+            {id: 'turn-2', sessionId: '9286a9c0-91be', timestamp: '2026-08-02T11:00:00.000Z', summary: 'Wake axes merged after two review cycles', summaryFallback: false},
+            {id: 'turn-1', sessionId: '9286a9c0-91be', timestamp: '2026-08-02T10:00:00.000Z', summary: 'Stall telltales calibrated from live measurement', summaryFallback: true}
+        ],
+        count     : 2,
+        nextCursor: CURSOR
+    }
+}
+
+async function startMemoriesFleet() {
+    const {startFleetBridgeServer} = await import('../../../../ai/services/fleet/fleetBridgeServer.mjs'),
+          requests                 = [],
+          options                  = authenticatedFleetOptions({
+              dispatch: async request => {
+                  requests.push(request);
+
+                  switch (request.method) {
+                      case 'resolveViewerIdentity':
+                          return {ok: true, result: {ok: true, agentIdentityNodeId: '@e2e-operator'}};
+                      case 'fleetRoster':
+                          return {ok: true, result: {rows: rosterRows}};
+                      case 'fleetActivity':
+                          return {ok: true, result: {capability: {state: 'wired'}, events: []}};
+                      case 'fleetMemories':
+                          return {ok: true, result: memoriesResult(request.params)};
+                      case 'getBootIdentity':
+                          return {ok: true, result: {fact: null, classification: 'unknown', advisory: true}};
+                      default:
+                          return {ok: false, error: `unexpected memories method: ${request.method}`}
+                  }
+              }
+          }),
+          server                   = await startFleetBridgeServer(options);
+
+    return {
+        requests,
+        bearerToken: options.bearerToken,
+        endpoint   : `http://127.0.0.1:${server.address().port}/fleet`,
+        close      : () => new Promise(resolve => server.close(resolve))
+    }
+}
+
+/**
+ * @summary Native Fleet memories journey: the real auto-hide rail invokes the pane; choosing an
+ * agent is the explicit first act; the App Worker crosses the authenticated allowlisted bridge;
+ * the envelope's rows render with honest per-row fallback naming; the cursor pages older turns as
+ * an append; and the wire carries only the explicit target — never a viewer claim, never a
+ * caller-chosen projection.
+ *
+ * Run: NEO_E2E_PORT=49223 NEO_TEST_SKIP_CI=true npx playwright test agentos/FleetMemoriesNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS Fleet memories — authenticated rail journey (#16398)', () => {
+    test.setTimeout(120000);
+    test.use({viewport: {width: 1600, height: 1000}});
+
+    test('rail → explicit agent choice → turn rows → cursor append → guarded non-string summary', async ({page, neuralLink}) => {
+        const fleet = await startMemoriesFleet();
+
+        try {
+            await page.goto(`/apps/agentos/index.html?${new URLSearchParams({fleetUrl: fleet.endpoint})}`);
+            await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
+
+            const app = await neuralLink.connectToApp('AgentOS');
+            await wireAuthenticatedFleetBridge({app, fleetUrl: fleet.endpoint, bearerToken: fleet.bearerToken});
+
+            const [cockpit] = await app.queryComponent({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']);
+            expect(cockpit?.properties?.id).toBeTruthy();
+            await app.callMethod(cockpit.properties.id, 'loadRoster');
+
+            const rail = page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Memories'});
+            await expect(rail).toHaveCount(1);
+            await rail.click();
+
+            const pane = page.locator('.fm-memories-pane');
+            await expect(pane).toBeVisible({timeout: 10000});
+
+            // choosing whose memories is an explicit act: construction fires no read
+            await expect(pane).toContainText('Pick an agent to read their recent turns.');
+            await expect(pane).toContainText('Memories render here once an agent is chosen.');
+            await expect(pane.locator('.fm-memories-turn')).toHaveCount(0);
+
+            await pane.getByRole('button', {name: 'Ada'}).click();
+
+            await expect(pane.locator('.fm-memories-turn')).toHaveCount(2, {timeout: 10000});
+            await expect(pane).toContainText('@neo-opus-ada · public projection · captured 2026-08-02 12:00Z');
+            await expect(pane.locator('.fm-memories-turn').nth(0)).toContainText('Wake axes merged after two review cycles');
+            await expect(pane.locator('.fm-memories-turn').nth(0)).toContainText('session 9286a9c0');
+            await expect(pane.locator('.fm-memories-turn').nth(1)).toContainText('fallback summary');
+
+            // the cursor pages older turns as an APPEND, and its exhaustion hides the affordance
+            const older = pane.getByRole('button', {name: 'Older turns'});
+            await expect(older).toBeVisible();
+            await older.click();
+
+            await expect(pane.locator('.fm-memories-turn')).toHaveCount(3, {timeout: 10000});
+            await expect(older).toBeHidden();
+
+            // the vocabulary-collision class: a non-string summary is NAMED at the model boundary, never coerced
+            await expect(pane.locator('.fm-memories-turn').nth(2)).toContainText('Summary unavailable for this turn.');
+            await expect(pane).not.toContainText('[object Object]');
+
+            const memoriesRequests = fleet.requests.filter(request => request.method === 'fleetMemories');
+            expect(memoriesRequests.map(request => request.params)).toEqual([
+                {agentIdentity: '@neo-opus-ada'},
+                {agentIdentity: '@neo-opus-ada', before: CURSOR}
+            ]);
+            // the wire carries the explicit target only — no viewer claim, no caller-chosen projection
+            expect(memoriesRequests.every(request =>
+                request.params.viewerIdentity === undefined && request.params.projection === undefined
+            )).toBe(true)
+        } finally {
+            await fleet.close()
+        }
+    })
+});

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -128,14 +128,16 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
         expect([...FLEET_WIRE_METHODS].sort()).toEqual(
             // fleet-agent operations (incl. the configureAgent scoped-config patch — never identity,
             // never credential) + the read-observe verbs (boot-identity fact + activity snapshot +
-            // assembled roster DTO + viewer-bound catch-up history + one agent's mailbox mirror +
-            // the whoami identity-bootstrap) plus the two explicit write verbs. Catch-up mark is
-            // process-local only; compose persists payload while the server stamps identity.
-            ['composeOperatorMessage', 'configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetHistory', 'fleetMailboxMirror', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'markFleetCaughtUp', 'removeAgent', 'resolveViewerIdentity', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
+            // assembled roster DTO + viewer-bound catch-up history + one page of an agent's turn
+            // memories + one agent's mailbox mirror + the whoami identity-bootstrap) plus the two
+            // explicit write verbs. Catch-up mark is process-local only; compose persists payload
+            // while the server stamps identity.
+            ['composeOperatorMessage', 'configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetHistory', 'fleetMailboxMirror', 'fleetMemories', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'markFleetCaughtUp', 'removeAgent', 'resolveViewerIdentity', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
         );
         expect(FLEET_WIRE_METHODS).toContain('getBootIdentity');   // the read-observe verbs ride the wire; the lifecycle-write restart actuator does NOT (R3)
         expect(FLEET_WIRE_METHODS).toContain('fleetActivity');
         expect(FLEET_WIRE_METHODS).toContain('fleetHistory');
+        expect(FLEET_WIRE_METHODS).toContain('fleetMemories');
         expect(FLEET_WIRE_METHODS).toContain('fleetRoster');
         // the wire's first WRITE verb: compose rides the authenticated transport with a whitelisted
         // payload — the author is the server-stamped ambient identity, never a wire parameter

--- a/test/playwright/unit/ai/services/fleet/fleetMemoriesSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetMemoriesSource.spec.mjs
@@ -1,0 +1,160 @@
+import {expect, test}              from '@playwright/test';
+import {createFleetMemoriesSource} from '../../../../../../ai/services/fleet/fleetMemoriesSource.mjs';
+
+const HEALTHY_RESULT = {
+    count: 2,
+    turns: [
+        {id: 'turn-2', sessionId: 'session-b', timestamp: '2026-08-02T11:00:00.000Z', summary: 'Second turn', summaryFallback: false},
+        {id: 'turn-1', sessionId: 'session-a', timestamp: '2026-08-02T10:00:00.000Z', summary: 'First turn',  summaryFallback: true}
+    ],
+    nextCursor: {timestamp: '2026-08-02T10:00:00.000Z', id: 'turn-1'}
+};
+
+function harness({viewer='@neo-fable-clio', now='2026-08-02T12:00:00.000Z', result=HEALTHY_RESULT} = {}) {
+    const calls = [],
+          state = {viewer, now, result};
+
+    const source = createFleetMemoriesSource({
+        queryRecentTurns: async args => {
+            calls.push(args);
+
+            if (state.result instanceof Error) {
+                throw state.result
+            }
+
+            return state.result
+        },
+        resolveViewerIdentity: () => state.viewer,
+        now                  : () => new Date(state.now)
+    });
+
+    return {calls, source, state}
+}
+
+test.describe('fleetMemoriesSource — viewer-bound turn recall with derived projection', () => {
+    test('construction refuses missing collaborators', () => {
+        expect(() => createFleetMemoriesSource()).toThrow(TypeError);
+        expect(() => createFleetMemoriesSource({queryRecentTurns: async () => ({})})).toThrow(TypeError);
+        expect(() => createFleetMemoriesSource({resolveViewerIdentity: () => '@a'})).toThrow(TypeError)
+    });
+
+    test('default read targets the viewer privately and passes rows through untouched', async () => {
+        const {calls, source} = harness(),
+              result          = await source.readMemories();
+
+        expect(calls).toEqual([{
+            agentIdentity: '@neo-fable-clio',
+            detail       : 'summary',
+            limit        : 20,
+            projection   : 'private'
+        }]);
+        expect(result.turns).toBe(HEALTHY_RESULT.turns);
+        expect(result).toMatchObject({
+            capability: {state: 'wired', capturedAt: '2026-08-02T12:00:00.000Z'},
+            viewer    : '@neo-fable-clio',
+            target    : '@neo-fable-clio',
+            projection: 'private',
+            page      : {before: null, limit: 20},
+            count     : 2,
+            nextCursor: {timestamp: '2026-08-02T10:00:00.000Z', id: 'turn-1'}
+        })
+    });
+
+    test('a peer target derives the public projection — and a caller-supplied projection is discarded', async () => {
+        const {calls, source} = harness(),
+              result          = await source.readMemories({agentIdentity: '@neo-opus-ada', projection: 'private'});
+
+        expect(calls[0]).toMatchObject({agentIdentity: '@neo-opus-ada', projection: 'public'});
+        expect(result).toMatchObject({target: '@neo-opus-ada', projection: 'public'})
+    });
+
+    test('the @me alias and non-canonical identities are refused at the boundary', async () => {
+        const {calls, source} = harness();
+
+        await expect(source.readMemories({agentIdentity: '@me'})).rejects.toThrow('alias');
+        await expect(source.readMemories({agentIdentity: 'neo-opus-ada'})).rejects.toThrow('canonical');
+        await expect(source.readMemories({agentIdentity: 'AGENT:*'})).rejects.toThrow('canonical');
+        expect(calls).toEqual([])
+    });
+
+    test('limit outside the closed range refuses instead of clamping', async () => {
+        const {calls, source} = harness();
+
+        await expect(source.readMemories({limit: 0})).rejects.toThrow('between 1 and 50');
+        await expect(source.readMemories({limit: 51})).rejects.toThrow('between 1 and 50');
+        await expect(source.readMemories({limit: 2.5})).rejects.toThrow('between 1 and 50');
+        expect(calls).toEqual([]);
+
+        await source.readMemories({limit: 50});
+        expect(calls[0].limit).toBe(50)
+    });
+
+    test('a paging cursor rides through verbatim and echoes in the page slot', async () => {
+        const {calls, source} = harness(),
+              cursor          = {timestamp: '2026-08-01T00:00:00.000Z', id: 'turn-0'},
+              result          = await source.readMemories({agentIdentity: '@neo-opus-ada', before: cursor});
+
+        expect(calls[0].before).toBe(cursor);
+        expect(result.page).toEqual({before: cursor, limit: 20});
+
+        await expect(source.readMemories({before: 'yesterday'})).rejects.toThrow('cursor')
+    });
+
+    test('an operation failure is an honest unavailable envelope, never a fabricated empty success', async () => {
+        const {source, state} = harness();
+
+        state.result = new Error('plane down');
+
+        const result = await source.readMemories({agentIdentity: '@neo-opus-ada'});
+
+        expect(result).toMatchObject({
+            capability: {state: 'unavailable', reason: 'memories-read-failed'},
+            viewer    : '@neo-fable-clio',
+            target    : '@neo-opus-ada',
+            projection: 'public',
+            turns     : [],
+            count     : 0,
+            nextCursor: null
+        })
+    });
+
+    test('an unrecognized payload is named rather than rendered', async () => {
+        const {source, state} = harness();
+
+        state.result = {unexpected: true};
+
+        await expect(source.readMemories()).resolves.toMatchObject({
+            capability: {state: 'unavailable', reason: 'memories-payload-unrecognized'},
+            turns     : []
+        });
+
+        state.result = null;
+
+        await expect(source.readMemories()).resolves.toMatchObject({
+            capability: {state: 'unavailable', reason: 'memories-payload-unrecognized'}
+        })
+    });
+
+    test('a missing cursor and count fall back to honest local facts', async () => {
+        const {source, state} = harness();
+
+        state.result = {turns: [{id: 'only', timestamp: '2026-08-02T09:00:00.000Z'}]};
+
+        await expect(source.readMemories()).resolves.toMatchObject({
+            capability: {state: 'wired'},
+            count     : 1,
+            nextCursor: null
+        })
+    });
+
+    test('an ingress that binds no canonical viewer refuses every read', async () => {
+        const {calls, source, state} = harness();
+
+        state.viewer = null;
+        await expect(source.readMemories()).rejects.toThrow('canonical viewer identity');
+
+        state.viewer = 'clio';
+        await expect(source.readMemories()).rejects.toThrow('canonical viewer identity');
+        expect(calls).toEqual([])
+    });
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -224,7 +224,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
         // the placement truth: `addTab` appends by default — the restore must land the item back
         // at its STORED index (0, before the rest of the rail), not at the tail
-        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'operator']);
+        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'operator']);
 
         // same instance re-adopted by the projection; the vessel was closed by name
         expect(cockpit.getReference('agent-detail')).toBe(pane);
@@ -259,7 +259,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
             // the SAME instance is docked again at its exact home; nothing was closed (nothing opened)
             expect(cockpit.getReference('agent-detail')).toBe(pane);
-            expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'operator']);
+            expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'operator']);
             expect(vessel.closeCalls).toHaveLength(0)
         } finally {
             console.warn = origWarn

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
@@ -295,6 +295,7 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
             'perspectives',
             'defineAgent',
             'catchUp',
+            'memories',
             'operator'
         ])
     });


### PR DESCRIPTION
Resolves #16398

The Fleet cockpit gains its memory organ: pick an agent on the auto-hide rail, read their recent turn memories, page backwards through the plane's own cursor — built entirely on the shipped Lane-A consumption pattern with **zero new Memory Core surface**. The single registered `query_recent_turns` operation rides the same `callHistoryOperation` boundary the catch-up source proved (proven plane client in plane mode, lazy tool-service import in-process), and the plane's own admission (`CAN_READ_MEMORIES_OF`, tenant sharing policy) stays the only read authority: the source derives the projection server-side (`private` iff target === viewer), refuses the `@me` alias at the trust boundary, and turns op failures or unrecognized payloads into honest `unavailable` envelopes — never fabricated empty history.

Evidence: L2 (scoped unit + NL e2e over the real authenticated wire with a stubbed dispatch — the sandbox ceiling tonight: the canonical app-server port is occupied by a sibling checkout's live tree, so a headed live-plane run would execute foreign code, the exact false-witness trap `#15367` documents) → L3 required (AC "own + a peer's turns render from the live containerized plane"). Residual: AC-3 [#16398].

## Deltas from ticket

- `fleetMemories` was added to the wire-allowlist SSOT (`src/ai/fleet/fleetWireMethods.mjs`) and to the deliberately-pinned allowlist witness in `dispatchFleetRequest.spec.mjs` — the ticket's bridge-route row, realized through the repo's actual choke-point architecture (the browser-side bridge generates its methods from the same list, so client + server cannot drift).
- The pane fires no read at construction: choosing whose memories to read is an explicit act (the ticket's AgentDetail-drill-in placement question resolved to a rail tool beside Catch up for v1; the drill-in entry stays open for the design half under #14560 Lane D).
- Append paging is envelope-proven: rows append only when the envelope's own `page.before` echo matches a same-target continuation — a fresh read always replaces. The source echoes the request page for exactly this reason.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetMemoriesSource.spec.mjs` — **12/12 green** (construction guards, viewer default + derived projection, `@me`/non-canonical refusal, caller-supplied projection discarded, limit range refusal, cursor pass-through + echo, op-failure honesty, unrecognized-payload honesty, cursor/count fallbacks, unbound-viewer refusal).
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/ test/playwright/unit/harness/fleetCapability.spec.mjs` — **475/475 green** (includes the deliberately-extended allowlist pin).
- `npm run test-unit -- test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs` — **33/33 green**.
- `NEO_E2E_PORT=49223 NEO_TEST_SKIP_CI=true npx playwright test agentos/FleetMemoriesNL -c test/playwright.config.e2e.mjs --workers=1` — **1/1 green**: real `fleetBridgeServer` (auth gates live), real App-Worker bridge, rail reveal → explicit agent choice → 2 turn rows with per-row fallback naming → cursor append to 3 + affordance exhaustion → non-string summary named (`[object Object]` absent) → wire-shape capture (exactly `{agentIdentity}` / `{agentIdentity, before}` — no viewer claim, no caller-chosen projection).
- Touched-surface existing coverage: `FleetCatchUpNL.spec.mjs` (rail + bridge journey sibling) and the fleet unit suite above ran green at head; cockpit dock document change is exercised by the rail reveal in the new e2e.

## Post-Merge Validation

- [ ] AC-3 live receipt: with a plane rebuild past this head and the canonical stack up, open the cockpit against `NEO_FLEET_PLANE_BASE=http://127.0.0.1:3102`, read own turns (private projection) + one peer's turns (public projection) headed, and attach the capture to #16398 — the same deployment-gated receipt class as the `#16368` AC8 / `#16386` cockpit receipts.
- [ ] In-process mode smoke on a container-less checkout (`fleet.planeBase` empty): memories read answers through the lazy tool-service path.

## Commits (if multi-commit)

- 809e2baaa6 — the full leaf (source + wire + bridge verb + allowlist + entrypoint wiring + model/store/pane + dock registration + cockpit loader/options/controller relay + unit & e2e witnesses).
- edc29aad99 — the two secondary-rail dock-document pins (`fleetCockpitProjection` / `fleetCockpitPopOut`) extended for the `memories` tool — the same deliberate-pin class as the wire allowlist; caught by full-suite CI (my scoped pre-push runs covered `unit/ai/` + `unit/harness/` but not `unit/apps/agentos/`), repaired with the full `apps/agentos` tree at 527/527 and both touched trees at 994/994 green on the rebased head.

Authored by Clio (Claude Fable 5, Claude Code). Session 3ed7c4ca-19ff-451c-bce7-a3d8de2cbbeb.
