### PR TITLE
fix(hooks): let the your-call citation exemption name the authority it cites (#16411)

### DIFF
--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -76,6 +76,34 @@ function isReportedMentionContext(text, startIndex) {
 }
 
 /**
+ * The tokens that may sit between a citation anchor and the phrase it attributes.
+ *
+ * The exemption used to be adjacency-anchored (`/\bper\s+$/`), so it matched only the citation-FREE
+ * `per your call` and fired on the form §critical_gates #1 mandates — naming the gate that makes a merge
+ * the operator's decision. Satisfying that gate and passing this detector were therefore in tension, and
+ * the tension resolved the wrong way: the honest phrasing tripped while the phrasing that passed cited
+ * nothing.
+ *
+ * An allowlist, deliberately not a wildcard. Accepting `per` anywhere in the 80-character window would
+ * exempt real deference that happens to cite something earlier — the genuine slip this detector exists to
+ * catch. Ordinary prose between the anchor and the phrase still fires.
+ *
+ * Whitespace alone must be able to bridge: a backticked citation is already replaced by a space in
+ * `stripMarkdownCode`, so the idiomatic `` per `§critical_gates #1` that's your call `` reaches this
+ * predicate with its citation erased.
+ * @type {RegExp}
+ */
+const CITATION_BRIDGE = /^(?:[\s,;:.()[\]–—-]|§[\w.-]+|#\d+|\d+|gate|rule|that'?s|that\s+is|it'?s|it\s+is)*$/;
+
+/**
+ * Anchors a citation of a prior operator decision. Matched RIGHTMOST — the greedy head pushes the anchor
+ * as late as possible, so `per your call, but honestly, your call?` is judged on the nearest anchor and
+ * the trailing deferential use still fires.
+ * @type {RegExp}
+ */
+const CITATION_ANCHOR = /^[\s\S]*\b(?:per|as\s+you\s+(?:said|directed|called))\b([\s\S]*)$/;
+
+/**
  * @summary Checks whether a local "your call" match cites a prior operator decision.
  * @param {String} phrase Matched deference phrase.
  * @param {String} text Searchable assistant final-turn text.
@@ -87,10 +115,10 @@ function isAttributiveCitationContext(phrase, text, startIndex) {
         return false;
     }
 
-    const prefix = text.slice(Math.max(0, startIndex - 80), startIndex).toLowerCase();
+    const prefix  = text.slice(Math.max(0, startIndex - 80), startIndex).toLowerCase(),
+          anchored = CITATION_ANCHOR.exec(prefix);
 
-    return /\bper\s+$/.test(prefix) ||
-           /\bas\s+you\s+(?:said|directed|called)\W*$/.test(prefix);
+    return anchored !== null && CITATION_BRIDGE.test(anchored[1]);
 }
 
 /**

--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -91,9 +91,33 @@ function isReportedMentionContext(text, startIndex) {
  * Whitespace alone must be able to bridge: a backticked citation is already replaced by a space in
  * `stripMarkdownCode`, so the idiomatic `` per `§critical_gates #1` that's your call `` reaches this
  * predicate with its citation erased.
+ *
+ * Checked token-by-token rather than as one starred alternation. The alternation form
+ * (`/^(?:…|\d+|#\d+|…)*$/`) had AMBIGUOUS alternatives — a run of digits can be partitioned between
+ * `\d+` and `#\d+` in exponentially many ways, so a long numeric run drove catastrophic backtracking.
+ * CodeQL caught it on this very change (alert 119, "many repetitions of '0'"). Splitting first makes each
+ * token match a single anchored pattern with no outer quantifier, which is linear by construction — the
+ * separator set is the same one that used to live inside the alternation.
  * @type {RegExp}
  */
-const CITATION_BRIDGE = /^(?:[\s,;:.()[\]–—-]|§[\w.-]+|#\d+|\d+|gate|rule|that'?s|that\s+is|it'?s|it\s+is)*$/;
+const CITATION_BRIDGE_TOKEN = /^(?:§[\w.-]+|#\d+|\d+|gate|rule|that'?s|that|it'?s|is)$/;
+
+/**
+ * Splits a bridge into tokens. Empty tokens are expected — a bridge of pure separators (`': '`, or the
+ * whitespace left where a backticked citation was) splits to nothing but empties, and must pass.
+ * @type {RegExp}
+ */
+const CITATION_BRIDGE_SEPARATORS = /[\s,;:.()[\]–—-]+/;
+
+/**
+ * @summary Checks whether every token between a citation anchor and the phrase is citation-shaped.
+ * @param {String} bridge Text between the anchor and the phrase.
+ * @returns {Boolean}
+ */
+function isCitationBridge(bridge) {
+    return bridge.split(CITATION_BRIDGE_SEPARATORS)
+        .every(token => token === '' || CITATION_BRIDGE_TOKEN.test(token));
+}
 
 /**
  * Anchors a citation of a prior operator decision. Matched RIGHTMOST — the greedy head pushes the anchor
@@ -118,7 +142,7 @@ function isAttributiveCitationContext(phrase, text, startIndex) {
     const prefix  = text.slice(Math.max(0, startIndex - 80), startIndex).toLowerCase(),
           anchored = CITATION_ANCHOR.exec(prefix);
 
-    return anchored !== null && CITATION_BRIDGE.test(anchored[1]);
+    return anchored !== null && isCitationBridge(anchored[1]);
 }
 
 /**

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -79,6 +79,39 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
             .toBeNull();
     });
 
+    test('the citation may NAME the authority it cites (#16411)', () => {
+        // From a live false positive on a merge-eligibility hand-off. §critical_gates #1
+        // requires handing a merge to the operator, so every correct execution of that gate ends on a
+        // sentence assigning the decision — and the accurate way to write one names the gate. The old
+        // adjacency anchor (`/\bper\s+$/`) matched only the citation-FREE `per your call`, so the honest
+        // phrasing tripped while the phrasing that passed cited nothing.
+        expect(matchDeferencePhrase("Merge-eligible; per §critical_gates #1 that's your call.")).toBeNull();
+        expect(matchDeferencePhrase("As you said, per gate #1, that's your call.")).toBeNull();
+        // Anticipated rather than transcript-observed, and the narrowest of the four: a dash bridging the
+        // citation to the phrase. Cut this assertion and the dash characters together if a reviewer wants
+        // the exemption held to observed forms only — the word allowlist, not the punctuation, is what
+        // keeps the guard below honest.
+        expect(matchDeferencePhrase('Eligible per rule 1 — your call.')).toBeNull();
+
+        // A backticked citation is replaced by a space upstream in `stripMarkdownCode`, so this predicate
+        // sees `per   that's` with the citation erased. Whitespace alone therefore has to bridge, or the
+        // most idiomatic form in this repo would remain a false positive.
+        expect(matchDeferencePhrase("Merge-eligible; per `§critical_gates #1` that's your call.")).toBeNull();
+    });
+
+    test('a citation anchor does NOT exempt ordinary deference around it (#16411)', () => {
+        // The over-correction, pinned rather than intended. Widening to "`per` appears anywhere in the
+        // 80-character window" would exempt exactly the slip this detector exists to catch, so the bridge
+        // is an allowlist: any ordinary prose between the anchor and the phrase still fires.
+        expect(matchDeferencePhrase("Per your earlier note, I've left the direction open, your call."))
+            .toBe('your call');
+        expect(matchDeferencePhrase('As you said the sequencing matters, so which one first — your call?'))
+            .toBe('your call');
+        // Citation SHAPE is not authority: a §section or #ticket nearby exempts nothing without an anchor.
+        expect(matchDeferencePhrase('§critical_gates #1 is the gate. Your call on the merge?'))
+            .toBe('your call');
+    });
+
     test('still matches live deference uses of your call', () => {
         expect(matchDeferencePhrase('Your call on the branch cut.')).toBe('your call');
         expect(matchDeferencePhrase("It's your call whether I pick this up.")).toBe('your call');


### PR DESCRIPTION
Resolves #16411

Related: #16325 / PR #16326 (the same pattern-complete-but-composition-blind failure one level up, in the phrase list rather than the exemptions)

The `your call` exemption was adjacency-anchored — `/\bper\s+$/` matched only the citation-FREE `per your call`, and fired on the form this repo mandates.

§critical_gates #1 requires an agent to hand a merge to the human operator. Every correct execution of that gate produces a turn-terminal sentence assigning the decision, and the accurate way to write one names the gate. So **satisfying gate #1 and passing the deference detector were in tension, and the tension resolved the wrong way**: the honest phrasing (cite the rule) tripped, while the phrasing that passed (`per your call`) cites nothing and reads worse. Live instance: PR #16397 reported merge-eligible 2026-08-02.

Evidence: L2 (unit coverage at exact head; the matcher is pure and fully reachable in-sandbox) → L2 required, every AC being an assertion on a return value.

## The fix, and the trap it had to avoid

The citation window may now contain the cited authority: a **bounded allowlist** of citation tokens (`§section`, `#ticket`, bare digits, `gate`, `rule`), copular connectives (`that's` / `that is` / `it's` / `it is`), punctuation, dashes and whitespace between the anchor and the phrase.

**An allowlist, deliberately not a wildcard.** The ticket's named trap is widening to "`per` appears anywhere in 80 characters", which would exempt real deference that happens to cite something earlier — the genuine slip this detector exists to catch. That over-correction is **pinned by a spec, not avoided by intent**.

**Two details that only surface empirically:**

**Whitespace alone has to bridge.** `stripMarkdownCode` runs first and replaces a backticked citation with a space, so the most idiomatic form in this repo — `` per `§critical_gates #1` that's your call `` — reaches this predicate as `per   that's` with its citation already erased. A citation-shape requirement would have left exactly that form still firing, which is the shape I'd most often write.

**The anchor matches rightmost, not leftmost.** With a leftmost anchor, `as you said, per gate #1, that's your call` fails: the bridge from `as you said` contains `per`, which is not an allowlisted token. A greedy head pushes the anchor as late as possible, which also keeps `per your call, but honestly, your call?` firing on its trailing deferential use.

## The `:74-75` audit — a positive finding, deliberately not fixed here

The ticket required auditing `isReportedMentionContext`'s two patterns for the same adjacency narrowness. **They have it.** Probed against the exact head:

| phrasing | today |
|---|---|
| `The phrase your call is in the corpus.` | exempt |
| `The reported phrase your call fired.` | **fires** |
| `The deference phrase, your call, fired at turn-end.` | **fires** |
| `The phrase list entry your call needs no change.` | **fires** |

A modifier between the determiner and the noun breaks the exemption. The tripping shape is the sentence `DEFERENCE_REMINDER` itself asks an agent to write when reporting a false positive — *"open a ticket to sharpen it"* — so the hook currently penalizes its own friction→gold instruction.

**Left unchanged on purpose.** The ticket conditions any change there on *"a phrasing observed in a real transcript rather than invented for the test"*, and I have reachability, not an observed instance. Inventing one to justify the change is precisely what that AC forbids. Recorded on the ticket with this evidence and an explicit trigger: the first transcript instance promotes it to a follow-up. Folding it in would also make this PR two decisions — the second fix is a different widening (tolerating a modifier run *and* trailing punctuation after the noun) with its own over-correction analysis.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/hooks/ --workers=1
  263 passed (12.0s)
```

Directory-scoped rather than file-scoped: both importers of this module — `stopHookDecision.mjs` and `laneStateStopHook.mjs` — have their specs in the same folder, so the folder is the regression surface. 15 of those are this matcher's own (2 tests added).

**Mutation-verified.** Each new term reverted turns the predicted specs red:

| term deleted | specs that go red |
|---|---|
| bridge allowlist → `[\s\S]*` (the ticket's named over-correction) | the new anchor-does-not-exempt guard **and** the pre-existing *"still fires when a live use follows a carved mention"* |
| rightmost anchor → leftmost | the citation-may-name case (`as you said, per gate #1`) |

The first row is the one worth reading: the trap the ticket warned about is caught by a **pre-existing** regression test as well as the new one, so this widening could not have shipped silently even without the guard I added.

## Deltas

- One predicate widened (`isAttributiveCitationContext`) plus two module-level regex constants naming the anchor and the bridge. No `DEFERENCE_PHRASES` entry added or removed; no new exemption category; `isReportedMentionContext` untouched.
- **Substrate accretion:** net +34 lines in the module, mostly the JSDoc explaining the gate-#1 tension so the next reader does not re-derive it. Sunset condition carried from the ticket: if `your call` ever needs a *third* context carve-out, the phrase is the wrong instrument and should be replaced by a turn-shape check — whether the turn names and starts a next lane, which is the thing this detector only proxies for.
- One assertion is anticipated rather than transcript-observed and is labelled as such in the spec (a dash bridging citation to phrase). It and the dash characters can be cut together; the word allowlist, not the punctuation, is what keeps the over-correction guard honest.

## Post-Merge Validation

- [ ] A merge-eligibility hand-off citing §critical_gates #1 completes a turn without the hook firing.
- [ ] The hook still fires on a genuine lane-handback that happens to cite a ticket earlier in the sentence.

## What this does NOT fix

The hook was substantively right about my turn even while wrong about the phrase: I ended on a table of items awaiting the operator instead of naming and starting my next lane, which is the §swarm_topology_anchor AND-discipline. A phrase detector cannot see turn shape, and this PR does not pretend to.

Authored by Vega (Claude Opus 5, Claude Code). Session 11695cce-9854-4be2-80c3-8ea4322298bf.
