### PR TITLE
fix(memory-core): fail incomplete graph exports (#16407)

### DIFF
--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -166,17 +166,28 @@ class DatabaseService extends Base {
      * Helper method to export the Native Graph (Nodes and Edges) as JSONL.
      * @param {String} backupPath The directory to save the backup file.
      * @param {String} filePrefix The prefix for the backup filename.
-     * @returns {Promise<number>} The total number of graph elements exported.
+     * @returns {Promise<{collection: String, backupFile: String|null, expected: Number, exported: Number, skipped: Number, skippedIds: String[]}>} Export statistics preserving source-row completeness.
+     * @throws {Error} `GRAPH_COUNT_QUERY_FAILED` when the source tables cannot be counted.
+     * @throws {Error} `PARTIAL_COLLECTION_EXPORT` when one or more counted rows cannot be exported.
      * @private
      */
     async #exportGraph(backupPath, filePrefix) {
         logger.log(`Fetching all nodes and edges from the native graph...`);
-        const GraphService = (await import('./GraphService.mjs')).default;
+        const GraphService   = (await import('./GraphService.mjs')).default,
+              collectionName = 'native-graph',
+              emptyStats     = {
+                  collection: collectionName,
+                  backupFile: null,
+                  expected  : 0,
+                  exported  : 0,
+                  skipped   : 0,
+                  skippedIds: []
+              };
 
         // Ensure graph is initialized
         if (!GraphService.db || !GraphService.db.storage || !GraphService.db.storage.db) {
              logger.log(`Graph database not initialized. Skipping graph export.`);
-             return 0;
+             return emptyStats
         }
 
         const db = GraphService.db.storage.db;
@@ -187,16 +198,24 @@ class DatabaseService extends Base {
         try {
             nodesCount = db.prepare('SELECT count(*) as c FROM Nodes').get().c || 0;
             edgesCount = db.prepare('SELECT count(*) as c FROM Edges').get().c || 0;
-        } catch (e) {
-            logger.error(`Error querying Native Graph tables: ${e.message}`);
-            return 0;
+        } catch (cause) {
+            logger.error(`Error querying Native Graph tables: ${cause.message}`);
+
+            const error = new Error(`GRAPH_COUNT_QUERY_FAILED: could not count ${collectionName} rows (${cause.message}).`, {cause});
+            error.code    = 'GRAPH_COUNT_QUERY_FAILED';
+            error.details = {
+                collection: collectionName,
+                cause     : cause.message,
+                stage     : 'count'
+            };
+            throw error
         }
 
         const totalCount = nodesCount + edgesCount;
 
         if (totalCount === 0) {
             logger.log(`No nodes or edges found in the native graph to export.`);
-            return 0;
+            return emptyStats
         }
 
         logger.log(`Found ${nodesCount} nodes and ${edgesCount} edges to export.`);
@@ -208,38 +227,58 @@ class DatabaseService extends Base {
         const timestamp   = new Date().toISOString().replace(/:/g, '-');
         const backupFile  = path.join(backupPath, `${filePrefix}-${timestamp}.jsonl`);
         const writeStream = fs.createWriteStream(backupFile);
-
-        let exported = 0;
+        const stats       = {
+            collection: collectionName,
+            backupFile,
+            expected  : totalCount,
+            exported  : 0,
+            skipped   : 0,
+            skippedIds: []
+        };
 
         // Export Nodes
-        const nodesStmt = db.prepare('SELECT data FROM Nodes');
+        const nodesStmt = db.prepare('SELECT id, data FROM Nodes');
         for (const row of nodesStmt.iterate()) {
              try {
                  const node   = JSON.parse(row.data);
                  const record = { type: 'node', data: node };
                  writeStream.write(JSON.stringify(record) + '\n');
-                 exported++;
-             } catch(e) {
-                 logger.error(`Error parsing node during export`, e);
+                 stats.exported++;
+             } catch (error) {
+                 stats.skipped++;
+                 stats.skippedIds.push(`node:${row.id}`);
+                 logger.error(`Error parsing node during export`, error);
              }
         }
 
         // Export Edges
-        const edgesStmt = db.prepare('SELECT data FROM Edges');
+        const edgesStmt = db.prepare('SELECT id, data FROM Edges');
         for (const row of edgesStmt.iterate()) {
              try {
                  const edge   = JSON.parse(row.data);
                  const record = { type: 'edge', data: edge };
                  writeStream.write(JSON.stringify(record) + '\n');
-                 exported++;
-             } catch(e) {
-                 logger.error(`Error parsing edge during export`, e);
+                 stats.exported++;
+             } catch (error) {
+                 stats.skipped++;
+                 stats.skippedIds.push(`edge:${row.id}`);
+                 logger.error(`Error parsing edge during export`, error);
              }
         }
 
         await new Promise(resolve => writeStream.end(resolve));
-        logger.log(`Successfully exported ${exported} graph elements to: ${backupFile}`);
-        return exported;
+        if (stats.exported !== stats.expected) {
+            const error = new Error(
+                `PARTIAL_COLLECTION_EXPORT: ${collectionName} exported ${stats.exported}/${stats.expected} ` +
+                `records to ${backupFile}; skipped ${stats.skipped} unreadable graph row(s).`
+            );
+            error.code    = 'PARTIAL_COLLECTION_EXPORT';
+            error.details = stats;
+            throw error
+        }
+
+        logger.log(`Successfully exported ${stats.exported}/${stats.expected} graph elements to: ${backupFile}`);
+        return stats
     }
 
     /**
@@ -318,8 +357,7 @@ class DatabaseService extends Base {
             }
 
             if (include.includes('graph')) {
-                const graphCount = await this.#exportGraph(backupPath, 'graph-backup');
-                graphStats       = {expected: graphCount, exported: graphCount};
+                graphStats = await this.#exportGraph(backupPath, 'graph-backup')
             }
 
             const memoryCount          = memoryStats?.exported || 0,

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.graphBackup.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.graphBackup.spec.mjs
@@ -84,6 +84,7 @@ test.describe('Memory_DatabaseService — graph backup import (#10949)', () => {
                 endsWithNewline   : graphBackupContent.endsWith('\n'),
                 expectedRecordCount,
                 exportedMessage  : exportResult.message,
+                graphStats       : exportResult.graph,
                 hasTypedEdge     : graphBackupRecords.some(record => record.type === 'edge' && record.data.type === 'TEST_RESTORE_EDGE'),
                 imported          : importResult.imported,
                 nodeRecords       : graphBackupRecords.filter(record => record.type === 'node').length,
@@ -116,6 +117,8 @@ test.describe('Memory_DatabaseService — graph backup import (#10949)', () => {
 
             expect(proof.expectedRecordCount).toBeGreaterThanOrEqual(3);
             expect(proof.exportedMessage).toContain('graph elements');
+            expect(proof.graphStats.expected).toBe(proof.expectedRecordCount);
+            expect(proof.graphStats.exported).toBe(proof.expectedRecordCount);
             expect(proof.endsWithNewline).toBe(true);
             expect(proof.recordCount).toBe(proof.expectedRecordCount);
             expect(proof.nodeRecords).toBe(2);
@@ -124,6 +127,127 @@ test.describe('Memory_DatabaseService — graph backup import (#10949)', () => {
             expect(proof.imported).toBeGreaterThanOrEqual(3);
             expect(proof.restoredEdgeId).toBeTruthy();
             expect(proof.restoredEdgeData.type).toBe('TEST_RESTORE_EDGE');
+        } finally {
+            fs.rmSync(tmpDir, {recursive: true, force: true});
+        }
+    });
+
+    test('fails loud when graph rows or source counts cannot be read (#16407)', async () => {
+        const tmpDir    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-graph-backup-completeness-'));
+        const graphPath = path.join(tmpDir, 'memory-core-graph.sqlite');
+        const script    = String.raw`
+            await import('./src/Neo.mjs');
+            await import('./src/core/_export.mjs');
+            await import('./src/manager/Instance.mjs');
+            await import('./ai/mcp/server/memory-core/config.template.mjs');
+
+            const GraphService          = (await import('./ai/services/memory-core/GraphService.mjs')).default;
+            const MemoryDatabaseService = (await import('./ai/services/memory-core/DatabaseService.mjs')).default;
+
+            await GraphService.ready();
+            await MemoryDatabaseService.ready();
+
+            await GraphService.db.storage.clear();
+            GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            const db         = GraphService.db.storage.db;
+            const insertNode = db.prepare('INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)');
+
+            insertNode.run('graph-backup-corrupt-source', null, '{invalid-source-json');
+            insertNode.run('graph-backup-corrupt-target', null, '{invalid-target-json');
+            db.prepare('INSERT INTO Edges (id, user_id, source, target, type, data) VALUES (?, ?, ?, ?, ?, ?)')
+                .run(
+                    'graph-backup-corrupt-edge',
+                    null,
+                    'graph-backup-corrupt-source',
+                    'graph-backup-corrupt-target',
+                    'CORRUPT_BACKUP_EDGE',
+                    '{invalid-edge-json'
+                );
+
+            let shortfall;
+            try {
+                const result = await MemoryDatabaseService.exportDatabase({
+                    include   : ['graph'],
+                    backupPath: ${JSON.stringify(tmpDir)}
+                });
+                shortfall = {ok: true, result};
+            } catch (error) {
+                shortfall = {
+                    code   : error.code,
+                    details: error.details,
+                    message: error.message,
+                    ok     : false
+                }
+            }
+
+            db.exec('DELETE FROM Nodes; DROP TABLE Edges;');
+
+            let countRead;
+            try {
+                const result = await MemoryDatabaseService.exportDatabase({
+                    include   : ['graph'],
+                    backupPath: ${JSON.stringify(tmpDir)}
+                });
+                countRead = {ok: true, result};
+            } catch (error) {
+                countRead = {
+                    code   : error.code,
+                    details: error.details,
+                    message: error.message,
+                    ok     : false
+                }
+            }
+
+            console.log('GRAPH_BACKUP_COMPLETENESS_RESULT:' + JSON.stringify({countRead, shortfall}));
+        `;
+
+        try {
+            const result = spawnSync(process.execPath, ['--input-type=module', '--eval', script], {
+                cwd     : process.cwd(),
+                encoding: 'utf8',
+                env     : {
+                    ...process.env,
+                    NEO_MEMORY_DB_PATH_TEST: graphPath,
+                    UNIT_TEST_MODE         : 'true'
+                },
+                timeout: 30_000
+            });
+
+            expect(result.error, `${result.stderr}\n${result.stdout}`).toBeUndefined();
+            expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(0);
+
+            const output = result.stdout.match(/^GRAPH_BACKUP_COMPLETENESS_RESULT:(.+)$/m);
+
+            expect(output, result.stdout).toBeTruthy();
+
+            const {countRead, shortfall} = JSON.parse(output[1]);
+
+            expect(shortfall.ok).toBe(false);
+            expect(shortfall.code).toBe('DATABASE_EXPORT_ERROR');
+            expect(shortfall.message).toContain('PARTIAL_COLLECTION_EXPORT: native-graph exported 0/3');
+            expect(shortfall.details).toMatchObject({
+                collection: 'native-graph',
+                expected  : 3,
+                exported  : 0,
+                skipped   : 3
+            });
+            expect(shortfall.details.skippedIds).toEqual(expect.arrayContaining([
+                'node:graph-backup-corrupt-source',
+                'node:graph-backup-corrupt-target',
+                'edge:graph-backup-corrupt-edge'
+            ]));
+
+            expect(countRead.ok).toBe(false);
+            expect(countRead.code).toBe('DATABASE_EXPORT_ERROR');
+            expect(countRead.message).toContain('GRAPH_COUNT_QUERY_FAILED');
+            expect(countRead.details).toMatchObject({
+                collection: 'native-graph',
+                stage     : 'count'
+            });
         } finally {
             fs.rmSync(tmpDir, {recursive: true, force: true});
         }


### PR DESCRIPTION
Resolves #16407

Related: #16404

Native graph backup now preserves its authoritative source-row count through the public export result and refuses to report success when counted node or edge rows cannot be serialized. Partial exports carry collection, artifact, expected, exported, skipped, and typed skipped-row identities through the existing database-export error boundary; graph count-query failures now carry a distinct read-stage failure instead of masquerading as an empty graph.

Evidence: L2 (real SQLite graph exporter plus backup-receipt unit witnesses) → L2 required (all close-target ACs). No residuals.

## Deltas from ticket

- `skippedIds` qualify native row identities as `node:<id>` or `edge:<id>` so equal IDs across the two tables remain unambiguous.
- Count-query errors carry `collection`, `stage`, and bounded cause text in `details`; no `captureOutcome` or continuity vocabulary changed.

## Test Evidence

- Red witness: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/DatabaseService.graphBackup.spec.mjs` failed at the intended seam because three counted malformed graph rows returned success; the healthy round-trip passed in the same run.
- Native graph completeness and healthy export/import: the same focused command passed 4/4 after the repair.
- Graph export, neighboring collection export, and failed-backup receipt composition: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/DatabaseService.graphBackup.spec.mjs test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs` — 53/53 passed.
- Full unit safety net: `npm run test-unit` — 11,000 passed and 5 skipped; four unrelated `DragDrop` cases failed only under local fully-parallel execution and passed 23/23 with the documented CI serialization (`--workers=1`), while one live-provider summarization case returned `null`. Neither failing surface imports or exercises the touched graph exporter.
- `node --check` for both changed `.mjs` files and `git diff --check` passed.
- `npm run agent-preflight -- --change-class restoration --commit-subject "fix(memory-core): fail incomplete graph exports (#16407)" ...` passed; pre-commit whitespace, shorthand, AiConfig-test-mutation, derived-domain, JSDoc-type, ticket-archaeology, block-alignment, and parse gates also passed.
- UI/app surface: None found; this PR changes the Memory Core backup path and its Node-based unit witness.

## Post-Merge Validation

- [ ] Confirm the next scheduled healthy backup receipt remains successful and its graph source count matches the persisted JSONL row count.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session ae7661c9-1f40-46f9-a696-8fcb3310d7ef.
