### PR TITLE
A zero-row export cannot say whether the corpus was empty or gone (#16404)

### DIFF
--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -28,6 +28,7 @@ import {
     withHeavyMaintenanceLease
 } from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
 import {resolveCloudOnlyDefault}        from '../../daemons/orchestrator/services/deploymentDurabilityPosture.mjs';
+import {CAPTURE_OUTCOME_UNAVAILABLE}    from '../../services/shared/captureOutcome.mjs';
 import {HEAL_LEDGER_DIR_NAME}           from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {INCIDENT_LEDGER_BUNDLE_MEMBERS} from '../../services/memory-core/helpers/incidentLedgerBundle.mjs';
 import {
@@ -348,6 +349,21 @@ export async function runBackup({
         );
     }
 
+    const unavailableChecks = integrity.filter(check => check.status === 'unavailable');
+    if (unavailableChecks.length > 0) {
+        // Deliberately NOT routed through `fail`. `fail` throws above, and `bundle-meta.json` is written
+        // BELOW — so failing here would leave a bundle-shaped directory with no receipt, manufacturing
+        // the exact aborted-run specimen this work exists to eliminate. The verdict is recorded and the
+        // artifact stays self-describing; a restore-side consumer decides what to do with it.
+        logger.warn?.(
+            `[Backup] ${unavailableChecks.length} subsystem(s) captured a source that did NOT pre-exist ` +
+            `the read: ${unavailableChecks.map(c => c.subsystem).join(', ')}. The rows recorded for those ` +
+            `describe a store this backup created, not a corpus that was there — do not read them as a ` +
+            `recovery source. Legitimate on a genuine first run; on a populated deployment it means the ` +
+            `corpus was GONE at capture time, not empty.`
+        );
+    }
+
     const emptyChecks = integrity.filter(check => check.status === 'empty');
     if (emptyChecks.length > 0) {
         // Non-fatal (a fresh environment legitimately backs up empty subsystems), but loud: a zero-row
@@ -426,7 +442,7 @@ export async function countNonEmptyJsonlLines(filePath) {
  *
  * @param {Object} layout     The bundle's per-subsystem destination directory map.
  * @param {Object} subsystems The runBackup `subsystems` map of SDK return values.
- * @returns {Promise<Array<{subsystem: String, status: String, sourceCount: Number, bundleCount: Number, reason: String}>>} `status` is `pass` (positive row-count parity) / `empty` (source and bundle both zero — non-fatal, not a usable recovery source) / `fail` (row-count mismatch) / `skipped` (non-numeric source count); count + reason fields present per status.
+ * @returns {Promise<Array<{subsystem: String, status: String, sourceCount: Number, bundleCount: Number, reason: String}>>} `status` is `pass` (positive row-count parity) / `empty` (source and bundle both zero — non-fatal, not a usable recovery source) / `unavailable` (the exporter established that a source did not pre-exist the read, so its rows describe a store the capture created) / `fail` (row-count mismatch) / `skipped` (non-numeric source count); count + reason fields present per status.
  */
 export async function verifyBundleIntegrity(layout, subsystems) {
     const verifiable = ['kb', 'mc', 'graph'];
@@ -461,12 +477,25 @@ export async function verifyBundleIntegrity(layout, subsystems) {
             // populated deployment a zero-row export is the gutted-store signature (the corruption a
             // backup is supposed to survive) — surface it as 'empty' (visible, non-fatal) rather than
             // a silent 'pass' so a downstream canary/alert can act on bundle-meta.integrity.
-            const status = sourceCount === 0 ? 'empty' : 'pass';
-            const entry  = {subsystem, status, sourceCount, bundleCount};
+            //
+            // 'unavailable' outranks BOTH. The exporter established that a source did not pre-exist the
+            // read that measured it, so parity here proves only that two numbers agree about a corpus
+            // that was not there. Note this is deliberately NOT gated on `sourceCount === 0`: a
+            // subsystem can capture its memories and find its summaries collection absent, and that
+            // bundle has positive row parity while being useless for half of what it claims to hold.
+            const unavailable = raw?.captureOutcome === CAPTURE_OUTCOME_UNAVAILABLE;
+            const status      = unavailable ? 'unavailable' : sourceCount === 0 ? 'empty' : 'pass';
+            const entry       = {subsystem, status, sourceCount, bundleCount};
 
             if (status === 'empty') {
                 entry.reason = 'source and bundle both report zero rows — empty backup is not a usable ' +
                     'recovery source (fresh-env legitimate; populated-deployment corruption-suspicious)';
+            }
+
+            if (status === 'unavailable') {
+                entry.reason = 'at least one source did not pre-exist the read that measured it — the ' +
+                    'rows this bundle reports for it describe a store the capture itself created, not a ' +
+                    'corpus that was there to capture';
             }
 
             checks.push(entry);

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -6,6 +6,7 @@ import DatabaseLifecycleService from './DatabaseLifecycleService.mjs';
 import {
     chromaConnect,
     chromaDeleteCollection,
+    chromaListCollectionNames,
     createSilentExecutor,
     isChromaCollectionNotFoundError,
     registerNeoChromaEmbeddingFunctions
@@ -326,23 +327,30 @@ class ChromaManager extends Base {
     }
 
     /**
+     * @summary Non-mutating enumeration of every collection this client can see.
+     *
+     * `#resolveKnowledgeBaseCollection` answers "does this collection exist?" by making it true — it
+     * catches not-found and creates. A caller that needs the pre-read answer therefore cannot ask any
+     * resolver for it, and must enumerate instead. Deliberately public and deliberately NOT wired into
+     * resolution: the auto-create is load-bearing for first-run bootstrap and shared by every reader in
+     * the system, so the backup lane's reporting need is served beside it, never inside it.
+     *
+     * Returns the whole list rather than a per-name predicate so a caller checking several collections
+     * takes ONE snapshot — N predicates would each observe a different instant, and the verdict they
+     * feed is a statement about a single moment before the export began.
+     *
+     * @returns {Promise<String[]>} Collection names, having created nothing.
+     * @see https://github.com/neomjs/neo/issues/16348
+     */
+    async listCollectionNames() {
+        return await chromaListCollectionNames({client: this.client})
+    }
+
+    /**
      * @returns {Promise<String[]>}
      */
     async #getActiveKnowledgeBaseSwapCollections() {
-        const names  = [];
-        const limit  = 1000;
-        let   offset = 0;
-
-        do {
-            const collections = await this.client.listCollections({limit, offset});
-            names.push(...collections.map(collection => collection.name));
-
-            if (collections.length < limit) {
-                break;
-            }
-
-            offset += limit;
-        } while (true);
+        const names = await chromaListCollectionNames({client: this.client});
 
         return names.filter(name => this.#isActiveKnowledgeBaseSwapName(name)).sort();
     }

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -1,4 +1,7 @@
 import aiConfig                        from '../../mcp/server/knowledge-base/config.mjs';
+import {classifyCaptureOutcome,
+        probeExistingSources,
+        sourceExistedIn}               from '../shared/captureOutcome.mjs';
 import {partitionRowsByVectorValidity} from '../memory-core/helpers/vectorWriteInvariant.mjs';
 import {validateJsonlSourceFile}       from '../memory-core/helpers/vectorJsonlSourceValidation.mjs';
 import Base                            from '../../../src/core/Base.mjs';
@@ -114,16 +117,39 @@ class DatabaseService extends Base {
      *
      * @param {Object}  options
      * @param {String} [options.backupPath=aiConfig.backupPath] Directory for the JSONL artifact.
-     * @returns {Promise<{message: String, count: Number}>} `count` is the numeric export row count,
-     *          consumed by the backup orchestrator's `verifyBundleIntegrity` for KB row-count parity
-     *          (without it the verifier reads a non-numeric source count and skips KB parity).
+     * @returns {Promise<{message: String, count: Number, captureOutcome: String, sourceExisted: Boolean|null}>}
+     *          `count` is the numeric export row count, consumed by the backup orchestrator's
+     *          `verifyBundleIntegrity` for KB row-count parity (without it the verifier reads a
+     *          non-numeric source count and skips KB parity). `captureOutcome` says what that count
+     *          MEANS — `captured` / `empty` / `unavailable` — because a count of zero alone cannot
+     *          distinguish a genuinely empty corpus from one this read replaced with an empty one.
      */
     async exportDatabase({backupPath = aiConfig.backupPath} = {}) {
         try {
             logger.log('Starting knowledge base export...');
+
+            // BEFORE resolution, and that ordering is the whole mechanism.
+            // `getKnowledgeBaseCollection` answers "does this exist?" by making it true: it catches a
+            // not-found and creates the canonical collection. After that call the question is
+            // unanswerable — the store reports zero rows, honestly, about a collection the backup
+            // itself brought into existence. This is the last moment the pre-read answer survives.
+            const probe = await probeExistingSources({
+                listNames: () => ChromaManager.listCollectionNames(),
+                logger,
+                label    : 'knowledge base'
+            });
+
             const collection = await ChromaManager.getKnowledgeBaseCollection();
             const count      = await this.#exportCollection(collection, backupPath, 'knowledge-base-backup');
-            return {message: `Export complete. Exported ${count} knowledge base chunks.`, count};
+            const existed    = sourceExistedIn(probe, aiConfig.collectionName);
+
+            return {
+                message       : `Export complete. Exported ${count} knowledge base chunks.`,
+                count,
+                captureOutcome: classifyCaptureOutcome({sourceExisted: existed, rowCount: count}),
+                sourceExisted : existed,
+                ...(probe.probeError ? {sourceProbeError: probe.probeError} : {})
+            };
         } catch (error) {
             logger.error('[DatabaseService] Error exporting knowledge base:', error);
             const exportError = new Error(`DATABASE_EXPORT_ERROR: ${error.message}`);

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -9,6 +9,8 @@ import DestructiveOperationGuard                                  from '../../mc
 import {partitionRowsByVectorValidity, summarizeVectorRejections} from './helpers/vectorWriteInvariant.mjs';
 import {validateJsonlSourceFile}                                  from './helpers/vectorJsonlSourceValidation.mjs';
 import {importGraphJsonl}                                         from './helpers/graphJsonlImport.mjs';
+import {classifyCaptureOutcome, probeExistingSources,
+        sourceExistedIn, worstCaptureOutcome}                     from '../shared/captureOutcome.mjs';
 
 /**
  * @summary Service for exporting and importing memory core data.
@@ -163,10 +165,43 @@ class DatabaseService extends Base {
     }
 
     /**
+     * @summary Stamps one collection's export stats with what its row count MEANS.
+     *
+     * Mutates in place because the stats object is already the receipt fragment persisted into
+     * `bundle-meta.json`; returning a copy would leave the original — the one that travels — unstamped.
+     *
+     * @param {Object}  stats          The `#exportCollection` result to annotate.
+     * @param {Object}  probe          A `probeExistingSources` result.
+     * @param {String}  collectionName The name whose pre-existence was probed.
+     * @returns {Object} The same `stats`, annotated.
+     * @private
+     */
+    #stampCaptureOutcome(stats, probe, collectionName) {
+        const sourceExisted = sourceExistedIn(probe, collectionName);
+
+        stats.sourceExisted  = sourceExisted;
+        stats.captureOutcome = classifyCaptureOutcome({sourceExisted, rowCount: stats.exported});
+
+        if (probe.probeError) {
+            stats.sourceProbeError = probe.probeError
+        }
+
+        return stats
+    }
+
+    /**
      * Helper method to export the Native Graph (Nodes and Edges) as JSONL.
+     *
+     * **Returns a verdict, not just a number.** Two of the exits below produce zero rows for reasons
+     * that have nothing to do with an empty graph — an uninitialized database and a failed table query —
+     * and the previous bare `return 0` made both byte-identical to a deployment that genuinely holds no
+     * nodes. That is the same conflation as the Chroma resolvers', in a different store, feeding the
+     * same receipt, so it carries the same `sourceExisted` signal rather than a second vocabulary.
+     *
      * @param {String} backupPath The directory to save the backup file.
      * @param {String} filePrefix The prefix for the backup filename.
-     * @returns {Promise<number>} The total number of graph elements exported.
+     * @returns {Promise<{count: Number, sourceExisted: Boolean, reason: String|null}>} `sourceExisted`
+     *          is false only when the graph store could not be read at all.
      * @private
      */
     async #exportGraph(backupPath, filePrefix) {
@@ -176,7 +211,7 @@ class DatabaseService extends Base {
         // Ensure graph is initialized
         if (!GraphService.db || !GraphService.db.storage || !GraphService.db.storage.db) {
              logger.log(`Graph database not initialized. Skipping graph export.`);
-             return 0;
+             return {count: 0, sourceExisted: false, reason: 'native graph database is not initialized'};
         }
 
         const db = GraphService.db.storage.db;
@@ -189,14 +224,14 @@ class DatabaseService extends Base {
             edgesCount = db.prepare('SELECT count(*) as c FROM Edges').get().c || 0;
         } catch (e) {
             logger.error(`Error querying Native Graph tables: ${e.message}`);
-            return 0;
+            return {count: 0, sourceExisted: false, reason: `native graph tables could not be queried: ${e.message}`};
         }
 
         const totalCount = nodesCount + edgesCount;
 
         if (totalCount === 0) {
             logger.log(`No nodes or edges found in the native graph to export.`);
-            return 0;
+            return {count: 0, sourceExisted: true, reason: null};
         }
 
         logger.log(`Found ${nodesCount} nodes and ${edgesCount} edges to export.`);
@@ -239,7 +274,7 @@ class DatabaseService extends Base {
 
         await new Promise(resolve => writeStream.end(resolve));
         logger.log(`Successfully exported ${exported} graph elements to: ${backupFile}`);
-        return exported;
+        return {count: exported, sourceExisted: true, reason: null};
     }
 
     /**
@@ -302,24 +337,58 @@ class DatabaseService extends Base {
             logger.log('Starting agent memory export...');
             let memoryStats = null, summaryStats = null, temporalSummaryStats = null, graphStats = null;
 
+            // BEFORE any collection is resolved, and that ordering is the whole mechanism. All four
+            // collection getters are `getOrCreateCollection` — create-on-missing by construction — so
+            // after the first resolve the question "did this exist?" is permanently unanswerable: the
+            // store reports zero rows, honestly, about a collection this read brought into existence.
+            // One enumeration for every collection below, so their verdicts describe the same instant.
+            const probe = await probeExistingSources({
+                listNames: async () => {
+                    const managers = await StorageRouter.getActiveManagers();
+
+                    if (managers.length === 0) {
+                        // Not "no collections exist" — no engine could be asked. Throwing routes this to
+                        // `probeError` and an `unavailable` verdict, where returning `[]` would assert
+                        // positive absence the probe never established.
+                        throw new Error(`no active vector manager for engine '${aiConfig.engine}'`)
+                    }
+
+                    return (await Promise.all(managers.map(manager => manager.listCollectionNames()))).flat()
+                },
+                logger,
+                label    : 'memory core'
+            });
+
             if (include.includes('memories')) {
                 const collection = await StorageRouter.getMemoryCollection();
                 memoryStats      = await this.#exportCollection(collection, backupPath, 'memory-backup', aiConfig.collections.memory);
+                this.#stampCaptureOutcome(memoryStats, probe, aiConfig.collections.memory);
             }
 
             if (include.includes('summaries')) {
                 const collection = await StorageRouter.getSummaryCollection();
                 summaryStats     = await this.#exportCollection(collection, backupPath, 'summaries-backup', aiConfig.collections.session);
+                this.#stampCaptureOutcome(summaryStats, probe, aiConfig.collections.session);
             }
 
             if (include.includes('temporal-summaries')) {
                 const collection = await StorageRouter.getTemporalSummaryCollection();
                 temporalSummaryStats = await this.#exportCollection(collection, backupPath, 'temporal-summary-backup', aiConfig.collections.temporalSummary);
+                this.#stampCaptureOutcome(temporalSummaryStats, probe, aiConfig.collections.temporalSummary);
             }
 
             if (include.includes('graph')) {
-                const graphCount = await this.#exportGraph(backupPath, 'graph-backup');
-                graphStats       = {expected: graphCount, exported: graphCount};
+                // The graph lives in SQLite, not Chroma, so its pre-existence answer comes from the
+                // exporter itself rather than from the collection probe.
+                const graph = await this.#exportGraph(backupPath, 'graph-backup');
+
+                graphStats = {
+                    expected      : graph.count,
+                    exported      : graph.count,
+                    sourceExisted : graph.sourceExisted,
+                    captureOutcome: classifyCaptureOutcome({sourceExisted: graph.sourceExisted, rowCount: graph.count}),
+                    ...(graph.reason ? {sourceProbeError: graph.reason} : {})
+                };
             }
 
             const memoryCount          = memoryStats?.exported || 0,
@@ -335,6 +404,16 @@ class DatabaseService extends Base {
             if (summaryStats) result.summaries = summaryStats;
             if (temporalSummaryStats) result.temporalSummaries = temporalSummaryStats;
             if (graphStats) result.graph = graphStats;
+
+            // The subsystem is only as trustworthy as its least-trustworthy part. The May-2026 recovery
+            // specimen is exactly this shape — a bundle with memories and no summaries file at all — so
+            // the fold takes the worst member rather than the majority. Per-collection verdicts stay on
+            // their own stats; a consumer that needs to know WHICH part failed reads those.
+            result.captureOutcome = worstCaptureOutcome(
+                [memoryStats, summaryStats, temporalSummaryStats, graphStats]
+                    .filter(Boolean)
+                    .map(stats => stats.captureOutcome)
+            );
 
             return result
         } catch (error) {

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -6,6 +6,7 @@ import ChromaLifecycleService from '../lifecycle/ChromaLifecycleService.mjs';
 import {
     chromaConnect,
     chromaDeleteCollection,
+    chromaListCollectionNames,
     createDynamicTextEmbeddingFunction,
     createSilentExecutor,
     isChromaCollectionNotFoundError,
@@ -301,6 +302,26 @@ class ChromaManager extends AbstractVectorManager {
 
         this.graphCollection = await this._graphCollectionPromise;
         return this.graphCollection;
+    }
+
+    /**
+     * @summary Non-mutating enumeration of every collection this client can see.
+     *
+     * All four collection getters above are `getOrCreateCollection` — create-on-missing BY
+     * CONSTRUCTION, with no not-found branch to interrogate. So a deleted collection is silently
+     * replaced by an empty one during the very read meant to capture it, and `count()` then reports
+     * `0` honestly. Nothing downstream can recover the distinction, which is why the backup lane asks
+     * this question BEFORE resolving anything.
+     *
+     * Peer-symmetric with `Neo.ai.services.knowledge-base.ChromaManager#listCollectionNames`. Kept
+     * beside the getters rather than inside them: auto-create is required for first-run bootstrap and
+     * shared by every reader in the system, so this reports on the resolvers without altering them.
+     *
+     * @returns {Promise<String[]>} Collection names, having created nothing.
+     * @see https://github.com/neomjs/neo/issues/16348
+     */
+    async listCollectionNames() {
+        return await chromaListCollectionNames({client: this.client})
     }
 
     /**

--- a/ai/services/shared/captureOutcome.mjs
+++ b/ai/services/shared/captureOutcome.mjs
@@ -98,3 +98,57 @@ export function worstCaptureOutcome(outcomes = []) {
 
     return present[0] ?? CAPTURE_OUTCOME_UNAVAILABLE
 }
+
+/**
+ * @summary Runs the pre-existence enumeration once, best-effort, and records why if it could not.
+ *
+ * **Best-effort by design, and the design only holds because of the classifier's asymmetry.** A probe
+ * failure can never downgrade a real capture — `rowCount > 0` short-circuits to `captured` — so the only
+ * reachable consequence is that a genuinely-empty source reports `unavailable`. That is the safe
+ * direction, and it is far cheaper than the alternative: propagating would let a `listCollections`
+ * hiccup abort a priority-zero backup lane that would otherwise have written a perfectly good bundle.
+ *
+ * The failure is recorded, never swallowed. It warns, and the returned `probeError` is meant to travel
+ * into the receipt — a carve-out that quiets a guard without leaving a trace is how a silent channel
+ * gets opened.
+ *
+ * One enumeration serves every collection a caller checks, so all their verdicts describe the same
+ * instant rather than a drifting sequence of instants.
+ *
+ * @param {Object}    options
+ * @param {Function}  options.listNames A zero-arg async returning existing source names.
+ * @param {Object}   [options.logger]   Warn sink; `console`-shaped.
+ * @param {String}   [options.label]    Subsystem name for the warning.
+ * @returns {Promise<{existing: Set<String>|null, probeError: String|null}>} `existing` is `null` exactly
+ *          when the probe could not answer.
+ */
+export async function probeExistingSources({listNames, logger, label = 'source'} = {}) {
+    try {
+        return {existing: new Set(await listNames()), probeError: null}
+    } catch (error) {
+        const probeError = error?.message ?? String(error);
+
+        logger?.warn?.(
+            `[CaptureOutcome] Could not establish pre-existence for ${label}: ${probeError}. Zero-row ` +
+            `exports will be reported as 'unavailable' rather than 'empty', because an unestablished ` +
+            `source is not a source known to be empty.`
+        );
+
+        return {existing: null, probeError}
+    }
+}
+
+/**
+ * @summary Reads one name out of a probe result, preserving "could not answer" as `null`.
+ *
+ * Deliberately NOT `probe?.existing?.has(name) ?? false`: collapsing an unanswerable probe to `false`
+ * would be indistinguishable from a positively-absent source, and the whole point of the tri-state is
+ * that "I did not establish this" is its own fact.
+ *
+ * @param {{existing: Set<String>|null}} probe
+ * @param {String}                       name
+ * @returns {Boolean|null}
+ */
+export function sourceExistedIn(probe, name) {
+    return probe?.existing ? probe.existing.has(name) : null
+}

--- a/ai/services/shared/captureOutcome.mjs
+++ b/ai/services/shared/captureOutcome.mjs
@@ -1,0 +1,100 @@
+/**
+ * @module ai/services/shared/captureOutcome
+ * @summary The single definition of what a backup export's row count MEANS — one vocabulary, shared by
+ * the two peer DatabaseServices that produce it and the backup orchestrator that reads it.
+ *
+ * A count of `0` answers "how many rows did I write". It does not answer "was there a corpus here",
+ * and the backup receipt has only ever recorded the first. Live evidence for the gap: 4 of 36 bundles
+ * in one store carry `expected: 0, exported: 0` with the message `"Export complete."`, spread across
+ * four separate dates — byte-identical to a legitimately empty deployment.
+ *
+ * The producing seam is a resolver, not a counter. Both vector stores create a missing collection on
+ * read (`knowledge-base/ChromaManager#resolveKnowledgeBaseCollection` catches not-found and creates;
+ * `memory-core/managers/ChromaManager` uses `getOrCreateCollection` by construction), and the native
+ * graph export returns `0` for an uninitialized database. So the store the backup measures can be one
+ * the backup's own read brought into existence — and every layer above then reports that zero honestly.
+ *
+ * Centralized rather than duplicated per service, unlike the deliberately-mirrored `#exportCollection`
+ * helpers: those are private implementation, this is the wire contract persisted into
+ * `bundle-meta.json` and branched on by `verifyBundleIntegrity`. A vocabulary spelled in three places
+ * drifts, and a receipt whose producer and reader disagree is worse than one that says nothing.
+ *
+ * @see https://github.com/neomjs/neo/issues/16348
+ */
+
+/**
+ * The source was reached and returned rows.
+ * @type {String}
+ */
+export const CAPTURE_OUTCOME_CAPTURED = 'captured';
+
+/**
+ * The source was reached, positively pre-existed, and genuinely held nothing.
+ * @type {String}
+ */
+export const CAPTURE_OUTCOME_EMPTY = 'empty';
+
+/**
+ * Zero rows WITHOUT a positively-established pre-existing source: the collection was absent before the
+ * read that measured it, the backing store was not initialized, or pre-existence could not be
+ * established at all.
+ * @type {String}
+ */
+export const CAPTURE_OUTCOME_UNAVAILABLE = 'unavailable';
+
+/**
+ * Severity order, worst first. `worstCaptureOutcome` folds a bundle's per-collection verdicts through
+ * this, so a subsystem is only as trustworthy as its least-trustworthy part.
+ * @type {String[]}
+ */
+const OUTCOME_SEVERITY = [CAPTURE_OUTCOME_UNAVAILABLE, CAPTURE_OUTCOME_EMPTY, CAPTURE_OUTCOME_CAPTURED];
+
+/**
+ * @summary Classifies one export's row count against whether its source was positively established to
+ * pre-exist the read.
+ *
+ * **An allowlist of positively-established states, never a denylist of known-bad ones.** Only a
+ * `sourceExisted === true` earns `empty`; every other input — `false`, `null` from a probe that could
+ * not answer, `undefined` from a caller that never asked — lands on `unavailable`. Unanticipated cases
+ * therefore fail toward "I cannot vouch for this" by construction rather than by someone remembering
+ * to enumerate the next failure mode. Over-condemning a genuinely-empty store is the safe direction:
+ * it costs a loud receipt, where the inverse costs a false recovery source.
+ *
+ * **`rowCount > 0` short-circuits to `captured` and deliberately ignores `sourceExisted`.** Rows are
+ * self-evidencing — a collection created by this very read holds nothing — so a probe that failed or
+ * was never run can never downgrade a genuine capture. That asymmetry is what makes the probe safe to
+ * treat as best-effort at its call sites.
+ *
+ * @param {Object}         options
+ * @param {Boolean|null}  [options.sourceExisted] `true` only when pre-existence was positively
+ *                        established by a non-mutating probe; `false` when positively absent; `null`
+ *                        when the probe itself could not answer.
+ * @param {Number}         options.rowCount       Rows the export actually wrote.
+ * @returns {String} One of `captured` / `empty` / `unavailable`.
+ */
+export function classifyCaptureOutcome({sourceExisted = null, rowCount} = {}) {
+    if (Number.isFinite(rowCount) && rowCount > 0) {
+        return CAPTURE_OUTCOME_CAPTURED
+    }
+
+    return sourceExisted === true ? CAPTURE_OUTCOME_EMPTY : CAPTURE_OUTCOME_UNAVAILABLE
+}
+
+/**
+ * @summary Folds several per-collection verdicts into the one a subsystem reports.
+ *
+ * A subsystem that captured its memories but whose summaries collection was absent is NOT a healthy
+ * capture, so the fold takes the worst member rather than the majority or the first. The May-2026
+ * recovery specimen is exactly this shape — a bundle with memories and no summaries file at all —
+ * which is why the verdict is per collection and the subsystem's is derived, not measured separately.
+ *
+ * An empty list yields `unavailable`: nothing was measured, so nothing was established.
+ *
+ * @param {String[]} outcomes
+ * @returns {String} One of `captured` / `empty` / `unavailable`.
+ */
+export function worstCaptureOutcome(outcomes = []) {
+    const present = OUTCOME_SEVERITY.filter(outcome => outcomes.includes(outcome));
+
+    return present[0] ?? CAPTURE_OUTCOME_UNAVAILABLE
+}

--- a/ai/services/shared/vector/chromaClientPrimitives.mjs
+++ b/ai/services/shared/vector/chromaClientPrimitives.mjs
@@ -182,6 +182,12 @@ function assertEmbeddingFunction(embeddingFunction, label) {
  *    canonical-name refusal. The substrate-level invariant fires regardless of
  *    harness or config state.
  *
+ * 4. **`chromaListCollectionNames({client})`** — paginated, NON-MUTATING enumeration. Both
+ *    subsystems needed the identical page loop to answer one question the resolvers destroy the
+ *    answer to: did this collection exist BEFORE the read that measured it. It belongs beside the
+ *    other client-lifecycle helpers precisely because it is not resolution — it creates nothing, so
+ *    it carries none of the per-subsystem semantics listed below.
+ *
  * **What this module does NOT own (per V-B-A on the ticket's prescription):**
  *
  * - `getOrCreateCollection` / `getCollection` / `createCollection` — collection-resolution
@@ -311,4 +317,45 @@ export async function chromaDeleteCollection({client, name, subsystem, confirmat
 
     assertCanonicalCollectionDeleteAllowed({name, subsystem, confirmation});
     return await client.deleteCollection({name})
+}
+
+/**
+ * @summary Enumerates every collection name the client can see, creating nothing.
+ *
+ * The one non-mutating way to ask "does this collection exist?" against a store whose resolvers
+ * answer that question by making it true. `getCollection` throws not-found without creating, but both
+ * subsystems wrap it in retry/swap-aware resolution that ends in a create; `listCollections` has no
+ * such tail, which is why the backup lane's pre-existence probe reads through here.
+ *
+ * Pages rather than taking the first batch: the previous KB-local copy of this loop existed because a
+ * single unpaged call silently truncates at the server's page size, and a truncated enumeration would
+ * report a live collection as absent — a false `unavailable` verdict for a healthy store.
+ *
+ * Throws on client failure rather than returning an empty list. An empty result and an unreachable
+ * server are different facts, and collapsing them here would hand callers the exact conflation this
+ * probe exists to break.
+ *
+ * @param {Object}  options
+ * @param {Object}  options.client    The chromadb library client (with `.listCollections`).
+ * @param {Number} [options.pageSize] Rows per request; the loop stops on the first short page.
+ * @returns {Promise<String[]>} Collection names, in server order.
+ * @see https://github.com/neomjs/neo/issues/16348
+ */
+export async function chromaListCollectionNames({client, pageSize = 1000} = {}) {
+    const names  = [];
+    let   offset = 0;
+
+    while (true) {
+        const page = await client.listCollections({limit: pageSize, offset});
+
+        names.push(...page.map(collection => collection.name));
+
+        if (page.length < pageSize) {
+            break
+        }
+
+        offset += pageSize
+    }
+
+    return names
 }

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -31,7 +31,15 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
     let SDK, runBackup;
     let KB_ChromaManager, Memory_StorageRouter;
     let originalKbCollection, originalMcGetMemory, originalMcGetSummary;
+    let originalKbListNames, originalMcGetActiveManagers;
     let workRoot, bundleRoot, conceptsSourceDir, trajectoriesSourceFile;
+
+    // What the non-mutating pre-existence probe reports, per subsystem. Stubbing the collection GETTER
+    // is not enough: the exporter asks whether a collection existed BEFORE it resolved anything, and a
+    // fixture that only conjures a handle answers "no" — truthfully — which classifies every zero-row
+    // export as `unavailable`. Populated fixtures are unaffected either way (rows prove pre-existence),
+    // so this exists for the zero-row cases, where `empty` and `unavailable` are the whole distinction.
+    let kbCollectionNames, mcCollectionNames;
 
     const fakeCollection = (rows, name) => ({
         name,
@@ -88,12 +96,35 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
             [{id: 's-1', embedding: [0.4], metadata: {cat: 'feat'}, document: 'sum-doc'}],
             'fake-sum'
         );
+
+        const kbConfig = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default,
+              mcConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        // Default posture: every canonical collection pre-existed, which is what every populated test
+        // here means. The probe compares against the CONFIG names, not the fake handle's `.name`.
+        kbCollectionNames = [kbConfig.collectionName];
+        mcCollectionNames = [
+            mcConfig.collections.memory,
+            mcConfig.collections.session,
+            mcConfig.collections.temporalSummary,
+            mcConfig.collections.graph
+        ];
+
+        originalKbListNames         = KB_ChromaManager.listCollectionNames.bind(KB_ChromaManager);
+        originalMcGetActiveManagers = Memory_StorageRouter.getActiveManagers.bind(Memory_StorageRouter);
+
+        KB_ChromaManager.listCollectionNames   = async () => [...kbCollectionNames];
+        Memory_StorageRouter.getActiveManagers = async () => [
+            {listCollectionNames: async () => [...mcCollectionNames]}
+        ];
     });
 
     test.afterAll(() => {
         KB_ChromaManager.getKnowledgeBaseCollection = originalKbCollection;
+        KB_ChromaManager.listCollectionNames        = originalKbListNames;
         Memory_StorageRouter.getMemoryCollection    = originalMcGetMemory;
         Memory_StorageRouter.getSummaryCollection   = originalMcGetSummary;
+        Memory_StorageRouter.getActiveManagers      = originalMcGetActiveManagers;
 
         if (workRoot && fs.existsSync(workRoot)) {
             fs.rmSync(workRoot, {recursive: true, force: true});
@@ -326,10 +357,124 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
             expect(mcIntegrity.sourceCount).toBe(0);
             expect(mcIntegrity.bundleCount).toBe(0);
             expect(warnings.some(w => /ZERO rows|empty backup/i.test(w))).toBe(true);  // runBackup warned, non-fatally
+
+            // The control that makes the assertion above mean something: this bundle reports `empty`
+            // BECAUSE the probe positively established both collections pre-existed. Without it, `empty`
+            // could be the default for any zero-row export and the next test would prove nothing.
+            expect(result.meta.subsystems.mc.memories.sourceExisted) .toBe(true);
+            expect(result.meta.subsystems.mc.summaries.sourceExisted).toBe(true);
+            expect(result.meta.subsystems.mc.captureOutcome).toBe('empty');
         } finally {
             Memory_StorageRouter.getMemoryCollection  = savedMem;
             Memory_StorageRouter.getSummaryCollection = savedSum;
         }
+    });
+
+    test('a collection that did NOT pre-exist reports `unavailable`, never `empty` (#16348)', async () => {
+        // The live specimen: a re-embed cutover left the canonical collection transiently absent, the
+        // resolver re-created it empty, `count()` returned 0 honestly, and the receipt said
+        // "Export complete." — byte-identical to a deployment that legitimately holds nothing. 4 of 36
+        // bundles in one store carry that signature across four separate dates.
+        const warnings      = [];
+        const captureLogger = {log: () => {}, error: () => {}, warn: msg => warnings.push(msg)};
+        const savedMem      = Memory_StorageRouter.getMemoryCollection;
+        const savedSum      = Memory_StorageRouter.getSummaryCollection;
+        const savedNames    = [...mcCollectionNames];
+
+        try {
+            // Zero rows AND no pre-existing collection — the resolver's create-on-missing is what the
+            // production path does here, and the fixture reproduces its observable result rather than
+            // hand-setting a flag: nothing below tells the exporter what verdict to reach.
+            Memory_StorageRouter.getMemoryCollection  = async () => fakeCollection([], 'conjured-mem');
+            Memory_StorageRouter.getSummaryCollection = async () => fakeCollection([], 'conjured-sum');
+            mcCollectionNames.length                  = 0;
+
+            const result = await runBackup({
+                bundleRoot: path.join(workRoot, 'bundle-unavailable'),
+                conceptsSourceDir,
+                trajectoriesSourceFile,
+                logger    : captureLogger
+            });
+
+            const mcIntegrity = result.meta.integrity.find(check => check.subsystem === 'mc');
+
+            expect(mcIntegrity.status).toBe('unavailable');
+            expect(mcIntegrity.status).not.toBe('empty');
+            expect(mcIntegrity.reason).toMatch(/did not pre-exist/);
+            expect(result.meta.subsystems.mc.memories.sourceExisted).toBe(false);
+            expect(result.meta.subsystems.mc.memories.captureOutcome).toBe('unavailable');
+            expect(warnings.some(w => /did NOT pre-exist/i.test(w))).toBe(true);
+
+            // Non-fatal by design. `fail` throws before bundle-meta.json is written, so routing this
+            // through it would leave a bundle-shaped directory with no receipt — manufacturing the very
+            // aborted-run specimen this work exists to eliminate. The receipt must survive to say so.
+            expect(fs.existsSync(path.join(workRoot, 'bundle-unavailable', 'bundle-meta.json'))).toBe(true);
+
+            // The other side of the ticket's falsifier, in the same bundle: KB is populated and its
+            // collection pre-existed, so it must still read `captured` / `pass`. Without this, a probe
+            // that simply reported `unavailable` for everything would satisfy the assertions above.
+            expect(result.meta.subsystems.kb.captureOutcome).toBe('captured');
+            expect(result.meta.integrity.find(check => check.subsystem === 'kb').status).toBe('pass');
+        } finally {
+            Memory_StorageRouter.getMemoryCollection  = savedMem;
+            Memory_StorageRouter.getSummaryCollection = savedSum;
+            mcCollectionNames.push(...savedNames);
+        }
+    });
+
+    test('a subsystem with rows AND an absent collection is `unavailable` despite positive parity (#16348)', async () => {
+        // The May-2026 recovery specimen: a bundle with memories and NO summaries file at all. The
+        // subsystem's row count is positive, parity holds, and half of what it claims to hold is
+        // missing — so the verdict cannot be gated on `sourceCount === 0`.
+        const silentLogger = {log: () => {}, error: () => {}, warn: () => {}};
+        const savedSum     = Memory_StorageRouter.getSummaryCollection;
+        const savedNames   = [...mcCollectionNames];
+
+        try {
+            Memory_StorageRouter.getSummaryCollection = async () => fakeCollection([], 'conjured-sum');
+            // Memories still pre-exist; only the summaries collection is gone.
+            mcCollectionNames.splice(mcCollectionNames.indexOf(savedNames[1]), 1);
+
+            const result = await runBackup({
+                bundleRoot: path.join(workRoot, 'bundle-partial'),
+                conceptsSourceDir,
+                trajectoriesSourceFile,
+                logger    : silentLogger
+            });
+
+            const mcIntegrity = result.meta.integrity.find(check => check.subsystem === 'mc');
+
+            expect(mcIntegrity.sourceCount).toBeGreaterThan(0);        // positive parity...
+            expect(mcIntegrity.bundleCount).toBe(mcIntegrity.sourceCount);
+            expect(mcIntegrity.status).toBe('unavailable');            // ...and still not trustworthy
+            expect(mcIntegrity.status).not.toBe('pass');
+
+            // Per-collection granularity is the point: a consumer must be able to tell WHICH half.
+            expect(result.meta.subsystems.mc.memories.captureOutcome) .toBe('captured');
+            expect(result.meta.subsystems.mc.summaries.captureOutcome).toBe('unavailable');
+        } finally {
+            Memory_StorageRouter.getSummaryCollection = savedSum;
+            mcCollectionNames.length                  = 0;
+            mcCollectionNames.push(...savedNames);
+        }
+    });
+
+    test('verifyBundleIntegrity is unchanged for a receipt carrying no capture verdict (#16348)', async () => {
+        // Backward compatibility, asserted rather than assumed: every bundle already on disk predates
+        // the verdict, and a reader that treated a missing `captureOutcome` as "unavailable" would
+        // retroactively condemn the entire archive. Absent verdict means the old two-way answer.
+        const tempRoot = path.join(workRoot, 'legacy-receipt');
+        const layout   = {kb: path.join(tempRoot, 'kb'), mc: path.join(tempRoot, 'mc'), graph: path.join(tempRoot, 'graph')};
+
+        Object.values(layout).forEach(dir => fs.mkdirSync(dir, {recursive: true}));
+        fs.writeFileSync(path.join(layout.kb, 'kb.jsonl'), '{"id":"a"}\n{"id":"b"}\n');
+
+        const checks = await verifyBundleIntegrity(layout, {kb: {count: 2}, mc: {count: 0}, graph: {count: 0}});
+
+        expect(checks.find(c => c.subsystem === 'kb').status).toBe('pass');
+        expect(checks.find(c => c.subsystem === 'mc').status).toBe('empty');
+        expect(checks.find(c => c.subsystem === 'graph').status).toBe('empty');
+        expect(checks.some(c => c.status === 'unavailable')).toBe(false);
     });
 
     test('countNonEmptyJsonlLines: streams a JSONL file, counting non-empty lines (#14082)', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -21,6 +21,13 @@ import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 import fs              from 'fs';
 import path            from 'path';
+// The COMMITTED templates, never `config.mjs` — that path resolves a repo-local ignored overlay, so
+// a test reading it asserts against whatever this machine happens to carry, and the same spec can
+// pass here while failing on a peer's box for reasons the diff cannot show. `lint-config-template-ssot`
+// refuses it. Read at each use site below rather than snapshotted: the proxies are reactive, and a
+// captured leaf is a second, stale config authority.
+import KB_Config from '../../../../../../ai/mcp/server/knowledge-base/config.template.mjs';
+import MC_Config from '../../../../../../ai/mcp/server/memory-core/config.template.mjs';
 
 // Serial mode: this file mutates KB + MC singleton collection accessors across
 // beforeAll/afterAll. Serial ordering within this file prevents local multi-worker
@@ -34,12 +41,16 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
     let originalKbListNames, originalMcGetActiveManagers;
     let workRoot, bundleRoot, conceptsSourceDir, trajectoriesSourceFile;
 
-    // What the non-mutating pre-existence probe reports, per subsystem. Stubbing the collection GETTER
-    // is not enough: the exporter asks whether a collection existed BEFORE it resolved anything, and a
-    // fixture that only conjures a handle answers "no" — truthfully — which classifies every zero-row
-    // export as `unavailable`. Populated fixtures are unaffected either way (rows prove pre-existence),
-    // so this exists for the zero-row cases, where `empty` and `unavailable` are the whole distinction.
-    let kbCollectionNames, mcCollectionNames;
+    // Which logical collections the pre-existence probe should report as ABSENT. Stubbing the
+    // collection GETTER is not enough: the exporter asks whether a collection existed BEFORE it
+    // resolved anything, and a fixture that only conjures a handle answers "no" — truthfully — which
+    // classifies every zero-row export as `unavailable`. Populated fixtures are unaffected either way
+    // (rows prove pre-existence), so this exists for the zero-row cases, where `empty` and
+    // `unavailable` are the whole distinction.
+    //
+    // Keyed by LOGICAL name, not by collection name, so the stubs can resolve the reactive config
+    // proxy at call time instead of snapshotting it into a mutable array.
+    let hiddenCollections;
 
     const fakeCollection = (rows, name) => ({
         name,
@@ -97,26 +108,24 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
             'fake-sum'
         );
 
-        const kbConfig = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default,
-              mcConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-
         // Default posture: every canonical collection pre-existed, which is what every populated test
         // here means. The probe compares against the CONFIG names, not the fake handle's `.name`.
-        kbCollectionNames = [kbConfig.collectionName];
-        mcCollectionNames = [
-            mcConfig.collections.memory,
-            mcConfig.collections.session,
-            mcConfig.collections.temporalSummary,
-            mcConfig.collections.graph
-        ];
+        hiddenCollections = new Set();
 
         originalKbListNames         = KB_ChromaManager.listCollectionNames.bind(KB_ChromaManager);
         originalMcGetActiveManagers = Memory_StorageRouter.getActiveManagers.bind(Memory_StorageRouter);
 
-        KB_ChromaManager.listCollectionNames   = async () => [...kbCollectionNames];
-        Memory_StorageRouter.getActiveManagers = async () => [
-            {listCollectionNames: async () => [...mcCollectionNames]}
-        ];
+        KB_ChromaManager.listCollectionNames = async () =>
+            hiddenCollections.has('kb') ? [] : [KB_Config.collectionName];
+
+        Memory_StorageRouter.getActiveManagers = async () => [{
+            listCollectionNames: async () => [
+                ['memory',          MC_Config.collections.memory],
+                ['summary',         MC_Config.collections.session],
+                ['temporalSummary', MC_Config.collections.temporalSummary],
+                ['graph',           MC_Config.collections.graph]
+            ].filter(([key]) => !hiddenCollections.has(key)).map(([, name]) => name)
+        }];
     });
 
     test.afterAll(() => {
@@ -379,7 +388,6 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         const captureLogger = {log: () => {}, error: () => {}, warn: msg => warnings.push(msg)};
         const savedMem      = Memory_StorageRouter.getMemoryCollection;
         const savedSum      = Memory_StorageRouter.getSummaryCollection;
-        const savedNames    = [...mcCollectionNames];
 
         try {
             // Zero rows AND no pre-existing collection — the resolver's create-on-missing is what the
@@ -387,7 +395,7 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
             // hand-setting a flag: nothing below tells the exporter what verdict to reach.
             Memory_StorageRouter.getMemoryCollection  = async () => fakeCollection([], 'conjured-mem');
             Memory_StorageRouter.getSummaryCollection = async () => fakeCollection([], 'conjured-sum');
-            mcCollectionNames.length                  = 0;
+            hiddenCollections.add('memory').add('summary');
 
             const result = await runBackup({
                 bundleRoot: path.join(workRoot, 'bundle-unavailable'),
@@ -418,7 +426,7 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         } finally {
             Memory_StorageRouter.getMemoryCollection  = savedMem;
             Memory_StorageRouter.getSummaryCollection = savedSum;
-            mcCollectionNames.push(...savedNames);
+            hiddenCollections.clear();
         }
     });
 
@@ -428,12 +436,11 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         // missing — so the verdict cannot be gated on `sourceCount === 0`.
         const silentLogger = {log: () => {}, error: () => {}, warn: () => {}};
         const savedSum     = Memory_StorageRouter.getSummaryCollection;
-        const savedNames   = [...mcCollectionNames];
 
         try {
             Memory_StorageRouter.getSummaryCollection = async () => fakeCollection([], 'conjured-sum');
             // Memories still pre-exist; only the summaries collection is gone.
-            mcCollectionNames.splice(mcCollectionNames.indexOf(savedNames[1]), 1);
+            hiddenCollections.add('summary');
 
             const result = await runBackup({
                 bundleRoot: path.join(workRoot, 'bundle-partial'),
@@ -454,8 +461,7 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
             expect(result.meta.subsystems.mc.summaries.captureOutcome).toBe('unavailable');
         } finally {
             Memory_StorageRouter.getSummaryCollection = savedSum;
-            mcCollectionNames.length                  = 0;
-            mcCollectionNames.push(...savedNames);
+            hiddenCollections.clear();
         }
     });
 


### PR DESCRIPTION
Resolves #16404

A backup's row count answers *"how many rows did I write"*. It has never answered *"was there a corpus here"* — and the two questions have the same answer shape: `0`. Every subsystem receipt now carries a `captureOutcome` beside its count: `captured` (reached, rows returned), `empty` (positively pre-existed, genuinely held nothing), `unavailable` (zero rows **without** an established pre-existing source).

Evidence: L3 (real production path through `runBackup`, red/green-verified per assertion; the store is stubbed at the manager boundary, which sits *above* the code under test) → L4 not reached: the post-merge item below needs a live Chroma with a deliberately absent collection, which no unit fixture can supply. Residual: the `unavailable`-on-a-real-store direction is unwitnessed until that run.

## Deltas from ticket

**1. The mechanism on the parent ticket was wrong, and this PR carries the corrected one.** `#16348`'s body prescribes making `expected` vs `exported` express shortfall, and my own first shape on it named `backup.mjs:227`'s `?? 0` as *"where 'unavailable' becomes 'empty'"*. Reading the producer falsified that and two neighbouring assertions — `countOf` feeds only `embedding.counts`, the raw SDK return is written verbatim to `bundle-meta.json`, and `verifyBundleIntegrity` reads `raw?.count` directly. The correction is on the parent ([the correction](https://github.com/neomjs/neo/issues/16348#issuecomment-5159420838), [the corrected shape](https://github.com/neomjs/neo/issues/16348#issuecomment-5159954428)), left standing above rather than edited away, and `#16404` was filed from the corrected version.

**2. `expected`/`exported` are untouched; the distinction lands in a sibling field.** The parent's AC says shortfall must be expressible in the receipt. It is — via `captureOutcome` + `sourceExisted` — but not by changing the two count fields it names. Those two are honest already: the export really did write 0 of 0 rows. What was missing is what that zero *means*, which is not a count.

**3. A third defect site, found by auditing the boundary class rather than the reported specimen.** `#exportGraph` returned a bare `0` for an uninitialized SQLite graph database **and** for a failed table query — both byte-identical to a genuinely empty graph, in a subsystem `verifyBundleIntegrity` checks. Same conflation, different store, same receipt, so it carries the same `sourceExisted` signal rather than a second vocabulary.

## The mechanism, read from source

The truth is destroyed **before** `backup.mjs` runs. The vector-store resolvers convert *absent* into *empty*:

| subsystem | site | spelling |
|---|---|---|
| KB | `knowledge-base/ChromaManager.mjs:154-184` | `getCollection` → catch not-found → `createCollection` |
| MC | `memory-core/managers/ChromaManager.mjs:238,257,276,295` | `getOrCreateCollection` ×4 — create-on-missing **by construction**, no not-found branch at all |

A deleted collection is silently recreated empty, `count()` returns 0 honestly, and every layer above reports that honestly too. A grep for `createCollection` alone finds the KB half and misses all four MC sites.

**The load-bearing decision is a refusal: the resolvers are NOT changed.** Their auto-create is required for first-run bootstrap and shared by every reader in the system. Risking the vector store's hot path to improve a backup receipt is the wrong trade. The probe reports on them from beside them.

**And the probe runs before any collection is resolved, because that ordering IS the mechanism.** After the first resolve the question is permanently unanswerable. That the probe is genuinely first is a property of the lane, not an assumption: `backup.mjs` is a standalone script (`import.meta.url === process.argv[1]`, `npm run ai:backup`), and neither lifecycle service resolves a collection on `ready()` — checked. In a long-lived MCP process an earlier reader would already have created it and the probe would say `true`: correctly, but uselessly. This is scoped to the backup process and says so in the JSDoc.

## Design decisions worth the review's attention

**The classifier is an allowlist of positively-established states.** Only `sourceExisted === true` earns `empty`; `false`, a `null` from a probe that could not answer, and an absent argument all land on `unavailable`. Cases nobody enumerated fail toward *"I cannot vouch for this"* by construction. Over-condemning a genuinely empty store costs a loud receipt; the inverse costs a false recovery source.

**`rowCount > 0` short-circuits to `captured`, ignoring the probe entirely.** Rows are self-evidencing — a collection created by this very read holds nothing — so a failed probe can never downgrade a genuine capture. That asymmetry is what makes a best-effort probe safe, and it is why only one existing test moved when the wiring landed.

**The probe is best-effort, and the failure is recorded rather than swallowed.** Propagating would let a `listCollections` hiccup abort a priority-zero backup lane that would otherwise write a perfectly good bundle. It warns, and `sourceProbeError` travels into the receipt — a carve-out that quiets a guard without leaving a trace is how a silent channel gets opened.

**`unavailable` is deliberately NOT routed through integrity `fail`.** `fail` throws *above* the point where `bundle-meta.json` is written, so failing would leave a bundle-shaped directory with no receipt — manufacturing the exact aborted-run specimen the parent ticket exists to eliminate. A spec asserts the receipt survives.

**The integrity mapping is not gated on `sourceCount === 0`.** A subsystem can capture its memories and find its summaries collection absent: positive row parity on a bundle useless for half of what it claims to hold. That is the May-2026 recovery specimen, and it is why verdicts are per collection with the subsystem's folded from the **worst** member.

**Restore-side selection needs no change and gets none.** An all-`unavailable` bundle already yields `rowTotal === 0` and is refused as `BUNDLE_EMPTY` by the guard merged in #16384. A partially-`unavailable` bundle stays restorable, which is correct — it IS restorable for the subsystems that captured, and the receipt now names which. Adding a second refusal would duplicate a working guard, which is a mistake I already made once in this lane and the existing suite caught.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback | Docs |
|---|---|---|---|---|
| `KB_DatabaseService.exportDatabase` result | This PR | Adds `captureOutcome`, `sourceExisted`, optional `sourceProbeError` | `count` / `message` unchanged | JSDoc `@returns` |
| `Memory_DatabaseService.exportDatabase` result | This PR | Per-collection verdict on each stats block; subsystem verdict = worst member | Existing `memories`/`summaries`/`graph` fields unchanged | JSDoc `@returns` |
| `verifyBundleIntegrity` status | `backup.mjs:431` | New `unavailable` beside `pass`/`empty`/`fail`/`skipped` | A receipt without `captureOutcome` classifies exactly as before — pinned by test | JSDoc `@returns` |
| `ChromaManager.listCollectionNames()` | New, both managers | Non-mutating enumeration; creates nothing | None — resolvers untouched | JSDoc `@summary` |
| `chromaListCollectionNames({client})` | New | Paginated; **throws** on client failure rather than returning `[]` | None | Module doc, item 4 |
| `#exportGraph` return | `memory-core/DatabaseService.mjs` | `{count, sourceExisted, reason}` instead of a bare number | Private; single in-class caller | JSDoc `@returns` |

**No caller migration.** Every field is additive; the only changed return shape is a private method with one in-class call site. Nothing outside `ai/services/knowledge-base/DatabaseService.mjs`, `ai/services/memory-core/DatabaseService.mjs` and `ai/scripts/maintenance/backup.mjs` imports `captureOutcome.mjs` (sweep + positive control below).

**Placement:** `ai/services/shared/` already holds `a2aCollisionTags.mjs` (82 LOC) and `storeWriteGuard.mjs` (68 LOC) — cross-service vocabularies centralized because a contract spelled in two services drifts. The peer `#exportCollection` helpers stay deliberately duplicated: they are private implementation, this is the wire contract persisted into `bundle-meta.json`.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
→ 23 passed (5.3s)
```

**Three of the four new assertions are RED-verified** against the foundation commit (`07cfd589dc`, rewritten to `455baabb53` — same tree) by reverting the wiring and keeping the spec. `backup.spec.mjs` is `mode: 'serial'`, so a single run reports *"12 did not run"* after the first failure — each was therefore invoked individually rather than read off one summary:

```
a collection that did NOT pre-exist reports `unavailable`
  Expected: "unavailable"   Received: "empty"        ← the live conflation, exactly
a subsystem with rows AND an absent collection is `unavailable` despite positive parity
  Expected: "unavailable"   Received: "pass"         ← the May-2026 specimen read as healthy
runBackup propagates an empty subsystem … (control added to it)
  Expected: true            Received: undefined      ← `sourceExisted` did not exist
```

**The fourth is a regression guard, NOT a defect witness, and passes both before and after** — `3 passed` pre-fix. A receipt carrying no `captureOutcome` must classify exactly as it did, because every bundle already on disk predates the verdict and a reader that treated an absent verdict as `unavailable` would retroactively condemn the whole archive. Stating that rather than counting it as coverage.

**Two controls, because either direction could be satisfied the wrong way:**

- the `empty` test now asserts `sourceExisted === true`, so `empty` is a positive finding rather than the default any zero-row export would get. Without it the `unavailable` test proves nothing.
- the `unavailable` bundle asserts a populated KB in the **same bundle** still reads `captured` / `pass`. Without it, a probe that reported `unavailable` for everything would satisfy every safety assertion.

**An existing test flipped, and the FIXTURE was wrong, not the assertion.** `runBackup propagates an empty subsystem` began returning `unavailable`: it stubbed the collection *getter* but not pre-existence, so the fake collection genuinely did not pre-exist and `unavailable` was the truthful verdict. Fixed by stubbing the probe source too — changing the assertion instead would have destroyed the only coverage of `empty`. Only that one test moved; the populated ones were unaffected because `rowCount > 0` short-circuits regardless of the probe.

**Consumer sweep**, with a positive control that it can return non-zero:

```
grep -rl "captureOutcome" ai/ --include='*.mjs'
→ ai/scripts/maintenance/backup.mjs
  ai/services/shared/captureOutcome.mjs
  ai/services/knowledge-base/DatabaseService.mjs
  ai/services/memory-core/DatabaseService.mjs
```

Wider run: `2378 passed, 6 failed` across `ai/scripts/maintenance/`, `ai/services/knowledge-base/`, `ai/services/memory-core/`. Five are load-sensitive (all timing/timeout specs; they pass in a smaller set). The sixth, `HealthService.spec.mjs:1228`, fails in isolation too — and was confirmed **pre-existing** by running it in a separate worktree carrying none of these changes, where it fails identically. None of the six imports any changed module (checked directly, against the positive control above).

Non-CI lint gates run locally, one file at a time (`zsh` does not word-split, so a passed list reaches a single-file tool as one bogus filename): `check-ticket-archaeology`, `check-block-alignment`, `node --check` — all clean, with a positive control proving the archaeology tool fails on an injected bare `#N`. Block alignment was hand-corrected, not `--fix`ed, which has corrupted destructuring before.

## Post-Merge Validation

- [ ] With a deliberately absent MC collection on a live Chroma, run the backup lane and confirm the receipt records `unavailable` (not `empty`) and `bundle-meta.json` is still written.
- [ ] Confirm a normal populated run still records `captured` / integrity `pass` on every subsystem.
- [ ] Re-count the zero-capture rate against the **off-docker** bundle store. The 4-of-36 measurement is from one store; if its rate differs materially, that difference is itself a finding about which lane writes which store.

The first is the L4 gap named in the Evidence line: no unit fixture can prove a real Chroma produces the absent-collection condition the probe reads.

## Commits

- `455baabb53` — the non-mutating probe primitive, `listCollectionNames()` on both managers, and the `captured`/`empty`/`unavailable` vocabulary. Foundation, no caller.
- `a31c2319af` — wires it into both export paths, folds MC's per-collection verdicts, repairs `#exportGraph`, and teaches `verifyBundleIntegrity` what a zero means.
- `c892b51ce3` — CI finding: the fixture read `ai/mcp/server/*/config.mjs`, the overlay-resolving path, so the spec asserted against whatever the running machine carries. Switched to the committed `config.template.mjs` singletons and stopped snapshotting the reactive proxy into a mutable array. No production change, no assertion change; 23 passed either way. **I had evaluated the ADR-0019 gate before starting and concluded it did not fire, because the diff adds no config leaf — it fires on config READS IN TESTS too.** Diligence missed it; `lint-config-template-ssot` did not, which is the argument the ADR makes about itself.

Rebased onto `363261e509`. Both commits were originally authored as `07cfd589dc` / `464ff1332b` carrying `(#16348)` in their subjects — the parent, not the close target — which `lint-pr-body` correctly rejected: a reader of the commit graph would conclude this PR closes `#16348`, and it does not. Retargeted to `(#16404)` by cherry-pick; **both rewritten trees hash byte-identically to the originals** (`ea4ae13d8f…` / `6c28b21b73…`), so only the subjects moved.

---

Authored by Ada (Opus 5, Claude Code). Session: `56105163-6e66-44b6-8c6f-9e81bc1be08c`.


