### PR TITLE
fix: DockFlip play resolves under rendering starvation (#16425)

### DIFF
--- a/src/main/addon/DockFlip.mjs
+++ b/src/main/addon/DockFlip.mjs
@@ -423,6 +423,12 @@ class DockFlip extends Base {
      * a starved tick as its instant-landing signal — animating a document that cannot paint
      * would only hold transform-scaled mid-motion rects live for async measurers to read as
      * layout truth.
+     *
+     * The race disposes BOTH arms symmetrically (the sibling ResizeObserver dam's contract):
+     * a frame win clears the timer, and a dam win cancels the pending rAF callback. Without
+     * the cancellation, every timer-won wait in a frame-starved-but-visible window would
+     * leave its callback queued — dock operations accumulate them unboundedly, and they all
+     * fire in one burst when the window finally presents again.
      * @param {Number} [budgetMs=100] Generously above one healthy frame (17-34ms), far below
      * a perceivable stall — a presenting document virtually always wins with a real frame.
      * @returns {Promise<Boolean>} true when a real frame serviced the wait, false when the dam fired
@@ -430,12 +436,14 @@ class DockFlip extends Base {
      */
     #nextFrame(budgetMs=100) {
         return new Promise(resolve => {
-            let timer = setTimeout(() => {
-                timer = null;
-                resolve(false)
-            }, budgetMs);
+            let frameId   = null,
+                timer     = setTimeout(() => {
+                    timer = null;
+                    globalThis.cancelAnimationFrame?.(frameId);
+                    resolve(false)
+                }, budgetMs);
 
-            requestAnimationFrame(() => {
+            frameId = requestAnimationFrame(() => {
                 if (timer !== null) {
                     clearTimeout(timer);
                     timer = null;

--- a/src/main/addon/DockFlip.mjs
+++ b/src/main/addon/DockFlip.mjs
@@ -31,6 +31,21 @@ const MOTION_EPSILON_POSITION = 0.5,
  * Presentation-only by contract: the committed document never waits on motion — a failed or
  * skipped animation lands the final layout instantly (every path here is fail-safe), and
  * `prefers-reduced-motion: reduce` renders the instant path by construction.
+ *
+ * Starvation-proof by contract, two layers for two starvation classes:
+ * 1. HIDDEN documents (`document.hidden === true` — agent browser panes, background tabs)
+ *    instant-land at `play()` entry: motion is unpresentable there by definition, rAF is
+ *    never serviced, AND main-thread timers are visibility-clamped (>=1s, down to ~1
+ *    wake/min under intensive throttling) — no in-page wait of any kind stays bounded.
+ * 2. OCCLUDED-but-visible windows service no frames but keep normal timer clamps, so every
+ *    frame wait inside `play()` races the native rAF arm against a timer dam (`#nextFrame`).
+ *    Frames win in every presenting document, keeping motion frame-locked; the dam bounds
+ *    the wait where no frame comes, degrading motion to the instant path while correctness
+ *    and liveness hold.
+ * Pre-repair, a raw `requestAnimationFrame` await wedged every awaiting consumer forever
+ * (witnessed: the workstation tour preamble hung inside `refreshDockWorkspace`). Same law as
+ * the ResizeObserver addon's timer-raced dispatch dam + hidden poll: paint-gated carriers
+ * need a paint-independent arm.
  * @class Neo.main.addon.DockFlip
  * @extends Neo.main.addon.Base
  */
@@ -399,6 +414,38 @@ class DockFlip extends Base {
     }
 
     /**
+     * One frame boundary that cannot starve. The native rAF arm wins in every presenting
+     * document (identical timing to a raw `requestAnimationFrame` await); the timer dam
+     * bounds the wait in rendering-starved documents, where rAF callbacks are never serviced
+     * and a raw await would wedge the caller forever. The dam result lets callers
+     * distinguish a serviced frame from a starved tick: loops re-check DOM state either way
+     * (delta application is message-driven and needs no frames), while the release path uses
+     * a starved tick as its instant-landing signal — animating a document that cannot paint
+     * would only hold transform-scaled mid-motion rects live for async measurers to read as
+     * layout truth.
+     * @param {Number} [budgetMs=100] Generously above one healthy frame (17-34ms), far below
+     * a perceivable stall — a presenting document virtually always wins with a real frame.
+     * @returns {Promise<Boolean>} true when a real frame serviced the wait, false when the dam fired
+     * @private
+     */
+    #nextFrame(budgetMs=100) {
+        return new Promise(resolve => {
+            let timer = setTimeout(() => {
+                timer = null;
+                resolve(false)
+            }, budgetMs);
+
+            requestAnimationFrame(() => {
+                if (timer !== null) {
+                    clearTimeout(timer);
+                    timer = null;
+                    resolve(true)
+                }
+            })
+        })
+    }
+
+    /**
      * Phase 2: wait for the new tree's marker elements, invert them onto their old geometry,
      * then play the transition to their new geometry. Safe to call unconditionally after a
      * swap — with no prior `captureFirst()` snapshot, or under reduced motion, it no-ops and
@@ -410,7 +457,9 @@ class DockFlip extends Base {
      * @param {Object} opts
      * @param {String} opts.hostId            The dock host element id
      * @param {String} opts.markerPrefix      The marker-class prefix used in `captureFirst()`
-     * @param {Number} [opts.maxFrames=15]    Bounded frame-poll for the new tree to appear
+     * @param {Number} [opts.maxFrames=15]    Bounded frame-poll for the new tree to appear.
+     * Every poll tick rides `#nextFrame`, so the bound holds in TIME even where no frame is
+     * ever serviced (maxFrames × dam budget) — not only in serviced-frame count
      * @param {Boolean} [opts.geometryOnly=false] Consumer-declared geometry-only projection:
      * no topology swap can be pending, so an exact, lineage-unchanged marker set whose rects
      * already moved may be classified as landed-in-place (`hasLandedInPlace`). Without this
@@ -471,6 +520,17 @@ class DockFlip extends Base {
             return false
         }
 
+        // A hidden document cannot present motion by definition — and it throttles the very
+        // carriers a bounded wait could ride: rAF is never serviced, and main-thread timers
+        // are visibility-clamped (>=1s per tick, down to ~1 wake/min under intensive
+        // throttling), so even the timer dam degrades from milliseconds to minutes there
+        // (witnessed: the pane tour preamble sat wedged in stage A at ~1 tick/min). The RO
+        // addon keys its hidden poll on the same discriminator. Occluded-but-visible windows
+        // keep normal timer clamps, so the dam below remains the carrier for that class.
+        if (document.hidden) {
+            return false
+        }
+
         const
             firstLineages = first.lineages,
             firstMarkers  = first.markers,
@@ -511,7 +571,7 @@ class DockFlip extends Base {
             // proof the swap already happened.
             if (!preservedMarkerSet && !landedInPlace) {
                 while (frame < maxFrames && first.els.length > 0 && first.els.every(el => el.isConnected)) {
-                    await new Promise(resolve => requestAnimationFrame(resolve));
+                    await this.#nextFrame();
                     frame++
                 }
             }
@@ -520,7 +580,7 @@ class DockFlip extends Base {
             markers = this.collectMarkers(hostId, markerPrefix);
 
             while (markers.size < 1 && frame < maxFrames * 2) {
-                await new Promise(resolve => requestAnimationFrame(resolve));
+                await this.#nextFrame();
                 frame++;
                 markers = this.collectMarkers(hostId, markerPrefix)
             }
@@ -536,7 +596,7 @@ class DockFlip extends Base {
             // delaying here would expose the clipped final tree for one paint before the
             // inverse transform is installed.
             if (!preservedMarkerSet && !landedInPlace) {
-                await new Promise(resolve => requestAnimationFrame(resolve))
+                await this.#nextFrame()
             }
 
             markers.forEach((el, key) => {
@@ -629,7 +689,18 @@ class DockFlip extends Base {
                 fade && (el.style.opacity = '0.001')
             });
 
-            await new Promise(resolve => requestAnimationFrame(resolve));
+            // The invert must be committed by a real frame before the transition is released —
+            // a starved tick here means the document is not painting, so there is no motion to
+            // present: land instantly instead of transitioning into a void (and instead of
+            // holding transform-scaled mid-motion rects live for async measurers to misread
+            // as layout truth).
+            const framed = await this.#nextFrame();
+
+            if (!framed) {
+                cleanup();
+
+                return false
+            }
 
             if (interrupted || this.isDestroyed) {
                 cleanup(true);

--- a/test/playwright/e2e/workstation/WorkstationStarvedTourNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationStarvedTourNL.spec.mjs
@@ -1,0 +1,168 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: the dense tour and the Sparkline offscreen pipeline survive rendering starvation.
+ *
+ * Sibling to WorkstationStarvedGeometryNL, which proved grid GEOMETRY converges without
+ * rendering opportunities. This spec closes the remaining starved legs of the same physical
+ * law: paint-gated carriers die in documents that never paint — hidden browser panes,
+ * occluded or backgrounded windows — while worker timers and postMessage keep flowing.
+ *
+ * Two claims, one rig:
+ *
+ * 1. REGISTRATION LEG — Sparkline offscreen registration is message-driven end to end
+ *    (`afterSetMounted` → worker timeout → `DomAccess#transferCanvasToWorker` →
+ *    `transferControlToOffscreen` → direct transfer to the Canvas Worker →
+ *    `registerCanvasDirect` → `canvasRegistered` ping → flag flip) and completes under full
+ *    starvation for EVERY sparkline, before any tour interaction. No leg may ride rAF, RO,
+ *    or paint. Instrumented classification falsified the original worker-first-paint
+ *    hypothesis: registration was never the starved leg.
+ *
+ * 2. TOUR LEG — the dense tour completes 11 deterministic beats + 6 surface cues under the
+ *    rig. Pre-repair it hung FOREVER in the `startTour` preamble: `DockFlip#play` awaited raw
+ *    `requestAnimationFrame` promises (stage-A detach poll, stage-B marker poll, settle frame,
+ *    release frame) whose loops were bounded in frame COUNT, not time — in a never-painting
+ *    document the first await wedged every dock re-projection. The repair is two-layered:
+ *    hidden documents instant-land at `play()` entry (motion is unpresentable there, and
+ *    hidden pages ALSO visibility-clamp main-thread timers to >=1s/tick — even a timer dam
+ *    degrades to minutes, witnessed live in the agent pane); occluded-but-visible windows
+ *    keep normal timer clamps, so each frame wait races a timer dam (`#nextFrame`) there.
+ *    This spec's hidden override exercises the entry discriminator; the dam owns the
+ *    occluded class at the unit floor (DockFlip.spec.mjs). Live panes only ever progressed
+ *    because CDP screenshots force compositor frames — tooling, not product.
+ *
+ * The tour is driven through the Neural Link fixture (`callMethod`), not the play button:
+ * with rAF black-holed, locator actionability checks would hang by design. All settlement is
+ * bounded expect.poll on state — no fixed-delay sleeps, no locator actions.
+ *
+ * Run: npx playwright test WorkstationStarvedTourNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Workstation rendering starvation: sparkline registration + dense tour (#16425)', () => {
+    test.setTimeout(300000);
+    test.use({viewport: {width: 1280, height: 720}});
+
+    test('every sparkline registers and the dense tour completes without a single rendering opportunity', async ({page, neuralLink}) => {
+        await page.addInitScript(() => {
+            // The starvation rig — identical to WorkstationStarvedGeometryNL: no native
+            // deliveries, no serviced frames, a hidden document.
+            window.ResizeObserver = class {
+                observe() {}
+                unobserve() {}
+                disconnect() {}
+            };
+
+            window.__starvedFrameRequests = 0;
+
+            window.requestAnimationFrame = () => {
+                window.__starvedFrameRequests++;
+                return 0
+            };
+            window.cancelAnimationFrame = () => {};
+
+            Object.defineProperty(Document.prototype, 'hidden', {
+                configurable: true,
+                get         : () => true
+            });
+            Object.defineProperty(Document.prototype, 'visibilityState', {
+                configurable: true,
+                get         : () => 'hidden'
+            });
+        });
+
+        await page.goto('/apps/workstation/index.html');
+
+        // RIG CONTROL: the app must actually see the starved environment.
+        const rig = await page.evaluate(() => ({
+            hidden         : document.hidden,
+            visibilityState: document.visibilityState
+        }));
+
+        expect(rig.hidden).toBe(true);
+        expect(rig.visibilityState).toBe('hidden');
+
+        // Boot leg (the ResizeObserver-addon starvation carrier owns the geometry claim —
+        // WorkstationStarvedGeometryNL; here it is only the gate that the app reached a
+        // living state to measure against).
+        await expect.poll(
+            () => page.evaluate(() => document.querySelectorAll('[role="row"]').length),
+            {message: 'the row pool populates without rendering opportunities', timeout: 30000}
+        ).toBeGreaterThan(20);
+
+        const app         = await neuralLink.connectToApp('Workstation'),
+              workspaces  = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+              wsList      = Array.isArray(workspaces) ? workspaces : workspaces ? [workspaces] : [],
+              workspaceId = wsList[0]?.id;
+
+        expect(workspaceId).toBeTruthy();
+
+        // REGISTRATION LEG: every mounted Sparkline flips offscreenRegistered with zero
+        // serviced frames — measured, not delayed-for.
+        const readSparklineCensus = async () => {
+            const instances = await app.findInstances(
+                {className: 'Neo.component.Sparkline'},
+                ['id', 'mounted', 'offscreenRegistered']
+            );
+            const list = Array.isArray(instances) ? instances : instances ? [instances] : [];
+
+            return {
+                mounted   : list.filter(entry => entry.properties?.mounted).length,
+                registered: list.filter(entry => entry.properties?.offscreenRegistered).length,
+                total     : list.length
+            }
+        };
+
+        await expect.poll(async () => {
+            const census = await readSparklineCensus();
+            return census.total > 0 && census.registered === census.total
+        }, {message: 'every sparkline completes offscreen registration under starvation', timeout: 30000}).toBe(true);
+
+        const census = await readSparklineCensus();
+
+        expect(census.total, 'the pool renders a real sparkline population').toBeGreaterThan(10);
+        expect(census.mounted, 'every sparkline is mounted').toBe(census.total);
+        expect(census.registered, 'every sparkline is registered into the Canvas Worker').toBe(census.total);
+
+        // TOUR LEG: the full dense tour settles with a complete receipt. The RPC is fired
+        // without awaiting so no bridge timeout can shadow the app-side truth; the receipt
+        // poll is the settle gate.
+        const tourRpc = app.callMethod(workspaceId, 'startTour').catch(error => ({rpcError: String(error)}));
+
+        await expect.poll(async () => {
+            try {
+                const state = await app.getComponent(workspaceId, ['lastTourReceipt']);
+                return !!state?.lastTourReceipt
+            } catch {
+                return false
+            }
+        }, {message: 'the tour settles with a receipt under starvation', timeout: 200000}).toBe(true);
+
+        await tourRpc;
+
+        const {lastTourReceipt} = await app.getComponent(workspaceId, ['lastTourReceipt']);
+
+        expect(lastTourReceipt.errors, 'the starved tour reports zero errors').toEqual([]);
+        expect(lastTourReceipt.completed, 'the starved tour completes').toBe(true);
+        expect(lastTourReceipt.log?.length, 'all 11 deterministic beats executed').toBe(11);
+        expect(lastTourReceipt.cueReceipts?.length, 'all 6 surface cues settled').toBe(6);
+        expect(lastTourReceipt.cueReceipts.map(entry => entry.cue.type),
+            'the cue set includes the canvas-update pulse')
+            .toContain('canvas-update');
+
+        const canvasUpdate = lastTourReceipt.cueReceipts.find(entry => entry.cue.type === 'canvas-update');
+
+        expect(canvasUpdate.receipt, 'the canvas-update cue produced an observable receipt (not the fail-closed false)')
+            .toMatchObject({componentId: expect.stringContaining('sparkline')});
+
+        // The operator-visible truth: the exact completion caption.
+        const caption = await page.evaluate(() =>
+            document.querySelector('.workstation-tour-caption')?.textContent ?? null);
+
+        expect(caption).toBe('Tour complete — 11 deterministic beats and 6 surface cues settled.');
+
+        // RIG CONTROL, closing: frames were requested but never serviced — the run really
+        // happened under starvation (a rig failure must fail the spec, not green-wash it).
+        const frameRequests = await page.evaluate(() => window.__starvedFrameRequests);
+
+        expect(frameRequests).toBeGreaterThan(0)
+    });
+});

--- a/test/playwright/unit/dashboard/DockFlip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockFlip.spec.mjs
@@ -842,6 +842,75 @@ test.describe('Neo.main.addon.DockFlip', () => {
         })
     });
 
+    test('cancels the losing rAF arm on every timer-won wait — no late frame callback stays queued (#16425)', async () => {
+        // The race must dispose BOTH arms (the ResizeObserver dam contract). Without the
+        // cancellation, each timer-won wait in a frame-starved-but-visible window leaves its
+        // callback queued; dock operations accumulate them unboundedly and they all fire in
+        // one burst when the window presents again.
+        const
+            markerClass = 'dock-flip-item-alpha',
+            marker      = createMarker(markerClass, {height: 100, left: 0, top: 0, width: 100}),
+            host        = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            };
+
+        marker.parentElement = host;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = () => ({
+            getPropertyValue(name) {
+                return name === '--dock-transition-duration' ? '260ms' : 'linear'
+            }
+        });
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.setRect({height: 100, left: 80, top: 40, width: 100});
+
+        // Black-holed rAF with id bookkeeping: callbacks register but are never invoked.
+        const
+            registered          = new Set(),
+            cancelled           = new Set(),
+            originalCancelFrame = globalThis.cancelAnimationFrame;
+
+        let nextFrameId = 0;
+
+        globalThis.requestAnimationFrame = () => {
+            const id = ++nextFrameId;
+            registered.add(id);
+            return id
+        };
+        globalThis.cancelAnimationFrame = id => cancelled.add(id);
+
+        try {
+            await expect(dockFlip.play({
+                hostId      : 'dock-host',
+                markerPrefix: 'dock-flip-item-',
+                maxFrames   : 2
+            })).resolves.toBe(false);
+
+            expect(registered.size, 'two detach polls, one replacement settle, and one release tick registered').toBe(4);
+            expect([...cancelled].sort(), 'every timer-won wait cancelled exactly its own losing arm')
+                .toEqual([...registered].sort());
+            expect([...registered].filter(id => !cancelled.has(id)),
+                'no frame callback stays queued after the starved run').toEqual([])
+        } finally {
+            originalCancelFrame === undefined
+                ? delete globalThis.cancelAnimationFrame
+                : globalThis.cancelAnimationFrame = originalCancelFrame
+        }
+    });
+
     test('restores the host class and every temporary style when a post-invert frame fails', async () => {
         const
             markerClass     = 'dock-flip-item-alpha',

--- a/test/playwright/unit/dashboard/DockFlip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockFlip.spec.mjs
@@ -652,6 +652,196 @@ test.describe('Neo.main.addon.DockFlip', () => {
         await expect(playPromise).resolves.toBe(false)
     });
 
+    test('instant-lands at entry in a hidden document without arming a single wait (#16425)', async () => {
+        // A hidden document cannot present motion, services no rAF, and visibility-clamps
+        // main-thread timers (>=1s per tick, ~1 wake/min intensive) — so neither frame waits
+        // nor the timer dam stay bounded there. The entry discriminator must land instantly
+        // before any wait is armed.
+        const
+            markerClass = 'dock-flip-item-alpha',
+            marker      = createMarker(markerClass, {height: 100, left: 0, top: 0, width: 100}),
+            host        = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            };
+
+        marker.parentElement = host;
+
+        globalThis.document = {
+            hidden: true,
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = () => ({
+            getPropertyValue(name) {
+                return name === '--dock-transition-duration' ? '260ms' : 'linear'
+            }
+        });
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.setRect({height: 100, left: 80, top: 40, width: 100});
+
+        let frameRequests = 0;
+
+        globalThis.requestAnimationFrame = () => ++frameRequests;
+
+        await expect(dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-'
+        })).resolves.toBe(false);
+
+        expect(frameRequests, 'no frame wait is ever armed in a hidden document').toBe(0);
+        expect(marker.style, 'no presentation state is touched').toEqual({})
+    });
+
+    test('lands instantly when rendering starvation never services the release frame (#16425)', async () => {
+        // Rendering-starved documents (hidden panes, occluded windows) request frames that are
+        // never serviced. Pre-dam, play() awaited the raw rAF promise here and never resolved,
+        // wedging every awaiting consumer (the workstation tour hung in refreshDockWorkspace).
+        // The timer dam bounds the wait; a starved release tick lands instantly with a full
+        // presentation cleanup.
+        const
+            markerClass     = 'dock-flip-item-alpha',
+            marker          = createMarker(markerClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            sourceBody      = {parentElement: null},
+            destinationBody = {
+                parentElement: null,
+                getBoundingClientRect() {
+                    return {bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100}
+                }
+            },
+            host            = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            },
+            visibleStyle = {
+                contain    : 'none',
+                filter     : 'none',
+                overflowX  : 'visible',
+                overflowY  : 'visible',
+                perspective: 'none',
+                transform  : 'none',
+                willChange : 'auto',
+                getPropertyValue(name) {
+                    return name === '--dock-transition-duration' ? '260ms' : 'linear'
+                }
+            };
+
+        sourceBody.parentElement      = host;
+        destinationBody.parentElement = host;
+        marker.parentElement          = sourceBody;
+        marker.style.position         = 'relative';
+        marker.style.zIndex           = '11';
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = element => element === destinationBody
+            ? {...visibleStyle, overflowX: 'hidden', overflowY: 'hidden'}
+            : visibleStyle;
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.parentElement = destinationBody;
+        marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
+
+        let frameRequests = 0;
+
+        globalThis.requestAnimationFrame = () => ++frameRequests;
+
+        const startedAt = Date.now();
+
+        await expect(dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-'
+        })).resolves.toBe(false);
+
+        expect(Date.now() - startedAt, 'the dam bounds the starved wait in time').toBeLessThan(5000);
+        expect(frameRequests, 'exactly the release frame was requested on the preserved path').toBe(1);
+        expect(host.classList.contains('dock-animating')).toBe(false);
+        expect(marker.style).toMatchObject({
+            opacity        : '',
+            position       : 'relative',
+            transform      : '',
+            transformOrigin: '',
+            transition     : '',
+            zIndex         : '11'
+        });
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false)
+    });
+
+    test('bounds the detach and settle polls in time when no frame is ever serviced (#16425)', async () => {
+        // The same ambiguous same-parent fixture the presenting-mode test animates (frame
+        // stub invoking callbacks) resolves to an instant landing under starvation: the polls
+        // tick on the dam instead of frames, stay count-bounded, and the starved release tick
+        // skips the transition.
+        const
+            markerClass = 'dock-flip-item-alpha',
+            marker      = createMarker(markerClass, {height: 100, left: 0, top: 0, width: 100}),
+            host        = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            };
+
+        marker.parentElement = host;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = () => ({
+            getPropertyValue(name) {
+                return name === '--dock-transition-duration' ? '260ms' : 'linear'
+            }
+        });
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.setRect({height: 100, left: 80, top: 40, width: 100});
+
+        let frameRequests = 0;
+
+        globalThis.requestAnimationFrame = () => ++frameRequests;
+
+        const startedAt = Date.now();
+
+        await expect(dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-',
+            maxFrames   : 2
+        })).resolves.toBe(false);
+
+        expect(Date.now() - startedAt, 'the dam bounds every starved poll in time').toBeLessThan(5000);
+        expect(frameRequests, 'two detach polls, one replacement settle, and one starved release tick').toBe(4);
+        expect(host.classList.contains('dock-animating')).toBe(false);
+        expect(marker.style).toMatchObject({
+            opacity        : '',
+            transform      : '',
+            transformOrigin: '',
+            transition     : ''
+        })
+    });
+
     test('restores the host class and every temporary style when a post-invert frame fails', async () => {
         const
             markerClass     = 'dock-flip-item-alpha',


### PR DESCRIPTION
Resolves #16425

The classification the ticket demanded convicted a different seam than either of its hypotheses: the Sparkline offscreen-registration triangle is message-driven end to end and registers 31/31 under full synthetic starvation (and live in the hidden pane) — the starved leg was `DockFlip#play`, which awaited raw `requestAnimationFrame` promises at four points with loops bounded in frame COUNT, not time. In a never-painting document the first await wedged forever, and every dock re-projection funnels through `refreshDockWorkspace → flip.play()`, so the dense tour hung in its preamble before firing a single scene event. The repair is two layers at that owning seam, one per starvation class: hidden documents (`document.hidden === true`) instant-land at entry — motion is unpresentable there, and hidden pages ALSO visibility-clamp main-thread timers (>=1s/tick, ~1 wake/min intensive), so no in-page wait of any kind stays bounded (witnessed live: the dam-only iteration left the pane tour wedged-in-practice); occluded-but-visible windows keep normal timer clamps, so every former raw rAF await now rides `#nextFrame` — the native rAF arm raced against a 100ms timer dam, with BOTH arms disposed symmetrically (frame win clears the timer; dam win cancels the retained rAF id — cycle-1 hardening, matching the sibling ResizeObserver dam's contract). Frames win in every presenting document (motion frame-locked, presenting behavior unchanged); the dam bounds the wait where no frame comes, and a starved release tick lands instantly instead of transitioning into a void. Under the rig the dense tour now completes 11 beats + 6 cues in ~15s with the exact completion caption; in the real hidden pane the tour progresses through beats live and settles (the residual overflow-cue leg is #16434). The close target #16425 is truth-folded to the classified owner and carries the `DockFlip#play` Contract Ledger (RA-2).

Evidence: L3 achieved (CI-runnable starved-rig e2e + live hidden-pane probe at head) → L3 required (every close-target AC is runtime-observable in CI or the live pane; no operator-gated surface). Residual: none on the close-target ACs — the pane overflow-cue leg is #16434, the timer-throttling carrier audit is #16435.

## Deltas from ticket

- The ticket's original Fix anticipated classifying between main-side dispatch and worker-side confirmation; instrumentation falsified BOTH — registration was never the starved leg (receipts: issue comment `5165222999`). The repair therefore lands in `src/main/addon/DockFlip.mjs`; the witness spec still pins the registration AC (census assertion) so the exonerated mechanism cannot silently regress. The ticket body is now truth-folded to this classification with the original premise preserved as falsified archaeology.
- Second repair layer (the hidden entry discriminator) emerged from the live-pane re-measure: genuinely hidden pages clamp main-thread timers, so the dam alone degrades to minutes there. Synthetic rigs cannot model this (their `hidden` is a JS override; their timers run free) — the law is documented at the addon seam and audited swarm-wide via #16435.
- Cycle-1 hardening (Emmy RA-1): `#nextFrame` disposes both race arms — a timer win now cancels the pending rAF callback, so frame-starved-but-visible windows accumulate zero queued callbacks across dock operations.
- Residuals filed instead of scope-crept: #16434 (overflow cue starves pane-only), #16435 (main-thread timer visibility-throttling carrier audit).

## Test Evidence

All receipts at the current exact head `86a2ab8efa`:

- `npm run test-unit -- test/playwright/unit/dashboard/DockFlip.spec.mjs` → **15/15 passed** (3.4s): all 11 pre-existing presenting-path tests keep their exact frame-count pins under the dam; 4 starvation witnesses — hidden entry discriminator (0 frame requests, no state touched), starved release instant-landing (1 request, full cleanup, time-bounded), starved bounded polls (4 requests, same fixture as the presenting variant with the opposite outcome), and the cycle-1 cancellation witness (black-holed rAF with id bookkeeping: 4 timer-won waits register 4 arms, cancel exactly those 4, zero callbacks left queued).
- `npx playwright test WorkstationStarvedTourNL -c test/playwright/playwright.config.e2e.mjs --workers=1` → **1/1 passed** (15.5s at head): registration census 31/31 mounted+registered under zero serviced frames, tour receipt `completed: true`, 11-entry log, 6 cue receipts including a non-false `canvas-update`, exact caption `Tour complete — 11 deterministic beats and 6 surface cues settled.`, rig-liveness controls.
- `npx playwright test WorkstationStarvedGeometryNL WorkstationDockFlipResizeNL DockMotionNL WorkstationSplitterGridGeometryNL -c ... --workers=1` → **11/11 passed** (50s, pre-RA-1 head; the RA-1 delta touches only the timer-win branch these presenting-mode specs never enter — frame wins clear the timer exactly as before).
- Headed `workstation/WorkstationNL`: fails `securityFullyClippedFrames` on this branch **and identically on baseline `e10992deb3`** (3 vs 2 zero-rect samples, timing-sensitive) — pre-existing, receipts posted to #16356; every monitor before that point passes on both runs, including both fixed-stage bursts with multi-frame staging (real FLIP motion demonstrably plays with the dam active).
- Live hidden pane (operator-symptom environment, receipts on #16425 comment `5165465808`): `document.hidden: true` with real bounds, all sparklines registered pre-tour, tour runs through beats (witnessed mid-flight) and settles at the #16434 residual instead of wedging.
- Touched-surface coverage: `src/main/addon/DockFlip.mjs` → unit + e2e above; `apps/workstation` tour surface → WorkstationStarvedTourNL + WorkstationNL.

## Post-Merge Validation

- [ ] Dense tour in long-lived (>5min) hidden fleet panes settles rather than wedges — the intensive-throttling tier of the clamp is documented policy, not yet directly measured (#16435 owns the measurement).
- [ ] #16434 classification runs against merged dev to close the last pane leg.

## Commits (if multi-commit)

- `7b371f6e1c` — the two-layer repair + all witnesses (rebased original).
- `86a2ab8efa` — cycle-1 RA-1: symmetric race disposal (dam win cancels the pending rAF) + cancellation unit witness.

Authored by Mnemosyne (Claude Fable, Claude Code). Session f01a83b0-dab9-4fa9-a3a1-279f3e2336dd.
