### PR TITLE
feat(ai): a zero-row export claims emptiness only when lineage supports it (#16404)

### DIFF
--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -296,9 +296,15 @@ export async function readPreviousBundleIdentities(backupRoot, logger = console)
 /**
  * @summary Builds the capture block: what each source held, and whether it is the same source.
  *
- * `readComplete` is `true` for every receipt that exists, and that is a fact about this substrate
+ * Every receipt that reaches here describes a complete read, and that is a fact about this substrate
  * rather than an assumption — `#exportCollection` throws `PARTIAL_COLLECTION_EXPORT` when
- * `exported !== expected`, so a partial read aborts the backup and never reaches a receipt.
+ * `exported !== expected`, so a partial read aborts the backup and never reaches a receipt. It is
+ * therefore not recorded as an axis; see {@link module:ai/services/shared/captureReceipt}.
+ *
+ * A receipt carrying no readable count is passed through as-is rather than defaulted to zero. The
+ * classification of that case belongs to `buildSourceReceipt`, which has one rule for it; a `?? 0`
+ * here would have made the malformed case indistinguishable from a measured empty before the rule
+ * ever ran.
  *
  * @param {Object} options
  * @param {Object} options.subsystems Receipt map assembled by `runBackup`.
@@ -317,12 +323,11 @@ export async function buildCaptureBlock({subsystems, backupRoot, logger = consol
 
         const rowCount = typeof receipt === 'number'
             ? receipt
-            : receipt.count ?? receipt.exported ?? 0;
+            : receipt.count ?? receipt.exported;
 
         sources[key] = buildSourceReceipt({
             source        : key,
             rowCount,
-            readComplete  : true,
             collectionId  : receipt.collectionId ?? null,
             previousId    : identities[key] ?? null,
             comparedBundle: bundleName
@@ -626,16 +631,17 @@ async function captureBackup({
         );
     }
 
-    const emptyChecks = integrity.filter(check => check.status === 'empty');
-    if (emptyChecks.length > 0) {
-        // Non-fatal (a fresh environment legitimately backs up empty subsystems), but loud: a zero-row
-        // export from a normally-populated deployment is the gutted-store signature, and a backup of an
-        // empty store is a false recovery source. The 'empty' status is carried in bundle-meta.integrity
-        // for a downstream canary/alert to escalate on.
+    const zeroRowChecks = integrity.filter(check => check.status === 'zero-rows');
+    if (zeroRowChecks.length > 0) {
+        // Non-fatal (a fresh environment legitimately backs up zero-row subsystems), but loud: a
+        // zero-row export from a normally-populated deployment is the gutted-store signature, and a
+        // backup holding no rows is a false recovery source. The 'zero-rows' status is carried in
+        // bundle-meta.integrity for a downstream canary/alert to escalate on. It reports what the
+        // bundle HOLDS; whether the source was genuinely empty is the capture block's question.
         logger.warn?.(
-            `[Backup] ${emptyChecks.length} subsystem(s) exported ZERO rows — empty backup is not a usable ` +
-            `recovery source: ${emptyChecks.map(c => c.subsystem).join(', ')}. Legitimate for a fresh ` +
-            `environment; corruption-suspicious for a populated deployment.`
+            `[Backup] ${zeroRowChecks.length} subsystem(s) exported ZERO rows — a bundle holding no rows is ` +
+            `not a usable recovery source: ${zeroRowChecks.map(c => c.subsystem).join(', ')}. Legitimate for ` +
+            `a fresh environment; corruption-suspicious for a populated deployment.`
         );
     }
 
@@ -700,11 +706,15 @@ export async function countNonEmptyJsonlLines(filePath) {
  * numeric count (KB, MC memories+summaries, MC graph), this function streams the bundle's JSONL
  * files to count non-empty lines (streaming so 1+ GB exports do not exceed V8's max string length)
  * and compares — mismatch indicates a partial/torn write that the
- * caller treats as a fail-the-bundle condition. Zero-zero parity (source and bundle both empty) is
- * reported as `empty`, not `pass`: a backup of an empty/gutted store is surfaced non-fatally because
- * it is not a usable recovery source (a fresh environment is legitimately empty; a populated
- * deployment reporting zero rows is the gutted-store signature). `runBackup` warns on `empty`
+ * caller treats as a fail-the-bundle condition. Zero-zero parity (source and bundle both report zero)
+ * is reported as `zero-rows`, not `pass`: a backup of an empty/gutted store is surfaced non-fatally
+ * because it is not a usable recovery source (a fresh environment is legitimately empty; a populated
+ * deployment reporting zero rows is the gutted-store signature). `runBackup` warns on `zero-rows`
  * subsystems and persists the status into `bundle-meta.integrity` for a downstream canary/alert.
+ *
+ * The status answers what the BUNDLE holds, never why. Whether the source was genuinely empty is the
+ * `capture` block's question — see {@link module:ai/services/shared/captureReceipt} — and the two are
+ * kept lexically apart so one artifact cannot publish two meanings of `empty` about the same zero.
  *
  * For file-copy subsystems (concepts, trajectories, mailbox) the source side has no
  * authoritative count to compare against — `copyJsonlSource`'s reported `copied` field
@@ -712,7 +722,7 @@ export async function countNonEmptyJsonlLines(filePath) {
  *
  * @param {Object} layout     The bundle's per-subsystem destination directory map.
  * @param {Object} subsystems The runBackup `subsystems` map of SDK return values.
- * @returns {Promise<Array<{subsystem: String, status: String, sourceCount: Number, bundleCount: Number, reason: String}>>} `status` is `pass` (positive row-count parity) / `empty` (source and bundle both zero — non-fatal, not a usable recovery source) / `fail` (row-count mismatch) / `skipped` (non-numeric source count); count + reason fields present per status.
+ * @returns {Promise<Array<{subsystem: String, status: String, sourceCount: Number, bundleCount: Number, reason: String}>>} `status` is `pass` (positive row-count parity) / `zero-rows` (source and bundle both zero — non-fatal, not a usable recovery source) / `fail` (row-count mismatch) / `skipped` (non-numeric source count); count + reason fields present per status.
  */
 export async function verifyBundleIntegrity(layout, subsystems) {
     const verifiable = ['kb', 'mc', 'graph'];
@@ -742,17 +752,22 @@ export async function verifyBundleIntegrity(layout, subsystems) {
         }
 
         if (bundleCount === sourceCount) {
-            // Empty-parity is NOT a healthy pass: a backup whose source AND bundle are both empty is
-            // not a usable recovery source. Legitimate for a fresh environment, but for a normally-
+            // Zero-parity is NOT a healthy pass: a bundle whose source AND files both report zero rows
+            // is not a usable recovery source. Legitimate for a fresh environment, but for a normally-
             // populated deployment a zero-row export is the gutted-store signature (the corruption a
-            // backup is supposed to survive) — surface it as 'empty' (visible, non-fatal) rather than
-            // a silent 'pass' so a downstream canary/alert can act on bundle-meta.integrity.
-            const status = sourceCount === 0 ? 'empty' : 'pass';
+            // backup is supposed to survive) — surface it as 'zero-rows' (visible, non-fatal) rather
+            // than a silent 'pass' so a downstream canary/alert can act on bundle-meta.integrity.
+            //
+            // Named 'zero-rows' and not 'empty' on purpose: this is a statement about what the bundle
+            // HOLDS, which is why it disqualifies a restore no matter what caused the zero. The
+            // capture block answers the separate question of whether the source was genuinely empty,
+            // and one artifact carrying both meanings under one word is how they came to disagree.
+            const status = sourceCount === 0 ? 'zero-rows' : 'pass';
             const entry  = {subsystem, status, sourceCount, bundleCount};
 
-            if (status === 'empty') {
-                entry.reason = 'source and bundle both report zero rows — empty backup is not a usable ' +
-                    'recovery source (fresh-env legitimate; populated-deployment corruption-suspicious)';
+            if (status === 'zero-rows') {
+                entry.reason = 'source and bundle both report zero rows — a bundle holding no rows is not a ' +
+                    'usable recovery source (fresh-env legitimate; populated-deployment corruption-suspicious)';
             }
 
             checks.push(entry);
@@ -835,24 +850,6 @@ async function buildVersionDescriptor(projectRoot, logger) {
 }
 
 /**
- * Applies retention policy to the backup root.
- *
- * Two-axis policy:
- *   - `keepMinimum` — newest N bundles retained unconditionally regardless of age
- *   - `maxDays`     — bundles older than this many days are eligible for deletion
- *
- * A bundle survives if EITHER axis protects it (i.e., it's in the keepMinimum-newest
- * window OR younger than maxDays). Both defaults match the original hardcoded
- * constants (`K=3, N_DAYS=30`) so omitting the `retention` argument preserves
- * existing behavior.
- *
- * @param {String} backupRoot
- * @param {Object} logger
- * @param {Object} [retention]
- * @param {Number} [retention.keepMinimum=3] Newest N bundles to retain unconditionally.
- * @param {Number} [retention.maxDays=30]    Bundles older than this in days are eligible for deletion.
- */
-/**
  * @summary Enumerates the PUBLISHED bundles under a backup root, newest first.
  *
  * "Published" is not a synonym for "present". A bundle becomes authoritative only when the
@@ -898,6 +895,28 @@ export async function listPublishedBundles(backupRoot) {
     return backups
 }
 
+/**
+ * Applies retention policy to the backup root.
+ *
+ * Two-axis policy:
+ *   - `keepMinimum` — newest N bundles retained unconditionally regardless of age
+ *   - `maxDays`     — bundles older than this many days are eligible for deletion
+ *
+ * A bundle survives if EITHER axis protects it (i.e., it's in the keepMinimum-newest
+ * window OR younger than maxDays). Both defaults match the original hardcoded
+ * constants (`K=3, N_DAYS=30`) so omitting the `retention` argument preserves
+ * existing behavior.
+ *
+ * Enumerates through {@link listPublishedBundles}, so a `.backup-partial-*` staging directory is
+ * never a retention candidate and never counts toward `keepMinimum` — an in-flight capture must not
+ * be able to age a real recovery source out of the floor.
+ *
+ * @param {String} backupRoot
+ * @param {Object} logger
+ * @param {Object} [retention]
+ * @param {Number} [retention.keepMinimum=3] Newest N bundles to retain unconditionally.
+ * @param {Number} [retention.maxDays=30]    Bundles older than this in days are eligible for deletion.
+ */
 export async function cleanOldBackups(backupRoot, logger, retention = {}) {
     if (!await fs.pathExists(backupRoot)) return;
 

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -23,6 +23,7 @@ import {
     Memory_LifecycleService
 } from '../../services.mjs';
 
+import {buildSourceReceipt}             from '../../services/shared/captureReceipt.mjs';
 import {
     resolveHeavyMaintenanceLeasePath,
     withHeavyMaintenanceLease
@@ -236,6 +237,99 @@ export function buildEmbeddingContract({subsystems}) {
         expectedConsumer: {model, provider},
         schemaVersion   : 1
     }
+}
+
+/**
+ * The sources whose identity is observable, and where each one's receipt lives in `subsystems`.
+ *
+ * The native graph is deliberately ABSENT. It is SQLite-backed and has no collection identity, so it
+ * could only ever record `lineage: unknown` — a permanent row that says nothing. Its own emptiness
+ * question is real but needs a different instrument, and inventing an always-unknown entry here would
+ * dress that gap as coverage.
+ * @type {Object[]}
+ */
+const LINEAGE_SOURCES = Object.freeze([
+    {key: 'kb',           read: subsystems => subsystems.kb},
+    {key: 'mc.memories',  read: subsystems => subsystems.mc?.memories},
+    {key: 'mc.summaries', read: subsystems => subsystems.mc?.summaries}
+]);
+
+/**
+ * @summary Reads the identities the previous PUBLISHED bundle recorded, keyed by source.
+ *
+ * Consumes {@link listPublishedBundles}, so a `.backup-partial-*` staging directory can never be the
+ * comparison basis — comparing against a capture that never completed would report a changed identity
+ * for an event that did not happen.
+ *
+ * Fail-soft by design: a missing, unreadable, or pre-`capture` bundle yields no identities, which
+ * degrades every lineage axis to `unknown` rather than aborting a backup. A backup that refuses to run
+ * because it cannot find its predecessor is a worse failure than one that cannot prove emptiness.
+ *
+ * @param {String} backupRoot Directory holding published bundles.
+ * @param {Object} [logger=console] Diagnostic sink.
+ * @returns {Promise<{bundleName: String|null, identities: Object}>}
+ */
+export async function readPreviousBundleIdentities(backupRoot, logger = console) {
+    const [previous] = await listPublishedBundles(backupRoot);
+
+    if (!previous) return {bundleName: null, identities: {}};
+
+    try {
+        const meta = await fs.readJson(path.join(previous.path, 'bundle-meta.json'));
+
+        // Prefer the structured capture block; fall back to the raw receipts so the FIRST bundle
+        // written after this change still has something to compare against next time.
+        const identities = {};
+        for (const {key, read} of LINEAGE_SOURCES) {
+            identities[key] = meta?.capture?.sources?.[key]?.collectionId
+                ?? read(meta?.subsystems || {})?.collectionId
+                ?? null;
+        }
+
+        return {bundleName: previous.name, identities}
+    } catch (error) {
+        logger.warn?.(`[Backup] Could not read identities from ${previous.name}: ${error.message}. Lineage degrades to unknown.`);
+        return {bundleName: previous.name, identities: {}}
+    }
+}
+
+/**
+ * @summary Builds the capture block: what each source held, and whether it is the same source.
+ *
+ * `readComplete` is `true` for every receipt that exists, and that is a fact about this substrate
+ * rather than an assumption — `#exportCollection` throws `PARTIAL_COLLECTION_EXPORT` when
+ * `exported !== expected`, so a partial read aborts the backup and never reaches a receipt.
+ *
+ * @param {Object} options
+ * @param {Object} options.subsystems Receipt map assembled by `runBackup`.
+ * @param {String} options.backupRoot Directory holding published bundles.
+ * @param {Object} [options.logger=console] Diagnostic sink.
+ * @returns {Promise<Object>} The `capture` block for `bundle-meta.json`.
+ */
+export async function buildCaptureBlock({subsystems, backupRoot, logger = console}) {
+    const {bundleName, identities} = await readPreviousBundleIdentities(backupRoot, logger);
+    const sources                  = {};
+
+    for (const {key, read} of LINEAGE_SOURCES) {
+        const receipt = read(subsystems);
+
+        if (!receipt) continue;
+
+        const rowCount = typeof receipt === 'number'
+            ? receipt
+            : receipt.count ?? receipt.exported ?? 0;
+
+        sources[key] = buildSourceReceipt({
+            source        : key,
+            rowCount,
+            readComplete  : true,
+            collectionId  : receipt.collectionId ?? null,
+            previousId    : identities[key] ?? null,
+            comparedBundle: bundleName
+        });
+    }
+
+    return {schemaVersion: 1, comparedTo: bundleName, sources}
 }
 
 /**
@@ -550,12 +644,20 @@ async function captureBackup({
     const versionInfo         = await buildVersionDescriptor(PROJECT_ROOT, logger);
     const publishedSubsystems = rebaseBundleReceiptPaths(subsystems, resolvedRoot, publishedRoot);
     const embedding           = buildEmbeddingContract({subsystems: publishedSubsystems});
-    const meta                = {
+    // Compared against the previous PUBLISHED bundle — the rename has not run yet, so this bundle is
+    // still staging and cannot select itself as its own predecessor.
+    const capture = await buildCaptureBlock({
+        subsystems: publishedSubsystems,
+        backupRoot: path.dirname(publishedRoot),
+        logger
+    });
+    const meta = {
         bundleVersion: 1,
         timestamp,
         completedAt,
         subsystems   : publishedSubsystems,
         integrity,
+        capture,
         topology,
         embedding,
         ...versionInfo
@@ -750,10 +852,23 @@ async function buildVersionDescriptor(projectRoot, logger) {
  * @param {Number} [retention.keepMinimum=3] Newest N bundles to retain unconditionally.
  * @param {Number} [retention.maxDays=30]    Bundles older than this in days are eligible for deletion.
  */
-export async function cleanOldBackups(backupRoot, logger, retention = {}) {
-    if (!await fs.pathExists(backupRoot)) return;
-
-    const {keepMinimum = 3, maxDays = 30} = retention;
+/**
+ * @summary Enumerates the PUBLISHED bundles under a backup root, newest first.
+ *
+ * "Published" is not a synonym for "present". A bundle becomes authoritative only when the
+ * same-filesystem rename completes; before that it is a `.backup-partial-*` staging directory, which
+ * this enumeration skips by construction because it does not carry the `backup-` prefix. That is the
+ * same boundary restore and retention already rely on, and it is why lineage comparison must consume
+ * this function rather than its own `readdir` — a comparison against a half-written staging directory
+ * would report a changed identity for a capture that never completed.
+ *
+ * Directories whose timestamp suffix does not parse are omitted rather than sorted arbitrarily.
+ *
+ * @param {String} backupRoot Directory holding the bundles.
+ * @returns {Promise<Object[]>} `{name, path, date, time}` newest-first; empty when the root is absent.
+ */
+export async function listPublishedBundles(backupRoot) {
+    if (!await fs.pathExists(backupRoot)) return [];
 
     const entries = await fs.readdir(backupRoot, { withFileTypes: true });
 
@@ -779,6 +894,16 @@ export async function cleanOldBackups(backupRoot, logger, retention = {}) {
     }
 
     backups.sort((a, b) => b.time - a.time);
+
+    return backups
+}
+
+export async function cleanOldBackups(backupRoot, logger, retention = {}) {
+    if (!await fs.pathExists(backupRoot)) return;
+
+    const {keepMinimum = 3, maxDays = 30} = retention;
+
+    const backups = await listPublishedBundles(backupRoot);
 
     const K           = keepMinimum;
     const N_DAYS      = maxDays;

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -631,16 +631,17 @@ async function captureBackup({
         );
     }
 
-    const zeroRowChecks = integrity.filter(check => check.status === 'zero-rows');
-    if (zeroRowChecks.length > 0) {
-        // Non-fatal (a fresh environment legitimately backs up zero-row subsystems), but loud: a
-        // zero-row export from a normally-populated deployment is the gutted-store signature, and a
-        // backup holding no rows is a false recovery source. The 'zero-rows' status is carried in
+    const emptyChecks = integrity.filter(check => check.status === 'empty');
+    if (emptyChecks.length > 0) {
+        // Non-fatal (a fresh environment legitimately backs up empty subsystems), but loud: a zero-row
+        // export from a normally-populated deployment is the gutted-store signature, and a backup
+        // holding no rows is a false recovery source. The 'empty' status is carried in
         // bundle-meta.integrity for a downstream canary/alert to escalate on. It reports what the
-        // bundle HOLDS; whether the source was genuinely empty is the capture block's question.
+        // bundle HOLDS; whether the source was genuinely empty is the capture block's separate
+        // question, answered there as `provenEmpty`.
         logger.warn?.(
-            `[Backup] ${zeroRowChecks.length} subsystem(s) exported ZERO rows — a bundle holding no rows is ` +
-            `not a usable recovery source: ${zeroRowChecks.map(c => c.subsystem).join(', ')}. Legitimate for ` +
+            `[Backup] ${emptyChecks.length} subsystem(s) exported ZERO rows — a bundle holding no rows is ` +
+            `not a usable recovery source: ${emptyChecks.map(c => c.subsystem).join(', ')}. Legitimate for ` +
             `a fresh environment; corruption-suspicious for a populated deployment.`
         );
     }
@@ -701,20 +702,44 @@ export async function countNonEmptyJsonlLines(filePath) {
 }
 
 /**
+ * The FROZEN wire vocabulary of `bundle-meta.integrity[].status`.
+ *
+ * **Adding a value here is a breaking change to every reader already deployed, and this file cannot
+ * make it safe.** Compatibility is one-directional: a reader we ship today can be taught to accept
+ * yesterday's tokens, but a reader running on a plane four figures of commits behind can never be
+ * taught tomorrow's. It classifies what it knows and silently ignores what it does not — and for this
+ * particular field, "ignored" resolves to *no zero-row subsystem found*, i.e. `restorable: true` for a
+ * bundle holding nothing.
+ *
+ * Measured, not theorised: renaming `empty` → `zero-rows` for lexical clarity produced old-reader +
+ * new-bundle ⇒ `restorable: true` while the other three cells of the matrix stayed `false` — three of
+ * four green. Vocabulary that needs to change belongs on a field nothing has persisted yet.
+ * @type {Object}
+ */
+export const INTEGRITY_STATUS = Object.freeze({
+    empty  : 'empty',
+    fail   : 'fail',
+    pass   : 'pass',
+    skipped: 'skipped'
+});
+
+/**
  * Verifies row-count parity between source collections and the JSONL files written into the
  * bundle. For subsystems whose `manageDatabaseBackup({action: 'export'})` SDK call returns a
  * numeric count (KB, MC memories+summaries, MC graph), this function streams the bundle's JSONL
  * files to count non-empty lines (streaming so 1+ GB exports do not exceed V8's max string length)
  * and compares — mismatch indicates a partial/torn write that the
  * caller treats as a fail-the-bundle condition. Zero-zero parity (source and bundle both report zero)
- * is reported as `zero-rows`, not `pass`: a backup of an empty/gutted store is surfaced non-fatally
+ * is reported as `empty`, not `pass`: a backup of an empty/gutted store is surfaced non-fatally
  * because it is not a usable recovery source (a fresh environment is legitimately empty; a populated
- * deployment reporting zero rows is the gutted-store signature). `runBackup` warns on `zero-rows`
+ * deployment reporting zero rows is the gutted-store signature). `runBackup` warns on `empty`
  * subsystems and persists the status into `bundle-meta.integrity` for a downstream canary/alert.
  *
  * The status answers what the BUNDLE holds, never why. Whether the source was genuinely empty is the
  * `capture` block's question — see {@link module:ai/services/shared/captureReceipt} — and the two are
- * kept lexically apart so one artifact cannot publish two meanings of `empty` about the same zero.
+ * kept lexically apart by naming that one `provenEmpty`, so one artifact never publishes two meanings
+ * of the bare word `empty`. The separation is deliberately carried on the NEW field: this status is a
+ * wire value that readers already deployed classify by exact match. See {@link INTEGRITY_STATUS}.
  *
  * For file-copy subsystems (concepts, trajectories, mailbox) the source side has no
  * authoritative count to compare against — `copyJsonlSource`'s reported `copied` field
@@ -722,7 +747,7 @@ export async function countNonEmptyJsonlLines(filePath) {
  *
  * @param {Object} layout     The bundle's per-subsystem destination directory map.
  * @param {Object} subsystems The runBackup `subsystems` map of SDK return values.
- * @returns {Promise<Array<{subsystem: String, status: String, sourceCount: Number, bundleCount: Number, reason: String}>>} `status` is `pass` (positive row-count parity) / `zero-rows` (source and bundle both zero — non-fatal, not a usable recovery source) / `fail` (row-count mismatch) / `skipped` (non-numeric source count); count + reason fields present per status.
+ * @returns {Promise<Array<{subsystem: String, status: String, sourceCount: Number, bundleCount: Number, reason: String}>>} `status` is one of the frozen {@link INTEGRITY_STATUS} values — `pass` (positive row-count parity) / `empty` (source and bundle both zero — non-fatal, not a usable recovery source) / `fail` (row-count mismatch) / `skipped` (non-numeric source count); count + reason fields present per status.
  */
 export async function verifyBundleIntegrity(layout, subsystems) {
     const verifiable = ['kb', 'mc', 'graph'];
@@ -733,14 +758,14 @@ export async function verifyBundleIntegrity(layout, subsystems) {
         const sourceCount = typeof raw === 'number' ? raw : raw?.count;
 
         if (typeof sourceCount !== 'number') {
-            checks.push({subsystem, status: 'skipped', reason: 'no numeric source count returned by SDK'});
+            checks.push({subsystem, status: INTEGRITY_STATUS.skipped, reason: 'no numeric source count returned by SDK'});
             continue;
         }
 
         const dir = layout[subsystem];
 
         if (!await fs.pathExists(dir)) {
-            checks.push({subsystem, status: 'fail', sourceCount, bundleCount: 0, reason: `bundle directory missing: ${dir}`});
+            checks.push({subsystem, status: INTEGRITY_STATUS.fail, sourceCount, bundleCount: 0, reason: `bundle directory missing: ${dir}`});
             continue;
         }
 
@@ -755,17 +780,19 @@ export async function verifyBundleIntegrity(layout, subsystems) {
             // Zero-parity is NOT a healthy pass: a bundle whose source AND files both report zero rows
             // is not a usable recovery source. Legitimate for a fresh environment, but for a normally-
             // populated deployment a zero-row export is the gutted-store signature (the corruption a
-            // backup is supposed to survive) — surface it as 'zero-rows' (visible, non-fatal) rather
-            // than a silent 'pass' so a downstream canary/alert can act on bundle-meta.integrity.
+            // backup is supposed to survive) — surface it as 'empty' (visible, non-fatal) rather than
+            // a silent 'pass' so a downstream canary/alert can act on bundle-meta.integrity.
             //
-            // Named 'zero-rows' and not 'empty' on purpose: this is a statement about what the bundle
-            // HOLDS, which is why it disqualifies a restore no matter what caused the zero. The
-            // capture block answers the separate question of whether the source was genuinely empty,
-            // and one artifact carrying both meanings under one word is how they came to disagree.
-            const status = sourceCount === 0 ? 'zero-rows' : 'pass';
+            // 'empty' is a WIRE VALUE and must not be renamed for clarity, however tempting.
+            // It is the only token readers deployed before today classify, and this substrate has
+            // planes running four figures of commits behind: emit anything else and those readers see
+            // no zero-row subsystem at all, i.e. `restorable: true` for a bundle holding nothing. The
+            // lexical separation from the capture block's provenance claim lives on `provenEmpty`,
+            // which no bundle on disk carries yet and can therefore still be named freely.
+            const status = sourceCount === 0 ? INTEGRITY_STATUS.empty : INTEGRITY_STATUS.pass;
             const entry  = {subsystem, status, sourceCount, bundleCount};
 
-            if (status === 'zero-rows') {
+            if (status === INTEGRITY_STATUS.empty) {
                 entry.reason = 'source and bundle both report zero rows — a bundle holding no rows is not a ' +
                     'usable recovery source (fresh-env legitimate; populated-deployment corruption-suspicious)';
             }
@@ -774,7 +801,7 @@ export async function verifyBundleIntegrity(layout, subsystems) {
         } else {
             checks.push({
                 subsystem,
-                status: 'fail',
+                status: INTEGRITY_STATUS.fail,
                 sourceCount,
                 bundleCount,
                 reason: `row-count mismatch: source=${sourceCount}, bundle=${bundleCount} (delta ${bundleCount - sourceCount})`

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -6,6 +6,7 @@ import DatabaseLifecycleService from './DatabaseLifecycleService.mjs';
 import {
     chromaConnect,
     chromaDeleteCollection,
+    chromaListCollectionNames,
     createSilentExecutor,
     isChromaCollectionNotFoundError,
     registerNeoChromaEmbeddingFunctions
@@ -326,23 +327,30 @@ class ChromaManager extends Base {
     }
 
     /**
+     * @summary Non-mutating enumeration of every collection this client can see.
+     *
+     * `#resolveKnowledgeBaseCollection` answers "does this collection exist?" by making it true — it
+     * catches not-found and creates. A caller that needs the pre-read answer therefore cannot ask any
+     * resolver for it, and must enumerate instead. Deliberately public and deliberately NOT wired into
+     * resolution: the auto-create is load-bearing for first-run bootstrap and shared by every reader in
+     * the system, so the backup lane's reporting need is served beside it, never inside it.
+     *
+     * Returns the whole list rather than a per-name predicate so a caller checking several collections
+     * takes ONE snapshot — N predicates would each observe a different instant, and the verdict they
+     * feed is a statement about a single moment before the export began.
+     *
+     * @returns {Promise<String[]>} Collection names, having created nothing.
+     * @see https://github.com/neomjs/neo/issues/16348
+     */
+    async listCollectionNames() {
+        return await chromaListCollectionNames({client: this.client})
+    }
+
+    /**
      * @returns {Promise<String[]>}
      */
     async #getActiveKnowledgeBaseSwapCollections() {
-        const names  = [];
-        const limit  = 1000;
-        let   offset = 0;
-
-        do {
-            const collections = await this.client.listCollections({limit, offset});
-            names.push(...collections.map(collection => collection.name));
-
-            if (collections.length < limit) {
-                break;
-            }
-
-            offset += limit;
-        } while (true);
+        const names = await chromaListCollectionNames({client: this.client});
 
         return names.filter(name => this.#isActiveKnowledgeBaseSwapName(name)).sort();
     }

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -327,26 +327,6 @@ class ChromaManager extends Base {
     }
 
     /**
-     * @summary Non-mutating enumeration of every collection this client can see.
-     *
-     * `#resolveKnowledgeBaseCollection` answers "does this collection exist?" by making it true — it
-     * catches not-found and creates. A caller that needs the pre-read answer therefore cannot ask any
-     * resolver for it, and must enumerate instead. Deliberately public and deliberately NOT wired into
-     * resolution: the auto-create is load-bearing for first-run bootstrap and shared by every reader in
-     * the system, so the backup lane's reporting need is served beside it, never inside it.
-     *
-     * Returns the whole list rather than a per-name predicate so a caller checking several collections
-     * takes ONE snapshot — N predicates would each observe a different instant, and the verdict they
-     * feed is a statement about a single moment before the export began.
-     *
-     * @returns {Promise<String[]>} Collection names, having created nothing.
-     * @see https://github.com/neomjs/neo/issues/16348
-     */
-    async listCollectionNames() {
-        return await chromaListCollectionNames({client: this.client})
-    }
-
-    /**
      * @returns {Promise<String[]>}
      */
     async #getActiveKnowledgeBaseSwapCollections() {

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -114,16 +114,24 @@ class DatabaseService extends Base {
      *
      * @param {Object}  options
      * @param {String} [options.backupPath=aiConfig.backupPath] Directory for the JSONL artifact.
-     * @returns {Promise<{message: String, count: Number}>} `count` is the numeric export row count,
-     *          consumed by the backup orchestrator's `verifyBundleIntegrity` for KB row-count parity
-     *          (without it the verifier reads a non-numeric source count and skips KB parity).
+     * @returns {Promise<{message: String, count: Number, collectionId: String|null}>} `count` is the
+     *          numeric export row count, consumed by the backup orchestrator's `verifyBundleIntegrity`
+     *          for KB row-count parity (without it the verifier reads a non-numeric source count and
+     *          skips KB parity). `collectionId` is the source's identity at capture time — the axis
+     *          that lets a `count: 0` receipt distinguish "this source was empty" from "a different
+     *          source is here now"; `null` degrades that axis to `unknown` rather than asserting
+     *          continuity. See `ai/services/shared/captureReceipt.mjs`.
      */
     async exportDatabase({backupPath = aiConfig.backupPath} = {}) {
         try {
             logger.log('Starting knowledge base export...');
             const collection = await ChromaManager.getKnowledgeBaseCollection();
             const count      = await this.#exportCollection(collection, backupPath, 'knowledge-base-backup');
-            return {message: `Export complete. Exported ${count} knowledge base chunks.`, count};
+            return {
+                message     : `Export complete. Exported ${count} knowledge base chunks.`,
+                count,
+                collectionId: collection?.id ?? null
+            };
         } catch (error) {
             logger.error('[DatabaseService] Error exporting knowledge base:', error);
             const exportError = new Error(`DATABASE_EXPORT_ERROR: ${error.message}`);

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -49,11 +49,18 @@ class DatabaseService extends Base {
      * @param {String} backupPath The directory to save the backup file.
      * @param {String} filePrefix The prefix for the backup filename.
      * @param {String} collectionName Stable collection label for logs, stats, and fail-loud errors.
-     * @returns {Promise<{collection: String, backupFile: String|null, expected: Number, exported: Number, skipped: Number, skippedIds: String[]}>} Export statistics.
+     * @returns {Promise<{collection: String, collectionId: String|null, backupFile: String|null, expected: Number, exported: Number, skipped: Number, skippedIds: String[]}>} Export statistics.
      * @private
      */
     async #exportCollection(collection, backupPath, filePrefix, collectionName = collection.name || filePrefix) {
         logger.log(`Fetching all documents from "${collectionName}"...`);
+
+        // Identity, captured beside the name and never in place of it. The name survives a promotion
+        // by construction — `VectorService` swaps shadow into canonical under the same name — so only
+        // the id can distinguish "the same source held nothing" from "a different source is here now".
+        // Absent on sources that have no Chroma handle (the native graph); `null` degrades the
+        // lineage axis to `unknown` rather than asserting continuity it cannot observe.
+        const collectionId = collection?.id ?? null;
 
         // 1. Get total count first
         const count = await collection.count();
@@ -61,6 +68,7 @@ class DatabaseService extends Base {
             logger.log(`No documents found in ${collectionName} to export.`);
             return {
                 collection: collectionName,
+                collectionId,
                 backupFile: null,
                 expected  : 0,
                 exported  : 0,
@@ -77,6 +85,7 @@ class DatabaseService extends Base {
         const writeStream = fs.createWriteStream(backupFile);
         const stats       = {
             collection: collectionName,
+            collectionId,
             backupFile,
             expected  : count,
             exported  : 0,

--- a/ai/services/memory-core/helpers/bundleIntegrity.mjs
+++ b/ai/services/memory-core/helpers/bundleIntegrity.mjs
@@ -17,35 +17,32 @@
  * historical recovery source — a worse outage than the defect this exists to fix. Absence resolves
  * to `null` (unknown), which is a third answer and not a quiet `false`.
  *
- * **This module answers SURVIVABILITY, and deliberately no longer uses the word `empty` for it.** The
- * question here is "does this bundle carry rows a restore could bring back", and the answer is `no`
- * for a zero-row subsystem regardless of WHY it is zero — a genuinely empty store and a gutted one are
- * equally unrecoverable. Provenance — whether there was anything to capture in the first place — is a
- * different proposition owned by {@link module:ai/services/shared/captureReceipt}, which reserves
- * `empty` for the claim that the facts actually support. The two blocks previously both said `empty`
- * about the same zero and could disagree, so this one says `zero-rows` and the disagreement has no
- * vocabulary left to happen in.
- */
-
-/**
- * The `bundle-meta.integrity` statuses that mean "no rows survived into the bundle".
+ * **This module answers SURVIVABILITY.** The question here is "does this bundle carry rows a restore
+ * could bring back", and the answer is `no` for a zero-row subsystem regardless of WHY it is zero — a
+ * genuinely empty store and a gutted one are equally unrecoverable. Provenance — whether there was
+ * anything to capture in the first place — is a different proposition owned by
+ * {@link module:ai/services/shared/captureReceipt}, which names its claim `provenEmpty` precisely so
+ * that one artifact never publishes two meanings of the bare word `empty`.
  *
- * `empty` is retained as an accepted INPUT and never written again. Bundles published before the
- * rename carry it, they are still live recovery sources, and a reader that matched only the new value
- * would silently promote every one of them from `restorable: false` to `restorable: true` — turning a
- * vocabulary correction into the exact false-green this module exists to end.
- * @type {String[]}
+ * **`status: 'empty'` is a WIRE VALUE and is deliberately never renamed.** An earlier revision
+ * renamed it to `zero-rows` for lexical clarity and introduced a false green:
+ * a reader deployed before the rename classifies only `'empty'`, so a bundle written *after* it reads
+ * as having no zero-row subsystems at all, i.e. `restorable: true` for a bundle holding nothing.
+ * Measured across the four-cell matrix — old/old, new/old, new/new all `false`; **old-reader +
+ * new-bundle `true`**. Compatibility here is one-directional by construction: a new reader can be
+ * taught old tokens, but readers already deployed can never be taught new ones, and this substrate
+ * has planes running four figures of commits behind. The lexical fix therefore belongs on the field
+ * nothing has persisted yet, never on this one.
  */
-const ZERO_ROW_STATUSES = Object.freeze(['zero-rows', 'empty']);
 
 /**
  * @summary Names the subsystems whose export brought back no rows.
  * @param {Array<Object>|undefined|null} integrity `bundle-meta.integrity` checks.
  * @returns {String[]} Subsystem names, empty when none or when the block is absent.
  */
-export function zeroRowSubsystems(integrity) {
+export function emptySubsystems(integrity) {
     return Array.isArray(integrity)
-        ? integrity.filter(check => ZERO_ROW_STATUSES.includes(check?.status)).map(check => check?.subsystem ?? 'unknown')
+        ? integrity.filter(check => check?.status === 'empty').map(check => check?.subsystem ?? 'unknown')
         : [];
 }
 
@@ -57,15 +54,15 @@ export function zeroRowSubsystems(integrity) {
  * either choice is a lie — `false` condemns historical bundles, `true` re-creates the false-green
  * this module exists to end.
  *
- * ANY zero-row subsystem disqualifies the whole bundle. A partial restore is not a restore: recovering
+ * ANY empty subsystem disqualifies the whole bundle. A partial restore is not a restore: recovering
  * memories while the knowledge base comes back with nothing is a silently incomplete system, which is
  * the failure mode that is hardest to notice afterwards.
  *
  * **Lineage does not soften this.** A zero-row source whose collection identity CHANGED is not
- * `empty` in the capture receipt's sense — the facts do not support that claim — and it is still
- * unrestorable here, because the bundle holds no rows either way. Reading the provenance verdict into
- * this one would promote the most suspicious bundle in the series, a zero-row capture over a replaced
- * source, into a usable recovery source.
+ * `provenEmpty` in the capture receipt's sense — the facts do not support that claim — and it is
+ * still unrestorable here, because the bundle holds no rows either way. Reading the provenance
+ * verdict into this one would promote the most suspicious bundle in the series, a zero-row capture
+ * over a replaced source, into a usable recovery source.
  *
  * @param {Array<Object>|undefined|null} integrity `bundle-meta.integrity` checks.
  * @returns {Boolean|null}
@@ -75,17 +72,17 @@ export function isBundleRestorable(integrity) {
         return null;
     }
 
-    return zeroRowSubsystems(integrity).length === 0;
+    return emptySubsystems(integrity).length === 0;
 }
 
 /**
  * @summary Projects the integrity checks into the compact summary receipts and health blocks embed.
  * @param {Array<Object>|undefined|null} integrity `bundle-meta.integrity` checks.
- * @returns {{restorable: Boolean|null, zeroRowSubsystems: String[]}}
+ * @returns {{restorable: Boolean|null, emptySubsystems: String[]}}
  */
 export function summarizeBundleIntegrity(integrity) {
     return {
-        zeroRowSubsystems: zeroRowSubsystems(integrity),
-        restorable       : isBundleRestorable(integrity)
+        emptySubsystems: emptySubsystems(integrity),
+        restorable     : isBundleRestorable(integrity)
     }
 }

--- a/ai/services/memory-core/helpers/bundleIntegrity.mjs
+++ b/ai/services/memory-core/helpers/bundleIntegrity.mjs
@@ -16,16 +16,36 @@
  * contain them. Treating missing evidence as a failing verdict would retroactively condemn every
  * historical recovery source — a worse outage than the defect this exists to fix. Absence resolves
  * to `null` (unknown), which is a third answer and not a quiet `false`.
+ *
+ * **This module answers SURVIVABILITY, and deliberately no longer uses the word `empty` for it.** The
+ * question here is "does this bundle carry rows a restore could bring back", and the answer is `no`
+ * for a zero-row subsystem regardless of WHY it is zero — a genuinely empty store and a gutted one are
+ * equally unrecoverable. Provenance — whether there was anything to capture in the first place — is a
+ * different proposition owned by {@link module:ai/services/shared/captureReceipt}, which reserves
+ * `empty` for the claim that the facts actually support. The two blocks previously both said `empty`
+ * about the same zero and could disagree, so this one says `zero-rows` and the disagreement has no
+ * vocabulary left to happen in.
  */
 
 /**
- * @summary Names the subsystems whose export was classified `empty`.
+ * The `bundle-meta.integrity` statuses that mean "no rows survived into the bundle".
+ *
+ * `empty` is retained as an accepted INPUT and never written again. Bundles published before the
+ * rename carry it, they are still live recovery sources, and a reader that matched only the new value
+ * would silently promote every one of them from `restorable: false` to `restorable: true` — turning a
+ * vocabulary correction into the exact false-green this module exists to end.
+ * @type {String[]}
+ */
+const ZERO_ROW_STATUSES = Object.freeze(['zero-rows', 'empty']);
+
+/**
+ * @summary Names the subsystems whose export brought back no rows.
  * @param {Array<Object>|undefined|null} integrity `bundle-meta.integrity` checks.
  * @returns {String[]} Subsystem names, empty when none or when the block is absent.
  */
-export function emptySubsystems(integrity) {
+export function zeroRowSubsystems(integrity) {
     return Array.isArray(integrity)
-        ? integrity.filter(check => check?.status === 'empty').map(check => check?.subsystem ?? 'unknown')
+        ? integrity.filter(check => ZERO_ROW_STATUSES.includes(check?.status)).map(check => check?.subsystem ?? 'unknown')
         : [];
 }
 
@@ -37,9 +57,15 @@ export function emptySubsystems(integrity) {
  * either choice is a lie — `false` condemns historical bundles, `true` re-creates the false-green
  * this module exists to end.
  *
- * ANY empty subsystem disqualifies the whole bundle. A partial restore is not a restore: recovering
- * memories while the knowledge base comes back empty is a silently incomplete system, which is the
- * failure mode that is hardest to notice afterwards.
+ * ANY zero-row subsystem disqualifies the whole bundle. A partial restore is not a restore: recovering
+ * memories while the knowledge base comes back with nothing is a silently incomplete system, which is
+ * the failure mode that is hardest to notice afterwards.
+ *
+ * **Lineage does not soften this.** A zero-row source whose collection identity CHANGED is not
+ * `empty` in the capture receipt's sense — the facts do not support that claim — and it is still
+ * unrestorable here, because the bundle holds no rows either way. Reading the provenance verdict into
+ * this one would promote the most suspicious bundle in the series, a zero-row capture over a replaced
+ * source, into a usable recovery source.
  *
  * @param {Array<Object>|undefined|null} integrity `bundle-meta.integrity` checks.
  * @returns {Boolean|null}
@@ -49,17 +75,17 @@ export function isBundleRestorable(integrity) {
         return null;
     }
 
-    return emptySubsystems(integrity).length === 0;
+    return zeroRowSubsystems(integrity).length === 0;
 }
 
 /**
  * @summary Projects the integrity checks into the compact summary receipts and health blocks embed.
  * @param {Array<Object>|undefined|null} integrity `bundle-meta.integrity` checks.
- * @returns {{restorable: Boolean|null, emptySubsystems: String[]}}
+ * @returns {{restorable: Boolean|null, zeroRowSubsystems: String[]}}
  */
 export function summarizeBundleIntegrity(integrity) {
     return {
-        emptySubsystems: emptySubsystems(integrity),
-        restorable     : isBundleRestorable(integrity)
+        zeroRowSubsystems: zeroRowSubsystems(integrity),
+        restorable       : isBundleRestorable(integrity)
     }
 }

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -6,7 +6,6 @@ import ChromaLifecycleService from '../lifecycle/ChromaLifecycleService.mjs';
 import {
     chromaConnect,
     chromaDeleteCollection,
-    chromaListCollectionNames,
     createDynamicTextEmbeddingFunction,
     createSilentExecutor,
     isChromaCollectionNotFoundError,
@@ -302,26 +301,6 @@ class ChromaManager extends AbstractVectorManager {
 
         this.graphCollection = await this._graphCollectionPromise;
         return this.graphCollection;
-    }
-
-    /**
-     * @summary Non-mutating enumeration of every collection this client can see.
-     *
-     * All four collection getters above are `getOrCreateCollection` — create-on-missing BY
-     * CONSTRUCTION, with no not-found branch to interrogate. So a deleted collection is silently
-     * replaced by an empty one during the very read meant to capture it, and `count()` then reports
-     * `0` honestly. Nothing downstream can recover the distinction, which is why the backup lane asks
-     * this question BEFORE resolving anything.
-     *
-     * Peer-symmetric with `Neo.ai.services.knowledge-base.ChromaManager#listCollectionNames`. Kept
-     * beside the getters rather than inside them: auto-create is required for first-run bootstrap and
-     * shared by every reader in the system, so this reports on the resolvers without altering them.
-     *
-     * @returns {Promise<String[]>} Collection names, having created nothing.
-     * @see https://github.com/neomjs/neo/issues/16348
-     */
-    async listCollectionNames() {
-        return await chromaListCollectionNames({client: this.client})
     }
 
     /**

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -6,6 +6,7 @@ import ChromaLifecycleService from '../lifecycle/ChromaLifecycleService.mjs';
 import {
     chromaConnect,
     chromaDeleteCollection,
+    chromaListCollectionNames,
     createDynamicTextEmbeddingFunction,
     createSilentExecutor,
     isChromaCollectionNotFoundError,
@@ -301,6 +302,26 @@ class ChromaManager extends AbstractVectorManager {
 
         this.graphCollection = await this._graphCollectionPromise;
         return this.graphCollection;
+    }
+
+    /**
+     * @summary Non-mutating enumeration of every collection this client can see.
+     *
+     * All four collection getters above are `getOrCreateCollection` — create-on-missing BY
+     * CONSTRUCTION, with no not-found branch to interrogate. So a deleted collection is silently
+     * replaced by an empty one during the very read meant to capture it, and `count()` then reports
+     * `0` honestly. Nothing downstream can recover the distinction, which is why the backup lane asks
+     * this question BEFORE resolving anything.
+     *
+     * Peer-symmetric with `Neo.ai.services.knowledge-base.ChromaManager#listCollectionNames`. Kept
+     * beside the getters rather than inside them: auto-create is required for first-run bootstrap and
+     * shared by every reader in the system, so this reports on the resolvers without altering them.
+     *
+     * @returns {Promise<String[]>} Collection names, having created nothing.
+     * @see https://github.com/neomjs/neo/issues/16348
+     */
+    async listCollectionNames() {
+        return await chromaListCollectionNames({client: this.client})
     }
 
     /**

--- a/ai/services/shared/captureReceipt.mjs
+++ b/ai/services/shared/captureReceipt.mjs
@@ -28,12 +28,23 @@
  * describes a complete read by construction; that guarantee lives in the abort, not in a field that
  * only ever prints one value.
  *
- * **This module answers PROVENANCE, not survivability.** `empty` here means "there was genuinely
- * nothing to capture". Whether a bundle carries recoverable payload is a different proposition with a
- * different owner — {@link module:ai/services/memory-core/helpers/bundleIntegrity} — which classifies
- * a zero-row export as `zero-rows` and disqualifies it as a recovery source no matter WHY it is zero.
- * The two never contradict because they never claim the same thing: a `zero + changed` source is not
- * `empty` (the facts do not support the claim) and is still `zero-rows` (nothing to restore).
+ * **This module answers PROVENANCE, not survivability, and its claim is named `provenEmpty` for it.**
+ * It means "the facts establish there was genuinely nothing to capture". Whether a bundle carries
+ * recoverable payload is a different proposition with a different owner —
+ * {@link module:ai/services/memory-core/helpers/bundleIntegrity} — which classifies a zero-row export
+ * as `status: 'empty'` and disqualifies it as a recovery source no matter WHY it is zero. The two
+ * never contradict because they never claim the same thing: a `zero + changed` source is not
+ * `provenEmpty` (the facts do not support the claim) and its bundle is still `empty` (nothing to
+ * restore).
+ *
+ * **Why the lexical separation lands HERE and not on the older field.** Both blocks originally said
+ * `empty` about the same zero, and the obvious repair was to rename the survivability status to
+ * something like `zero-rows`. That was implemented, and it was wrong: `integrity[].status` is a
+ * persisted wire value matched by exact string in readers that are already deployed, so a bundle
+ * written with a new token reads to them as having no zero-row subsystem at all — `restorable: true`
+ * for a bundle holding nothing. Compatibility is one-directional by construction. This field is the
+ * one nothing has persisted yet, so it is the only one that can still be renamed for free, and it
+ * absorbs the whole distinction.
  *
  * @see https://github.com/neomjs/neo/issues/16404
  */
@@ -83,11 +94,11 @@ export function deriveLineage({currentId = null, previousId = null} = {}) {
 }
 
 /**
- * @summary Derives `empty` — the only verdict this module produces — from the recorded facts.
+ * @summary Derives `provenEmpty` — the only verdict this module produces — from the recorded facts.
  *
- * **`empty` requires both axes to line up: a measured zero, and a continuous lineage.** Any other
- * combination leaves the facts standing rather than collapsing them, because every other combination
- * has a reading in which the corpus was fine:
+ * **`provenEmpty` requires both axes to line up: a measured zero, and a continuous lineage.** Any
+ * other combination leaves the facts standing rather than collapsing them, because every other
+ * combination has a reading in which the corpus was fine:
  *
  * - `zero + changed` — the source was replaced between captures. A promotion or restore does this
  *   deliberately; so does a loss. The receipt says which facts it saw and refuses to guess.
@@ -101,7 +112,7 @@ export function deriveLineage({currentId = null, previousId = null} = {}) {
  * @param {String} options.lineage  A `LINEAGE` value.
  * @returns {Boolean} Whether the facts support the single claim "this source was genuinely empty".
  */
-export function derivesEmpty({rowState, lineage} = {}) {
+export function derivesProvenEmpty({rowState, lineage} = {}) {
     return rowState === ROW_STATE.zero
         && lineage  === LINEAGE.same
 }
@@ -126,7 +137,7 @@ export function derivesEmpty({rowState, lineage} = {}) {
  * @param {String|null} [options.collectionId] Identity observed this capture; `null` when unobservable.
  * @param {String|null} [options.previousId]   Identity the comparison bundle recorded.
  * @param {String|null} [options.comparedBundle] Bundle name the comparison ran against.
- * @returns {Object} The receipt entry, carrying every fact plus the derived `empty` claim.
+ * @returns {Object} The receipt entry, carrying every fact plus the derived `provenEmpty` claim.
  */
 export function buildSourceReceipt({
     source,
@@ -148,11 +159,11 @@ export function buildSourceReceipt({
 
     return {
         source,
-        rowCount: Number.isFinite(rowCount) ? rowCount : null,
+        rowCount   : Number.isFinite(rowCount) ? rowCount : null,
         rowState,
         lineage,
         collectionId,
         comparedBundle,
-        empty   : derivesEmpty({rowState, lineage})
+        provenEmpty: derivesProvenEmpty({rowState, lineage})
     }
 }

--- a/ai/services/shared/captureReceipt.mjs
+++ b/ai/services/shared/captureReceipt.mjs
@@ -1,0 +1,134 @@
+/**
+ * @module ai/services/shared/captureReceipt
+ * @summary The vocabulary a backup receipt uses to say what a row count MEANS, and the single rule
+ * that derives a verdict from it.
+ *
+ * A count of `0` answers "how many rows did I write". It does not answer "was there a corpus here",
+ * and the two questions have the same answer shape. Live evidence: 4 of 36 bundles in one store carry
+ * `expected: 0, exported: 0` with the message `"Export complete."`, across four separate dates.
+ *
+ * **Three facts, three axes — never one enum.** The predecessor of this module collapsed them onto a
+ * single `captured | empty | unavailable` value and was Drop+Superseded for it. Collapsing means any
+ * two of the facts cannot be stated at once, and it forced a changed collection identity to be read
+ * as data loss. Neo's own re-embed disproves that reading: `VectorService` rebuilds the corpus into a
+ * shadow collection and promotes it with a two-rename transaction — live → parking, shadow →
+ * canonical — so **every healthy re-embed changes the canonical collection's identity with nothing
+ * lost**. A restore does the same, by dropping and re-resolving. An identity that changes is a
+ * statement about lineage; loss is a different proposition needing its own evidence.
+ *
+ * So the receipt records the facts orthogonally and derives exactly one thing from them.
+ *
+ * @see https://github.com/neomjs/neo/issues/16404
+ */
+
+/**
+ * Did the source hold rows? A measurement, never a judgement.
+ * @type {Object}
+ */
+export const ROW_STATE = Object.freeze({populated: 'populated', zero: 'zero'});
+
+/**
+ * Did the read reach everything the source claimed to hold?
+ *
+ * `partial` is deliberately ABSENT. Every partial read in this substrate is converted into a thrown
+ * abort — `#exportCollection` throws `PARTIAL_COLLECTION_EXPORT` on `exported !== expected`, and the
+ * graph exporter does the same — so no published bundle can carry it. A vocabulary value nothing can
+ * emit is a promise the contract cannot keep; the value gets added when a producer exists AND the
+ * publication contract authorizes a bounded read, not before.
+ * @type {Object}
+ */
+export const READ_COMPLETENESS = Object.freeze({complete: 'complete', unavailable: 'unavailable'});
+
+/**
+ * Is this the same source that the comparison bundle observed?
+ *
+ * `unknown` is structural, not defensive: first run, a comparison bundle swept away by retention, and
+ * any capture whose predecessor recorded no identity all land here honestly. It is what lets an
+ * unmeasured event degrade instead of breaking the verdict.
+ * @type {Object}
+ */
+export const LINEAGE = Object.freeze({same: 'same', changed: 'changed', unknown: 'unknown'});
+
+/**
+ * @summary Compares one source's identity against the same source in the previous published bundle.
+ *
+ * Identity, not name. The name is stable across a promotion by construction — that is what promotion
+ * IS — so a name comparison would report continuity across exactly the event that breaks it.
+ *
+ * @param {Object}       options
+ * @param {String|null} [options.currentId]  Identity observed during this capture.
+ * @param {String|null} [options.previousId] Identity the comparison bundle recorded for the same source.
+ * @returns {String} A `LINEAGE` value.
+ */
+export function deriveLineage({currentId = null, previousId = null} = {}) {
+    if (!currentId || !previousId) {
+        return LINEAGE.unknown
+    }
+
+    return currentId === previousId ? LINEAGE.same : LINEAGE.changed
+}
+
+/**
+ * @summary Derives `empty` — the only verdict this module produces — from the three axes.
+ *
+ * **`empty` requires all three to line up: no rows, a complete read, and a continuous lineage.** Any
+ * other combination leaves the facts standing rather than collapsing them, because every other
+ * combination has a reading in which the corpus was fine:
+ *
+ * - `zero + complete + changed` — the source was replaced between captures. A promotion or restore
+ *   does this deliberately; so does a loss. The receipt says which facts it saw and refuses to guess.
+ * - `zero + complete + unknown` — nothing to compare against. First run looks exactly like this.
+ * - `zero + unavailable + *` — the read did not complete, so the zero describes the read, not the store.
+ * - `populated + *` — rows are self-evidencing; a source that returns rows was not empty.
+ *
+ * @param {Object} options
+ * @param {String} options.rowState          A `ROW_STATE` value.
+ * @param {String} options.readCompleteness  A `READ_COMPLETENESS` value.
+ * @param {String} options.lineage           A `LINEAGE` value.
+ * @returns {Boolean} Whether the facts support the single claim "this source was genuinely empty".
+ */
+export function derivesEmpty({rowState, readCompleteness, lineage} = {}) {
+    return rowState         === ROW_STATE.zero
+        && readCompleteness === READ_COMPLETENESS.complete
+        && lineage          === LINEAGE.same
+}
+
+/**
+ * @summary Assembles one source's receipt entry from its measured facts.
+ *
+ * Deliberately does NOT take a verdict argument. Callers supply what they observed; the derivation is
+ * this module's and stays in one place, so a second consumer cannot invent a fourth reading of the
+ * same three facts.
+ *
+ * @param {Object}       options
+ * @param {String}       options.source        Stable label for the source (collection name / `native-graph`).
+ * @param {Number}       options.rowCount      Rows the export actually wrote.
+ * @param {Boolean}      options.readComplete  Whether the read reached everything the source claimed.
+ * @param {String|null} [options.collectionId] Identity observed this capture; `null` when unobservable.
+ * @param {String|null} [options.previousId]   Identity the comparison bundle recorded.
+ * @param {String|null} [options.comparedBundle] Bundle name the comparison ran against.
+ * @returns {Object} The receipt entry, carrying every fact plus the derived `empty` claim.
+ */
+export function buildSourceReceipt({
+    source,
+    rowCount,
+    readComplete,
+    collectionId   = null,
+    previousId     = null,
+    comparedBundle = null
+} = {}) {
+    const rowState         = Number.isFinite(rowCount) && rowCount > 0 ? ROW_STATE.populated : ROW_STATE.zero,
+          readCompleteness = readComplete ? READ_COMPLETENESS.complete : READ_COMPLETENESS.unavailable,
+          lineage          = deriveLineage({currentId: collectionId, previousId});
+
+    return {
+        source,
+        rowCount: Number.isFinite(rowCount) ? rowCount : 0,
+        rowState,
+        readCompleteness,
+        lineage,
+        collectionId,
+        comparedBundle,
+        empty   : derivesEmpty({rowState, readCompleteness, lineage})
+    }
+}

--- a/ai/services/shared/captureReceipt.mjs
+++ b/ai/services/shared/captureReceipt.mjs
@@ -18,26 +18,40 @@
  *
  * So the receipt records the facts orthogonally and derives exactly one thing from them.
  *
+ * **Read completeness is NOT an axis here, and its absence is the same rule applied to itself.** An
+ * earlier revision carried `readCompleteness: complete | unavailable`, and nothing in the substrate
+ * could ever emit `unavailable`: `#exportCollection` throws `PARTIAL_COLLECTION_EXPORT` on
+ * `exported !== expected` and the graph exporter does the same, so a partial read aborts the capture
+ * and never reaches a receipt. A vocabulary value nothing can emit is a promise the contract cannot
+ * keep — the reason `partial` was excluded in the first place — so the whole axis is gone until a
+ * producer exists AND the publication contract authorizes a bounded read. Every published receipt
+ * describes a complete read by construction; that guarantee lives in the abort, not in a field that
+ * only ever prints one value.
+ *
+ * **This module answers PROVENANCE, not survivability.** `empty` here means "there was genuinely
+ * nothing to capture". Whether a bundle carries recoverable payload is a different proposition with a
+ * different owner — {@link module:ai/services/memory-core/helpers/bundleIntegrity} — which classifies
+ * a zero-row export as `zero-rows` and disqualifies it as a recovery source no matter WHY it is zero.
+ * The two never contradict because they never claim the same thing: a `zero + changed` source is not
+ * `empty` (the facts do not support the claim) and is still `zero-rows` (nothing to restore).
+ *
  * @see https://github.com/neomjs/neo/issues/16404
  */
 
 /**
  * Did the source hold rows? A measurement, never a judgement.
- * @type {Object}
- */
-export const ROW_STATE = Object.freeze({populated: 'populated', zero: 'zero'});
-
-/**
- * Did the read reach everything the source claimed to hold?
  *
- * `partial` is deliberately ABSENT. Every partial read in this substrate is converted into a thrown
- * abort — `#exportCollection` throws `PARTIAL_COLLECTION_EXPORT` on `exported !== expected`, and the
- * graph exporter does the same — so no published bundle can carry it. A vocabulary value nothing can
- * emit is a promise the contract cannot keep; the value gets added when a producer exists AND the
- * publication contract authorizes a bounded read, not before.
+ * `unestablished` is the answer when the producer handed over something that is not a row count —
+ * absent, `NaN`, `Infinity`, or negative. It is a THIRD answer on purpose: coercing a malformed
+ * observation to `0` manufactures affirmative evidence of emptiness out of a broken instrument, which
+ * is the same conflation this module exists to break, one layer earlier.
  * @type {Object}
  */
-export const READ_COMPLETENESS = Object.freeze({complete: 'complete', unavailable: 'unavailable'});
+export const ROW_STATE = Object.freeze({
+    populated    : 'populated',
+    zero         : 'zero',
+    unestablished: 'unestablished'
+});
 
 /**
  * Is this the same source that the comparison bundle observed?
@@ -69,28 +83,27 @@ export function deriveLineage({currentId = null, previousId = null} = {}) {
 }
 
 /**
- * @summary Derives `empty` — the only verdict this module produces — from the three axes.
+ * @summary Derives `empty` — the only verdict this module produces — from the recorded facts.
  *
- * **`empty` requires all three to line up: no rows, a complete read, and a continuous lineage.** Any
- * other combination leaves the facts standing rather than collapsing them, because every other
- * combination has a reading in which the corpus was fine:
+ * **`empty` requires both axes to line up: a measured zero, and a continuous lineage.** Any other
+ * combination leaves the facts standing rather than collapsing them, because every other combination
+ * has a reading in which the corpus was fine:
  *
- * - `zero + complete + changed` — the source was replaced between captures. A promotion or restore
- *   does this deliberately; so does a loss. The receipt says which facts it saw and refuses to guess.
- * - `zero + complete + unknown` — nothing to compare against. First run looks exactly like this.
- * - `zero + unavailable + *` — the read did not complete, so the zero describes the read, not the store.
+ * - `zero + changed` — the source was replaced between captures. A promotion or restore does this
+ *   deliberately; so does a loss. The receipt says which facts it saw and refuses to guess.
+ * - `zero + unknown` — nothing to compare against. First run looks exactly like this.
+ * - `unestablished + *` — the count is not a measurement, so it cannot evidence a measurement's
+ *   conclusion. A broken instrument reads as no evidence, never as evidence of nothing.
  * - `populated + *` — rows are self-evidencing; a source that returns rows was not empty.
  *
  * @param {Object} options
- * @param {String} options.rowState          A `ROW_STATE` value.
- * @param {String} options.readCompleteness  A `READ_COMPLETENESS` value.
- * @param {String} options.lineage           A `LINEAGE` value.
+ * @param {String} options.rowState A `ROW_STATE` value.
+ * @param {String} options.lineage  A `LINEAGE` value.
  * @returns {Boolean} Whether the facts support the single claim "this source was genuinely empty".
  */
-export function derivesEmpty({rowState, readCompleteness, lineage} = {}) {
-    return rowState         === ROW_STATE.zero
-        && readCompleteness === READ_COMPLETENESS.complete
-        && lineage          === LINEAGE.same
+export function derivesEmpty({rowState, lineage} = {}) {
+    return rowState === ROW_STATE.zero
+        && lineage  === LINEAGE.same
 }
 
 /**
@@ -100,10 +113,16 @@ export function derivesEmpty({rowState, readCompleteness, lineage} = {}) {
  * this module's and stays in one place, so a second consumer cannot invent a fourth reading of the
  * same three facts.
  *
+ * **A malformed count is rejected, never repaired.** Absent, `NaN`, `Infinity` and negative values do
+ * not describe a number of rows, so they cannot stand in for one: they classify as
+ * `ROW_STATE.unestablished`, and `rowCount` reports the raw finite observation or `null` when the
+ * producer supplied nothing a number could be read from. An earlier revision coalesced all four to
+ * `0`, which let a broken exporter plus an unchanged identity derive `empty: true` — a positive claim
+ * of emptiness assembled entirely out of the absence of evidence.
+ *
  * @param {Object}       options
  * @param {String}       options.source        Stable label for the source (collection name / `native-graph`).
  * @param {Number}       options.rowCount      Rows the export actually wrote.
- * @param {Boolean}      options.readComplete  Whether the read reached everything the source claimed.
  * @param {String|null} [options.collectionId] Identity observed this capture; `null` when unobservable.
  * @param {String|null} [options.previousId]   Identity the comparison bundle recorded.
  * @param {String|null} [options.comparedBundle] Bundle name the comparison ran against.
@@ -112,23 +131,28 @@ export function derivesEmpty({rowState, readCompleteness, lineage} = {}) {
 export function buildSourceReceipt({
     source,
     rowCount,
-    readComplete,
     collectionId   = null,
     previousId     = null,
     comparedBundle = null
 } = {}) {
-    const rowState         = Number.isFinite(rowCount) && rowCount > 0 ? ROW_STATE.populated : ROW_STATE.zero,
-          readCompleteness = readComplete ? READ_COMPLETENESS.complete : READ_COMPLETENESS.unavailable,
-          lineage          = deriveLineage({currentId: collectionId, previousId});
+    const measured = Number.isFinite(rowCount) && rowCount >= 0,
+          lineage  = deriveLineage({currentId: collectionId, previousId});
+
+    let rowState;
+
+    if (!measured) {
+        rowState = ROW_STATE.unestablished
+    } else {
+        rowState = rowCount > 0 ? ROW_STATE.populated : ROW_STATE.zero
+    }
 
     return {
         source,
-        rowCount: Number.isFinite(rowCount) ? rowCount : 0,
+        rowCount: Number.isFinite(rowCount) ? rowCount : null,
         rowState,
-        readCompleteness,
         lineage,
         collectionId,
         comparedBundle,
-        empty   : derivesEmpty({rowState, readCompleteness, lineage})
+        empty   : derivesEmpty({rowState, lineage})
     }
 }

--- a/ai/services/shared/vector/chromaClientPrimitives.mjs
+++ b/ai/services/shared/vector/chromaClientPrimitives.mjs
@@ -182,11 +182,10 @@ function assertEmbeddingFunction(embeddingFunction, label) {
  *    canonical-name refusal. The substrate-level invariant fires regardless of
  *    harness or config state.
  *
- * 4. **`chromaListCollectionNames({client})`** — paginated, NON-MUTATING enumeration. Both
- *    subsystems needed the identical page loop to answer one question the resolvers destroy the
- *    answer to: did this collection exist BEFORE the read that measured it. It belongs beside the
- *    other client-lifecycle helpers precisely because it is not resolution — it creates nothing, so
- *    it carries none of the per-subsystem semantics listed below.
+ * 4. **`chromaListCollectionNames({client})`** — paginated, NON-MUTATING enumeration, consumed by
+ *    KB shadow-swap discovery. It belongs beside the other client-lifecycle helpers precisely
+ *    because it is not resolution — it creates nothing, so it carries none of the per-subsystem
+ *    semantics listed below.
  *
  * **What this module does NOT own (per V-B-A on the ticket's prescription):**
  *
@@ -322,14 +321,14 @@ export async function chromaDeleteCollection({client, name, subsystem, confirmat
 /**
  * @summary Enumerates every collection name the client can see, creating nothing.
  *
- * The one non-mutating way to ask "does this collection exist?" against a store whose resolvers
- * answer that question by making it true. `getCollection` throws not-found without creating, but both
- * subsystems wrap it in retry/swap-aware resolution that ends in a create; `listCollections` has no
- * such tail, which is why the backup lane's pre-existence probe reads through here.
+ * The one non-mutating way to enumerate against a store whose resolvers answer "does this collection
+ * exist?" by making it true. `getCollection` throws not-found without creating, but both subsystems
+ * wrap it in retry/swap-aware resolution that ends in a create; `listCollections` has no such tail,
+ * which is why shadow-swap discovery reads through here rather than through a resolver.
  *
  * Pages rather than taking the first batch: the previous KB-local copy of this loop existed because a
  * single unpaged call silently truncates at the server's page size, and a truncated enumeration would
- * report a live collection as absent — a false `unavailable` verdict for a healthy store.
+ * report a live collection as absent — for swap discovery, that orphans an in-flight swap collection.
  *
  * Throws on client failure rather than returning an empty list. An empty result and an unreachable
  * server are different facts, and collapsing them here would hand callers the exact conflation this

--- a/ai/services/shared/vector/chromaClientPrimitives.mjs
+++ b/ai/services/shared/vector/chromaClientPrimitives.mjs
@@ -182,6 +182,12 @@ function assertEmbeddingFunction(embeddingFunction, label) {
  *    canonical-name refusal. The substrate-level invariant fires regardless of
  *    harness or config state.
  *
+ * 4. **`chromaListCollectionNames({client})`** — paginated, NON-MUTATING enumeration. Both
+ *    subsystems needed the identical page loop to answer one question the resolvers destroy the
+ *    answer to: did this collection exist BEFORE the read that measured it. It belongs beside the
+ *    other client-lifecycle helpers precisely because it is not resolution — it creates nothing, so
+ *    it carries none of the per-subsystem semantics listed below.
+ *
  * **What this module does NOT own (per V-B-A on the ticket's prescription):**
  *
  * - `getOrCreateCollection` / `getCollection` / `createCollection` — collection-resolution
@@ -311,4 +317,45 @@ export async function chromaDeleteCollection({client, name, subsystem, confirmat
 
     assertCanonicalCollectionDeleteAllowed({name, subsystem, confirmation});
     return await client.deleteCollection({name})
+}
+
+/**
+ * @summary Enumerates every collection name the client can see, creating nothing.
+ *
+ * The one non-mutating way to ask "does this collection exist?" against a store whose resolvers
+ * answer that question by making it true. `getCollection` throws not-found without creating, but both
+ * subsystems wrap it in retry/swap-aware resolution that ends in a create; `listCollections` has no
+ * such tail, which is why the backup lane's pre-existence probe reads through here.
+ *
+ * Pages rather than taking the first batch: the previous KB-local copy of this loop existed because a
+ * single unpaged call silently truncates at the server's page size, and a truncated enumeration would
+ * report a live collection as absent — a false `unavailable` verdict for a healthy store.
+ *
+ * Throws on client failure rather than returning an empty list. An empty result and an unreachable
+ * server are different facts, and collapsing them here would hand callers the exact conflation this
+ * probe exists to break.
+ *
+ * @param {Object}  options
+ * @param {Object}  options.client    The chromadb library client (with `.listCollections`).
+ * @param {Number} [options.pageSize] Rows per request; the loop stops on the first short page.
+ * @returns {Promise<String[]>} Collection names, in server order.
+ * @see https://github.com/neomjs/neo/issues/16348
+ */
+export async function chromaListCollectionNames({client, pageSize = 1000} = {}) {
+    const names  = [];
+    let   offset = 0;
+
+    while (true) {
+        const page = await client.listCollections({limit: pageSize, offset});
+
+        names.push(...page.map(collection => collection.name));
+
+        if (page.length < pageSize) {
+            break
+        }
+
+        offset += pageSize
+    }
+
+    return names
 }

--- a/learn/agentos/tooling/RestorationRunbook.md
+++ b/learn/agentos/tooling/RestorationRunbook.md
@@ -125,6 +125,40 @@ Reading the output: `clean` is artifact-verified and restorable. `manifest-false
 it does not have — do not restore from it. `export-failed` is the fail-loud path working correctly.
 `no-mc-claim` / `empty-claim` mean the subsystem exported nothing at all.
 
+### Reading `bundle-meta.json`: two blocks, two different questions
+
+A bundle records **two** verdicts about a zero-row export, and they answer different questions. Read
+the right one for what you are deciding.
+
+| block | question | values | use it to decide |
+|---|---|---|---|
+| `integrity[]` | **Survivability** — does this bundle hold rows a restore could bring back? | `pass` · `zero-rows` · `fail` · `skipped` | **Whether to restore from this bundle.** |
+| `capture.sources{}` | **Provenance** — was there genuinely nothing to capture? | `empty: true/false` plus the facts behind it | **Whether to investigate.** |
+
+**Only `integrity` gates a restore.** Any subsystem reading `zero-rows` disqualifies the whole bundle
+— a partial restore is not a restore, and recovering memories while the knowledge base comes back
+with nothing is the kind of incompleteness that is hardest to notice afterwards. This holds no matter
+what the capture block says.
+
+**`capture` tells you whether a zero is expected.** Each source records its row state, whether its
+collection identity is the same one the previous bundle saw (`lineage`), and derives `empty` only
+when both line up: a measured zero over an unchanged source.
+
+- `empty: true` — a real empty source. Normal for a fresh environment.
+- `empty: false` with `lineage: "changed"` — **the one to investigate.** The collection was replaced
+  between captures. A re-embed or a restore does that deliberately with nothing lost, and so does a
+  loss; the receipt refuses to guess. Correlate with maintenance history before concluding anything.
+- `empty: false` with `lineage: "unknown"` — nothing to compare against. The first bundle after this
+  field shipped always reads this way, as does one whose predecessor was swept by retention.
+- `rowState: "unestablished"` — the exporter returned something that was not a row count. The zero is
+  a broken instrument, not a measurement; nothing about the corpus follows from it.
+
+**Legacy bundles degrade, they do not fail.** A bundle published before this block existed carries no
+`capture` at all, and one published before the `empty` → `zero-rows` rename carries the old token in
+`integrity`. Both are still read correctly and still disqualify exactly as they did. A bundle with no
+`integrity` block at all resolves to `restorable: null` — unknown, which is a third answer and not a
+quiet "unusable"; check it with `ai:check-backup-integrity` above rather than assuming either way.
+
 ## Restoration Procedures
 
 ### 1. Knowledge Base (KB)

--- a/learn/agentos/tooling/RestorationRunbook.md
+++ b/learn/agentos/tooling/RestorationRunbook.md
@@ -132,32 +132,41 @@ the right one for what you are deciding.
 
 | block | question | values | use it to decide |
 |---|---|---|---|
-| `integrity[]` | **Survivability** — does this bundle hold rows a restore could bring back? | `pass` · `zero-rows` · `fail` · `skipped` | **Whether to restore from this bundle.** |
-| `capture.sources{}` | **Provenance** — was there genuinely nothing to capture? | `empty: true/false` plus the facts behind it | **Whether to investigate.** |
+| `integrity[]` | **Survivability** — does this bundle hold rows a restore could bring back? | `pass` · `empty` · `fail` · `skipped` | **Whether to restore from this bundle.** |
+| `capture.sources{}` | **Provenance** — was there genuinely nothing to capture? | `provenEmpty: true/false` plus the facts behind it | **Whether to investigate.** |
 
-**Only `integrity` gates a restore.** Any subsystem reading `zero-rows` disqualifies the whole bundle
-— a partial restore is not a restore, and recovering memories while the knowledge base comes back
-with nothing is the kind of incompleteness that is hardest to notice afterwards. This holds no matter
-what the capture block says.
+The two use different words on purpose. `integrity[].status: "empty"` says *this bundle holds no rows
+for this subsystem*; `capture.sources[].provenEmpty` says *the facts establish there was nothing to
+capture*. They are different claims about the same zero, and they can legitimately disagree.
+
+**Only `integrity` gates a restore.** Any subsystem reading `empty` disqualifies the whole bundle — a
+partial restore is not a restore, and recovering memories while the knowledge base comes back with
+nothing is the kind of incompleteness that is hardest to notice afterwards. This holds no matter what
+the capture block says.
 
 **`capture` tells you whether a zero is expected.** Each source records its row state, whether its
-collection identity is the same one the previous bundle saw (`lineage`), and derives `empty` only
-when both line up: a measured zero over an unchanged source.
+collection identity is the same one the previous bundle saw (`lineage`), and derives `provenEmpty`
+only when both line up: a measured zero over an unchanged source.
 
-- `empty: true` — a real empty source. Normal for a fresh environment.
-- `empty: false` with `lineage: "changed"` — **the one to investigate.** The collection was replaced
-  between captures. A re-embed or a restore does that deliberately with nothing lost, and so does a
-  loss; the receipt refuses to guess. Correlate with maintenance history before concluding anything.
-- `empty: false` with `lineage: "unknown"` — nothing to compare against. The first bundle after this
-  field shipped always reads this way, as does one whose predecessor was swept by retention.
+- `provenEmpty: true` — a real empty source. Normal for a fresh environment.
+- `provenEmpty: false` with `lineage: "changed"` — **the one to investigate.** The collection was
+  replaced between captures. A re-embed or a restore does that deliberately with nothing lost, and so
+  does a loss; the receipt refuses to guess. Correlate with maintenance history before concluding.
+- `provenEmpty: false` with `lineage: "unknown"` — nothing to compare against. The first bundle after
+  this field shipped reads this way, as does one whose predecessor was swept by retention.
 - `rowState: "unestablished"` — the exporter returned something that was not a row count. The zero is
   a broken instrument, not a measurement; nothing about the corpus follows from it.
 
-**Legacy bundles degrade, they do not fail.** A bundle published before this block existed carries no
-`capture` at all, and one published before the `empty` → `zero-rows` rename carries the old token in
-`integrity`. Both are still read correctly and still disqualify exactly as they did. A bundle with no
-`integrity` block at all resolves to `restorable: null` — unknown, which is a third answer and not a
-quiet "unusable"; check it with `ai:check-backup-integrity` above rather than assuming either way.
+**Legacy bundles degrade, they do not fail.** A bundle published before the `capture` block existed
+carries no `capture` at all; it is still read correctly and still disqualifies exactly as it did. A
+bundle with no `integrity` block either resolves to `restorable: null` — unknown, which is a third
+answer and not a quiet "unusable"; check it with `ai:check-backup-integrity` above rather than
+assuming either way.
+
+**`integrity[].status` values never change spelling.** A bundle is read by whatever version is
+deployed where it lands, and those readers match the status by exact string — so a renamed token
+reads to them as *no empty subsystem found*, i.e. a zero-row bundle reported as restorable. New
+meaning goes on new fields, never on this one.
 
 ## Restoration Procedures
 

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -496,14 +496,14 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         expect(mc.reason).toMatch(/no numeric source count/);
     });
 
-    test('verifyBundleIntegrity: empty (not a silent pass) when source and bundle are both zero (#14030)', async () => {
+    test('verifyBundleIntegrity: zero-rows (not a silent pass) when source and bundle are both zero (#14030)', async () => {
         const tempRoot = path.join(workRoot, 'integrity-empty');
         const kbDir    = path.join(tempRoot, 'kb');
 
         fs.mkdirSync(kbDir, {recursive: true});
         // The gutted-store signature: a populated deployment whose export came back empty. Both
         // sides agree at zero, so the old `bundleCount === sourceCount` branch reported 'pass' —
-        // a false recovery source. It must surface as 'empty', never 'pass'.
+        // a false recovery source. It must surface as 'zero-rows', never 'pass'.
         fs.writeFileSync(path.join(kbDir, 'kb-data.jsonl'), '');
 
         const checks = await verifyBundleIntegrity(
@@ -512,17 +512,17 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         );
 
         const kb = checks.find(c => c.subsystem === 'kb');
-        expect(kb.status).toBe('empty');
+        expect(kb.status).toBe('zero-rows');
         expect(kb.status).not.toBe('pass');
         expect(kb.sourceCount).toBe(0);
         expect(kb.bundleCount).toBe(0);
         expect(kb.reason).toMatch(/not a usable recovery source/);
     });
 
-    test('runBackup propagates an empty subsystem to bundle-meta.integrity "empty" + a non-fatal warning (#14048)', async () => {
-        // Close-target proof: the helper status alone is not enough — runBackup must keep an empty
-        // subsystem non-fatal, WARN, and persist `empty` into bundle-meta.integrity (the canary/alert
-        // handoff). Force MC (memories + summaries) to export zero rows.
+    test('runBackup propagates a zero-row subsystem to bundle-meta.integrity + a non-fatal warning (#14048)', async () => {
+        // Close-target proof: the helper status alone is not enough — runBackup must keep a zero-row
+        // subsystem non-fatal, WARN, and persist the status into bundle-meta.integrity (the
+        // canary/alert handoff). Force MC (memories + summaries) to export zero rows.
         const warnings      = [];
         const captureLogger = {log: () => {}, error: () => {}, warn: msg => warnings.push(msg)};
         const savedMem      = Memory_StorageRouter.getMemoryCollection;
@@ -540,10 +540,10 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
             });
 
             const mcIntegrity = result.meta.integrity.find(check => check.subsystem === 'mc');
-            expect(mcIntegrity.status).toBe('empty');           // persisted into bundle-meta.integrity
+            expect(mcIntegrity.status).toBe('zero-rows');       // persisted into bundle-meta.integrity
             expect(mcIntegrity.sourceCount).toBe(0);
             expect(mcIntegrity.bundleCount).toBe(0);
-            expect(warnings.some(w => /ZERO rows|empty backup/i.test(w))).toBe(true);  // runBackup warned, non-fatally
+            expect(warnings.some(w => /ZERO rows|holding no rows/i.test(w))).toBe(true);  // runBackup warned, non-fatally
         } finally {
             Memory_StorageRouter.getMemoryCollection  = savedMem;
             Memory_StorageRouter.getSummaryCollection = savedSum;
@@ -893,5 +893,169 @@ test.describe('backup.mjs — capture lineage: a zero-row export is not a claim 
 
         expect(bundleName).toBe('backup-2026-08-02T10-00-00.000Z');
         expect(identities).toEqual({})
+    });
+});
+
+/**
+ * @summary One zero, two propositions, and the proof they cannot contradict each other.
+ *
+ * A bundle-meta carries two verdicts about the same zero-row export. `capture` answers PROVENANCE —
+ * was there genuinely nothing to capture — and `integrity` answers SURVIVABILITY — does this bundle
+ * hold rows a restore could bring back. At the head this suite was written against, both called it
+ * `empty`, and a `zero + changed` source published `capture.empty=false` beside
+ * `integrity[kb].status="empty"` in one artifact while every downstream consumer read only the
+ * latter.
+ *
+ * The repair is lexical, not behavioural: survivability says `zero-rows`, provenance keeps `empty`,
+ * and restorability is deliberately NOT rewired through lineage — a zero-row bundle over a replaced
+ * source is the most suspicious specimen in the series, and reading provenance into the recovery
+ * verdict would promote exactly it.
+ *
+ * These specs traverse the real producers into the real consumers, because the defect was invisible
+ * to every unit that tested one side alone.
+ */
+test.describe('bundle-meta — provenance and survivability never contradict (#16404)', () => {
+    let buildCaptureBlock, verifyBundleIntegrity, isBundleRestorable, summarizeBundleIntegrity, zeroRowSubsystems;
+    let root;
+
+    test.beforeAll(async () => {
+        ({buildCaptureBlock, verifyBundleIntegrity} =
+            await import('../../../../../../ai/scripts/maintenance/backup.mjs'));
+        ({isBundleRestorable, summarizeBundleIntegrity, zeroRowSubsystems} =
+            await import('../../../../../../ai/services/memory-core/helpers/bundleIntegrity.mjs'));
+    });
+
+    test.beforeEach(() => {
+        root = path.resolve(process.cwd(), 'tmp', `bundle-coherence-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(root, {recursive: true});
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(root, {recursive: true, force: true});
+    });
+
+    /**
+     * Assembles a bundle-meta the way `runBackup` does — real `verifyBundleIntegrity` over a real
+     * bundle tree, real `buildCaptureBlock` over a real predecessor — so neither block is hand-built
+     * and neither can drift from the producer it is supposed to mirror.
+     *
+     * @param {Object}       options
+     * @param {Number}       options.rows        Rows written into the bundle AND reported by the source.
+     * @param {String|null} [options.currentId]  KB collection identity observed this capture.
+     * @param {String|null} [options.previousId] Identity the predecessor bundle recorded; omit for first run.
+     * @returns {Promise<Object>} `{integrity, capture}` as `bundle-meta.json` would carry them.
+     */
+    async function buildMeta({rows, currentId = 'kb-id', previousId = null}) {
+        const bundleTree   = path.join(root, 'tree'),
+              kbDir        = path.join(bundleTree, 'kb'),
+              predecessors = path.join(root, 'published');
+
+        fs.mkdirSync(kbDir,        {recursive: true});
+        fs.mkdirSync(predecessors, {recursive: true});
+        fs.writeFileSync(path.join(kbDir, 'kb-data.jsonl'), '{"id":"r"}\n'.repeat(rows));
+
+        if (previousId) {
+            const dir = path.join(predecessors, 'backup-2026-08-02T10-00-00.000Z');
+            fs.mkdirSync(dir, {recursive: true});
+            fs.writeFileSync(path.join(dir, 'bundle-meta.json'), JSON.stringify({
+                capture: {schemaVersion: 1, sources: {kb: {collectionId: previousId}}}
+            }));
+        }
+
+        return {
+            integrity: await verifyBundleIntegrity(
+                {kb: kbDir, mc: path.join(bundleTree, 'no-mc'), graph: path.join(bundleTree, 'no-graph')},
+                {kb: rows}
+            ),
+            capture  : await buildCaptureBlock({
+                subsystems: {kb: {count: rows, collectionId: currentId}},
+                backupRoot: predecessors
+            })
+        };
+    }
+
+    test('zero + SAME identity: genuinely empty, and still not a recovery source', async () => {
+        const {integrity, capture} = await buildMeta({rows: 0, currentId: 'kb-id', previousId: 'kb-id'});
+
+        expect(capture.sources.kb.empty).toBe(true);           // provenance: nothing was there
+        expect(integrity[0].status).toBe('zero-rows');         // survivability: nothing to restore
+        expect(isBundleRestorable(integrity)).toBe(false);
+    });
+
+    test('zero + CHANGED identity: NOT provably empty, and NOT restorable either — the case that used to contradict', async () => {
+        // The exact specimen: the capture block refuses the emptiness claim while the bundle still
+        // holds no rows. Both statements are true, and neither is the other's negation. Before the
+        // rename these were `empty=false` and `status="empty"` in one file.
+        const {integrity, capture} = await buildMeta({rows: 0, currentId: 'kb-id-new', previousId: 'kb-id-old'});
+
+        expect(capture.sources.kb.lineage).toBe('changed');
+        expect(capture.sources.kb.empty).toBe(false);
+        expect(integrity[0].status).toBe('zero-rows');
+        // Load-bearing: lineage must NOT soften the recovery verdict. A zero-row bundle over a
+        // replaced source is the most suspicious specimen there is; promoting it to restorable would
+        // be a false green delivered by the very field added to prevent one.
+        expect(isBundleRestorable(integrity)).toBe(false);
+    });
+
+    test('zero + UNKNOWN identity (first run): NOT provably empty, NOT restorable', async () => {
+        const {integrity, capture} = await buildMeta({rows: 0, currentId: 'kb-id', previousId: null});
+
+        expect(capture.sources.kb.lineage).toBe('unknown');
+        expect(capture.sources.kb.empty).toBe(false);
+        expect(isBundleRestorable(integrity)).toBe(false);
+    });
+
+    test('POSITIVE CONTROL — positive rows: not empty, and restorable', async () => {
+        // Without this, every assertion above passes for a build that hard-codes `false`.
+        const {integrity, capture} = await buildMeta({rows: 3, currentId: 'kb-id', previousId: 'kb-id'});
+
+        expect(capture.sources.kb.rowState).toBe('populated');
+        expect(capture.sources.kb.empty).toBe(false);
+        expect(integrity[0].status).toBe('pass');
+        expect(isBundleRestorable(integrity)).toBe(true);
+        expect(zeroRowSubsystems(integrity)).toEqual([]);
+    });
+
+    test('a LEGACY bundle — `empty` status, no capture block — behaves exactly as it did before', async () => {
+        // Bundles already on disk carry the old token and no capture block at all. The rename must be
+        // invisible to them: still named, still disqualifying, no crash on the absent block.
+        const legacy = [{subsystem: 'kb', status: 'empty', sourceCount: 0, bundleCount: 0}];
+
+        expect(zeroRowSubsystems(legacy)).toEqual(['kb']);
+        expect(isBundleRestorable(legacy)).toBe(false);
+        expect(summarizeBundleIntegrity(legacy)).toEqual({zeroRowSubsystems: ['kb'], restorable: false});
+    });
+
+    test('an ABSENT integrity block stays UNKNOWN — absence is a third answer, not a quiet false', async () => {
+        expect(isBundleRestorable(undefined)).toBeNull();
+        expect(summarizeBundleIntegrity(undefined)).toEqual({zeroRowSubsystems: [], restorable: null});
+    });
+
+    test('MIXED Memory Core: one re-embedded collection does not carry its sibling\'s verdict', async () => {
+        const capture = await buildCaptureBlock({
+            subsystems: {
+                mc: {
+                    memories : {count: 0, collectionId: 'mem-id'},        // same identity → genuinely empty
+                    summaries: {count: 0, collectionId: 'sum-id-new'}     // re-embedded → unprovable
+                }
+            },
+            backupRoot: root
+        });
+
+        // No predecessor exists under `root`, so both degrade to unknown and NEITHER claims empty —
+        // the honest first-run state, asserted here so the mixed case cannot silently become uniform.
+        expect(capture.sources['mc.memories'].empty).toBe(false);
+        expect(capture.sources['mc.summaries'].empty).toBe(false);
+        expect(capture.sources['mc.memories'].collectionId).toBe('mem-id');
+        expect(capture.sources['mc.summaries'].collectionId).toBe('sum-id-new');
+    });
+
+    test('the word `empty` survives in exactly ONE block of a published bundle-meta', async () => {
+        // The mechanical form of the whole repair. If a future edit reintroduces the token into the
+        // survivability block, this fails without anyone having to notice the semantics drifted.
+        const {integrity, capture} = await buildMeta({rows: 0, currentId: 'kb-id', previousId: 'kb-id'});
+
+        expect(JSON.stringify(integrity)).not.toContain('empty');
+        expect(JSON.stringify(capture)).toContain('empty');
     });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -759,3 +759,139 @@ test.describe('backup corruption canary — reachable by name', () => {
         expect(runbook).toContain('lastSuccessful');
     });
 });
+
+test.describe('backup.mjs — capture lineage: a zero-row export is not a claim of emptiness (#16404)', () => {
+    let buildCaptureBlock, listPublishedBundles, readPreviousBundleIdentities, captureRoot;
+
+    /**
+     * Writes a published bundle whose meta records one identity per source.
+     * @param {String} name Bundle directory name.
+     * @param {Object} sources `{key: collectionId}`.
+     */
+    function writePublishedBundle(name, sources) {
+        const dir = path.join(captureRoot, name);
+        fs.mkdirSync(dir, {recursive: true});
+        fs.writeFileSync(path.join(dir, 'bundle-meta.json'), JSON.stringify({
+            capture: {
+                schemaVersion: 1,
+                sources      : Object.fromEntries(
+                    Object.entries(sources).map(([key, collectionId]) => [key, {collectionId}])
+                )
+            }
+        }));
+    }
+
+    test.beforeAll(async () => {
+        ({buildCaptureBlock, listPublishedBundles, readPreviousBundleIdentities} =
+            await import('../../../../../../ai/scripts/maintenance/backup.mjs'));
+    });
+
+    test.beforeEach(() => {
+        captureRoot = path.resolve(process.cwd(), 'tmp', `capture-lineage-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(captureRoot, {recursive: true});
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(captureRoot, {recursive: true, force: true});
+    });
+
+    test('listPublishedBundles skips staging directories and returns newest first', async () => {
+        writePublishedBundle('backup-2026-08-01T10-00-00.000Z', {});
+        writePublishedBundle('backup-2026-08-03T10-00-00.000Z', {});
+        // The staging directory an interrupted capture leaves behind. It is a real directory with a
+        // real mtime; only the missing `backup-` prefix keeps it out, which is the contract restore
+        // and retention already depend on.
+        fs.mkdirSync(path.join(captureRoot, '.backup-partial-backup-2026-08-04T10-00-00.000Z-XyZ'), {recursive: true});
+
+        const bundles = await listPublishedBundles(captureRoot);
+
+        expect(bundles.map(b => b.name)).toEqual([
+            'backup-2026-08-03T10-00-00.000Z',
+            'backup-2026-08-01T10-00-00.000Z'
+        ]);
+    });
+
+    test('a zero-row export with an UNCHANGED identity is genuinely empty', async () => {
+        writePublishedBundle('backup-2026-08-02T10-00-00.000Z', {kb: 'collection-uuid-a'});
+
+        const {sources} = await buildCaptureBlock({
+            subsystems: {kb: {count: 0, collectionId: 'collection-uuid-a'}},
+            backupRoot: captureRoot
+        });
+
+        expect(sources.kb.lineage).toBe('same');
+        expect(sources.kb.empty).toBe(true)
+    });
+
+    test('a zero-row export with a CHANGED identity is NOT empty — it is unexplained', async () => {
+        // The defect this ticket exists for. Both captures report zero rows and both would have logged
+        // "Export complete."; only the identity distinguishes "the same source held nothing" from
+        // "a different source is here now". A promotion or a restore changes the id legitimately — so
+        // this asserts the receipt REFUSES the empty claim, not that it reports loss.
+        writePublishedBundle('backup-2026-08-02T10-00-00.000Z', {kb: 'collection-uuid-a'});
+
+        const {sources} = await buildCaptureBlock({
+            subsystems: {kb: {count: 0, collectionId: 'collection-uuid-b'}},
+            backupRoot: captureRoot
+        });
+
+        expect(sources.kb.rowState).toBe('zero');
+        expect(sources.kb.lineage).toBe('changed');
+        expect(sources.kb.empty).toBe(false)
+    });
+
+    test('a zero-row export with no predecessor degrades to unknown rather than claiming empty', async () => {
+        const {comparedTo, sources} = await buildCaptureBlock({
+            subsystems: {kb: {count: 0, collectionId: 'collection-uuid-a'}},
+            backupRoot: captureRoot
+        });
+
+        expect(comparedTo).toBeNull();
+        expect(sources.kb.lineage).toBe('unknown');
+        expect(sources.kb.empty).toBe(false)
+    });
+
+    test('a populated export is never reported empty, whatever the lineage says', async () => {
+        writePublishedBundle('backup-2026-08-02T10-00-00.000Z', {kb: 'collection-uuid-a'});
+
+        const {sources} = await buildCaptureBlock({
+            subsystems: {kb: {count: 12, collectionId: 'collection-uuid-b'}},
+            backupRoot: captureRoot
+        });
+
+        expect(sources.kb.rowState).toBe('populated');
+        expect(sources.kb.empty).toBe(false)
+    });
+
+    test('per-collection Memory Core receipts each carry their own lineage', async () => {
+        writePublishedBundle('backup-2026-08-02T10-00-00.000Z', {
+            'mc.memories' : 'memories-uuid-a',
+            'mc.summaries': 'summaries-uuid-a'
+        });
+
+        const {sources} = await buildCaptureBlock({
+            subsystems: {
+                mc: {
+                    memories : {exported: 0, collectionId: 'memories-uuid-a'},
+                    summaries: {exported: 0, collectionId: 'summaries-uuid-b'}
+                }
+            },
+            backupRoot: captureRoot
+        });
+
+        expect(sources['mc.memories'].empty).toBe(true);
+        // One re-embedded collection must not drag its sibling's verdict with it.
+        expect(sources['mc.summaries'].empty).toBe(false)
+    });
+
+    test('an unreadable predecessor degrades lineage instead of failing the backup', async () => {
+        const dir = path.join(captureRoot, 'backup-2026-08-02T10-00-00.000Z');
+        fs.mkdirSync(dir, {recursive: true});
+        fs.writeFileSync(path.join(dir, 'bundle-meta.json'), '{ this is not json');
+
+        const {bundleName, identities} = await readPreviousBundleIdentities(captureRoot, {warn: () => {}});
+
+        expect(bundleName).toBe('backup-2026-08-02T10-00-00.000Z');
+        expect(identities).toEqual({})
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -496,14 +496,14 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         expect(mc.reason).toMatch(/no numeric source count/);
     });
 
-    test('verifyBundleIntegrity: zero-rows (not a silent pass) when source and bundle are both zero (#14030)', async () => {
+    test('verifyBundleIntegrity: empty (not a silent pass) when source and bundle are both zero (#14030)', async () => {
         const tempRoot = path.join(workRoot, 'integrity-empty');
         const kbDir    = path.join(tempRoot, 'kb');
 
         fs.mkdirSync(kbDir, {recursive: true});
         // The gutted-store signature: a populated deployment whose export came back empty. Both
         // sides agree at zero, so the old `bundleCount === sourceCount` branch reported 'pass' —
-        // a false recovery source. It must surface as 'zero-rows', never 'pass'.
+        // a false recovery source. It must surface as 'empty', never 'pass'.
         fs.writeFileSync(path.join(kbDir, 'kb-data.jsonl'), '');
 
         const checks = await verifyBundleIntegrity(
@@ -512,14 +512,14 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         );
 
         const kb = checks.find(c => c.subsystem === 'kb');
-        expect(kb.status).toBe('zero-rows');
+        expect(kb.status).toBe('empty');
         expect(kb.status).not.toBe('pass');
         expect(kb.sourceCount).toBe(0);
         expect(kb.bundleCount).toBe(0);
         expect(kb.reason).toMatch(/not a usable recovery source/);
     });
 
-    test('runBackup propagates a zero-row subsystem to bundle-meta.integrity + a non-fatal warning (#14048)', async () => {
+    test('runBackup propagates an empty subsystem to bundle-meta.integrity "empty" + a non-fatal warning (#14048)', async () => {
         // Close-target proof: the helper status alone is not enough — runBackup must keep a zero-row
         // subsystem non-fatal, WARN, and persist the status into bundle-meta.integrity (the
         // canary/alert handoff). Force MC (memories + summaries) to export zero rows.
@@ -540,7 +540,7 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
             });
 
             const mcIntegrity = result.meta.integrity.find(check => check.subsystem === 'mc');
-            expect(mcIntegrity.status).toBe('zero-rows');       // persisted into bundle-meta.integrity
+            expect(mcIntegrity.status).toBe('empty');           // persisted into bundle-meta.integrity
             expect(mcIntegrity.sourceCount).toBe(0);
             expect(mcIntegrity.bundleCount).toBe(0);
             expect(warnings.some(w => /ZERO rows|holding no rows/i.test(w))).toBe(true);  // runBackup warned, non-fatally
@@ -820,7 +820,7 @@ test.describe('backup.mjs — capture lineage: a zero-row export is not a claim 
         });
 
         expect(sources.kb.lineage).toBe('same');
-        expect(sources.kb.empty).toBe(true)
+        expect(sources.kb.provenEmpty).toBe(true)
     });
 
     test('a zero-row export with a CHANGED identity is NOT empty — it is unexplained', async () => {
@@ -837,7 +837,7 @@ test.describe('backup.mjs — capture lineage: a zero-row export is not a claim 
 
         expect(sources.kb.rowState).toBe('zero');
         expect(sources.kb.lineage).toBe('changed');
-        expect(sources.kb.empty).toBe(false)
+        expect(sources.kb.provenEmpty).toBe(false)
     });
 
     test('a zero-row export with no predecessor degrades to unknown rather than claiming empty', async () => {
@@ -848,7 +848,7 @@ test.describe('backup.mjs — capture lineage: a zero-row export is not a claim 
 
         expect(comparedTo).toBeNull();
         expect(sources.kb.lineage).toBe('unknown');
-        expect(sources.kb.empty).toBe(false)
+        expect(sources.kb.provenEmpty).toBe(false)
     });
 
     test('a populated export is never reported empty, whatever the lineage says', async () => {
@@ -860,7 +860,7 @@ test.describe('backup.mjs — capture lineage: a zero-row export is not a claim 
         });
 
         expect(sources.kb.rowState).toBe('populated');
-        expect(sources.kb.empty).toBe(false)
+        expect(sources.kb.provenEmpty).toBe(false)
     });
 
     test('per-collection Memory Core receipts each carry their own lineage', async () => {
@@ -879,9 +879,9 @@ test.describe('backup.mjs — capture lineage: a zero-row export is not a claim 
             backupRoot: captureRoot
         });
 
-        expect(sources['mc.memories'].empty).toBe(true);
+        expect(sources['mc.memories'].provenEmpty).toBe(true);
         // One re-embedded collection must not drag its sibling's verdict with it.
-        expect(sources['mc.summaries'].empty).toBe(false)
+        expect(sources['mc.summaries'].provenEmpty).toBe(false)
     });
 
     test('an unreadable predecessor degrades lineage instead of failing the backup', async () => {
@@ -901,27 +901,34 @@ test.describe('backup.mjs — capture lineage: a zero-row export is not a claim 
  *
  * A bundle-meta carries two verdicts about the same zero-row export. `capture` answers PROVENANCE —
  * was there genuinely nothing to capture — and `integrity` answers SURVIVABILITY — does this bundle
- * hold rows a restore could bring back. At the head this suite was written against, both called it
- * `empty`, and a `zero + changed` source published `capture.empty=false` beside
- * `integrity[kb].status="empty"` in one artifact while every downstream consumer read only the
- * latter.
+ * hold rows a restore could bring back. Both originally called it `empty`, so a `zero + changed`
+ * source published `capture.empty=false` beside `integrity[kb].status="empty"` in one artifact while
+ * every downstream consumer read only the latter.
  *
- * The repair is lexical, not behavioural: survivability says `zero-rows`, provenance keeps `empty`,
- * and restorability is deliberately NOT rewired through lineage — a zero-row bundle over a replaced
- * source is the most suspicious specimen in the series, and reading provenance into the recovery
- * verdict would promote exactly it.
+ * The repair is lexical, not behavioural, and **which side gets renamed is the load-bearing part.**
+ * The first attempt renamed the survivability status to `zero-rows` and introduced a worse defect
+ * than the one it fixed: `integrity[].status` is a persisted wire value matched by exact string, so a
+ * reader deployed before the rename classifies a NEW bundle as having no zero-row subsystem at all —
+ * `restorable: true` for a bundle holding nothing. Compatibility runs one way only. So the status
+ * keeps its token forever and the provenance claim, which nothing has persisted yet, is the one that
+ * moved: it is named `provenEmpty`.
  *
- * These specs traverse the real producers into the real consumers, because the defect was invisible
- * to every unit that tested one side alone.
+ * Restorability is deliberately NOT rewired through lineage either — a zero-row bundle over a
+ * replaced source is the most suspicious specimen in the series, and reading provenance into the
+ * recovery verdict would promote exactly it.
+ *
+ * These specs traverse the real producers into the real consumers, because both defects were
+ * invisible to every unit that tested one side, or one version, alone.
  */
 test.describe('bundle-meta — provenance and survivability never contradict (#16404)', () => {
-    let buildCaptureBlock, verifyBundleIntegrity, isBundleRestorable, summarizeBundleIntegrity, zeroRowSubsystems;
+    let buildCaptureBlock, verifyBundleIntegrity, INTEGRITY_STATUS;
+    let isBundleRestorable, summarizeBundleIntegrity, emptySubsystems;
     let root;
 
     test.beforeAll(async () => {
-        ({buildCaptureBlock, verifyBundleIntegrity} =
+        ({buildCaptureBlock, verifyBundleIntegrity, INTEGRITY_STATUS} =
             await import('../../../../../../ai/scripts/maintenance/backup.mjs'));
-        ({isBundleRestorable, summarizeBundleIntegrity, zeroRowSubsystems} =
+        ({isBundleRestorable, summarizeBundleIntegrity, emptySubsystems} =
             await import('../../../../../../ai/services/memory-core/helpers/bundleIntegrity.mjs'));
     });
 
@@ -977,20 +984,20 @@ test.describe('bundle-meta — provenance and survivability never contradict (#1
     test('zero + SAME identity: genuinely empty, and still not a recovery source', async () => {
         const {integrity, capture} = await buildMeta({rows: 0, currentId: 'kb-id', previousId: 'kb-id'});
 
-        expect(capture.sources.kb.empty).toBe(true);           // provenance: nothing was there
-        expect(integrity[0].status).toBe('zero-rows');         // survivability: nothing to restore
+        expect(capture.sources.kb.provenEmpty).toBe(true);   // provenance: nothing was there
+        expect(integrity[0].status).toBe('empty');           // survivability: nothing to restore
         expect(isBundleRestorable(integrity)).toBe(false);
     });
 
     test('zero + CHANGED identity: NOT provably empty, and NOT restorable either — the case that used to contradict', async () => {
         // The exact specimen: the capture block refuses the emptiness claim while the bundle still
         // holds no rows. Both statements are true, and neither is the other's negation. Before the
-        // rename these were `empty=false` and `status="empty"` in one file.
+        // rename these were `empty=false` and `status="empty"` in one file — one word, two meanings.
         const {integrity, capture} = await buildMeta({rows: 0, currentId: 'kb-id-new', previousId: 'kb-id-old'});
 
         expect(capture.sources.kb.lineage).toBe('changed');
-        expect(capture.sources.kb.empty).toBe(false);
-        expect(integrity[0].status).toBe('zero-rows');
+        expect(capture.sources.kb.provenEmpty).toBe(false);
+        expect(integrity[0].status).toBe('empty');
         // Load-bearing: lineage must NOT soften the recovery verdict. A zero-row bundle over a
         // replaced source is the most suspicious specimen there is; promoting it to restorable would
         // be a false green delivered by the very field added to prevent one.
@@ -1001,7 +1008,7 @@ test.describe('bundle-meta — provenance and survivability never contradict (#1
         const {integrity, capture} = await buildMeta({rows: 0, currentId: 'kb-id', previousId: null});
 
         expect(capture.sources.kb.lineage).toBe('unknown');
-        expect(capture.sources.kb.empty).toBe(false);
+        expect(capture.sources.kb.provenEmpty).toBe(false);
         expect(isBundleRestorable(integrity)).toBe(false);
     });
 
@@ -1010,25 +1017,25 @@ test.describe('bundle-meta — provenance and survivability never contradict (#1
         const {integrity, capture} = await buildMeta({rows: 3, currentId: 'kb-id', previousId: 'kb-id'});
 
         expect(capture.sources.kb.rowState).toBe('populated');
-        expect(capture.sources.kb.empty).toBe(false);
+        expect(capture.sources.kb.provenEmpty).toBe(false);
         expect(integrity[0].status).toBe('pass');
         expect(isBundleRestorable(integrity)).toBe(true);
-        expect(zeroRowSubsystems(integrity)).toEqual([]);
+        expect(emptySubsystems(integrity)).toEqual([]);
     });
 
-    test('a LEGACY bundle — `empty` status, no capture block — behaves exactly as it did before', async () => {
-        // Bundles already on disk carry the old token and no capture block at all. The rename must be
-        // invisible to them: still named, still disqualifying, no crash on the absent block.
+    test('a LEGACY bundle — no capture block at all — behaves exactly as it did before', async () => {
+        // Bundles already on disk carry no capture block. Nothing about this change may reach them:
+        // still named, still disqualifying, no crash on the absent block.
         const legacy = [{subsystem: 'kb', status: 'empty', sourceCount: 0, bundleCount: 0}];
 
-        expect(zeroRowSubsystems(legacy)).toEqual(['kb']);
+        expect(emptySubsystems(legacy)).toEqual(['kb']);
         expect(isBundleRestorable(legacy)).toBe(false);
-        expect(summarizeBundleIntegrity(legacy)).toEqual({zeroRowSubsystems: ['kb'], restorable: false});
+        expect(summarizeBundleIntegrity(legacy)).toEqual({emptySubsystems: ['kb'], restorable: false});
     });
 
     test('an ABSENT integrity block stays UNKNOWN — absence is a third answer, not a quiet false', async () => {
         expect(isBundleRestorable(undefined)).toBeNull();
-        expect(summarizeBundleIntegrity(undefined)).toEqual({zeroRowSubsystems: [], restorable: null});
+        expect(summarizeBundleIntegrity(undefined)).toEqual({emptySubsystems: [], restorable: null});
     });
 
     test('MIXED Memory Core: one re-embedded collection does not carry its sibling\'s verdict', async () => {
@@ -1044,18 +1051,77 @@ test.describe('bundle-meta — provenance and survivability never contradict (#1
 
         // No predecessor exists under `root`, so both degrade to unknown and NEITHER claims empty —
         // the honest first-run state, asserted here so the mixed case cannot silently become uniform.
-        expect(capture.sources['mc.memories'].empty).toBe(false);
-        expect(capture.sources['mc.summaries'].empty).toBe(false);
+        expect(capture.sources['mc.memories'].provenEmpty).toBe(false);
+        expect(capture.sources['mc.summaries'].provenEmpty).toBe(false);
         expect(capture.sources['mc.memories'].collectionId).toBe('mem-id');
         expect(capture.sources['mc.summaries'].collectionId).toBe('sum-id-new');
     });
 
-    test('the word `empty` survives in exactly ONE block of a published bundle-meta', async () => {
-        // The mechanical form of the whole repair. If a future edit reintroduces the token into the
-        // survivability block, this fails without anyone having to notice the semantics drifted.
+    test('the bare property `empty` exists in NEITHER block — one word, one owner', async () => {
+        // The mechanical form of the repair. `integrity` owns the token as a status VALUE; the
+        // provenance claim is a property named for what it proves. Neither block publishes a bare
+        // `empty` key, so no reader can pick one up and assume the other's meaning.
         const {integrity, capture} = await buildMeta({rows: 0, currentId: 'kb-id', previousId: 'kb-id'});
 
-        expect(JSON.stringify(integrity)).not.toContain('empty');
-        expect(JSON.stringify(capture)).toContain('empty');
+        expect(integrity[0]).not.toHaveProperty('empty');
+        expect(capture.sources.kb).not.toHaveProperty('empty');
+        expect(capture.sources.kb).toHaveProperty('provenEmpty');
+        expect(integrity[0].status).toBe('empty');
+    });
+
+    /**
+     * The version axis. Every spec above reads a bundle with the reader that wrote it, and the
+     * defect this describe block exists to prevent was invisible to all of them: a rename of the
+     * status token left old-reader + new-bundle returning `restorable: true` for a bundle holding
+     * nothing, while old/old, new/old and new/new all stayed correct. Three of four cells green.
+     *
+     * Compatibility here is one-directional by construction. A reader we ship can be taught to accept
+     * yesterday's tokens; a reader already running on a plane four figures of commits behind can never
+     * be taught tomorrow's — it matches what it knows and silently drops the rest, which for this
+     * field resolves to "no zero-row subsystem found".
+     */
+    test.describe('cross-version: a bundle written today must disqualify under a reader shipped before it', () => {
+        /**
+         * A reader frozen at the previous contract, spelled out rather than imported so it cannot
+         * drift when the live one changes. This IS the deployed population.
+         * @param {Array<Object>} integrity
+         * @returns {Boolean} The old contract's restorability verdict.
+         */
+        const oldReaderSaysRestorable = integrity =>
+            integrity.filter(check => check?.status === 'empty').length === 0;
+
+        test('WITNESS: oldReader(newBundle) === false', async () => {
+            const {integrity} = await buildMeta({rows: 0, currentId: 'kb-id', previousId: 'kb-id'});
+
+            expect(oldReaderSaysRestorable(integrity)).toBe(false);
+            expect(isBundleRestorable(integrity)).toBe(false);
+        });
+
+        test('POSITIVE CONTROL: the old reader still says TRUE for a genuinely restorable new bundle', async () => {
+            // Without this the witness passes for a reader hard-coded to `false`.
+            const {integrity} = await buildMeta({rows: 3, currentId: 'kb-id', previousId: 'kb-id'});
+
+            expect(oldReaderSaysRestorable(integrity)).toBe(true);
+            expect(isBundleRestorable(integrity)).toBe(true);
+        });
+
+        test('the writer emits ONLY tokens the frozen wire vocabulary declares', async () => {
+            // The structural guard. A new status value cannot be introduced without this failing,
+            // which is the only place the one-directional compatibility can be enforced at all —
+            // by the writer, since the readers are already deployed and cannot be changed.
+            const known = new Set(Object.values(INTEGRITY_STATUS));
+
+            for (const rows of [0, 3]) {
+                const {integrity} = await buildMeta({rows, currentId: 'kb-id', previousId: 'kb-id'});
+
+                for (const check of integrity) {
+                    expect(known, `rows=${rows} emitted an undeclared status: ${check.status}`)
+                        .toContain(check.status);
+                }
+            }
+
+            expect(Object.isFrozen(INTEGRITY_STATUS)).toBe(true);
+            expect([...known].sort()).toEqual(['empty', 'fail', 'pass', 'skipped']);
+        });
     });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -860,24 +860,39 @@ test.describe('adversarial IO + encoding edges', () => {
  * a contract end up one edit apart.
  */
 test.describe('backup receipt — the integrity verdict travels with the status', () => {
-    const EMPTY = [
-        {subsystem: 'kb', status: 'empty', sourceCount: 0, bundleCount: 0},
-        {subsystem: 'mc', status: 'empty', sourceCount: 0, bundleCount: 0}
+    const ZERO_ROWS = [
+        {subsystem: 'kb', status: 'zero-rows', sourceCount: 0, bundleCount: 0},
+        {subsystem: 'mc', status: 'zero-rows', sourceCount: 0, bundleCount: 0}
     ];
     const CLEAN = [{subsystem: 'kb', status: 'pass', sourceCount: 61206, bundleCount: 61206}];
 
-    test('a zero-row bundle is marked NOT restorable, and names which subsystems were empty', () => {
+    test('a zero-row bundle is marked NOT restorable, and names which subsystems brought back nothing', () => {
         const receipt = buildBackupReceipt({
             backup    : {durationMs: 24, error: null, status: 'success'},
             bundleName: 'backup-2026-07-31T04-57-18.233Z',
-            integrity : EMPTY
+            integrity : ZERO_ROWS
         });
 
         // The run completed — that stays true and stays reported.
         expect(receipt.backup.status).toBe('success');
         // …and the receipt now also says it is not a recovery source, with the reason named.
         expect(receipt.integrity.restorable).toBe(false);
-        expect(receipt.integrity.emptySubsystems).toEqual(['kb', 'mc']);
+        expect(receipt.integrity.zeroRowSubsystems).toEqual(['kb', 'mc']);
+    });
+
+    test('a LEGACY `empty` status still disqualifies — the rename must not resurrect old bundles', () => {
+        // Bundles published before the `empty` → `zero-rows` rename carry the old token and are still
+        // live recovery sources. A reader matching only the new value would silently flip every one of
+        // them from `restorable: false` to `restorable: true` — a vocabulary correction turning into
+        // the exact false-green the verdict exists to end.
+        const receipt = buildBackupReceipt({
+            backup    : {durationMs: 24, error: null, status: 'success'},
+            bundleName: 'backup-2026-06-14T02-11-05.000Z',
+            integrity : [{subsystem: 'kb', status: 'empty', sourceCount: 0, bundleCount: 0}]
+        });
+
+        expect(receipt.integrity.restorable).toBe(false);
+        expect(receipt.integrity.zeroRowSubsystems).toEqual(['kb']);
     });
 
     test('POSITIVE CONTROL: a clean bundle is restorable and names nothing', () => {
@@ -888,7 +903,7 @@ test.describe('backup receipt — the integrity verdict travels with the status'
         });
 
         expect(receipt.integrity.restorable).toBe(true);
-        expect(receipt.integrity.emptySubsystems).toEqual([]);
+        expect(receipt.integrity.zeroRowSubsystems).toEqual([]);
     });
 
     test('an ABSENT verdict is unknown, never false — old receipts must not read as unusable', () => {
@@ -900,7 +915,7 @@ test.describe('backup receipt — the integrity verdict travels with the status'
         });
 
         expect(receipt.integrity.restorable).toBeNull();
-        expect(receipt.integrity.emptySubsystems).toEqual([]);
+        expect(receipt.integrity.zeroRowSubsystems).toEqual([]);
     });
 
     test('the schema version is UNCHANGED — the field is additive or existing receipts are rejected', () => {

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -860,9 +860,9 @@ test.describe('adversarial IO + encoding edges', () => {
  * a contract end up one edit apart.
  */
 test.describe('backup receipt — the integrity verdict travels with the status', () => {
-    const ZERO_ROWS = [
-        {subsystem: 'kb', status: 'zero-rows', sourceCount: 0, bundleCount: 0},
-        {subsystem: 'mc', status: 'zero-rows', sourceCount: 0, bundleCount: 0}
+    const EMPTY = [
+        {subsystem: 'kb', status: 'empty', sourceCount: 0, bundleCount: 0},
+        {subsystem: 'mc', status: 'empty', sourceCount: 0, bundleCount: 0}
     ];
     const CLEAN = [{subsystem: 'kb', status: 'pass', sourceCount: 61206, bundleCount: 61206}];
 
@@ -870,29 +870,31 @@ test.describe('backup receipt — the integrity verdict travels with the status'
         const receipt = buildBackupReceipt({
             backup    : {durationMs: 24, error: null, status: 'success'},
             bundleName: 'backup-2026-07-31T04-57-18.233Z',
-            integrity : ZERO_ROWS
+            integrity : EMPTY
         });
 
         // The run completed — that stays true and stays reported.
         expect(receipt.backup.status).toBe('success');
         // …and the receipt now also says it is not a recovery source, with the reason named.
         expect(receipt.integrity.restorable).toBe(false);
-        expect(receipt.integrity.zeroRowSubsystems).toEqual(['kb', 'mc']);
+        expect(receipt.integrity.emptySubsystems).toEqual(['kb', 'mc']);
     });
 
-    test('a LEGACY `empty` status still disqualifies — the rename must not resurrect old bundles', () => {
-        // Bundles published before the `empty` → `zero-rows` rename carry the old token and are still
-        // live recovery sources. A reader matching only the new value would silently flip every one of
-        // them from `restorable: false` to `restorable: true` — a vocabulary correction turning into
-        // the exact false-green the verdict exists to end.
+    test('the projection KEY is wire-stable at schemaVersion 1 — a receipt reader must not lose the field', () => {
+        // This key was briefly renamed to `zeroRowSubsystems` for lexical clarity. A receipt is read
+        // by whatever version is deployed where it lands, and a reader looking for `emptySubsystems`
+        // finds `undefined` — which reads as "no subsystem was empty", not as "I do not understand this
+        // receipt". Renaming a projected key without a schemaVersion bump is the same class of silent
+        // downgrade as renaming the status token itself.
         const receipt = buildBackupReceipt({
             backup    : {durationMs: 24, error: null, status: 'success'},
             bundleName: 'backup-2026-06-14T02-11-05.000Z',
             integrity : [{subsystem: 'kb', status: 'empty', sourceCount: 0, bundleCount: 0}]
         });
 
+        expect(Object.keys(receipt.integrity).sort()).toEqual(['emptySubsystems', 'restorable']);
+        expect(receipt.integrity.emptySubsystems).toEqual(['kb']);
         expect(receipt.integrity.restorable).toBe(false);
-        expect(receipt.integrity.zeroRowSubsystems).toEqual(['kb']);
     });
 
     test('POSITIVE CONTROL: a clean bundle is restorable and names nothing', () => {
@@ -903,7 +905,7 @@ test.describe('backup receipt — the integrity verdict travels with the status'
         });
 
         expect(receipt.integrity.restorable).toBe(true);
-        expect(receipt.integrity.zeroRowSubsystems).toEqual([]);
+        expect(receipt.integrity.emptySubsystems).toEqual([]);
     });
 
     test('an ABSENT verdict is unknown, never false — old receipts must not read as unusable', () => {
@@ -915,7 +917,7 @@ test.describe('backup receipt — the integrity verdict travels with the status'
         });
 
         expect(receipt.integrity.restorable).toBeNull();
-        expect(receipt.integrity.zeroRowSubsystems).toEqual([]);
+        expect(receipt.integrity.emptySubsystems).toEqual([]);
     });
 
     test('the schema version is UNCHANGED — the field is additive or existing receipts are rejected', () => {

--- a/test/playwright/unit/ai/services/shared/captureReceipt.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/captureReceipt.spec.mjs
@@ -3,7 +3,7 @@ import {test, expect} from '@playwright/test';
 import {
     buildSourceReceipt,
     deriveLineage,
-    derivesEmpty,
+    derivesProvenEmpty,
     LINEAGE,
     ROW_STATE
 } from '../../../../../../ai/services/shared/captureReceipt.mjs';
@@ -20,7 +20,7 @@ import {
  */
 test.describe('ai/services/shared/captureReceipt — orthogonal facts, one derived claim', () => {
     test('`empty` requires a measured zero AND a continuous lineage', () => {
-        expect(derivesEmpty({rowState: ROW_STATE.zero, lineage: LINEAGE.same})).toBe(true);
+        expect(derivesProvenEmpty({rowState: ROW_STATE.zero, lineage: LINEAGE.same})).toBe(true);
     });
 
     test('a CHANGED lineage never derives `empty` — the falsifier that dropped the predecessor', () => {
@@ -35,7 +35,7 @@ test.describe('ai/services/shared/captureReceipt — orthogonal facts, one deriv
         });
 
         expect(promoted.lineage).toBe(LINEAGE.changed);
-        expect(promoted.empty).toBe(false);
+        expect(promoted.provenEmpty).toBe(false);
         // The facts survive rather than collapsing: a consumer can still see there were zero rows.
         expect(promoted.rowState).toBe(ROW_STATE.zero);
     });
@@ -49,7 +49,7 @@ test.describe('ai/services/shared/captureReceipt — orthogonal facts, one deriv
         });
 
         expect(firstRun.lineage).toBe(LINEAGE.unknown);
-        expect(firstRun.empty).toBe(false);
+        expect(firstRun.provenEmpty).toBe(false);
     });
 
     test('rows are self-evidencing: a populated source is never `empty`, whatever its lineage', () => {
@@ -62,7 +62,7 @@ test.describe('ai/services/shared/captureReceipt — orthogonal facts, one deriv
             });
 
             expect(populated.rowState, `previousId=${previousId}`).toBe(ROW_STATE.populated);
-            expect(populated.empty,    `previousId=${previousId}`).toBe(false);
+            expect(populated.provenEmpty,    `previousId=${previousId}`).toBe(false);
         }
     });
 
@@ -141,7 +141,7 @@ test.describe('ai/services/shared/captureReceipt — orthogonal facts, one deriv
 
                 expect(receipt.lineage).toBe(LINEAGE.same);
                 expect(receipt.rowState).toBe(ROW_STATE.unestablished);
-                expect(receipt.empty).toBe(false);
+                expect(receipt.provenEmpty).toBe(false);
             });
         }
 
@@ -165,7 +165,7 @@ test.describe('ai/services/shared/captureReceipt — orthogonal facts, one deriv
 
             expect(measured.rowState).toBe(ROW_STATE.zero);
             expect(measured.rowCount).toBe(0);
-            expect(measured.empty).toBe(true);
+            expect(measured.provenEmpty).toBe(true);
         });
     });
 });

--- a/test/playwright/unit/ai/services/shared/captureReceipt.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/captureReceipt.spec.mjs
@@ -5,7 +5,6 @@ import {
     deriveLineage,
     derivesEmpty,
     LINEAGE,
-    READ_COMPLETENESS,
     ROW_STATE
 } from '../../../../../../ai/services/shared/captureReceipt.mjs';
 
@@ -19,13 +18,9 @@ import {
  * identity with nothing lost. These specs pin the axes as orthogonal and `empty` as the one derived
  * claim, so the collapse cannot come back by accident.
  */
-test.describe('ai/services/shared/captureReceipt — three facts, one derived claim', () => {
-    test('`empty` requires zero rows AND a complete read AND a continuous lineage', () => {
-        expect(derivesEmpty({
-            rowState        : ROW_STATE.zero,
-            readCompleteness: READ_COMPLETENESS.complete,
-            lineage         : LINEAGE.same
-        })).toBe(true);
+test.describe('ai/services/shared/captureReceipt — orthogonal facts, one derived claim', () => {
+    test('`empty` requires a measured zero AND a continuous lineage', () => {
+        expect(derivesEmpty({rowState: ROW_STATE.zero, lineage: LINEAGE.same})).toBe(true);
     });
 
     test('a CHANGED lineage never derives `empty` — the falsifier that dropped the predecessor', () => {
@@ -35,7 +30,6 @@ test.describe('ai/services/shared/captureReceipt — three facts, one derived cl
         const promoted = buildSourceReceipt({
             source      : 'neo-knowledge-base',
             rowCount    : 0,
-            readComplete: true,
             collectionId: 'shadow-id-after-promote',
             previousId  : 'canonical-id-before-promote'
         });
@@ -44,14 +38,12 @@ test.describe('ai/services/shared/captureReceipt — three facts, one derived cl
         expect(promoted.empty).toBe(false);
         // The facts survive rather than collapsing: a consumer can still see there were zero rows.
         expect(promoted.rowState).toBe(ROW_STATE.zero);
-        expect(promoted.readCompleteness).toBe(READ_COMPLETENESS.complete);
     });
 
     test('an UNKNOWN lineage never derives `empty` — first run has nothing to compare against', () => {
         const firstRun = buildSourceReceipt({
             source      : 'neo-agent-memory',
             rowCount    : 0,
-            readComplete: true,
             collectionId: 'some-id',
             previousId  : null
         });
@@ -60,25 +52,11 @@ test.describe('ai/services/shared/captureReceipt — three facts, one derived cl
         expect(firstRun.empty).toBe(false);
     });
 
-    test('an INCOMPLETE read never derives `empty` — the zero describes the read, not the store', () => {
-        const unread = buildSourceReceipt({
-            source      : 'neo-agent-memory',
-            rowCount    : 0,
-            readComplete: false,
-            collectionId: 'same-id',
-            previousId  : 'same-id'
-        });
-
-        expect(unread.readCompleteness).toBe(READ_COMPLETENESS.unavailable);
-        expect(unread.empty).toBe(false);
-    });
-
     test('rows are self-evidencing: a populated source is never `empty`, whatever its lineage', () => {
         for (const previousId of ['same-id', 'different-id', null]) {
             const populated = buildSourceReceipt({
                 source      : 'neo-agent-memory',
                 rowCount    : 94325,
-                readComplete: true,
                 collectionId: 'same-id',
                 previousId
             });
@@ -94,7 +72,6 @@ test.describe('ai/services/shared/captureReceipt — three facts, one derived cl
         const receipt = buildSourceReceipt({
             source      : 'neo-agent-sessions',
             rowCount    : 12,
-            readComplete: true,
             collectionId: 'b',
             previousId  : 'a'
         });
@@ -114,17 +91,81 @@ test.describe('ai/services/shared/captureReceipt — three facts, one derived cl
         expect(deriveLineage()).toBe(LINEAGE.unknown);
     });
 
-    test('`partial` is absent from the completeness vocabulary until a producer exists', () => {
-        // Every partial read in this substrate becomes a thrown abort (`PARTIAL_COLLECTION_EXPORT`),
-        // so no published bundle can carry the value. Shipping it would be a promise the contract
-        // cannot keep; this pins its absence so it is re-added deliberately, with a producer.
-        expect(Object.values(READ_COMPLETENESS)).toEqual(['complete', 'unavailable']);
-        expect(Object.values(READ_COMPLETENESS)).not.toContain('partial');
-    });
-
     test('the axis vocabularies are frozen — a consumer cannot widen a verdict at runtime', () => {
         expect(Object.isFrozen(ROW_STATE)).toBe(true);
-        expect(Object.isFrozen(READ_COMPLETENESS)).toBe(true);
         expect(Object.isFrozen(LINEAGE)).toBe(true);
+    });
+
+    test('read-completeness is NOT an axis — the rule that excluded `partial` applied to itself', () => {
+        // An earlier revision carried `readCompleteness: complete | unavailable`, and nothing in the
+        // substrate could emit `unavailable`: a partial read throws `PARTIAL_COLLECTION_EXPORT` and
+        // aborts before any receipt exists. That is the same reason `partial` was excluded, so the
+        // whole axis went with it. This pins the absence so it returns only with a producer.
+        const receipt = buildSourceReceipt({
+            source      : 'neo-knowledge-base',
+            rowCount    : 0,
+            collectionId: 'same-id',
+            previousId  : 'same-id'
+        });
+
+        expect(receipt).not.toHaveProperty('readCompleteness');
+        expect(Object.values(ROW_STATE)).not.toContain('partial');
+    });
+
+    /**
+     * A malformed count is not a small number — it is no number. Coercing it to `0` lets a broken
+     * exporter plus an unchanged identity assemble a POSITIVE claim of emptiness entirely out of the
+     * absence of evidence, which is the module's own conflation reappearing one layer earlier.
+     */
+    test.describe('malformed counts fail honest', () => {
+        // Every case pairs the bad count with MATCHING identities, so lineage is `same` and the only
+        // thing standing between the receipt and `empty: true` is the row-state rule under test.
+        const malformed = [
+            ['absent',    undefined],
+            ['null',      null],
+            ['NaN',       NaN],
+            ['Infinity',  Infinity],
+            ['-Infinity', -Infinity],
+            ['negative',  -1],
+            ['a string',  '0']
+        ];
+
+        for (const [label, rowCount] of malformed) {
+            test(`${label} is \`unestablished\`, never a measured zero`, () => {
+                const receipt = buildSourceReceipt({
+                    source      : 'neo-knowledge-base',
+                    rowCount,
+                    collectionId: 'same-id',
+                    previousId  : 'same-id'
+                });
+
+                expect(receipt.lineage).toBe(LINEAGE.same);
+                expect(receipt.rowState).toBe(ROW_STATE.unestablished);
+                expect(receipt.empty).toBe(false);
+            });
+        }
+
+        test('a non-numeric count is reported as `null`, not repaired into `0`', () => {
+            const absent = buildSourceReceipt({source: 'kb', rowCount: undefined, collectionId: 'a', previousId: 'a'});
+
+            expect(absent.rowCount).toBeNull();
+        });
+
+        test('a negative count is retained verbatim — the operator needs to see what the producer emitted', () => {
+            const negative = buildSourceReceipt({source: 'kb', rowCount: -1, collectionId: 'a', previousId: 'a'});
+
+            expect(negative.rowCount).toBe(-1);
+            expect(negative.rowState).toBe(ROW_STATE.unestablished);
+        });
+
+        test('zero itself is still a MEASURED zero — the guard must not swallow the honest case', () => {
+            // The positive control. If `unestablished` ever widened to cover a real 0, every one of the
+            // specs above would still pass while the module stopped making its only claim.
+            const measured = buildSourceReceipt({source: 'kb', rowCount: 0, collectionId: 'a', previousId: 'a'});
+
+            expect(measured.rowState).toBe(ROW_STATE.zero);
+            expect(measured.rowCount).toBe(0);
+            expect(measured.empty).toBe(true);
+        });
     });
 });

--- a/test/playwright/unit/ai/services/shared/captureReceipt.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/captureReceipt.spec.mjs
@@ -1,0 +1,130 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    buildSourceReceipt,
+    deriveLineage,
+    derivesEmpty,
+    LINEAGE,
+    READ_COMPLETENESS,
+    ROW_STATE
+} from '../../../../../../ai/services/shared/captureReceipt.mjs';
+
+/**
+ * @summary The receipt vocabulary and its single derivation rule.
+ *
+ * The predecessor of this module collapsed three independent facts onto one `captured | empty |
+ * unavailable` enum and was Drop+Superseded for it: a changed collection identity was read as data
+ * loss, which Neo's own re-embed disproves — `VectorService` rebuilds into a shadow collection and
+ * promotes it live → parking, shadow → canonical, so every healthy re-embed changes the canonical
+ * identity with nothing lost. These specs pin the axes as orthogonal and `empty` as the one derived
+ * claim, so the collapse cannot come back by accident.
+ */
+test.describe('ai/services/shared/captureReceipt — three facts, one derived claim', () => {
+    test('`empty` requires zero rows AND a complete read AND a continuous lineage', () => {
+        expect(derivesEmpty({
+            rowState        : ROW_STATE.zero,
+            readCompleteness: READ_COMPLETENESS.complete,
+            lineage         : LINEAGE.same
+        })).toBe(true);
+    });
+
+    test('a CHANGED lineage never derives `empty` — the falsifier that dropped the predecessor', () => {
+        // A re-embed promotes a shadow collection into the canonical name, and a restore drops and
+        // re-resolves. Both change the identity deliberately, with nothing lost. Reading that as
+        // "the corpus was gone" is the exact defect this module exists to prevent.
+        const promoted = buildSourceReceipt({
+            source      : 'neo-knowledge-base',
+            rowCount    : 0,
+            readComplete: true,
+            collectionId: 'shadow-id-after-promote',
+            previousId  : 'canonical-id-before-promote'
+        });
+
+        expect(promoted.lineage).toBe(LINEAGE.changed);
+        expect(promoted.empty).toBe(false);
+        // The facts survive rather than collapsing: a consumer can still see there were zero rows.
+        expect(promoted.rowState).toBe(ROW_STATE.zero);
+        expect(promoted.readCompleteness).toBe(READ_COMPLETENESS.complete);
+    });
+
+    test('an UNKNOWN lineage never derives `empty` — first run has nothing to compare against', () => {
+        const firstRun = buildSourceReceipt({
+            source      : 'neo-agent-memory',
+            rowCount    : 0,
+            readComplete: true,
+            collectionId: 'some-id',
+            previousId  : null
+        });
+
+        expect(firstRun.lineage).toBe(LINEAGE.unknown);
+        expect(firstRun.empty).toBe(false);
+    });
+
+    test('an INCOMPLETE read never derives `empty` — the zero describes the read, not the store', () => {
+        const unread = buildSourceReceipt({
+            source      : 'neo-agent-memory',
+            rowCount    : 0,
+            readComplete: false,
+            collectionId: 'same-id',
+            previousId  : 'same-id'
+        });
+
+        expect(unread.readCompleteness).toBe(READ_COMPLETENESS.unavailable);
+        expect(unread.empty).toBe(false);
+    });
+
+    test('rows are self-evidencing: a populated source is never `empty`, whatever its lineage', () => {
+        for (const previousId of ['same-id', 'different-id', null]) {
+            const populated = buildSourceReceipt({
+                source      : 'neo-agent-memory',
+                rowCount    : 94325,
+                readComplete: true,
+                collectionId: 'same-id',
+                previousId
+            });
+
+            expect(populated.rowState, `previousId=${previousId}`).toBe(ROW_STATE.populated);
+            expect(populated.empty,    `previousId=${previousId}`).toBe(false);
+        }
+    });
+
+    test('a populated source with a CHANGED lineage keeps both facts — positive rows must not erase the change', () => {
+        // The May-2026 partial specimen in reverse: positive row parity is not a reason to stop
+        // reporting that the source is not the one the previous bundle observed.
+        const receipt = buildSourceReceipt({
+            source      : 'neo-agent-sessions',
+            rowCount    : 12,
+            readComplete: true,
+            collectionId: 'b',
+            previousId  : 'a'
+        });
+
+        expect(receipt.rowState).toBe(ROW_STATE.populated);
+        expect(receipt.lineage).toBe(LINEAGE.changed);
+    });
+
+    test('lineage compares IDENTITY, and a missing id on either side is `unknown` rather than `same`', () => {
+        expect(deriveLineage({currentId: 'a',  previousId: 'a'})).toBe(LINEAGE.same);
+        expect(deriveLineage({currentId: 'a',  previousId: 'b'})).toBe(LINEAGE.changed);
+        // Absent evidence is not evidence of continuity — the failure mode that would silently
+        // manufacture `empty` for every source whose id could not be observed.
+        expect(deriveLineage({currentId: 'a',  previousId: null})).toBe(LINEAGE.unknown);
+        expect(deriveLineage({currentId: null, previousId: 'a'})).toBe(LINEAGE.unknown);
+        expect(deriveLineage({currentId: null, previousId: null})).toBe(LINEAGE.unknown);
+        expect(deriveLineage()).toBe(LINEAGE.unknown);
+    });
+
+    test('`partial` is absent from the completeness vocabulary until a producer exists', () => {
+        // Every partial read in this substrate becomes a thrown abort (`PARTIAL_COLLECTION_EXPORT`),
+        // so no published bundle can carry the value. Shipping it would be a promise the contract
+        // cannot keep; this pins its absence so it is re-added deliberately, with a producer.
+        expect(Object.values(READ_COMPLETENESS)).toEqual(['complete', 'unavailable']);
+        expect(Object.values(READ_COMPLETENESS)).not.toContain('partial');
+    });
+
+    test('the axis vocabularies are frozen — a consumer cannot widen a verdict at runtime', () => {
+        expect(Object.isFrozen(ROW_STATE)).toBe(true);
+        expect(Object.isFrozen(READ_COMPLETENESS)).toBe(true);
+        expect(Object.isFrozen(LINEAGE)).toBe(true);
+    });
+});


### PR DESCRIPTION
Resolves #16404

A backup receipt could not distinguish "this source was genuinely empty" from "the corpus is gone" — both produce `expected: 0, exported: 0` and log `Export complete.` Exporters now emit each source's **collection id** beside its name, and `runBackup` compares every source against the previous **published** bundle, so `bundle-meta.json` carries a `capture` block that states its facts orthogonally — row state × lineage — and derives exactly one claim from them. `empty` is asserted only when both line up: a measured zero over an unchanged identity.

The name cannot carry this. `VectorService` rebuilds a corpus into a shadow collection and promotes it under the same name, so **every healthy re-embed keeps the name and changes the id**. A name comparison would report continuity across exactly the event that breaks it, and an identity comparison alone would report a successful maintenance run as data loss. Hence lineage is a fact the receipt records, not a verdict it acts on.

**The title claim is now true of the whole artifact, which it was not at the first review head.** `capture.empty` and `integrity[].status` both said `empty` about the same zero and could disagree; every downstream consumer read only the latter. The provenance claim is now named **`provenEmpty`**, so the two propositions no longer share a word to disagree in — and the persisted status keeps its spelling, because that one is not ours to change (see Deltas).

Evidence: L2 (mock dispatch — the derivation, the published/staging boundary, the producer→consumer traversal and the cross-VERSION reader matrix are exercised against real bundle trees; five separate mutations verified) → L3 required (a live `npm run ai:backup` writing a `capture` block into a real bundle and comparing against a real predecessor). Residual: the `[L3-deferred — operator handoff needed]` AC [#16404].

## Deltas from ticket

**`listPublishedBundles` was extracted, not written.** The `backup-<timestamp>` convention that separates a published bundle from a `.backup-partial-*` staging directory is currently defined **independently in six places** (`restore.mjs:905`, `backup.mjs` ×2, `backupCorruptionTimeline.mjs:237`, `defragChromaDB.mjs:306`, `HealthService.mjs:732`). Writing a seventh for lineage would have let the comparison basis drift from the one restore and retention already trust — and a comparison against a half-written staging directory reports a changed identity for a capture that never completed. So the enumeration is lifted out of `cleanOldBackups` and both consumers share it. Consolidating the remaining four call sites is deliberately **not** in this PR.

**The native graph is excluded from lineage.** It is SQLite-backed with no collection identity, so it could only ever record `lineage: unknown` — a permanent row that says nothing. Its emptiness question is real and needs a different instrument; an always-unknown entry would dress that gap as coverage.

**Three deltas added by the cross-family review** ([@neo-gpt-emmy](https://github.com/neomjs/neo/pull/16442#pullrequestreview-4845206981), [@neo-gpt](https://github.com/neomjs/neo/pull/16442#pullrequestreview-4845271549)); #16404's Contract Ledger and ACs are amended to match, with the superseded versions retained:

1. **One emptiness authority — and it is the NEW field that moved.** `capture.sources[].empty` → **`provenEmpty`**. The two blocks answer different questions: survivability ("does this bundle hold rows a restore could bring back") is `no` for a zero-row subsystem *regardless of why*, and provenance ("was there anything to capture") is what lineage qualifies. **Restorability is deliberately NOT rewired through lineage** — a zero-row bundle over a *replaced* source is the most suspicious specimen in a series, and making the capture verdict authoritative would promote precisely it from `restorable: false` to `restorable: true`.

    **The first attempt renamed the other side, and that was a release blocker** ([@neo-gpt](https://github.com/neomjs/neo/pull/16442#pullrequestreview-4846977834)). Moving `integrity[].status` from `empty` to `zero-rows` produced **old-reader + new-bundle ⇒ `restorable: true`** while old/old, new/old and new/new all stayed `false` — three of four cells green, and the failing one reports the gutted-store signature as a usable recovery source. I had taught the new reader to accept the old token and never asked the mirror question; a deployed reader matches by exact string and silently drops what it does not know, which for this field resolves to *no empty subsystem found*.

    So compatibility is one-directional by construction, and the distinction belongs on the field with no history. `integrity[].status`, `emptySubsystems` and the receipt's `{emptySubsystems, restorable}` projection are all **unchanged**; net effect on every existing consumer is zero. `INTEGRITY_STATUS` now freezes the wire vocabulary and the writer emits only from it.

2. **Malformed counts fail honest.** Absent / `NaN` / `±Infinity` / negative counts classified as `rowState: zero` and, with matching identities, derived `empty: true` — a positive claim of emptiness assembled entirely out of a broken instrument. They now classify as `ROW_STATE.unestablished`, and the raw observation is reported rather than repaired to `0`. The producer-side `?? 0` in `buildCaptureBlock` was the same defect one layer up and is gone.

3. **Three unreachable surfaces removed, not documented.** `READ_COMPLETENESS` had no producer that could emit `unavailable` — a partial read throws `PARTIAL_COLLECTION_EXPORT` and aborts before any receipt exists. That is verbatim the rule the module already stated for excluding `partial`, so the axis is gone until a producer exists; keeping it while citing that rule against `partial` was the inconsistency Emmy caught. Both public `ChromaManager.listCollectionNames()` wrappers reached **no caller** under the converged design and are removed — as is the JSDoc claiming the backup lane read through them, which described a call that never existed. The shared paginated primitive stays: KB shadow-swap discovery is its real consumer, and it de-duplicates a page loop.

Also restored the `cleanOldBackups` JSDoc the extraction had orphaned (two adjacent blocks above `listPublishedBundles`, none on the retained export), and documented the two-block contract at the operator boundary in the Restoration Runbook.

## Test Evidence

The directly affected surfaces, run together: `captureReceipt.spec.mjs`, `backup.spec.mjs`, `offHostSync.spec.mjs`, `restore.spec.mjs`, `HealthService.spec.mjs` → **259 passed**. Includes #16418's atomic-publication specs and #14030/#14048's zero-parity specs unchanged, so the untouched wire contract is regression-checked rather than assumed.

**The cross-version matrix, measured directly** against a reader frozen at `55017737d6` — the instrument that found the blocker and the one that now proves it closed:

```
old reader + old bundle  →  restorable=false   ok
old reader + NEW bundle  →  restorable=false   ok      (was TRUE before the revert)
new reader + old bundle  →  restorable=false   ok
new reader + NEW bundle  →  restorable=false   ok
```

**Mutation-verified, because a new passing test proves nothing on its own.** Five independent mutations, each failing exactly the specs that should:

| mutation | result |
|---|---|
| `INTEGRITY_STATUS.empty` → `'zero-rows'` (reintroduce the blocker) | **witness fails** — `Expected: false / Received: true`, the exact defect |
| …same mutation, vocabulary guard | **fails independently** — declared set no longer `['empty','fail','pass','skipped']` |
| `buildSourceReceipt` reverts to the old row-state rule | **8 failed** — every malformed case; the *"zero is still a MEASURED zero"* positive control still passed, proving the guard does not over-fire |
| drop the legacy status from the reader | **2 failed** — both legacy-compat specs, nothing else |
| `deriveLineage` always returns `same` | **1 failed** — the changed-identity spec alone |

Method note for a re-runner: this file sets `test.describe.configure({mode: 'serial'})` at **file level**, so the first failure aborts every later spec. The single-spec mutations need `-g` isolation to observe the intended failure rather than a masked skip — I read a masked run as "the guard does not bite" once before catching it.

**One unrelated failure, reported rather than rounded off.** `npm run test-unit -- test/playwright/unit/ai` → **8757 passed, 5 skipped, 1 failed**: `MemoryService.Lifecycle.spec.mjs:72`, a retry-timer count. It **passes in isolation** (5/5) and this diff touches nothing in `MemoryService`. Stashing the entire change and running the same command at `777c0a0f43` fails a **different** spec — `McpServerListToolsSmoke.spec.mjs:488` — while `MemoryService.Lifecycle` passes. Two code states, two different specs, both order-dependent: local full-tree runs carry leaked-state flake independent of this work. CI runs `workers:1` and is the authority.

Surfaces touched: `ai/scripts/maintenance/backup.mjs` → `backup.spec.mjs` | `ai/services/shared/captureReceipt.mjs` → `captureReceipt.spec.mjs` | `ai/services/memory-core/helpers/bundleIntegrity.mjs` → covered by the new consumer-traversing block in `backup.spec.mjs` + `offHostSync.spec.mjs` | `ai/services/{knowledge-base,memory-core}/DatabaseService.mjs` → covered through the orchestrator specs; no dedicated exporter spec asserts the receipt shape (`None found`).

**The consumer-traversing suite the reviews required** — `bundle-meta — provenance and survivability never contradict (#16404)` — drives the **real** `verifyBundleIntegrity` and `buildCaptureBlock` over real bundle trees into the **real** `isBundleRestorable` / `summarizeBundleIntegrity`, covering `zero+same`, `zero+changed`, `zero+unknown`, positive rows (positive control), legacy no-capture, absent-integrity, and mixed Memory Core. Neither block is hand-built, so neither can drift from the producer it mirrors.

**Plus the version axis, which every one of those specs was blind to.** They each read a bundle with the reader that wrote it — the configuration in which the blocker was invisible. A nested `cross-version` block pins `oldReader(newBundle) === false` against a reader **spelled out at the old contract inside the spec** rather than imported, so it cannot drift when the live one changes; a positive control proves that same reader still returns `true` for a genuinely restorable new bundle; and a vocabulary assertion pins the writer to the frozen declared set.

## Post-Merge Validation

- [ ] A live `npm run ai:backup` writes a `capture` block into `bundle-meta.json` with one entry per Chroma-backed source.
- [ ] The first post-merge bundle records `comparedTo: null` and every source reads `lineage: unknown` — the honest first-run state, not a defect.
- [ ] The second bundle compares against the first and reports `lineage: same` for untouched collections.
- [ ] A deliberate re-embed produces `lineage: changed` with `provenEmpty: false` on a zero-row source, rather than a loss claim — **and that bundle is still reported `restorable: false`**.
- [ ] A bundle published before this change still reads `restorable: false` from its `empty` status, and a bundle published *after* it reads `restorable: false` on a **pre-change reader**. The second half is the one this PR nearly got wrong.
- [ ] The verification log is appended to #16404 before final close, per its `[L3-deferred — operator handoff needed]` AC.

## Commits

- `af0db33319` — non-mutating collection enumeration, salvaged from the dropped predecessor
- `437fde5a55` — three orthogonal facts, one derived claim (the `captureReceipt` vocabulary)
- `55017737d6` — exporters emit identity; `runBackup` compares against the previous published bundle
- `777c0a0f43` — malformed counts fail honest; three unreachable surfaces removed *(also renamed the integrity status — reverted below)*
- `5b04029fd5` — a wire value is not renameable for clarity: revert the status rename, move the distinction to `provenEmpty`, freeze the vocabulary, add the cross-version witness

## Evolution

The predecessor of `captureReceipt` collapsed the facts onto a single `captured | empty | unavailable` enum and was Drop+Superseded for it: collapsing means any two facts cannot be stated at once, and it forced a changed collection identity to be read as data loss. @neo-gpt falsified the *semantic* rather than the placement, and `VectorService.mjs:706-710` confirmed it — shadow → canonical promotion changes the id with nothing lost. An earlier pivot had moved the whole design from capture-side to restore-side specifically to dodge a false "lost" verdict after a restore; under the corrected semantic that problem stops existing, so the pivot was solving a problem the wrong predicate had manufactured.

The review round then found the same class of error one level up, twice. I had written the rule *"a vocabulary value nothing can emit is a promise the contract cannot keep"* into the module doc to justify excluding `partial` — and shipped `unavailable` with no production writer in the same file. And I had fixed the conflation between "zero rows" and "genuinely empty" inside the new block while leaving the old block making the collapsed claim under the same word, where every consumer was still reading it. Emmy and Euclid found both independently, from different directions. Neither was a coding slip: both are what it looks like to verify the artifact you are building and not the artifact it lands in.

Then the fix for the second one introduced a worse defect than it removed, and that is the pivot worth recording. Renaming the persisted status looked like pure lexical hygiene, so I checked compatibility in the direction I was thinking about — new reader, old bundle — wrote a spec for it, and presented it as the load-bearing safety property. The other direction never came up. An already-deployed reader matches by exact string and silently drops what it does not know, and here "dropped" resolves to *no empty subsystem found*: the original defect needed a `zero + changed` lineage to misfire, mine misfired on every zero-row bundle. @neo-gpt reproduced it as a four-cell matrix with one cell red. The general rule, now enforced by a frozen vocabulary and a witness rather than by remembering: **a wire value's spelling is owned by its oldest reader, not its newest writer** — so new meaning goes on new fields. I had measured a deployed plane 1211 commits behind an hour earlier in this same session and still did not apply it to my own diff.

Authored by Ada (Claude Opus 5, Claude Code). Session eeacb603-97f1-4241-9b2f-3a542cab6d2c.
