### PR TITLE
fix(draggable): root the selection-guard class guards at globalThis.document (#16419)

### DIFF
--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -358,8 +358,10 @@ class DragDrop extends Base {
         // sensor's own `drag:end`. The Mouse sensor owns the physical mousedown→release bracket,
         // including lost-release recovery on its own move stream; this line just keeps the two
         // layers from drifting should that bracket's semantics ever change.
-        // Guarded: bare test harnesses may stub `document` without a body/classList.
-        document.body?.classList?.remove('neo-drag-active');
+        // Guarded at the globalThis root: bare test harnesses may stub `document` without a
+        // body/classList — or provide no `document` at all (a bare `document` reference would
+        // throw ReferenceError there before the optional chain can engage).
+        globalThis.document?.body?.classList?.remove('neo-drag-active');
 
         DragDrop.prototype.promoteWindowDragParkRecovery.call(me);
 

--- a/src/main/draggable/sensor/Mouse.mjs
+++ b/src/main/draggable/sensor/Mouse.mjs
@@ -125,8 +125,10 @@ class Mouse extends Base {
                 // button is still down, so suppression must hold until release. Released in
                 // endGesture — on mouseup, or on the gesture's own move stream observing the
                 // primary button gone (an off-document release never reaches onMouseUp).
-                // Guarded: bare test harnesses may stub `document` without a body/classList.
-                document.body?.classList?.add('neo-drag-active');
+                // Guarded at the globalThis root: bare test harnesses may stub `document`
+                // without a body/classList — or provide no `document` at all (a bare `document`
+                // reference would throw ReferenceError there before the chain can engage).
+                globalThis.document?.body?.classList?.add('neo-drag-active');
 
                 document.addEventListener('dragstart', preventDefault);
                 document.addEventListener('mousemove', me.onDistanceChange);
@@ -181,7 +183,8 @@ class Mouse extends Base {
 
         clearTimeout(me.mouseDownTimeout);
 
-        document.body?.classList?.remove('neo-drag-active');
+        // Same globalThis-root guard as the add site (see onMouseDown).
+        globalThis.document?.body?.classList?.remove('neo-drag-active');
 
         document.removeEventListener('dragstart', preventDefault);
         document.removeEventListener('mousemove', me.onDistanceChange);

--- a/src/main/draggable/sensor/Mouse.mjs
+++ b/src/main/draggable/sensor/Mouse.mjs
@@ -125,10 +125,8 @@ class Mouse extends Base {
                 // button is still down, so suppression must hold until release. Released in
                 // endGesture — on mouseup, or on the gesture's own move stream observing the
                 // primary button gone (an off-document release never reaches onMouseUp).
-                // Guarded at the globalThis root: bare test harnesses may stub `document`
-                // without a body/classList — or provide no `document` at all (a bare `document`
-                // reference would throw ReferenceError there before the chain can engage).
-                globalThis.document?.body?.classList?.add('neo-drag-active');
+                // Guarded: bare test harnesses may stub `document` without a body/classList.
+                document.body?.classList?.add('neo-drag-active');
 
                 document.addEventListener('dragstart', preventDefault);
                 document.addEventListener('mousemove', me.onDistanceChange);
@@ -183,8 +181,7 @@ class Mouse extends Base {
 
         clearTimeout(me.mouseDownTimeout);
 
-        // Same globalThis-root guard as the add site (see onMouseDown).
-        globalThis.document?.body?.classList?.remove('neo-drag-active');
+        document.body?.classList?.remove('neo-drag-active');
 
         document.removeEventListener('dragstart', preventDefault);
         document.removeEventListener('mousemove', me.onDistanceChange);

--- a/test/playwright/unit/main/addon/DragDrop.spec.mjs
+++ b/test/playwright/unit/main/addon/DragDrop.spec.mjs
@@ -676,6 +676,30 @@ test.describe('Neo.main.addon.DragDrop — generation-scoped physical window dra
         expect(addon.windowDragParkedGeometry).toBeNull()
     });
 
+    test('a reset completes safely when no document exists at all', () => {
+        // Deterministic pin for the full-suite ordering failure: resetDragState must no-op its
+        // class-list side effect when globalThis.document is entirely ABSENT — a bare
+        // `document` root reference throws ReferenceError before any optional chain engages.
+        const addon         = {},
+              savedDocument = globalThis.document,
+              hadDocument   = 'document' in globalThis;
+
+        try {
+            delete globalThis.document;
+
+            DragDrop.prototype.resetDragState.call(addon)
+        } finally {
+            hadDocument ? globalThis.document = savedDocument : delete globalThis.document
+        }
+
+        // The between-gestures baseline is applied unchanged: the document guard protects only
+        // the side effect, never the state-reset semantics.
+        expect(addon.dragCancelled).toBe(false);
+        expect(addon.dragZoneId).toBe(null);
+        expect(addon.windowDragGeneration).toBe(1);
+        expect(addon.windowDragMovePromises).toBeInstanceOf(Set)
+    });
+
     test('a reset makes the older native completion inert', async () => {
         let resolveMove;
 


### PR DESCRIPTION
Resolves #16419

The full-suite gate interference @neo-gpt surfaced while validating #16417 is root-caused and closed: `DragDrop.mjs:362`'s `document.body?.classList?.remove('neo-drag-active')` guarded `body`/`classList` but not the `document` root, so any document-less harness context threw `ReferenceError: document is not defined` — schedule-dependent, which is why the three reset witnesses failed only inside the full 11k suite. The optional chain is now rooted at `globalThis.document?` at the proven site, and a deterministic no-document witness pins the exact `ReferenceError` in the DragDrop unit spec — red against the pre-fix line, green with it, no dependence on full-suite ordering. Browser behavior unchanged (`document` always present there).

Evidence: L3 (failing-configuration reproduction + deterministic red/green witness + two consecutive full-suite runs green at the fix head) → L2 required (unit-harness defect). No residuals.

## Deltas from ticket

- **Scope narrowed at review (cycle 1, RA-2):** the two proactive `Mouse.mjs` edits are dropped. The sensor's methods require `document` on the very next statements (`document.addEventListener` / `removeEventListener`), so guarding only the class-list side effect promised a no-document method contract the lifecycle does not deliver — the reviewer's exact-source probe falsified the broader claim. The ticket body was amended in place (my own artifact) to match; the Mouse bracket's #16381 shape is browser-correct as-is.
- **RA-1 witness added:** `a reset completes safely when no document exists at all` — deletes `globalThis.document` inside a `finally`-restored boundary, drives `resetDragState()` on the minimal addon shape, asserts completion plus unchanged baseline semantics (`dragZoneId: null`, `windowDragGeneration: 1`, fresh `Set`). Red/green proven: against dev's pre-fix line it fails with exactly `ReferenceError: document is not defined`.
- The reproduction dossier in the ticket body also falsified the initial correlation hypothesis (my `Mouse.spec.mjs` as the poisoner: failures persist with it removed) and pure CPU load (concurrent 3704-test suite alongside the exact file: green) before the recovered stack named the mechanism.

## Test Evidence

- Deterministic witness red/green: pre-fix line → `ReferenceError` (red); fix head → **28/28** on `unit/main/addon/DragDrop` (incl. the new witness) and the untouched `unit/main/draggable/sensor/Mouse` 4/4
- Reproduction at clean `63149823e2` (pre-fix): full suite ×2 → the same 3 reset witnesses fail with the `ReferenceError` stack; exact-file/slices green; shard bisection cornered the failing configuration
- **Fix head, full suite ×2 consecutive: the three reset witnesses explicitly green** (`:639` and `:679` at 1ms, `:895` at 103ms); zero DragDrop failures in either run
- Remaining full-suite failures at the fix head are the unrelated, out-of-scope set named in the ticket (`MemoryService.Lifecycle:72` teardown flake, service-gated `SessionSummarization`, `StoreFilterProfile:21`) — no DragDrop among them

## Commits

- `51ca9b7de7` — the root guard at the proven site (+ the since-reverted proactive Mouse edits)
- follow-up — RA-1 deterministic witness + RA-2 scope narrowing (Mouse reverted to dev)

## Post-Merge Validation

- [ ] @neo-gpt's #16417 gate re-run goes green on the merged dev (his lane carried the non-green receipt transparently; this fix removes its cause)

Authored by Phoebe (Kimi K3, OpenCode). Session 0b6854a1-2b0f-457a-8a16-2e8f9d0983c8 (origin) — review-cycle work in session f6f84a9c-5706-460b-84e7-46e8cbfe5743.
