### PR TITLE
feat: resize deliveries survive rendering starvation (#16402)

### DIFF
--- a/src/main/addon/ResizeObserver.mjs
+++ b/src/main/addon/ResizeObserver.mjs
@@ -23,6 +23,20 @@ import DomEvents from '../DomEvents.mjs';
  * This guarantees the App Worker always receives the freshest possible layout data without
  * ever being overwhelmed, regardless of how aggressively the DOM is mutating.
  *
+ * **Rendering-Starvation Contract:**
+ * Both the native `ResizeObserver` (spec: deliveries ride rendering opportunities) and a pure
+ * rAF-locked dispatch starve in documents that never paint — hidden browser panes, occluded or
+ * backgrounded windows. Worker timers and postMessage keep flowing there, so a grid keeps
+ * receiving data while its geometry silently fossilizes at the last delivered box. Two additive
+ * guards keep this carrier truthful without touching the visible-path behavior:
+ * 1. The dispatch dam races `requestAnimationFrame` against a timer fallback. On a rendering
+ *    document rAF always wins (vsync coalescing preserved byte-for-byte); on a starved document
+ *    the timer opens the dam.
+ * 2. While `document.hidden` with registered targets, a slow poll compares each target's
+ *    border-box against the last dispatched size (layout computes without paint) and feeds
+ *    synthetic entries through the exact same dispatch pipeline — covering boxes that change
+ *    while the native observer cannot fire at all.
+ *
  * @class Neo.main.addon.ResizeObserver
  * @extends Neo.main.addon.Base
  */
@@ -39,6 +53,14 @@ class NeoResizeObserver extends Base {
          */
         instance: null,
         /**
+         * Poll cadence in ms for hidden documents, where the native observer cannot deliver
+         * at all. Browsers throttle hidden-page timers (typically to 1Hz, intensively to
+         * 1/min), so the effective cadence is a floor, not a promise — convergence degrades
+         * gracefully, it never dies.
+         * @member {Number} hiddenPollInterval=1000
+         */
+        hiddenPollInterval: 1000,
+        /**
          * If a target node is not found when calling register(),
          * we can specify the amount of retries with a 100ms delay.
          * @member {Number} registerAttempts=3
@@ -54,14 +76,39 @@ class NeoResizeObserver extends Base {
                 'register',
                 'unregister'
             ]
-        }
+        },
+        /**
+         * Delay in ms for the timer arm of the dispatch race. Any value above one frame
+         * period keeps rAF winning on every rendering document; the timer only ever fires
+         * where no frame will come.
+         * @member {Number} starvedFlushDelay=100
+         */
+        starvedFlushDelay: 100
     }
 
+    /**
+     * Bound visibilitychange listener, kept for removal on destroy.
+     * @member {Function|null} #boundVisibilityChange=null
+     * @private
+     */
+    #boundVisibilityChange = null
+    /**
+     * Last dispatched border-box size per target id. The hidden poll compares against the
+     * size the worker actually knows about, not against the previous poll tick.
+     * @member {Map} #lastDispatchedSize=new Map()
+     * @private
+     */
+    #lastDispatchedSize = new Map()
     /**
      * @member {Map} #pendingEntries=new Map()
      * @private
      */
     #pendingEntries = new Map()
+    /**
+     * @member {Number|null} #pollIntervalId=null
+     * @private
+     */
+    #pollIntervalId = null
     /**
      * @member {Number|null} #rAFId=null
      * @private
@@ -72,6 +119,12 @@ class NeoResizeObserver extends Base {
      * @private
      */
     #targetToComponents = {}
+    /**
+     * Timer arm of the dispatch race.
+     * @member {Number|null} #timerId=null
+     * @private
+     */
+    #timerId = null
 
     /**
      * @param {Object} config
@@ -81,7 +134,14 @@ class NeoResizeObserver extends Base {
 
         let me = this;
 
-        me.instance = new ResizeObserver(me.onResize.bind(me))
+        me.instance = new ResizeObserver(me.onResize.bind(me));
+
+        me.#boundVisibilityChange = me.onVisibilityChange.bind(me);
+        document.addEventListener('visibilitychange', me.#boundVisibilityChange);
+
+        // A document can already be hidden at addon construction time (e.g. an embedded
+        // pane booting in the background) — sync once instead of waiting for a flip.
+        me.syncPollState()
     }
 
     /**
@@ -98,22 +158,46 @@ class NeoResizeObserver extends Base {
             me.#pendingEntries.set(entry.target, entry)
         });
 
+        me.armDispatch()
+    }
+
+    /**
+     * Arms the dispatch race for the pending queue: rAF for vsync coalescing on rendering
+     * documents, a timer fallback for documents that will never service a frame. Whichever
+     * fires first dispatches and disarms the other.
+     * @protected
+     */
+    armDispatch() {
+        let me = this;
+
         if (!me.#rAFId) {
             me.#rAFId = requestAnimationFrame(() => {
                 me.dispatchResizeEvents()
             })
         }
+
+        if (!me.#timerId) {
+            me.#timerId = setTimeout(() => {
+                me.dispatchResizeEvents()
+            }, me.starvedFlushDelay)
+        }
     }
 
     /**
      * Dispatches the accumulated events and resets the queue.
+     * Disarms both race arms first: called from either one, cancelling the already-fired
+     * arm is a harmless no-op, cancelling the pending one prevents a duplicate dispatch.
      * @protected
      */
     dispatchResizeEvents() {
         let me      = this,
             entries = Array.from(me.#pendingEntries.values());
 
-        me.#rAFId = null;
+        me.#rAFId  !== null && cancelAnimationFrame(me.#rAFId);
+        me.#timerId !== null && clearTimeout(me.#timerId);
+
+        me.#rAFId   = null;
+        me.#timerId = null;
         me.#pendingEntries.clear();
 
         entries.forEach(entry => {
@@ -124,6 +208,11 @@ class NeoResizeObserver extends Base {
                 contentBoxSize            = entry.contentBoxSize[0],
                 devicePixelContentBoxSize = entry.devicePixelContentBoxSize?.[0] || {}, // Not supported in Safari yet
                 path                      = DomEvents.getPathFromElement(entry.target).map(e => DomEvents.getTargetData(e));
+
+            me.#lastDispatchedSize.set(entry.target.id, {
+                blockSize : borderBoxSize.blockSize,
+                inlineSize: borderBoxSize.inlineSize
+            });
 
             Neo.worker.Manager.sendMessage('app', {
                 action   : 'domEvent',
@@ -156,6 +245,110 @@ class NeoResizeObserver extends Base {
     }
 
     /**
+     * Builds an entry-shaped object for a box the native observer could not report.
+     * Reading offset metrics and computed style forces layout, which hidden documents
+     * compute fine — only paint is unavailable — so every field carries layout truth.
+     * @param {HTMLElement} node
+     * @returns {Object} Consumable by dispatchResizeEvents() like a native entry
+     * @protected
+     */
+    createSyntheticEntry(node) {
+        let style         = getComputedStyle(node),
+            pf            = prop => parseFloat(style.getPropertyValue(prop)) || 0,
+            blockSize     = node.offsetHeight,
+            inlineSize    = node.offsetWidth,
+            paddingLeft   = pf('padding-left'),
+            paddingTop    = pf('padding-top'),
+            contentWidth  = inlineSize - paddingLeft - pf('padding-right') - pf('border-left-width') - pf('border-right-width'),
+            contentHeight = blockSize - paddingTop - pf('padding-bottom') - pf('border-top-width') - pf('border-bottom-width');
+
+        return {
+            target        : node,
+            borderBoxSize : [{blockSize, inlineSize}],
+            contentBoxSize: [{blockSize: contentHeight, inlineSize: contentWidth}],
+
+            // Per spec, contentRect is the content box positioned relative to the padding origin
+            contentRect: {
+                bottom: paddingTop + contentHeight,
+                height: contentHeight,
+                left  : paddingLeft,
+                right : paddingLeft + contentWidth,
+                top   : paddingTop,
+                width : contentWidth,
+                x     : paddingLeft,
+                y     : paddingTop
+            }
+        }
+    }
+
+    /**
+     *
+     */
+    destroy() {
+        let me = this;
+
+        me.#rAFId        !== null && cancelAnimationFrame(me.#rAFId);
+        me.#timerId      !== null && clearTimeout(me.#timerId);
+        me.#pollIntervalId !== null && clearInterval(me.#pollIntervalId);
+
+        me.#boundVisibilityChange && document.removeEventListener('visibilitychange', me.#boundVisibilityChange);
+
+        super.destroy()
+    }
+
+    /**
+     * @protected
+     */
+    onVisibilityChange() {
+        this.syncPollState()
+    }
+
+    /**
+     * Walks every registered target and queues a synthetic entry for each border-box that
+     * moved away from the last size the worker was told about. Feeding the shared queue
+     * keeps ordering, coalescing and payload shape identical to the native path.
+     * @protected
+     */
+    pollHiddenTargets() {
+        let me = this;
+
+        Object.keys(me.#targetToComponents).forEach(id => {
+            let node = DomAccess.getElement(id);
+
+            if (!node) {
+                return
+            }
+
+            let last = me.#lastDispatchedSize.get(id);
+
+            if (!last || last.blockSize !== node.offsetHeight || last.inlineSize !== node.offsetWidth) {
+                me.#pendingEntries.set(node, me.createSyntheticEntry(node))
+            }
+        });
+
+        me.#pendingEntries.size > 0 && me.armDispatch()
+    }
+
+    /**
+     * Starts or stops the hidden poll so it runs exactly while both conditions hold:
+     * the document is hidden AND at least one target is registered.
+     * @protected
+     */
+    syncPollState() {
+        let me        = this,
+            needsPoll = document.hidden && Object.keys(me.#targetToComponents).length > 0;
+
+        if (needsPoll && me.#pollIntervalId === null) {
+            me.#pollIntervalId = setInterval(() => {
+                me.pollHiddenTargets()
+            }, me.hiddenPollInterval)
+        } else if (!needsPoll && me.#pollIntervalId !== null) {
+            clearInterval(me.#pollIntervalId);
+            me.#pollIntervalId = null
+        }
+    }
+
+    /**
      * @param {Object} data
      * @param {String} data.componentId
      * @param {String} data.id
@@ -172,7 +365,12 @@ class NeoResizeObserver extends Base {
                 me.#targetToComponents[data.id].push(data.componentId)
             }
 
-            me.instance.observe(node)
+            me.instance.observe(node);
+
+            // A target registered inside a hidden document gets NO initial native delivery
+            // (observe() schedules it for a rendering step that will not come) — the poll
+            // is what carries its first real box to the worker.
+            me.syncPollState()
         } else if (count < me.registerAttempts) {
             await me.timeout(100);
             count++;
@@ -196,7 +394,9 @@ class NeoResizeObserver extends Base {
 
             if (me.#targetToComponents[id].length === 0) {
                 delete me.#targetToComponents[id];
-                node && me.instance.unobserve(node)
+                me.#lastDispatchedSize.delete(id);
+                node && me.instance.unobserve(node);
+                me.syncPollState()
             }
         }
     }

--- a/src/main/addon/ResizeObserver.mjs
+++ b/src/main/addon/ResizeObserver.mjs
@@ -29,13 +29,17 @@ import DomEvents from '../DomEvents.mjs';
  * backgrounded windows. Worker timers and postMessage keep flowing there, so a grid keeps
  * receiving data while its geometry silently fossilizes at the last delivered box. Two additive
  * guards keep this carrier truthful without touching the visible-path behavior:
- * 1. The dispatch dam races `requestAnimationFrame` against a timer fallback. On a rendering
- *    document rAF always wins (vsync coalescing preserved byte-for-byte); on a starved document
- *    the timer opens the dam.
+ * 1. The dispatch dam races `requestAnimationFrame` against a timer fallback. rAF wins
+ *    whenever frames arrive faster than the timer delay (frame-rate-normative, not absolute:
+ *    below ~10fps at the default delay the timer may open the dam first and split a batch —
+ *    coalescing degrades gracefully, delivery correctness is unchanged); on a starved
+ *    document the timer opens the dam.
  * 2. While `document.hidden` with registered targets, a slow poll compares each target's
  *    border-box against the last dispatched size (layout computes without paint) and feeds
  *    synthetic entries through the exact same dispatch pipeline — covering boxes that change
- *    while the native observer cannot fire at all.
+ *    while the native observer cannot fire at all. The poll arms on `document.hidden` ONLY:
+ *    an occluded-but-not-hidden window keeps just the timer arm (deliveries the native
+ *    observer still makes flush without frames) — a named residual, not full coverage.
  *
  * @class Neo.main.addon.ResizeObserver
  * @extends Neo.main.addon.Base
@@ -78,9 +82,9 @@ class NeoResizeObserver extends Base {
             ]
         },
         /**
-         * Delay in ms for the timer arm of the dispatch race. Any value above one frame
-         * period keeps rAF winning on every rendering document; the timer only ever fires
-         * where no frame will come.
+         * Delay in ms for the timer arm of the dispatch race. rAF wins whenever frames
+         * arrive faster than this delay (~1000/delay fps); below that the timer may split
+         * a batch — graceful coalescing degradation, never a duplicate or lost delivery.
          * @member {Number} starvedFlushDelay=100
          */
         starvedFlushDelay: 100

--- a/test/playwright/e2e/workstation/WorkstationStarvedGeometryNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationStarvedGeometryNL.spec.mjs
@@ -1,0 +1,167 @@
+import { test, expect } from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: grid geometry converges without rendering opportunities.
+ *
+ * A grid acquires geometry once at mount (a paint-independent layout read) and forever after
+ * through ResizeObserver deliveries — and BOTH the native observer (spec: deliveries ride
+ * rendering opportunities) and the addon's rAF-locked dispatch dam starve in documents that
+ * never paint: hidden browser panes, occluded or backgrounded windows. Worker timers and
+ * postMessage keep flowing there, so a data-driven grid keeps streaming while a
+ * geometry-driven grid fossilizes at its last delivered box (witnessed live: the 100k Matrix
+ * booted as a 1-row pool at worker containerWidth 2, and a dock resize left the worker at
+ * 335.85 against a 226.05 DOM box until one forced frame flushed it). The repair keeps RO as
+ * the fast path and adds two guards in the main-thread addon: a timer arm racing the rAF dam,
+ * and a hidden poll that feeds synthetic entries through the same dispatch pipeline.
+ *
+ * This spec runs the real workstation app under a fully synthetic starvation rig, installed
+ * before any app script: the native ResizeObserver replaced with a silent stub (no deliveries,
+ * ever), requestAnimationFrame black-holed (no serviced frames), and document.hidden
+ * overridden to true (the poll's arming condition). Under that rig, ONLY the new carrier can
+ * move geometry to the worker.
+ *
+ * Worker truth is asserted through its DOM artifact (the same content-space technique the
+ * splitter-geometry spec binds): the rendered row pool is sized from worker availableHeight
+ * (pool = availableRows + buffer), so the DOM row count is a direct function of the geometry
+ * the worker last received. A dead carrier caps it at the mount-time snapshot forever:
+ *   1. boot leg — the pool must exceed a 1-row degenerate mount, with cells rendering real
+ *      content across mounted columns;
+ *   2. geometry-change leg — shrinking the bottom dock zone grows the Matrix pane VERTICALLY;
+ *      the row pool can only grow if the worker learned the taller box through the new
+ *      carrier (pre-fix it holds at the boot count forever);
+ *   3. control legs — the Feed grid keeps painting fresh rows throughout (the ingestion
+ *      stream is geometry-independent and must never trade against the geometry stream), and
+ *      the rig itself is asserted live (hidden document, frames requested but never serviced)
+ *      so a broken rig fails the run instead of green-washing it.
+ *
+ * All settlement is bounded expect.poll on state — no fixed-delay sleeps. No locator actions:
+ * with rAF black-holed, actionability stability checks would hang; the spec drives the page
+ * through evaluate() only.
+ *
+ * Run: npx playwright test WorkstationStarvedGeometryNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Workstation rendering starvation: grid geometry still converges (#16402)', () => {
+    test.setTimeout(120000);
+    test.use({ viewport: { width: 1280, height: 720 } });
+
+    const GRID_ID      = 'neo-grid-container-1',
+          FEED_GRID_ID = 'neo-grid-container-2';
+
+    const readMatrixState = (page, gridId) => page.evaluate(id => {
+        const grid  = document.getElementById(id),
+              rect  = grid?.getBoundingClientRect(),
+              cells = grid ? [...grid.querySelectorAll('[role="gridcell"]')] : [];
+
+        return {
+            gridHeight    : rect ? rect.height : -1,
+            gridWidth     : rect ? rect.width : -1,
+            mountedColumns: new Set(cells.map(cell => cell.getAttribute('aria-colindex')).filter(Boolean)).size,
+            renderedCells : cells.filter(cell => cell.textContent.trim().length > 0).length,
+            rows          : grid ? grid.querySelectorAll('[role="row"]').length : -1
+        }
+    }, gridId);
+
+    test('boot pool, geometry change, and feed control under a starved renderer', async ({ page }) => {
+        await page.addInitScript(() => {
+            // The starvation rig — installed before any app script runs:
+            // no native deliveries, no serviced frames, a hidden document.
+            window.ResizeObserver = class {
+                observe() {}
+                unobserve() {}
+                disconnect() {}
+            };
+
+            window.__starvedFrameRequests = 0;
+
+            window.requestAnimationFrame = () => {
+                window.__starvedFrameRequests++;
+                return 0
+            };
+            window.cancelAnimationFrame = () => {};
+
+            Object.defineProperty(Document.prototype, 'hidden', {
+                configurable: true,
+                get         : () => true
+            });
+            Object.defineProperty(Document.prototype, 'visibilityState', {
+                configurable: true,
+                get         : () => 'hidden'
+            });
+        });
+
+        await page.goto('/apps/workstation/index.html');
+
+        // RIG CONTROL: the app must actually see the starved environment.
+        const rig = await page.evaluate(() => ({
+            hidden         : document.hidden,
+            visibilityState: document.visibilityState
+        }));
+
+        expect(rig.hidden).toBe(true);
+        expect(rig.visibilityState).toBe('hidden');
+
+        // BOOT LEG: with the native observer silent and no frames, only the hidden poll can
+        // carry the Matrix pane's real box to the worker. The row pool (worker
+        // availableHeight) must outgrow a degenerate 1-row mount, and cells must render
+        // real content across several mounted columns (worker containerWidth windowing).
+        await expect.poll(
+            async () => (await readMatrixState(page, GRID_ID)).rows,
+            { message: 'the Matrix row pool populates without a single rendering opportunity', timeout: 30000 }
+        ).toBeGreaterThan(20);
+
+        await expect.poll(
+            async () => (await readMatrixState(page, GRID_ID)).renderedCells,
+            { message: 'Matrix cells render real content', timeout: 15000 }
+        ).toBeGreaterThan(40);
+
+        const bootState = await readMatrixState(page, GRID_ID);
+
+        expect(bootState.mountedColumns, 'boot mounts a real column set')
+            .toBeGreaterThanOrEqual(3);
+
+        // FEED CONTROL baseline: the newest feed cell text (a per-batch timestamp/counter).
+        const feedSnapshot = () => page.evaluate(id => {
+            const grid = document.getElementById(id);
+            return grid ? [...grid.querySelectorAll('[role="gridcell"]')].map(cell => cell.textContent).join('|') : ''
+        }, FEED_GRID_ID);
+
+        const feedBefore = await feedSnapshot();
+
+        // GEOMETRY-CHANGE LEG: shrinking the bottom dock zone grows the Matrix pane
+        // VERTICALLY under starvation. The rendered row pool is a direct function of the
+        // worker's availableHeight — it can only grow past its boot count if the worker
+        // learned the taller box through a delivery no frame ever carried.
+        const domHeightAfterFlex = await page.evaluate(feedGridId => {
+            let zoneChild = document.getElementById(feedGridId);
+
+            while (zoneChild && !zoneChild.parentElement?.classList.contains('neo-dashboard-dock-edge-zone')) {
+                zoneChild = zoneChild.parentElement
+            }
+
+            zoneChild.style.flex = '0 0 60px';
+
+            return document.getElementById('neo-grid-container-1').getBoundingClientRect().height
+        }, FEED_GRID_ID);
+
+        const bootRows = bootState.rows;
+
+        expect(domHeightAfterFlex, 'the zone mutation grew the grid layout box (trigger premise)')
+            .toBeGreaterThan(bootState.gridHeight + 100);
+
+        await expect.poll(
+            async () => (await readMatrixState(page, GRID_ID)).rows,
+            { message: 'the taller box grows the row pool without frames', timeout: 15000 }
+        ).toBeGreaterThan(bootRows + 1);
+
+        // FEED CONTROL: ingestion kept painting fresh rows while the geometry carrier worked.
+        await expect.poll(
+            async () => (await feedSnapshot()) !== feedBefore,
+            { message: 'the feed grid keeps painting fresh rows throughout', timeout: 10000 }
+        ).toBe(true);
+
+        // RIG CONTROL, closing: frames were requested but never serviced — the run really
+        // happened under starvation (a rig failure must fail the spec, not green-wash it).
+        const frameRequests = await page.evaluate(() => window.__starvedFrameRequests);
+        expect(frameRequests).toBeGreaterThan(0)
+    });
+});

--- a/test/playwright/unit/main/addon/ResizeObserver.spec.mjs
+++ b/test/playwright/unit/main/addon/ResizeObserver.spec.mjs
@@ -1,0 +1,342 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'MainResizeObserverTest'
+    },
+    mockLocalStorage: false,
+    mockMain        : false,
+    neoConfig       : {
+        unitTestMode: true
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+// The addon imports the eager DomAccess/DomEvents main-thread singletons and constructs a
+// native ResizeObserver. Install every main-thread surface BEFORE the dynamic import; the
+// specs then drive entries, frames, timers and visibility flips by hand.
+const nodeMap = new Map();
+
+const originalDocument         = globalThis.document,
+      originalWindow           = globalThis.window,
+      originalGetComputedStyle = globalThis.getComputedStyle,
+      originalResizeObserver   = globalThis.ResizeObserver,
+      originalRaf              = globalThis.requestAnimationFrame,
+      originalCaf              = globalThis.cancelAnimationFrame;
+
+let hiddenState = false,
+    roCallback  = null,
+    rafQueue    = new Map(),
+    rafSequence = 0,
+    sentMessages;
+
+const documentRef = new EventTarget();
+
+documentRef.body           = {};
+documentRef.getElementById = id => nodeMap.get(id) ?? null;
+
+Object.defineProperty(documentRef, 'hidden', {
+    configurable: true,
+    get         : () => hiddenState
+});
+
+globalThis.document = documentRef;
+globalThis.window   = new EventTarget();
+
+globalThis.getComputedStyle = node => ({
+    getPropertyValue: prop => String(node.styleValues?.[prop] ?? '0')
+});
+
+globalThis.ResizeObserver = class {
+    constructor(callback) { roCallback = callback }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+};
+
+globalThis.requestAnimationFrame = callback => {
+    rafSequence++;
+    rafQueue.set(rafSequence, callback);
+    return rafSequence
+};
+
+globalThis.cancelAnimationFrame = id => {
+    rafQueue.delete(id)
+};
+
+// Flushes the pending rAF queue, simulating one serviced frame.
+function serviceFrame() {
+    const callbacks = [...rafQueue.values()];
+    rafQueue.clear();
+    callbacks.forEach(callback => callback(performance.now()))
+}
+
+function setHidden(value) {
+    hiddenState = value;
+    documentRef.dispatchEvent(new Event('visibilitychange'))
+}
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+// Other main-thread singletons in the import graph forward visibility flips over the same
+// worker bridge; the contract under test is the resize stream alone.
+const resizeMessages = () => sentMessages.filter(entry => entry.message.eventName === 'resize');
+
+// Node shape covering the read-set of DomEvents.getTargetData() plus the addon's own
+// offset metric and computed-style reads.
+function makeNode(id, width, height, styleValues={}) {
+    const node = {
+        id,
+        childElementCount: 0,
+        classList        : [],
+        clientLeft       : 0,
+        clientTop        : 0,
+        dataset          : {},
+        draggable        : false,
+        getAttribute     : () => null,
+        isConnected      : true,
+        nodeName         : 'DIV',
+        offsetHeight     : height,
+        offsetWidth      : width,
+        parentNode       : null,
+        styleValues,
+        style            : {},
+        tagName          : 'DIV',
+
+        getBoundingClientRect() {
+            return {
+                bottom: node.offsetHeight, height: node.offsetHeight, left: 0, right: node.offsetWidth,
+                top   : 0, width: node.offsetWidth, x: 0, y: 0
+            }
+        }
+    };
+
+    Object.defineProperties(node, {
+        clientHeight: {get: () => node.offsetHeight},
+        clientWidth : {get: () => node.offsetWidth}
+    });
+
+    nodeMap.set(id, node);
+
+    return node
+}
+
+// A native-shaped ResizeObserverEntry for the fake observer to deliver.
+function makeEntry(node) {
+    const blockSize = node.offsetHeight, inlineSize = node.offsetWidth;
+
+    return {
+        target                   : node,
+        borderBoxSize            : [{blockSize, inlineSize}],
+        contentBoxSize           : [{blockSize, inlineSize}],
+        devicePixelContentBoxSize: [{blockSize, inlineSize}],
+
+        contentRect: {
+            bottom: blockSize, height: blockSize, left: 0, right: inlineSize,
+            top   : 0, width: inlineSize, x: 0, y: 0
+        }
+    }
+}
+
+// The unit harness pre-installs worker-facing stubs on Neo.main.addon.ResizeObserver and
+// Neo.main.DomAccess; importing the real main-thread modules collides with both. Swap the
+// stubs out for this file and back in afterAll — with worker-process reuse, later spec
+// files (the grid suite reads the mock's fixed 1000x1000 rects) must find what they expect.
+const stubAddonNamespace     = Neo.main.addon.ResizeObserver,
+      stubDomAccessNamespace = Neo.main.DomAccess;
+
+delete Neo.main.addon.ResizeObserver;
+delete Neo.main.DomAccess;
+
+const {default: AddonClass} = await import('../../../../../src/main/addon/ResizeObserver.mjs');
+
+/**
+ * @summary Starvation contract of the resize carrier.
+ *
+ * The native observer delivers at rendering opportunities and the dispatch dam was
+ * rAF-locked — in a document that never paints (hidden pane, occluded window), geometry
+ * deliveries starved forever while worker timers and postMessage kept flowing, freezing
+ * every geometry-dependent consumer at its last known box. These specs pin the two guards:
+ * the dispatch race (rAF vs timer — first one opens the dam, no duplicates) and the hidden
+ * poll (synthetic entries for boxes the native observer cannot report, through the same
+ * dispatch pipeline).
+ */
+test.describe('Neo.main.addon.ResizeObserver — rendering-starvation contract', () => {
+    let addon;
+
+    test.beforeEach(() => {
+        nodeMap.clear();
+        rafQueue.clear();
+        hiddenState  = false;
+        sentMessages = [];
+
+        Neo.worker.Manager ??= {};
+        Neo.worker.Manager.sendMessage = (destination, message) => {
+            sentMessages.push({destination, message})
+        };
+
+        addon = Neo.create(AddonClass, {
+            hiddenPollInterval: 60,
+            starvedFlushDelay : 40,
+            windowId          : 1
+        })
+    });
+
+    test.afterEach(() => {
+        addon.destroy()
+    });
+
+    test.afterAll(() => {
+        Neo.main.addon.ResizeObserver = stubAddonNamespace;
+        Neo.main.DomAccess            = stubDomAccessNamespace;
+
+        const restore = (key, value) => {
+            value === undefined ? delete globalThis[key] : globalThis[key] = value
+        };
+
+        restore('document',              originalDocument);
+        restore('window',                originalWindow);
+        restore('getComputedStyle',      originalGetComputedStyle);
+        restore('ResizeObserver',        originalResizeObserver);
+        restore('requestAnimationFrame', originalRaf);
+        restore('cancelAnimationFrame',  originalCaf)
+    });
+
+    test('starved dam: a native entry dispatches via the timer arm when no frame ever comes', async () => {
+        const node = makeNode('target-1', 300, 200);
+
+        await addon.register({componentId: 'component-1', id: 'target-1'});
+
+        roCallback([makeEntry(node)]);
+        expect(resizeMessages().length).toBe(0); // dam armed, nothing flushed yet
+
+        await wait(120); // > starvedFlushDelay, rAF queue deliberately never serviced
+
+        expect(resizeMessages().length).toBe(1);
+
+        const {data} = resizeMessages()[0].message;
+
+        expect(resizeMessages()[0].message.eventName).toBe('resize');
+        expect(data.id).toBe('target-1');
+        expect(data.componentIds).toEqual(['component-1']);
+        expect(data.borderBoxSize).toEqual({blockSize: 200, inlineSize: 300});
+
+        // A frame serviced AFTER the timer flush must not double-dispatch
+        serviceFrame();
+        await wait(60);
+        expect(resizeMessages().length).toBe(1)
+    });
+
+    test('rendering dam: rAF wins the race and the timer arm never double-dispatches', async () => {
+        const node = makeNode('target-1', 300, 200);
+
+        await addon.register({componentId: 'component-1', id: 'target-1'});
+
+        roCallback([makeEntry(node)]);
+        serviceFrame(); // the vsync path, exactly as before the starvation guards
+
+        expect(resizeMessages().length).toBe(1);
+
+        await wait(120); // outlive starvedFlushDelay: the cancelled timer must stay silent
+        expect(resizeMessages().length).toBe(1)
+    });
+
+    test('hidden boot: a target registered in a hidden document gets its first box from the poll', async () => {
+        setHidden(true);
+
+        const node = makeNode('target-1', 388, 550);
+
+        await addon.register({componentId: 'component-1', id: 'target-1'});
+
+        // No native entry ever fires (observe() scheduled a rendering step that will not come)
+        await wait(200); // > hiddenPollInterval + starvedFlushDelay
+
+        expect(resizeMessages().length).toBe(1);
+        expect(resizeMessages()[0].message.data.borderBoxSize).toEqual({blockSize: 550, inlineSize: 388})
+    });
+
+    test('hidden poll: silent while the box holds, delivers when it moves, tracks the new baseline', async () => {
+        setHidden(true);
+
+        const node = makeNode('target-1', 388, 550);
+
+        await addon.register({componentId: 'component-1', id: 'target-1'});
+        await wait(200);
+        expect(resizeMessages().length).toBe(1); // first box delivered
+
+        await wait(150); // unchanged box: no re-delivery
+        expect(resizeMessages().length).toBe(1);
+
+        node.offsetWidth = 226; // the dock-resize class: layout moved, no frame will report it
+        await wait(200);
+        expect(resizeMessages().length).toBe(2);
+        expect(resizeMessages()[1].message.data.borderBoxSize).toEqual({blockSize: 550, inlineSize: 226});
+
+        await wait(150); // new baseline holds: silent again
+        expect(resizeMessages().length).toBe(2)
+    });
+
+    test('synthetic payload: content box and contentRect subtract padding and border from layout truth', async () => {
+        setHidden(true);
+
+        makeNode('target-1', 300, 200, {
+            'border-left-width': '2', 'border-right-width': '2', 'border-top-width': '2', 'border-bottom-width': '2',
+            'padding-left'     : '10', 'padding-right': '10', 'padding-top': '5', 'padding-bottom': '5'
+        });
+
+        await addon.register({componentId: 'component-1', id: 'target-1'});
+        await wait(200);
+
+        const {data} = resizeMessages()[0].message;
+
+        expect(data.borderBoxSize).toEqual({blockSize: 200, inlineSize: 300});
+        expect(data.contentBoxSize).toEqual({blockSize: 200 - 10 - 4, inlineSize: 300 - 20 - 4});
+        expect(data.contentRect).toEqual({
+            bottom: 5 + 186, height: 186, left: 10, right: 10 + 276, top: 5, width: 276, x: 10, y: 5
+        })
+    });
+
+    test('visibility flip: revealing the document retires the poll; re-hiding restarts it', async () => {
+        setHidden(true);
+
+        const node = makeNode('target-1', 388, 550);
+
+        await addon.register({componentId: 'component-1', id: 'target-1'});
+        await wait(200);
+        expect(resizeMessages().length).toBe(1);
+
+        setHidden(false);
+        node.offsetWidth = 226;
+        await wait(200); // poll retired: the native observer owns the visible document
+        expect(resizeMessages().length).toBe(1);
+
+        setHidden(true);
+        await wait(200); // poll re-armed: the moved box is now its business
+        expect(resizeMessages().length).toBe(2);
+        expect(resizeMessages()[1].message.data.borderBoxSize).toEqual({blockSize: 550, inlineSize: 226})
+    });
+
+    test('unregister: drops the baseline and stops the poll with the last target', async () => {
+        setHidden(true);
+
+        makeNode('target-1', 388, 550);
+
+        await addon.register({componentId: 'component-1', id: 'target-1'});
+        await wait(200);
+        expect(resizeMessages().length).toBe(1);
+
+        addon.unregister({componentId: 'component-1', id: 'target-1'});
+        await wait(150); // zero targets: interval gone, nothing polls
+        expect(resizeMessages().length).toBe(1);
+
+        // A fresh registration of the same id must re-deliver even at the unchanged size:
+        // the baseline was dropped with the registration, not remembered across lifecycles.
+        await addon.register({componentId: 'component-2', id: 'target-1'});
+        await wait(200);
+        expect(resizeMessages().length).toBe(2);
+        expect(resizeMessages()[1].message.data.componentIds).toEqual(['component-2'])
+    });
+});


### PR DESCRIPTION
Resolves #16402

The 100k Matrix "freeze" is environmental, and the owning seam is the resize carrier itself: a grid acquires geometry once at mount (paint-independent `getLayoutRect` read) and forever after through ResizeObserver deliveries — which were paint-gated twice over (the native observer delivers at rendering opportunities per spec, and the addon's dispatch dam was rAF-locked). In any rendering-starved window (hidden browser pane, occluded/backgrounded window) worker timers and postMessage keep flowing, so the data-driven Feed streams on while the geometry-driven Matrix fossilizes at its last delivered box — the exact reported signature, with onset at the tour's step-2 `resizeSplit` because that is the first geometry-invalidating beat. This PR repairs the carrier additively in `Neo.main.addon.ResizeObserver`: the dispatch dam now races rAF against a timer arm (rAF wins on every rendering document — vsync coalescing preserved; the timer opens the dam where no frame will come), and a hidden poll compares registered targets' border boxes against the last dispatched size, feeding synthetic entries through the exact same dispatch pipeline (covering boxes the native observer can never report while hidden, including a target's FIRST box when registered into a hidden document). RO stays the fast path; zero grid/dashboard/consumer changes — safe by construction because #16390 made resize re-processing idempotent.

Evidence: L2 achieved (local headed e2e + unit + live hidden-pane validation at the real environment; PR CI carries no e2e job, so e2e receipts are local runs recorded below) → L2 covers the restated close-target ACs (worker geometry convergence without rendering opportunities, feed control, no fixed delays). Residual: the sparkline OffscreenCanvas registration leg discovered during closing validation is split to #16425 (full hidden-pane tour completion depends on it; grid legs are complete here).

## Deltas from ticket

- AC2 restated on-ticket by the ticket author with receipts (issuecomment-5160783031): the original bound a "natural update pulse" the census proved does not exist (no driver touches the scale store; post-tour idle is by design). The restated invariant — worker geometry converges to the DOM box without rendering opportunities — is what this PR witnesses.
- Closing validation in the real hidden pane surfaced a SECOND, independent starvation leg: sparkline `offscreenRegistered` never flips hidden, so the dense tour still stops fail-closed at its `canvas-update` cue even with geometry healthy → filed as #16425 with the classification plan. Grid geometry, pool, scroll, and dock beats are all receipted working hidden at this head.
- The e2e witness asserts worker truth through its DOM artifact (row pool = f(worker availableHeight)) rather than Neural-Link reads: during authoring, the NL fixture bound the first same-appName session (a live Browser-pane session captured the fixture and served a foreign window's stale geometry). The DOM-artifact form is immune to session routing and needs no NL infra in CI.

## Test Evidence

- `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/main/addon/ResizeObserver.spec.mjs` — 7 passed (dam race both ways, no double-dispatch; hidden-boot first-box delivery; baseline silence/re-delivery; synthetic payload box math; visibility flip lifecycle; unregister cleanup).
- `npx playwright test WorkstationStarvedGeometryNL WorkstationSplitterGridGeometryNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 3 passed (new starved witness + the #16375 geometry suite at this head).
- Red-proof: with `src/main/addon/ResizeObserver.mjs` stashed (pre-fix), the witness fails deterministically at "the taller box grows the row pool without frames" (pool frozen at boot count) — the discriminator binds the defect, not the environment.
- `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/grid/` — 52 passed (regression).
- Live hidden-pane receipts (real `document.hidden`, 0 rAF ticks, receipts on #16402): pre-fix, a semantic `resizeSplit` left worker `containerWidth` at 335.85 against a 226.05 DOM box until a forced frame; post-fix the worker converged to 226.05 within the poll cadence with no frame ever serviced, and the tour's scroll beat now lands hidden with real cells rendered at row 49999.
- apps/workstation surface: `WorkstationStarvedGeometryNL` (new) + `WorkstationSplitterGridGeometryNL` (existing) as above.

## Post-Merge Validation

- [ ] Dense tour in a real hidden Browser pane at merged head: grid legs (resizeSplit convergence, scroll beat, pool) healthy; full `11/11 + 6 cues` completion lands with #16425.
- [ ] Visible-path spot check across RO consumers (grid resize, Helix, MagicMoveText) — behavior byte-identical (rAF wins the dam race on rendering documents).

## Related

Related: #16425 · #16375 · PR #16390 · #16391

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 3bdbcbb5-b77b-46f5-88b7-9dbb124733fe.
