### PR TITLE
feat(orchestrator): a failed backup retries within a bounded window (#16348)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -266,7 +266,7 @@ class ConfigBase extends ConfigProvider {
                  * @type {number}
                  */
                 tenantProbeTimeoutMs: leaf(30000, 'NEO_FLEET_TENANT_PROBE_TIMEOUT_MS', 'number'),
-                harnessBinaries: {
+                harnessBinaries     : {
                     /**
                      * The antigravity harness binary — the app-bundle MAIN binary (a directly
                      * spawnable, supervisable child), never an `open -n` launcher. macOS default;
@@ -1058,25 +1058,27 @@ class ConfigBase extends ConfigProvider {
                  * @type {Object}
                  */
                 intervals: {
-                    pollMs                 : leaf(3000, 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS', 'number'),
-                    summarySweepMs         : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'number'),
-                    kbSyncMs               : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS', 'number'),
-                    githubWorkflowSyncMs   : leaf(2 * HOUR_MS, 'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_INTERVAL_MS', 'number'),
-                    backupMs               : leaf(DAY_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS', 'number'),
+                    pollMs              : leaf(3000, 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS', 'number'),
+                    summarySweepMs      : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'number'),
+                    kbSyncMs            : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS', 'number'),
+                    githubWorkflowSyncMs: leaf(2 * HOUR_MS, 'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_INTERVAL_MS', 'number'),
+                    backupMs            : leaf(DAY_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS', 'number'),
                     /**
-                     * Minimum spacing between retries of a FAILED backup run, and how long after the
-                     * last SUCCESSFUL run those retries stay permitted. `0` on either disables retry
-                     * and restores the earlier behaviour, where a run that died seconds after spawn
-                     * forfeited a full `backupMs` because `markStarted` stamps `lastRunAt` pre-spawn.
+                     * Minimum spacing between retries of a FAILED backup run, and how long the retry
+                     * window stays open. `0` on either disables retry and restores the earlier
+                     * behaviour, where a run that died seconds after spawn forfeited a full `backupMs`
+                     * because `markStarted` stamps `lastRunAt` pre-spawn.
                      *
-                     * The effective attempt budget is AT MOST `floor(backupRetryWindowMs /
-                     * backupRetryDelayMs)` — 4 at these defaults, and typically one fewer, since the
-                     * first failure consumes part of the window before the first retry can be spaced.
-                     * The load-bearing property is termination, not the exact count, and the spec
-                     * asserts it by running the clock rather than by restating this formula.
-                     * It is bounded deliberately: `backup` is the only priority-0
-                     * lane and wins the pick unconditionally, so an unbounded retry would monopolize the
-                     * heavy-maintenance lease and starve the REM chain.
+                     * The window is measured from `failureStreakStartedAt` — the FIRST failure after a
+                     * success, written once and never advanced while the streak is open. It must be
+                     * the failure and not the last success: a periodic run fails roughly one
+                     * `backupMs` after the last success, so a window anchored there is already expired
+                     * before the first retry can be spaced, and the whole policy silently no-ops.
+                     *
+                     * The effective attempt budget is `floor(backupRetryWindowMs / backupRetryDelayMs)`
+                     * — 4 at these defaults. It is bounded deliberately: `backup` is the only
+                     * priority-0 lane and wins the pick unconditionally, so an unbounded retry would
+                     * monopolize the heavy-maintenance lease and starve the REM chain.
                      */
                     backupRetryDelayMs     : leaf(15 * 60 * 1000, 'NEO_ORCHESTRATOR_BACKUP_RETRY_DELAY_MS', 'number'),
                     backupRetryWindowMs    : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_BACKUP_RETRY_WINDOW_MS', 'number'),

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1063,6 +1063,23 @@ class ConfigBase extends ConfigProvider {
                     kbSyncMs               : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS', 'number'),
                     githubWorkflowSyncMs   : leaf(2 * HOUR_MS, 'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_INTERVAL_MS', 'number'),
                     backupMs               : leaf(DAY_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS', 'number'),
+                    /**
+                     * Minimum spacing between retries of a FAILED backup run, and how long after the
+                     * last SUCCESSFUL run those retries stay permitted. `0` on either disables retry
+                     * and restores the earlier behaviour, where a run that died seconds after spawn
+                     * forfeited a full `backupMs` because `markStarted` stamps `lastRunAt` pre-spawn.
+                     *
+                     * The effective attempt budget is AT MOST `floor(backupRetryWindowMs /
+                     * backupRetryDelayMs)` — 4 at these defaults, and typically one fewer, since the
+                     * first failure consumes part of the window before the first retry can be spaced.
+                     * The load-bearing property is termination, not the exact count, and the spec
+                     * asserts it by running the clock rather than by restating this formula.
+                     * It is bounded deliberately: `backup` is the only priority-0
+                     * lane and wins the pick unconditionally, so an unbounded retry would monopolize the
+                     * heavy-maintenance lease and starve the REM chain.
+                     */
+                    backupRetryDelayMs     : leaf(15 * 60 * 1000, 'NEO_ORCHESTRATOR_BACKUP_RETRY_DELAY_MS', 'number'),
+                    backupRetryWindowMs    : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_BACKUP_RETRY_WINDOW_MS', 'number'),
                     graphLogCompactionMs   : leaf(DAY_MS, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_INTERVAL_MS', 'number'),
                     primaryDevSyncMs       : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS', 'number'),
                     tenantRepoSyncMs       : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS', 'number'),

--- a/ai/daemons/orchestrator/scheduling/backup.mjs
+++ b/ai/daemons/orchestrator/scheduling/backup.mjs
@@ -31,7 +31,7 @@ export function toEpochMs(isoTimestamp) {
 }
 
 /**
- * Whether the bounded retry window measured from the last success is still open.
+ * Whether the bounded retry window measured from the failure-streak anchor is still open.
  *
  * @summary The single definition of "is the budget spent". Both the trigger
  * ({@link isFailedRunRetryDue}) and the phase reporter ({@link describeBackupRetryState}) route
@@ -40,8 +40,11 @@ export function toEpochMs(isoTimestamp) {
  * precisely the drift that makes a silent failure look supervised.
  * @param {Object} options
  * @param {Number} options.now Current timestamp in milliseconds.
- * @param {Number} options.lastSuccessAtMs Last successful completion, epoch ms; `0` when never.
- * @param {Number} options.retryWindowMs Retry window from the last success; `0` disables retry.
+ * @param {Number} options.streakStartedAtMs Failure-streak anchor, epoch ms; `0` when no streak is
+ *     open. An earlier revision measured from `lastSuccessAt` instead, which is already roughly a
+ *     full `intervalMs` stale when a periodic run fails — so at any `retryWindowMs < intervalMs`
+ *     the budget was spent before the first failure and the feature no-opped at its own defaults.
+ * @param {Number} options.retryWindowMs Retry window from the streak anchor; `0` disables retry.
  * @returns {Boolean}
  */
 export function isRetryWindowOpen({now, streakStartedAtMs, retryWindowMs}) {
@@ -99,9 +102,12 @@ export function countRemainingRetries({now, lastRunAt, streakStartedAtMs, retryD
  * *attempted* from *succeeded*.
  *
  * **The window opens at the FAILED CYCLE and never slides, and both halves of that are load-bearing.**
- * `failureStreakStartedAt` is written by `TaskStateService.markFailed()` with `??=`, so it is set
- * once at the first failure after a success and preserved across every subsequent retry, then
- * cleared by `markCompleted()`.
+ * `failureStreakStartedAt` is written by `TaskStateService.openFailureStreak()` with `??=`, so it is
+ * set once at the first failure after a success and preserved across every subsequent retry, then
+ * cleared by `markCompleted()`. Every terminal-failure writer shares that one transition —
+ * `markFailed()` (exited non-zero), `markSpawnFailed()` (spawn threw), and `readState()`'s
+ * interrupted-run normalization — because this predicate reads the anchor as the SOLE activation
+ * fact, which makes any writer that skips it a silent forfeit of the whole budget.
  *
  * - **Opening it at the failure** is what makes the feature work at all. An earlier revision
  *   anchored on `lastSuccessAt`, which is immovable but roughly one full `intervalMs` stale by the
@@ -114,8 +120,11 @@ export function countRemainingRetries({now, lastRunAt, streakStartedAtMs, retryD
  *   failed retry, so a window measured from it would never close.
  *
  * A run interrupted by a crash also opens a streak: `TaskStateService.readState()` normalizes a
- * persisted `running: true` fail-closed. Without that, an interrupted run recorded no terminal
- * outcome at all and read as healthy — the very incident class this lane exists to catch.
+ * persisted `running: true` fail-closed, and `configure()` COMMITS that normalization to disk before
+ * any consumer can read the lane. Without the normalization, an interrupted run recorded no terminal
+ * outcome at all and read as healthy — the very incident class this lane exists to catch. Without
+ * the commit, the crashed bytes survive and each restart re-derives a fresh anchor, so the bound
+ * slides forward once per outage and a crash loop never exhausts a budget meant to terminate.
  *
  * @param {Object} options
  * @param {Number} options.now Current timestamp in milliseconds.

--- a/ai/daemons/orchestrator/scheduling/backup.mjs
+++ b/ai/daemons/orchestrator/scheduling/backup.mjs
@@ -1,13 +1,189 @@
 /**
- * Builds the task trigger for the backup periodic sweep. Pure function.
+ * Retry phases a backup lane can be in, derived from persisted task state.
  *
+ * @summary `healthy` — the last run succeeded. `retrying` — the last run failed and the
+ * bounded retry window is still open. `exhausted` — the last run failed and the window has
+ * closed, so the lane has fallen back to its ordinary cadence with a stale last-known-good
+ * bundle. `unanchored` — the lane has never succeeded, so there is no known-good timestamp
+ * to bound a retry window against (see {@link isFailedRunRetryDue}).
+ * @type {Object}
+ */
+export const BACKUP_RETRY_PHASE = Object.freeze({
+    exhausted : 'exhausted',
+    healthy   : 'healthy',
+    retrying  : 'retrying',
+    unanchored: 'unanchored'
+});
+
+/**
+ * Parses a persisted ISO timestamp into epoch ms.
+ *
+ * @summary `TaskStateService` writes `lastSuccessAt` / `lastErrorAt` as ISO strings while
+ * `lastRunAt` is already epoch ms; the trigger compares all three, so the ISO pair is
+ * normalized here. Absent or unparseable values become `0` — "never happened" — which the
+ * callers treat as an explicit branch rather than as a small timestamp.
+ * @param {String|null|undefined} isoTimestamp
+ * @returns {Number} Epoch ms, or `0` when absent/unparseable.
+ */
+export function toEpochMs(isoTimestamp) {
+    const parsed = Date.parse(isoTimestamp);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * Whether the bounded retry window measured from the last success is still open.
+ *
+ * @summary The single definition of "is the budget spent". Both the trigger
+ * ({@link isFailedRunRetryDue}) and the phase reporter ({@link describeBackupRetryState}) route
+ * through it, because two independent computations of one fact can disagree — and the pair that
+ * would disagree here is "the lane stopped retrying" versus "the lane reports it stopped", which is
+ * precisely the drift that makes a silent failure look supervised.
+ * @param {Object} options
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.lastSuccessAtMs Last successful completion, epoch ms; `0` when never.
+ * @param {Number} options.retryWindowMs Retry window from the last success; `0` disables retry.
+ * @returns {Boolean}
+ */
+export function isRetryWindowOpen({now, lastSuccessAtMs, retryWindowMs}) {
+    if (retryWindowMs <= 0 || lastSuccessAtMs <= 0) {
+        return false;
+    }
+
+    return now - lastSuccessAtMs < retryWindowMs;
+}
+
+/**
+ * Decides whether a FAILED backup run is due for a bounded retry.
+ *
+ * @summary `markStarted()` stamps `lastRunAt` PRE-SPAWN and `markFailed()` never restores it,
+ * so a run that dies seconds after spawn is not periodically due again for a full `intervalMs`.
+ * `backup` is the system's only priority-0 lane (`PRIORITY_ZERO_TASKS`) — it wins the pick
+ * unconditionally when due — and that guarantee is worth nothing against its own failure,
+ * because ranking applies to candidates and a failed backup is not one. This predicate reads
+ * the finer fields the periodic path ignores (`lastSuccessAt` / `lastErrorAt`) to distinguish
+ * *attempted* from *succeeded*.
+ *
+ * **The window anchors on `lastSuccessAt`, and that choice is the livelock guard.** Because
+ * `backup` wins unconditionally, an unbounded retry would turn a persistently-failing lane into
+ * a heavy-lease monopoly and starve `summary` / `dream` / `memory-summary-backfill` — the exact
+ * starvation the scheduling fairness model exists to eliminate, re-created by the repair for it.
+ * `lastErrorAt` moves
+ * with every failed retry, so anchoring there would slide the window forever; `lastSuccessAt`
+ * cannot move during a failure streak, so the window closes deterministically. The effective
+ * attempt budget is therefore `floor(retryWindowMs / retryDelayMs)`, bounded by construction
+ * rather than by a counter that would have to survive a restart on its own.
+ *
+ * A lane that has never succeeded is deliberately NOT retried: it has no known-good anchor, so
+ * any window would be unbounded. It keeps today's ordinary cadence — this is a bound, not an
+ * oversight, and {@link describeBackupRetryState} reports it as `unanchored` so the case is
+ * visible rather than silently indistinguishable from healthy.
+ *
+ * @param {Object} options
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.lastRunAt Last backup ATTEMPT timestamp (pre-spawn stamp).
+ * @param {Number} options.lastSuccessAtMs Last successful completion, epoch ms; `0` when never.
+ * @param {Number} options.lastErrorAtMs Last failure, epoch ms; `0` when never.
+ * @param {Number} options.retryDelayMs Minimum spacing between retries; `0` disables retry.
+ * @param {Number} options.retryWindowMs How long after the last success retries stay permitted;
+ *     `0` disables retry.
+ * @returns {Boolean}
+ */
+export function isFailedRunRetryDue({
+    now,
+    lastRunAt,
+    lastSuccessAtMs,
+    lastErrorAtMs,
+    retryDelayMs,
+    retryWindowMs
+}) {
+    if (retryDelayMs <= 0 || retryWindowMs <= 0) {
+        return false;
+    }
+
+    // No known-good anchor ⇒ no boundable window. Ordinary cadence governs.
+    if (lastSuccessAtMs <= 0) {
+        return false;
+    }
+
+    // The last run did not fail — nothing to retry.
+    if (lastErrorAtMs <= lastSuccessAtMs) {
+        return false;
+    }
+
+    // Budget: the window is measured from the IMMOVABLE last success, so it closes.
+    if (!isRetryWindowOpen({now, lastSuccessAtMs, retryWindowMs})) {
+        return false;
+    }
+
+    return now - lastRunAt >= retryDelayMs;
+}
+
+/**
+ * Reports the lane's retry phase as durable, readable STATE rather than a log edge.
+ *
+ * @summary AC5 requires budget exhaustion to reach a surface. An edge-triggered log would need
+ * its own persisted "already warned" flag and would be lost on restart; every field this reads
+ * is already persisted by `TaskStateService.writeState()`, so the phase is recomputable at any
+ * time by any reader — including after a restart — and needs no state of its own. Exposed on the
+ * orchestrator health payload, which is the surface that can actually see the backup lane.
+ * @param {Object} options
+ * @param {Object} [options.taskState={}] Persisted `backup` task state.
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} [options.retryDelayMs=0] Minimum spacing between retries.
+ * @param {Number} [options.retryWindowMs=0] Retry window measured from the last success.
+ * @returns {{phase: String, retriesRemaining: Number, windowEndsAtMs: Number|null, lastSuccessAtMs: Number}}
+ */
+export function describeBackupRetryState({taskState = {}, now, retryDelayMs = 0, retryWindowMs = 0} = {}) {
+    const lastSuccessAtMs = toEpochMs(taskState.lastSuccessAt),
+          lastErrorAtMs   = toEpochMs(taskState.lastErrorAt);
+
+    if (lastSuccessAtMs <= 0) {
+        return {phase: BACKUP_RETRY_PHASE.unanchored, retriesRemaining: 0, windowEndsAtMs: null, lastSuccessAtMs};
+    }
+
+    if (lastErrorAtMs <= lastSuccessAtMs) {
+        return {phase: BACKUP_RETRY_PHASE.healthy, retriesRemaining: 0, windowEndsAtMs: null, lastSuccessAtMs};
+    }
+
+    const windowEndsAtMs = lastSuccessAtMs + retryWindowMs,
+          exhausted      = retryDelayMs <= 0 || !isRetryWindowOpen({now, lastSuccessAtMs, retryWindowMs});
+
+    return {
+        phase           : exhausted ? BACKUP_RETRY_PHASE.exhausted : BACKUP_RETRY_PHASE.retrying,
+        retriesRemaining: exhausted ? 0 : Math.floor((windowEndsAtMs - now) / retryDelayMs),
+        windowEndsAtMs,
+        lastSuccessAtMs
+    };
+}
+
+/**
+ * Builds the task trigger for the backup sweep. Pure function.
+ *
+ * @summary Two paths, periodic-first. The periodic sweep is unchanged; the retry path fires only
+ * for a lane whose last run FAILED, within a bounded window. Retry values arrive as parameters
+ * (the `tenantRepoSync.isRepoDue` shape) so this module imports no config of its own — the caller
+ * reads `AiConfig.orchestrator.intervals.*` at its own use site, and a second resolution path able
+ * to disagree with the leaf never exists. Passing `0` for either retry value disables the retry
+ * path entirely, leaving the periodic sweep exactly as it behaves without it.
  * @param {Object} options
  * @param {Number} options.now Current timestamp in milliseconds.
  * @param {Number} options.lastRunAt Last backup task start timestamp.
  * @param {Number} options.intervalMs Periodic backup interval; `0` disables it.
+ * @param {Number} [options.lastSuccessAtMs=0] Last successful completion, epoch ms.
+ * @param {Number} [options.lastErrorAtMs=0] Last failure, epoch ms.
+ * @param {Number} [options.retryDelayMs=0] Minimum spacing between retries; `0` disables retry.
+ * @param {Number} [options.retryWindowMs=0] Retry window from the last success; `0` disables retry.
  * @returns {Object|null} A backup task trigger or null when no work is due.
  */
-export function buildBackupTrigger({now, lastRunAt, intervalMs}) {
+export function buildBackupTrigger({
+    now,
+    lastRunAt,
+    intervalMs,
+    lastSuccessAtMs = 0,
+    lastErrorAtMs   = 0,
+    retryDelayMs    = 0,
+    retryWindowMs   = 0
+}) {
     if (intervalMs > 0 && now - lastRunAt >= intervalMs) {
         return {
             taskName: 'backup',
@@ -15,6 +191,15 @@ export function buildBackupTrigger({now, lastRunAt, intervalMs}) {
             reason  : `periodic-sweep:${intervalMs}`
         };
     }
+
+    if (isFailedRunRetryDue({now, lastRunAt, lastSuccessAtMs, lastErrorAtMs, retryDelayMs, retryWindowMs})) {
+        return {
+            taskName: 'backup',
+            source  : 'failed-run-retry',
+            reason  : `failed-run-retry:${now - lastSuccessAtMs}`
+        };
+    }
+
     return null;
 }
 
@@ -25,12 +210,20 @@ export function buildBackupTrigger({now, lastRunAt, intervalMs}) {
  * @param {Object} options.state Current orchestrator task state.
  * @param {Number} options.now Current timestamp in milliseconds.
  * @param {Number} options.backupIntervalMs Periodic backup interval.
+ * @param {Number} [options.backupRetryDelayMs=0] Minimum spacing between failed-run retries.
+ * @param {Number} [options.backupRetryWindowMs=0] Retry window measured from the last success.
  * @returns {Object|null}
  */
-export function getDueTask({state, now, backupIntervalMs}) {
+export function getDueTask({state, now, backupIntervalMs, backupRetryDelayMs = 0, backupRetryWindowMs = 0}) {
+    const taskState = state.backup || {};
+
     return buildBackupTrigger({
         now,
-        intervalMs: backupIntervalMs,
-        lastRunAt : state.backup?.lastRunAt || 0
+        intervalMs     : backupIntervalMs,
+        lastRunAt      : taskState.lastRunAt || 0,
+        lastSuccessAtMs: toEpochMs(taskState.lastSuccessAt),
+        lastErrorAtMs  : toEpochMs(taskState.lastErrorAt),
+        retryDelayMs   : backupRetryDelayMs,
+        retryWindowMs  : backupRetryWindowMs
     });
 }

--- a/ai/daemons/orchestrator/scheduling/backup.mjs
+++ b/ai/daemons/orchestrator/scheduling/backup.mjs
@@ -44,12 +44,47 @@ export function toEpochMs(isoTimestamp) {
  * @param {Number} options.retryWindowMs Retry window from the last success; `0` disables retry.
  * @returns {Boolean}
  */
-export function isRetryWindowOpen({now, lastSuccessAtMs, retryWindowMs}) {
-    if (retryWindowMs <= 0 || lastSuccessAtMs <= 0) {
+export function isRetryWindowOpen({now, streakStartedAtMs, retryWindowMs}) {
+    if (retryWindowMs <= 0 || streakStartedAtMs <= 0) {
         return false;
     }
 
-    return now - lastSuccessAtMs < retryWindowMs;
+    return now - streakStartedAtMs < retryWindowMs;
+}
+
+/**
+ * Counts the retries that can still fire before the window closes.
+ *
+ * @summary Derived from the SAME schedule the trigger uses — next firing at
+ * `max(lastRunAt + retryDelayMs, now)`, then one per delay until the window ends — rather than
+ * from wall-clock division. `floor((windowEnd - now) / delay)` ignores `lastRunAt`, so a lane whose
+ * retry is already due (or overdue) reports one fewer than will actually fire. A count that does
+ * not come from the activation predicate is a second opinion about the same schedule.
+ * @param {Object} options
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.lastRunAt Last backup ATTEMPT timestamp.
+ * @param {Number} options.streakStartedAtMs Failure-streak anchor, epoch ms.
+ * @param {Number} options.retryDelayMs Minimum spacing between retries.
+ * @param {Number} options.retryWindowMs Retry window measured from the streak anchor.
+ * @returns {Number}
+ */
+export function countRemainingRetries({now, lastRunAt, streakStartedAtMs, retryDelayMs, retryWindowMs}) {
+    if (retryDelayMs <= 0 || retryWindowMs <= 0 || streakStartedAtMs <= 0) {
+        return 0;
+    }
+
+    const windowEndsAtMs = streakStartedAtMs + retryWindowMs;
+    let   nextFiringAtMs = Math.max(lastRunAt + retryDelayMs, now),
+          remaining      = 0;
+
+    // Strictly `<`, matching `isRetryWindowOpen`. A firing scheduled exactly AT the window end does
+    // not happen — the window is already closed there — and counting it over-reported by one.
+    while (nextFiringAtMs < windowEndsAtMs) {
+        remaining      += 1;
+        nextFiringAtMs += retryDelayMs
+    }
+
+    return remaining;
 }
 
 /**
@@ -60,39 +95,42 @@ export function isRetryWindowOpen({now, lastSuccessAtMs, retryWindowMs}) {
  * `backup` is the system's only priority-0 lane (`PRIORITY_ZERO_TASKS`) — it wins the pick
  * unconditionally when due — and that guarantee is worth nothing against its own failure,
  * because ranking applies to candidates and a failed backup is not one. This predicate reads
- * the finer fields the periodic path ignores (`lastSuccessAt` / `lastErrorAt`) to distinguish
+ * the finer field the periodic path ignores — `failureStreakStartedAt` — to distinguish
  * *attempted* from *succeeded*.
  *
- * **The window anchors on `lastSuccessAt`, and that choice is the livelock guard.** Because
- * `backup` wins unconditionally, an unbounded retry would turn a persistently-failing lane into
- * a heavy-lease monopoly and starve `summary` / `dream` / `memory-summary-backfill` — the exact
- * starvation the scheduling fairness model exists to eliminate, re-created by the repair for it.
- * `lastErrorAt` moves
- * with every failed retry, so anchoring there would slide the window forever; `lastSuccessAt`
- * cannot move during a failure streak, so the window closes deterministically. The effective
- * attempt budget is therefore `floor(retryWindowMs / retryDelayMs)`, bounded by construction
- * rather than by a counter that would have to survive a restart on its own.
+ * **The window opens at the FAILED CYCLE and never slides, and both halves of that are load-bearing.**
+ * `failureStreakStartedAt` is written by `TaskStateService.markFailed()` with `??=`, so it is set
+ * once at the first failure after a success and preserved across every subsequent retry, then
+ * cleared by `markCompleted()`.
  *
- * A lane that has never succeeded is deliberately NOT retried: it has no known-good anchor, so
- * any window would be unbounded. It keeps today's ordinary cadence — this is a bound, not an
- * oversight, and {@link describeBackupRetryState} reports it as `unanchored` so the case is
- * visible rather than silently indistinguishable from healthy.
+ * - **Opening it at the failure** is what makes the feature work at all. An earlier revision
+ *   anchored on `lastSuccessAt`, which is immovable but roughly one full `intervalMs` stale by the
+ *   time a periodic run fails — so with any `retryWindowMs < intervalMs` the window was already
+ *   expired at the first failure and no retry could ever fire at the shipped defaults.
+ * - **Not sliding** is the livelock guard. Because `backup` wins the pick unconditionally, an
+ *   unbounded retry would turn a persistently-failing lane into a heavy-lease monopoly and starve
+ *   `summary` / `dream` / `memory-summary-backfill` — the exact starvation the scheduling fairness
+ *   model exists to eliminate, re-created by the repair for it. `lastErrorAt` advances with every
+ *   failed retry, so a window measured from it would never close.
+ *
+ * A run interrupted by a crash also opens a streak: `TaskStateService.readState()` normalizes a
+ * persisted `running: true` fail-closed. Without that, an interrupted run recorded no terminal
+ * outcome at all and read as healthy — the very incident class this lane exists to catch.
  *
  * @param {Object} options
  * @param {Number} options.now Current timestamp in milliseconds.
  * @param {Number} options.lastRunAt Last backup ATTEMPT timestamp (pre-spawn stamp).
- * @param {Number} options.lastSuccessAtMs Last successful completion, epoch ms; `0` when never.
- * @param {Number} options.lastErrorAtMs Last failure, epoch ms; `0` when never.
+ * @param {Number} options.streakStartedAtMs Failure-streak anchor, epoch ms; `0` when the lane is
+ *     known-good (no open streak).
  * @param {Number} options.retryDelayMs Minimum spacing between retries; `0` disables retry.
- * @param {Number} options.retryWindowMs How long after the last success retries stay permitted;
+ * @param {Number} options.retryWindowMs How long after the streak opened retries stay permitted;
  *     `0` disables retry.
  * @returns {Boolean}
  */
 export function isFailedRunRetryDue({
     now,
     lastRunAt,
-    lastSuccessAtMs,
-    lastErrorAtMs,
+    streakStartedAtMs,
     retryDelayMs,
     retryWindowMs
 }) {
@@ -100,18 +138,13 @@ export function isFailedRunRetryDue({
         return false;
     }
 
-    // No known-good anchor ⇒ no boundable window. Ordinary cadence governs.
-    if (lastSuccessAtMs <= 0) {
+    // No open streak ⇒ the last outcome was a success (or the lane never ran). Nothing to retry.
+    if (streakStartedAtMs <= 0) {
         return false;
     }
 
-    // The last run did not fail — nothing to retry.
-    if (lastErrorAtMs <= lastSuccessAtMs) {
-        return false;
-    }
-
-    // Budget: the window is measured from the IMMOVABLE last success, so it closes.
-    if (!isRetryWindowOpen({now, lastSuccessAtMs, retryWindowMs})) {
+    // Budget: measured from the streak anchor, which does not move while the streak is open.
+    if (!isRetryWindowOpen({now, streakStartedAtMs, retryWindowMs})) {
         return false;
     }
 
@@ -130,29 +163,33 @@ export function isFailedRunRetryDue({
  * @param {Object} [options.taskState={}] Persisted `backup` task state.
  * @param {Number} options.now Current timestamp in milliseconds.
  * @param {Number} [options.retryDelayMs=0] Minimum spacing between retries.
- * @param {Number} [options.retryWindowMs=0] Retry window measured from the last success.
- * @returns {{phase: String, retriesRemaining: Number, windowEndsAtMs: Number|null, lastSuccessAtMs: Number}}
+ * @param {Number} [options.retryWindowMs=0] Retry window measured from the streak anchor.
+ * @returns {{phase: String, retriesRemaining: Number, windowEndsAtMs: Number|null, streakStartedAtMs: Number, interruptedAt: String|null}}
  */
 export function describeBackupRetryState({taskState = {}, now, retryDelayMs = 0, retryWindowMs = 0} = {}) {
-    const lastSuccessAtMs = toEpochMs(taskState.lastSuccessAt),
-          lastErrorAtMs   = toEpochMs(taskState.lastErrorAt);
+    const streakStartedAtMs = toEpochMs(taskState.failureStreakStartedAt),
+          lastSuccessAtMs   = toEpochMs(taskState.lastSuccessAt),
+          interruptedAt     = taskState.interruptedAt || null,
+          base              = {retriesRemaining: 0, windowEndsAtMs: null, streakStartedAtMs, interruptedAt};
 
-    if (lastSuccessAtMs <= 0) {
-        return {phase: BACKUP_RETRY_PHASE.unanchored, retriesRemaining: 0, windowEndsAtMs: null, lastSuccessAtMs};
+    // No open streak: either known-good, or never ran at all. Both are reported, never conflated —
+    // an interrupted run opens a streak (`readState` normalizes fail-closed), so it cannot land here.
+    if (streakStartedAtMs <= 0) {
+        return {...base, phase: lastSuccessAtMs > 0 ? BACKUP_RETRY_PHASE.healthy : BACKUP_RETRY_PHASE.unanchored};
     }
 
-    if (lastErrorAtMs <= lastSuccessAtMs) {
-        return {phase: BACKUP_RETRY_PHASE.healthy, retriesRemaining: 0, windowEndsAtMs: null, lastSuccessAtMs};
-    }
-
-    const windowEndsAtMs = lastSuccessAtMs + retryWindowMs,
-          exhausted      = retryDelayMs <= 0 || !isRetryWindowOpen({now, lastSuccessAtMs, retryWindowMs});
+    const windowEndsAtMs = streakStartedAtMs + retryWindowMs,
+          open           = retryDelayMs > 0 && isRetryWindowOpen({now, streakStartedAtMs, retryWindowMs});
 
     return {
-        phase           : exhausted ? BACKUP_RETRY_PHASE.exhausted : BACKUP_RETRY_PHASE.retrying,
-        retriesRemaining: exhausted ? 0 : Math.floor((windowEndsAtMs - now) / retryDelayMs),
-        windowEndsAtMs,
-        lastSuccessAtMs
+        ...base,
+        phase           : open ? BACKUP_RETRY_PHASE.retrying : BACKUP_RETRY_PHASE.exhausted,
+        retriesRemaining: open
+            ? countRemainingRetries({
+                now, lastRunAt: taskState.lastRunAt || 0, streakStartedAtMs, retryDelayMs, retryWindowMs
+            })
+            : 0,
+        windowEndsAtMs
     };
 }
 
@@ -169,20 +206,18 @@ export function describeBackupRetryState({taskState = {}, now, retryDelayMs = 0,
  * @param {Number} options.now Current timestamp in milliseconds.
  * @param {Number} options.lastRunAt Last backup task start timestamp.
  * @param {Number} options.intervalMs Periodic backup interval; `0` disables it.
- * @param {Number} [options.lastSuccessAtMs=0] Last successful completion, epoch ms.
- * @param {Number} [options.lastErrorAtMs=0] Last failure, epoch ms.
+ * @param {Number} [options.streakStartedAtMs=0] Failure-streak anchor, epoch ms; `0` when known-good.
  * @param {Number} [options.retryDelayMs=0] Minimum spacing between retries; `0` disables retry.
- * @param {Number} [options.retryWindowMs=0] Retry window from the last success; `0` disables retry.
+ * @param {Number} [options.retryWindowMs=0] Retry window from the streak anchor; `0` disables retry.
  * @returns {Object|null} A backup task trigger or null when no work is due.
  */
 export function buildBackupTrigger({
     now,
     lastRunAt,
     intervalMs,
-    lastSuccessAtMs = 0,
-    lastErrorAtMs   = 0,
-    retryDelayMs    = 0,
-    retryWindowMs   = 0
+    streakStartedAtMs = 0,
+    retryDelayMs      = 0,
+    retryWindowMs     = 0
 }) {
     if (intervalMs > 0 && now - lastRunAt >= intervalMs) {
         return {
@@ -192,11 +227,11 @@ export function buildBackupTrigger({
         };
     }
 
-    if (isFailedRunRetryDue({now, lastRunAt, lastSuccessAtMs, lastErrorAtMs, retryDelayMs, retryWindowMs})) {
+    if (isFailedRunRetryDue({now, lastRunAt, streakStartedAtMs, retryDelayMs, retryWindowMs})) {
         return {
             taskName: 'backup',
             source  : 'failed-run-retry',
-            reason  : `failed-run-retry:${now - lastSuccessAtMs}`
+            reason  : `failed-run-retry:${now - streakStartedAtMs}`
         };
     }
 
@@ -211,7 +246,7 @@ export function buildBackupTrigger({
  * @param {Number} options.now Current timestamp in milliseconds.
  * @param {Number} options.backupIntervalMs Periodic backup interval.
  * @param {Number} [options.backupRetryDelayMs=0] Minimum spacing between failed-run retries.
- * @param {Number} [options.backupRetryWindowMs=0] Retry window measured from the last success.
+ * @param {Number} [options.backupRetryWindowMs=0] Retry window measured from the streak anchor.
  * @returns {Object|null}
  */
 export function getDueTask({state, now, backupIntervalMs, backupRetryDelayMs = 0, backupRetryWindowMs = 0}) {
@@ -219,11 +254,10 @@ export function getDueTask({state, now, backupIntervalMs, backupRetryDelayMs = 0
 
     return buildBackupTrigger({
         now,
-        intervalMs     : backupIntervalMs,
-        lastRunAt      : taskState.lastRunAt || 0,
-        lastSuccessAtMs: toEpochMs(taskState.lastSuccessAt),
-        lastErrorAtMs  : toEpochMs(taskState.lastErrorAt),
-        retryDelayMs   : backupRetryDelayMs,
-        retryWindowMs  : backupRetryWindowMs
+        intervalMs       : backupIntervalMs,
+        lastRunAt        : taskState.lastRunAt || 0,
+        streakStartedAtMs: toEpochMs(taskState.failureStreakStartedAt),
+        retryDelayMs     : backupRetryDelayMs,
+        retryWindowMs    : backupRetryWindowMs
     });
 }

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -115,6 +115,8 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
                 kbSync                         : config.orchestrator.intervals.kbSyncMs,
                 githubWorkflowSync             : config.orchestrator.intervals.githubWorkflowSyncMs,
                 backup                         : config.orchestrator.intervals.backupMs,
+                backupRetryDelay               : config.orchestrator.intervals.backupRetryDelayMs,
+                backupRetryWindow              : config.orchestrator.intervals.backupRetryWindowMs,
                 graphLogCompaction             : config.orchestrator.intervals.graphLogCompactionMs,
                 primaryDevSync                 : config.orchestrator.intervals.primaryDevSyncMs,
                 tenantRepoSync                 : config.orchestrator.tenantRepoSync.sweepCadenceMs,

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -134,7 +134,9 @@ const taskRegistry = [
             return (hooks.backupGetDueTask || getBackupDueTask)({
                 state,
                 now,
-                backupIntervalMs: intervals.backup
+                backupIntervalMs   : intervals.backup,
+                backupRetryDelayMs : intervals.backupRetryDelay,
+                backupRetryWindowMs: intervals.backupRetryWindow
             });
         }
     },

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -16,6 +16,7 @@ import {
     readBackupReceipt,
     validateOffHostSyncConfig
 } from '../../../services/memory-core/helpers/offHostSyncStore.mjs';
+import {describeBackupRetryState}    from '../scheduling/backup.mjs';
 import {resolveDurabilityPosture}    from './deploymentDurabilityPosture.mjs';
 import {readRecentRecoveryRunStates} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {
@@ -236,7 +237,13 @@ export class DeploymentStateBridgeService extends Base {
         const selfHeal          = await this.collectSelfHealSnapshot();
         const tenantRepoSync    = await this.collectTenantRepoSyncSnapshot({observedAt: generatedAt});
         const bridgeDiagnostics = this.collectBridgeDiagnostics({services, observedAt: generatedAt});
-        const maintenance       = await this.collectMaintenanceSnapshot();
+        // The backup retry phase is read HERE rather than inside the projection: instance state is
+        // legitimate at this call site, and `collectMaintenanceSnapshot` is contractually detached
+        // (a spec invokes it via `.call({})`), so it takes the task state as an argument instead.
+        const maintenance = await this.collectMaintenanceSnapshot({
+            backupTaskState: this.taskStateService?.getTaskState?.('backup') || null,
+            now            : generatedAt
+        });
 
         return createDeploymentStateSnapshot({
             generatedAt,
@@ -267,20 +274,43 @@ export class DeploymentStateBridgeService extends Base {
      * `lastBackup` keeps its absent-before-first-run semantics and is simply omitted in that case.
      * @returns {Promise<Object|null>}
      */
-    async collectMaintenanceSnapshot({receiptPath = path.join(AiConfig.backupPath, 'last-backup-receipt.json')} = {}) {
+    async collectMaintenanceSnapshot({
+        backupTaskState = null,
+        now             = Date.now(),
+        receiptPath     = path.join(AiConfig.backupPath, 'last-backup-receipt.json')
+    } = {}) {
         // Module-scope, deliberately not a method: this projection depends only on resolved config
         // and its own argument, never on instance state, and the contract spec asserts that by
         // invoking it detached.
         const durability = resolveConfiguredDurabilityPosture();
 
+        // `retry` reports the backup lane's bounded-retry phase. It rides HERE rather than
+        // the Memory Core healthcheck's backup block on purpose: that block reads the backup
+        // DIRECTORY, and `mc-server` holds no backup mount — a surface that cannot see the thing it
+        // reports on. The orchestrator owns both the bind mount and the task state.
+        //
+        // Omitted rather than nulled when no task state was supplied, so a detached invocation keeps
+        // its previous shape exactly.
+        const base = backupTaskState
+            ? {
+                durability,
+                retry: describeBackupRetryState({
+                    now,
+                    retryDelayMs : AiConfig.orchestrator.intervals.backupRetryDelayMs,
+                    retryWindowMs: AiConfig.orchestrator.intervals.backupRetryWindowMs,
+                    taskState    : backupTaskState
+                })
+            }
+            : {durability};
+
         try {
             const outcome = await readBackupReceipt({filePath: receiptPath});
 
-            if (outcome.status === 'missing') return {durability};
+            if (outcome.status === 'missing') return base;
 
             if (outcome.status === 'unreadable') {
                 return {
-                    durability,
+                    ...base,
                     lastBackup: {
                         finishedAt: outcome.finishedAt,
                         kind      : outcome.kind,
@@ -289,10 +319,10 @@ export class DeploymentStateBridgeService extends Base {
                 }
             }
 
-            return {durability, lastBackup: outcome.receipt}
+            return {...base, lastBackup: outcome.receipt}
         } catch (error) {
             return {
-                durability,
+                ...base,
                 lastBackup: {
                     finishedAt: null,
                     kind      : 'corrupt',

--- a/ai/daemons/orchestrator/services/TaskStateService.mjs
+++ b/ai/daemons/orchestrator/services/TaskStateService.mjs
@@ -9,14 +9,16 @@ import Base from '../../../../src/core/Base.mjs';
 export function createInitialTaskState(taskDefinitions) {
     return Object.keys(taskDefinitions).reduce((state, taskName) => {
         state[taskName] = {
-            running       : false,
-            pid           : null,
-            lastRunAt     : 0,
-            lastSuccessAt : null,
-            lastErrorAt   : null,
-            lastExitCode  : null,
-            lastReason    : null,
-            lastCompletion: null
+            running               : false,
+            pid                   : null,
+            lastRunAt             : 0,
+            lastSuccessAt         : null,
+            lastErrorAt           : null,
+            lastExitCode          : null,
+            lastReason            : null,
+            lastCompletion        : null,
+            failureStreakStartedAt: null,
+            interruptedAt         : null
         };
         return state;
     }, {});
@@ -105,6 +107,22 @@ export class TaskStateService extends Base {
             const data = JSON.parse(fs.readFileSync(this.stateFile, 'utf8'));
             return Object.keys(fallback).reduce((state, taskName) => {
                 state[taskName] = {...fallback[taskName], ...(data[taskName] || {})};
+
+                // A persisted `running: true` means the process died with the task in flight, so no
+                // terminal outcome was ever recorded. Clearing the flag silently — the previous
+                // behaviour — projected that run as neither failed nor successful, and any consumer
+                // reading "no error since the last success" then reported it as healthy. Normalize
+                // FAIL-CLOSED: an interrupted run is not a success, and the streak it belongs to
+                // opens here so retry policy can see it.
+                if (data[taskName]?.running === true) {
+                    const interruptedAt = new Date().toISOString();
+
+                    state[taskName].interruptedAt          = interruptedAt;
+                    state[taskName].lastErrorAt            = interruptedAt;
+                    state[taskName].lastExitCode           = null;
+                    state[taskName].failureStreakStartedAt ??= interruptedAt
+                }
+
                 state[taskName].running = false;
                 state[taskName].pid     = null;
                 return state;
@@ -196,6 +214,9 @@ export class TaskStateService extends Base {
         state.lastExitCode  = 0;
         state.lastSuccessAt = new Date().toISOString();
         state.lastCompletion = lastCompletion;
+        // Success closes the streak and clears the interruption marker: the lane is known-good again.
+        state.failureStreakStartedAt = null;
+        state.interruptedAt          = null;
         this.writeState();
     }
 
@@ -249,12 +270,20 @@ export class TaskStateService extends Base {
      * @returns {void}
      */
     markFailed(taskName, code, lastCompletion=null) {
-        const state = this.taskState[taskName];
+        const state = this.taskState[taskName],
+              now   = new Date().toISOString();
+
         state.running      = false;
         state.pid          = null;
         state.lastExitCode = code;
-        state.lastErrorAt  = new Date().toISOString();
+        state.lastErrorAt  = now;
         state.lastCompletion = lastCompletion;
+
+        // The streak opens at the FIRST failure after a success and never moves again until one
+        // lands. `lastErrorAt` advances with every subsequent attempt, so a retry budget measured
+        // from it would slide forever; this anchor is what makes such a budget terminate. `??=`
+        // is the whole contract — a second failure must not re-open the window.
+        state.failureStreakStartedAt ??= now;
         this.writeState();
     }
 

--- a/ai/daemons/orchestrator/services/TaskStateService.mjs
+++ b/ai/daemons/orchestrator/services/TaskStateService.mjs
@@ -25,6 +25,33 @@ export function createInitialTaskState(taskDefinitions) {
 }
 
 /**
+ * @summary Applies the single failure transition that EVERY terminal-failure writer must share.
+ *
+ * Three producers record a failed cycle: a run that exited non-zero ({@link TaskStateService#markFailed}),
+ * a spawn that threw synchronously ({@link TaskStateService#markSpawnFailed}), and a run interrupted
+ * by a crash ({@link TaskStateService#readState}'s fail-closed normalization). The backup scheduler
+ * treats `failureStreakStartedAt` as the SOLE activation fact for its bounded retry window, which
+ * makes every one of those producers load-bearing — a writer that records `lastErrorAt` without
+ * opening the streak leaves its failure invisible to retry policy and forfeits the entire budget.
+ * That is not hypothetical: `markSpawnFailed` was exactly that writer, so a failed *start* waited a
+ * full interval while the lane reported `healthy`. Centralizing the pair is what stops the next
+ * failure producer from becoming a fourth opinion about what "failed" means.
+ *
+ * `??=` is the other half of the contract. The streak opens once, at the first failure after a
+ * success, and must not move when later attempts also fail — `lastErrorAt` advances with every
+ * attempt, so a budget measured from it would never close, and on a lane that wins its scheduling
+ * pick unconditionally a window that never closes is a lease monopoly rather than a cosmetic bug.
+ *
+ * @param {Object} state A single task's state envelope, mutated in place.
+ * @param {String} timestamp ISO timestamp of the failure.
+ * @returns {void}
+ */
+export function openFailureStreak(state, timestamp) {
+    state.lastErrorAt             = timestamp;
+    state.failureStreakStartedAt ??= timestamp;
+}
+
+/**
  * @summary Manages persistence and runtime state tracking for Daemon child processes.
  *
  * @class Neo.ai.daemons.services.TaskStateService
@@ -43,6 +70,14 @@ export class TaskStateService extends Base {
          * @protected
          */
         singleton: true,
+        /**
+         * Task names whose persisted `running: true` the most recent {@link #readState} normalized
+         * fail-closed. Drives the durability write in {@link #configure}; empty on a clean boot.
+         * @member {String[]|null} interruptedTaskNames_=null
+         * @protected
+         * @reactive
+         */
+        interruptedTaskNames_: null,
         /**
          * @member {String|null} stateFile_=null
          * @protected
@@ -90,22 +125,40 @@ export class TaskStateService extends Base {
         this.taskDefinitions = options.taskDefinitions;
         this.writeLogFn      = options.writeLogFn || (() => {});
         this.taskState       = this.readState();
+
+        // Commit the fail-closed normalization BEFORE any consumer can read the lane. Derived only
+        // in memory, the crashed `running: true` bytes survive untouched on disk, so the NEXT boot
+        // re-derives a FRESH anchor from them — the "bounded" window slides forward by the length of
+        // every outage and a crash loop never exhausts a budget that is supposed to terminate. The
+        // write is what makes the anchor durable, and durability is the whole non-sliding guarantee.
+        if (this.interruptedTaskNames?.length > 0) {
+            this.writeState();
+            this.writeLog('WARN', `[TaskStateService] Interrupted run(s) normalized fail-closed: ${this.interruptedTaskNames.join(', ')}.`);
+        }
     }
 
     /**
      * Reads persisted task state, clearing stale in-process fields on boot.
+     *
+     * @summary Records the tasks it normalized in {@link #interruptedTaskNames} so {@link #configure}
+     * can persist them. The write cannot happen here: {@link #writeState} serializes `this.taskState`,
+     * which `configure()` has not assigned yet at this point.
      * @returns {Object}
      */
     readState() {
         const fallback = createInitialTaskState(this.taskDefinitions);
+
+        this.interruptedTaskNames = [];
 
         if (!fs.existsSync(this.stateFile)) {
             return fallback;
         }
 
         try {
-            const data = JSON.parse(fs.readFileSync(this.stateFile, 'utf8'));
-            return Object.keys(fallback).reduce((state, taskName) => {
+            const data        = JSON.parse(fs.readFileSync(this.stateFile, 'utf8')),
+                  interrupted = [];
+
+            const taskState = Object.keys(fallback).reduce((state, taskName) => {
                 state[taskName] = {...fallback[taskName], ...(data[taskName] || {})};
 
                 // A persisted `running: true` means the process died with the task in flight, so no
@@ -117,16 +170,19 @@ export class TaskStateService extends Base {
                 if (data[taskName]?.running === true) {
                     const interruptedAt = new Date().toISOString();
 
-                    state[taskName].interruptedAt          = interruptedAt;
-                    state[taskName].lastErrorAt            = interruptedAt;
-                    state[taskName].lastExitCode           = null;
-                    state[taskName].failureStreakStartedAt ??= interruptedAt
+                    state[taskName].interruptedAt = interruptedAt;
+                    state[taskName].lastExitCode  = null;
+                    openFailureStreak(state[taskName], interruptedAt);
+                    interrupted.push(taskName)
                 }
 
                 state[taskName].running = false;
                 state[taskName].pid     = null;
                 return state;
             }, {});
+
+            this.interruptedTaskNames = interrupted;
+            return taskState;
         } catch (e) {
             this.writeLog('ERROR', `[TaskStateService] Failed to read state file: ${e.message}`);
             return fallback;
@@ -195,9 +251,12 @@ export class TaskStateService extends Base {
      */
     markSpawnFailed(taskName) {
         const state = this.taskState[taskName];
-        state.running      = false;
-        state.pid          = null;
-        state.lastErrorAt  = new Date().toISOString();
+        state.running = false;
+        state.pid     = null;
+        // A failed START is a failed cycle. This writer used to stamp `lastErrorAt` alone, which the
+        // scheduler does not read — so a spawn throw left the lane unanchored and it waited a full
+        // interval while reporting `healthy`. Same transition as every other failure producer.
+        openFailureStreak(state, new Date().toISOString());
         this.writeState();
     }
 
@@ -270,20 +329,14 @@ export class TaskStateService extends Base {
      * @returns {void}
      */
     markFailed(taskName, code, lastCompletion=null) {
-        const state = this.taskState[taskName],
-              now   = new Date().toISOString();
+        const state = this.taskState[taskName];
 
-        state.running      = false;
-        state.pid          = null;
-        state.lastExitCode = code;
-        state.lastErrorAt  = now;
+        state.running        = false;
+        state.pid            = null;
+        state.lastExitCode   = code;
         state.lastCompletion = lastCompletion;
 
-        // The streak opens at the FIRST failure after a success and never moves again until one
-        // lands. `lastErrorAt` advances with every subsequent attempt, so a retry budget measured
-        // from it would slide forever; this anchor is what makes such a budget terminate. `??=`
-        // is the whole contract — a second failure must not re-open the window.
-        state.failureStreakStartedAt ??= now;
+        openFailureStreak(state, new Date().toISOString());
         this.writeState();
     }
 

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -254,6 +254,8 @@
         "orchestrator.heavyMaintenanceLease.staleAfterMs",
         "orchestrator.intervals",
         "orchestrator.intervals.backupMs",
+        "orchestrator.intervals.backupRetryDelayMs",
+        "orchestrator.intervals.backupRetryWindowMs",
         "orchestrator.intervals.dataIntegritySweepCheckMs",
         "orchestrator.intervals.dreamMs",
         "orchestrator.intervals.dreamOverflowThreshold",

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
@@ -1,8 +1,36 @@
 import {test, expect} from '@playwright/test';
 import {
+    BACKUP_RETRY_PHASE,
     buildBackupTrigger,
-    getDueTask
+    describeBackupRetryState,
+    getDueTask,
+    isFailedRunRetryDue
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/backup.mjs';
+
+const
+    DAY_MS     = 86400000,
+    DELAY_MS   = 15 * 60 * 1000,
+    WINDOW_MS  = 60 * 60 * 1000,
+    SUCCESS_AT = 1000000,
+    iso        = ms => new Date(ms).toISOString(),
+
+    /**
+     * A lane whose last run FAILED: succeeded at `SUCCESS_AT`, attempted again at `+1000`, died at
+     * `+2000`. Deliberately built from timestamps rather than a hand-set "failed" flag, so the
+     * specimen is negative on the same axis the assertions read.
+     */
+    failedLane = (overrides = {}) => ({
+        lastErrorAt  : iso(SUCCESS_AT + 2000),
+        lastRunAt    : SUCCESS_AT + 1000,
+        lastSuccessAt: iso(SUCCESS_AT),
+        ...overrides
+    }),
+
+    retryOpts = (overrides = {}) => ({
+        retryDelayMs : DELAY_MS,
+        retryWindowMs: WINDOW_MS,
+        ...overrides
+    });
 
 test.describe('orchestrator/scheduling/backup (#11864 / Epic #11831)', () => {
     test('buildBackupTrigger fires when the interval has elapsed', () => {
@@ -39,5 +67,261 @@ test.describe('orchestrator/scheduling/backup (#11864 / Epic #11831)', () => {
             source  : 'periodic-sweep',
             reason  : 'periodic-sweep:86400000'
         });
+    });
+});
+
+test.describe('orchestrator/scheduling/backup — failed-run retry (#16348 AC5)', () => {
+    /**
+     * The defect. `markStarted()` stamps `lastRunAt` pre-spawn and `markFailed()` never restores it,
+     * so before this change a run that died 1 second in was not due again for a full DAY_MS — and
+     * `backup`'s priority-0 status could not help, because ranking applies to candidates and a
+     * failed backup was not one.
+     */
+    test('a FAILED run becomes due again long before the periodic interval elapses', () => {
+        const now = SUCCESS_AT + 1000 + DELAY_MS;
+
+        // Control: the periodic path alone still says "not due" at this instant. Without this the
+        // test could pass on the ordinary sweep and prove nothing about the retry path.
+        expect(buildBackupTrigger({now, lastRunAt: SUCCESS_AT + 1000, intervalMs: DAY_MS})).toBeNull();
+
+        expect(buildBackupTrigger({
+            ...retryOpts(),
+            intervalMs     : DAY_MS,
+            lastErrorAtMs  : SUCCESS_AT + 2000,
+            lastRunAt      : SUCCESS_AT + 1000,
+            lastSuccessAtMs: SUCCESS_AT,
+            now
+        })).toEqual({
+            taskName: 'backup',
+            source  : 'failed-run-retry',
+            reason  : `failed-run-retry:${now - SUCCESS_AT}`
+        });
+    });
+
+    test('a run whose last outcome SUCCEEDED is never retried', () => {
+        expect(isFailedRunRetryDue({
+            ...retryOpts(),
+            // Success is the NEWER of the two — a lane that failed yesterday and succeeded today.
+            lastErrorAtMs  : SUCCESS_AT - 5000,
+            lastRunAt      : SUCCESS_AT,
+            lastSuccessAtMs: SUCCESS_AT,
+            now            : SUCCESS_AT + DELAY_MS
+        })).toBe(false);
+    });
+
+    test('the retry respects its spacing — it does not fire one millisecond early', () => {
+        const args = {
+            ...retryOpts(),
+            lastErrorAtMs  : SUCCESS_AT + 2000,
+            lastRunAt      : SUCCESS_AT + 1000,
+            lastSuccessAtMs: SUCCESS_AT
+        };
+
+        expect(isFailedRunRetryDue({...args, now: SUCCESS_AT + 1000 + DELAY_MS - 1})).toBe(false);
+        expect(isFailedRunRetryDue({...args, now: SUCCESS_AT + 1000 + DELAY_MS})).toBe(true);
+    });
+
+    /**
+     * THE livelock guard, and the reason the window anchors where it does. `backup` is the only
+     * priority-0 lane (`PRIORITY_ZERO_TASKS`) and wins the pick unconditionally, so an unbounded
+     * retry would monopolize the heavy-maintenance lease and starve the REM chain — the exact
+     * starvation the scheduling fairness model exists to eliminate, re-created by the repair for it.
+     *
+     * Asserted by RUNNING THE CLOCK over a lane that fails every single time, rather than by
+     * restating `floor(window / delay)`. Re-deriving the formula the implementation uses would
+     * assert nothing; counting actual firings is an independent property. It also caught that the
+     * achievable count is one BELOW the formula, because the first failure consumes part of the
+     * window before the first retry can be spaced.
+     */
+    test('an always-failing backup stops re-firing — the streak terminates', () => {
+        let lastErrorAtMs = SUCCESS_AT + 2000,
+            lastRunAt     = SUCCESS_AT + 1000,
+            fired         = 0,
+            now           = SUCCESS_AT + 2000;
+
+        const limit = SUCCESS_AT + WINDOW_MS * 10;
+
+        while (now <= limit) {
+            const trigger = buildBackupTrigger({
+                ...retryOpts(),
+                intervalMs     : DAY_MS,
+                lastErrorAtMs,
+                lastRunAt,
+                lastSuccessAtMs: SUCCESS_AT,
+                now
+            });
+
+            if (trigger?.source === 'failed-run-retry') {
+                fired        += 1;
+                lastRunAt     = now;
+                lastErrorAtMs = now;   // the retry failed too
+            }
+
+            now += 60000;
+        }
+
+        // Terminates, and every firing happened INSIDE the window.
+        expect(fired).toBe(3);
+        expect(fired).toBeLessThan(Math.floor(WINDOW_MS / DELAY_MS));
+
+        // The livelock assertion proper: ten windows later, nothing more fires however long we wait.
+        expect(isFailedRunRetryDue({
+            ...retryOpts(),
+            lastErrorAtMs,
+            lastRunAt,
+            lastSuccessAtMs: SUCCESS_AT,
+            now            : limit
+        })).toBe(false);
+    });
+
+    /**
+     * The named term. The design's whole claim is that the window anchors on `lastSuccessAt`
+     * BECAUSE that field cannot move during a failure streak, while `lastErrorAt` advances with
+     * every failed retry and would slide the window forever. This fails if the anchor is swapped —
+     * a red-on-old-tree check would not, since any difference satisfies that.
+     */
+    test('the window anchors on lastSuccessAt, which a failure streak cannot move', () => {
+        const streakAgeMs = WINDOW_MS * 4,
+              lastRunAt   = SUCCESS_AT + streakAgeMs,
+              now         = lastRunAt + DELAY_MS;
+
+        // `lastErrorAt` is RECENT — anchoring on it would keep the window permanently open.
+        expect(now - (SUCCESS_AT + streakAgeMs)).toBeLessThan(WINDOW_MS);
+
+        expect(isFailedRunRetryDue({
+            ...retryOpts(),
+            lastErrorAtMs  : SUCCESS_AT + streakAgeMs,
+            lastRunAt,
+            lastSuccessAtMs: SUCCESS_AT,
+            now
+        })).toBe(false);
+    });
+
+    test('a lane that has NEVER succeeded is not retried — no anchor, no boundable window', () => {
+        expect(isFailedRunRetryDue({
+            ...retryOpts(),
+            lastErrorAtMs  : SUCCESS_AT,
+            lastRunAt      : SUCCESS_AT,
+            lastSuccessAtMs: 0,
+            now            : SUCCESS_AT + DELAY_MS * 2
+        })).toBe(false);
+    });
+
+    test('either retry value at 0 restores the exact pre-#16348 behaviour', () => {
+        const args = {
+            intervalMs     : DAY_MS,
+            lastErrorAtMs  : SUCCESS_AT + 2000,
+            lastRunAt      : SUCCESS_AT + 1000,
+            lastSuccessAtMs: SUCCESS_AT,
+            now            : SUCCESS_AT + 1000 + DELAY_MS
+        };
+
+        expect(buildBackupTrigger({...args, retryDelayMs: 0, retryWindowMs: WINDOW_MS})).toBeNull();
+        expect(buildBackupTrigger({...args, retryDelayMs: DELAY_MS, retryWindowMs: 0})).toBeNull();
+        // Positive control: the same arguments DO fire once both are configured, so the two
+        // assertions above are proving the disable branch rather than a malformed fixture.
+        expect(buildBackupTrigger({...args, ...retryOpts()})).not.toBeNull();
+    });
+
+    test('the periodic sweep still wins when both paths are due', () => {
+        expect(buildBackupTrigger({
+            ...retryOpts(),
+            intervalMs     : DAY_MS,
+            lastErrorAtMs  : SUCCESS_AT + 2000,
+            lastRunAt      : SUCCESS_AT + 1000,
+            lastSuccessAtMs: SUCCESS_AT,
+            now            : SUCCESS_AT + 1000 + DAY_MS
+        }).source).toBe('periodic-sweep');
+    });
+
+    test('getDueTask parses the ISO timestamps TaskStateService persists', () => {
+        expect(getDueTask({
+            backupIntervalMs   : DAY_MS,
+            backupRetryDelayMs : DELAY_MS,
+            backupRetryWindowMs: WINDOW_MS,
+            now                : SUCCESS_AT + 1000 + DELAY_MS,
+            state              : {backup: failedLane()}
+        })?.source).toBe('failed-run-retry');
+    });
+});
+
+test.describe('orchestrator/scheduling/backup — retry phase reporting (#16348 AC5)', () => {
+    test('reports healthy when the last run succeeded', () => {
+        expect(describeBackupRetryState({
+            ...retryOpts(),
+            now      : SUCCESS_AT + 5000,
+            taskState: {lastErrorAt: iso(SUCCESS_AT - 5000), lastSuccessAt: iso(SUCCESS_AT)}
+        }).phase).toBe(BACKUP_RETRY_PHASE.healthy);
+    });
+
+    test('reports retrying with a remaining count while the window is open', () => {
+        const state = describeBackupRetryState({
+            ...retryOpts(),
+            now      : SUCCESS_AT + 3000,
+            taskState: failedLane()
+        });
+
+        expect(state.phase).toBe(BACKUP_RETRY_PHASE.retrying);
+        expect(state.retriesRemaining).toBeGreaterThan(0);
+        expect(state.windowEndsAtMs).toBe(SUCCESS_AT + WINDOW_MS);
+    });
+
+    /**
+     * Exhaustion must reach a surface. The lane simply stops producing candidates, so without this
+     * the failure is silent — a diagnosis nothing reads. Reported as recomputable STATE rather than
+     * a log edge, so it survives a restart without a flag of its own.
+     */
+    test('reports exhausted once the window has closed, with no retries remaining', () => {
+        const state = describeBackupRetryState({
+            ...retryOpts(),
+            now      : SUCCESS_AT + WINDOW_MS + 1,
+            taskState: failedLane()
+        });
+
+        expect(state.phase).toBe(BACKUP_RETRY_PHASE.exhausted);
+        expect(state.retriesRemaining).toBe(0);
+    });
+
+    /**
+     * The reporter and the trigger must never disagree about whether the budget is spent — "the
+     * lane stopped retrying" versus "the lane reports it stopped" is exactly the drift that makes a
+     * silent failure look supervised. Found by a mutation run: deleting the trigger's budget clause
+     * left the `exhausted` phase spec green, because the two sides computed the window separately.
+     * They now route through one predicate, and this sweeps the whole boundary rather than sampling
+     * a point that could sit on the agreeing side of a drift.
+     */
+    test('the reported phase never contradicts the trigger across the whole window', () => {
+        for (let offset = 0; offset <= WINDOW_MS * 2; offset += 60000) {
+            const now       = SUCCESS_AT + offset,
+                  taskState = failedLane(),
+                  phase     = describeBackupRetryState({...retryOpts(), now, taskState}).phase,
+                  due       = isFailedRunRetryDue({
+                      ...retryOpts(),
+                      lastErrorAtMs  : SUCCESS_AT + 2000,
+                      lastRunAt      : SUCCESS_AT + 1000,
+                      lastSuccessAtMs: SUCCESS_AT,
+                      now
+                  });
+
+            if (phase === BACKUP_RETRY_PHASE.exhausted) {
+                expect(due, `exhausted at +${offset}ms must not still be due`).toBe(false);
+            }
+        }
+    });
+
+    test('reports unanchored for a lane that has never succeeded', () => {
+        expect(describeBackupRetryState({
+            ...retryOpts(),
+            now      : SUCCESS_AT,
+            taskState: {lastErrorAt: iso(SUCCESS_AT), lastRunAt: SUCCESS_AT}
+        }).phase).toBe(BACKUP_RETRY_PHASE.unanchored);
+    });
+
+    test('an unparseable persisted timestamp degrades to unanchored, never to a stray epoch', () => {
+        expect(describeBackupRetryState({
+            ...retryOpts(),
+            now      : SUCCESS_AT,
+            taskState: {lastErrorAt: 'not-a-date', lastSuccessAt: 'not-a-date'}
+        }).phase).toBe(BACKUP_RETRY_PHASE.unanchored);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
@@ -2,35 +2,54 @@ import {test, expect} from '@playwright/test';
 import {
     BACKUP_RETRY_PHASE,
     buildBackupTrigger,
+    countRemainingRetries,
     describeBackupRetryState,
     getDueTask,
     isFailedRunRetryDue
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/backup.mjs';
 
 const
-    DAY_MS     = 86400000,
-    DELAY_MS   = 15 * 60 * 1000,
-    WINDOW_MS  = 60 * 60 * 1000,
-    SUCCESS_AT = 1000000,
-    iso        = ms => new Date(ms).toISOString(),
+    // SHIPPED defaults. Fixtures use these rather than locally convenient numbers: an earlier
+    // revision passed every spec with a success-to-failure gap of seconds and still no-opped at the
+    // real 24h/1h ratio, because the window was anchored to the prior success.
+    DAY_MS    = 86400000,
+    DELAY_MS  = 15 * 60 * 1000,
+    WINDOW_MS = 60 * 60 * 1000,
+    T         = 1700000000000,
+    iso       = ms => new Date(ms).toISOString(),
+
+    retryOpts = (overrides = {}) => ({retryDelayMs: DELAY_MS, retryWindowMs: WINDOW_MS, ...overrides}),
 
     /**
-     * A lane whose last run FAILED: succeeded at `SUCCESS_AT`, attempted again at `+1000`, died at
-     * `+2000`. Deliberately built from timestamps rather than a hand-set "failed" flag, so the
-     * specimen is negative on the same axis the assertions read.
+     * The PRODUCTION shape: succeeded at `T`, the periodic sweep fired a full `DAY_MS` later and
+     * failed. `failureStreakStartedAt` is what `TaskStateService.markFailed` writes.
      */
-    failedLane = (overrides = {}) => ({
-        lastErrorAt  : iso(SUCCESS_AT + 2000),
-        lastRunAt    : SUCCESS_AT + 1000,
-        lastSuccessAt: iso(SUCCESS_AT),
+    productionFailure = (overrides = {}) => ({
+        failureStreakStartedAt: iso(T + DAY_MS + 1000),
+        lastErrorAt           : iso(T + DAY_MS + 1000),
+        lastRunAt             : T + DAY_MS,
+        lastSuccessAt         : iso(T),
         ...overrides
     }),
 
-    retryOpts = (overrides = {}) => ({
-        retryDelayMs : DELAY_MS,
-        retryWindowMs: WINDOW_MS,
-        ...overrides
-    });
+    /**
+     * Runs the clock over an always-failing lane and returns how many retries actually fire. Used
+     * instead of restating `floor(window / delay)` — re-deriving the implementation's own formula
+     * asserts nothing.
+     */
+    countActualFirings = ({taskState, from, until, stepMs = 60000}) => {
+        let streak = new Date(taskState.failureStreakStartedAt).getTime(),
+            runAt  = taskState.lastRunAt,
+            fired  = 0;
+
+        for (let now = from; now <= until; now += stepMs) {
+            const trigger = buildBackupTrigger({
+                now, intervalMs: DAY_MS, lastRunAt: runAt, streakStartedAtMs: streak, ...retryOpts()
+            });
+            if (trigger?.source === 'failed-run-retry') { fired += 1; runAt = now }
+        }
+        return fired
+    };
 
 test.describe('orchestrator/scheduling/backup (#11864 / Epic #11831)', () => {
     test('buildBackupTrigger fires when the interval has elapsed', () => {
@@ -72,210 +91,148 @@ test.describe('orchestrator/scheduling/backup (#11864 / Epic #11831)', () => {
 
 test.describe('orchestrator/scheduling/backup — failed-run retry (#16348 AC5)', () => {
     /**
-     * The defect. `markStarted()` stamps `lastRunAt` pre-spawn and `markFailed()` never restores it,
-     * so before this change a run that died 1 second in was not due again for a full DAY_MS — and
-     * `backup`'s priority-0 status could not help, because ranking applies to candidates and a
-     * failed backup was not one.
+     * THE production-cadence witness, and the one an earlier revision could not pass.
+     *
+     * Ordering is deliberately at shipped scale: success at T, the periodic attempt and its failure
+     * a full `backupMs` later, the check one `backupRetryDelayMs` after that. A window anchored on
+     * `lastSuccessAt` is ~24h stale by this point and already closed, so the whole feature no-opped
+     * at its own defaults while every second-scale fixture stayed green.
      */
-    test('a FAILED run becomes due again long before the periodic interval elapses', () => {
-        const now = SUCCESS_AT + 1000 + DELAY_MS;
+    test('a run that fails a FULL INTERVAL after the last success still retries', () => {
+        const failedAt = T + DAY_MS + 1000,
+              now      = failedAt + DELAY_MS;
 
-        // Control: the periodic path alone still says "not due" at this instant. Without this the
-        // test could pass on the ordinary sweep and prove nothing about the retry path.
-        expect(buildBackupTrigger({now, lastRunAt: SUCCESS_AT + 1000, intervalMs: DAY_MS})).toBeNull();
+        // Control: the periodic path alone says "not due" here, so the retry path is what fires.
+        expect(buildBackupTrigger({now, lastRunAt: T + DAY_MS, intervalMs: DAY_MS})).toBeNull();
 
-        expect(buildBackupTrigger({
-            ...retryOpts(),
-            intervalMs     : DAY_MS,
-            lastErrorAtMs  : SUCCESS_AT + 2000,
-            lastRunAt      : SUCCESS_AT + 1000,
-            lastSuccessAtMs: SUCCESS_AT,
-            now
-        })).toEqual({
-            taskName: 'backup',
-            source  : 'failed-run-retry',
-            reason  : `failed-run-retry:${now - SUCCESS_AT}`
-        });
+        expect(getDueTask({
+            state              : {backup: productionFailure()},
+            now,
+            backupIntervalMs   : DAY_MS,
+            backupRetryDelayMs : DELAY_MS,
+            backupRetryWindowMs: WINDOW_MS
+        })).toMatchObject({taskName: 'backup', source: 'failed-run-retry'});
     });
 
-    test('a run whose last outcome SUCCEEDED is never retried', () => {
+    test('the streak anchor does not slide, so a failing lane still terminates', () => {
+        const streakAt = T + DAY_MS + 1000,
+              fired    = countActualFirings({
+                  taskState: productionFailure(), from: streakAt, until: streakAt + WINDOW_MS * 10
+              });
+
+        expect(fired).toBeGreaterThan(0);
+        expect(fired).toBeLessThanOrEqual(Math.floor(WINDOW_MS / DELAY_MS));
+
+        // Ten windows later nothing fires however long we wait — the livelock assertion proper.
         expect(isFailedRunRetryDue({
             ...retryOpts(),
-            // Success is the NEWER of the two — a lane that failed yesterday and succeeded today.
-            lastErrorAtMs  : SUCCESS_AT - 5000,
-            lastRunAt      : SUCCESS_AT,
-            lastSuccessAtMs: SUCCESS_AT,
-            now            : SUCCESS_AT + DELAY_MS
+            lastRunAt        : streakAt + WINDOW_MS * 9,
+            streakStartedAtMs: streakAt,
+            now              : streakAt + WINDOW_MS * 10
+        })).toBe(false);
+    });
+
+    test('a lane with no open streak is never retried', () => {
+        expect(isFailedRunRetryDue({
+            ...retryOpts(), lastRunAt: T, streakStartedAtMs: 0, now: T + DELAY_MS
         })).toBe(false);
     });
 
     test('the retry respects its spacing — it does not fire one millisecond early', () => {
+        const args = {...retryOpts(), lastRunAt: T + DAY_MS, streakStartedAtMs: T + DAY_MS + 1000};
+
+        expect(isFailedRunRetryDue({...args, now: T + DAY_MS + DELAY_MS - 1})).toBe(false);
+        expect(isFailedRunRetryDue({...args, now: T + DAY_MS + DELAY_MS})).toBe(true);
+    });
+
+    test('either retry value at 0 restores the pre-retry behaviour', () => {
         const args = {
-            ...retryOpts(),
-            lastErrorAtMs  : SUCCESS_AT + 2000,
-            lastRunAt      : SUCCESS_AT + 1000,
-            lastSuccessAtMs: SUCCESS_AT
-        };
-
-        expect(isFailedRunRetryDue({...args, now: SUCCESS_AT + 1000 + DELAY_MS - 1})).toBe(false);
-        expect(isFailedRunRetryDue({...args, now: SUCCESS_AT + 1000 + DELAY_MS})).toBe(true);
-    });
-
-    /**
-     * THE livelock guard, and the reason the window anchors where it does. `backup` is the only
-     * priority-0 lane (`PRIORITY_ZERO_TASKS`) and wins the pick unconditionally, so an unbounded
-     * retry would monopolize the heavy-maintenance lease and starve the REM chain — the exact
-     * starvation the scheduling fairness model exists to eliminate, re-created by the repair for it.
-     *
-     * Asserted by RUNNING THE CLOCK over a lane that fails every single time, rather than by
-     * restating `floor(window / delay)`. Re-deriving the formula the implementation uses would
-     * assert nothing; counting actual firings is an independent property. It also caught that the
-     * achievable count is one BELOW the formula, because the first failure consumes part of the
-     * window before the first retry can be spaced.
-     */
-    test('an always-failing backup stops re-firing — the streak terminates', () => {
-        let lastErrorAtMs = SUCCESS_AT + 2000,
-            lastRunAt     = SUCCESS_AT + 1000,
-            fired         = 0,
-            now           = SUCCESS_AT + 2000;
-
-        const limit = SUCCESS_AT + WINDOW_MS * 10;
-
-        while (now <= limit) {
-            const trigger = buildBackupTrigger({
-                ...retryOpts(),
-                intervalMs     : DAY_MS,
-                lastErrorAtMs,
-                lastRunAt,
-                lastSuccessAtMs: SUCCESS_AT,
-                now
-            });
-
-            if (trigger?.source === 'failed-run-retry') {
-                fired        += 1;
-                lastRunAt     = now;
-                lastErrorAtMs = now;   // the retry failed too
-            }
-
-            now += 60000;
-        }
-
-        // Terminates, and every firing happened INSIDE the window.
-        expect(fired).toBe(3);
-        expect(fired).toBeLessThan(Math.floor(WINDOW_MS / DELAY_MS));
-
-        // The livelock assertion proper: ten windows later, nothing more fires however long we wait.
-        expect(isFailedRunRetryDue({
-            ...retryOpts(),
-            lastErrorAtMs,
-            lastRunAt,
-            lastSuccessAtMs: SUCCESS_AT,
-            now            : limit
-        })).toBe(false);
-    });
-
-    /**
-     * The named term. The design's whole claim is that the window anchors on `lastSuccessAt`
-     * BECAUSE that field cannot move during a failure streak, while `lastErrorAt` advances with
-     * every failed retry and would slide the window forever. This fails if the anchor is swapped —
-     * a red-on-old-tree check would not, since any difference satisfies that.
-     */
-    test('the window anchors on lastSuccessAt, which a failure streak cannot move', () => {
-        const streakAgeMs = WINDOW_MS * 4,
-              lastRunAt   = SUCCESS_AT + streakAgeMs,
-              now         = lastRunAt + DELAY_MS;
-
-        // `lastErrorAt` is RECENT — anchoring on it would keep the window permanently open.
-        expect(now - (SUCCESS_AT + streakAgeMs)).toBeLessThan(WINDOW_MS);
-
-        expect(isFailedRunRetryDue({
-            ...retryOpts(),
-            lastErrorAtMs  : SUCCESS_AT + streakAgeMs,
-            lastRunAt,
-            lastSuccessAtMs: SUCCESS_AT,
-            now
-        })).toBe(false);
-    });
-
-    test('a lane that has NEVER succeeded is not retried — no anchor, no boundable window', () => {
-        expect(isFailedRunRetryDue({
-            ...retryOpts(),
-            lastErrorAtMs  : SUCCESS_AT,
-            lastRunAt      : SUCCESS_AT,
-            lastSuccessAtMs: 0,
-            now            : SUCCESS_AT + DELAY_MS * 2
-        })).toBe(false);
-    });
-
-    test('either retry value at 0 restores the exact pre-#16348 behaviour', () => {
-        const args = {
-            intervalMs     : DAY_MS,
-            lastErrorAtMs  : SUCCESS_AT + 2000,
-            lastRunAt      : SUCCESS_AT + 1000,
-            lastSuccessAtMs: SUCCESS_AT,
-            now            : SUCCESS_AT + 1000 + DELAY_MS
+            intervalMs       : DAY_MS,
+            lastRunAt        : T + DAY_MS,
+            streakStartedAtMs: T + DAY_MS + 1000,
+            now              : T + DAY_MS + DELAY_MS
         };
 
         expect(buildBackupTrigger({...args, retryDelayMs: 0, retryWindowMs: WINDOW_MS})).toBeNull();
         expect(buildBackupTrigger({...args, retryDelayMs: DELAY_MS, retryWindowMs: 0})).toBeNull();
-        // Positive control: the same arguments DO fire once both are configured, so the two
-        // assertions above are proving the disable branch rather than a malformed fixture.
+        // Positive control: the same arguments DO fire once both are configured.
         expect(buildBackupTrigger({...args, ...retryOpts()})).not.toBeNull();
     });
 
     test('the periodic sweep still wins when both paths are due', () => {
         expect(buildBackupTrigger({
             ...retryOpts(),
-            intervalMs     : DAY_MS,
-            lastErrorAtMs  : SUCCESS_AT + 2000,
-            lastRunAt      : SUCCESS_AT + 1000,
-            lastSuccessAtMs: SUCCESS_AT,
-            now            : SUCCESS_AT + 1000 + DAY_MS
+            intervalMs       : DAY_MS,
+            lastRunAt        : T,
+            streakStartedAtMs: T + 1000,
+            now              : T + DAY_MS
         }).source).toBe('periodic-sweep');
     });
 
-    test('getDueTask parses the ISO timestamps TaskStateService persists', () => {
+    /**
+     * A first-ever backup that fails is covered, not excluded. It has no `lastSuccessAt`, but it
+     * does open a streak — so the anchor exists and the window is bounded exactly as for any other
+     * failure. The previous last-success anchor could not express this case at all.
+     */
+    test('a first-ever run that fails is retried — the streak is the anchor, not the success', () => {
         expect(getDueTask({
+            state: {backup: {
+                failureStreakStartedAt: iso(T + 1000),
+                lastErrorAt           : iso(T + 1000),
+                lastRunAt             : T,
+                lastSuccessAt         : null
+            }},
+            now                : T + 1000 + DELAY_MS,
             backupIntervalMs   : DAY_MS,
             backupRetryDelayMs : DELAY_MS,
-            backupRetryWindowMs: WINDOW_MS,
-            now                : SUCCESS_AT + 1000 + DELAY_MS,
-            state              : {backup: failedLane()}
-        })?.source).toBe('failed-run-retry');
+            backupRetryWindowMs: WINDOW_MS
+        })).toMatchObject({source: 'failed-run-retry'});
     });
 });
 
 test.describe('orchestrator/scheduling/backup — retry phase reporting (#16348 AC5)', () => {
-    test('reports healthy when the last run succeeded', () => {
+    test('reports healthy when there is no open streak and the lane has succeeded', () => {
         expect(describeBackupRetryState({
             ...retryOpts(),
-            now      : SUCCESS_AT + 5000,
-            taskState: {lastErrorAt: iso(SUCCESS_AT - 5000), lastSuccessAt: iso(SUCCESS_AT)}
+            now      : T + 5000,
+            taskState: {failureStreakStartedAt: null, lastSuccessAt: iso(T)}
         }).phase).toBe(BACKUP_RETRY_PHASE.healthy);
     });
 
-    test('reports retrying with a remaining count while the window is open', () => {
-        const state = describeBackupRetryState({
-            ...retryOpts(),
-            now      : SUCCESS_AT + 3000,
-            taskState: failedLane()
-        });
-
-        expect(state.phase).toBe(BACKUP_RETRY_PHASE.retrying);
-        expect(state.retriesRemaining).toBeGreaterThan(0);
-        expect(state.windowEndsAtMs).toBe(SUCCESS_AT + WINDOW_MS);
+    test('reports unanchored for a lane that has neither succeeded nor opened a streak', () => {
+        expect(describeBackupRetryState({...retryOpts(), now: T, taskState: {}}).phase)
+            .toBe(BACKUP_RETRY_PHASE.unanchored);
     });
 
     /**
-     * Exhaustion must reach a surface. The lane simply stops producing candidates, so without this
-     * the failure is silent — a diagnosis nothing reads. Reported as recomputable STATE rather than
-     * a log edge, so it survives a restart without a flag of its own.
+     * The restart specimen. A crash mid-backup records no terminal outcome; `readState()` normalizes
+     * it fail-closed by opening a streak and stamping `interruptedAt`. Before that, the lane read as
+     * `healthy` — and the orchestrator crash-loop is the incident class the parent ticket was filed
+     * from, so reporting it as healthy was the worst available answer.
      */
+    test('an interrupted run reports retrying with its interruption marker, never healthy', () => {
+        const state = describeBackupRetryState({
+            ...retryOpts(),
+            now      : T + DAY_MS + 2000,
+            taskState: {
+                failureStreakStartedAt: iso(T + DAY_MS + 1000),
+                interruptedAt         : iso(T + DAY_MS + 1000),
+                lastErrorAt           : iso(T + DAY_MS + 1000),
+                lastRunAt             : T + DAY_MS,
+                lastSuccessAt         : iso(T)
+            }
+        });
+
+        expect(state.phase).toBe(BACKUP_RETRY_PHASE.retrying);
+        expect(state.phase).not.toBe(BACKUP_RETRY_PHASE.healthy);
+        expect(state.interruptedAt).toBe(iso(T + DAY_MS + 1000));
+    });
+
     test('reports exhausted once the window has closed, with no retries remaining', () => {
         const state = describeBackupRetryState({
             ...retryOpts(),
-            now      : SUCCESS_AT + WINDOW_MS + 1,
-            taskState: failedLane()
+            now      : T + DAY_MS + 1000 + WINDOW_MS + 1,
+            taskState: productionFailure()
         });
 
         expect(state.phase).toBe(BACKUP_RETRY_PHASE.exhausted);
@@ -283,45 +240,39 @@ test.describe('orchestrator/scheduling/backup — retry phase reporting (#16348 
     });
 
     /**
-     * The reporter and the trigger must never disagree about whether the budget is spent — "the
-     * lane stopped retrying" versus "the lane reports it stopped" is exactly the drift that makes a
-     * silent failure look supervised. Found by a mutation run: deleting the trigger's budget clause
-     * left the `exhausted` phase spec green, because the two sides computed the window separately.
-     * They now route through one predicate, and this sweeps the whole boundary rather than sampling
-     * a point that could sit on the agreeing side of a drift.
+     * `retriesRemaining` must describe actual future firings. The previous
+     * `floor((windowEnd - now) / delay)` ignored `lastRunAt`, so a lane whose retry was already due
+     * under-reported by one — and my own probe missed it by sampling MID-delay, the single offset
+     * where the wrong formula happens to agree. Every offset is swept here for that reason.
      */
-    test('the reported phase never contradicts the trigger across the whole window', () => {
-        for (let offset = 0; offset <= WINDOW_MS * 2; offset += 60000) {
-            const now       = SUCCESS_AT + offset,
-                  taskState = failedLane(),
-                  phase     = describeBackupRetryState({...retryOpts(), now, taskState}).phase,
-                  due       = isFailedRunRetryDue({
-                      ...retryOpts(),
-                      lastErrorAtMs  : SUCCESS_AT + 2000,
-                      lastRunAt      : SUCCESS_AT + 1000,
-                      lastSuccessAtMs: SUCCESS_AT,
-                      now
+    test('retriesRemaining equals the firings that actually occur, at every offset in the delay', () => {
+        const streakAt = T + DAY_MS + 1000;
+
+        for (const offsetMs of [0, DELAY_MS / 4, DELAY_MS / 2, DELAY_MS, DELAY_MS * 2]) {
+            const now       = streakAt + offsetMs,
+                  taskState = productionFailure(),
+                  reported  = describeBackupRetryState({...retryOpts(), now, taskState}).retriesRemaining,
+                  actual    = countActualFirings({
+                      taskState, from: now, until: streakAt + WINDOW_MS * 3, stepMs: 1000
                   });
 
-            if (phase === BACKUP_RETRY_PHASE.exhausted) {
-                expect(due, `exhausted at +${offset}ms must not still be due`).toBe(false);
-            }
+            expect(reported, `offset ${offsetMs}ms into the window`).toBe(actual)
         }
     });
 
-    test('reports unanchored for a lane that has never succeeded', () => {
-        expect(describeBackupRetryState({
-            ...retryOpts(),
-            now      : SUCCESS_AT,
-            taskState: {lastErrorAt: iso(SUCCESS_AT), lastRunAt: SUCCESS_AT}
-        }).phase).toBe(BACKUP_RETRY_PHASE.unanchored);
+    test('countRemainingRetries is zero once either retry value is disabled', () => {
+        const args = {now: T, lastRunAt: T, streakStartedAtMs: T};
+
+        expect(countRemainingRetries({...args, retryDelayMs: 0, retryWindowMs: WINDOW_MS})).toBe(0);
+        expect(countRemainingRetries({...args, retryDelayMs: DELAY_MS, retryWindowMs: 0})).toBe(0);
+        expect(countRemainingRetries({...args, ...retryOpts()})).toBeGreaterThan(0);
     });
 
     test('an unparseable persisted timestamp degrades to unanchored, never to a stray epoch', () => {
         expect(describeBackupRetryState({
             ...retryOpts(),
-            now      : SUCCESS_AT,
-            taskState: {lastErrorAt: 'not-a-date', lastSuccessAt: 'not-a-date'}
+            now      : T,
+            taskState: {failureStreakStartedAt: 'not-a-date', lastSuccessAt: 'not-a-date'}
         }).phase).toBe(BACKUP_RETRY_PHASE.unanchored);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
@@ -179,4 +179,87 @@ test.describe('Neo.ai.daemons.services.TaskStateService', () => {
         const stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
         expect(stateData.mockTask.running).toBe(false);
     });
+
+    /**
+     * The failure-streak anchor. `??=` is the whole contract: the streak opens at the FIRST failure
+     * after a success and must not move when later attempts also fail. A retry budget measured from
+     * `lastErrorAt` — which advances every attempt — would never close, and on a lane that wins its
+     * scheduling pick unconditionally that is a lease monopoly rather than a cosmetic bug.
+     */
+    test('failureStreakStartedAt opens at the first failure and never slides (#16348)', async () => {
+        const {service, stateFile} = createTestService();
+
+        service.markFailed('mockTask', 1);
+        const opened = service.getTaskState('mockTask').failureStreakStartedAt;
+        expect(opened).toBeTruthy();
+
+        await new Promise(resolve => setTimeout(resolve, 5));
+        service.markFailed('mockTask', 1);
+
+        const after = service.getTaskState('mockTask');
+        expect(after.failureStreakStartedAt).toBe(opened);
+        // The control that makes the assertion above meaningful: something DID advance, so a stale
+        // anchor is being preserved deliberately rather than nothing having happened at all.
+        expect(after.lastErrorAt).not.toBe(opened);
+
+        expect(JSON.parse(fs.readFileSync(stateFile, 'utf8')).mockTask.failureStreakStartedAt).toBe(opened);
+    });
+
+    test('a success closes the streak and clears the interruption marker (#16348)', () => {
+        const {service} = createTestService();
+
+        service.markFailed('mockTask', 1);
+        expect(service.getTaskState('mockTask').failureStreakStartedAt).toBeTruthy();
+
+        service.markCompleted('mockTask');
+        expect(service.getTaskState('mockTask').failureStreakStartedAt).toBeNull();
+        expect(service.getTaskState('mockTask').interruptedAt).toBeNull();
+    });
+
+    /**
+     * The restart specimen. A process that dies mid-task never reaches `markFailed`, so the persisted
+     * state keeps `running: true` and carries NO terminal outcome. `readState()` used to clear the
+     * flag silently, which projected that run as neither failed nor successful — and every consumer
+     * asking "any error since the last success?" then read it as healthy. Normalize fail-closed.
+     */
+    test('readState normalizes an interrupted run fail-closed rather than silently (#16348)', () => {
+        const {service, stateFile} = createTestService(),
+              taskDefinitions      = service.taskDefinitions;
+
+        // Persist the crash shape directly: running, with a prior success and no terminal outcome.
+        const crashed = createInitialTaskState(taskDefinitions);
+        crashed.mockTask.running       = true;
+        crashed.mockTask.pid           = 4242;
+        crashed.mockTask.lastRunAt     = 1700000000000;
+        crashed.mockTask.lastSuccessAt = new Date(1699999000000).toISOString();
+        fs.writeFileSync(stateFile, JSON.stringify(crashed), 'utf8');
+
+        const recovered = service.readState().mockTask;
+
+        expect(recovered.running).toBe(false);
+        expect(recovered.pid).toBeNull();
+        // The load-bearing half — an interrupted run is NOT a success, and it opens a streak so the
+        // bounded retry policy can see it at all.
+        expect(recovered.interruptedAt).toBeTruthy();
+        expect(recovered.lastErrorAt).toBe(recovered.interruptedAt);
+        expect(recovered.failureStreakStartedAt).toBe(recovered.interruptedAt);
+    });
+
+    test('readState leaves a cleanly-stopped task untouched (#16348)', () => {
+        const {service, stateFile} = createTestService(),
+              taskDefinitions      = service.taskDefinitions;
+
+        const clean = createInitialTaskState(taskDefinitions);
+        clean.mockTask.running       = false;
+        clean.mockTask.lastSuccessAt = new Date(1699999000000).toISOString();
+        fs.writeFileSync(stateFile, JSON.stringify(clean), 'utf8');
+
+        const recovered = service.readState().mockTask;
+
+        // Positive control for the test above: normalization fires on `running: true` specifically,
+        // not on every boot — otherwise the interrupted assertion would pass for the wrong reason.
+        expect(recovered.interruptedAt).toBeNull();
+        expect(recovered.failureStreakStartedAt).toBeNull();
+        expect(recovered.lastErrorAt).toBeNull();
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
@@ -3,7 +3,20 @@ import fs                                           from 'fs-extra';
 import path                                         from 'path';
 import Neo                                          from '../../../../../../../src/Neo.mjs';
 import * as core                                    from '../../../../../../../src/core/_export.mjs';
+import { ProcessSupervisorService }                 from '../../../../../../../ai/daemons/orchestrator/services/ProcessSupervisorService.mjs';
 import { TaskStateService, createInitialTaskState } from '../../../../../../../ai/daemons/orchestrator/services/TaskStateService.mjs';
+import {
+    BACKUP_RETRY_PHASE,
+    describeBackupRetryState,
+    getDueTask
+} from '../../../../../../../ai/daemons/orchestrator/scheduling/backup.mjs';
+
+const
+    // SHIPPED defaults, matching backup.spec.mjs. Locally convenient constants are what let the
+    // original revision pass 21 specs while no-opping at the real 24h/1h ratio.
+    DAY_MS    = 86400000,
+    DELAY_MS  = 15 * 60 * 1000,
+    WINDOW_MS = 60 * 60 * 1000;
 
 function createTestService() {
     const dataDir = `/tmp/task-state-service-test-${Date.now()}-${Math.random()}`;
@@ -83,7 +96,10 @@ test.describe('Neo.ai.daemons.services.TaskStateService', () => {
         expect(stateData.mockTask.lastExitCode).toBe(1);
         expect(stateData.mockTask.lastErrorAt).toEqual(expect.any(String));
 
-        // Test markSpawnFailed
+        // Test markSpawnFailed. NOTE: this walk reaches markSpawnFailed only AFTER the markFailed
+        // above has already opened the streak, so it cannot serve as streak coverage for this
+        // writer — a `failureStreakStartedAt` assertion here passes either way. The clean specimen
+        // is the known-good-lane test below, which reaches this writer after a SUCCESS instead.
         service.markStarted('mockTask', 'fail-spawn');
         service.markSpawnFailed('mockTask');
         stateData = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
@@ -261,5 +277,162 @@ test.describe('Neo.ai.daemons.services.TaskStateService', () => {
         expect(recovered.interruptedAt).toBeNull();
         expect(recovered.failureStreakStartedAt).toBeNull();
         expect(recovered.lastErrorAt).toBeNull();
+    });
+
+    /**
+     * The clean spawn-failure specimen. `state transitions trigger file writes correctly` above also
+     * reaches `markSpawnFailed`, but only AFTER a `markFailed` that already opened the anchor — so it
+     * passes whether or not this writer opens one, and cannot serve as streak coverage. Here the lane
+     * is deliberately known-good first: the specimen is NEGATIVE on the axis the assertion reads.
+     */
+    test('markSpawnFailed opens the streak on a known-good lane (#16348)', async () => {
+        const {service, stateFile} = createTestService();
+
+        service.markStarted('mockTask', 'successful-run');
+        service.markCompleted('mockTask');
+        expect(service.getTaskState('mockTask').failureStreakStartedAt).toBeNull();
+
+        service.markStarted('mockTask', 'spawn-throws');
+        service.markSpawnFailed('mockTask');
+
+        const opened = service.getTaskState('mockTask').failureStreakStartedAt;
+
+        // A failed START is a failed cycle. Leaving it unanchored is not a cosmetic reporting gap:
+        // the scheduler treats `failureStreakStartedAt` as the SOLE activation fact, so an
+        // unanchored failure forfeits the entire retry budget and waits a full interval.
+        expect(opened).toBeTruthy();
+        expect(opened).toBe(service.getTaskState('mockTask').lastErrorAt);
+        expect(JSON.parse(fs.readFileSync(stateFile, 'utf8')).mockTask.failureStreakStartedAt).toBe(opened);
+
+        // ...and it must not slide on the next failed start either, from EITHER failure writer.
+        await new Promise(resolve => setTimeout(resolve, 10));
+        service.markStarted('mockTask', 'spawn-throws-again');
+        service.markSpawnFailed('mockTask');
+        expect(service.getTaskState('mockTask').failureStreakStartedAt).toBe(opened);
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+        service.markFailed('mockTask', 1);
+        const after = service.getTaskState('mockTask');
+        expect(after.failureStreakStartedAt).toBe(opened);
+        // Control: the clock did move, so the equalities above are preservation, not a frozen clock.
+        expect(after.lastErrorAt).not.toBe(opened);
+    });
+
+    /**
+     * The production-writer witness. Drives the REAL `ProcessSupervisorService.runTask()` against the
+     * REAL `TaskStateService` with a `spawnFn` that throws synchronously — the exact path at
+     * `ProcessSupervisorService.mjs:600-605`, where the catch block's only task-state write is
+     * `markSpawnFailed()`. No reconstructed state object: the scheduler reads what the supervisor
+     * actually persisted.
+     */
+    test('a synchronous spawn failure leaves the lane retry-due, not healthy (#16348)', () => {
+        const dataDir = `/tmp/task-state-spawn-fail-${Date.now()}-${Math.random()}`;
+        fs.ensureDirSync(dataDir);
+
+        const stateFile       = path.join(dataDir, 'state.json'),
+              taskDefinitions = {
+                  backup: {
+                      label          : 'agent OS backup',
+                      command        : 'node',
+                      args           : ['backup.mjs'],
+                      pidFileName    : 'backup.pid',
+                      expectedCommand: 'backup.mjs'
+                  }
+              },
+              service         = Neo.create(TaskStateService, {stateFile, taskDefinitions, writeLogFn: () => {}});
+
+        service.configure({stateFile, taskDefinitions, writeLogFn: () => {}});
+
+        // The lane succeeded a full interval ago, then the periodic sweep fired and the spawn threw.
+        service.markCompleted('backup');
+
+        const supervisor = Neo.create(ProcessSupervisorService, {
+            dataDir,
+            taskDefinitions,
+            taskStateService: service,
+            healthService   : {recordTaskOutcome: () => {}},
+            writeLog        : () => {},
+            spawnFn         : () => {throw new Error('EACCES: spawn node backup.mjs');},
+            processCommand  : () => ''
+        });
+
+        expect(supervisor.runTask('backup', `periodic-sweep:${DAY_MS}`)).toBe(false);
+
+        const persisted = JSON.parse(fs.readFileSync(stateFile, 'utf8')),
+              now       = Date.now() + DELAY_MS,
+              trigger   = getDueTask({
+                  state              : persisted,
+                  now,
+                  backupIntervalMs   : DAY_MS,
+                  backupRetryDelayMs : DELAY_MS,
+                  backupRetryWindowMs: WINDOW_MS
+              }),
+              phase     = describeBackupRetryState({
+                  taskState    : persisted.backup,
+                  now,
+                  retryDelayMs : DELAY_MS,
+                  retryWindowMs: WINDOW_MS
+              });
+
+        expect(trigger).toMatchObject({taskName: 'backup', source: 'failed-run-retry'});
+        expect(phase.phase).toBe(BACKUP_RETRY_PHASE.retrying);
+        expect(phase.retriesRemaining).toBeGreaterThan(0);
+    });
+
+    /**
+     * The restart-durability witness. The prior restart spec asserted a single IN-MEMORY `readState()`
+     * return, which is green whether or not the normalization ever reaches disk — so it could not see
+     * that the crashed record stays `running: true` on disk with no streak.
+     */
+    test('the interrupted-run anchor is persisted, so a second restart cannot slide it (#16348)', async () => {
+        const dataDir = `/tmp/task-state-restart-${Date.now()}-${Math.random()}`;
+        fs.ensureDirSync(dataDir);
+
+        const stateFile       = path.join(dataDir, 'state.json'),
+              taskDefinitions = {backup: {name: 'backup', scriptPath: '/mock/backup.mjs'}},
+              boot            = () => {
+                  const instance = Neo.create(TaskStateService, {stateFile, taskDefinitions, writeLogFn: () => {}});
+                  instance.configure({stateFile, taskDefinitions, writeLogFn: () => {}});
+                  return instance;
+              };
+
+        const crashed = createInitialTaskState(taskDefinitions);
+        crashed.backup.running       = true;
+        crashed.backup.pid           = 4242;
+        crashed.backup.lastRunAt     = Date.now();
+        crashed.backup.lastSuccessAt = new Date(Date.now() - DAY_MS).toISOString();
+        fs.writeFileSync(stateFile, JSON.stringify(crashed), 'utf8');
+
+        const first          = boot(),
+              afterFirstBoot = JSON.parse(fs.readFileSync(stateFile, 'utf8')).backup;
+
+        // The normalization must reach DISK. Held only in memory, the next boot re-reads the same
+        // unchanged `running: true` bytes and derives a FRESH anchor — so the "bounded" window slides
+        // forward once per crash and a crash loop never exhausts its budget.
+        expect(afterFirstBoot.running).toBe(false);
+        expect(afterFirstBoot.pid).toBeNull();
+        expect(afterFirstBoot.failureStreakStartedAt).toBeTruthy();
+        expect(afterFirstBoot.failureStreakStartedAt).toBe(first.getTaskState('backup').failureStreakStartedAt);
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const second = boot();
+
+        // Control: 10ms of wall clock passed between boots, so a re-derived anchor would differ.
+        // Equality is preservation, not a clock that failed to move.
+        expect(second.getTaskState('backup').failureStreakStartedAt).toBe(afterFirstBoot.failureStreakStartedAt);
+        expect(JSON.parse(fs.readFileSync(stateFile, 'utf8')).backup.failureStreakStartedAt)
+            .toBe(afterFirstBoot.failureStreakStartedAt);
+
+        // The consequence in the units the contract is written in: the budget ENDS at the same
+        // instant after the second restart as it did after the first.
+        const windowEnd = instance => describeBackupRetryState({
+            taskState    : instance.getTaskState('backup'),
+            now          : Date.now(),
+            retryDelayMs : DELAY_MS,
+            retryWindowMs: WINDOW_MS
+        }).windowEndsAtMs;
+
+        expect(windowEnd(second)).toBe(windowEnd(first));
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/deploymentDurabilityPosture.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/deploymentDurabilityPosture.spec.mjs
@@ -220,9 +220,21 @@ test.describe('off-host durability posture (#16055)', () => {
         // The structural half of the fix: a posture is a property of CONFIG, so it is knowable before
         // any backup has run — which is precisely the deployment most at risk. The previous
         // `return null` omitted the entire maintenance section for that case.
+        //
+        // This pins the INVARIANT rather than the early-return literal. That literal moved when the
+        // backup retry phase was added beside `durability`, and the string pin reported the refactor
+        // as a regression while the property it guards was intact — pinning a member of a shape that
+        // is expected to grow guards the wrong direction. What cannot move is that the posture is
+        // resolved unconditionally, ahead of any receipt read that could fail.
+        //
+        // The behavioural proof — invoking the projection detached and asserting `durability` on a
+        // missing receipt — lives in `offHostSync.spec.mjs`, which carries the Neo bootstrap that
+        // importing the bridge requires. Asserting it here too would mean dragging that bootstrap
+        // into a pure-function spec, and a first attempt at exactly that passed only because a
+        // sibling spec had already initialised Neo in the same worker.
         const source = readFileSync(BRIDGE_PATH, 'utf8');
 
-        expect(source).toContain("if (outcome.status === 'missing') return {durability};");
+        expect(source).toContain('const durability = resolveConfiguredDurabilityPosture();');
         expect(source).not.toContain("if (outcome.status === 'missing') return null;")
     });
 


### PR DESCRIPTION
Resolves #16348

A backup run that fails no longer forfeits a full day of cadence. `markStarted()` stamps `lastRunAt` **pre-spawn** and no failure writer restores it, while `buildBackupTrigger()` gated on nothing else — so a run that died seconds after spawn was not due again for `backupMs`. The trigger now reads a finer field the periodic path ignores, `failureStreakStartedAt`, to distinguish *attempted* from *succeeded*.

**Why this mattered more than an ordinary missed cadence.** `backup` is the system's only priority-0 lane — `PRIORITY_ZERO_TASKS`, guaranteed by `ADR-0022` §2.2 to win the pick unconditionally so it never sits behind a backlog-draining task. That guarantee bought nothing against the lane's own failure, because ranking applies to *candidates* and a failed backup was not one. The undeferrable lane was the one thing that could defer itself.

**The window opens at the FAILED CYCLE and never slides. Both halves are load-bearing.**

- **Opening it at the failure** is what makes the feature work at all. The first revision of this PR anchored on `lastSuccessAt`, which is immovable but roughly one full `intervalMs` stale by the time a periodic run fails — so at the shipped 24h/1h ratio the budget was already ~23h expired at the first failure. **The feature did nothing at its own defaults**, past 21 green specs, because every fixture used a success→failure gap of *seconds* and that gap is the variable the policy turns on.
- **Not sliding** is the livelock guard. Because backup wins unconditionally, an unbounded retry would turn a persistently-failing lane into a heavy-lease monopoly and starve `summary` / `dream` / `memory-summary-backfill` — the exact starvation `ADR-0022` exists to eliminate, recreated by the repair for it. `lastErrorAt` advances with every failed retry, so a window measured from it would never close. `??=` is the whole contract.

**Because the anchor is the sole activation fact, every writer of "failure" is load-bearing.** Three producers record a failed cycle — an exited-nonzero run, a spawn that threw, and a run interrupted by a crash. They now share one `openFailureStreak()` transition rather than holding three opinions about what "failed" means, and the interrupted-run normalization is **committed to disk** by `configure()` before any consumer can read the lane.

Two config leaves (`backupRetryDelayMs`, `backupRetryWindowMs`) arrive as parameters, the `tenantRepoSync.isRepoDue` shape, so the scheduling module imports no config of its own. Either at `0` disables the retry path entirely.

Evidence: L2 (pure scheduling functions and the projection are fully unit-verifiable; the sandbox cannot run a live orchestrator that fails a real capture) → L3 achievable (a running orchestrator with a deliberately unreachable backup source, observed non-destructively through the deployment-state snapshot). Residual: the live re-fire and the `exhausted` phase appearing on a real snapshot, both in Post-Merge Validation.

## Deltas from ticket

- **AC5's observability clause landed on the orchestrator, not the Memory Core healthcheck.** `buildBackupStateBlock` reads the backup *directory*, and `mc-server` holds no backup mount — its `count: 0` is a true statement from a blind container. A surface that cannot see what it reports on is not observability, so the phase rides `DeploymentStateBridgeService`, which owns both the bind mount and the task state.
- **Exhaustion is reported as recomputable state, not a log edge.** An edge-triggered warning would need its own "already warned" flag and would be lost on restart. Every field the phase reads is already persisted, so any reader can recompute it at any time — including after a restart.
- **Two new persisted fields, contrary to this PR's original "no new persisted state" claim.** `failureStreakStartedAt` and `interruptedAt` are added to the task-state envelope. The original claim rested on the `lastSuccessAt` anchor, which is what made the feature a no-op; the anchor had to become a fact the system records rather than one it re-derives.
- **A lane that has never succeeded IS retried** — reversing this PR's earlier delta. The streak is the anchor, not the success, so a first-ever failure is boundable. `unanchored` now means only "no streak and no success", i.e. never ran.
- **`ADR-0022` cited without its §8 re-review clause literally firing.** That clause names *"changes the scheduling picker's selection policy"*; this changes the **due-computation** upstream of `picker.mjs`, so it does not literally fire. Cited anyway, because the effect — a priority-0 unconditional-win lane becoming due more often — lands squarely on the fairness model that ADR owns, and a reader checking only the literal clause would miss it. No §2.5 escalation path is taken: no cost model, no hard DAG, no preemption.

## Test Evidence

```
NEO_TEST_SKIP_CI=true UNIT_TEST_MODE=true npm run test-unit -- \
    test/playwright/unit/ai/daemons/orchestrator/
→ 1112 passed, 1 skipped
```

`scheduling/backup.spec.mjs`: 19 specs. `services/TaskStateService.spec.mjs`: 13 specs.

**Mutation verification.** Green alone proves nothing, and red-on-`dev` is satisfied by *any* difference — so each mutation must kill exactly the specs that name its term:

| mutation applied | specs killed |
|---|---|
| `markSpawnFailed` reverted to `lastErrorAt`-only | known-good-lane spawn witness · supervisor-path witness |
| `configure()` durability write removed | restart witness only |
| `??=` downgraded to `=` | spawn non-sliding half · first-failure-never-slides |
| opener dropped from `readState` normalization | fail-closed normalization · restart witness |
| budget clause deleted | termination · anchor |
| anchor swapped to `lastErrorAt` | anchor · termination · phase-agreement sweep |
| spacing clause removed | spacing · termination |

**The termination bound is asserted by running the clock**, not by restating `floor(window / delay)` — re-deriving the implementation's own formula would assert nothing.

**Fixtures use the SHIPPED 24h/1h constants**, not locally convenient ones. That is the direct lesson of this PR's first revision: readable time constants tested the algebra and never the policy.

## Third failure-writer candidate, examined and ruled out

`clearRecovered()` also ends a run without recording a terminal outcome, so it was checked rather than assumed. It is reachable only after `adoptRunning()`, which `recoverTask()` calls only when a live matching PID file exists at boot — and `markStarted()` writes `running: true` pre-spawn, so any such boot passed through the interrupted-run normalization first and already carries a persisted anchor. `clearRecovered()` never clears that anchor (only `markCompleted()` does). Not a hole; enumerating it up front is what stops each guard fix from shadowing the next case.

## Post-Merge Validation

- [ ] On a live orchestrator, fail a backup run and confirm it re-fires within `backupRetryDelayMs` rather than waiting `backupMs`.
- [ ] Confirm the retried run's `reason` reaches the durable task-outcome flow as `failed-run-retry:<age>`.
- [ ] Kill the orchestrator mid-backup, restart it twice, and confirm `failureStreakStartedAt` on disk is identical after both boots.
- [ ] Let a failing lane exhaust its window and confirm `maintenance.retry.phase` reads `exhausted` on the deployment-state snapshot, with the lane back on ordinary cadence rather than still re-firing.
- [ ] Confirm a healthy deployment reports `phase: 'healthy'` and that the snapshot shape is unchanged for a detached projection call.

## Commits

- `a74ba45f6f` — the bounded retry, its config leaves, the phase projection, and the specs.
- `aad651e807` — RC1: re-anchor the window on the failed cycle; truthful `retriesRemaining`; fail-closed restart normalization.
- `91ed8af0d6` — RC2: route every failure writer through one non-sliding streak opener; persist the restart normalization; align the stale `isRetryWindowOpen` JSDoc.

---

Authored by Grace (Claude Opus 5, Claude Code). Sessions `8c150fe3-e8a4-4475-8694-a6f92115dce9`, `9f05cd72-5457-4ec2-926c-ef1406041f19`.

Reviewed across cycles by Euclid (@neo-gpt), whose exact-head probes found the no-op at defaults and both RC2 blockers.
