### PR TITLE
feat: the Brain-fault banner speaks with the lifecycle owner's voice (#16051)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -297,12 +297,22 @@ class FleetCockpit extends Container {
      */
     dockPreviewProducer = null
     /**
-     * In-flight latch for {@link #loadBrainHealth} — one health pull airborne at a time, the same
-     * overlap suppression the liveness tick applies to the surface reads.
-     * @member {Boolean} brainHealthReadInFlight=false
+     * Monotonic read-fence for the Brain-health pulls — an immediate first read, an interval tick,
+     * and a timed-out-but-still-pending read can coexist; only the newest generation may write, so
+     * a late answer can never overwrite newer truth.
+     * @member {Number} brainHealthReadGeneration=0
      * @protected
      */
-    brainHealthReadInFlight = false
+    brainHealthReadGeneration = 0
+    /**
+     * Unsettled Brain-health reads on the wire — counted like {@link #streamReadInFlight}, capped at
+     * {@link #maxReadsInFlight} by the liveness tick, and released only on the read's OWN settle
+     * (never on the bounded-race timeout), so hung pulls can never accumulate unboundedly while a
+     * timed-out slot still frees the surface to keep re-reading.
+     * @member {Number} brainHealthReadInFlight=0
+     * @protected
+     */
+    brainHealthReadInFlight = 0
     /**
      * The retained diagnosis pointer for the DAEMON surface — the "why" the spine banner names
      * instead of generic copy. Per-surface like {@link #gridDegradedReason}: a transport sibling
@@ -2622,9 +2632,9 @@ class FleetCockpit extends Container {
         // against a bridge already failing to answer, which is precisely when piling on is worst.
         // Skipping a tick loses nothing: the next one reads the same live truth, only later.
         me.livenessTimerId = setInterval(() => {
-            if (me.streamReadInFlight < me.maxReadsInFlight) me.loadActivity();
-            if (me.gridReadInFlight   < me.maxReadsInFlight) me.loadRoster();
-            me.brainHealthReadInFlight || me.loadBrainHealth()
+            if (me.streamReadInFlight      < me.maxReadsInFlight) me.loadActivity();
+            if (me.gridReadInFlight        < me.maxReadsInFlight) me.loadRoster();
+            if (me.brainHealthReadInFlight < me.maxReadsInFlight) me.loadBrainHealth()
         }, me.livenessPollInterval);
 
         // The daemon surface has no other first read: unlike roster/activity (seeded then wired
@@ -2666,15 +2676,23 @@ class FleetCockpit extends Container {
      * @protected
      */
     applyBrainHealth(response) {
-        let me = this;
+        let me    = this,
+            state = BRAIN_HEALTH_STATES.includes(response?.state) ? response.state : null;
 
         if (me.isDestroyed) return;
 
-        let state = BRAIN_HEALTH_STATES.includes(response?.state) ? response.state : null,
-            cause = state ? response.cause : null;
+        if (!state) {
+            // Transport truth is not daemon truth in EITHER direction: a rejection, timeout,
+            // unavailable envelope, or malformed payload must not fabricate a fault — and it must
+            // not ERASE a last-known one. A visible fault stays visible until the lifecycle owner
+            // itself answers otherwise; only a valid answer moves this surface.
+            return
+        }
 
         me.daemonState          = state;
-        me.daemonDegradedReason = cause ? (cause.detail || cause.source || null) : null;
+        me.daemonDegradedReason = state !== 'running' && response.cause
+            ? (response.cause.detail || response.cause.source || null)
+            : null;
 
         me.syncSpineBanner()
     }
@@ -2683,24 +2701,38 @@ class FleetCockpit extends Container {
      * @summary Pulls whole-Brain health from the shell's lifecycle owner — the re-read obligation.
      *
      * Pull, never push: rides the liveness cadence for as long as the cockpit renders, so a fault
-     * arriving after mount still surfaces and a recovery still clears. An absent shell (dev-server
-     * mode) or a rejected invoke resolves to the silent surface via {@link #applyBrainHealth} —
-     * absence is unknown, never nominal, and never a fabricated degradation.
+     * arriving after mount still surfaces and a recovery still clears. The read follows the same
+     * bounded discipline as the wire reads — `boundedRead` frees the surface on a hung pull
+     * while the wire-settle release plus the {@link #maxReadsInFlight} cap bound accumulation, and
+     * the generation fence discards any late answer. Transport failure (absent shell, rejection,
+     * timeout) reaches {@link #applyBrainHealth} as `null` and moves nothing.
      * @protected
      */
     async loadBrainHealth() {
         let me = this;
 
-        if (me.brainHealthReadInFlight) return;
-
-        me.brainHealthReadInFlight = true;
+        // BEFORE any early exit: absence is newer knowledge, and an older pending read must not
+        // outlive it (the same rule the wire reads follow).
+        const generation = ++me.brainHealthReadGeneration;
 
         try {
-            me.applyBrainHealth(await Neo.Main.brainHealth())
+            me.brainHealthReadInFlight++;
+
+            // Invoke INSIDE the chain: a synchronous throw becomes a rejection of the tracked
+            // promise, so the reject path owns the slot release (the sync-throw falsifier class).
+            const response = await boundedRead(
+                Promise.resolve().then(() => Neo.Main.brainHealth()),
+                me.livenessReadTimeout,
+                () => { me.brainHealthReadInFlight-- }
+            );
+
+            if (generation !== me.brainHealthReadGeneration || me.isDestroyed) return;
+
+            me.applyBrainHealth(response)
         } catch (error) {
+            if (generation !== me.brainHealthReadGeneration || me.isDestroyed) return;
+
             me.applyBrainHealth(null)
-        } finally {
-            me.brainHealthReadInFlight = false
         }
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -32,6 +32,14 @@ import '../../../../src/tab/Container.mjs'; // registers the `tab-container` nty
  * at the surface that died.
  * @type {Number}
  */
+/**
+ * Brain daemon states the shell lifecycle owner can report. Mirrors `BRAIN_STATES` in
+ * `harness/appLifecycle.mjs` — the hemisphere boundary forbids importing it (apps code stays
+ * shell-agnostic), so the vocabulary is duplicated here and anything outside it is unknown → silent.
+ * @type {String[]}
+ */
+const BRAIN_HEALTH_STATES = Object.freeze(['degraded', 'running', 'stopped']);
+
 const LIVENESS_POLL_INTERVAL = 15000;
 
 /**
@@ -288,6 +296,39 @@ class FleetCockpit extends Container {
      * @protected
      */
     dockPreviewProducer = null
+    /**
+     * In-flight latch for {@link #loadBrainHealth} — one health pull airborne at a time, the same
+     * overlap suppression the liveness tick applies to the surface reads.
+     * @member {Boolean} brainHealthReadInFlight=false
+     * @protected
+     */
+    brainHealthReadInFlight = false
+    /**
+     * The retained diagnosis pointer for the DAEMON surface — the "why" the spine banner names
+     * instead of generic copy. Per-surface like {@link #gridDegradedReason}: a transport sibling
+     * must never be able to supply or silence this cause. Written only by {@link #applyBrainHealth},
+     * from the lifecycle owner's retained cause (its detail, falling back to its source key).
+     * @member {String|null} daemonDegradedReason=null
+     * @protected
+     */
+    daemonDegradedReason = null
+    /**
+     * Brain daemon health for the spine banner's third surface — `'running'|'degraded'|'stopped'`,
+     * mirroring the shell lifecycle owner's state vocabulary.
+     *
+     * **`null` by default, and that silence is deliberate rather than a placeholder.** Defaulting to
+     * `'running'` would have the banner assert "the organism is fine" on the strength of never
+     * having asked — the fabrication this cockpit's render discipline exists to prevent. `null`
+     * renders nothing and claims nothing; `deriveSpineBanner` treats absence as UNKNOWN.
+     *
+     * Fed by {@link #loadBrainHealth}: a pull on the shell's named health capability riding the
+     * liveness cadence — deliberately NOT a main→renderer push channel, and deliberately NOT the
+     * per-agent fleet wire, whose process rows answer "which agents run", never "is the organism
+     * impaired".
+     * @member {String|null} daemonState=null
+     * @protected
+     */
+    daemonState = null
     /**
      * The grid's held `adapterState` — absent-item materialization reads from HERE, so a committed
      * layout change can never reset a live grid back to its sample badge.
@@ -2582,8 +2623,13 @@ class FleetCockpit extends Container {
         // Skipping a tick loses nothing: the next one reads the same live truth, only later.
         me.livenessTimerId = setInterval(() => {
             if (me.streamReadInFlight < me.maxReadsInFlight) me.loadActivity();
-            if (me.gridReadInFlight   < me.maxReadsInFlight) me.loadRoster()
-        }, me.livenessPollInterval)
+            if (me.gridReadInFlight   < me.maxReadsInFlight) me.loadRoster();
+            me.brainHealthReadInFlight || me.loadBrainHealth()
+        }, me.livenessPollInterval);
+
+        // The daemon surface has no other first read: unlike roster/activity (seeded then wired
+        // elsewhere), waiting a full cadence would leave a boot-time fault invisible for it.
+        me.loadBrainHealth()
     }
 
     /**
@@ -2606,6 +2652,55 @@ class FleetCockpit extends Container {
         if (me.livenessTimerId !== null) {
             clearInterval(me.livenessTimerId);
             me.livenessTimerId = null
+        }
+    }
+
+    /**
+     * @summary Applies one Brain-health wire answer onto the owner-held daemon surface, then re-syncs.
+     *
+     * The vocabulary check keeps the documented member contract honest: anything that is not a
+     * recognized Brain state — a transport envelope (`{ok: false}`), a rejection mapped to `null`,
+     * a malformed payload — lands as `null`/`null`, which renders NOTHING. Transport trouble is the
+     * transport surface's story; this surface only ever speaks with the lifecycle owner's voice.
+     * @param {Object|null} response The lifecycle owner's `{state, cause}` payload, or anything else.
+     * @protected
+     */
+    applyBrainHealth(response) {
+        let me = this;
+
+        if (me.isDestroyed) return;
+
+        let state = BRAIN_HEALTH_STATES.includes(response?.state) ? response.state : null,
+            cause = state ? response.cause : null;
+
+        me.daemonState          = state;
+        me.daemonDegradedReason = cause ? (cause.detail || cause.source || null) : null;
+
+        me.syncSpineBanner()
+    }
+
+    /**
+     * @summary Pulls whole-Brain health from the shell's lifecycle owner — the re-read obligation.
+     *
+     * Pull, never push: rides the liveness cadence for as long as the cockpit renders, so a fault
+     * arriving after mount still surfaces and a recovery still clears. An absent shell (dev-server
+     * mode) or a rejected invoke resolves to the silent surface via {@link #applyBrainHealth} —
+     * absence is unknown, never nominal, and never a fabricated degradation.
+     * @protected
+     */
+    async loadBrainHealth() {
+        let me = this;
+
+        if (me.brainHealthReadInFlight) return;
+
+        me.brainHealthReadInFlight = true;
+
+        try {
+            me.applyBrainHealth(await Neo.Main.brainHealth())
+        } catch (error) {
+            me.applyBrainHealth(null)
+        } finally {
+            me.brainHealthReadInFlight = false
         }
     }
 
@@ -2671,6 +2766,10 @@ class FleetCockpit extends Container {
             // each state travels WITH its own cause: the derivation reports the reason of the
             // surface that decided the verdict, and no sibling can supply or silence it
             let {hidden, kind, text} = deriveSpineBanner({
+                // Daemon health ranks above a stale feed: a dead daemon is usually what MADE the feed
+                // stale, so the transport line alone would name the symptom and drop the diagnosis.
+                // Silent while `daemonState` is null — absence is unknown, never nominal.
+                daemon: {state: me.daemonState,        reason: me.daemonDegradedReason},
                 grid  : {state: me.gridAdapterState,   reason: me.gridDegradedReason},
                 stream: {state: me.streamAdapterState, reason: me.streamDegradedReason}
             });

--- a/apps/agentos/view/fleet/spineBanner.mjs
+++ b/apps/agentos/view/fleet/spineBanner.mjs
@@ -5,10 +5,34 @@
  * last-known data instead of failing silent. Render-only over existing truth — this module
  * produces no probes.
  *
- * Precedence: `sample` (unreachable — cold) beats `stale` (reachable but degraded) beats `live`.
- * A fully live spine renders NOTHING — nominal earns zero pixels, the same exception-based
- * discipline the cards follow. Per-AGENT truth (wake/throttle telltales) is a different surface;
- * this line only speaks for the fleet transport itself.
+ * Precedence: `sample` (unreachable — cold) beats `daemon` (a Brain daemon down) beats `stale`
+ * (reachable but degraded) beats `live`. A fully live spine renders NOTHING — nominal earns zero
+ * pixels, the same exception-based discipline the cards follow. Per-AGENT truth (wake/throttle
+ * telltales) is a different surface.
+ *
+ * ## Why daemon health joins a line that used to speak only for the transport
+ *
+ * The shell spec requires that a daemon going down surfaces as a tray-state change **plus ONE
+ * cockpit banner with the diagnosis pointer — never a popup storm**. "One banner" is the whole
+ * requirement, so a second banner component would violate the spec it was added to satisfy. This
+ * line is the cockpit's single honesty surface, so daemon health belongs here, following the same
+ * per-surface-reason discipline as the other two rather than as a special case.
+ *
+ * **A dead daemon outranks a stale feed because it usually CAUSES one.** Reporting "feed degraded"
+ * while a daemon is down names the symptom and drops the diagnosis, which is precisely the pointer
+ * the spec asks for. It sits below `sample` because an unreachable transport cannot have answered a
+ * daemon-status pull in the first place — the two are near-exclusive, and when the server is silent
+ * "start the server" is the actionable line.
+ *
+ * **Daemon silence renders nothing, and does not claim health.** An absent daemon surface is
+ * unknown, not nominal — but inventing a degradation from missing information is a false alarm, and
+ * the transport line already speaks when the server is silent (that is exactly the `sample` case).
+ * So absence stays quiet here and the operator still gets told, by the surface that actually knows.
+ *
+ * **`degraded` is reused as the `kind` rather than minting a fourth.** The severity is the same and
+ * the existing skin already carries it; the DIAGNOSIS travels in the text, where a screen reader
+ * reaches it. Distinguishing a dead daemon from a stale feed by colour alone would be a WCAG 1.4.1
+ * failure, and the tray state carries the state distinction the spec pairs this banner with.
  *
  * **A reason belongs to a SURFACE, never to the spine.** This module used to take one loose
  * `degradedReason` alongside two loose states, and that shape had a race it could not express: the
@@ -43,15 +67,26 @@ function reasonFor(surfaces, state) {
 }
 
 /**
- * @summary Derives the spine banner from the two owner-held surface truths.
+ * Brain daemon states that warrant the banner. `running` is nominal and earns zero pixels; an absent
+ * or unrecognised state is UNKNOWN and also stays quiet — see the module note on daemon silence.
+ * Mirrors `harness/appLifecycle.mjs`'s `BRAIN_STATES` minus the nominal one.
+ * @type {String[]}
+ */
+const DAEMON_FAULT_STATES = Object.freeze(['degraded', 'stopped']);
+
+/**
+ * @summary Derives the spine banner from the owner-held surface truths.
  * @param {Object} options
  * @param {{state: String, reason: ?String}} options.grid The roster surface: `'sample'|'stale'|'live'`
  *     plus the safe cause the owner retained for THAT surface, if it learned one.
  * @param {{state: String, reason: ?String}} options.stream The activity surface, same shape.
+ * @param {{state: String, reason: ?String}} [options.daemon] Brain daemon health:
+ *     `'running'|'degraded'|'stopped'`, with the diagnosis pointer as its reason. Optional — a caller
+ *     that has not pulled daemon truth passes nothing rather than guessing `running`.
  * @returns {{hidden: Boolean, kind: String, text: String}} `kind` is `'live'|'cold'|'degraded'`
  *     — the class hook; `hidden` is `true` only for the fully live spine.
  */
-export function deriveSpineBanner({grid, stream}) {
+export function deriveSpineBanner({daemon, grid, stream}) {
     const surfaces = [grid, stream],
           states   = surfaces.map(surface => surface?.state);
 
@@ -70,6 +105,31 @@ export function deriveSpineBanner({grid, stream}) {
             text: reason
                 ? `Fleet data unavailable — showing the static roster · ${reason}`
                 : 'Fleet server offline — showing the static roster · start it: npm run ai:fleet-server'
+        }
+    }
+
+    // ABOVE `stale` deliberately: a dead daemon is usually what MADE the feed stale, so reporting the
+    // feed alone would name the symptom and drop the diagnosis pointer the spec requires. Read from
+    // its own surface via the same helper, so the daemon's cause can never be supplied or silenced by
+    // a transport sibling.
+    if (DAEMON_FAULT_STATES.includes(daemon?.state)) {
+        const reason = reasonFor([daemon], daemon.state),
+              // The state is part of the sentence, not just the class: `stopped` and `degraded` are
+              // different operator situations (nothing running vs something wrong), and a banner that
+              // said only "degraded" for both would make the tray the sole place that distinction
+              // exists — unreachable to a screen reader.
+              label  = daemon.state === 'stopped' ? 'stopped' : 'degraded';
+
+        return {
+            hidden: false,
+            kind  : 'degraded',
+            // Same reason-or-fallback discipline as the transport lines. The fallback names WHERE to
+            // look rather than what to run: unlike the fleet server there is no single restart verb
+            // that is right for every daemon, and printing a confident wrong command is worse than
+            // pointing at the surface that knows which daemon died.
+            text: reason
+                ? `Agent OS ${label} — showing the cockpit over a partial organism · ${reason}`
+                : `Agent OS ${label} — showing the cockpit over a partial organism · check the tray state and the daemon log`
         }
     }
 

--- a/harness/appLifecycle.mjs
+++ b/harness/appLifecycle.mjs
@@ -6,6 +6,16 @@ export const BRAIN_STATES = Object.freeze(['running', 'degraded', 'stopped']);
 
 const brainStates = new Set(BRAIN_STATES);
 
+// Severity encodes the supersession rule: an owned-child fault outranks every window-scoped or
+// readiness cause, mirroring settleBrainBoot's `up && !brainFaulted` vote.
+const CAUSE_SEVERITY = Object.freeze({
+    'boot-not-ready'         : 1,
+    'cockpit-closed'         : 1,
+    'cockpit-destroyed'      : 1,
+    'owned-child-termination': 2,
+    'render-process-gone'    : 1
+});
+
 /**
  * @summary Creates the one shell owner for the retained cockpit, tray truth, and Brain teardown.
  * @param {Object} options
@@ -25,6 +35,7 @@ export function createAppLifecycle({
 }) {
     let
         allowFinalQuit = false,
+        brainCause     = null,
         brainFaulted   = false,
         brainState     = 'stopped',
         cockpitWindow  = null,
@@ -35,13 +46,41 @@ export function createAppLifecycle({
         trayController = null;
 
     /**
+     * @summary Retains the ONE bounded degrade cause under severity-tiered first-cause-wins.
+     * Within a tier the first cause of an episode survives; a higher-severity cause supersedes a
+     * lower one, never the reverse.
+     * @param {String} source A key of CAUSE_SEVERITY.
+     * @param {String|null} [detail=null] Bounded human-readable summary from the observation site.
+     * @returns {Object}
+     */
+    function recordBrainCause(source, detail = null) {
+        const severity = CAUSE_SEVERITY[source];
+
+        if (!severity) {
+            throw new Error(`Unsupported harness Brain cause source: ${source}`)
+        }
+
+        if (!brainCause || severity > brainCause.severity) {
+            brainCause = {detail, observedAt: Date.now(), severity, source}
+        }
+
+        return brainCause
+    }
+
+    /**
      * @summary Projects the lifecycle owner's current Brain truth into the existing tray handle.
+     * A retained cause never survives out of a degraded episode: `running` recovers, and an
+     * explicit quit/teardown (`stopped`) must never render as impairment.
      * @param {'running'|'degraded'|'stopped'} state
      * @returns {String}
      */
     function setBrainState(state) {
         if (!brainStates.has(state)) {
             throw new Error(`Unsupported harness Brain state: ${state}`)
+        }
+
+        if (state === 'running' || state === 'stopped') {
+            brainCause = null
         }
 
         if (brainState !== state) {
@@ -59,6 +98,7 @@ export function createAppLifecycle({
      * @returns {'running'|'degraded'}
      */
     function settleBrainBoot(up) {
+        up || recordBrainCause('boot-not-ready');
         return setBrainState(up && !brainFaulted ? 'running' : 'degraded')
     }
 
@@ -106,11 +146,13 @@ export function createAppLifecycle({
             cockpitWindow.on('close', onCockpitClose);
             cockpitWindow.once('closed', () => {
                 if (!explicitQuit && !allowFinalQuit) {
+                    recordBrainCause('cockpit-closed');
                     setBrainState('degraded')
                 }
             });
             cockpitWindow.webContents?.once?.('render-process-gone', () => {
                 if (!explicitQuit && !allowFinalQuit) {
+                    recordBrainCause('render-process-gone');
                     setBrainState('degraded')
                 }
             })
@@ -125,6 +167,7 @@ export function createAppLifecycle({
      */
     function openCockpit() {
         if (!cockpitWindow || cockpitWindow.isDestroyed()) {
+            recordBrainCause('cockpit-destroyed');
             setBrainState('degraded');
             return false
         }
@@ -167,23 +210,31 @@ export function createAppLifecycle({
 
     /**
      * @summary Marks unexpected owned-child termination as degraded without inventing a poller.
+     * The termination edge is the fault-observation site, so the cause (which child, which event)
+     * is produced here — downstream consumers can never reconstruct it.
      * @param {import('node:events').EventEmitter} child
+     * @param {String|null} [label=null] The owned child's registry identity, e.g. 'orchestrator'.
      * @returns {Function} Removes both observation listeners.
      */
-    function watchBrainChild(child) {
-        const onUnexpectedTermination = () => {
+    function watchBrainChild(child, label = null) {
+        const onUnexpectedTermination = summary => {
             if (!teardown && !explicitQuit && !allowFinalQuit) {
                 brainFaulted = true;
+                recordBrainCause('owned-child-termination', `${label ?? 'brain-child'}: ${summary}`.slice(0, 200));
                 setBrainState('degraded')
             }
         };
 
-        child.once('error', onUnexpectedTermination);
-        child.once('exit', onUnexpectedTermination);
+        const
+            onError = error => onUnexpectedTermination(`error ${String(error?.message ?? error ?? 'unknown')}`),
+            onExit  = (code, signal) => onUnexpectedTermination(signal ? `exit signal ${signal}` : `exit code ${code}`);
+
+        child.once('error', onError);
+        child.once('exit', onExit);
 
         return () => {
-            child.off('error', onUnexpectedTermination);
-            child.off('exit', onUnexpectedTermination)
+            child.off('error', onError);
+            child.off('exit', onExit)
         }
     }
 
@@ -263,6 +314,17 @@ export function createAppLifecycle({
     return {
         attachCockpitWindow,
         exitTerminal,
+        /**
+         * @summary The shell health wire payload: current state plus the retained cause.
+         * Severity stays producer-internal; the wire carries `{source, detail, observedAt}`.
+         * @returns {{state: String, cause: {source: String, detail: String|null, observedAt: Number}|null}}
+         */
+        get brainHealth() {
+            return {
+                cause: brainCause ? {detail: brainCause.detail, observedAt: brainCause.observedAt, source: brainCause.source} : null,
+                state: brainState
+            }
+        },
         get brainState() { return brainState },
         installTray,
         invokeTrayAction,

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -886,7 +886,7 @@ const appLifecycle = createAppLifecycle({
  */
 function registerBrainChild(entry) {
     brainState.children.push(entry);
-    appLifecycle.watchBrainChild(entry.child);
+    appLifecycle.watchBrainChild(entry.child, entry.label);
     return entry
 }
 
@@ -1046,6 +1046,16 @@ app.whenReady().then(async () => {
     }
 
     ipcMain.handle('fleet-request', fleetCapability.request);
+
+    // Whole-Brain health crosses ONLY from the lifecycle owner — never composed from per-agent
+    // fleet rows. Untrusted senders reject (transport truth, never daemon truth).
+    ipcMain.handle('brain-health', event => {
+        if (!isTrustedIpcSender(event)) {
+            throw new Error('brain-health: untrusted sender')
+        }
+
+        return appLifecycle.brainHealth
+    });
 
     const win1 = createHarnessWindow(APP_URL);
 

--- a/harness/preload.cjs
+++ b/harness/preload.cjs
@@ -6,6 +6,9 @@ const {contextBridge, ipcRenderer} = require('electron');
 // capabilities land with their consuming leaves (E5 carries the contract; additions amend the
 // shell ADR §2.3 first).
 contextBridge.exposeInMainWorld('neoShell', {
+    // Pull-shaped whole-Brain health from the lifecycle owner. Consumers that render this answer
+    // must re-read it for as long as they render (interval is leaf property).
+    brainHealth : () => ipcRenderer.invoke('brain-health'),
     fleetRequest: request => ipcRenderer.invoke('fleet-request', request),
     shellVersion: process.versions.electron
 });

--- a/learn/agentos/decisions/0034-electron-shell-architecture.md
+++ b/learn/agentos/decisions/0034-electron-shell-architecture.md
@@ -150,6 +150,39 @@ adoption.
    surface as part of the §5 E5 leaf. The Add-Peer **curated-intent boundary** (Body submits
    `{harnessType, id, repo/account facts}` — never command/args/env) is the design contract that
    surface implements.
+7. **Whole-Brain health is a named read affordance from the lifecycle owner** *(amended
+   2026-08-03, #16051 — the PR #16050 Drop+Supersede consequence)*: the preload exposes ONE
+   additional capability, `brainHealth()` → `ipcRenderer.invoke('brain-health')`, answered by a
+   main-process handler that binds the **app-lifecycle owner's** surface (`appLifecycle.brainState`
+   plus a retained cause) and validates the sender per §2.3.4 before answering.
+   **Pull-shaped by design:** a renderer-initiated request/response keeps the audited surface
+   bounded, adds no unsolicited main→renderer event channel, and cannot leak listeners across
+   renderer generations (a dead renderer is itself a degrade source). An unpolled or unanswerable
+   affordance claims nothing — the fail-closed shape of this posture — where a push channel
+   invites silence to read as health. **The consumer obligation is symmetric:** a surface
+   rendering this affordance re-reads it for as long as it renders — a single mount-time read
+   re-imports silence-as-health through the consumer. The re-read interval is leaf property; the
+   obligation is not.
+   **Payload:** plain data — `{state, cause: {source, detail, observedAt} | null}`, `state` from
+   `BRAIN_STATES`. No credential bytes (§2.3.5/.6 untouched), no window or Node references.
+   **Producer contract:** the cause is produced where the fault is observed — the
+   `watchBrainChild` termination edge carries the owned child's identity + termination summary;
+   the cockpit-gone, render-process-gone, and boot-not-ready degrade sites name themselves. ONE
+   bounded record under **severity-tiered first-cause-wins**: within a tier the first cause of a
+   degraded episode is retained, and an owned-child fault supersedes a window-scoped cause —
+   never the reverse — encoding the child-fault primacy `settleBrainBoot` already votes
+   (`up && !brainFaulted`). The record clears on re-entry to `running` AND on transition to
+   `stopped` — an explicit quit/teardown must never render as impairment. Never accumulated
+   main-side.
+   **Failure semantics:** an invoke rejection or an absent `neoShell` is TRANSPORT truth and maps
+   to the consumer's transport surface — never daemon truth.
+   **Ownership boundary:** whole-Brain health never routes through `FleetControlBridge` /
+   `FLEET_WIRE_METHODS` — per-agent process rows answer "which agents run", not "is the organism
+   impaired" (§4, rejected shapes). The fleet allowlist is the discipline model (§2.3.4), never
+   the transport.
+   **Witness obligation:** the consuming leaf's evidence is a shell-transition-driven witness —
+   the lifecycle owner's transition drives the rendered banner; hand-assigned consumer state
+   witnesses a pass-through and is not wiring evidence.
 
 **Falsifier:** any leaf needing a renderer capability the preload cannot express through a named,
 allowlisted intent amends THIS section first (ADR-0005 lifecycle) — it never flips a window to
@@ -262,6 +295,10 @@ violates this section on its face — shell awareness lives in the packaging roo
   makes it *tempting* (BrowserWindows feel ownable from main).
 - **Renderer-readable bearer tokens** — rejected during review of this record: a token the
   renderer can read still crosses the boundary; capability-internal attachment replaced it.
+- **Per-agent fleet rows as whole-Brain health** — rejected in PR #16050's Drop+Supersede review:
+  `fleetRuntimeStatus()` composes per-agent process truth and cannot produce the organism's
+  impairment state; the fields it "fed" had no writer at all. Whole-Brain health crosses from the
+  lifecycle owner via §2.3.7 — never inferred from fleet rows.
 
 ## 5. Decomposition — the E-leaf gate (map lives on the #13377 epic)
 

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -130,6 +130,7 @@ class Main extends core.Base {
         remote: {
             app: [
                 'alert',
+                'brainHealth',
                 'editRoute',
                 'fleetRequest',
                 'getByPath',
@@ -259,6 +260,18 @@ class Main extends core.Base {
         });
 
         window.location.hash = hashArr.join('&')
+    }
+
+    /**
+     * @summary Pull whole-Brain health from the Electron shell's lifecycle owner, when one hosts us.
+     * Resolves the owner's `{state, cause}` payload. Without a shell (dev-server mode) it returns a
+     * typed unavailable envelope, so consumers read absence as transport truth, never daemon truth.
+     * @returns {Promise<Object>|Object}
+     */
+    brainHealth() {
+        return globalThis.neoShell?.brainHealth
+            ? globalThis.neoShell.brainHealth()
+            : {ok: false, error: 'brain: shell health capability unavailable'}
     }
 
     /**

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1322,7 +1322,9 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         expect(banner.calls[0].text).toContain('degraded');
         expect(banner.calls[0].text).toContain('orchestrator: error spawn ENOENT');
 
-        // Recovery is ALSO the shell's transition, not the test resetting fields.
+        // Recovery is ALSO the shell's transition — the owner's `running` write, which is the
+        // terminal step any future restart machinery performs. Restart machinery itself (a second
+        // boot-settle after an owned-child fault) is lifecycle-service scope, not this leaf's.
         lifecycle.setBrainState('running');
         cockpit.applyBrainHealth(lifecycle.brainHealth);
 
@@ -1331,26 +1333,55 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         expect(banner.calls[1].hidden).toBe(true)
     });
 
-    test('transport truth never becomes daemon truth: envelopes and rejections land silent', () => {
+    test('⭐ transport failure never impersonates recovery: fault → dead transport → retained; only running clears', () => {
         const banner  = makeBanner(),
               cockpit = {
                   ...makeHost('live', 'live', banner),
                   applyBrainHealth    : FleetCockpit.prototype.applyBrainHealth,
-                  daemonDegradedReason: 'stale-from-earlier',
-                  daemonState         : 'degraded'
+                  daemonDegradedReason: null,
+                  daemonState         : null
               };
 
-        // The dev-server envelope (no shell) carries no `state` — the surface goes silent instead of
-        // freezing its last fault or fabricating one from transport trouble.
-        cockpit.applyBrainHealth({error: 'brain: shell health capability unavailable', ok: false});
+        // a real fault from the lifecycle owner
+        cockpit.applyBrainHealth({cause: {detail: 'orchestrator: exit code 1', observedAt: 1, source: 'owned-child-termination'}, state: 'degraded'});
 
+        expect(cockpit.daemonState).toBe('degraded');
+        expect(banner.calls[0].hidden).toBe(false);
+        expect(banner.calls[0].text).toContain('orchestrator: exit code 1');
+
+        // the transport dies: an unavailable envelope AND a rejection-mapped null. A dead transport
+        // is not a recovered organism — the KNOWN fault must stay visible, not be erased.
+        cockpit.applyBrainHealth({error: 'brain: shell health capability unavailable', ok: false});
+        cockpit.applyBrainHealth(null);
+
+        expect(cockpit.daemonState).toBe('degraded');
+        expect(cockpit.daemonDegradedReason).toBe('orchestrator: exit code 1');
+        expect(banner.calls, 'transport answers repaint nothing').toHaveLength(1);
+
+        // ONLY the owner's own running answer clears the fault
+        cockpit.applyBrainHealth({cause: null, state: 'running'});
+
+        expect(cockpit.daemonState).toBe('running');
+        expect(cockpit.daemonDegradedReason).toBeNull();
+        expect(banner.calls[1].hidden).toBe(true)
+    });
+
+    test('dev-server mode stays silent: transport-only answers on a never-fed surface write nothing', () => {
+        const banner  = makeBanner(),
+              cockpit = {
+                  ...makeHost('live', 'live', banner),
+                  applyBrainHealth    : FleetCockpit.prototype.applyBrainHealth,
+                  daemonDegradedReason: null,
+                  daemonState         : null
+              };
+
+        cockpit.applyBrainHealth({error: 'brain: shell health capability unavailable', ok: false});
+        cockpit.applyBrainHealth(null);
+
+        // never fed → still null/null, and no banner write at all: silence claims nothing
         expect(cockpit.daemonState).toBeNull();
         expect(cockpit.daemonDegradedReason).toBeNull();
-        expect(banner.calls[0].hidden).toBe(true);
-
-        // The rejection path maps to `null` before reaching the mapping — same silent landing.
-        cockpit.applyBrainHealth(null);
-        expect(cockpit.daemonState).toBeNull()
+        expect(banner.calls).toEqual([])
     });
 
     test('a cold owner writes the REAL slot: cold class hook, visible, cause + shipped remedy', () => {
@@ -1721,7 +1752,7 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
             cleared,
             polls                  : 0,
             brainReads             : 0,
-            brainHealthReadInFlight: false,
+            brainHealthReadInFlight: 0,
             gridReadInFlight       : 0,
             livenessPollInterval   : 50,
             livenessTimerId        : null,
@@ -2035,22 +2066,103 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
             // both wire seams, every tick: re-driving the real verbs IS the mechanism
             expect(host.polls, 'the owner must poll, not just hold a timer id').toBeGreaterThanOrEqual(4);
 
-            // the third seam rides the same cadence: immediate read plus tick re-reads
-            expect(host.brainReads, 'the Brain read must re-drive on the cadence, not just once').toBeGreaterThanOrEqual(2);
-
-            // overlap suppression: an airborne Brain read makes the next tick skip, never stack
-            const before = host.brainReads;
-
-            host.brainHealthReadInFlight = true;
-            await new Promise(resolve => setTimeout(resolve, 25));
-            expect(host.brainReads, 'an unresolved Brain read suppresses the tick — skip, never stack').toBe(before);
-
-            host.brainHealthReadInFlight = false;
-            await new Promise(resolve => setTimeout(resolve, 25));
-            expect(host.brainReads, 'suppression is a skip, not a stop').toBeGreaterThan(before)
+            // the third seam rides the same cadence: immediate read plus tick re-reads. Overlap and
+            // hang behavior are witnessed by the never-settle tests below against REAL promises —
+            // never by assigning the in-flight field here.
+            expect(host.brainReads, 'the Brain read must re-drive on the cadence, not just once').toBeGreaterThanOrEqual(2)
         } finally {
             host.stopLiveness()
         }
+    });
+
+    /**
+     * @summary Builds a host wired to the REAL loadBrainHealth with a controllable Neo.Main mock.
+     * Returns the host, the recorded apply calls, and the hung wires' resolvers — so the tests can
+     * settle a wire deliberately instead of ever assigning the in-flight field.
+     */
+    const makeBrainReadHost = ({timeout}) => {
+        const
+            applied = [],
+            wires   = [],
+            host    = {
+                applied,
+                wires,
+                brainHealthReadGeneration: 0,
+                brainHealthReadInFlight  : 0,
+                isDestroyed              : false,
+                livenessReadTimeout      : timeout,
+                maxReadsInFlight         : 2,
+                applyBrainHealth(response) { applied.push(response) },
+                loadBrainHealth: FleetCockpit.prototype.loadBrainHealth
+            };
+
+        return host
+    };
+
+    const withMainMock = async (host, run) => {
+        const hadNeo   = Boolean(globalThis.Neo),
+              original = globalThis.Neo?.Main;
+
+        (globalThis.Neo ??= {}).Main = {brainHealth: () => new Promise(resolve => host.wires.push(resolve))};
+
+        try {
+            await run()
+        } finally {
+            if (original === undefined) { delete globalThis.Neo.Main } else { globalThis.Neo.Main = original }
+            if (!hadNeo) { delete globalThis.Neo }
+        }
+    };
+
+    test('a Brain read that NEVER settles must not freeze the surface — bounded slot, capped wires', async () => {
+        const host = makeBrainReadHost({timeout: 20});
+
+        await withMainMock(host, async () => {
+            // the first read hangs: the bounded race frees the CALLER on the timeout…
+            const first = host.loadBrainHealth();
+
+            expect(host.brainHealthReadInFlight).toBe(1);
+            await first;
+
+            expect(host.applied, 'the timed-out read lands as transport truth').toEqual([null]);
+            // …while the WIRE never settled, so its slot stays counted — the accumulation bound
+            expect(host.brainHealthReadInFlight).toBe(1);
+
+            // the surface is NOT frozen: a second read launches under the cap and hangs too
+            await host.loadBrainHealth();
+            expect(host.brainHealthReadInFlight).toBe(2);
+
+            // two hung wires reach the cap: the tick guard now suppresses — bounded, never a stop
+            expect(host.brainHealthReadInFlight < host.maxReadsInFlight).toBe(false);
+
+            // a hung wire finally answering releases its slot but its answer goes nowhere
+            host.applied.length = 0;
+            host.wires[0]({cause: null, state: 'running'});
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(host.applied, 'a wire the race already dropped never writes').toEqual([]);
+            expect(host.brainHealthReadInFlight, 'its settle still frees the slot').toBe(1)
+        })
+    });
+
+    test('a slow Brain answer landing after a newer read never writes — the generation fence', async () => {
+        const host = makeBrainReadHost({timeout: 500});
+
+        await withMainMock(host, async () => {
+            const slow = host.loadBrainHealth(),
+                  fast = host.loadBrainHealth();
+
+            // the NEWER read answers first with current truth
+            host.wires[1]({cause: null, state: 'running'});
+            await fast;
+            expect(host.applied).toEqual([{cause: null, state: 'running'}]);
+
+            // the STALE wire answers late — inside its timeout window, but past its generation
+            host.wires[0]({cause: {detail: 'stale news', observedAt: 1, source: 'owned-child-termination'}, state: 'degraded'});
+            await slow;
+
+            expect(host.applied, 'older news never overwrites newer truth').toEqual([{cause: null, state: 'running'}]);
+            expect(host.brainHealthReadInFlight, 'both wires settled, both slots free').toBe(0)
+        })
     })
 });
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -12,10 +12,12 @@ setup({
     }
 });
 
-import {test, expect}  from '@playwright/test';
-import {readFileSync}  from 'fs';
-import path            from 'path';
-import {fileURLToPath} from 'url';
+import {test, expect}       from '@playwright/test';
+import {EventEmitter}       from 'node:events';
+import {createAppLifecycle} from '../../../../../../../harness/appLifecycle.mjs';
+import {readFileSync}       from 'fs';
+import path                 from 'path';
+import {fileURLToPath}      from 'url';
 import Neo             from '../../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../../src/core/_export.mjs';
 import Instance        from '../../../../../../../src/manager/Instance.mjs';
@@ -1252,6 +1254,103 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         gridAdapterState,
         streamAdapterState,
         syncSpineBanner: FleetCockpit.prototype.syncSpineBanner
+    });
+
+    // ⭐ The daemon surface reaching the REAL slot. The derivation being correct is a separate suite;
+    // this asserts the cockpit actually FEEDS it, because a derivation nothing feeds is indistinguishable
+    // from an absent feature — and the wiring is the half that makes the shell spec's banner exist.
+    test('⭐ a dead daemon reaches the slot with the diagnosis, outranking a stale feed', () => {
+        const banner = makeBanner(),
+              host   = {
+                  ...makeHost('live', 'stale', banner),
+                  daemonDegradedReason: 'orchestrator exited',
+                  daemonState         : 'stopped'
+              };
+
+        host.syncSpineBanner();
+
+        const {cls, hidden, text} = banner.calls[0];
+
+        expect(cls).toEqual(['fm-spine-banner', 'fm-spine-banner-degraded']);
+        expect(hidden).toBe(false);
+        expect(text).toContain('stopped');
+        expect(text).toContain('orchestrator exited');
+        // The stale feed is the symptom; it must not be the sentence.
+        expect(text).not.toContain('last-known data')
+    });
+
+    test('⭐ an unfed daemon surface stays SILENT on a live owner — absence claims nothing', () => {
+        // `daemonState` is null until the runtime pull lands. This asserts the default is honest
+        // silence rather than an implicit "the organism is fine", which is what defaulting to
+        // `'running'` would have asserted on the strength of never having asked.
+        const banner = makeBanner();
+
+        makeHost('live', 'live', banner).syncSpineBanner();
+
+        expect(banner.calls[0].hidden).toBe(true);
+        expect(banner.calls[0].text).toBe('')
+    });
+
+    // ⭐ The producer→cockpit→slot witness the predecessor lacked: the SHELL transition drives the
+    // banner. A test that hand-assigns `daemonState` witnesses only a pass-through — that misreading
+    // is what made the closed predecessor PR look delivered while its fields had no writer at all.
+    test('⭐ a SHELL transition drives the banner: lifecycle owner → wire payload → feed → slot', () => {
+        const
+            child     = new EventEmitter(),
+            lifecycle = createAppLifecycle({
+                app          : Object.assign(new EventEmitter(), {exit() {}, quit() {}}),
+                teardownBrain: async () => ({})
+            }),
+            banner    = makeBanner(),
+            cockpit   = {
+                ...makeHost('live', 'live', banner),
+                applyBrainHealth       : FleetCockpit.prototype.applyBrainHealth,
+                brainHealthReadInFlight: false,
+                daemonDegradedReason   : null,
+                daemonState            : null
+            };
+
+        lifecycle.setBrainState('running');
+        lifecycle.watchBrainChild(child, 'orchestrator');
+        child.emit('error', new Error('spawn ENOENT'));
+
+        // The payload is the producer's own wire truth, never test-fabricated consumer state.
+        cockpit.applyBrainHealth(lifecycle.brainHealth);
+
+        expect(cockpit.daemonState).toBe('degraded');
+        expect(banner.calls[0].hidden).toBe(false);
+        expect(banner.calls[0].text).toContain('degraded');
+        expect(banner.calls[0].text).toContain('orchestrator: error spawn ENOENT');
+
+        // Recovery is ALSO the shell's transition, not the test resetting fields.
+        lifecycle.setBrainState('running');
+        cockpit.applyBrainHealth(lifecycle.brainHealth);
+
+        expect(cockpit.daemonState).toBe('running');
+        expect(cockpit.daemonDegradedReason).toBeNull();
+        expect(banner.calls[1].hidden).toBe(true)
+    });
+
+    test('transport truth never becomes daemon truth: envelopes and rejections land silent', () => {
+        const banner  = makeBanner(),
+              cockpit = {
+                  ...makeHost('live', 'live', banner),
+                  applyBrainHealth    : FleetCockpit.prototype.applyBrainHealth,
+                  daemonDegradedReason: 'stale-from-earlier',
+                  daemonState         : 'degraded'
+              };
+
+        // The dev-server envelope (no shell) carries no `state` — the surface goes silent instead of
+        // freezing its last fault or fabricating one from transport trouble.
+        cockpit.applyBrainHealth({error: 'brain: shell health capability unavailable', ok: false});
+
+        expect(cockpit.daemonState).toBeNull();
+        expect(cockpit.daemonDegradedReason).toBeNull();
+        expect(banner.calls[0].hidden).toBe(true);
+
+        // The rejection path maps to `null` before reaching the mapping — same silent landing.
+        cockpit.applyBrainHealth(null);
+        expect(cockpit.daemonState).toBeNull()
     });
 
     test('a cold owner writes the REAL slot: cold class hook, visible, cause + shipped remedy', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1719,13 +1719,17 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
         // on the first tick. The `*ReadInFlight` pair mirrors the class defaults the latch reads.
         return {
             cleared,
-            polls               : 0,
-            gridReadInFlight    : 0,
-            livenessPollInterval: 50,
-            livenessTimerId     : null,
-            maxReadsInFlight    : 2,
-            streamReadInFlight  : 0,
+            polls                  : 0,
+            brainReads             : 0,
+            brainHealthReadInFlight: false,
+            gridReadInFlight       : 0,
+            livenessPollInterval   : 50,
+            livenessTimerId        : null,
+            maxReadsInFlight       : 2,
+            streamReadInFlight     : 0,
             loadActivity() { this.polls++; return Promise.resolve() },
+            // the third seam counts separately: the wire-read expectations stay untouched by it
+            loadBrainHealth() { this.brainReads++; return Promise.resolve() },
             loadRoster()   { this.polls++; return Promise.resolve() },
             startLiveness: FleetCockpit.prototype.startLiveness,
             stopLiveness : FleetCockpit.prototype.stopLiveness,
@@ -2023,10 +2027,27 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
         host.startLiveness();
 
         try {
+            // the daemon surface has no other first load — arming the owner IS its first read
+            expect(host.brainReads, 'the immediate first Brain read must not wait a full cadence').toBe(1);
+
             await new Promise(resolve => setTimeout(resolve, 45));
 
-            // both seams, every tick: re-driving the real verbs IS the mechanism
-            expect(host.polls, 'the owner must poll, not just hold a timer id').toBeGreaterThanOrEqual(4)
+            // both wire seams, every tick: re-driving the real verbs IS the mechanism
+            expect(host.polls, 'the owner must poll, not just hold a timer id').toBeGreaterThanOrEqual(4);
+
+            // the third seam rides the same cadence: immediate read plus tick re-reads
+            expect(host.brainReads, 'the Brain read must re-drive on the cadence, not just once').toBeGreaterThanOrEqual(2);
+
+            // overlap suppression: an airborne Brain read makes the next tick skip, never stack
+            const before = host.brainReads;
+
+            host.brainHealthReadInFlight = true;
+            await new Promise(resolve => setTimeout(resolve, 25));
+            expect(host.brainReads, 'an unresolved Brain read suppresses the tick — skip, never stack').toBe(before);
+
+            host.brainHealthReadInFlight = false;
+            await new Promise(resolve => setTimeout(resolve, 25));
+            expect(host.brainReads, 'suppression is a skip, not a stop').toBeGreaterThan(before)
         } finally {
             host.stopLiveness()
         }

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -2151,6 +2151,10 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
             const slow = host.loadBrainHealth(),
                   fast = host.loadBrainHealth();
 
+            // the mock's invoke sits one microtask deep (the sync-throw guard wraps it in a
+            // resolved-promise chain), so the wires materialize only after a flush
+            await expect.poll(() => host.wires.length).toBe(2);
+
             // the NEWER read answers first with current truth
             host.wires[1]({cause: null, state: 'running'});
             await fast;

--- a/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
@@ -13,6 +13,99 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
 
     const STATES = ['sample', 'stale', 'live'];
 
+    // ⭐ The daemon surface: the shell spec's "tray-state change + ONE cockpit banner with the
+    // diagnosis pointer — never a popup storm". The storm clause is a property of EPISODES, not
+    // renders, so it is asserted as such below rather than assumed from the return type.
+    test.describe('⭐ daemon health — ONE banner per episode, ranked above a stale feed', () => {
+        const live = {grid: {state: 'live'}, stream: {state: 'live'}};
+
+        test('a stopped and a degraded daemon each speak, and `running` stays silent', () => {
+            // `running` must earn zero pixels like every other nominal state.
+            expect(deriveSpineBanner({...live, daemon: {state: 'running'}})).toEqual({hidden: true, kind: 'live', text: ''});
+
+            for (const state of ['degraded', 'stopped']) {
+                const result = deriveSpineBanner({...live, daemon: {state}});
+
+                expect(result.hidden, state).toBe(false);
+                expect(result.kind, state).toBe('degraded');
+                // The two are different operator situations, so the SENTENCE distinguishes them —
+                // not just the class. A screen reader reaches text, never a colour.
+                expect(result.text, state).toContain(state === 'stopped' ? 'stopped' : 'degraded')
+            }
+        });
+
+        test('⭐ daemon silence renders NOTHING and does not claim health', () => {
+            // Absence is UNKNOWN, not nominal. Inventing a degradation from missing information is a
+            // false alarm; claiming health from it is the fabrication. Both are wrong, so it stays
+            // quiet — and the transport line already speaks when the server is silent.
+            for (const daemon of [undefined, null, {}, {state: null}, {state: 'unknown'}, {state: ''}]) {
+                const result = deriveSpineBanner({...live, daemon});
+
+                expect(result.hidden, JSON.stringify(daemon)).toBe(true);
+                expect(result.text, JSON.stringify(daemon)).toBe('')
+            }
+        });
+
+        test('⭐ a dead daemon OUTRANKS a stale feed — the diagnosis, not the symptom', () => {
+            // A dead daemon is usually what made the feed stale. Reporting the feed alone would name
+            // the symptom and drop the pointer the spec asks for.
+            const result = deriveSpineBanner({
+                grid  : {state: 'stale', reason: 'feed went quiet'},
+                stream: {state: 'stale'},
+                daemon: {state: 'stopped', reason: 'orchestrator exited'}
+            });
+
+            expect(result.text).toContain('orchestrator exited');
+            expect(result.text).not.toContain('last-known data');
+            // Control: remove the daemon fault and the SAME input must fall back to the stale line,
+            // which is what proves the daemon branch is doing the ranking rather than the text.
+            expect(deriveSpineBanner({
+                grid: {state: 'stale', reason: 'feed went quiet'}, stream: {state: 'stale'}
+            }).text).toContain('last-known data')
+        });
+
+        test('an unreachable transport still wins — it cannot have answered a daemon pull', () => {
+            const result = deriveSpineBanner({
+                grid: {state: 'sample'}, stream: {state: 'live'}, daemon: {state: 'stopped'}
+            });
+
+            expect(result.kind).toBe('cold');
+            expect(result.text).toContain('static roster')
+        });
+
+        test('⭐ N daemons down in ONE episode yield ONE banner — the storm clause, asserted', () => {
+            // The spec's "never a popup storm" is about episodes. The derivation is total and returns
+            // exactly one line whatever the fault breadth, so the storm is unrepresentable rather than
+            // debounced — and a caller cannot turn three dead daemons into three banners.
+            const episode = deriveSpineBanner({
+                ...live,
+                daemon: {state: 'stopped', reason: 'orchestrator, fleet and chroma all exited'}
+            });
+
+            expect(Array.isArray(episode)).toBe(false);
+            expect(Object.keys(episode).sort()).toEqual(['hidden', 'kind', 'text']);
+            expect(episode.text.match(/Agent OS/g)).toHaveLength(1);
+
+            // And it is IDEMPOTENT across re-derivation: a polling consumer re-deriving the same
+            // episode produces an identical line, so nothing accumulates per poll.
+            expect(deriveSpineBanner({...live, daemon: {state: 'stopped', reason: 'orchestrator, fleet and chroma all exited'}}))
+                .toEqual(episode)
+        });
+
+        test('a daemon reason cannot be supplied OR silenced by a transport sibling', () => {
+            // The module's per-surface-reason doctrine, applied to the new surface: a `stale` grid
+            // carrying a reason must not lend it to the daemon line.
+            const result = deriveSpineBanner({
+                grid  : {state: 'stale', reason: 'grid-owned cause'},
+                stream: {state: 'live'},
+                daemon: {state: 'degraded'}
+            });
+
+            expect(result.text).not.toContain('grid-owned cause');
+            expect(result.text).toContain('check the tray state and the daemon log')
+        });
+    });
+
     test('the full 3×3 matrix: cold beats degraded beats live; only live+live hides', () => {
         for (const gridAdapterState of STATES) {
             for (const streamAdapterState of STATES) {

--- a/test/playwright/unit/harness/appLifecycle.spec.mjs
+++ b/test/playwright/unit/harness/appLifecycle.spec.mjs
@@ -279,6 +279,104 @@ test.describe('harness app lifecycle', () => {
         expect(tray.states).toEqual([])
     });
 
+    test.describe('brainHealth cause retention (ADR 0034 §2.3.7)', () => {
+        test('an owned-child fault names the child and event on the wire, severity stays internal', () => {
+            const
+                app       = createFakeApp(),
+                child     = new EventEmitter(),
+                lifecycle = createAppLifecycle({app, teardownBrain: async () => ({})});
+
+            expect(lifecycle.brainHealth).toEqual({cause: null, state: 'stopped'});
+
+            lifecycle.setBrainState('running');
+            lifecycle.watchBrainChild(child, 'orchestrator');
+            child.emit('exit', 1);
+
+            const health = lifecycle.brainHealth;
+
+            expect(health.state).toBe('degraded');
+            expect(Object.keys(health.cause).sort()).toEqual(['detail', 'observedAt', 'source']);
+            expect(health.cause.source).toBe('owned-child-termination');
+            expect(health.cause.detail).toBe('orchestrator: exit code 1');
+            expect(typeof health.cause.observedAt).toBe('number')
+        });
+
+        test('an owned-child fault supersedes a window-scoped cause, never the reverse', () => {
+            const
+                app       = createFakeApp(),
+                child     = new EventEmitter(),
+                cockpit   = createFakeWindow(),
+                tray      = createFakeTrayFactory(),
+                lifecycle = createAppLifecycle({app, teardownBrain: async () => ({})});
+
+            lifecycle.attachCockpitWindow(cockpit);
+            lifecycle.installTray(tray.factory);
+            lifecycle.setBrainState('running');
+            lifecycle.watchBrainChild(child, 'fleet');
+
+            cockpit.emit('closed');
+            expect(lifecycle.brainHealth.cause.source).toBe('cockpit-closed');
+
+            child.emit('error', new Error('spawn ENOENT'));
+            expect(lifecycle.brainHealth.cause.detail).toBe('fleet: error spawn ENOENT');
+
+            // The reverse direction: a later window-scoped observation never displaces the child fault.
+            cockpit.webContents.emit('render-process-gone');
+            expect(lifecycle.brainHealth.cause.source).toBe('owned-child-termination')
+        });
+
+        test('first cause wins within a tier and the detail stays bounded', () => {
+            const
+                app       = createFakeApp(),
+                child     = new EventEmitter(),
+                cockpit   = createFakeWindow(),
+                tray      = createFakeTrayFactory(),
+                lifecycle = createAppLifecycle({app, teardownBrain: async () => ({})});
+
+            lifecycle.attachCockpitWindow(cockpit);
+            lifecycle.installTray(tray.factory);
+            lifecycle.setBrainState('running');
+
+            cockpit.emit('closed');
+            cockpit.webContents.emit('render-process-gone');
+            expect(lifecycle.brainHealth.cause.source).toBe('cockpit-closed');
+
+            lifecycle.watchBrainChild(child, 'orchestrator');
+            child.emit('error', new Error('x'.repeat(400)));
+            expect(lifecycle.brainHealth.cause.detail.length).toBeLessThanOrEqual(200)
+        });
+
+        test('boot-not-ready is a recorded cause, and recovery to running clears it', () => {
+            const
+                app       = createFakeApp(),
+                lifecycle = createAppLifecycle({app, teardownBrain: async () => ({})});
+
+            expect(lifecycle.settleBrainBoot(false)).toBe('degraded');
+            expect(lifecycle.brainHealth.cause.source).toBe('boot-not-ready');
+
+            expect(lifecycle.settleBrainBoot(true)).toBe('running');
+            expect(lifecycle.brainHealth).toEqual({cause: null, state: 'running'})
+        });
+
+        test('an explicit quit path never renders as impairment: stopped clears the cause', async () => {
+            const
+                app       = createFakeApp(),
+                child     = new EventEmitter(),
+                lifecycle = createAppLifecycle({app, teardownBrain: async () => ({})});
+
+            lifecycle.setBrainState('running');
+            lifecycle.watchBrainChild(child, 'fleet');
+            child.emit('exit', null, 'SIGKILL');
+
+            expect(lifecycle.brainHealth.cause.detail).toBe('fleet: exit signal SIGKILL');
+
+            // exitTerminal reaches 'stopped' without ever passing through 'running'.
+            await lifecycle.exitTerminal(0);
+
+            expect(lifecycle.brainHealth).toEqual({cause: null, state: 'stopped'})
+        })
+    });
+
     test('keeps smoke terminal, trayless, and exact-once across repeated exit requests', async () => {
         const
             app       = createFakeApp(),

--- a/test/playwright/unit/harness/preload.spec.mjs
+++ b/test/playwright/unit/harness/preload.spec.mjs
@@ -130,13 +130,13 @@ function cockpitDom({rosterState='sample', rosterLabel='static roster · offline
 }
 
 test.describe('Electron harness preload capability', () => {
-    test('exposes one Fleet promise capability and no raw transport or secret facts', async () => {
+    test('exposes exactly the named promise capabilities and no raw transport or secret facts', async () => {
         const
             {exposed, invokes} = await loadPreload(),
             request            = {method: 'listAgents', params: {}};
 
         expect(exposed.name).toBe('neoShell');
-        expect(Object.keys(exposed.value).sort()).toEqual(['fleetRequest', 'shellVersion']);
+        expect(Object.keys(exposed.value).sort()).toEqual(['brainHealth', 'fleetRequest', 'shellVersion']);
         expect(exposed.value.shellVersion).toBe('42.0.0');
         expect(exposed.value).not.toHaveProperty('bearerToken');
         expect(exposed.value).not.toHaveProperty('defineFleetAgent');
@@ -145,7 +145,11 @@ test.describe('Electron harness preload capability', () => {
         expect(exposed.value).not.toHaveProperty('node');
 
         await expect(exposed.value.fleetRequest(request)).resolves.toEqual({ok: true, result: []});
-        expect(invokes).toEqual([['fleet-request', request]])
+
+        // The health pull crosses its own named channel and carries no payload — the renderer can
+        // ask, never influence.
+        await expect(exposed.value.brainHealth()).resolves.toEqual({ok: true, result: []});
+        expect(invokes).toEqual([['fleet-request', request], ['brain-health']])
     })
 
     test('keeps credential capture in the one main-owned channel with no renderer input surface', async () => {


### PR DESCRIPTION
Resolves #16051

The cockpit banner for Brain daemon faults now exists end-to-end, on the amended architecture: ADR 0034 gains §2.3.7 (the settled amendment — severity-tiered first-cause-wins, the symmetric consumer re-read obligation, cause clearing on both `running` re-entry and `stopped`), the lifecycle owner produces and retains the ONE bounded cause at the fault-observation site (`watchBrainChild` now receives the owned child's registry label and captures the termination event's own summary — the zero-argument handler it replaces structurally could not see either), a sender-validated `brain-health` invoke crosses it to the renderer beside `fleet-request`, `Neo.Main.brainHealth()` bridges the App Worker with a typed unavailable envelope in dev-server mode, and `FleetCockpit` pulls it on the existing liveness cadence plus one immediate first read — under the file's own bounded-read discipline (generation fence, counted slots capped at the tick, `boundedRead` timeout with wire-settle slot release). The salvaged `spineBanner` daemon reducer and its pure tests re-land unchanged from the closed predecessor PR `#16050` — the reducer was never the defect; the producer and boundary were missing.

Settlement provenance: the ADR amendment was drafted, narrowed, and settled with @neo-opus-vega (design authority for `#14793` and the `#16050` Drop+Supersede) on the ticket — https://github.com/neomjs/neo/issues/16051#issuecomment-5165427978 — with explicit no-second-round direction to open this PR directly. All three binding narrowings are folded into the ADR text and asserted in specs.

Review round 1 (@neo-gpt, PRR 4844097247) confirmed the architecture and named three fault-matrix blockers, all repaired at `ba52a8fef6`: the health pull joins the bounded-read/generation/cap discipline (never-settle witnessed against real hung promises), transport failure retains last-known daemon truth instead of erasing it (only a valid `running` answer clears), and the recovery claim is rescoped to the owner's `running` transition — restart machinery (a second boot-settle after an owned-child fault) is lifecycle-service scope, not this leaf's.

Evidence: L2 achieved (hermetic unit — producer cause retention, transport allowlist contract, bounded/fenced feed mapping incl. the resolve/reject/never-settle matrix, and a slot witness driven by the REAL lifecycle owner module) → L3 shell-runtime observation deferred: no harness-smoke fault injection exists today, so the packaged-shell observation rides Post-Merge Validation. Residual: real-shell fault observation, annotated `[L3-deferred — operator handoff needed]` on #16051.

## Deltas from ticket

- The three settlement narrowings are post-ticket-body scope, folded per the settlement comment: owned-child faults supersede window-scoped causes (never the reverse), consumers must re-read for as long as they render (interval stays leaf property — it rides the existing liveness cadence, zero new timers), and `stopped` clears the cause so an explicit quit never renders as impairment.
- Review-round-1 repairs (same architecture, three fault edges): bounded/capped/fenced health pull; retain-on-transport-failure; recovery claim scoped to the owner's transition.
- `startLiveness` issues one immediate first health read: unlike roster/activity, the daemon surface has no other first load, and waiting a full cadence would leave a boot-time fault invisible.
- `BRAIN_HEALTH_STATES` is deliberately duplicated in `FleetCockpit` (mirroring `harness/appLifecycle.mjs`'s `BRAIN_STATES`): the hemisphere boundary forbids apps code importing from the packaging root, so the vocabulary is mirrored and anything outside it moves nothing.
- The witness composition honors the settlement's race note at unit grain: the producer-driven witness calls the feed mapping synchronously (no wall-clock poll race); any future shell-level E2E must tolerate one poll cycle between transition and banner.

## Test Evidence

Per-file runs (the multi-file `test-unit` invocation undercounts — it silently omitted the liveness suite, 113 reported where per-file runs total 120+; discovered on this branch, per-file receipts are the verification standard here):

- `test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs` → **86 passed**, including: the producer-driven slot witness (real `createAppLifecycle` transition drives fault AND recovery), the transport control sequence (fault → dead transport → RETAINED → running → cleared), dev-server silence, the never-settle witness (real hung promises: timeout frees the caller, wire-settle frees the slot, cap suppresses at 2), and the generation fence (a slow stale answer never overwrites newer truth).
- `test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs` → **12 passed** (salvaged pure suite unchanged: ranking, silence, episode idempotence, WCAG state-in-sentence).
- `test/playwright/unit/harness/appLifecycle.spec.mjs` → **13 passed** (five cause-retention tests: supersession both directions, tier-internal first-cause-wins, bounded detail, boot-not-ready, quit-path clearing via `exitTerminal`).
- `test/playwright/unit/harness/preload.spec.mjs` → **11 passed** (allowlist pinned to exactly three named capabilities; the health pull crosses its own channel with no payload).

## Post-Merge Validation

- [ ] Packaged shell observation: boot the harness, kill an owned Brain child, the banner names the child and event with the degraded sentence; tray and banner agree. `[L3-deferred — operator handoff needed]`
- [ ] Dev-server mode: no shell present — the daemon surface stays silent (no fabricated degradation), transport surfaces unaffected.

Runtime-restart recovery (a second `settleBrainBoot(true)` after an owned-child fault) is explicitly OUT of this close target: `brainFaulted` is boot-window-sticky by design and no restart machinery exists yet — that transition belongs to the Brain lifecycle service leaf (ADR 0034 §5 E4).

## Commits

- 1f3e38f2e2 — ADR 0034 §2.3.7 + §4 fold; lifecycle-owner cause producer; `brain-health` handler; preload capability; harness specs.
- f83d0fcb07 — salvaged reducer + pure tests re-land; `Neo.Main.brainHealth` bridge; FleetCockpit feed (fields, mapping, cadence hook); witness specs.
- 2a9f586312 — liveness falsifier hosts learn the third seam; cadence witness pins immediate first read + cadence re-reads; per-file receipt correction.
- ba52a8fef6 — review round 1: bounded/capped/fenced health pull with real never-settle witnesses; retain-on-transport-failure control sequence; recovery claim rescoped.

Authored by Clio (Claude Fable 5, Claude Code). Session 65e414e1-48a4-49a0-a430-70a81911f9fc.
