### PR TITLE
feat(backup): give abrupt-death staging residue a bounded lifecycle (#16427)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1633,7 +1633,21 @@ class ConfigBase extends ConfigProvider {
                     intervalMs: DAY_MS,
                     retention : {
                         keepMinimum: 3,
-                        maxDays    : 30
+                        maxDays    : 30,
+                        /**
+                         * How many `.backup-partial-*` staging directories left by ABRUPT death
+                         * survive the residue sweep, newest first.
+                         *
+                         * A count rather than an age bound, deliberately. The residue is the only
+                         * surviving evidence of a termination that recorded no terminal outcome,
+                         * and any age short enough to cap capacity is also short enough to delete
+                         * the artifact an operator is mid-investigation on. A count bounds growth
+                         * without making that judgement. `0` reclaims every partial not currently
+                         * in flight; the in-flight staging root is excluded explicitly, never by
+                         * relying on it being the newest.
+                         * @type {Number}
+                         */
+                        keepPartials: 2
                     },
                     /**
                      * How many candidate bundles `verifyLatestBackupRestorable` may FULLY validate

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -18,6 +18,7 @@ import {
 } from '../../../services/memory-core/helpers/offHostSyncStore.mjs';
 import {describeBackupRetryState}    from '../scheduling/backup.mjs';
 import {resolveDurabilityPosture}    from './deploymentDurabilityPosture.mjs';
+import {summarizeStagingResidue}     from '../../../scripts/maintenance/backupStagingResidueCore.mjs';
 import {readRecentRecoveryRunStates} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {
     queryHealLedger,
@@ -275,33 +276,43 @@ export class DeploymentStateBridgeService extends Base {
      * @returns {Promise<Object|null>}
      */
     async collectMaintenanceSnapshot({
-        backupTaskState = null,
-        now             = Date.now(),
-        receiptPath     = path.join(AiConfig.backupPath, 'last-backup-receipt.json')
+        backupTaskState   = null,
+        now               = Date.now(),
+        receiptPath       = path.join(AiConfig.backupPath, 'last-backup-receipt.json'),
+        stagingResidueRoot = AiConfig.backupPath
     } = {}) {
         // Module-scope, deliberately not a method: this projection depends only on resolved config
         // and its own argument, never on instance state, and the contract spec asserts that by
         // invoking it detached.
         const durability = resolveConfiguredDurabilityPosture();
 
-        // `retry` reports the backup lane's bounded-retry phase. It rides HERE rather than
-        // the Memory Core healthcheck's backup block on purpose: that block reads the backup
-        // DIRECTORY, and `mc-server` holds no backup mount — a surface that cannot see the thing it
-        // reports on. The orchestrator owns both the bind mount and the task state.
+        // `stagingResidue` is projected UNCONDITIONALLY, for the same reason `durability` is: it is a
+        // property of the backup ROOT rather than of any run, so it is exactly knowable at all times.
+        // `.backup-partial-*` residue is invisible to every root-level enumerator by construction —
+        // that invisibility is the safety property keeping torn bundles unrestorable — so this is the only surface
+        // its footprint can be seen from at all. Omitting it when clean would make "no residue"
+        // indistinguishable from "not reported", which is the failure the `durability` block exists
+        // to avoid.
         //
-        // Omitted rather than nulled when no task state was supplied, so a detached invocation keeps
-        // its previous shape exactly.
-        const base = backupTaskState
-            ? {
-                durability,
-                retry: describeBackupRetryState({
-                    now,
-                    retryDelayMs : AiConfig.orchestrator.intervals.backupRetryDelayMs,
-                    retryWindowMs: AiConfig.orchestrator.intervals.backupRetryWindowMs,
-                    taskState    : backupTaskState
-                })
-            }
-            : {durability};
+        // `retry` reports the backup lane's bounded-retry phase, and is omitted rather than nulled
+        // when no task state was supplied so a detached invocation keeps its run-dependent shape.
+        //
+        // Both ride HERE rather than on the Memory Core healthcheck's backup block: that block reads
+        // the backup DIRECTORY and `mc-server` holds no backup mount, so it reports from a blind
+        // container. This orchestrator owns the bind mount and the task state.
+        const base = {
+            durability,
+            stagingResidue: await summarizeStagingResidue(stagingResidueRoot)
+        };
+
+        if (backupTaskState) {
+            base.retry = describeBackupRetryState({
+                now,
+                retryDelayMs : AiConfig.orchestrator.intervals.backupRetryDelayMs,
+                retryWindowMs: AiConfig.orchestrator.intervals.backupRetryWindowMs,
+                taskState    : backupTaskState
+            })
+        }
 
         try {
             const outcome = await readBackupReceipt({filePath: receiptPath});

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -287,7 +287,9 @@ export class DeploymentStateBridgeService extends Base {
         const durability = resolveConfiguredDurabilityPosture();
 
         // `stagingResidue` is projected UNCONDITIONALLY, for the same reason `durability` is: it is a
-        // property of the backup ROOT rather than of any run, so it is exactly knowable at all times.
+        // property of the backup ROOT rather than of any run, so it is always REPORTABLE — which is
+        // not the same as always successfully measured, and `status` carries that difference: an
+        // observation that failed reports `unreadable` with null counts, never a zero.
         // `.backup-partial-*` residue is invisible to every root-level enumerator by construction —
         // that invisibility is the safety property keeping torn bundles unrestorable — so this is the only surface
         // its footprint can be seen from at all. Omitting it when clean would make "no residue"

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -28,6 +28,7 @@ import {
     withHeavyMaintenanceLease
 } from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
 import {resolveCloudOnlyDefault}        from '../../daemons/orchestrator/services/deploymentDurabilityPosture.mjs';
+import {cleanStagingResidue}            from './backupStagingResidueCore.mjs';
 import {HEAL_LEDGER_DIR_NAME}           from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {INCIDENT_LEDGER_BUNDLE_MEMBERS} from '../../services/memory-core/helpers/incidentLedgerBundle.mjs';
 import {
@@ -314,6 +315,7 @@ async function assertBackupDestinationAbsent(targetPath, message) {
  *                                                       (`{healAttemptsFile, healEventsDir, recoveryRunsDir}`).
  *                                                       Omitted in production — resolved from AiConfig at the use site.
  * @param {Function} [options.cleanOldBackupsImpl]       Retention cleaner seam; defaults to `cleanOldBackups`.
+ * @param {Function} [options.cleanStagingResidueImpl]   Staging-residue sweep seam; defaults to `cleanStagingResidue`.
  * @param {Object}  [options.logger=console]             Log sink; useful for tests.
  * @returns {Promise<{bundleRoot: String, timestamp: String, subsystems: Object}>}
  */
@@ -323,8 +325,9 @@ export async function runBackup({
     trajectoriesSourceFile = DEFAULT_TRAJECTORIES_FILE,
     sentToCullSourceFile   = DEFAULT_SENT_TO_CULL_FILE,
     ledgerSources,
-    cleanOldBackupsImpl    = cleanOldBackups,
-    logger                 = console
+    cleanOldBackupsImpl      = cleanOldBackups,
+    cleanStagingResidueImpl  = cleanStagingResidue,
+    logger                   = console
 } = {}) {
     const timestamp    = new Date().toISOString().replace(/:/g, '-');
     const resolvedRoot = bundleRoot ?? path.join(AiConfig.backupPath, `backup-${timestamp}`);
@@ -358,6 +361,22 @@ export async function runBackup({
                     throw error
                 }
             }
+        }
+
+        // Reclaim staging residue BEFORE capture, not with the post-publication retention sweep.
+        // Both are reclamation, but they answer different questions: retention prunes published
+        // history once the new bundle is safely authoritative, while this bounds a namespace whose
+        // growth is what makes the very next capture fail on a full volume. Doing it first is also
+        // what gives the exclusion teeth — `stagingRoot` exists and is the newest entry right now,
+        // so excluding it is a real operation rather than a no-op assertion made after the rename.
+        // Non-fatal by construction: a residue sweep must never be able to fail a backup.
+        try {
+            await cleanStagingResidueImpl(parentRoot, logger, {
+                excludePath : stagingRoot,
+                keepPartials: AiConfig.maintenance.backup.retention.keepPartials
+            })
+        } catch (error) {
+            logger.warn?.(`[Backup] staging-residue sweep failed; continuing with capture: ${error.message}`)
         }
 
         result = await captureBackup({

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -28,7 +28,7 @@ import {
     withHeavyMaintenanceLease
 } from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
 import {resolveCloudOnlyDefault}        from '../../daemons/orchestrator/services/deploymentDurabilityPosture.mjs';
-import {cleanStagingResidue}            from './backupStagingResidueCore.mjs';
+import {cleanStagingResidue, createStagingRoot} from './backupStagingResidueCore.mjs';
 import {HEAL_LEDGER_DIR_NAME}           from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
 import {INCIDENT_LEDGER_BUNDLE_MEMBERS} from '../../services/memory-core/helpers/incidentLedgerBundle.mjs';
 import {
@@ -343,9 +343,7 @@ export async function runBackup({
     const stagingHint = path.basename(resolvedRoot)
         .replace(/[^a-zA-Z0-9._-]/g, '_')
         .slice(0, 48) || 'bundle';
-    const stagingRoot = await fs.mkdtemp(
-        path.join(parentRoot, `.backup-partial-${stagingHint}-`)
-    );
+    const stagingRoot = await createStagingRoot(parentRoot, stagingHint);
 
     let result;
 

--- a/ai/scripts/maintenance/backupStagingResidueCore.mjs
+++ b/ai/scripts/maintenance/backupStagingResidueCore.mjs
@@ -46,6 +46,26 @@ export function isStagingResidueName(name) {
 }
 
 /**
+ * Creates the unique staging directory a backup assembles into.
+ *
+ * @summary The CREATOR lives here, beside the enumerator and the sweep, so the three cannot hold
+ * different opinions about what the namespace is. An earlier revision exported {@link STAGING_PREFIX}
+ * as "the one owner" while `backup.mjs` kept its own `.backup-partial-` literal — two symbols that
+ * agreed only by coincidence, and whose divergence would have made the sweep and the snapshot blind
+ * to newly-created residue while every test stayed green. Sharing the constant was not enough;
+ * owning the operation is what makes the claim structural rather than aspirational.
+ *
+ * `mkdtemp` supplies the per-run unique suffix and defaults to 0700. Sibling placement under the
+ * bundle's own parent guarantees a same-filesystem rename at publication.
+ * @param {String} parentRoot Absolute directory the bundle publishes into.
+ * @param {String} stagingHint Bounded, filesystem-safe hint of the intended final basename.
+ * @returns {Promise<String>} Absolute path of the created staging directory.
+ */
+export async function createStagingRoot(parentRoot, stagingHint) {
+    return fs.mkdtemp(path.join(parentRoot, `${STAGING_PREFIX}${stagingHint}-`))
+}
+
+/**
  * Recursively sums the byte size of a directory's regular files.
  *
  * @summary Stats only — it never reads file contents, so a multi-GB partial costs one stat per
@@ -98,7 +118,15 @@ export async function listStagingResidue(backupRoot, {withBytes = false} = {}) {
     try {
         entries = await fs.readdir(backupRoot, {withFileTypes: true})
     } catch (error) {
-        return []
+        // ENOENT is an ANSWER: no root, therefore no residue. Every other code — ENOTDIR, EACCES,
+        // EIO — is a FAILED OBSERVATION, and returning `[]` for it would make "I could not look"
+        // wear the same shape as "I looked and found nothing". That is the precise defect this
+        // module's own JSDoc calls out in the Memory Core healthcheck's blind `count: 0`, and it
+        // would silently no-op the sweep on an unreadable root while reporting a clean footprint.
+        if (error.code === 'ENOENT') {
+            return []
+        }
+        throw error
     }
 
     const residue = [];
@@ -132,16 +160,37 @@ export async function listStagingResidue(backupRoot, {withBytes = false} = {}) {
  * @summary Belongs on a surface that holds the backup mount. The Memory Core healthcheck does not
  * and reports `count: 0` from a blind container — a true statement carrying no information, which
  * is indistinguishable from a passing check.
+ *
+ * **`status` exists so this surface cannot commit that same error itself.** A readable root with no
+ * residue reports `{status: 'ok', count: 0}`; a root that could not be read reports
+ * `{status: 'unreadable', count: null}`. The counts are `null` rather than `0` on failure precisely
+ * because a consumer summing or thresholding them must not be handed a measured-looking zero when
+ * no measurement occurred. Absent-root is not a failure: it resolves to `ok` with a count of `0`,
+ * because "there is no backup root" is a real answer to "how much residue is there".
  * @param {String} backupRoot Absolute backup root.
- * @returns {Promise<{count: Number, bytes: Number, oldestMtimeMs: Number|null}>}
+ * @returns {Promise<{status: String, count: Number|null, bytes: Number|null, oldestMtimeMs: Number|null, errorCode: String|null}>}
  */
 export async function summarizeStagingResidue(backupRoot) {
-    const residue = await listStagingResidue(backupRoot, {withBytes: true});
+    let residue;
+
+    try {
+        residue = await listStagingResidue(backupRoot, {withBytes: true})
+    } catch (error) {
+        return {
+            status       : 'unreadable',
+            count        : null,
+            bytes        : null,
+            oldestMtimeMs: null,
+            errorCode    : error.code || null
+        }
+    }
 
     return {
+        status       : 'ok',
         count        : residue.length,
         bytes        : residue.reduce((sum, entry) => sum + entry.bytes, 0),
-        oldestMtimeMs: residue.length > 0 ? residue[residue.length - 1].mtimeMs : null
+        oldestMtimeMs: residue.length > 0 ? residue[residue.length - 1].mtimeMs : null,
+        errorCode    : null
     }
 }
 

--- a/ai/scripts/maintenance/backupStagingResidueCore.mjs
+++ b/ai/scripts/maintenance/backupStagingResidueCore.mjs
@@ -1,0 +1,222 @@
+import fs   from 'fs-extra';
+import path from 'path';
+
+/**
+ * @module ai/scripts/maintenance/backupStagingResidueCore
+ *
+ * @summary The one owner of the `.backup-partial-*` staging namespace: its prefix, its
+ * enumeration, and its retention policy.
+ *
+ * Atomic backup publication assembles every bundle in a `mkdtemp` staging directory and
+ * renames it into place only after the integrity gate passes. A leading dot keeps that directory
+ * invisible to all five root-level enumerators, every one of which gates on `startsWith('backup-')`
+ * — retention, legacy-bundle migration, the restorability walk, the corruption timeline, and the
+ * Memory Core healthcheck. **That invisibility is the safety property, not an oversight**: it is
+ * why a torn bundle can never be selected as restorable. Nothing here widens any of those five
+ * predicates, and nothing here may.
+ *
+ * What invisibility cost is a lifecycle. A caught failure removes its own staging directory, but
+ * abrupt death — SIGKILL, OOM, host loss, container stop mid-write — cannot, so the residue was
+ * permanent and unowned. Each one holds real exported rows, and the trigger is precisely an
+ * orchestrator crash-loop, so partials accumulate fastest exactly when a filling backup volume
+ * hurts most: one per restart that reaches the backup lane.
+ *
+ * This module never imports Neo or AiConfig: it takes a resolved root and a resolved policy, so it
+ * is safe to import from the maintenance entrypoint and from an orchestrator service alike. The
+ * prefix lives here as ONE shared constant rather than as a sixth hardcoded literal, because the
+ * sweep and the surface that reports on it must not be able to disagree about what they are
+ * naming.
+ */
+
+/**
+ * The staging-directory prefix. Its leading dot is what excludes it from `startsWith('backup-')`
+ * discovery, so this constant is a safety boundary rather than a naming convention.
+ * @type {String}
+ */
+export const STAGING_PREFIX = '.backup-partial-';
+
+/**
+ * Whether a directory entry name belongs to the staging namespace.
+ *
+ * @param {String} name Directory basename.
+ * @returns {Boolean}
+ */
+export function isStagingResidueName(name) {
+    return name.startsWith(STAGING_PREFIX);
+}
+
+/**
+ * Recursively sums the byte size of a directory's regular files.
+ *
+ * @summary Stats only — it never reads file contents, so a multi-GB partial costs one stat per
+ * entry rather than any IO proportional to its size. Unreadable entries contribute `0` instead of
+ * throwing: a residue sweep that dies on one bad inode leaves the whole namespace unreclaimed, and
+ * an approximate size is worth more here than an exact failure.
+ * @param {String} targetPath Absolute directory path.
+ * @returns {Promise<Number>} Total bytes.
+ */
+export async function measureDirectoryBytes(targetPath) {
+    let total = 0;
+
+    let entries;
+    try {
+        entries = await fs.readdir(targetPath, {withFileTypes: true})
+    } catch (error) {
+        return 0
+    }
+
+    for (const entry of entries) {
+        const entryPath = path.join(targetPath, entry.name);
+
+        if (entry.isDirectory()) {
+            total += await measureDirectoryBytes(entryPath)
+        } else if (entry.isFile()) {
+            try {
+                total += (await fs.stat(entryPath)).size
+            } catch (error) {
+                // Vanished or unreadable mid-walk; contributes nothing rather than aborting.
+            }
+        }
+    }
+
+    return total
+}
+
+/**
+ * Enumerates the staging residue under a backup root, newest first.
+ *
+ * @summary Ordered by `mtimeMs` rather than by the `mkdtemp` random suffix, which carries no time
+ * information at all. The returned `bytes` is omitted unless asked for, because the size walk is
+ * the only part of this that touches more than one directory level.
+ * @param {String} backupRoot Absolute backup root.
+ * @param {Object} [options]
+ * @param {Boolean} [options.withBytes=false] Also measure each directory's total size.
+ * @returns {Promise<Object[]>} `[{name, path, mtimeMs, bytes}]`, newest first.
+ */
+export async function listStagingResidue(backupRoot, {withBytes = false} = {}) {
+    let entries;
+    try {
+        entries = await fs.readdir(backupRoot, {withFileTypes: true})
+    } catch (error) {
+        return []
+    }
+
+    const residue = [];
+
+    for (const entry of entries) {
+        if (!entry.isDirectory() || !isStagingResidueName(entry.name)) continue;
+
+        const residuePath = path.join(backupRoot, entry.name);
+
+        try {
+            const stats = await fs.stat(residuePath);
+
+            residue.push({
+                name   : entry.name,
+                path   : residuePath,
+                mtimeMs: stats.mtimeMs,
+                bytes  : withBytes ? await measureDirectoryBytes(residuePath) : null
+            })
+        } catch (error) {
+            // Removed between readdir and stat — a concurrent sweep won the race; nothing to report.
+        }
+    }
+
+    residue.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    return residue
+}
+
+/**
+ * Reports the staging-residue footprint for an observability surface.
+ *
+ * @summary Belongs on a surface that holds the backup mount. The Memory Core healthcheck does not
+ * and reports `count: 0` from a blind container — a true statement carrying no information, which
+ * is indistinguishable from a passing check.
+ * @param {String} backupRoot Absolute backup root.
+ * @returns {Promise<{count: Number, bytes: Number, oldestMtimeMs: Number|null}>}
+ */
+export async function summarizeStagingResidue(backupRoot) {
+    const residue = await listStagingResidue(backupRoot, {withBytes: true});
+
+    return {
+        count        : residue.length,
+        bytes        : residue.reduce((sum, entry) => sum + entry.bytes, 0),
+        oldestMtimeMs: residue.length > 0 ? residue[residue.length - 1].mtimeMs : null
+    }
+}
+
+/**
+ * Chooses which staging directories to reclaim. Pure — the whole policy, decided without IO.
+ *
+ * @summary Forensic-retention COUNT, deliberately not an age bound. The residue is the only
+ * surviving evidence of an abrupt termination, and an age bound short enough to cap capacity is
+ * exactly the one that deletes the artifact an operator is still diagnosing. A count keeps the
+ * newest failures for inspection while making unbounded growth impossible, which is the property
+ * that was actually missing.
+ *
+ * `excludePath` is honoured as an EXPLICIT exclusion rather than inferred from the heavy-maintenance
+ * lease that serialises this lane, and rather than left to the accident that an in-flight staging
+ * directory is also the newest. Both of those would be true today and silently false after any
+ * change to either mechanism.
+ *
+ * @param {Object[]} residue Entries from {@link listStagingResidue}, newest first.
+ * @param {Object} options
+ * @param {Number} options.keepPartials How many newest partials to preserve for forensics.
+ * @param {String} [options.excludePath=null] A staging directory that must never be reclaimed.
+ * @returns {Object[]} The subset to remove.
+ */
+export function selectStagingResidueForRemoval(residue, {keepPartials, excludePath = null}) {
+    const candidates = residue.filter(entry => entry.path !== excludePath);
+
+    if (!(keepPartials >= 0)) {
+        return []
+    }
+
+    return candidates.slice(keepPartials)
+}
+
+/**
+ * Reclaims staging residue beyond the forensic-retention count.
+ *
+ * @summary Every removal is logged with the directory's name and age. Silent reclamation would
+ * destroy the forensic trail for the exact incident class this namespace records, and a sweep that
+ * leaves no trace is indistinguishable from one that never ran.
+ * @param {String} backupRoot Absolute backup root.
+ * @param {Object} logger Log sink exposing `log` and optionally `warn` / `error`.
+ * @param {Object} options
+ * @param {Number} options.keepPartials How many newest partials to preserve.
+ * @param {String} [options.excludePath=null] A staging directory that must never be reclaimed.
+ * @param {Number} [options.now=Date.now()] Clock seam for age reporting.
+ * @returns {Promise<{inspected: Number, removed: String[], failed: String[], keptForForensics: Number}>}
+ */
+export async function cleanStagingResidue(backupRoot, logger, {keepPartials, excludePath = null, now = Date.now()}) {
+    const residue = await listStagingResidue(backupRoot),
+          doomed  = selectStagingResidueForRemoval(residue, {keepPartials, excludePath}),
+          removed = [],
+          failed  = [];
+
+    for (const entry of doomed) {
+        const ageHours = Math.round((now - entry.mtimeMs) / 3600000);
+
+        try {
+            logger.log(`[Retention] Reclaiming backup staging residue: ${entry.name} (age: ${ageHours}h)`);
+            await fs.remove(entry.path);
+            removed.push(entry.name)
+        } catch (error) {
+            failed.push(entry.name);
+            const message = `[Retention] Failed to reclaim staging residue ${entry.name}: ${error.message}`;
+            logger.error ? logger.error(message) : logger.log(message)
+        }
+    }
+
+    if (removed.length > 0) {
+        logger.log(`[Retention] Reclaimed ${removed.length} backup staging residue director(ies); kept the newest ${Math.min(keepPartials, residue.length - doomed.length)} for forensics.`)
+    }
+
+    return {
+        inspected       : residue.length,
+        removed,
+        failed,
+        keptForForensics: residue.length - removed.length
+    }
+}

--- a/ai/scripts/maintenance/backupStagingResidueCore.mjs
+++ b/ai/scripts/maintenance/backupStagingResidueCore.mjs
@@ -66,35 +66,70 @@ export async function createStagingRoot(parentRoot, stagingHint) {
 }
 
 /**
+ * The ONE rule every observation site in this module applies to a filesystem error.
+ *
+ * @summary `ENOENT` is the only skippable code, because it is the only one that carries
+ * information: the entry is genuinely not there, which for this namespace is a real answer (an
+ * absent root) or a benign race (a concurrent sweep removed a partial between `readdir` and
+ * `stat`). Every other code — `ENOTDIR`, `EACCES`, `EPERM`, `EIO` — means *the observation failed*,
+ * and a failed observation must never be reported as a measurement.
+ *
+ * This lives as a named helper rather than as three copies of an `if` because the first repair of
+ * this defect fixed exactly one of the four catch sites and left the other three intact: the root
+ * `readdir` was corrected while the per-entry `stat` and both recursive size reads kept swallowing
+ * everything, so an unreadable child still produced `{status:'ok', count:0}`. Fixing one site of a
+ * shared class is how the next site gets shadowed. One rule, one place, applied at every site.
+ *
+ * @param {Error} error A filesystem error.
+ * @returns {Boolean} True when the error is a genuine absence and may be skipped.
+ */
+export function isSkippableAbsence(error) {
+    return error?.code === 'ENOENT';
+}
+
+/**
  * Recursively sums the byte size of a directory's regular files.
  *
  * @summary Stats only — it never reads file contents, so a multi-GB partial costs one stat per
- * entry rather than any IO proportional to its size. Unreadable entries contribute `0` instead of
- * throwing: a residue sweep that dies on one bad inode leaves the whole namespace unreclaimed, and
- * an approximate size is worth more here than an exact failure.
+ * entry rather than any IO proportional to its size.
+ *
+ * An entry that vanished mid-walk contributes `0` and the walk continues: that is a real race
+ * against the sweep, not a failure. Anything else PROPAGATES — an unreadable payload reporting
+ * `bytes: 0` alongside `status: 'ok'` is a measured-looking zero for a measurement that never
+ * happened, which is the exact defect this module exists to avoid committing.
  * @param {String} targetPath Absolute directory path.
+ * @param {Object} [options]
+ * @param {Object} [options.fsImpl=fs] Filesystem seam. Injected by specs to produce a deterministic
+ *     `EACCES`: real permission fixtures behave differently under root, which CI runs as, so a
+ *     permission-based witness would pass locally and prove nothing where it matters.
  * @returns {Promise<Number>} Total bytes.
+ * @throws {Error} Any non-`ENOENT` filesystem error.
  */
-export async function measureDirectoryBytes(targetPath) {
-    let total = 0;
+export async function measureDirectoryBytes(targetPath, {fsImpl = fs} = {}) {
+    let total = 0,
+        entries;
 
-    let entries;
     try {
-        entries = await fs.readdir(targetPath, {withFileTypes: true})
+        entries = await fsImpl.readdir(targetPath, {withFileTypes: true})
     } catch (error) {
-        return 0
+        if (isSkippableAbsence(error)) {
+            return 0
+        }
+        throw error
     }
 
     for (const entry of entries) {
         const entryPath = path.join(targetPath, entry.name);
 
         if (entry.isDirectory()) {
-            total += await measureDirectoryBytes(entryPath)
+            total += await measureDirectoryBytes(entryPath, {fsImpl})
         } else if (entry.isFile()) {
             try {
-                total += (await fs.stat(entryPath)).size
+                total += (await fsImpl.stat(entryPath)).size
             } catch (error) {
-                // Vanished or unreadable mid-walk; contributes nothing rather than aborting.
+                if (!isSkippableAbsence(error)) {
+                    throw error
+                }
             }
         }
     }
@@ -111,19 +146,17 @@ export async function measureDirectoryBytes(targetPath) {
  * @param {String} backupRoot Absolute backup root.
  * @param {Object} [options]
  * @param {Boolean} [options.withBytes=false] Also measure each directory's total size.
+ * @param {Object} [options.fsImpl=fs] Filesystem seam; see {@link measureDirectoryBytes}.
  * @returns {Promise<Object[]>} `[{name, path, mtimeMs, bytes}]`, newest first.
+ * @throws {Error} Any non-`ENOENT` filesystem error, at the root or at any entry beneath it.
  */
-export async function listStagingResidue(backupRoot, {withBytes = false} = {}) {
+export async function listStagingResidue(backupRoot, {withBytes = false, fsImpl = fs} = {}) {
     let entries;
     try {
-        entries = await fs.readdir(backupRoot, {withFileTypes: true})
+        entries = await fsImpl.readdir(backupRoot, {withFileTypes: true})
     } catch (error) {
-        // ENOENT is an ANSWER: no root, therefore no residue. Every other code — ENOTDIR, EACCES,
-        // EIO — is a FAILED OBSERVATION, and returning `[]` for it would make "I could not look"
-        // wear the same shape as "I looked and found nothing". That is the precise defect this
-        // module's own JSDoc calls out in the Memory Core healthcheck's blind `count: 0`, and it
-        // would silently no-op the sweep on an unreadable root while reporting a clean footprint.
-        if (error.code === 'ENOENT') {
+        // No root, therefore no residue — the one code that is an answer. See isSkippableAbsence.
+        if (isSkippableAbsence(error)) {
             return []
         }
         throw error
@@ -137,16 +170,22 @@ export async function listStagingResidue(backupRoot, {withBytes = false} = {}) {
         const residuePath = path.join(backupRoot, entry.name);
 
         try {
-            const stats = await fs.stat(residuePath);
+            const stats = await fsImpl.stat(residuePath);
 
             residue.push({
                 name   : entry.name,
                 path   : residuePath,
                 mtimeMs: stats.mtimeMs,
-                bytes  : withBytes ? await measureDirectoryBytes(residuePath) : null
+                bytes  : withBytes ? await measureDirectoryBytes(residuePath, {fsImpl}) : null
             })
         } catch (error) {
             // Removed between readdir and stat — a concurrent sweep won the race; nothing to report.
+            // An entry we can SEE but cannot STAT is a different thing entirely: dropping it silently
+            // would delete it from the count AND from the sweep's work list, so the residue would be
+            // both unreported and unreclaimed. That propagates.
+            if (!isSkippableAbsence(error)) {
+                throw error
+            }
         }
     }
 
@@ -167,14 +206,19 @@ export async function listStagingResidue(backupRoot, {withBytes = false} = {}) {
  * because a consumer summing or thresholding them must not be handed a measured-looking zero when
  * no measurement occurred. Absent-root is not a failure: it resolves to `ok` with a count of `0`,
  * because "there is no backup root" is a real answer to "how much residue is there".
+ *
+ * A failure ANYWHERE in the walk lands here — the root, an entry it could see but not stat, or a
+ * payload it could not size. All of them are the same class and all of them report `unreadable`.
  * @param {String} backupRoot Absolute backup root.
+ * @param {Object} [options]
+ * @param {Object} [options.fsImpl] Filesystem seam; see {@link measureDirectoryBytes}.
  * @returns {Promise<{status: String, count: Number|null, bytes: Number|null, oldestMtimeMs: Number|null, errorCode: String|null}>}
  */
-export async function summarizeStagingResidue(backupRoot) {
+export async function summarizeStagingResidue(backupRoot, {fsImpl} = {}) {
     let residue;
 
     try {
-        residue = await listStagingResidue(backupRoot, {withBytes: true})
+        residue = await listStagingResidue(backupRoot, {withBytes: true, ...(fsImpl && {fsImpl})})
     } catch (error) {
         return {
             status       : 'unreadable',
@@ -236,10 +280,13 @@ export function selectStagingResidueForRemoval(residue, {keepPartials, excludePa
  * @param {Number} options.keepPartials How many newest partials to preserve.
  * @param {String} [options.excludePath=null] A staging directory that must never be reclaimed.
  * @param {Number} [options.now=Date.now()] Clock seam for age reporting.
+ * @param {Object} [options.fsImpl=fs] Filesystem seam; see {@link measureDirectoryBytes}.
  * @returns {Promise<{inspected: Number, removed: String[], failed: String[], keptForForensics: Number}>}
+ * @throws {Error} Any non-`ENOENT` enumeration failure, so an unreadable namespace reaches
+ *     `runBackup`'s warning path instead of silently reclaiming nothing.
  */
-export async function cleanStagingResidue(backupRoot, logger, {keepPartials, excludePath = null, now = Date.now()}) {
-    const residue = await listStagingResidue(backupRoot),
+export async function cleanStagingResidue(backupRoot, logger, {keepPartials, excludePath = null, now = Date.now(), fsImpl = fs}) {
+    const residue = await listStagingResidue(backupRoot, {fsImpl}),
           doomed  = selectStagingResidueForRemoval(residue, {keepPartials, excludePath}),
           removed = [],
           failed  = [];

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -535,7 +535,13 @@ test.describe('Tier 1 Config Immutability', () => {
             intervalMs: 24 * 60 * 60 * 1000,
             retention : {
                 keepMinimum: 3,
-                maxDays    : 30
+                maxDays    : 30,
+                // How many `.backup-partial-*` staging directories left by ABRUPT death survive the
+                // residue sweep. A forensic-retention count rather than an age bound: the residue is
+                // the only surviving evidence of a termination that recorded no terminal outcome, and
+                // any age short enough to cap capacity also deletes the artifact an operator may be
+                // mid-investigation on.
+                keepPartials: 2
             },
             // Bounds how many bundles `verifyLatestBackupRestorable` validates while walking back past
             // an unusable newest one. A policy value rather than a module constant: a primitive-local

--- a/test/playwright/unit/ai/scripts/maintenance/backupStagingResidueCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backupStagingResidueCore.spec.mjs
@@ -1,0 +1,213 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'path';
+import {
+    cleanStagingResidue,
+    isStagingResidueName,
+    listStagingResidue,
+    selectStagingResidueForRemoval,
+    STAGING_PREFIX,
+    summarizeStagingResidue
+} from '../../../../../../ai/scripts/maintenance/backupStagingResidueCore.mjs';
+
+const HOUR_MS = 3600000;
+
+/**
+ * Builds a backup root holding published bundles and staging residue with controlled mtimes, so
+ * "newest first" is a property of the fixture rather than of directory-creation timing.
+ */
+function createBackupRoot({partials = 0, bundles = 0, bytesPerPartial = 0} = {}) {
+    const backupRoot = `/tmp/backup-staging-residue-${Date.now()}-${Math.random()}`;
+    fs.ensureDirSync(backupRoot);
+
+    const now     = Date.now(),
+          created = [];
+
+    for (let i = 0; i < partials; i++) {
+        // Oldest first, so index 0 is the oldest and the LAST created is the newest.
+        const dir = path.join(backupRoot, `${STAGING_PREFIX}backup-2026-08-0${i + 1}-abc${i}`);
+        fs.ensureDirSync(dir);
+
+        if (bytesPerPartial > 0) {
+            fs.writeFileSync(path.join(dir, 'memories.jsonl'), 'x'.repeat(bytesPerPartial), 'utf8')
+        }
+
+        const mtime = new Date(now - (partials - i) * HOUR_MS);
+        fs.utimesSync(dir, mtime, mtime);
+        created.push(dir)
+    }
+
+    for (let i = 0; i < bundles; i++) {
+        fs.ensureDirSync(path.join(backupRoot, `backup-2026-08-0${i + 1}T00-00-00.000Z`))
+    }
+
+    return {backupRoot, created};
+}
+
+test.describe('backupStagingResidueCore — the .backup-partial-* lifecycle (#16427)', () => {
+    /**
+     * AC1. The defect was unbounded growth: abrupt death cannot clean up after itself, and every
+     * root-level enumerator is blind to the residue by design, so nothing ever reclaimed it. The
+     * assertion is on the SURVIVING SET after repeated crashes, not on a single sweep's return.
+     */
+    test('residue cannot grow without bound across repeated abrupt terminations', async () => {
+        const {backupRoot} = createBackupRoot({partials: 9}),
+              logger       = {log: () => {}};
+
+        await cleanStagingResidue(backupRoot, logger, {keepPartials: 2});
+
+        const survivors = await listStagingResidue(backupRoot);
+        expect(survivors).toHaveLength(2);
+
+        // A second crash wave must not ratchet the floor upward.
+        createBackupRoot({partials: 0});
+        for (let i = 0; i < 5; i++) {
+            fs.ensureDirSync(path.join(backupRoot, `${STAGING_PREFIX}wave2-${i}`))
+        }
+
+        await cleanStagingResidue(backupRoot, logger, {keepPartials: 2});
+        expect(await listStagingResidue(backupRoot)).toHaveLength(2);
+    });
+
+    test('the survivors are the NEWEST partials, so the most recent failure stays inspectable', async () => {
+        const {backupRoot, created} = createBackupRoot({partials: 5}),
+              newest                = created.slice(-2).map(dir => path.basename(dir));
+
+        await cleanStagingResidue(backupRoot, {log: () => {}}, {keepPartials: 2});
+
+        const survivorNames = (await listStagingResidue(backupRoot)).map(entry => entry.name);
+        expect(survivorNames.sort()).toEqual(newest.sort());
+    });
+
+    /**
+     * AC2. Asserted EXPLICITLY rather than inferred from the heavy-maintenance lease that serialises
+     * the lane, and rather than left to the accident that an in-flight staging root is also the
+     * newest. `keepPartials: 0` removes that accidental protection, so only the explicit exclusion
+     * can save it — which is exactly the condition under which the AC has teeth.
+     */
+    test('an in-flight staging directory is never reclaimed, even at keepPartials 0', async () => {
+        const {backupRoot, created} = createBackupRoot({partials: 4}),
+              inFlight              = created[0]; // the OLDEST — first to die without the exclusion
+
+        await cleanStagingResidue(backupRoot, {log: () => {}}, {
+            excludePath : inFlight,
+            keepPartials: 0
+        });
+
+        expect(fs.existsSync(inFlight)).toBe(true);
+        expect(await listStagingResidue(backupRoot)).toHaveLength(1);
+    });
+
+    /**
+     * The safety property atomic publication delivered, and the most likely thing a careless fix
+     * breaks. A leading dot is what keeps an incomplete bundle out of the restorability walk.
+     */
+    test('the staging namespace never overlaps the published `backup-` namespace', async () => {
+        const {backupRoot} = createBackupRoot({partials: 3, bundles: 4});
+
+        const residue         = await listStagingResidue(backupRoot),
+              publishedByName = (await fs.readdir(backupRoot)).filter(name => name.startsWith('backup-'));
+
+        expect(residue).toHaveLength(3);
+        expect(publishedByName).toHaveLength(4);
+
+        // The pin: nothing this module reports can be seen by a `startsWith('backup-')` enumerator,
+        // and nothing a published-bundle enumerator sees can be reported here. Two disjoint sets.
+        for (const entry of residue) {
+            expect(entry.name.startsWith('backup-')).toBe(false);
+            expect(publishedByName).not.toContain(entry.name)
+        }
+
+        expect(isStagingResidueName('backup-2026-08-01T00-00-00.000Z')).toBe(false);
+        expect(isStagingResidueName(`${STAGING_PREFIX}anything`)).toBe(true);
+    });
+
+    test('a sweep leaves every published bundle untouched', async () => {
+        const {backupRoot} = createBackupRoot({partials: 5, bundles: 3});
+
+        await cleanStagingResidue(backupRoot, {log: () => {}}, {keepPartials: 0});
+
+        const remaining = (await fs.readdir(backupRoot)).filter(name => name.startsWith('backup-'));
+        expect(remaining).toHaveLength(3);
+    });
+
+    /**
+     * AC5. The residue is the only surviving evidence of a termination that recorded no terminal
+     * outcome, so a reclamation that leaves no trace is indistinguishable from one that never ran.
+     */
+    test('every reclamation is logged with the directory name and its age', async () => {
+        const {backupRoot, created} = createBackupRoot({partials: 3}),
+              lines                 = [],
+              oldest                = path.basename(created[0]);
+
+        await cleanStagingResidue(backupRoot, {log: line => lines.push(line)}, {keepPartials: 2});
+
+        const removalLine = lines.find(line => line.includes(oldest));
+        expect(removalLine).toBeTruthy();
+        expect(removalLine).toMatch(/age: \d+h/);
+    });
+
+    /**
+     * A stray FILE carrying the staging prefix is not residue. `mkdtemp` only ever creates
+     * directories, so a prefixed file is something else entirely — and sweeping or counting it
+     * would let an unrelated artifact drive a reclamation decision.
+     */
+    test('a non-directory entry carrying the prefix is neither swept nor counted', async () => {
+        const {backupRoot, created} = createBackupRoot({partials: 3}),
+              strayFile             = path.join(backupRoot, `${STAGING_PREFIX}stray-file`);
+
+        await fs.writeFile(strayFile, 'not-a-directory', 'utf8');
+
+        expect(await listStagingResidue(backupRoot)).toHaveLength(3);
+        expect((await summarizeStagingResidue(backupRoot)).count).toBe(3);
+
+        const result = await cleanStagingResidue(backupRoot, {log: () => {}}, {keepPartials: 2});
+
+        expect(result.inspected).toBe(3);
+        expect(result.removed).toEqual([path.basename(created[0])]);
+        expect(fs.existsSync(strayFile)).toBe(true);
+    });
+
+    test('summarizeStagingResidue reports count and bytes for the observability surface', async () => {
+        const {backupRoot} = createBackupRoot({partials: 3, bytesPerPartial: 128});
+
+        const summary = await summarizeStagingResidue(backupRoot);
+
+        expect(summary.count).toBe(3);
+        expect(summary.bytes).toBe(384);
+        expect(summary.oldestMtimeMs).toBeLessThan(Date.now());
+    });
+
+    test('a clean root reports zero rather than omitting the block', async () => {
+        const {backupRoot} = createBackupRoot({bundles: 2});
+
+        expect(await summarizeStagingResidue(backupRoot)).toMatchObject({
+            bytes        : 0,
+            count        : 0,
+            oldestMtimeMs: null
+        });
+    });
+
+    test('a missing backup root degrades to empty rather than throwing', async () => {
+        expect(await listStagingResidue('/tmp/does-not-exist-16427')).toEqual([]);
+        expect(await summarizeStagingResidue('/tmp/does-not-exist-16427')).toMatchObject({bytes: 0, count: 0});
+    });
+
+    test('selectStagingResidueForRemoval is pure and keeps the newest N', () => {
+        const residue = [
+            {name: 'c', path: '/r/c', mtimeMs: 300},
+            {name: 'b', path: '/r/b', mtimeMs: 200},
+            {name: 'a', path: '/r/a', mtimeMs: 100}
+        ];
+
+        expect(selectStagingResidueForRemoval(residue, {keepPartials: 1}).map(e => e.name)).toEqual(['b', 'a']);
+        expect(selectStagingResidueForRemoval(residue, {keepPartials: 0}).map(e => e.name)).toEqual(['c', 'b', 'a']);
+        expect(selectStagingResidueForRemoval(residue, {keepPartials: 9})).toEqual([]);
+
+        // The exclusion is applied BEFORE the keep-count, so an in-flight entry never consumes one
+        // of the forensic slots it is not competing for.
+        expect(
+            selectStagingResidueForRemoval(residue, {excludePath: '/r/c', keepPartials: 1}).map(e => e.name)
+        ).toEqual(['a']);
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/backupStagingResidueCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backupStagingResidueCore.spec.mjs
@@ -253,6 +253,66 @@ test.describe('backupStagingResidueCore — the .backup-partial-* lifecycle (#16
         await expect(cleanStagingResidue(notADirectory, {log: () => {}}, {keepPartials: 0})).rejects.toThrow();
     });
 
+    /**
+     * The error-truth rule applies at EVERY observation site, not just the root `readdir`. The first
+     * repair fixed one of four catch sites; an entry that could be listed but not stat'd was still
+     * dropped silently, which removed it from the count AND from the sweep's work list — unreported
+     * and unreclaimed at once.
+     *
+     * The failure is INJECTED rather than produced with real permissions on purpose: `chmod` does not
+     * stop root, and CI runs as root, so a permission fixture would pass locally and prove nothing
+     * where it counts. The thing under test is the error-code classification, which an injected code
+     * exercises exactly.
+     */
+    test('an entry that can be listed but not stat-ed propagates, never vanishes (#16427)', async () => {
+        const {backupRoot} = createBackupRoot({partials: 2}),
+              eacces       = Object.assign(new Error('permission denied'), {code: 'EACCES'}),
+              fsImpl       = {
+                  readdir: (...args) => fs.readdir(...args),
+                  stat   : () => Promise.reject(eacces)
+              };
+
+        await expect(listStagingResidue(backupRoot, {fsImpl})).rejects.toThrow('permission denied');
+
+        const summary = await summarizeStagingResidue(backupRoot, {fsImpl});
+        expect(summary.status).toBe('unreadable');
+        expect(summary.count).toBeNull();
+        expect(summary.errorCode).toBe('EACCES');
+
+        // The sweep must reach runBackup's warning path rather than reporting a clean no-op.
+        await expect(
+            cleanStagingResidue(backupRoot, {log: () => {}}, {fsImpl, keepPartials: 0})
+        ).rejects.toThrow('permission denied');
+
+        // Positive control: the SAME shape with ENOENT is a genuine race and is still skipped, so
+        // the assertions above are about the error CODE and not merely about stat failing at all.
+        const enoent = Object.assign(new Error('gone'), {code: 'ENOENT'});
+        const raced  = await summarizeStagingResidue(backupRoot, {
+            fsImpl: {readdir: (...args) => fs.readdir(...args), stat: () => Promise.reject(enoent)}
+        });
+        expect(raced).toMatchObject({count: 0, status: 'ok'});
+    });
+
+    test('a partial whose payload cannot be sized propagates instead of reporting zero bytes (#16427)', async () => {
+        const {backupRoot} = createBackupRoot({partials: 1, bytesPerPartial: 64}),
+              eacces       = Object.assign(new Error('payload unreadable'), {code: 'EACCES'}),
+              // The partial itself stats fine; only the recursive size walk fails — the exact shape
+              // that previously produced `{status:'ok', count:1, bytes:0}`.
+              fsImpl       = {
+                  readdir: (target, opts) => target === backupRoot
+                      ? fs.readdir(target, opts)
+                      : Promise.reject(eacces),
+                  stat   : (...args) => fs.stat(...args)
+              };
+
+        const summary = await summarizeStagingResidue(backupRoot, {fsImpl});
+
+        expect(summary.status).toBe('unreadable');
+        expect(summary.bytes).toBeNull();
+        expect(summary.count).toBeNull();
+        expect(summary.errorCode).toBe('EACCES');
+    });
+
     test('selectStagingResidueForRemoval is pure and keeps the newest N', () => {
         const residue = [
             {name: 'c', path: '/r/c', mtimeMs: 300},

--- a/test/playwright/unit/ai/scripts/maintenance/backupStagingResidueCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backupStagingResidueCore.spec.mjs
@@ -3,6 +3,7 @@ import fs             from 'fs-extra';
 import path           from 'path';
 import {
     cleanStagingResidue,
+    createStagingRoot,
     isStagingResidueName,
     listStagingResidue,
     selectStagingResidueForRemoval,
@@ -173,24 +174,83 @@ test.describe('backupStagingResidueCore — the .backup-partial-* lifecycle (#16
 
         const summary = await summarizeStagingResidue(backupRoot);
 
+        expect(summary.status).toBe('ok');
         expect(summary.count).toBe(3);
         expect(summary.bytes).toBe(384);
         expect(summary.oldestMtimeMs).toBeLessThan(Date.now());
     });
 
-    test('a clean root reports zero rather than omitting the block', async () => {
+    test('a clean root reports an OK zero rather than omitting the block', async () => {
         const {backupRoot} = createBackupRoot({bundles: 2});
 
         expect(await summarizeStagingResidue(backupRoot)).toMatchObject({
             bytes        : 0,
             count        : 0,
-            oldestMtimeMs: null
+            errorCode    : null,
+            oldestMtimeMs: null,
+            status       : 'ok'
         });
     });
 
-    test('a missing backup root degrades to empty rather than throwing', async () => {
+    /**
+     * An absent root is an ANSWER — "no backup root" genuinely means "no residue" — so it resolves
+     * `ok`, unlike an unreadable one below. This pair is the discriminator: without both, `ok` could
+     * not be distinguished from "the catch swallowed everything".
+     */
+    test('a missing backup root is an OK zero, not a failed observation', async () => {
         expect(await listStagingResidue('/tmp/does-not-exist-16427')).toEqual([]);
-        expect(await summarizeStagingResidue('/tmp/does-not-exist-16427')).toMatchObject({bytes: 0, count: 0});
+        expect(await summarizeStagingResidue('/tmp/does-not-exist-16427')).toMatchObject({
+            count : 0,
+            status: 'ok'
+        });
+    });
+
+    /**
+     * The namespace-ownership coupling. Sharing a constant is not ownership — an earlier revision
+     * exported `STAGING_PREFIX` as "the one owner" while the writer kept its own `.backup-partial-`
+     * literal, so the two agreed only by coincidence and could diverge silently, blinding the sweep
+     * and the snapshot to newly-created residue with every test still green. This drives the REAL
+     * creator and asserts the round trip: what the producer makes, the consumers must see.
+     */
+    test('what createStagingRoot makes, the enumerator and the predicate both recognize', async () => {
+        const {backupRoot} = createBackupRoot({bundles: 2}),
+              created      = await createStagingRoot(backupRoot, 'backup-2026-08-03T00-00-00.000Z'),
+              basename     = path.basename(created);
+
+        expect(isStagingResidueName(basename)).toBe(true);
+        expect(basename.startsWith('backup-')).toBe(false);
+
+        const seen = await listStagingResidue(backupRoot);
+        expect(seen.map(entry => entry.path)).toContain(created);
+
+        // ...and the in-flight exclusion can address it, which is what `runBackup` relies on.
+        expect(selectStagingResidueForRemoval(seen, {excludePath: created, keepPartials: 0})).toEqual([]);
+    });
+
+    /**
+     * Error truth. `ENOENT` is an answer; every other code is a FAILED OBSERVATION. Returning `[]`
+     * for both would make "I could not look" wear the same shape as "I looked and found nothing" —
+     * the blind `count: 0` this module's own docstring warns about, committed by the module itself.
+     */
+    test('an unreadable root fails loudly instead of reporting a clean zero', async () => {
+        const {backupRoot}  = createBackupRoot({partials: 2}),
+              notADirectory = path.join(backupRoot, 'regular-file');
+
+        fs.writeFileSync(notADirectory, 'x', 'utf8');
+
+        // The enumerator throws rather than inventing an empty answer...
+        await expect(listStagingResidue(notADirectory)).rejects.toThrow();
+
+        // ...the observability surface reports the failure EXPLICITLY, with null counts so no
+        // consumer can sum or threshold a measurement that never happened...
+        const summary = await summarizeStagingResidue(notADirectory);
+        expect(summary.status).toBe('unreadable');
+        expect(summary.count).toBeNull();
+        expect(summary.bytes).toBeNull();
+        expect(summary.errorCode).toBe('ENOTDIR');
+
+        // ...and the sweep propagates, reaching runBackup's warning path instead of silently no-oping.
+        await expect(cleanStagingResidue(notADirectory, {log: () => {}}, {keepPartials: 0})).rejects.toThrow();
     });
 
     test('selectStagingResidueForRemoval is pure and keeps the newest N', () => {

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -14,7 +14,7 @@ setup({
 import Neo                                                             from '../../../../../../src/Neo.mjs';
 import * as core                                                       from '../../../../../../src/core/_export.mjs';
 import {test, expect}                                                  from '@playwright/test';
-import {mkdtempSync, rmSync, readFileSync, writeFileSync, readdirSync} from 'node:fs';
+import {mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync, readdirSync} from 'node:fs';
 import {open, rename}                                                  from 'node:fs/promises';
 import {spawn}                                                         from 'node:child_process';
 import {tmpdir}                                                        from 'node:os';
@@ -711,6 +711,42 @@ test.describe('wrapper + projection behavioral witnesses', () => {
             writeFileSync(receiptPath, 'not json{');
             const unreadable = await collect({receiptPath});
             expect(unreadable.lastBackup).toEqual({finishedAt: null, kind: 'corrupt', status: 'unreadable'});
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    /**
+     * `.backup-partial-*` residue is invisible to all five root-level enumerators by construction —
+     * that invisibility is the safety property — so the orchestrator snapshot is the only place its
+     * footprint can be seen. The Memory Core healthcheck's backup block reads the backup DIRECTORY
+     * and `mc-server` holds no backup mount, so it reports `count: 0` from a blind container: a true
+     * statement carrying no information, indistinguishable from a passing check.
+     */
+    test('projection: staging-residue count and bytes ride the orchestrator snapshot, reported even when clean (#16427)', async () => {
+        const root = makeTmp();
+        try {
+            const bridge  = (await import('../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs')).default;
+            const collect = opts => bridge.prototype.collectMaintenanceSnapshot.call({}, opts);
+
+            const receiptPath = path.join(root, 'last-backup-receipt.json');
+
+            // Reported as an explicit zero, never omitted: "no residue" must not read the same as
+            // "nothing about residue is reportable" — the failure the durability block exists to end.
+            const clean = await collect({receiptPath, stagingResidueRoot: root});
+            expect(clean.stagingResidue).toEqual({bytes: 0, count: 0, oldestMtimeMs: null});
+
+            mkdirSync(path.join(root, '.backup-partial-backup-2026-08-03-aaa'), {recursive: true});
+            writeFileSync(path.join(root, '.backup-partial-backup-2026-08-03-aaa', 'memories.jsonl'), 'x'.repeat(64));
+            mkdirSync(path.join(root, '.backup-partial-backup-2026-08-03-bbb'), {recursive: true});
+
+            // A published bundle must not be counted as residue — the two namespaces stay disjoint.
+            mkdirSync(path.join(root, 'backup-2026-08-03T00-00-00.000Z'), {recursive: true});
+
+            const withResidue = await collect({receiptPath, stagingResidueRoot: root});
+            expect(withResidue.stagingResidue.count).toBe(2);
+            expect(withResidue.stagingResidue.bytes).toBe(64);
+            expect(withResidue.stagingResidue.oldestMtimeMs).toBeGreaterThan(0);
         } finally {
             rmSync(root, {force: true, recursive: true})
         }

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -734,7 +734,9 @@ test.describe('wrapper + projection behavioral witnesses', () => {
             // Reported as an explicit zero, never omitted: "no residue" must not read the same as
             // "nothing about residue is reportable" — the failure the durability block exists to end.
             const clean = await collect({receiptPath, stagingResidueRoot: root});
-            expect(clean.stagingResidue).toEqual({bytes: 0, count: 0, oldestMtimeMs: null});
+            expect(clean.stagingResidue).toEqual({
+                bytes: 0, count: 0, errorCode: null, oldestMtimeMs: null, status: 'ok'
+            });
 
             mkdirSync(path.join(root, '.backup-partial-backup-2026-08-03-aaa'), {recursive: true});
             writeFileSync(path.join(root, '.backup-partial-backup-2026-08-03-aaa', 'memories.jsonl'), 'x'.repeat(64));
@@ -744,9 +746,26 @@ test.describe('wrapper + projection behavioral witnesses', () => {
             mkdirSync(path.join(root, 'backup-2026-08-03T00-00-00.000Z'), {recursive: true});
 
             const withResidue = await collect({receiptPath, stagingResidueRoot: root});
+            expect(withResidue.stagingResidue.status).toBe('ok');
             expect(withResidue.stagingResidue.count).toBe(2);
             expect(withResidue.stagingResidue.bytes).toBe(64);
             expect(withResidue.stagingResidue.oldestMtimeMs).toBeGreaterThan(0);
+
+            // An unreadable root must NOT reach the snapshot as a measured zero. The projection
+            // still writes — observability degrades, never blocks — but it says so, and the counts
+            // are null so nothing downstream can sum a measurement that never happened.
+            // The specimen is a regular FILE that exists: an absent path is ENOENT, which is a real
+            // answer and correctly reports `ok`, so it could not discriminate here.
+            const notADirectory = path.join(root, 'not-a-directory');
+            writeFileSync(notADirectory, 'x');
+
+            const unreadable = await collect({receiptPath, stagingResidueRoot: notADirectory});
+            expect(unreadable.stagingResidue).toMatchObject({
+                bytes    : null,
+                count    : null,
+                errorCode: 'ENOTDIR',
+                status   : 'unreadable'
+            });
         } finally {
             rmSync(root, {force: true, recursive: true})
         }


### PR DESCRIPTION
Resolves #16427

Atomic backup publication assembles every bundle in a `.backup-partial-*` staging directory and renames it into place only after the integrity gate passes. A leading dot keeps that directory invisible to all five root-level enumerators — retention, legacy-bundle migration, the restorability walk, the corruption timeline, and the Memory Core healthcheck — every one of which gates on `startsWith('backup-')`.

**That invisibility is the safety property, and this PR does not touch it.** It is why a torn bundle can never be selected as restorable. What it cost is a lifecycle: a caught failure removes its own staging directory, but abrupt death — SIGKILL, OOM, host loss, container stop mid-write — cannot, so the residue was permanent and unowned.

**Why that is worth a lifecycle rather than a shrug.** Each partial holds real exported rows, and production bundles run to multiple GB. The trigger is precisely the orchestrator crash-loop (#16230 / #16242, 325 restarts) that produced the specimen behind #16348 — so partials accrue one per restart that reaches the backup lane, accumulating fastest exactly when a filling backup volume hurts most. #16201 already relocated `backupPath` out of the git working tree because ~133 GB of bundles sat one `git clean -x` away; backup-volume capacity is a live concern here, not a hypothetical.

Evidence: L2 (the removal policy, enumeration, sweep, and snapshot projection are fully unit-verifiable; the sandbox cannot SIGKILL a live orchestrator mid-capture to produce genuine residue, nor fill a real backup volume) → L3 achievable (a running orchestrator with a deliberately killed backup run, observed non-destructively through the deployment-state snapshot). Residual: AC6 [#16427] — the post-kill behaviour and the still-verified previous bundle, both in Post-Merge Validation.

## The policy: a forensic-retention COUNT, not an age bound

The ticket prescribed three options and asked for a deliberate choice rather than a fold. This is option 2 plus the observability half of option 3.

An age bound was rejected on the merits, not on effort. The residue is the only surviving evidence of a termination that recorded no terminal outcome, and **any age short enough to cap capacity is also short enough to delete the artifact an operator is mid-investigation on.** A count bounds growth without making that judgement at all. `keepPartials: 2` keeps the two newest failures inspectable; `0` reclaims everything not in flight.

## Shape

- **`ai/scripts/maintenance/backupStagingResidueCore.mjs`** owns the namespace: the prefix, **the creator** (`createStagingRoot`), enumeration, the pure removal policy, and the sweep. It imports no Neo and no AiConfig, taking a resolved root and a resolved policy — so the maintenance entrypoint and an orchestrator service can both consume it.

  *(RC1 correction: the first revision of this PR claimed "the prefix lives here as ONE shared constant" while `backup.mjs` kept its own `.backup-partial-` literal. They agreed only by coincidence and could diverge silently, blinding the sweep and the snapshot to newly-created residue with every test green. Sharing a constant was not ownership — the creator now lives in the module too, which makes divergence structurally impossible rather than merely tested.)*
- **Error truth: a failed observation is not an absence.** `ENOENT` is an answer — no root, no residue — and resolves `ok` with a count of `0`. Every other code (`ENOTDIR`, `EACCES`, IO) is a *failed look*: the enumerator throws, the sweep propagates into `runBackup`'s existing warning path rather than silently no-oping, and the snapshot reports `{status: 'unreadable', count: null, bytes: null, errorCode}`. The counts are `null` rather than `0` deliberately — that distinction **is** the fix, because a consumer summing or thresholding them must never be handed a measured-looking zero when no measurement occurred.

  *(RC1 correction, and an uncomfortable one: this module's own docstring warns about the Memory Core healthcheck reporting `count: 0` from a container holding no backup mount. The first implementation committed exactly that error one function below the warning, swallowing every `readdir` failure into an empty list. Found by @neo-gpt's exact-head `ENOTDIR` probe, not by me.)*
- **The sweep runs BEFORE capture**, not alongside the post-publication retention pass. Both reclaim, but they answer different questions: retention prunes published history once the new bundle is safely authoritative, while this bounds a namespace whose growth is what makes the *very next* capture fail on a full volume. Running first is also what gives the in-flight exclusion teeth — `stagingRoot` exists and is the newest entry at that moment, so excluding it is a real operation rather than a no-op assertion made after the rename. It is wrapped non-fatally: a residue sweep must never be able to fail a backup.
- **`stagingResidue` `{status, count, bytes, oldestMtimeMs, errorCode}`** rides the orchestrator deployment-state snapshot **unconditionally**, for the same reason the `durability` block does: it is a property of the backup root rather than of any run, so "no residue" must not read the same as "nothing about residue is reportable". *Knowable is not the same as always successfully measured* — hence `status`, which is exactly the claim the first revision over-reached on.
- **Config:** `maintenance.backup.retention.keepPartials: 2`, a plain nested key inside the existing `maintenance` object leaf beside `keepMinimum` / `maxDays`. No new env binding — the ticket needs none, and ADR-0019 §A7 treats a speculative env knob as YAGNI.

**Verifying AC3 mechanically, and one disambiguation.** `git diff origin/dev...HEAD` touches no `startsWith('backup-')` line in any production predicate — the only two the diff adds are JSDoc in the new module. A reviewer running that grep will find **six** sites, not the five the ticket names: the sixth is `defragChromaDB.mjs:306`, whose `cleanOldBackups` enumerates `dist/chromadb-backups/<target>` under its own `maintenance.defrag.snapshotRetention` policy. Different namespace, different root, not a backup-root enumerator — the ticket's five is correct, and this note exists so that is not re-derived.

## Deltas from ticket

- **`stagingResidueRoot` was added as an injectable option** on `collectMaintenanceSnapshot`, mirroring the existing `receiptPath` default. Without it the detached projection spec reads the developer's real `~/.neo-ai/backups`, making its assertions environment-dependent — a test whose value depends on the machine it runs on.
- **The observability block is unconditional, unlike the `retry` block merged in #16421.** `retry` is genuinely run-dependent and is omitted when no task state is supplied; a residue footprint is not. The `durability` precedent governs.

## AiConfig / ADR-0019

Read before authoring, per the §critical_gates read-gate. The leaf is a plain nested key in an existing object leaf; the value is read at its use site (`AiConfig.maintenance.backup.retention.keepPartials` in `runBackup`, `AiConfig.backupPath` as the snapshot default) with no alias, no export, no pass-along, no defensive `?.`, and no runtime mutation. `planeMember` does not apply — the leaf is a count, not a path resolving beneath the plane anchor.

## Test Evidence

```
NEO_TEST_SKIP_CI=true UNIT_TEST_MODE=true npm run test-unit -- \
    test/playwright/unit/ai/daemons/orchestrator/ \
    test/playwright/unit/ai/scripts/maintenance/ \
    test/playwright/unit/ai/config.template.spec.mjs
→ 1634 passed, 1 skipped
```

15 specs in `backupStagingResidueCore.spec.mjs`, plus the projection witness in `offHostSync.spec.mjs`.

**Mutation verification.** Green alone proves nothing, so each mutation must kill exactly the specs that name its term:

| mutation applied | specs killed |
|---|---|
| staging namespace widened to include `backup-` | the disjointness pin · **the spec that would have caught published bundles being deleted** · the clean-root report |
| in-flight exclusion dropped | the exclusion witness · the pure-policy exclusion case |
| retention bound off by one | growth bound · newest-survivor ordering · the log witness · the stray-file case · the exclusion witness · the pure policy |
| **writer's prefix diverged from the owner's constant** | the producer→consumer round-trip witness, and only it |
| **error-truth branch removed** (all failures → clean-empty) | the `ENOTDIR` witness · the projection's unreadable case |

The first is the careless fix the ticket names, caught both as a contract violation and as actual data destruction. The last two are the RC1 repairs, each falsifiable in isolation.

The absent-root case is deliberately a **separate** spec from the unreadable one. Without both, `status: 'ok'` could not be distinguished from "the catch swallowed everything" — which is the exact indistinguishability this whole repair is about.

## Honest gaps

- **The PER-ENTRY removal-failure branch still has no witness.** Root-level read failure is now covered by the `ENOTDIR` specimen, but an individual `fs.remove` failing mid-sweep — the `failed[]` accumulator and its `logger.error` — is not: a genuinely unremovable directory needs a permission fixture whose behaviour differs under root, which CI runs as, so it would pass locally and prove nothing in CI. A named gap beats a flaky witness.
- **Two spec defects found in my own tests, both the same shape.** One was named "a failed removal is reported" and asserted `failed` was *empty* — the non-directory entry it built is not residue, so nothing was ever doomed; it now asserts what it proves. The other, written during this RC1 repair, used a **non-existent path** as its "unreadable" specimen — that is `ENOENT`, which correctly reports `ok`, so it could not discriminate at all. Both are one error: **a specimen must be negative on the axis the assertion reads**, and a specimen I did not validate is not evidence.

## Post-Merge Validation

- [ ] Kill a backup run abruptly (SIGKILL mid-capture), confirm a `.backup-partial-*` directory survives, and confirm the previous complete bundle is still the verified restorable one.
- [ ] Repeat past `keepPartials`, and confirm the surviving set stops growing and holds the newest partials.
- [ ] Confirm each reclamation appears in the orchestrator log with the directory name and its age.
- [ ] Confirm `maintenance.stagingResidue` reports non-zero `count`/`bytes` on the deployment-state snapshot while residue exists, and an explicit zero once reclaimed.

## Commits

- `633edab0b9` — the residue core, the pre-capture sweep, the config leaf, the snapshot projection, and the specs.
- `7558ff4b34` — pin `keepPartials` in the Tier-1 maintenance policy defaults.
- `ee2fc03693` — RC1: move the creator into the namespace owner; distinguish a failed observation from an absence; backfill #16427's Contract Ledger.

---

Authored by Grace (Claude Opus 5, Claude Code). Session `9f05cd72-5457-4ec2-926c-ef1406041f19`.

Filed out of my own `Approve+Follow-Up` review of @neo-gpt's PR #16418, whose trade this PR deliberately preserves: permanent-but-inert beats prunable-but-dangerous.
