### PR TITLE
fix(tab): overflow control re-arms a transiently unmounted mount on sync (#16434)

### DIFF
--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -537,6 +537,11 @@ class VdomLifecycle extends Base {
      * Creates the vnode tree for this component and mounts the component in case
      * - you pass true for the mount param
      * - or the autoMount config is set to true
+     *
+     * Lifecycle contract for awaiting callers: the returned promise settles when the REAL
+     * attempt settles. A theme-file deferral chains through the re-entered attempt instead of
+     * resolving early, and a rejected attempt releases `isVnodeInitializing` (component + app
+     * level) before rethrowing, so a caller-side retry on a later trigger is always possible.
      * @param {Boolean} [mount] Mount the DOM after the vnode got created
      * @returns {Promise<any>} If getting there, we return the data from vdom.Helper: create(), containing the vnode.
      */
@@ -548,13 +553,18 @@ class VdomLifecycle extends Base {
 
         if (unitTestMode && !allowVdomUpdatesInTests) return;
 
-        // Verify that the critical rendering path => CSS files for the new tree is in place
+        // Verify that the critical rendering path => CSS files for the new tree is in place.
+        // Deferred is not done: the returned promise settles only when the re-entered attempt
+        // settles (chained recursively across repeated deferrals), so an awaiting caller — and
+        // any caller-side single-flight latch — tracks the REAL mount attempt instead of a
+        // wrapper that resolves before the work begins. Rejections propagate through the chain
+        // for the same reason.
         if (!unitTestMode && autoMount && currentWorker.countLoadingThemeFiles !== 0) {
-            currentWorker.on('themeFilesLoaded', function() {
-                !me.mounted && me.initVnode(mount)
-            }, me, {once: true});
-
-            return
+            return new Promise((resolve, reject) => {
+                currentWorker.on('themeFilesLoaded', function() {
+                    me.mounted ? resolve() : me.initVnode(mount).then(resolve, reject)
+                }, me, {once: true})
+            })
         }
 
         me.isVnodeInitializing = true;
@@ -614,8 +624,17 @@ class VdomLifecycle extends Base {
         } catch (err) {
             // Mirror executeVdomUpdate()'s error contract: the in-flight state MUST be released on
             // failure, or the component wedges permanently (isVdomUpdating never clears and the
-            // registry entry blocks every ancestor update via isChildUpdating).
-            me.isVdomUpdating = false;
+            // registry entry blocks every ancestor update via isChildUpdating). The initializing
+            // flags belong to the same contract: a rejection that left isVnodeInitializing=true
+            // silently blocked every future initVnode consumer gating on it — no retry could
+            // ever run for the component's lifetime.
+            me.isVdomUpdating       = false;
+            me.isVnodeInitializing  = false;
+
+            if (app && !app.vnodeInitialized) {
+                app.isVnodeInitializing = false
+            }
+
             VDomUpdate.unregisterInFlightUpdate(me.id);
 
             console.error('initVnode error', err, me.id);

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -464,8 +464,12 @@ class Overflow extends Plugin {
             // document's lifetime. The mount path itself is starvation-proof (message-driven
             // vnode create + insert; verified live in a fully hidden document), so
             // re-attempting here makes the surface self-healing against any transient
-            // un-mounter. The latch bounds it to one in-flight attempt; the align follows
-            // only a successful mount (mirroring the sync-time re-align below).
+            // un-mounter. The latch bounds it to one in-flight attempt — which relies on
+            // initVnode's lifecycle contract: its promise settles only when the REAL attempt
+            // settles (a theme-file deferral chains through the re-entered attempt), and a
+            // rejection releases isVnodeInitializing before rethrowing, so the guard above
+            // re-opens and a later sync retries. The align follows only a successful mount
+            // (mirroring the sync-time re-align below).
             if (!me.control.mounted && !me.control.isVnodeInitializing && !me.remountArming) {
                 me.remountArming = true;
 

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -156,6 +156,12 @@ class Overflow extends Plugin {
      * @member {Boolean} queuedRecapture=false
      */
     queuedRecapture = false
+    /**
+     * A re-mount attempt for a transiently unmounted control is in flight — see `syncControl`.
+     * Prevents overlapping re-arms when syncs land faster than the mount round-trip settles.
+     * @member {Boolean} remountArming=false
+     */
+    remountArming = false
 
     /**
      * @param {Object} config
@@ -449,6 +455,29 @@ class Overflow extends Plugin {
                 me.control.menuList.items = menuItems
             } else {
                 me.control.menu = menuConfig
+            }
+
+            // Re-arm a transiently unmounted control. A floating instance mounts once at
+            // create; any later unmount (a re-projection wave, a tour reset) previously
+            // ratcheted into a permanent wedge — every following sync only mutated menu
+            // items on the unmounted instance, and the overflow surface was gone for the
+            // document's lifetime. The mount path itself is starvation-proof (message-driven
+            // vnode create + insert; verified live in a fully hidden document), so
+            // re-attempting here makes the surface self-healing against any transient
+            // un-mounter. The latch bounds it to one in-flight attempt; the align follows
+            // only a successful mount (mirroring the sync-time re-align below).
+            if (!me.control.mounted && !me.control.isVnodeInitializing && !me.remountArming) {
+                me.remountArming = true;
+
+                me.control.initVnode(true)
+                    .then(() => {
+                        const {control} = me;
+                        control && !control.isDestroyed && control.mounted && control.alignTo()
+                    })
+                    .catch(() => {})
+                    .finally(() => {
+                        me.remountArming = false
+                    })
             }
         } else {
             // OUT-OF-COLLECTION mount: a floating button rooted directly at document.body, NOT a trailing

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -322,6 +322,113 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         expect(createdConfig.menu.items, 'the menu config retains the exact hidden-tab projection')
             .toHaveLength(1);
         expect(plugin.control, 'and assigns the fresh instance as the new control').not.toBeNull()
+    });
+
+    test('re-arm: a transiently unmounted control re-mounts on the next sync — once, latched, aligned after the mount lands (#16434)', async () => {
+        // A floating control mounts once at create. A transient unmount (a re-projection wave,
+        // a tour reset) previously ratcheted into a permanent wedge: the update branch only
+        // mutated menu items on the unmounted instance, and no path ever re-attempted the
+        // mount. The re-arm makes the surface self-healing; this pins its full lifecycle.
+        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const hiddenMeta = [{text: 'Agents', iconCls: 'fa fa-users', index: 0}];
+
+        let aligned     = 0,
+            initCalls   = 0,
+            initArg     = null,
+            resolveInit = null;
+
+        plugin.control = {
+            isDestroyed        : false,
+            isVnodeInitializing: false,
+            menuList           : {items: []},
+            mounted            : false,
+            alignTo() {
+                aligned++
+            },
+            initVnode(mount) {
+                initCalls++;
+                initArg = mount;
+                return new Promise(resolve => {
+                    resolveInit = resolve
+                })
+            }
+        };
+
+        plugin.syncControl(hiddenMeta, {activeIndex: 0});
+
+        expect(initCalls, 'the unmounted control gets exactly one re-mount attempt').toBe(1);
+        expect(initArg, 'the re-attempt is a mounting initVnode').toBe(true);
+        expect(plugin.remountArming, 'the latch holds while the attempt is in flight').toBe(true);
+        expect(aligned, 'no align before the mount lands').toBe(0);
+
+        // A second sync during the in-flight attempt must not double-arm.
+        plugin.syncControl(hiddenMeta, {activeIndex: 0});
+        expect(initCalls, 'the latch bounds the re-arm to one in-flight attempt').toBe(1);
+
+        // The mount lands: the chained align fires once, the latch releases.
+        plugin.control.mounted = true;
+        resolveInit();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(aligned, 'the re-mounted control is re-pinned to the owner edge').toBe(1);
+        expect(plugin.remountArming, 'the latch releases after settlement').toBe(false);
+
+        // A mounted control takes the ordinary update path: no re-arm churn, sync-time re-align only.
+        plugin.syncControl(hiddenMeta, {activeIndex: 0});
+        expect(initCalls, 'a mounted control is never re-armed').toBe(1);
+        expect(aligned, 'the ordinary sync-time re-align fires for the mounted control').toBe(2)
+    });
+
+    test('re-arm skips a control whose own initVnode is still in flight (#16434)', async () => {
+        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        let initCalls = 0;
+
+        plugin.control = {
+            isDestroyed        : false,
+            isVnodeInitializing: true,
+            menuList           : {items: []},
+            mounted            : false,
+            alignTo() {},
+            initVnode() {
+                initCalls++;
+                return Promise.resolve()
+            }
+        };
+
+        plugin.syncControl([{text: 'Agents', iconCls: 'fa fa-users', index: 0}], {activeIndex: 0});
+
+        expect(initCalls, 'a first mount already in flight is never doubled').toBe(0);
+        expect(plugin.remountArming, 'the latch stays untouched').toBe(false)
+    });
+
+    test('re-arm: a rejected re-mount releases the latch without align or unhandled rejection (#16434)', async () => {
+        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        let aligned = 0;
+
+        plugin.control = {
+            isDestroyed        : false,
+            isVnodeInitializing: false,
+            menuList           : {items: []},
+            mounted            : false,
+            alignTo() {
+                aligned++
+            },
+            initVnode() {
+                return Promise.reject(new Error('transient mount failure'))
+            }
+        };
+
+        plugin.syncControl([{text: 'Agents', iconCls: 'fa fa-users', index: 0}], {activeIndex: 0});
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(plugin.remountArming, 'a failed attempt releases the latch so the NEXT sync can retry').toBe(false);
+        expect(aligned, 'no align on a failed mount').toBe(0)
     })
 });
 

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -405,30 +405,130 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         expect(plugin.remountArming, 'the latch stays untouched').toBe(false)
     });
 
-    test('re-arm: a rejected re-mount releases the latch without align or unhandled rejection (#16434)', async () => {
+    test('re-arm vs the REAL producer: a theme-file deferral holds the latch across syncs — no listener stacking (#16434)', async () => {
+        // The deferred initVnode branch settles only when the re-entered attempt settles
+        // (VdomLifecycle chains through the once-listener). The latch therefore spans the
+        // WHOLE deferral: repeated syncs must not register overlapping themeFilesLoaded
+        // callbacks. Pre-repair the wrapper resolved early, the latch released, and every
+        // sync stacked another listener (reviewer falsifier: registrations 1 → 2).
         const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
         await new Promise(resolve => setTimeout(resolve, 0));
 
-        let aligned = 0;
+        const
+            hiddenMeta       = [{text: 'Agents', iconCls: 'fa fa-users', index: 0}],
+            worker           = Neo.currentWorker,
+            themeCallbacks   = [],
+            originalOn       = worker.on,
+            originalCount    = worker.countLoadingThemeFiles,
+            originalUnitMode = Neo.config.unitTestMode,
+            control          = Neo.create({
+                module  : (await import('../../../../../src/component/Base.mjs')).default,
+                appName : 'test-app',
+                floating: true,
+                parentId: 'document.body',
+                windowId: 1
+            });
 
-        plugin.control = {
-            isDestroyed        : false,
-            isVnodeInitializing: false,
-            menuList           : {items: []},
-            mounted            : false,
-            alignTo() {
-                aligned++
-            },
-            initVnode() {
-                return Promise.reject(new Error('transient mount failure'))
-            }
+        worker.on = (event, callback) => {
+            (event === 'themeFilesLoaded' || event?.themeFilesLoaded) && themeCallbacks.push(
+                typeof event === 'string' ? callback : event.themeFilesLoaded
+            )
         };
+        worker.countLoadingThemeFiles = 1;
 
-        plugin.syncControl([{text: 'Agents', iconCls: 'fa fa-users', index: 0}], {activeIndex: 0});
+        plugin.control = control;
+
+        try {
+            // The gate check reads config synchronously at call time: expose the real
+            // (non-unit) branch for exactly the arming calls, restore right after.
+            Neo.config.unitTestMode = false;
+            plugin.syncControl(hiddenMeta, {activeIndex: 0});
+
+            expect(themeCallbacks.length, 'the first sync arms exactly one deferral listener').toBe(1);
+            expect(plugin.remountArming, 'the latch holds across the deferral, not just the call').toBe(true);
+
+            plugin.syncControl(hiddenMeta, {activeIndex: 0});
+
+            expect(themeCallbacks.length, 'a second sync during the deferral stacks NO second listener').toBe(1);
+            Neo.config.unitTestMode = originalUnitMode;
+
+            // Theme files land: the deferral re-enters (unit mode early-returns the attempt),
+            // the chained promise settles, the latch releases.
+            worker.countLoadingThemeFiles = 0;
+            themeCallbacks[0]();
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(plugin.remountArming, 'the latch releases when the REAL attempt settles').toBe(false)
+        } finally {
+            Neo.config.unitTestMode = originalUnitMode;
+            worker.on = originalOn;
+            originalCount === undefined
+                ? delete worker.countLoadingThemeFiles
+                : worker.countLoadingThemeFiles = originalCount;
+            control.destroy()
+        }
+    });
+
+    test('re-arm vs the REAL producer: a rejected attempt releases isVnodeInitializing so the next sync retries (#16434)', async () => {
+        // Pre-repair, a real vnode-creation rejection left isVnodeInitializing=true, so the
+        // guard skipped every later sync and the promised retry never ran (reviewer
+        // falsifier: create calls 1 → 1). The catch now releases the flag; this drives the
+        // REAL initVnode through a rejecting Neo.vdom.Helper.create and proves the retry.
+        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
         await new Promise(resolve => setTimeout(resolve, 0));
 
-        expect(plugin.remountArming, 'a failed attempt releases the latch so the NEXT sync can retry').toBe(false);
-        expect(aligned, 'no align on a failed mount').toBe(0)
+        // The Helper registers Neo.vdom.Helper at import time; this spec's own module graph
+        // does not load it otherwise.
+        await import('../../../../../src/vdom/Helper.mjs');
+
+        const
+            hiddenMeta     = [{text: 'Agents', iconCls: 'fa fa-users', index: 0}],
+            originalAllow  = Neo.config.allowVdomUpdatesInTests,
+            originalApp    = Neo.apps?.['test-app'],
+            originalCreate = Neo.vdom.Helper.create,
+            originalError  = console.error,
+            control        = Neo.create({
+                module  : (await import('../../../../../src/component/Base.mjs')).default,
+                appName : 'test-app',
+                floating: true,
+                parentId: 'document.body',
+                windowId: 1
+            });
+
+        let createCalls = 0;
+
+        Neo.apps ??= {};
+        Neo.apps['test-app'] = {fire: () => {}, mounted: true, vnodeInitialized: true};
+        Neo.config.allowVdomUpdatesInTests = true;
+        Neo.vdom.Helper.create = () => {
+            createCalls++;
+            return Promise.reject(new Error('transient vnode-creation failure'))
+        };
+        console.error = () => {}; // initVnode's catch logs the rejection by contract
+
+        plugin.control = control;
+
+        try {
+            plugin.syncControl(hiddenMeta, {activeIndex: 0});
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(createCalls, 'the first sync drives one real create attempt').toBe(1);
+            expect(control.isVnodeInitializing, 'the rejection releases the core initializing flag').toBe(false);
+            expect(plugin.remountArming, 'the rejection releases the plugin latch').toBe(false);
+
+            plugin.syncControl(hiddenMeta, {activeIndex: 0});
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(createCalls, 'the next sync RETRIES with a second real create attempt').toBe(2);
+            expect(control.isVnodeInitializing, 'the retry rejection releases the flag again').toBe(false);
+            expect(plugin.remountArming, 'the latch is reusable across failed attempts').toBe(false)
+        } finally {
+            Neo.config.allowVdomUpdatesInTests = originalAllow;
+            Neo.vdom.Helper.create = originalCreate;
+            console.error = originalError;
+            originalApp === undefined ? delete Neo.apps['test-app'] : Neo.apps['test-app'] = originalApp;
+            control.destroy()
+        }
     })
 });
 


### PR DESCRIPTION
Resolves #16434

The classified defect was never a starved pipe — it was a ratchet. In worker mode a floating control's `mounted` flips optimistically on vnode receipt (`VdomLifecycle#onInitVnode`), and the overflow control mounts exactly once at create: any later transient unmount (a re-projection wave, a tour reset) left `syncControl`'s update branch mutating menu items on an unmounted instance forever — `waitForOverflowMenu` polled `control.mounted` forever-false, `navigateOverflowMenu` produced no receipt, and the dense tour stopped fail-closed at the overflow cue in genuinely hidden panes. The classification's decisive falsifier proved the mount path itself is starvation-proof: a direct `initVnode(true)` on the live wedged control in a fully hidden document produced the insertNode delta and a real DOM rect instantly. The repair is one arm at the owning seam — `syncControl` re-attempts the mount for an existing unmounted control (not mid-init; one in-flight attempt via a `remountArming` latch; owner-edge re-align chained after a successful mount; a failed attempt leaves the control retryable on a later sync) — **plus the two core lifecycle repairs cycle 1's real-producer falsifiers demanded to make those guarantees mechanically true**: the theme-deferred `initVnode` now returns a promise chained through the re-entered attempt (deferred is not done — no early latch release, no listener stacking), and a rejected attempt releases `isVnodeInitializing` (component + app level, the same wedge-class contract the catch already enforced for `isVdomUpdating`) before rethrowing, so a later sync can actually retry. The overflow surface is self-healing against any transient un-mounter; the un-mounter's identity is documented as open narrative on #16434's classification thread, explicitly non-blocking by the ticket's own R8.

Evidence: L3 achieved (real-producer unit witnesses + live hidden-pane end-to-end tour completion) → L3 required (the close-target ACs name the classified receipt, the repair, and the pane tour completing). Residual: none.

## Deltas from ticket

- The ticket's Fix §1-2 anticipated classifying a starved leg among the overflow plugin's measurement/projection paths; instrumentation dissolved all candidate parking windows — the mount path is healthy under starvation, and the defect is the transient-unmount + create-once ratchet (classification rounds 1-2 on the ticket).
- Cycle-1 (Euclid, real-producer falsifiers): the original latch was scoped to a wrapper promise whose producer deferred work (theme loads) and stranded a core flag on rejection. Both are now repaired at the core seam (`src/mixin/VdomLifecycle.mjs#initVnode`): deferral-chained settlement + rejection releases the initializing flags. The plugin re-arm code is unchanged; its one-in-flight/retry prose is now exact, and both reviewer falsifiers are encoded as permanent real-producer unit witnesses.
- The witness plan's "extend the synthetic rig" clause is intentionally not exercised: the rig cannot model the pane's transient (its tour never wedged); the deterministic floor is the unit suite and the live pane carries the end-to-end proof.

## Test Evidence

All receipts at head `384e94d057` (dev `7b3e52b9f4` + two commits):

- `npm run test-unit -- test/playwright/unit/tab/plugin/Overflow.spec.mjs` → **23/23 passed**: the re-arm lifecycle pins (once + latched + aligned-after-mount + no churn on mounted; mid-init skip) plus the two cycle-1 real-producer witnesses — theme-deferral single-flight (recording `currentWorker.on`: repeated syncs register exactly ONE `themeFilesLoaded` listener while the latch spans the whole deferral; the latch releases only when the chained attempt settles) and rejection-retry (a rejecting `Neo.vdom.Helper.create` driven through the REAL `initVnode`: the catch releases `isVnodeInitializing`, and the next sync retries with a second real create attempt — the reviewer's exact 1 → 1 falsifier now measures 1 → 2).
- `npm run test-unit` (full sweep, the core mixin change) → **11,180 passed** (5 skipped / 2 not-run: pre-existing markers).
- `npx playwright test WorkstationStarvedTourNL WorkstationStarvedGeometryNL -c ... --workers=1` → **2/2 passed** (49.6s at head).
- **Live hidden pane, end-to-end (the close-target's own AC, at the cycle-0 head):** fresh reload → `startTour` via NL → `Tour complete — 11 deterministic beats and 6 surface cues settled.` with `document.hidden: true` throughout, 11/11 pips, the overflow control alive in the DOM mid-tour AND post-settlement, formal receipt `completed: true, errors: [], elapsedMs: 67525`. The identical pre-repair run stopped at `Tour stopped — overflow: overflow returned no observable receipt` (receipts on #16434). The cycle-1 delta touches only deferral/rejection legs the pane's happy path never entered.
- Touched-surface coverage: `src/tab/plugin/Overflow.mjs` + `src/mixin/VdomLifecycle.mjs` → unit suites above (plugin 23/23, full sweep 11,180); `apps/workstation` tour surface → starved-tour e2e + live pane receipt.

## Post-Merge Validation

- [ ] The dense tour completes end-to-end in long-lived hidden fleet panes across the swarm (the >5min intensive-throttling tier remains #16435's measurement).

## Commits (if multi-commit)

- `55a4f2622e` — the re-mount arm + latch + 3 unit witnesses.
- `384e94d057` — cycle-1: core lifecycle truth (deferral-chained settlement + rejection releases init flags) + the two real-producer witnesses.

Authored by Mnemosyne (Claude Fable, Claude Code). Session f01a83b0-dab9-4fa9-a3a1-279f3e2336dd.
