### PR TITLE
fix(build): portable prepare lifecycle — the POSIX bracket guard blocked every native-Windows install (#16393)

### DIFF
--- a/buildScripts/util/prepare.mjs
+++ b/buildScripts/util/prepare.mjs
@@ -41,8 +41,15 @@ export function resolveHuskyBin(root=repoRoot) {
         throw new Error(`prepare: husky package not found at '${packagePath}' — run with the repo's dependencies installed`);
     }
 
-    const bin   = JSON.parse(readFileSync(packagePath, 'utf8')).bin,
-          entry = typeof bin === 'string' ? bin : bin?.husky ?? Object.values(bin ?? {})[0];
+    let bin;
+
+    try {
+        bin = JSON.parse(readFileSync(packagePath, 'utf8')).bin;
+    } catch (error) {
+        throw new Error(`prepare: cannot parse husky's package.json at '${packagePath}' (${error.message})`);
+    }
+
+    const entry = typeof bin === 'string' ? bin : bin?.husky ?? Object.values(bin ?? {})[0];
 
     if (typeof entry !== 'string' || entry.length === 0) {
         throw new Error(`prepare: husky's package.json declares no bin entry at '${packagePath}'`);

--- a/buildScripts/util/prepare.mjs
+++ b/buildScripts/util/prepare.mjs
@@ -1,0 +1,74 @@
+import {spawnSync}     from 'node:child_process';
+import {existsSync}    from 'node:fs';
+import path            from 'node:path';
+import process         from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    repoRoot   = path.resolve(path.dirname(__filename), '../..');
+
+/**
+ * @module buildScripts/util/prepare
+ * @summary The npm `prepare` lifecycle, made portable. Its predecessor was a POSIX one-liner —
+ * `if [ "$npm_config_package_lock_only" = "true" ]; then exit 0; fi; husky && node ...` — and on
+ * native Windows, where npm runs lifecycle scripts through `cmd.exe`, the bracket test does not
+ * exist, so `npm install` failed before husky ever ran: every native-Windows clone was blocked at
+ * the lifecycle, whatever the contributor's platform toolchain.
+ *
+ * The behavior contract is preserved exactly:
+ *
+ * - **`--package-lock-only` short-circuits.** The guard exists so lock-maintenance runs mutate
+ *   nothing — no hooks, no materialized configs. Preserved, and now expressed in JavaScript
+ *   instead of shell test syntax.
+ * - **husky first, then `initServerConfigs.mjs`.** Same order as the `&&` chain.
+ * - **A husky failure fails the install**, exactly as the chain's left operand did. A lifecycle
+ *   that silently proceeds past a failed hook installer is a hookless repo reporting ready.
+ */
+
+/**
+ * @summary The husky entrypoint, resolved from the package itself — never a PATH shim, so the
+ * script works identically under cmd.exe, PowerShell, and POSIX shells.
+ * @param {String} [root=repoRoot]
+ * @returns {String}
+ */
+export function resolveHuskyBin(root=repoRoot) {
+    const candidate = path.join(root, 'node_modules', 'husky', 'bin.js');
+
+    if (!existsSync(candidate)) {
+        throw new Error(`prepare: husky entrypoint not found at '${candidate}' — run with the repo's dependencies installed`);
+    }
+
+    return candidate
+}
+
+/**
+ * @summary Runs the prepare lifecycle. Seams are injected so the contract is testable without
+ * mutating hooks or writing configs.
+ * @param {Object} [options]
+ * @param {String} [options.root=repoRoot]
+ * @param {Object} [options.env=process.env]
+ * @param {Function} [options.spawnFn=spawnSync]
+ * @returns {{skipped: String|null, stage: String, status: Number}}
+ */
+export function runPrepare({root=repoRoot, env=process.env, spawnFn=spawnSync}={}) {
+    if (env.npm_config_package_lock_only === 'true') {
+        return {skipped: 'package-lock-only', stage: 'guard', status: 0}
+    }
+
+    const huskyResult = spawnFn(process.execPath, [resolveHuskyBin(root)], {cwd: root, env, stdio: 'inherit'});
+
+    if (huskyResult.status !== 0) {
+        return {skipped: null, stage: 'husky', status: huskyResult.status ?? 1}
+    }
+
+    const configResult = spawnFn(process.execPath, [path.join(root, 'ai', 'scripts', 'setup', 'initServerConfigs.mjs')], {cwd: root, env, stdio: 'inherit'});
+
+    return {skipped: null, stage: 'initServerConfigs', status: configResult.status ?? 1}
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+
+if (isMain) {
+    process.exit(runPrepare().status)
+}

--- a/buildScripts/util/prepare.mjs
+++ b/buildScripts/util/prepare.mjs
@@ -1,8 +1,8 @@
-import {spawnSync}     from 'node:child_process';
-import {existsSync}    from 'node:fs';
-import path            from 'node:path';
-import process         from 'node:process';
-import {fileURLToPath} from 'node:url';
+import {spawnSync}                from 'node:child_process';
+import {existsSync, readFileSync} from 'node:fs';
+import path                       from 'node:path';
+import process                    from 'node:process';
+import {fileURLToPath}            from 'node:url';
 
 const
     __filename = fileURLToPath(import.meta.url),
@@ -27,16 +27,31 @@ const
  */
 
 /**
- * @summary The husky entrypoint, resolved from the package itself — never a PATH shim, so the
- * script works identically under cmd.exe, PowerShell, and POSIX shells.
+ * @summary The husky entrypoint, resolved from the package's own `bin` declaration — never a PATH
+ * shim, so the script works identically under cmd.exe, PowerShell, and POSIX shells. The
+ * declaration is read, not assumed: a husky release that moves its entrypoint resolves through
+ * its manifest rather than breaking a hardcode.
  * @param {String} [root=repoRoot]
  * @returns {String}
  */
 export function resolveHuskyBin(root=repoRoot) {
-    const candidate = path.join(root, 'node_modules', 'husky', 'bin.js');
+    const packagePath = path.join(root, 'node_modules', 'husky', 'package.json');
+
+    if (!existsSync(packagePath)) {
+        throw new Error(`prepare: husky package not found at '${packagePath}' — run with the repo's dependencies installed`);
+    }
+
+    const bin   = JSON.parse(readFileSync(packagePath, 'utf8')).bin,
+          entry = typeof bin === 'string' ? bin : bin?.husky ?? Object.values(bin ?? {})[0];
+
+    if (typeof entry !== 'string' || entry.length === 0) {
+        throw new Error(`prepare: husky's package.json declares no bin entry at '${packagePath}'`);
+    }
+
+    const candidate = path.join(root, 'node_modules', 'husky', entry);
 
     if (!existsSync(candidate)) {
-        throw new Error(`prepare: husky entrypoint not found at '${candidate}' — run with the repo's dependencies installed`);
+        throw new Error(`prepare: husky entrypoint '${entry}' not found at '${candidate}' — the package is present but its bin target is missing`);
     }
 
     return candidate
@@ -56,13 +71,28 @@ export function runPrepare({root=repoRoot, env=process.env, spawnFn=spawnSync}={
         return {skipped: 'package-lock-only', stage: 'guard', status: 0}
     }
 
-    const huskyResult = spawnFn(process.execPath, [resolveHuskyBin(root)], {cwd: root, env, stdio: 'inherit'});
+    // A failure-to-LAUNCH is not a status: spawnSync signals it through `result.error` with
+    // `status: null`, and with `stdio: 'inherit'` no child exists to print anything — so reading
+    // only `status` would surface an install failure as a bare exit 1 with zero diagnostic, the
+    // same invisibility class this module exists to remove (and most likely to fire on the
+    // platform it serves).
+    const spawnChecked = (file, args) => {
+        const result = spawnFn(file, args, {cwd: root, env, stdio: 'inherit'});
+
+        if (result.error) {
+            throw new Error(`prepare: failed to launch '${path.basename(args[0] ?? file)}' (${result.error.code ?? result.error.message})`)
+        }
+
+        return result
+    };
+
+    const huskyResult = spawnChecked(process.execPath, [resolveHuskyBin(root)]);
 
     if (huskyResult.status !== 0) {
         return {skipped: null, stage: 'husky', status: huskyResult.status ?? 1}
     }
 
-    const configResult = spawnFn(process.execPath, [path.join(root, 'ai', 'scripts', 'setup', 'initServerConfigs.mjs')], {cwd: root, env, stdio: 'inherit'});
+    const configResult = spawnChecked(process.execPath, [path.join(root, 'ai', 'scripts', 'setup', 'initServerConfigs.mjs')]);
 
     return {skipped: null, stage: 'initServerConfigs', status: configResult.status ?? 1}
 }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "devindex:update"                      : "node ./apps/devindex/services/cli.mjs update --limit 200",
         "generate-docs-json"                   : "node ./buildScripts/docs/generateDocsJson.mjs",
         "install-brain"                        : "node ./buildScripts/util/installBrain.mjs",
-        "prepare"                              : "if [ \"$npm_config_package_lock_only\" = \"true\" ]; then exit 0; fi; husky && node ./ai/scripts/setup/initServerConfigs.mjs",
+        "prepare"                              : "node ./buildScripts/util/prepare.mjs",
         "server-start"                         : "webpack serve -c ./buildScripts/webpack/webpack.server.config.mjs --open",
         "test"                                 : "playwright test -c test/playwright/playwright.config.mjs",
         "test-components"                      : "playwright test -c test/playwright/playwright.config.component.mjs",

--- a/test/playwright/unit/buildScripts/prepare.spec.mjs
+++ b/test/playwright/unit/buildScripts/prepare.spec.mjs
@@ -68,15 +68,48 @@ test.describe('buildScripts/util/prepare — the portable prepare lifecycle', ()
         const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'prepare-spec-'));
 
         try {
-            expect(() => resolveHuskyBin(empty)).toThrow(/husky entrypoint not found/);
+            expect(() => resolveHuskyBin(empty)).toThrow(/husky package not found/);
         } finally {
             fs.rmSync(empty, {force: true, recursive: true})
         }
     });
 
-    test('the real entrypoint runs clean on this host: guard, husky, configs — POSIX parity receipt', () => {
-        // The behavior contract on a POSIX host must be identical before and after the move: this
-        // is the receipt that the portable script does what the one-liner did here.
+    test('a husky package declaring no bin entry is a named error', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'prepare-spec-'));
+
+        fs.mkdirSync(path.join(dir, 'node_modules', 'husky'), {recursive: true});
+        fs.writeFileSync(path.join(dir, 'node_modules', 'husky', 'package.json'), '{}');
+
+        try {
+            expect(() => resolveHuskyBin(dir)).toThrow(/declares no bin entry/);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('a bin target missing from disk is a named error naming the entry', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'prepare-spec-'));
+
+        fs.mkdirSync(path.join(dir, 'node_modules', 'husky'), {recursive: true});
+        fs.writeFileSync(path.join(dir, 'node_modules', 'husky', 'package.json'), JSON.stringify({bin: {husky: 'bin.js'}}));
+
+        try {
+            expect(() => resolveHuskyBin(dir)).toThrow(/'bin\.js' not found/);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('a failure-to-launch throws with the error code — never a bare exit 1 with no diagnostic', () => {
+        // spawnSync signals failure-to-launch through `error`, not `status`: reading only `status`
+        // maps it to 1 with zero output, the same invisibility class this module exists to remove.
+        const spawnFn = () => ({error: Object.assign(new Error('spawn node ENOENT'), {code: 'ENOENT'}), status: null});
+
+        expect(() => runPrepare({env: {}, spawnFn})).toThrow(/failed to launch.*ENOENT/);
+    });
+
+    test('the husky entrypoint resolves from the package\'s own bin declaration on this host', () => {
+        // The resolution is read from husky's manifest, not hardcoded — and it exists here.
         expect(fs.existsSync(resolveHuskyBin(repoRoot))).toBe(true);
     });
 });

--- a/test/playwright/unit/buildScripts/prepare.spec.mjs
+++ b/test/playwright/unit/buildScripts/prepare.spec.mjs
@@ -87,6 +87,19 @@ test.describe('buildScripts/util/prepare — the portable prepare lifecycle', ()
         }
     });
 
+    test('a corrupt husky manifest is a named parse error, matching its neighbours', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'prepare-spec-'));
+
+        fs.mkdirSync(path.join(dir, 'node_modules', 'husky'), {recursive: true});
+        fs.writeFileSync(path.join(dir, 'node_modules', 'husky', 'package.json'), '{not json');
+
+        try {
+            expect(() => resolveHuskyBin(dir)).toThrow(/cannot parse husky's package\.json/);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
     test('a bin target missing from disk is a named error naming the entry', () => {
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'prepare-spec-'));
 

--- a/test/playwright/unit/buildScripts/prepare.spec.mjs
+++ b/test/playwright/unit/buildScripts/prepare.spec.mjs
@@ -1,0 +1,82 @@
+import {test, expect}  from '@playwright/test';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {
+    resolveHuskyBin,
+    runPrepare
+} from '../../../../buildScripts/util/prepare.mjs';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    repoRoot   = path.resolve(path.dirname(__filename), '../../../..');
+
+/**
+ * @summary The portable prepare lifecycle: the lock-only guard short-circuits, husky runs first,
+ * and a husky failure fails the install — the exact contract the POSIX one-liner had, expressed
+ * without shell test syntax, so cmd.exe hosts can run it at all.
+ */
+test.describe('buildScripts/util/prepare — the portable prepare lifecycle', () => {
+    const recordingSpawn = results => {
+        const calls = [];
+        return {
+            calls,
+            spawnFn: (file, args, opts) => {
+                calls.push({file, args, opts});
+                return {status: results[calls.length - 1] ?? 0}
+            }
+        };
+    };
+
+    test('the lock-only guard short-circuits BEFORE anything runs', () => {
+        const {calls, spawnFn} = recordingSpawn([]),
+              result           = runPrepare({env: {npm_config_package_lock_only: 'true'}, spawnFn});
+
+        expect(result).toEqual({skipped: 'package-lock-only', stage: 'guard', status: 0});
+        expect(calls).toEqual([]);
+    });
+
+    test('husky runs first, then initServerConfigs — order preserved from the && chain', () => {
+        const {calls, spawnFn} = recordingSpawn([0, 0]),
+              result           = runPrepare({env: {}, spawnFn});
+
+        expect(result.status).toBe(0);
+        expect(calls.length).toBe(2);
+        expect(calls[0].args[0]).toBe(resolveHuskyBin(repoRoot));
+        expect(calls[1].args[0].endsWith(path.join('ai', 'scripts', 'setup', 'initServerConfigs.mjs'))).toBe(true);
+    });
+
+    test('a husky failure fails the install and initServerConfigs never runs — the old left-operand rule', () => {
+        const {calls, spawnFn} = recordingSpawn([1]),
+              result           = runPrepare({env: {}, spawnFn});
+
+        expect(result).toEqual({skipped: null, stage: 'husky', status: 1});
+        expect(calls.length).toBe(1);
+    });
+
+    test('an initServerConfigs failure propagates its status', () => {
+        const {calls, spawnFn} = recordingSpawn([0, 2]),
+              result           = runPrepare({env: {}, spawnFn});
+
+        expect(result).toEqual({skipped: null, stage: 'initServerConfigs', status: 2});
+        expect(calls.length).toBe(2);
+    });
+
+    test('a missing husky entrypoint is a named error, not an opaque spawn failure', () => {
+        const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'prepare-spec-'));
+
+        try {
+            expect(() => resolveHuskyBin(empty)).toThrow(/husky entrypoint not found/);
+        } finally {
+            fs.rmSync(empty, {force: true, recursive: true})
+        }
+    });
+
+    test('the real entrypoint runs clean on this host: guard, husky, configs — POSIX parity receipt', () => {
+        // The behavior contract on a POSIX host must be identical before and after the move: this
+        // is the receipt that the portable script does what the one-liner did here.
+        expect(fs.existsSync(resolveHuskyBin(repoRoot))).toBe(true);
+    });
+});


### PR DESCRIPTION
Resolves #16393

The root `prepare` lifecycle is portable. The POSIX one-liner (`if [ "$npm_config_package_lock_only" = "true" ]; then exit 0; fi; husky && node ./ai/scripts/setup/initServerConfigs.mjs`) ran lifecycle scripts through `cmd.exe` on native Windows, where the bracket test does not exist — every native-Windows `npm install` failed at the lifecycle before husky ever ran, blocking the exact contributor class the two-path install tier's Windows win is meant to serve. The contract is now `buildScripts/util/prepare.mjs`, with zero shell conditionals anywhere.

Evidence: L2 (unit specs + POSIX parity receipts, below) → L4 required (a native-Windows `npm install` completing the lifecycle — no Windows seat on this host). Residual: the native-Windows receipt [#16393 Post-Merge Validation].

## The contract, preserved exactly

- **`--package-lock-only` short-circuits** — the guard's origin (lock-maintenance runs must not mutate hooks or materialize configs), now expressed in JavaScript instead of shell test syntax.
- **husky first, then `initServerConfigs.mjs`** — the `&&` chain's order.
- **A husky failure fails the install** — the chain's left-operand rule; a lifecycle that proceeds past a failed hook installer is a hookless repo reporting ready. Propagated statuses are asserted, and `initServerConfigs` never runs after a husky failure.

The husky entrypoint resolves from the package itself (`node_modules/husky/bin.js`) — never a PATH shim, so cmd.exe, PowerShell, and POSIX shells all reach it. Seams (`env`, `spawnFn`) are injected so the contract is testable without mutating hooks or writing configs.

## Deltas from ticket

- Option 1 of the ticket's two (one portable entrypoint) chosen over option 2 (drop the guard): the guard's origin was verified before preserving it (`b06392b37c`, a lock-maintenance deps fix — the short-circuit is load-bearing for lock-only workflows, not ceremony).

## Test Evidence

- `test/playwright/unit/buildScripts/prepare.spec.mjs` (new, body project): guard short-circuits before anything runs; husky-first ordering; husky failure fails the install with `initServerConfigs` never called; initServerConfigs failure propagates; missing husky entrypoint is a named error. **6/6 green.**
- POSIX parity receipts (this host): `npm_config_package_lock_only=true node buildScripts/util/prepare.mjs` → silent, exit 0; full `node buildScripts/util/prepare.mjs` → husky + `initServerConfigs` output identical to the one-liner's, exit 0.
- Scoped suite incl. the sibling `installBrain.spec.mjs`: **17/17 green.**

## Post-Merge Validation

- [ ] **Native-Windows receipt** (the ticket's AC1): a fresh clone on native Windows completes `npm install` through the lifecycle — cmd.exe, no WSL/Git-Bash shim. Needs a Windows seat; operator handoff. **Log `{argv1: path.resolve(process.argv[1]), __filename, isMain}` alongside it** — settles the drive-letter-case risk in the in-repo `isMain` idiom (5 call sites) at zero extra cost on the same run.
- [ ] POSIX behavior stays identical on the first post-merge contributor install (guard, husky, configs — the parity receipts above are the pre-merge witness).

## Commits

- `069b45fcb6` — `fix(build): portable prepare lifecycle — the POSIX bracket guard blocked every native-Windows install (#16393)` (single commit: the script, its spec, the one-line manifest swap)

Authored by Iris (Moonshot Kimi K3, Kimi Code CLI). Session 69b4b2b4-9f78-40aa-a653-6bd93ddde065.
