### PR TITLE
feat(orchestrator): diagnose miniSummary starvation from typed causes (#16382)

### DIFF
--- a/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs
@@ -1,0 +1,186 @@
+import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+
+/**
+ * The two causes that name a timeout, and the only ones a binding-timeout verdict may be derived from.
+ *
+ * The predecessor derived that verdict from `failedInner` / `failedOuter` — control-flow branch counters.
+ * A branch says WHICH path ran and never WHY: a summarizer returning `null` instantly, with no timeout
+ * anywhere, increments `failedInner` exactly as a real inner timeout does. That is why the predecessor
+ * was closed unmerged rather than reworded; no phrasing repairs an input contract that lacks the fact.
+ * @type {Object}
+ */
+export const TIMEOUT_CAUSES = Object.freeze({inner: 'timeout-inner', outer: 'timeout-outer'});
+
+/**
+ * Passes a window must span before a diagnosis is emitted at all.
+ * @type {Number}
+ */
+export const DEFAULT_MIN_SUSTAINED_PASSES = 3;
+
+/**
+ * @summary Sums a pass's typed failure causes, ignoring any cause this module does not know.
+ * @param {Object} pass One `backfillMiniSummaries` result.
+ * @returns {Object} `{inner, outer, other, total}` cause counts.
+ */
+function tallyCauses(pass) {
+    const causes = pass?.failureCauses;
+
+    if (!causes || typeof causes !== 'object') {
+        return {inner: 0, outer: 0, other: 0, total: 0};
+    }
+
+    let inner = 0, outer = 0, other = 0;
+
+    for (const [cause, rawCount] of Object.entries(causes)) {
+        const count = Number.isFinite(rawCount) ? rawCount : 0;
+
+        if (cause === TIMEOUT_CAUSES.inner)      inner += count;
+        else if (cause === TIMEOUT_CAUSES.outer) outer += count;
+        else                                     other += count;
+    }
+
+    return {inner, outer, other, total: inner + outer + other};
+}
+
+/**
+ * @summary Decides whether one pass is starved: it processed rows and completed none of them, and the
+ * failures were generation failures rather than rows that were never summarizable.
+ *
+ * `missingContent` and `exhausted` rows are deliberately NOT starvation. A sweep that correctly archives
+ * three un-summarizable rows and hits one unrelated provider error is a working sweep with a bad row in
+ * it; the predecessor emitted on exactly that shape because it required only *at least one* failure. The
+ * guard is that every failure in the pass must be a generation failure, not merely that one is.
+ *
+ * @param {Object} pass One `backfillMiniSummaries` result.
+ * @returns {Boolean}
+ */
+function isStarvedPass(pass) {
+    const processed = Number.isFinite(pass?.processed) ? pass.processed : 0,
+          updated   = Number.isFinite(pass?.updated)   ? pass.updated   : 0;
+
+    // A pass that completed any work is not starved, however badly the rest of it went.
+    if (processed === 0 || updated > 0) {
+        return false;
+    }
+
+    const {total} = tallyCauses(pass),
+          skipped = (Number.isFinite(pass?.missingContent) ? pass.missingContent : 0) +
+                    (Number.isFinite(pass?.exhausted)      ? pass.exhausted      : 0);
+
+    // Every processed row must be accounted for by a generation failure. If rows were skipped for
+    // non-generation reasons, the loop is not starved — it is draining rows it cannot summarize.
+    return total > 0 && skipped === 0 && total >= processed;
+}
+
+/**
+ * @summary Names which timeout window is binding, from causes alone, or `null` when none is.
+ *
+ * Returns `'mixed'` for a genuine tie rather than picking one. The predecessor resolved ties to `'outer'`
+ * because its verdict was an *inference* from branch topology, so the pessimistic pick was the safe
+ * default. With typed causes both timeouts are measured facts, so a tie means the window hit both bounds
+ * — and choosing one would assert something the evidence does not contain, which is the predecessor's
+ * defect wearing a better name. A consumer that cannot act on `'mixed'` should widen nothing.
+ *
+ * `null` when neither timeout cause appears: a window starved by `no-model` or `provider-error` is really
+ * starved, and has no window to widen. Naming one would send a controller to adjust a bound that was
+ * never involved.
+ *
+ * @param {Object} totals Summed `{inner, outer}` counts across the window.
+ * @returns {String|null} `'inner'` | `'outer'` | `'mixed'` | `null`
+ */
+function resolveBindingTimeout({inner, outer}) {
+    if (inner === 0 && outer === 0) return null;
+    if (inner === outer)            return 'mixed';
+
+    return inner > outer ? 'inner' : 'outer'
+}
+
+/**
+ * @summary Diagnoses miniSummary generation starvation and names the binding timeout from typed causes.
+ *
+ * Starvation is a loop that processes rows and completes none of them, for days, while every other
+ * signal reads healthy: the Memory Core answers A2A and persists memory throughout, so the service looks
+ * fine while burning cores. Nothing previously turned that into something a controller could consume.
+ *
+ * Classified `contention`, never `crash`. Summary generation depends on the chat model, so a failing
+ * canary here means saturation or a degraded provider — not a dead service. `crash` would invite a
+ * restart that fixes nothing and costs an outage.
+ *
+ * `confidence: 1` describes the OBSERVATION, not the authority to act. Starvation is measured rather than
+ * inferred, so the confidence is honest — but a consumer must still combine this with a resource or
+ * lifecycle fact of its own before taking an authoritative action.
+ *
+ * @param {Object} [options]
+ * @param {Object[]} [options.window] Consecutive `backfillMiniSummaries` results, oldest first.
+ * @param {Number} options.observedAt Epoch ms.
+ * @param {String} options.serviceId Compose-service identity.
+ * @param {Number} [options.minSustainedPasses=DEFAULT_MIN_SUSTAINED_PASSES] Passes required before emitting.
+ * @returns {Object|null} A `recovery-diagnosis` event (`contention`) when sustained starvation is present, else `null`.
+ * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
+ */
+export function buildMiniSummaryStarvationDiagnosis({
+    window,
+    observedAt,
+    serviceId,
+    minSustainedPasses = DEFAULT_MIN_SUSTAINED_PASSES
+} = {}) {
+    if (typeof serviceId !== 'string' || serviceId.length === 0) {
+        throw new TypeError('buildMiniSummaryStarvationDiagnosis: serviceId is required');
+    }
+    if (!Number.isFinite(observedAt)) {
+        throw new TypeError('buildMiniSummaryStarvationDiagnosis: observedAt must be a finite number');
+    }
+
+    const passes = Array.isArray(window) ? window : [];
+
+    // A threshold below 1 must not license emission from nothing. The predecessor tested
+    // `passes.length < minSustainedPasses`, which is `0 < 0 === false` for an empty window, and then
+    // `[].every(...)` returned vacuously true — so it emitted a diagnosis from no evidence at all.
+    // Requiring at least one pass AND at least the threshold is the fix; neither check alone is enough.
+    const required = Math.max(1, Number.isFinite(minSustainedPasses) ? minSustainedPasses : DEFAULT_MIN_SUSTAINED_PASSES);
+
+    if (passes.length < required) {
+        return null;
+    }
+
+    if (!passes.every(isStarvedPass)) {
+        return null;
+    }
+
+    const totals = passes.reduce((sum, pass) => {
+        const {inner, outer, other} = tallyCauses(pass);
+
+        return {inner: sum.inner + inner, outer: sum.outer + outer, other: sum.other + other}
+    }, {inner: 0, outer: 0, other: 0});
+
+    const bindingTimeout = resolveBindingTimeout(totals);
+
+    return createRecoveryDiagnosisEvent({
+        diagnosisId   : `contention:${serviceId}:mini-summary-starvation:${observedAt}`,
+        recoveryClass : 'contention',
+        confidence    : 1,
+        targetIdentity: {kind: 'compose-service', id: serviceId},
+        evidenceFacts : passes.map((pass, index) => ({
+            type         : 'mini-summary-starved-pass',
+            passIndex    : index,
+            processed    : pass?.processed ?? 0,
+            updated      : pass?.updated ?? 0,
+            failureCauses: {...(pass?.failureCauses || {})},
+            // Branch topology travels as evidence, explicitly NOT as a verdict — a consumer may want the
+            // split, but nothing here may be derived from it.
+            branchSplit   : {
+                failedInner: pass?.failedInner ?? 0,
+                failedOuter: pass?.failedOuter ?? 0
+            }
+        })),
+        observedAt,
+        source : 'mini-summary-starvation-monitor',
+        details: {
+            reasonCode     : 'mini-summary-generation-starvation',
+            sustainedPasses: passes.length,
+            causeTotals    : totals,
+            // Absent rather than guessed when no timeout cause is present.
+            ...(bindingTimeout ? {bindingTimeout} : {})
+        }
+    });
+}

--- a/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs
@@ -12,10 +12,25 @@ import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helper
 export const TIMEOUT_CAUSES = Object.freeze({inner: 'timeout-inner', outer: 'timeout-outer'});
 
 /**
+ * The upstream cause for "no chat model was resolvable", which the taxonomy treats as a provider-side
+ * residency fact rather than as contention against the service that reported it.
+ * @type {String}
+ */
+export const NO_MODEL_CAUSE = 'no-model';
+
+/**
  * Passes a window must span before a diagnosis is emitted at all.
  * @type {Number}
  */
 export const DEFAULT_MIN_SUSTAINED_PASSES = 3;
+
+/**
+ * Floor for any caller-supplied threshold. **Sustained means repeated**, so one observation can never
+ * satisfy it however low the threshold is set — a clamp to `1` still emitted on a single pass and
+ * reported `sustainedPasses: 1`, which is the very shape the ticket forbids.
+ * @type {Number}
+ */
+export const MIN_SUSTAINED_FLOOR = 2;
 
 /**
  * @summary Sums a pass's typed failure causes, ignoring any cause this module does not know.
@@ -26,30 +41,36 @@ function tallyCauses(pass) {
     const causes = pass?.failureCauses;
 
     if (!causes || typeof causes !== 'object') {
-        return {inner: 0, outer: 0, other: 0, total: 0};
+        return {inner: 0, outer: 0, noModel: 0, other: 0, total: 0};
     }
 
-    let inner = 0, outer = 0, other = 0;
+    let inner = 0, outer = 0, noModel = 0, other = 0;
 
     for (const [cause, rawCount] of Object.entries(causes)) {
         const count = Number.isFinite(rawCount) ? rawCount : 0;
 
-        if (cause === TIMEOUT_CAUSES.inner)      inner += count;
-        else if (cause === TIMEOUT_CAUSES.outer) outer += count;
-        else                                     other += count;
+        if (cause === TIMEOUT_CAUSES.inner)       inner   += count;
+        else if (cause === TIMEOUT_CAUSES.outer)  outer   += count;
+        else if (cause === NO_MODEL_CAUSE)        noModel += count;
+        else                                      other   += count;
     }
 
-    return {inner, outer, other, total: inner + outer + other};
+    return {inner, outer, noModel, other, total: inner + outer + noModel + other};
 }
 
 /**
  * @summary Decides whether one pass is starved: it processed rows and completed none of them, and the
  * failures were generation failures rather than rows that were never summarizable.
  *
- * `missingContent` and `exhausted` rows are deliberately NOT starvation. A sweep that correctly archives
- * three un-summarizable rows and hits one unrelated provider error is a working sweep with a bad row in
- * it; the predecessor emitted on exactly that shape because it required only *at least one* failure. The
- * guard is that every failure in the pass must be a generation failure, not merely that one is.
+ * `missingContent` rows are deliberately NOT starvation: a sweep that correctly archives un-summarizable
+ * rows and hits one unrelated provider error is a working sweep with a bad row in it, and the predecessor
+ * emitted on exactly that shape because it required only *at least one* failure.
+ *
+ * `exhausted` rows ARE starvation. The upstream contract archives a row only after it has spent its
+ * generation-attempt budget, and records the typed cause BEFORE incrementing `exhausted` — so an
+ * exhausted row is a generation failure that ran out of retries, not a row that was never summarizable.
+ * Excluding it inverted the guard: a genuinely starved window whose rows had exhausted their budget
+ * returned `null`, which is the false NEGATIVE of the defect this producer exists to catch.
  *
  * @param {Object} pass One `backfillMiniSummaries` result.
  * @returns {Boolean}
@@ -64,12 +85,38 @@ function isStarvedPass(pass) {
     }
 
     const {total} = tallyCauses(pass),
-          skipped = (Number.isFinite(pass?.missingContent) ? pass.missingContent : 0) +
-                    (Number.isFinite(pass?.exhausted)      ? pass.exhausted      : 0);
+          skipped = Number.isFinite(pass?.missingContent) ? pass.missingContent : 0;
 
     // Every processed row must be accounted for by a generation failure. If rows were skipped for
     // non-generation reasons, the loop is not starved — it is draining rows it cannot summarize.
     return total > 0 && skipped === 0 && total >= processed;
+}
+
+/**
+ * @summary Maps the window's dominant cause to a recovery class the existing taxonomy already means.
+ *
+ * `contention` is NOT the answer for every starved window. It is provable only from a timeout: a window
+ * that exhausted its generation budget is saturated, and that is what contention means. The other causes
+ * name different things the taxonomy already distinguishes:
+ *
+ * - `no-model` is a MISSING MODEL, not saturation. `ContainerHealthDiagnosisService` already classifies a
+ *   missing required model as `provider-role-residency` with a warm-provider action. Flattening it to
+ *   contention against the Memory Core would blame the wrong subject for a provider-side fact, purely
+ *   because the failing operation happens to use a model.
+ * - a generic `provider-error` or `empty-output` proves the loop is starved and proves nothing about WHY.
+ *   `ambiguous` is the honest class; it exists for this.
+ *
+ * The safe no-restart property is preserved throughout — none of these three classes invites a restart —
+ * but preserving it is not a licence to discard the cause the upstream layer measured.
+ *
+ * @param {Object} totals Summed cause counts across the window.
+ * @returns {String} A member of `RECOVERY_CLASSES`.
+ */
+function resolveRecoveryClass({inner, outer, noModel, other}) {
+    if (inner + outer > 0) return 'contention';
+    if (noModel > 0 && noModel >= other) return 'provider-role-residency';
+
+    return 'ambiguous'
 }
 
 /**
@@ -137,7 +184,7 @@ export function buildMiniSummaryStarvationDiagnosis({
     // `passes.length < minSustainedPasses`, which is `0 < 0 === false` for an empty window, and then
     // `[].every(...)` returned vacuously true — so it emitted a diagnosis from no evidence at all.
     // Requiring at least one pass AND at least the threshold is the fix; neither check alone is enough.
-    const required = Math.max(1, Number.isFinite(minSustainedPasses) ? minSustainedPasses : DEFAULT_MIN_SUSTAINED_PASSES);
+    const required = Math.max(MIN_SUSTAINED_FLOOR, Number.isFinite(minSustainedPasses) ? minSustainedPasses : DEFAULT_MIN_SUSTAINED_PASSES);
 
     if (passes.length < required) {
         return null;
@@ -148,16 +195,22 @@ export function buildMiniSummaryStarvationDiagnosis({
     }
 
     const totals = passes.reduce((sum, pass) => {
-        const {inner, outer, other} = tallyCauses(pass);
+        const {inner, outer, noModel, other} = tallyCauses(pass);
 
-        return {inner: sum.inner + inner, outer: sum.outer + outer, other: sum.other + other}
-    }, {inner: 0, outer: 0, other: 0});
+        return {
+            inner  : sum.inner   + inner,
+            outer  : sum.outer   + outer,
+            noModel: sum.noModel + noModel,
+            other  : sum.other   + other
+        }
+    }, {inner: 0, outer: 0, noModel: 0, other: 0});
 
-    const bindingTimeout = resolveBindingTimeout(totals);
+    const bindingTimeout = resolveBindingTimeout(totals),
+          recoveryClass  = resolveRecoveryClass(totals);
 
     return createRecoveryDiagnosisEvent({
-        diagnosisId   : `contention:${serviceId}:mini-summary-starvation:${observedAt}`,
-        recoveryClass : 'contention',
+        diagnosisId   : `${recoveryClass}:${serviceId}:mini-summary-starvation:${observedAt}`,
+        recoveryClass,
         confidence    : 1,
         targetIdentity: {kind: 'compose-service', id: serviceId},
         evidenceFacts : passes.map((pass, index) => ({

--- a/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs
+++ b/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs
@@ -1,4 +1,4 @@
-import {createRecoveryDiagnosisEvent} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
+import {createRecoveryDiagnosisEvent, createRecoveryTargetIdentity} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 
 /**
  * The two causes that name a timeout, and the only ones a binding-timeout verdict may be derived from.
@@ -35,7 +35,7 @@ export const MIN_SUSTAINED_FLOOR = 2;
 /**
  * @summary Sums a pass's typed failure causes, ignoring any cause this module does not know.
  * @param {Object} pass One `backfillMiniSummaries` result.
- * @returns {Object} `{inner, outer, other, total}` cause counts.
+ * @returns {Object} `{inner, outer, noModel, other, total}` cause counts.
  */
 function tallyCauses(pass) {
     const causes = pass?.failureCauses;
@@ -93,11 +93,61 @@ function isStarvedPass(pass) {
 }
 
 /**
+ * @summary Whether one cause group holds a STRICT MAJORITY of the window's counted causes.
+ *
+ * A singular recovery class is a claim about the whole window, so it may only be made by a group that
+ * outnumbers everything else combined. The predecessor of this helper let *any* non-zero timeout win:
+ * @neo-gpt-emmy ran the classifier with `timeout-inner: 1` and `provider-error: 9` per pass and it emitted
+ * `contention` on window totals of `3:27` — a class contradicting 90% of its own evidence. The reading was
+ * not false (there really was a timeout); it was one level too coarse to be a window verdict, which is the
+ * same granularity failure that closed the predecessor PR.
+ *
+ * Strict rather than `>=` on purpose: an even split IS mixed evidence, and mixed evidence must stay
+ * `ambiguous` rather than resolve to whichever branch happens to be tested first.
+ *
+ * @param {Number} group Summed counts for one cause group.
+ * @param {Number} total Summed counts across every group.
+ * @returns {Boolean}
+ */
+function holdsMajority(group, total) {
+    return group > 0 && group * 2 > total;
+}
+
+/**
+ * @summary Validates a caller-supplied provider target, or `null` when it cannot be trusted.
+ *
+ * Mirrors `ContainerHealthDiagnosisService.readProviderTargetIdentity`: an unparseable target degrades the
+ * diagnosis rather than throwing, because a malformed target is a caller-authority problem and must never
+ * suppress a real starvation signal.
+ *
+ * A target naming the reporting service itself is REFUSED. That is not provider authority — it is the
+ * exact false subject this repair exists to remove, re-entering through a parameter. Provider-ness cannot
+ * be probed from this input; "not the service that reported the failure" is the one check available, so
+ * it is the one that is enforced. Cost: a co-located provider deployment degrades to `ambiguous` and keeps
+ * its `noModel` counts, which loses precision and asserts nothing false.
+ *
+ * @param {Object|null} providerTarget Caller-supplied target identity candidate.
+ * @param {String} serviceId The service that REPORTED the starvation.
+ * @returns {Object|null} A validated target identity, or `null`.
+ */
+function readProviderTarget(providerTarget, serviceId) {
+    if (!providerTarget || typeof providerTarget !== 'object') return null;
+
+    try {
+        const target = createRecoveryTargetIdentity(providerTarget);
+
+        return target.kind === 'compose-service' && target.id === serviceId ? null : target;
+    } catch {
+        return null;
+    }
+}
+
+/**
  * @summary Maps the window's dominant cause to a recovery class the existing taxonomy already means.
  *
- * `contention` is NOT the answer for every starved window. It is provable only from a timeout: a window
- * that exhausted its generation budget is saturated, and that is what contention means. The other causes
- * name different things the taxonomy already distinguishes:
+ * `contention` is NOT the answer for every starved window. It is provable only from a MAJORITY of
+ * timeouts: a window that exhausted its generation budget is saturated, and that is what contention
+ * means. The other causes name different things the taxonomy already distinguishes:
  *
  * - `no-model` is a MISSING MODEL, not saturation. `ContainerHealthDiagnosisService` already classifies a
  *   missing required model as `provider-role-residency` with a warm-provider action. Flattening it to
@@ -105,16 +155,28 @@ function isStarvedPass(pass) {
  *   because the failing operation happens to use a model.
  * - a generic `provider-error` or `empty-output` proves the loop is starved and proves nothing about WHY.
  *   `ambiguous` is the honest class; it exists for this.
+ * - anything mixed is `ambiguous` too. A class is a claim about the window, not about its loudest row.
+ *
+ * `provider-role-residency` additionally requires a validated provider target. The class names a
+ * provider-side subject and `RecoveryActuatorService` derives its action target straight from
+ * `targetIdentity.id`, so emitting it against the reporting service would aim a warm-provider capability
+ * call at a container that hosts no provider. The upstream `backfillMiniSummaries` result carries an
+ * aggregate cause tally and no provider identity, so without caller-supplied authority the honest class
+ * is `ambiguous` — with `unresolvedProviderTarget` naming what was missing, so a consumer that DOES hold
+ * provider authority can finish the classification instead of re-deriving this rule.
  *
  * The safe no-restart property is preserved throughout — none of these three classes invites a restart —
  * but preserving it is not a licence to discard the cause the upstream layer measured.
  *
  * @param {Object} totals Summed cause counts across the window.
+ * @param {Object|null} providerTarget Validated provider target, or `null`.
  * @returns {String} A member of `RECOVERY_CLASSES`.
  */
-function resolveRecoveryClass({inner, outer, noModel, other}) {
-    if (inner + outer > 0) return 'contention';
-    if (noModel > 0 && noModel >= other) return 'provider-role-residency';
+function resolveRecoveryClass({inner, outer, noModel, other}, providerTarget) {
+    const total = inner + outer + noModel + other;
+
+    if (holdsMajority(inner + outer, total))             return 'contention';
+    if (holdsMajority(noModel, total) && providerTarget) return 'provider-role-residency';
 
     return 'ambiguous'
 }
@@ -131,6 +193,11 @@ function resolveRecoveryClass({inner, outer, noModel, other}) {
  * `null` when neither timeout cause appears: a window starved by `no-model` or `provider-error` is really
  * starved, and has no window to widen. Naming one would send a controller to adjust a bound that was
  * never involved.
+ *
+ * Consulted ONLY for a `contention` window. A binding timeout is a verdict, and a minority of timeouts
+ * cannot support one: three inner timeouts among thirty provider errors would have reported
+ * `bindingTimeout: 'inner'` — "the inner window is too small" — off 10% of the evidence. The counts
+ * themselves still travel in `causeTotals`, so gating the verdict discards nothing measured.
  *
  * @param {Object} totals Summed `{inner, outer}` counts across the window.
  * @returns {String|null} `'inner'` | `'outer'` | `'mixed'` | `null`
@@ -149,9 +216,15 @@ function resolveBindingTimeout({inner, outer}) {
  * signal reads healthy: the Memory Core answers A2A and persists memory throughout, so the service looks
  * fine while burning cores. Nothing previously turned that into something a controller could consume.
  *
- * Classified `contention`, never `crash`. Summary generation depends on the chat model, so a failing
+ * Never `crash`, whichever class is emitted. Summary generation depends on the chat model, so a failing
  * canary here means saturation or a degraded provider — not a dead service. `crash` would invite a
  * restart that fixes nothing and costs an outage.
+ *
+ * The class is derived from a MAJORITY of the window's typed causes, never from the mere presence of one:
+ * `contention` for timeout-dominant windows, `provider-role-residency` for `no-model`-dominant windows
+ * that also carry a validated provider target, and `ambiguous` for everything else — including mixed
+ * evidence, which is the common real shape. `causeTotals` always carries the full tally, so a class that
+ * declines to be precise never costs a consumer the measurement.
  *
  * `confidence: 1` describes the OBSERVATION, not the authority to act. Starvation is measured rather than
  * inferred, so the confidence is honest — but a consumer must still combine this with a resource or
@@ -160,16 +233,22 @@ function resolveBindingTimeout({inner, outer}) {
  * @param {Object} [options]
  * @param {Object[]} [options.window] Consecutive `backfillMiniSummaries` results, oldest first.
  * @param {Number} options.observedAt Epoch ms.
- * @param {String} options.serviceId Compose-service identity.
+ * @param {String} options.serviceId Compose-service identity that REPORTED the starvation.
  * @param {Number} [options.minSustainedPasses=DEFAULT_MIN_SUSTAINED_PASSES] Passes required before emitting.
- * @returns {Object|null} A `recovery-diagnosis` event (`contention`) when sustained starvation is present, else `null`.
+ * @param {Object} [options.providerTarget] Target identity of the service HOSTING the chat provider, when
+ *     the caller holds that authority — the only way a `no-model`-dominant window can be classified
+ *     `provider-role-residency`, because the upstream cause tally does not name a provider. Unparseable,
+ *     absent, or self-referential targets degrade the class to `ambiguous`; they never throw.
+ * @returns {Object|null} A `recovery-diagnosis` event (`contention` | `provider-role-residency` |
+ *     `ambiguous`) when sustained starvation is present, else `null`.
  * @throws {TypeError} when `serviceId` is missing/empty or `observedAt` is not a finite number.
  */
 export function buildMiniSummaryStarvationDiagnosis({
     window,
     observedAt,
     serviceId,
-    minSustainedPasses = DEFAULT_MIN_SUSTAINED_PASSES
+    minSustainedPasses = DEFAULT_MIN_SUSTAINED_PASSES,
+    providerTarget
 } = {}) {
     if (typeof serviceId !== 'string' || serviceId.length === 0) {
         throw new TypeError('buildMiniSummaryStarvationDiagnosis: serviceId is required');
@@ -205,14 +284,24 @@ export function buildMiniSummaryStarvationDiagnosis({
         }
     }, {inner: 0, outer: 0, noModel: 0, other: 0});
 
-    const bindingTimeout = resolveBindingTimeout(totals),
-          recoveryClass  = resolveRecoveryClass(totals);
+    const total           = totals.inner + totals.outer + totals.noModel + totals.other,
+          validatedTarget = readProviderTarget(providerTarget, serviceId),
+          recoveryClass   = resolveRecoveryClass(totals, validatedTarget),
+          // A verdict only where the evidence supports one: see `resolveBindingTimeout`.
+          bindingTimeout  = recoveryClass === 'contention' ? resolveBindingTimeout(totals) : null,
+          // The window reads as a missing-model story but no provider could be named. Stated rather than
+          // silently folded into `ambiguous`, so a consumer holding provider authority can finish the
+          // classification — naming a limitation and quietly dropping it is how a gap becomes a waiver.
+          unresolvedProviderTarget = recoveryClass === 'ambiguous' && holdsMajority(totals.noModel, total);
 
     return createRecoveryDiagnosisEvent({
         diagnosisId   : `${recoveryClass}:${serviceId}:mini-summary-starvation:${observedAt}`,
         recoveryClass,
         confidence    : 1,
-        targetIdentity: {kind: 'compose-service', id: serviceId},
+        // `RecoveryActuatorService` derives its action target from `targetIdentity.id`, so a provider-side
+        // class MUST carry the provider — targeting the reporting service would warm a provider on a
+        // container that hosts none.
+        targetIdentity: recoveryClass === 'provider-role-residency' ? validatedTarget : {kind: 'compose-service', id: serviceId},
         evidenceFacts : passes.map((pass, index) => ({
             type         : 'mini-summary-starved-pass',
             passIndex    : index,
@@ -232,8 +321,9 @@ export function buildMiniSummaryStarvationDiagnosis({
             reasonCode     : 'mini-summary-generation-starvation',
             sustainedPasses: passes.length,
             causeTotals    : totals,
-            // Absent rather than guessed when no timeout cause is present.
-            ...(bindingTimeout ? {bindingTimeout} : {})
+            // Absent rather than guessed when no timeout cause holds the window.
+            ...(bindingTimeout ? {bindingTimeout} : {}),
+            ...(unresolvedProviderTarget ? {unresolvedProviderTarget: true} : {})
         }
     });
 }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.spec.mjs
@@ -1,0 +1,171 @@
+import {expect, test} from '@playwright/test';
+
+import {buildMiniSummaryStarvationDiagnosis,
+        DEFAULT_MIN_SUSTAINED_PASSES,
+        TIMEOUT_CAUSES} from '../../../../../../../ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs';
+
+const SERVICE_ID  = 'mc-server',
+      OBSERVED_AT = 1_785_700_000_000;
+
+/**
+ * miniSummary generation-starvation detection.
+ *
+ * The predecessor was closed unmerged for deriving a timeout verdict from control-flow branch counters,
+ * so the assertions here are weighted toward the things that go WRONG silently: emitting from no
+ * evidence, emitting on a sweep that is merely draining bad rows, and naming a binding timeout that no
+ * cause supports. A detector that only proves it fires on a real starvation is the shape that failed.
+ */
+test.describe('Neo.ai.daemons.orchestrator miniSummaryStarvationDiagnosis', () => {
+    const starvedPass = (causes, extra = {}) => ({
+        processed     : Object.values(causes).reduce((sum, count) => sum + count, 0),
+        updated       : 0,
+        deferred      : 0,
+        missingContent: 0,
+        exhausted     : 0,
+        failedInner   : 0,
+        failedOuter   : 0,
+        failureCauses : causes,
+        ...extra
+    });
+
+    const windowOf = (pass, count = DEFAULT_MIN_SUSTAINED_PASSES) => Array.from({length: count}, () => pass);
+
+    test('a sustained inner-timeout window diagnoses contention and names the inner window', () => {
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window: windowOf(starvedPass({[TIMEOUT_CAUSES.inner]: 4})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        });
+
+        expect(event).toBeTruthy();
+        // contention, never crash: a model-dependent canary means saturation, not a dead service, and a
+        // restart would cost an outage while fixing nothing.
+        expect(event.recoveryClass).toBe('contention');
+        expect(event.details.bindingTimeout).toBe('inner');
+        expect(event.details.sustainedPasses).toBe(DEFAULT_MIN_SUSTAINED_PASSES);
+    });
+
+    test('an outer-dominant window names the outer window', () => {
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window: windowOf(starvedPass({[TIMEOUT_CAUSES.outer]: 3})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        });
+
+        expect(event.details.bindingTimeout).toBe('outer');
+    });
+
+    test('a tie reports mixed rather than picking one (#16382)', () => {
+        // Supersedes the predecessor's tie-resolves-to-outer rule. That rule compensated for a verdict
+        // INFERRED from branch topology; with typed causes both timeouts are measured, so a tie means the
+        // window genuinely hit both bounds. Choosing one asserts a fact the evidence does not contain.
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window    : windowOf(starvedPass({[TIMEOUT_CAUSES.inner]: 2, [TIMEOUT_CAUSES.outer]: 2})),
+            observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        });
+
+        expect(event.details.bindingTimeout).toBe('mixed');
+    });
+
+    test('a starved window with NO timeout cause names no binding timeout at all (#16382)', () => {
+        // Real starvation, nothing to widen. `provider-error` means the provider failed, not that a window
+        // was too small — naming one would send a controller to adjust a bound that was never involved.
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window: windowOf(starvedPass({'provider-error': 5})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        });
+
+        expect(event).toBeTruthy();
+        expect(event.details.bindingTimeout).toBeUndefined();
+        expect(event.details.causeTotals).toEqual({inner: 0, outer: 0, other: 15});
+    });
+
+    test('an empty window with a zero threshold emits NOTHING (@neo-gpt-emmy)', () => {
+        // The predecessor's live defect: `0 < 0` is false and `[].every(...)` is vacuously true, so it
+        // emitted a diagnosis from no evidence whatsoever. Both halves of the guard are needed.
+        expect(buildMiniSummaryStarvationDiagnosis({
+            window: [], observedAt: OBSERVED_AT, serviceId: SERVICE_ID, minSustainedPasses: 0
+        })).toBeNull();
+
+        expect(buildMiniSummaryStarvationDiagnosis({
+            window: [], observedAt: OBSERVED_AT, serviceId: SERVICE_ID, minSustainedPasses: -5
+        })).toBeNull();
+
+        expect(buildMiniSummaryStarvationDiagnosis({
+            observedAt: OBSERVED_AT, serviceId: SERVICE_ID, minSustainedPasses: 0
+        })).toBeNull();
+    });
+
+    test('a single-pass window does not satisfy a zero threshold (@neo-gpt-emmy)', () => {
+        const single = [starvedPass({[TIMEOUT_CAUSES.inner]: 3})];
+
+        // One pass is not a sustained window; a zero threshold must not make it one.
+        expect(buildMiniSummaryStarvationDiagnosis({
+            window: single, observedAt: OBSERVED_AT, serviceId: SERVICE_ID, minSustainedPasses: 0
+        })).toBeTruthy();
+        expect(buildMiniSummaryStarvationDiagnosis({
+            window: single, observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        })).toBeNull();
+    });
+
+    test('a mixed-cause pass draining un-summarizable rows does NOT diagnose starvation (@neo-gpt-emmy)', () => {
+        // The predecessor's second live defect: it required only *at least one* branch failure, so a sweep
+        // that correctly archived three un-summarizable rows and hit one unrelated error read as starved.
+        // That is a working sweep with a bad row in it.
+        const draining = {
+            processed     : 4,
+            updated       : 0,
+            missingContent: 3,
+            exhausted     : 0,
+            failureCauses : {'provider-error': 1}
+        };
+
+        expect(buildMiniSummaryStarvationDiagnosis({
+            window: windowOf(draining), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        })).toBeNull();
+    });
+
+    test('a window that completes any work is not starved', () => {
+        const partial = starvedPass({[TIMEOUT_CAUSES.inner]: 3}, {updated: 1});
+
+        expect(buildMiniSummaryStarvationDiagnosis({
+            window: windowOf(partial), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        })).toBeNull();
+    });
+
+    test('one recovered pass inside an otherwise starved window suppresses the diagnosis', () => {
+        const window = windowOf(starvedPass({[TIMEOUT_CAUSES.inner]: 3}));
+        window[1] = starvedPass({[TIMEOUT_CAUSES.inner]: 3}, {updated: 2});
+
+        expect(buildMiniSummaryStarvationDiagnosis({
+            window, observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        })).toBeNull();
+    });
+
+    test('branch counters travel as evidence but never source the verdict (#16382)', () => {
+        // The deletion test, applied to the verdict: branch topology that DISAGREES with the causes must
+        // not move `bindingTimeout`. If it can, the producer is reading branches again — which is exactly
+        // how the predecessor failed.
+        const misleading = starvedPass({[TIMEOUT_CAUSES.outer]: 4}, {failedInner: 99, failedOuter: 0});
+
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window: windowOf(misleading), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        });
+
+        expect(event.details.bindingTimeout).toBe('outer');
+        expect(event.evidenceFacts[0].branchSplit).toEqual({failedInner: 99, failedOuter: 0});
+    });
+
+    test('an unrecognised cause is counted as other, never silently dropped', () => {
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window    : windowOf(starvedPass({'some-future-cause': 2})),
+            observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        });
+
+        expect(event).toBeTruthy();
+        expect(event.details.causeTotals.other).toBe(6);
+        expect(event.details.bindingTimeout).toBeUndefined();
+    });
+
+    test('argument guards reject a missing serviceId or a non-finite observedAt', () => {
+        expect(() => buildMiniSummaryStarvationDiagnosis({window: [], observedAt: OBSERVED_AT}))
+            .toThrow(/serviceId is required/);
+        expect(() => buildMiniSummaryStarvationDiagnosis({window: [], serviceId: SERVICE_ID}))
+            .toThrow(/observedAt must be a finite number/);
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.spec.mjs
@@ -22,6 +22,15 @@ const SERVICE_ID  = 'mc-server',
       OBSERVED_AT = 1_785_700_000_000;
 
 /**
+ * A provider target in the vocabulary the CONSUMERS actually use.
+ *
+ * Taken from `ContainerHealthDiagnosisService`/`RecoveryActuatorService` fixtures, where a provider target
+ * is the compose service HOSTING the model (`model` / `local-model`) — there is no `provider` kind in
+ * `RECOVERY_TARGET_IDENTITY_KINDS`. Written as a literal for the same reason as `UPSTREAM` above.
+ */
+const PROVIDER_TARGET = Object.freeze({kind: 'compose-service', id: 'model'});
+
+/**
  * miniSummary generation-starvation detection.
  *
  * The predecessor was closed unmerged for deriving a timeout verdict from control-flow branch counters,
@@ -173,17 +182,135 @@ test.describe('Neo.ai.daemons.orchestrator miniSummaryStarvationDiagnosis', () =
         })).toBeNull();
     });
 
-    test('no-model is provider-role-residency, never contention against this service (@neo-gpt-emmy)', () => {
-        // A missing model is a provider-side fact. `ContainerHealthDiagnosisService` already classifies it
-        // as `provider-role-residency`; flattening it to contention would blame the Memory Core for a
-        // provider's absence purely because the failing operation happens to use a model.
+    test('no-model is never contention against this service (@neo-gpt-emmy)', () => {
+        // A missing model is a provider-side fact. Flattening it to contention would blame the Memory Core
+        // for a provider's absence purely because the failing operation happens to use a model.
         const event = buildMiniSummaryStarvationDiagnosis({
             window: windowOf(starvedPass({[UPSTREAM.noModel]: 3})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
         });
 
-        expect(event.recoveryClass).toBe('provider-role-residency');
+        expect(event.recoveryClass).not.toBe('contention');
         expect(event.details.bindingTimeout).toBeUndefined();
+    });
+
+    test('no-model with a provider target is provider-role-residency AIMED AT THE PROVIDER (@neo-gpt-emmy)', () => {
+        // Cycle-2 finding. The class alone was not the contract: `RecoveryActuatorService` derives its
+        // action target from `targetIdentity.id` (RecoveryActuatorService.mjs:428), and
+        // `ContainerHealthDiagnosisService` resolves provider-residency targets from the PROVIDER fact
+        // (ContainerHealthDiagnosisService.mjs:460). Emitting the class against `mc-server` would send a
+        // warm-provider capability call to a container that hosts no provider.
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window        : windowOf(starvedPass({[UPSTREAM.noModel]: 3})),
+            observedAt    : OBSERVED_AT,
+            serviceId     : SERVICE_ID,
+            providerTarget: PROVIDER_TARGET
+        });
+
+        expect(event.recoveryClass).toBe('provider-role-residency');
+        expect(event.targetIdentity).toEqual(PROVIDER_TARGET);
+        // The falsifier that matters: the target is NOT the service that reported the starvation.
+        expect(event.targetIdentity.id).not.toBe(SERVICE_ID);
         expect(event.diagnosisId.startsWith('provider-role-residency:')).toBe(true);
+        expect(event.details.unresolvedProviderTarget).toBeUndefined();
+    });
+
+    test('no-model WITHOUT provider authority degrades to ambiguous and says so (@neo-gpt-emmy)', () => {
+        // `backfillMiniSummaries` returns an aggregate cause tally and no provider identity
+        // (MemoryService.mjs:2182), so this is the shape production actually produces today. The class
+        // must not assert a provider subject it cannot name — and must not swallow the fact that it
+        // WOULD have, or a consumer holding provider authority has to re-derive the majority rule.
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window: windowOf(starvedPass({[UPSTREAM.noModel]: 3})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        });
+
+        expect(event.recoveryClass).toBe('ambiguous');
+        expect(event.targetIdentity).toEqual({kind: 'compose-service', id: SERVICE_ID});
+        expect(event.details.unresolvedProviderTarget).toBe(true);
+        // Nothing measured is lost by declining to be precise.
+        expect(event.details.causeTotals.noModel).toBe(9);
+    });
+
+    test('an untrustworthy provider target degrades rather than throwing or passing through (@neo-gpt-emmy)', () => {
+        // Three ways a caller can fail to hold authority. Each must fail CLOSED: a malformed target is a
+        // caller problem and must never suppress a real starvation signal, and must never be forwarded to
+        // an actuator that will treat `targetIdentity.id` as a service key.
+        const candidates = [
+            {label: 'unknown kind',     target: {kind: 'provider', id: 'ollama'}},
+            {label: 'missing id',       target: {kind: 'compose-service'}},
+            // The defect re-entering through the new door: a caller lazily passing its own identity.
+            {label: 'the reporter itself', target: {kind: 'compose-service', id: SERVICE_ID}}
+        ];
+
+        for (const {label, target} of candidates) {
+            const event = buildMiniSummaryStarvationDiagnosis({
+                window        : windowOf(starvedPass({[UPSTREAM.noModel]: 3})),
+                observedAt    : OBSERVED_AT,
+                serviceId     : SERVICE_ID,
+                providerTarget: target
+            });
+
+            expect(event, `${label} must still emit a diagnosis`).toBeTruthy();
+            expect(event.recoveryClass, `${label} must not earn provider-role-residency`).toBe('ambiguous');
+            expect(event.targetIdentity).toEqual({kind: 'compose-service', id: SERVICE_ID});
+            expect(event.details.unresolvedProviderTarget).toBe(true);
+        }
+    });
+
+    test('a minority of timeouts does NOT earn contention (@neo-gpt-emmy)', () => {
+        // Emmy's exact cycle-2 counterexample: `timeout-inner: 1` + `provider-error: 9` per pass emitted
+        // `contention` on window totals of 3:27, because any non-zero timeout won. The reading was TRUE —
+        // there really was a timeout — and one level too coarse to be a window verdict. A class is a claim
+        // about the window, so it takes a majority of the window.
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window    : windowOf(starvedPass({[UPSTREAM.timeoutInner]: 1, [UPSTREAM.providerError]: 9})),
+            observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        });
+
+        expect(event).toBeTruthy();
+        expect(event.recoveryClass).toBe('ambiguous');
+        expect(event.details.causeTotals).toEqual({inner: 3, outer: 0, noModel: 0, other: 27});
+        // And the second half: a minority timeout may not name a binding window either. Reporting
+        // `bindingTimeout: 'inner'` off 3 of 30 failures is the same defect one field over.
+        expect(event.details.bindingTimeout).toBeUndefined();
+    });
+
+    test('an even cause split stays ambiguous — mixed evidence is not a verdict (@neo-gpt-emmy)', () => {
+        // The strictness control for the majority rule. With `>=` instead of `>`, a 50/50 window resolves
+        // to whichever branch is tested first, which is an ordering artefact masquerading as a diagnosis.
+        for (const rival of [UPSTREAM.providerError, UPSTREAM.noModel]) {
+            const event = buildMiniSummaryStarvationDiagnosis({
+                window    : windowOf(starvedPass({[UPSTREAM.timeoutInner]: 5, [rival]: 5})),
+                observedAt: OBSERVED_AT, serviceId: SERVICE_ID, providerTarget: PROVIDER_TARGET
+            });
+
+            expect(event.recoveryClass, `timeouts tied with ${rival}`).toBe('ambiguous');
+            expect(event.details.bindingTimeout).toBeUndefined();
+        }
+    });
+
+    test('a binding timeout is reported EXACTLY when the class is contention (#16382)', () => {
+        // The invariant behind the two gates above, asserted as a pair so neither can drift alone: a
+        // contention window always names its binding bound, and nothing else ever does.
+        const cases = [
+            {causes: {[UPSTREAM.timeoutInner]: 4},                              expected: 'contention'},
+            {causes: {[UPSTREAM.timeoutInner]: 2, [UPSTREAM.timeoutOuter]: 2},  expected: 'contention'},
+            {causes: {[UPSTREAM.timeoutInner]: 1, [UPSTREAM.providerError]: 9}, expected: 'ambiguous'},
+            {causes: {[UPSTREAM.noModel]: 4},                                   expected: 'provider-role-residency'},
+            {causes: {[UPSTREAM.providerError]: 4},                             expected: 'ambiguous'}
+        ];
+
+        for (const {causes, expected} of cases) {
+            const event = buildMiniSummaryStarvationDiagnosis({
+                window    : windowOf(starvedPass(causes)),
+                observedAt: OBSERVED_AT, serviceId: SERVICE_ID, providerTarget: PROVIDER_TARGET
+            });
+
+            expect(event.recoveryClass, JSON.stringify(causes)).toBe(expected);
+            expect(
+                event.details.bindingTimeout !== undefined,
+                `${JSON.stringify(causes)} → ${expected} must ${expected === 'contention' ? '' : 'not '}name a binding timeout`
+            ).toBe(expected === 'contention');
+        }
     });
 
     test('a generic provider-error proves starvation but not contention — ambiguous (@neo-gpt-emmy)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.spec.mjs
@@ -1,8 +1,22 @@
 import {expect, test} from '@playwright/test';
 
 import {buildMiniSummaryStarvationDiagnosis,
-        DEFAULT_MIN_SUSTAINED_PASSES,
-        TIMEOUT_CAUSES} from '../../../../../../../ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs';
+        DEFAULT_MIN_SUSTAINED_PASSES} from '../../../../../../../ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs';
+
+/**
+ * Cause vocabulary written as UPSTREAM LITERALS, deliberately not imported from the producer.
+ *
+ * @neo-gpt-emmy's mutation probe: with fixtures built from the producer's own exported `TIMEOUT_CAUSES`,
+ * renaming that constant to `timeout-inner-typo` moved implementation and tests together and the suite
+ * stayed green — while the real string `MemoryService` emits stopped resolving. A consumer's fixtures
+ * must speak the PRODUCER's vocabulary, or they test the consumer's agreement with itself.
+ */
+const UPSTREAM = Object.freeze({
+    timeoutInner : 'timeout-inner',
+    timeoutOuter : 'timeout-outer',
+    noModel      : 'no-model',
+    providerError: 'provider-error'
+});
 
 const SERVICE_ID  = 'mc-server',
       OBSERVED_AT = 1_785_700_000_000;
@@ -32,7 +46,7 @@ test.describe('Neo.ai.daemons.orchestrator miniSummaryStarvationDiagnosis', () =
 
     test('a sustained inner-timeout window diagnoses contention and names the inner window', () => {
         const event = buildMiniSummaryStarvationDiagnosis({
-            window: windowOf(starvedPass({[TIMEOUT_CAUSES.inner]: 4})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+            window: windowOf(starvedPass({[UPSTREAM.timeoutInner]: 4})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
         });
 
         expect(event).toBeTruthy();
@@ -45,7 +59,7 @@ test.describe('Neo.ai.daemons.orchestrator miniSummaryStarvationDiagnosis', () =
 
     test('an outer-dominant window names the outer window', () => {
         const event = buildMiniSummaryStarvationDiagnosis({
-            window: windowOf(starvedPass({[TIMEOUT_CAUSES.outer]: 3})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+            window: windowOf(starvedPass({[UPSTREAM.timeoutOuter]: 3})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
         });
 
         expect(event.details.bindingTimeout).toBe('outer');
@@ -56,7 +70,7 @@ test.describe('Neo.ai.daemons.orchestrator miniSummaryStarvationDiagnosis', () =
         // INFERRED from branch topology; with typed causes both timeouts are measured, so a tie means the
         // window genuinely hit both bounds. Choosing one asserts a fact the evidence does not contain.
         const event = buildMiniSummaryStarvationDiagnosis({
-            window    : windowOf(starvedPass({[TIMEOUT_CAUSES.inner]: 2, [TIMEOUT_CAUSES.outer]: 2})),
+            window    : windowOf(starvedPass({[UPSTREAM.timeoutInner]: 2, [UPSTREAM.timeoutOuter]: 2})),
             observedAt: OBSERVED_AT, serviceId: SERVICE_ID
         });
 
@@ -72,7 +86,8 @@ test.describe('Neo.ai.daemons.orchestrator miniSummaryStarvationDiagnosis', () =
 
         expect(event).toBeTruthy();
         expect(event.details.bindingTimeout).toBeUndefined();
-        expect(event.details.causeTotals).toEqual({inner: 0, outer: 0, other: 15});
+        expect(event.recoveryClass).toBe('ambiguous');
+        expect(event.details.causeTotals).toEqual({inner: 0, outer: 0, noModel: 0, other: 15});
     });
 
     test('an empty window with a zero threshold emits NOTHING (@neo-gpt-emmy)', () => {
@@ -91,16 +106,26 @@ test.describe('Neo.ai.daemons.orchestrator miniSummaryStarvationDiagnosis', () =
         })).toBeNull();
     });
 
-    test('a single-pass window does not satisfy a zero threshold (@neo-gpt-emmy)', () => {
-        const single = [starvedPass({[TIMEOUT_CAUSES.inner]: 3})];
+    test('a single-pass window emits NOTHING at any threshold (@neo-gpt-emmy)', () => {
+        const single = [starvedPass({[UPSTREAM.timeoutInner]: 3})];
 
-        // One pass is not a sustained window; a zero threshold must not make it one.
-        expect(buildMiniSummaryStarvationDiagnosis({
-            window: single, observedAt: OBSERVED_AT, serviceId: SERVICE_ID, minSustainedPasses: 0
-        })).toBeTruthy();
+        // My first version of this test asserted `toBeTruthy()` here while its own title and comment said
+        // one pass is not sustained — the assertion contradicted the name above it, and the PR body then
+        // repeated the title's claim. Sustained means REPEATED; no threshold can make one observation two.
+        for (const minSustainedPasses of [0, 1, -5]) {
+            expect(buildMiniSummaryStarvationDiagnosis({
+                window: single, observedAt: OBSERVED_AT, serviceId: SERVICE_ID, minSustainedPasses
+            }), `threshold ${minSustainedPasses} must not make one pass sustained`).toBeNull();
+        }
+
         expect(buildMiniSummaryStarvationDiagnosis({
             window: single, observedAt: OBSERVED_AT, serviceId: SERVICE_ID
         })).toBeNull();
+
+        // Two passes DO satisfy an explicit floor — the guard must not become a blanket refusal.
+        expect(buildMiniSummaryStarvationDiagnosis({
+            window: [single[0], single[0]], observedAt: OBSERVED_AT, serviceId: SERVICE_ID, minSustainedPasses: 2
+        })).toBeTruthy();
     });
 
     test('a mixed-cause pass draining un-summarizable rows does NOT diagnose starvation (@neo-gpt-emmy)', () => {
@@ -120,8 +145,69 @@ test.describe('Neo.ai.daemons.orchestrator miniSummaryStarvationDiagnosis', () =
         })).toBeNull();
     });
 
+    test('exhausted rows are GENERATION failures and still diagnose (@neo-gpt-emmy)', () => {
+        // The false negative: `exhausted` means the row spent its generation-attempt budget, and the
+        // upstream layer records the typed cause BEFORE incrementing it. Excluding it made a genuinely
+        // starved window return null — the inverse of the defect this producer exists to catch.
+        const exhaustedPass = {
+            processed     : 2,
+            updated       : 0,
+            missingContent: 0,
+            exhausted     : 2,
+            failureCauses : {[UPSTREAM.timeoutInner]: 2}
+        };
+
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window: windowOf(exhaustedPass), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        });
+
+        expect(event).toBeTruthy();
+        expect(event.details.bindingTimeout).toBe('inner');
+
+        // And the control that keeps the fix from swallowing the original guard: missingContent still
+        // exempts, because an un-summarizable row was never a generation attempt.
+        expect(buildMiniSummaryStarvationDiagnosis({
+            window    : windowOf({processed: 4, updated: 0, missingContent: 3, exhausted: 0,
+                                  failureCauses: {[UPSTREAM.providerError]: 1}}),
+            observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        })).toBeNull();
+    });
+
+    test('no-model is provider-role-residency, never contention against this service (@neo-gpt-emmy)', () => {
+        // A missing model is a provider-side fact. `ContainerHealthDiagnosisService` already classifies it
+        // as `provider-role-residency`; flattening it to contention would blame the Memory Core for a
+        // provider's absence purely because the failing operation happens to use a model.
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window: windowOf(starvedPass({[UPSTREAM.noModel]: 3})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        });
+
+        expect(event.recoveryClass).toBe('provider-role-residency');
+        expect(event.details.bindingTimeout).toBeUndefined();
+        expect(event.diagnosisId.startsWith('provider-role-residency:')).toBe(true);
+    });
+
+    test('a generic provider-error proves starvation but not contention — ambiguous (@neo-gpt-emmy)', () => {
+        // It proves the loop is starved and proves nothing about why. `ambiguous` exists for exactly this.
+        const event = buildMiniSummaryStarvationDiagnosis({
+            window: windowOf(starvedPass({[UPSTREAM.providerError]: 4})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+        });
+
+        expect(event.recoveryClass).toBe('ambiguous');
+        expect(event.details.bindingTimeout).toBeUndefined();
+    });
+
+    test('a timeout window is the ONLY shape that earns contention', () => {
+        // The positive control for the three classes above: without it, the mapping could collapse every
+        // window to ambiguous and each negative assertion would still pass.
+        for (const cause of [UPSTREAM.timeoutInner, UPSTREAM.timeoutOuter]) {
+            expect(buildMiniSummaryStarvationDiagnosis({
+                window: windowOf(starvedPass({[cause]: 3})), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
+            }).recoveryClass).toBe('contention');
+        }
+    });
+
     test('a window that completes any work is not starved', () => {
-        const partial = starvedPass({[TIMEOUT_CAUSES.inner]: 3}, {updated: 1});
+        const partial = starvedPass({[UPSTREAM.timeoutInner]: 3}, {updated: 1});
 
         expect(buildMiniSummaryStarvationDiagnosis({
             window: windowOf(partial), observedAt: OBSERVED_AT, serviceId: SERVICE_ID
@@ -129,8 +215,8 @@ test.describe('Neo.ai.daemons.orchestrator miniSummaryStarvationDiagnosis', () =
     });
 
     test('one recovered pass inside an otherwise starved window suppresses the diagnosis', () => {
-        const window = windowOf(starvedPass({[TIMEOUT_CAUSES.inner]: 3}));
-        window[1] = starvedPass({[TIMEOUT_CAUSES.inner]: 3}, {updated: 2});
+        const window = windowOf(starvedPass({[UPSTREAM.timeoutInner]: 3}));
+        window[1] = starvedPass({[UPSTREAM.timeoutInner]: 3}, {updated: 2});
 
         expect(buildMiniSummaryStarvationDiagnosis({
             window, observedAt: OBSERVED_AT, serviceId: SERVICE_ID
@@ -141,7 +227,7 @@ test.describe('Neo.ai.daemons.orchestrator miniSummaryStarvationDiagnosis', () =
         // The deletion test, applied to the verdict: branch topology that DISAGREES with the causes must
         // not move `bindingTimeout`. If it can, the producer is reading branches again — which is exactly
         // how the predecessor failed.
-        const misleading = starvedPass({[TIMEOUT_CAUSES.outer]: 4}, {failedInner: 99, failedOuter: 0});
+        const misleading = starvedPass({[UPSTREAM.timeoutOuter]: 4}, {failedInner: 99, failedOuter: 0});
 
         const event = buildMiniSummaryStarvationDiagnosis({
             window: windowOf(misleading), observedAt: OBSERVED_AT, serviceId: SERVICE_ID


### PR DESCRIPTION
Resolves #16382

Related: #16388 (the typed causes this consumes, merged), #14418 (the controller that consumes this), #16223 (the live starvation the chain serves)

Nothing turned *"the loop processes rows and completes none"* into a diagnosis a controller could consume. The backfill reports its tallies to a log line and returns them to its caller, and the Memory Core answers A2A and persists memory throughout — so the service reads healthy while burning cores for days.

Pure producer mirroring the six siblings in the same folder: injected samples, no I/O, `null` when clean.

Evidence: L2 (unit coverage at exact head; the producer is pure and fully reachable in-sandbox) → L2 required, every AC being an assertion on a return value. Residual: which cause dominates on the CPU-only plane of #16223 is a live-plane observation, listed under Post-Merge.

## This is a successor, and the predecessor's defect is the design constraint

PR #16383 was closed unmerged on @neo-gpt-emmy's terminal Drop+Supersede. It derived `dominantBranch` from `failedInner` / `failedOuter`. **A branch counter says WHICH control-flow path ran and never WHY** — a summarizer returning `null` instantly, with no timeout anywhere, increments `failedInner` exactly as a real inner timeout does. Her falsifier was my own regression, which injected precisely that summarizer.

#16388 (merged) added typed causes, so the fact now exists at the source. This reads `failureCauses`. **Branch topology still travels, as `evidenceFacts[].branchSplit`, explicitly labelled observation rather than verdict** — a consumer may legitimately want the split; nothing here may be derived from it.

## Deltas from ticket

**A tie reports `'mixed'`, superseding the ticket's original tie-resolves-to-`outer` rule.** That rule existed because a branch-derived verdict was an *inference*, so the pessimistic pick was the safe default. With typed causes both timeouts are measured facts, so a tie means the window genuinely hit both bounds — and choosing one asserts something the evidence does not contain, which is the predecessor's defect with a better name. Amended on the ticket with the reasoning, and flagged for challenge there before I wrote a line of this.

**The consequence I am least sure of, stated rather than buried:** this shifts work onto #14418's controller — three enum values instead of two, and "widen nothing on `mixed`" means a genuinely mixed window gets no relief until something else changes. The argument that the pessimistic pick is better *because* it always yields an action is not obviously wrong; it is an argument for acting on less evidence. I would rather lose it in review than encode my side silently. @neo-opus-grace has the open question of whether `mixed` needs an explicit no-op knob on her `reconfigure` registry rather than being implied by absence.

**`bindingTimeout` is absent, not guessed, when no timeout cause holds the window.** A window starved entirely by `no-model` or `provider-error` is real starvation with no window to widen. Emitting a binding timeout there would send a controller to adjust a bound that was never involved. Cycle 2 extended this to a *minority* of timeouts, for the same reason.

**Never `crash`, and the class follows a strict majority of typed causes.** Summary generation depends on the chat model, so a failing canary here is saturation or a degraded provider, not a dead service. `crash` would invite a restart that fixes nothing and costs an outage. `contention`, `provider-role-residency`, and `ambiguous` are all already in `RECOVERY_CLASSES`, so this widens nothing.

## Cycle-2 repairs (@neo-gpt-emmy's second Request Changes)

Both counterexamples were reproduced against the exact head — measured, not hypothetical — and both were real.

**1. A class was decided by presence, not dominance.** `timeout-inner: 1` + `provider-error: 9` per pass emitted `contention` on window totals of `3:27`, because `inner + outer > 0` let any single timeout win. **The reading was TRUE** — there really was a timeout — and one level too coarse to be a window verdict. That is the same granularity failure that closed the predecessor PR, which is why care could not catch it: nothing in the observation is false, so re-reading finds nothing. A class is now claimed only by a **strict majority** of its own cause group; an even split stays `ambiguous`, because mixed evidence is not a verdict. The same gate now covers `bindingTimeout` — reporting `'inner'` off 3 of 30 failures was the identical defect one field over, and the counts still travel untouched in `causeTotals`.

**2. A provider-side class was aimed at the service that reported it.** A `no-model` window emitted `provider-role-residency` targeted at `compose-service:mc-server`. Verified downstream: `RecoveryActuatorService.mjs:428` sets `serviceKey = diagnosis.targetIdentity.id`, and `ContainerHealthDiagnosisService.mjs:460` resolves provider-residency targets from the **provider** fact (its fixtures target `model` / `local-model`, the container hosting ollama). So the tuple would have sent a warm-provider capability call to a container that hosts no provider.

Emmy's supplement closed the escape hatch I would otherwise have taken: `MemoryService.backfillMiniSummaries` returns `{processed, updated, deferred, missingContent, exhausted, runBudgetHit, failedInner, failedOuter, failureCauses}` (`MemoryService.mjs:2182`) — an aggregate cause tally and **no provider identity**. The producer cannot name a provider from its input.

So the class now requires a caller-supplied `providerTarget`, and **the default path — the one production takes today — is `ambiguous` targeted at the reporting service.** Rather than drop the fact on the floor, that path sets `details.unresolvedProviderTarget: true`: the window reads as a missing-model story, no provider could be named, and a consumer holding provider authority can finish the classification instead of re-deriving the majority rule. Naming a limitation and then quietly dropping it is how a gap becomes a waiver.

A target that is unparseable, absent, or **names the reporting service itself** degrades to `ambiguous` rather than throwing — a malformed target is a caller-authority problem and must never suppress a real starvation signal. The self-target refusal is the narrow one worth challenging: provider-ness cannot be probed from this input, so "not the service that reported the failure" is the only check available, and it costs precision on a hypothetical co-located deployment. I would rather refuse the exact defect re-entering through the new parameter.

**`confidence: 1` describes the observation, not the authority.** Starvation is measured rather than inferred, so the confidence is honest — but the multi-fact requirement gates *authoritative actions*, not records. Stated in the module JSDoc so a future consumer cannot read it as a licence to actuate alone.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/daemons/orchestrator/services/ --workers=1
  660 passed (18.6s)
```

Directory-scoped: the new producer sits beside six sibling diagnosis producers plus the services consuming the shared `createRecoveryDiagnosisEvent`, so the folder is the regression surface. **22 of those are this producer's own** (`grep -c '^    test('` at head) — cycle 2's count of 16 was correct against the previous head and my receipt's 18 was wrong; the figure above is measured, not carried forward. The run includes the merge of `origin/dev`, so it is not a clean delta against the earlier 650.

**Mutation-verified, per the ticket's deletion-test AC.** Each discriminating term reverted to its predecessor form turns the predicted specs red; restoring turns them green. Every row below was executed, not reasoned:

| mutation | specs that go red |
|---|---|
| empty-window guard → the predecessor's single `length < threshold` check | empty window with a zero threshold emits nothing |
| `isStarvedPass` → "at least one failure" | a pass draining un-summarizable rows must not diagnose |
| tie branch → `'outer'` | a tie reports `mixed` |
| **cycle 2:** timeout majority → `inner + outer > 0` | minority-of-timeouts · even-split · binding-timeout invariant |
| **cycle 2:** strict majority `>` → `>=` | even-split (the strictness control) |
| **cycle 2:** drop `&& providerTarget` from the class | without-provider-authority · untrustworthy-target · never-contention |
| **cycle 2:** drop the self-target refusal | untrustworthy-target (the reporter-itself case) |
| **cycle 2:** `targetIdentity` → always the reporting service | provider-residency aimed at the provider |
| **cycle 2:** drop the `bindingTimeout` class gate | minority-of-timeouts · even-split · binding-timeout invariant |

That table is the point of the PR as much as the producer is: the predecessor passed its own happy-path tests too.

One probe returned more than predicted, and it is worth recording: dropping `&& providerTarget` also reddened *"no-model is never contention"* — because `createRecoveryDiagnosisEvent` itself throws on a null `targetIdentity`. The shared contract independently refuses a provider-residency class with no target, so the fail-closed path is enforced twice.

**Emmy's two negative probes, both live defects in the closed PR, are pinned as specs:**

- an empty or single-pass window emits nothing even at a zero threshold — `window.length < minSustainedPasses` is `0 < 0 === false` and `[].every(...)` is vacuously `true`, so it previously emitted a diagnosis from no evidence whatsoever;
- a sweep that correctly archives three un-summarizable rows and hits one unrelated error does not read as starvation — the predecessor required only *at least one* failure, defeating a guard its own ticket claimed.

And one the ticket did not ask for: **a misleading branch split that disagrees with the causes must not move the verdict** (`failedInner: 99` against `timeout-outer: 4` still reports `outer`). Without it, "reads causes" would be provable only by inspection.

## Post-Merge Validation

- [ ] Scheduling lands (`#14418` or its own leaf) and the producer runs against real sweeps on a live plane.
- [ ] On the CPU-only deployment behind #16223, a real starved window produces a diagnosis — and the plane says **which class**: whether `timeout-inner` actually holds a majority, or whether the truth is `provider-error` (→ `ambiguous`) or `no-model` (→ `ambiguous` + `unresolvedProviderTarget`, until a caller holds provider authority). No instrument could distinguish these before #16388, and the majority rule means the live answer is now a measurement rather than a foregone conclusion.
- [ ] Whoever wires the caller decides whether to supply `providerTarget` from compose topology. Until then the `provider-role-residency` branch is reachable only from a caller that holds provider authority — stated plainly because an unexercised branch is a claim about the future, not the present.

## Deltas

- New: `ai/daemons/orchestrator/services/miniSummaryStarvationDiagnosis.mjs` (pure producer) and its spec.
- Cycle 2 adds one optional input, `providerTarget`, and no other surface. The class/target/`bindingTimeout` tuple changed shape; nothing outside this producer and its spec was touched.
- No existing behaviour altered; nothing removed. Scheduling is explicitly out of scope, matching how `#14075` shipped a pure producer and deferred wiring to `#14026`.

Authored by Vega (Claude Opus 5, Claude Code). Session eb230051-9e42-4e6b-b540-112a79accc3a.

