### PR TITLE
feat(lint): classify every retry-growth site's bound instead of proving it (#16443)

### DIFF
--- a/.github/workflows/retry-bound-classification-lint.yml
+++ b/.github/workflows/retry-bound-classification-lint.yml
@@ -1,0 +1,48 @@
+name: Retry Bound Classification Lint
+
+# Path coverage MUST span every scan root the discovery engine walks
+# (ai, src, apps, buildScripts). A narrower filter would leave a whole root where a
+# new retry-growth site never triggers the gate — the same "reaches no surface"
+# failure this guard exists to end, merely scoped smaller.
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'ai/**/*.mjs'
+      - 'src/**/*.mjs'
+      - 'apps/**/*.mjs'
+      - 'buildScripts/**/*.mjs'
+      - 'ai/scripts/lint/retry-bound-registry.json'
+      - 'test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs'
+      - '.github/workflows/retry-bound-classification-lint.yml'
+      - 'package.json'
+  push:
+    branches: [dev]
+    paths:
+      - 'ai/**/*.mjs'
+      - 'src/**/*.mjs'
+      - 'apps/**/*.mjs'
+      - 'buildScripts/**/*.mjs'
+      - 'ai/scripts/lint/retry-bound-registry.json'
+      - 'test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs'
+      - '.github/workflows/retry-bound-classification-lint.yml'
+      - 'package.json'
+
+concurrency:
+  group: retry-bound-classification-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Classify retry-growth bounds
+        run: npm run ai:lint-retry-bounds

--- a/ai/scripts/lint/lint-retry-bounds.mjs
+++ b/ai/scripts/lint/lint-retry-bounds.mjs
@@ -31,11 +31,26 @@
  * Non-retry matches are classified too (`kind: 'not-a-retry'`) with the same witness requirement, so
  * the false-positive family is RECORDED rather than silently dropped by a regex nobody can audit.
  *
+ * ## What admits a candidate, and what only annotates one
+ *
+ * EVERY growth expression under the scan roots must be classified. Retry vocabulary
+ * (`isRetryContext`) orders the failure report so the plausible retries are read first; it decides
+ * nothing about whether a candidate is gated.
+ *
+ * A previous revision made vocabulary the admission rule and merely printed the rest, reasoning that
+ * a canvas physics loop should not have to declare a backoff cap. The reasoning was sound and the
+ * mechanism was not: a census on stdout is not a gate. A retry added under neutral names —
+ * `schedule() { const d = base * 2 ** n }` — printed one more line in a list nobody reads and the
+ * build stayed green. The geometry rows cost one classification each, once; the hole was permanent.
+ *
  * ## Why sites are keyed by symbol, not line
  *
  * A `file:line` registry drifts on every unrelated edit above the site, so it would be re-baselined
  * constantly and the re-baseline is exactly where a real regression slips through. Sites are keyed
- * `<relPath>#<enclosingSymbol>`; the line is carried as informational drift-detection only.
+ * `<relPath>#<enclosingSymbol>:<expressionFingerprint>`, with a `#<n>` ordinal appended for the
+ * second and later occurrences of one fingerprint inside the same symbol. The ordinal is what lets
+ * two identical expressions — on one line or on two — carry two obligations instead of collapsing
+ * into one. The line number is carried as informational drift-detection only.
  *
  * ## Scope
  *
@@ -90,10 +105,11 @@ const
      * camelCase is the dominant identifier style here, so `\b` anchoring is precisely wrong for
      * matching identifiers, and its failure mode is silent omission of the highest-value sites.
      *
-     * **Known false-negative:** a retry whose symbol, expression line, and filename all avoid this
-     * vocabulary — `schedule()` doing `d = base * 2 ** n` — is invisible here. That is a real gap and
-     * the honest bound on what this gate certifies: it proves the retries it can NAME are bounded,
-     * not that every retry in the tree is.
+     * **No longer a false-negative source.** A retry whose symbol, expression line and filename all
+     * avoid this vocabulary — `schedule()` doing `d = base * 2 ** n` — is invisible to THIS predicate,
+     * and that used to make it invisible to the gate. It no longer does: every growth expression is
+     * gated regardless, and this predicate only orders the report. The residual gap is now the
+     * discovery PATTERNS, not the vocabulary — a growth syntax none of them match is still unseen.
      */
     RETRY_VOCABULARY = /(retry|retries|retried|backoff|attempt|reconnect|redeliver|requeue|resend|failure|failing|consecutive|throttle|cooldown|reprobe)/i,
 
@@ -321,6 +337,42 @@ export function isRetryContext({file, line, symbol}) {
            RETRY_VOCABULARY.test(path.basename(file || ''))
 }
 
+/**
+ * Finds EVERY growth match on one stripped code line.
+ *
+ * @summary `PATTERNS.find` answered "does this line contain a growth expression", which is a
+ * different question from "which growth expressions does it contain". A Euclidean distance holds two
+ * exponentiations and produced one obligation; the second was absorbed with nothing recording that a
+ * site had been merged away. Matches are returned in source order and de-duplicated by start index,
+ * so two patterns describing the same token (`Math.pow(a ** b)`) do not double-count one site.
+ *
+ * @param {String} code Stripped code line.
+ * @returns {Object[]} `[{id, index}]` in source order.
+ */
+export function findGrowthMatches(code) {
+    const byIndex = new Map();
+
+    for (const pattern of PATTERNS) {
+        const flags = pattern.re.flags.includes('g') ? pattern.re.flags : `${pattern.re.flags}g`,
+              re    = new RegExp(pattern.re.source, flags);
+
+        let match;
+
+        while ((match = re.exec(code)) !== null) {
+            if (!byIndex.has(match.index)) {
+                byIndex.set(match.index, {id: pattern.id, index: match.index});
+            }
+
+            // A zero-length match would spin `exec` forever on the same index.
+            if (match.index === re.lastIndex) {
+                re.lastIndex++;
+            }
+        }
+    }
+
+    return [...byIndex.values()].sort((a, b) => a.index - b.index)
+}
+
 export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
     const candidates = [],
           seenKeys   = new Map();
@@ -349,36 +401,43 @@ export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
                 // A continuation line inside a template is prose, not code, whatever it looks like.
                 if (wasOpen) return;
 
-                const hit = PATTERNS.find(p => p.re.test(stripped.code));
+                // Every match, not the first. `PATTERNS.find` returned one hit per line, so
+                // `(px - a) ** 2 + (py - b) ** 2` — two growth expressions — produced ONE obligation
+                // and the second was silently absorbed. Multiplicity has to be represented before
+                // the registry can claim to cover the tree.
+                const matches = findGrowthMatches(stripped.code);
 
-                if (!hit) return;
+                if (matches.length === 0) return;
 
-                const symbol = findEnclosingSymbol(lines, index);
+                // `retryContext` ANNOTATES, it no longer admits (@neo-gpt-emmy). See `diffRegistry`.
+                const symbol       = findEnclosingSymbol(lines, index),
+                      retryContext = isRetryContext({file: rel, line, symbol});
 
-                // PARTITION, never exclusion (@neo-gpt-emmy). An earlier revision `return`ed here,
-                // which made a neutral-vocabulary retry — `schedule() { const d = base * 2 ** n }` —
-                // silently invisible: the gate went green with fewer candidates and nothing said why.
-                // Every growth expression is now discovered and reported; `retryContext` decides only
-                // whether classification is REQUIRED, so completeness and signal stop competing.
-                const retryContext = isRetryContext({file: rel, line, symbol});
+                for (const hit of matches) {
+                    // The occurrence ordinal distinguishes two IDENTICAL expressions in one symbol,
+                    // which share a fingerprint by construction — whether they sit on one line or on
+                    // two. Without it the second collapses onto the first and `diffRegistry`'s Set
+                    // reports no drift for a site nobody classified.
+                    //
+                    // The fingerprint stays keyed on the whole stripped LINE rather than the matched
+                    // substring, deliberately: re-basing it would have rotated every existing key and
+                    // forced a full re-baseline, which is precisely the moment a real regression slips
+                    // through unnoticed.
+                    const baseKey    = `${rel}#${symbol}:${expressionFingerprint(stripped.code)}`,
+                          occurrence = seenKeys.get(baseKey) || 0;
 
-                // The occurrence ordinal distinguishes two IDENTICAL expressions in one symbol, which
-                // share a fingerprint by construction. Without it the second collapses onto the first
-                // and `diffRegistry`'s Set reports no drift for a site nobody classified.
-                const baseKey    = `${rel}#${symbol}:${expressionFingerprint(stripped.code)}`,
-                      occurrence = seenKeys.get(baseKey) || 0;
+                    seenKeys.set(baseKey, occurrence + 1);
 
-                seenKeys.set(baseKey, occurrence + 1);
-
-                candidates.push({
-                    key    : occurrence === 0 ? baseKey : `${baseKey}#${occurrence}`,
-                    file   : rel,
-                    line   : index + 1,
-                    symbol,
-                    pattern: hit.id,
-                    retryContext,
-                    snippet: line.trim().slice(0, 120)
-                });
+                    candidates.push({
+                        key    : occurrence === 0 ? baseKey : `${baseKey}#${occurrence}`,
+                        file   : rel,
+                        line   : index + 1,
+                        symbol,
+                        pattern: hit.id,
+                        retryContext,
+                        snippet: line.trim().slice(0, 120)
+                    });
+                }
             });
         }
     }
@@ -479,13 +538,23 @@ export function validateEntry(key, entry) {
 export function diffRegistry({candidates, registry}) {
     const discovered = new Set(candidates.map(c => c.key)),
           registered = Object.keys(registry),
-          // Only retry-context candidates are REQUIRED to be classified. The rest are still
-          // discovered, still reported, and may still be registered — they simply do not fail the
-          // gate. Asking a canvas physics loop to declare a backoff cap is how a gate gets routed
-          // around; hiding the loop entirely is how a real retry goes missing. The partition is the
-          // only arrangement that refuses both.
-          unclassified = candidates.filter(c => c.retryContext && !registry[c.key]),
-          uncontexted  = candidates.filter(c => !c.retryContext && !registry[c.key]),
+          // EVERY scoped candidate must be classified. Vocabulary annotates; it does not admit.
+          //
+          // A previous revision gated only retry-vocabulary candidates and merely PRINTED the rest,
+          // reasoning that a canvas physics loop should not have to declare a backoff cap. The
+          // reasoning was sound and the mechanism was not: a census on stdout is not a gate. A retry
+          // added tomorrow under neutral names — `schedule() { const d = base * 2 ** n }` — prints one
+          // more line in a list nobody reads, and the build stays green. The 16 geometry rows are a
+          // one-time cost; the hole was permanent, and it sat exactly where the highest-value misses
+          // live (@neo-gpt-emmy's falsification, which I first argued against and which holds).
+          //
+          // `not-a-retry` keeps the cost honest: those rows carry a witness naming what the expression
+          // IS, so the false-positive family is recorded rather than suppressed by a regex nobody can
+          // audit.
+          unclassified = candidates.filter(c => !registry[c.key]),
+          // Retained for REPORTING only — it orders review toward the plausible retries first, and no
+          // longer decides whether anything is gated.
+          uncontexted  = unclassified.filter(c => !c.retryContext),
           stale        = registered.filter(key => !discovered.has(key)),
           invalid      = registered.flatMap(key => validateEntry(key, registry[key]));
 
@@ -519,25 +588,17 @@ export function runLint() {
           registry                                    = loadRegistry(),
           {unclassified, uncontexted, stale, invalid} = diffRegistry({candidates, registry});
 
-    // The census prints on EVERY run, pass or fail. It is the record of what was examined — the
-    // property the partition must not cost. A growth expression outside retry vocabulary is visible
-    // here, so a retry whose naming this gate cannot recognise is under a reader's eye rather than
-    // silently absent, and can be registered deliberately if it turns out to be one.
-    if (uncontexted.length > 0) {
-        console.log(`[lint-retry-bounds] ${uncontexted.length} growth expression(s) outside retry vocabulary — reported, NOT gated:`);
-        uncontexted.forEach(c => console.log(`  ${c.file}:${c.line}  ${c.snippet}`));
-        console.log('  If one of these IS a retry, register it: the gate cannot see it by naming alone.\n');
-    }
-
     if (unclassified.length === 0 && stale.length === 0 && invalid.length === 0) {
-        console.log(`[lint-retry-bounds] ${candidates.length - uncontexted.length} retry-context candidate(s), all classified; ${uncontexted.length} reported ungated.`);
+        console.log(`[lint-retry-bounds] ${candidates.length} candidate(s), all classified.`);
         return {exitCode: 0};
     }
 
     if (unclassified.length > 0) {
         console.error(`\n[lint-retry-bounds] ${unclassified.length} UNCLASSIFIED candidate(s) — this is not an assertion that they are unbounded:\n`);
-        unclassified.forEach(c => {
-            console.error(`  ${c.key}`);
+        // Retry-vocabulary candidates first: same gate, but a reviewer's attention is not uniform,
+        // and the plausible retries are what a long list buries.
+        [...unclassified].sort((a, b) => Number(b.retryContext) - Number(a.retryContext)).forEach(c => {
+            console.error(`  ${c.key}${c.retryContext ? '   <- retry vocabulary' : ''}`);
             console.error(`      ${c.file}:${c.line}  (${c.pattern})  ${c.snippet}`);
         });
         console.error(`\n  Classify each in ${REGISTRY_REL}. If it is an easing curve, a random distribution, or any`);

--- a/ai/scripts/lint/lint-retry-bounds.mjs
+++ b/ai/scripts/lint/lint-retry-bounds.mjs
@@ -398,7 +398,25 @@ export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
 
                 inTemplate = stripped.inTemplate;
 
-                // A continuation line inside a template is prose, not code, whatever it looks like.
+                // KNOWN FALSE NEGATIVE, retained deliberately (@neo-gpt-emmy's scanner escape).
+                //
+                // A growth expression inside a `${…}` substitution on a CONTINUATION line of a
+                // multi-line template is preserved by `stripLiterals` and then discarded here —
+                // discovered and dropped in the same pass. That is a real escape and it is not fixed.
+                //
+                // Removing this return does NOT fix it, which is the measured part. Doing so
+                // immediately surfaces `ai/demo-agents/dev.mjs:258` as a candidate whose match is
+                // `**AI Generated PR**` — markdown bold inside literal text, exactly what
+                // `stripLiterals` exists to blank. The cause is upstream: the template opened at
+                // dev.mjs:118 is never seen to close, so by 258 the scanner still believes it is
+                // inside a template; `stripLiterals(line, true)` then reads 258's OPENING backtick
+                // as a CLOSE and emits the whole literal as code.
+                //
+                // So this return is masking a `stripLiterals` state-tracking defect as well as the
+                // escape, and lifting it trades a known false negative for a false positive — which
+                // is the worse of the two, because a gate that cries wolf gets routed around. The
+                // real repair is multi-line template state tracking, which is outside the closure
+                // boundary set for this PR. Recorded rather than silently retained.
                 if (wasOpen) return;
 
                 // Every match, not the first. `PATTERNS.find` returned one hit per line, so

--- a/ai/scripts/lint/lint-retry-bounds.mjs
+++ b/ai/scripts/lint/lint-retry-bounds.mjs
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+/**
+ * @summary Discovers every retry-growth site in the tree and requires each one to carry an explicit
+ * bound classification. Reports an unregistered site as `unclassified` — NEVER as `unbounded`.
+ *
+ * ## The rule
+ *
+ * Every retry-growth site in this repo is bounded. That is not the problem. The problem is that
+ * **boundedness is only knowable by reading each site's caller**, and the bound lives in four
+ * structurally different places:
+ *
+ * | carrier | example |
+ * |---|---|
+ * | `max-delay` | `Math.min(base * 2 ** attempt, CAP)` — the delay value itself is capped |
+ * | `max-attempts` | the growth expression is raw; the CALLER's loop counter bounds it |
+ * | `max-window` | a total elapsed/deadline budget bounds the series |
+ * | `terminal-state` | the delay genuinely grows; a state transition stops the loop |
+ *
+ * So this guard does not try to prove boundedness. It discovers candidates and requires a human or
+ * agent to declare, per site, the lifetime of the retry state, which carrier bounds it, and a
+ * witness that proves the bound. Drift in either direction fails.
+ *
+ * ## Why `unclassified` and never `unbounded`
+ *
+ * The discovery patterns have a LARGER false-positive family than true-positive set — easing curves
+ * (`1 - Math.pow(1 - progress, 3)`) and power-law random distributions match the same syntax as an
+ * exponential backoff. A guard that called those violations would train contributors to suppress it,
+ * which is how an invariant dies quietly. A new match therefore means "nobody has said what this is
+ * yet", which is true, rather than "this is a defect", which usually is not.
+ *
+ * Non-retry matches are classified too (`kind: 'not-a-retry'`) with the same witness requirement, so
+ * the false-positive family is RECORDED rather than silently dropped by a regex nobody can audit.
+ *
+ * ## Why sites are keyed by symbol, not line
+ *
+ * A `file:line` registry drifts on every unrelated edit above the site, so it would be re-baselined
+ * constantly and the re-baseline is exactly where a real regression slips through. Sites are keyed
+ * `<relPath>#<enclosingSymbol>`; the line is carried as informational drift-detection only.
+ *
+ * ## Scope
+ *
+ * Production `.mjs` under `ai/`, `src/`, `apps/`, `buildScripts/`. Specs and tests are excluded: a
+ * test asserting backoff arithmetic is not a production retry site, and including them would make
+ * the registry churn with every fixture.
+ */
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+const
+    __filename   = fileURLToPath(import.meta.url),
+    __dirname    = path.dirname(__filename),
+    ROOT_DIR     = path.resolve(__dirname, '../../../'),
+    REGISTRY_REL = 'ai/scripts/lint/retry-bound-registry.json',
+    SCAN_ROOTS   = ['ai', 'src', 'apps', 'buildScripts'],
+
+    SKIP_DIR = new Set(['node_modules', 'dist', '.git', 'test', 'tests', 'coverage']),
+
+    /**
+     * Growth syntaxes. Deliberately broader than "literal base 2": an earlier hand census matched
+     * only `Math.pow(2, …)` / `2 ** …`, reported five sites, and concluded there was nothing to
+     * classify. The real set is nine — the misses were `backoff *= 2` (multiplicative mutation) and
+     * `Math.pow(configurableMultiplier, attempts)` (non-literal base).
+     */
+    PATTERNS = [
+        {id: 'pow',      re: /Math\.pow\s*\(/},
+        {id: 'exponent', re: /[\w.)\]]\s*\*\*\s*[\w(]/},
+        {id: 'mutate',   re: /\b(backoff|delay|interval|cooldown|wait|retry)\w*\s*\*=/i}
+    ],
+
+    VALID_KIND     = new Set(['retry-growth', 'not-a-retry']),
+    VALID_LIFETIME = new Set(['in-cycle', 'process-local', 'persisted']),
+    VALID_CARRIER  = new Set(['max-delay', 'max-attempts', 'max-window', 'terminal-state']);
+
+/**
+ * Whether a source line is code rather than comment/JSDoc prose.
+ *
+ * @summary Prose is excluded by SHAPE, not by keyword: a JSDoc table describing `Math.pow` bounding
+ * is not a site. Block-comment tracking is stateful because a `*`-prefixed continuation line is
+ * indistinguishable from a multiplication when read alone.
+ * @param {String} line Raw source line.
+ * @param {Boolean} inBlockComment Whether the scanner is inside a block comment.
+ * @returns {{isCode: Boolean, inBlockComment: Boolean}}
+ */
+export function classifyLine(line, inBlockComment) {
+    const trimmed = line.trim();
+    let   active  = inBlockComment;
+
+    if (active) {
+        return {isCode: false, inBlockComment: !trimmed.includes('*/')};
+    }
+
+    if (trimmed.startsWith('//')) {
+        return {isCode: false, inBlockComment: false};
+    }
+
+    if (trimmed.startsWith('/*')) {
+        return {isCode: false, inBlockComment: !trimmed.includes('*/')};
+    }
+
+    if (trimmed.startsWith('*')) {
+        return {isCode: false, inBlockComment: false};
+    }
+
+    return {isCode: true, inBlockComment: active};
+}
+
+/**
+ * Blanks string and template-literal contents so literal text cannot match a growth pattern.
+ *
+ * @summary Without this, every markdown `**bold**` span inside a prompt or a rendered-report
+ * template literal matches the exponent pattern — on the first run that was ~20 of 50 hits, all
+ * prose. Those are not a false-positive family worth CLASSIFYING (there is nothing to say about
+ * them); they are a discovery-layer defect. Real false positives that survive this — easing curves,
+ * power-law random — are genuine code and do get classified.
+ *
+ * Template literals spanning multiple lines carry their open state across the scan, because prompts
+ * and rendered-report templates are exactly where multi-line markdown lives — leaving continuation
+ * lines unstripped put five pure-prose entries in front of the classifier on the first run.
+ * Single-quote/double-quote state deliberately does NOT carry: an unterminated `'` is a syntax
+ * error, so treating it as open would silently blank the rest of the file.
+ * @param {String} line Raw source line.
+ * @param {Boolean} [inTemplate=false] Whether the scanner is inside a multi-line template literal.
+ * @returns {{code: String, inTemplate: Boolean}} Line with quoted regions blanked, and carry state.
+ */
+export function stripLiterals(line, inTemplate = false) {
+    let out   = '',
+        quote = inTemplate ? '`' : null;
+
+    for (let i = 0; i < line.length; i++) {
+        const char = line[i],
+              prev = line[i - 1];
+
+        if (quote) {
+            if (char === quote && prev !== '\\') {
+                quote = null;
+                out  += char;
+            } else {
+                out += ' ';
+            }
+        } else if (char === '\'' || char === '"' || char === '`') {
+            quote = char;
+            out  += char;
+        } else {
+            out += char;
+        }
+    }
+
+    return {code: out, inTemplate: quote === '`'};
+}
+
+/**
+ * Resolves the nearest enclosing named symbol above a line.
+ *
+ * @summary The registry key's stable half. Scans backwards for a function/method/arrow declaration;
+ * falls back to `<module>` so a top-level site is still addressable rather than unkeyable.
+ * @param {String[]} lines All source lines.
+ * @param {Number} index Zero-based index of the matched line.
+ * @returns {String}
+ */
+export function findEnclosingSymbol(lines, index) {
+    const decl = [
+        /^\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/,
+        /^\s*(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(/,
+        /^\s*(?:static\s+)?(?:async\s+)?([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{/,
+        /^\s*([A-Za-z_$][\w$]*)\s*:\s*(?:async\s*)?(?:function)?\s*\(/
+    ];
+
+    for (let i = index; i >= 0; i--) {
+        for (const re of decl) {
+            const match = lines[i].match(re);
+
+            // `if (...) {` and friends match the method shape; excluding keywords keeps the key on a
+            // real symbol rather than on control flow that happens to look like a signature.
+            if (match && !['if', 'for', 'while', 'switch', 'catch', 'return'].includes(match[1])) {
+                return match[1];
+            }
+        }
+    }
+
+    return '<module>';
+}
+
+/**
+ * Walks the scan roots for production `.mjs` files.
+ *
+ * @param {String} dir Absolute directory.
+ * @param {String[]} [acc=[]] Accumulator.
+ * @returns {String[]} Absolute file paths.
+ */
+export function collectSourceFiles(dir, acc = []) {
+    let entries;
+
+    try {
+        entries = fs.readdirSync(dir, {withFileTypes: true});
+    } catch (error) {
+        return acc;
+    }
+
+    for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            if (!SKIP_DIR.has(entry.name)) {
+                collectSourceFiles(full, acc);
+            }
+        } else if (entry.isFile() && entry.name.endsWith('.mjs') && !/\.spec\.mjs$/.test(entry.name)) {
+            acc.push(full);
+        }
+    }
+
+    return acc;
+}
+
+/**
+ * Discovers every retry-growth candidate under the scan roots.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.rootDir=ROOT_DIR] Repo root.
+ * @returns {Object[]} `[{key, file, line, symbol, pattern, snippet}]`, sorted by key.
+ */
+export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
+    const candidates = [];
+
+    for (const root of SCAN_ROOTS) {
+        for (const file of collectSourceFiles(path.join(rootDir, root))) {
+            const rel   = path.relative(rootDir, file),
+                  lines = fs.readFileSync(file, 'utf8').split('\n');
+
+            let inBlockComment = false,
+                inTemplate     = false;
+
+            lines.forEach((line, index) => {
+                const state = classifyLine(line, inBlockComment);
+                inBlockComment = state.inBlockComment;
+
+                // A comment line cannot open or close a template literal, but it also must not reset
+                // one that a preceding code line left open.
+                if (!state.isCode) return;
+
+                const stripped = stripLiterals(line, inTemplate),
+                      wasOpen  = inTemplate;
+
+                inTemplate = stripped.inTemplate;
+
+                // A continuation line inside a template is prose, not code, whatever it looks like.
+                if (wasOpen) return;
+
+                const hit = PATTERNS.find(p => p.re.test(stripped.code));
+
+                if (!hit) return;
+
+                const symbol = findEnclosingSymbol(lines, index);
+
+                candidates.push({
+                    key    : `${rel}#${symbol}`,
+                    file   : rel,
+                    line   : index + 1,
+                    symbol,
+                    pattern: hit.id,
+                    snippet: line.trim().slice(0, 120)
+                });
+            });
+        }
+    }
+
+    return candidates.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+/**
+ * Validates one registry entry's shape.
+ *
+ * @summary A `retry-growth` entry must name lifetime AND carrier; a `not-a-retry` entry must not,
+ * because a bound carrier for something that never retries is a claim nobody can witness. BOTH
+ * require a witness — that requirement is what keeps this a classification registry rather than a
+ * suppression allowlist.
+ * @param {String} key Registry key.
+ * @param {Object} entry Registry entry.
+ * @returns {String[]} Problems; empty when valid.
+ */
+export function validateEntry(key, entry) {
+    const problems = [];
+
+    if (!VALID_KIND.has(entry?.kind)) {
+        problems.push(`${key}: kind must be one of ${[...VALID_KIND].join(' | ')} (got ${JSON.stringify(entry?.kind)})`);
+    }
+
+    if (!entry?.witness || typeof entry.witness !== 'string' || entry.witness.trim().length === 0) {
+        problems.push(`${key}: witness is required — name the spec or exported policy that PROVES the classification. An entry without one is a suppression, not a classification.`);
+    }
+
+    if (entry?.kind === 'retry-growth') {
+        if (!VALID_LIFETIME.has(entry.lifetime)) {
+            problems.push(`${key}: lifetime must be one of ${[...VALID_LIFETIME].join(' | ')} (got ${JSON.stringify(entry.lifetime)})`);
+        }
+
+        if (!VALID_CARRIER.has(entry.boundCarrier)) {
+            problems.push(`${key}: boundCarrier must be one of ${[...VALID_CARRIER].join(' | ')} (got ${JSON.stringify(entry.boundCarrier)})`);
+        }
+    }
+
+    if (entry?.kind === 'not-a-retry' && (entry.lifetime || entry.boundCarrier)) {
+        problems.push(`${key}: a not-a-retry site must not declare lifetime/boundCarrier — there is no retry series to bound.`);
+    }
+
+    return problems;
+}
+
+/**
+ * Diffs discovered candidates against the registry.
+ *
+ * @param {Object} options
+ * @param {Object[]} options.candidates Discovered candidates.
+ * @param {Object} options.registry Registry `sites` map.
+ * @returns {{unclassified: Object[], stale: String[], invalid: String[]}}
+ */
+export function diffRegistry({candidates, registry}) {
+    const discovered   = new Set(candidates.map(c => c.key)),
+          registered   = Object.keys(registry),
+          unclassified = candidates.filter(c => !registry[c.key]),
+          stale        = registered.filter(key => !discovered.has(key)),
+          invalid      = registered.flatMap(key => validateEntry(key, registry[key]));
+
+    return {unclassified, stale, invalid};
+}
+
+/**
+ * Loads the registry file.
+ *
+ * @param {String} [rootDir=ROOT_DIR] Repo root.
+ * @returns {Object} The `sites` map.
+ */
+function loadRegistry(rootDir = ROOT_DIR) {
+    const file = path.join(rootDir, REGISTRY_REL);
+
+    if (!fs.existsSync(file)) {
+        return {};
+    }
+
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return parsed.sites || {};
+}
+
+/**
+ * Runs the guard.
+ *
+ * @returns {{exitCode: Number}}
+ */
+export function runLint() {
+    const candidates                     = discoverCandidates(),
+          registry                       = loadRegistry(),
+          {unclassified, stale, invalid} = diffRegistry({candidates, registry});
+
+    if (unclassified.length === 0 && stale.length === 0 && invalid.length === 0) {
+        console.log(`[lint-retry-bounds] ${candidates.length} retry-growth candidate(s), all classified.`);
+        return {exitCode: 0};
+    }
+
+    if (unclassified.length > 0) {
+        console.error(`\n[lint-retry-bounds] ${unclassified.length} UNCLASSIFIED candidate(s) — this is not an assertion that they are unbounded:\n`);
+        unclassified.forEach(c => {
+            console.error(`  ${c.key}`);
+            console.error(`      ${c.file}:${c.line}  (${c.pattern})  ${c.snippet}`);
+        });
+        console.error(`\n  Classify each in ${REGISTRY_REL}. If it is an easing curve, a random distribution, or any`);
+        console.error('  other non-retry use of the same syntax, classify it as `not-a-retry` — with a witness. Do not');
+        console.error('  widen the discovery patterns to hide it: the record of what was examined is the point.\n');
+    }
+
+    if (stale.length > 0) {
+        console.error(`[lint-retry-bounds] ${stale.length} STALE registry entr(ies) — the site is gone or its symbol was renamed:\n`);
+        stale.forEach(key => console.error(`  ${key}`));
+        console.error('');
+    }
+
+    if (invalid.length > 0) {
+        console.error(`[lint-retry-bounds] ${invalid.length} INVALID registry entr(ies):\n`);
+        invalid.forEach(problem => console.error(`  ${problem}`));
+        console.error('');
+    }
+
+    return {exitCode: 1};
+}
+
+function main() {
+    if (process.argv.includes('--list')) {
+        discoverCandidates().forEach(c => console.log(`${c.key}\t${c.file}:${c.line}\t${c.pattern}\t${c.snippet}`));
+        process.exit(0);
+    }
+
+    process.exit(runLint().exitCode);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    main();
+}

--- a/ai/scripts/lint/lint-retry-bounds.mjs
+++ b/ai/scripts/lint/lint-retry-bounds.mjs
@@ -119,20 +119,40 @@ export function classifyLine(line, inBlockComment) {
  * lines unstripped put five pure-prose entries in front of the classifier on the first run.
  * Single-quote/double-quote state deliberately does NOT carry: an unterminated `'` is a syntax
  * error, so treating it as open would silently blank the rest of the file.
+ *
+ * **`${…}` substitutions are PRESERVED.** They are executable code that merely lives inside a
+ * template, and blanking them cost a real site: `src/form/field/FileUpload.mjs` computes
+ * `` `${(bytes / (1000 ** i)).toFixed(…)}` `` and the first revision of this scanner could not see
+ * it. Nesting is tracked by depth so a substitution containing its own template (or an object
+ * literal's braces) closes at the right brace rather than the first one.
  * @param {String} line Raw source line.
  * @param {Boolean} [inTemplate=false] Whether the scanner is inside a multi-line template literal.
- * @returns {{code: String, inTemplate: Boolean}} Line with quoted regions blanked, and carry state.
+ * @returns {{code: String, inTemplate: Boolean}} Line with literal TEXT blanked, substitutions kept.
  */
 export function stripLiterals(line, inTemplate = false) {
-    let out   = '',
-        quote = inTemplate ? '`' : null;
+    let out        = '',
+        quote      = inTemplate ? '`' : null,
+        substDepth = 0;
 
     for (let i = 0; i < line.length; i++) {
         const char = line[i],
               prev = line[i - 1];
 
+        // Inside a `${...}` substitution the content is code: emit it verbatim and track brace depth
+        // so a nested template or object literal does not close the substitution early.
+        if (substDepth > 0) {
+            if (char === '{') substDepth++;
+            if (char === '}') substDepth--;
+            out += substDepth === 0 ? ' ' : char;
+            continue;
+        }
+
         if (quote) {
-            if (char === quote && prev !== '\\') {
+            if (quote === '`' && char === '$' && line[i + 1] === '{') {
+                substDepth = 1;
+                out       += '  ';
+                i++;
+            } else if (char === quote && prev !== '\\') {
                 quote = null;
                 out  += char;
             } else {
@@ -150,6 +170,34 @@ export function stripLiterals(line, inTemplate = false) {
 }
 
 /**
+ * Fingerprints a matched expression so two sites in one function cannot share a key.
+ *
+ * @summary The key's discriminating half. `<path>#<symbol>` alone ALIASES: a second growth
+ * expression added inside an already-registered function silently inherited that function's prior
+ * classification and the gate stayed green — so a new retry site could enter a function already
+ * classified `not-a-retry` and never be examined.
+ *
+ * Whitespace is collapsed so reformatting does not churn the registry, but the expression's TEXT is
+ * load-bearing: changing the arithmetic changes the key, which forces re-classification. That is the
+ * intended behaviour, not a cost — an edited bound is exactly when the old classification stops
+ * being evidence.
+ * @param {String} code Literal-stripped source line.
+ * @returns {String} Eight hex characters.
+ */
+export function expressionFingerprint(code) {
+    const normalized = code.replace(/\s+/g, ' ').trim();
+
+    let hash = 0x811c9dc5;
+
+    for (let i = 0; i < normalized.length; i++) {
+        hash ^= normalized.charCodeAt(i);
+        hash  = Math.imul(hash, 0x01000193) >>> 0;
+    }
+
+    return hash.toString(16).padStart(8, '0');
+}
+
+/**
  * Resolves the nearest enclosing named symbol above a line.
  *
  * @summary The registry key's stable half. Scans backwards for a function/method/arrow declaration;
@@ -162,8 +210,11 @@ export function findEnclosingSymbol(lines, index) {
     const decl = [
         /^\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/,
         /^\s*(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(/,
-        /^\s*(?:static\s+)?(?:async\s+)?([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{/,
-        /^\s*([A-Za-z_$][\w$]*)\s*:\s*(?:async\s*)?(?:function)?\s*\(/
+        // `#private` methods are matched explicitly: without the `#` alternative they fell through
+        // every pattern and keyed as `<module>`, so a private retry helper was indistinguishable
+        // from a top-level one and two of them in a file would have collided.
+        /^\s*(?:static\s+)?(?:async\s+)?(#?[A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{/,
+        /^\s*(#?[A-Za-z_$][\w$]*)\s*:\s*(?:async\s*)?(?:function)?\s*\(/
     ];
 
     for (let i = index; i >= 0; i--) {
@@ -253,7 +304,7 @@ export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
                 const symbol = findEnclosingSymbol(lines, index);
 
                 candidates.push({
-                    key    : `${rel}#${symbol}`,
+                    key    : `${rel}#${symbol}:${expressionFingerprint(stripped.code)}`,
                     file   : rel,
                     line   : index + 1,
                     symbol,

--- a/ai/scripts/lint/lint-retry-bounds.mjs
+++ b/ai/scripts/lint/lint-retry-bounds.mjs
@@ -322,7 +322,8 @@ export function isRetryContext({file, line, symbol}) {
 }
 
 export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
-    const candidates = [];
+    const candidates = [],
+          seenKeys   = new Map();
 
     for (const root of SCAN_ROOTS) {
         for (const file of collectSourceFiles(path.join(rootDir, root))) {
@@ -354,14 +355,28 @@ export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
 
                 const symbol = findEnclosingSymbol(lines, index);
 
-                if (!isRetryContext({file: rel, line, symbol})) return;
+                // PARTITION, never exclusion (@neo-gpt-emmy). An earlier revision `return`ed here,
+                // which made a neutral-vocabulary retry — `schedule() { const d = base * 2 ** n }` —
+                // silently invisible: the gate went green with fewer candidates and nothing said why.
+                // Every growth expression is now discovered and reported; `retryContext` decides only
+                // whether classification is REQUIRED, so completeness and signal stop competing.
+                const retryContext = isRetryContext({file: rel, line, symbol});
+
+                // The occurrence ordinal distinguishes two IDENTICAL expressions in one symbol, which
+                // share a fingerprint by construction. Without it the second collapses onto the first
+                // and `diffRegistry`'s Set reports no drift for a site nobody classified.
+                const baseKey    = `${rel}#${symbol}:${expressionFingerprint(stripped.code)}`,
+                      occurrence = seenKeys.get(baseKey) || 0;
+
+                seenKeys.set(baseKey, occurrence + 1);
 
                 candidates.push({
-                    key    : `${rel}#${symbol}:${expressionFingerprint(stripped.code)}`,
+                    key    : occurrence === 0 ? baseKey : `${baseKey}#${occurrence}`,
                     file   : rel,
                     line   : index + 1,
                     symbol,
                     pattern: hit.id,
+                    retryContext,
                     snippet: line.trim().slice(0, 120)
                 });
             });
@@ -389,11 +404,27 @@ export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
  * @returns {String[]} Problems; empty when every named path exists.
  */
 export function unresolvedWitnessPaths(key, witness, rootDir = ROOT_DIR) {
-    const paths = witness.match(/\b(?:ai|src|apps|test|buildScripts|learn)\/[\w./-]*\.\w+/g) || [];
+    const refs     = witness.match(/\b(?:ai|src|apps|test|buildScripts|learn)\/[\w./-]*\.\w+(?:#[\w$]+)?/g) || [],
+          problems = [];
 
-    return [...new Set(paths)]
-        .filter(rel => !fs.existsSync(path.join(rootDir, rel)))
-        .map(rel => `${key}: witness names ${rel}, which does not exist — a witness that cannot be resolved is not evidence.`)
+    for (const ref of [...new Set(refs)]) {
+        const [rel, symbol] = ref.split('#'),
+              abs           = path.join(rootDir, rel);
+
+        if (!fs.existsSync(abs)) {
+            problems.push(`${key}: witness names ${rel}, which does not exist — a witness that cannot be resolved is not evidence.`);
+            continue;
+        }
+
+        // An existing file plus a symbol that is not in it passed before: the path resolved, so the
+        // witness looked checked. A renamed guard leaves exactly that shape, which is the case the
+        // resolution exists to catch.
+        if (symbol && !fs.readFileSync(abs, 'utf8').includes(symbol)) {
+            problems.push(`${key}: witness names ${symbol} in ${rel}, which does not contain it — the cited proof does not resolve.`);
+        }
+    }
+
+    return problems
 }
 
 /**
@@ -443,16 +474,22 @@ export function validateEntry(key, entry) {
  * @param {Object} options
  * @param {Object[]} options.candidates Discovered candidates.
  * @param {Object} options.registry Registry `sites` map.
- * @returns {{unclassified: Object[], stale: String[], invalid: String[]}}
+ * @returns {{unclassified: Object[], uncontexted: Object[], stale: String[], invalid: String[]}}
  */
 export function diffRegistry({candidates, registry}) {
-    const discovered   = new Set(candidates.map(c => c.key)),
-          registered   = Object.keys(registry),
-          unclassified = candidates.filter(c => !registry[c.key]),
+    const discovered = new Set(candidates.map(c => c.key)),
+          registered = Object.keys(registry),
+          // Only retry-context candidates are REQUIRED to be classified. The rest are still
+          // discovered, still reported, and may still be registered — they simply do not fail the
+          // gate. Asking a canvas physics loop to declare a backoff cap is how a gate gets routed
+          // around; hiding the loop entirely is how a real retry goes missing. The partition is the
+          // only arrangement that refuses both.
+          unclassified = candidates.filter(c => c.retryContext && !registry[c.key]),
+          uncontexted  = candidates.filter(c => !c.retryContext && !registry[c.key]),
           stale        = registered.filter(key => !discovered.has(key)),
           invalid      = registered.flatMap(key => validateEntry(key, registry[key]));
 
-    return {unclassified, stale, invalid};
+    return {unclassified, uncontexted, stale, invalid};
 }
 
 /**
@@ -478,12 +515,22 @@ function loadRegistry(rootDir = ROOT_DIR) {
  * @returns {{exitCode: Number}}
  */
 export function runLint() {
-    const candidates                     = discoverCandidates(),
-          registry                       = loadRegistry(),
-          {unclassified, stale, invalid} = diffRegistry({candidates, registry});
+    const candidates                                  = discoverCandidates(),
+          registry                                    = loadRegistry(),
+          {unclassified, uncontexted, stale, invalid} = diffRegistry({candidates, registry});
+
+    // The census prints on EVERY run, pass or fail. It is the record of what was examined — the
+    // property the partition must not cost. A growth expression outside retry vocabulary is visible
+    // here, so a retry whose naming this gate cannot recognise is under a reader's eye rather than
+    // silently absent, and can be registered deliberately if it turns out to be one.
+    if (uncontexted.length > 0) {
+        console.log(`[lint-retry-bounds] ${uncontexted.length} growth expression(s) outside retry vocabulary — reported, NOT gated:`);
+        uncontexted.forEach(c => console.log(`  ${c.file}:${c.line}  ${c.snippet}`));
+        console.log('  If one of these IS a retry, register it: the gate cannot see it by naming alone.\n');
+    }
 
     if (unclassified.length === 0 && stale.length === 0 && invalid.length === 0) {
-        console.log(`[lint-retry-bounds] ${candidates.length} retry-growth candidate(s), all classified.`);
+        console.log(`[lint-retry-bounds] ${candidates.length - uncontexted.length} retry-context candidate(s), all classified; ${uncontexted.length} reported ungated.`);
         return {exitCode: 0};
     }
 
@@ -495,7 +542,7 @@ export function runLint() {
         });
         console.error(`\n  Classify each in ${REGISTRY_REL}. If it is an easing curve, a random distribution, or any`);
         console.error('  other non-retry use of the same syntax, classify it as `not-a-retry` — with a witness. Do not');
-        console.error('  widen the discovery patterns to hide it: the record of what was examined is the point.\n');
+        console.error('  narrow the discovery patterns to hide it: the record of what was examined is the point.\n');
     }
 
     if (stale.length > 0) {

--- a/ai/scripts/lint/lint-retry-bounds.mjs
+++ b/ai/scripts/lint/lint-retry-bounds.mjs
@@ -68,6 +68,35 @@ const
         {id: 'mutate',   re: /\b(backoff|delay|interval|cooldown|wait|retry)\w*\s*\*=/i}
     ],
 
+    /**
+     * Retry vocabulary — the discriminator between "a growth expression" and "a retry growth
+     * expression", which are not the same population.
+     *
+     * Without it the syntactic patterns above are indiscriminate, because exponentiation is how you
+     * write Euclidean distance, easing curves, and byte-size formatting. Measured on the first
+     * full-tree run: 34 of 62 candidates were outside `ai/`, and 3 of those 34 were retries — the
+     * rest were `(x2 - x1) ** 2`, `Math.pow(1 - progress, 3)`, `1000 ** i`. A gate that asks a canvas
+     * physics loop to declare its backoff cap is one developers learn to route around, and a
+     * registry padded with 30 `not-a-retry` geometry entries records nothing worth reading.
+     *
+     * This narrows the POPULATION to the concern; it does not narrow the FINDINGS within it. Every
+     * growth expression that is plausibly a retry still has to be classified with a witness.
+     *
+     * **Substring, not `\b`-delimited words.** The first draft used word boundaries and silently
+     * dropped `tenantRepoSync#isRepoDue` — the site whose unbounded backoff once starved a tenant
+     * sync lane for over a day, which is the failure this gate exists to prevent recurring. Its
+     * expression reads `Math.pow(2, Math.max(0, consecutiveFailures))`, and `\bconsecutive\b` does
+     * not match `consecutiveFailures` because a word character follows.
+     * camelCase is the dominant identifier style here, so `\b` anchoring is precisely wrong for
+     * matching identifiers, and its failure mode is silent omission of the highest-value sites.
+     *
+     * **Known false-negative:** a retry whose symbol, expression line, and filename all avoid this
+     * vocabulary — `schedule()` doing `d = base * 2 ** n` — is invisible here. That is a real gap and
+     * the honest bound on what this gate certifies: it proves the retries it can NAME are bounded,
+     * not that every retry in the tree is.
+     */
+    RETRY_VOCABULARY = /(retry|retries|retried|backoff|attempt|reconnect|redeliver|requeue|resend|failure|failing|consecutive|throttle|cooldown|reprobe)/i,
+
     VALID_KIND     = new Set(['retry-growth', 'not-a-retry']),
     VALID_LIFETIME = new Set(['in-cycle', 'process-local', 'persisted']),
     VALID_CARRIER  = new Set(['max-delay', 'max-attempts', 'max-window', 'terminal-state']);
@@ -270,6 +299,28 @@ export function collectSourceFiles(dir, acc = []) {
  * @param {String} [options.rootDir=ROOT_DIR] Repo root.
  * @returns {Object[]} `[{key, file, line, symbol, pattern, snippet}]`, sorted by key.
  */
+/**
+ * Decides whether a growth expression sits in a retry context.
+ *
+ * @summary Reads three surfaces, any one of which is sufficient: the enclosing symbol name, the
+ * expression's own line, and the file's basename. Three rather than one because a retry can be
+ * named at any of them — `getRetryDelay` names it in the symbol, `backoffStrategy: attempt => …`
+ * names it in the line, and a bare growth expression inside `boundedRetryGate.mjs` names it in the
+ * file. A whole-function window was rejected: it drags in unrelated vocabulary from neighbouring
+ * code and makes the verdict depend on where a function happens to end.
+ *
+ * @param {Object} options
+ * @param {String} options.file Repo-relative path.
+ * @param {String} options.line The raw source line holding the expression.
+ * @param {String} options.symbol Enclosing symbol name.
+ * @returns {Boolean}
+ */
+export function isRetryContext({file, line, symbol}) {
+    return RETRY_VOCABULARY.test(symbol || '') ||
+           RETRY_VOCABULARY.test(line   || '') ||
+           RETRY_VOCABULARY.test(path.basename(file || ''))
+}
+
 export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
     const candidates = [];
 
@@ -303,6 +354,8 @@ export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
 
                 const symbol = findEnclosingSymbol(lines, index);
 
+                if (!isRetryContext({file: rel, line, symbol})) return;
+
                 candidates.push({
                     key    : `${rel}#${symbol}:${expressionFingerprint(stripped.code)}`,
                     file   : rel,
@@ -316,6 +369,31 @@ export function discoverCandidates({rootDir = ROOT_DIR} = {}) {
     }
 
     return candidates.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+/**
+ * Resolves every repo-relative path a witness names.
+ *
+ * @summary Presence of a witness string is not evidence; a witness naming a spec that was deleted
+ * two refactors ago reads exactly like a witness naming a live one, and the registry would keep
+ * asserting a bound nobody can check. This is the difference between "someone typed a witness" and
+ * "the witness resolves" — and only the second is worth a gate.
+ *
+ * Deliberately narrow: it resolves **paths**, because a path is mechanically checkable, and it does
+ * not attempt to verify that a named symbol or clamp still exists inside the file. Those still rest
+ * on review. Half a resolution beats none, and claiming more would be its own unwitnessed assertion.
+ *
+ * @param {String} key Registry key, for the message.
+ * @param {String} witness The witness text.
+ * @param {String} [rootDir] Repo root.
+ * @returns {String[]} Problems; empty when every named path exists.
+ */
+export function unresolvedWitnessPaths(key, witness, rootDir = ROOT_DIR) {
+    const paths = witness.match(/\b(?:ai|src|apps|test|buildScripts|learn)\/[\w./-]*\.\w+/g) || [];
+
+    return [...new Set(paths)]
+        .filter(rel => !fs.existsSync(path.join(rootDir, rel)))
+        .map(rel => `${key}: witness names ${rel}, which does not exist — a witness that cannot be resolved is not evidence.`)
 }
 
 /**
@@ -338,6 +416,8 @@ export function validateEntry(key, entry) {
 
     if (!entry?.witness || typeof entry.witness !== 'string' || entry.witness.trim().length === 0) {
         problems.push(`${key}: witness is required — name the spec or exported policy that PROVES the classification. An entry without one is a suppression, not a classification.`);
+    } else {
+        problems.push(...unresolvedWitnessPaths(key, entry.witness));
     }
 
     if (entry?.kind === 'retry-growth') {

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -1,0 +1,204 @@
+{
+    "$schema": {
+        "purpose": "Explicit bound classification for every retry-growth candidate. A candidate absent from `sites` is UNCLASSIFIED, never \"unbounded\".",
+        "kind": [
+            "retry-growth",
+            "not-a-retry"
+        ],
+        "lifetime": [
+            "in-cycle",
+            "process-local",
+            "persisted"
+        ],
+        "boundCarrier": [
+            "max-delay",
+            "max-attempts",
+            "max-window",
+            "terminal-state"
+        ],
+        "witness": "REQUIRED for every entry. Names the spec or the bounding construct that PROVES the classification. An entry without one is a suppression, not a classification.",
+        "regenerate": "node ai/scripts/lint/lint-retry-bounds.mjs --list"
+    },
+    "sites": {
+        "ai/agent/Loop.mjs#processEvent": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-attempts",
+            "witness": "`retryCount < this.maxRetries` guard at ai/agent/Loop.mjs#processEvent; `maxRetries: 3` config member",
+            "note": "Recursive retry; the guard is the bound, the delay is uncapped by design (1s/2s/4s then stop)."
+        },
+        "ai/daemons/embed/drainCycle.mjs#getBackoffDelayMs": {
+            "kind": "retry-growth",
+            "lifetime": "persisted",
+            "boundCarrier": "max-delay",
+            "witness": "`MAX_RECORD_COOLDOWN_MS` clamp in the same expression; test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs",
+            "note": "Per-record attempt persists across cycles in retryState, so a delay cap is required \u2014 an attempt budget would not bound wall-clock."
+        },
+        "ai/daemons/message/drainCycle.mjs#getMessageDrainBackoffDelayMs": {
+            "kind": "retry-growth",
+            "lifetime": "in-cycle",
+            "boundCarrier": "max-attempts",
+            "witness": "caller loop `for (let attempt = 0; attempt <= maxRetries; attempt++)` at ai/daemons/message/drainCycle.mjs#drainMessageWalRecords",
+            "note": "Returns a RAW exponential and is indistinguishable from a defect at the growth site; the bound is the caller. This is the case that defeats any returned-vs-consumed heuristic."
+        },
+        "ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs#isRepoDue": {
+            "kind": "retry-growth",
+            "lifetime": "persisted",
+            "boundCarrier": "max-delay",
+            "witness": "`backoffCapMs` leaf (ai/configBase.mjs orchestrator.tenantRepoSync); test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs",
+            "note": "consecutiveFailures persists in the orchestrator state volume and survives restart; uncapped it stranded a deployment ~128h (#16224)."
+        },
+        "ai/daemons/orchestrator/services/RecoveryActuatorService.mjs#computeBackoffUntil": {
+            "kind": "retry-growth",
+            "lifetime": "persisted",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(maxBackoffMs, ...)` in the same expression",
+            "note": "Heal-attempt backoff; cap is co-located with the growth."
+        },
+        "ai/scripts/benchmark/setupClass-cold-start.mjs#roundMetric": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "ai/services/github-workflow/GraphqlService.mjs#<module>": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(this.retryMaxDelayMs, ...)` in the same expression",
+            "note": "GitHub GraphQL transport retry."
+        },
+        "ai/services/gitlab-workflow/GitLabClient.mjs#<module>": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(this.retryMaxDelayMs, ...)` in the same expression",
+            "note": "GitLab transport retry; mirrors GraphqlService."
+        },
+        "ai/services/knowledge-base/ChromaManager.mjs#getKnowledgeBaseCollection": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-window",
+            "witness": "`retry.maxTotalDelayMs - totalDelayMs` remaining-budget clamp in #getCollectionResolveRetryDelay",
+            "note": "The only max-window instance: bounded by TOTAL delay spent, not by a per-delay cap alone (it also carries maxDelayMs)."
+        },
+        "ai/services/knowledge-base/VectorService.mjs#evaluateEmbeddingInput": {
+            "kind": "retry-growth",
+            "lifetime": "in-cycle",
+            "boundCarrier": "max-attempts",
+            "witness": "`retries < maxRetries` guard at the call site; throws on exhaustion",
+            "note": "Embedding batch retry inside one pass."
+        },
+        "ai/services/memory-core/MemoryService.mjs#_scheduleMemoryGraphProjection": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(..., aiConfig.memoryService.graphProjectionRetryMaxMs)` in the same expression"
+        },
+        "ai/services/memory-core/WebhookDeliveryService.mjs#deliver": {
+            "kind": "retry-growth",
+            "lifetime": "in-cycle",
+            "boundCarrier": "max-attempts",
+            "witness": "`attempt <= maxRetries` guard in the same loop",
+            "note": "Multiplicative mutation (`backoff *= 2`) \u2014 the syntax family a base-2 exponent census misses entirely."
+        },
+        "ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe": {
+            "kind": "retry-growth",
+            "lifetime": "persisted",
+            "boundCarrier": "terminal-state",
+            "witness": "`attempts >= maxUnfreezeAttempts` => status `contained` in the same function; test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeDecision.spec.mjs",
+            "note": "The delay value GROWS without a cap by design (anti-thrash widening); the series is bounded because a terminal state stops it. No delay-shaped check can see this bound."
+        },
+        "ai/services/shared/boundedRetryGate.mjs#settleFlight": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(failureTtlMaxMs, ...)` in the same expression",
+            "note": "The shared flight gate; #16307 records why it is NOT the right mechanism for persisted cadence state."
+        },
+        "apps/devindex/services/GitHub.mjs#<module>": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(this.restRetryMaxDelayMs, ...)` applied twice (pre- and post-jitter)"
+        },
+        "apps/devindex/services/Spider.mjs#pickStrategy": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#drawNetwork": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#drawShockwaves": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#updateAgents": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#updatePhysics": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "apps/portal/canvas/ServicesCanvas.mjs#findNearestNode": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "apps/portal/canvas/ServicesCanvas.mjs#findNeighbors": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "apps/portal/canvas/ServicesCanvas.mjs#updatePhysics": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "apps/portal/canvas/ServicesCanvas.mjs#updateRunners": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "src/canvas/Header.mjs#getStreamOffset": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "src/canvas/Sparkline.mjs#renderLoop": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "src/dashboard/DockDropIndicators.mjs#getCandidateHitPoint": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "src/data/connection/WebSocket.mjs#<module>": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(1000 * Math.pow(2, attempt - 1), 30000)` in the default backoffStrategy",
+            "note": "Body-side reconnect; the only retry-growth site outside ai/."
+        },
+        "src/main/DomEvents.mjs#getDistance": {
+            "kind": "not-a-retry",
+            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
+            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
+        },
+        "src/manager/DragCoordinator.mjs#settleNativeWindowDisposition": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(5000, ...)` plus a clamped exponent `Math.min(dispositionAttempts - 1, 4)`",
+            "note": "Bounded twice \u2014 the delay is capped AND the exponent itself is clamped."
+        }
+    }
+}

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -38,7 +38,7 @@
             "kind": "retry-growth",
             "lifetime": "in-cycle",
             "boundCarrier": "max-attempts",
-            "witness": "caller loop `for (let attempt = 0; attempt <= maxRetries; attempt++)` at ai/daemons/message/drainCycle.mjs#drainMessageWalRecords",
+            "witness": "caller loop `for (let attempt = 0; attempt <= maxRetries; attempt++)` at ai/daemons/message/drainCycle.mjs#processMessageBatch",
             "note": "Returns a RAW exponential and is indistinguishable from a defect at the growth site; the bound is the caller. This is the case that defeats any returned-vs-consumed heuristic."
         },
         "ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs#isRepoDue:6475b546": {

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -20,6 +20,126 @@
         "regenerate": "node ai/scripts/lint/lint-retry-bounds.mjs --list"
     },
     "sites": {
+        "ai/scripts/benchmark/setupClass-cold-start.mjs#roundMetric:1a518c5e": {
+            "kind": "not-a-retry",
+            "witness": "`10 ** decimals` is decimal-place rounding: the exponent is a formatting precision argument, not an attempt counter. No loop encloses it.",
+            "note": "Classified because every growth expression is gated, not because it was suspected."
+        },
+        "apps/devindex/services/Spider.mjs#pickStrategy:af20cfdb": {
+            "kind": "not-a-retry",
+            "witness": "`Math.pow(Math.random(), 3)` is a cubic-bias power-law over [0,1) shaping a jitter offset; the exponent is the constant 3 and cannot grow.",
+            "note": "The nearest true-positive shape in the tree — a random offset in a crawler — and still not a retry series: nothing re-attempts on it."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#drawNetwork:3d84b270": {
+            "kind": "not-a-retry",
+            "witness": "Euclidean distance from a wave origin — `(posX - wave.x)**2`; squares a coordinate delta with a literal exponent.",
+            "note": "First of two exponentiations on this line; the second is keyed `#1`."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#drawNetwork:3d84b270#1": {
+            "kind": "not-a-retry",
+            "witness": "Second term of the same Euclidean distance — `(posY - wave.y)**2`.",
+            "note": "Represented separately because occurrence multiplicity is what the key ordinal exists to preserve."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#drawShockwaves:085f4fbe": {
+            "kind": "not-a-retry",
+            "witness": "`1 - Math.pow(1 - progress, 3)` is a cubic ease-out over a normalized 0..1 animation progress; the exponent is the literal 3.",
+            "note": "Progress is bounded by the animation, not by an attempt budget."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#updateAgents:9d5b2f14": {
+            "kind": "not-a-retry",
+            "witness": "Vector magnitude of an agent velocity — `agents[idx + 2]**2`; squares a velocity component.",
+            "note": "First of two exponentiations on this line."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#updateAgents:9d5b2f14#1": {
+            "kind": "not-a-retry",
+            "witness": "Second term of the same velocity magnitude — `agents[idx + 3]**2`.",
+            "note": "Represented separately for occurrence multiplicity."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#updatePhysics:085f4fbe": {
+            "kind": "not-a-retry",
+            "witness": "The same cubic ease-out expression as `drawShockwaves`, in the physics tick; identical text, different enclosing symbol, so a distinct key.",
+            "note": "Shares a fingerprint with the drawShockwaves site — the symbol component of the key is what separates them."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#updatePhysics:9e2d05f4": {
+            "kind": "not-a-retry",
+            "witness": "Euclidean distance to a buffered point — `(px - buffer[idx])**2`.",
+            "note": "First of two exponentiations on this line."
+        },
+        "apps/portal/canvas/HomeCanvas.mjs#updatePhysics:9e2d05f4#1": {
+            "kind": "not-a-retry",
+            "witness": "Second term of the same distance — `(py - buffer[idx + 1])**2`.",
+            "note": "Represented separately for occurrence multiplicity."
+        },
+        "apps/portal/canvas/ServicesCanvas.mjs#findNearestNode:173ce0f0": {
+            "kind": "not-a-retry",
+            "witness": "Squared-distance comparison — `(nx - x) ** 2`; kept squared to avoid a sqrt in the nearest-node scan.",
+            "note": "First of two exponentiations on this line."
+        },
+        "apps/portal/canvas/ServicesCanvas.mjs#findNearestNode:173ce0f0#1": {
+            "kind": "not-a-retry",
+            "witness": "Second term of the same squared distance — `(ny - y) ** 2`.",
+            "note": "Represented separately for occurrence multiplicity."
+        },
+        "apps/portal/canvas/ServicesCanvas.mjs#findNeighbors:822f999b": {
+            "kind": "not-a-retry",
+            "witness": "Euclidean distance in the neighbour scan — `(x - cx) ** 2`.",
+            "note": "First of two exponentiations on this line."
+        },
+        "apps/portal/canvas/ServicesCanvas.mjs#findNeighbors:822f999b#1": {
+            "kind": "not-a-retry",
+            "witness": "Second term of the same distance — `(y - cy) ** 2`.",
+            "note": "Represented separately for occurrence multiplicity."
+        },
+        "apps/portal/canvas/ServicesCanvas.mjs#updatePhysics:a46dec3a": {
+            "kind": "not-a-retry",
+            "witness": "`Math.pow(active, 2)` squares a normalized activation for a falloff curve; the exponent is the literal 2.",
+            "note": "Reassigns its own input, which is the shape `mutate` exists to catch — but the multiplier is a constant square, not a growth factor."
+        },
+        "apps/portal/canvas/ServicesCanvas.mjs#updateRunners:4255fb33": {
+            "kind": "not-a-retry",
+            "witness": "Squared cursor distance — `(tx - me.mouse.x) ** 2`.",
+            "note": "First of two exponentiations on this line."
+        },
+        "apps/portal/canvas/ServicesCanvas.mjs#updateRunners:4255fb33#1": {
+            "kind": "not-a-retry",
+            "witness": "Second term of the same squared distance — `(ty - me.mouse.y) ** 2`.",
+            "note": "Represented separately for occurrence multiplicity."
+        },
+        "src/canvas/Header.mjs#getStreamOffset:08d3b17b": {
+            "kind": "not-a-retry",
+            "witness": "`Math.pow((1 + Math.cos(...)) / 2, 3)` cubes a raised-cosine envelope for a sharper falloff; the source comment says so and the exponent is the literal 3.",
+            "note": "Input is a cosine, bounded to [0,1] before the exponentiation."
+        },
+        "src/canvas/Sparkline.mjs#renderLoop:649bd37d": {
+            "kind": "not-a-retry",
+            "witness": "`1 - Math.pow(1 - progress, 3)` — cubic ease-out on a 0..1 render progress.",
+            "note": "Same easing shape as the HomeCanvas sites."
+        },
+        "src/dashboard/DockDropIndicators.mjs#getCandidateHitPoint:47d9a25f": {
+            "kind": "not-a-retry",
+            "witness": "Squared hit-test distance — `(pointX - center.x) ** 2`; squared to rank candidates without a sqrt.",
+            "note": "First of two exponentiations on this line."
+        },
+        "src/dashboard/DockDropIndicators.mjs#getCandidateHitPoint:47d9a25f#1": {
+            "kind": "not-a-retry",
+            "witness": "Second term of the same squared distance — `(pointY - center.y) ** 2`.",
+            "note": "Represented separately for occurrence multiplicity."
+        },
+        "src/form/field/FileUpload.mjs#formatSize:38dbd980": {
+            "kind": "not-a-retry",
+            "witness": "`bytes / (1000 ** i)` converts to an SI magnitude; `i` is an index into the `sizes` unit array, bounded by that array's length.",
+            "note": "The candidate the discovery patterns were first tuned against — it survives inside a template literal, which is why stripLiterals retains substitutions."
+        },
+        "src/main/DomEvents.mjs#getDistance:841a9de1": {
+            "kind": "not-a-retry",
+            "witness": "Euclidean distance between two pointer positions — `(x2 - x1) ** 2`.",
+            "note": "First of two exponentiations on this line."
+        },
+        "src/main/DomEvents.mjs#getDistance:841a9de1#1": {
+            "kind": "not-a-retry",
+            "witness": "Second term of the same distance — `(y2 - y1) ** 2`.",
+            "note": "Represented separately for occurrence multiplicity."
+        },
         "ai/agent/Loop.mjs#processEvent:e3df926d": {
             "kind": "retry-growth",
             "lifetime": "process-local",

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -20,185 +20,115 @@
         "regenerate": "node ai/scripts/lint/lint-retry-bounds.mjs --list"
     },
     "sites": {
-        "ai/agent/Loop.mjs#processEvent": {
+        "ai/agent/Loop.mjs#processEvent:e3df926d": {
             "kind": "retry-growth",
             "lifetime": "process-local",
             "boundCarrier": "max-attempts",
             "witness": "`retryCount < this.maxRetries` guard at ai/agent/Loop.mjs#processEvent; `maxRetries: 3` config member",
             "note": "Recursive retry; the guard is the bound, the delay is uncapped by design (1s/2s/4s then stop)."
         },
-        "ai/daemons/embed/drainCycle.mjs#getBackoffDelayMs": {
+        "ai/daemons/embed/drainCycle.mjs#getBackoffDelayMs:c791d8f6": {
             "kind": "retry-growth",
             "lifetime": "persisted",
             "boundCarrier": "max-delay",
             "witness": "`MAX_RECORD_COOLDOWN_MS` clamp in the same expression; test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs",
-            "note": "Per-record attempt persists across cycles in retryState, so a delay cap is required \u2014 an attempt budget would not bound wall-clock."
+            "note": "Per-record attempt persists across cycles in retryState, so a delay cap is required — an attempt budget would not bound wall-clock."
         },
-        "ai/daemons/message/drainCycle.mjs#getMessageDrainBackoffDelayMs": {
+        "ai/daemons/message/drainCycle.mjs#getMessageDrainBackoffDelayMs:39b52338": {
             "kind": "retry-growth",
             "lifetime": "in-cycle",
             "boundCarrier": "max-attempts",
             "witness": "caller loop `for (let attempt = 0; attempt <= maxRetries; attempt++)` at ai/daemons/message/drainCycle.mjs#drainMessageWalRecords",
             "note": "Returns a RAW exponential and is indistinguishable from a defect at the growth site; the bound is the caller. This is the case that defeats any returned-vs-consumed heuristic."
         },
-        "ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs#isRepoDue": {
+        "ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs#isRepoDue:6475b546": {
             "kind": "retry-growth",
             "lifetime": "persisted",
             "boundCarrier": "max-delay",
             "witness": "`backoffCapMs` leaf (ai/configBase.mjs orchestrator.tenantRepoSync); test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs",
             "note": "consecutiveFailures persists in the orchestrator state volume and survives restart; uncapped it stranded a deployment ~128h (#16224)."
         },
-        "ai/daemons/orchestrator/services/RecoveryActuatorService.mjs#computeBackoffUntil": {
+        "ai/daemons/orchestrator/services/RecoveryActuatorService.mjs#computeBackoffUntil:2cfb36dc": {
             "kind": "retry-growth",
             "lifetime": "persisted",
             "boundCarrier": "max-delay",
             "witness": "`Math.min(maxBackoffMs, ...)` in the same expression",
             "note": "Heal-attempt backoff; cap is co-located with the growth."
         },
-        "ai/scripts/benchmark/setupClass-cold-start.mjs#roundMetric": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "ai/services/github-workflow/GraphqlService.mjs#<module>": {
+        "ai/services/github-workflow/GraphqlService.mjs##getRetryDelay:626883e2": {
             "kind": "retry-growth",
             "lifetime": "process-local",
             "boundCarrier": "max-delay",
             "witness": "`Math.min(this.retryMaxDelayMs, ...)` in the same expression",
             "note": "GitHub GraphQL transport retry."
         },
-        "ai/services/gitlab-workflow/GitLabClient.mjs#<module>": {
+        "ai/services/gitlab-workflow/GitLabClient.mjs##getRetryDelay:626883e2": {
             "kind": "retry-growth",
             "lifetime": "process-local",
             "boundCarrier": "max-delay",
             "witness": "`Math.min(this.retryMaxDelayMs, ...)` in the same expression",
             "note": "GitLab transport retry; mirrors GraphqlService."
         },
-        "ai/services/knowledge-base/ChromaManager.mjs#getKnowledgeBaseCollection": {
+        "ai/services/knowledge-base/ChromaManager.mjs##getCollectionResolveRetryDelay:247f4675": {
             "kind": "retry-growth",
             "lifetime": "process-local",
             "boundCarrier": "max-window",
             "witness": "`retry.maxTotalDelayMs - totalDelayMs` remaining-budget clamp in #getCollectionResolveRetryDelay",
             "note": "The only max-window instance: bounded by TOTAL delay spent, not by a per-delay cap alone (it also carries maxDelayMs)."
         },
-        "ai/services/knowledge-base/VectorService.mjs#evaluateEmbeddingInput": {
+        "ai/services/knowledge-base/VectorService.mjs#evaluateEmbeddingInput:2603053b": {
             "kind": "retry-growth",
             "lifetime": "in-cycle",
             "boundCarrier": "max-attempts",
             "witness": "`retries < maxRetries` guard at the call site; throws on exhaustion",
             "note": "Embedding batch retry inside one pass."
         },
-        "ai/services/memory-core/MemoryService.mjs#_scheduleMemoryGraphProjection": {
-            "kind": "retry-growth",
-            "lifetime": "process-local",
-            "boundCarrier": "max-delay",
-            "witness": "`Math.min(..., aiConfig.memoryService.graphProjectionRetryMaxMs)` in the same expression"
-        },
-        "ai/services/memory-core/WebhookDeliveryService.mjs#deliver": {
-            "kind": "retry-growth",
-            "lifetime": "in-cycle",
-            "boundCarrier": "max-attempts",
-            "witness": "`attempt <= maxRetries` guard in the same loop",
-            "note": "Multiplicative mutation (`backoff *= 2`) \u2014 the syntax family a base-2 exponent census misses entirely."
-        },
-        "ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe": {
+        "ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe:5b01edc6": {
             "kind": "retry-growth",
             "lifetime": "persisted",
             "boundCarrier": "terminal-state",
             "witness": "`attempts >= maxUnfreezeAttempts` => status `contained` in the same function; test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeDecision.spec.mjs",
             "note": "The delay value GROWS without a cap by design (anti-thrash widening); the series is bounded because a terminal state stops it. No delay-shaped check can see this bound."
         },
-        "ai/services/shared/boundedRetryGate.mjs#settleFlight": {
+        "ai/services/memory-core/MemoryService.mjs#_scheduleMemoryGraphProjection:f2eb13d7": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(..., aiConfig.memoryService.graphProjectionRetryMaxMs)` in the same expression"
+        },
+        "ai/services/memory-core/WebhookDeliveryService.mjs#deliver:f7f23e9f": {
+            "kind": "retry-growth",
+            "lifetime": "in-cycle",
+            "boundCarrier": "max-attempts",
+            "witness": "`attempt <= maxRetries` guard in the same loop",
+            "note": "Multiplicative mutation (`backoff *= 2`) — the syntax family a base-2 exponent census misses entirely."
+        },
+        "ai/services/shared/boundedRetryGate.mjs#settleFlight:e1ea3176": {
             "kind": "retry-growth",
             "lifetime": "process-local",
             "boundCarrier": "max-delay",
             "witness": "`Math.min(failureTtlMaxMs, ...)` in the same expression",
             "note": "The shared flight gate; #16307 records why it is NOT the right mechanism for persisted cadence state."
         },
-        "apps/devindex/services/GitHub.mjs#<module>": {
+        "apps/devindex/services/GitHub.mjs##getRetryDelay:41482917": {
             "kind": "retry-growth",
             "lifetime": "process-local",
             "boundCarrier": "max-delay",
             "witness": "`Math.min(this.restRetryMaxDelayMs, ...)` applied twice (pre- and post-jitter)"
         },
-        "apps/devindex/services/Spider.mjs#pickStrategy": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "apps/portal/canvas/HomeCanvas.mjs#drawNetwork": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "apps/portal/canvas/HomeCanvas.mjs#drawShockwaves": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "apps/portal/canvas/HomeCanvas.mjs#updateAgents": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "apps/portal/canvas/HomeCanvas.mjs#updatePhysics": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "apps/portal/canvas/ServicesCanvas.mjs#findNearestNode": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "apps/portal/canvas/ServicesCanvas.mjs#findNeighbors": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "apps/portal/canvas/ServicesCanvas.mjs#updatePhysics": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "apps/portal/canvas/ServicesCanvas.mjs#updateRunners": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "src/canvas/Header.mjs#getStreamOffset": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "src/canvas/Sparkline.mjs#renderLoop": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "src/dashboard/DockDropIndicators.mjs#getCandidateHitPoint": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "src/data/connection/WebSocket.mjs#<module>": {
+        "src/data/connection/WebSocket.mjs#<module>:a5cd8f47": {
             "kind": "retry-growth",
             "lifetime": "process-local",
             "boundCarrier": "max-delay",
             "witness": "`Math.min(1000 * Math.pow(2, attempt - 1), 30000)` in the default backoffStrategy",
-            "note": "Body-side reconnect; the only retry-growth site outside ai/."
+            "note": "Body-side reconnect. One of three retry-growth sites outside ai/, alongside apps/devindex/services/GitHub.mjs and src/manager/DragCoordinator.mjs."
         },
-        "src/main/DomEvents.mjs#getDistance": {
-            "kind": "not-a-retry",
-            "witness": "Geometry/easing/physics \u2014 no retry series exists; verified by reading the enclosing function.",
-            "note": "Non-retry use of the same syntax. Recorded rather than filtered so the examined set stays auditable."
-        },
-        "src/manager/DragCoordinator.mjs#settleNativeWindowDisposition": {
+        "src/manager/DragCoordinator.mjs#settleNativeWindowDisposition:acca199c": {
             "kind": "retry-growth",
             "lifetime": "process-local",
             "boundCarrier": "max-delay",
             "witness": "`Math.min(5000, ...)` plus a clamped exponent `Math.min(dispositionAttempts - 1, 4)`",
-            "note": "Bounded twice \u2014 the delay is capped AND the exponent itself is clamped."
+            "note": "Bounded twice — the delay is capped AND the exponent itself is clamped."
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "ai:lint-identity-engine-coherence"    : "node ./ai/scripts/lint/lint-identity-engine-coherence.mjs",
         "ai:lint-identity-vocabulary"          : "node ./ai/scripts/lint/lint-identity-vocabulary.mjs",
         "ai:lint-mcp-test-locations"           : "node ./ai/scripts/lint/lint-mcp-test-locations.mjs",
+        "ai:lint-retry-bounds"                 : "node ./ai/scripts/lint/lint-retry-bounds.mjs",
         "ai:lint-skill-manifest"               : "node ./ai/scripts/lint/lint-skill-manifest.mjs",
         "ai:lint-tree-json"                    : "node ./ai/scripts/lint/lint-tree-json.mjs",
         "ai:skill-size-report"                 : "node ./ai/scripts/lint/lint-skill-manifest.mjs --report-sizes",

--- a/test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs
@@ -6,7 +6,9 @@ import {
     diffRegistry,
     discoverCandidates,
     findEnclosingSymbol,
+    isRetryContext,
     stripLiterals,
+    unresolvedWitnessPaths,
     validateEntry
 } from '../../../../../../ai/scripts/lint/lint-retry-bounds.mjs';
 
@@ -15,6 +17,20 @@ const ROOT_DIR = path.resolve(process.cwd()),
       SITES    = REGISTRY.sites,
       LIVE     = discoverCandidates({rootDir: ROOT_DIR});
 
+/**
+ * Looks a site up by `file#symbol`, ignoring the expression fingerprint.
+ *
+ * Keying on the full registry key would make every assertion churn whenever an unrelated character
+ * of the expression changes, which is the opposite of what the fingerprint is for.
+ */
+function siteStartingWith(prefix) {
+    const hit = Object.entries(SITES).find(([key]) => key.startsWith(prefix));
+
+    expect(hit, `no registry entry starts with ${prefix}`).toBeTruthy();
+
+    return hit[1];
+}
+
 test.describe('lint-retry-bounds — discovery + explicit bound classification (#16443)', () => {
     /**
      * The guard's whole premise: the candidate set comes from a scan, not from a hand-maintained
@@ -22,7 +38,7 @@ test.describe('lint-retry-bounds — discovery + explicit bound classification (
      * three times before this ticket existed.
      */
     test('the candidate set is DISCOVERED, and the live tree is fully classified', () => {
-        expect(LIVE.length).toBeGreaterThan(20);
+        expect(LIVE.length).toBeGreaterThan(10);
 
         const {unclassified, stale, invalid} = diffRegistry({candidates: LIVE, registry: SITES});
 
@@ -82,7 +98,7 @@ test.describe('lint-retry-bounds — discovery + explicit bound classification (
      * exponential; the bound is the caller's loop.
      */
     test('message drain classifies in-cycle/max-attempts — the bound is in the CALLER', () => {
-        const entry = SITES['ai/daemons/message/drainCycle.mjs#getMessageDrainBackoffDelayMs'];
+        const entry = siteStartingWith('ai/daemons/message/drainCycle.mjs#getMessageDrainBackoffDelayMs');
 
         expect(entry.kind).toBe('retry-growth');
         expect(entry.lifetime).toBe('in-cycle');
@@ -95,7 +111,7 @@ test.describe('lint-retry-bounds — discovery + explicit bound classification (
      * grows here by design; a terminal state stops the series.
      */
     test('freeze reprobe classifies terminal-state — a growing delay that is still bounded', () => {
-        const entry = SITES['ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe'];
+        const entry = siteStartingWith('ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe');
 
         expect(entry.boundCarrier).toBe('terminal-state');
         expect(entry.lifetime).toBe('persisted');
@@ -110,24 +126,66 @@ test.describe('lint-retry-bounds — discovery + explicit bound classification (
     });
 
     /**
-     * The false-positive family is RECORDED, not filtered. A path/filename exclusion would hide the
-     * examined set behind a regex nobody audits — and would silently swallow a future retry site
-     * that happened to live in an excluded path.
+     * Supersedes an earlier test asserting the non-retry family is recorded rather than filtered.
+     * That design collapsed on measurement: a full-tree run produced 62 candidates of which 34 sat
+     * outside `ai/` and only 3 of those were retries — the rest were `(x2 - x1) ** 2`,
+     * `Math.pow(1 - progress, 3)` and `1000 ** i`. Asking a canvas physics loop to declare its
+     * backoff cap makes a gate developers route around, and 14 registry rows saying "Euclidean
+     * distance is not a retry" record nothing worth reading.
+     *
+     * The exclusion is SEMANTIC, not a path filter — which is what the superseded test was really
+     * protecting against, and that property is asserted directly below.
      */
-    test('non-retry matches are classified with witnesses, not path-filtered away', () => {
-        const notRetries = Object.entries(SITES).filter(([, e]) => e.kind === 'not-a-retry');
+    test('the discriminator excludes non-retries by vocabulary, never by path', () => {
+        // Same scan roots, opposite verdicts — so the exclusion cannot be a path rule.
+        expect(isRetryContext({file: 'src/main/DomEvents.mjs',        line: 'return Math.sqrt((x2 - x1) ** 2)', symbol: 'getDistance'})).toBe(false);
+        expect(isRetryContext({file: 'src/canvas/Sparkline.mjs',      line: 'progress = 1 - Math.pow(1 - progress, 3);', symbol: 'renderLoop'})).toBe(false);
+        expect(isRetryContext({file: 'src/form/field/FileUpload.mjs', line: 'bytes / (1000 ** i)', symbol: 'formatSize'})).toBe(false);
 
-        expect(notRetries.length).toBeGreaterThan(5);
-        notRetries.forEach(([key, entry]) => {
-            expect(entry.witness, `${key} needs a witness`).toBeTruthy();
-            expect(entry.lifetime).toBeUndefined();
-            expect(entry.boundCarrier).toBeUndefined();
+        expect(isRetryContext({file: 'src/data/connection/WebSocket.mjs', line: 'backoffStrategy: attempt => Math.min(1000 * Math.pow(2, attempt - 1), 30000),', symbol: '<module>'})).toBe(true);
+        expect(isRetryContext({file: 'apps/devindex/services/GitHub.mjs', line: 'this.restRetryBaseDelayMs * 2 ** (attempt - 1)', symbol: '#getRetryDelay'})).toBe(true);
+    });
+
+    /**
+     * The regression guard for the bug this discriminator introduced and nearly shipped: the first
+     * draft used `\b`-delimited words, and `\bconsecutive\b` does not match `consecutiveFailures`
+     * because a word character follows. That silently dropped `tenantRepoSync#isRepoDue` — the site
+     * whose unbounded backoff once starved a tenant sync lane for over a day. camelCase is the
+     * dominant identifier style here, so word-boundary anchoring fails precisely on the
+     * highest-value sites, and it fails by omission rather than by error.
+     */
+    test('camelCase identifiers are matched — the sites that motivated the gate stay discovered', () => {
+        expect(isRetryContext({file: 'ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs', line: 'const backoffMultiplier = Math.pow(2, Math.max(0, consecutiveFailures));', symbol: 'isRepoDue'})).toBe(true);
+        expect(isRetryContext({file: 'src/manager/DragCoordinator.mjs', line: '2 ** Math.min(candidate.dispositionAttempts - 1, 4)', symbol: 'settleNativeWindowDisposition'})).toBe(true);
+
+        const discovered = LIVE.map(c => c.file);
+
+        ['tenantRepoSync.mjs', 'boundedRetryGate.mjs', 'ai/agent/Loop.mjs', 'DragCoordinator.mjs']
+            .forEach(marker => expect(discovered.some(f => f.includes(marker)), `${marker} must stay discovered`).toBe(true));
+    });
+
+    /**
+     * A witness naming a spec deleted two refactors ago reads exactly like one naming a live spec,
+     * so presence was never evidence. Resolution is deliberately limited to PATHS — symbols and
+     * clamps still rest on review, and claiming otherwise would be its own unwitnessed assertion.
+     */
+    test('a witness naming a path that does not exist is not evidence', () => {
+        expect(unresolvedWitnessPaths('k', 'guard at ai/agent/Loop.mjs')).toEqual([]);
+        expect(unresolvedWitnessPaths('k', '`Math.min(a, b)` clamp in the same expression')).toEqual([]);
+
+        expect(unresolvedWitnessPaths('k', 'proven by test/playwright/unit/ai/deleted/gone.spec.mjs').join(' '))
+            .toMatch(/does not exist/);
+
+        // And it is wired into entry validation, not merely available.
+        expect(validateEntry('k', {
+            kind: 'not-a-retry', witness: 'see ai/services/vanished/Nope.mjs'
+        }).join(' ')).toMatch(/does not exist/);
+    });
+
+    test('every live witness resolves', () => {
+        Object.entries(SITES).forEach(([key, entry]) => {
+            expect(unresolvedWitnessPaths(key, entry.witness)).toEqual([]);
         });
-
-        // Canvas easing lives under apps/ and src/ — both inside the scan roots, proving the family
-        // is reached and classified rather than excluded by path.
-        expect(notRetries.some(([key]) => key.startsWith('src/'))).toBe(true);
-        expect(notRetries.some(([key]) => key.startsWith('apps/'))).toBe(true);
     });
 
     test('literal contents cannot match — markdown bold is not an exponent', () => {

--- a/test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs
@@ -6,6 +6,7 @@ import {
     diffRegistry,
     discoverCandidates,
     findEnclosingSymbol,
+    findGrowthMatches,
     isRetryContext,
     stripLiterals,
     unresolvedWitnessPaths,
@@ -126,17 +127,91 @@ test.describe('lint-retry-bounds — discovery + explicit bound classification (
     });
 
     /**
-     * Supersedes an earlier test asserting the non-retry family is recorded rather than filtered.
-     * That design collapsed on measurement: a full-tree run produced 62 candidates of which 34 sat
-     * outside `ai/` and only 3 of those were retries — the rest were `(x2 - x1) ** 2`,
-     * `Math.pow(1 - progress, 3)` and `1000 ** i`. Asking a canvas physics loop to declare its
-     * backoff cap makes a gate developers route around, and 14 registry rows saying "Euclidean
-     * distance is not a retry" record nothing worth reading.
+     * The control @neo-gpt-emmy asked for, and the one I argued against before conceding.
      *
-     * The exclusion is SEMANTIC, not a path filter — which is what the superseded test was really
-     * protecting against, and that property is asserted directly below.
+     * The argument I lost, recorded because the measurement in it was real and only the conclusion
+     * was wrong: a full-tree run produces candidates that are overwhelmingly NOT retries — Euclidean
+     * distances, easing curves, `1000 ** i` — and I read that as "do not gate them", since a registry
+     * row saying "Euclidean distance is not a retry" reads as recording nothing. What the measurement
+     * actually supports is only that the rows are low-VALUE, not that they are optional. They are
+     * paid once; the hole they leave is permanent, and it sits exactly where the highest-value misses
+     * live.
+     *
+     * A real backoff whose file, symbol AND variable names all avoid retry vocabulary must still be
+     * GATED, not merely printed. An earlier revision gated only retry-vocabulary candidates and
+     * console.logged the rest, on the reasoning that a canvas physics loop should not have to declare
+     * a backoff cap. The reasoning was fine; the mechanism was not — a census on stdout is not a gate,
+     * so this exact shape stayed green forever. Vocabulary now orders review and admits nothing.
      */
-    test('the discriminator excludes non-retries by vocabulary, never by path', () => {
+    test('a neutral-named retry is UNCLASSIFIED, not merely reported — vocabulary annotates, it does not admit', () => {
+        const neutral = {
+            key         : 'src/time/Clock.mjs#schedule:deadbeef',
+            file        : 'src/time/Clock.mjs',
+            line        : 12,
+            symbol      : 'schedule',
+            pattern     : 'exponent',
+            retryContext: isRetryContext({file: 'src/time/Clock.mjs', symbol: 'schedule', line: 'const d = base * 2 ** n;'}),
+            snippet     : 'const d = base * 2 ** n;'
+        };
+
+        // The premise of the control: this site is invisible to the vocabulary. If that ever becomes
+        // true-by-vocabulary the control stops testing what it claims, so it is asserted, not assumed.
+        expect(neutral.retryContext).toBe(false);
+
+        const {unclassified} = diffRegistry({candidates: [neutral], registry: {}});
+
+        expect(unclassified.map(c => c.key)).toEqual([neutral.key]);
+    });
+
+    /**
+     * Occurrence multiplicity, including identical text. Two identical growth expressions in one
+     * enclosing symbol share a fingerprint by construction, so without an ordinal the second collapses
+     * onto the first and `diffRegistry`'s Set reports no drift for a site nobody classified.
+     */
+    test('two identical expressions in one symbol create TWO obligations', () => {
+        const lines = [
+            'function schedule() {',
+            '    const a = base * 2 ** n;',
+            '    const b = base * 2 ** n;',
+            '}'
+        ];
+
+        expect(findEnclosingSymbol(lines, 1)).toBe('schedule');
+        expect(findEnclosingSymbol(lines, 2)).toBe('schedule');
+
+        const first  = {key: 'f.mjs#schedule:abc',    retryContext: true},
+              second = {key: 'f.mjs#schedule:abc#1',  retryContext: true};
+
+        // Distinct keys, so registering one leaves the other outstanding.
+        const {unclassified} = diffRegistry({
+            candidates: [first, second],
+            registry  : {'f.mjs#schedule:abc': {kind: 'not-a-retry', witness: 'w'}}
+        });
+
+        expect(unclassified.map(c => c.key)).toEqual([second.key]);
+    });
+
+    /**
+     * Multiple matches on ONE source line. `PATTERNS.find` answered "does this line contain a growth
+     * expression"; a Euclidean distance contains two, and the second was absorbed with nothing
+     * recording that a site had been merged away.
+     */
+    test('a line holding two growth expressions yields two matches, de-duplicated by position', () => {
+        expect(findGrowthMatches('dist = (nx - x) ** 2 + (ny - y) ** 2;')).toHaveLength(2);
+        expect(findGrowthMatches('const d = base * 2 ** n;')).toHaveLength(1);
+        expect(findGrowthMatches('const plain = a + b;')).toHaveLength(0);
+
+        // Overlapping patterns describing one token must not double-count it.
+        const overlapping = findGrowthMatches('Math.pow(a, 2)');
+
+        expect(overlapping).toHaveLength(1);
+        expect(overlapping[0].id).toBe('pow');
+
+        // Source order, so the registry ordinal is stable rather than pattern-declaration dependent.
+        expect(findGrowthMatches('x = (a) ** 2 + Math.pow(b, 2);').map(m => m.id)).toEqual(['exponent', 'pow']);
+    });
+
+    test('vocabulary still separates the plausible retries from the geometry, for review ordering', () => {
         // Same scan roots, opposite verdicts — so the exclusion cannot be a path rule.
         expect(isRetryContext({file: 'src/main/DomEvents.mjs',        line: 'return Math.sqrt((x2 - x1) ** 2)', symbol: 'getDistance'})).toBe(false);
         expect(isRetryContext({file: 'src/canvas/Sparkline.mjs',      line: 'progress = 1 - Math.pow(1 - progress, 3);', symbol: 'renderLoop'})).toBe(false);

--- a/test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs
@@ -1,0 +1,163 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'path';
+import {
+    classifyLine,
+    diffRegistry,
+    discoverCandidates,
+    findEnclosingSymbol,
+    stripLiterals,
+    validateEntry
+} from '../../../../../../ai/scripts/lint/lint-retry-bounds.mjs';
+
+const ROOT_DIR = path.resolve(process.cwd()),
+      REGISTRY = JSON.parse(fs.readFileSync(path.join(ROOT_DIR, 'ai/scripts/lint/retry-bound-registry.json'), 'utf8')),
+      SITES    = REGISTRY.sites,
+      LIVE     = discoverCandidates({rootDir: ROOT_DIR});
+
+test.describe('lint-retry-bounds — discovery + explicit bound classification (#16443)', () => {
+    /**
+     * The guard's whole premise: the candidate set comes from a scan, not from a hand-maintained
+     * list. A checker carrying its own site list would be re-stating the census that was wrong
+     * three times before this ticket existed.
+     */
+    test('the candidate set is DISCOVERED, and the live tree is fully classified', () => {
+        expect(LIVE.length).toBeGreaterThan(20);
+
+        const {unclassified, stale, invalid} = diffRegistry({candidates: LIVE, registry: SITES});
+
+        expect(unclassified).toEqual([]);
+        expect(stale).toEqual([]);
+        expect(invalid).toEqual([]);
+    });
+
+    /**
+     * The single most important behavioural property. An unregistered match means "nobody has said
+     * what this is", which is true — not "this is a defect", which usually is not, because the
+     * non-retry family is larger than the retry family.
+     */
+    test('an unregistered candidate is UNCLASSIFIED, never asserted unbounded', () => {
+        const registryWithoutOne = {...SITES};
+        delete registryWithoutOne[LIVE[0].key];
+
+        const {unclassified} = diffRegistry({candidates: LIVE, registry: registryWithoutOne});
+
+        expect(unclassified.map(c => c.key)).toEqual([LIVE[0].key]);
+        // The verdict object carries no notion of "unbounded" at all — the vocabulary cannot express it.
+        expect(JSON.stringify(unclassified)).not.toContain('unbounded');
+    });
+
+    test('a registry entry whose site is gone fails as drift', () => {
+        const {stale} = diffRegistry({
+            candidates: LIVE,
+            registry  : {...SITES, 'ai/does/not/exist.mjs#ghost': {kind: 'not-a-retry', witness: 'n/a'}}
+        });
+
+        expect(stale).toEqual(['ai/does/not/exist.mjs#ghost']);
+    });
+
+    /**
+     * The registry must not degenerate into a suppression allowlist. A witness is what separates
+     * "we examined this and here is the proof" from "we agreed to stop asking".
+     */
+    test('every entry requires a witness, and a retry-growth entry requires lifetime + carrier', () => {
+        expect(validateEntry('k', {kind: 'retry-growth', lifetime: 'in-cycle', boundCarrier: 'max-attempts', witness: 'spec'})).toEqual([]);
+
+        expect(validateEntry('k', {kind: 'retry-growth', lifetime: 'in-cycle', boundCarrier: 'max-attempts'}).join(' '))
+            .toMatch(/witness is required/);
+        expect(validateEntry('k', {kind: 'retry-growth', boundCarrier: 'max-attempts', witness: 'w'}).join(' '))
+            .toMatch(/lifetime must be/);
+        expect(validateEntry('k', {kind: 'retry-growth', lifetime: 'in-cycle', witness: 'w'}).join(' '))
+            .toMatch(/boundCarrier must be/);
+        expect(validateEntry('k', {kind: 'nonsense', witness: 'w'}).join(' ')).toMatch(/kind must be/);
+
+        // A non-retry cannot claim a bound carrier: there is no series to bound.
+        expect(validateEntry('k', {kind: 'not-a-retry', boundCarrier: 'max-delay', witness: 'w'}).join(' '))
+            .toMatch(/must not declare lifetime\/boundCarrier/);
+    });
+
+    /**
+     * The case that defeats a "returned vs consumed" heuristic — my first proposed rule, which
+     * would have produced a false positive on its first run. The growth site returns a raw
+     * exponential; the bound is the caller's loop.
+     */
+    test('message drain classifies in-cycle/max-attempts — the bound is in the CALLER', () => {
+        const entry = SITES['ai/daemons/message/drainCycle.mjs#getMessageDrainBackoffDelayMs'];
+
+        expect(entry.kind).toBe('retry-growth');
+        expect(entry.lifetime).toBe('in-cycle');
+        expect(entry.boundCarrier).toBe('max-attempts');
+        expect(entry.witness).toMatch(/caller loop/i);
+    });
+
+    /**
+     * Proves the schema admits a bound that is NOT a cap on the delay value. The delay genuinely
+     * grows here by design; a terminal state stops the series.
+     */
+    test('freeze reprobe classifies terminal-state — a growing delay that is still bounded', () => {
+        const entry = SITES['ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe'];
+
+        expect(entry.boundCarrier).toBe('terminal-state');
+        expect(entry.lifetime).toBe('persisted');
+    });
+
+    test('all four bound carriers have a real instance — the schema is not aspirational', () => {
+        const carriers = new Set(
+            Object.values(SITES).filter(e => e.kind === 'retry-growth').map(e => e.boundCarrier)
+        );
+
+        expect([...carriers].sort()).toEqual(['max-attempts', 'max-delay', 'max-window', 'terminal-state']);
+    });
+
+    /**
+     * The false-positive family is RECORDED, not filtered. A path/filename exclusion would hide the
+     * examined set behind a regex nobody audits — and would silently swallow a future retry site
+     * that happened to live in an excluded path.
+     */
+    test('non-retry matches are classified with witnesses, not path-filtered away', () => {
+        const notRetries = Object.entries(SITES).filter(([, e]) => e.kind === 'not-a-retry');
+
+        expect(notRetries.length).toBeGreaterThan(5);
+        notRetries.forEach(([key, entry]) => {
+            expect(entry.witness, `${key} needs a witness`).toBeTruthy();
+            expect(entry.lifetime).toBeUndefined();
+            expect(entry.boundCarrier).toBeUndefined();
+        });
+
+        // Canvas easing lives under apps/ and src/ — both inside the scan roots, proving the family
+        // is reached and classified rather than excluded by path.
+        expect(notRetries.some(([key]) => key.startsWith('src/'))).toBe(true);
+        expect(notRetries.some(([key]) => key.startsWith('apps/'))).toBe(true);
+    });
+
+    test('literal contents cannot match — markdown bold is not an exponent', () => {
+        expect(stripLiterals('const a = `**bold** text`;').code).not.toMatch(/\*\*b/);
+        expect(stripLiterals('const x = base ** attempt;').code).toMatch(/\*\*/);
+
+        // Multi-line template state carries, so a prose continuation line is not scanned as code.
+        expect(stripLiterals('const s = `line one', false).inTemplate).toBe(true);
+        expect(stripLiterals('  2. **Feature Namespace:** prose', true).code.trim()).toBe('');
+    });
+
+    test('comment lines are excluded by shape, including block continuations', () => {
+        expect(classifyLine('  const a = 2 ** b;', false).isCode).toBe(true);
+        expect(classifyLine('  // 2 ** b', false).isCode).toBe(false);
+        expect(classifyLine('   * a table describing Math.pow bounding', false).isCode).toBe(false);
+        expect(classifyLine('/* opens', false).inBlockComment).toBe(true);
+        expect(classifyLine(' still inside 2 ** b', true).isCode).toBe(false);
+    });
+
+    test('sites key on the enclosing symbol, so unrelated edits above do not re-baseline', () => {
+        const lines = [
+            'function outer() {',
+            '    if (x) {',
+            '        return 2 ** n;',
+            '    }',
+            '}'
+        ];
+
+        // `if` must not become the key — control flow matches the method-signature shape.
+        expect(findEnclosingSymbol(lines, 2)).toBe('outer');
+        expect(findEnclosingSymbol(['const a = 1;'], 0)).toBe('<module>');
+    });
+});


### PR DESCRIPTION
Resolves #16443

The operator asked for a standing rule — *backoff times must not grow indefinitely*. **The rule already holds:** all 16 retry-growth sites on `dev` are bounded. What does not exist is any way to *know* that without reading each site's caller, and the bound lives in four structurally different places.

Evidence: L2 (discovery, classification schema, and drift detection are fully unit-verifiable, and the guard is red-proofed end to end by introducing a synthetic site; the sandbox cannot prove a future contributor's un-run code is bounded — nothing can, which is why this classifies rather than proves) → L2 sufficient. Residual: none.

## Why this is a classification gate and not a bounds check

**I ran the census by hand three times and got it wrong every time.** Five sites (matched literal base-2 only) → concluded "nothing to fix" and reported that. Then nine. Then sixteen, after @neo-gpt-emmy corrected the population in a pre-filing concept review. Each miss was a whole syntax family: `backoff *= 2`, `Math.pow(configurableMultiplier, attempts)`.

I let the regex, not the problem, define the population. That is the ticket's premise and it is also its evidence.

## The four carriers, all with real instances

| carrier | meaning | example |
|---|---|---|
| `max-delay` | the delay value itself is capped | `Math.min(base * 2 ** attempt, CAP)` |
| `max-attempts` | the growth expression is raw; the **caller's** loop bounds it | `message/drainCycle` |
| `max-window` | a total elapsed budget bounds the series | `ChromaManager` (`maxTotalDelayMs - totalDelayMs`) |
| `terminal-state` | the delay genuinely grows; a state transition stops the loop | `freezeReprobeDecision` |

`freezeReprobeDecision` is the one that proves the schema needed a fourth carrier: its delay widens without a cap **by design** (anti-thrash), and the series is bounded because `maxUnfreezeAttempts` produces a `contained` terminal state. No delay-shaped check can see that bound.

## `unclassified`, never `unbounded`

The non-retry family — easing curves, physics distance, power-law random — is **larger** than the retry family (14 vs 16 after literal stripping). A gate that called those violations would train contributors to add suppressions, which is how an invariant actually dies. So an unregistered match reports **`unclassified`**, meaning "nobody has said what this is yet", which is true. A spec asserts the verdict vocabulary cannot even express `unbounded`.

Non-retry matches are **classified** (`kind: 'not-a-retry'`) with the same witness requirement, so the examined set stays auditable rather than hidden behind a path filter.

## Two heuristics rejected after they failed on real code

- **"returned vs consumed"** — my first proposed rule, and it false-positives on its first run: `message/drainCycle.mjs` returns a raw exponential and is correctly bounded by its caller's loop. A spec now pins that exact case.
- **Path/filename exclusion for the canvas family** — would hide the examined set behind a regex nobody audits, and would silently swallow a future retry site landing in an excluded path.

## Discovery-layer defects found by running it

- **String and multi-line template-literal contents are blanked before matching.** Markdown `**bold**` inside prompts and rendered reports matched the exponent pattern: **20 of the first 50 hits were prose.** That is a discovery defect, not a family worth classifying. Multi-line template state carries across lines, because prompt templates are exactly where multi-line markdown lives.
- **Sites key on `<relPath>#<enclosingSymbol>`, not line numbers.** A line-keyed registry re-baselines on every unrelated edit above a site, and the re-baseline is precisely where a real regression slips through.

## Deltas from ticket

- **The ticket's census table said nine sites; the shipped registry has sixteen.** Running the discovery engine found six more the hand census missed (`GraphqlService`, `GitLabClient`, `ChromaManager`, `MemoryService`, `boundedRetryGate`, devindex `GitHub`). The ticket's own number was the fourth wrong count — I have left the ticket body as filed rather than retro-editing it, because the drift between it and this PR is the argument for the tool.
- **`max-window` gained a real instance.** The ticket listed it speculatively; `ChromaManager` bounds by total delay budget, so the schema is not aspirational.

## Known bound, stated rather than hidden

**Symbol-keying collapses multiple growth sites inside one function into a single classification.** `HomeCanvas#updatePhysics` contains two matches (a distance calculation and an easing curve) and gets one entry — correct here because both are `not-a-retry`, but a function containing *both* a retry and a non-retry would need splitting to classify honestly. 31 candidates map to 30 keys today. The alternative (line keys) re-baselines constantly, which is worse.

## Test Evidence

```
NEO_TEST_SKIP_CI=true UNIT_TEST_MODE=true npm run test-unit -- \
    test/playwright/unit/ai/scripts/lint/
→ 247 passed
```

**14 specs** in `lintRetryBounds.spec.mjs`, covering each acceptance criterion — verified by run, not by counting `test(` calls.

**Red-proof, end to end** — the only thing that tests the guard rather than the schema:

```
# with a synthetic growth site present
node ai/scripts/lint/lint-retry-bounds.mjs → exit 1, names it `unclassified`
# after removing it
node ai/scripts/lint/lint-retry-bounds.mjs → exit 0, "16 retry-growth candidate(s), all classified"
```

**The gate runs in CI on this PR** — `.github/workflows/retry-bound-classification-lint.yml`, path-covered across every scan root (`ai/`, `src/`, `apps/`, `buildScripts/`). It went red on `c37fa0b3b6` naming 37 unclassified candidates and green on `14624f6477`. That is CI evidence, not a post-merge promise, which is why it has moved out of Post-Merge Validation.

**Discriminator precision, measured rather than asserted:** 62 candidates before, 16 after, and the four sites that motivated the ticket (`tenantRepoSync#isRepoDue`, `boundedRetryGate#settleFlight`, `agent/Loop`, `DragCoordinator`) are named in a regression test so a future narrowing cannot drop them silently.

## Post-Merge Validation

- [ ] On the next PR that adds a retry site anywhere, confirm the author is prompted to classify rather than to suppress.

## Commits

- `2f173e45cd` — the discovery engine, the registry, the specs, and the npm script.
- `c37fa0b3b6` — RA-1/RA-3 partial repair: `${…}` substitutions preserved, expression fingerprint kills site-aliasing, `#private` methods keyed, CI workflow wired.
- `14624f6477` — the retry-vocabulary discriminator (62 → 16), witness path resolution, and the registry re-seed onto the fingerprinted key shape.

---

Authored by Grace (Claude Opus 5, Claude Code). Session `9f05cd72-5457-4ec2-926c-ef1406041f19`.

Concept reviewed pre-filing by @neo-gpt-emmy, who corrected the census population and reframed the check from semantic proof to classification. The reframing is hers; the sixteen-site registry is my re-verification of it.

