### PR TITLE
fix(ai): publish backup bundles atomically (#16417)

### DIFF
--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -239,7 +239,72 @@ export function buildEmbeddingContract({subsystems}) {
 }
 
 /**
+ * @summary Rewrites JSON-safe export receipt paths from the private capture root to the final
+ * published root without changing unrelated strings.
+ * @param {*} value Receipt value to clone.
+ * @param {String} stagingRoot Private same-parent capture root.
+ * @param {String} publishedRoot Final caller-visible bundle root.
+ * @returns {*} Cloned receipt value carrying only published bundle paths.
+ */
+function rebaseBundleReceiptPaths(value, stagingRoot, publishedRoot) {
+    if (typeof value === 'string') {
+        if (value === stagingRoot) {
+            return publishedRoot
+        }
+
+        const stagingPrefix = stagingRoot.endsWith(path.sep) ? stagingRoot : `${stagingRoot}${path.sep}`;
+
+        return value.startsWith(stagingPrefix)
+            ? path.join(publishedRoot, value.slice(stagingPrefix.length))
+            : value
+    }
+
+    if (Array.isArray(value)) {
+        return value.map(item => rebaseBundleReceiptPaths(item, stagingRoot, publishedRoot))
+    }
+
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, item]) => [
+                key,
+                rebaseBundleReceiptPaths(item, stagingRoot, publishedRoot)
+            ])
+        )
+    }
+
+    return value
+}
+
+/**
+ * @summary Fails unless a publication destination is truly absent. `lstat` is intentional:
+ * `pathExists` collapses access failures into false and follows away dangling symlinks, while only
+ * `ENOENT` is evidence that rename will not target an existing filesystem entry.
+ * @param {String} targetPath Final bundle path.
+ * @param {String} message Stable refusal prefix.
+ * @returns {Promise<void>}
+ */
+async function assertBackupDestinationAbsent(targetPath, message) {
+    try {
+        await fs.lstat(targetPath)
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return
+        }
+
+        throw error
+    }
+
+    throw new Error(`${message}: ${targetPath}`)
+}
+
+/**
  * Executes a full-substrate backup.
+ *
+ * Capture is assembled in a unique sibling directory outside the root-level `backup-*`
+ * candidate namespace. The final path is published with a same-filesystem rename only after
+ * every export, the integrity gate, and `bundle-meta.json` have completed. Caught failures remove
+ * only this invocation's staging directory; abrupt process death can leave a self-identifying
+ * `.backup-partial-*` directory that restore and retention discovery ignore by construction.
  *
  * @param {Object}   options
  * @param {String}  [options.bundleRoot=null]            Absolute bundle path. If null, a timestamped dir under the default root is used.
@@ -248,6 +313,7 @@ export function buildEmbeddingContract({subsystems}) {
  * @param {Object}  [options.ledgerSources]              Override for the incident-ledger source paths
  *                                                       (`{healAttemptsFile, healEventsDir, recoveryRunsDir}`).
  *                                                       Omitted in production — resolved from AiConfig at the use site.
+ * @param {Function} [options.cleanOldBackupsImpl]       Retention cleaner seam; defaults to `cleanOldBackups`.
  * @param {Object}  [options.logger=console]             Log sink; useful for tests.
  * @returns {Promise<{bundleRoot: String, timestamp: String, subsystems: Object}>}
  */
@@ -257,10 +323,130 @@ export async function runBackup({
     trajectoriesSourceFile = DEFAULT_TRAJECTORIES_FILE,
     sentToCullSourceFile   = DEFAULT_SENT_TO_CULL_FILE,
     ledgerSources,
+    cleanOldBackupsImpl    = cleanOldBackups,
     logger                 = console
 } = {}) {
     const timestamp    = new Date().toISOString().replace(/:/g, '-');
     const resolvedRoot = bundleRoot ?? path.join(AiConfig.backupPath, `backup-${timestamp}`);
+    const parentRoot   = path.dirname(resolvedRoot);
+
+    await fs.ensureDir(parentRoot);
+    await assertBackupDestinationAbsent(resolvedRoot, 'Backup destination already exists');
+
+    // Keep a bounded, filesystem-safe hint of the intended final basename visible for diagnostics
+    // while making the stage impossible to confuse with a root-level restore/retention candidate.
+    // `mkdtemp` adds the per-run unique suffix, and sibling placement guarantees same-filesystem
+    // rename without making a long-but-valid explicit destination exceed NAME_MAX.
+    const stagingHint = path.basename(resolvedRoot)
+        .replace(/[^a-zA-Z0-9._-]/g, '_')
+        .slice(0, 48) || 'bundle';
+    const stagingRoot = await fs.mkdtemp(
+        path.join(parentRoot, `.backup-partial-${stagingHint}-`)
+    );
+
+    let result;
+
+    try {
+        // `mkdtemp` deliberately defaults to 0700. The old directly-created final directory used
+        // mkdir's 0777&umask semantics, so preserve that mode where the backing filesystem supports
+        // POSIX chmod. ACL/SMB-backed mounts may reject chmod even though mkdir + rename are valid.
+        if (process.platform !== 'win32') {
+            try {
+                await fs.chmod(stagingRoot, 0o777 & ~process.umask())
+            } catch (error) {
+                if (!['EPERM', 'ENOSYS', 'ENOTSUP', 'EOPNOTSUPP'].includes(error.code)) {
+                    throw error
+                }
+            }
+        }
+
+        result = await captureBackup({
+            conceptsSourceDir,
+            ledgerSources,
+            logger,
+            publishedRoot: resolvedRoot,
+            resolvedRoot : stagingRoot,
+            sentToCullSourceFile,
+            timestamp,
+            trajectoriesSourceFile
+        });
+
+        // This catches an ordinary destination appearing during capture. Node has no portable
+        // RENAME_NOREPLACE for directories, so the heavy-maintenance lease remains the cooperative
+        // writer guarantee across this final check + rename boundary.
+        await assertBackupDestinationAbsent(resolvedRoot, 'Backup destination appeared during capture');
+
+        await fs.rename(stagingRoot, resolvedRoot)
+    } catch (error) {
+        try {
+            await fs.remove(stagingRoot)
+        } catch (cleanupError) {
+            try {
+                logger.warn?.(`[Backup] failed to remove staging directory after capture failure: ${cleanupError.message}`)
+            } catch {
+                // Preserve the capture failure: cleanup diagnostics are strictly secondary.
+            }
+        }
+
+        throw error
+    }
+
+    const {retention, ...publishedResult} = result;
+
+    // Retention is deliberately post-publication: pruning to the configured floor before the new
+    // bundle is authoritative would leave one fewer recovery source if integrity/meta/rename later
+    // failed. Cleanup failure cannot invalidate an already-complete published bundle.
+    try {
+        logger.log('[8/8] Applying retention sweep...')
+    } catch {
+        // Publication already succeeded; retention still runs when a diagnostic sink is closed.
+    }
+
+    try {
+        await cleanOldBackupsImpl(AiConfig.backupPath, logger, retention)
+    } catch (error) {
+        try {
+            logger.warn?.(`[Backup] retention sweep failed after publication: ${error.message}`)
+        } catch {
+            // A diagnostic sink cannot turn a completed, published bundle into a reported failure.
+        }
+    }
+
+    try {
+        logger.log(`✅ Backup complete: ${resolvedRoot}`)
+    } catch {
+        // Publication already succeeded. A closed terminal or custom diagnostic sink cannot turn
+        // the completed bundle into a reported backup failure and a contradictory failed receipt.
+    }
+
+    return {...publishedResult, bundleRoot: resolvedRoot}
+}
+
+/**
+ * @summary Captures every bundle member and completion receipt into a private staging directory.
+ * Publication is deliberately owned by `runBackup()` so this helper can never return a path that a
+ * restore, retention, receipt, or off-host-sync consumer treats as authoritative.
+ * @param {Object} options
+ * @param {String} options.resolvedRoot Unique non-candidate staging root.
+ * @param {String} options.publishedRoot Final caller-visible bundle root.
+ * @param {String} options.timestamp Final bundle timestamp shared with the publication name.
+ * @param {String} options.conceptsSourceDir Concept Ontology source directory.
+ * @param {String} options.trajectoriesSourceFile RLAIF trajectories source file.
+ * @param {String} options.sentToCullSourceFile Mailbox archive source file.
+ * @param {Object} [options.ledgerSources] Incident-ledger source paths.
+ * @param {Object} options.logger Log sink.
+ * @returns {Promise<{timestamp: String, completedAt: String, subsystems: Object, meta: Object, retention: Object}>}
+ */
+async function captureBackup({
+    resolvedRoot,
+    publishedRoot,
+    timestamp,
+    conceptsSourceDir,
+    trajectoriesSourceFile,
+    sentToCullSourceFile,
+    ledgerSources,
+    logger
+}) {
     // Resolved leaves read HERE rather than captured at module scope: `healAttemptsPath` and
     // `recoveryRunStateDir` are plane members and therefore env-relocatable per deployment, so a
     // module-scope capture would bundle whatever the path was at import time.
@@ -330,13 +516,11 @@ export async function runBackup({
         sources: resolvedLedgerSources
     });
 
-    logger.log('[8/8] Applying retention sweep...');
-    // Retention comes from Tier-1 AI maintenance policy; missing keys fail loud
-    // at the direct resolved-leaf read site. Bundle root, retention sweep, receipt, and
-    // snapshot-root all resolve from the same `AiConfig.backupPath` leaf (the CLI wrapper
-    // loads the gitignored overlay before this call so the local overlay is honored too).
+    // Resolve retention while the bundle is still private so a missing policy fails before
+    // publication. The actual sweep runs after rename: a failed capture must retain the full
+    // previous recovery floor.
     await loadTopLevelAiConfig();
-    await cleanOldBackups(AiConfig.backupPath, logger, resolveBackupRetention());
+    const retention = resolveBackupRetention();
 
     logger.log('Verifying bundle integrity (row-count parity)...');
     const integrity    = await verifyBundleIntegrity(layout, subsystems);
@@ -361,15 +545,16 @@ export async function runBackup({
         );
     }
 
-    const completedAt = new Date().toISOString();
-    const topology    = buildTopologyDescriptor();
-    const versionInfo = await buildVersionDescriptor(PROJECT_ROOT, logger);
-    const embedding   = buildEmbeddingContract({subsystems});
-    const meta        = {
+    const completedAt         = new Date().toISOString();
+    const topology            = buildTopologyDescriptor();
+    const versionInfo         = await buildVersionDescriptor(PROJECT_ROOT, logger);
+    const publishedSubsystems = rebaseBundleReceiptPaths(subsystems, resolvedRoot, publishedRoot);
+    const embedding           = buildEmbeddingContract({subsystems: publishedSubsystems});
+    const meta                = {
         bundleVersion: 1,
         timestamp,
         completedAt,
-        subsystems,
+        subsystems   : publishedSubsystems,
         integrity,
         topology,
         embedding,
@@ -377,8 +562,7 @@ export async function runBackup({
     };
     await fs.writeJson(path.join(resolvedRoot, 'bundle-meta.json'), meta, { spaces: 2 });
 
-    logger.log(`✅ Backup complete: ${resolvedRoot}`);
-    return {bundleRoot: resolvedRoot, timestamp, completedAt, subsystems, meta};
+    return {timestamp, completedAt, subsystems: publishedSubsystems, meta, retention};
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -28,7 +28,7 @@ import path            from 'path';
 test.describe.configure({mode: 'serial'});
 
 test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 2)', () => {
-    let SDK, runBackup;
+    let SDK, fsExtra, runBackup;
     let KB_ChromaManager, Memory_StorageRouter;
     let originalKbCollection, originalMcGetMemory, originalMcGetSummary;
     let workRoot, bundleRoot, conceptsSourceDir, trajectoriesSourceFile;
@@ -54,6 +54,7 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
 
     test.beforeAll(async () => {
         SDK                   = await import('../../../../../../ai/services.mjs');
+        fsExtra               = (await import('fs-extra')).default;
         ({runBackup, verifyBundleIntegrity, countNonEmptyJsonlLines, noticeLegacyBackupRoot} = await import('../../../../../../ai/scripts/maintenance/backup.mjs'));
         KB_ChromaManager      = SDK.KB_ChromaManager;
         Memory_StorageRouter  = SDK.Memory_StorageRouter;
@@ -143,6 +144,223 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         // graph subfolder exists but GraphService.db is not wired in unit-test mode,
         // so no graph-backup file is emitted. This is the documented "source has no data"
         // branch per ticket AC ("non-empty content when the source subsystems have data").
+    });
+
+    test('keeps the final root invisible until capture completes, then publishes it without staging residue (#16417)', async () => {
+        const
+            finalRoot      = path.join(workRoot, 'publish-after-capture'),
+            silentLogger   = {log: () => {}, error: () => {}},
+            originalRename = fsExtra.rename;
+
+        let releaseRename, signalRenameStarted;
+
+        const renameStarted = new Promise(resolve => { signalRenameStarted = resolve });
+        const renameRelease = new Promise(resolve => { releaseRename = resolve });
+        let backupPromise;
+
+        try {
+            fsExtra.rename = async function(source, destination) {
+                if (destination === finalRoot) {
+                    expect(path.basename(source)).toMatch(/^\.backup-partial-/);
+                    expect(fs.existsSync(path.join(source, 'bundle-meta.json'))).toBe(true);
+                    expect(fs.existsSync(finalRoot)).toBe(false);
+                    signalRenameStarted();
+                    await renameRelease
+                }
+
+                return originalRename.call(this, source, destination)
+            };
+
+            backupPromise = runBackup({
+                bundleRoot: finalRoot,
+                conceptsSourceDir,
+                trajectoriesSourceFile,
+                logger    : silentLogger
+            });
+
+            const boundary = await Promise.race([
+                renameStarted.then(() => 'rename'),
+                backupPromise.then(() => 'completed')
+            ]);
+
+            expect(boundary).toBe('rename');
+            expect(fs.existsSync(finalRoot)).toBe(false);
+            expect(
+                fs.readdirSync(workRoot).filter(name => name.startsWith(`.backup-partial-${path.basename(finalRoot)}-`))
+            ).toHaveLength(1);
+
+            releaseRename();
+
+            const result        = await backupPromise;
+            const persistedMeta = JSON.parse(fs.readFileSync(path.join(finalRoot, 'bundle-meta.json'), 'utf8'));
+            const mcBackupFile  = result.subsystems.mc.memories.backupFile;
+
+            expect(result.bundleRoot).toBe(finalRoot);
+            expect(fs.existsSync(path.join(finalRoot, 'bundle-meta.json'))).toBe(true);
+            expect(JSON.stringify({persistedMeta, result})).not.toContain('.backup-partial-');
+            expect(mcBackupFile.startsWith(`${finalRoot}${path.sep}`)).toBe(true);
+            expect(fs.existsSync(mcBackupFile)).toBe(true);
+            expect(persistedMeta.subsystems.mc.memories.backupFile).toBe(mcBackupFile);
+
+            if (process.platform !== 'win32') {
+                expect(fs.statSync(finalRoot).mode & 0o777).toBe(0o777 & ~process.umask())
+            }
+
+            expect(
+                fs.readdirSync(workRoot).filter(name => name.startsWith(`.backup-partial-${path.basename(finalRoot)}-`))
+            ).toHaveLength(0);
+        } finally {
+            releaseRename?.();
+            fsExtra.rename = originalRename;
+            await backupPromise?.catch(() => {});
+        }
+    });
+
+    test('a caught mid-capture failure leaves neither final nor staging root and preserves the original error (#16417)', async () => {
+        const
+            failure          = new Error('forced graph export failure'),
+            finalRoot        = path.join(workRoot, 'failed-capture'),
+            silentLogger     = {log: () => {}, error: () => {}},
+            backupService    = SDK.Memory_DatabaseService,
+            servicePrototype = Object.getPrototypeOf(backupService),
+            originalBackup   = servicePrototype.manageDatabaseBackup;
+
+        let thrown;
+
+        try {
+            servicePrototype.manageDatabaseBackup = async function(options) {
+                if (options.include?.length === 1 && options.include[0] === 'graph') {
+                    throw failure
+                }
+
+                return originalBackup.call(this, options)
+            };
+
+            try {
+                await runBackup({
+                    bundleRoot: finalRoot,
+                    conceptsSourceDir,
+                    trajectoriesSourceFile,
+                    logger    : silentLogger
+                })
+            } catch (error) {
+                thrown = error
+            }
+
+            expect(thrown).toBe(failure);
+            expect(fs.existsSync(finalRoot)).toBe(false);
+            expect(
+                fs.readdirSync(workRoot).filter(name => name.startsWith(`.backup-partial-${path.basename(finalRoot)}-`))
+            ).toHaveLength(0);
+        } finally {
+            servicePrototype.manageDatabaseBackup = originalBackup;
+        }
+    });
+
+    test('an existing final destination fails loud without mutating it (#16417)', async () => {
+        const
+            finalRoot    = path.join(workRoot, 'existing-destination'),
+            sentinelPath = path.join(finalRoot, 'sentinel.txt'),
+            silentLogger = {log: () => {}, error: () => {}};
+
+        fs.mkdirSync(finalRoot, {recursive: true});
+        fs.writeFileSync(sentinelPath, 'keep-me');
+
+        await expect(runBackup({
+            bundleRoot: finalRoot,
+            conceptsSourceDir,
+            trajectoriesSourceFile,
+            logger    : silentLogger
+        })).rejects.toThrow(/already exists/i);
+
+        expect(fs.readFileSync(sentinelPath, 'utf8')).toBe('keep-me');
+        expect(fs.readdirSync(finalRoot)).toEqual(['sentinel.txt']);
+    });
+
+    test('a dangling final-destination symlink fails loud and remains untouched (#16417)', async () => {
+        test.skip(process.platform === 'win32', 'symlink creation requires elevated privileges on some Windows hosts');
+
+        const
+            finalRoot     = path.join(workRoot, 'dangling-destination'),
+            missingTarget = path.join(workRoot, 'missing-symlink-target'),
+            silentLogger  = {log: () => {}, error: () => {}};
+
+        fs.symlinkSync(missingTarget, finalRoot);
+
+        await expect(runBackup({
+            bundleRoot: finalRoot,
+            conceptsSourceDir,
+            trajectoriesSourceFile,
+            logger    : silentLogger
+        })).rejects.toThrow(/already exists/i);
+
+        expect(fs.lstatSync(finalRoot).isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(finalRoot)).toBe(missingTarget);
+    });
+
+    test('a long explicit final basename still has a bounded staging basename (#16417)', async () => {
+        test.skip(process.platform === 'win32', 'the parent plus 230-character filename can exceed legacy MAX_PATH');
+
+        const finalRoot = path.join(workRoot, `long-${'x'.repeat(225)}`);
+        const result    = await runBackup({
+            bundleRoot         : finalRoot,
+            cleanOldBackupsImpl: async () => {},
+            conceptsSourceDir,
+            trajectoriesSourceFile,
+            logger             : {log: () => {}, error: () => {}}
+        });
+
+        expect(result.bundleRoot).toBe(finalRoot);
+        expect(fs.existsSync(path.join(finalRoot, 'bundle-meta.json'))).toBe(true);
+    });
+
+    test('retention runs only after publication and cannot invalidate a completed bundle (#16417)', async () => {
+        const
+            finalRoot = path.join(workRoot, 'retention-after-publish'),
+            warnings  = [];
+
+        const result = await runBackup({
+            bundleRoot         : finalRoot,
+            cleanOldBackupsImpl: async () => {
+                expect(fs.existsSync(path.join(finalRoot, 'bundle-meta.json'))).toBe(true);
+                throw new Error('forced retention failure')
+            },
+            conceptsSourceDir,
+            trajectoriesSourceFile,
+            logger: {
+                error: () => {},
+                log  : () => {},
+                warn : message => warnings.push(message)
+            }
+        });
+
+        expect(result.bundleRoot).toBe(finalRoot);
+        expect(fs.existsSync(path.join(finalRoot, 'bundle-meta.json'))).toBe(true);
+        expect(warnings).toEqual([expect.stringContaining('forced retention failure')]);
+    });
+
+    test('throwing post-publication diagnostics neither fail the bundle nor suppress retention (#16417)', async () => {
+        const finalRoot       = path.join(workRoot, 'throwing-success-log');
+        let   retentionCalled = false;
+
+        const result = await runBackup({
+            bundleRoot         : finalRoot,
+            cleanOldBackupsImpl: async () => { retentionCalled = true },
+            conceptsSourceDir,
+            trajectoriesSourceFile,
+            logger             : {
+                error: () => {},
+                log  : message => {
+                    if (message.startsWith('[8/8]') || message.startsWith('✅ Backup complete:')) {
+                        throw new Error('closed terminal')
+                    }
+                }
+            }
+        });
+
+        expect(result.bundleRoot).toBe(finalRoot);
+        expect(retentionCalled).toBe(true);
+        expect(fs.existsSync(path.join(finalRoot, 'bundle-meta.json'))).toBe(true);
     });
 
     test('reports missing concept/trajectory sources as non-fatal notes', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -464,7 +464,7 @@ test.describe('owner boundary + overlay order (source contracts)', () => {
 
         // Bundle root + retention resolve from the AiConfig leaf, never the module constant
         expect(source).toContain('path.join(AiConfig.backupPath, `backup-${timestamp}`)');
-        expect(source).toContain('cleanOldBackups(AiConfig.backupPath,');
+        expect(source).toContain('cleanOldBackupsImpl(AiConfig.backupPath, logger, retention)');
         expect(runBackupBody).not.toContain('DEFAULT_BACKUP_ROOT, `backup-');
     });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -1092,6 +1092,18 @@ test.describe('verifyLatestBackupRestorable — falls back past an unusable newe
         expect(verdict.examined).toBe(2);
     });
 
+    test('an abrupt-death staging directory is never a restore candidate, even when it contains parseable rows (#16417)', async () => {
+        writeValidBundle('backup-2026-08-01T12-13-23.398Z');
+        writeValidBundle('.backup-partial-backup-2026-08-02T05-12-55.917Z-dead-process');
+
+        const verdict = await verifyLatestBackupRestorable({backupRoot: probeRoot, logger: silent});
+
+        expect(verdict.restorable).toBe(true);
+        expect(verdict.bundleRoot).toContain('backup-2026-08-01T12-13-23.398Z');
+        expect(verdict.examined).toBe(1);
+        expect(verdict.skipped).toEqual([]);
+    });
+
     test('the fallback crosses every unusable class, not just the one that caused the incident', async () => {
         // Three distinct failure shapes stacked ABOVE the only good bundle. If the walk only handled
         // the shape it was written for, one of these would stop it.


### PR DESCRIPTION
Resolves #16417

Backup bundles now assemble in a unique same-parent, non-candidate staging directory and become restore-authoritative only through a final same-filesystem rename after every export, integrity check, and `bundle-meta.json` write completes. Caught failures remove only their owned staging directory; abrupt-death residue remains self-identifying and invisible to restore/retention discovery. The published layout and metadata schema remain unchanged.

Related: #16348

Evidence: L3 (real-filesystem staging, write completion, and rename exercised against disposable SDK-backed collections) → L3 required (AC8 live scheduled-backup observation). Residual: AC8 [#16417].

## Deltas from ticket

- Final-destination admission uses `lstat`, so an existing directory, inaccessible entry, or dangling symlink never looks absent and is never overwritten.
- Receipt paths returned by the SDK exporters are rebased from the private staging root to the published root before `bundle-meta.json` is persisted or the result is returned.
- Retention policy still resolves before publication, but pruning runs only after rename. A failed capture therefore preserves the configured recovery floor, while retention or diagnostic-sink failure cannot turn an already-published bundle into a contradictory failed receipt.
- The staging hint is bounded for long explicit bundle basenames, and the prior directory-permission behavior is preserved where the backing filesystem supports POSIX `chmod`.
- No bundle layout, receipt schema, config surface, or restore import behavior changed.

## Test Evidence

- Baseline RED: the new publication witness failed before the production change because the final root already existed while capture was paused (`1 failed`, `45 passed`; remaining serial cases skipped after the failure).
- Backup / retention / restore / off-host sync: `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs` — `130 passed`.
- The rename-boundary witness verifies `bundle-meta.json` exists in staging while the final root is absent, then verifies exact published MC receipt paths and zero staging residue.
- Failure/no-clobber witnesses cover original-error identity, existing destinations, dangling symlinks, long explicit basenames, post-publication retention failure, and throwing diagnostic sinks.
- Repository-wide run 1: `npm run test-unit` — `11089 passed`, with three untouched DragDrop reset tests plus one MemoryService timer-teardown test failing under full-suite load.
- Exact failing-file control: `npm run test-unit -- test/playwright/unit/main/addon/DragDrop.spec.mjs test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs` — `28 passed`.
- Repository-wide run 2: `npm run test-unit` — `11090 passed`; the same three untouched DragDrop reset tests failed under full-suite load, while the MemoryService failure did not recur. Emmy and Phoebe received the two-run evidence for the order/load-dependent lane.
- `git diff --check`, `node --check ai/scripts/maintenance/backup.mjs`, and the restoration-class agent preflight passed.

## Post-Merge Validation

- [ ] Observe the next scheduled deployment backup: no final `backup-*` directory exists before completion; one appears only after `bundle-meta.json` is complete.
- [ ] Verify `last-backup-receipt.json` and any off-host sync invocation name that exact published bundle path, never a `.backup-partial-*` path.
- [ ] Confirm the scheduled run leaves no owned staging residue; preserve any pre-existing abrupt-death residue for separate forensic cleanup policy.

## Evolution

Adversarial validation surfaced two publication-adjacent truth splits before handoff: SDK receipts initially retained private staging paths, and pre-publication retention would have reduced the previous recovery floor if a later gate failed. The final shape rebases receipts before metadata persistence and moves pruning after publication while resolving policy before it; both pivots are pinned by discriminating tests.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 97816bde-fe7c-4b23-98c4-fbe4d89ed53d.
