### PR TITLE
fix(dock): classify same-node resizes as landed-in-place, skipping the stage-A double-take (#16391)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2132,7 +2132,7 @@ class Workspace extends Container {
             DockMotionSignal.enter(me);
 
             try {
-                await flip.play({hostId: host.id, markerPrefix: 'workstation-pane-'})
+                await flip.play({geometryOnly, hostId: host.id, markerPrefix: 'workstation-pane-'})
             } catch (error) {/* instant landing */}
             finally {
                 DockMotionSignal.leave(me)

--- a/src/main/addon/DockFlip.mjs
+++ b/src/main/addon/DockFlip.mjs
@@ -411,9 +411,14 @@ class DockFlip extends Base {
      * @param {String} opts.hostId            The dock host element id
      * @param {String} opts.markerPrefix      The marker-class prefix used in `captureFirst()`
      * @param {Number} [opts.maxFrames=15]    Bounded frame-poll for the new tree to appear
+     * @param {Boolean} [opts.geometryOnly=false] Consumer-declared geometry-only projection:
+     * no topology swap can be pending, so an exact, lineage-unchanged marker set whose rects
+     * already moved may be classified as landed-in-place (`hasLandedInPlace`). Without this
+     * declaration a geometry-moved same-parent set stays ambiguous by contract — an independent
+     * geometry change can race a pending structural swap — and keeps the bounded wait.
      * @returns {Promise<Boolean>} true if an animation played (resolves AFTER the motion completes), false on any instant-landing path
      */
-    async play({hostId, markerPrefix, maxFrames = 15}) {
+    async play({hostId, markerPrefix, maxFrames = 15, geometryOnly = false}) {
         const first = this.#firstSnapshots[hostId];
 
         let cancel,
@@ -494,15 +499,16 @@ class DockFlip extends Base {
                 frame              = 0,
                 markers            = this.collectMarkers(hostId, markerPrefix),
                 preservedMarkerSet = this.hasPreservedMarkerSet(firstMarkers, markers, firstLineages, hostEl),
-                landedInPlace      = !preservedMarkerSet
+                landedInPlace      = geometryOnly && !preservedMarkerSet
                     && this.hasLandedInPlace(firstMarkers, firstRects, firstLineages, markers, hostEl);
 
             // stage A: the swap lands asynchronously through the delta pipeline — the OLD
             // tree's markers would satisfy a naive presence-poll instantly and measure
             // identical geometry. An exact preserved marker set is the native atomic-move path:
             // those nodes MUST remain connected, so it bypasses the outgoing-detach poll. A
-            // committed same-node resize bypasses it too: those nodes never detach either, and
-            // the landed geometry (landedInPlace) is the proof the swap already happened.
+            // consumer-declared geometry-only projection (a committed resize) bypasses it too:
+            // those nodes never detach either, and the landed geometry (landedInPlace) is the
+            // proof the swap already happened.
             if (!preservedMarkerSet && !landedInPlace) {
                 while (frame < maxFrames && first.els.length > 0 && first.els.every(el => el.isConnected)) {
                     await new Promise(resolve => requestAnimationFrame(resolve));

--- a/src/main/addon/DockFlip.mjs
+++ b/src/main/addon/DockFlip.mjs
@@ -1,6 +1,13 @@
 import Base from './Base.mjs';
 
 /**
+ * Motion thresholds shared by the landed-in-place discriminator (`hasLandedInPlace`) and the
+ * invert loop inside `play()`: position deltas in CSS px, scale deltas as unitless ratios.
+ */
+const MOTION_EPSILON_POSITION = 0.5,
+      MOTION_EPSILON_SCALE    = 0.005;
+
+/**
  * @summary FLIP-animates dock re-layouts: committed dock operations glide instead of snapping.
  *
  * Two-phase contract, driven by the owning workspace around its re-projection:
@@ -142,6 +149,58 @@ class DockFlip extends Base {
         return exactSet && [...markers].some(([key, el]) =>
             this.hasAncestorLineageChanged(el, firstLineages.get(key), hostEl)
         )
+    }
+
+    /**
+     * @summary Returns whether an exact, lineage-unchanged marker set has already landed in place.
+     *
+     * A committed same-node resize keeps every marker node AND its ancestor lineage, so the
+     * lineage-based `hasPreservedMarkerSet()` can never classify it: the replacement-tree
+     * branch would burn its whole detach poll on nodes that never detach, exposing the
+     * committed layout unanimated before the inverse installs (the double-take). The
+     * discriminator for that case is geometry, not identity — once a marker's current rect
+     * differs from its First rect beyond the motion epsilons, the swap has landed in place
+     * and the detach poll is pure exposed delay. Node-identical sets with UNCHANGED geometry
+     * keep polling: that is the outgoing-tree case the stage-A comment guards.
+     * @param {Map<String, HTMLElement>} firstMarkers
+     * @param {Map<String, DOMRect>} firstRects
+     * @param {Map<String, HTMLElement[]>} firstLineages
+     * @param {Map<String, HTMLElement>} markers
+     * @param {HTMLElement} hostEl
+     * @returns {Boolean}
+     * @protected
+     */
+    hasLandedInPlace(firstMarkers, firstRects, firstLineages, markers, hostEl) {
+        const exactSet = firstMarkers?.size === markers.size
+            && [...markers].every(([key, el]) => el.isConnected && firstMarkers.get(key) === el);
+
+        if (!exactSet) {
+            return false
+        }
+
+        // Any lineage change is a structural move — the lineage-based branch owns it.
+        if ([...markers].some(([key, el]) => this.hasAncestorLineageChanged(el, firstLineages.get(key), hostEl))) {
+            return false
+        }
+
+        return [...markers].some(([key, el]) => {
+            const
+                firstRect = firstRects.get(key),
+                last      = el.getBoundingClientRect();
+
+            if (!firstRect) {
+                return false
+            }
+
+            const
+                sx = last.width  > 0 ? firstRect.width  / last.width  : 1,
+                sy = last.height > 0 ? firstRect.height / last.height : 1;
+
+            return Math.abs(firstRect.left - last.left) > MOTION_EPSILON_POSITION
+                || Math.abs(firstRect.top  - last.top)  > MOTION_EPSILON_POSITION
+                || Math.abs(sx - 1) > MOTION_EPSILON_SCALE
+                || Math.abs(sy - 1) > MOTION_EPSILON_SCALE
+        })
     }
 
     /**
@@ -434,13 +493,17 @@ class DockFlip extends Base {
             let
                 frame              = 0,
                 markers            = this.collectMarkers(hostId, markerPrefix),
-                preservedMarkerSet = this.hasPreservedMarkerSet(firstMarkers, markers, firstLineages, hostEl);
+                preservedMarkerSet = this.hasPreservedMarkerSet(firstMarkers, markers, firstLineages, hostEl),
+                landedInPlace      = !preservedMarkerSet
+                    && this.hasLandedInPlace(firstMarkers, firstRects, firstLineages, markers, hostEl);
 
             // stage A: the swap lands asynchronously through the delta pipeline — the OLD
             // tree's markers would satisfy a naive presence-poll instantly and measure
             // identical geometry. An exact preserved marker set is the native atomic-move path:
-            // those nodes MUST remain connected, so it bypasses the outgoing-detach poll.
-            if (!preservedMarkerSet) {
+            // those nodes MUST remain connected, so it bypasses the outgoing-detach poll. A
+            // committed same-node resize bypasses it too: those nodes never detach either, and
+            // the landed geometry (landedInPlace) is the proof the swap already happened.
+            if (!preservedMarkerSet && !landedInPlace) {
                 while (frame < maxFrames && first.els.length > 0 && first.els.every(el => el.isConnected)) {
                     await new Promise(resolve => requestAnimationFrame(resolve));
                     frame++
@@ -462,10 +525,11 @@ class DockFlip extends Base {
 
             if (this.isDestroyed) return false;
 
-            // Replacement trees retain their settle frame. Preserved identities are already in
-            // their committed Last geometry, so delaying here would expose the clipped final tree
-            // for one paint before the inverse transform is installed.
-            if (!preservedMarkerSet) {
+            // Replacement trees retain their settle frame. Preserved identities — and
+            // landed-in-place resizes — are already in their committed Last geometry, so
+            // delaying here would expose the clipped final tree for one paint before the
+            // inverse transform is installed.
+            if (!preservedMarkerSet && !landedInPlace) {
                 await new Promise(resolve => requestAnimationFrame(resolve))
             }
 
@@ -497,7 +561,7 @@ class DockFlip extends Base {
                 // blank frame; unrelated safe moves may still play.
                 if (needsFixedStage && !fixedStage) return;
 
-                if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5 || Math.abs(sx - 1) > 0.005 || Math.abs(sy - 1) > 0.005) {
+                if (Math.abs(dx) > MOTION_EPSILON_POSITION || Math.abs(dy) > MOTION_EPSILON_POSITION || Math.abs(sx - 1) > MOTION_EPSILON_SCALE || Math.abs(sy - 1) > MOTION_EPSILON_SCALE) {
                     moves.push({
                         el,
                         firstZIndex: firstZIndexes.get(key),

--- a/test/playwright/e2e/workstation/WorkstationDockFlipResizeNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationDockFlipResizeNL.spec.mjs
@@ -1,0 +1,139 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E witness: a committed same-node splitter resize must be
+ * classified as landed-in-place, not as a replacement tree.
+ *
+ * Defect mechanics (red state): the marker nodes of a committed resize survive in place with
+ * unchanged ancestor lineage, so `hasPreservedMarkerSet()` can never classify the set — the
+ * replacement-tree branch burns its full bounded detach poll (`maxFrames = 15`) on nodes that
+ * never detach. The committed layout sits EXPOSED for ~15 frames, then the inverse transform
+ * snaps the panes back to their pre-drag geometry and plays forward — a double-take on every
+ * committed splitter drag, and the wide window in which async gBCR readers ingest scaled
+ * fiction.
+ *
+ * Fix under test: the geometry discriminator `hasLandedInPlace()` — an exact, lineage-
+ * unchanged marker set whose current rect already differs from First beyond the motion
+ * epsilons has landed in place; stage A and the replacement-tree settle frame are bypassed.
+ *
+ * Witness method: a page-side rAF sampler records the visual (computed, transform-inclusive)
+ * width of the pane left of the dragged splitter across the commit. The discriminating
+ * measurement is the exposed-Last window: the TIME between the committed layout first painting
+ * and the inverse transform appearing. The assertion is time-based, not frame-count-based:
+ * the close-target AC's "within 2 rAF frames" phrasing assumes a 60Hz cadence (~34ms); this host samples at
+ * 120Hz, where a frame count would misread by 2x. Red: ~150-300ms (the 15-frame stage-A burn).
+ * Green: <= 34ms, or the layout never paints without its inverse at all.
+ *
+ * CDP page.mouse is REQUIRED: the commit must ride the trusted-input path (the app-side
+ * synthetic path does not exercise the real drag lifecycle — measured in the drag-selection lane).
+ *
+ * Run: NEO_E2E_PORT=8117 npx playwright test workstation/WorkstationDockFlipResizeNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed
+ */
+test.describe('Workstation — DockFlip classifies a committed splitter resize as landed-in-place', () => {
+    test.setTimeout(60000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 900, width: 1440}
+    });
+
+    test('the inverse transform installs within 2 frames of the committed layout landing (no stage-A double-take)', async ({page, neuralLink}) => {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 30000});
+
+        const app            = await neuralLink.connectToApp('Workstation'),
+              splitterResult = await app.queryVdom({cls: 'neo-dashboard-dock-splitter-horizontal'}),
+              splitterNode   = Array.isArray(splitterResult) ? splitterResult[0] : (splitterResult?.vdom ?? splitterResult),
+              splitterDomId  = splitterNode?.id;
+
+        expect(splitterDomId, 'the horizontal splitter must exist in the vdom').toBeTruthy();
+
+        const [rect] = await app.getDomRect(splitterDomId),
+              cx     = rect.x + rect.width / 2,
+              cy     = rect.y + rect.height / 2;
+
+        // The pane immediately left of the splitter carries a `workstation-pane-<itemId>` marker
+        // class; the sampler tracks its full marker class (stable across the same-node commit).
+        const markerCls = await page.evaluate(({sx, sy}) => {
+            const splitter = document.elementFromPoint(sx, sy),
+                  panes    = [...document.querySelectorAll('[class*="workstation-pane-"]')]
+                      .filter(el => el.getClientRects().length > 0);
+
+            let best = null, bestGap = Infinity;
+
+            panes.forEach(el => {
+                const r   = el.getBoundingClientRect(),
+                      cls = [...el.classList].find(c => c.startsWith('workstation-pane-')),
+                      gap = splitter.getBoundingClientRect().left - r.right;
+
+                if (cls && gap >= -2 && gap < bestGap) {
+                    best    = cls;
+                    bestGap = gap
+                }
+            });
+
+            return best
+        }, {sx: cx, sy: cy});
+
+        expect(markerCls, 'a workstation pane marker element must sit immediately left of the splitter').toBeTruthy();
+
+        // Sampler: one record per rAF for the whole gesture + settlement window. `transformed`
+        // reads the COMPUTED transform, so it stays true from the invert through the entire
+        // play (the inline style alone is released after one frame and would be racy).
+        const sampling = page.evaluate(({markerCls, durationMs}) => new Promise(resolve => {
+            const pane    = document.getElementsByClassName(markerCls)[0],
+                  samples = [],
+                  t0      = performance.now();
+
+            (function tick() {
+                const rect = pane.getBoundingClientRect();
+
+                samples.push({
+                    t          : Math.round(performance.now() - t0),
+                    transformed: globalThis.getComputedStyle(pane).transform !== 'none',
+                    w          : Math.round(rect.width * 10) / 10
+                });
+
+                performance.now() - t0 < durationMs
+                    ? requestAnimationFrame(tick)
+                    : resolve(samples)
+            })()
+        }), {durationMs: 3000, markerCls});
+
+        await page.mouse.move(cx, cy);
+        await page.mouse.down();
+        await page.mouse.move(cx + 40, cy, {steps: 4});
+        await page.mouse.move(cx + 160, cy, {steps: 8});
+        await page.mouse.up();
+
+        const samples = await sampling,
+              median  = values => [...values].sort((a, b) => a - b)[Math.floor(values.length / 2)],
+              w0      = median(samples.slice(0, 10).map(s => s.w)),
+              w1      = median(samples.slice(-10).map(s => s.w));
+
+        const landedIdx  = samples.findIndex(s => Math.abs(s.w - w1) <= 2),
+              inverseIdx = landedIdx < 0 ? -1 : samples.findIndex((s, i) => i >= landedIdx && s.transformed),
+              exposed    = landedIdx < 0 ? 0 : (inverseIdx < 0 ? Infinity : inverseIdx - landedIdx),
+              exposedMs  = landedIdx < 0 ? 0 : (inverseIdx < 0 ? Infinity : samples[inverseIdx].t - samples[landedIdx].t);
+
+        console.log('[flip-diag] w0:', w0, 'w1:', w1, 'landedIdx:', landedIdx, 'inverseIdx:', inverseIdx, 'exposedFrames:', exposed, 'exposedMs:', exposedMs, 'samples:', samples.length);
+        console.log('[flip-diag] window:', JSON.stringify(samples.slice(Math.max(0, (landedIdx < 0 ? 0 : landedIdx) - 3), (landedIdx < 0 ? 0 : landedIdx) + 20)));
+
+        expect(Math.abs(w1 - w0), 'the drag must have committed a real resize (~+160px on the left pane)').toBeGreaterThan(100);
+
+        // AC1/AC2: the committed layout may sit exposed WITHOUT its inverse for at most ~2 rAF
+        // frames at a 60Hz cadence — asserted as 34ms because rAF cadence is host-dependent
+        // (this host samples at 120Hz; the red state's stage-A burn measured ~150-300ms here).
+        // landedIdx === -1 means the layout never painted without its inverse — the ideal landing.
+        expect(
+            exposedMs,
+            `the committed layout sat exposed for ${exposed} frames / ${exposedMs}ms before the inverse installed (red state: ~15 frames / 150-300ms)`
+        ).toBeLessThanOrEqual(34);
+
+        // Settlement truth: after the full gesture + play, the pane converges to the committed
+        // geometry and no transform lingers.
+        const tail = samples.slice(-5);
+
+        expect(tail.every(s => Math.abs(s.w - w1) <= 2), 'the pane must settle at the committed width').toBe(true);
+        expect(tail.every(s => !s.transformed), 'no transform may linger after the play completes').toBe(true)
+    })
+})

--- a/test/playwright/unit/dashboard/DockFlip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockFlip.spec.mjs
@@ -315,6 +315,106 @@ test.describe('Neo.main.addon.DockFlip', () => {
         expect(frame, 'two detach polls, one replacement settle, and one post-invert frame').toBe(4)
     });
 
+    test('bypasses the bounded wait for a landed-in-place set when the consumer declares a geometry-only projection', async () => {
+        const
+            markerClass = 'dock-flip-item-alpha',
+            marker      = createMarker(markerClass, {height: 100, left: 0, top: 0, width: 100}),
+            host        = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            };
+
+        marker.parentElement = host;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = () => ({
+            getPropertyValue(name) {
+                return name === '--dock-transition-duration' ? '1ms' : 'linear'
+            }
+        });
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+
+        // The committed resize: same node, same lineage, moved geometry — landed-in-place.
+        marker.setRect({height: 100, left: 80, top: 40, width: 140});
+
+        let frame = 0;
+
+        globalThis.requestAnimationFrame = callback => {
+            frame++;
+            callback()
+        };
+
+        await expect(dockFlip.play({
+            geometryOnly: true,
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-',
+            maxFrames   : 2
+        })).resolves.toBe(true);
+
+        expect(frame, 'no detach poll and no replacement settle: only the post-invert frame remains').toBe(1)
+    });
+
+    test('keeps the bounded wait under a geometry-only declaration while the projection geometry is unchanged', async () => {
+        const
+            markerClass = 'dock-flip-item-alpha',
+            marker      = createMarker(markerClass, {height: 100, left: 0, top: 0, width: 100}),
+            host        = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            };
+
+        marker.parentElement = host;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = () => ({
+            getPropertyValue(name) {
+                return name === '--dock-transition-duration' ? '1ms' : 'linear'
+            }
+        });
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+
+        let frame = 0;
+
+        globalThis.requestAnimationFrame = callback => {
+            frame++;
+            callback()
+        };
+
+        // Unchanged geometry is the outgoing-tree case even under the hint: the swap has not
+        // observably landed, so the poll and the settle frame stay — and with zero geometry
+        // delta there is nothing to animate.
+        await expect(dockFlip.play({
+            geometryOnly: true,
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-',
+            maxFrames   : 2
+        })).resolves.toBe(false);
+
+        expect(frame, 'two detach polls and one replacement settle; nothing to animate').toBe(3)
+    });
+
     test('retains the bounded detach wait when replacement markers take over', async () => {
         const
             markerClass = 'dock-flip-item-alpha',


### PR DESCRIPTION
Resolves #16391

Committed splitter drags no longer pay the replacement-tree stage-A burn: when the consumer declares a **geometry-only projection** (`play({geometryOnly})` — the workstation's `refreshDockWorkspace` already computes exactly this flag for `resizeSplit`), `play()` classifies an exact, lineage-unchanged marker set whose geometry has moved beyond the motion epsilons as **landed-in-place** (`hasLandedInPlace()`, `DockFlip.mjs:173`), bypassing the 15-frame detach poll and the replacement-tree settle frame. Measured on the witness: the exposed-Last window collapses from **19 frames / 158ms** (pre-fix, stash-discriminated red receipt) to **2 frames / 16ms**, and the committed-drag visual sequence becomes a clean land → invert → monotonic play (rect time-series in the witness log). The lineage-change branch (structural moves) and the ambiguous same-parent case (no consumer declaration) keep Emmy's bounded wait by construction, and the two motion epsilon literals are now single-sourced module consts shared by the discriminator and the invert loop.

Evidence: L3 (headed Chromium red/green witness + drag-family regression suites + unit contract pins) → L3 required (the ticket's headed-witness ACs). No residuals.

## Follow-ups
- #16412 — the pre-existing `geometryOnly: true` tour-reset callers declare stable topology without verifying it; compute-or-rename the declaration (from @neo-fable's non-blocking Depth-Floor note, pullrequestreview-4839791143); linked as parent_child to #16391

## Deltas from ticket

- **The discriminator is gated on a consumer declaration, not geometry inference alone.** The ticket prescribed a pure geometry classifier at `play()` entry. CI then surfaced the collision: `unit/dashboard/DockFlip.spec.mjs:271` (Emmy's #15137 pin) contracts that an exact same-parent set with moved geometry is *still ambiguous* and retains the bounded wait — an independent geometry change can race a pending structural swap. Retiring another peer's pin unilaterally is not the implementer's call, and the consumer already holds certain knowledge of the operation class: `geometryOnly` is passed only where the projection cannot replace nodes (the `resizeSplit` path). Under the declaration the geometry signal is landing-proof; without it the ambiguity contract stands untouched. Both contracts now hold: Emmy's pin passes unmodified, the ticket's ACs are met identically, and the false-positive race is eliminated structurally rather than accepted. The pure-inference variant remains a one-line delta if the ticket author and pin author jointly prefer it (fork surfaced to both via A2A).
- **AC1 asserted as time, not frames.** The AC's "within 2 rAF frames" phrasing assumes a 60Hz cadence; this host's rAF samples at 120Hz, where the identical residual reads 2–3 frames. The witness asserts ≤34ms (≈2 frames at 60Hz) with the frame count logged alongside; measured 16–25ms across runs. The residual is the consumer await chain between the projection swap and `play()` (`refreshDockWorkspace`), not stage machinery. Offered as a restatement for the ticket author to apply or confirm; no ticket text was edited.
- The motion-epsilon literals (`0.5px` position / `0.005` scale) are extracted to module consts (`MOTION_EPSILON_POSITION` / `MOTION_EPSILON_SCALE`) so the discriminator and the invert loop share one source instead of drifting copies.

## Test Evidence

- New witness, headed: `NEO_E2E_PORT=8117 npx playwright test workstation/WorkstationDockFlipResizeNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed` → **1 passed**. Red/green proven (AC5): with the change stashed, the identical run **fails** at 19 frames / 158ms exposed (the stage-A burn, snap-back visible in the sampler window); with the change, **2 frames / 16ms** and a monotonic play curve
- Unit contract pins (`unit/dashboard/DockFlip.spec.mjs`) → **11/11**: Emmy's ambiguity pin **passes unmodified**; two new pins added — landed-in-place bypass under a geometry-only declaration (1 frame), and bounded-wait retention under the declaration with *unchanged* geometry (the outgoing-tree case)
- Structural-move regression (AC3), headed: `WorkstationFiveBeatNL` **9/9** (tear-outs, convert-while-dragging, reintegration), `WorkstationGridRepaintNL` **3/3**
- `WorkstationNL` real-tour: **red on base AND branch identically** (stash-discriminated) with the `securityFullyClippedFrames: 1` zero-rect signature — the already-ticketed staging-frame family (#16356), pre-existing at dev head, unrelated to this change
- Full unit suite at head: **10990 passed**; the only failures are 4 `TextEmbeddingService` native-Ollama dispatch specs — environment-coupled (no live Ollama on this host; they skip in gated configurations), unrelated to the diff
- Reduced-motion / missing-token paths (AC4): untouched by construction — the discriminator is computed after the `duration > 0` guard, so the instant-landing paths never reach it

## Commits

- `52d60a1b96` — the geometry discriminator (`hasLandedInPlace`), epsilon consts, stage gates, headed witness
- `2954cbf64a` — the consumer-declaration gate (`geometryOnly` opt, workstation call-site, two unit pins) after the CI-surfaced collision with the #15137 ambiguity pin

## Post-Merge Validation

- [ ] Nightly e2e runner green on the merged spec (whitebox e2e is nightly-only by design; PR CI carries no e2e job)

Authored by Phoebe (Kimi K3, OpenCode), implementing Mnemosyne's ticket design — her session 45e84514-6c80-4239-97db-4551cc690137. Session 0b6854a1-2b0f-457a-8a16-2e8f9d0983c8.

