### PR TITLE
fix(docs): replace the whole plist array, never an index (#16440)

### DIFF
--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -250,8 +250,9 @@ plutil -replace StandardOutPath -string "${NEO_WAKE_RECEIVER_STATE_DIR}/launchd.
 plutil -replace StandardErrorPath -string "${NEO_WAKE_RECEIVER_STATE_DIR}/launchd.err.log" "${NEO_WAKE_PLIST}"
 plutil -lint "${NEO_WAKE_PLIST}"
 
-# `lint` is NOT sufficient here — see the note below. Assert no placeholder survived.
+# `lint` is NOT sufficient here — see the note after this block. Assert no placeholder survived.
 plutil -p "${NEO_WAKE_PLIST}" | grep -q '__' && { echo 'FAIL: placeholder survived in wake plist'; exit 1; }
+```
 
 **Replace the whole `ProgramArguments` array, never an index.** `plutil -replace
 ProgramArguments.0` **inserts** at index 0 instead of replacing it: the
@@ -273,6 +274,7 @@ host receiver through the loopback-mapped host address, so a `0.0.0.0` bind is
 an unnecessary widening — keep it loopback unless a measured LAN path requires
 otherwise.
 
+```sh
 cp ai/deploy/com.neomjs.agent-os-host-edge.plist "${NEO_HOST_EDGE_PLIST}"
 plutil -replace ProgramArguments -json "[\"$(command -v node)\", \"ai/daemons/orchestrator/hostEdge.mjs\"]" "${NEO_HOST_EDGE_PLIST}"
 plutil -replace WorkingDirectory -string "${NEO_REPO_ROOT}" "${NEO_HOST_EDGE_PLIST}"

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -237,16 +237,36 @@ if launchctl print "gui/$(id -u)/com.neomjs.agent-os-host-edge" >/dev/null 2>&1;
 fi
 
 cp ai/deploy/com.neomjs.agent-os-wake.plist "${NEO_WAKE_PLIST}"
-plutil -replace ProgramArguments.0 -string "$(command -v node)" "${NEO_WAKE_PLIST}"
-plutil -replace ProgramArguments.3 -string "${NEO_WAKE_RECEIVER_MANIFEST}" "${NEO_WAKE_PLIST}"
-plutil -replace ProgramArguments.5 -string "${NEO_WAKE_RECEIVER_STATE_DIR}" "${NEO_WAKE_PLIST}"
-plutil -replace ProgramArguments.7 -string "127.0.0.1" "${NEO_WAKE_PLIST}"
-plutil -replace ProgramArguments.9 -string "3199" "${NEO_WAKE_PLIST}"
+plutil -replace ProgramArguments -json "[
+  \"$(command -v node)\", \"ai/daemons/wake/receiver.mjs\",
+  \"--manifest\",  \"${NEO_WAKE_RECEIVER_MANIFEST}\",
+  \"--state-dir\", \"${NEO_WAKE_RECEIVER_STATE_DIR}\",
+  \"--host\",      \"127.0.0.1\",
+  \"--port\",      \"3199\"
+]" "${NEO_WAKE_PLIST}"
 plutil -replace WorkingDirectory -string "${NEO_REPO_ROOT}" "${NEO_WAKE_PLIST}"
 plutil -replace EnvironmentVariables.PATH -string "${PATH}" "${NEO_WAKE_PLIST}"
 plutil -replace StandardOutPath -string "${NEO_WAKE_RECEIVER_STATE_DIR}/launchd.out.log" "${NEO_WAKE_PLIST}"
 plutil -replace StandardErrorPath -string "${NEO_WAKE_RECEIVER_STATE_DIR}/launchd.err.log" "${NEO_WAKE_PLIST}"
 plutil -lint "${NEO_WAKE_PLIST}"
+
+# `lint` is NOT sufficient here — see the note below. Assert no placeholder survived.
+plutil -p "${NEO_WAKE_PLIST}" | grep -q '__' && { echo 'FAIL: placeholder survived in wake plist'; exit 1; }
+
+**Replace the whole `ProgramArguments` array, never an index.** `plutil -replace
+ProgramArguments.0` **inserts** at index 0 instead of replacing it: the
+placeholder survives one slot to the right and becomes `argv[1]`, so `node` is
+handed `__NODE_BIN__` as its script path and the agent never launches. The wake
+plist degrades worst under the per-index form, because each insert shifts every
+later placeholder and the remaining index arithmetic is then wrong.
+
+**`plutil -lint` reports `OK` on the corrupted result** — the shifted array is
+structurally valid — so there is no install-time diagnostic and the failure only
+shows up as an agent that silently never runs. That is why the placeholder
+assertion above exists, and why `lint` alone must not be trusted as the check.
+Dictionary-key replacement (`WorkingDirectory`, `EnvironmentVariables.*`,
+`StandardOutPath`, `StandardErrorPath`, including nested dotted keys) replaces
+correctly and is fine as written; the defect is specific to **array indices**.
 
 The receiver binds `127.0.0.1` deliberately: the container plane reaches the
 host receiver through the loopback-mapped host address, so a `0.0.0.0` bind is
@@ -254,13 +274,14 @@ an unnecessary widening — keep it loopback unless a measured LAN path requires
 otherwise.
 
 cp ai/deploy/com.neomjs.agent-os-host-edge.plist "${NEO_HOST_EDGE_PLIST}"
-plutil -replace ProgramArguments.0 -string "$(command -v node)" "${NEO_HOST_EDGE_PLIST}"
+plutil -replace ProgramArguments -json "[\"$(command -v node)\", \"ai/daemons/orchestrator/hostEdge.mjs\"]" "${NEO_HOST_EDGE_PLIST}"
 plutil -replace WorkingDirectory -string "${NEO_REPO_ROOT}" "${NEO_HOST_EDGE_PLIST}"
 plutil -replace EnvironmentVariables.PATH -string "${PATH}" "${NEO_HOST_EDGE_PLIST}"
 plutil -replace EnvironmentVariables.NEO_AI_ORCHESTRATOR_DIR -string "${NEO_HOST_EDGE_STATE_DIR}" "${NEO_HOST_EDGE_PLIST}"
 plutil -replace StandardOutPath -string "${NEO_HOST_EDGE_STATE_DIR}/launchd.out.log" "${NEO_HOST_EDGE_PLIST}"
 plutil -replace StandardErrorPath -string "${NEO_HOST_EDGE_STATE_DIR}/launchd.err.log" "${NEO_HOST_EDGE_PLIST}"
 plutil -lint "${NEO_HOST_EDGE_PLIST}"
+plutil -p "${NEO_HOST_EDGE_PLIST}" | grep -q '__' && { echo 'FAIL: placeholder survived in host-edge plist'; exit 1; }
 
 launchctl bootstrap "gui/$(id -u)" "${NEO_WAKE_PLIST}"
 launchctl bootstrap "gui/$(id -u)" "${NEO_HOST_EDGE_PLIST}"


### PR DESCRIPTION
Resolves #16440

Related: `D#16193` (fork provisioning — this is its first-boot instance), `#16229` (introduced the procedure this repairs, closed), `#16167` (the Docker hard-cut this runbook serves)

`plutil -replace ProgramArguments.0` **inserts** at index 0 instead of replacing it. The placeholder survives one slot to the right and becomes `argv[1]`, so `node` is handed `__NODE_BIN__` as its script path and the LaunchAgent never starts.

Evidence: L1 (documentation; verified by executing the corrected procedure against the real templates) — no runtime surface changes, so L1 is the ceiling and the executed run is the floor.

## Why this was expensive rather than merely wrong

**`plutil -lint` reports `OK` on the corrupted result**, because a shifted array is structurally valid:

```
$ plutil -replace ProgramArguments.0 -string "$(command -v node)" probe.plist
$ plutil -p probe.plist
  ProgramArguments => ["/opt/homebrew/bin/node", "__NODE_BIN__", "ai/daemons/orchestrator/hostEdge.mjs"]
$ plutil -lint probe.plist
probe.plist: OK
```

A contributor follows the runbook exactly, the only validation it offers blesses the output, and the agent silently never runs. **There is no error string to search for.** @neo-opus-ada surfaced this from a cold-boot dataset (machine rebooted for the first time since the Docker cutover, nothing came back) and suspected it is why the wake receiver on that machine has been run by hand from a terminal rather than supervised — which fits: the supervision step was never viable.

The wake plist degrades worst because it patched **five** indices (`.0 .3 .5 .7 .9`). Each insert shifts every later placeholder, so the index arithmetic in steps 2–5 was already wrong by the time those lines ran.

## The scope is narrower than the symptom, and that is the point

The naive fix is a block-wide rewrite. It would be an over-correction, and one control establishes why:

| form | behaviour |
|---|---|
| `plutil -replace WorkingDirectory -string …` | **replaces correctly** ✅ |
| `plutil -replace EnvironmentVariables.PATH -string …` | **replaces correctly** ✅ (nested dotted key, still fine) |
| `plutil -replace ProgramArguments.0 -string …` | **inserts** ❌ |

Dictionary-key replacement — including nested dotted keys — is correct. Only **array indices** misbehave. So this touches **6 lines of 15** and leaves the **9 dictionary-key lines byte-identical**:

```
removed: 6 plutil lines (every one a ProgramArguments.<index>)
added:   4 plutil lines (2 whole-array replaces + 2 placeholder assertions)
dict-key lines touched: 0
```

## The fix

One whole-array `-replace … -json` call per plist. Beyond correctness, this **removes the index arithmetic entirely** — the five-index sequence was fragile even where each individual call succeeded, because every step depended on the array shape the previous step left behind.

Two additions beyond the mechanical repair:

1. **A placeholder assertion after each `lint`.** `lint` is not a sufficient check here, so the runbook now asserts no `__…__` survived. This is the check that would have caught the original defect at install time.
2. **An inline note** naming the insert-not-replace behaviour, the `lint`-blesses-corruption consequence, and the dict-key-vs-array-index boundary — so the pattern is not reintroduced and the next author knows why `lint` alone is not trusted.

## Test Evidence

Two witnesses, because the first one was insufficient and @neo-gpt-emmy caught why.

**Witness 2 (added after review) — every `sh`/`bash` fence in the file parses.** The original
evidence below verified the commands I *extracted*; it could not verify that the *published*
fenced block was followable, which is exactly the gap Emmy found (`sh -n` over the fence exited 2).
Both edited fences now pass. One pre-existing fence (168-181) fails on `<angle-bracket>` substitution
placeholders — a different class (shell intended as shell, followable after substitution), deliberately
left alone rather than bent to make the witness green.

**Witness 1 — executed the corrected procedure against the real templates in `ai/deploy/`, not a mock:**

```
./w2.plist: OK
--- wake ProgramArguments ---
  0 => "/opt/homebrew/bin/node"      5 => "/tmp/wstate"
  1 => "ai/daemons/wake/receiver.mjs" 6 => "--host"
  2 => "--manifest"                   7 => "127.0.0.1"
  3 => "/tmp/routes.json"             8 => "--port"
  4 => "--state-dir"                  9 => "3199"

./h2.plist: OK
--- host-edge ProgramArguments ---
  0 => "/opt/homebrew/bin/node"
  1 => "ai/daemons/orchestrator/hostEdge.mjs"

=== BOTH CLEAN: lint OK, zero placeholders survived ===
```

All 10 wake elements resolve in the correct order; host-edge resolves both. Reproduced on macOS Darwin 25.6.0.

**The new assertion earned its place by failing first — against a run of my own.** My initial verification skipped three of the `-replace` lines (`EnvironmentVariables.PATH`, `StandardOutPath`, `StandardErrorPath`), and the assertion fired: `FAIL: placeholder survived in wake plist`. Inspecting *which* placeholders survived showed they were exactly the three keys my abbreviated run had skipped — my test was incomplete, the fix was sound. Recording it because it is the honest demonstration that the guard discriminates: it caught an incomplete procedure on its first real use, which is precisely the class of failure the original runbook could not report.

## Post-Merge Validation

- [ ] A contributor (or a clean machine) follows the runbook verbatim and gets two LaunchAgents that actually load — `launchctl print gui/$(id -u)/com.neomjs.agent-os-wake` shows a running process rather than a spawn failure.
- [ ] Whether the wake receiver *should* be supervised at all stays open (`D#16193`); this only makes the documented procedure work.

## Deltas

- One file: `ai/scripts/lifecycle/local-agent-os/README.md`. No `.mjs` touched, no runtime surface, no ADR impact.
- **Substrate accretion:** net +~20 lines, all of it the inline note explaining the trap and the two assertions. Justification: the defect is invisible by construction — a note that prevents one reintroduction pays for itself, and the assertion converts a silent failure into an install-time error. Sunset condition: if the install procedure is ever replaced by a script (rather than copy-paste steps), the note belongs in that script's JSDoc and the prose here retires with the block.
- Deliberately **not** fixed: the other four legs of the cold-boot chain (Colima no-auto-start, `lms server start`, `lms load` readiness, the un-elected bridge/dev-server lanes). Those are the provisioning-*contract* question and stay `D#16193`'s.

Authored by Vega (Claude Opus 5, Claude Code) — from @neo-opus-ada's cold-boot dataset, reproduced and scope-narrowed before filing. Session 11695cce-9854-4be2-80c3-8ea4322298bf.
